### PR TITLE
feat(reborn): make authorization trust-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,6 +4006,7 @@ dependencies = [
  "chrono",
  "ironclaw_filesystem",
  "ironclaw_host_api",
+ "ironclaw_trust",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/ironclaw_authorization/Cargo.toml
+++ b/crates/ironclaw_authorization/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
+ironclaw_trust = { path = "../ironclaw_trust" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -17,8 +17,9 @@ use ironclaw_host_api::{
     AgentId, CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, Decision, DenyReason,
     EffectKind, ExecutionContext, HostApiError, InvocationFingerprint, InvocationId, MissionId,
     NetworkPolicy, Obligation, Obligations, Principal, ProjectId, ResourceCeiling,
-    ResourceEstimate, ResourceScope, TenantId, ThreadId, UserId, VirtualPath,
+    ResourceEstimate, ResourceScope, SandboxQuota, TenantId, ThreadId, UserId, VirtualPath,
 };
+use ironclaw_trust::{AuthorityCeiling, TrustDecision};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -39,6 +40,41 @@ pub trait CapabilityDispatchAuthorizer: Send + Sync {
         _context: &ExecutionContext,
         _descriptor: &CapabilityDescriptor,
         _estimate: &ResourceEstimate,
+    ) -> Decision {
+        Decision::Deny {
+            reason: DenyReason::MissingGrant,
+        }
+    }
+}
+
+/// Trust-aware capability dispatch authorizer.
+///
+/// This trait is the host-policy-aware counterpart to
+/// [`CapabilityDispatchAuthorizer`]. Callers pass the policy-validated
+/// [`TrustDecision`] alongside the serializable [`ExecutionContext`]. We keep
+/// this separate because `ironclaw_trust::EffectiveTrustClass` deliberately
+/// does not implement `Deserialize`; it should not be embedded directly in
+/// wire-shaped execution contexts.
+#[async_trait]
+pub trait TrustAwareCapabilityDispatchAuthorizer: Send + Sync {
+    /// Authorize a dispatch using both explicit grants/leases and the
+    /// policy-derived authority ceiling.
+    async fn authorize_dispatch_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        trust_decision: &TrustDecision,
+    ) -> Decision;
+
+    /// Authorize a background-process spawn using both explicit grants/leases
+    /// and the policy-derived authority ceiling.
+    async fn authorize_spawn_with_trust(
+        &self,
+        _context: &ExecutionContext,
+        _descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+        _trust_decision: &TrustDecision,
     ) -> Decision {
         Decision::Deny {
             reason: DenyReason::MissingGrant,
@@ -78,6 +114,41 @@ impl CapabilityDispatchAuthorizer for GrantAuthorizer {
             &spawn_descriptor(descriptor),
             estimate,
             context.grants.grants.iter(),
+        )
+    }
+}
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for GrantAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        trust_decision: &TrustDecision,
+    ) -> Decision {
+        authorize_from_grants_with_trust(
+            context,
+            descriptor,
+            estimate,
+            context.grants.grants.iter(),
+            trust_decision,
+        )
+    }
+
+    async fn authorize_spawn_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        trust_decision: &TrustDecision,
+    ) -> Decision {
+        authorize_from_grants_with_trust(
+            context,
+            &spawn_descriptor(descriptor),
+            estimate,
+            context.grants.grants.iter(),
+            trust_decision,
         )
     }
 }
@@ -697,6 +768,58 @@ where
     }
 }
 
+#[async_trait]
+impl<S> TrustAwareCapabilityDispatchAuthorizer for LeaseBackedAuthorizer<'_, S>
+where
+    S: CapabilityLeaseStore + ?Sized,
+{
+    async fn authorize_dispatch_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        trust_decision: &TrustDecision,
+    ) -> Decision {
+        if context.validate().is_err() {
+            return Decision::Deny {
+                reason: DenyReason::InternalInvariantViolation,
+            };
+        }
+
+        let lease_grants = self.leases.active_grants_for_context(context).await;
+        authorize_from_grants_with_trust(
+            context,
+            descriptor,
+            estimate,
+            context.grants.grants.iter().chain(lease_grants.iter()),
+            trust_decision,
+        )
+    }
+
+    async fn authorize_spawn_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        trust_decision: &TrustDecision,
+    ) -> Decision {
+        if context.validate().is_err() {
+            return Decision::Deny {
+                reason: DenyReason::InternalInvariantViolation,
+            };
+        }
+
+        let lease_grants = self.leases.active_grants_for_context(context).await;
+        authorize_from_grants_with_trust(
+            context,
+            &spawn_descriptor(descriptor),
+            estimate,
+            context.grants.grants.iter().chain(lease_grants.iter()),
+            trust_decision,
+        )
+    }
+}
+
 fn spawn_descriptor(descriptor: &CapabilityDescriptor) -> CapabilityDescriptor {
     let mut descriptor = descriptor.clone();
     if !descriptor.effects.contains(&EffectKind::SpawnProcess) {
@@ -711,6 +834,42 @@ fn authorize_from_grants<'a>(
     estimate: &ResourceEstimate,
     grants: impl Iterator<Item = &'a CapabilityGrant>,
 ) -> Decision {
+    authorize_from_grants_with_authority_ceiling(context, descriptor, estimate, grants, None)
+}
+
+fn authorize_from_grants_with_trust<'a>(
+    context: &ExecutionContext,
+    descriptor: &CapabilityDescriptor,
+    estimate: &ResourceEstimate,
+    grants: impl Iterator<Item = &'a CapabilityGrant>,
+    trust_decision: &TrustDecision,
+) -> Decision {
+    if context.validate().is_err() {
+        return Decision::Deny {
+            reason: DenyReason::InternalInvariantViolation,
+        };
+    }
+    if context.trust != trust_decision.effective_trust.class() {
+        return Decision::Deny {
+            reason: DenyReason::PolicyDenied,
+        };
+    }
+    authorize_from_grants_with_authority_ceiling(
+        context,
+        descriptor,
+        estimate,
+        grants,
+        Some(&trust_decision.authority_ceiling),
+    )
+}
+
+fn authorize_from_grants_with_authority_ceiling<'a>(
+    context: &ExecutionContext,
+    descriptor: &CapabilityDescriptor,
+    estimate: &ResourceEstimate,
+    grants: impl Iterator<Item = &'a CapabilityGrant>,
+    authority_ceiling: Option<&AuthorityCeiling>,
+) -> Decision {
     if context.validate().is_err() {
         return Decision::Deny {
             reason: DenyReason::InternalInvariantViolation,
@@ -724,9 +883,17 @@ fn authorize_from_grants<'a>(
         .filter(|grant| grant_is_active(grant))
     {
         saw_active_matching_grant = true;
+        let effective_resource_ceiling = intersect_resource_ceilings(
+            grant.constraints.resource_ceiling.as_ref(),
+            authority_ceiling.and_then(|ceiling| ceiling.max_resource_ceiling.as_ref()),
+        );
         if effects_are_covered(&descriptor.effects, &grant.constraints.allowed_effects)
-            && resource_estimate_is_covered(estimate, grant.constraints.resource_ceiling.as_ref())
-            && let Some(obligations) = obligations_for_grant(descriptor, grant)
+            && authority_ceiling.is_none_or(|ceiling| {
+                effects_are_covered(&descriptor.effects, &ceiling.allowed_effects)
+            })
+            && resource_estimate_is_covered(estimate, effective_resource_ceiling.as_ref())
+            && let Some(obligations) =
+                obligations_for_grant(descriptor, grant, effective_resource_ceiling)
         {
             return Decision::Allow { obligations };
         }
@@ -746,6 +913,7 @@ fn authorize_from_grants<'a>(
 fn obligations_for_grant(
     descriptor: &CapabilityDescriptor,
     grant: &CapabilityGrant,
+    effective_resource_ceiling: Option<ResourceCeiling>,
 ) -> Option<Obligations> {
     let mut obligations = Vec::new();
 
@@ -772,7 +940,7 @@ fn obligations_for_grant(
         }
     }
 
-    if let Some(ceiling) = grant.constraints.resource_ceiling.as_ref() {
+    if let Some(ceiling) = effective_resource_ceiling {
         obligations.push(Obligation::EnforceResourceCeiling {
             ceiling: ceiling.clone(),
         });
@@ -825,6 +993,134 @@ fn grant_is_active(grant: &CapabilityGrant) -> bool {
         .expires_at
         .is_none_or(|expires_at| expires_at > Utc::now())
         && grant.constraints.max_invocations != Some(0)
+}
+
+/// Returns true when an existing grant exceeds the current policy-derived
+/// authority ceiling and should be reissued or revoked by a trust-change
+/// invalidation listener.
+///
+/// This helper is intentionally synchronous and store-agnostic: the
+/// `ironclaw_trust::InvalidationBus` runs listeners synchronously, while this
+/// crate's durable lease stores are async. Higher-level host wiring can use
+/// this predicate inside whatever transactional store/reconciliation path it
+/// owns, without introducing nested blocking executors or process/runtime dependencies here.
+pub fn grant_exceeds_authority_ceiling(
+    grant: &CapabilityGrant,
+    authority_ceiling: &AuthorityCeiling,
+) -> bool {
+    !effects_are_covered(
+        &grant.constraints.allowed_effects,
+        &authority_ceiling.allowed_effects,
+    ) || resource_ceiling_exceeds_authority(
+        grant.constraints.resource_ceiling.as_ref(),
+        authority_ceiling.max_resource_ceiling.as_ref(),
+    )
+}
+
+fn resource_ceiling_exceeds_authority(
+    grant_ceiling: Option<&ResourceCeiling>,
+    authority_ceiling: Option<&ResourceCeiling>,
+) -> bool {
+    match (grant_ceiling, authority_ceiling) {
+        (None, Some(_)) => true,
+        (None, None) | (Some(_), None) => false,
+        (Some(grant), Some(authority)) => {
+            limit_exceeds(&grant.max_usd, &authority.max_usd)
+                || limit_exceeds(&grant.max_input_tokens, &authority.max_input_tokens)
+                || limit_exceeds(&grant.max_output_tokens, &authority.max_output_tokens)
+                || limit_exceeds(&grant.max_wall_clock_ms, &authority.max_wall_clock_ms)
+                || limit_exceeds(&grant.max_output_bytes, &authority.max_output_bytes)
+                || sandbox_quota_exceeds_authority(
+                    grant.sandbox.as_ref(),
+                    authority.sandbox.as_ref(),
+                )
+        }
+    }
+}
+
+fn sandbox_quota_exceeds_authority(
+    grant_quota: Option<&SandboxQuota>,
+    authority_quota: Option<&SandboxQuota>,
+) -> bool {
+    match (grant_quota, authority_quota) {
+        (None, Some(_)) => true,
+        (None, None) | (Some(_), None) => false,
+        (Some(grant), Some(authority)) => {
+            limit_exceeds(&grant.cpu_time_ms, &authority.cpu_time_ms)
+                || limit_exceeds(&grant.memory_bytes, &authority.memory_bytes)
+                || limit_exceeds(&grant.disk_bytes, &authority.disk_bytes)
+                || limit_exceeds(&grant.network_egress_bytes, &authority.network_egress_bytes)
+                || limit_exceeds(&grant.process_count, &authority.process_count)
+        }
+    }
+}
+
+fn limit_exceeds<T>(grant: &Option<T>, authority: &Option<T>) -> bool
+where
+    T: PartialOrd,
+{
+    match (grant, authority) {
+        (Some(grant), Some(authority)) => grant > authority,
+        (None, Some(_)) => true,
+        (None, None) | (Some(_), None) => false,
+    }
+}
+
+fn intersect_resource_ceilings(
+    grant_ceiling: Option<&ResourceCeiling>,
+    authority_ceiling: Option<&ResourceCeiling>,
+) -> Option<ResourceCeiling> {
+    match (grant_ceiling, authority_ceiling) {
+        (None, None) => None,
+        (Some(ceiling), None) | (None, Some(ceiling)) => Some(ceiling.clone()),
+        (Some(grant), Some(authority)) => Some(ResourceCeiling {
+            max_usd: stricter_limit(&grant.max_usd, &authority.max_usd),
+            max_input_tokens: stricter_limit(&grant.max_input_tokens, &authority.max_input_tokens),
+            max_output_tokens: stricter_limit(
+                &grant.max_output_tokens,
+                &authority.max_output_tokens,
+            ),
+            max_wall_clock_ms: stricter_limit(
+                &grant.max_wall_clock_ms,
+                &authority.max_wall_clock_ms,
+            ),
+            max_output_bytes: stricter_limit(&grant.max_output_bytes, &authority.max_output_bytes),
+            sandbox: intersect_sandbox_quotas(grant.sandbox.as_ref(), authority.sandbox.as_ref()),
+        }),
+    }
+}
+
+fn intersect_sandbox_quotas(
+    grant_quota: Option<&SandboxQuota>,
+    authority_quota: Option<&SandboxQuota>,
+) -> Option<SandboxQuota> {
+    match (grant_quota, authority_quota) {
+        (None, None) => None,
+        (Some(quota), None) | (None, Some(quota)) => Some(quota.clone()),
+        (Some(grant), Some(authority)) => Some(SandboxQuota {
+            cpu_time_ms: stricter_limit(&grant.cpu_time_ms, &authority.cpu_time_ms),
+            memory_bytes: stricter_limit(&grant.memory_bytes, &authority.memory_bytes),
+            disk_bytes: stricter_limit(&grant.disk_bytes, &authority.disk_bytes),
+            network_egress_bytes: stricter_limit(
+                &grant.network_egress_bytes,
+                &authority.network_egress_bytes,
+            ),
+            process_count: stricter_limit(&grant.process_count, &authority.process_count),
+        }),
+    }
+}
+
+fn stricter_limit<T>(left: &Option<T>, right: &Option<T>) -> Option<T>
+where
+    T: Clone + PartialOrd,
+{
+    match (left, right) {
+        (Some(left), Some(right)) if right < left => Some(right.clone()),
+        (Some(left), Some(_)) => Some(left.clone()),
+        (Some(left), None) => Some(left.clone()),
+        (None, Some(right)) => Some(right.clone()),
+        (None, None) => None,
+    }
 }
 
 fn resource_estimate_is_covered(

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -887,10 +887,12 @@ fn authorize_from_grants_with_authority_ceiling<'a>(
             grant.constraints.resource_ceiling.as_ref(),
             authority_ceiling.and_then(|ceiling| ceiling.max_resource_ceiling.as_ref()),
         );
+        let authority_effects_allow_descriptor = match authority_ceiling {
+            Some(ceiling) => effects_are_covered(&descriptor.effects, &ceiling.allowed_effects),
+            None => true,
+        };
         if effects_are_covered(&descriptor.effects, &grant.constraints.allowed_effects)
-            && authority_ceiling.is_none_or(|ceiling| {
-                effects_are_covered(&descriptor.effects, &ceiling.allowed_effects)
-            })
+            && authority_effects_allow_descriptor
             && resource_estimate_is_covered(estimate, effective_resource_ceiling.as_ref())
             && let Some(obligations) =
                 obligations_for_grant(descriptor, grant, effective_resource_ceiling)
@@ -988,11 +990,11 @@ fn effects_are_covered(required: &[EffectKind], allowed: &[EffectKind]) -> bool 
 }
 
 fn grant_is_active(grant: &CapabilityGrant) -> bool {
-    grant
-        .constraints
-        .expires_at
-        .is_none_or(|expires_at| expires_at > Utc::now())
-        && grant.constraints.max_invocations != Some(0)
+    let grant_not_expired = match grant.constraints.expires_at.as_ref() {
+        Some(expires_at) => expires_at > &Utc::now(),
+        None => true,
+    };
+    grant_not_expired && grant.constraints.max_invocations != Some(0)
 }
 
 /// Returns true when an existing grant exceeds the current policy-derived
@@ -1147,15 +1149,18 @@ fn resource_estimate_is_covered(
             estimate.output_bytes.as_ref(),
             ceiling.max_output_bytes.as_ref(),
         )
-        && ceiling.sandbox.as_ref().is_none_or(|sandbox| {
-            options_within_ceiling(
-                estimate.network_egress_bytes.as_ref(),
-                sandbox.network_egress_bytes.as_ref(),
-            ) && options_within_ceiling(
-                estimate.process_count.as_ref(),
-                sandbox.process_count.as_ref(),
-            )
-        })
+        && match ceiling.sandbox.as_ref() {
+            Some(sandbox) => {
+                options_within_ceiling(
+                    estimate.network_egress_bytes.as_ref(),
+                    sandbox.network_egress_bytes.as_ref(),
+                ) && options_within_ceiling(
+                    estimate.process_count.as_ref(),
+                    sandbox.process_count.as_ref(),
+                )
+            }
+            None => true,
+        }
 }
 
 fn options_within_ceiling<T>(estimate: Option<&T>, maximum: Option<&T>) -> bool

--- a/crates/ironclaw_authorization/tests/capability_access_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_access_contract.rs
@@ -1,6 +1,7 @@
 use chrono::{Duration, Utc};
 use ironclaw_authorization::*;
 use ironclaw_host_api::*;
+use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 use serde_json::json;
 
 #[tokio::test]
@@ -202,6 +203,271 @@ async fn capability_access_denies_when_grant_does_not_cover_declared_effects() {
             reason: DenyReason::PolicyDenied
         }
     );
+}
+
+#[tokio::test]
+async fn capability_access_with_trust_denies_when_authority_ceiling_excludes_effect() {
+    let descriptor = CapabilityDescriptor {
+        effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
+        ..wasm_descriptor()
+    };
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability, EffectKind::Network],
+    );
+    let context = execution_context(CapabilitySet {
+        grants: vec![grant],
+    });
+    let trust = trust_decision(vec![EffectKind::DispatchCapability], None);
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch_with_trust(&context, &descriptor, &ResourceEstimate::default(), &trust)
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_with_trust_denies_when_estimate_exceeds_authority_ceiling() {
+    let descriptor = wasm_descriptor();
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.resource_ceiling = Some(ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: None,
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: Some(2048),
+        sandbox: None,
+    });
+    let context = execution_context(CapabilitySet {
+        grants: vec![grant],
+    });
+    let trust = trust_decision(
+        vec![EffectKind::DispatchCapability],
+        Some(ResourceCeiling {
+            max_usd: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            max_wall_clock_ms: None,
+            max_output_bytes: Some(1024),
+            sandbox: None,
+        }),
+    );
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch_with_trust(
+            &context,
+            &descriptor,
+            &ResourceEstimate {
+                output_bytes: Some(1500),
+                ..ResourceEstimate::default()
+            },
+            &trust,
+        )
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_with_trust_clamps_runtime_resource_obligation_to_authority_ceiling() {
+    let descriptor = wasm_descriptor();
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.resource_ceiling = Some(ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: None,
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: Some(2048),
+        sandbox: None,
+    });
+    let context = execution_context(CapabilitySet {
+        grants: vec![grant],
+    });
+    let trust = trust_decision(
+        vec![EffectKind::DispatchCapability],
+        Some(ResourceCeiling {
+            max_usd: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            max_wall_clock_ms: None,
+            max_output_bytes: Some(1024),
+            sandbox: None,
+        }),
+    );
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch_with_trust(
+            &context,
+            &descriptor,
+            &ResourceEstimate {
+                output_bytes: Some(512),
+                ..ResourceEstimate::default()
+            },
+            &trust,
+        )
+        .await;
+
+    let Decision::Allow { obligations } = decision else {
+        panic!("expected allow with clamped obligation, got {decision:?}");
+    };
+    assert!(
+        obligations
+            .as_slice()
+            .iter()
+            .any(|obligation| matches!(obligation, Obligation::EnforceOutputLimit { bytes: 1024 }))
+    );
+    assert!(
+        !obligations
+            .as_slice()
+            .iter()
+            .any(|obligation| matches!(obligation, Obligation::EnforceOutputLimit { bytes: 2048 }))
+    );
+}
+
+#[tokio::test]
+async fn capability_access_with_trust_denies_when_context_trust_differs_from_decision() {
+    let descriptor = wasm_descriptor();
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    let mut context = execution_context(CapabilitySet {
+        grants: vec![grant],
+    });
+    context.trust = TrustClass::UserTrusted;
+    let trust = trust_decision(vec![EffectKind::DispatchCapability], None);
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch_with_trust(&context, &descriptor, &ResourceEstimate::default(), &trust)
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_spawn_with_trust_requires_spawn_process_in_authority_ceiling() {
+    let descriptor = wasm_descriptor();
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
+    );
+    let context = execution_context(CapabilitySet {
+        grants: vec![grant],
+    });
+    let trust = trust_decision(vec![EffectKind::DispatchCapability], None);
+
+    let decision = GrantAuthorizer::new()
+        .authorize_spawn_with_trust(&context, &descriptor, &ResourceEstimate::default(), &trust)
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
+    );
+}
+
+#[test]
+fn grant_exceeds_authority_ceiling_detects_effect_reductions() {
+    let grant = grant_for(
+        CapabilityId::new("echo.say").unwrap(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability, EffectKind::Network],
+    );
+    let ceiling = AuthorityCeiling {
+        allowed_effects: vec![EffectKind::DispatchCapability],
+        max_resource_ceiling: None,
+    };
+
+    assert!(grant_exceeds_authority_ceiling(&grant, &ceiling));
+}
+
+#[test]
+fn grant_exceeds_authority_ceiling_detects_resource_reductions() {
+    let mut grant = grant_for(
+        CapabilityId::new("echo.say").unwrap(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.resource_ceiling = Some(ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: None,
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: Some(2048),
+        sandbox: None,
+    });
+    let ceiling = AuthorityCeiling {
+        allowed_effects: vec![EffectKind::DispatchCapability],
+        max_resource_ceiling: Some(ResourceCeiling {
+            max_usd: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            max_wall_clock_ms: None,
+            max_output_bytes: Some(1024),
+            sandbox: None,
+        }),
+    };
+
+    assert!(grant_exceeds_authority_ceiling(&grant, &ceiling));
+}
+
+#[test]
+fn grant_exceeds_authority_ceiling_keeps_grants_within_ceiling() {
+    let mut grant = grant_for(
+        CapabilityId::new("echo.say").unwrap(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.resource_ceiling = Some(ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: None,
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: Some(512),
+        sandbox: None,
+    });
+    let ceiling = AuthorityCeiling {
+        allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
+        max_resource_ceiling: Some(ResourceCeiling {
+            max_usd: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            max_wall_clock_ms: None,
+            max_output_bytes: Some(1024),
+            sandbox: None,
+        }),
+    };
+
+    assert!(!grant_exceeds_authority_ceiling(&grant, &ceiling));
 }
 
 #[tokio::test]
@@ -463,6 +729,21 @@ fn wasm_descriptor() -> CapabilityDescriptor {
         effects: vec![EffectKind::DispatchCapability],
         default_permission: PermissionMode::Allow,
         resource_profile: None,
+    }
+}
+
+fn trust_decision(
+    allowed_effects: Vec<EffectKind>,
+    max_resource_ceiling: Option<ResourceCeiling>,
+) -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::sandbox(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects,
+            max_resource_ceiling,
+        },
+        provenance: TrustProvenance::Default,
+        evaluated_at: Utc::now(),
     }
 }
 

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -4,9 +4,11 @@ use std::sync::{
 };
 
 use async_trait::async_trait;
+use chrono::Utc;
 use ironclaw_authorization::*;
 use ironclaw_filesystem::{DirEntry, FileStat, FilesystemError, LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
+use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
 
 #[tokio::test]
 async fn lease_authorizer_allows_matching_active_lease_without_context_grant() {
@@ -36,6 +38,39 @@ async fn lease_authorizer_allows_matching_active_lease_without_context_grant() {
             .await
             .unwrap(),
         lease
+    );
+}
+
+#[tokio::test]
+async fn lease_backed_authorizer_with_trust_denies_when_authority_ceiling_excludes_effect() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let capability = CapabilityId::new("echo.say").unwrap();
+    let mut descriptor = descriptor(capability.clone());
+    descriptor.effects = vec![EffectKind::DispatchCapability, EffectKind::Network];
+
+    leases
+        .issue(CapabilityLease::new(
+            context.resource_scope.clone(),
+            grant_for(
+                capability,
+                Principal::Extension(context.extension_id.clone()),
+                vec![EffectKind::DispatchCapability, EffectKind::Network],
+            ),
+        ))
+        .await
+        .unwrap();
+    let trust = trust_decision(vec![EffectKind::DispatchCapability], None);
+
+    let decision = LeaseBackedAuthorizer::new(&leases)
+        .authorize_dispatch_with_trust(&context, &descriptor, &ResourceEstimate::default(), &trust)
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
     );
 }
 
@@ -972,6 +1007,21 @@ impl RootFilesystem for CountingFilesystem {
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.create_dir_all(path).await
+    }
+}
+
+fn trust_decision(
+    allowed_effects: Vec<EffectKind>,
+    max_resource_ceiling: Option<ResourceCeiling>,
+) -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::sandbox(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects,
+            max_resource_ceiling,
+        },
+        provenance: TrustProvenance::Default,
+        evaluated_at: Utc::now(),
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the authorization-side consumer seam for host trust policy decisions.

`ironclaw_authorization` now depends on `ironclaw_trust` and can authorize dispatch/spawn against the policy-validated `TrustDecision` produced by the trust engine.

Adds:

- `TrustAwareCapabilityDispatchAuthorizer`
- trust-aware dispatch/spawn methods for `GrantAuthorizer`
- trust-aware dispatch/spawn methods for `LeaseBackedAuthorizer`
- `grant_exceeds_authority_ceiling(...)` helper for future trust-change invalidation listeners

Authorization now checks:

- `ExecutionContext.trust == TrustDecision.effective_trust.class()`
- descriptor effects are covered by both the explicit grant and `TrustDecision.authority_ceiling.allowed_effects`
- resource estimates are covered by the intersection of grant resource ceiling and trust authority ceiling
- runtime resource obligations use the stricter intersected ceiling

## Invalidation note

This PR intentionally does **not** wire a full `InvalidationBus` listener inside `ironclaw_authorization`.

Reason: `ironclaw_trust::InvalidationBus` is synchronous and fail-closed, while authorization's durable lease stores are async. A direct listener here would require nested blocking or a new transactional/reconciliation seam. Instead, this PR adds the synchronous, store-agnostic `grant_exceeds_authority_ceiling(...)` predicate that higher-level host wiring can use inside the proper store/reconciliation path.

## Tests

Added coverage for:

- grant-backed trust-aware dispatch denying when authority ceiling excludes an effect
- grant-backed trust-aware dispatch denying when estimate exceeds trust authority ceiling
- grant-backed trust-aware dispatch clamping resource obligations to the stricter trust ceiling
- trust/context effective-class mismatch denial
- trust-aware spawn requiring `SpawnProcess` in authority ceiling
- lease-backed trust-aware dispatch authority ceiling enforcement
- `grant_exceeds_authority_ceiling(...)` effect/resource reduction detection and retainable grants

## Verification

Passed locally:

```bash
cargo fmt --check
cargo check -p ironclaw_authorization
cargo clippy -p ironclaw_authorization --all-targets -- -D warnings
cargo test -p ironclaw_authorization
```
