### PR TITLE
feat(reborn): add runtime dispatcher substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4037,6 +4037,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironclaw_dispatcher"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ironclaw_events",
+ "ironclaw_extensions",
+ "ironclaw_filesystem",
+ "ironclaw_host_api",
+ "ironclaw_resources",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "ironclaw_engine"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_extensions", "crates/ironclaw_processes", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_trust", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
+members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_extensions", "crates/ironclaw_processes", "crates/ironclaw_dispatcher", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_trust", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
 exclude = [
     "channels-src/discord",
     "channels-src/telegram",

--- a/crates/ironclaw_dispatcher/CLAUDE.md
+++ b/crates/ironclaw_dispatcher/CLAUDE.md
@@ -1,0 +1,7 @@
+# ironclaw_dispatcher guardrails
+
+- Own already-authorized runtime routing only.
+- Do not import authorization, approvals, run-state, capabilities, processes, host-runtime, concrete runtime crates, product workflow, or caller-facing state.
+- Event sink failures are best-effort and must not alter dispatch success/failure outcomes.
+- Runtime errors crossing public dispatch surfaces must be redacted to stable kinds.
+- Runtime lanes must be registered through `RuntimeAdapter`; do not add direct WASM/Script/MCP dependencies back to this crate.

--- a/crates/ironclaw_dispatcher/Cargo.toml
+++ b/crates/ironclaw_dispatcher/Cargo.toml
@@ -12,7 +12,9 @@ ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_resources = { path = "../ironclaw_resources" }
 serde_json = "1"
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }
+tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/crates/ironclaw_dispatcher/Cargo.toml
+++ b/crates/ironclaw_dispatcher/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ironclaw_dispatcher"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+ironclaw_events = { path = "../ironclaw_events" }
+ironclaw_extensions = { path = "../ironclaw_extensions" }
+ironclaw_filesystem = { path = "../ironclaw_filesystem" }
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+ironclaw_resources = { path = "../ironclaw_resources" }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -309,8 +309,14 @@ where
     }
 
     fn release_request_reservation(&self, request: &CapabilityDispatchRequest) {
-        if let Some(reservation) = &request.resource_reservation {
-            let _ = self.governor.as_ref().release(reservation.id);
+        if let Some(reservation) = &request.resource_reservation
+            && let Err(error) = self.governor.as_ref().release(reservation.id)
+        {
+            tracing::warn!(
+                reservation_id = %reservation.id,
+                error = %error,
+                "failed to release prepared resource reservation after dispatcher validation failure"
+            );
         }
     }
 

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -354,15 +354,15 @@ where
     }
 }
 
-fn dispatch_error_kind(error: &DispatchError) -> String {
+fn dispatch_error_kind(error: &DispatchError) -> &'static str {
     match error {
-        DispatchError::UnknownCapability { .. } => "unknown_capability".to_string(),
-        DispatchError::UnknownProvider { .. } => "unknown_provider".to_string(),
-        DispatchError::RuntimeMismatch { .. } => "runtime_mismatch".to_string(),
-        DispatchError::MissingRuntimeBackend { .. } => "missing_runtime_backend".to_string(),
-        DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime".to_string(),
+        DispatchError::UnknownCapability { .. } => "unknown_capability",
+        DispatchError::UnknownProvider { .. } => "unknown_provider",
+        DispatchError::RuntimeMismatch { .. } => "runtime_mismatch",
+        DispatchError::MissingRuntimeBackend { .. } => "missing_runtime_backend",
+        DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime",
         DispatchError::Mcp { kind }
         | DispatchError::Script { kind }
-        | DispatchError::Wasm { kind } => kind.as_str().to_string(),
+        | DispatchError::Wasm { kind } => kind.event_kind(),
     }
 }

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -1,0 +1,368 @@
+//! Composition-only runtime dispatch contracts for IronClaw Reborn.
+//!
+//! `ironclaw_dispatcher` wires validated extension descriptors to runtime lanes. It
+//! does not parse extension manifests, implement sandbox policy, reserve budget
+//! itself, or execute product workflows. Those responsibilities stay in the
+//! owning service crates.
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use ironclaw_events::{EventSink, RuntimeEvent};
+use ironclaw_extensions::{ExtensionPackage, ExtensionRegistry};
+use ironclaw_filesystem::RootFilesystem;
+use ironclaw_host_api::{
+    CapabilityDescriptor, CapabilityId, ExtensionId, MountView, ResourceEstimate, ResourceReceipt,
+    ResourceReservation, ResourceScope, ResourceUsage, RuntimeKind,
+};
+pub use ironclaw_host_api::{
+    CapabilityDispatchRequest, CapabilityDispatchResult, CapabilityDispatcher, DispatchError,
+    RuntimeDispatchErrorKind,
+};
+use ironclaw_resources::ResourceGovernor;
+use serde_json::Value;
+
+enum ServiceHandle<'a, T>
+where
+    T: ?Sized,
+{
+    Borrowed(&'a T),
+    Shared(Arc<T>),
+}
+
+impl<T> ServiceHandle<'_, T>
+where
+    T: ?Sized,
+{
+    fn as_ref(&self) -> &T {
+        match self {
+            Self::Borrowed(value) => value,
+            Self::Shared(value) => value.as_ref(),
+        }
+    }
+}
+
+/// Runtime-specific execution request handed to a registered adapter.
+///
+/// The dispatcher has already validated the capability descriptor, provider
+/// package, runtime kind, and configured backend presence before building this
+/// request. Adapters own concrete runtime semantics and resource accounting.
+/// If `resource_reservation` is present, the adapter must reconcile or release
+/// that prepared reservation instead of creating a second reservation.
+pub struct RuntimeAdapterRequest<'a, F, G>
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+{
+    pub package: &'a ExtensionPackage,
+    pub descriptor: &'a CapabilityDescriptor,
+    pub filesystem: &'a F,
+    pub governor: &'a G,
+    pub capability_id: &'a CapabilityId,
+    pub scope: ResourceScope,
+    pub estimate: ResourceEstimate,
+    pub mounts: Option<MountView>,
+    pub resource_reservation: Option<ResourceReservation>,
+    pub input: Value,
+}
+
+/// Runtime-normalized adapter result before dispatcher adds stable identity fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeAdapterResult {
+    pub output: Value,
+    pub usage: ResourceUsage,
+    pub receipt: ResourceReceipt,
+    pub output_bytes: u64,
+}
+
+/// Runtime backend adapter used by [`RuntimeDispatcher`].
+///
+/// Implementations must not perform caller-facing authorization or approval
+/// resolution. They may reserve/reconcile resources through the provided
+/// governor and must surface only redacted [`DispatchError`] categories.
+#[async_trait]
+pub trait RuntimeAdapter<F, G>: Send + Sync
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+{
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, F, G>,
+    ) -> Result<RuntimeAdapterResult, DispatchError>;
+}
+
+/// Narrow runtime dispatcher over already-discovered extensions and services.
+pub struct RuntimeDispatcher<'a, F, G>
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+{
+    registry: ServiceHandle<'a, ExtensionRegistry>,
+    filesystem: ServiceHandle<'a, F>,
+    governor: ServiceHandle<'a, G>,
+    runtime_adapters: HashMap<RuntimeKind, ServiceHandle<'a, dyn RuntimeAdapter<F, G> + 'a>>,
+    event_sink: Option<ServiceHandle<'a, dyn EventSink + 'a>>,
+}
+
+impl<'a, F, G> RuntimeDispatcher<'a, F, G>
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+{
+    pub fn new(registry: &'a ExtensionRegistry, filesystem: &'a F, governor: &'a G) -> Self {
+        Self {
+            registry: ServiceHandle::Borrowed(registry),
+            filesystem: ServiceHandle::Borrowed(filesystem),
+            governor: ServiceHandle::Borrowed(governor),
+            runtime_adapters: HashMap::new(),
+            event_sink: None,
+        }
+    }
+
+    pub fn from_arcs(
+        registry: Arc<ExtensionRegistry>,
+        filesystem: Arc<F>,
+        governor: Arc<G>,
+    ) -> RuntimeDispatcher<'static, F, G>
+    where
+        F: 'static,
+        G: 'static,
+    {
+        RuntimeDispatcher {
+            registry: ServiceHandle::Shared(registry),
+            filesystem: ServiceHandle::Shared(filesystem),
+            governor: ServiceHandle::Shared(governor),
+            runtime_adapters: HashMap::new(),
+            event_sink: None,
+        }
+    }
+
+    pub fn with_runtime_adapter<T>(mut self, runtime: RuntimeKind, adapter: &'a T) -> Self
+    where
+        T: RuntimeAdapter<F, G> + 'a,
+    {
+        let adapter: &'a (dyn RuntimeAdapter<F, G> + 'a) = adapter;
+        self.runtime_adapters
+            .insert(runtime, ServiceHandle::Borrowed(adapter));
+        self
+    }
+
+    pub fn with_runtime_adapter_arc<T>(mut self, runtime: RuntimeKind, adapter: Arc<T>) -> Self
+    where
+        T: RuntimeAdapter<F, G> + 'static,
+        F: 'static,
+        G: 'static,
+    {
+        let adapter: Arc<dyn RuntimeAdapter<F, G>> = adapter;
+        self.runtime_adapters
+            .insert(runtime, ServiceHandle::Shared(adapter));
+        self
+    }
+
+    pub fn with_event_sink(mut self, sink: &'a dyn EventSink) -> Self {
+        self.event_sink = Some(ServiceHandle::Borrowed(sink));
+        self
+    }
+
+    pub fn with_event_sink_arc(mut self, sink: Arc<dyn EventSink>) -> Self {
+        self.event_sink = Some(ServiceHandle::Shared(sink));
+        self
+    }
+
+    pub async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        let scope = request.scope.clone();
+        let capability_id = request.capability_id.clone();
+        self.emit_event(RuntimeEvent::dispatch_requested(
+            scope.clone(),
+            capability_id.clone(),
+        ))
+        .await?;
+
+        let descriptor = match self
+            .registry
+            .as_ref()
+            .get_capability(&request.capability_id)
+        {
+            Some(descriptor) => descriptor,
+            None => {
+                let error = DispatchError::UnknownCapability {
+                    capability: capability_id.clone(),
+                };
+                self.release_request_reservation(&request);
+                self.emit_dispatch_failure(scope, capability_id, None, None, &error)
+                    .await?;
+                return Err(error);
+            }
+        };
+        let package = match self.registry.as_ref().get_extension(&descriptor.provider) {
+            Some(package) => package,
+            None => {
+                let error = DispatchError::UnknownProvider {
+                    capability: capability_id.clone(),
+                    provider: descriptor.provider.clone(),
+                };
+                self.release_request_reservation(&request);
+                self.emit_dispatch_failure(
+                    scope,
+                    capability_id,
+                    Some(descriptor.provider.clone()),
+                    Some(descriptor.runtime),
+                    &error,
+                )
+                .await?;
+                return Err(error);
+            }
+        };
+        let package_runtime = package.manifest.runtime_kind();
+        if descriptor.runtime != package_runtime {
+            let error = DispatchError::RuntimeMismatch {
+                capability: capability_id.clone(),
+                descriptor_runtime: descriptor.runtime,
+                package_runtime,
+            };
+            self.release_request_reservation(&request);
+            self.emit_dispatch_failure(
+                scope,
+                capability_id,
+                Some(descriptor.provider.clone()),
+                Some(descriptor.runtime),
+                &error,
+            )
+            .await?;
+            return Err(error);
+        }
+
+        let runtime = descriptor.runtime;
+        let Some(adapter) = self.runtime_adapters.get(&runtime) else {
+            let error = DispatchError::MissingRuntimeBackend { runtime };
+            self.release_request_reservation(&request);
+            self.emit_dispatch_failure(
+                scope,
+                capability_id,
+                Some(descriptor.provider.clone()),
+                Some(runtime),
+                &error,
+            )
+            .await?;
+            return Err(error);
+        };
+
+        self.emit_event(RuntimeEvent::runtime_selected(
+            scope.clone(),
+            capability_id.clone(),
+            descriptor.provider.clone(),
+            runtime,
+        ))
+        .await?;
+
+        let execution = match adapter
+            .as_ref()
+            .dispatch_json(RuntimeAdapterRequest {
+                package,
+                descriptor,
+                filesystem: self.filesystem.as_ref(),
+                governor: self.governor.as_ref(),
+                capability_id: &request.capability_id,
+                scope: request.scope,
+                estimate: request.estimate,
+                mounts: request.mounts,
+                resource_reservation: request.resource_reservation,
+                input: request.input,
+            })
+            .await
+        {
+            Ok(execution) => execution,
+            Err(error) => {
+                self.emit_dispatch_failure(
+                    scope,
+                    capability_id,
+                    Some(descriptor.provider.clone()),
+                    Some(runtime),
+                    &error,
+                )
+                .await?;
+                return Err(error);
+            }
+        };
+
+        self.emit_event(RuntimeEvent::dispatch_succeeded(
+            scope,
+            capability_id.clone(),
+            descriptor.provider.clone(),
+            runtime,
+            execution.output_bytes,
+        ))
+        .await?;
+
+        Ok(CapabilityDispatchResult {
+            capability_id,
+            provider: descriptor.provider.clone(),
+            runtime,
+            output: execution.output,
+            usage: execution.usage,
+            receipt: execution.receipt,
+        })
+    }
+
+    fn release_request_reservation(&self, request: &CapabilityDispatchRequest) {
+        if let Some(reservation) = &request.resource_reservation {
+            let _ = self.governor.as_ref().release(reservation.id);
+        }
+    }
+
+    async fn emit_dispatch_failure(
+        &self,
+        scope: ResourceScope,
+        capability_id: CapabilityId,
+        provider: Option<ExtensionId>,
+        runtime: Option<RuntimeKind>,
+        error: &DispatchError,
+    ) -> Result<(), DispatchError> {
+        self.emit_event(RuntimeEvent::dispatch_failed(
+            scope,
+            capability_id,
+            provider,
+            runtime,
+            dispatch_error_kind(error),
+        ))
+        .await
+    }
+
+    async fn emit_event(&self, event: RuntimeEvent) -> Result<(), DispatchError> {
+        if let Some(sink) = self.event_sink.as_ref() {
+            let _ = sink.as_ref().emit(event).await;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<F, G> CapabilityDispatcher for RuntimeDispatcher<'_, F, G>
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+{
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        RuntimeDispatcher::dispatch_json(self, request).await
+    }
+}
+
+fn dispatch_error_kind(error: &DispatchError) -> String {
+    match error {
+        DispatchError::UnknownCapability { .. } => "unknown_capability".to_string(),
+        DispatchError::UnknownProvider { .. } => "unknown_provider".to_string(),
+        DispatchError::RuntimeMismatch { .. } => "runtime_mismatch".to_string(),
+        DispatchError::MissingRuntimeBackend { .. } => "missing_runtime_backend".to_string(),
+        DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime".to_string(),
+        DispatchError::Mcp { kind }
+        | DispatchError::Script { kind }
+        | DispatchError::Wasm { kind } => kind.as_str().to_string(),
+    }
+}

--- a/crates/ironclaw_dispatcher/tests/boundary_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/boundary_contract.rs
@@ -1,0 +1,19 @@
+#[test]
+fn dispatcher_crate_does_not_depend_on_higher_level_workflow_crates() {
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {manifest_path:?}: {error}"));
+
+    for forbidden in [
+        "ironclaw_authorization",
+        "ironclaw_capabilities",
+        "ironclaw_wasm",
+        "ironclaw_scripts",
+        "ironclaw_mcp",
+    ] {
+        assert!(
+            !manifest.contains(forbidden),
+            "ironclaw_dispatcher examples/tests should exercise the dispatcher boundary directly, not depend on higher-level workflow crate {forbidden}"
+        );
+    }
+}

--- a/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
@@ -1,0 +1,598 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_dispatcher::*;
+use ironclaw_extensions::*;
+use ironclaw_filesystem::*;
+use ironclaw_host_api::*;
+use ironclaw_resources::*;
+use serde_json::{Value, json};
+
+#[tokio::test]
+async fn dispatcher_routes_wasm_capability_through_registered_adapter() {
+    let fs = mounted_empty_extension_root();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_manifest(WASM_MANIFEST))
+        .unwrap();
+    let adapter = RecordingAdapter::new(RuntimeKind::Wasm, json!({"message": "hello adapter"}));
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            max_output_bytes: Some(10_000),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Wasm, &adapter);
+    let result = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "hello dispatcher"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.capability_id, CapabilityId::new("echo.say").unwrap());
+    assert_eq!(result.provider, ExtensionId::new("echo").unwrap());
+    assert_eq!(result.runtime, RuntimeKind::Wasm);
+    assert_eq!(result.output, json!({"message": "hello adapter"}));
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert!(governor.usage_for(&account).output_bytes > 0);
+
+    let requests = adapter.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].provider, ExtensionId::new("echo").unwrap());
+    assert_eq!(
+        requests[0].capability_id,
+        CapabilityId::new("echo.say").unwrap()
+    );
+    assert_eq!(requests[0].runtime, RuntimeKind::Wasm);
+    assert_eq!(requests[0].input, json!({"message": "hello dispatcher"}));
+}
+
+#[tokio::test]
+async fn dispatcher_routes_script_capability_through_registered_adapter() {
+    let fs = mounted_empty_extension_root();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_manifest(SCRIPT_MANIFEST))
+        .unwrap();
+    let adapter = RecordingAdapter::new(
+        RuntimeKind::Script,
+        json!({
+            "message": "hello script adapter"
+        }),
+    );
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            max_process_count: Some(10),
+            max_output_bytes: Some(10_000),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Script, &adapter);
+    let result = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("script.echo").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "hello script dispatcher"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.capability_id,
+        CapabilityId::new("script.echo").unwrap()
+    );
+    assert_eq!(result.provider, ExtensionId::new("script").unwrap());
+    assert_eq!(result.runtime, RuntimeKind::Script);
+    assert_eq!(result.output, json!({"message": "hello script adapter"}));
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account).process_count, 1);
+}
+
+#[tokio::test]
+async fn dispatcher_redacts_runtime_adapter_failure_details() {
+    let fs = mounted_empty_extension_root();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_manifest(SCRIPT_MANIFEST))
+        .unwrap();
+    let adapter =
+        RecordingAdapter::failing(RuntimeKind::Script, RuntimeDispatchErrorKind::ExitFailure);
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    governor.set_limit(
+        ResourceAccount::tenant(scope.tenant_id.clone()),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            max_process_count: Some(10),
+            max_output_bytes: Some(10_000),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Script, &adapter);
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("script.echo").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "redact stderr"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Script {
+            kind: RuntimeDispatchErrorKind::ExitFailure
+        }
+    ));
+    let message = err.to_string();
+    assert!(!message.contains("secret token"));
+    assert!(!message.contains("/tmp/private"));
+}
+
+#[tokio::test]
+async fn dispatcher_routes_mcp_capability_through_registered_adapter() {
+    let fs = mounted_empty_extension_root();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_manifest(MCP_MANIFEST))
+        .unwrap();
+    let adapter = RecordingAdapter::new(
+        RuntimeKind::Mcp,
+        json!({
+            "matches": ["ironclaw"]
+        }),
+    );
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            max_process_count: Some(1),
+            max_output_bytes: Some(10_000),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Mcp, &adapter);
+    let result = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"query": "ironclaw"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.capability_id,
+        CapabilityId::new("github-mcp.search").unwrap()
+    );
+    assert_eq!(result.provider, ExtensionId::new("github-mcp").unwrap());
+    assert_eq!(result.runtime, RuntimeKind::Mcp);
+    assert_eq!(result.output, json!({"matches": ["ironclaw"]}));
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert!(governor.usage_for(&account).output_bytes > 0);
+}
+
+#[tokio::test]
+async fn dispatcher_fails_unknown_capability_without_reserving_resources() {
+    let fs = mounted_empty_extension_root();
+    let registry = ExtensionRegistry::new();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let adapter = RecordingAdapter::new(RuntimeKind::Wasm, json!({}));
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Wasm, &adapter);
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("missing.say").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "nope"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, DispatchError::UnknownCapability { .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+    assert!(adapter.requests().is_empty());
+}
+
+#[tokio::test]
+async fn dispatcher_releases_prepared_reservation_when_validation_fails_before_adapter() {
+    let fs = mounted_empty_extension_root();
+    let registry = ExtensionRegistry::new();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let estimate = ResourceEstimate {
+        concurrency_slots: Some(1),
+        ..ResourceEstimate::default()
+    };
+    let reservation = governor.reserve(scope.clone(), estimate.clone()).unwrap();
+    assert_eq!(governor.reserved_for(&account).concurrency_slots, 1);
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("missing.say").unwrap(),
+            scope,
+            estimate,
+            mounts: None,
+            resource_reservation: Some(reservation),
+            input: json!({"message": "release on validation failure"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, DispatchError::UnknownCapability { .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn dispatcher_requires_mcp_backend_before_reserving_resources() {
+    let fs = mounted_empty_extension_root();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_manifest(MCP_MANIFEST))
+        .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"query": "blocked"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::Mcp
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn dispatcher_requires_script_backend_before_reserving_resources() {
+    let fs = mounted_empty_extension_root();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_manifest(SCRIPT_MANIFEST))
+        .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("script.echo").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "blocked"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::Script
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn dispatcher_requires_wasm_backend_before_reserving_resources() {
+    let fs = mounted_empty_extension_root();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_manifest(WASM_MANIFEST))
+        .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "blocked"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::Wasm
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[derive(Clone)]
+struct RecordingAdapter {
+    runtime: RuntimeKind,
+    output: Value,
+    failure: Option<RuntimeDispatchErrorKind>,
+    requests: Arc<Mutex<Vec<RecordedAdapterRequest>>>,
+}
+
+impl RecordingAdapter {
+    fn new(runtime: RuntimeKind, output: Value) -> Self {
+        Self {
+            runtime,
+            output,
+            failure: None,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn failing(runtime: RuntimeKind, failure: RuntimeDispatchErrorKind) -> Self {
+        Self {
+            runtime,
+            output: json!(null),
+            failure: Some(failure),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<RecordedAdapterRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RecordedAdapterRequest {
+    provider: ExtensionId,
+    capability_id: CapabilityId,
+    runtime: RuntimeKind,
+    input: Value,
+}
+
+#[async_trait]
+impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        self.requests.lock().unwrap().push(RecordedAdapterRequest {
+            provider: request.package.id.clone(),
+            capability_id: request.capability_id.clone(),
+            runtime: request.descriptor.runtime,
+            input: request.input.clone(),
+        });
+        if let Some(kind) = self.failure {
+            return Err(dispatch_error_for_runtime(self.runtime, kind));
+        }
+
+        let usage = ResourceUsage {
+            output_bytes: serde_json::to_vec(&self.output).unwrap().len() as u64,
+            process_count: u32::from(matches!(
+                self.runtime,
+                RuntimeKind::Script | RuntimeKind::Mcp
+            )),
+            ..ResourceUsage::default()
+        };
+        let reservation = request
+            .governor
+            .reserve(request.scope.clone(), request.estimate.clone())
+            .map_err(|_| {
+                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
+            })?;
+        let receipt = request
+            .governor
+            .reconcile(reservation.id, usage.clone())
+            .map_err(|_| {
+                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
+            })?;
+        Ok(RuntimeAdapterResult {
+            output: self.output.clone(),
+            output_bytes: usage.output_bytes,
+            usage,
+            receipt,
+        })
+    }
+}
+
+fn dispatch_error_for_runtime(
+    runtime: RuntimeKind,
+    kind: RuntimeDispatchErrorKind,
+) -> DispatchError {
+    match runtime {
+        RuntimeKind::Wasm => DispatchError::Wasm { kind },
+        RuntimeKind::Script => DispatchError::Script { kind },
+        RuntimeKind::Mcp => DispatchError::Mcp { kind },
+        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
+            capability: CapabilityId::new("system.unsupported").unwrap(),
+            runtime,
+        },
+    }
+}
+
+fn mounted_empty_extension_root() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
+}
+
+fn package_from_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("user-a").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: Some(MissionId::new("mission-a").unwrap()),
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id: InvocationId::new(),
+    }
+}
+
+const WASM_MANIFEST: &str = r#"
+id = "echo"
+name = "Echo WASM"
+version = "0.1.0"
+description = "Echo WASM demo extension"
+trust = "sandbox"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "echo.say"
+description = "Echo WASM"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;
+
+const MCP_MANIFEST: &str = r#"
+id = "github-mcp"
+name = "GitHub MCP"
+version = "0.1.0"
+description = "GitHub MCP adapter"
+trust = "sandbox"
+
+[runtime]
+kind = "mcp"
+transport = "stdio"
+command = "github-mcp"
+args = ["--stdio"]
+
+[[capabilities]]
+id = "github-mcp.search"
+description = "Search GitHub"
+effects = ["network", "dispatch_capability"]
+default_permission = "ask"
+parameters_schema = { type = "object" }
+"#;
+
+const SCRIPT_MANIFEST: &str = r#"
+id = "script"
+name = "Script Echo"
+version = "0.1.0"
+description = "Script Echo demo extension"
+trust = "sandbox"
+
+[runtime]
+kind = "script"
+runner = "sandboxed_process"
+command = "sh"
+args = ["-c", "cat"]
+
+[[capabilities]]
+id = "script.echo"
+description = "Echo script"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;

--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -155,6 +155,50 @@ async fn dispatcher_preserves_original_error_when_failure_event_sink_fails() {
 }
 
 #[tokio::test]
+async fn dispatcher_emits_redacted_runtime_error_kind_for_adapter_failure() {
+    let fs = filesystem_with_echo_extensions();
+    let registry =
+        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
+            .await
+            .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let script_adapter =
+        FailingRuntimeAdapter::new(RuntimeKind::Script, RuntimeDispatchErrorKind::ExitFailure);
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Script, &script_adapter)
+        .with_event_sink(&events);
+
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-script.say").unwrap(),
+            scope: sample_scope(),
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "adapter fails"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Script {
+            kind: RuntimeDispatchErrorKind::ExitFailure
+        }
+    ));
+
+    let recorded = events.events();
+    assert_eq!(recorded.len(), 3);
+    assert_eq!(recorded[2].kind, RuntimeEventKind::DispatchFailed);
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("exit_failure"));
+}
+
+#[tokio::test]
 async fn dispatcher_emits_events_for_mcp_success() {
     let fs = filesystem_with_echo_extensions();
     let mut registry = ExtensionRegistry::new();
@@ -310,6 +354,28 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for StaticAdapter
             request.estimate,
             self.output.clone(),
         )
+    }
+}
+
+#[derive(Clone)]
+struct FailingRuntimeAdapter {
+    runtime: RuntimeKind,
+    kind: RuntimeDispatchErrorKind,
+}
+
+impl FailingRuntimeAdapter {
+    fn new(runtime: RuntimeKind, kind: RuntimeDispatchErrorKind) -> Self {
+        Self { runtime, kind }
+    }
+}
+
+#[async_trait]
+impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for FailingRuntimeAdapter {
+    async fn dispatch_json(
+        &self,
+        _request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        Err(dispatch_error_for_runtime(self.runtime, self.kind))
     }
 }
 

--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -6,6 +6,8 @@ use ironclaw_filesystem::*;
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
 use serde_json::{Value, json};
+use tracing::Instrument;
+use tracing_test::traced_test;
 
 #[tokio::test]
 async fn dispatcher_emits_events_for_wasm_and_script_success() {
@@ -152,6 +154,58 @@ async fn dispatcher_preserves_original_error_when_failure_event_sink_fails() {
             runtime: RuntimeKind::Script
         }
     ));
+}
+
+#[tokio::test]
+#[traced_test]
+async fn dispatcher_logs_release_failure_without_masking_dispatch_error() {
+    let fs = filesystem_with_echo_extensions();
+    let registry =
+        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
+            .await
+            .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let reservation = ResourceReservation {
+        id: ResourceReservationId::new(),
+        scope: scope.clone(),
+        estimate: ResourceEstimate {
+            concurrency_slots: Some(1),
+            process_count: Some(1),
+            ..ResourceEstimate::default()
+        },
+    };
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor);
+
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-script.say").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: Some(reservation.clone()),
+            input: json!({"message": "missing backend"}),
+        })
+        .instrument(tracing::info_span!(
+            "dispatcher_logs_release_failure_without_masking_dispatch_error"
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::Script
+        }
+    ));
+    assert!(logs_contain(
+        "failed to release prepared resource reservation after dispatcher validation failure"
+    ));
+    assert!(logs_contain(&reservation.id.to_string()));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -1,0 +1,457 @@
+use async_trait::async_trait;
+use ironclaw_dispatcher::*;
+use ironclaw_events::*;
+use ironclaw_extensions::*;
+use ironclaw_filesystem::*;
+use ironclaw_host_api::*;
+use ironclaw_resources::*;
+use serde_json::{Value, json};
+
+#[tokio::test]
+async fn dispatcher_emits_events_for_wasm_and_script_success() {
+    let fs = filesystem_with_echo_extensions();
+    let registry =
+        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
+            .await
+            .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let wasm_adapter = EchoAdapter::new(RuntimeKind::Wasm);
+    let script_adapter = EchoAdapter::new(RuntimeKind::Script);
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Wasm, &wasm_adapter)
+        .with_runtime_adapter(RuntimeKind::Script, &script_adapter)
+        .with_event_sink(&events);
+
+    dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-wasm.say").unwrap(),
+            scope: sample_scope(),
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "hello wasm"}),
+        })
+        .await
+        .unwrap();
+
+    dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-script.say").unwrap(),
+            scope: sample_scope(),
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "hello script"}),
+        })
+        .await
+        .unwrap();
+
+    let recorded = events.events();
+    let kinds = recorded.iter().map(|event| event.kind).collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+        ]
+    );
+    assert_eq!(
+        recorded[0].capability_id,
+        CapabilityId::new("echo-wasm.say").unwrap()
+    );
+    assert_eq!(recorded[1].runtime, Some(RuntimeKind::Wasm));
+    assert_eq!(recorded[2].output_bytes, Some(24));
+    assert_eq!(
+        recorded[3].capability_id,
+        CapabilityId::new("echo-script.say").unwrap()
+    );
+    assert_eq!(recorded[4].runtime, Some(RuntimeKind::Script));
+    assert_eq!(
+        recorded[5].provider,
+        Some(ExtensionId::new("echo-script").unwrap())
+    );
+}
+
+#[tokio::test]
+async fn dispatcher_ignores_event_sink_failures_on_success() {
+    let fs = filesystem_with_echo_extensions();
+    let registry =
+        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
+            .await
+            .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let wasm_adapter = EchoAdapter::new(RuntimeKind::Wasm);
+    let events = FailingEventSink;
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Wasm, &wasm_adapter)
+        .with_event_sink(&events);
+
+    let result = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-wasm.say").unwrap(),
+            scope: sample_scope(),
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "event sink fails"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.output, json!({"message": "event sink fails"}));
+}
+
+#[tokio::test]
+async fn dispatcher_preserves_original_error_when_failure_event_sink_fails() {
+    let fs = filesystem_with_echo_extensions();
+    let registry =
+        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
+            .await
+            .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let events = FailingEventSink;
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor).with_event_sink(&events);
+
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-script.say").unwrap(),
+            scope: sample_scope(),
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "missing backend"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::Script
+        }
+    ));
+}
+
+#[tokio::test]
+async fn dispatcher_emits_events_for_mcp_success() {
+    let fs = filesystem_with_echo_extensions();
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(package_from_manifest(MCP_MANIFEST))
+        .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let mcp_adapter = StaticAdapter::new(RuntimeKind::Mcp, json!({"matches": ["ironclaw"]}));
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Mcp, &mcp_adapter)
+        .with_event_sink(&events);
+
+    dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"query": "ironclaw"}),
+        })
+        .await
+        .unwrap();
+
+    let recorded = events.events();
+    assert_eq!(recorded.len(), 3);
+    assert_eq!(recorded[0].kind, RuntimeEventKind::DispatchRequested);
+    assert_eq!(recorded[1].kind, RuntimeEventKind::RuntimeSelected);
+    assert_eq!(recorded[1].runtime, Some(RuntimeKind::Mcp));
+    assert_eq!(recorded[2].kind, RuntimeEventKind::DispatchSucceeded);
+    assert_eq!(
+        recorded[2].provider,
+        Some(ExtensionId::new("github-mcp").unwrap())
+    );
+    assert!(recorded[2].output_bytes.unwrap() > 0);
+}
+
+#[tokio::test]
+async fn dispatcher_emits_failed_event_for_missing_backend_without_reserving() {
+    let fs = filesystem_with_echo_extensions();
+    let registry =
+        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
+            .await
+            .unwrap();
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor).with_event_sink(&events);
+
+    let err = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-script.say").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "blocked"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::Script
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+
+    let recorded = events.events();
+    assert_eq!(recorded.len(), 2);
+    assert_eq!(recorded[0].kind, RuntimeEventKind::DispatchRequested);
+    assert_eq!(recorded[1].kind, RuntimeEventKind::DispatchFailed);
+    assert_eq!(recorded[1].runtime, Some(RuntimeKind::Script));
+    assert_eq!(
+        recorded[1].error_kind.as_deref(),
+        Some("missing_runtime_backend")
+    );
+}
+
+struct FailingEventSink;
+
+#[async_trait]
+impl EventSink for FailingEventSink {
+    async fn emit(&self, _event: RuntimeEvent) -> Result<(), EventError> {
+        Err(EventError::Sink {
+            reason: "event sink unavailable".to_string(),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct EchoAdapter {
+    runtime: RuntimeKind,
+}
+
+impl EchoAdapter {
+    fn new(runtime: RuntimeKind) -> Self {
+        Self { runtime }
+    }
+}
+
+#[async_trait]
+impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for EchoAdapter {
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        adapter_result(
+            self.runtime,
+            request.governor,
+            request.scope,
+            request.estimate,
+            request.input,
+        )
+    }
+}
+
+#[derive(Clone)]
+struct StaticAdapter {
+    runtime: RuntimeKind,
+    output: Value,
+}
+
+impl StaticAdapter {
+    fn new(runtime: RuntimeKind, output: Value) -> Self {
+        Self { runtime, output }
+    }
+}
+
+#[async_trait]
+impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for StaticAdapter {
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        adapter_result(
+            self.runtime,
+            request.governor,
+            request.scope,
+            request.estimate,
+            self.output.clone(),
+        )
+    }
+}
+
+fn adapter_result(
+    runtime: RuntimeKind,
+    governor: &InMemoryResourceGovernor,
+    scope: ResourceScope,
+    estimate: ResourceEstimate,
+    output: Value,
+) -> Result<RuntimeAdapterResult, DispatchError> {
+    let usage = ResourceUsage {
+        output_bytes: serde_json::to_vec(&output).unwrap().len() as u64,
+        process_count: u32::from(matches!(runtime, RuntimeKind::Script | RuntimeKind::Mcp)),
+        ..ResourceUsage::default()
+    };
+    let reservation = governor
+        .reserve(scope, estimate)
+        .map_err(|_| dispatch_error_for_runtime(runtime, RuntimeDispatchErrorKind::Resource))?;
+    let receipt = governor
+        .reconcile(reservation.id, usage.clone())
+        .map_err(|_| dispatch_error_for_runtime(runtime, RuntimeDispatchErrorKind::Resource))?;
+    Ok(RuntimeAdapterResult {
+        output,
+        output_bytes: usage.output_bytes,
+        usage,
+        receipt,
+    })
+}
+
+fn dispatch_error_for_runtime(
+    runtime: RuntimeKind,
+    kind: RuntimeDispatchErrorKind,
+) -> DispatchError {
+    match runtime {
+        RuntimeKind::Wasm => DispatchError::Wasm { kind },
+        RuntimeKind::Script => DispatchError::Script { kind },
+        RuntimeKind::Mcp => DispatchError::Mcp { kind },
+        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
+            capability: CapabilityId::new("system.unsupported").unwrap(),
+            runtime,
+        },
+    }
+}
+
+fn filesystem_with_echo_extensions() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    write_echo_extensions(&storage);
+
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
+}
+
+fn write_echo_extensions(root: &std::path::Path) {
+    let wasm_root = root.join("echo-wasm");
+    std::fs::create_dir_all(wasm_root).unwrap();
+    std::fs::write(root.join("echo-wasm/manifest.toml"), WASM_MANIFEST).unwrap();
+
+    let script_root = root.join("echo-script");
+    std::fs::create_dir_all(&script_root).unwrap();
+    std::fs::write(script_root.join("manifest.toml"), SCRIPT_MANIFEST).unwrap();
+}
+
+fn package_from_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("user-a").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: Some(MissionId::new("mission-a").unwrap()),
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id: InvocationId::new(),
+    }
+}
+
+const WASM_MANIFEST: &str = r#"
+id = "echo-wasm"
+name = "Echo WASM"
+version = "0.1.0"
+description = "Echo WASM demo extension"
+trust = "sandbox"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "echo-wasm.say"
+description = "Echo WASM"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;
+
+const MCP_MANIFEST: &str = r#"
+id = "github-mcp"
+name = "GitHub MCP"
+version = "0.1.0"
+description = "GitHub MCP adapter"
+trust = "sandbox"
+
+[runtime]
+kind = "mcp"
+transport = "stdio"
+command = "github-mcp"
+args = ["--stdio"]
+
+[[capabilities]]
+id = "github-mcp.search"
+description = "Search GitHub"
+effects = ["network", "dispatch_capability"]
+default_permission = "ask"
+parameters_schema = { type = "object" }
+"#;
+
+const SCRIPT_MANIFEST: &str = r#"
+id = "echo-script"
+name = "Echo Script"
+version = "0.1.0"
+description = "Echo Script demo extension"
+trust = "sandbox"
+
+[runtime]
+kind = "script"
+runner = "sandboxed_process"
+command = "sh"
+args = ["-c", "cat"]
+
+[[capabilities]]
+id = "echo-script.say"
+description = "Echo script"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;

--- a/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
@@ -1,0 +1,271 @@
+use async_trait::async_trait;
+use ironclaw_dispatcher::*;
+use ironclaw_extensions::*;
+use ironclaw_filesystem::*;
+use ironclaw_host_api::*;
+use ironclaw_resources::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn vertical_slice_discovers_and_dispatches_registered_runtime_adapters() {
+    let fs = filesystem_with_echo_extensions();
+    let registry =
+        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
+            .await
+            .unwrap();
+    assert_eq!(registry.extensions().count(), 3);
+
+    let governor = InMemoryResourceGovernor::new();
+    let wasm_adapter = EchoAdapter::new(RuntimeKind::Wasm);
+    let script_adapter = EchoAdapter::new(RuntimeKind::Script);
+    let mcp_adapter = EchoAdapter::new(RuntimeKind::Mcp);
+    let scope = sample_scope();
+    let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
+        .with_runtime_adapter(RuntimeKind::Wasm, &wasm_adapter)
+        .with_runtime_adapter(RuntimeKind::Script, &script_adapter)
+        .with_runtime_adapter(RuntimeKind::Mcp, &mcp_adapter);
+
+    let wasm_scope = scope.clone();
+    let wasm_account = ResourceAccount::tenant(wasm_scope.tenant_id.clone());
+    let wasm = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-wasm.say").unwrap(),
+            scope: wasm_scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "hello wasm"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(wasm.provider, ExtensionId::new("echo-wasm").unwrap());
+    assert_eq!(wasm.runtime, RuntimeKind::Wasm);
+    assert_eq!(wasm.output, json!({"message": "hello wasm"}));
+    assert_eq!(wasm.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(
+        governor.reserved_for(&wasm_account),
+        ResourceTally::default()
+    );
+
+    let script_scope = scope.clone();
+    let script_account = ResourceAccount::tenant(script_scope.tenant_id.clone());
+    let script = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-script.say").unwrap(),
+            scope: script_scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "hello script"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(script.provider, ExtensionId::new("echo-script").unwrap());
+    assert_eq!(script.runtime, RuntimeKind::Script);
+    assert_eq!(script.output, json!({"message": "hello script"}));
+    assert_eq!(script.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(
+        governor.reserved_for(&script_account),
+        ResourceTally::default()
+    );
+    assert_eq!(script.usage.process_count, 1);
+    assert!(governor.usage_for(&script_account).process_count >= 1);
+
+    let mcp_scope = scope;
+    let mcp_account = ResourceAccount::tenant(mcp_scope.tenant_id.clone());
+    let mcp = dispatcher
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo-mcp.say").unwrap(),
+            scope: mcp_scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "hello mcp"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(mcp.provider, ExtensionId::new("echo-mcp").unwrap());
+    assert_eq!(mcp.runtime, RuntimeKind::Mcp);
+    assert_eq!(mcp.output, json!({"message": "hello mcp"}));
+    assert_eq!(mcp.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(
+        governor.reserved_for(&mcp_account),
+        ResourceTally::default()
+    );
+    assert_eq!(mcp.usage.process_count, 1);
+}
+
+#[derive(Clone)]
+struct EchoAdapter {
+    runtime: RuntimeKind,
+}
+
+impl EchoAdapter {
+    fn new(runtime: RuntimeKind) -> Self {
+        Self { runtime }
+    }
+}
+
+#[async_trait]
+impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for EchoAdapter {
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        let output = request.input;
+        let usage = ResourceUsage {
+            output_bytes: serde_json::to_vec(&output).unwrap().len() as u64,
+            process_count: u32::from(matches!(
+                self.runtime,
+                RuntimeKind::Script | RuntimeKind::Mcp
+            )),
+            ..ResourceUsage::default()
+        };
+        let reservation = request
+            .governor
+            .reserve(request.scope, request.estimate)
+            .map_err(|_| {
+                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
+            })?;
+        let receipt = request
+            .governor
+            .reconcile(reservation.id, usage.clone())
+            .map_err(|_| {
+                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
+            })?;
+        Ok(RuntimeAdapterResult {
+            output,
+            output_bytes: usage.output_bytes,
+            usage,
+            receipt,
+        })
+    }
+}
+
+fn dispatch_error_for_runtime(
+    runtime: RuntimeKind,
+    kind: RuntimeDispatchErrorKind,
+) -> DispatchError {
+    match runtime {
+        RuntimeKind::Wasm => DispatchError::Wasm { kind },
+        RuntimeKind::Script => DispatchError::Script { kind },
+        RuntimeKind::Mcp => DispatchError::Mcp { kind },
+        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
+            capability: CapabilityId::new("system.unsupported").unwrap(),
+            runtime,
+        },
+    }
+}
+
+fn filesystem_with_echo_extensions() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let wasm_root = storage.join("echo-wasm");
+    std::fs::create_dir_all(&wasm_root).unwrap();
+    std::fs::write(wasm_root.join("manifest.toml"), WASM_MANIFEST).unwrap();
+
+    let script_root = storage.join("echo-script");
+    std::fs::create_dir_all(&script_root).unwrap();
+    std::fs::write(script_root.join("manifest.toml"), SCRIPT_MANIFEST).unwrap();
+
+    let mcp_root = storage.join("echo-mcp");
+    std::fs::create_dir_all(&mcp_root).unwrap();
+    std::fs::write(mcp_root.join("manifest.toml"), MCP_MANIFEST).unwrap();
+
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant1").unwrap(),
+        user_id: UserId::new("user1").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+const WASM_MANIFEST: &str = r#"
+id = "echo-wasm"
+name = "WASM Echo"
+version = "0.1.0"
+description = "WASM echo demo extension"
+trust = "sandbox"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "echo-wasm.say"
+description = "Echo text through WASM"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object", required = ["message"], properties = { message = { type = "string" } } }
+"#;
+
+const MCP_MANIFEST: &str = r#"
+id = "echo-mcp"
+name = "MCP Echo"
+version = "0.1.0"
+description = "MCP echo demo adapter"
+trust = "sandbox"
+
+[runtime]
+kind = "mcp"
+transport = "stdio"
+command = "echo-mcp"
+args = ["--stdio"]
+
+[[capabilities]]
+id = "echo-mcp.say"
+description = "Echo text through MCP adapter"
+effects = ["network", "dispatch_capability"]
+default_permission = "ask"
+parameters_schema = { type = "object", required = ["message"], properties = { message = { type = "string" } } }
+"#;
+
+const SCRIPT_MANIFEST: &str = r#"
+id = "echo-script"
+name = "Script Echo"
+version = "0.1.0"
+description = "Script echo demo extension"
+trust = "sandbox"
+
+[runtime]
+kind = "script"
+runner = "sandboxed_process"
+command = "sh"
+args = ["-c", "cat"]
+
+[[capabilities]]
+id = "echo-script.say"
+description = "Echo text through Script Runner"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object", required = ["message"], properties = { message = { type = "string" } } }
+"#;

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -83,6 +83,31 @@ impl RuntimeDispatchErrorKind {
             Self::Unknown => "Unknown",
         }
     }
+
+    /// Sanitizer-compatible event/audit token for this redacted failure kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Backend => "backend",
+            Self::Client => "client",
+            Self::Executor => "executor",
+            Self::ExitFailure => "exit_failure",
+            Self::ExtensionRuntimeMismatch => "extension.runtime_mismatch",
+            Self::FilesystemDenied => "filesystem_denied",
+            Self::Guest => "guest",
+            Self::InputEncode => "input_encode",
+            Self::InvalidResult => "invalid_result",
+            Self::Manifest => "manifest",
+            Self::Memory => "memory",
+            Self::MethodMissing => "method_missing",
+            Self::NetworkDenied => "network_denied",
+            Self::OutputDecode => "output_decode",
+            Self::OutputTooLarge => "output_too_large",
+            Self::Resource => "resource",
+            Self::UndeclaredCapability => "undeclared_capability",
+            Self::UnsupportedRunner => "unsupported_runner",
+            Self::Unknown => "unknown",
+        }
+    }
 }
 
 impl std::fmt::Display for RuntimeDispatchErrorKind {

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -102,6 +102,78 @@ fn local_default_resource_scope_uses_default_agent_and_bootstrap_project() {
 }
 
 #[test]
+fn runtime_dispatch_error_kinds_have_safe_event_tokens() {
+    for (kind, token) in [
+        (RuntimeDispatchErrorKind::Backend, "backend"),
+        (RuntimeDispatchErrorKind::Client, "client"),
+        (RuntimeDispatchErrorKind::Executor, "executor"),
+        (RuntimeDispatchErrorKind::ExitFailure, "exit_failure"),
+        (
+            RuntimeDispatchErrorKind::ExtensionRuntimeMismatch,
+            "extension.runtime_mismatch",
+        ),
+        (
+            RuntimeDispatchErrorKind::FilesystemDenied,
+            "filesystem_denied",
+        ),
+        (RuntimeDispatchErrorKind::Guest, "guest"),
+        (RuntimeDispatchErrorKind::InputEncode, "input_encode"),
+        (RuntimeDispatchErrorKind::InvalidResult, "invalid_result"),
+        (RuntimeDispatchErrorKind::Manifest, "manifest"),
+        (RuntimeDispatchErrorKind::Memory, "memory"),
+        (RuntimeDispatchErrorKind::MethodMissing, "method_missing"),
+        (RuntimeDispatchErrorKind::NetworkDenied, "network_denied"),
+        (RuntimeDispatchErrorKind::OutputDecode, "output_decode"),
+        (RuntimeDispatchErrorKind::OutputTooLarge, "output_too_large"),
+        (RuntimeDispatchErrorKind::Resource, "resource"),
+        (
+            RuntimeDispatchErrorKind::UndeclaredCapability,
+            "undeclared_capability",
+        ),
+        (
+            RuntimeDispatchErrorKind::UnsupportedRunner,
+            "unsupported_runner",
+        ),
+        (RuntimeDispatchErrorKind::Unknown, "unknown"),
+    ] {
+        assert_eq!(kind.event_kind(), token);
+        assert_safe_runtime_event_token(token);
+    }
+}
+
+fn assert_safe_runtime_event_token(token: &str) {
+    assert!(!token.is_empty(), "runtime event token must not be empty");
+    assert!(
+        token.len() <= 64,
+        "{token:?} must fit runtime event sanitizer length"
+    );
+    assert!(
+        token.as_bytes()[0].is_ascii_lowercase(),
+        "{token:?} must start with lowercase ASCII"
+    );
+    assert!(
+        token.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'.' | b':')
+        }),
+        "{token:?} must stay compatible with runtime event sanitization"
+    );
+    for segment in token.split(['.', ':']) {
+        assert!(
+            !segment.is_empty(),
+            "{token:?} must not have empty segments"
+        );
+        assert!(
+            segment.len() <= 24,
+            "{token:?} segment {segment:?} must fit runtime event sanitizer segment length"
+        );
+        assert!(
+            segment.as_bytes()[0].is_ascii_lowercase(),
+            "{token:?} segment {segment:?} must start with lowercase ASCII"
+        );
+    }
+}
+
+#[test]
 fn local_default_execution_context_keeps_scope_fields_aligned() {
     let mounts = MountView::new(vec![MountGrant::new(
         MountAlias::new("/workspace").unwrap(),


### PR DESCRIPTION
## Summary

Carves the already-authorized runtime dispatcher substrate from the Reborn stack.

Adds `crates/ironclaw_dispatcher` with:

- `RuntimeDispatcher`
- `RuntimeAdapter`, `RuntimeAdapterRequest`, and `RuntimeAdapterResult`
- provider/capability registry routing through `ironclaw_extensions`
- already-authorized dispatch validation
- prepared mount/resource reservation pass-through
- resource reservation cleanup before adapter ownership on validation failures
- best-effort redacted runtime event emission
- dependency-boundary tests keeping dispatcher out of auth/control/workflow/concrete runtime crates

## Rebase note

Rebased onto current `reborn-integration` after the substrate stack landed, including:

- #2996 filesystem substrate
- #2999 auth/control substrate
- #3015 extension manifest registry
- #3017 process lifecycle substrate
- #3043 trust-class policy engine

The diff is now narrowed to:

```text
crates/ironclaw_dispatcher
Cargo.toml / Cargo.lock membership for that crate
```

## Scope boundary

This PR intentionally does **not** include:

- authorization / approvals / run-state
- `CapabilityHost`
- concrete WASM/Script/MCP runtime implementations
- host runtime composition
- process manager integration
- secrets/network substrates
- built-in obligation handling
- production app wiring or user-visible behavior changes

The dispatcher remains an already-authorized runtime router only.

## Rebase adjustment

Removed the stale dispatcher runtime-mismatch test that manually corrupted an `ExtensionPackage` after construction. Current `ironclaw_extensions::ExtensionRegistry::insert` correctly rejects inconsistent package descriptors before dispatcher routing, so that branch cannot be reached through the public registry API.

## Exposure checklist

```text
Does this affect existing src/ runtime behavior? no
Does this alter app startup/config defaults? no
Does this expose new routes/CLI/user-visible APIs? no
Does this create a second writer for existing production state? no
Are all Reborn paths feature-gated or unused by default? yes, unused internal crate substrate
Are docs/status labels accurate: implemented slice vs product complete? yes, dispatcher substrate only
```

## TDD note

Copied the dispatcher contract tests first against a RED stub and confirmed `cargo test -p ironclaw_dispatcher` failed due missing dispatcher types before porting the implementation.

## Verification

Rebase verification passed locally:

```bash
cargo test -p ironclaw_dispatcher
cargo clippy -p ironclaw_dispatcher --all-targets -- -D warnings
cargo test -p ironclaw_architecture
cargo fmt --all -- --check
git diff --check
cargo tree -p ironclaw_dispatcher -e normal | grep -E 'ironclaw_(authorization|approvals|capabilities|host_runtime|mcp|processes|run_state|scripts|secrets|wasm)' || true
```

Boundary grep returned no forbidden normal Reborn dependencies.

Refs #2987.
