### PR TITLE
fix: interrupt during llm and tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4004,6 +4004,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]

--- a/crates/ironclaw_engine/Cargo.toml
+++ b/crates/ironclaw_engine/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
+tokio-util = "0.7"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 sha2 = "0.10"

--- a/crates/ironclaw_engine/src/executor/loop_engine.rs
+++ b/crates/ironclaw_engine/src/executor/loop_engine.rs
@@ -8,6 +8,7 @@
 
 use std::sync::Arc;
 
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use crate::capability::lease::LeaseManager;
@@ -121,6 +122,8 @@ pub struct ExecutionLoop {
     store: Option<Arc<dyn crate::traits::store::Store>>,
     /// Runtime platform metadata for self-awareness in system prompts.
     platform_info: Option<crate::executor::prompt::PlatformInfo>,
+    /// Cancellation token for cooperative interrupt during LLM/tool calls.
+    cancel_token: CancellationToken,
 }
 
 impl ExecutionLoop {
@@ -146,6 +149,7 @@ impl ExecutionLoop {
             retrieval: None,
             store: None,
             platform_info: None,
+            cancel_token: CancellationToken::new(),
         }
     }
 
@@ -182,6 +186,12 @@ impl ExecutionLoop {
     /// Set platform metadata for self-awareness in system prompts.
     pub fn with_platform_info(mut self, info: crate::executor::prompt::PlatformInfo) -> Self {
         self.platform_info = Some(info);
+        self
+    }
+
+    /// Set the cancellation token for cooperative interrupt.
+    pub fn with_cancel_token(mut self, token: CancellationToken) -> Self {
+        self.cancel_token = token;
         self
     }
 
@@ -430,6 +440,7 @@ impl ExecutionLoop {
             self.store.as_ref(),
             self.platform_info.as_ref(),
             &checkpoint.persisted_state,
+            &self.cancel_token,
         )
         .await;
 

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -446,6 +446,7 @@ pub async fn execute_orchestrator(
     store: Option<&Arc<dyn Store>>,
     platform_info: Option<&crate::executor::prompt::PlatformInfo>,
     persisted_state: &serde_json::Value,
+    cancel_token: &tokio_util::sync::CancellationToken,
 ) -> Result<OrchestratorResult, EngineError> {
     let mut total_tokens = TokenUsage::default();
 
@@ -541,44 +542,60 @@ pub async fn execute_orchestrator(
 
                     // __llm_complete__(messages, actions, config)
                     "__llm_complete__" => {
-                        handle_llm_complete(
-                            args,
-                            kwargs,
-                            thread,
-                            LlmCompleteDeps {
-                                llm,
-                                effects,
-                                leases,
-                                store,
-                                platform_info,
-                            },
-                            &mut total_tokens,
-                        )
-                        .await
+                        tokio::select! {
+                            result = handle_llm_complete(
+                                args,
+                                kwargs,
+                                thread,
+                                LlmCompleteDeps {
+                                    llm,
+                                    effects,
+                                    leases,
+                                    store,
+                                    platform_info,
+                                },
+                                &mut total_tokens,
+                            ) => result,
+                            _ = cancel_token.cancelled() => {
+                                break;
+                            }
+                        }
                     }
 
                     // __execute_code_step__(code, state)
                     "__execute_code_step__" => {
-                        handle_execute_code_step(
-                            args, kwargs, thread, llm, effects, leases, policy, event_tx,
-                        )
-                        .await
+                        tokio::select! {
+                            result = handle_execute_code_step(
+                                args, kwargs, thread, llm, effects, leases, policy, event_tx,
+                            ) => result,
+                            _ = cancel_token.cancelled() => {
+                                break;
+                            }
+                        }
                     }
 
                     // __execute_action__(name, params, call_id=...)
                     "__execute_action__" => {
-                        handle_execute_action(
-                            args, kwargs, thread, effects, leases, policy, event_tx,
-                        )
-                        .await
+                        tokio::select! {
+                            result = handle_execute_action(
+                                args, kwargs, thread, effects, leases, policy, event_tx,
+                            ) => result,
+                            _ = cancel_token.cancelled() => {
+                                break;
+                            }
+                        }
                     }
 
                     // __execute_actions_parallel__(calls)
                     "__execute_actions_parallel__" => {
-                        handle_execute_actions_parallel(
-                            args, thread, effects, leases, policy, event_tx,
-                        )
-                        .await
+                        tokio::select! {
+                            result = handle_execute_actions_parallel(
+                                args, thread, effects, leases, policy, event_tx,
+                            ) => result,
+                            _ = cancel_token.cancelled() => {
+                                break;
+                            }
+                        }
                     }
 
                     // __check_signals__()
@@ -688,6 +705,12 @@ pub async fn execute_orchestrator(
             }
         }
     }
+
+    // Loop was broken by cancellation token
+    Ok(OrchestratorResult {
+        outcome: ThreadOutcome::Stopped,
+        tokens_used: total_tokens,
+    })
 }
 
 // ── Host function handlers ──────────────────────────────────

--- a/crates/ironclaw_engine/src/runtime/manager.rs
+++ b/crates/ironclaw_engine/src/runtime/manager.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 
 use crate::capability::lease::LeaseManager;
@@ -26,6 +27,7 @@ use crate::types::thread::{Thread, ThreadConfig, ThreadId, ThreadState, ThreadTy
 struct RunningThread {
     signal_tx: SignalSender,
     handle: tokio::task::JoinHandle<Result<ThreadOutcome, EngineError>>,
+    cancel_token: CancellationToken,
 }
 
 /// Top-level orchestrator for thread lifecycle.
@@ -326,6 +328,9 @@ impl ThreadManager {
         // Create signal channel
         let (tx, rx) = messaging::signal_channel(32);
 
+        // Create cancellation token for cooperative interrupt
+        let cancel_token = CancellationToken::new();
+
         // Build execution loop
         let llm = Arc::clone(&self.llm);
         let effects = Arc::clone(&self.effects);
@@ -339,7 +344,8 @@ impl ThreadManager {
             .with_capabilities(Arc::clone(&self.capabilities))
             .with_event_tx(self.event_tx.clone())
             .with_retrieval(retrieval)
-            .with_store(Arc::clone(&self.store));
+            .with_store(Arc::clone(&self.store))
+            .with_cancel_token(cancel_token.clone());
 
         // Spawn background task
         let store_for_task = Arc::clone(&self.store);
@@ -405,6 +411,7 @@ impl ThreadManager {
             RunningThread {
                 signal_tx: tx,
                 handle,
+                cancel_token: cancel_token.clone(),
             },
         );
 
@@ -428,6 +435,7 @@ impl ThreadManager {
         }
         let running = self.running.read().await;
         if let Some(rt) = running.get(&thread_id) {
+            rt.cancel_token.cancel();
             let _ = rt.signal_tx.send(ThreadSignal::Stop).await;
             Ok(())
         } else {

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1184,13 +1184,14 @@ impl Agent {
             let handle_fut = self.handle_message(&message);
             tokio::pin!(handle_fut);
 
+            let mut stream_open = true;
             let result = loop {
                 tokio::select! {
                     biased;
                     outcome = &mut handle_fut => {
                         break outcome;
                     }
-                    interrupt_msg = message_stream.next() => {
+                    interrupt_msg = message_stream.next(), if stream_open => {
                         match interrupt_msg {
                             Some(imsg) => {
                                 let sub = imsg
@@ -1211,7 +1212,7 @@ impl Agent {
                                 }
                             }
                             None => {
-                                // Stream ended — let handle_fut finish
+                                stream_open = false;
                             }
                         }
                     }

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -264,6 +264,10 @@ pub struct Agent {
     /// Engine v2 mission manager for firing learning missions (set after engine init).
     pub(crate) mission_manager_slot:
         Arc<tokio::sync::RwLock<Option<Arc<ironclaw_engine::MissionManager>>>>,
+    /// Cancellation token for the currently running chat turn. Set before
+    /// entering the agentic loop, cancelled by `process_interrupt`.
+    pub(super) active_cancel_token:
+        Arc<tokio::sync::Mutex<Option<tokio_util::sync::CancellationToken>>>,
 }
 
 impl Agent {
@@ -336,6 +340,7 @@ impl Agent {
             routine_config,
             routine_engine_slot: Arc::new(tokio::sync::RwLock::new(None)),
             mission_manager_slot: Arc::new(tokio::sync::RwLock::new(None)),
+            active_cancel_token: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 
@@ -1173,7 +1178,47 @@ impl Agent {
             // Store successfully extracted document text in workspace for indexing
             self.store_extracted_documents(&message).await;
 
-            match self.handle_message(&message).await {
+            // Run handle_message while concurrently listening for interrupt
+            // messages. This allows `/stop` to cancel a running LLM call or
+            // tool execution mid-flight.
+            let handle_fut = self.handle_message(&message);
+            tokio::pin!(handle_fut);
+
+            let result = loop {
+                tokio::select! {
+                    biased;
+                    outcome = &mut handle_fut => {
+                        break outcome;
+                    }
+                    interrupt_msg = message_stream.next() => {
+                        match interrupt_msg {
+                            Some(imsg) => {
+                                let sub = imsg
+                                    .structured_submission
+                                    .as_ref()
+                                    .cloned()
+                                    .unwrap_or_else(|| SubmissionParser::parse(&imsg.content));
+                                if matches!(sub, Submission::Interrupt) {
+                                    // Cancel the active turn immediately
+                                    if let Some(token) = self.active_cancel_token.lock().await.take() {
+                                        token.cancel();
+                                    }
+                                    tracing::debug!("Interrupt received while turn in progress, cancelling");
+                                } else {
+                                    tracing::debug!(
+                                        "Non-interrupt message received while turn in progress, dropping"
+                                    );
+                                }
+                            }
+                            None => {
+                                // Stream ended — let handle_fut finish
+                            }
+                        }
+                    }
+                }
+            };
+
+            match result {
                 Ok(HandleOutcome::Respond(response)) => {
                     // Hook: BeforeOutbound — allow hooks to modify or suppress outbound
                     let event = crate::hooks::HookEvent::Outbound {

--- a/src/agent/agentic_loop.rs
+++ b/src/agent/agentic_loop.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use tokio_util::sync::CancellationToken;
 
 use crate::agent::session::PendingApproval;
 use crate::error::Error;
@@ -135,6 +136,14 @@ pub trait LoopDelegate: Send + Sync {
 
     /// Called after each successful iteration (no error, no early return).
     async fn after_iteration(&self, _iteration: usize) {}
+
+    /// Return a cancellation token that, when cancelled, aborts the current
+    /// LLM call or tool execution mid-flight. The default returns a token
+    /// that is never cancelled (backward-compatible for delegates that don't
+    /// support interruption).
+    fn cancellation_token(&self) -> CancellationToken {
+        CancellationToken::new()
+    }
 }
 
 /// Warning injected after repeated identical failing tool calls.
@@ -237,8 +246,17 @@ pub async fn run_agentic_loop(
             return Ok(outcome);
         }
 
-        // Call LLM
-        let output = delegate.call_llm(reasoning, reason_ctx, iteration).await?;
+        // Call LLM — cancellable via the delegate's token
+        let cancel = delegate.cancellation_token();
+        let output = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                return Ok(LoopOutcome::Stopped);
+            }
+            result = delegate.call_llm(reasoning, reason_ctx, iteration) => {
+                result?
+            }
+        };
 
         match &output.result {
             RespondResult::Text(text) => {
@@ -344,10 +362,17 @@ pub async fn run_agentic_loop(
                 // Reset the flag before execution; delegates set it in execute_tool_calls.
                 reason_ctx.last_tool_batch_all_failed = false;
 
-                if let Some(outcome) = delegate
-                    .execute_tool_calls(tool_calls, content, reason_ctx)
-                    .await?
-                {
+                let cancel = delegate.cancellation_token();
+                let tool_outcome = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        return Ok(LoopOutcome::Stopped);
+                    }
+                    result = delegate.execute_tool_calls(tool_calls, content, reason_ctx) => {
+                        result?
+                    }
+                };
+                if let Some(outcome) = tool_outcome {
                     return Ok(outcome);
                 }
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::agent::Agent;
@@ -108,6 +109,7 @@ impl Agent {
         session: Arc<Mutex<Session>>,
         thread_id: Uuid,
         initial_messages: Vec<ChatMessage>,
+        cancel_token: CancellationToken,
     ) -> Result<AgenticLoopResult, Error> {
         // Detect group chat from channel metadata (needed before loading system prompt)
         let is_group_chat = message
@@ -284,6 +286,7 @@ impl Agent {
             user_tz,
             turn_usage: std::sync::Mutex::new(TurnUsageSummary::default()),
             cached_admin_tool_policy: tokio::sync::OnceCell::new(),
+            cancel_token,
         };
 
         // If /skill-name mentions were expanded, rewrite the last user message
@@ -398,6 +401,7 @@ struct ChatDelegate<'a> {
     user_tz: chrono_tz::Tz,
     turn_usage: std::sync::Mutex<TurnUsageSummary>,
     cached_admin_tool_policy: crate::tools::permissions::AdminToolPolicyCache,
+    cancel_token: CancellationToken,
 }
 
 impl ChatDelegate<'_> {
@@ -431,6 +435,10 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
             return LoopSignal::Stop;
         }
         LoopSignal::Continue
+    }
+
+    fn cancellation_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
     }
 
     async fn before_llm_call(
@@ -1814,6 +1822,7 @@ mod tests {
 
     use async_trait::async_trait;
     use rust_decimal::Decimal;
+    use tokio_util::sync::CancellationToken;
 
     use crate::agent::agent_loop::{Agent, AgentDeps};
     use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
@@ -2447,7 +2456,14 @@ mod tests {
         let tenant = agent.tenant_ctx("test-user").await;
 
         let result = agent
-            .run_agentic_loop(&message, tenant, session, thread_id, initial_messages)
+            .run_agentic_loop(
+                &message,
+                tenant,
+                session,
+                thread_id,
+                initial_messages,
+                CancellationToken::new(),
+            )
             .await
             .expect("dispatcher run should succeed");
 
@@ -3454,7 +3470,14 @@ mod tests {
         // timeout will fire and the test will fail.
         let result = tokio::time::timeout(
             Duration::from_secs(5),
-            agent.run_agentic_loop(&message, tenant, session, thread_id, initial_messages),
+            agent.run_agentic_loop(
+                &message,
+                tenant,
+                session,
+                thread_id,
+                initial_messages,
+                CancellationToken::new(),
+            ),
         )
         .await;
 
@@ -3588,6 +3611,7 @@ mod tests {
                 Arc::clone(&session),
                 thread_id,
                 initial_messages,
+                CancellationToken::new(),
             )
             .await;
         assert!(result.is_ok(), "dispatcher run failed");
@@ -3723,7 +3747,14 @@ mod tests {
         // max_tool_iterations.
         let result = tokio::time::timeout(
             Duration::from_secs(5),
-            agent.run_agentic_loop(&message, tenant, session, thread_id, initial_messages),
+            agent.run_agentic_loop(
+                &message,
+                tenant,
+                session,
+                thread_id,
+                initial_messages,
+                CancellationToken::new(),
+            ),
         )
         .await;
 
@@ -3782,6 +3813,7 @@ mod tests {
                     session.clone(),
                     thread_id,
                     initial_messages,
+                    CancellationToken::new(),
                 )
                 .await
                 .expect("dispatcher run should succeed");

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -715,9 +715,19 @@ impl Agent {
             .await;
 
         // Run the agentic tool execution loop
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        *self.active_cancel_token.lock().await = Some(cancel_token.clone());
         let result = self
-            .run_agentic_loop(message, tenant, session.clone(), thread_id, turn_messages)
+            .run_agentic_loop(
+                message,
+                tenant,
+                session.clone(),
+                thread_id,
+                turn_messages,
+                cancel_token,
+            )
             .await;
+        *self.active_cancel_token.lock().await = None;
 
         // Re-acquire lock and check if interrupted
         let mut sess = session.lock().await;
@@ -1316,6 +1326,9 @@ impl Agent {
                     .unwrap_or_else(|| "gateway".to_string());
                 thread.interrupt();
                 drop(sess);
+                if let Some(token) = self.active_cancel_token.lock().await.take() {
+                    token.cancel();
+                }
                 self.clear_conversation_live_state(thread_id, &channel, &user_id)
                     .await;
                 Ok(SubmissionResult::ok_with_message("Interrupted."))
@@ -2037,6 +2050,8 @@ impl Agent {
             }
 
             // Continue the agentic loop (a tool was already executed this turn)
+            let cancel_token = tokio_util::sync::CancellationToken::new();
+            *self.active_cancel_token.lock().await = Some(cancel_token.clone());
             let result = self
                 .run_agentic_loop(
                     message,
@@ -2044,8 +2059,10 @@ impl Agent {
                     session.clone(),
                     thread_id,
                     context_messages,
+                    cancel_token,
                 )
                 .await;
+            *self.active_cancel_token.lock().await = None;
 
             // Handle the result
             let mut sess = session.lock().await;


### PR DESCRIPTION
## Summary

<!-- 2-5 bullet points: what changed and why -->
fix the bug that /interrupt do not work

in webui, send many messages once before llm answers,and then send /interrupt, it will still response the messages one by one

-

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: <!-- describe what you tested -->
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

  - src/agent/agent_loop.rs — main event loop message dispatch; affects all message processing
  - src/agent/agentic_loop.rs — LoopDelegate trait gains cancellation_token() method; all three delegate impls (ChatDelegate, JobDelegate, ContainerDelegate)
  must implement it (only ChatDelegate wired with a real token; others get a default no-op token)
  - crates/ironclaw_engine/src/executor/orchestrator.rs — v2 LLM/tool execution; early exit on cancel could leave partial step state
  - Could break: any LoopDelegate implementor outside the repo that doesn't implement cancellation_token(); orchestrator callers that don't pass the new
  cancel_token parameter

## Rollback Plan

revert

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
