### PR TITLE
fix: restrict test HTTP remap targets to HTTP(S)

### DIFF
--- a/src/http_intercept.rs
+++ b/src/http_intercept.rs
@@ -72,6 +72,9 @@ fn is_loopback_target(base_url: &str) -> bool {
     let Ok(parsed) = reqwest::Url::parse(base_url) else {
         return false;
     };
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return false;
+    }
     let Some(host) = parsed.host_str() else {
         return false;
     };
@@ -198,6 +201,9 @@ mod tests {
         assert!(is_loopback_target("http://localhost:8080"));
         assert!(is_loopback_target("http://127.0.0.1"));
         assert!(is_loopback_target("http://127.0.0.1:8080"));
+        assert!(is_loopback_target("http://[::1]:8080"));
+        assert!(!is_loopback_target("ftp://localhost:8080"));
+        assert!(!is_loopback_target("file://localhost/tmp/mock"));
         assert!(!is_loopback_target("https://api.anthropic.com"));
         assert!(!is_loopback_target("http://192.168.1.1"));
         assert!(!is_loopback_target("http://10.0.0.1"));


### PR DESCRIPTION
## Summary
- restrict `IRONCLAW_TEST_HTTP_REMAP` targets to HTTP(S) loopback URLs
- add regression coverage for IPv6 loopback and non-HTTP(S) loopback-shaped targets

## Change Type
Bug fix / security hardening

## Linked Issue
None

## Validation
- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=2 cargo test -p ironclaw --bin ironclaw http_intercept::tests::loopback_target_validation -- --exact --nocapture`

## Security Impact
Narrows the test/debug-only HTTP remap affordance by rejecting non-HTTP(S) URL schemes before registering a remap target. No production behavior outside the existing test/debug gate is expanded.

## Database Impact
None

## Blast Radius
Limited to `src/http_intercept.rs` remap target validation and unit coverage.

## Rollback Plan
Revert this PR.

## Review Follow-Through
I will monitor CI/review feedback and address requested changes.

## Review track
Standard
