### PR TITLE
fix(release): keep root package distributable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
-publish = false
 
 [package.metadata.wix]
 upgrade-guid = "D0156E61-BA37-451E-8AB9-1A2ECCCFA48F"


### PR DESCRIPTION
## Summary
- remove the root package `publish = false` flag that caused cargo-dist to stop planning native artifacts for `ironclaw-v0.27.0`
- restores cargo-dist local artifact matrix generation for the root `ironclaw` app

## Verification
- `dist host --steps=create --tag=ironclaw-v0.27.0 --output-format=json > /tmp/ironclaw-dist-plan-fixed.json`
- `jq '.ci.github.artifacts_matrix.include | length' /tmp/ironclaw-dist-plan-fixed.json` => `7`
- `jq '{tag:.announcement_tag,title:.announcement_title, matrix_len:(.ci.github.artifacts_matrix.include | length), upload_files:(.upload_files|length), artifact_count:(.artifacts|length)}' /tmp/ironclaw-dist-plan-fixed.json` => matrix_len `7`, artifact_count `29`
- `git diff --check`