### PR TITLE
feat(reborn): wire extension manifests to trust policy input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,6 +4084,7 @@ version = "0.1.0"
 dependencies = [
  "ironclaw_filesystem",
  "ironclaw_host_api",
+ "ironclaw_trust",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/ironclaw_extensions/Cargo.toml
+++ b/crates/ironclaw_extensions/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [dependencies]
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
+ironclaw_trust = { path = "../ironclaw_trust", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -5,13 +5,15 @@
 //! execute WASM modules, start Docker containers, connect to MCP servers, resolve
 //! secrets, or reserve resources.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
 use ironclaw_host_api::{
-    CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, HostApiError, PermissionMode,
-    ResourceProfile, RuntimeKind, TrustClass, VirtualPath,
+    CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, HostApiError, PackageId,
+    PackageIdentity, PackageSource, PermissionMode, RequestedTrustClass, ResourceProfile,
+    RuntimeKind, TrustClass, VirtualPath,
 };
+use ironclaw_trust::TrustPolicyInput;
 use serde::Deserialize;
 use thiserror::Error;
 
@@ -110,6 +112,12 @@ pub struct ExtensionManifest {
     pub name: String,
     pub version: String,
     pub description: String,
+    /// Manifest-declared trust request. This is untrusted metadata and must
+    /// be evaluated by `ironclaw_trust` before it can affect authorization.
+    pub requested_trust: RequestedTrustClass,
+    /// Safe declarative descriptor metadata derived from [`requested_trust`].
+    /// Privileged requests remain sandboxed here; effective privileged trust
+    /// only comes from a host policy [`TrustPolicyInput`].
     pub trust: TrustClass,
     pub runtime: ExtensionRuntime,
     pub capabilities: Vec<CapabilityManifest>,
@@ -153,12 +161,15 @@ impl ExtensionManifest {
             .map(CapabilityManifest::from_raw)
             .collect::<Result<Vec<_>, _>>()?;
 
+        let trust = requested_trust_to_descriptor_trust(raw.trust);
+
         Ok(Self {
             id,
             name: raw.name,
             version: raw.version,
             description: raw.description,
-            trust: raw.trust,
+            requested_trust: raw.trust,
+            trust,
             runtime,
             capabilities,
         })
@@ -248,6 +259,48 @@ impl ExtensionPackage {
             root,
             manifest,
             capabilities,
+        })
+    }
+
+    /// Build the trust-policy identity for this package.
+    ///
+    /// `PackageId` and `ExtensionId` share the same underlying vocabulary in
+    /// V1; the conversion still goes through the validated constructor so this
+    /// crate does not rely on representation details.
+    pub fn package_identity(
+        &self,
+        source: PackageSource,
+        digest: Option<String>,
+        signer: Option<String>,
+    ) -> Result<PackageIdentity, ExtensionError> {
+        Ok(PackageIdentity::new(
+            PackageId::new(self.id.as_str().to_string())?,
+            source,
+            digest,
+            signer,
+        ))
+    }
+
+    /// Build the trust-policy input for this package.
+    ///
+    /// Requested authority is the canonical set of capability ids declared by
+    /// the package. The returned value is still untrusted input; callers must
+    /// pass it to `ironclaw_trust::TrustPolicy::evaluate` to get an effective
+    /// [`ironclaw_trust::TrustDecision`].
+    pub fn trust_policy_input(
+        &self,
+        source: PackageSource,
+        digest: Option<String>,
+        signer: Option<String>,
+    ) -> Result<TrustPolicyInput, ExtensionError> {
+        Ok(TrustPolicyInput {
+            identity: self.package_identity(source, digest, signer)?,
+            requested_trust: self.manifest.requested_trust,
+            requested_authority: self
+                .capabilities
+                .iter()
+                .map(|descriptor| descriptor.id.clone())
+                .collect::<BTreeSet<_>>(),
         })
     }
 }
@@ -395,10 +448,24 @@ struct RawManifest {
     name: String,
     version: String,
     description: String,
-    trust: TrustClass,
+    #[serde(default = "default_requested_trust")]
+    trust: RequestedTrustClass,
     runtime: RawRuntime,
     #[serde(default)]
     capabilities: Vec<RawCapability>,
+}
+
+fn default_requested_trust() -> RequestedTrustClass {
+    RequestedTrustClass::Untrusted
+}
+
+fn requested_trust_to_descriptor_trust(requested: RequestedTrustClass) -> TrustClass {
+    match requested {
+        RequestedTrustClass::ThirdParty => TrustClass::UserTrusted,
+        RequestedTrustClass::Untrusted
+        | RequestedTrustClass::FirstPartyRequested
+        | RequestedTrustClass::SystemRequested => TrustClass::Sandbox,
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -14,7 +14,7 @@ use ironclaw_host_api::{
     RuntimeKind, TrustClass, VirtualPath,
 };
 use ironclaw_trust::TrustPolicyInput;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use thiserror::Error;
 
 /// Extension manifest and registry failures.
@@ -273,8 +273,9 @@ impl ExtensionPackage {
         digest: Option<String>,
         signer: Option<String>,
     ) -> Result<PackageIdentity, ExtensionError> {
+        validate_package_consistency(self)?;
         Ok(PackageIdentity::new(
-            PackageId::new(self.id.as_str().to_string())?,
+            PackageId::new(self.manifest.id.as_str().to_string())?,
             source,
             digest,
             signer,
@@ -448,7 +449,10 @@ struct RawManifest {
     name: String,
     version: String,
     description: String,
-    #[serde(default = "default_requested_trust")]
+    #[serde(
+        default = "default_requested_trust",
+        deserialize_with = "deserialize_requested_trust"
+    )]
     trust: RequestedTrustClass,
     runtime: RawRuntime,
     #[serde(default)]
@@ -457,6 +461,34 @@ struct RawManifest {
 
 fn default_requested_trust() -> RequestedTrustClass {
     RequestedTrustClass::Untrusted
+}
+
+fn deserialize_requested_trust<'de, D>(deserializer: D) -> Result<RequestedTrustClass, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    match value.as_str() {
+        "untrusted" => Ok(RequestedTrustClass::Untrusted),
+        "third_party" => Ok(RequestedTrustClass::ThirdParty),
+        "first_party_requested" => Ok(RequestedTrustClass::FirstPartyRequested),
+        "system_requested" => Ok(RequestedTrustClass::SystemRequested),
+        "sandbox" => Err(serde::de::Error::custom(
+            "trust = \"sandbox\" is obsolete; use \"untrusted\"",
+        )),
+        "user_trusted" => Err(serde::de::Error::custom(
+            "trust = \"user_trusted\" is obsolete; use \"third_party\"",
+        )),
+        "first_party" => Err(serde::de::Error::custom(
+            "trust = \"first_party\" is obsolete; use \"first_party_requested\"",
+        )),
+        "system" => Err(serde::de::Error::custom(
+            "trust = \"system\" is obsolete; use \"system_requested\"",
+        )),
+        _ => Err(serde::de::Error::custom(format!(
+            "unsupported trust value {value:?}; expected one of untrusted, third_party, first_party_requested, system_requested"
+        ))),
+    }
 }
 
 fn requested_trust_to_descriptor_trust(requested: RequestedTrustClass) -> TrustClass {

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -97,6 +97,56 @@ fn package_builds_trust_policy_input_from_requested_manifest_trust() {
 }
 
 #[test]
+fn package_trust_policy_input_rejects_mutated_public_descriptors() {
+    let manifest = ExtensionManifest::parse(WASM_MANIFEST).unwrap();
+    let mut package = ExtensionPackage::from_manifest(
+        manifest,
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    package.capabilities[0].id = CapabilityId::new("echo.mutated").unwrap();
+
+    let err = package
+        .trust_policy_input(PackageSource::Bundled, None, None)
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::InvalidManifest { reason } if reason.contains("capability descriptors")
+    ));
+}
+
+#[test]
+fn missing_manifest_trust_defaults_to_untrusted() {
+    let manifest =
+        ExtensionManifest::parse(&WASM_MANIFEST.replace("trust = \"untrusted\"\n", "")).unwrap();
+
+    assert_eq!(manifest.requested_trust, RequestedTrustClass::Untrusted);
+    assert_eq!(manifest.trust, TrustClass::Sandbox);
+    let package = ExtensionPackage::from_manifest(
+        manifest,
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    assert_eq!(package.capabilities[0].trust_ceiling, TrustClass::Sandbox);
+}
+
+#[test]
+fn legacy_manifest_trust_values_get_actionable_error() {
+    let err = ExtensionManifest::parse(
+        &WASM_MANIFEST.replace("trust = \"untrusted\"", "trust = \"sandbox\""),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::ManifestParse { reason }
+            if reason.contains("trust = \"sandbox\" is obsolete")
+                && reason.contains("use \"untrusted\"")
+    ));
+}
+
+#[test]
 fn invalid_extension_id_is_rejected() {
     let err =
         ExtensionManifest::parse(&WASM_MANIFEST.replace("id = \"echo\"", "id = \"Echo/Bad\""))

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -1,12 +1,14 @@
 use ironclaw_extensions::*;
 use ironclaw_filesystem::*;
 use ironclaw_host_api::*;
+use ironclaw_trust::TrustPolicyInput;
 use tempfile::tempdir;
 
 #[test]
 fn valid_wasm_manifest_parses_and_extracts_capability_descriptor() {
     let manifest = ExtensionManifest::parse(WASM_MANIFEST).unwrap();
     assert_eq!(manifest.id.as_str(), "echo");
+    assert_eq!(manifest.requested_trust, RequestedTrustClass::Untrusted);
     assert_eq!(manifest.trust, TrustClass::Sandbox);
     assert!(matches!(
         manifest.runtime,
@@ -28,6 +30,70 @@ fn valid_wasm_manifest_parses_and_extracts_capability_descriptor() {
     assert_eq!(descriptor.default_permission, PermissionMode::Allow);
     assert_eq!(descriptor.effects, vec![EffectKind::DispatchCapability]);
     assert_eq!(descriptor.parameters_schema["type"], "object");
+}
+
+#[test]
+fn manifest_privileged_trust_request_is_metadata_and_descriptor_stays_sandboxed() {
+    let manifest = ExtensionManifest::parse(
+        &WASM_MANIFEST.replace("trust = \"untrusted\"", "trust = \"first_party_requested\""),
+    )
+    .unwrap();
+
+    assert_eq!(
+        manifest.requested_trust,
+        RequestedTrustClass::FirstPartyRequested
+    );
+    assert_eq!(manifest.trust, TrustClass::Sandbox);
+
+    let package = ExtensionPackage::from_manifest(
+        manifest,
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    assert_eq!(package.capabilities[0].trust_ceiling, TrustClass::Sandbox);
+}
+
+#[test]
+fn package_builds_trust_policy_input_from_requested_manifest_trust() {
+    let manifest = ExtensionManifest::parse(
+        &WASM_MANIFEST.replace("trust = \"untrusted\"", "trust = \"first_party_requested\""),
+    )
+    .unwrap();
+    let package = ExtensionPackage::from_manifest(
+        manifest,
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+
+    let input: TrustPolicyInput = package
+        .trust_policy_input(
+            PackageSource::LocalManifest {
+                path: "/system/extensions/echo/manifest.toml".to_string(),
+            },
+            Some("sha256:abc".to_string()),
+            Some("alice@example.com".to_string()),
+        )
+        .unwrap();
+
+    assert_eq!(input.identity.package_id.as_str(), "echo");
+    assert!(matches!(
+        input.identity.source,
+        PackageSource::LocalManifest { ref path } if path == "/system/extensions/echo/manifest.toml"
+    ));
+    assert_eq!(input.identity.digest.as_deref(), Some("sha256:abc"));
+    assert_eq!(input.identity.signer.as_deref(), Some("alice@example.com"));
+    assert_eq!(
+        input.requested_trust,
+        RequestedTrustClass::FirstPartyRequested
+    );
+    assert_eq!(
+        input
+            .requested_authority
+            .iter()
+            .map(|id| id.as_str().to_string())
+            .collect::<Vec<_>>(),
+        vec!["echo.say"]
+    );
 }
 
 #[test]
@@ -83,6 +149,7 @@ fn script_runtime_keeps_runner_metadata_without_execution() {
 fn mcp_runtime_keeps_transport_metadata_without_connecting() {
     let manifest = ExtensionManifest::parse(MCP_MANIFEST).unwrap();
     assert_eq!(manifest.runtime_kind(), RuntimeKind::Mcp);
+    assert_eq!(manifest.requested_trust, RequestedTrustClass::ThirdParty);
     assert_eq!(manifest.trust, TrustClass::UserTrusted);
     assert!(matches!(
         manifest.runtime,
@@ -301,7 +368,7 @@ id = "echo"
 name = "Echo"
 version = "0.1.0"
 description = "Echo demo extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "wasm"
@@ -320,7 +387,7 @@ id = "ordered"
 name = "Ordered"
 version = "0.1.0"
 description = "Ordered capability demo extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "wasm"
@@ -367,7 +434,7 @@ id = "project-tools"
 name = "Project Tools"
 version = "0.1.0"
 description = "Project-local CLI helpers"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "script"
@@ -389,7 +456,7 @@ id = "project-tools"
 name = "Project Tools"
 version = "0.1.0"
 description = "Project-local CLI helpers"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "script"
@@ -410,7 +477,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "user_trusted"
+trust = "third_party"
 
 [runtime]
 kind = "mcp"
@@ -451,7 +518,7 @@ id = "empty"
 name = "Empty"
 version = "0.1.0"
 description = "No capabilities"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "wasm"
@@ -768,7 +835,7 @@ id = "conversation"
 name = "Conversation"
 version = "0.1.0"
 description = "Conversation service"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "first_party"
@@ -787,7 +854,7 @@ id = "audit"
 name = "Audit"
 version = "0.1.0"
 description = "Audit service"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "system"
@@ -806,7 +873,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "user_trusted"
+trust = "third_party"
 
 [runtime]
 kind = "mcp"
@@ -825,7 +892,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "user_trusted"
+trust = "third_party"
 
 [runtime]
 kind = "mcp"
@@ -845,7 +912,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "user_trusted"
+trust = "third_party"
 
 [runtime]
 kind = "mcp"
@@ -864,7 +931,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "user_trusted"
+trust = "third_party"
 
 [runtime]
 kind = "mcp"
@@ -884,7 +951,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "user_trusted"
+trust = "third_party"
 
 [runtime]
 kind = "mcp"
@@ -904,7 +971,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "user_trusted"
+trust = "third_party"
 
 [runtime]
 kind = "mcp"


### PR DESCRIPTION
## Summary

Wires extension manifests into the trust-policy input model introduced by the Reborn trust substrate.

This keeps extension/registry changes separate from the authorization consumer PR (#3070) and stacks on `reborn-auth-trust-policy`.

Changes:

- parse manifest `trust` as `RequestedTrustClass`
- retain safe declarative `TrustClass` metadata for `CapabilityDescriptor::trust_ceiling`
- keep privileged manifest requests (`first_party_requested`, `system_requested`) sandboxed until host policy evaluates them
- add `ExtensionPackage::package_identity(...)`
- add `ExtensionPackage::trust_policy_input(...)`
- derive requested authority from declared capability ids using a canonical `BTreeSet`

## Scope boundary

This PR does not evaluate trust policy, call authorization, or touch process/runtime execution. It only turns validated extension package metadata into `TrustPolicyInput` for the host wiring layer.

## Tests

Added coverage for:

- privileged requested trust is metadata only and descriptor trust remains sandboxed
- package builds `TrustPolicyInput` with identity/source/digest/signer/requested trust/requested authority
- existing extension parsing/discovery/registry behavior with requested-trust manifest values

## Verification

Passed locally:

```bash
cargo fmt --check
cargo check -p ironclaw_extensions
cargo clippy -p ironclaw_extensions --all-targets -- -D warnings
cargo test -p ironclaw_extensions
```
