### PR TITLE
feat(telegram): add allowed_chat_ids for group-level access control

### DIFF
--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -286,6 +286,24 @@ const RESPOND_TO_ALL_GROUP_PATH: &str = "state/respond_to_all_group_messages";
 /// Workspace path for persisting allowed_chat_ids (JSON array of i64).
 const ALLOWED_CHAT_IDS_PATH: &str = "state/allowed_chat_ids";
 
+/// Result of checking whether a group chat is allowed.
+/// Returns `Some(true)` if the group is explicitly in the allowlist,
+/// `Some(false)` if explicitly rejected, or `None` if no filter is configured
+/// (all groups allowed).
+fn check_group_allowed(chat_id: i64, allowed_ids: &[i64]) -> Option<bool> {
+    if allowed_ids.is_empty() {
+        return None; // No filter configured — allow all groups
+    }
+    Some(allowed_ids.contains(&chat_id))
+}
+
+/// Parse allowed_chat_ids from raw workspace JSON.
+/// Returns None if no data or invalid JSON (no filter configured).
+/// Returns Some(Vec) — empty vec means "allow all", non-empty means filter.
+fn parse_allowed_chat_ids(json: &str) -> Option<Vec<i64>> {
+    serde_json::from_str::<Vec<i64>>(json).ok()
+}
+
 // ============================================================================
 // Channel Metadata
 // ============================================================================
@@ -2204,22 +2222,21 @@ fn handle_message(message: TelegramMessage) {
     // messages from those groups. DMs are always allowed.
     // When a group IS allowed, also bypass dm_policy — so you can have
     // pairing DMs but still let anyone @mention the bot in allowed groups.
-    let is_allowed_group = false;
+    let mut is_allowed_group = false;
     if !is_private {
-        if let Ok(allowed_json) = channel_host::workspace_read(ALLOWED_CHAT_IDS_PATH) {
-            if !allowed_json.is_empty() && allowed_json != "[]" {
-                if let Ok(allowed_ids) = serde_json::from_str::<Vec<i64>>(&allowed_json) {
-                    if !allowed_ids.is_empty() {
-                        if !allowed_ids.contains(&message.chat.id) {
-                            channel_host::log(
-                                channel_host::LogLevel::Debug,
-                                &format!("Dropping message from disallowed group {}", message.chat.id),
-                            );
-                            return;
-                        }
-                        is_allowed_group = true;
-                    }
+        if let Some(allowed_ids) = channel_host::workspace_read(ALLOWED_CHAT_IDS_PATH)
+            .and_then(|json| parse_allowed_chat_ids(&json))
+        {
+            match check_group_allowed(message.chat.id, &allowed_ids) {
+                Some(false) => {
+                    channel_host::log(
+                        channel_host::LogLevel::Debug,
+                        &format!("Dropping message from disallowed group {}", message.chat.id),
+                    );
+                    return;
                 }
+                Some(true) => is_allowed_group = true,
+                None => {} // No filter — allow all groups
             }
         }
     }
@@ -3431,5 +3448,68 @@ mod tests {
                 half_limit,
             );
         }
+    }
+
+    // =========================================================================
+    // allowed_chat_ids group filter tests
+    // =========================================================================
+
+    #[test]
+    fn test_check_group_allowed_no_filter() {
+        // Empty list = no filter configured → None (allow all)
+        assert_eq!(check_group_allowed(-5263819573, &[]), None);
+    }
+
+    #[test]
+    fn test_check_group_allowed_explicit_match() {
+        let ids = vec![-5263819573, -1001234567];
+        assert_eq!(check_group_allowed(-5263819573, &ids), Some(true));
+        assert_eq!(check_group_allowed(-1001234567, &ids), Some(true));
+    }
+
+    #[test]
+    fn test_check_group_allowed_explicit_reject() {
+        let ids = vec![-5263819573];
+        assert_eq!(check_group_allowed(-9999999999, &ids), Some(false));
+    }
+
+    #[test]
+    fn test_parse_allowed_chat_ids_valid() {
+        assert_eq!(parse_allowed_chat_ids("[-5263819573]"), Some(vec![-5263819573]));
+        assert_eq!(parse_allowed_chat_ids("[-1, -2, -3]"), Some(vec![-1, -2, -3]));
+    }
+
+    #[test]
+    fn test_parse_allowed_chat_ids_empty_array() {
+        assert_eq!(parse_allowed_chat_ids("[]"), Some(vec![]));
+    }
+
+    #[test]
+    fn test_parse_allowed_chat_ids_whitespace() {
+        // Whitespace in JSON should still parse correctly
+        assert_eq!(parse_allowed_chat_ids(" [ -5263819573 ] "), Some(vec![-5263819573]));
+    }
+
+    #[test]
+    fn test_parse_allowed_chat_ids_invalid_json() {
+        assert_eq!(parse_allowed_chat_ids("not json"), None);
+        assert_eq!(parse_allowed_chat_ids(""), None);
+    }
+
+    #[test]
+    fn test_parse_allowed_chat_ids_wrong_types() {
+        // String values instead of numbers → parse fails
+        assert_eq!(parse_allowed_chat_ids("[\"abc\"]"), None);
+    }
+
+    #[test]
+    fn test_check_group_allowed_with_dm_bypass_logic() {
+        // Simulates: allowed_chat_ids=[-5263819573], dm_policy=pairing
+        // Owner in allowed group → should bypass dm_policy
+        let ids = vec![-5263819573];
+        assert_eq!(check_group_allowed(-5263819573, &ids), Some(true));
+
+        // Random group NOT in list → should be rejected (not bypass dm_policy)
+        assert_eq!(check_group_allowed(-9999, &ids), Some(false));
     }
 }

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -283,6 +283,9 @@ const BOT_USERNAME_PATH: &str = "state/bot_username";
 /// Workspace path for persisting respond_to_all_group_messages flag.
 const RESPOND_TO_ALL_GROUP_PATH: &str = "state/respond_to_all_group_messages";
 
+/// Workspace path for persisting allowed_chat_ids (JSON array of i64).
+const ALLOWED_CHAT_IDS_PATH: &str = "state/allowed_chat_ids";
+
 // ============================================================================
 // Channel Metadata
 // ============================================================================
@@ -361,6 +364,11 @@ struct TelegramConfig {
     /// Whether to respond to all group messages (not just mentions).
     #[serde(default)]
     respond_to_all_group_messages: bool,
+
+    /// Allowed group chat IDs. If non-empty, only messages from these groups
+    /// are processed. DMs are unaffected. Empty = allow all groups.
+    #[serde(default)]
+    allowed_chat_ids: Option<Vec<i64>>,
 
     /// Public tunnel URL for webhook mode (injected by host from global settings).
     #[serde(default)]
@@ -621,6 +629,23 @@ impl Guest for TelegramChannel {
             RESPOND_TO_ALL_GROUP_PATH,
             &config.respond_to_all_group_messages.to_string(),
         );
+
+        // Persist allowed_chat_ids for group filtering
+        let allowed_chat_ids_json =
+            serde_json::to_string(&config.allowed_chat_ids.clone().unwrap_or_default())
+                .unwrap_or_else(|_| "[]".to_string());
+        let _ = channel_host::workspace_write(ALLOWED_CHAT_IDS_PATH, &allowed_chat_ids_json);
+        if let Some(ref ids) = config.allowed_chat_ids {
+            if !ids.is_empty() {
+                channel_host::log(
+                    channel_host::LogLevel::Info,
+                    &format!(
+                        "Group chat restriction enabled: {} allowed groups",
+                        ids.len()
+                    ),
+                );
+            }
+        }
 
         let webhook_mode = webhook_mode(&config);
 
@@ -2175,12 +2200,36 @@ fn handle_message(message: TelegramMessage) {
 
     let is_private = message.chat.chat_type == "private";
 
+    // Group chat ID restriction: if allowed_chat_ids is set, only process
+    // messages from those groups. DMs are always allowed.
+    // When a group IS allowed, also bypass dm_policy — so you can have
+    // pairing DMs but still let anyone @mention the bot in allowed groups.
+    let is_allowed_group = false;
+    if !is_private {
+        if let Ok(allowed_json) = channel_host::workspace_read(ALLOWED_CHAT_IDS_PATH) {
+            if !allowed_json.is_empty() && allowed_json != "[]" {
+                if let Ok(allowed_ids) = serde_json::from_str::<Vec<i64>>(&allowed_json) {
+                    if !allowed_ids.is_empty() {
+                        if !allowed_ids.contains(&message.chat.id) {
+                            channel_host::log(
+                                channel_host::LogLevel::Debug,
+                                &format!("Dropping message from disallowed group {}", message.chat.id),
+                            );
+                            return;
+                        }
+                        is_allowed_group = true;
+                    }
+                }
+            }
+        }
+    }
+
     let owner_id = channel_host::workspace_read(OWNER_ID_PATH)
         .filter(|s| !s.is_empty())
         .and_then(|s| s.parse::<i64>().ok());
     let is_owner = owner_id == Some(from.id);
 
-    if !is_owner {
+    if !is_owner && !is_allowed_group {
         // Non-owner senders remain guests. Apply authorization based on
         // dm_policy / allow_from before letting them chat in their own scope.
         let dm_policy =


### PR DESCRIPTION
## Problem

I want my bot to respond in my group chat, but keep DMs restricted. Currently `dm_policy` controls both DMs and groups as a single knob — setting `dm_policy: "pairing"` locks down groups too, so only authorized users can @mention the bot even in my own group.

This is the same gap described in #79 under **Per-group policies** — there's no way to control access per group independently of DM pairing policy.

## Fix

Add `allowed_chat_ids` to `TelegramConfig` — a group-level filter independent of `dm_policy`:

```json
{
  "config": {
    "dm_policy": "pairing",
    "respond_to_all_group_messages": false,
    "allowed_chat_ids": [-5263819573]
  }
}
```

- Empty or missing → allow all groups (no behavior change)
- `[-1234567]` → only process messages from those group chat IDs
- Messages from allowed groups bypass `dm_policy` — anyone can @mention the bot in allowed groups regardless of pairing/allowlist
- DMs always controlled by `dm_policy` as before

50 lines, 1 file, fully backward compatible.

Part of #79