### PR TITLE
feat(reborn): add script and mcp runtime lanes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4136,6 +4136,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironclaw_mcp"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ironclaw_extensions",
+ "ironclaw_host_api",
+ "ironclaw_resources",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "ironclaw_processes"
 version = "0.1.0"
 dependencies = [
@@ -4187,6 +4200,18 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "ironclaw_scripts"
+version = "0.1.0"
+dependencies = [
+ "ironclaw_extensions",
+ "ironclaw_host_api",
+ "ironclaw_resources",
+ "rust_decimal_macros",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_extensions", "crates/ironclaw_processes", "crates/ironclaw_dispatcher", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_trust", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
+members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_extensions", "crates/ironclaw_processes", "crates/ironclaw_dispatcher", "crates/ironclaw_scripts", "crates/ironclaw_mcp", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_trust", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
 exclude = [
     "channels-src/discord",
     "channels-src/telegram",

--- a/crates/ironclaw_mcp/Cargo.toml
+++ b/crates/ironclaw_mcp/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ironclaw_mcp"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+ironclaw_extensions = { path = "../ironclaw_extensions" }
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+ironclaw_resources = { path = "../ironclaw_resources" }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -1,0 +1,366 @@
+//! MCP adapter contracts for IronClaw Reborn.
+//!
+//! `ironclaw_mcp` adapts manifest-declared MCP tools into IronClaw
+//! capabilities. It does not grant MCP servers ambient filesystem, secret, or
+//! network authority; the host-selected client is the only integration point and
+//! resource accounting still happens through the host governor.
+
+use async_trait::async_trait;
+use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
+use ironclaw_host_api::{
+    CapabilityId, ExtensionId, ResourceEstimate, ResourceReservation, ResourceReservationId,
+    ResourceScope, ResourceUsage, RuntimeKind,
+};
+use ironclaw_resources::{ResourceError, ResourceGovernor, ResourceReceipt};
+use serde_json::Value;
+use thiserror::Error;
+
+/// Host-owned MCP adapter limits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpRuntimeConfig {
+    pub max_output_bytes: u64,
+}
+
+impl Default for McpRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            max_output_bytes: 1024 * 1024,
+        }
+    }
+}
+
+impl McpRuntimeConfig {
+    pub fn for_testing() -> Self {
+        Self {
+            max_output_bytes: 64 * 1024,
+        }
+    }
+}
+
+/// JSON invocation passed to a manifest-declared MCP capability.
+#[derive(Debug, Clone, PartialEq)]
+pub struct McpInvocation {
+    pub input: Value,
+}
+
+/// Full resource-governed MCP execution request.
+#[derive(Debug)]
+pub struct McpExecutionRequest<'a> {
+    pub package: &'a ExtensionPackage,
+    pub capability_id: &'a CapabilityId,
+    pub scope: ResourceScope,
+    pub estimate: ResourceEstimate,
+    pub resource_reservation: Option<ResourceReservation>,
+    pub invocation: McpInvocation,
+}
+
+/// Host-normalized request handed to the configured MCP client adapter.
+#[derive(Debug, Clone, PartialEq)]
+pub struct McpClientRequest {
+    pub provider: ExtensionId,
+    pub capability_id: CapabilityId,
+    pub scope: ResourceScope,
+    pub transport: String,
+    pub command: Option<String>,
+    pub args: Vec<String>,
+    pub url: Option<String>,
+    pub input: Value,
+    pub max_output_bytes: u64,
+}
+
+/// Raw MCP adapter output before resource reconciliation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct McpClientOutput {
+    pub output: Value,
+    pub usage: ResourceUsage,
+    pub output_bytes: Option<u64>,
+}
+
+impl McpClientOutput {
+    pub fn json(value: Value) -> Self {
+        Self {
+            output: value,
+            usage: ResourceUsage::default(),
+            output_bytes: None,
+        }
+    }
+}
+
+/// Host-selected MCP client adapter.
+///
+/// Implementations must enforce `McpClientRequest::max_output_bytes` while
+/// reading MCP server output, before constructing the structured JSON `Value`.
+/// The runtime re-checks serialized output size after the adapter returns, but
+/// that check is a second line of defense rather than the primary memory bound.
+#[async_trait]
+pub trait McpClient: Send + Sync {
+    async fn call_tool(&self, request: McpClientRequest) -> Result<McpClientOutput, String>;
+}
+
+/// Parsed MCP capability result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpCapabilityResult {
+    pub output: Value,
+    pub reservation_id: ResourceReservationId,
+    pub usage: ResourceUsage,
+    pub output_bytes: u64,
+}
+
+/// Full resource-governed MCP execution result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpExecutionResult {
+    pub result: McpCapabilityResult,
+    pub receipt: ResourceReceipt,
+}
+
+/// MCP runtime failures.
+#[derive(Debug, Error)]
+pub enum McpError {
+    #[error("resource governor error: {0}")]
+    Resource(Box<ResourceError>),
+    #[error("MCP client error: {reason}")]
+    Client { reason: String },
+    #[error("unsupported MCP transport {transport}")]
+    UnsupportedTransport { transport: String },
+    #[error("extension {extension} uses runtime {actual:?}, not RuntimeKind::Mcp")]
+    ExtensionRuntimeMismatch {
+        extension: ExtensionId,
+        actual: RuntimeKind,
+    },
+    #[error("capability {capability} is not declared by this extension package")]
+    CapabilityNotDeclared { capability: CapabilityId },
+    #[error("MCP descriptor mismatch: {reason}")]
+    DescriptorMismatch { reason: String },
+    #[error("invalid MCP invocation: {reason}")]
+    InvalidInvocation { reason: String },
+    #[error("MCP output limit exceeded: limit {limit}, actual {actual}")]
+    OutputLimitExceeded { limit: u64, actual: u64 },
+}
+
+impl From<ResourceError> for McpError {
+    fn from(error: ResourceError) -> Self {
+        Self::Resource(Box::new(error))
+    }
+}
+
+/// Runtime for executing manifest-declared MCP capabilities through a host adapter.
+#[derive(Debug, Clone)]
+pub struct McpRuntime<C> {
+    config: McpRuntimeConfig,
+    client: C,
+}
+
+impl<C> McpRuntime<C>
+where
+    C: McpClient,
+{
+    pub fn new(config: McpRuntimeConfig, client: C) -> Self {
+        Self { config, client }
+    }
+
+    pub fn config(&self) -> &McpRuntimeConfig {
+        &self.config
+    }
+
+    pub async fn execute_extension_json<G>(
+        &self,
+        governor: &G,
+        request: McpExecutionRequest<'_>,
+    ) -> Result<McpExecutionResult, McpError>
+    where
+        G: ResourceGovernor + ?Sized,
+    {
+        let client_request = self.prepare_client_request(&request)?;
+        let transport = client_request.transport.clone();
+        let reservation = reserve_or_use_existing(
+            governor,
+            request.scope.clone(),
+            request.estimate.clone(),
+            request.resource_reservation.clone(),
+        )?;
+
+        let output = match self.client.call_tool(client_request).await {
+            Ok(output) => output,
+            Err(reason) => {
+                return Err(release_after_failure(
+                    governor,
+                    reservation.id,
+                    McpError::Client { reason },
+                ));
+            }
+        };
+
+        let serialized_len = serde_json::to_vec(&output.output)
+            .map_err(|error| {
+                release_after_failure(
+                    governor,
+                    reservation.id,
+                    McpError::InvalidInvocation {
+                        reason: error.to_string(),
+                    },
+                )
+            })?
+            .len() as u64;
+        let output_bytes = output
+            .output_bytes
+            .unwrap_or(serialized_len)
+            .max(serialized_len);
+        if output_bytes > self.config.max_output_bytes {
+            return Err(release_after_failure(
+                governor,
+                reservation.id,
+                McpError::OutputLimitExceeded {
+                    limit: self.config.max_output_bytes,
+                    actual: output_bytes,
+                },
+            ));
+        }
+
+        let mut usage = output.usage;
+        usage.output_bytes = usage.output_bytes.max(output_bytes);
+        if transport == "stdio" {
+            usage.process_count = usage.process_count.max(1);
+        }
+        let receipt = governor.reconcile(reservation.id, usage.clone())?;
+        Ok(McpExecutionResult {
+            result: McpCapabilityResult {
+                output: output.output,
+                reservation_id: reservation.id,
+                usage,
+                output_bytes,
+            },
+            receipt,
+        })
+    }
+
+    fn prepare_client_request(
+        &self,
+        request: &McpExecutionRequest<'_>,
+    ) -> Result<McpClientRequest, McpError> {
+        let descriptor = request
+            .package
+            .capabilities
+            .iter()
+            .find(|descriptor| &descriptor.id == request.capability_id)
+            .cloned()
+            .ok_or_else(|| McpError::CapabilityNotDeclared {
+                capability: request.capability_id.clone(),
+            })?;
+
+        if descriptor.runtime != RuntimeKind::Mcp {
+            return Err(McpError::ExtensionRuntimeMismatch {
+                extension: request.package.id.clone(),
+                actual: descriptor.runtime,
+            });
+        }
+        if descriptor.provider != request.package.id {
+            return Err(McpError::DescriptorMismatch {
+                reason: format!(
+                    "descriptor {} provider {} does not match package {}",
+                    descriptor.id, descriptor.provider, request.package.id
+                ),
+            });
+        }
+
+        let (transport, command, args, url) = match &request.package.manifest.runtime {
+            ExtensionRuntime::Mcp {
+                transport,
+                command,
+                args,
+                url,
+            } => (transport, command, args, url),
+            other => {
+                return Err(McpError::ExtensionRuntimeMismatch {
+                    extension: request.package.id.clone(),
+                    actual: other.kind(),
+                });
+            }
+        };
+
+        if !matches!(transport.as_str(), "stdio" | "http" | "sse") {
+            return Err(McpError::UnsupportedTransport {
+                transport: transport.clone(),
+            });
+        }
+        if transport == "stdio" && command.is_none() {
+            return Err(McpError::InvalidInvocation {
+                reason: "stdio MCP transport requires a manifest command".to_string(),
+            });
+        }
+        if matches!(transport.as_str(), "http" | "sse") && url.is_none() {
+            return Err(McpError::InvalidInvocation {
+                reason: format!("{transport} MCP transport requires a manifest url"),
+            });
+        }
+
+        Ok(McpClientRequest {
+            provider: request.package.id.clone(),
+            capability_id: request.capability_id.clone(),
+            scope: request.scope.clone(),
+            transport: transport.clone(),
+            command: command.clone(),
+            args: args.clone(),
+            url: url.clone(),
+            input: request.invocation.input.clone(),
+            max_output_bytes: self.config.max_output_bytes,
+        })
+    }
+}
+
+/// Object-safe MCP executor interface used by the kernel composition layer.
+#[async_trait]
+pub trait McpExecutor: Send + Sync {
+    async fn execute_extension_json(
+        &self,
+        governor: &dyn ResourceGovernor,
+        request: McpExecutionRequest<'_>,
+    ) -> Result<McpExecutionResult, McpError>;
+}
+
+#[async_trait]
+impl<C> McpExecutor for McpRuntime<C>
+where
+    C: McpClient,
+{
+    async fn execute_extension_json(
+        &self,
+        governor: &dyn ResourceGovernor,
+        request: McpExecutionRequest<'_>,
+    ) -> Result<McpExecutionResult, McpError> {
+        McpRuntime::execute_extension_json(self, governor, request).await
+    }
+}
+
+fn reserve_or_use_existing<G>(
+    governor: &G,
+    scope: ResourceScope,
+    estimate: ResourceEstimate,
+    reservation: Option<ResourceReservation>,
+) -> Result<ResourceReservation, McpError>
+where
+    G: ResourceGovernor + ?Sized,
+{
+    if let Some(reservation) = reservation {
+        if reservation.scope != scope || reservation.estimate != estimate {
+            return Err(McpError::Resource(Box::new(
+                ResourceError::ReservationMismatch { id: reservation.id },
+            )));
+        }
+        return Ok(reservation);
+    }
+    governor.reserve(scope, estimate).map_err(McpError::from)
+}
+
+fn release_after_failure<G>(
+    governor: &G,
+    reservation_id: ResourceReservationId,
+    original: McpError,
+) -> McpError
+where
+    G: ResourceGovernor + ?Sized,
+{
+    match governor.release(reservation_id) {
+        Ok(_) => original,
+        Err(error) => McpError::Resource(Box::new(error)),
+    }
+}

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -1,0 +1,426 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_extensions::*;
+use ironclaw_host_api::*;
+use ironclaw_mcp::*;
+use ironclaw_resources::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn mcp_runtime_reserves_calls_adapter_and_reconciles_success() {
+    let package = package_from_manifest(MCP_MANIFEST);
+    let client = RecordingMcpClient::new(Ok(McpClientOutput::json(json!({
+        "items": ["issue-1"]
+    }))));
+    let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client.clone());
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            max_process_count: Some(1),
+            max_output_bytes: Some(10_000),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let result = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &package,
+                capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    process_count: Some(1),
+                    output_bytes: Some(10_000),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: McpInvocation {
+                    input: json!({"query": "ironclaw"}),
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.result.output, json!({"items": ["issue-1"]}));
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert!(governor.usage_for(&account).output_bytes > 0);
+    assert_eq!(governor.usage_for(&account).process_count, 1);
+
+    let requests = client.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].provider,
+        ExtensionId::new("github-mcp").unwrap()
+    );
+    assert_eq!(
+        requests[0].capability_id,
+        CapabilityId::new("github-mcp.search").unwrap()
+    );
+    assert_eq!(requests[0].transport, "stdio");
+    assert_eq!(requests[0].command.as_deref(), Some("github-mcp"));
+    assert_eq!(requests[0].args, vec!["--stdio".to_string()]);
+    assert_eq!(requests[0].url, None);
+    assert_eq!(requests[0].input, json!({"query": "ironclaw"}));
+    assert_eq!(
+        requests[0].max_output_bytes,
+        McpRuntimeConfig::for_testing().max_output_bytes
+    );
+}
+
+#[tokio::test]
+async fn mcp_runtime_denies_budget_before_adapter_call() {
+    let package = package_from_manifest(MCP_MANIFEST);
+    let client = RecordingMcpClient::new(Ok(McpClientOutput::json(json!({"ok": true}))));
+    let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client.clone());
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(0),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &package,
+                capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: McpInvocation { input: json!({}) },
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, McpError::Resource(_)));
+    assert!(client.requests.lock().unwrap().is_empty());
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn mcp_runtime_releases_reservation_when_adapter_fails() {
+    let package = package_from_manifest(MCP_MANIFEST);
+    let client = RecordingMcpClient::new(Err("server disconnected".to_string()));
+    let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client.clone());
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &package,
+                capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: McpInvocation { input: json!({}) },
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, McpError::Client { .. }));
+    assert_eq!(client.requests.lock().unwrap().len(), 1);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn mcp_runtime_rejects_non_mcp_or_undeclared_capability_before_reserving() {
+    let non_mcp = package_from_manifest(SCRIPT_MANIFEST);
+    let mcp = package_from_manifest(MCP_MANIFEST);
+    let client = RecordingMcpClient::new(Ok(McpClientOutput::json(json!({"ok": true}))));
+    let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client.clone());
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(0),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let non_mcp_err = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &non_mcp,
+                capability_id: &CapabilityId::new("script.echo").unwrap(),
+                scope: scope.clone(),
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: McpInvocation { input: json!({}) },
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        non_mcp_err,
+        McpError::ExtensionRuntimeMismatch {
+            actual: RuntimeKind::Script,
+            ..
+        }
+    ));
+
+    let missing_err = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &mcp,
+                capability_id: &CapabilityId::new("github-mcp.missing").unwrap(),
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: McpInvocation { input: json!({}) },
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        missing_err,
+        McpError::CapabilityNotDeclared { .. }
+    ));
+    assert!(client.requests.lock().unwrap().is_empty());
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn mcp_runtime_enforces_output_limit_and_releases_reservation() {
+    let package = package_from_manifest(MCP_MANIFEST);
+    let client = RecordingMcpClient::new(Ok(McpClientOutput::json(json!({
+        "large": "this output is intentionally too large"
+    }))));
+    let runtime = McpRuntime::new(
+        McpRuntimeConfig {
+            max_output_bytes: 8,
+        },
+        client,
+    );
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &package,
+                capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    output_bytes: Some(10_000),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: McpInvocation { input: json!({}) },
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, McpError::OutputLimitExceeded { .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn mcp_runtime_can_enforce_client_reported_output_size_without_serializing_for_size() {
+    let package = package_from_manifest(MCP_MANIFEST);
+    let client = RecordingMcpClient::new(Ok(McpClientOutput {
+        output: json!({"small": true}),
+        usage: ResourceUsage::default(),
+        output_bytes: Some(1_000),
+    }));
+    let runtime = McpRuntime::new(
+        McpRuntimeConfig {
+            max_output_bytes: 8,
+        },
+        client,
+    );
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &package,
+                capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    output_bytes: Some(10_000),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: McpInvocation { input: json!({}) },
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        McpError::OutputLimitExceeded { actual: 1_000, .. }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn mcp_runtime_rejects_output_when_adapter_under_reports_size() {
+    let package = package_from_manifest(MCP_MANIFEST);
+    let client = RecordingMcpClient::new(Ok(McpClientOutput {
+        output: json!({"large": "this output exceeds the configured limit"}),
+        usage: ResourceUsage::default(),
+        output_bytes: Some(1),
+    }));
+    let runtime = McpRuntime::new(
+        McpRuntimeConfig {
+            max_output_bytes: 8,
+        },
+        client,
+    );
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &package,
+                capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    output_bytes: Some(10_000),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: McpInvocation { input: json!({}) },
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, McpError::OutputLimitExceeded { .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[derive(Clone)]
+struct RecordingMcpClient {
+    output: Result<McpClientOutput, String>,
+    requests: Arc<Mutex<Vec<McpClientRequest>>>,
+}
+
+impl RecordingMcpClient {
+    fn new(output: Result<McpClientOutput, String>) -> Self {
+        Self {
+            output,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl McpClient for RecordingMcpClient {
+    async fn call_tool(&self, request: McpClientRequest) -> Result<McpClientOutput, String> {
+        self.requests.lock().unwrap().push(request);
+        self.output.clone()
+    }
+}
+
+fn package_from_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant1").unwrap(),
+        user_id: UserId::new("user1").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+const MCP_MANIFEST: &str = r#"
+id = "github-mcp"
+name = "GitHub MCP"
+version = "0.1.0"
+description = "GitHub MCP adapter"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "stdio"
+command = "github-mcp"
+args = ["--stdio"]
+
+[[capabilities]]
+id = "github-mcp.search"
+description = "Search GitHub"
+effects = ["network", "dispatch_capability"]
+default_permission = "ask"
+parameters_schema = { type = "object" }
+"#;
+
+const SCRIPT_MANIFEST: &str = r#"
+id = "script"
+name = "Script Echo"
+version = "0.1.0"
+description = "Script demo extension"
+trust = "untrusted"
+
+[runtime]
+kind = "script"
+runner = "sandboxed_process"
+command = "script-echo"
+args = ["--json"]
+
+[[capabilities]]
+id = "script.echo"
+description = "Echo text"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;

--- a/crates/ironclaw_scripts/Cargo.toml
+++ b/crates/ironclaw_scripts/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ironclaw_scripts"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+ironclaw_extensions = { path = "../ironclaw_extensions" }
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+ironclaw_resources = { path = "../ironclaw_resources" }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+rust_decimal_macros = "1"

--- a/crates/ironclaw_scripts/src/lib.rs
+++ b/crates/ironclaw_scripts/src/lib.rs
@@ -1,0 +1,569 @@
+//! Script runner contracts for IronClaw Reborn.
+//!
+//! `ironclaw_scripts` executes declared script/CLI capabilities through a
+//! host-selected backend. Extension manifests describe the command metadata, but
+//! extensions do not receive raw Docker flags, host paths, ambient environment,
+//! secrets, or network by default.
+
+use std::{
+    io::{Read, Write},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
+use ironclaw_host_api::{
+    CapabilityId, ExtensionId, ResourceEstimate, ResourceReservation, ResourceReservationId,
+    ResourceScope, ResourceUsage, RuntimeKind,
+};
+use ironclaw_resources::{ResourceError, ResourceGovernor, ResourceReceipt};
+use serde_json::Value;
+use thiserror::Error;
+
+/// Script runner limits owned by the host runtime, not by extension manifests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptRuntimeConfig {
+    pub max_stdout_bytes: u64,
+    pub max_stderr_bytes: u64,
+    pub max_wall_clock_ms: u64,
+}
+
+impl Default for ScriptRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            max_stdout_bytes: 1024 * 1024,
+            max_stderr_bytes: 64 * 1024,
+            max_wall_clock_ms: 30_000,
+        }
+    }
+}
+
+impl ScriptRuntimeConfig {
+    pub fn for_testing() -> Self {
+        Self {
+            max_stdout_bytes: 64 * 1024,
+            max_stderr_bytes: 16 * 1024,
+            max_wall_clock_ms: 5_000,
+        }
+    }
+}
+
+/// JSON invocation passed to a script capability.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScriptInvocation {
+    pub input: Value,
+}
+
+/// Full resource-governed script execution request.
+#[derive(Debug)]
+pub struct ScriptExecutionRequest<'a> {
+    pub package: &'a ExtensionPackage,
+    pub capability_id: &'a CapabilityId,
+    pub scope: ResourceScope,
+    pub estimate: ResourceEstimate,
+    pub resource_reservation: Option<ResourceReservation>,
+    pub invocation: ScriptInvocation,
+}
+
+/// Host-normalized request handed to the configured backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptBackendRequest {
+    pub provider: ExtensionId,
+    pub capability_id: CapabilityId,
+    pub scope: ResourceScope,
+    pub runner: String,
+    pub image: Option<String>,
+    pub command: String,
+    pub args: Vec<String>,
+    pub stdin_json: String,
+    pub max_stdout_bytes: u64,
+    pub max_stderr_bytes: u64,
+    pub max_wall_clock_ms: u64,
+}
+
+/// Raw backend output before the script runtime parses stdout as JSON.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptBackendOutput {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub wall_clock_ms: u64,
+}
+
+impl ScriptBackendOutput {
+    pub fn json(value: Value) -> Self {
+        Self {
+            exit_code: 0,
+            stdout: serde_json::to_vec(&value).unwrap_or_else(|_| b"null".to_vec()),
+            stderr: Vec::new(),
+            wall_clock_ms: 0,
+        }
+    }
+}
+
+/// Backend interface for sandboxed script execution.
+pub trait ScriptBackend: Send + Sync {
+    fn execute(&self, request: ScriptBackendRequest) -> Result<ScriptBackendOutput, String>;
+}
+
+/// Docker CLI backend for V1 script execution.
+///
+/// This backend intentionally accepts only normalized manifest-derived command
+/// fields. It does not expose raw Docker flags to extensions, does not mount host
+/// paths, does not pass host environment variables, and disables container
+/// network access by default.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DockerScriptBackend;
+
+impl ScriptBackend for DockerScriptBackend {
+    fn execute(&self, request: ScriptBackendRequest) -> Result<ScriptBackendOutput, String> {
+        if request.runner != "docker" {
+            return Err(format!(
+                "DockerScriptBackend cannot execute runner {}",
+                request.runner
+            ));
+        }
+        let image = request
+            .image
+            .clone()
+            .ok_or_else(|| "DockerScriptBackend requires an image".to_string())?;
+        validate_docker_image_reference(&image)?;
+
+        execute_docker_request(request, &image)
+    }
+}
+
+/// Parsed script capability result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptCapabilityResult {
+    pub output: Value,
+    pub reservation_id: ResourceReservationId,
+    pub usage: ResourceUsage,
+    pub output_bytes: u64,
+}
+
+/// Full resource-governed script execution result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptExecutionResult {
+    pub result: ScriptCapabilityResult,
+    pub receipt: ResourceReceipt,
+}
+
+/// Script runtime failures.
+#[derive(Debug, Error)]
+pub enum ScriptError {
+    #[error("resource governor error: {0}")]
+    Resource(Box<ResourceError>),
+    #[error("script backend error: {reason}")]
+    Backend { reason: String },
+    #[error("unsupported script runner {runner}")]
+    UnsupportedRunner { runner: String },
+    #[error("extension {extension} uses runtime {actual:?}, not RuntimeKind::Script")]
+    ExtensionRuntimeMismatch {
+        extension: ExtensionId,
+        actual: RuntimeKind,
+    },
+    #[error("capability {capability} is not declared by this extension package")]
+    CapabilityNotDeclared { capability: CapabilityId },
+    #[error("script descriptor mismatch: {reason}")]
+    DescriptorMismatch { reason: String },
+    #[error("invalid script invocation: {reason}")]
+    InvalidInvocation { reason: String },
+    #[error("script exited with code {code}: {stderr}")]
+    ExitFailure { code: i32, stderr: String },
+    #[error("script output limit exceeded: limit {limit}, actual {actual}")]
+    OutputLimitExceeded { limit: u64, actual: u64 },
+    #[error("script timed out after {limit_ms} ms")]
+    Timeout { limit_ms: u64 },
+    #[error("script stdout is invalid JSON: {reason}")]
+    InvalidOutput { reason: String },
+}
+
+impl From<ResourceError> for ScriptError {
+    fn from(error: ResourceError) -> Self {
+        Self::Resource(Box::new(error))
+    }
+}
+
+/// Runtime for executing manifest-declared script capabilities.
+#[derive(Debug, Clone)]
+pub struct ScriptRuntime<B> {
+    config: ScriptRuntimeConfig,
+    backend: B,
+}
+
+impl<B> ScriptRuntime<B>
+where
+    B: ScriptBackend,
+{
+    pub fn new(config: ScriptRuntimeConfig, backend: B) -> Self {
+        Self { config, backend }
+    }
+
+    pub fn config(&self) -> &ScriptRuntimeConfig {
+        &self.config
+    }
+
+    pub fn execute_extension_json<G>(
+        &self,
+        governor: &G,
+        request: ScriptExecutionRequest<'_>,
+    ) -> Result<ScriptExecutionResult, ScriptError>
+    where
+        G: ResourceGovernor + ?Sized,
+    {
+        let backend_request = self.prepare_backend_request(&request)?;
+        let reservation = reserve_or_use_existing(
+            governor,
+            request.scope.clone(),
+            request.estimate.clone(),
+            request.resource_reservation.clone(),
+        )?;
+
+        let output = match self.backend.execute(backend_request) {
+            Ok(output) => output,
+            Err(reason) => {
+                return Err(release_after_failure(
+                    governor,
+                    reservation.id,
+                    ScriptError::Backend { reason },
+                ));
+            }
+        };
+
+        if output.stdout.len() as u64 > self.config.max_stdout_bytes {
+            return Err(release_after_failure(
+                governor,
+                reservation.id,
+                ScriptError::OutputLimitExceeded {
+                    limit: self.config.max_stdout_bytes,
+                    actual: output.stdout.len() as u64,
+                },
+            ));
+        }
+
+        if output.exit_code != 0 {
+            return Err(release_after_failure(
+                governor,
+                reservation.id,
+                ScriptError::ExitFailure {
+                    code: output.exit_code,
+                    stderr: bounded_lossy(&output.stderr, self.config.max_stderr_bytes),
+                },
+            ));
+        }
+
+        let parsed = match serde_json::from_slice::<Value>(&output.stdout) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                return Err(release_after_failure(
+                    governor,
+                    reservation.id,
+                    ScriptError::InvalidOutput {
+                        reason: error.to_string(),
+                    },
+                ));
+            }
+        };
+
+        let output_bytes = output.stdout.len() as u64;
+        let usage = ResourceUsage {
+            wall_clock_ms: output.wall_clock_ms,
+            output_bytes,
+            process_count: 1,
+            ..ResourceUsage::default()
+        };
+        let receipt = governor.reconcile(reservation.id, usage.clone())?;
+        Ok(ScriptExecutionResult {
+            result: ScriptCapabilityResult {
+                output: parsed,
+                reservation_id: reservation.id,
+                usage,
+                output_bytes,
+            },
+            receipt,
+        })
+    }
+
+    fn prepare_backend_request(
+        &self,
+        request: &ScriptExecutionRequest<'_>,
+    ) -> Result<ScriptBackendRequest, ScriptError> {
+        let descriptor = request
+            .package
+            .capabilities
+            .iter()
+            .find(|descriptor| &descriptor.id == request.capability_id)
+            .cloned()
+            .ok_or_else(|| ScriptError::CapabilityNotDeclared {
+                capability: request.capability_id.clone(),
+            })?;
+
+        if descriptor.runtime != RuntimeKind::Script {
+            return Err(ScriptError::ExtensionRuntimeMismatch {
+                extension: request.package.id.clone(),
+                actual: descriptor.runtime,
+            });
+        }
+        if descriptor.provider != request.package.id {
+            return Err(ScriptError::DescriptorMismatch {
+                reason: format!(
+                    "descriptor {} provider {} does not match package {}",
+                    descriptor.id, descriptor.provider, request.package.id
+                ),
+            });
+        }
+
+        let (runner, image, command, args) = match &request.package.manifest.runtime {
+            ExtensionRuntime::Script {
+                runner,
+                image,
+                command,
+                args,
+            } => (runner, image, command, args),
+            other => {
+                return Err(ScriptError::ExtensionRuntimeMismatch {
+                    extension: request.package.id.clone(),
+                    actual: other.kind(),
+                });
+            }
+        };
+        if runner == "docker" && image.is_none() {
+            return Err(ScriptError::UnsupportedRunner {
+                runner: runner.clone(),
+            });
+        }
+
+        let stdin_json = serde_json::to_string(&request.invocation.input).map_err(|error| {
+            ScriptError::InvalidInvocation {
+                reason: error.to_string(),
+            }
+        })?;
+
+        Ok(ScriptBackendRequest {
+            provider: request.package.id.clone(),
+            capability_id: request.capability_id.clone(),
+            scope: request.scope.clone(),
+            runner: runner.clone(),
+            image: image.clone(),
+            command: command.clone(),
+            args: args.clone(),
+            stdin_json,
+            max_stdout_bytes: self.config.max_stdout_bytes,
+            max_stderr_bytes: self.config.max_stderr_bytes,
+            max_wall_clock_ms: self.config.max_wall_clock_ms,
+        })
+    }
+}
+
+/// Object-safe script executor interface used by the kernel composition layer.
+pub trait ScriptExecutor: Send + Sync {
+    fn execute_extension_json(
+        &self,
+        governor: &dyn ResourceGovernor,
+        request: ScriptExecutionRequest<'_>,
+    ) -> Result<ScriptExecutionResult, ScriptError>;
+}
+
+impl<B> ScriptExecutor for ScriptRuntime<B>
+where
+    B: ScriptBackend,
+{
+    fn execute_extension_json(
+        &self,
+        governor: &dyn ResourceGovernor,
+        request: ScriptExecutionRequest<'_>,
+    ) -> Result<ScriptExecutionResult, ScriptError> {
+        ScriptRuntime::execute_extension_json(self, governor, request)
+    }
+}
+
+fn validate_docker_image_reference(image: &str) -> Result<(), String> {
+    if image.is_empty() {
+        return Err("Docker image reference must not be empty".to_string());
+    }
+    if image.starts_with('-') {
+        return Err("Docker image reference must not start with '-'".to_string());
+    }
+    if image.chars().any(char::is_whitespace) {
+        return Err("Docker image reference must not contain whitespace".to_string());
+    }
+    Ok(())
+}
+
+fn execute_docker_request(
+    request: ScriptBackendRequest,
+    image: &str,
+) -> Result<ScriptBackendOutput, String> {
+    let started = Instant::now();
+    let mut child = Command::new("docker")
+        .arg("run")
+        .arg("--rm")
+        .arg("-i")
+        .arg("--network")
+        .arg("none")
+        .arg(image)
+        .arg(&request.command)
+        .args(&request.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Docker child stdout was not captured".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Docker child stderr was not captured".to_string())?;
+    let stdout_limit = request.max_stdout_bytes;
+    let stderr_limit = request.max_stderr_bytes;
+    let stdout_reader = thread::spawn(move || read_bounded(stdout, stdout_limit));
+    let stderr_reader = thread::spawn(move || read_bounded(stderr, stderr_limit));
+
+    let stdin_json = request.stdin_json.clone();
+    let mut stdin_writer = child.stdin.take().map(|mut stdin| {
+        thread::spawn(move || {
+            stdin
+                .write_all(stdin_json.as_bytes())
+                .map_err(|error| error.to_string())
+        })
+    });
+
+    let timeout = Duration::from_millis(request.max_wall_clock_ms);
+    let status = loop {
+        if let Some(status) = child.try_wait().map_err(|error| error.to_string())? {
+            break status;
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            if let Some(stdin_writer) = stdin_writer.take() {
+                let _ = stdin_writer.join();
+            }
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return Err(format!(
+                "script timed out after {} ms",
+                request.max_wall_clock_ms
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+
+    if let Some(stdin_writer) = stdin_writer.take() {
+        stdin_writer
+            .join()
+            .map_err(|_| "stdin writer panicked".to_string())??;
+    }
+
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| "stdout reader panicked".to_string())??;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| "stderr reader panicked".to_string())??;
+
+    Ok(ScriptBackendOutput {
+        exit_code: status.code().unwrap_or(-1),
+        stdout,
+        stderr,
+        wall_clock_ms: started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+    })
+}
+
+fn read_bounded<R>(mut reader: R, limit: u64) -> Result<Vec<u8>, String>
+where
+    R: Read,
+{
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    let mut output = Vec::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| error.to_string())?;
+        if read == 0 {
+            return Ok(output);
+        }
+        if output.len().saturating_add(read) > limit {
+            return Err(format!("output exceeded {limit} bytes"));
+        }
+        output.extend_from_slice(&buffer[..read]);
+    }
+}
+
+fn reserve_or_use_existing<G>(
+    governor: &G,
+    scope: ResourceScope,
+    estimate: ResourceEstimate,
+    reservation: Option<ResourceReservation>,
+) -> Result<ResourceReservation, ScriptError>
+where
+    G: ResourceGovernor + ?Sized,
+{
+    if let Some(reservation) = reservation {
+        if reservation.scope != scope || reservation.estimate != estimate {
+            return Err(ScriptError::Resource(Box::new(
+                ResourceError::ReservationMismatch { id: reservation.id },
+            )));
+        }
+        return Ok(reservation);
+    }
+    governor.reserve(scope, estimate).map_err(ScriptError::from)
+}
+
+fn release_after_failure<G>(
+    governor: &G,
+    reservation_id: ResourceReservationId,
+    original: ScriptError,
+) -> ScriptError
+where
+    G: ResourceGovernor + ?Sized,
+{
+    match governor.release(reservation_id) {
+        Ok(_) => original,
+        Err(error) => ScriptError::Resource(Box::new(error)),
+    }
+}
+
+fn bounded_lossy(bytes: &[u8], limit: u64) -> String {
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    let end = bytes.len().min(limit);
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::{read_bounded, validate_docker_image_reference};
+
+    #[test]
+    fn read_bounded_rejects_output_larger_than_limit() {
+        let err = read_bounded(Cursor::new(b"abcdef"), 4).unwrap_err();
+        assert!(err.contains("output exceeded 4 bytes"));
+    }
+
+    #[test]
+    fn read_bounded_allows_output_at_limit() {
+        let output = read_bounded(Cursor::new(b"abcd"), 4).unwrap();
+        assert_eq!(output, b"abcd");
+    }
+
+    #[test]
+    fn docker_image_reference_rejects_cli_flag_injection() {
+        let err = validate_docker_image_reference("--network=host").unwrap_err();
+        assert!(err.contains("must not start with '-'"));
+    }
+
+    #[test]
+    fn docker_image_reference_rejects_whitespace() {
+        let err = validate_docker_image_reference("alpine --privileged").unwrap_err();
+        assert!(err.contains("must not contain whitespace"));
+    }
+}

--- a/crates/ironclaw_scripts/tests/script_runner_contract.rs
+++ b/crates/ironclaw_scripts/tests/script_runner_contract.rs
@@ -1,0 +1,376 @@
+use std::sync::{Arc, Mutex};
+
+use ironclaw_extensions::*;
+use ironclaw_host_api::*;
+use ironclaw_resources::*;
+use ironclaw_scripts::*;
+use serde_json::json;
+
+#[test]
+fn script_runtime_reserves_executes_and_reconciles_success() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput {
+        exit_code: 0,
+        stdout: br#"{"message":"hello script"}"#.to_vec(),
+        stderr: Vec::new(),
+        wall_clock_ms: 7,
+    });
+    let runtime = ScriptRuntime::new(ScriptRuntimeConfig::for_testing(), backend.clone());
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            max_process_count: Some(10),
+            max_output_bytes: Some(10_000),
+            ..ResourceLimits::default()
+        },
+    );
+    let capability_id = CapabilityId::new("script.echo").unwrap();
+
+    let execution = runtime
+        .execute_extension_json(
+            &governor,
+            ScriptExecutionRequest {
+                package: &script_package(),
+                capability_id: &capability_id,
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    process_count: Some(1),
+                    output_bytes: Some(10_000),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: ScriptInvocation {
+                    input: json!({"message":"hello script", "command":"malicious override"}),
+                },
+            },
+        )
+        .unwrap();
+
+    assert_eq!(execution.result.output, json!({"message":"hello script"}));
+    assert_eq!(execution.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account).process_count, 1);
+    assert!(governor.usage_for(&account).output_bytes > 0);
+
+    let requests = backend.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].runner, "docker");
+    assert_eq!(requests[0].image.as_deref(), Some("alpine:latest"));
+    assert_eq!(requests[0].command, "script-echo");
+    assert_eq!(requests[0].args, vec!["--json".to_string()]);
+    assert_eq!(requests[0].capability_id, capability_id);
+    assert!(requests[0].stdin_json.contains("hello script"));
+    assert_eq!(
+        requests[0].max_stdout_bytes,
+        ScriptRuntimeConfig::for_testing().max_stdout_bytes
+    );
+    assert_eq!(
+        requests[0].max_stderr_bytes,
+        ScriptRuntimeConfig::for_testing().max_stderr_bytes
+    );
+    assert_eq!(
+        requests[0].max_wall_clock_ms,
+        ScriptRuntimeConfig::for_testing().max_wall_clock_ms
+    );
+    assert!(!requests[0].command.contains("malicious"));
+}
+
+#[test]
+fn script_runtime_denies_budget_before_backend_execution() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput::json(json!({"ok": true})));
+    let runtime = ScriptRuntime::new(ScriptRuntimeConfig::for_testing(), backend.clone());
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_output_bytes: Some(1),
+            ..ResourceLimits::default()
+        },
+    );
+    let capability_id = CapabilityId::new("script.echo").unwrap();
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            ScriptExecutionRequest {
+                package: &script_package(),
+                capability_id: &capability_id,
+                scope,
+                estimate: ResourceEstimate {
+                    output_bytes: Some(10_000),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: ScriptInvocation { input: json!({}) },
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, ScriptError::Resource(_)));
+    assert!(backend.requests.lock().unwrap().is_empty());
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[test]
+fn script_runtime_releases_reservation_when_backend_exits_nonzero() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput {
+        exit_code: 2,
+        stdout: Vec::new(),
+        stderr: b"failed".to_vec(),
+        wall_clock_ms: 4,
+    });
+    let runtime = ScriptRuntime::new(ScriptRuntimeConfig::for_testing(), backend);
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            ..ResourceLimits::default()
+        },
+    );
+    let capability_id = CapabilityId::new("script.echo").unwrap();
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            ScriptExecutionRequest {
+                package: &script_package(),
+                capability_id: &capability_id,
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: ScriptInvocation { input: json!({}) },
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, ScriptError::ExitFailure { code: 2, .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[test]
+fn script_runtime_releases_reservation_when_output_limit_fails() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput {
+        exit_code: 0,
+        stdout: br#"{"too":"large"}"#.to_vec(),
+        stderr: Vec::new(),
+        wall_clock_ms: 1,
+    });
+    let runtime = ScriptRuntime::new(
+        ScriptRuntimeConfig {
+            max_stdout_bytes: 4,
+            ..ScriptRuntimeConfig::for_testing()
+        },
+        backend,
+    );
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            ..ResourceLimits::default()
+        },
+    );
+    let capability_id = CapabilityId::new("script.echo").unwrap();
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            ScriptExecutionRequest {
+                package: &script_package(),
+                capability_id: &capability_id,
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: ScriptInvocation { input: json!({}) },
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, ScriptError::OutputLimitExceeded { .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[test]
+fn script_runtime_rejects_non_script_package_before_reserving() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput::json(json!({"ok": true})));
+    let runtime = ScriptRuntime::new(ScriptRuntimeConfig::for_testing(), backend);
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(0),
+            ..ResourceLimits::default()
+        },
+    );
+    let capability_id = CapabilityId::new("echo.say").unwrap();
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            ScriptExecutionRequest {
+                package: &wasm_package(),
+                capability_id: &capability_id,
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: ScriptInvocation { input: json!({}) },
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, ScriptError::ExtensionRuntimeMismatch { .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[test]
+fn script_runtime_rejects_undeclared_capability_before_reserving() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput::json(json!({"ok": true})));
+    let runtime = ScriptRuntime::new(ScriptRuntimeConfig::for_testing(), backend);
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(0),
+            ..ResourceLimits::default()
+        },
+    );
+    let capability_id = CapabilityId::new("script.missing").unwrap();
+
+    let err = runtime
+        .execute_extension_json(
+            &governor,
+            ScriptExecutionRequest {
+                package: &script_package(),
+                capability_id: &capability_id,
+                scope,
+                estimate: ResourceEstimate {
+                    concurrency_slots: Some(1),
+                    ..ResourceEstimate::default()
+                },
+                resource_reservation: None,
+                invocation: ScriptInvocation { input: json!({}) },
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, ScriptError::CapabilityNotDeclared { .. }));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+}
+
+#[derive(Clone)]
+struct RecordingScriptBackend {
+    output: Arc<Mutex<Result<ScriptBackendOutput, String>>>,
+    requests: Arc<Mutex<Vec<ScriptBackendRequest>>>,
+}
+
+impl RecordingScriptBackend {
+    fn success(output: ScriptBackendOutput) -> Self {
+        Self {
+            output: Arc::new(Mutex::new(Ok(output))),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl ScriptBackend for RecordingScriptBackend {
+    fn execute(&self, request: ScriptBackendRequest) -> Result<ScriptBackendOutput, String> {
+        self.requests.lock().unwrap().push(request);
+        self.output.lock().unwrap().clone()
+    }
+}
+
+fn script_package() -> ExtensionPackage {
+    package_from_manifest(SCRIPT_MANIFEST)
+}
+
+fn wasm_package() -> ExtensionPackage {
+    package_from_manifest(WASM_MANIFEST)
+}
+
+fn package_from_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant1").unwrap(),
+        user_id: UserId::new("user1").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+const SCRIPT_MANIFEST: &str = r#"
+id = "script"
+name = "Script Echo"
+version = "0.1.0"
+description = "Script demo extension"
+trust = "untrusted"
+
+[runtime]
+kind = "script"
+backend = "docker"
+image = "alpine:latest"
+command = "script-echo"
+args = ["--json"]
+
+[[capabilities]]
+id = "script.echo"
+description = "Echo text"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;
+
+const WASM_MANIFEST: &str = r#"
+id = "echo"
+name = "Echo"
+version = "0.1.0"
+description = "Echo demo extension"
+trust = "untrusted"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "echo.say"
+description = "Echo text"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;


### PR DESCRIPTION
## Summary

Carves the smaller non-WASM runtime lane substrates from the Reborn stack.

Adds:

```text
crates/ironclaw_scripts
crates/ironclaw_mcp
```

`ironclaw_scripts` includes:

- `ScriptRuntime`
- `ScriptRuntimeConfig`
- `ScriptExecutionRequest` / `ScriptExecutionResult`
- `ScriptBackend` contract and backend request/output shapes
- declared-capability/runtime validation before resource reservation
- reservation/reconcile/release flow
- output limit enforcement

`ironclaw_mcp` includes:

- `McpRuntime`
- `McpRuntimeConfig`
- `McpExecutionRequest` / `McpExecutionResult`
- `McpClient` contract and client request/output shapes
- declared-capability/runtime validation before resource reservation
- reservation/reconcile/release flow
- output limit enforcement

## Current status

Rebased onto current `reborn-integration` after the prerequisite substrate stack landed, including #3023, #3072, and #3076.

The diff is now narrowed to only:

```text
crates/ironclaw_scripts
crates/ironclaw_mcp
Cargo.toml / Cargo.lock membership for those crates
```

This slice is independent of the remaining in-flight Reborn PRs (#3028 WASM runtime lane and #3071 CapabilityHost base).

## Scope boundary

This PR intentionally does **not** include:

- WASM runtime lane (`ironclaw_wasm`) — separate PR
- dispatcher adapter wiring
- host runtime composition
- `CapabilityHost`
- built-in obligation handling
- secrets/network substrates
- production app wiring or user-visible behavior changes

## Exposure checklist

```text
Does this affect existing src/ runtime behavior? no
Does this alter app startup/config defaults? no
Does this expose new routes/CLI/user-visible APIs? no
Does this create a second writer for existing production state? no
Are all Reborn paths feature-gated or unused by default? yes, unused internal crate substrate
Are docs/status labels accurate: implemented slice vs product complete? yes, Script/MCP runtime lane substrate only
```

## TDD note

Copied the Script/MCP contract tests first against RED stubs and confirmed `cargo test -p ironclaw_scripts -p ironclaw_mcp` failed due missing runtime/client/backend types before porting the implementations.

## Verification

Passed after rebasing onto current `reborn-integration`:

```bash
cargo fmt --all -- --check
cargo test -p ironclaw_scripts -p ironclaw_mcp
cargo clippy -p ironclaw_scripts -p ironclaw_mcp --all-targets -- -D warnings
cargo test -p ironclaw_architecture
python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD
bash scripts/pre-commit-safety.sh
git diff --check
cargo tree -p ironclaw_scripts -e normal | grep -E 'ironclaw_(authorization|approvals|capabilities|dispatcher|host_runtime|processes|run_state|secrets|network|wasm)' || true
cargo tree -p ironclaw_mcp -e normal | grep -E 'ironclaw_(authorization|approvals|capabilities|dispatcher|host_runtime|processes|run_state|secrets|network|wasm)' || true
```

Boundary greps returned no forbidden normal Reborn dependencies.

Refs #2987.

