### PR TITLE
feat(reborn): add WIT-compatible WASM tool runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4287,6 +4287,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironclaw_wasm"
+version = "0.1.0"
+dependencies = [
+ "ironclaw_host_api",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasmtime",
+ "wasmtime-wasi",
+ "wat",
+ "wit-component 0.245.1",
+ "wit-parser 0.245.1",
+]
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9091,6 +9106,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da55e60097e8b37b475a0fa35c3420dd71d9eb7bd66109978ab55faf56a57efb"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10001,9 +10028,9 @@ dependencies = [
  "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.244.0",
 ]
 
 [[package]]
@@ -10035,9 +10062,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.244.0",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wasmparser 0.244.0",
  "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4894f10d2d5cbc17c77e91f86a1e48e191a788da4425293b55c98b44ba3fcac9"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.245.1",
+ "wasm-metadata 0.245.1",
+ "wasmparser 0.245.1",
+ "wit-parser 0.245.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_extensions", "crates/ironclaw_processes", "crates/ironclaw_dispatcher", "crates/ironclaw_scripts", "crates/ironclaw_mcp", "crates/ironclaw_secrets", "crates/ironclaw_network", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_trust", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
+members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_extensions", "crates/ironclaw_processes", "crates/ironclaw_dispatcher", "crates/ironclaw_scripts", "crates/ironclaw_mcp", "crates/ironclaw_wasm", "crates/ironclaw_secrets", "crates/ironclaw_network", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_trust", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
 exclude = [
     "channels-src/discord",
     "channels-src/telegram",

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -274,6 +274,27 @@ fn boundary_rules() -> Vec<BoundaryRule> {
             ],
         },
         BoundaryRule {
+            crate_name: "ironclaw_wasm",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_events",
+                "ironclaw_extensions",
+                "ironclaw_filesystem",
+                "ironclaw_host_runtime",
+                "ironclaw_mcp",
+                "ironclaw_network",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_secrets",
+                "ironclaw_trust",
+            ],
+        },
+        BoundaryRule {
             crate_name: "ironclaw_dispatcher",
             forbidden: vec![
                 "ironclaw_authorization",

--- a/crates/ironclaw_wasm/CLAUDE.md
+++ b/crates/ironclaw_wasm/CLAUDE.md
@@ -1,0 +1,24 @@
+# ironclaw_wasm
+
+Owns the Reborn WASM component runtime lane.
+
+## Responsibilities
+
+- Load, compile, validate, meter, and execute already-selected WASM components for Reborn.
+- Use the canonical WIT/component-model ABI from `wit/tool.wit` and later `wit/channel.wit`.
+- Provide thin host-import adapters for workspace, time, logging, secret-existence checks, tool invocation, and HTTP egress.
+- Fail closed by default for host capabilities that are not explicitly wired by the Reborn composition root.
+
+## Non-responsibilities
+
+- Do not decide which tools/channels are exposed to the LLM.
+- Do not own authorization, approvals, trust policy, dispatcher routing, run-state, or `CapabilityHost` orchestration.
+- Do not perform direct production HTTP or secret retrieval; route those through injected host seams. Production HTTP egress belongs to the shared runtime egress service tracked by #3085.
+- Do not modify or depend on V1 `src/tools/wasm/*` or `src/channels/wasm/*`; those are compatibility references only.
+
+## Safety rules
+
+- No JSON pointer/length ABI (`invoke_json`, `alloc`, `output_ptr`, `output_len`) in Reborn WASM.
+- Instantiate fresh component instances per call.
+- Preserve fuel, epoch timeout, memory, and table/instance limits.
+- `ResourceUsage.network_egress_bytes` counts outbound request body bytes only; response-size limits are separate.

--- a/crates/ironclaw_wasm/Cargo.toml
+++ b/crates/ironclaw_wasm/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ironclaw_wasm"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+serde_json = "1"
+thiserror = "2"
+tracing = "0.1"
+wasmtime = { version = "43.0.1", features = ["component-model"] }
+wasmtime-wasi = "43.0.1"
+
+[dev-dependencies]
+wat = "1.245.1"
+wit-component = "0.245.1"
+wit-parser = "0.245.1"

--- a/crates/ironclaw_wasm/src/lib.rs
+++ b/crates/ironclaw_wasm/src/lib.rs
@@ -1,0 +1,789 @@
+//! Reborn WASM component runtime lane.
+//!
+//! This crate owns the Reborn-only WASM runtime surface. It intentionally uses
+//! the canonical WIT/component-model contract in `wit/tool.wit` instead of the
+//! temporary JSON pointer/length ABI that was abandoned before landing.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use ironclaw_host_api::ResourceUsage;
+use thiserror::Error;
+use wasmtime::component::Linker;
+use wasmtime::{Config, Engine, ResourceLimiter, Store};
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+
+#[allow(clippy::all)]
+mod bindings {
+    wasmtime::component::bindgen!({
+        path: "../../wit/tool.wit",
+        world: "sandboxed-tool",
+        with: {},
+    });
+}
+
+/// WIT package version supported by the Reborn WASM tool runtime.
+pub const WIT_TOOL_VERSION: &str = "0.3.0";
+
+const DEFAULT_MEMORY_BYTES: u64 = 10 * 1024 * 1024;
+const DEFAULT_FUEL: u64 = 500_000_000;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+const EPOCH_TICK_INTERVAL: Duration = Duration::from_millis(500);
+const MAX_LOGS_PER_EXECUTION: usize = 1_000;
+const MAX_LOG_MESSAGE_BYTES: usize = 4 * 1024;
+
+/// Errors returned by the Reborn WASM runtime.
+#[derive(Debug, Error)]
+pub enum WasmError {
+    #[error("failed to create WASM engine: {0}")]
+    EngineCreationFailed(String),
+    #[error("failed to compile WIT component: {0}")]
+    CompilationFailed(String),
+    #[error("failed to configure WASM store: {0}")]
+    StoreConfiguration(String),
+    #[error("failed to configure WASM linker: {0}")]
+    LinkerConfiguration(String),
+    #[error("failed to instantiate WIT component: {0}")]
+    InstantiationFailed(String),
+    #[error("failed to execute WIT component: {0}")]
+    ExecutionFailed(String),
+    #[error("tool schema export did not return a valid JSON object: {0}")]
+    InvalidSchema(String),
+}
+
+/// Errors returned by injected host services.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum WasmHostError {
+    #[error("{0}")]
+    Denied(String),
+    #[error("{0}")]
+    Unavailable(String),
+    #[error("{0}")]
+    Failed(String),
+    #[error("{0}")]
+    FailedAfterRequestSent(String),
+}
+
+impl WasmHostError {
+    fn request_was_sent(&self) -> bool {
+        matches!(self, Self::FailedAfterRequestSent(_))
+    }
+}
+
+/// HTTP request shape exposed through the WIT `host.http-request` import.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmHttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers_json: String,
+    pub body: Option<Vec<u8>>,
+    pub timeout_ms: Option<u32>,
+}
+
+/// HTTP response shape returned to a WASM guest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmHttpResponse {
+    pub status: u16,
+    pub headers_json: String,
+    pub body: Vec<u8>,
+}
+
+/// Host HTTP seam used by the WIT runtime.
+///
+/// Production composition should wire this to the shared Reborn runtime egress
+/// service. Until that service exists, the default implementation denies every
+/// request so WASM cannot perform direct network I/O.
+pub trait WasmHostHttp: Send + Sync {
+    fn request(&self, request: WasmHttpRequest) -> Result<WasmHttpResponse, WasmHostError>;
+}
+
+/// Fail-closed HTTP host service.
+#[derive(Debug, Default)]
+pub struct DenyWasmHostHttp;
+
+impl WasmHostHttp for DenyWasmHostHttp {
+    fn request(&self, _request: WasmHttpRequest) -> Result<WasmHttpResponse, WasmHostError> {
+        Err(WasmHostError::Unavailable(
+            "WASM HTTP egress is not configured".to_string(),
+        ))
+    }
+}
+
+/// Recording HTTP host service for tests and development fixtures.
+#[derive(Debug)]
+pub struct RecordingWasmHostHttp {
+    requests: Mutex<Vec<WasmHttpRequest>>,
+    response: Result<WasmHttpResponse, WasmHostError>,
+}
+
+impl RecordingWasmHostHttp {
+    pub fn ok(response: WasmHttpResponse) -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            response: Ok(response),
+        }
+    }
+
+    pub fn err(error: WasmHostError) -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            response: Err(error),
+        }
+    }
+
+    pub fn requests(&self) -> Result<Vec<WasmHttpRequest>, WasmHostError> {
+        self.requests
+            .lock()
+            .map(|requests| requests.clone())
+            .map_err(|_| WasmHostError::Failed("recording HTTP request log is poisoned".into()))
+    }
+}
+
+impl WasmHostHttp for RecordingWasmHostHttp {
+    fn request(&self, request: WasmHttpRequest) -> Result<WasmHttpResponse, WasmHostError> {
+        self.requests
+            .lock()
+            .map_err(|_| WasmHostError::Failed("recording HTTP request log is poisoned".into()))?
+            .push(request);
+        self.response.clone()
+    }
+}
+
+pub trait WasmHostWorkspace: Send + Sync {
+    fn read(&self, path: &str) -> Option<String>;
+}
+
+#[derive(Debug, Default)]
+pub struct DenyWasmHostWorkspace;
+
+impl WasmHostWorkspace for DenyWasmHostWorkspace {
+    fn read(&self, _path: &str) -> Option<String> {
+        None
+    }
+}
+
+pub trait WasmHostSecrets: Send + Sync {
+    fn exists(&self, name: &str) -> bool;
+}
+
+#[derive(Debug, Default)]
+pub struct DenyWasmHostSecrets;
+
+impl WasmHostSecrets for DenyWasmHostSecrets {
+    fn exists(&self, _name: &str) -> bool {
+        false
+    }
+}
+
+pub trait WasmHostTools: Send + Sync {
+    fn invoke(&self, alias: &str, params_json: &str) -> Result<String, WasmHostError>;
+}
+
+#[derive(Debug, Default)]
+pub struct DenyWasmHostTools;
+
+impl WasmHostTools for DenyWasmHostTools {
+    fn invoke(&self, _alias: &str, _params_json: &str) -> Result<String, WasmHostError> {
+        Err(WasmHostError::Unavailable(
+            "WASM tool invocation is not configured".to_string(),
+        ))
+    }
+}
+
+pub trait WasmHostClock: Send + Sync {
+    fn now_millis(&self) -> u64;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemWasmHostClock;
+
+impl WasmHostClock for SystemWasmHostClock {
+    fn now_millis(&self) -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+            .unwrap_or(0)
+    }
+}
+
+/// Host services made available to one WASM tool execution.
+#[derive(Clone)]
+pub struct WitToolHost {
+    http: Arc<dyn WasmHostHttp>,
+    workspace: Arc<dyn WasmHostWorkspace>,
+    secrets: Arc<dyn WasmHostSecrets>,
+    tools: Arc<dyn WasmHostTools>,
+    clock: Arc<dyn WasmHostClock>,
+}
+
+impl WitToolHost {
+    pub fn deny_all() -> Self {
+        Self {
+            http: Arc::new(DenyWasmHostHttp),
+            workspace: Arc::new(DenyWasmHostWorkspace),
+            secrets: Arc::new(DenyWasmHostSecrets),
+            tools: Arc::new(DenyWasmHostTools),
+            clock: Arc::new(SystemWasmHostClock),
+        }
+    }
+
+    pub fn with_http<T>(mut self, http: Arc<T>) -> Self
+    where
+        T: WasmHostHttp + 'static,
+    {
+        self.http = http;
+        self
+    }
+
+    pub fn with_workspace<T>(mut self, workspace: Arc<T>) -> Self
+    where
+        T: WasmHostWorkspace + 'static,
+    {
+        self.workspace = workspace;
+        self
+    }
+
+    pub fn with_secrets<T>(mut self, secrets: Arc<T>) -> Self
+    where
+        T: WasmHostSecrets + 'static,
+    {
+        self.secrets = secrets;
+        self
+    }
+
+    pub fn with_tools<T>(mut self, tools: Arc<T>) -> Self
+    where
+        T: WasmHostTools + 'static,
+    {
+        self.tools = tools;
+        self
+    }
+
+    pub fn with_clock<T>(mut self, clock: Arc<T>) -> Self
+    where
+        T: WasmHostClock + 'static,
+    {
+        self.clock = clock;
+        self
+    }
+}
+
+impl Default for WitToolHost {
+    fn default() -> Self {
+        Self::deny_all()
+    }
+}
+
+/// Resource limits for one WIT tool execution.
+#[derive(Debug, Clone)]
+pub struct WitToolLimits {
+    pub memory_bytes: u64,
+    pub fuel: u64,
+    pub timeout: Duration,
+}
+
+impl Default for WitToolLimits {
+    fn default() -> Self {
+        Self {
+            memory_bytes: DEFAULT_MEMORY_BYTES,
+            fuel: DEFAULT_FUEL,
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+impl WitToolLimits {
+    pub fn with_memory_bytes(mut self, memory_bytes: u64) -> Self {
+        self.memory_bytes = memory_bytes;
+        self
+    }
+
+    pub fn with_fuel(mut self, fuel: u64) -> Self {
+        self.fuel = fuel;
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+/// Configuration for the Reborn WIT tool runtime.
+#[derive(Debug, Clone, Default)]
+pub struct WitToolRuntimeConfig {
+    pub default_limits: WitToolLimits,
+}
+
+impl WitToolRuntimeConfig {
+    pub fn for_testing() -> Self {
+        Self {
+            default_limits: WitToolLimits::default()
+                .with_memory_bytes(1024 * 1024)
+                .with_fuel(100_000)
+                .with_timeout(Duration::from_secs(5)),
+        }
+    }
+}
+
+/// Compiled WIT tool component plus metadata extracted from its WIT exports.
+pub struct PreparedWitTool {
+    name: String,
+    description: String,
+    schema: serde_json::Value,
+    component: wasmtime::component::Component,
+    limits: WitToolLimits,
+}
+
+impl PreparedWitTool {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn schema(&self) -> &serde_json::Value {
+        &self.schema
+    }
+
+    pub fn limits(&self) -> &WitToolLimits {
+        &self.limits
+    }
+}
+
+impl std::fmt::Debug for PreparedWitTool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreparedWitTool")
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("schema", &self.schema)
+            .field("limits", &self.limits)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Request passed to a WIT tool component.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WitToolRequest {
+    pub params_json: String,
+    pub context_json: Option<String>,
+}
+
+impl WitToolRequest {
+    pub fn new(params_json: impl Into<String>) -> Self {
+        Self {
+            params_json: params_json.into(),
+            context_json: None,
+        }
+    }
+
+    pub fn with_context(mut self, context_json: impl Into<String>) -> Self {
+        self.context_json = Some(context_json.into());
+        self
+    }
+}
+
+/// Log level captured from the WIT host `log` import.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WasmLogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+/// One guest-emitted log message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmLogRecord {
+    pub level: WasmLogLevel,
+    pub message: String,
+}
+
+/// Result of one WIT tool execution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WitToolExecution {
+    pub output_json: Option<String>,
+    pub error: Option<String>,
+    pub usage: ResourceUsage,
+    pub logs: Vec<WasmLogRecord>,
+}
+
+/// Reborn WIT-compatible WASM tool runtime.
+pub struct WitToolRuntime {
+    engine: Engine,
+    config: WitToolRuntimeConfig,
+}
+
+impl WitToolRuntime {
+    pub fn new(config: WitToolRuntimeConfig) -> Result<Self, WasmError> {
+        let mut wasmtime_config = Config::new();
+        wasmtime_config.wasm_component_model(true);
+        wasmtime_config.wasm_threads(false);
+        wasmtime_config.consume_fuel(true);
+        wasmtime_config.epoch_interruption(true);
+        wasmtime_config.debug_info(false);
+
+        let engine = Engine::new(&wasmtime_config)
+            .map_err(|error| WasmError::EngineCreationFailed(error.to_string()))?;
+        spawn_epoch_ticker(engine.clone())?;
+
+        Ok(Self { engine, config })
+    }
+
+    pub fn config(&self) -> &WitToolRuntimeConfig {
+        &self.config
+    }
+
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    pub fn prepare(&self, name: &str, wasm_bytes: &[u8]) -> Result<PreparedWitTool, WasmError> {
+        let component = wasmtime::component::Component::new(&self.engine, wasm_bytes)
+            .map_err(|error| WasmError::CompilationFailed(error.to_string()))?;
+        let limits = self.config.default_limits.clone();
+        let (description, schema) = self.extract_metadata(&component, &limits)?;
+
+        Ok(PreparedWitTool {
+            name: name.to_string(),
+            description,
+            schema,
+            component,
+            limits,
+        })
+    }
+
+    pub fn execute(
+        &self,
+        prepared: &PreparedWitTool,
+        host: WitToolHost,
+        request: WitToolRequest,
+    ) -> Result<WitToolExecution, WasmError> {
+        let started = Instant::now();
+        let (mut store, instance) =
+            self.instantiate(&prepared.component, host, &prepared.limits)?;
+        let tool = instance.near_agent_tool();
+        let request = bindings::exports::near::agent::tool::Request {
+            params: request.params_json,
+            context: request.context_json,
+        };
+        let response = tool
+            .call_execute(&mut store, &request)
+            .map_err(|error| WasmError::ExecutionFailed(error.to_string()))?;
+
+        let mut usage = store.data().usage.clone();
+        usage.wall_clock_ms = elapsed_millis(started);
+        usage.output_bytes = response
+            .output
+            .as_deref()
+            .map(|output| output.len().min(u64::MAX as usize) as u64)
+            .unwrap_or(0);
+        let logs = store.data().logs.clone();
+
+        Ok(WitToolExecution {
+            output_json: response.output,
+            error: response.error,
+            usage,
+            logs,
+        })
+    }
+
+    fn extract_metadata(
+        &self,
+        component: &wasmtime::component::Component,
+        limits: &WitToolLimits,
+    ) -> Result<(String, serde_json::Value), WasmError> {
+        let (mut store, instance) = self.instantiate(component, WitToolHost::deny_all(), limits)?;
+        let tool = instance.near_agent_tool();
+        let description = tool
+            .call_description(&mut store)
+            .map_err(|error| WasmError::ExecutionFailed(error.to_string()))?;
+        let schema_json = tool
+            .call_schema(&mut store)
+            .map_err(|error| WasmError::ExecutionFailed(error.to_string()))?;
+        let schema = serde_json::from_str::<serde_json::Value>(&schema_json)
+            .map_err(|error| WasmError::InvalidSchema(error.to_string()))?;
+        if !schema.is_object() {
+            return Err(WasmError::InvalidSchema(
+                "schema export must return a JSON object".to_string(),
+            ));
+        }
+        Ok((description, schema))
+    }
+
+    fn instantiate(
+        &self,
+        component: &wasmtime::component::Component,
+        host: WitToolHost,
+        limits: &WitToolLimits,
+    ) -> Result<(Store<StoreData>, bindings::SandboxedTool), WasmError> {
+        let mut store = Store::new(&self.engine, StoreData::new(host, limits.memory_bytes));
+        configure_store(&mut store, limits)?;
+        let linker = create_linker(&self.engine)?;
+        let instance = bindings::SandboxedTool::instantiate(&mut store, component, &linker)
+            .map_err(|error| classify_instantiation_error(error.to_string()))?;
+        Ok((store, instance))
+    }
+}
+
+impl std::fmt::Debug for WitToolRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WitToolRuntime")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+fn spawn_epoch_ticker(engine: Engine) -> Result<(), WasmError> {
+    std::thread::Builder::new()
+        .name("reborn-wasm-epoch-ticker".into())
+        .spawn(move || {
+            loop {
+                std::thread::sleep(EPOCH_TICK_INTERVAL);
+                engine.increment_epoch();
+            }
+        })
+        .map(|_| ())
+        .map_err(|error| WasmError::EngineCreationFailed(error.to_string()))
+}
+
+fn elapsed_millis(started: Instant) -> u64 {
+    started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+fn configure_store(store: &mut Store<StoreData>, limits: &WitToolLimits) -> Result<(), WasmError> {
+    store
+        .set_fuel(limits.fuel)
+        .map_err(|error| WasmError::StoreConfiguration(error.to_string()))?;
+    store.epoch_deadline_trap();
+    let ticks = (limits.timeout.as_millis() / EPOCH_TICK_INTERVAL.as_millis()).max(1) as u64;
+    store.set_epoch_deadline(ticks);
+    store.limiter(|data| &mut data.limiter);
+    Ok(())
+}
+
+fn create_linker(engine: &Engine) -> Result<Linker<StoreData>, WasmError> {
+    let mut linker = Linker::new(engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker)
+        .map_err(|error| WasmError::LinkerConfiguration(error.to_string()))?;
+    bindings::SandboxedTool::add_to_linker::<_, wasmtime::component::HasSelf<_>>(
+        &mut linker,
+        |state: &mut StoreData| state,
+    )
+    .map_err(|error| WasmError::LinkerConfiguration(error.to_string()))?;
+    Ok(linker)
+}
+
+fn classify_instantiation_error(message: String) -> WasmError {
+    if message.contains("near:agent") || message.contains("import") {
+        WasmError::InstantiationFailed(format!(
+            "{message}. This usually means the component was compiled against a different WIT version than the host supports (host: {WIT_TOOL_VERSION})."
+        ))
+    } else {
+        WasmError::InstantiationFailed(message)
+    }
+}
+
+struct StoreData {
+    host: WitToolHost,
+    limiter: WasmResourceLimiter,
+    wasi: WasiCtx,
+    table: ResourceTable,
+    usage: ResourceUsage,
+    logs: Vec<WasmLogRecord>,
+}
+
+impl StoreData {
+    fn new(host: WitToolHost, memory_limit: u64) -> Self {
+        Self {
+            host,
+            limiter: WasmResourceLimiter::new(memory_limit),
+            wasi: WasiCtxBuilder::new().build(),
+            table: ResourceTable::new(),
+            usage: ResourceUsage::default(),
+            logs: Vec::new(),
+        }
+    }
+}
+
+impl WasiView for StoreData {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
+    }
+}
+
+impl bindings::near::agent::host::Host for StoreData {
+    fn log(&mut self, level: bindings::near::agent::host::LogLevel, message: String) {
+        if self.logs.len() >= MAX_LOGS_PER_EXECUTION {
+            return;
+        }
+        let message = truncate_log_message(message);
+        let level = match level {
+            bindings::near::agent::host::LogLevel::Trace => WasmLogLevel::Trace,
+            bindings::near::agent::host::LogLevel::Debug => WasmLogLevel::Debug,
+            bindings::near::agent::host::LogLevel::Info => WasmLogLevel::Info,
+            bindings::near::agent::host::LogLevel::Warn => WasmLogLevel::Warn,
+            bindings::near::agent::host::LogLevel::Error => WasmLogLevel::Error,
+        };
+        self.logs.push(WasmLogRecord { level, message });
+    }
+
+    fn now_millis(&mut self) -> u64 {
+        self.host.clock.now_millis()
+    }
+
+    fn workspace_read(&mut self, path: String) -> Option<String> {
+        self.host.workspace.read(&path)
+    }
+
+    fn http_request(
+        &mut self,
+        method: String,
+        url: String,
+        headers_json: String,
+        body: Option<Vec<u8>>,
+        timeout_ms: Option<u32>,
+    ) -> Result<bindings::near::agent::host::HttpResponse, String> {
+        let request_body_bytes = body.as_ref().map(|body| body.len() as u64).unwrap_or(0);
+        let response = self.host.http.request(WasmHttpRequest {
+            method,
+            url,
+            headers_json,
+            body,
+            timeout_ms,
+        });
+        match response {
+            Ok(response) => {
+                self.record_network_egress(request_body_bytes);
+                Ok(bindings::near::agent::host::HttpResponse {
+                    status: response.status,
+                    headers_json: response.headers_json,
+                    body: response.body,
+                })
+            }
+            Err(error) => {
+                if error.request_was_sent() {
+                    self.record_network_egress(request_body_bytes);
+                }
+                Err(error.to_string())
+            }
+        }
+    }
+
+    fn tool_invoke(&mut self, alias: String, params_json: String) -> Result<String, String> {
+        self.host
+            .tools
+            .invoke(&alias, &params_json)
+            .map_err(|error| error.to_string())
+    }
+
+    fn secret_exists(&mut self, name: String) -> bool {
+        self.host.secrets.exists(&name)
+    }
+}
+
+impl StoreData {
+    fn record_network_egress(&mut self, request_body_bytes: u64) {
+        self.usage.network_egress_bytes = self
+            .usage
+            .network_egress_bytes
+            .saturating_add(request_body_bytes);
+    }
+}
+
+fn truncate_log_message(message: String) -> String {
+    if message.len() <= MAX_LOG_MESSAGE_BYTES {
+        return message;
+    }
+
+    let mut end = MAX_LOG_MESSAGE_BYTES;
+    while !message.is_char_boundary(end) {
+        end = end.saturating_sub(1);
+    }
+    message[..end].to_string()
+}
+
+#[derive(Debug)]
+struct WasmResourceLimiter {
+    memory_limit: u64,
+    memory_used: u64,
+    max_tables: u32,
+    max_instances: u32,
+}
+
+impl WasmResourceLimiter {
+    fn new(memory_limit: u64) -> Self {
+        Self {
+            memory_limit,
+            memory_used: 0,
+            max_tables: 10,
+            max_instances: 10,
+        }
+    }
+}
+
+impl ResourceLimiter for WasmResourceLimiter {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> Result<bool, wasmtime::Error> {
+        let desired = desired as u64;
+        if desired > self.memory_limit {
+            tracing::warn!(
+                current,
+                desired,
+                limit = self.memory_limit,
+                "WASM memory growth denied"
+            );
+            return Ok(false);
+        }
+        self.memory_used = desired;
+        Ok(true)
+    }
+
+    fn table_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> Result<bool, wasmtime::Error> {
+        if desired > 10_000 {
+            tracing::warn!(current, desired, "WASM table growth denied");
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
+    fn instances(&self) -> usize {
+        self.max_instances as usize
+    }
+
+    fn tables(&self) -> usize {
+        self.max_tables as usize
+    }
+
+    fn memories(&self) -> usize {
+        self.max_instances as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_LOG_MESSAGE_BYTES, truncate_log_message};
+
+    #[test]
+    fn truncate_log_message_respects_utf8_boundaries() {
+        let message = "é".repeat(MAX_LOG_MESSAGE_BYTES);
+        let truncated = truncate_log_message(message);
+        assert!(truncated.len() <= MAX_LOG_MESSAGE_BYTES);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+}

--- a/crates/ironclaw_wasm/tests/wit_tool_runtime_contract.rs
+++ b/crates/ironclaw_wasm/tests/wit_tool_runtime_contract.rs
@@ -1,0 +1,311 @@
+use std::sync::Arc;
+
+use ironclaw_wasm::{
+    DenyWasmHostHttp, RecordingWasmHostHttp, WasmHostHttp, WasmHttpRequest, WasmHttpResponse,
+    WitToolHost, WitToolRequest, WitToolRuntime, WitToolRuntimeConfig,
+};
+use serde_json::json;
+use wit_component::{ComponentEncoder, StringEncoding, embed_component_metadata};
+use wit_parser::Resolve;
+
+const COUNTER_TOOL_WAT: &str = r#"
+(module
+  (type (;0;) (func (param i32 i32 i32)))
+  (type (;1;) (func (result i64)))
+  (type (;2;) (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+  (type (;3;) (func (param i32 i32 i32 i32 i32)))
+  (type (;4;) (func (param i32 i32) (result i32)))
+  (import "near:agent/host@0.3.0" "log" (func $log (type 0)))
+  (import "near:agent/host@0.3.0" "now-millis" (func $now (type 1)))
+  (import "near:agent/host@0.3.0" "workspace-read" (func $workspace_read (type 0)))
+  (import "near:agent/host@0.3.0" "http-request" (func $http_request (type 2)))
+  (import "near:agent/host@0.3.0" "tool-invoke" (func $tool_invoke (type 3)))
+  (import "near:agent/host@0.3.0" "secret-exists" (func $secret_exists (type 4)))
+  (memory (export "memory") 1)
+  (global $heap (mut i32) (i32.const 4096))
+  (global $count (mut i32) (i32.const 0))
+  (data (i32.const 1024) "{\22type\22:\22object\22}")
+  (data (i32.const 2048) "fixture description")
+  (data (i32.const 3072) "1")
+  (data (i32.const 3073) "2")
+  (func $schema (result i32)
+    i32.const 16
+    i32.const 1024
+    i32.store
+    i32.const 20
+    i32.const 17
+    i32.store
+    i32.const 16)
+  (func $description (result i32)
+    i32.const 32
+    i32.const 2048
+    i32.store
+    i32.const 36
+    i32.const 19
+    i32.store
+    i32.const 32)
+  (func $execute (param i32 i32 i32 i32 i32) (result i32)
+    global.get $count
+    i32.const 1
+    i32.add
+    global.set $count
+
+    i32.const 48
+    i32.const 1
+    i32.store
+    i32.const 52
+    global.get $count
+    i32.const 1
+    i32.eq
+    if (result i32)
+      i32.const 3072
+    else
+      i32.const 3073
+    end
+    i32.store
+    i32.const 56
+    i32.const 1
+    i32.store
+    i32.const 60
+    i32.const 0
+    i32.store
+    i32.const 48)
+  (func $post (param i32))
+  (func $realloc (param $old i32) (param $old_align i32) (param $new_size i32) (param $new_align i32) (result i32)
+    (local $ret i32)
+    global.get $heap
+    local.set $ret
+    global.get $heap
+    local.get $new_size
+    i32.add
+    global.set $heap
+    local.get $ret)
+  (func $_initialize)
+  (export "near:agent/tool@0.3.0#execute" (func $execute))
+  (export "cabi_post_near:agent/tool@0.3.0#execute" (func $post))
+  (export "near:agent/tool@0.3.0#schema" (func $schema))
+  (export "cabi_post_near:agent/tool@0.3.0#schema" (func $post))
+  (export "near:agent/tool@0.3.0#description" (func $description))
+  (export "cabi_post_near:agent/tool@0.3.0#description" (func $post))
+  (export "cabi_realloc" (func $realloc))
+  (export "_initialize" (func $_initialize))
+)
+"#;
+
+const HTTP_TOOL_WAT: &str = r#"
+(module
+  (type (;0;) (func (param i32 i32 i32)))
+  (type (;1;) (func (result i64)))
+  (type (;2;) (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+  (type (;3;) (func (param i32 i32 i32 i32 i32)))
+  (type (;4;) (func (param i32 i32) (result i32)))
+  (import "near:agent/host@0.3.0" "log" (func $log (type 0)))
+  (import "near:agent/host@0.3.0" "now-millis" (func $now (type 1)))
+  (import "near:agent/host@0.3.0" "workspace-read" (func $workspace_read (type 0)))
+  (import "near:agent/host@0.3.0" "http-request" (func $http_request (type 2)))
+  (import "near:agent/host@0.3.0" "tool-invoke" (func $tool_invoke (type 3)))
+  (import "near:agent/host@0.3.0" "secret-exists" (func $secret_exists (type 4)))
+  (memory (export "memory") 1)
+  (global $heap (mut i32) (i32.const 4096))
+  (data (i32.const 128) "POST")
+  (data (i32.const 160) "https://example.test/api")
+  (data (i32.const 224) "{}")
+  (data (i32.const 256) "hello")
+  (data (i32.const 1024) "{\22type\22:\22object\22}")
+  (data (i32.const 2048) "fixture description")
+  (data (i32.const 3072) "1")
+  (func $schema (result i32)
+    i32.const 16
+    i32.const 1024
+    i32.store
+    i32.const 20
+    i32.const 17
+    i32.store
+    i32.const 16)
+  (func $description (result i32)
+    i32.const 32
+    i32.const 2048
+    i32.store
+    i32.const 36
+    i32.const 19
+    i32.store
+    i32.const 32)
+  (func $execute (param i32 i32 i32 i32 i32) (result i32)
+    i32.const 128
+    i32.const 4
+    i32.const 160
+    i32.const 24
+    i32.const 224
+    i32.const 2
+    i32.const 1
+    i32.const 256
+    i32.const 5
+    i32.const 0
+    i32.const 0
+    i32.const 512
+    call $http_request
+
+    i32.const 48
+    i32.const 1
+    i32.store
+    i32.const 52
+    i32.const 3072
+    i32.store
+    i32.const 56
+    i32.const 1
+    i32.store
+    i32.const 60
+    i32.const 0
+    i32.store
+    i32.const 48)
+  (func $post (param i32))
+  (func $realloc (param $old i32) (param $old_align i32) (param $new_size i32) (param $new_align i32) (result i32)
+    (local $ret i32)
+    global.get $heap
+    local.set $ret
+    global.get $heap
+    local.get $new_size
+    i32.add
+    global.set $heap
+    local.get $ret)
+  (func $_initialize)
+  (export "near:agent/tool@0.3.0#execute" (func $execute))
+  (export "cabi_post_near:agent/tool@0.3.0#execute" (func $post))
+  (export "near:agent/tool@0.3.0#schema" (func $schema))
+  (export "cabi_post_near:agent/tool@0.3.0#schema" (func $post))
+  (export "near:agent/tool@0.3.0#description" (func $description))
+  (export "cabi_post_near:agent/tool@0.3.0#description" (func $post))
+  (export "cabi_realloc" (func $realloc))
+  (export "_initialize" (func $_initialize))
+)
+"#;
+
+fn tool_component(wat_src: &str) -> Vec<u8> {
+    let mut module = wat::parse_str(wat_src).expect("fixture WAT must parse");
+    let mut resolve = Resolve::default();
+    let package = resolve
+        .push_str("tool.wit", include_str!("../../../wit/tool.wit"))
+        .expect("tool WIT must parse");
+    let world = resolve
+        .select_world(&[package], Some("sandboxed-tool"))
+        .expect("sandboxed-tool world must exist");
+
+    embed_component_metadata(&mut module, &resolve, world, StringEncoding::UTF8)
+        .expect("component metadata must embed");
+
+    let mut encoder = ComponentEncoder::default()
+        .module(&module)
+        .expect("fixture module must decode")
+        .validate(true);
+    encoder.encode().expect("component must encode")
+}
+
+#[test]
+fn prepares_metadata_from_wit_tool_component() {
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+    let prepared = runtime
+        .prepare("counter", &tool_component(COUNTER_TOOL_WAT))
+        .unwrap();
+
+    assert_eq!(prepared.name(), "counter");
+    assert_eq!(prepared.description(), "fixture description");
+    assert_eq!(prepared.schema(), &json!({ "type": "object" }));
+}
+
+#[test]
+fn executes_wit_tool_with_fresh_component_instance_per_call() {
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+    let prepared = runtime
+        .prepare("counter", &tool_component(COUNTER_TOOL_WAT))
+        .unwrap();
+    let host = WitToolHost::deny_all();
+
+    let first = runtime
+        .execute(&prepared, host.clone(), WitToolRequest::new(r#"{"q":1}"#))
+        .unwrap();
+    let second = runtime
+        .execute(&prepared, host, WitToolRequest::new(r#"{"q":2}"#))
+        .unwrap();
+
+    assert_eq!(first.output_json.as_deref(), Some("1"));
+    assert_eq!(second.output_json.as_deref(), Some("1"));
+    assert!(first.error.is_none());
+    assert!(second.error.is_none());
+}
+
+#[test]
+fn http_import_delegates_to_recording_host_and_counts_request_body_only() {
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+    let prepared = runtime
+        .prepare("http", &tool_component(HTTP_TOOL_WAT))
+        .unwrap();
+    let http = Arc::new(RecordingWasmHostHttp::ok(WasmHttpResponse {
+        status: 201,
+        headers_json: r#"{"content-type":"text/plain"}"#.to_string(),
+        body: b"response body is not egress".to_vec(),
+    }));
+    let host = WitToolHost::deny_all().with_http(http.clone());
+
+    let executed = runtime
+        .execute(&prepared, host, WitToolRequest::new("{}"))
+        .unwrap();
+
+    let requests = http.requests().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].method, "POST");
+    assert_eq!(requests[0].url, "https://example.test/api");
+    assert_eq!(requests[0].headers_json, "{}");
+    assert_eq!(requests[0].body.as_deref(), Some(&b"hello"[..]));
+    assert_eq!(executed.usage.network_egress_bytes, 5);
+}
+
+#[test]
+fn http_import_counts_request_body_when_host_reports_failure_after_send() {
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+    let prepared = runtime
+        .prepare("http", &tool_component(HTTP_TOOL_WAT))
+        .unwrap();
+    let http = Arc::new(RecordingWasmHostHttp::err(
+        ironclaw_wasm::WasmHostError::FailedAfterRequestSent(
+            "response body limit exceeded".to_string(),
+        ),
+    ));
+    let host = WitToolHost::deny_all().with_http(http.clone());
+
+    let executed = runtime
+        .execute(&prepared, host, WitToolRequest::new("{}"))
+        .unwrap();
+
+    let requests = http.requests().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].body.as_deref(), Some(&b"hello"[..]));
+    assert_eq!(executed.usage.network_egress_bytes, 5);
+}
+
+#[test]
+fn default_http_host_fails_closed_without_recording_egress() {
+    let denied = DenyWasmHostHttp
+        .request(WasmHttpRequest {
+            method: "GET".to_string(),
+            url: "https://example.test/".to_string(),
+            headers_json: "{}".to_string(),
+            body: Some(b"should-not-send".to_vec()),
+            timeout_ms: None,
+        })
+        .unwrap_err();
+    assert!(denied.to_string().contains("not configured"));
+
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+    let prepared = runtime
+        .prepare("http", &tool_component(HTTP_TOOL_WAT))
+        .unwrap();
+    let executed = runtime
+        .execute(
+            &prepared,
+            WitToolHost::deny_all(),
+            WitToolRequest::new("{}"),
+        )
+        .unwrap();
+
+    assert_eq!(executed.usage.network_egress_bytes, 0);
+}

--- a/docs/reborn/README.md
+++ b/docs/reborn/README.md
@@ -20,6 +20,8 @@ The `reborn-integration` branch currently exposes Reborn structure primarily thr
 | Authorization substrate | `crates/ironclaw_authorization/` |
 | Approval substrate | `crates/ironclaw_approvals/` |
 | Run-state substrate | `crates/ironclaw_run_state/` |
+| WASM runtime lane | `crates/ironclaw_wasm/` |
+| WASM runtime contract | `docs/reborn/contracts/wasm.md` |
 | Replay fixtures | `tests/fixtures/llm_traces/README.md` |
 | Replay workflow | `.github/workflows/replay-gate.yml` |
 | E2E test harness | `tests/e2e/README.md` |
@@ -38,6 +40,7 @@ docs/reborn/contracts/events-projections.md
 docs/reborn/contracts/memory.md
 docs/reborn/contracts/secrets.md
 docs/reborn/contracts/network.md
+docs/reborn/contracts/wasm.md
 docs/reborn/contracts/migration-compatibility.md
 ```
 

--- a/docs/reborn/contracts/wasm.md
+++ b/docs/reborn/contracts/wasm.md
@@ -1,0 +1,42 @@
+# Reborn WASM runtime contract
+
+The Reborn WASM runtime executes sandboxed extension components through the canonical component-model ABI declared in `wit/tool.wit`.
+
+## ABI
+
+- Tool components implement world `near:agent/sandboxed-tool@0.3.0`.
+- The host imports are the `near:agent/host@0.3.0` interface:
+  - `log`
+  - `now-millis`
+  - `workspace-read`
+  - `http-request`
+  - `tool-invoke`
+  - `secret-exists`
+- Tool components export `near:agent/tool@0.3.0`:
+  - `description() -> string`
+  - `schema() -> string`
+  - `execute(request) -> response`
+
+The abandoned JSON pointer/length ABI (`alloc`, `invoke_json`, `output_ptr`, `output_len`, and runtime-specific HTTP imports such as `http_request_utf8`) is not part of Reborn.
+
+## Runtime invariants
+
+- Compile once, instantiate a fresh component instance for every execution.
+- Apply fuel, epoch-timeout, memory, table, and instance limits to every metadata and execution call.
+- Treat WIT metadata as the source of runtime compatibility: `description()` and `schema()` are called through generated Wasmtime component bindings.
+- Keep V1 `src/tools/wasm/*` and `src/channels/wasm/*` as compatibility references only; Reborn is a separate binary path.
+
+## Host capability seams
+
+All host capabilities are injected through explicit Rust seams. The default host is fail-closed:
+
+- HTTP egress returns an unavailable error unless a host implementation is injected.
+- Workspace reads return `None` unless a workspace implementation is injected.
+- Secret access is existence-only and returns `false` unless a secret implementation is injected.
+- Nested tool invocation returns unavailable unless a tool implementation is injected.
+
+Production HTTP must be wired to the shared Reborn runtime egress service tracked by #3085, not implemented directly inside `ironclaw_wasm`.
+
+## Network accounting
+
+`ResourceUsage.network_egress_bytes` counts outbound request body bytes only. Response body limits and response scanning are separate host-egress responsibilities and must not be recorded as egress usage. If the host reports that a request was sent but later failed during response handling, the request body still counts as egress; fail-closed denials before send count zero.


### PR DESCRIPTION
## Summary

Replacement for the closed JSON-ABI WASM runtime PR (#3028). This PR adds a clean Reborn-only WASM tool runtime built on the canonical WIT/component-model contract in `wit/tool.wit`.

## What changed

- Adds `crates/ironclaw_wasm` as the Reborn WASM runtime lane.
- Uses `wasmtime::component::bindgen!` against `near:agent/sandboxed-tool@0.3.0`.
- Compiles WIT components and extracts metadata via typed `description()` / `schema()` exports.
- Executes tools via typed `execute(request) -> response` and instantiates a fresh component instance per call.
- Adds fail-closed injectable host seams for:
  - HTTP egress
  - workspace reads
  - secret existence checks
  - nested tool invocation
  - host time/logging
- Adds `RecordingWasmHostHttp` for deterministic tests/dev fixtures.
- Preserves fuel, epoch-timeout, memory/table/instance limiting.
- Records `ResourceUsage.network_egress_bytes` as outbound request body bytes only:
  - pre-send denials count zero,
  - host errors after send count request bytes,
  - response bytes are never counted as egress.
- Adds architecture guardrails so `ironclaw_wasm` does not depend upward on dispatcher/capability/runtime/network/secrets crates.
- Documents the Reborn WASM contract in `docs/reborn/contracts/wasm.md`.

## Explicit non-goals

- Does not touch V1 `src/tools/wasm/*` or `src/channels/wasm/*`.
- Does not implement production HTTP egress directly in `ironclaw_wasm`; real egress should be wired through the shared runtime egress service tracked by #3085.
- Does not add WIT channel runtime yet; this PR is tool-runtime only.
- Does not include the abandoned JSON pointer/length ABI (`invoke_json`, `alloc`, `output_ptr`, `output_len`, `http_request_utf8`).

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_wasm`
- `cargo clippy -p ironclaw_wasm --all-targets -- -D warnings`
- `cargo test -p ironclaw_architecture`
- `python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
- `bash scripts/pre-commit-safety.sh`
- `git diff --check`
- `cargo tree -p ironclaw_wasm -e normal` forbidden-dependency grep
- External Claude code review: no blocking findings

Part of #2987. Supersedes #3028.
