### PR TITLE
Tighten v2 structured tool prompts

### DIFF
--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -1,7 +1,6 @@
 //! System prompt construction for the execution loop.
 //!
-//! Builds a CodeAct/RLM system prompt that instructs the LLM to write
-//! Python code in ```repl blocks with tools available as callable functions.
+//! Builds the v2 execution-loop system prompt.
 //!
 //! Prompt templates live in `crates/ironclaw_engine/prompts/` as plain
 //! markdown files for easy inspection and iteration. They are embedded
@@ -80,6 +79,8 @@ const STRUCTURED_TOOL_PREAMBLE: &str = r#"You are IronClaw, a personal AI assist
 Use the provider's structured tool_calls interface for every action.
 Do not emit Python, repl, py, or other executable fenced code blocks.
 Do not call tools as Python functions.
+Do not write tool invocations in assistant text. Never output `[[call_tool ...]]`, `<tool_call>`, `<function_call>`, JSON tool-call blobs, or function-style calls such as `tool_name(...)`.
+Only the provider-level `tool_calls` field invokes tools. If you need a tool, return a structured tool call instead of describing or printing the call.
 When no action is needed, answer in plain text.
 "#;
 
@@ -88,6 +89,7 @@ const STRUCTURED_TOOL_POSTAMBLE: &str = r#"
 
 Use structured tool calls when you need data, persistence, external effects, or system state.
 After tool results are available, continue with another structured tool call or return the final plain-text answer.
+Some integrations use literal UI blocks such as `[[choice_set]]...[[/choice_set]]` in final user-facing text. These are UI markup only; do not invent other bracketed control blocks, especially `[[call_tool ...]]`.
 "#;
 
 /// Well-known title for the CodeAct preamble overlay.
@@ -99,14 +101,10 @@ pub const PROMPT_OVERLAY_TAG: &str = "prompt_overlay";
 /// Maximum size for a prompt overlay document (in chars).
 const MAX_PROMPT_OVERLAY_CHARS: usize = 4000;
 
-/// Build the system prompt for CodeAct/RLM execution.
+/// Build the system prompt for v2 execution.
 ///
-/// The prompt instructs the LLM to:
-/// - Write Python code in ```repl fenced blocks
-/// - Call tools as regular Python functions
-/// - Use llm_query(prompt, context) for sub-agent calls
-/// - Use FINAL(answer) to return the final answer
-/// - Access thread context via the `context` variable
+/// The prompt instructs the LLM to use provider-level structured tool calls,
+/// not CodeAct, Python, or text-encoded tool-call syntax.
 ///
 /// If a Store is provided, checks for a runtime prompt overlay (a MemoryDoc
 /// with tag "prompt_overlay" and title "prompt:codeact_preamble") and appends
@@ -223,6 +221,9 @@ mod tests {
             build_codeact_system_prompt(&[], None, ProjectId(uuid::Uuid::nil()), None).await;
         assert!(prompt.contains("structured tool_calls"));
         assert!(prompt.contains("Do not emit Python"));
+        assert!(prompt.contains("Never output `[[call_tool ...]]`"));
+        assert!(prompt.contains("Only the provider-level `tool_calls` field invokes tools"));
+        assert!(prompt.contains("do not invent other bracketed control blocks"));
         assert!(prompt.contains("Strategy"));
         assert!(!prompt.contains("Learned Rules"));
     }

--- a/crates/ironclaw_skills/src/parser.rs
+++ b/crates/ironclaw_skills/src/parser.rs
@@ -62,6 +62,7 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkill, SkillParseError> {
 /// This is intentionally crate-private and should remain limited to the
 /// install-recovery path. Normal discovery/loading must keep using
 /// [`parse_skill_md`] so invalid names are rejected.
+#[cfg(feature = "registry")]
 pub(crate) fn parse_skill_md_for_install_recovery(
     content: &str,
 ) -> Result<ParsedSkill, SkillParseError> {
@@ -73,6 +74,7 @@ pub(crate) fn parse_skill_md_for_install_recovery(
 ///
 /// Used by install recovery to mutate a single field (`name`) while preserving
 /// any unknown YAML keys that the typed `SkillManifest` would otherwise drop.
+#[cfg(feature = "registry")]
 pub(crate) fn split_skill_md_frontmatter(
     content: &str,
 ) -> Result<(String, String), SkillParseError> {

--- a/integrations/abound/workspace/AGENTS.md
+++ b/integrations/abound/workspace/AGENTS.md
@@ -28,6 +28,7 @@ When greeting a user, say:
 ## Available Tools
 
 Use ONLY these built-in tools — never use the `http` tool for Abound calls:
+Invoke tools only through the provider's structured `tool_calls` interface. Do not print tool-call syntax, Python-style calls, JSON call blobs, `[[call_tool ...]]`, `<tool_call>`, or `<function_call>` in assistant text.
 
 - **`abound_account_info`** — get recipients, funding sources, payment reason keys, and limits
 - **`abound_exchange_rate`** — get current USD/INR rates
@@ -40,7 +41,7 @@ Use ONLY these built-in tools — never use the `http` tool for Abound calls:
 Follow EXACTLY this order every time. Do not skip or reorder steps.
 
 ### Step 1 — Get account info
-Call `abound_account_info`. Use the real IDs it returns — never invent or guess IDs.
+Use the `abound_account_info` tool. Use the real IDs it returns — never invent or guess IDs.
 
 ### Step 2 — Choose recipient
 Present recipients as a `[[choice_set]]`. Wait for selection before proceeding.
@@ -51,7 +52,7 @@ Present payment reasons from account info as a `[[choice_set]]`. Wait for select
 If the user names a purpose not exactly in the list (e.g. "Investment"), map it silently to the closest available key (e.g. IR015 for Mutual Fund Investment) and proceed — do NOT ask again or block.
 
 ### Step 4 — Initiate
-Call `abound_send_wire(action=initiate, funding_source_id=..., beneficiary_ref_id=..., amount=..., payment_reason_key=...)` using only real IDs from account info.
+Use the `abound_send_wire` tool with `action` set to `initiate`, passing `funding_source_id`, `beneficiary_ref_id`, `amount`, and `payment_reason_key` through structured `tool_calls` using only real IDs from account info.
 
 **Output the raw tool result JSON verbatim as your response text — do not summarize, paraphrase, or reformat it.** The frontend parses this JSON directly. Example of correct output:
 
@@ -60,12 +61,12 @@ Call `abound_send_wire(action=initiate, funding_source_id=..., beneficiary_ref_i
 ```
 
 ### Step 5 — Send (approval notification)
-When the user confirms ("send now" or similar), call `abound_send_wire(action=send, amount=..., beneficiary_ref_id=..., payment_reason_key=...)`.
+When the user confirms ("send now" or similar), use the `abound_send_wire` tool with `action` set to `send`, plus the amount, beneficiary, and payment reason.
 
 Tell the user: "Notification sent for wire transfer of $X. Waiting for your approval on the remote client."
 
 ### Step 6 — Execute (after approval)
-Only after the user confirms they approved on the remote client, call `abound_send_wire(action=execute, funding_source_id=..., beneficiary_ref_id=..., amount=..., payment_reason_key=...)`.
+Only after the user confirms they approved on the remote client, use the `abound_send_wire` tool with `action` set to `execute`, plus the funding source, beneficiary, amount, and payment reason.
 
 **NEVER call `execute` without calling `send` first.**
 **NEVER call `execute` directly when the user says "send now" — that maps to `send`, not `execute`.**
@@ -91,6 +92,7 @@ When the user needs to choose from options (payment reasons, recipients, amounts
 
 **RULES:**
 - The `[[choice_set]]` and `[[/choice_set]]` markers MUST appear literally in your output — they are parsed by the frontend
+- `[[choice_set]]` is the only bracketed control block you may output. Never output `[[call_tool ...]]` or any other `[[...]]` tool/control syntax.
 - **NEVER include more than one `[[choice_set]]` block per message.**
 - Every item MUST include an `image_url` field with a relevant Unsplash image URL (append `?w=400`)
 - Pick the top 4-5 most relevant options from the actual account data

--- a/skills/abound-api/SKILL.md
+++ b/skills/abound-api/SKILL.md
@@ -90,8 +90,8 @@ Use these built-in tools — do NOT construct raw HTTP requests:
 
 - **`abound_account_info`** — Get account info (limits, recipients, funding sources). No parameters.
 - **`abound_exchange_rate`** — Get current exchange rate. Params: `from_currency`, `to_currency`.
-- **`analyze_transfer`** — Analyze USD/INR timing. Params: `amount` (number), `for_wire` (bool). Returns `{"message":"...","plot":{...}}`. **Call `FINAL(result)` in the same code block, on the very next line after the await — never split into a separate step.**
-- **`validate_transfer_target`** — Probability of hitting a target USD/INR rate across 6 horizons. Params: `target_rate` (number). Returns `{"message":"...","plot":{...}}`. **Call `FINAL(result)` in the same code block, on the very next line after the await — never split into a separate step.**
+- **`analyze_transfer`** — Analyze USD/INR timing. Params: `amount` (number), `for_wire` (bool). Returns `{"message":"...","plot":{...}}`; after the structured tool call completes, present the returned message/plot in plain text.
+- **`validate_transfer_target`** — Probability of hitting a target USD/INR rate across 6 horizons. Params: `target_rate` (number). Returns `{"message":"...","plot":{...}}`; after the structured tool call completes, present the returned message/plot in plain text.
 - **`abound_send_wire`** — The primary wire transfer tool. **Always pass `action` explicitly.** Four actions:
   - **action='initiate'**: Runs timing analysis, returns a graph/plot and transfer details. Requires: `funding_source_id`, `beneficiary_ref_id`, `amount`, `payment_reason_key`.
   - **action='send'**: Sends a notification to the user's remote client for approval. Requires: `amount`, `beneficiary_ref_id`, `payment_reason_key`.
@@ -107,8 +107,8 @@ Use these built-in tools — do NOT construct raw HTTP requests:
 4. **Never reveal internal credential or configuration names.**
 5. **Never mention capabilities unrelated to Abound.**
 6. **Never include raw URLs in responses.**
-7. **NEVER invent account data.** Every bank name, recipient name, account number, mask, ID, or payment reason you emit MUST come verbatim from the most recent `abound_account_info` response in the current conversation. If you haven't called `abound_account_info` yet, call it before emitting any choice_set. Never carry forward values from the skill's examples — those are placeholders.
-8. **If the user questions the data** — says "wtf", "are you sure?", "that's wrong", "what accounts do I have", or otherwise expresses doubt about the accounts / recipients / funding sources shown — **immediately re-call `abound_account_info`** and present the fresh response before answering.
+7. **NEVER invent account data.** Every bank name, recipient name, account number, mask, ID, or payment reason you emit MUST come verbatim from the most recent `abound_account_info` response in the current conversation. If you haven't used the `abound_account_info` tool yet, use it before emitting any choice_set. Never carry forward values from the skill's examples — those are placeholders.
+8. **If the user questions the data** — says "wtf", "are you sure?", "that's wrong", "what accounts do I have", or otherwise expresses doubt about the accounts / recipients / funding sources shown — **immediately use the `abound_account_info` tool again** and present the fresh response before answering.
 9. **Never expose raw IDs to the user.** `funding_source_id`, `beneficiary_ref_id`, `payment_reason_key`, and any other opaque identifier are internal — never include them in chat messages, choice_set titles/subtitles/descriptions/cta_labels, or plain-text prompts shown to the user. Users see bank names, recipient names, masks (`****0013`), and human-readable reasons only. Keep the IDs in your own state and pass them to `abound_send_wire` when calling the tool.
 
 ## Welcome Message
@@ -128,25 +128,23 @@ Credentials are injected automatically. If API calls fail with auth errors, say:
 
 ## Workflow
 
+All tool use must go through the provider's structured `tool_calls` interface. Do not print tool-call syntax, Python-style calls, JSON call blobs, `[[call_tool ...]]`, `<tool_call>`, or `<function_call>` in assistant text.
+
 ### Sending money:
-1. Call `abound_account_info` to get limits, recipients, funding sources. Extract `min_limit` and `max_limit` from the response — you will need them in step 5.
+1. Use the `abound_account_info` tool through structured `tool_calls` to get limits, recipients, funding sources. Extract `min_limit` and `max_limit` from the response — you will need them in step 5.
 2. **Validate the transfer amount against account limits.** If the user's requested amount is below `min_limit.amount` or above `max_limit.amount`, do NOT proceed. Instead, tell the user the valid range using the `formatted_amount` fields (e.g. "Transfers must be between **$5** and **$5,000**. How much would you like to send?") and wait for them to provide a new amount. Repeat this check until the amount is within range before continuing.
 3. **Present recipients as a `[[choice_set]]`** — one card per recipient, using real names and account masks from the API response. DO NOT list as bullet points or plain text. Stop and wait for the user to pick one.
 4. **Ask the user which funding source to use** — list the funding sources straight from the `abound_account_info` response as plain text (e.g. "Which account should we debit? You have: BankAccount ****0103"). DO NOT auto-select, even if there is only one funding source — always ask and wait for the user to confirm. Every bank name and account mask you mention MUST come verbatim from the API response — never invent values. **Never show the `funding_source_id` (or any other raw ID) to the user — only bank name + masked account.** Keep the `funding_source_id` internally and pass it to `abound_send_wire` when needed.
 5. **Present payment reasons as a `[[choice_set]]`** — pick the top 4-5 most relevant reasons from the API response. DO NOT list as bullet points or plain text. Stop and wait for the user to pick one.
-6. Call `abound_send_wire(action="initiate", ...)` with the selected `funding_source_id`, `beneficiary_ref_id`, `amount`, and `payment_reason_key`. **All four parameters are strictly required** — `funding_source_id` is just as required as `payment_reason_key`; never call `initiate` without a user-selected funding source. This runs analysis internally and returns a graph + transfer details. **Call `FINAL(result)` in the same code block:**
-   ```python
-   result = await abound_send_wire(action="initiate", funding_source_id="...", beneficiary_ref_id="...", amount=100, payment_reason_key="...")
-   FINAL(result)
-   ```
+6. Use the `abound_send_wire` tool with `action` set to `initiate`, passing the selected `funding_source_id`, `beneficiary_ref_id`, `amount`, and `payment_reason_key` through structured `tool_calls`. **All four parameters are strictly required** — `funding_source_id` is just as required as `payment_reason_key`; never initiate without a user-selected funding source. This runs analysis internally and returns a graph + transfer details.
 7. The UI shows the analysis graph and two options to the user: **"Send now"** or **"Wait for better rate"**.
-8. If user says **"send now"**: Call `abound_send_wire(action="send", amount=100, beneficiary_ref_id="...", payment_reason_key="...")`. This sends a notification to their app for approval.
+8. If user says **"send now"**: Use the `abound_send_wire` tool with `action` set to `send`, plus the amount, beneficiary, and payment reason. This sends a notification to their app for approval.
    - **If the tool returns a success message**: Tell the user "I've sent a notification to your app — please approve it there, then let me know."
    - **If the tool returns a failure message**: Tell the user the notification failed and offer to retry. **Do NOT proceed to `execute` or `wait`.** The user must retry `send` or start over with `initiate`.
-9. If user says **"wait"**: Call `abound_send_wire(action="wait", target_rate=<rate>, current_rate=<rate>)` using the rates from the initiate analysis. This creates an hourly rate monitor. When the tool returns, tell the user the monitor is active and **always include these two options as a list**:
+9. If user says **"wait"**: Use the `abound_send_wire` tool with `action` set to `wait`, passing the target and current rates from the initiate analysis. This creates an hourly rate monitor. When the tool returns, tell the user the monitor is active and **always include these two options as a list**:
    - You can change the target rate at any time (e.g. "change target rate to ₹98")
    - You can change the check interval at any time (e.g. "check every 2 hours instead")
-10. **After the user confirms approval** (says "approved", "done", "confirmed", etc.): Call `abound_send_wire(action="execute", funding_source_id="...", beneficiary_ref_id="...", amount=100, payment_reason_key="...")`. This executes the actual wire transfer.
+10. **After the user confirms approval** (says "approved", "done", "confirmed", etc.): Use the `abound_send_wire` tool with `action` set to `execute`, plus the funding source, beneficiary, amount, and payment reason. This executes the actual wire transfer.
 
 **CRITICAL**: Never call `action="execute"` unless BOTH conditions are met: (1) `action="send"` returned a success message, AND (2) the user has explicitly confirmed they approved the notification on their remote client. If `send` failed, you must retry `send` or restart with `initiate` — never skip to `execute`.
 
@@ -154,7 +152,7 @@ Credentials are injected automatically. If API calls fail with auth errors, say:
 If the user says anything like "start fresh", "start over", "cancel", "new transfer", "different amount", "change recipient", or otherwise indicates they want to abandon the current transfer flow — **immediately discard all prior transfer state** (amount, recipient, funding source, payment reason) and go back to step 1 of the sending money workflow. Do not reuse any parameters from the previous flow. Ask the user what they'd like to do as if this is a new conversation.
 
 ### Checking rates:
-1. Call `abound_exchange_rate`
+1. Use the `abound_exchange_rate` tool through structured `tool_calls`
 2. Show both market and effective rates in plain language
 3. Advise whether it's a good time
 

--- a/skills/forex-timing/SKILL.md
+++ b/skills/forex-timing/SKILL.md
@@ -62,6 +62,8 @@ If you catch yourself about to emit `|`-separated cells, stop and rewrite as a l
 
 ## Available Tools
 
+When a tool is needed, use the provider's structured `tool_calls` interface. Do not print tool-call syntax, Python-style calls, JSON call blobs, `[[call_tool ...]]`, `<tool_call>`, or `<function_call>` in assistant text.
+
 - **`analyze_transfer`** — Recommend whether to transfer USD→INR now or wait. Uses volatility regime, RSI(14), and DXY momentum. Returns a message, hit rate, target rate, and 3-day projection cone. Param: `amount` (optional, USD).
 - **`validate_transfer_target`** — Given a desired USD/INR rate, compute the probability of hitting it across 6 horizons (3d–365d). Param: `target_rate` (required).
 - **`abound_send_wire`** — Three-action wire transfer:
@@ -77,10 +79,10 @@ If you catch yourself about to emit `|`-separated cells, stop and rewrite as a l
 
 - User asks "should I send now?" or "is this a good time?" (analysis only, no transfer) → call `analyze_transfer`
 - User asks "can I get 86 INR per dollar?" or names a target rate → call `validate_transfer_target`
-- User wants to send/transfer/wire money → call `abound_send_wire` (NOT `analyze_transfer`)
-- User says "send now" / confirms after seeing analysis → call `abound_send_wire(transfer_token=<token>, action="send")`
-- User says "wait" / declines → call `abound_send_wire(transfer_token=<token>, action="wait")` — this automatically creates an hourly rate monitoring mission using the target rate from the analysis. Present the tool's response message to the user.
-- User asks for historical data or charts → call `time` first, then `forex_historical_data` with explicit `start_date` and `end_date`
+- User wants to send/transfer/wire money → use the `abound_send_wire` tool through structured `tool_calls` (NOT `analyze_transfer`)
+- User says "send now" / confirms after seeing analysis → use the `abound_send_wire` tool with the send action through structured `tool_calls`
+- User says "wait" / declines → use the `abound_send_wire` tool with the wait action through structured `tool_calls`; this automatically creates an hourly rate monitoring mission using the target rate from the analysis. Present the tool's response message to the user.
+- User asks for historical data or charts → use the `time` tool first, then `forex_historical_data` with explicit `start_date` and `end_date`
 
 ## Presenting Results
 
@@ -115,13 +117,13 @@ When the user wants to **monitor exchange rates** or get alerts on rate threshol
   Params: `threshold` (required), `from_currency` (default USD), `to_currency` (default INR), `message_id` (default rate_alert).
 
 Example mission goal for rate monitoring:
-> "Call abound_rate_alert(threshold=90) each run. Report the result via FINAL()."
+> "On each run, use the `abound_rate_alert` tool through structured tool_calls with threshold 90, then report the returned message."
 
 **CRITICAL: For mission threads that monitor rates, always use `abound_rate_alert` — never chain `abound_exchange_rate` + `abound_create_notification` manually.** The single tool is deterministic and avoids parsing errors.
 
 ## Rules
 
-- **Never call `analyze_transfer` before `abound_send_wire`** — the analysis is built into `abound_send_wire` and runs automatically. Calling both wastes a step and breaks the flow.
+- **Never use `analyze_transfer` before `abound_send_wire` for a wire flow** — the analysis is built into `abound_send_wire` and runs automatically. Calling both wastes a step and breaks the flow.
 - `analyze_transfer` and `validate_transfer_target` are USD/INR only. Don't use them for other pairs.
 - `forex_historical_data` works for any Massive-supported pair.
 - Always uppercase currency codes (USD, INR, not usd, inr).


### PR DESCRIPTION
## Summary
- clarify the v2 execution prompt that only provider-level tool_calls invoke tools
- remove CodeAct/Python/FINAL-style call examples from Abound and forex prompt surfaces
- keep choice_set as UI markup while explicitly banning invented bracketed tool/control blocks
- gate install-recovery parser helpers behind the registry feature so clippy stays clean when ironclaw_engine builds ironclaw_skills without registry

## Why this prevents pseudo tool-call output
The problematic sample prompt had two conflicting signals: the API tools payload correctly exposed structured function tools, but the prompt/skill text still contained CodeAct-era examples like function-style calls, FINAL(result), and imperative prose such as Call abound_*. That can make the model emit textual call syntax such as [[call_tool ...]] instead of populating the provider tool_calls field.

This change makes the contract explicit at every prompt surface used by the Abound flow: if a tool is needed, the model must return a structured provider tool_call; assistant text is never an invocation mechanism. The remaining [[choice_set]] syntax is documented as UI markup only, and the prompt now says not to invent other bracketed blocks.

## Verification
- cargo fmt --all -- --check
- cargo clippy -p ironclaw_engine --all-targets -- -D warnings
- cargo test -p ironclaw_engine executor::prompt::tests
- cargo test -p ironclaw --lib bridge::llm_adapter::tests