### PR TITLE
  Fix TUI interrupt dispatch during active turns

### DIFF
--- a/crates/ironclaw_tui/examples/dev.rs
+++ b/crates/ironclaw_tui/examples/dev.rs
@@ -150,9 +150,12 @@ fn mock_skill_categories() -> Vec<SkillCategory> {
 
 fn main() {
     let config = TuiAppConfig {
+        user_id: "dev-user".into(),
+        channel: "tui".into(),
         version: "0.22.0-dev".into(),
         model: "gpt-5.4".into(),
         layout: TuiLayout::default(),
+        interrupt_handle: None,
         context_window: 128_000,
         tools: mock_tool_categories(),
         skills: mock_skill_categories(),

--- a/crates/ironclaw_tui/src/app.rs
+++ b/crates/ironclaw_tui/src/app.rs
@@ -9,7 +9,10 @@
 //! The app owns the terminal, manages alternate screen / raw mode, and
 //! renders frames at ~30fps using a tick timer.
 
+use std::future::Future;
 use std::io::{self, Write};
+use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 
 use ratatui::Terminal;
@@ -55,11 +58,26 @@ pub struct TuiAppHandle {
     pub join_handle: std::thread::JoinHandle<()>,
 }
 
+/// Narrow out-of-band interrupt hook supplied by the host crate.
+///
+/// The TUI crate stays decoupled from the agent and engine crates; it only
+/// knows that Esc can ask the host to interrupt the active channel/user work.
+pub trait InterruptHandle: Send + Sync {
+    fn interrupt_active<'a>(
+        &'a self,
+        user_id: &'a str,
+        channel: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+}
+
 /// Configuration for creating a TuiApp.
 pub struct TuiAppConfig {
+    pub user_id: String,
+    pub channel: String,
     pub version: String,
     pub model: String,
     pub layout: TuiLayout,
+    pub interrupt_handle: Option<Arc<dyn InterruptHandle>>,
     /// Maximum context window size in tokens (e.g., 128_000, 200_000).
     pub context_window: u64,
     /// Tool categories for the welcome screen.
@@ -134,6 +152,10 @@ async fn run_tui(
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
+
+    let interrupt_handle = config.interrupt_handle.clone();
+    let interrupt_user_id = config.user_id.clone();
+    let interrupt_channel = config.channel.clone();
 
     // State
     let mut state = AppState {
@@ -266,7 +288,16 @@ async fn run_tui(
                 let Some(event) = event else {
                     break; // Channel closed
                 };
-                handle_event(event, &mut state, &mut widgets, &msg_tx, &layout).await;
+                let interrupt_requested =
+                    handle_event(event, &mut state, &mut widgets, &msg_tx, &layout).await;
+                if interrupt_requested {
+                    dispatch_out_of_band_interrupt(
+                        interrupt_handle.as_ref(),
+                        &interrupt_user_id,
+                        &interrupt_channel,
+                    )
+                    .await;
+                }
             }
         }
 
@@ -358,7 +389,9 @@ async fn handle_event(
     widgets: &mut BuiltinWidgets,
     msg_tx: &mpsc::Sender<TuiUserMessage>,
     layout: &TuiLayout,
-) {
+) -> bool {
+    let mut interrupt_requested = false;
+
     match event {
         TuiEvent::Paste(text) => {
             let approval_active = state.pending_approval.is_some();
@@ -503,6 +536,7 @@ async fn handle_event(
                         )
                         .await;
                     state.status_text.clear();
+                    interrupt_requested = true;
                 }
                 InputAction::ApprovalUp => {
                     if let Some(ref mut ap) = state.pending_approval {
@@ -1445,6 +1479,18 @@ async fn handle_event(
                 created_at: chrono::Utc::now(),
             });
         }
+    }
+
+    interrupt_requested
+}
+
+async fn dispatch_out_of_band_interrupt(
+    interrupt_handle: Option<&Arc<dyn InterruptHandle>>,
+    user_id: &str,
+    channel: &str,
+) {
+    if let Some(handle) = interrupt_handle {
+        handle.interrupt_active(user_id, channel).await;
     }
 }
 
@@ -2528,6 +2574,7 @@ mod tests {
     use crate::widgets::{ActiveTab, ApprovalRequest, MessageRole, ThreadStatus};
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::layout::Rect;
+    use std::sync::Mutex as StdMutex;
 
     async fn apply_event(state: &mut AppState, event: TuiEvent) {
         let layout = TuiLayout::default();
@@ -2550,6 +2597,66 @@ mod tests {
             messages.push(message);
         }
         messages
+    }
+
+    struct RecordingInterruptHandle {
+        calls: Arc<StdMutex<Vec<(String, String)>>>,
+    }
+
+    impl InterruptHandle for RecordingInterruptHandle {
+        fn interrupt_active<'a>(
+            &'a self,
+            user_id: &'a str,
+            channel: &'a str,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+            Box::pin(async move {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push((user_id.to_string(), channel.to_string()));
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn esc_requests_interrupt_and_keeps_message_fallback() {
+        let mut state = AppState {
+            current_thread_id: Some("thread-123".to_string()),
+            ..Default::default()
+        };
+        let layout = TuiLayout::default();
+        let mut widgets = create_default_widgets(&layout);
+        let (msg_tx, mut msg_rx) = mpsc::channel(4);
+
+        let interrupt_requested = handle_event(
+            TuiEvent::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            &mut state,
+            &mut widgets,
+            &msg_tx,
+            &layout,
+        )
+        .await;
+
+        assert!(interrupt_requested);
+        let message = msg_rx.try_recv().unwrap();
+        assert_eq!(message.text, "/interrupt");
+        assert_eq!(message.thread_id.as_deref(), Some("thread-123"));
+    }
+
+    #[tokio::test]
+    async fn out_of_band_interrupt_dispatches_user_and_channel() {
+        let calls = Arc::new(StdMutex::new(Vec::new()));
+        let handle: Arc<dyn InterruptHandle> = Arc::new(RecordingInterruptHandle {
+            calls: Arc::clone(&calls),
+        });
+
+        dispatch_out_of_band_interrupt(Some(&handle), "user-1", "tui").await;
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            &[("user-1".to_string(), "tui".to_string())]
+        );
     }
 
     fn make_snapshot(width: u16, height: u16) -> ScreenSnapshot {

--- a/crates/ironclaw_tui/src/lib.rs
+++ b/crates/ironclaw_tui/src/lib.rs
@@ -40,7 +40,7 @@ pub mod spinner;
 pub mod theme;
 pub mod widgets;
 
-pub use app::{TuiAppConfig, TuiAppHandle, start_tui};
+pub use app::{InterruptHandle, TuiAppConfig, TuiAppHandle, start_tui};
 pub use event::{
     EngineThreadDetailEntry, EngineThreadEntry, EngineThreadMessageEntry, HistoryApprovalRequest,
     HistoryMessage, ThreadEntry, TuiAttachment, TuiEvent, TuiLogEntry, TuiUiAction, TuiUserMessage,

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -61,6 +61,7 @@ pub use router::{
     has_pending_auth,
     // Initialization
     init_engine,
+    interrupt_active_engine_threads,
     is_engine_v2_enabled,
     list_engine_missions,
     list_engine_projects,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2858,6 +2858,52 @@ pub async fn resolve_gate(
     .await
 }
 
+async fn stop_active_engine_threads(
+    state: &EngineState,
+    channel: &str,
+    user_id: &str,
+) -> Result<u32, Error> {
+    let conv_id = state
+        .conversation_manager
+        .get_or_create_conversation(channel, user_id)
+        .await
+        .map_err(|e| engine_err("conversation error", e))?;
+
+    let conv = state.conversation_manager.get_conversation(conv_id).await;
+    let active_threads = conv
+        .as_ref()
+        .map(|c| c.active_threads.clone())
+        .unwrap_or_default();
+
+    let mut stopped = 0u32;
+    for tid in &active_threads {
+        if state.thread_manager.is_running(*tid).await {
+            if let Err(e) = state.thread_manager.stop_thread(*tid, user_id).await {
+                debug!(thread_id = %tid, error = %e, "engine v2: failed to stop thread");
+            } else {
+                stopped += 1;
+            }
+        }
+    }
+
+    Ok(stopped)
+}
+
+/// Stop active engine threads for a channel/user without going through the
+/// agent message queue. Used by interactive surfaces that need Esc/cancel to
+/// bypass a blocked dispatch loop.
+pub async fn interrupt_active_engine_threads(channel: &str, user_id: &str) -> Result<u32, Error> {
+    let Some(lock) = ENGINE_STATE.get() else {
+        return Ok(0);
+    };
+    let guard = lock.read().await;
+    let Some(state) = guard.as_ref() else {
+        return Ok(0);
+    };
+
+    stop_active_engine_threads(state, channel, user_id).await
+}
+
 /// Handle an interrupt submission — stop active engine threads.
 pub async fn handle_interrupt(
     agent: &Agent,
@@ -2873,32 +2919,7 @@ pub async fn handle_interrupt(
         .as_ref()
         .ok_or_else(|| engine_err("init", "engine state is empty"))?;
 
-    let conv_id = state
-        .conversation_manager
-        .get_or_create_conversation(&message.channel, &message.user_id)
-        .await
-        .map_err(|e| engine_err("conversation error", e))?;
-
-    let conv = state.conversation_manager.get_conversation(conv_id).await;
-    let active_threads = conv
-        .as_ref()
-        .map(|c| c.active_threads.clone())
-        .unwrap_or_default();
-
-    let mut stopped = 0u32;
-    for tid in &active_threads {
-        if state.thread_manager.is_running(*tid).await {
-            if let Err(e) = state
-                .thread_manager
-                .stop_thread(*tid, &message.user_id)
-                .await
-            {
-                debug!(thread_id = %tid, error = %e, "engine v2: failed to stop thread");
-            } else {
-                stopped += 1;
-            }
-        }
-    }
+    let stopped = stop_active_engine_threads(state, &message.channel, &message.user_id).await?;
 
     if stopped > 0 {
         debug!(stopped, "engine v2: interrupted running threads");

--- a/src/channels/tui.rs
+++ b/src/channels/tui.rs
@@ -4,7 +4,9 @@
 //! between the agent's `Channel` trait and `ironclaw_tui`'s event/message
 //! channels.
 
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -12,7 +14,9 @@ use async_trait::async_trait;
 use tokio::sync::{Mutex, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 
-use ironclaw_tui::{SkillCategory, ToolCategory, TuiAppConfig, TuiEvent, TuiLayout, start_tui};
+use ironclaw_tui::{
+    InterruptHandle, SkillCategory, ToolCategory, TuiAppConfig, TuiEvent, TuiLayout, start_tui,
+};
 
 use crate::channels::web::log_layer::LogBroadcaster;
 use crate::channels::{
@@ -194,6 +198,28 @@ fn build_engine_thread_detail_event(detail: crate::bridge::EngineThreadDetail) -
     }
 }
 
+struct EngineInterruptHandle;
+
+impl InterruptHandle for EngineInterruptHandle {
+    fn interrupt_active<'a>(
+        &'a self,
+        user_id: &'a str,
+        channel: &'a str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            if let Err(err) = crate::bridge::interrupt_active_engine_threads(channel, user_id).await
+            {
+                tracing::warn!(
+                    channel,
+                    user_id,
+                    error = %err,
+                    "TUI out-of-band interrupt failed"
+                );
+            }
+        })
+    }
+}
+
 /// TUI channel backed by `ironclaw_tui`.
 pub struct TuiChannel {
     user_id: String,
@@ -308,9 +334,12 @@ impl Channel for TuiChannel {
         }
 
         let config = TuiAppConfig {
+            user_id: self.user_id.clone(),
+            channel: "tui".to_string(),
             version: self.version.clone(),
             model: self.model.clone(),
             layout: self.layout.clone(),
+            interrupt_handle: Some(Arc::new(EngineInterruptHandle)),
             context_window: self.context_window,
             tools: self.tools.clone(),
             skills: self.skills.clone(),


### PR DESCRIPTION

## Summary

  - Add a narrow TUI interrupt hook for stopping active engine work out-of-band.
  - Wire the TUI channel to the bridge interrupt path while preserving the existing `/interrupt` fallback.
  - Refactor active engine thread stopping into shared logic and add regression coverage for Esc interrupt behavior.
  
<!-- 2-5 bullet points: what changed and why -->

-

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

  Fixes #2142

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
