### PR TITLE
feat(llm): native LLM reasoning trace, provider-agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6375,8 +6375,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f7a3f0c7c00eaced15a68ee16e1bd6bb709ff598d11b9aedac8b628217dc09"
+source = "git+https://github.com/failsafesecurity/rig.git?branch=ironclaw-reasoning#c455b0c67210855ce9c596b85f3fe301fe2854b9"
 dependencies = [
  "as-any",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,6 +264,15 @@ required-features = ["libsql", "integration"]
 name = "html_to_markdown"
 required-features = ["html-to-markdown"]
 
+# Temporary fork of rig-core 0.30 that adds `reasoning_content` to the
+# OpenAI-compatible `Message::Assistant` variant. Without this, serde
+# silently drops the field during deserialization for every provider
+# that goes through rig's openai code path (GLM, DeepSeek, Grok, Qwen,
+# Kimi, OpenRouter, Together, Fireworks). Remove once upstream merges
+# https://github.com/0xPlaygrounds/rig/pull/<TBD>.
+[patch.crates-io]
+rig-core = { git = "https://github.com/failsafesecurity/rig.git", branch = "ironclaw-reasoning" }
+
 [profile.release]
 strip = true          # Remove debug symbols from release binaries
 

--- a/crates/ironclaw_common/src/event.rs
+++ b/crates/ironclaw_common/src/event.rs
@@ -433,6 +433,21 @@ pub enum AppEvent {
         decisions: Vec<ToolDecisionDto>,
     },
 
+    /// Native reasoning channel emitted by the underlying LLM
+    /// (Anthropic extended thinking, GLM/DeepSeek/Grok/Qwen/Kimi
+    /// `reasoning_content`, OpenAI o-series reasoning summaries).
+    /// Provider-agnostic: the extractor that produced this content
+    /// is configured in `llm_reasoning_extractors.json`. Distinct
+    /// from `ReasoningUpdate` (the agent's narrative about tool
+    /// choice) and `Thinking` (UX status spinner).
+    #[serde(rename = "llm_reasoning")]
+    LlmReasoning {
+        content: String,
+        model: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_id: Option<String>,
+    },
+
     /// Full (non-truncated) tool output (verbose/debug mode only).
     #[serde(rename = "tool_result_full")]
     ToolResultFull {
@@ -722,6 +737,7 @@ impl AppEvent {
             Self::ExtensionStatus { .. } => "extension_status",
             Self::ReasoningUpdate { .. } => "reasoning_update",
             Self::JobReasoning { .. } => "job_reasoning",
+            Self::LlmReasoning { .. } => "llm_reasoning",
             Self::ToolResultFull { .. } => "tool_result_full",
             Self::TurnMetrics { .. } => "turn_metrics",
             Self::ThreadStateChanged { .. } => "thread_state_changed",
@@ -898,6 +914,11 @@ mod tests {
                 job_id: String::new(),
                 narrative: String::new(),
                 decisions: vec![],
+            },
+            AppEvent::LlmReasoning {
+                content: String::new(),
+                model: String::new(),
+                thread_id: None,
             },
             AppEvent::ToolResultFull {
                 name: String::new(),

--- a/crates/ironclaw_engine/src/executor/loop_engine.rs
+++ b/crates/ironclaw_engine/src/executor/loop_engine.rs
@@ -602,6 +602,7 @@ mod tests {
                 Ok(LlmOutput {
                     response: LlmResponse::Text("(no more responses)".into()),
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 })
             } else {
                 Ok(responses.remove(0))
@@ -679,6 +680,7 @@ mod tests {
                 output_tokens: 50,
                 ..Default::default()
             },
+            reasoning: None,
         }
     }
 
@@ -697,6 +699,7 @@ mod tests {
                 output_tokens: 50,
                 ..Default::default()
             },
+            reasoning: None,
         }
     }
 
@@ -1532,6 +1535,7 @@ mod tests {
                 output_tokens: 80,
                 ..Default::default()
             },
+            reasoning: None,
         }
     }
 
@@ -1961,6 +1965,7 @@ mod tests {
                     content: None,
                 },
                 usage: TokenUsage::default(),
+                reasoning: None,
             },
             text_response("I couldn't access that tool"),
         ]));

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -783,6 +783,15 @@ async fn handle_llm_complete(
             total_tokens.output_tokens += output.usage.output_tokens;
             total_tokens.cost_usd += output.usage.cost_usd;
 
+            if let Some(reasoning) = output.reasoning.as_ref() {
+                if !reasoning.is_empty() {
+                    thread.add_event(EventKind::LlmReasoning {
+                        content: reasoning.clone(),
+                        model: deps.llm.model_name().to_string(),
+                    });
+                }
+            }
+
             let usage = serde_json::json!({
                 "input_tokens": output.usage.input_tokens,
                 "output_tokens": output.usage.output_tokens,
@@ -3980,6 +3989,7 @@ mod tests {
             Ok(crate::traits::llm::LlmOutput {
                 response: crate::types::step::LlmResponse::Text("ok".into()),
                 usage: crate::types::step::TokenUsage::default(),
+                reasoning: None,
             })
         }
     }
@@ -4043,6 +4053,7 @@ mod tests {
             Ok(crate::traits::llm::LlmOutput {
                 response: crate::types::step::LlmResponse::Text("ok".into()),
                 usage: crate::types::step::TokenUsage::default(),
+                reasoning: None,
             })
         }
     }

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -2140,6 +2140,7 @@ mod tests {
             Ok(crate::traits::llm::LlmOutput {
                 response: crate::types::step::LlmResponse::Text("stub".into()),
                 usage: crate::types::step::TokenUsage::default(),
+                reasoning: None,
             })
         }
     }
@@ -3148,6 +3149,7 @@ except Exception as e:
                     config.model.as_deref().unwrap_or("default")
                 )),
                 usage: crate::types::step::TokenUsage::default(),
+                reasoning: None,
             })
         }
     }

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -604,6 +604,7 @@ mod tests {
                 Ok(LlmOutput {
                     response: LlmResponse::Text("done".into()),
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 })
             } else {
                 Ok(r.remove(0))
@@ -813,6 +814,7 @@ mod tests {
             Arc::new(MockLlm(Mutex::new(vec![LlmOutput {
                 response: LlmResponse::Text("Hello!".into()),
                 usage: TokenUsage::default(),
+                reasoning: None,
             }]))),
             Arc::new(MockEffects),
             store.clone(),
@@ -881,6 +883,7 @@ mod tests {
             Arc::new(MockLlm(Mutex::new(vec![LlmOutput {
                 response: LlmResponse::Text("Recovered".into()),
                 usage: TokenUsage::default(),
+                reasoning: None,
             }]))),
             Arc::new(MockEffects),
             store.clone(),

--- a/crates/ironclaw_engine/src/runtime/manager.rs
+++ b/crates/ironclaw_engine/src/runtime/manager.rs
@@ -700,6 +700,7 @@ mod tests {
                 responses: Mutex::new(vec![LlmOutput {
                     response: LlmResponse::Text(msg.into()),
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 }]),
             })
         }
@@ -718,6 +719,7 @@ mod tests {
                 Ok(LlmOutput {
                     response: LlmResponse::Text("done".into()),
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 })
             } else {
                 Ok(r.remove(0))
@@ -1351,6 +1353,7 @@ mod tests {
                         content: None,
                     },
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 },
                 LlmOutput {
                     response: LlmResponse::ActionCalls {
@@ -1362,10 +1365,12 @@ mod tests {
                         content: None,
                     },
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 },
                 LlmOutput {
                     response: LlmResponse::Text("done".into()),
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 },
             ]),
         });
@@ -1408,6 +1413,7 @@ mod tests {
                     content: None,
                 },
                 usage: TokenUsage::default(),
+                reasoning: None,
             })
             .collect();
 

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -3428,6 +3428,7 @@ mod tests {
                 responses: Mutex::new(vec![LlmOutput {
                     response: LlmResponse::Text(msg.into()),
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 }]),
             })
         }
@@ -3446,6 +3447,7 @@ mod tests {
                 Ok(LlmOutput {
                     response: LlmResponse::Text("done".into()),
                     usage: TokenUsage::default(),
+                    reasoning: None,
                 })
             } else {
                 Ok(r.remove(0))

--- a/crates/ironclaw_engine/src/traits/llm.rs
+++ b/crates/ironclaw_engine/src/traits/llm.rs
@@ -38,6 +38,11 @@ pub struct LlmCallConfig {
 pub struct LlmOutput {
     pub response: LlmResponse,
     pub usage: TokenUsage,
+    /// Native reasoning trace from the provider (Anthropic extended
+    /// thinking, OpenAI o-series reasoning summaries, GLM/DeepSeek/
+    /// Grok/Qwen/Kimi `reasoning_content`, Gemini thought parts, etc.).
+    /// `None` when the provider returned no reasoning channel.
+    pub reasoning: Option<String>,
 }
 
 /// Abstraction over language model providers.

--- a/crates/ironclaw_engine/src/types/event.rs
+++ b/crates/ironclaw_engine/src/types/event.rs
@@ -307,6 +307,18 @@ pub enum EventKind {
         content_preview: String,
     },
 
+    // ── LLM reasoning trace ─────────────────────────────────
+    /// Native chain-of-thought from the LLM, captured from
+    /// provider-specific reasoning channels (Anthropic extended
+    /// thinking, OpenAI o-series summaries, GLM/DeepSeek/Grok/
+    /// Qwen/Kimi `reasoning_content`, Gemini thought parts, etc.).
+    /// Distinct from `MessageAdded` (the assistant's user-facing
+    /// reply) and from any UX "thinking" status indicator.
+    LlmReasoning {
+        content: String,
+        model: String,
+    },
+
     // ── Thread tree ─────────────────────────────────────────
     ChildSpawned {
         child_id: ThreadId,

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -2208,6 +2208,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -2223,6 +2224,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -1863,6 +1863,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -1878,6 +1879,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -1905,6 +1907,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -1920,6 +1923,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -1947,6 +1951,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -1963,6 +1968,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 });
             }
 
@@ -1987,6 +1993,7 @@ mod tests {
                 finish_reason: FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -3059,6 +3066,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -3076,6 +3084,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 });
             }
             // Tools available: always call one.
@@ -3092,6 +3101,7 @@ mod tests {
                 finish_reason: FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -3269,6 +3279,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -3285,6 +3296,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 });
             }
             // Always call a tool that does not exist in the registry.
@@ -3301,6 +3313,7 @@ mod tests {
                 finish_reason: FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -3331,6 +3344,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -3351,6 +3365,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -2789,6 +2789,7 @@ mod tests {
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
 
@@ -2804,6 +2805,7 @@ mod tests {
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
         }

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -7017,6 +7017,7 @@ Use this skill to set up a Pika meeting.
                 Ok(ironclaw_engine::LlmOutput {
                     response: ironclaw_engine::types::step::LlmResponse::Text("done".into()),
                     usage: ironclaw_engine::types::step::TokenUsage::default(),
+                    reasoning: None,
                 })
             }
             fn model_name(&self) -> &str {

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -162,6 +162,7 @@ impl LlmBackend for LlmBridgeAdapter {
                         response.cache_creation_input_tokens,
                     ),
                 },
+                reasoning: response.reasoning,
             });
         }
 
@@ -257,6 +258,7 @@ impl LlmBackend for LlmBridgeAdapter {
                     response.cache_creation_input_tokens,
                 ),
             },
+            reasoning: response.reasoning,
         })
     }
 
@@ -662,6 +664,7 @@ mod tests {
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -685,6 +688,7 @@ mod tests {
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -851,6 +855,7 @@ mod tests {
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -975,6 +980,7 @@ mod tests {
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -1582,6 +1588,7 @@ And also check the token price:\n\
                 finish_reason: crate::llm::FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -1672,6 +1679,7 @@ And also check the token price:\n\
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
         async fn complete_with_tools(
@@ -1686,6 +1694,7 @@ And also check the token price:\n\
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -1761,6 +1770,7 @@ And also check the token price:\n\
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
             async fn complete_with_tools(
@@ -1820,6 +1830,7 @@ And also check the token price:\n\
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
             async fn complete_with_tools(
@@ -1890,6 +1901,7 @@ And also check the token price:\n\
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 2_000,
                     cache_creation_input_tokens: 1_000,
+                    reasoning: None,
                 })
             }
             async fn complete_with_tools(

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4695,6 +4695,11 @@ fn thread_event_to_app_events(
             })
             .into_iter()
             .collect(),
+        EventKind::LlmReasoning { content, model } => vec![AppEvent::LlmReasoning {
+            content: content.clone(),
+            model: model.clone(),
+            thread_id: Some(thread_id.into()),
+        }],
         EventKind::StateChanged { from, to, reason } => {
             vec![AppEvent::ThreadStateChanged {
                 thread_id: thread_id.into(),
@@ -5969,6 +5974,7 @@ pub(crate) mod test_support {
                 Ok(ironclaw_engine::LlmOutput {
                     response: ironclaw_engine::LlmResponse::Text("done".into()),
                     usage: ironclaw_engine::TokenUsage::default(),
+                    reasoning: None,
                 })
             }
             fn model_name(&self) -> &str {
@@ -6666,6 +6672,7 @@ mod tests {
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
 
@@ -6681,6 +6688,7 @@ mod tests {
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
         }
@@ -8073,6 +8081,7 @@ mod tests {
                 Ok(ironclaw_engine::LlmOutput {
                     response: ironclaw_engine::LlmResponse::Text("done".into()),
                     usage: ironclaw_engine::TokenUsage::default(),
+                    reasoning: None,
                 })
             }
             fn model_name(&self) -> &str {
@@ -8497,6 +8506,7 @@ mod tests {
                         "missing-pairing".into()
                     }),
                     usage: ironclaw_engine::TokenUsage::default(),
+                    reasoning: None,
                 })
             }
 
@@ -8650,6 +8660,7 @@ mod tests {
                         "snapshot-missing".into()
                     }),
                     usage: ironclaw_engine::TokenUsage::default(),
+                    reasoning: None,
                 })
             }
 
@@ -9323,6 +9334,7 @@ mod tests {
             Ok(ironclaw_engine::LlmOutput {
                 response: ironclaw_engine::LlmResponse::Text(self.text.clone()),
                 usage: ironclaw_engine::TokenUsage::default(),
+                reasoning: None,
             })
         }
 
@@ -9891,6 +9903,7 @@ mod tests {
                 Ok(ironclaw_engine::LlmOutput {
                     response: ironclaw_engine::LlmResponse::Text("ok".into()),
                     usage: ironclaw_engine::TokenUsage::default(),
+                    reasoning: None,
                 })
             }
             fn model_name(&self) -> &str {

--- a/src/hooks/session_summary.rs
+++ b/src/hooks/session_summary.rs
@@ -400,6 +400,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -274,6 +274,7 @@ impl LlmProvider for AnthropicOAuthProvider {
             output_tokens: response.usage.output_tokens,
             cache_creation_input_tokens: response.usage.cache_creation_input_tokens,
             cache_read_input_tokens: response.usage.cache_read_input_tokens,
+            reasoning: None,
         })
     }
 
@@ -351,6 +352,7 @@ impl LlmProvider for AnthropicOAuthProvider {
             output_tokens: response.usage.output_tokens,
             cache_creation_input_tokens: response.usage.cache_creation_input_tokens,
             cache_read_input_tokens: response.usage.cache_read_input_tokens,
+            reasoning: None,
         })
     }
 

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -142,6 +142,7 @@ impl LlmProvider for BedrockProvider {
             finish_reason: map_stop_reason(response.stop_reason()),
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -207,6 +208,7 @@ impl LlmProvider for BedrockProvider {
             finish_reason: map_stop_reason(response.stop_reason()),
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            reasoning: None,
         })
     }
 

--- a/src/llm/codex_chatgpt.rs
+++ b/src/llm/codex_chatgpt.rs
@@ -702,6 +702,7 @@ impl LlmProvider for CodexChatGptProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -755,6 +756,7 @@ impl LlmProvider for CodexChatGptProvider {
             finish_reason,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 }

--- a/src/llm/failover.rs
+++ b/src/llm/failover.rs
@@ -414,6 +414,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 }))),
                 tool_complete_result: Mutex::new(Some(Ok(ToolCompletionResponse {
                     content: Some(content.to_string()),
@@ -423,6 +424,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 }))),
             }
         }
@@ -806,6 +808,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -833,6 +836,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 

--- a/src/llm/gemini_oauth.rs
+++ b/src/llm/gemini_oauth.rs
@@ -2042,6 +2042,7 @@ impl GeminiOauthProvider {
                 output_tokens,
                 cache_read_input_tokens: cached_content_tokens,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             },
             tool_calls,
             thought_sigs,
@@ -2162,6 +2163,7 @@ impl LlmProvider for GeminiOauthProvider {
             tool_calls,
             cache_read_input_tokens: response.cache_read_input_tokens,
             cache_creation_input_tokens: response.cache_creation_input_tokens,
+            reasoning: None,
         })
     }
 }

--- a/src/llm/github_copilot.rs
+++ b/src/llm/github_copilot.rs
@@ -262,6 +262,7 @@ impl LlmProvider for GithubCopilotProvider {
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -348,6 +349,7 @@ impl LlmProvider for GithubCopilotProvider {
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            reasoning: None,
         })
     }
 

--- a/src/llm/llm_reasoning.rs
+++ b/src/llm/llm_reasoning.rs
@@ -1,0 +1,471 @@
+//! Provider-agnostic extractor for the LLM's native reasoning channel.
+//!
+//! Different providers ship the model's chain-of-thought in different
+//! places in the response JSON. Rather than hardcoding per-provider
+//! switches, the per-provider knowledge lives in
+//! [`llm_reasoning_extractors.json`] (config-as-data) and this module
+//! walks the rig-core typed response — converted to a generic
+//! `serde_json::Value` — applying the matching entry's rules.
+//!
+//! Adding support for a new provider is one new JSON entry; no Rust
+//! change required.
+//!
+//! Three rule kinds cover every provider seen so far:
+//!
+//! * `field` — the reasoning is a flat string field on the assistant
+//!   message (e.g. GLM/DeepSeek/Grok/Qwen `reasoning_content`,
+//!   Kimi K2.6 `reasoning`).
+//!
+//! * `block` — the reasoning is a typed content block, identified
+//!   either by `{type: "thinking"|"reasoning"}` (Anthropic, OpenAI
+//!   o-series, Mistral 2509+) or by a boolean flag like
+//!   `{thought: true}` (Gemini). The text lives in a sibling field.
+//!   The text-field path supports a tiny `key[*].subkey` form so
+//!   array-of-objects shapes (OpenAI `summary[*].text`,
+//!   Mistral `thinking[*].text`) work without writing special cases.
+//!
+//! * `regex_in_content` — text is embedded in the assistant content
+//!   string with delimiters (Mistral Magistral 2506 uses
+//!   `<think>...</think>`). The pattern's first capture group is the
+//!   reasoning.
+//!
+//! When multiple rules are listed for one provider they are tried in
+//! order; the first non-empty result wins. This handles version drift
+//! within a model family (e.g. Magistral 2506 vs 2509+, Kimi K2 vs
+//! K2.6) without forcing a separate entry per version.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const EXTRACTORS_JSON: &str = include_str!("llm_reasoning_extractors.json");
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ExtractorEntryRaw {
+    #[allow(dead_code)]
+    name: String,
+    model_match: String,
+    rules: Vec<Rule>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Rule {
+    /// Flat string field at any depth in the response.
+    Field { field: String },
+    /// Typed content block. Either:
+    /// * `type_field` + `type_value` (e.g. `"type": "thinking"`), or
+    /// * `flag_field` (boolean true on the block, e.g. `"thought": true`).
+    Block {
+        #[serde(default)]
+        type_field: Option<String>,
+        #[serde(default)]
+        type_value: Option<String>,
+        #[serde(default)]
+        flag_field: Option<String>,
+        /// Field on the matched block holding the reasoning text.
+        /// Supports `key[*].subkey` for array-of-objects shapes.
+        text_field: String,
+    },
+    /// Regex against any string field named `content`. Capture group 1
+    /// is the reasoning text. Multiple matches are concatenated.
+    RegexInContent { pattern: String },
+}
+
+struct CompiledEntry {
+    model_re: Regex,
+    rules: Vec<CompiledRule>,
+}
+
+enum CompiledRule {
+    Field(String),
+    Block {
+        type_field: Option<String>,
+        type_value: Option<String>,
+        flag_field: Option<String>,
+        text_field_outer: String,
+        text_field_inner: Option<String>,
+    },
+    Regex(Regex),
+}
+
+fn compiled_entries() -> &'static [CompiledEntry] {
+    static CACHE: OnceLock<Vec<CompiledEntry>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let raw: Vec<ExtractorEntryRaw> = serde_json::from_str(EXTRACTORS_JSON)
+            .expect("llm_reasoning_extractors.json is malformed; fix the file");
+        raw.into_iter()
+            .filter_map(|entry| {
+                let model_re = match Regex::new(&entry.model_match) {
+                    Ok(re) => re,
+                    Err(e) => {
+                        tracing::warn!(
+                            entry = %entry.name,
+                            pattern = %entry.model_match,
+                            error = %e,
+                            "skipping reasoning extractor entry: invalid model_match regex",
+                        );
+                        return None;
+                    }
+                };
+                let rules = entry
+                    .rules
+                    .into_iter()
+                    .filter_map(|r| compile_rule(r, &entry.name))
+                    .collect();
+                Some(CompiledEntry { model_re, rules })
+            })
+            .collect()
+    })
+}
+
+fn compile_rule(rule: Rule, entry_name: &str) -> Option<CompiledRule> {
+    match rule {
+        Rule::Field { field } => Some(CompiledRule::Field(field)),
+        Rule::Block {
+            type_field,
+            type_value,
+            flag_field,
+            text_field,
+        } => {
+            let (outer, inner) = match text_field.split_once("[*].") {
+                Some((o, i)) => (o.to_string(), Some(i.to_string())),
+                None => (text_field, None),
+            };
+            Some(CompiledRule::Block {
+                type_field,
+                type_value,
+                flag_field,
+                text_field_outer: outer,
+                text_field_inner: inner,
+            })
+        }
+        Rule::RegexInContent { pattern } => match Regex::new(&pattern) {
+            Ok(re) => Some(CompiledRule::Regex(re)),
+            Err(e) => {
+                tracing::warn!(
+                    entry = %entry_name,
+                    pattern = %pattern,
+                    error = %e,
+                    "skipping regex_in_content rule: invalid pattern",
+                );
+                None
+            }
+        },
+    }
+}
+
+/// Extract reasoning text from a provider response.
+///
+/// Returns `None` when no entry matches the model name, no rule
+/// produces text, or the resulting text is empty.
+pub fn extract_reasoning(model: &str, raw_response: &Value) -> Option<String> {
+    let entry = compiled_entries()
+        .iter()
+        .find(|e| e.model_re.is_match(model))?;
+
+    for rule in &entry.rules {
+        let mut chunks: Vec<String> = Vec::new();
+        match rule {
+            CompiledRule::Field(name) => collect_field(raw_response, name, &mut chunks),
+            CompiledRule::Block {
+                type_field,
+                type_value,
+                flag_field,
+                text_field_outer,
+                text_field_inner,
+            } => collect_block(
+                raw_response,
+                type_field.as_deref(),
+                type_value.as_deref(),
+                flag_field.as_deref(),
+                text_field_outer,
+                text_field_inner.as_deref(),
+                &mut chunks,
+            ),
+            CompiledRule::Regex(re) => collect_regex(raw_response, re, &mut chunks),
+        }
+        let chunks: Vec<String> = chunks
+            .into_iter()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !chunks.is_empty() {
+            return Some(chunks.join("\n\n"));
+        }
+    }
+    None
+}
+
+fn collect_field(v: &Value, name: &str, out: &mut Vec<String>) {
+    match v {
+        Value::Object(map) => {
+            if let Some(s) = map.get(name).and_then(|x| x.as_str()) {
+                out.push(s.to_string());
+            }
+            for (_, child) in map {
+                collect_field(child, name, out);
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr {
+                collect_field(child, name, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_block(
+    v: &Value,
+    type_field: Option<&str>,
+    type_value: Option<&str>,
+    flag_field: Option<&str>,
+    text_outer: &str,
+    text_inner: Option<&str>,
+    out: &mut Vec<String>,
+) {
+    match v {
+        Value::Object(map) => {
+            let by_type = match (type_field, type_value) {
+                (Some(tf), Some(tv)) => map.get(tf).and_then(|x| x.as_str()) == Some(tv),
+                _ => false,
+            };
+            let by_flag = match flag_field {
+                Some(ff) => map.get(ff).and_then(|x| x.as_bool()) == Some(true),
+                None => false,
+            };
+            if by_type || by_flag {
+                if let Some(text_value) = map.get(text_outer) {
+                    extract_text(text_value, text_inner, out);
+                }
+            }
+            for (_, child) in map {
+                collect_block(
+                    child, type_field, type_value, flag_field, text_outer, text_inner, out,
+                );
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr {
+                collect_block(
+                    child, type_field, type_value, flag_field, text_outer, text_inner, out,
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn extract_text(v: &Value, inner: Option<&str>, out: &mut Vec<String>) {
+    match (v, inner) {
+        (Value::String(s), None) => out.push(s.clone()),
+        (Value::Array(arr), Some(inner_key)) => {
+            for item in arr {
+                if let Some(s) = item.get(inner_key).and_then(|x| x.as_str()) {
+                    out.push(s.to_string());
+                }
+            }
+        }
+        (Value::Array(arr), None) => {
+            for item in arr {
+                if let Some(s) = item.as_str() {
+                    out.push(s.to_string());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_regex(v: &Value, re: &Regex, out: &mut Vec<String>) {
+    match v {
+        Value::Object(map) => {
+            if let Some(s) = map.get("content").and_then(|x| x.as_str()) {
+                for caps in re.captures_iter(s) {
+                    if let Some(m) = caps.get(1) {
+                        out.push(m.as_str().to_string());
+                    }
+                }
+            }
+            for (_, child) in map {
+                collect_regex(child, re, out);
+            }
+        }
+        Value::Array(arr) => {
+            for child in arr {
+                collect_regex(child, re, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn config_loads() {
+        let entries = compiled_entries();
+        assert!(
+            entries.len() >= 8,
+            "expected at least 8 provider entries, got {}",
+            entries.len()
+        );
+    }
+
+    #[test]
+    fn glm_flat_field() {
+        let raw = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning_content": "Let me think...",
+                    "content": "Final answer."
+                }
+            }]
+        });
+        assert_eq!(
+            extract_reasoning("glm-5", &raw),
+            Some("Let me think...".to_string())
+        );
+    }
+
+    #[test]
+    fn anthropic_thinking_block() {
+        let raw = json!({
+            "content": [
+                { "type": "thinking", "thinking": "Step 1, step 2." },
+                { "type": "text", "text": "Done." }
+            ]
+        });
+        assert_eq!(
+            extract_reasoning("claude-sonnet-4-5", &raw),
+            Some("Step 1, step 2.".to_string())
+        );
+    }
+
+    #[test]
+    fn openai_o_series_summary_array() {
+        let raw = json!({
+            "output": [
+                { "type": "reasoning", "id": "r_1", "summary": [
+                    { "type": "summary_text", "text": "thinking part 1" },
+                    { "type": "summary_text", "text": "thinking part 2" }
+                ]},
+                { "type": "message", "content": [{ "type": "output_text", "text": "answer" }] }
+            ]
+        });
+        assert_eq!(
+            extract_reasoning("o3-mini", &raw),
+            Some("thinking part 1\n\nthinking part 2".to_string())
+        );
+    }
+
+    #[test]
+    fn gemini_thought_flag() {
+        let raw = json!({
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        { "thought": true, "text": "internal" },
+                        { "text": "external" }
+                    ]
+                }
+            }]
+        });
+        assert_eq!(
+            extract_reasoning("gemini-2.5-pro", &raw),
+            Some("internal".to_string())
+        );
+    }
+
+    #[test]
+    fn mistral_magistral_2509_typed() {
+        let raw = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        { "type": "thinking", "thinking": [
+                            { "type": "text", "text": "trace" }
+                        ]},
+                        { "type": "text", "text": "answer" }
+                    ]
+                }
+            }]
+        });
+        assert_eq!(
+            extract_reasoning("magistral-medium-1.2", &raw),
+            Some("trace".to_string())
+        );
+    }
+
+    #[test]
+    fn mistral_magistral_2506_inline_tags() {
+        let raw = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>inline thoughts</think>actual answer"
+                }
+            }]
+        });
+        assert_eq!(
+            extract_reasoning("magistral-medium-2506", &raw),
+            Some("inline thoughts".to_string())
+        );
+    }
+
+    #[test]
+    fn kimi_k2_thinking_uses_reasoning_content() {
+        let raw = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning_content": "kimi trace",
+                    "content": "answer"
+                }
+            }]
+        });
+        assert_eq!(
+            extract_reasoning("kimi-k2-thinking", &raw),
+            Some("kimi trace".to_string())
+        );
+    }
+
+    #[test]
+    fn kimi_k2_6_uses_reasoning() {
+        let raw = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning": "kimi 2.6 trace",
+                    "content": "answer"
+                }
+            }]
+        });
+        assert_eq!(
+            extract_reasoning("kimi-k2.6", &raw),
+            Some("kimi 2.6 trace".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_model_returns_none() {
+        let raw = json!({ "anything": "here" });
+        assert_eq!(extract_reasoning("some-novel-model-9000", &raw), None);
+    }
+
+    #[test]
+    fn empty_reasoning_returns_none() {
+        let raw = json!({
+            "choices": [{ "message": { "reasoning_content": "" }}]
+        });
+        assert_eq!(extract_reasoning("glm-5", &raw), None);
+    }
+}

--- a/src/llm/llm_reasoning_extractors.json
+++ b/src/llm/llm_reasoning_extractors.json
@@ -1,0 +1,75 @@
+[
+  {
+    "name": "Anthropic Claude (extended thinking)",
+    "model_match": "(?i)^claude",
+    "rules": [
+      { "kind": "block", "type_field": "type", "type_value": "thinking", "text_field": "thinking" }
+    ]
+  },
+  {
+    "name": "OpenAI o-series / gpt-5-thinking (Responses API)",
+    "model_match": "(?i)^(o[1-9]|gpt-5-thinking|gpt-5-codex)",
+    "rules": [
+      { "kind": "block", "type_field": "type", "type_value": "reasoning", "text_field": "summary[*].text" }
+    ]
+  },
+  {
+    "name": "Google Gemini (thinking)",
+    "model_match": "(?i)^gemini",
+    "rules": [
+      { "kind": "block", "flag_field": "thought", "text_field": "text" }
+    ]
+  },
+  {
+    "name": "GLM (Z.AI / direct)",
+    "model_match": "(?i)^glm",
+    "rules": [
+      { "kind": "field", "field": "reasoning_content" }
+    ]
+  },
+  {
+    "name": "DeepSeek",
+    "model_match": "(?i)^deepseek",
+    "rules": [
+      { "kind": "field", "field": "reasoning_content" }
+    ]
+  },
+  {
+    "name": "xAI Grok",
+    "model_match": "(?i)^grok",
+    "rules": [
+      { "kind": "field", "field": "reasoning_content" }
+    ]
+  },
+  {
+    "name": "Qwen",
+    "model_match": "(?i)^qwen",
+    "rules": [
+      { "kind": "field", "field": "reasoning_content" }
+    ]
+  },
+  {
+    "name": "Moonshot Kimi",
+    "model_match": "(?i)^kimi",
+    "rules": [
+      { "kind": "field", "field": "reasoning" },
+      { "kind": "field", "field": "reasoning_content" }
+    ]
+  },
+  {
+    "name": "Mistral Magistral",
+    "model_match": "(?i)^magistral",
+    "rules": [
+      { "kind": "block", "type_field": "type", "type_value": "thinking", "text_field": "thinking[*].text" },
+      { "kind": "regex_in_content", "pattern": "<think>([\\s\\S]*?)</think>" }
+    ]
+  },
+  {
+    "name": "OpenRouter (any model)",
+    "model_match": "(?i)^openrouter/",
+    "rules": [
+      { "kind": "field", "field": "reasoning" },
+      { "kind": "field", "field": "reasoning_content" }
+    ]
+  }
+]

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -25,6 +25,7 @@ mod nearai_chat;
 pub mod oauth_helpers;
 pub mod openai_codex_provider;
 pub mod openai_codex_session;
+pub mod llm_reasoning;
 mod provider;
 mod reasoning;
 pub mod recording;

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -584,6 +584,7 @@ impl LlmProvider for NearAiChatProvider {
             output_tokens,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -688,6 +689,7 @@ impl LlmProvider for NearAiChatProvider {
             output_tokens,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 

--- a/src/llm/openai_codex_provider.rs
+++ b/src/llm/openai_codex_provider.rs
@@ -271,6 +271,7 @@ impl LlmProvider for OpenAiCodexProvider {
             finish_reason: parsed.finish_reason,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -327,6 +328,7 @@ impl LlmProvider for OpenAiCodexProvider {
             finish_reason,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -232,6 +232,12 @@ pub struct CompletionResponse {
     /// Tokens written to the provider's server-side prompt cache (Anthropic).
     /// Zero when caching is not supported or no new prefix was cached.
     pub cache_creation_input_tokens: u32,
+    /// Native reasoning channel from the provider (Anthropic extended
+    /// thinking, GLM/DeepSeek/Grok/Qwen/Kimi `reasoning_content`,
+    /// OpenAI o-series reasoning summaries, etc.). `None` when the model
+    /// does not produce reasoning or no extractor matches the model name.
+    /// Populated by `llm::llm_reasoning::extract_reasoning`.
+    pub reasoning: Option<String>,
 }
 
 /// Why the completion finished.
@@ -393,6 +399,9 @@ pub struct ToolCompletionResponse {
     pub cache_read_input_tokens: u32,
     /// Tokens written to the provider's server-side prompt cache (Anthropic).
     pub cache_creation_input_tokens: u32,
+    /// Native reasoning channel from the provider. See
+    /// [`CompletionResponse::reasoning`] for details.
+    pub reasoning: Option<String>,
 }
 
 /// Metadata about a model returned by the provider's API.

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -3398,6 +3398,7 @@ That's my plan."#;
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
         }
@@ -3749,6 +3750,7 @@ That's my plan."#;
                 finish_reason: self.finish_reason,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }

--- a/src/llm/response_cache.rs
+++ b/src/llm/response_cache.rs
@@ -366,6 +366,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -381,6 +382,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -418,6 +418,15 @@ fn extract_cache_creation<T: Serialize>(raw: &T) -> u32 {
         .unwrap_or(0)
 }
 
+/// Extract the model's native reasoning channel (chain-of-thought) from a
+/// provider response. The per-provider knowledge lives in
+/// `llm_reasoning_extractors.json`; this just serializes the typed response
+/// to a generic JSON value and delegates.
+fn extract_reasoning_from_raw<T: Serialize>(model: &str, raw: &T) -> Option<String> {
+    let value = serde_json::to_value(raw).ok()?;
+    crate::llm::llm_reasoning::extract_reasoning(model, &value)
+}
+
 /// Build a rig-core CompletionRequest from our internal types.
 ///
 /// When `cache_retention` is not `None`, injects a top-level `cache_control`
@@ -558,6 +567,8 @@ where
 
         let (text, _tool_calls, finish) = extract_response(&response.choice, &response.usage);
 
+        let reasoning = extract_reasoning_from_raw(&self.model_name, &response.raw_response);
+
         let resp = CompletionResponse {
             content: text.unwrap_or_default(),
             input_tokens: saturate_u32(response.usage.input_tokens),
@@ -565,6 +576,7 @@ where
             finish_reason: finish,
             cache_read_input_tokens: saturate_u32(response.usage.cached_input_tokens),
             cache_creation_input_tokens: extract_cache_creation(&response.raw_response),
+            reasoning,
         };
 
         if resp.cache_read_input_tokens > 0 {
@@ -630,6 +642,8 @@ where
             }
         }
 
+        let reasoning = extract_reasoning_from_raw(&self.model_name, &response.raw_response);
+
         let resp = ToolCompletionResponse {
             content: text,
             tool_calls,
@@ -638,6 +652,7 @@ where
             finish_reason: finish,
             cache_read_input_tokens: saturate_u32(response.usage.cached_input_tokens),
             cache_creation_input_tokens: extract_cache_creation(&response.raw_response),
+            reasoning,
         };
 
         if resp.cache_read_input_tokens > 0 {

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -427,6 +427,41 @@ fn extract_reasoning_from_raw<T: Serialize>(model: &str, raw: &T) -> Option<Stri
     crate::llm::llm_reasoning::extract_reasoning(model, &value)
 }
 
+/// Build the Anthropic `thinking` request parameter for Claude models.
+///
+/// Anthropic only emits `thinking` content blocks when the request opts in
+/// via a top-level `thinking: { type: "enabled", budget_tokens: N }` field.
+/// Without this, Claude's reasoning extractor (which matches `^claude` and
+/// looks for `type: "thinking"` blocks) finds nothing and
+/// `CompletionResponse.reasoning` is `None`.
+///
+/// Budget defaults to 4096 and is overridable via `ANTHROPIC_THINKING_BUDGET`.
+/// Setting the env var to `0` disables extended thinking entirely.
+/// `budget_tokens` must be strictly less than `max_tokens`; we cap at
+/// `max_tokens.saturating_sub(1024)` to leave headroom for the actual answer.
+fn anthropic_thinking_param(model: &str, max_tokens: Option<u32>) -> Option<serde_json::Value> {
+    if !model.starts_with("claude-") {
+        return None;
+    }
+    let budget = std::env::var("ANTHROPIC_THINKING_BUDGET")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(4096);
+    if budget == 0 {
+        return None;
+    }
+    let max = max_tokens.unwrap_or(8192);
+    let actual_budget = budget.min(max.saturating_sub(1024));
+    if actual_budget < 1024 {
+        // Anthropic requires budget_tokens >= 1024; bail rather than send invalid request.
+        return None;
+    }
+    Some(serde_json::json!({
+        "type": "enabled",
+        "budget_tokens": actual_budget,
+    }))
+}
+
 /// Build a rig-core CompletionRequest from our internal types.
 ///
 /// When `cache_retention` is not `None`, injects a top-level `cache_control`
@@ -435,8 +470,16 @@ fn extract_reasoning_from_raw<T: Serialize>(model: &str, raw: &T) -> Option<Stri
 /// the request root — which is exactly what Anthropic's **automatic caching**
 /// expects. The API auto-places the cache breakpoint at the last cacheable
 /// block and moves it forward as conversations grow.
+///
+/// When `model` matches `claude-*`, also injects a top-level `thinking`
+/// parameter so Anthropic emits extended-thinking content blocks (which the
+/// reasoning extractor then surfaces as `CompletionResponse.reasoning`).
+/// Anthropic requires `temperature=1` when extended thinking is on; we
+/// achieve that by clearing any caller-supplied temperature on Claude
+/// requests (rig-core omits the field, Anthropic defaults to 1).
 #[allow(clippy::too_many_arguments)]
 fn build_rig_request(
+    model: &str,
     preamble: Option<String>,
     mut history: Vec<RigMessage>,
     tools: Vec<RigToolDefinition>,
@@ -455,15 +498,28 @@ fn build_rig_request(
         reason: format!("Failed to build chat history: {}", e),
     })?;
 
-    // Inject top-level cache_control for Anthropic automatic prompt caching.
-    let additional_params = match cache_retention {
+    let cache_control_value = match cache_retention {
         CacheRetention::None => None,
-        CacheRetention::Short => Some(serde_json::json!({
-            "cache_control": {"type": "ephemeral"}
-        })),
-        CacheRetention::Long => Some(serde_json::json!({
-            "cache_control": {"type": "ephemeral", "ttl": "1h"}
-        })),
+        CacheRetention::Short => Some(serde_json::json!({"type": "ephemeral"})),
+        CacheRetention::Long => Some(serde_json::json!({"type": "ephemeral", "ttl": "1h"})),
+    };
+
+    let thinking_value = anthropic_thinking_param(model, max_tokens);
+    let thinking_enabled = thinking_value.is_some();
+
+    let additional_params = match (cache_control_value, thinking_value) {
+        (None, None) => None,
+        (Some(cc), None) => Some(serde_json::json!({"cache_control": cc})),
+        (None, Some(th)) => Some(serde_json::json!({"thinking": th})),
+        (Some(cc), Some(th)) => {
+            Some(serde_json::json!({"cache_control": cc, "thinking": th}))
+        }
+    };
+
+    let final_temperature = if thinking_enabled {
+        None
+    } else {
+        temperature.map(round_f32_to_f64)
     };
 
     Ok(RigRequest {
@@ -471,7 +527,7 @@ fn build_rig_request(
         chat_history,
         documents: Vec::new(),
         tools,
-        temperature: temperature.map(round_f32_to_f64),
+        temperature: final_temperature,
         max_tokens: max_tokens.map(|t| t as u64),
         tool_choice,
         additional_params,
@@ -548,6 +604,7 @@ where
         let (preamble, history) = convert_messages(&messages);
 
         let mut rig_req = build_rig_request(
+            model_override.as_deref().unwrap_or(&self.model_name),
             preamble,
             history,
             Vec::new(),
@@ -610,6 +667,7 @@ where
         let tool_choice = convert_tool_choice(request.tool_choice.as_deref());
 
         let mut rig_req = build_rig_request(
+            model_override.as_deref().unwrap_or(&self.model_name),
             preamble,
             history,
             tools,
@@ -1869,6 +1927,7 @@ mod tests {
     #[test]
     fn test_build_rig_request_injects_cache_control_short() {
         let req = build_rig_request(
+            "glm-5",
             Some("You are helpful.".to_string()),
             vec![RigMessage::user("Hello")],
             Vec::new(),
@@ -1892,6 +1951,7 @@ mod tests {
     #[test]
     fn test_build_rig_request_injects_cache_control_long() {
         let req = build_rig_request(
+            "glm-5",
             Some("You are helpful.".to_string()),
             vec![RigMessage::user("Hello")],
             Vec::new(),
@@ -1912,6 +1972,7 @@ mod tests {
     #[test]
     fn test_build_rig_request_no_cache_control_when_none() {
         let req = build_rig_request(
+            "glm-5",
             Some("You are helpful.".to_string()),
             vec![RigMessage::user("Hello")],
             Vec::new(),
@@ -1925,6 +1986,148 @@ mod tests {
         assert!(
             req.additional_params.is_none(),
             "additional_params should be None when cache is disabled"
+        );
+    }
+
+    /// Save/restore an env var around a test so concurrent tests in this module
+    /// don't observe partial mutations. Mirrors the pattern used in
+    /// src/cli/doctor.rs.
+    struct EnvGuard {
+        key: &'static str,
+        prior: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn new(key: &'static str) -> Self {
+            let prior = std::env::var(key).ok();
+            // SAFETY: Caller holds ENV_MUTEX via lock_env() before constructing.
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: Caller holds ENV_MUTEX via lock_env() for the test scope.
+            unsafe {
+                match self.prior.take() {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_rig_request_injects_thinking_for_claude() {
+        let _mutex = crate::config::helpers::lock_env();
+        let _guard = EnvGuard::new("ANTHROPIC_THINKING_BUDGET");
+
+        let req = build_rig_request(
+            "claude-sonnet-4-6",
+            Some("You are helpful.".to_string()),
+            vec![RigMessage::user("Hello")],
+            Vec::new(),
+            None,
+            Some(0.5),
+            Some(8192),
+            CacheRetention::None,
+        )
+        .unwrap();
+
+        let params = req
+            .additional_params
+            .expect("Claude requests must inject thinking param");
+        assert_eq!(params["thinking"]["type"], "enabled");
+        assert_eq!(params["thinking"]["budget_tokens"], 4096);
+        assert!(
+            req.temperature.is_none(),
+            "temperature must be cleared on Claude requests with extended thinking"
+        );
+    }
+
+    #[test]
+    fn test_build_rig_request_thinking_combines_with_cache_control() {
+        let _mutex = crate::config::helpers::lock_env();
+        let _guard = EnvGuard::new("ANTHROPIC_THINKING_BUDGET");
+
+        let req = build_rig_request(
+            "claude-opus-4-1",
+            Some("You are helpful.".to_string()),
+            vec![RigMessage::user("Hello")],
+            Vec::new(),
+            None,
+            None,
+            Some(8192),
+            CacheRetention::Short,
+        )
+        .unwrap();
+
+        let params = req
+            .additional_params
+            .expect("Claude+cache requests must include both fields");
+        assert_eq!(params["cache_control"]["type"], "ephemeral");
+        assert_eq!(params["thinking"]["type"], "enabled");
+    }
+
+    #[test]
+    fn test_build_rig_request_no_thinking_for_non_claude() {
+        let _mutex = crate::config::helpers::lock_env();
+        let _guard = EnvGuard::new("ANTHROPIC_THINKING_BUDGET");
+        let req = build_rig_request(
+            "glm-5",
+            Some("You are helpful.".to_string()),
+            vec![RigMessage::user("Hello")],
+            Vec::new(),
+            None,
+            Some(0.5),
+            Some(8192),
+            CacheRetention::None,
+        )
+        .unwrap();
+
+        assert!(req.additional_params.is_none());
+        assert!(
+            req.temperature.is_some(),
+            "non-Claude models keep their caller-supplied temperature"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_thinking_param_disabled_when_budget_zero() {
+        let _mutex = crate::config::helpers::lock_env();
+        let _guard = EnvGuard::new("ANTHROPIC_THINKING_BUDGET");
+        // SAFETY: holding ENV_MUTEX above.
+        unsafe {
+            std::env::set_var("ANTHROPIC_THINKING_BUDGET", "0");
+        }
+        let p = anthropic_thinking_param("claude-sonnet-4-6", Some(8192));
+        assert!(p.is_none(), "ANTHROPIC_THINKING_BUDGET=0 must disable thinking");
+    }
+
+    #[test]
+    fn test_anthropic_thinking_param_caps_at_max_tokens() {
+        let _mutex = crate::config::helpers::lock_env();
+        let _guard = EnvGuard::new("ANTHROPIC_THINKING_BUDGET");
+        // SAFETY: holding ENV_MUTEX above.
+        unsafe {
+            std::env::set_var("ANTHROPIC_THINKING_BUDGET", "10000");
+        }
+        let p = anthropic_thinking_param("claude-sonnet-4-6", Some(4096));
+        let v = p.expect("should still emit thinking with reduced budget");
+        assert_eq!(v["budget_tokens"], 4096u32 - 1024);
+    }
+
+    #[test]
+    fn test_anthropic_thinking_param_skips_when_max_too_small() {
+        let _mutex = crate::config::helpers::lock_env();
+        let _guard = EnvGuard::new("ANTHROPIC_THINKING_BUDGET");
+        let p = anthropic_thinking_param("claude-sonnet-4-6", Some(1024));
+        assert!(
+            p.is_none(),
+            "max_tokens too low to leave 1024 budget headroom must skip thinking"
         );
     }
 

--- a/src/llm/smart_routing.rs
+++ b/src/llm/smart_routing.rs
@@ -1588,6 +1588,7 @@ mod tests {
             finish_reason: crate::llm::FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         };
         assert!(SmartRoutingProvider::response_is_uncertain(&response));
     }
@@ -1601,6 +1602,7 @@ mod tests {
             finish_reason: crate::llm::FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         };
         assert!(SmartRoutingProvider::response_is_uncertain(&response));
     }
@@ -1614,6 +1616,7 @@ mod tests {
             finish_reason: crate::llm::FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         };
         assert!(!SmartRoutingProvider::response_is_uncertain(&response));
     }
@@ -1628,6 +1631,7 @@ mod tests {
             finish_reason: crate::llm::FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         };
         assert!(!SmartRoutingProvider::response_is_uncertain(&response));
     }

--- a/src/orchestrator/api.rs
+++ b/src/orchestrator/api.rs
@@ -224,6 +224,7 @@ async fn llm_complete(
         finish_reason: format_finish_reason(resp.finish_reason),
         cache_read_input_tokens: resp.cache_read_input_tokens,
         cache_creation_input_tokens: resp.cache_creation_input_tokens,
+        reasoning: resp.reasoning,
     }))
 }
 
@@ -256,6 +257,7 @@ async fn llm_complete_with_tools(
         finish_reason: format_finish_reason(resp.finish_reason),
         cache_read_input_tokens: resp.cache_read_input_tokens,
         cache_creation_input_tokens: resp.cache_creation_input_tokens,
+        reasoning: resp.reasoning,
     }))
 }
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -214,6 +214,7 @@ impl LlmProvider for StubLlm {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -233,6 +234,7 @@ impl LlmProvider for StubLlm {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 }

--- a/src/tools/builtin/memory.rs
+++ b/src/tools/builtin/memory.rs
@@ -1771,6 +1771,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
 

--- a/src/worker/api.rs
+++ b/src/worker/api.rs
@@ -56,6 +56,8 @@ pub struct ProxyCompletionResponse {
     pub cache_read_input_tokens: u32,
     #[serde(default)]
     pub cache_creation_input_tokens: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -80,6 +82,8 @@ pub struct ProxyToolCompletionResponse {
     pub cache_read_input_tokens: u32,
     #[serde(default)]
     pub cache_creation_input_tokens: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
 }
 
 /// Completion result for the worker to report when done.
@@ -238,6 +242,7 @@ impl WorkerHttpClient {
             finish_reason: parse_finish_reason(&proxy_resp.finish_reason),
             cache_read_input_tokens: proxy_resp.cache_read_input_tokens,
             cache_creation_input_tokens: proxy_resp.cache_creation_input_tokens,
+            reasoning: proxy_resp.reasoning.clone(),
         })
     }
 
@@ -268,6 +273,7 @@ impl WorkerHttpClient {
             finish_reason: parse_finish_reason(&proxy_resp.finish_reason),
             cache_read_input_tokens: proxy_resp.cache_read_input_tokens,
             cache_creation_input_tokens: proxy_resp.cache_creation_input_tokens,
+            reasoning: proxy_resp.reasoning.clone(),
         })
     }
 

--- a/tests/admin_tool_policy_e2e.rs
+++ b/tests/admin_tool_policy_e2e.rs
@@ -50,6 +50,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
 
@@ -70,6 +71,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -62,6 +62,7 @@ impl LlmBackend for ScriptedLlm {
             Ok(LlmOutput {
                 response: LlmResponse::Text("done".into()),
                 usage: TokenUsage::default(),
+                reasoning: None,
             })
         } else {
             Ok(queue.remove(0))
@@ -109,6 +110,7 @@ impl LlmBackend for ActionCapturingScriptedLlm {
             Ok(LlmOutput {
                 response: LlmResponse::Text("done".into()),
                 usage: TokenUsage::default(),
+                reasoning: None,
             })
         } else {
             Ok(queue.remove(0))
@@ -895,6 +897,7 @@ async fn gate_paused_transitions_thread_to_waiting() {
             content: None,
         },
         usage: TokenUsage::default(),
+        reasoning: None,
     }]);
 
     let store = TestStore::new();
@@ -963,6 +966,7 @@ async fn gate_paused_authentication_carries_credential_name() {
             content: None,
         },
         usage: TokenUsage::default(),
+        reasoning: None,
     }]);
 
     let store = TestStore::new();
@@ -1026,10 +1030,12 @@ async fn gate_paused_thread_resumes_to_completion() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::Text("done".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 
@@ -1106,10 +1112,12 @@ async fn tool_info_does_not_gate_callable_tool_into_next_llm_callable_set() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::Text("done".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 
@@ -1186,10 +1194,12 @@ async fn approval_resolution_executes_pending_call_directly() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::Text("done".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 
@@ -1329,6 +1339,7 @@ async fn auth_resolution_retries_same_pending_action_without_second_pause() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::ActionCalls {
@@ -1340,10 +1351,12 @@ async fn auth_resolution_retries_same_pending_action_without_second_pause() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::Text("done".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 
@@ -1457,10 +1470,12 @@ async fn approval_chains_directly_into_auth_for_install_flow() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::Text("notion connected".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 
@@ -1585,6 +1600,7 @@ async fn install_auth_resume_followed_by_aliased_tool_call_completes_without_han
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::ActionCalls {
@@ -1596,10 +1612,12 @@ async fn install_auth_resume_followed_by_aliased_tool_call_completes_without_han
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::Text("done".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 
@@ -2323,6 +2341,7 @@ async fn auto_approve_mode_skips_approval_for_standard_tools() {
             content: None,
         },
         usage: TokenUsage::default(),
+        reasoning: None,
     }]);
 
     let store = TestStore::new();
@@ -2420,6 +2439,7 @@ async fn gate_resume_with_execution_obligation() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         // Phase 2 after resume: http succeeds (approved), then LLM returns text
         // refusal. The orchestrator should detect "run the echo tool" intent from
@@ -2427,6 +2447,7 @@ async fn gate_resume_with_execution_obligation() {
         LlmOutput {
             response: LlmResponse::Text("I cannot execute tools from this reply path.".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         // After obligation nudge: echo tool call
         LlmOutput {
@@ -2439,11 +2460,13 @@ async fn gate_resume_with_execution_obligation() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         // Final text
         LlmOutput {
             response: LlmResponse::Text("Echo returned: obligation resume test".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 

--- a/tests/engine_v2_skill_codeact.rs
+++ b/tests/engine_v2_skill_codeact.rs
@@ -54,6 +54,7 @@ impl LlmBackend for ScriptedLlm {
             Ok(LlmOutput {
                 response: LlmResponse::Text("done".into()),
                 usage: TokenUsage::default(),
+                reasoning: None,
             })
         } else {
             Ok(queue.remove(0))
@@ -93,6 +94,7 @@ impl LlmBackend for CapturingScriptedLlm {
             Ok(LlmOutput {
                 response: LlmResponse::Text("done".into()),
                 usage: TokenUsage::default(),
+                reasoning: None,
             })
         } else {
             Ok(queue.remove(0))
@@ -581,6 +583,7 @@ FINAL(str(result))
             content: None,
         },
         usage: TokenUsage::default(),
+        reasoning: None,
     }]);
 
     // 3. Mock HTTP effects with canned GitHub response
@@ -693,6 +696,7 @@ FINAL(str(result))
             content: None,
         },
         usage: TokenUsage::default(),
+        reasoning: None,
     }]);
 
     let mut canned = HashMap::new();
@@ -770,6 +774,7 @@ async fn non_matching_goal_skips_skill_codeact() {
     let llm = ScriptedLlm::new(vec![LlmOutput {
         response: LlmResponse::Text("The weather is sunny.".into()),
         usage: TokenUsage::default(),
+        reasoning: None,
     }]);
 
     let effects = HttpMockEffects::new(HashMap::new());
@@ -832,10 +837,12 @@ async fn skill_prompt_context_survives_pause_and_resume() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::Text("done".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 
@@ -931,6 +938,7 @@ async fn skill_prompt_context_survives_compaction_and_resume() {
         LlmOutput {
             response: LlmResponse::Text("Compaction summary text".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::ActionCalls {
@@ -945,10 +953,12 @@ async fn skill_prompt_context_survives_compaction_and_resume() {
                 content: None,
             },
             usage: TokenUsage::default(),
+            reasoning: None,
         },
         LlmOutput {
             response: LlmResponse::Text("done".into()),
             usage: TokenUsage::default(),
+            reasoning: None,
         },
     ]);
 

--- a/tests/glm5_reasoning_live.rs
+++ b/tests/glm5_reasoning_live.rs
@@ -1,0 +1,47 @@
+//! Live integration test that exercises the patched rig-core fork end-to-end:
+//! GLM-5 (Z.AI OpenAI-compatible) → rig-core (forked: Message::Assistant carries
+//! reasoning_content) → llm_reasoning extractor → CompletionResponse.reasoning.
+//!
+//! Run with: BLUE_API_KEY=... cargo test --test glm5_reasoning_live -- --ignored
+//! Skipped by default to avoid hitting paid APIs in CI.
+
+use ironclaw::llm::{ChatMessage, CompletionRequest, LlmProvider, RigAdapter};
+
+#[tokio::test]
+#[ignore]
+async fn glm5_reasoning_lands_in_completion_response() {
+    let api_key = std::env::var("BLUE_API_KEY").expect("BLUE_API_KEY env var required");
+    let base_url = std::env::var("BLUE_BASE_URL")
+        .unwrap_or_else(|_| "https://api.z.ai/api/paas/v4".to_string());
+
+    use rig::client::CompletionClient;
+    use rig::providers::openai;
+
+    let client: openai::Client = openai::Client::builder()
+        .api_key(&api_key)
+        .base_url(&base_url)
+        .build()
+        .expect("build openai client");
+    let client = client.completions_api();
+    let model = client.completion_model("glm-5");
+    let adapter = RigAdapter::new(model, "glm-5");
+
+    let req = CompletionRequest::new(vec![ChatMessage::user(
+        "Reply with the single word OK and nothing else.",
+    )])
+    .with_max_tokens(100);
+
+    let resp = adapter.complete(req).await.expect("completion");
+
+    eprintln!("== content: {:?}", resp.content);
+    eprintln!("== reasoning: {:?}", resp.reasoning);
+
+    assert!(
+        resp.reasoning
+            .as_ref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        "expected reasoning_content to be populated; got {:?}",
+        resp.reasoning
+    );
+}

--- a/tests/openai_compat_integration.rs
+++ b/tests/openai_compat_integration.rs
@@ -75,6 +75,7 @@ impl LlmProvider for MockLlmProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -103,6 +104,7 @@ impl LlmProvider for MockLlmProvider {
                 finish_reason: FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         } else {
             Ok(ToolCompletionResponse {
@@ -113,6 +115,7 @@ impl LlmProvider for MockLlmProvider {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             })
         }
     }
@@ -153,6 +156,7 @@ impl LlmProvider for FixedModelProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -168,6 +172,7 @@ impl LlmProvider for FixedModelProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 

--- a/tests/provider_chaos.rs
+++ b/tests/provider_chaos.rs
@@ -90,6 +90,7 @@ impl LlmProvider for FlakeyProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -119,6 +120,7 @@ impl LlmProvider for FlakeyProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 }
@@ -198,6 +200,7 @@ impl LlmProvider for GarbageProvider {
             finish_reason: FinishReason::Unknown,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -214,6 +217,7 @@ impl LlmProvider for GarbageProvider {
             finish_reason: FinishReason::Unknown,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 }
@@ -258,6 +262,7 @@ impl LlmProvider for ReliableProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 
@@ -274,6 +279,7 @@ impl LlmProvider for ReliableProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning: None,
         })
     }
 }

--- a/tests/sonnet_reasoning_live.rs
+++ b/tests/sonnet_reasoning_live.rs
@@ -1,0 +1,57 @@
+//! Live integration test that exercises end-to-end reasoning capture for Anthropic Claude:
+//! Claude Sonnet 4.6 (Anthropic direct) → rig-core anthropic provider → llm_reasoning
+//! extractor (`^claude` rule, matches `type: "thinking"` content blocks) →
+//! CompletionResponse.reasoning.
+//!
+//! Run with:
+//!   ANTHROPIC_API_KEY=sk-ant-... \
+//!     cargo test --test sonnet_reasoning_live -- --ignored
+//!
+//! Anthropic only emits thinking content blocks when the request opts in via
+//! `thinking: { type: "enabled", budget_tokens: N }`. RigAdapter injects that
+//! parameter automatically for any model whose name starts with `claude-`,
+//! using the budget from `ANTHROPIC_THINKING_BUDGET` (default 4096).
+//!
+//! Skipped by default to avoid hitting paid APIs in CI.
+
+use ironclaw::llm::{ChatMessage, CompletionRequest, LlmProvider, RigAdapter};
+
+#[tokio::test]
+#[ignore]
+async fn sonnet_reasoning_lands_in_completion_response() {
+    let api_key =
+        std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY env var required");
+
+    use rig::client::CompletionClient;
+    use rig::providers::anthropic;
+
+    let client: anthropic::Client = anthropic::Client::builder()
+        .api_key(&api_key)
+        .build()
+        .expect("build anthropic client");
+    let model_name = std::env::var("ANTHROPIC_MODEL")
+        .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
+    let model = client.completion_model(&model_name);
+    let adapter = RigAdapter::new(model, &model_name);
+
+    // max_tokens needs to be large enough for budget_tokens + actual answer.
+    let req = CompletionRequest::new(vec![ChatMessage::user(
+        "What is 7 times 8? Think step by step, then give the final answer.",
+    )])
+    .with_max_tokens(8192);
+
+    let resp = adapter.complete(req).await.expect("completion");
+
+    eprintln!("== model: {}", model_name);
+    eprintln!("== content: {:?}", resp.content);
+    eprintln!("== reasoning: {:?}", resp.reasoning);
+
+    assert!(
+        resp.reasoning
+            .as_ref()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        "expected extended-thinking reasoning to be populated; got {:?}",
+        resp.reasoning
+    );
+}

--- a/tests/sonnet_reasoning_live.rs
+++ b/tests/sonnet_reasoning_live.rs
@@ -1,5 +1,5 @@
 //! Live integration test that exercises end-to-end reasoning capture for Anthropic Claude:
-//! Claude Sonnet 4.6 (Anthropic direct) → rig-core anthropic provider → llm_reasoning
+//! Claude Sonnet 4.6 (claude-sonnet-4-6, Anthropic direct) → rig-core anthropic provider → llm_reasoning
 //! extractor (`^claude` rule, matches `type: "thinking"` content blocks) →
 //! CompletionResponse.reasoning.
 //!
@@ -30,7 +30,7 @@ async fn sonnet_reasoning_lands_in_completion_response() {
         .build()
         .expect("build anthropic client");
     let model_name = std::env::var("ANTHROPIC_MODEL")
-        .unwrap_or_else(|_| "claude-sonnet-4-5-20250929".to_string());
+        .unwrap_or_else(|_| "claude-sonnet-4-6".to_string());
     let model = client.completion_model(&model_name);
     let adapter = RigAdapter::new(model, &model_name);
 

--- a/tests/support/replay_outcome.rs
+++ b/tests/support/replay_outcome.rs
@@ -364,6 +364,7 @@ fn event_kind_name(kind: &ironclaw_engine::EventKind) -> &'static str {
         EventKind::CodeExecutionFailed { .. } => "CodeExecutionFailed",
         EventKind::CodeExecuted { .. } => "CodeExecuted",
         EventKind::OrchestratorRollback { .. } => "OrchestratorRollback",
+        EventKind::LlmReasoning { .. } => "LlmReasoning",
         EventKind::Unknown => "Unknown",
     }
 }

--- a/tests/support/trace_llm.rs
+++ b/tests/support/trace_llm.rs
@@ -702,6 +702,7 @@ impl LlmProvider for TraceLlm {
                         finish_reason: FinishReason::Stop,
                         cache_read_input_tokens: 0,
                         cache_creation_input_tokens: 0,
+                        reasoning: None,
                     });
                 }
                 TraceResponse::ToolCalls { .. } => {
@@ -739,6 +740,7 @@ impl LlmProvider for TraceLlm {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning: None,
             }),
             TraceResponse::ToolCalls {
                 tool_calls,
@@ -762,6 +764,7 @@ impl LlmProvider for TraceLlm {
                     finish_reason: FinishReason::ToolUse,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning: None,
                 })
             }
             TraceResponse::UserInput { .. } => Err(LlmError::RequestFailed {


### PR DESCRIPTION
## Summary

Adds end-to-end support for capturing the model's native chain-of-thought (Anthropic extended thinking, OpenAI o-series summaries, GLM/DeepSeek/Grok/Qwen/Kimi `reasoning_content`, Gemini thought parts, Mistral Magistral inline `<think>` tags) and exposes it as a first-class IronClaw event, distinct from the agent's own `ReasoningUpdate` narrative and from any UX "thinking" status spinner.

This started because Z.AI's GLM-5 returns `reasoning_content` on every response, but rig-core 0.30 silently drops it during deserialization on every provider that flows through its OpenAI-compatible code path. Once we had to fix that, it was cleaner to expose reasoning generically rather than wire it provider-by-provider.

## How it's exposed

```
RigAdapter (or any LlmProvider)
  → CompletionResponse.reasoning: Option<String>
  → LlmOutput.reasoning: Option<String>             (engine trait)
  → EventKind::LlmReasoning { content, model }      (engine event)
  → AppEvent::LlmReasoning { content, model, thread_id }   (channel)
```

The bridge router translates `EventKind::LlmReasoning` → `AppEvent::LlmReasoning` so external channels (TUI, ACP, webhook subscribers) see the new variant. The orchestrator emits the event right after `handle_llm_complete` when the LLM output carries non-empty reasoning. Worker proxy round-trips reasoning through `ProxyCompletionResponse` / `ProxyToolCompletionResponse`.

## Provider knowledge as config

Per-provider extraction lives in `src/llm/llm_reasoning_extractors.json` — config-as-data with three rule kinds:

| kind | shape | examples |
| --- | --- | --- |
| `field` | flat key on the response | GLM, DeepSeek, Grok, OpenRouter |
| `block` | nested array of typed blocks | Anthropic `content[].thinking`, Gemini `parts[].thought`, OpenAI o-series `choices[].message.summary[]` |
| `regex_in_content` | pull `<tag>` regions out of `content` | Mistral Magistral 2506 inline `<think>…</think>` |

Adding a new model = adding one JSON entry, no Rust change. The walker traverses the raw `serde_json::Value` so it doesn't care whether the response is `choices[]` flat or `candidates.content.parts[]` nested.

## rig-core fork

`[patch.crates-io]` redirects `rig-core` to a fork branch at `failsafesecurity/rig:ironclaw-reasoning`. The diff is one field — `reasoning_content: Option<String>` on `Message::Assistant` in the OpenAI provider. Without it serde drops the field on the floor for every OpenAI-compatible backend (GLM, DeepSeek, Grok, Qwen, Kimi, OpenRouter, Together, Fireworks).

I'll open the upstream PR to 0xPlaygrounds/rig and we can drop the patch once it lands. Visible in `Cargo.toml` with a comment so it doesn't disappear into the workspace.

## Tests

- 11 unit tests in `src/llm/llm_reasoning.rs` cover every rule kind plus the no-match case (`config_loads`, `glm_flat_field`, `anthropic_thinking_block`, `gemini_thought_flag`, `openai_o_series_summary_array`, Kimi/Mistral variants, `unknown_model_returns_none`, `empty_reasoning_returns_none`).
- `tests/glm5_reasoning_live.rs` (`#[ignore]`, follows the existing `e2e_live_*` pattern) exercises the full chain against a real Z.AI GLM-5 endpoint when `BLUE_API_KEY` is set. Locally verified — got non-empty `reasoning` on a single-turn "reply OK" prompt.

## Test plan

- [ ] `cargo test` (default features) passes
- [ ] `cargo test --test glm5_reasoning_live -- --ignored` with a Z.AI key returns non-empty reasoning
- [ ] Reasoning event surfaces in TUI / ACP for at least one OpenAI-compat provider, one Anthropic provider, one Gemini provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)