### PR TITLE
feat(reborn): add secrets and network boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4149,6 +4149,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironclaw_network"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ironclaw_host_api",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "ironclaw_processes"
 version = "0.1.0"
 dependencies = [
@@ -4212,6 +4222,18 @@ dependencies = [
  "rust_decimal_macros",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ironclaw_secrets"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ironclaw_host_api",
+ "secrecy",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_extensions", "crates/ironclaw_processes", "crates/ironclaw_dispatcher", "crates/ironclaw_scripts", "crates/ironclaw_mcp", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_trust", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
+members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_extensions", "crates/ironclaw_processes", "crates/ironclaw_dispatcher", "crates/ironclaw_scripts", "crates/ironclaw_mcp", "crates/ironclaw_secrets", "crates/ironclaw_network", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_trust", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
 exclude = [
     "channels-src/discord",
     "channels-src/telegram",

--- a/crates/ironclaw_network/CLAUDE.md
+++ b/crates/ironclaw_network/CLAUDE.md
@@ -1,7 +1,7 @@
 # ironclaw_network guardrails
 
-- Own network policy evaluation and scoped network permits only.
-- Do not perform HTTP I/O, DNS resolution, proxying, secret injection, resource reservation, audit/event emission, or product workflow here.
+- Own network policy evaluation and scoped network permits only; actual egress enforcement happens at the runtime/network execution boundary.
+- Do not perform HTTP I/O, DNS/redirect revalidation, proxying, response limiting, secret injection, resource reservation, audit/event emission, or product workflow here.
 - Preserve tenant/user/project scope in requests, permits, and errors.
 - Fail closed when no target pattern matches or no allowed targets are configured.
 - Keep host matching intentionally simple: exact host or one leading wildcard label (`*.example.com`), never arbitrary regex.

--- a/crates/ironclaw_network/CLAUDE.md
+++ b/crates/ironclaw_network/CLAUDE.md
@@ -1,0 +1,8 @@
+# ironclaw_network guardrails
+
+- Own network policy evaluation and scoped network permits only.
+- Do not perform HTTP I/O, DNS resolution, proxying, secret injection, resource reservation, audit/event emission, or product workflow here.
+- Preserve tenant/user/project scope in requests, permits, and errors.
+- Fail closed when no target pattern matches or no allowed targets are configured.
+- Keep host matching intentionally simple: exact host or one leading wildcard label (`*.example.com`), never arbitrary regex.
+- Do not depend on runtime, workflow, secret, filesystem, resource, event, approval, or authorization crates.

--- a/crates/ironclaw_network/CLAUDE.md
+++ b/crates/ironclaw_network/CLAUDE.md
@@ -2,7 +2,7 @@
 
 - Own network policy evaluation and scoped network permits only; actual egress enforcement happens at the runtime/network execution boundary.
 - Do not perform HTTP I/O, DNS/redirect revalidation, proxying, response limiting, secret injection, resource reservation, audit/event emission, or product workflow here.
-- Preserve tenant/user/project scope in requests, permits, and errors.
+- Preserve tenant/user/agent/project scope in requests, permits, and errors.
 - Fail closed when no target pattern matches or no allowed targets are configured.
 - Keep host matching intentionally simple: exact host or one leading wildcard label (`*.example.com`), never arbitrary regex.
 - Do not depend on runtime, workflow, secret, filesystem, resource, event, approval, or authorization crates.

--- a/crates/ironclaw_network/Cargo.toml
+++ b/crates/ironclaw_network/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ironclaw_network"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_network/src/lib.rs
+++ b/crates/ironclaw_network/src/lib.rs
@@ -2,7 +2,9 @@
 //!
 //! This crate evaluates host API [`NetworkPolicy`] values against scoped network
 //! requests. It does not perform HTTP I/O, resolve DNS, inject secrets, reserve
-//! resources, or emit audit/events.
+//! resources, or emit audit/events. Actual egress enforcement, DNS/redirect
+//! revalidation, and response limiting belong at the runtime/network execution
+//! boundary.
 
 use std::net::IpAddr;
 

--- a/crates/ironclaw_network/src/lib.rs
+++ b/crates/ironclaw_network/src/lib.rs
@@ -1,0 +1,219 @@
+//! Network policy boundary for IronClaw Reborn.
+//!
+//! This crate evaluates host API [`NetworkPolicy`] values against scoped network
+//! requests. It does not perform HTTP I/O, resolve DNS, inject secrets, reserve
+//! resources, or emit audit/events.
+
+use std::net::IpAddr;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTarget, NetworkTargetPattern, ResourceScope,
+};
+use thiserror::Error;
+
+/// One scoped network operation to authorize before a runtime performs I/O.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkRequest {
+    pub scope: ResourceScope,
+    pub target: NetworkTarget,
+    pub method: NetworkMethod,
+    pub estimated_bytes: Option<u64>,
+}
+
+/// Metadata permit returned after policy evaluation succeeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkPermit {
+    pub scope: ResourceScope,
+    pub target: NetworkTarget,
+    pub method: NetworkMethod,
+    pub estimated_bytes: Option<u64>,
+}
+
+/// Network policy denial. Variants intentionally carry metadata only.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NetworkPolicyError {
+    #[error("network target is not allowed by policy")]
+    TargetDenied {
+        scope: Box<ResourceScope>,
+        target: NetworkTarget,
+    },
+    #[error(
+        "network target is private, loopback, link-local, documentation, or otherwise host-local"
+    )]
+    PrivateTargetDenied {
+        scope: Box<ResourceScope>,
+        target: NetworkTarget,
+    },
+    #[error("network egress estimate {estimated} exceeds limit {limit}")]
+    EgressLimitExceeded {
+        scope: Box<ResourceScope>,
+        estimated: u64,
+        limit: u64,
+    },
+}
+
+impl NetworkPolicyError {
+    pub fn is_target_denied(&self) -> bool {
+        matches!(self, Self::TargetDenied { .. })
+    }
+
+    pub fn is_private_target_denied(&self) -> bool {
+        matches!(self, Self::PrivateTargetDenied { .. })
+    }
+
+    pub fn is_egress_limit_exceeded(&self) -> bool {
+        matches!(self, Self::EgressLimitExceeded { .. })
+    }
+}
+
+/// Scoped network policy evaluation contract.
+#[async_trait]
+pub trait NetworkPolicyEnforcer: Send + Sync {
+    /// Authorizes one scoped network request without performing I/O.
+    async fn authorize(&self, request: NetworkRequest)
+    -> Result<NetworkPermit, NetworkPolicyError>;
+}
+
+/// Static policy enforcer for contract tests and composition scaffolding.
+#[derive(Debug, Clone)]
+pub struct StaticNetworkPolicyEnforcer {
+    policy: NetworkPolicy,
+}
+
+impl StaticNetworkPolicyEnforcer {
+    pub fn new(policy: NetworkPolicy) -> Self {
+        Self { policy }
+    }
+
+    pub fn policy(&self) -> &NetworkPolicy {
+        &self.policy
+    }
+}
+
+#[async_trait]
+impl NetworkPolicyEnforcer for StaticNetworkPolicyEnforcer {
+    async fn authorize(
+        &self,
+        request: NetworkRequest,
+    ) -> Result<NetworkPermit, NetworkPolicyError> {
+        if let Some(limit) = self.policy.max_egress_bytes
+            && let Some(estimated) = request.estimated_bytes
+            && estimated > limit
+        {
+            return Err(NetworkPolicyError::EgressLimitExceeded {
+                scope: Box::new(request.scope),
+                estimated,
+                limit,
+            });
+        }
+
+        if self.policy.deny_private_ip_ranges
+            && let Ok(ip) = request.target.host.parse::<IpAddr>()
+            && is_private_or_loopback_ip(ip)
+        {
+            return Err(NetworkPolicyError::PrivateTargetDenied {
+                scope: Box::new(request.scope),
+                target: request.target,
+            });
+        }
+
+        if !network_policy_allows(&self.policy, &request.target) {
+            return Err(NetworkPolicyError::TargetDenied {
+                scope: Box::new(request.scope),
+                target: request.target,
+            });
+        }
+
+        Ok(NetworkPermit {
+            scope: request.scope,
+            target: request.target,
+            method: request.method,
+            estimated_bytes: request.estimated_bytes,
+        })
+    }
+}
+
+pub fn network_policy_allows(policy: &NetworkPolicy, target: &NetworkTarget) -> bool {
+    if policy.allowed_targets.is_empty() {
+        return false;
+    }
+    if policy.deny_private_ip_ranges
+        && let Ok(ip) = target.host.parse::<IpAddr>()
+        && is_private_or_loopback_ip(ip)
+    {
+        return false;
+    }
+    policy
+        .allowed_targets
+        .iter()
+        .any(|pattern| target_matches_pattern(target, pattern))
+}
+
+pub fn target_matches_pattern(target: &NetworkTarget, pattern: &NetworkTargetPattern) -> bool {
+    if let Some(scheme) = pattern.scheme
+        && scheme != target.scheme
+    {
+        return false;
+    }
+    if let Some(port) = pattern.port
+        && Some(port) != target.port
+    {
+        return false;
+    }
+    host_matches_pattern(&target.host.to_ascii_lowercase(), &pattern.host_pattern)
+}
+
+pub fn host_matches_pattern(host: &str, pattern: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    let pattern = pattern.to_ascii_lowercase();
+    if let Some(suffix) = pattern.strip_prefix("*.") {
+        let suffix_with_dot = format!(".{suffix}");
+        let Some(prefix) = host.strip_suffix(&suffix_with_dot) else {
+            return false;
+        };
+        !prefix.is_empty() && !prefix.contains('.')
+    } else {
+        host == pattern
+    }
+}
+
+pub fn is_private_or_loopback_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_broadcast()
+                || ip.is_documentation()
+                || ip.is_multicast()
+                || ip.octets()[0] == 0
+                || is_carrier_grade_nat_v4(ip)
+        }
+        IpAddr::V6(ip) => {
+            ip.is_loopback()
+                || ip.is_unspecified()
+                || ip.is_unique_local()
+                || ip.is_unicast_link_local()
+                || ip.is_multicast()
+                || is_documentation_v6(ip)
+        }
+    }
+}
+
+fn is_carrier_grade_nat_v4(ip: std::net::Ipv4Addr) -> bool {
+    let [first, second, ..] = ip.octets();
+    first == 100 && (64..=127).contains(&second)
+}
+
+fn is_documentation_v6(ip: std::net::Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    segments[0] == 0x2001 && segments[1] == 0x0db8
+}
+
+pub fn scheme_label(scheme: NetworkScheme) -> &'static str {
+    match scheme {
+        NetworkScheme::Http => "http",
+        NetworkScheme::Https => "https",
+    }
+}

--- a/crates/ironclaw_network/src/lib.rs
+++ b/crates/ironclaw_network/src/lib.rs
@@ -47,6 +47,11 @@ pub enum NetworkPolicyError {
         scope: Box<ResourceScope>,
         target: NetworkTarget,
     },
+    #[error("network egress estimate is required when limit {limit} is configured")]
+    EgressEstimateRequired {
+        scope: Box<ResourceScope>,
+        limit: u64,
+    },
     #[error("network egress estimate {estimated} exceeds limit {limit}")]
     EgressLimitExceeded {
         scope: Box<ResourceScope>,
@@ -66,6 +71,10 @@ impl NetworkPolicyError {
 
     pub fn is_egress_limit_exceeded(&self) -> bool {
         matches!(self, Self::EgressLimitExceeded { .. })
+    }
+
+    pub fn is_egress_estimate_required(&self) -> bool {
+        matches!(self, Self::EgressEstimateRequired { .. })
     }
 }
 
@@ -99,15 +108,20 @@ impl NetworkPolicyEnforcer for StaticNetworkPolicyEnforcer {
         &self,
         request: NetworkRequest,
     ) -> Result<NetworkPermit, NetworkPolicyError> {
-        if let Some(limit) = self.policy.max_egress_bytes
-            && let Some(estimated) = request.estimated_bytes
-            && estimated > limit
-        {
-            return Err(NetworkPolicyError::EgressLimitExceeded {
-                scope: Box::new(request.scope),
-                estimated,
-                limit,
-            });
+        if let Some(limit) = self.policy.max_egress_bytes {
+            let Some(estimated) = request.estimated_bytes else {
+                return Err(NetworkPolicyError::EgressEstimateRequired {
+                    scope: Box::new(request.scope),
+                    limit,
+                });
+            };
+            if estimated > limit {
+                return Err(NetworkPolicyError::EgressLimitExceeded {
+                    scope: Box::new(request.scope),
+                    estimated,
+                    limit,
+                });
+            }
         }
 
         if self.policy.deny_private_ip_ranges
@@ -193,6 +207,9 @@ pub fn is_private_or_loopback_ip(ip: IpAddr) -> bool {
                 || is_carrier_grade_nat_v4(ip)
         }
         IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                return is_private_or_loopback_ip(IpAddr::V4(mapped));
+            }
             ip.is_loopback()
                 || ip.is_unspecified()
                 || ip.is_unique_local()

--- a/crates/ironclaw_network/tests/boundary_contract.rs
+++ b/crates/ironclaw_network/tests/boundary_contract.rs
@@ -1,0 +1,29 @@
+#[test]
+fn network_crate_does_not_depend_on_workflow_runtime_secret_or_observability_crates() {
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {manifest_path:?}: {error}"));
+
+    for forbidden in [
+        "ironclaw_authorization",
+        "ironclaw_approvals",
+        "ironclaw_capabilities",
+        "ironclaw_dispatcher",
+        "ironclaw_events",
+        "ironclaw_extensions",
+        "ironclaw_filesystem",
+        "ironclaw_host_runtime",
+        "ironclaw_mcp",
+        "ironclaw_processes",
+        "ironclaw_resources",
+        "ironclaw_run_state",
+        "ironclaw_scripts",
+        "ironclaw_secrets",
+        "ironclaw_wasm",
+    ] {
+        assert!(
+            !manifest.contains(forbidden),
+            "ironclaw_network must stay a low-level scoped network policy service, not depend on {forbidden}"
+        );
+    }
+}

--- a/crates/ironclaw_network/tests/network_policy_contract.rs
+++ b/crates/ironclaw_network/tests/network_policy_contract.rs
@@ -1,0 +1,210 @@
+use ironclaw_host_api::{
+    InvocationId, NetworkMethod, NetworkPolicy, NetworkScheme, NetworkTarget, NetworkTargetPattern,
+    ProjectId, ResourceScope, TenantId, ThreadId, UserId,
+};
+use ironclaw_network::{NetworkPolicyEnforcer, NetworkRequest, StaticNetworkPolicyEnforcer};
+
+#[tokio::test]
+async fn network_policy_allows_exact_scoped_target_without_executing_io() {
+    let scope = sample_scope("tenant-a", "user-a");
+    let policy = NetworkPolicy {
+        allowed_targets: vec![pattern(
+            Some(NetworkScheme::Https),
+            "api.example.test",
+            Some(443),
+        )],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(1024),
+    };
+    let enforcer = StaticNetworkPolicyEnforcer::new(policy);
+
+    let permit = enforcer
+        .authorize(NetworkRequest {
+            scope: scope.clone(),
+            target: target(NetworkScheme::Https, "api.example.test", Some(443)),
+            method: NetworkMethod::Post,
+            estimated_bytes: Some(512),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(permit.scope, scope);
+    assert_eq!(permit.target.host, "api.example.test");
+    assert_eq!(permit.method, NetworkMethod::Post);
+    assert_eq!(permit.estimated_bytes, Some(512));
+}
+
+#[tokio::test]
+async fn network_policy_supports_one_label_wildcard_hosts_only() {
+    let enforcer = StaticNetworkPolicyEnforcer::new(NetworkPolicy {
+        allowed_targets: vec![pattern(Some(NetworkScheme::Https), "*.example.test", None)],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(1024),
+    });
+    let scope = sample_scope("tenant-a", "user-a");
+
+    enforcer
+        .authorize(NetworkRequest {
+            scope: scope.clone(),
+            target: target(NetworkScheme::Https, "api.example.test", None),
+            method: NetworkMethod::Get,
+            estimated_bytes: Some(0),
+        })
+        .await
+        .unwrap();
+
+    let apex = enforcer
+        .authorize(NetworkRequest {
+            scope: scope.clone(),
+            target: target(NetworkScheme::Https, "example.test", None),
+            method: NetworkMethod::Get,
+            estimated_bytes: Some(0),
+        })
+        .await
+        .unwrap_err();
+    assert!(apex.is_target_denied());
+
+    let nested_subdomain = enforcer
+        .authorize(NetworkRequest {
+            scope,
+            target: target(NetworkScheme::Https, "deep.api.example.test", None),
+            method: NetworkMethod::Get,
+            estimated_bytes: Some(0),
+        })
+        .await
+        .unwrap_err();
+    assert!(nested_subdomain.is_target_denied());
+}
+
+#[tokio::test]
+async fn network_policy_denies_scheme_host_port_and_egress_mismatches() {
+    let enforcer = StaticNetworkPolicyEnforcer::new(NetworkPolicy {
+        allowed_targets: vec![pattern(
+            Some(NetworkScheme::Https),
+            "api.example.test",
+            Some(443),
+        )],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(10),
+    });
+    let scope = sample_scope("tenant-a", "user-a");
+
+    let wrong_scheme = enforcer
+        .authorize(NetworkRequest {
+            scope: scope.clone(),
+            target: target(NetworkScheme::Http, "api.example.test", Some(443)),
+            method: NetworkMethod::Get,
+            estimated_bytes: Some(1),
+        })
+        .await
+        .unwrap_err();
+    assert!(wrong_scheme.is_target_denied());
+
+    let wrong_host = enforcer
+        .authorize(NetworkRequest {
+            scope: scope.clone(),
+            target: target(NetworkScheme::Https, "evil.example.test", Some(443)),
+            method: NetworkMethod::Get,
+            estimated_bytes: Some(1),
+        })
+        .await
+        .unwrap_err();
+    assert!(wrong_host.is_target_denied());
+
+    let wrong_port = enforcer
+        .authorize(NetworkRequest {
+            scope: scope.clone(),
+            target: target(NetworkScheme::Https, "api.example.test", Some(8443)),
+            method: NetworkMethod::Get,
+            estimated_bytes: Some(1),
+        })
+        .await
+        .unwrap_err();
+    assert!(wrong_port.is_target_denied());
+
+    let too_large = enforcer
+        .authorize(NetworkRequest {
+            scope,
+            target: target(NetworkScheme::Https, "api.example.test", Some(443)),
+            method: NetworkMethod::Post,
+            estimated_bytes: Some(11),
+        })
+        .await
+        .unwrap_err();
+    assert!(too_large.is_egress_limit_exceeded());
+}
+
+#[tokio::test]
+async fn network_policy_denies_non_public_literal_ips_allowed_by_host_contract() {
+    for host in ["100.64.0.1", "2001:db8::1"] {
+        let enforcer = StaticNetworkPolicyEnforcer::new(NetworkPolicy {
+            allowed_targets: vec![pattern(Some(NetworkScheme::Http), host, None)],
+            deny_private_ip_ranges: true,
+            max_egress_bytes: Some(1024),
+        });
+        let scope = sample_scope("tenant-a", "user-a");
+
+        let err = enforcer
+            .authorize(NetworkRequest {
+                scope,
+                target: target(NetworkScheme::Http, host, None),
+                method: NetworkMethod::Get,
+                estimated_bytes: Some(0),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.is_private_target_denied());
+        assert!(!format!("{err}").contains("/tmp"));
+    }
+}
+
+#[tokio::test]
+async fn network_policy_is_fail_closed_without_allowed_targets() {
+    let enforcer = StaticNetworkPolicyEnforcer::new(NetworkPolicy::default());
+    let scope = sample_scope("tenant-a", "user-a");
+
+    let err = enforcer
+        .authorize(NetworkRequest {
+            scope,
+            target: target(NetworkScheme::Https, "api.example.test", None),
+            method: NetworkMethod::Get,
+            estimated_bytes: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(err.is_target_denied());
+}
+
+fn target(scheme: NetworkScheme, host: &str, port: Option<u16>) -> NetworkTarget {
+    NetworkTarget {
+        scheme,
+        host: host.to_string(),
+        port,
+    }
+}
+
+fn pattern(
+    scheme: Option<NetworkScheme>,
+    host_pattern: &str,
+    port: Option<u16>,
+) -> NetworkTargetPattern {
+    NetworkTargetPattern {
+        scheme,
+        host_pattern: host_pattern.to_string(),
+        port,
+    }
+}
+
+fn sample_scope(tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: None,
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id: InvocationId::new(),
+    }
+}

--- a/crates/ironclaw_network/tests/network_policy_contract.rs
+++ b/crates/ironclaw_network/tests/network_policy_contract.rs
@@ -160,6 +160,72 @@ async fn network_policy_denies_non_public_literal_ips_allowed_by_host_contract()
 }
 
 #[tokio::test]
+async fn network_policy_denies_ipv4_mapped_private_ipv6_literals() {
+    for host in ["::ffff:127.0.0.1", "::ffff:10.0.0.1"] {
+        let enforcer = StaticNetworkPolicyEnforcer::new(NetworkPolicy {
+            allowed_targets: vec![pattern(Some(NetworkScheme::Http), host, None)],
+            deny_private_ip_ranges: true,
+            max_egress_bytes: Some(1024),
+        });
+        let scope = sample_scope("tenant-a", "user-a");
+
+        let err = enforcer
+            .authorize(NetworkRequest {
+                scope,
+                target: target(NetworkScheme::Http, host, None),
+                method: NetworkMethod::Get,
+                estimated_bytes: Some(0),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.is_private_target_denied());
+    }
+
+    let public_mapped_host = "::ffff:8.8.8.8";
+    let enforcer = StaticNetworkPolicyEnforcer::new(NetworkPolicy {
+        allowed_targets: vec![pattern(Some(NetworkScheme::Http), public_mapped_host, None)],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(1024),
+    });
+    enforcer
+        .authorize(NetworkRequest {
+            scope: sample_scope("tenant-a", "user-a"),
+            target: target(NetworkScheme::Http, public_mapped_host, None),
+            method: NetworkMethod::Get,
+            estimated_bytes: Some(0),
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn network_policy_requires_egress_estimate_when_limit_is_configured() {
+    let enforcer = StaticNetworkPolicyEnforcer::new(NetworkPolicy {
+        allowed_targets: vec![pattern(
+            Some(NetworkScheme::Https),
+            "api.example.test",
+            Some(443),
+        )],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(10),
+    });
+    let scope = sample_scope("tenant-a", "user-a");
+
+    let err = enforcer
+        .authorize(NetworkRequest {
+            scope,
+            target: target(NetworkScheme::Https, "api.example.test", Some(443)),
+            method: NetworkMethod::Get,
+            estimated_bytes: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(err.is_egress_estimate_required());
+}
+
+#[tokio::test]
 async fn network_policy_is_fail_closed_without_allowed_targets() {
     let enforcer = StaticNetworkPolicyEnforcer::new(NetworkPolicy::default());
     let scope = sample_scope("tenant-a", "user-a");

--- a/crates/ironclaw_secrets/CLAUDE.md
+++ b/crates/ironclaw_secrets/CLAUDE.md
@@ -1,0 +1,7 @@
+# ironclaw_secrets guardrails
+
+- Own scoped secret metadata, storage, and one-shot lease mechanics only.
+- Never expose raw secret material through metadata, errors, debug output, audit records, events, or dispatch results.
+- Preserve tenant/user/project isolation; no global handle lookup unless an explicit admin-scoped API is introduced later.
+- Do not implement authorization, approval, run-state, runtime injection, network access, process lifecycle, or product workflow semantics here.
+- Keep raw secret access explicit through `SecretStore::consume(...)`; consumers must request a scoped lease first.

--- a/crates/ironclaw_secrets/CLAUDE.md
+++ b/crates/ironclaw_secrets/CLAUDE.md
@@ -1,7 +1,8 @@
 # ironclaw_secrets guardrails
 
-- Own scoped secret metadata, storage, and one-shot lease mechanics only.
+- Own scoped secret metadata, storage, and one-shot lease mechanics only; runtime injection is not enforced here.
 - Never expose raw secret material through metadata, errors, debug output, audit records, events, or dispatch results.
 - Preserve tenant/user/project isolation; no global handle lookup unless an explicit admin-scoped API is introduced later.
 - Do not implement authorization, approval, run-state, runtime injection, network access, process lifecycle, or product workflow semantics here.
 - Keep raw secret access explicit through `SecretStore::consume(...)`; consumers must request a scoped lease first.
+- Treat `SecretStore::put(...)` as a trusted setup/composition/storage-code primitive, not a runtime/plugin API.

--- a/crates/ironclaw_secrets/CLAUDE.md
+++ b/crates/ironclaw_secrets/CLAUDE.md
@@ -2,7 +2,7 @@
 
 - Own scoped secret metadata, storage, and one-shot lease mechanics only; runtime injection is not enforced here.
 - Never expose raw secret material through metadata, errors, debug output, audit records, events, or dispatch results.
-- Preserve tenant/user/project isolation; no global handle lookup unless an explicit admin-scoped API is introduced later.
+- Preserve tenant/user/agent/project isolation; no global handle lookup unless an explicit admin-scoped API is introduced later.
 - Do not implement authorization, approval, run-state, runtime injection, network access, process lifecycle, or product workflow semantics here.
 - Keep raw secret access explicit through `SecretStore::consume(...)`; consumers must request a scoped lease first.
 - Treat `SecretStore::put(...)` as a trusted setup/composition/storage-code primitive, not a runtime/plugin API.

--- a/crates/ironclaw_secrets/Cargo.toml
+++ b/crates/ironclaw_secrets/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ironclaw_secrets"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+secrecy = "0.10"
+thiserror = "2"
+uuid = { version = "1", features = ["v4", "serde"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -2,7 +2,9 @@
 //!
 //! This crate stores and leases secret material behind opaque
 //! [`SecretHandle`] values. It does not decide authorization, inject secrets into
-//! runtimes, emit audit records, or expose raw values through metadata.
+//! runtimes, emit audit records, or expose raw values through metadata. Runtime
+//! injection is not enforced until a higher-level obligation-handler/runtime
+//! composition slice consumes these primitives.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -103,6 +105,10 @@ impl SecretStoreError {
 #[async_trait]
 pub trait SecretStore: Send + Sync {
     /// Stores or replaces a secret under the caller's tenant/user/project scope and returns redacted metadata.
+    ///
+    /// Intended for trusted setup, composition, migration, or storage-code paths that are already
+    /// allowed to manage secret material. This low-level primitive intentionally does not authorize
+    /// arbitrary runtime/plugin callers.
     async fn put(
         &self,
         scope: ResourceScope,

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -1,0 +1,349 @@
+//! Tenant-scoped secret service boundary for IronClaw Reborn.
+//!
+//! This crate stores and leases secret material behind opaque
+//! [`SecretHandle`] values. It does not decide authorization, inject secrets into
+//! runtimes, emit audit records, or expose raw values through metadata.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Mutex, MutexGuard};
+
+use async_trait::async_trait;
+use ironclaw_host_api::{ProjectId, ResourceScope, SecretHandle, TenantId, UserId};
+pub use secrecy::SecretString as SecretMaterial;
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Opaque identifier for a one-shot secret lease.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SecretLeaseId(Uuid);
+
+impl SecretLeaseId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for SecretLeaseId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for SecretLeaseId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Redacted metadata for a stored secret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretMetadata {
+    pub scope: ResourceScope,
+    pub handle: SecretHandle,
+}
+
+/// Lease lifecycle for one secret access.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretLeaseStatus {
+    Active,
+    Consumed,
+    Revoked,
+}
+
+/// Metadata for a scoped one-shot secret lease.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretLease {
+    pub id: SecretLeaseId,
+    pub scope: ResourceScope,
+    pub handle: SecretHandle,
+    pub status: SecretLeaseStatus,
+}
+
+/// Secret service failures. Variants intentionally avoid secret material.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SecretStoreError {
+    #[error("unknown secret {handle} for tenant/user scope")]
+    UnknownSecret {
+        scope: Box<ResourceScope>,
+        handle: SecretHandle,
+    },
+    #[error("unknown secret lease {lease_id} for tenant/user scope")]
+    UnknownLease {
+        scope: Box<ResourceScope>,
+        lease_id: SecretLeaseId,
+    },
+    #[error("secret lease {lease_id} was already consumed")]
+    LeaseConsumed { lease_id: SecretLeaseId },
+    #[error("secret lease {lease_id} was revoked")]
+    LeaseRevoked { lease_id: SecretLeaseId },
+    #[error("secret store state is unavailable: {reason}")]
+    StoreUnavailable { reason: String },
+}
+
+impl SecretStoreError {
+    pub fn is_unknown_secret(&self) -> bool {
+        matches!(self, Self::UnknownSecret { .. })
+    }
+
+    pub fn is_unknown_lease(&self) -> bool {
+        matches!(self, Self::UnknownLease { .. })
+    }
+
+    pub fn is_consumed(&self) -> bool {
+        matches!(self, Self::LeaseConsumed { .. })
+    }
+
+    pub fn is_revoked(&self) -> bool {
+        matches!(self, Self::LeaseRevoked { .. })
+    }
+}
+
+/// Scoped secret store contract.
+#[async_trait]
+pub trait SecretStore: Send + Sync {
+    /// Stores or replaces a secret under the caller's tenant/user/project scope and returns redacted metadata.
+    async fn put(
+        &self,
+        scope: ResourceScope,
+        handle: SecretHandle,
+        material: SecretMaterial,
+    ) -> Result<SecretMetadata, SecretStoreError>;
+
+    /// Returns redacted metadata for a secret without exposing material.
+    async fn metadata(
+        &self,
+        scope: &ResourceScope,
+        handle: &SecretHandle,
+    ) -> Result<Option<SecretMetadata>, SecretStoreError>;
+
+    /// Creates a one-shot lease for later secret consumption.
+    async fn lease_once(
+        &self,
+        scope: &ResourceScope,
+        handle: &SecretHandle,
+    ) -> Result<SecretLease, SecretStoreError>;
+
+    /// Consumes an active one-shot lease and returns secret material exactly once.
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretMaterial, SecretStoreError>;
+
+    /// Revokes an active one-shot lease without returning material.
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretLease, SecretStoreError>;
+
+    /// Lists leases visible to the caller's tenant/user/project scope.
+    async fn leases_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<SecretLease>, SecretStoreError>;
+}
+
+/// In-memory secret store for contract tests and non-durable demos.
+#[derive(Debug, Default)]
+pub struct InMemorySecretStore {
+    state: Mutex<SecretState>,
+}
+
+impl InMemorySecretStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock_state(&self) -> Result<MutexGuard<'_, SecretState>, SecretStoreError> {
+        self.state
+            .lock()
+            .map_err(|error| SecretStoreError::StoreUnavailable {
+                reason: error.to_string(),
+            })
+    }
+}
+
+#[derive(Debug, Default)]
+struct SecretState {
+    secrets: HashMap<SecretKey, SecretRecord>,
+    leases: HashMap<SecretLeaseKey, LeaseRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SecretKey {
+    tenant_id: TenantId,
+    user_id: UserId,
+    project_id: Option<ProjectId>,
+    handle: SecretHandle,
+}
+
+impl SecretKey {
+    fn new(scope: &ResourceScope, handle: &SecretHandle) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: scope.user_id.clone(),
+            project_id: scope.project_id.clone(),
+            handle: handle.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SecretLeaseKey {
+    tenant_id: TenantId,
+    user_id: UserId,
+    project_id: Option<ProjectId>,
+    lease_id: SecretLeaseId,
+}
+
+impl SecretLeaseKey {
+    fn new(scope: &ResourceScope, lease_id: SecretLeaseId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: scope.user_id.clone(),
+            project_id: scope.project_id.clone(),
+            lease_id,
+        }
+    }
+
+    fn matches_scope(&self, scope: &ResourceScope) -> bool {
+        self.tenant_id == scope.tenant_id
+            && self.user_id == scope.user_id
+            && self.project_id == scope.project_id
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SecretRecord {
+    metadata: SecretMetadata,
+    material: SecretMaterial,
+}
+
+#[derive(Debug, Clone)]
+struct LeaseRecord {
+    lease: SecretLease,
+    material: SecretMaterial,
+}
+
+#[async_trait]
+impl SecretStore for InMemorySecretStore {
+    async fn put(
+        &self,
+        scope: ResourceScope,
+        handle: SecretHandle,
+        material: SecretMaterial,
+    ) -> Result<SecretMetadata, SecretStoreError> {
+        let metadata = SecretMetadata {
+            scope: scope.clone(),
+            handle: handle.clone(),
+        };
+        let record = SecretRecord {
+            metadata: metadata.clone(),
+            material,
+        };
+        self.lock_state()?
+            .secrets
+            .insert(SecretKey::new(&scope, &handle), record);
+        Ok(metadata)
+    }
+
+    async fn metadata(
+        &self,
+        scope: &ResourceScope,
+        handle: &SecretHandle,
+    ) -> Result<Option<SecretMetadata>, SecretStoreError> {
+        Ok(self
+            .lock_state()?
+            .secrets
+            .get(&SecretKey::new(scope, handle))
+            .map(|record| record.metadata.clone()))
+    }
+
+    async fn lease_once(
+        &self,
+        scope: &ResourceScope,
+        handle: &SecretHandle,
+    ) -> Result<SecretLease, SecretStoreError> {
+        let mut state = self.lock_state()?;
+        let secret = state
+            .secrets
+            .get(&SecretKey::new(scope, handle))
+            .ok_or_else(|| SecretStoreError::UnknownSecret {
+                scope: Box::new(scope.clone()),
+                handle: handle.clone(),
+            })?;
+        let lease = SecretLease {
+            id: SecretLeaseId::new(),
+            scope: scope.clone(),
+            handle: handle.clone(),
+            status: SecretLeaseStatus::Active,
+        };
+        let record = LeaseRecord {
+            lease: lease.clone(),
+            material: secret.material.clone(),
+        };
+        state
+            .leases
+            .insert(SecretLeaseKey::new(scope, lease.id), record);
+        Ok(lease)
+    }
+
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretMaterial, SecretStoreError> {
+        let mut state = self.lock_state()?;
+        let key = SecretLeaseKey::new(scope, lease_id);
+        let record = state
+            .leases
+            .get_mut(&key)
+            .ok_or_else(|| SecretStoreError::UnknownLease {
+                scope: Box::new(scope.clone()),
+                lease_id,
+            })?;
+        match record.lease.status {
+            SecretLeaseStatus::Active => {
+                record.lease.status = SecretLeaseStatus::Consumed;
+                Ok(record.material.clone())
+            }
+            SecretLeaseStatus::Consumed => Err(SecretStoreError::LeaseConsumed { lease_id }),
+            SecretLeaseStatus::Revoked => Err(SecretStoreError::LeaseRevoked { lease_id }),
+        }
+    }
+
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretLease, SecretStoreError> {
+        let mut state = self.lock_state()?;
+        let key = SecretLeaseKey::new(scope, lease_id);
+        let record = state
+            .leases
+            .get_mut(&key)
+            .ok_or_else(|| SecretStoreError::UnknownLease {
+                scope: Box::new(scope.clone()),
+                lease_id,
+            })?;
+        if record.lease.status == SecretLeaseStatus::Active {
+            record.lease.status = SecretLeaseStatus::Revoked;
+        }
+        Ok(record.lease.clone())
+    }
+
+    async fn leases_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<SecretLease>, SecretStoreError> {
+        Ok(self
+            .lock_state()?
+            .leases
+            .iter()
+            .filter(|(key, _)| key.matches_scope(scope))
+            .map(|(_, record)| record.lease.clone())
+            .collect())
+    }
+}

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -11,7 +11,10 @@ use std::fmt;
 use std::sync::{Mutex, MutexGuard};
 
 use async_trait::async_trait;
-use ironclaw_host_api::{ProjectId, ResourceScope, SecretHandle, TenantId, UserId};
+use ironclaw_host_api::{
+    AgentId, InvocationId, MissionId, ProjectId, ResourceScope, SecretHandle, TenantId, ThreadId,
+    UserId,
+};
 pub use secrecy::SecretString as SecretMaterial;
 use thiserror::Error;
 use uuid::Uuid;
@@ -181,6 +184,7 @@ struct SecretState {
 struct SecretKey {
     tenant_id: TenantId,
     user_id: UserId,
+    agent_id: Option<AgentId>,
     project_id: Option<ProjectId>,
     handle: SecretHandle,
 }
@@ -190,6 +194,7 @@ impl SecretKey {
         Self {
             tenant_id: scope.tenant_id.clone(),
             user_id: scope.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
             project_id: scope.project_id.clone(),
             handle: handle.clone(),
         }
@@ -200,7 +205,11 @@ impl SecretKey {
 struct SecretLeaseKey {
     tenant_id: TenantId,
     user_id: UserId,
+    agent_id: Option<AgentId>,
     project_id: Option<ProjectId>,
+    mission_id: Option<MissionId>,
+    thread_id: Option<ThreadId>,
+    invocation_id: InvocationId,
     lease_id: SecretLeaseId,
 }
 
@@ -209,7 +218,11 @@ impl SecretLeaseKey {
         Self {
             tenant_id: scope.tenant_id.clone(),
             user_id: scope.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
             project_id: scope.project_id.clone(),
+            mission_id: scope.mission_id.clone(),
+            thread_id: scope.thread_id.clone(),
+            invocation_id: scope.invocation_id,
             lease_id,
         }
     }
@@ -217,7 +230,11 @@ impl SecretLeaseKey {
     fn matches_scope(&self, scope: &ResourceScope) -> bool {
         self.tenant_id == scope.tenant_id
             && self.user_id == scope.user_id
+            && self.agent_id == scope.agent_id
             && self.project_id == scope.project_id
+            && self.mission_id == scope.mission_id
+            && self.thread_id == scope.thread_id
+            && self.invocation_id == scope.invocation_id
     }
 }
 
@@ -230,7 +247,7 @@ struct SecretRecord {
 #[derive(Debug, Clone)]
 struct LeaseRecord {
     lease: SecretLease,
-    material: SecretMaterial,
+    material: Option<SecretMaterial>,
 }
 
 #[async_trait]
@@ -288,7 +305,7 @@ impl SecretStore for InMemorySecretStore {
         };
         let record = LeaseRecord {
             lease: lease.clone(),
-            material: secret.material.clone(),
+            material: Some(secret.material.clone()),
         };
         state
             .leases
@@ -312,8 +329,14 @@ impl SecretStore for InMemorySecretStore {
             })?;
         match record.lease.status {
             SecretLeaseStatus::Active => {
+                let Some(material) = record.material.take() else {
+                    record.lease.status = SecretLeaseStatus::Consumed;
+                    return Err(SecretStoreError::StoreUnavailable {
+                        reason: "active lease material unavailable".to_string(),
+                    });
+                };
                 record.lease.status = SecretLeaseStatus::Consumed;
-                Ok(record.material.clone())
+                Ok(material)
             }
             SecretLeaseStatus::Consumed => Err(SecretStoreError::LeaseConsumed { lease_id }),
             SecretLeaseStatus::Revoked => Err(SecretStoreError::LeaseRevoked { lease_id }),
@@ -335,6 +358,7 @@ impl SecretStore for InMemorySecretStore {
                 lease_id,
             })?;
         if record.lease.status == SecretLeaseStatus::Active {
+            record.material = None;
             record.lease.status = SecretLeaseStatus::Revoked;
         }
         Ok(record.lease.clone())
@@ -351,5 +375,76 @@ impl SecretStore for InMemorySecretStore {
             .filter(|(key, _)| key.matches_scope(scope))
             .map(|(_, record)| record.lease.clone())
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{
+        InvocationId, MissionId, ProjectId, ResourceScope, SecretHandle, TenantId, ThreadId, UserId,
+    };
+
+    use crate::{InMemorySecretStore, SecretMaterial, SecretStore};
+
+    #[tokio::test]
+    async fn consumed_lease_record_drops_retained_material() {
+        let store = InMemorySecretStore::new();
+        let scope = sample_scope("tenant-a", "user-a");
+        let handle = SecretHandle::new("api_key").unwrap();
+        store
+            .put(
+                scope.clone(),
+                handle.clone(),
+                SecretMaterial::from("super-secret"),
+            )
+            .await
+            .unwrap();
+
+        let lease = store.lease_once(&scope, &handle).await.unwrap();
+        store.consume(&scope, lease.id).await.unwrap();
+
+        let state = store.state.lock().unwrap();
+        let leases_debug = format!("{:?}", state.leases);
+        assert!(
+            !leases_debug.contains("SecretBox"),
+            "consumed lease records must not retain cloned secret material: {leases_debug}"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoked_lease_record_drops_retained_material() {
+        let store = InMemorySecretStore::new();
+        let scope = sample_scope("tenant-a", "user-a");
+        let handle = SecretHandle::new("api_key").unwrap();
+        store
+            .put(
+                scope.clone(),
+                handle.clone(),
+                SecretMaterial::from("super-secret"),
+            )
+            .await
+            .unwrap();
+
+        let lease = store.lease_once(&scope, &handle).await.unwrap();
+        store.revoke(&scope, lease.id).await.unwrap();
+
+        let state = store.state.lock().unwrap();
+        let leases_debug = format!("{:?}", state.leases);
+        assert!(
+            !leases_debug.contains("SecretBox"),
+            "revoked lease records must not retain cloned secret material: {leases_debug}"
+        );
+    }
+
+    fn sample_scope(tenant: &str, user: &str) -> ResourceScope {
+        ResourceScope {
+            tenant_id: TenantId::new(tenant).unwrap(),
+            user_id: UserId::new(user).unwrap(),
+            agent_id: None,
+            project_id: Some(ProjectId::new("project-a").unwrap()),
+            mission_id: Some(MissionId::new("mission-a").unwrap()),
+            thread_id: Some(ThreadId::new("thread-a").unwrap()),
+            invocation_id: InvocationId::new(),
+        }
     }
 }

--- a/crates/ironclaw_secrets/tests/boundary_contract.rs
+++ b/crates/ironclaw_secrets/tests/boundary_contract.rs
@@ -1,0 +1,27 @@
+#[test]
+fn secrets_crate_does_not_depend_on_workflow_runtime_or_observability_crates() {
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {manifest_path:?}: {error}"));
+
+    for forbidden in [
+        "ironclaw_authorization",
+        "ironclaw_approvals",
+        "ironclaw_capabilities",
+        "ironclaw_dispatcher",
+        "ironclaw_events",
+        "ironclaw_extensions",
+        "ironclaw_host_runtime",
+        "ironclaw_mcp",
+        "ironclaw_processes",
+        "ironclaw_resources",
+        "ironclaw_run_state",
+        "ironclaw_scripts",
+        "ironclaw_wasm",
+    ] {
+        assert!(
+            !manifest.contains(forbidden),
+            "ironclaw_secrets must stay a low-level scoped secret service, not depend on {forbidden}"
+        );
+    }
+}

--- a/crates/ironclaw_secrets/tests/secret_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/secret_store_contract.rs
@@ -1,5 +1,6 @@
 use ironclaw_host_api::{
-    InvocationId, MissionId, ProjectId, ResourceScope, SecretHandle, TenantId, ThreadId, UserId,
+    AgentId, InvocationId, MissionId, ProjectId, ResourceScope, SecretHandle, TenantId, ThreadId,
+    UserId,
 };
 use ironclaw_secrets::{InMemorySecretStore, SecretLeaseStatus, SecretMaterial, SecretStore};
 use secrecy::ExposeSecret;
@@ -171,6 +172,54 @@ async fn secret_store_isolates_same_handle_between_users_and_projects() {
         .await
         .unwrap_err();
     assert!(cross_project.is_unknown_lease());
+}
+
+#[tokio::test]
+async fn secret_store_isolates_same_handle_between_agents() {
+    let store = InMemorySecretStore::new();
+    let mut agent_a = sample_scope("tenant-a", "user-a");
+    agent_a.agent_id = Some(AgentId::new("agent-a").unwrap());
+    let mut agent_b = agent_a.clone();
+    agent_b.agent_id = Some(AgentId::new("agent-b").unwrap());
+    let handle = SecretHandle::new("shared_name").unwrap();
+    store
+        .put(
+            agent_a.clone(),
+            handle.clone(),
+            SecretMaterial::from("agent-a-secret"),
+        )
+        .await
+        .unwrap();
+    store
+        .put(
+            agent_b.clone(),
+            handle.clone(),
+            SecretMaterial::from("agent-b-secret"),
+        )
+        .await
+        .unwrap();
+
+    let agent_a_lease = store.lease_once(&agent_a, &handle).await.unwrap();
+    let agent_b_lease = store.lease_once(&agent_b, &handle).await.unwrap();
+
+    let cross_agent = store.consume(&agent_b, agent_a_lease.id).await.unwrap_err();
+    assert!(cross_agent.is_unknown_lease());
+    assert_eq!(
+        store
+            .consume(&agent_a, agent_a_lease.id)
+            .await
+            .unwrap()
+            .expose_secret(),
+        "agent-a-secret"
+    );
+    assert_eq!(
+        store
+            .consume(&agent_b, agent_b_lease.id)
+            .await
+            .unwrap()
+            .expose_secret(),
+        "agent-b-secret"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_secrets/tests/secret_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/secret_store_contract.rs
@@ -1,0 +1,219 @@
+use ironclaw_host_api::{
+    InvocationId, MissionId, ProjectId, ResourceScope, SecretHandle, TenantId, ThreadId, UserId,
+};
+use ironclaw_secrets::{InMemorySecretStore, SecretLeaseStatus, SecretMaterial, SecretStore};
+use secrecy::ExposeSecret;
+
+#[tokio::test]
+async fn secret_store_returns_metadata_without_secret_material() {
+    let store = InMemorySecretStore::new();
+    let scope = sample_scope("tenant-a", "user-a");
+    let handle = SecretHandle::new("github_token").unwrap();
+
+    let metadata = store
+        .put(
+            scope.clone(),
+            handle.clone(),
+            SecretMaterial::from("ghp_secret_token"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(metadata.scope, scope);
+    assert_eq!(metadata.handle, handle);
+    assert!(!format!("{metadata:?}").contains("ghp_secret_token"));
+}
+
+#[tokio::test]
+async fn secret_store_consumes_one_shot_secret_lease() {
+    let store = InMemorySecretStore::new();
+    let scope = sample_scope("tenant-a", "user-a");
+    let handle = SecretHandle::new("api_key").unwrap();
+    store
+        .put(
+            scope.clone(),
+            handle.clone(),
+            SecretMaterial::from("super-secret"),
+        )
+        .await
+        .unwrap();
+
+    let lease = store.lease_once(&scope, &handle).await.unwrap();
+    assert_eq!(lease.scope, scope);
+    assert_eq!(lease.handle, handle);
+    assert_eq!(lease.status, SecretLeaseStatus::Active);
+
+    let value = store.consume(&scope, lease.id).await.unwrap();
+    assert_eq!(value.expose_secret(), "super-secret");
+
+    let second = store.consume(&scope, lease.id).await.unwrap_err();
+    assert!(second.is_consumed());
+}
+
+#[tokio::test]
+async fn secret_store_isolates_same_handle_between_tenants() {
+    let store = InMemorySecretStore::new();
+    let tenant_a = sample_scope("tenant-a", "user-a");
+    let tenant_b = sample_scope("tenant-b", "user-a");
+    let handle = SecretHandle::new("shared_name").unwrap();
+    store
+        .put(
+            tenant_a.clone(),
+            handle.clone(),
+            SecretMaterial::from("tenant-a-secret"),
+        )
+        .await
+        .unwrap();
+    store
+        .put(
+            tenant_b.clone(),
+            handle.clone(),
+            SecretMaterial::from("tenant-b-secret"),
+        )
+        .await
+        .unwrap();
+
+    let tenant_a_lease = store.lease_once(&tenant_a, &handle).await.unwrap();
+    let tenant_b_lease = store.lease_once(&tenant_b, &handle).await.unwrap();
+
+    assert_eq!(
+        store
+            .consume(&tenant_a, tenant_a_lease.id)
+            .await
+            .unwrap()
+            .expose_secret(),
+        "tenant-a-secret"
+    );
+    assert_eq!(
+        store
+            .consume(&tenant_b, tenant_b_lease.id)
+            .await
+            .unwrap()
+            .expose_secret(),
+        "tenant-b-secret"
+    );
+
+    let cross_scope = store
+        .consume(&tenant_b, tenant_a_lease.id)
+        .await
+        .unwrap_err();
+    assert!(cross_scope.is_unknown_lease());
+}
+
+#[tokio::test]
+async fn secret_store_isolates_same_handle_between_users_and_projects() {
+    let store = InMemorySecretStore::new();
+    let user_a = sample_scope("tenant-a", "user-a");
+    let user_b = sample_scope("tenant-a", "user-b");
+    let project_b = ResourceScope {
+        project_id: Some(ProjectId::new("project-b").unwrap()),
+        ..sample_scope("tenant-a", "user-a")
+    };
+    let handle = SecretHandle::new("shared_name").unwrap();
+    store
+        .put(
+            user_a.clone(),
+            handle.clone(),
+            SecretMaterial::from("user-a-project-a-secret"),
+        )
+        .await
+        .unwrap();
+    store
+        .put(
+            user_b.clone(),
+            handle.clone(),
+            SecretMaterial::from("user-b-project-a-secret"),
+        )
+        .await
+        .unwrap();
+    store
+        .put(
+            project_b.clone(),
+            handle.clone(),
+            SecretMaterial::from("user-a-project-b-secret"),
+        )
+        .await
+        .unwrap();
+
+    let user_a_lease = store.lease_once(&user_a, &handle).await.unwrap();
+    let user_b_lease = store.lease_once(&user_b, &handle).await.unwrap();
+    let project_b_lease = store.lease_once(&project_b, &handle).await.unwrap();
+
+    assert_eq!(
+        store
+            .consume(&user_a, user_a_lease.id)
+            .await
+            .unwrap()
+            .expose_secret(),
+        "user-a-project-a-secret"
+    );
+    assert_eq!(
+        store
+            .consume(&user_b, user_b_lease.id)
+            .await
+            .unwrap()
+            .expose_secret(),
+        "user-b-project-a-secret"
+    );
+    assert_eq!(
+        store
+            .consume(&project_b, project_b_lease.id)
+            .await
+            .unwrap()
+            .expose_secret(),
+        "user-a-project-b-secret"
+    );
+
+    let cross_user = store.consume(&user_b, user_a_lease.id).await.unwrap_err();
+    assert!(cross_user.is_unknown_lease());
+    let cross_project = store
+        .consume(&project_b, user_a_lease.id)
+        .await
+        .unwrap_err();
+    assert!(cross_project.is_unknown_lease());
+}
+
+#[tokio::test]
+async fn revoked_secret_lease_cannot_be_consumed() {
+    let store = InMemorySecretStore::new();
+    let scope = sample_scope("tenant-a", "user-a");
+    let handle = SecretHandle::new("api_key").unwrap();
+    store
+        .put(
+            scope.clone(),
+            handle.clone(),
+            SecretMaterial::from("super-secret"),
+        )
+        .await
+        .unwrap();
+
+    let lease = store.lease_once(&scope, &handle).await.unwrap();
+    let revoked = store.revoke(&scope, lease.id).await.unwrap();
+    assert_eq!(revoked.status, SecretLeaseStatus::Revoked);
+
+    let error = store.consume(&scope, lease.id).await.unwrap_err();
+    assert!(error.is_revoked());
+}
+
+#[tokio::test]
+async fn missing_secret_fails_without_creating_lease() {
+    let store = InMemorySecretStore::new();
+    let scope = sample_scope("tenant-a", "user-a");
+    let handle = SecretHandle::new("missing").unwrap();
+
+    let error = store.lease_once(&scope, &handle).await.unwrap_err();
+    assert!(error.is_unknown_secret());
+    assert_eq!(store.leases_for_scope(&scope).await.unwrap(), Vec::new());
+}
+
+fn sample_scope(tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: Some(MissionId::new("mission-a").unwrap()),
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id: InvocationId::new(),
+    }
+}

--- a/docs/reborn/contracts/network.md
+++ b/docs/reborn/contracts/network.md
@@ -1,0 +1,118 @@
+# IronClaw Reborn network service contract
+
+**Date:** 2026-04-26
+**Status:** V1 service-boundary slice
+**Crate:** `crates/ironclaw_network`
+**Depends on:** `docs/reborn/contracts/host-api.md`
+
+---
+
+## 1. Purpose
+
+`ironclaw_network` is the scoped network policy evaluation service for Reborn.
+
+It turns a host API `NetworkPolicy` plus a scoped target request into a metadata-only permit:
+
+```text
+NetworkRequest { ResourceScope, NetworkTarget, NetworkMethod, estimated_bytes }
+  -> NetworkPolicyEnforcer::authorize(...)
+  -> NetworkPermit or NetworkPolicyError
+```
+
+This crate does not perform HTTP I/O, DNS resolution, proxying, credential injection, resource reservation, audit emission, or product workflow. It is the boundary that future runtime/network adapters can call before they perform network effects.
+
+---
+
+## 2. Boundary
+
+The public contract is intentionally small:
+
+```rust
+NetworkRequest
+NetworkPermit
+NetworkPolicyError
+NetworkPolicyEnforcer
+StaticNetworkPolicyEnforcer
+network_policy_allows(...)
+target_matches_pattern(...)
+host_matches_pattern(...)
+is_private_or_loopback_ip(...)
+```
+
+Ownership remains:
+
+```text
+host_api       -> NetworkPolicy, NetworkTarget, NetworkMethod shapes
+network        -> scoped policy evaluation and metadata-only permits
+authorization  -> whether a caller has a grant with network authority
+capabilities   -> caller-facing workflow; currently fails closed on ApplyNetworkPolicy obligations
+host_runtime   -> future composition of network enforcers into runtime adapters/obligation handlers
+runtimes        -> perform I/O only after host-side authorization and network permit handling
+```
+
+---
+
+## 3. Policy semantics
+
+V1 semantics intentionally mirror the current WASM network import policy checks so they can later be centralized:
+
+- empty `allowed_targets` fails closed
+- `NetworkTargetPattern.scheme` must match when present
+- `NetworkTargetPattern.port` must match when present
+- `host_pattern` is exact host or one leading wildcard label such as `*.github.com`
+- wildcard patterns do not match the apex host itself or deeper multi-label subdomains
+- `deny_private_ip_ranges` blocks literal private, loopback, link-local, documentation, broadcast, multicast, unspecified, carrier-grade NAT, and unique-local IP targets
+- `max_egress_bytes` denies requests whose estimated bytes exceed the configured limit
+
+DNS/IP resolution safeguards against rebinding remain future work for the actual network execution/proxy boundary. This crate currently checks literal IP targets only.
+
+---
+
+## 4. Current API flow
+
+```rust
+let enforcer = StaticNetworkPolicyEnforcer::new(policy);
+let permit = enforcer
+    .authorize(NetworkRequest {
+        scope,
+        target,
+        method: NetworkMethod::Post,
+        estimated_bytes: Some(512),
+    })
+    .await?;
+```
+
+`NetworkPermit` carries only metadata needed by a runtime adapter to proceed. It does not hold sockets, HTTP clients, response bodies, secrets, raw host paths, or resource reservations.
+
+---
+
+## 5. Non-goals
+
+This slice does not implement:
+
+- HTTP client/proxy execution
+- DNS resolution or DNS-rebinding protection
+- resource reservation for network egress
+- credential or secret injection
+- durable audit/event emission
+- per-method policy matrices
+- per-tenant persisted policy stores
+- response body limiting or streaming
+- OAuth/token refresh flows
+
+Those should be added as separate service/composition slices without moving runtime execution or product workflow semantics into this crate.
+
+---
+
+## 6. Contract tests
+
+The crate tests cover:
+
+- exact scheme/host/port allow path
+- one-label wildcard host matching
+- wildcard apex and nested-subdomain denial
+- scheme/host/port mismatch denial
+- estimated egress limit denial
+- literal non-public IP denial
+- fail-closed empty policy behavior
+- crate boundary remains low-level and does not depend on workflow/runtime/secret/observability crates

--- a/docs/reborn/contracts/network.md
+++ b/docs/reborn/contracts/network.md
@@ -19,7 +19,7 @@ NetworkRequest { ResourceScope, NetworkTarget, NetworkMethod, estimated_bytes }
   -> NetworkPermit or NetworkPolicyError
 ```
 
-This crate does not perform HTTP I/O, DNS resolution, proxying, credential injection, resource reservation, audit emission, or product workflow. It is the boundary that future runtime/network adapters can call before they perform network effects.
+This crate does not perform HTTP I/O, DNS resolution, proxying, credential injection, resource reservation, audit emission, or product workflow. It is the boundary that future runtime/network adapters can call before they perform network effects. It only evaluates metadata policy; actual egress enforcement, DNS/redirect revalidation, and response limiting belong to the runtime/network execution boundary.
 
 ---
 

--- a/docs/reborn/contracts/network.md
+++ b/docs/reborn/contracts/network.md
@@ -61,8 +61,8 @@ V1 semantics intentionally mirror the current WASM network import policy checks 
 - `NetworkTargetPattern.port` must match when present
 - `host_pattern` is exact host or one leading wildcard label such as `*.github.com`
 - wildcard patterns do not match the apex host itself or deeper multi-label subdomains
-- `deny_private_ip_ranges` blocks literal private, loopback, link-local, documentation, broadcast, multicast, unspecified, carrier-grade NAT, and unique-local IP targets
-- `max_egress_bytes` denies requests whose estimated bytes exceed the configured limit
+- `deny_private_ip_ranges` blocks literal private, loopback, link-local, documentation, broadcast, multicast, unspecified, carrier-grade NAT, IPv4-mapped IPv6 private ranges, and unique-local IP targets
+- `max_egress_bytes` denies requests without an estimated byte count and requests whose estimated bytes exceed the configured limit
 
 DNS/IP resolution safeguards against rebinding remain future work for the actual network execution/proxy boundary. This crate currently checks literal IP targets only.
 
@@ -112,7 +112,7 @@ The crate tests cover:
 - one-label wildcard host matching
 - wildcard apex and nested-subdomain denial
 - scheme/host/port mismatch denial
-- estimated egress limit denial
-- literal non-public IP denial
+- estimated egress requirement and limit denial
+- literal non-public IP denial, including IPv4-mapped IPv6 private literals
 - fail-closed empty policy behavior
 - crate boundary remains low-level and does not depend on workflow/runtime/secret/observability crates

--- a/docs/reborn/contracts/secrets.md
+++ b/docs/reborn/contracts/secrets.md
@@ -21,7 +21,7 @@ ResourceScope + SecretHandle
   -> SecretMaterial exactly once
 ```
 
-The crate owns storage mechanics and one-shot lease state. It does not decide authorization, run approval flows, inject secrets into runtime requests, contact networks, emit audit events, or execute product workflows.
+The crate owns storage mechanics and one-shot lease state. It does not decide authorization, run approval flows, inject secrets into runtime requests, contact networks, emit audit events, or execute product workflows. It only provides the lease/consume primitive; runtime injection is not enforced until an obligation-handler/runtime composition slice wires it in.
 
 ---
 
@@ -84,6 +84,8 @@ let material = secrets.consume(&scope, lease.id).await?;
 ```
 
 `metadata` and `lease` are safe to log only as metadata; they do not include secret values. `material` is the only raw-value carrier and should stay inside the narrow injection path that requested it.
+
+`SecretStore::put(...)` is for trusted setup, composition, migration, or storage-code paths that are already allowed to manage secret material. It is not a runtime/plugin API, and it intentionally does not perform authorization itself.
 
 ---
 

--- a/docs/reborn/contracts/secrets.md
+++ b/docs/reborn/contracts/secrets.md
@@ -1,0 +1,117 @@
+# IronClaw Reborn secrets service contract
+
+**Date:** 2026-04-26
+**Status:** V1 service-boundary slice
+**Crate:** `crates/ironclaw_secrets`
+**Depends on:** `docs/reborn/contracts/host-api.md`
+
+---
+
+## 1. Purpose
+
+`ironclaw_secrets` is the scoped secret metadata and lease service for Reborn.
+
+It turns opaque host API handles into explicit, short-lived access leases:
+
+```text
+ResourceScope + SecretHandle
+  -> SecretStore::lease_once(...)
+  -> SecretLease
+  -> SecretStore::consume(...)
+  -> SecretMaterial exactly once
+```
+
+The crate owns storage mechanics and one-shot lease state. It does not decide authorization, run approval flows, inject secrets into runtime requests, contact networks, emit audit events, or execute product workflows.
+
+---
+
+## 2. Boundary
+
+The public contract is intentionally small:
+
+```rust
+SecretMaterial
+SecretMetadata
+SecretLeaseId
+SecretLeaseStatus
+SecretLease
+SecretStoreError
+SecretStore
+InMemorySecretStore
+```
+
+`SecretMaterial` is backed by `secrecy::SecretString`, so access to raw values is explicit through `ExposeSecret`. Metadata, lease records, and errors never contain raw values.
+
+Ownership remains:
+
+```text
+host_api       -> opaque SecretHandle and Action::UseSecret shapes
+secrets        -> scoped storage, metadata, and one-shot leases
+authorization  -> whether a caller may use a SecretHandle
+capabilities   -> caller-facing workflow; currently fails closed on InjectSecretOnce obligations
+host_runtime   -> future composition of secret services into runtime adapters/obligation handlers
+runtimes        -> consume injected values only after host-side authorization and lease handling
+```
+
+---
+
+## 3. Scope and isolation
+
+All operations receive a `ResourceScope`. The in-memory V1 implementation keys secrets and leases by tenant/user/project plus `SecretHandle` or `SecretLeaseId`.
+
+Rules:
+
+- no global handle lookup
+- the same `SecretHandle` in another tenant/user/project is a distinct secret
+- cross-scope lease consumption returns `UnknownLease`
+- missing secrets return `UnknownSecret` and do not create leases
+- consumed leases cannot be consumed again
+- revoked leases cannot be consumed
+
+This is the minimum shape needed before wiring secret injection into obligation handling.
+
+---
+
+## 4. Current API flow
+
+```rust
+let metadata = secrets
+    .put(scope.clone(), handle.clone(), SecretMaterial::from("token"))
+    .await?;
+
+let lease = secrets.lease_once(&scope, &handle).await?;
+let material = secrets.consume(&scope, lease.id).await?;
+```
+
+`metadata` and `lease` are safe to log only as metadata; they do not include secret values. `material` is the only raw-value carrier and should stay inside the narrow injection path that requested it.
+
+---
+
+## 5. Non-goals
+
+This slice does not implement:
+
+- durable encrypted secret persistence
+- platform keychain integration
+- secret rotation/versioning
+- secret audit emission
+- authorization policy for secret use
+- approval prompts for secret use
+- runtime environment/request injection
+- OAuth/token refresh flows
+- network policy enforcement
+
+Those should be added as separate service/composition slices without moving runtime or product workflow semantics into this crate.
+
+---
+
+## 6. Contract tests
+
+The crate tests cover:
+
+- metadata returns no raw secret material
+- one-shot leases consume exactly once
+- same-handle secrets are tenant/user/project isolated
+- revoked leases cannot be consumed
+- missing secrets fail without creating leases
+- crate boundary remains low-level and does not depend on workflow/runtime/observability crates

--- a/docs/reborn/contracts/secrets.md
+++ b/docs/reborn/contracts/secrets.md
@@ -57,16 +57,17 @@ runtimes        -> consume injected values only after host-side authorization an
 
 ## 3. Scope and isolation
 
-All operations receive a `ResourceScope`. The in-memory V1 implementation keys secrets and leases by tenant/user/project plus `SecretHandle` or `SecretLeaseId`.
+All operations receive a `ResourceScope`. The in-memory V1 implementation keys stored secrets by tenant/user/agent/project plus `SecretHandle`, and keys one-shot leases by the full resource scope plus `SecretLeaseId`.
 
 Rules:
 
 - no global handle lookup
-- the same `SecretHandle` in another tenant/user/project is a distinct secret
+- the same `SecretHandle` in another tenant/user/agent/project is a distinct secret
 - cross-scope lease consumption returns `UnknownLease`
 - missing secrets return `UnknownSecret` and do not create leases
 - consumed leases cannot be consumed again
 - revoked leases cannot be consumed
+- consumed and revoked lease tombstones drop retained cloned secret material
 
 This is the minimum shape needed before wiring secret injection into obligation handling.
 
@@ -113,7 +114,8 @@ The crate tests cover:
 
 - metadata returns no raw secret material
 - one-shot leases consume exactly once
-- same-handle secrets are tenant/user/project isolated
+- same-handle secrets are tenant/user/agent/project isolated
 - revoked leases cannot be consumed
 - missing secrets fail without creating leases
+- consumed and revoked lease records do not retain cloned secret material
 - crate boundary remains low-level and does not depend on workflow/runtime/observability crates


### PR DESCRIPTION
## Summary

Carves the first independent PR5 substrate slice from the Reborn stack.

Adds:

```text
crates/ironclaw_secrets
crates/ironclaw_network
```

`ironclaw_secrets` includes:

- scoped `SecretStore` contract;
- redacted `SecretMetadata`;
- one-shot `SecretLease` / `SecretLeaseId` lifecycle;
- in-memory reference store for contract tests and non-durable demos;
- tenant/user/project isolation tests;
- no raw secret material in metadata/errors/debug surfaces.

`ironclaw_network` includes:

- scoped `NetworkPolicyEnforcer` contract;
- metadata-only `NetworkRequest` / `NetworkPermit`;
- static policy evaluator over host-api `NetworkPolicy`;
- fail-closed target matching;
- exact-host and one-label wildcard matching;
- private/loopback/link-local/documentation IP denial;
- egress estimate limits.

## Scope boundary

This PR intentionally does **not** include:

- durable/encrypted production secret backends;
- keychain/master-key resolution;
- credential account metadata;
- brokered HTTP credential injection;
- HTTP I/O, DNS resolution, proxying, redirects, or provider clients;
- runtime adapter wiring;
- `CapabilityHost` / host-runtime composition;
- production app wiring or user-visible behavior changes.

That keeps this PR independent of in-flight/later runtime and capability work (#3028, #3071, PR4f).

## Exposure checklist

```text
Does this affect existing src/ runtime behavior? no
Does this alter app startup/config defaults? no
Does this expose new routes/CLI/user-visible APIs? no
Does this create a second writer for existing production state? no
Are all Reborn paths feature-gated or unused by default? yes, unused internal crate substrate
Are docs/status labels accurate: implemented slice vs product complete? yes, scoped secrets/network boundaries only
```

## Verification

Passed locally:

```bash
cargo fmt --all -- --check
cargo test -p ironclaw_secrets -p ironclaw_network
cargo clippy -p ironclaw_secrets -p ironclaw_network --all-targets -- -D warnings
cargo test -p ironclaw_architecture
python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD
bash scripts/pre-commit-safety.sh
git diff --check
cargo tree -p ironclaw_secrets -e normal | grep -E 'ironclaw_(authorization|approvals|capabilities|dispatcher|events|extensions|filesystem|host_runtime|mcp|network|processes|resources|run_state|scripts|wasm)' || true
cargo tree -p ironclaw_network -e normal | grep -E 'ironclaw_(authorization|approvals|capabilities|dispatcher|events|extensions|filesystem|host_runtime|mcp|processes|resources|run_state|scripts|secrets|wasm)' || true
```

Boundary greps returned no forbidden normal Reborn dependencies.

Refs #2987.
