### PR TITLE
fix(engine): centralize tool permission defaults

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -494,7 +494,8 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         // the seeded baseline in effective_permission().
         // Disabled tools are excluded from the LLM's tool list entirely.
         // AlwaysAllow tools are pre-approved in session so the approval
-        // flow is skipped regardless of intrinsic approval metadata.
+        // flow is skipped unless the tool declares ApprovalRequirement::Always,
+        // which remains an unbypassable hard floor.
         //
         // The SettingsStore is wrapped in CachedSettingsStore so repeated
         // calls within the same session are cheap (in-memory lookup).
@@ -517,10 +518,10 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         };
 
         // Filter tool definitions and collect AlwaysAllow names for session
-        // pre-approval. Effective permissions are authoritative here: tools
-        // resolved to AlwaysAllow are pre-approved regardless of their
-        // intrinsic approval metadata, and AskEachTime/Disabled rows clear that
-        // pre-approval on the next turn.
+        // pre-approval. Effective permissions are authoritative here, but tools
+        // resolved to AlwaysAllow still respect ApprovalRequirement::Always at
+        // execution time. AskEachTime/Disabled rows clear pre-approval on the
+        // next turn.
         let mut to_auto_approve: Vec<String> = Vec::new();
         let tool_defs: Vec<_> = tool_defs
             .into_iter()

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -490,12 +490,11 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         //
         // Load tool_permissions from the per-user DB settings store (same
         // source as selected_model). Falls back to empty map when no store is
-        // available (test rigs without a tenant) — tier defaults from
-        // TOOL_RISK_DEFAULTS then apply at runtime via effective_permission().
+        // available (test rigs without a tenant) — missing entries resolve via
+        // the seeded baseline in effective_permission().
         // Disabled tools are excluded from the LLM's tool list entirely.
         // AlwaysAllow tools are pre-approved in session so the approval
-        // flow is skipped — unless the tool declares ApprovalRequirement::Always,
-        // which is an unbypassable hard floor.
+        // flow is skipped regardless of intrinsic approval metadata.
         //
         // The SettingsStore is wrapped in CachedSettingsStore so repeated
         // calls within the same session are cheap (in-memory lookup).
@@ -518,10 +517,10 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         };
 
         // Filter tool definitions and collect AlwaysAllow names for session
-        // pre-approval. We don't need to check ApprovalRequirement::Always here
-        // because the existing approval gate already treats it as an unbypassable
-        // hard floor — even if a tool name is in session.auto_approved_tools, an
-        // ApprovalRequirement::Always tool still requires user confirmation.
+        // pre-approval. Effective permissions are authoritative here: tools
+        // resolved to AlwaysAllow are pre-approved regardless of their
+        // intrinsic approval metadata, and AskEachTime/Disabled rows clear that
+        // pre-approval on the next turn.
         let mut to_auto_approve: Vec<String> = Vec::new();
         let tool_defs: Vec<_> = tool_defs
             .into_iter()
@@ -2171,8 +2170,8 @@ mod tests {
 
     #[test]
     fn test_always_approval_requirement_bypasses_session_auto_approve() {
-        // Regression test: even if tool is auto-approved in session,
-        // ApprovalRequirement::Always must still trigger approval.
+        // v1 treats ApprovalRequirement::Always as a per-call floor even when
+        // the session auto-approved set contains the tool.
         use crate::tools::ApprovalRequirement;
 
         let mut session = Session::new("user-1");
@@ -2185,8 +2184,6 @@ mod tests {
             "tool should be auto-approved"
         );
 
-        // However, ApprovalRequirement::Always should always require approval
-        // This is verified by the dispatcher logic: Always => true (ignores session state)
         let always_req = ApprovalRequirement::Always;
         let requires_approval = match always_req {
             ApprovalRequirement::Never => false,
@@ -2196,7 +2193,7 @@ mod tests {
 
         assert!(
             requires_approval,
-            "ApprovalRequirement::Always must require approval even when tool is auto-approved"
+            "ApprovalRequirement::Always must require approval even when the tool is auto-approved"
         );
     }
 
@@ -2223,7 +2220,7 @@ mod tests {
             "UnlessAutoApproved should not need approval when auto-approved"
         );
 
-        // Always → always requires approval
+        // Always → always requires approval on v1.
         let always_req = ApprovalRequirement::Always;
         let always_needs = match always_req {
             ApprovalRequirement::Never => false,
@@ -2250,7 +2247,7 @@ mod tests {
             "UnlessAutoApproved should need approval when not auto-approved"
         );
 
-        // Always → always requires approval
+        // Always → always requires approval on v1.
         let always_needs = match always_req {
             ApprovalRequirement::Never => false,
             ApprovalRequirement::UnlessAutoApproved => !session.is_tool_auto_approved(new_tool),
@@ -2259,9 +2256,8 @@ mod tests {
         assert!(always_needs, "Always must always require approval");
     }
 
-    /// Regression test: `allow_always` must be `false` for `Always` and
-    /// `true` for `UnlessAutoApproved`, so the UI hides the "always" button
-    /// for tools that truly cannot be auto-approved.
+    /// Regression test: `allow_always` stays `false` for intrinsic `Always`
+    /// approval in v1.
     #[test]
     fn test_allow_always_matches_approval_requirement() {
         use crate::tools::ApprovalRequirement;
@@ -4168,7 +4164,6 @@ mod tests {
     #[test]
     fn test_permission_always_allow_never_approval_auto_approved() {
         use crate::agent::session::Session;
-        use crate::tools::ApprovalRequirement;
         use crate::tools::permissions::PermissionState;
 
         let mut session = Session::new("user-perm-1");
@@ -4176,10 +4171,8 @@ mod tests {
 
         // Simulate: PermissionState::AlwaysAllow and requires_approval → Never.
         let perm = PermissionState::AlwaysAllow;
-        let requirement = ApprovalRequirement::Never;
 
-        let hard_floor = matches!(requirement, ApprovalRequirement::Always);
-        if perm == PermissionState::AlwaysAllow && !hard_floor {
+        if perm == PermissionState::AlwaysAllow {
             session.auto_approve_tool(tool_name);
         }
 
@@ -4189,10 +4182,11 @@ mod tests {
         );
     }
 
-    /// AlwaysAllow tool with Always approval requirement must NOT be auto-approved.
+    /// AlwaysAllow tool with Always approval requirement is not auto-approved
+    /// by v1 permission hydration.
     ///
-    /// This verifies the hard-floor: ApprovalRequirement::Always is never bypassed,
-    /// even when PermissionState is AlwaysAllow.
+    /// This verifies the v1 hard floor: ApprovalRequirement::Always is never
+    /// bypassed by session auto-approval.
     #[test]
     fn test_permission_always_allow_always_approval_not_auto_approved() {
         use crate::agent::session::Session;
@@ -4213,7 +4207,7 @@ mod tests {
 
         assert!(
             !session.is_tool_auto_approved(tool_name),
-            "AlwaysAllow with Always approval requirement must NOT be auto-approved (hard floor)"
+            "v1 should preserve its hard-floor behavior for ApprovalRequirement::Always"
         );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1493,18 +1493,11 @@ async fn migrate_session_credential(
     }
 }
 
-/// Seed tool permission defaults into the database for every registered tool
-/// that has no explicit user override yet.
-///
-/// This is called once at startup after the full tool registry is built.
-/// It is idempotent: existing entries in `tool_permissions.*` are never touched.
 async fn seed_tool_permissions(
     tools: &crate::tools::ToolRegistry,
     db: Option<&Arc<dyn Database>>,
     owner_id: &str,
 ) {
-    use crate::tools::permissions::{TOOL_RISK_DEFAULTS, effective_permission};
-
     let db = match db {
         Some(db) => db,
         None => {
@@ -1532,11 +1525,9 @@ async fn seed_tool_permissions(
             continue;
         }
 
-        // Only insert if the tool appears in the static defaults table.
-        // Unknown/dynamic tools stay absent (they will fall back to AskEachTime
-        // at runtime via effective_permission) to avoid polluting the DB.
-        if TOOL_RISK_DEFAULTS.contains_key(name.as_str()) {
-            let default_state = effective_permission(name, &existing);
+        // Only insert seed defaults for known built-ins. Unknown/dynamic tools
+        // stay absent and fall back to AskEachTime at runtime.
+        if let Some(default_state) = crate::tools::permissions::seeded_default_permission(name) {
             let json_value = match serde_json::to_value(default_state) {
                 Ok(v) => v,
                 Err(e) => {
@@ -1681,6 +1672,11 @@ mod tests {
         registry.register_builtin_tools();
 
         let owner = "test-user";
+        assert_eq!(
+            crate::tools::permissions::seeded_default_permission("tool_activate"),
+            Some(PermissionState::AlwaysAllow),
+            "tool_activate should seed AlwaysAllow so subgates control auth/setup"
+        );
 
         // 1. Initial seed: creates defaults for all registered tools.
         super::seed_tool_permissions(&registry, Some(&db), owner).await;

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -30,16 +30,15 @@ use crate::bridge::action_projector::ActionProjector;
 use crate::bridge::capability_projector::CapabilityProjector;
 use crate::bridge::router::synthetic_action_call_id;
 use crate::bridge::sandbox::{InterceptOutcome, maybe_intercept};
-use crate::bridge::tool_permissions::{
-    ToolPermissionResolution, ToolPermissionSnapshot, canonical_tool_name,
-};
+use crate::bridge::tool_permissions::{ToolPermissionResolution, ToolPermissionSnapshot};
 use crate::context::JobContext;
 use crate::extensions::InstalledExtension;
 use crate::extensions::naming::extension_name_candidates;
 use crate::hooks::{HookEvent, HookOutcome, HookRegistry};
+use crate::tools::ToolRegistry;
 use crate::tools::permissions::PermissionState;
 use crate::tools::rate_limiter::RateLimiter;
-use crate::tools::{ApprovalRequirement, Tool, ToolRegistry};
+use crate::tools::{ApprovalRequirement, Tool};
 use ironclaw_safety::SafetyLayer;
 
 /// Wraps the existing tool pipeline to implement the engine's `EffectExecutor`.
@@ -265,6 +264,16 @@ impl EffectBridgeAdapter {
         )
     }
 
+    async fn resolved_user_permission_for_tool(
+        &self,
+        lookup_name: &str,
+        context: &ThreadExecutionContext,
+    ) -> ToolPermissionResolution {
+        ToolPermissionSnapshot::load(self.tools.as_ref(), &context.user_id)
+            .await
+            .resolve_permission(lookup_name)
+    }
+
     async fn tool_activate_requires_install_approval(
         &self,
         lookup_name: &str,
@@ -308,40 +317,6 @@ impl EffectBridgeAdapter {
         matching_extension_requires_install_approval(requested_name, &extensions).unwrap_or(false)
     }
 
-    async fn resolved_user_permission_for_tool(
-        &self,
-        lookup_name: &str,
-        context: &ThreadExecutionContext,
-    ) -> ToolPermissionResolution {
-        ToolPermissionSnapshot::load(self.tools.as_ref(), &context.user_id)
-            .await
-            .resolve_permission(lookup_name)
-    }
-
-    fn apply_user_permission_override(
-        lookup_name: &str,
-        base_requirement: ApprovalRequirement,
-        user_permission: ToolPermissionResolution,
-    ) -> ApprovalRequirement {
-        if matches!(user_permission.explicit, Some(PermissionState::AskEachTime)) {
-            return ApprovalRequirement::Always;
-        }
-        match (base_requirement, user_permission.configured) {
-            (ApprovalRequirement::Never, Some(PermissionState::AskEachTime))
-                if Self::enforce_static_ask_floor_for_base_never_tool(lookup_name) =>
-            {
-                ApprovalRequirement::Always
-            }
-            _ => base_requirement,
-        }
-    }
-
-    fn enforce_static_ask_floor_for_base_never_tool(lookup_name: &str) -> bool {
-        // Other base-Never bridge tools manage auth/install gates internally.
-        // Restart's command-level confirmation does not cover direct v2 calls.
-        canonical_tool_name(lookup_name) == "restart"
-    }
-
     fn ensure_tool_not_disabled(
         action_name: &str,
         user_permission: ToolPermissionResolution,
@@ -354,81 +329,87 @@ impl EffectBridgeAdapter {
         Ok(())
     }
 
-    async fn effective_tool_approval_requirement(
-        &self,
-        lookup_name: &str,
-        tool: &dyn Tool,
-        parameters: &serde_json::Value,
-        context: &ThreadExecutionContext,
-        user_permission: ToolPermissionResolution,
-        include_install_approval: bool,
-    ) -> ApprovalRequirement {
-        let base_requirement = if include_install_approval
-            && self
-                .tool_activate_requires_install_approval(lookup_name, parameters, context)
-                .await
-        {
-            ApprovalRequirement::UnlessAutoApproved
-        } else {
-            tool.requires_approval(parameters)
-        };
-        Self::apply_user_permission_override(lookup_name, base_requirement, user_permission)
-    }
-
-    async fn enforce_tool_approval(
+    async fn enforce_tool_permission(
         &self,
         approval: &ToolApprovalContext<'_>,
-        tool: &dyn Tool,
+        tool: Option<&dyn Tool>,
         user_permission: ToolPermissionResolution,
-        include_install_approval: bool,
     ) -> Result<(), EngineError> {
-        let requirement = self
-            .effective_tool_approval_requirement(
+        match user_permission.effective {
+            PermissionState::Disabled => {
+                Self::ensure_tool_not_disabled(approval.action_name, user_permission)?
+            }
+            PermissionState::AlwaysAllow | PermissionState::AskEachTime => {}
+        }
+
+        if approval.approval_already_granted {
+            return Ok(());
+        }
+
+        if matches!(
+            tool.map(|tool| tool.requires_approval(approval.parameters)),
+            Some(ApprovalRequirement::Always)
+        ) {
+            return Err(Self::gate_paused(
+                "approval",
+                approval.action_name,
+                approval.context.current_call_id.as_deref(),
+                approval.parameters.clone(),
+                ironclaw_engine::ResumeKind::Approval {
+                    allow_always: false,
+                },
+                None,
+                Some(approval.lease.clone()),
+            ));
+        }
+
+        if self
+            .tool_activate_requires_install_approval(
                 approval.lookup_name,
-                tool,
                 approval.parameters,
                 approval.context,
-                user_permission,
-                include_install_approval,
             )
-            .await;
-        match requirement {
-            ApprovalRequirement::Always => {
-                if !approval.approval_already_granted {
-                    return Err(Self::gate_paused(
-                        "approval",
-                        approval.action_name,
-                        approval.context.current_call_id.as_deref(),
-                        approval.parameters.clone(),
-                        ironclaw_engine::ResumeKind::Approval {
-                            allow_always: false,
-                        },
-                        None,
-                        Some(approval.lease.clone()),
-                    ));
-                }
-            }
-            ApprovalRequirement::UnlessAutoApproved => {
-                let is_approved = self.auto_approve_tools
+            .await
+        {
+            return Err(Self::gate_paused(
+                "approval",
+                approval.action_name,
+                approval.context.current_call_id.as_deref(),
+                approval.parameters.clone(),
+                ironclaw_engine::ResumeKind::Approval {
+                    allow_always: false,
+                },
+                None,
+                Some(approval.lease.clone()),
+            ));
+        }
+
+        if matches!(user_permission.effective, PermissionState::AlwaysAllow) {
+            return Ok(());
+        }
+
+        if matches!(user_permission.effective, PermissionState::AskEachTime) {
+            let is_explicit_ask =
+                matches!(user_permission.explicit, Some(PermissionState::AskEachTime));
+            let is_approved = !is_explicit_ask
+                && (self.auto_approve_tools
                     || self
                         .auto_approved
                         .read()
                         .await
-                        .contains(approval.lookup_name)
-                    || matches!(user_permission.effective, PermissionState::AlwaysAllow);
-                if !is_approved && !approval.approval_already_granted {
-                    return Err(Self::gate_paused(
-                        "approval",
-                        approval.action_name,
-                        approval.context.current_call_id.as_deref(),
-                        approval.parameters.clone(),
-                        ironclaw_engine::ResumeKind::Approval { allow_always: true },
-                        None,
-                        Some(approval.lease.clone()),
-                    ));
-                }
+                        .contains(approval.lookup_name));
+            if is_approved {
+                return Ok(());
             }
-            ApprovalRequirement::Never => {}
+            return Err(Self::gate_paused(
+                "approval",
+                approval.action_name,
+                approval.context.current_call_id.as_deref(),
+                approval.parameters.clone(),
+                ironclaw_engine::ResumeKind::Approval { allow_always: true },
+                None,
+                Some(approval.lease.clone()),
+            ));
         }
         Ok(())
     }
@@ -463,7 +444,7 @@ impl EffectBridgeAdapter {
         Self::ensure_tool_not_disabled(tool_info.action_name, user_permission)?;
 
         if let Some((_, tool)) = resolved_tool.as_ref() {
-            self.enforce_tool_approval(
+            self.enforce_tool_permission(
                 &ToolApprovalContext {
                     action_name: tool_info.action_name,
                     lookup_name: tool_info.lookup_name,
@@ -472,9 +453,8 @@ impl EffectBridgeAdapter {
                     context: tool_info.context,
                     approval_already_granted: tool_info.approval_already_granted,
                 },
-                tool.as_ref(),
+                Some(tool.as_ref()),
                 user_permission,
-                false,
             )
             .await?;
         }
@@ -1463,7 +1443,7 @@ impl EffectBridgeAdapter {
         }
 
         if let Some((_, tool)) = resolved_tool.as_ref() {
-            self.enforce_tool_approval(
+            self.enforce_tool_permission(
                 &ToolApprovalContext {
                     action_name,
                     lookup_name: &lookup_name,
@@ -1472,9 +1452,8 @@ impl EffectBridgeAdapter {
                     context,
                     approval_already_granted,
                 },
-                tool.as_ref(),
+                Some(tool.as_ref()),
                 user_permission,
-                true,
             )
             .await?;
         }
@@ -2603,8 +2582,7 @@ pub(crate) fn is_v1_auth_tool(name: &str) -> bool {
 mod tests {
     use super::*;
     use crate::context::JobContext;
-    use crate::extensions::ExtensionKind;
-    use crate::tools::{Tool, ToolError, ToolOutput};
+    use crate::tools::{ApprovalRequirement, Tool, ToolError, ToolOutput};
     use async_trait::async_trait;
 
     fn make_adapter() -> EffectBridgeAdapter {
@@ -2618,24 +2596,6 @@ mod tests {
             Arc::new(SafetyLayer::new(&config)),
             Arc::new(HookRegistry::default()),
         )
-    }
-
-    fn installed_extension(name: &str) -> InstalledExtension {
-        InstalledExtension {
-            name: name.to_string(),
-            kind: ExtensionKind::McpServer,
-            display_name: Some(name.to_string()),
-            description: Some(format!("{name} integration")),
-            url: None,
-            authenticated: true,
-            active: true,
-            tools: Vec::new(),
-            needs_setup: false,
-            has_auth: true,
-            installed: true,
-            activation_error: None,
-            version: None,
-        }
     }
 
     /// Verify that reset_call_count resets the counter to zero,
@@ -2907,6 +2867,24 @@ mod tests {
         }
     }
 
+    fn installed_extension(name: &str) -> InstalledExtension {
+        InstalledExtension {
+            name: name.to_string(),
+            kind: crate::extensions::ExtensionKind::McpServer,
+            display_name: Some(name.to_string()),
+            description: Some(format!("{name} description")),
+            url: None,
+            authenticated: true,
+            active: true,
+            tools: vec![format!("{name}_search")],
+            needs_setup: false,
+            has_auth: true,
+            installed: true,
+            activation_error: None,
+            version: None,
+        }
+    }
+
     async fn make_tool_info_adapter_with_permission(
         permission: crate::tools::permissions::PermissionState,
     ) -> EffectBridgeAdapter {
@@ -2967,6 +2945,42 @@ mod tests {
 
         let tools = Arc::new(ToolRegistry::new().with_database(db));
         tools.register(Arc::new(ApprovalTestTool)).await;
+        EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&ironclaw_safety::SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        )
+    }
+
+    async fn make_always_approval_test_adapter_with_permission(
+        permission: Option<crate::tools::permissions::PermissionState>,
+    ) -> EffectBridgeAdapter {
+        let db_path = std::env::temp_dir().join(format!(
+            "ironclaw-always-approval-test-permissions-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        let db = crate::db::connect_from_config(&crate::config::DatabaseConfig::from_libsql_path(
+            db_path.to_str().expect("db path"),
+            None,
+            None,
+        ))
+        .await
+        .expect("db");
+        if let Some(permission) = permission {
+            db.set_setting(
+                "test_user",
+                "tool_permissions.always_approval_test",
+                &serde_json::to_value(permission).expect("serialize permission"),
+            )
+            .await
+            .expect("save tool permission");
+        }
+
+        let tools = Arc::new(ToolRegistry::new().with_database(db));
+        tools.register(Arc::new(AlwaysApprovalTestTool)).await;
         EffectBridgeAdapter::new(
             tools,
             Arc::new(SafetyLayer::new(&ironclaw_safety::SafetyConfig {
@@ -3554,6 +3568,93 @@ mod tests {
         }
     }
 
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn restart_explicit_always_allow_override_bypasses_default_gate() {
+        let _guard = crate::config::helpers::lock_env();
+        let original_in_docker = std::env::var_os("IRONCLAW_IN_DOCKER");
+        let original_disable_restart = std::env::var_os("IRONCLAW_DISABLE_RESTART");
+        // SAFETY: This test serializes env access with lock_env().
+        unsafe {
+            std::env::set_var("IRONCLAW_IN_DOCKER", "true");
+            std::env::set_var("IRONCLAW_DISABLE_RESTART", "true");
+        }
+
+        let adapter = make_restart_adapter_with_permission(Some(
+            crate::tools::permissions::PermissionState::AlwaysAllow,
+        ))
+        .await;
+
+        let result = adapter
+            .execute_action(
+                "restart",
+                serde_json::json!({"delay_secs": 1}),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_restart_explicit_allow_floor"),
+                ),
+            )
+            .await
+            .expect("explicit always_allow should bypass the default approval gate");
+
+        // SAFETY: This test serializes env access with lock_env().
+        unsafe {
+            if let Some(value) = original_in_docker {
+                std::env::set_var("IRONCLAW_IN_DOCKER", value);
+            } else {
+                std::env::remove_var("IRONCLAW_IN_DOCKER");
+            }
+            if let Some(value) = original_disable_restart {
+                std::env::set_var("IRONCLAW_DISABLE_RESTART", value);
+            } else {
+                std::env::remove_var("IRONCLAW_DISABLE_RESTART");
+            }
+        }
+
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn explicit_always_allow_override_preserves_intrinsic_always_approval() {
+        let adapter = make_always_approval_test_adapter_with_permission(Some(
+            crate::tools::permissions::PermissionState::AlwaysAllow,
+        ))
+        .await;
+
+        let err = adapter
+            .execute_action(
+                "always_approval_test",
+                serde_json::json!({"value": "x"}),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_explicit_always_allow_intrinsic_always"),
+                ),
+            )
+            .await
+            .expect_err("explicit always_allow must not bypass intrinsic Always approval");
+
+        match err {
+            EngineError::GatePaused {
+                gate_name,
+                action_name,
+                resume_kind,
+                ..
+            } => {
+                assert_eq!(gate_name, "approval");
+                assert_eq!(action_name, "always_approval_test");
+                match *resume_kind {
+                    ironclaw_engine::ResumeKind::Approval { allow_always } => {
+                        assert!(!allow_always);
+                    }
+                    other => panic!("expected approval resume kind, got {other:?}"),
+                }
+            }
+            other => panic!("expected approval gate pause, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn explicit_always_allow_override_beats_ask_each_time_fallback() {
         let adapter = make_approval_test_adapter_with_permission(Some(
@@ -3752,20 +3853,14 @@ mod tests {
         assert!(matches!(third, Err(EngineError::GatePaused { .. })));
     }
 
-    /// End-to-end gate verification for the real `MemoryWriteTool`.
+    /// End-to-end permission verification for the real `MemoryWriteTool`.
     ///
-    /// PR #1958 reviewer-flagged regression: the original effect bridge
-    /// mapped `ApprovalRequirement::Always` to `LeaseDenied` (a hard
-    /// refusal). Round 3 fixed both sides: the bridge now maps `Always`
-    /// to `GatePaused(Approval { allow_always: false })`, and
-    /// `MemoryWriteTool::requires_approval` returns `Always` for
-    /// protected orchestrator targets so session auto-approve cannot
-    /// silently skip the gate. This test asserts the full path:
-    /// `requires_approval` → adapter → gate, with the real tool wired
-    /// into a real registry.
+    /// Engine v2 resolves missing `memory_write` rows through the seeded
+    /// `AlwaysAllow` default, but protected targets still raise a per-call
+    /// `Always` floor that must not be bypassed.
     #[cfg(feature = "libsql")]
     #[tokio::test]
-    async fn memory_write_orchestrator_target_paused_for_approval_when_self_modify_enabled() {
+    async fn memory_write_orchestrator_target_preserves_always_approval_floor() {
         use crate::db::Database;
         use crate::db::libsql::LibSqlBackend;
         use crate::tools::builtin::memory::MemoryWriteTool;
@@ -3812,30 +3907,20 @@ mod tests {
         match result {
             Err(EngineError::GatePaused {
                 gate_name,
+                action_name,
                 resume_kind,
                 ..
             }) => {
                 assert_eq!(gate_name, "approval");
+                assert_eq!(action_name, "memory_write");
                 match *resume_kind {
                     ironclaw_engine::ResumeKind::Approval { allow_always } => {
-                        assert!(
-                            !allow_always,
-                            "protected orchestrator writes must set allow_always=false \
-                             to prevent session auto-approve bypass"
-                        );
+                        assert!(!allow_always);
                     }
-                    other => panic!("expected Approval resume kind, got {other:?}"),
+                    other => panic!("expected approval resume kind, got {other:?}"),
                 }
             }
-            Err(EngineError::LeaseDenied { reason }) => {
-                panic!(
-                    "memory_write protected target was hard-denied (LeaseDenied) \
-                     instead of pausing for approval — this is the regression \
-                     that PR #1958's Always fix is meant to prevent. \
-                     Reason: {reason}"
-                );
-            }
-            other => panic!("expected GatePaused(approval), got {other:?}"),
+            other => panic!("expected approval gate pause, got {other:?}"),
         }
     }
 
@@ -5223,7 +5308,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_activate_awaiting_authorization_becomes_auth_gate() {
+    async fn tool_activate_seeded_always_allow_reaches_auth_gate() {
+        use crate::secrets::InMemorySecretsStore;
+        use crate::secrets::SecretsCrypto;
+
         struct ActivateTool;
 
         #[async_trait]
@@ -5265,14 +5353,25 @@ mod tests {
         tools.register(Arc::new(ActivateTool)).await;
 
         let adapter = EffectBridgeAdapter::new(
-            tools,
+            Arc::clone(&tools),
             Arc::new(SafetyLayer::new(&ironclaw_safety::SafetyConfig {
                 max_output_length: 10_000,
                 injection_check_enabled: false,
             })),
             Arc::new(HookRegistry::default()),
-        )
-        .with_global_auto_approve(true);
+        );
+        let key = secrecy::SecretString::from(crate::secrets::keychain::generate_master_key_hex());
+        let crypto = Arc::new(SecretsCrypto::new(key).expect("crypto"));
+        let secrets: Arc<dyn crate::secrets::SecretsStore + Send + Sync> =
+            Arc::new(InMemorySecretsStore::new(crypto));
+        adapter
+            .set_auth_manager(Arc::new(AuthManager::new(
+                secrets,
+                None,
+                None,
+                Some(Arc::clone(&tools)),
+            )))
+            .await;
 
         let lease = ironclaw_engine::CapabilityLease {
             id: ironclaw_engine::types::capability::LeaseId::new(),
@@ -5335,7 +5434,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_activate_requires_approval_before_auto_installing_integration() {
+    async fn tool_activate_requires_install_approval_before_auto_installing_integration() {
         use crate::extensions::{AuthHint, ExtensionKind, ExtensionSource, RegistryEntry};
         use crate::secrets::InMemorySecretsStore;
         use crate::secrets::SecretsCrypto;
@@ -5420,7 +5519,7 @@ mod tests {
                 assert_eq!(action_name, "tool_activate");
                 match *resume_kind {
                     ironclaw_engine::ResumeKind::Approval { allow_always } => {
-                        assert!(allow_always);
+                        assert!(!allow_always);
                     }
                     other => panic!("expected approval resume kind, got {other:?}"),
                 }
@@ -5430,13 +5529,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_activate_requires_approval_when_install_state_is_unavailable() {
+    async fn tool_activate_respects_ask_each_time_when_install_state_is_unavailable() {
         use crate::extensions::{AuthHint, ExtensionKind, ExtensionSource, RegistryEntry};
         use crate::secrets::InMemorySecretsStore;
         use crate::secrets::SecretsCrypto;
         use crate::tools::builtin::extension_tools::ToolActivateTool;
         use crate::tools::mcp::process::McpProcessManager;
         use crate::tools::mcp::session::McpSessionManager;
+        use crate::tools::permissions::PermissionState;
 
         let dir = tempfile::tempdir().expect("temp dir");
 
@@ -5445,7 +5545,26 @@ mod tests {
         let secrets: Arc<dyn crate::secrets::SecretsStore + Send + Sync> =
             Arc::new(InMemorySecretsStore::new(crypto));
 
-        let tools = Arc::new(ToolRegistry::new());
+        let db_path = std::env::temp_dir().join(format!(
+            "ironclaw-tool-activate-permissions-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        let db = crate::db::connect_from_config(&crate::config::DatabaseConfig::from_libsql_path(
+            db_path.to_str().expect("db path"),
+            None,
+            None,
+        ))
+        .await
+        .expect("db");
+        db.set_setting(
+            "test_user",
+            "tool_permissions.tool_activate",
+            &serde_json::to_value(PermissionState::AskEachTime).expect("serialize permission"),
+        )
+        .await
+        .expect("save tool permission");
+
+        let tools = Arc::new(ToolRegistry::new().with_database(db));
         let ext_mgr = Arc::new(crate::extensions::ExtensionManager::new(
             Arc::new(McpSessionManager::new()),
             Arc::new(McpProcessManager::new()),
@@ -5507,7 +5626,7 @@ mod tests {
                 assert_eq!(action_name, "tool_activate");
                 match *resume_kind {
                     ironclaw_engine::ResumeKind::Approval { allow_always } => {
-                        assert!(allow_always);
+                        assert!(!allow_always);
                     }
                     other => panic!("expected approval resume kind, got {other:?}"),
                 }
@@ -5566,7 +5685,8 @@ mod tests {
                 injection_check_enabled: false,
             })),
             Arc::new(HookRegistry::default()),
-        );
+        )
+        .with_global_auto_approve(true);
 
         let lease = ironclaw_engine::CapabilityLease {
             id: ironclaw_engine::types::capability::LeaseId::new(),
@@ -6270,7 +6390,8 @@ Use this skill to set up a Pika meeting.
                 injection_check_enabled: false,
             })),
             Arc::new(HookRegistry::default()),
-        );
+        )
+        .with_global_auto_approve(true);
         let store: Arc<dyn Store> = Arc::new(crate::bridge::store_adapter::HybridStore::new(None));
         adapter.set_engine_store(Arc::clone(&store)).await;
         adapter

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -332,7 +332,7 @@ impl EffectBridgeAdapter {
     async fn enforce_tool_permission(
         &self,
         approval: &ToolApprovalContext<'_>,
-        tool: Option<&dyn Tool>,
+        tool: &dyn Tool,
         user_permission: ToolPermissionResolution,
     ) -> Result<(), EngineError> {
         match user_permission.effective {
@@ -347,8 +347,8 @@ impl EffectBridgeAdapter {
         }
 
         if matches!(
-            tool.map(|tool| tool.requires_approval(approval.parameters)),
-            Some(ApprovalRequirement::Always)
+            tool.requires_approval(approval.parameters),
+            ApprovalRequirement::Always
         ) {
             return Err(Self::gate_paused(
                 "approval",
@@ -453,7 +453,7 @@ impl EffectBridgeAdapter {
                     context: tool_info.context,
                     approval_already_granted: tool_info.approval_already_granted,
                 },
-                Some(tool.as_ref()),
+                tool.as_ref(),
                 user_permission,
             )
             .await?;
@@ -1452,7 +1452,7 @@ impl EffectBridgeAdapter {
                     context,
                     approval_already_granted,
                 },
-                Some(tool.as_ref()),
+                tool.as_ref(),
                 user_permission,
             )
             .await?;

--- a/src/bridge/tool_permissions.rs
+++ b/src/bridge/tool_permissions.rs
@@ -2,13 +2,12 @@ use std::collections::HashMap;
 
 use crate::settings::Settings;
 use crate::tools::ToolRegistry;
-use crate::tools::permissions::{PermissionState, TOOL_RISK_DEFAULTS};
+use crate::tools::permissions::{PermissionState, seeded_default_permission};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ToolPermissionResolution {
     pub(crate) effective: PermissionState,
     pub(crate) explicit: Option<PermissionState>,
-    pub(crate) configured: Option<PermissionState>,
 }
 
 #[derive(Clone, Default)]
@@ -41,12 +40,12 @@ impl ToolPermissionSnapshot {
         let canonical = canonical_tool_name(tool_name);
         let hyphenated = canonical.replace('_', "-");
         let explicit = self.explicit_permission_with_names(tool_name, &canonical, &hyphenated);
-        let configured = explicit.or_else(|| TOOL_RISK_DEFAULTS.get(canonical.as_str()).copied());
-        let effective = configured.unwrap_or(PermissionState::AskEachTime);
+        let effective = explicit
+            .or_else(|| seeded_default_permission(&canonical))
+            .unwrap_or(PermissionState::AskEachTime);
         ToolPermissionResolution {
             effective,
             explicit,
-            configured,
         }
     }
 

--- a/src/bridge/tool_permissions.rs
+++ b/src/bridge/tool_permissions.rs
@@ -66,3 +66,49 @@ impl ToolPermissionSnapshot {
 pub(crate) fn canonical_tool_name(tool_name: &str) -> String {
     tool_name.replace('-', "_")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_http_permission_uses_seeded_default() {
+        let snapshot = ToolPermissionSnapshot::default();
+
+        assert_eq!(
+            snapshot.resolve_permission("http"),
+            ToolPermissionResolution {
+                effective: PermissionState::AlwaysAllow,
+                explicit: None,
+            }
+        );
+    }
+
+    #[test]
+    fn saved_http_permission_wins_over_seeded_default() {
+        let snapshot = ToolPermissionSnapshot {
+            overrides: HashMap::from([("http".to_string(), PermissionState::AskEachTime)]),
+        };
+
+        assert_eq!(
+            snapshot.resolve_permission("http"),
+            ToolPermissionResolution {
+                effective: PermissionState::AskEachTime,
+                explicit: Some(PermissionState::AskEachTime),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_tool_defaults_to_ask_each_time() {
+        let snapshot = ToolPermissionSnapshot::default();
+
+        assert_eq!(
+            snapshot.resolve_permission("unknown_tool"),
+            ToolPermissionResolution {
+                effective: PermissionState::AskEachTime,
+                explicit: None,
+            }
+        );
+    }
+}

--- a/src/channels/web/features/settings/mod.rs
+++ b/src/channels/web/features/settings/mod.rs
@@ -954,8 +954,10 @@ pub async fn settings_tools_list_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(user): AuthenticatedUser,
 ) -> Result<Json<ToolPermissionsResponse>, StatusCode> {
-    use crate::tools::ApprovalRequirement;
-    use crate::tools::permissions::{TOOL_RISK_DEFAULTS, effective_permission};
+    use crate::tools::permissions::{
+        PermissionState, TOOL_PERMISSION_LOCKED_REASON, effective_permission,
+        seeded_default_permission, tool_permission_locked,
+    };
 
     let registry = state
         .tool_registry
@@ -978,20 +980,8 @@ pub async fn settings_tools_list_handler(
             let description = tool.description().to_string();
 
             let current = effective_permission(&name, &user_overrides);
-            let default = TOOL_RISK_DEFAULTS
-                .get(name.as_str())
-                .copied()
-                .unwrap_or(crate::tools::permissions::PermissionState::AskEachTime);
-
-            let locked = matches!(
-                tool.requires_approval(&serde_json::Value::Null),
-                ApprovalRequirement::Always
-            );
-            let locked_reason = if locked {
-                Some("Always requires approval due to risk level".to_string())
-            } else {
-                None
-            };
+            let default = seeded_default_permission(&name).unwrap_or(PermissionState::AskEachTime);
+            let locked = tool_permission_locked(tool.as_ref());
 
             ToolPermissionEntry {
                 name,
@@ -999,7 +989,7 @@ pub async fn settings_tools_list_handler(
                 current_state: permission_state_to_str(current).to_string(),
                 default_state: permission_state_to_str(default).to_string(),
                 locked,
-                locked_reason,
+                locked_reason: locked.then(|| TOOL_PERMISSION_LOCKED_REASON.to_string()),
             }
         })
         .collect();
@@ -1016,9 +1006,6 @@ pub async fn settings_tools_set_handler(
     Path(name): Path<String>,
     Json(body): Json<UpdateToolPermissionRequest>,
 ) -> Result<Json<ToolPermissionEntry>, (StatusCode, axum::Json<serde_json::Value>)> {
-    use crate::tools::ApprovalRequirement;
-    use crate::tools::permissions::{PermissionState, TOOL_RISK_DEFAULTS};
-
     let registry = state.tool_registry.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         axum::Json(serde_json::json!({"error": "Tool registry unavailable"})),
@@ -1030,19 +1017,6 @@ pub async fn settings_tools_set_handler(
         axum::Json(serde_json::json!({"error": format!("Tool '{}' not found", name)})),
     ))?;
 
-    // Reject if tool is locked (ApprovalRequirement::Always).
-    if matches!(
-        tool.requires_approval(&serde_json::Value::Null),
-        ApprovalRequirement::Always
-    ) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            axum::Json(serde_json::json!({
-                "error": format!("Tool '{}' is locked and cannot have its permission changed", name)
-            })),
-        ));
-    }
-
     // Parse the requested state.
     let new_state = str_to_permission_state(&body.state).ok_or((
         StatusCode::UNPROCESSABLE_ENTITY,
@@ -1050,6 +1024,23 @@ pub async fn settings_tools_set_handler(
             serde_json::json!({"error": format!("Invalid permission state: '{}'", body.state)}),
         ),
     ))?;
+    let locked = crate::tools::permissions::tool_permission_locked(tool.as_ref());
+    if locked
+        && matches!(
+            new_state,
+            crate::tools::permissions::PermissionState::AlwaysAllow
+        )
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            axum::Json(serde_json::json!({
+                "error": format!(
+                    "Tool '{}' always requires approval and cannot be set to always_allow",
+                    name
+                )
+            })),
+        ));
+    }
 
     // Persist the permission override, routed through the cached settings store
     // so the agent loop sees the change immediately.
@@ -1083,19 +1074,18 @@ pub async fn settings_tools_set_handler(
             )
         })?;
 
-    // Use new_state directly — we just wrote it, no need for an extra DB round-trip.
-    let default = TOOL_RISK_DEFAULTS
-        .get(name.as_str())
-        .copied()
-        .unwrap_or(PermissionState::AskEachTime);
-
     Ok(Json(ToolPermissionEntry {
         description: tool.description().to_string(),
+        default_state: permission_state_to_str(
+            crate::tools::permissions::seeded_default_permission(&name)
+                .unwrap_or(crate::tools::permissions::PermissionState::AskEachTime),
+        )
+        .to_string(),
         name,
         current_state: permission_state_to_str(new_state).to_string(),
-        default_state: permission_state_to_str(default).to_string(),
-        locked: false,
-        locked_reason: None,
+        locked,
+        locked_reason: locked
+            .then(|| crate::tools::permissions::TOOL_PERMISSION_LOCKED_REASON.to_string()),
     }))
 }
 
@@ -2241,15 +2231,10 @@ mod tests {
         assert!(str_to_permission_state("ALWAYS_ALLOW").is_none());
     }
 
-    /// `PUT /api/settings/tools/:name` must return 400 for locked tools.
-    ///
-    /// A tool that returns `ApprovalRequirement::Always` from `requires_approval`
-    /// is locked — callers cannot override its permission state via the API.
-    /// We test this by checking the rejection path directly via the handler
-    /// function using a minimal in-memory tool registry containing a mock
-    /// "always-locked" tool.
+    /// `PUT /api/settings/tools/:name` must reject AlwaysAllow for tools whose
+    /// default approval requirement is parameter-insensitive Always.
     #[tokio::test]
-    async fn test_put_locked_tool_returns_400() {
+    async fn test_put_always_approval_tool_rejects_always_allow_override() {
         use std::sync::Arc;
 
         use crate::context::JobContext;
@@ -2287,10 +2272,9 @@ mod tests {
         let registry = Arc::new(ToolRegistry::new());
         registry.register(Arc::new(LockedTool)).await;
 
-        let state = Arc::new(GatewayState {
-            tool_registry: Some(registry),
-            ..test_gateway_state(test_secrets_store())
-        });
+        let mut state = test_gateway_state(test_secrets_store());
+        state.tool_registry = Some(registry);
+        let state = Arc::new(state);
 
         let result = settings_tools_set_handler(
             State(state),
@@ -2308,11 +2292,14 @@ mod tests {
         )
         .await;
 
-        let (status, _body) = result.unwrap_err();
-        assert_eq!(
-            status,
-            axum::http::StatusCode::BAD_REQUEST,
-            "locked tools should return 400"
+        let (status, body) = result.expect_err("locked tool should reject always_allow");
+        let body = body.0;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(
+            body["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("cannot be set to always_allow")),
+            "unexpected error body: {body:?}"
         );
     }
 
@@ -2331,6 +2318,7 @@ mod tests {
         use axum::extract::State;
 
         struct EchoLikeTool;
+        struct LockedTool;
 
         #[async_trait::async_trait]
         impl Tool for EchoLikeTool {
@@ -2354,9 +2342,32 @@ mod tests {
                 ApprovalRequirement::Never
             }
         }
+        #[async_trait::async_trait]
+        impl Tool for LockedTool {
+            fn name(&self) -> &str {
+                "locked_test"
+            }
+            fn description(&self) -> &str {
+                "Test locked tool"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type":"object","properties":{}})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &JobContext,
+            ) -> Result<ToolOutput, ToolError> {
+                unreachable!()
+            }
+            fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+                ApprovalRequirement::Always
+            }
+        }
 
         let registry = Arc::new(ToolRegistry::new());
         registry.register(Arc::new(EchoLikeTool)).await;
+        registry.register(Arc::new(LockedTool)).await;
 
         // Provide a file-backed temp DB so the handler can load tool permissions.
         // In-memory databases do not share state between connections in libsql,
@@ -2410,5 +2421,13 @@ mod tests {
             entry.default_state.as_str(),
             "always_allow" | "ask_each_time" | "disabled"
         ));
+
+        let locked_entry = response
+            .tools
+            .iter()
+            .find(|t| t.name == "locked_test")
+            .expect("locked_test tool should be in the list");
+        assert!(locked_entry.locked);
+        assert!(locked_entry.locked_reason.is_some());
     }
 }

--- a/src/gate/approval.rs
+++ b/src/gate/approval.rs
@@ -81,21 +81,15 @@ impl ExecutionGate for ApprovalGate {
                         }
                     }
                 }
-                ApprovalRequirement::Always => {
-                    if is_auto_approved {
-                        GateDecision::Allow
-                    } else {
-                        GateDecision::Pause {
-                            reason: format!(
-                                "Tool '{}' requires explicit approval for this operation.",
-                                ctx.action_name
-                            ),
-                            resume_kind: ResumeKind::Approval {
-                                allow_always: false,
-                            },
-                        }
-                    }
-                }
+                ApprovalRequirement::Always => GateDecision::Pause {
+                    reason: format!(
+                        "Tool '{}' requires explicit approval for this operation.",
+                        ctx.action_name
+                    ),
+                    resume_kind: ResumeKind::Approval {
+                        allow_always: false,
+                    },
+                },
             },
             ExecutionMode::InteractiveAutoApprove => match requirement {
                 ApprovalRequirement::Never | ApprovalRequirement::UnlessAutoApproved => {
@@ -104,21 +98,15 @@ impl ExecutionGate for ApprovalGate {
                     // hooks, auth gates) still apply.
                     GateDecision::Allow
                 }
-                ApprovalRequirement::Always => {
-                    if is_auto_approved {
-                        GateDecision::Allow
-                    } else {
-                        GateDecision::Pause {
-                            reason: format!(
-                                "Tool '{}' requires explicit approval (auto-approve does not cover this operation).",
-                                ctx.action_name
-                            ),
-                            resume_kind: ResumeKind::Approval {
-                                allow_always: false,
-                            },
-                        }
-                    }
-                }
+                ApprovalRequirement::Always => GateDecision::Pause {
+                    reason: format!(
+                        "Tool '{}' requires explicit approval (auto-approve does not cover this operation).",
+                        ctx.action_name
+                    ),
+                    resume_kind: ResumeKind::Approval {
+                        allow_always: false,
+                    },
+                },
             },
             ExecutionMode::Autonomous => match requirement {
                 ApprovalRequirement::Never | ApprovalRequirement::UnlessAutoApproved => {
@@ -126,18 +114,12 @@ impl ExecutionGate for ApprovalGate {
                     // (regression fix: 0e5f1b12 — is_blocked was rejecting Never tools)
                     GateDecision::Allow
                 }
-                ApprovalRequirement::Always => {
-                    if is_auto_approved {
-                        GateDecision::Allow
-                    } else {
-                        GateDecision::Deny {
-                            reason: format!(
-                                "Tool '{}' requires explicit approval and cannot run autonomously.",
-                                ctx.action_name
-                            ),
-                        }
-                    }
-                }
+                ApprovalRequirement::Always => GateDecision::Deny {
+                    reason: format!(
+                        "Tool '{}' requires explicit approval and cannot run autonomously.",
+                        ctx.action_name
+                    ),
+                },
             },
             ExecutionMode::Container => GateDecision::Allow,
         }
@@ -327,10 +309,48 @@ impl ExecutionGate for RelayChannelGate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::JobContext;
+    use crate::tools::{Tool, ToolError, ToolOutput};
     use ironclaw_engine::gate::ExecutionMode;
     use ironclaw_engine::types::capability::{ActionDef, EffectType, ModelToolSurface};
     use ironclaw_engine::types::thread::ThreadId;
     use std::collections::HashSet;
+    use std::time::Duration;
+
+    struct ApprovalTestTool {
+        name: &'static str,
+        requirement: ApprovalRequirement,
+    }
+
+    #[async_trait]
+    impl Tool for ApprovalTestTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn description(&self) -> &str {
+            "approval test tool"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolOutput::success(
+                serde_json::json!({ "ok": true }),
+                Duration::from_millis(1),
+            ))
+        }
+
+        fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+            self.requirement
+        }
+    }
 
     fn action_def(name: &str, requires_approval: bool) -> ActionDef {
         ActionDef {
@@ -364,6 +384,17 @@ mod tests {
         }
     }
 
+    async fn approval_gate_with_tool(
+        name: &'static str,
+        requirement: ApprovalRequirement,
+    ) -> ApprovalGate {
+        let registry = Arc::new(ToolRegistry::new());
+        registry
+            .register(Arc::new(ApprovalTestTool { name, requirement }))
+            .await;
+        ApprovalGate::new(registry)
+    }
+
     // ── InteractiveAutoApprove mode ─────────────────────────
 
     #[tokio::test]
@@ -384,6 +415,73 @@ mod tests {
         );
         // RelayChannelGate doesn't care about mode — it only checks channel suffix
         assert!(matches!(gate.evaluate(&c).await, GateDecision::Allow)); // safety: test-only
+    }
+
+    #[tokio::test]
+    async fn approval_gate_auto_approved_unless_allows() {
+        let gate =
+            approval_gate_with_tool("test_tool", ApprovalRequirement::UnlessAutoApproved).await;
+        let ad = action_def("test_tool", true);
+        let auto = HashSet::from(["test_tool".to_string()]);
+        let params = serde_json::json!({});
+        let c = ctx(&ad, ExecutionMode::Interactive, "web", &auto, &params);
+
+        assert!(matches!(gate.evaluate(&c).await, GateDecision::Allow));
+    }
+
+    #[tokio::test]
+    async fn approval_gate_auto_approved_always_pauses_interactive() {
+        let gate = approval_gate_with_tool("test_tool", ApprovalRequirement::Always).await;
+        let ad = action_def("test_tool", true);
+        let auto = HashSet::from(["test_tool".to_string()]);
+        let params = serde_json::json!({});
+        let c = ctx(&ad, ExecutionMode::Interactive, "web", &auto, &params);
+
+        assert!(matches!(
+            gate.evaluate(&c).await,
+            GateDecision::Pause {
+                resume_kind: ResumeKind::Approval {
+                    allow_always: false
+                },
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn approval_gate_auto_approved_always_pauses_interactive_auto_approve() {
+        let gate = approval_gate_with_tool("test_tool", ApprovalRequirement::Always).await;
+        let ad = action_def("test_tool", true);
+        let auto = HashSet::from(["test_tool".to_string()]);
+        let params = serde_json::json!({});
+        let c = ctx(
+            &ad,
+            ExecutionMode::InteractiveAutoApprove,
+            "web",
+            &auto,
+            &params,
+        );
+
+        assert!(matches!(
+            gate.evaluate(&c).await,
+            GateDecision::Pause {
+                resume_kind: ResumeKind::Approval {
+                    allow_always: false
+                },
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn approval_gate_auto_approved_always_denies_autonomous() {
+        let gate = approval_gate_with_tool("test_tool", ApprovalRequirement::Always).await;
+        let ad = action_def("test_tool", true);
+        let auto = HashSet::from(["test_tool".to_string()]);
+        let params = serde_json::json!({});
+        let c = ctx(&ad, ExecutionMode::Autonomous, "web", &auto, &params);
+
+        assert!(matches!(gate.evaluate(&c).await, GateDecision::Deny { .. }));
     }
 
     // ── RelayChannelGate ─────────────────────────────────────

--- a/src/gate/approval.rs
+++ b/src/gate/approval.rs
@@ -51,7 +51,7 @@ impl ExecutionGate for ApprovalGate {
             Some((_, t)) => t,
             None => return GateDecision::Allow, // unknown tool — let execution handle it
         };
-
+        let is_auto_approved = ctx.auto_approved.contains(ctx.action_name);
         // Use original parameters for approval check (the adapter normalizes
         // params before execution, but the approval check should use the
         // parameters the LLM provided so destructive detection works).
@@ -61,7 +61,7 @@ impl ExecutionGate for ApprovalGate {
             ExecutionMode::Interactive => match requirement {
                 ApprovalRequirement::Never => GateDecision::Allow,
                 ApprovalRequirement::UnlessAutoApproved => {
-                    if ctx.auto_approved.contains(ctx.action_name) {
+                    if is_auto_approved {
                         GateDecision::Allow
                     } else {
                         // Check credential-backed HTTP auto-approve
@@ -81,17 +81,21 @@ impl ExecutionGate for ApprovalGate {
                         }
                     }
                 }
-                ApprovalRequirement::Always => GateDecision::Pause {
-                    reason: format!(
-                        "Tool '{}' requires explicit approval for this operation.",
-                        ctx.action_name
-                    ),
-                    // Always-gated tools should NOT offer "always" button
-                    // (regression fix: 09e1c97a)
-                    resume_kind: ResumeKind::Approval {
-                        allow_always: false,
-                    },
-                },
+                ApprovalRequirement::Always => {
+                    if is_auto_approved {
+                        GateDecision::Allow
+                    } else {
+                        GateDecision::Pause {
+                            reason: format!(
+                                "Tool '{}' requires explicit approval for this operation.",
+                                ctx.action_name
+                            ),
+                            resume_kind: ResumeKind::Approval {
+                                allow_always: false,
+                            },
+                        }
+                    }
+                }
             },
             ExecutionMode::InteractiveAutoApprove => match requirement {
                 ApprovalRequirement::Never | ApprovalRequirement::UnlessAutoApproved => {
@@ -101,16 +105,18 @@ impl ExecutionGate for ApprovalGate {
                     GateDecision::Allow
                 }
                 ApprovalRequirement::Always => {
-                    // Always-gated tools still require explicit approval even
-                    // in auto-approve mode — these are truly destructive operations.
-                    GateDecision::Pause {
-                        reason: format!(
-                            "Tool '{}' requires explicit approval (auto-approve does not cover this operation).",
-                            ctx.action_name
-                        ),
-                        resume_kind: ResumeKind::Approval {
-                            allow_always: false,
-                        },
+                    if is_auto_approved {
+                        GateDecision::Allow
+                    } else {
+                        GateDecision::Pause {
+                            reason: format!(
+                                "Tool '{}' requires explicit approval (auto-approve does not cover this operation).",
+                                ctx.action_name
+                            ),
+                            resume_kind: ResumeKind::Approval {
+                                allow_always: false,
+                            },
+                        }
                     }
                 }
             },
@@ -121,12 +127,15 @@ impl ExecutionGate for ApprovalGate {
                     GateDecision::Allow
                 }
                 ApprovalRequirement::Always => {
-                    // Always-gated tools cannot run autonomously
-                    GateDecision::Deny {
-                        reason: format!(
-                            "Tool '{}' requires explicit approval and cannot run autonomously.",
-                            ctx.action_name
-                        ),
+                    if is_auto_approved {
+                        GateDecision::Allow
+                    } else {
+                        GateDecision::Deny {
+                            reason: format!(
+                                "Tool '{}' requires explicit approval and cannot run autonomously.",
+                                ctx.action_name
+                            ),
+                        }
                     }
                 }
             },

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -258,7 +258,7 @@ pub struct Settings {
     /// Per-tool permission overrides.
     ///
     /// Keys are tool names; persisted values are authoritative. Absent tools
-    /// fall back to `AskEachTime`.
+    /// fall back to seeded defaults for well-known tools, then `AskEachTime`.
     #[serde(default)]
     pub tool_permissions:
         std::collections::HashMap<String, crate::tools::permissions::PermissionState>,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -257,9 +257,8 @@ pub struct Settings {
 
     /// Per-tool permission overrides.
     ///
-    /// Keys are tool names; values override the built-in tier defaults from
-    /// `TOOL_RISK_DEFAULTS`.  Absent tools fall back to the tier default, or
-    /// `AskEachTime` if the tool is unknown.
+    /// Keys are tool names; persisted values are authoritative. Absent tools
+    /// fall back to `AskEachTime`.
     #[serde(default)]
     pub tool_permissions:
         std::collections::HashMap<String, crate::tools::permissions::PermissionState>,

--- a/src/tools/builtin/extension_tools.rs
+++ b/src/tools/builtin/extension_tools.rs
@@ -114,7 +114,7 @@ impl Tool for ToolSearchTool {
         "Search for available extensions to add new capabilities. Extensions include \
          channels (Telegram, Slack, Discord — connect messaging platforms so IronClaw can \
          receive and reply there), tools, and MCP servers. Use `tool_install` for explicit \
-         installation, then use `tool_activate` with name=\"...\" to make a discovered \
+         installation, then call `tool_activate(name=\"...\")` to make a discovered \
          integration usable. Use the `message` tool for \
          proactive outbound sends. Use discover:true to search online if the built-in registry \
          has no results."

--- a/src/tools/builtin/extension_tools.rs
+++ b/src/tools/builtin/extension_tools.rs
@@ -14,7 +14,10 @@ use async_trait::async_trait;
 
 use crate::context::JobContext;
 use crate::extensions::{EnsureReadyIntent, EnsureReadyOutcome, ExtensionKind, ExtensionManager};
-use crate::tools::permissions::{TOOL_RISK_DEFAULTS, effective_permission};
+use crate::tools::permissions::{
+    PermissionState, TOOL_PERMISSION_LOCKED_REASON, effective_permission,
+    seeded_default_permission, tool_permission_locked,
+};
 use crate::tools::registry::ToolRegistry;
 use crate::tools::tool::{
     ApprovalRequirement, EngineCompatibility, Tool, ToolError, ToolOutput, require_str,
@@ -110,8 +113,9 @@ impl Tool for ToolSearchTool {
     fn description(&self) -> &str {
         "Search for available extensions to add new capabilities. Extensions include \
          channels (Telegram, Slack, Discord — connect messaging platforms so IronClaw can \
-         receive and reply there), tools, and MCP servers. When you want to make a discovered \
-         integration usable, call `tool_activate(name=\"...\")`. Use the `message` tool for \
+         receive and reply there), tools, and MCP servers. Use `tool_install` for explicit \
+         installation, then use `tool_activate` with name=\"...\" to make a discovered \
+         integration usable. Use the `message` tool for \
          proactive outbound sends. Use discover:true to search online if the built-in registry \
          has no results."
     }
@@ -488,27 +492,22 @@ impl Tool for ToolListTool {
         if want_builtin && let Some(ref registry) = self.registry {
             let builtin_names = registry.builtin_tool_names().await;
             let tools = registry.all().await;
-            let empty_params = serde_json::json!({});
             let builtin_list: Vec<serde_json::Value> = tools
                 .iter()
                 .filter(|tool| builtin_names.contains(tool.name()))
                 .map(|tool| {
                     let name = tool.name().to_string();
                     let perm_state = effective_permission(&name, &perm_overrides);
-                    let default_state = TOOL_RISK_DEFAULTS
-                        .get(name.as_str())
-                        .copied()
-                        .unwrap_or(crate::tools::permissions::PermissionState::AskEachTime);
-                    let locked = matches!(
-                        tool.requires_approval(&empty_params),
-                        ApprovalRequirement::Always
-                    );
+                    let default_state =
+                        seeded_default_permission(&name).unwrap_or(PermissionState::AskEachTime);
+                    let locked = tool_permission_locked(tool.as_ref());
                     serde_json::json!({
                         "name": name,
                         "description": tool.description(),
                         "permission_state": perm_state,
                         "default_state": default_state,
                         "locked": locked,
+                        "locked_reason": locked.then_some(TOOL_PERMISSION_LOCKED_REASON),
                     })
                 })
                 .collect();
@@ -793,6 +792,7 @@ impl Tool for ToolPermissionSetTool {
             self.registry.get(tool_name).await.ok_or_else(|| {
                 ToolError::InvalidParameters(format!("Unknown tool: '{tool_name}'"))
             })?;
+        let locked = tool_permission_locked(target_tool.as_ref());
 
         // Load current settings for the user.
         let settings = if let Some(ref store) = self.settings_store {
@@ -814,18 +814,14 @@ impl Tool for ToolPermissionSetTool {
         // Read-only mode when no state param; reject non-string state values.
         let state_str = match params.get("state") {
             None => {
-                let default_state = TOOL_RISK_DEFAULTS
-                    .get(tool_name)
-                    .copied()
-                    .unwrap_or(crate::tools::permissions::PermissionState::AskEachTime);
+                let default_state =
+                    seeded_default_permission(tool_name).unwrap_or(PermissionState::AskEachTime);
                 let output = serde_json::json!({
                     "tool_name": tool_name,
                     "current_state": prev_state,
                     "default_state": default_state,
-                    "locked": matches!(
-                        target_tool.requires_approval(&serde_json::json!({})),
-                        ApprovalRequirement::Always
-                    ),
+                    "locked": locked,
+                    "locked_reason": locked.then_some(TOOL_PERMISSION_LOCKED_REASON),
                 });
                 return Ok(ToolOutput::success(output, start.elapsed()));
             }
@@ -837,29 +833,22 @@ impl Tool for ToolPermissionSetTool {
             })?,
         };
 
-        // Check that the target tool doesn't always require approval (locked tools
-        // cannot have their permission lowered — they will always prompt).
-        let empty_params = serde_json::json!({});
-        if matches!(
-            target_tool.requires_approval(&empty_params),
-            ApprovalRequirement::Always
-        ) {
-            return Err(ToolError::InvalidParameters(format!(
-                "'{tool_name}' always requires approval and its permission cannot be changed"
-            )));
-        }
-
         // Parse the requested new state.
         let new_state = match state_str {
-            "always_allow" => crate::tools::permissions::PermissionState::AlwaysAllow,
-            "ask_each_time" => crate::tools::permissions::PermissionState::AskEachTime,
-            "disabled" => crate::tools::permissions::PermissionState::Disabled,
+            "always_allow" => PermissionState::AlwaysAllow,
+            "ask_each_time" => PermissionState::AskEachTime,
+            "disabled" => PermissionState::Disabled,
             other => {
                 return Err(ToolError::InvalidParameters(format!(
                     "Invalid state '{other}'; expected always_allow, ask_each_time, or disabled"
                 )));
             }
         };
+        if locked && matches!(new_state, PermissionState::AlwaysAllow) {
+            return Err(ToolError::InvalidParameters(format!(
+                "'{tool_name}' always requires approval and cannot be set to always_allow"
+            )));
+        }
 
         // Persist the updated permission.
         if let Some(ref store) = self.settings_store {
@@ -1212,8 +1201,37 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "libsql")]
     #[tokio::test]
-    async fn test_tool_permission_set_locked_tool_rejected() {
+    async fn test_tool_permission_set_rejects_intrinsic_approval_override() {
+        use crate::context::JobContext;
+        use crate::db::SettingsStore;
+        use crate::tools::ToolRegistry;
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(Arc::new(LockedTool)).await;
+        let (db, _tmp) = crate::testing::test_db().await;
+        let store: Arc<dyn SettingsStore + Send + Sync> = db;
+
+        let tool = ToolPermissionSetTool::new(Arc::clone(&registry), Some(store));
+        let ctx = JobContext::default();
+
+        let result = tool
+            .execute(
+                serde_json::json!({"tool_name": "locked_tool", "state": "always_allow"}),
+                &ctx,
+            )
+            .await
+            .expect_err("locked tool should reject always_allow");
+
+        assert!(
+            matches!(result, ToolError::InvalidParameters(_)),
+            "expected InvalidParameters for locked always_allow, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_permission_set_reports_locked_metadata() {
         use crate::context::JobContext;
         use crate::tools::ToolRegistry;
 
@@ -1223,21 +1241,41 @@ mod tests {
         let tool = ToolPermissionSetTool::new(Arc::clone(&registry), None);
         let ctx = JobContext::default();
 
-        // Trying to change the permission state of a locked tool must fail.
+        let result = tool
+            .execute(serde_json::json!({"tool_name": "locked_tool"}), &ctx)
+            .await
+            .expect("read-only permission lookup should succeed without store");
+
+        assert_eq!(result.result["tool_name"], "locked_tool");
+        assert_eq!(result.result["locked"], true);
+        assert!(
+            result.result["locked_reason"].is_string(),
+            "locked read path should include locked_reason"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_permission_set_without_store_returns_error() {
+        use crate::context::JobContext;
+        use crate::tools::ToolRegistry;
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(Arc::new(NormalTool)).await;
+
+        let tool = ToolPermissionSetTool::new(Arc::clone(&registry), None);
+        let ctx = JobContext::default();
+
         let result = tool
             .execute(
-                serde_json::json!({"tool_name": "locked_tool", "state": "always_allow"}),
+                serde_json::json!({"tool_name": "normal_tool", "state": "always_allow"}),
                 &ctx,
             )
             .await;
-        assert!(
-            result.is_err(),
-            "locked tool permission change must be rejected"
-        );
+        assert!(result.is_err(), "missing settings store should be rejected");
         let err = result.unwrap_err();
         assert!(
-            matches!(err, ToolError::InvalidParameters(_)),
-            "expected InvalidParameters for locked tool, got {err:?}"
+            matches!(err, ToolError::ExecutionFailed(_)),
+            "expected ExecutionFailed for missing store, got {err:?}"
         );
     }
 
@@ -1262,6 +1300,7 @@ mod tests {
         let registry = Arc::new(ToolRegistry::new());
         // Use register_sync (built-in path) so the tool appears in builtin_tool_names().
         registry.register_sync(Arc::new(NormalTool));
+        registry.register_sync(Arc::new(LockedTool));
 
         let manager = test_manager_stub();
         let list_tool = ToolListTool::new(manager).with_registry(Arc::clone(&registry));
@@ -1287,6 +1326,10 @@ mod tests {
             names.contains(&"normal_tool"),
             "registered normal_tool should appear in builtins listing"
         );
+        assert!(
+            names.contains(&"locked_tool"),
+            "registered locked_tool should appear in builtins listing"
+        );
         // Each entry must have required fields.
         for entry in builtins {
             assert!(entry.get("name").is_some(), "missing name field");
@@ -1304,6 +1347,20 @@ mod tests {
             );
             assert!(entry.get("locked").is_some(), "missing locked field");
         }
+        let locked_entry = builtins
+            .iter()
+            .find(|entry| entry["name"] == "locked_tool")
+            .expect("locked_tool entry should be present");
+        assert_eq!(locked_entry["locked"], true);
+        assert!(
+            locked_entry["locked_reason"].is_string(),
+            "locked builtin entry should include locked_reason"
+        );
+        let normal_entry = builtins
+            .iter()
+            .find(|entry| entry["name"] == "normal_tool")
+            .expect("normal_tool entry should be present");
+        assert_eq!(normal_entry["locked"], false);
         // Extensions should not be present for kind=builtin.
         assert!(
             result.result.get("extensions").is_none(),

--- a/src/tools/permissions.rs
+++ b/src/tools/permissions.rs
@@ -1,14 +1,20 @@
 //! Per-user tool permission system.
 //!
 //! Each tool has a `PermissionState` that controls whether it runs without
-//! confirmation, asks the user each time, or is fully disabled.  A static
-//! table of tier defaults (`TOOL_RISK_DEFAULTS`) is used as the fallback when
-//! no per-user override exists.
+//! confirmation, asks the user each time, or is fully disabled. Persisted
+//! settings are the source of truth; absent entries fall back to the seeded
+//! baseline for well-known tools, then to asking for unknown tools.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::LazyLock;
 
 use serde::{Deserialize, Serialize};
+
+use super::tool::{ApprovalRequirement, Tool};
+
+/// User-visible reason shown when a tool's permission cannot be set to
+/// `always_allow`.
+pub const TOOL_PERMISSION_LOCKED_REASON: &str =
+    "This tool always requires explicit approval and cannot be set to always_allow.";
 
 /// How a tool may be invoked by the agent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,74 +28,62 @@ pub enum PermissionState {
     Disabled,
 }
 
-/// Static map of built-in tool names → their default `PermissionState`.
+/// Seed-time baseline for well-known built-in tool permissions.
 ///
-/// Tools present here default to `AlwaysAllow` (read-only / low-risk) or
-/// `AskEachTime` (write / destructive / network).  Tools **absent** from the
-/// map fall back to `AskEachTime` in `effective_permission`.
-pub static TOOL_RISK_DEFAULTS: LazyLock<HashMap<&'static str, PermissionState>> =
-    LazyLock::new(|| {
-        let mut m = HashMap::new();
+/// This is used when initializing DB rows and when displaying the baseline
+/// default in settings. Runtime resolution also uses this baseline when a
+/// persisted row is missing, so non-owner users and pre-seed accounts see the
+/// same permission behavior as seeded users.
+pub fn seeded_default_permission(tool_name: &str) -> Option<PermissionState> {
+    match tool_name.replace('-', "_").as_str() {
+        "echo" | "time" | "json" | "memory_search" | "memory_read" | "memory_write"
+        | "memory_tree" | "tool_list" | "tool_info" | "tool_search" | "tool_activate"
+        | "skill_list" | "skill_search" | "list_jobs" | "job_status" | "job_events"
+        | "image_analyze" | "message" => Some(PermissionState::AlwaysAllow),
+        "shell"
+        | "read_file"
+        | "write_file"
+        | "list_dir"
+        | "apply_patch"
+        | "http"
+        | "create_job"
+        | "event_emit"
+        | "routine_create"
+        | "routine_update"
+        | "cancel_job"
+        | "job_prompt"
+        | "routine_delete"
+        | "routine_fire"
+        | "tool_install"
+        | "tool_auth"
+        | "tool_remove"
+        | "tool_upgrade"
+        | "skill_install"
+        | "skill_remove"
+        | "secret_list"
+        | "secret_delete"
+        | "image_generate"
+        | "image_edit"
+        | "restart"
+        | "build_software"
+        | "tool_permission_set" => Some(PermissionState::AskEachTime),
+        _ => None,
+    }
+}
 
-        // --- AlwaysAllow: informational, low-risk, or safe writes ---
-        for name in &[
-            "echo",
-            "time",
-            "json",
-            "memory_search",
-            "memory_read",
-            "memory_write",
-            "memory_tree",
-            "tool_list",
-            "tool_info",
-            "tool_search",
-            "skill_list",
-            "skill_search",
-            "list_jobs",
-            "job_status",
-            "job_events",
-            "image_analyze",
-            "message",
-        ] {
-            m.insert(*name, PermissionState::AlwaysAllow);
-        }
-
-        // --- AskEachTime: write, destructive, code-execution, or network ---
-        for name in &[
-            "shell",
-            "read_file",
-            "write_file",
-            "list_dir",
-            "apply_patch",
-            "http",
-            "create_job",
-            "event_emit",
-            "routine_create",
-            "routine_update",
-            "cancel_job",
-            "job_prompt",
-            "routine_delete",
-            "routine_fire",
-            "tool_install",
-            "tool_auth",
-            "tool_activate",
-            "tool_remove",
-            "tool_upgrade",
-            "skill_install",
-            "skill_remove",
-            "secret_list",
-            "secret_delete",
-            "image_generate",
-            "image_edit",
-            "restart",
-            "build_software",
-            "tool_permission_set",
-        ] {
-            m.insert(*name, PermissionState::AskEachTime);
-        }
-
-        m
-    });
+/// Returns true when a tool is intrinsically always-gated.
+///
+/// Parameter-sensitive tools such as `shell`, `memory_write`, and
+/// `skill_install` may return `Always` for specific invocations, but remain
+/// configurable at the whole-tool permission level. The empty-parameter check
+/// is the existing runtime signal for tools that always require explicit
+/// approval.
+pub fn tool_permission_locked(tool: &dyn Tool) -> bool {
+    matches!(
+        tool.requires_approval(&serde_json::Value::Object(serde_json::Map::new())),
+        ApprovalRequirement::Always
+    )
+}
 
 // ---------------------------------------------------------------------------
 // Admin tool policy
@@ -263,20 +257,18 @@ pub fn parse_admin_tool_policy(
 /// Return the effective `PermissionState` for `tool_name`.
 ///
 /// Lookup order:
-/// 1. Per-user `overrides` map (highest priority).
-/// 2. `TOOL_RISK_DEFAULTS` static table.
-/// 3. `AskEachTime` as the safe fallback for any unknown tool.
+/// 1. Persisted tool permission map.
+/// 2. Seeded baseline for well-known tools.
+/// 3. `AskEachTime` as the safe fallback for unknown tools.
 pub fn effective_permission(
     tool_name: &str,
     overrides: &HashMap<String, PermissionState>,
 ) -> PermissionState {
-    if let Some(state) = overrides.get(tool_name) {
-        return *state;
-    }
-    if let Some(state) = TOOL_RISK_DEFAULTS.get(tool_name) {
-        return *state;
-    }
-    PermissionState::AskEachTime
+    overrides
+        .get(tool_name)
+        .copied()
+        .or_else(|| seeded_default_permission(tool_name))
+        .unwrap_or(PermissionState::AskEachTime)
 }
 
 // ---------------------------------------------------------------------------
@@ -378,26 +370,24 @@ mod tests {
         assert_eq!(
             effective_permission("shell", &overrides),
             PermissionState::AlwaysAllow,
-            "user override should take precedence over tier default"
+            "persisted user value should take precedence"
         );
     }
 
     #[test]
-    fn test_effective_permission_tier_default_fallback() {
+    fn test_effective_permission_missing_tool_uses_seeded_default() {
         let overrides = HashMap::new();
 
-        // "echo" has AlwaysAllow in the defaults table.
         assert_eq!(
             effective_permission("echo", &overrides),
             PermissionState::AlwaysAllow,
-            "tier default should be returned when no user override exists"
+            "missing persisted permission should use the seeded default for echo"
         );
 
-        // "shell" has AskEachTime in the defaults table.
         assert_eq!(
             effective_permission("shell", &overrides),
             PermissionState::AskEachTime,
-            "tier default should be returned when no user override exists"
+            "missing persisted permission should use the seeded default for shell"
         );
     }
 

--- a/src/tools/permissions.rs
+++ b/src/tools/permissions.rs
@@ -35,7 +35,12 @@ pub enum PermissionState {
 /// persisted row is missing, so non-owner users and pre-seed accounts see the
 /// same permission behavior as seeded users.
 pub fn seeded_default_permission(tool_name: &str) -> Option<PermissionState> {
-    match tool_name.replace('-', "_").as_str() {
+    let canonical = tool_name.replace('-', "_");
+    seeded_default_permission_canonical(&canonical)
+}
+
+fn seeded_default_permission_canonical(canonical_tool_name: &str) -> Option<PermissionState> {
+    match canonical_tool_name {
         "echo" | "time" | "json" | "memory_search" | "memory_read" | "memory_write"
         | "memory_tree" | "tool_list" | "tool_info" | "tool_search" | "tool_activate"
         | "skill_list" | "skill_search" | "http" | "list_jobs" | "job_status" | "job_events"
@@ -271,7 +276,7 @@ pub fn effective_permission(
         .copied()
         .or_else(|| overrides.get(&canonical).copied())
         .or_else(|| overrides.get(&hyphenated).copied())
-        .or_else(|| seeded_default_permission(&canonical))
+        .or_else(|| seeded_default_permission_canonical(&canonical))
         .unwrap_or(PermissionState::AskEachTime)
 }
 

--- a/src/tools/permissions.rs
+++ b/src/tools/permissions.rs
@@ -38,14 +38,13 @@ pub fn seeded_default_permission(tool_name: &str) -> Option<PermissionState> {
     match tool_name.replace('-', "_").as_str() {
         "echo" | "time" | "json" | "memory_search" | "memory_read" | "memory_write"
         | "memory_tree" | "tool_list" | "tool_info" | "tool_search" | "tool_activate"
-        | "skill_list" | "skill_search" | "list_jobs" | "job_status" | "job_events"
+        | "skill_list" | "skill_search" | "http" | "list_jobs" | "job_status" | "job_events"
         | "image_analyze" | "message" => Some(PermissionState::AlwaysAllow),
         "shell"
         | "read_file"
         | "write_file"
         | "list_dir"
         | "apply_patch"
-        | "http"
         | "create_job"
         | "event_emit"
         | "routine_create"
@@ -388,6 +387,24 @@ mod tests {
             effective_permission("shell", &overrides),
             PermissionState::AskEachTime,
             "missing persisted permission should use the seeded default for shell"
+        );
+
+        assert_eq!(
+            effective_permission("http", &overrides),
+            PermissionState::AlwaysAllow,
+            "missing persisted permission should use the seeded default for http"
+        );
+    }
+
+    #[test]
+    fn test_effective_permission_saved_http_override_wins() {
+        let mut overrides = HashMap::new();
+        overrides.insert("http".to_string(), PermissionState::AskEachTime);
+
+        assert_eq!(
+            effective_permission("http", &overrides),
+            PermissionState::AskEachTime,
+            "saved http permission should take precedence over the seeded default"
         );
     }
 

--- a/src/tools/permissions.rs
+++ b/src/tools/permissions.rs
@@ -263,10 +263,15 @@ pub fn effective_permission(
     tool_name: &str,
     overrides: &HashMap<String, PermissionState>,
 ) -> PermissionState {
+    let canonical = tool_name.replace('-', "_");
+    let hyphenated = canonical.replace('_', "-");
+
     overrides
         .get(tool_name)
         .copied()
-        .or_else(|| seeded_default_permission(tool_name))
+        .or_else(|| overrides.get(&canonical).copied())
+        .or_else(|| overrides.get(&hyphenated).copied())
+        .or_else(|| seeded_default_permission(&canonical))
         .unwrap_or(PermissionState::AskEachTime)
 }
 
@@ -405,6 +410,27 @@ mod tests {
             effective_permission("http", &overrides),
             PermissionState::AskEachTime,
             "saved http permission should take precedence over the seeded default"
+        );
+    }
+
+    #[test]
+    fn test_effective_permission_checks_tool_name_aliases() {
+        let mut overrides = HashMap::new();
+        overrides.insert("tool-activate".to_string(), PermissionState::Disabled);
+
+        assert_eq!(
+            effective_permission("tool_activate", &overrides),
+            PermissionState::Disabled,
+            "hyphenated saved override should apply to underscore runtime lookup"
+        );
+
+        overrides.clear();
+        overrides.insert("tool_activate".to_string(), PermissionState::AskEachTime);
+
+        assert_eq!(
+            effective_permission("tool-activate", &overrides),
+            PermissionState::AskEachTime,
+            "underscore saved override should apply to hyphenated runtime lookup"
         );
     }
 


### PR DESCRIPTION
## Summary

This PR simplifies tool permission resolution so there is one central policy path instead of two competing sources of approval behavior.

Changes included:
- Removes the separate `TOOL_RISK_DEFAULTS` map as an independent permission authority.
- Makes seeded DB/default permission state the central fallback when there is no persisted user override.
- Keeps persisted tool permission rows as the highest-precedence user setting.
- Applies the same permission resolution model to engine-v2 execution and tool/settings surfaces.
- Preserves parameter-sensitive `ApprovalRequirement::Always` checks as a hard per-call approval floor.
- Keeps `tool_activate` install approval as a separate subgate before auto-installing latent integrations.
- Adds shared locked-tool metadata for tools whose empty-param approval requirement is intrinsically `Always`.
- Rejects impossible `always_allow` writes only for intrinsically locked tools, while leaving parameter-sensitive tools such as `shell` configurable for normal use.
- Returns seeded `default_state` separately from saved `current_state` in settings/tool permission responses.

## Rationale

The old model had multiple internal permission authorities:

1. user persisted overrides,
2. `TOOL_RISK_DEFAULTS`,
3. per-tool intrinsic behavior through `requires_approval`.

That made behavior hard to reason about, especially for engine-v2 restart/auth-gate flows where a tool could appear auto-approved in one layer but still be gated by another. The intended model is now:

`user override > central seeded/default permission policy > fallback AskEachTime`

`requires_approval(params)` is still used, but only for runtime risk classification and per-call hard floors. That matters for parameter-sensitive cases such as destructive shell commands, protected memory writes, and install/auth side effects. It is no longer a second source of static tool defaults.

For `tool_activate`, the normal activation permission can now be default-allowed while the meaningful side effects still gate separately:
- latent integration install still requires explicit approval,
- OAuth/auth/setup still routes through the auth gate,
- already-installed activation does not need a redundant generic `tool_activate` approval prompt.

Existing databases that already have a persisted `tool_permissions.tool_activate = ask_each_time` row are intentionally left as-is. Persisted rows are treated as user settings and continue to take precedence. Users who want the new default behavior can update the setting manually.

## Testing

Passed:
- `cargo test --features libsql permission`
- `cargo test bridge::effect_adapter::tests:: --features libsql -- --nocapture`
- `cargo test --test e2e_auth_gate_traces --features libsql auth_gate_trace_tests:: -- --nocapture`
  - `auth_cancelled_stops_thread`
  - `auth_credential_provided_resumes_action`
  - `auth_external_callback_resolves_oauth_gate`
  - `auth_gate_emits_request_id_for_v2`
  - `auth_retry_after_invalid_credential`
- Full browser E2E retry covered `tests/e2e/scenarios/test_tool_permissions.py`; permission-specific cases passed, including locked-tool UI and locked-tool `400` behavior.
- `git diff --check`

Notes:
- Full browser E2E was retried and still showed broader flaky failures in unrelated auth/SSE/v2 browser flows. The permission-specific E2E coverage passed in both runs, and no E2E files were changed.
