### PR TITLE
fix(reborn): replace broad ProcessError From<HostApiError> with path helper

### DIFF
--- a/crates/ironclaw_processes/src/filesystem_store.rs
+++ b/crates/ironclaw_processes/src/filesystem_store.rs
@@ -21,7 +21,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::types::{
     ProcessError, ProcessRecord, ProcessResultRecord, ProcessResultStore, ProcessStart,
-    ProcessStatus, ProcessStore, ensure_status_transition, same_scope_owner,
+    ProcessStatus, ProcessStore, ensure_status_transition, invalid_path, same_scope_owner,
 };
 
 pub(crate) enum FilesystemHandle<'a, F>
@@ -401,11 +401,11 @@ fn process_record_path(
         "{}/{process_id}.json",
         process_records_root(scope)?.as_str()
     ))
-    .map_err(Into::into)
+    .map_err(invalid_path)
 }
 
 fn process_records_root(scope: &ResourceScope) -> Result<VirtualPath, ProcessError> {
-    VirtualPath::new(format!("{}/processes", tenant_user_root(scope))).map_err(Into::into)
+    VirtualPath::new(format!("{}/processes", tenant_user_root(scope))).map_err(invalid_path)
 }
 
 fn process_result_path(
@@ -416,11 +416,11 @@ fn process_result_path(
         "{}/{process_id}.json",
         process_results_root(scope)?.as_str()
     ))
-    .map_err(Into::into)
+    .map_err(invalid_path)
 }
 
 fn process_results_root(scope: &ResourceScope) -> Result<VirtualPath, ProcessError> {
-    VirtualPath::new(format!("{}/process-results", tenant_user_root(scope))).map_err(Into::into)
+    VirtualPath::new(format!("{}/process-results", tenant_user_root(scope))).map_err(invalid_path)
 }
 
 fn process_output_path(
@@ -431,7 +431,7 @@ fn process_output_path(
         "{}/output.json",
         process_outputs_root(scope, process_id)?.as_str()
     ))
-    .map_err(Into::into)
+    .map_err(invalid_path)
 }
 
 fn process_outputs_root(
@@ -442,7 +442,7 @@ fn process_outputs_root(
         "{}/process-outputs/{process_id}",
         tenant_user_root(scope)
     ))
-    .map_err(Into::into)
+    .map_err(invalid_path)
 }
 
 fn tenant_user_root(scope: &ResourceScope) -> String {

--- a/crates/ironclaw_processes/src/types.rs
+++ b/crates/ironclaw_processes/src/types.rs
@@ -352,3 +352,36 @@ pub(crate) fn same_scope_owner(left: &ResourceScope, right: &ResourceScope) -> b
         && left.user_id == right.user_id
         && left.agent_id == right.agent_id
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: the broad `From<HostApiError> for ProcessError` impl previously
+    /// mismapped every `HostApiError` shape (validation, invariant, mount, network)
+    /// to `ProcessError::InvalidPath`, poisoning error-kind classification at
+    /// path-construction call sites. The replacement `invalid_path` helper must
+    /// only be used where the call site has already established that a
+    /// `HostApiError` represents a path validation failure, and it must preserve
+    /// the original message in the `InvalidPath` payload.
+    #[test]
+    fn invalid_path_helper_maps_host_api_error_into_invalid_path_variant() {
+        let host_error = VirtualPath::new("not-absolute")
+            .expect_err("non-absolute virtual paths must be rejected by VirtualPath::new");
+        let host_error_message = host_error.to_string();
+
+        let process_error = invalid_path(host_error);
+
+        match process_error {
+            ProcessError::InvalidPath(reason) => {
+                assert_eq!(
+                    reason, host_error_message,
+                    "invalid_path helper must preserve the original HostApiError message"
+                );
+            }
+            other => panic!(
+                "invalid_path helper must map HostApiError to ProcessError::InvalidPath, got {other:?}"
+            ),
+        }
+    }
+}

--- a/crates/ironclaw_processes/src/types.rs
+++ b/crates/ironclaw_processes/src/types.rs
@@ -158,10 +158,16 @@ pub enum ProcessError {
     Deserialization(String),
 }
 
-impl From<HostApiError> for ProcessError {
-    fn from(error: HostApiError) -> Self {
-        Self::InvalidPath(error.to_string())
-    }
+/// Wraps a `HostApiError` raised while constructing a virtual path into the
+/// typed `InvalidPath` variant.
+///
+/// The broad `From<HostApiError> for ProcessError` impl was removed because it
+/// silently mismapped every `HostApiError` (validation, invariant, mount,
+/// network) to `InvalidPath`, poisoning error-kind classification downstream.
+/// Use this helper at path-construction sites where the only `HostApiError`
+/// shape is in fact a path/identifier validation failure.
+pub(crate) fn invalid_path(error: HostApiError) -> ProcessError {
+    ProcessError::InvalidPath(error.to_string())
 }
 
 impl From<FilesystemError> for ProcessError {


### PR DESCRIPTION
## Summary

Mirrors the `RunStateError` fix from #2999 onto `ironclaw_processes`. The blanket `impl From<HostApiError> for ProcessError` silently mapped every `HostApiError` variant (validation, invariant, mount, network) to `ProcessError::InvalidPath`, poisoning downstream error-kind classification at every `?` in the filesystem store.

## Change

- Drop `impl From<HostApiError> for ProcessError`.
- Add `pub(crate) fn invalid_path(HostApiError) -> ProcessError` helper.
- Switch the six path-construction sites in `filesystem_store.rs` (record/result/output paths + roots) to `.map_err(invalid_path)`. These are the only places where `InvalidPath` is the correct classification.
- Keep `impl From<FilesystemError> for ProcessError`. Consumers that need to discriminate `NotFound` continue to pattern-match on the typed variant via the existing `is_not_found` helper — same shape as run_state.

No behavior change for in-memory or non-filesystem code paths.

## Why now

Found during the architectural smell check on `reborn-integration` head `70aaa84ab`. This is the S1 finding — same class of bug as #2999, just on a sibling crate. Surgical fix; not bundled with the deferred S2 follow-ups (trust seal, dispatch authority envelope, approval re-attenuation).

## Verification

```
cargo fmt
cargo clippy --benches --tests --examples -p ironclaw_processes -- -D warnings
cargo test -p ironclaw_processes   # 44 passed
```

## Risk

Low. Two callers (`From<HostApiError>` impl removal) — both are inside `filesystem_store.rs` and both moved to the typed helper. No public-API surface change. No persistence change.