### PR TITLE
chore: bump github tool and slack channel registry versions

### DIFF
--- a/registry/channels/slack.json
+++ b/registry/channels/slack.json
@@ -2,7 +2,7 @@
   "name": "slack",
   "display_name": "Slack Channel",
   "kind": "channel",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Slack",
   "keywords": [

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -2,7 +2,7 @@
   "name": "github",
   "display_name": "GitHub",
   "kind": "tool",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "wit_version": "0.3.0",
   "description": "GitHub integration for repos, issues, PRs, branches, files, releases, and workflows. Search actions: search_repositories, search_code, search_issues_pull_requests.",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump GitHub tool registry version from 0.2.4 to 0.2.5
- bump Slack channel registry version from 0.3.1 to 0.3.2
- fixes the version-bump gate reported in actions run 25090114582 for PR #3056

## Verification
- GITHUB_BASE_REF=staging scripts/check-version-bumps.sh
- GITHUB_BASE_REF=main scripts/check-version-bumps.sh
- git diff --check HEAD~1 HEAD