### PR TITLE
docs(reborn): port harness map to integration branch

### DIFF
--- a/docs/reborn/README.md
+++ b/docs/reborn/README.md
@@ -1,0 +1,94 @@
+# Reborn Harness Map
+
+Reborn is IronClaw's host/runtime integration work. This page is the agent-facing map for Reborn harness, validation, and local evidence.
+
+This page is intentionally short. Use it for progressive disclosure: start here, then follow the smallest relevant repo-local source instead of loading every Reborn file into context.
+
+## Current Reborn sources in this branch
+
+The `reborn-integration` branch currently exposes Reborn structure primarily through implementation crates, crate-local agent docs, tests, and CI guardrails.
+
+| Need | Start with |
+| --- | --- |
+| Host API vocabulary | `crates/ironclaw_host_api/` |
+| Host API local rules | `crates/ironclaw_host_api/CLAUDE.md` |
+| Architecture dependency guardrails | `crates/ironclaw_architecture/` |
+| Reborn dependency-boundary tests | `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs` |
+| Events substrate | `crates/ironclaw_events/` |
+| Filesystem substrate | `crates/ironclaw_filesystem/` |
+| Resource governor substrate | `crates/ironclaw_resources/` |
+| Authorization substrate | `crates/ironclaw_authorization/` |
+| Approval substrate | `crates/ironclaw_approvals/` |
+| Run-state substrate | `crates/ironclaw_run_state/` |
+| Replay fixtures | `tests/fixtures/llm_traces/README.md` |
+| Replay workflow | `.github/workflows/replay-gate.yml` |
+| E2E test harness | `tests/e2e/README.md` |
+| Live/replay testing guide | `tests/support/LIVE_TESTING.md` |
+
+## Future Reborn contract docs
+
+When the Reborn contract-doc packet is present in this branch, agents should prefer these docs as the source of truth:
+
+```text
+docs/reborn/contracts/_contract-freeze-index.md
+docs/reborn/contracts/host-api.md
+docs/reborn/contracts/capability-access.md
+docs/reborn/contracts/dispatcher.md
+docs/reborn/contracts/events-projections.md
+docs/reborn/contracts/memory.md
+docs/reborn/contracts/secrets.md
+docs/reborn/contracts/network.md
+docs/reborn/contracts/migration-compatibility.md
+```
+
+Until then, use the crate-local `CLAUDE.md` files, public crate APIs, and architecture tests as the branch-local source of truth.
+
+## Harness docs
+
+| Harness area | Doc |
+| --- | --- |
+| Local per-worktree environment | `docs/reborn/harness/local-dev.md` |
+| Replay and compatibility fixtures | `docs/reborn/harness/replay.md` |
+| Logs, events, traces, debug bundles | `docs/reborn/harness/observability.md` |
+
+## Existing harness assets
+
+Reborn should reuse the existing IronClaw harness where possible:
+
+- `scripts/replay-snap.sh`
+- `scripts/trace-coverage.sh`
+- `tests/fixtures/llm_traces/README.md`
+- `tests/support/LIVE_TESTING.md`
+- `.github/workflows/replay-gate.yml`
+- `.github/workflows/e2e.yml`
+- `.github/workflows/live-canary.yml`
+- `scripts/check-boundaries.sh`
+- `scripts/check_gateway_boundaries.py`
+- `scripts/check_no_panics.py`
+
+## Harness principles
+
+1. Humans steer with issues, docs, plans, compatibility manifests, and acceptance criteria.
+2. Agents execute with isolated worktrees, deterministic fixtures, replay traces, E2E artifacts, and mechanical guardrails.
+3. `AGENTS.md` remains a quick-start map, not the full architecture spec.
+4. Reborn details should live in repo-local docs, crate-local `CLAUDE.md` files, tests, and scripts.
+5. Architecture boundaries should be mechanically enforced where possible.
+6. Product-surface compatibility should be proven through replay, E2E, and compatibility evidence before cutover.
+
+## Golden boundaries
+
+Preserve these Reborn boundaries unless the relevant contract or architecture test is deliberately changed:
+
+1. `ironclaw_host_api` stays vocabulary/contract-only.
+2. `ironclaw_architecture` stays test-only architecture enforcement.
+3. Low-level substrate crates should not depend upward on product/runtime orchestration.
+4. Product flows should not bypass authorization, approval, resource, network, secret, or event boundaries.
+5. Secrets and credential material must not appear in user-facing errors, logs, events, snapshots, or debug bundles.
+6. Persistence behavior that becomes production-facing must preserve PostgreSQL/libSQL parity unless explicitly scoped otherwise.
+7. Caller-level tests are required when a helper gates a side effect.
+
+## Related tracking issues
+
+- Reborn substrate/cutover parent: #2987
+- Reborn compatibility gate: #3020
+- Reborn product-surface migration: #3031

--- a/docs/reborn/harness/local-dev.md
+++ b/docs/reborn/harness/local-dev.md
@@ -1,0 +1,109 @@
+# Reborn Local Harness
+
+The Reborn local harness should be bootable per git worktree so agents can validate changes without shared mutable state.
+
+This document describes the target shape. It does not mean every command exists today.
+
+## What already exists
+
+Current branch-local harness assets include:
+
+- Rust unit/integration tests;
+- `crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs`;
+- E2E scenarios under `tests/e2e/scenarios/`;
+- replay fixtures under `tests/fixtures/llm_traces/`;
+- live/replay test guide at `tests/support/LIVE_TESTING.md`;
+- replay workflow at `.github/workflows/replay-gate.yml`.
+
+## Goals
+
+- Let agents run Reborn from an isolated worktree.
+- Avoid shared mutable state between concurrent agent tasks.
+- Prefer deterministic fake providers and fixtures over live external services.
+- Produce redacted artifacts that a reviewer or follow-up agent can inspect.
+- Make failures reproducible with a short command and a debug bundle.
+
+## Target command surface
+
+Future tooling may provide:
+
+```bash
+scripts/reborn-dev up
+scripts/reborn-dev down
+scripts/reborn-dev reset
+scripts/reborn-dev status
+scripts/reborn-dev logs
+scripts/reborn-dev seed
+scripts/reborn-dev doctor
+```
+
+## Per-worktree state
+
+Local harness state should live under:
+
+```text
+.pi/reborn-dev/
+  db/
+  logs/
+  events/
+  traces/
+  artifacts/
+  screenshots/
+  config.toml
+  tokens.json
+```
+
+Rules:
+
+- `.pi/reborn-dev/` is local-only state and must not be committed.
+- Local tokens must be fake, test-only, or redacted.
+- The harness must not require production secrets.
+- `reset` should delete only `.pi/reborn-dev/`, not user data outside the harness directory.
+
+## Expected local services
+
+A complete Reborn local harness should be able to start or simulate:
+
+- Reborn host/runtime composition;
+- web gateway;
+- fake or trace LLM provider;
+- fake embedding provider;
+- deterministic MCP fixture;
+- deterministic WASM capability fixture;
+- deterministic script runtime fixture;
+- fake OAuth provider;
+- fake channel/webhook adapters;
+- local libSQL and, where needed, PostgreSQL test backend;
+- JSONL event/audit/log sinks.
+
+## Doctor bundle
+
+`doctor` should create a redacted bundle:
+
+```text
+.pi/reborn-dev/artifacts/reborn-debug/<timestamp>/
+  config-redacted.json
+  logs.jsonl
+  events.jsonl
+  audit.jsonl
+  process-tree.json
+  failed-invocations.json
+  screenshots/
+  replay-command.txt
+```
+
+The bundle should let an agent answer:
+
+- What command was run?
+- Which tenant/user/project/agent/thread/run/invocation IDs were involved?
+- Which capability or runtime failed?
+- Was the failure authorization, approval, resource, network, secret, process, or runtime related?
+- Is there a replay command?
+
+## Safety requirements
+
+- Never write raw secrets to logs, events, snapshots, screenshots, or bundles.
+- Never call live external services unless the user explicitly opts in.
+- Prefer fake/local providers by default.
+- Use per-worktree ports, paths, and database names.
+- Fail closed when a required fake provider or fixture is missing.

--- a/docs/reborn/harness/observability.md
+++ b/docs/reborn/harness/observability.md
@@ -1,0 +1,116 @@
+# Reborn Observability Harness
+
+Reborn observability should be agent-readable. An agent debugging a failure should inspect structured logs, durable events, audit records, process state, and UI artifacts before proposing a fix.
+
+This document describes the target shape. It does not mean every field or command exists today.
+
+## Goals
+
+- Make Reborn failures explainable from local artifacts.
+- Preserve enough IDs to correlate a user action with runtime effects.
+- Keep sensitive values out of logs, events, snapshots, and user-facing errors.
+- Support replay and resume debugging.
+- Support #3020 compatibility evidence and #3031 product-surface migration evidence.
+
+## Common correlation fields
+
+Every Reborn log, event, audit record, trace, and process record should include these fields where applicable:
+
+```text
+tenant_id
+user_id
+project_id
+agent_id
+thread_id
+turn_id
+run_id
+invocation_id
+process_id
+extension_id
+capability_id
+runtime_kind
+approval_id
+lease_id
+```
+
+## Evidence surfaces
+
+Reborn debugging should be possible through:
+
+| Surface | Purpose |
+| --- | --- |
+| Logs | Human/agent-readable runtime diagnostics |
+| Durable events | Product-visible state changes and replay source |
+| Audit records | Security/control-plane decisions |
+| Process records | Background lifecycle and result state |
+| Replay snapshots | Deterministic compatibility evidence |
+| E2E artifacts | Browser-visible behavior |
+| Doctor bundles | Portable redacted debug context |
+
+## Redaction rules
+
+The following must not appear in user-facing errors, events, logs, audit records, snapshots, or doctor bundles:
+
+- raw secrets;
+- bearer tokens;
+- OAuth codes or refresh tokens;
+- host filesystem paths when a virtual path is available;
+- approval lease contents;
+- unapproved input/output;
+- backend error details that expose secrets or infrastructure internals;
+- private network details beyond approved policy diagnostics.
+
+## Failure classification
+
+Observable failures should classify the failing layer when possible:
+
+```text
+authorization
+approval
+auth_blocked
+resource_limit
+network_policy
+secret_unavailable
+filesystem
+memory
+runtime_dispatch
+process
+provider
+event_sink
+projection
+transport
+```
+
+## Doctor bundle target
+
+The local harness should eventually provide:
+
+```bash
+scripts/reborn-dev doctor
+```
+
+or an equivalent `ironclaw reborn doctor --bundle` command.
+
+The bundle should contain:
+
+```text
+config-redacted.json
+logs.jsonl
+events.jsonl
+audit.jsonl
+process-tree.json
+failed-invocations.json
+screenshots/
+replay-command.txt
+```
+
+## Best-effort vs fail-closed observability
+
+Observability failures must not silently change security semantics.
+
+General rule:
+
+- event/log sink delivery failure can be best-effort only when the owning contract says so;
+- audit/persistence failure must follow the domain contract;
+- unsupported obligations still fail closed;
+- redaction failure is a hard failure before exposing output.

--- a/docs/reborn/harness/replay.md
+++ b/docs/reborn/harness/replay.md
@@ -1,0 +1,93 @@
+# Reborn Replay Harness
+
+Reborn should reuse IronClaw's existing replay harness and extend it for Reborn compatibility evidence.
+
+This document describes the target shape. It does not mean every Reborn-specific fixture exists today.
+
+## What already exists
+
+Current replay assets include:
+
+- `tests/fixtures/llm_traces/README.md`;
+- `scripts/replay-snap.sh`;
+- `scripts/trace-coverage.sh`;
+- `.github/workflows/replay-gate.yml`;
+- `tests/snapshots/`;
+- `tests/support/LIVE_TESTING.md`.
+
+The existing replay model has two layers:
+
+| Layer | Purpose |
+| --- | --- |
+| JSON fixture | Scripted LLM/provider/tool behavior |
+| Snapshot output | Observed agent/runtime behavior |
+
+## Goals
+
+- Make compatibility behavior reviewable as snapshots.
+- Let agents validate Reborn changes without live LLM/provider calls.
+- Capture #3020 compatibility-gate evidence.
+- Capture #3031 product-surface migration evidence.
+- Detect drift in tool ordering, approval flow, events, redaction, and process state.
+
+## Target Reborn fixture families
+
+The compatibility gate should eventually include replay coverage for:
+
+- normal chat turn;
+- tool call chain;
+- approval required -> approve -> resume;
+- approval denied;
+- auth blocked;
+- MCP auth flow;
+- WASM capability call;
+- script capability call;
+- memory read/write/search;
+- secret lease usage;
+- network policy denial;
+- background process spawn/status/result;
+- SSE replay cursor;
+- WebSocket reconnect;
+- routine/job trigger;
+- extension install/activate/remove;
+- v1 product-surface compatibility cases from #3031;
+- #3020 blocking compatibility cases.
+
+## Snapshot review rule
+
+A snapshot diff should answer:
+
+- Which product surface changed?
+- Which contract or crate-local boundary allows or forbids the change?
+- Is this expected migration drift or a regression?
+- Does the change affect #3020 compatibility?
+- Does the change affect #3031 product-surface parity?
+- Are sensitive fields redacted?
+
+## Determinism requirements
+
+Replay fixtures should avoid:
+
+- wall-clock time;
+- random IDs unless injected;
+- live HTTP;
+- live OAuth;
+- live LLM calls;
+- environment-dependent filesystem listings;
+- unseeded memory/search state.
+
+Replay fixtures should prefer:
+
+- fixed IDs;
+- fake providers;
+- recorded HTTP exchanges;
+- deterministic tool outputs;
+- explicit memory setup;
+- local JSONL event/audit sinks;
+- redacted snapshots.
+
+## Event coverage
+
+The existing `scripts/trace-coverage.sh` reports event coverage for current snapshots.
+
+A future Reborn-specific coverage script can build on the same pattern once Reborn durable event types and snapshots are stable.


### PR DESCRIPTION
## Summary

Ports the Reborn harness documentation map from #3062 onto the canonical Reborn grouped integration branch, `reborn-integration`.

#3062 was merged into `staging-integration`, but the Reborn substrate PR stack has been landing into `reborn-integration`. This PR copies only the docs files from #3062 and adjusts the branch reference in `docs/reborn/README.md` from `staging-integration` to `reborn-integration`.

## Included

- `docs/reborn/README.md`
- `docs/reborn/harness/local-dev.md`
- `docs/reborn/harness/replay.md`
- `docs/reborn/harness/observability.md`

## Notes

- Docs-only.
- No runtime changes.
- No CI changes.
- No scripts or Cargo changes.
- Do not merge `staging-integration` into `reborn-integration`; the branches have diverged and `staging-integration` contains unrelated integration commits.

## Related

- #2987 Reborn substrate/cutover parent
- #3062 Original docs PR that targeted `staging-integration`
- #3020 Reborn compatibility gate
- #3031 Reborn product-surface migration

## Verification

```bash
git diff --check origin/reborn-integration...HEAD
git diff --stat origin/reborn-integration...HEAD
git diff --name-only origin/reborn-integration...HEAD
```

Diff is docs-only: 4 files, 412 insertions.
