### PR TITLE
fix(web): require admin for shared skill mutations

### DIFF
--- a/docs/drafts/ops/api.mdx
+++ b/docs/drafts/ops/api.mdx
@@ -370,8 +370,8 @@ curl -s -X POST \
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/api/skills` | List all discovered skills with trust level and activation status |
-| `POST` | `/api/skills/install` | Install a skill from ClawHub or a local path |
-| `DELETE` | `/api/skills/:name` | Remove an installed skill |
+| `POST` | `/api/skills/install` | Install a skill from ClawHub or a local path. Admin-only in multi-tenant mode because installed skills are shared globally. |
+| `DELETE` | `/api/skills/:name` | Remove an installed skill. Admin-only in multi-tenant mode because installed skills are shared globally. |
 | `GET` | `/api/skills/search` | Search the ClawHub registry |
 
 ### GET /api/skills/search

--- a/src/channels/web/CLAUDE.md
+++ b/src/channels/web/CLAUDE.md
@@ -110,8 +110,8 @@ subset that can later be replaced by a typed `Deps` alias.
 |--------|------|-------------|
 | GET | `/api/skills` | List installed skills |
 | POST | `/api/skills/search` | Search ClawHub registry + local skills |
-| POST | `/api/skills/install` | Install a skill from ClawHub or by URL/content |
-| DELETE | `/api/skills/{name}` | Remove an installed skill |
+| POST | `/api/skills/install` | Install a skill from ClawHub or by URL/content. Admin-only in multi-tenant mode because installed skills are shared globally. |
+| DELETE | `/api/skills/{name}` | Remove an installed skill. Admin-only in multi-tenant mode because installed skills are shared globally. |
 
 ### Extensions
 | Method | Path | Description |

--- a/src/channels/web/handlers/skills.rs
+++ b/src/channels/web/handlers/skills.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use futures::future::join_all;
 
-use crate::channels::web::auth::AuthenticatedUser;
+use crate::channels::web::auth::{AuthenticatedUser, UserIdentity};
 use crate::channels::web::platform::state::GatewayState;
 use crate::channels::web::types::*;
 
@@ -84,6 +84,19 @@ async fn skill_info(skill: ironclaw_skills::types::LoadedSkill) -> SkillInfo {
         has_requirements,
         has_scripts,
     }
+}
+
+fn require_skill_registry_admin_for_shared_mutation(
+    state: &GatewayState,
+    user: &UserIdentity,
+) -> Result<(), (StatusCode, String)> {
+    if state.multi_tenant_mode && !user.is_admin() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "Admin privileges required to modify shared skills".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 pub async fn skills_list_handler(
@@ -200,6 +213,8 @@ pub async fn skills_install_handler(
     headers: axum::http::HeaderMap,
     Json(req): Json<SkillInstallRequest>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
+    require_skill_registry_admin_for_shared_mutation(&state, &user)?;
+
     // Require explicit confirmation header to prevent accidental installs.
     // Chat tools have requires_approval(); this is the equivalent for the web API.
     if headers
@@ -342,6 +357,8 @@ pub async fn skills_remove_handler(
     headers: axum::http::HeaderMap,
     Path(name): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
+    require_skill_registry_admin_for_shared_mutation(&state, &user)?;
+
     // Require explicit confirmation header to prevent accidental removals.
     if headers
         .get("x-confirm-action")
@@ -399,6 +416,18 @@ pub async fn skills_remove_handler(
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::Arc;
+
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request, StatusCode},
+        routing::{delete, post},
+    };
+    use tower::ServiceExt;
+
+    use crate::channels::web::auth::UserIdentity;
+    use crate::channels::web::test_helpers::test_gateway_state;
 
     #[test]
     fn catalog_entry_matches_installed_slug_suffix() {
@@ -454,6 +483,63 @@ mod tests {
             ),
             "finance/mortgage-calculator"
         );
+    }
+
+    fn multi_tenant_state() -> Arc<crate::channels::web::platform::state::GatewayState> {
+        let state = test_gateway_state(None);
+        let mut inner = match Arc::try_unwrap(state) {
+            Ok(inner) => inner,
+            Err(_) => panic!("expected sole GatewayState reference in test"),
+        };
+        inner.multi_tenant_mode = true;
+        Arc::new(inner)
+    }
+
+    #[tokio::test]
+    async fn skill_install_requires_admin_in_multi_tenant_mode() {
+        let state = multi_tenant_state();
+        let app = Router::new()
+            .route("/api/skills/install", post(super::skills_install_handler))
+            .with_state(state);
+
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("/api/skills/install")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"name":"demo","content":"---\nname: demo\n---\n"}"#,
+            ))
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "member".to_string(),
+            role: "member".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+
+        let resp = app.oneshot(req).await.expect("response");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn skill_remove_requires_admin_in_multi_tenant_mode() {
+        let state = multi_tenant_state();
+        let app = Router::new()
+            .route("/api/skills/{name}", delete(super::skills_remove_handler))
+            .with_state(state);
+
+        let mut req = Request::builder()
+            .method("DELETE")
+            .uri("/api/skills/demo")
+            .body(Body::empty())
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "member".to_string(),
+            role: "member".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+
+        let resp = app.oneshot(req).await.expect("response");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

<!-- 2-5 bullet points: what changed and why -->
- Require admin privileges for `/api/skills/install` and `/api/skills/{name}` in multi-tenant mode.
- Fix an authorization gap where non-admin users could mutate globally shared installed skills.
- Add handler-level regression tests covering install and remove access control in multi-tenant mode.
- Update the web/API docs to document the multi-tenant admin requirement.


## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [✓] Bug fix
- [✓] Documentation
- [✓] Security

## Linked Issue

None.

## Validation

<!-- How did you verify this works? -->

- [✓] `cargo fmt --all -- --check`
- [✓] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [✓] `cargo build`
- [✓] Relevant tests pass
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing:
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review


## Security Impact

Yes. This change affects permissions on skill install/remove in the web gateway. In multi-tenant mode, installed skills are shared globally, so allowing non-admin mutation created a cross-tenant authorization issue.


## Database Impact

None.


## Blast Radius

Touches the web gateway skill management handlers and related docs only. Potential breakage is limited to skill install/remove behavior in multi-tenant mode, where non-admin requests now return `403`.

## Rollback Plan

Revert commit `5b71eb4` to restore the previous behavior. Rollback risk is low and isolated to the multi-tenant authorization check on skill install/remove endpoints.

## Review Follow-Through

Main reviewer judgment is whether this should remain limited to multi-tenant mode or be tightened further. The current change intentionally preserves single-tenant behavior to avoid adding end-user friction.


---

**Review track**: C 
