### PR TITLE
test(reborn): add phase 1 integration coverage

### DIFF
--- a/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
+++ b/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
@@ -1,0 +1,332 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_dispatcher::*;
+use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
+use ironclaw_extensions::*;
+use ironclaw_filesystem::*;
+use ironclaw_host_api::*;
+use ironclaw_resources::*;
+use serde_json::{Value, json};
+
+#[tokio::test]
+async fn runtime_dispatcher_routes_already_authorized_request_through_public_trait_object() {
+    let registry = Arc::new(registry_with_package(WASM_MANIFEST));
+    let filesystem = Arc::new(mounted_empty_extension_root());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let events = InMemoryEventSink::new();
+    let adapter = Arc::new(RecordingAdapter::new(
+        RuntimeKind::Wasm,
+        json!({"reply": "from adapter"}),
+    ));
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/project-a").unwrap(),
+        MountPermissions::read_only(),
+    )])
+    .unwrap();
+
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            max_output_bytes: Some(10_000),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let dispatcher = RuntimeDispatcher::from_arcs(
+        Arc::clone(&registry),
+        Arc::clone(&filesystem),
+        Arc::clone(&governor),
+    )
+    .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(&adapter))
+    .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatch_port: &dyn CapabilityDispatcher = &dispatcher;
+
+    let result = dispatch_port
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: Some(mounts.clone()),
+            resource_reservation: None,
+            input: json!({"message": "hello through public seam"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.capability_id, CapabilityId::new("echo.say").unwrap());
+    assert_eq!(result.provider, ExtensionId::new("echo").unwrap());
+    assert_eq!(result.runtime, RuntimeKind::Wasm);
+    assert_eq!(result.output, json!({"reply": "from adapter"}));
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert!(governor.usage_for(&account).output_bytes > 0);
+
+    let requests = adapter.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].provider, ExtensionId::new("echo").unwrap());
+    assert_eq!(
+        requests[0].capability_id,
+        CapabilityId::new("echo.say").unwrap()
+    );
+    assert_eq!(requests[0].runtime, RuntimeKind::Wasm);
+    assert_eq!(requests[0].scope, scope);
+    assert_eq!(requests[0].mounts, Some(mounts));
+    assert_eq!(
+        requests[0].input,
+        json!({"message": "hello through public seam"})
+    );
+
+    let recorded = events.events();
+    assert_eq!(recorded.len(), 3);
+    assert_eq!(recorded[0].kind, RuntimeEventKind::DispatchRequested);
+    assert_eq!(recorded[1].kind, RuntimeEventKind::RuntimeSelected);
+    assert_eq!(
+        recorded[1].provider,
+        Some(ExtensionId::new("echo").unwrap())
+    );
+    assert_eq!(recorded[1].runtime, Some(RuntimeKind::Wasm));
+    assert_eq!(recorded[2].kind, RuntimeEventKind::DispatchSucceeded);
+    assert_eq!(recorded[2].output_bytes, Some(result.usage.output_bytes));
+}
+
+#[tokio::test]
+async fn runtime_dispatcher_fails_closed_for_missing_backend_before_reservation_or_adapter_call() {
+    let registry = Arc::new(registry_with_package(SCRIPT_MANIFEST));
+    let filesystem = Arc::new(mounted_empty_extension_root());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let events = InMemoryEventSink::new();
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, filesystem, Arc::clone(&governor))
+        .with_event_sink_arc(Arc::new(events.clone()));
+    let dispatch_port: &dyn CapabilityDispatcher = &dispatcher;
+
+    let err = dispatch_port
+        .dispatch_json(CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("script.echo").unwrap(),
+            scope,
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message": "blocked"}),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::Script
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+
+    let recorded = events.events();
+    assert_eq!(recorded.len(), 2);
+    assert_eq!(recorded[0].kind, RuntimeEventKind::DispatchRequested);
+    assert_eq!(recorded[1].kind, RuntimeEventKind::DispatchFailed);
+    assert_eq!(recorded[1].runtime, Some(RuntimeKind::Script));
+    assert_eq!(
+        recorded[1].error_kind.as_deref(),
+        Some("missing_runtime_backend")
+    );
+}
+
+#[tokio::test]
+async fn registry_rejects_descriptor_package_runtime_mismatch_before_dispatcher_construction() {
+    let manifest = ExtensionManifest::parse(WASM_MANIFEST).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    let mut package = ExtensionPackage::from_manifest(manifest, root).unwrap();
+    package.capabilities[0].runtime = RuntimeKind::Script;
+
+    let err = ExtensionRegistry::new().insert(package).unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::InvalidManifest { reason }
+            if reason.contains("package capability descriptors do not match")
+    ));
+}
+
+#[derive(Clone)]
+struct RecordingAdapter {
+    runtime: RuntimeKind,
+    output: Value,
+    requests: Arc<Mutex<Vec<RecordedAdapterRequest>>>,
+}
+
+impl RecordingAdapter {
+    fn new(runtime: RuntimeKind, output: Value) -> Self {
+        Self {
+            runtime,
+            output,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<RecordedAdapterRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RecordedAdapterRequest {
+    provider: ExtensionId,
+    capability_id: CapabilityId,
+    runtime: RuntimeKind,
+    scope: ResourceScope,
+    mounts: Option<MountView>,
+    input: Value,
+}
+
+#[async_trait]
+impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        self.requests.lock().unwrap().push(RecordedAdapterRequest {
+            provider: request.package.id.clone(),
+            capability_id: request.capability_id.clone(),
+            runtime: request.descriptor.runtime,
+            scope: request.scope.clone(),
+            mounts: request.mounts.clone(),
+            input: request.input.clone(),
+        });
+
+        let output_bytes = serde_json::to_vec(&self.output).unwrap().len() as u64;
+        let usage = ResourceUsage {
+            output_bytes,
+            process_count: u32::from(matches!(
+                self.runtime,
+                RuntimeKind::Script | RuntimeKind::Mcp
+            )),
+            ..ResourceUsage::default()
+        };
+        let reservation = request
+            .governor
+            .reserve(request.scope, request.estimate)
+            .map_err(|_| {
+                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
+            })?;
+        let receipt = request
+            .governor
+            .reconcile(reservation.id, usage.clone())
+            .map_err(|_| {
+                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
+            })?;
+
+        Ok(RuntimeAdapterResult {
+            output: self.output.clone(),
+            usage,
+            receipt,
+            output_bytes,
+        })
+    }
+}
+
+fn dispatch_error_for_runtime(
+    runtime: RuntimeKind,
+    kind: RuntimeDispatchErrorKind,
+) -> DispatchError {
+    match runtime {
+        RuntimeKind::Wasm => DispatchError::Wasm { kind },
+        RuntimeKind::Script => DispatchError::Script { kind },
+        RuntimeKind::Mcp => DispatchError::Mcp { kind },
+        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
+            capability: CapabilityId::new("system.unsupported").unwrap(),
+            runtime,
+        },
+    }
+}
+
+fn registry_with_package(manifest: &str) -> ExtensionRegistry {
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package_from_manifest(manifest)).unwrap();
+    registry
+}
+
+fn package_from_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn mounted_empty_extension_root() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("user-a").unwrap(),
+        agent_id: Some(AgentId::new("agent-a").unwrap()),
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: Some(MissionId::new("mission-a").unwrap()),
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id: InvocationId::new(),
+    }
+}
+
+const WASM_MANIFEST: &str = r#"
+id = "echo"
+name = "Echo WASM"
+version = "0.1.0"
+description = "Echo WASM integration extension"
+trust = "sandbox"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "echo.say"
+description = "Echo through WASM"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;
+
+const SCRIPT_MANIFEST: &str = r#"
+id = "script"
+name = "Script Echo"
+version = "0.1.0"
+description = "Script integration extension"
+trust = "sandbox"
+
+[runtime]
+kind = "script"
+runner = "docker"
+image = "example/script:latest"
+command = "echo"
+args = []
+
+[[capabilities]]
+id = "script.echo"
+description = "Echo through Script"
+effects = ["dispatch_capability", "execute_code"]
+default_permission = "ask"
+parameters_schema = { type = "object" }
+"#;

--- a/crates/ironclaw_processes/tests/process_dispatch_integration.rs
+++ b/crates/ironclaw_processes/tests/process_dispatch_integration.rs
@@ -74,13 +74,13 @@ async fn process_services_complete_background_process_through_process_host_and_e
 async fn process_host_kill_preserves_terminal_state_and_suppresses_late_completion_event() {
     let events = InMemoryEventSink::new();
     let event_sink: Arc<dyn EventSink> = Arc::new(events.clone());
-    let process_store = Arc::new(EventingProcessStore::new(
-        InMemoryProcessStore::new(),
-        event_sink,
+    let executor = Arc::new(CancelThenLateSuccessExecutor::default());
+    let process_store = Arc::new(PostCompletionProbeStore::new(
+        EventingProcessStore::new(InMemoryProcessStore::new(), event_sink),
+        Arc::clone(&executor),
     ));
     let result_store = Arc::new(InMemoryProcessResultStore::new());
     let services = ProcessServices::new(Arc::clone(&process_store), Arc::clone(&result_store));
-    let executor = Arc::new(CancelThenLateSuccessExecutor::default());
     let manager = services.background_manager(Arc::clone(&executor));
     let host = services.host().with_poll_interval(Duration::from_millis(5));
     let invocation_id = InvocationId::new();
@@ -105,7 +105,12 @@ async fn process_host_kill_preserves_terminal_state_and_suppresses_late_completi
     )
     .await
     .unwrap();
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    timeout(
+        Duration::from_millis(200),
+        executor.wait_for_post_completion_status_probe(),
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         host.status(&scope, process_id)
@@ -154,8 +159,11 @@ impl ProcessExecutor for SuccessExecutor {
 #[derive(Default)]
 struct CancelThenLateSuccessExecutor {
     cancellations: AtomicUsize,
+    completion_attempts: AtomicUsize,
+    post_completion_status_probes: AtomicUsize,
     cancellation_notified: Notify,
     completion_attempt_notified: Notify,
+    post_completion_status_probe_notified: Notify,
 }
 
 impl CancelThenLateSuccessExecutor {
@@ -170,7 +178,31 @@ impl CancelThenLateSuccessExecutor {
     }
 
     async fn wait_for_completion_attempt(&self) {
-        self.completion_attempt_notified.notified().await;
+        loop {
+            let notified = self.completion_attempt_notified.notified();
+            if self.completion_attempts.load(Ordering::SeqCst) > 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    async fn wait_for_post_completion_status_probe(&self) {
+        loop {
+            let notified = self.post_completion_status_probe_notified.notified();
+            if self.post_completion_status_probes.load(Ordering::SeqCst) > 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    fn record_post_completion_status_probe(&self) {
+        if self.completion_attempts.load(Ordering::SeqCst) > 0 {
+            self.post_completion_status_probes
+                .fetch_add(1, Ordering::SeqCst);
+            self.post_completion_status_probe_notified.notify_waiters();
+        }
     }
 }
 
@@ -184,10 +216,74 @@ impl ProcessExecutor for CancelThenLateSuccessExecutor {
         self.cancellations.fetch_add(1, Ordering::SeqCst);
         self.cancellation_notified.notify_waiters();
         tokio::time::sleep(Duration::from_millis(25)).await;
+        self.completion_attempts.fetch_add(1, Ordering::SeqCst);
         self.completion_attempt_notified.notify_waiters();
         Ok(ProcessExecutionResult {
             output: json!({"should_not_publish": true}),
         })
+    }
+}
+
+struct PostCompletionProbeStore<S> {
+    inner: S,
+    probe: Arc<CancelThenLateSuccessExecutor>,
+}
+
+impl<S> PostCompletionProbeStore<S> {
+    fn new(inner: S, probe: Arc<CancelThenLateSuccessExecutor>) -> Self {
+        Self { inner, probe }
+    }
+}
+
+#[async_trait]
+impl<S> ProcessStore for PostCompletionProbeStore<S>
+where
+    S: ProcessStore,
+{
+    async fn start(&self, start: ProcessStart) -> Result<ProcessRecord, ProcessError> {
+        self.inner.start(start).await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<ProcessRecord, ProcessError> {
+        self.inner.complete(scope, process_id).await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+        error_kind: String,
+    ) -> Result<ProcessRecord, ProcessError> {
+        self.inner.fail(scope, process_id, error_kind).await
+    }
+
+    async fn kill(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<ProcessRecord, ProcessError> {
+        self.inner.kill(scope, process_id).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<Option<ProcessRecord>, ProcessError> {
+        let record = self.inner.get(scope, process_id).await?;
+        self.probe.record_post_completion_status_probe();
+        Ok(record)
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ProcessRecord>, ProcessError> {
+        self.inner.records_for_scope(scope).await
     }
 }
 

--- a/crates/ironclaw_processes/tests/process_dispatch_integration.rs
+++ b/crates/ironclaw_processes/tests/process_dispatch_integration.rs
@@ -1,0 +1,225 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use ironclaw_events::{EventSink, InMemoryEventSink, RuntimeEventKind};
+use ironclaw_host_api::*;
+use ironclaw_processes::*;
+use serde_json::json;
+use tokio::{sync::Notify, time::timeout};
+
+#[tokio::test]
+async fn process_services_complete_background_process_through_process_host_and_eventing_store() {
+    let events = InMemoryEventSink::new();
+    let event_sink: Arc<dyn EventSink> = Arc::new(events.clone());
+    let process_store = Arc::new(EventingProcessStore::new(
+        InMemoryProcessStore::new(),
+        event_sink,
+    ));
+    let result_store = Arc::new(InMemoryProcessResultStore::new());
+    let services = ProcessServices::new(Arc::clone(&process_store), Arc::clone(&result_store));
+    let manager = services.background_manager(Arc::new(SuccessExecutor));
+    let host = services.host().with_poll_interval(Duration::from_millis(5));
+    let invocation_id = InvocationId::new();
+    let process_id = ProcessId::new();
+    let scope = sample_scope(invocation_id, "tenant-a", "user-a");
+
+    let started = manager
+        .spawn(process_start(process_id, invocation_id, scope.clone()))
+        .await
+        .unwrap();
+    assert_eq!(started.status, ProcessStatus::Running);
+
+    let result = host.await_result(&scope, process_id).await.unwrap();
+
+    assert_eq!(result.status, ProcessStatus::Completed);
+    assert_eq!(result.output, Some(json!({"ok": true})));
+    assert_eq!(
+        host.status(&scope, process_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ProcessStatus::Completed
+    );
+    assert_eq!(
+        host.output(&scope, process_id).await.unwrap(),
+        Some(json!({"ok": true}))
+    );
+
+    let recorded = events.events();
+    let kinds = recorded.iter().map(|event| event.kind).collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            RuntimeEventKind::ProcessStarted,
+            RuntimeEventKind::ProcessCompleted,
+        ]
+    );
+    assert_eq!(recorded[0].process_id, Some(process_id));
+    assert_eq!(recorded[1].process_id, Some(process_id));
+    assert_eq!(
+        recorded[1].provider,
+        Some(ExtensionId::new("echo").unwrap())
+    );
+    assert_eq!(recorded[1].runtime, Some(RuntimeKind::Wasm));
+}
+
+#[tokio::test]
+async fn process_host_kill_preserves_terminal_state_and_suppresses_late_completion_event() {
+    let events = InMemoryEventSink::new();
+    let event_sink: Arc<dyn EventSink> = Arc::new(events.clone());
+    let process_store = Arc::new(EventingProcessStore::new(
+        InMemoryProcessStore::new(),
+        event_sink,
+    ));
+    let result_store = Arc::new(InMemoryProcessResultStore::new());
+    let services = ProcessServices::new(Arc::clone(&process_store), Arc::clone(&result_store));
+    let executor = Arc::new(CancelThenLateSuccessExecutor::default());
+    let manager = services.background_manager(Arc::clone(&executor));
+    let host = services.host().with_poll_interval(Duration::from_millis(5));
+    let invocation_id = InvocationId::new();
+    let process_id = ProcessId::new();
+    let scope = sample_scope(invocation_id, "tenant-a", "user-a");
+
+    let started = manager
+        .spawn(process_start(process_id, invocation_id, scope.clone()))
+        .await
+        .unwrap();
+    assert_eq!(started.status, ProcessStatus::Running);
+
+    let killed = host.kill(&scope, process_id).await.unwrap();
+    assert_eq!(killed.status, ProcessStatus::Killed);
+    timeout(Duration::from_millis(200), executor.wait_for_cancellation())
+        .await
+        .unwrap();
+
+    timeout(
+        Duration::from_millis(200),
+        executor.wait_for_completion_attempt(),
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    assert_eq!(
+        host.status(&scope, process_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ProcessStatus::Killed
+    );
+    let result = host.result(&scope, process_id).await.unwrap().unwrap();
+    assert_eq!(result.status, ProcessStatus::Killed);
+    assert_eq!(result.output, None);
+    assert_eq!(host.output(&scope, process_id).await.unwrap(), None);
+    assert_eq!(executor.cancellations.load(Ordering::SeqCst), 1);
+
+    let recorded = events.events();
+    let kinds = recorded.iter().map(|event| event.kind).collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            RuntimeEventKind::ProcessStarted,
+            RuntimeEventKind::ProcessKilled
+        ]
+    );
+    assert!(
+        !kinds.contains(&RuntimeEventKind::ProcessCompleted),
+        "late executor success must not emit a misleading completion event"
+    );
+}
+
+struct SuccessExecutor;
+
+#[async_trait]
+impl ProcessExecutor for SuccessExecutor {
+    async fn execute(
+        &self,
+        request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        assert_eq!(request.input, json!({"message": "runtime payload"}));
+        Ok(ProcessExecutionResult {
+            output: json!({"ok": true}),
+        })
+    }
+}
+
+#[derive(Default)]
+struct CancelThenLateSuccessExecutor {
+    cancellations: AtomicUsize,
+    cancellation_notified: Notify,
+    completion_attempt_notified: Notify,
+}
+
+impl CancelThenLateSuccessExecutor {
+    async fn wait_for_cancellation(&self) {
+        loop {
+            let notified = self.cancellation_notified.notified();
+            if self.cancellations.load(Ordering::SeqCst) > 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    async fn wait_for_completion_attempt(&self) {
+        self.completion_attempt_notified.notified().await;
+    }
+}
+
+#[async_trait]
+impl ProcessExecutor for CancelThenLateSuccessExecutor {
+    async fn execute(
+        &self,
+        request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        request.cancellation.cancelled().await;
+        self.cancellations.fetch_add(1, Ordering::SeqCst);
+        self.cancellation_notified.notify_waiters();
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        self.completion_attempt_notified.notify_waiters();
+        Ok(ProcessExecutionResult {
+            output: json!({"should_not_publish": true}),
+        })
+    }
+}
+
+fn process_start(
+    process_id: ProcessId,
+    invocation_id: InvocationId,
+    scope: ResourceScope,
+) -> ProcessStart {
+    ProcessStart {
+        process_id,
+        parent_process_id: None,
+        invocation_id,
+        scope,
+        extension_id: ExtensionId::new("echo").unwrap(),
+        capability_id: CapabilityId::new("echo.say").unwrap(),
+        runtime: RuntimeKind::Wasm,
+        grants: CapabilitySet::default(),
+        mounts: MountView::default(),
+        estimated_resources: ResourceEstimate::default(),
+        resource_reservation_id: None,
+        input: json!({"message": "runtime payload"}),
+    }
+}
+
+fn sample_scope(invocation_id: InvocationId, tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: Some(AgentId::new("agent-a").unwrap()),
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: Some(MissionId::new("mission-a").unwrap()),
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id,
+    }
+}


### PR DESCRIPTION
## Summary

Adds Phase 1 Reborn caller-level integration coverage from #3067 now that `ironclaw_processes` (#3017) and `ironclaw_dispatcher` (#3023) have landed on `reborn-integration`.

This PR intentionally adds tests only; no production behavior changes.

## Coverage

- `crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs`
  - routes an already-authorized request through the public `CapabilityDispatcher` trait object
  - preserves scope/capability/input/mounts into the runtime adapter
  - returns normalized dispatch results and reconciles resources
  - emits dispatch lifecycle events
  - fails closed for missing runtime backends before reservation/adapter execution
  - verifies descriptor/package runtime mismatch is rejected at the public extension registry seam

- `crates/ironclaw_processes/tests/process_dispatch_integration.rs`
  - completes a background process through `ProcessServices` + `ProcessHost`
  - persists/readbacks result and output through the host surface
  - emits process lifecycle events through `EventingProcessStore`
  - verifies `kill` transitions to `Killed`, signals cancellation, blocks late executor success from overwriting terminal state, and suppresses misleading completion events

## Verification

```bash
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-integration-target \
  cargo test -p ironclaw_dispatcher -p ironclaw_processes

CARGO_TARGET_DIR=/tmp/ironclaw-reborn-integration-target \
  cargo clippy -q -p ironclaw_dispatcher -p ironclaw_processes --all-targets -- -D warnings

cargo fmt --check
git diff --check
```

Refs #3067.
