### PR TITLE
test(reborn): add runtime lane dispatch smoke coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,10 +4140,14 @@ name = "ironclaw_mcp"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "ironclaw_dispatcher",
+ "ironclaw_events",
  "ironclaw_extensions",
+ "ironclaw_filesystem",
  "ironclaw_host_api",
  "ironclaw_resources",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -4216,12 +4220,18 @@ dependencies = [
 name = "ironclaw_scripts"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "ironclaw_dispatcher",
+ "ironclaw_events",
  "ironclaw_extensions",
+ "ironclaw_filesystem",
  "ironclaw_host_api",
  "ironclaw_resources",
  "rust_decimal_macros",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -4290,9 +4300,17 @@ dependencies = [
 name = "ironclaw_wasm"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "ironclaw_dispatcher",
+ "ironclaw_events",
+ "ironclaw_extensions",
+ "ironclaw_filesystem",
  "ironclaw_host_api",
+ "ironclaw_resources",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
@@ -541,7 +541,7 @@ id = "echo"
 name = "Echo WASM"
 version = "0.1.0"
 description = "Echo WASM demo extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "wasm"
@@ -560,7 +560,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "mcp"
@@ -581,7 +581,7 @@ id = "script"
 name = "Script Echo"
 version = "0.1.0"
 description = "Script Echo demo extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "script"

--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -520,7 +520,7 @@ id = "echo-wasm"
 name = "Echo WASM"
 version = "0.1.0"
 description = "Echo WASM demo extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "wasm"
@@ -539,7 +539,7 @@ id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
 description = "GitHub MCP adapter"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "mcp"
@@ -560,7 +560,7 @@ id = "echo-script"
 name = "Echo Script"
 version = "0.1.0"
 description = "Echo Script demo extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "script"

--- a/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
+++ b/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
@@ -295,7 +295,7 @@ id = "echo"
 name = "Echo WASM"
 version = "0.1.0"
 description = "Echo WASM integration extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "wasm"
@@ -314,7 +314,7 @@ id = "script"
 name = "Script Echo"
 version = "0.1.0"
 description = "Script integration extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "script"

--- a/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
@@ -214,7 +214,7 @@ id = "echo-wasm"
 name = "WASM Echo"
 version = "0.1.0"
 description = "WASM echo demo extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "wasm"
@@ -233,7 +233,7 @@ id = "echo-mcp"
 name = "MCP Echo"
 version = "0.1.0"
 description = "MCP echo demo adapter"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "mcp"
@@ -254,7 +254,7 @@ id = "echo-script"
 name = "Script Echo"
 version = "0.1.0"
 description = "Script echo demo extension"
-trust = "sandbox"
+trust = "untrusted"
 
 [runtime]
 kind = "script"

--- a/crates/ironclaw_mcp/Cargo.toml
+++ b/crates/ironclaw_mcp/Cargo.toml
@@ -13,4 +13,8 @@ serde_json = "1"
 thiserror = "2"
 
 [dev-dependencies]
+ironclaw_dispatcher = { path = "../ironclaw_dispatcher" }
+ironclaw_events = { path = "../ironclaw_events" }
+ironclaw_filesystem = { path = "../ironclaw_filesystem" }
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
+++ b/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
@@ -1,0 +1,348 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_dispatcher::{
+    RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
+};
+use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
+use ironclaw_extensions::{ExtensionManifest, ExtensionPackage};
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::*;
+use ironclaw_mcp::*;
+use ironclaw_resources::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn mcp_lane_dispatches_manifest_transport_and_reconciles_through_dispatcher() {
+    let client = RecordingMcpClient::new(Ok(McpClientOutput {
+        output: json!({"items":["issue-1"]}),
+        usage: ResourceUsage {
+            wall_clock_ms: 9,
+            ..ResourceUsage::default()
+        },
+        output_bytes: None,
+    }));
+    let adapter = Arc::new(McpRuntimeAdapter::new(client.clone()));
+    let (dispatcher, governor, events, account) = dispatcher_with_mcp_adapter(adapter);
+
+    let result = dispatcher
+        .dispatch_json(dispatch_request(json!({"query":"ironclaw"})))
+        .await
+        .unwrap();
+
+    assert_eq!(result.runtime, RuntimeKind::Mcp);
+    assert_eq!(result.output, json!({"items":["issue-1"]}));
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(result.usage.process_count, 1);
+    assert_eq!(result.usage.wall_clock_ms, 9);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert!(governor.usage_for(&account).output_bytes > 0);
+
+    let requests = client.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].transport, "stdio");
+    assert_eq!(requests[0].command.as_deref(), Some("github-mcp"));
+    assert_eq!(requests[0].args, vec!["--stdio".to_string()]);
+    assert_eq!(requests[0].input, json!({"query":"ironclaw"}));
+
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+        ],
+    );
+}
+
+#[tokio::test]
+async fn mcp_lane_client_failure_releases_reservation_and_emits_sanitized_failure() {
+    let client = RecordingMcpClient::new(Err("server disconnected with raw stderr".to_string()));
+    let adapter = Arc::new(McpRuntimeAdapter::new(client));
+    let (dispatcher, governor, events, account) = dispatcher_with_mcp_adapter(adapter);
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request(json!({"query":"fail"})))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Mcp {
+            kind: RuntimeDispatchErrorKind::Client
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("client"));
+}
+
+#[tokio::test]
+async fn mcp_lane_output_limit_releases_reservation_and_emits_output_too_large_failure() {
+    let client = RecordingMcpClient::new(Ok(McpClientOutput {
+        output: json!({"large":"this output is too large for the adapter limit"}),
+        usage: ResourceUsage::default(),
+        output_bytes: Some(1_000),
+    }));
+    let adapter = Arc::new(McpRuntimeAdapter::with_config(
+        McpRuntimeConfig {
+            max_output_bytes: 8,
+        },
+        client,
+    ));
+    let (dispatcher, governor, events, account) = dispatcher_with_mcp_adapter(adapter);
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request(json!({"query":"large"})))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Mcp {
+            kind: RuntimeDispatchErrorKind::OutputTooLarge
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("output_too_large"));
+}
+
+#[derive(Clone)]
+struct McpRuntimeAdapter<C> {
+    runtime: McpRuntime<C>,
+}
+
+impl<C> McpRuntimeAdapter<C>
+where
+    C: McpClient,
+{
+    fn new(client: C) -> Self {
+        Self::with_config(McpRuntimeConfig::for_testing(), client)
+    }
+
+    fn with_config(config: McpRuntimeConfig, client: C) -> Self {
+        Self {
+            runtime: McpRuntime::new(config, client),
+        }
+    }
+}
+
+#[async_trait]
+impl<C> RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for McpRuntimeAdapter<C>
+where
+    C: McpClient + Send + Sync,
+{
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        let execution = self
+            .runtime
+            .execute_extension_json(
+                request.governor,
+                McpExecutionRequest {
+                    package: request.package,
+                    capability_id: request.capability_id,
+                    scope: request.scope,
+                    estimate: request.estimate,
+                    resource_reservation: request.resource_reservation,
+                    invocation: McpInvocation {
+                        input: request.input,
+                    },
+                },
+            )
+            .await
+            .map_err(|error| DispatchError::Mcp {
+                kind: mcp_error_kind(&error),
+            })?;
+
+        Ok(RuntimeAdapterResult {
+            output: execution.result.output,
+            usage: execution.result.usage,
+            receipt: execution.receipt,
+            output_bytes: execution.result.output_bytes,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct RecordingMcpClient {
+    output: Result<McpClientOutput, String>,
+    requests: Arc<Mutex<Vec<McpClientRequest>>>,
+}
+
+impl RecordingMcpClient {
+    fn new(output: Result<McpClientOutput, String>) -> Self {
+        Self {
+            output,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<McpClientRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl McpClient for RecordingMcpClient {
+    async fn call_tool(&self, request: McpClientRequest) -> Result<McpClientOutput, String> {
+        self.requests.lock().unwrap().push(request);
+        self.output.clone()
+    }
+}
+
+fn dispatcher_with_mcp_adapter<T>(
+    adapter: Arc<T>,
+) -> (
+    RuntimeDispatcher<'static, LocalFilesystem, InMemoryResourceGovernor>,
+    Arc<InMemoryResourceGovernor>,
+    InMemoryEventSink,
+    ResourceAccount,
+)
+where
+    T: RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> + 'static,
+{
+    let account = sample_account();
+    let registry = Arc::new(registry_with_package(MCP_MANIFEST));
+    let filesystem = Arc::new(mounted_empty_extension_root());
+    let governor = Arc::new(governor_with_default_limit(account.clone()));
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, filesystem, Arc::clone(&governor))
+        .with_runtime_adapter_arc(RuntimeKind::Mcp, adapter)
+        .with_event_sink_arc(Arc::new(events.clone()));
+    (dispatcher, governor, events, account)
+}
+
+fn registry_with_package(manifest: &str) -> ironclaw_extensions::ExtensionRegistry {
+    let mut registry = ironclaw_extensions::ExtensionRegistry::new();
+    registry.insert(package_from_manifest(manifest)).unwrap();
+    registry
+}
+
+fn package_from_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn mounted_empty_extension_root() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
+}
+
+fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGovernor {
+    let governor = InMemoryResourceGovernor::new();
+    governor.set_limit(
+        account,
+        ResourceLimits {
+            max_concurrency_slots: Some(10),
+            max_process_count: Some(10),
+            max_output_bytes: Some(100_000),
+            ..ResourceLimits::default()
+        },
+    );
+    governor
+}
+
+fn dispatch_request(input: serde_json::Value) -> CapabilityDispatchRequest {
+    CapabilityDispatchRequest {
+        capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+        scope: sample_scope(),
+        estimate: ResourceEstimate {
+            concurrency_slots: Some(1),
+            process_count: Some(1),
+            output_bytes: Some(10_000),
+            ..ResourceEstimate::default()
+        },
+        mounts: None,
+        resource_reservation: None,
+        input,
+    }
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("user-a").unwrap(),
+        agent_id: Some(AgentId::new("agent-a").unwrap()),
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: Some(MissionId::new("mission-a").unwrap()),
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn sample_account() -> ResourceAccount {
+    ResourceAccount::tenant(TenantId::new("tenant-a").unwrap())
+}
+
+fn assert_event_kinds(events: &InMemoryEventSink, expected: &[RuntimeEventKind]) {
+    let actual = events
+        .events()
+        .into_iter()
+        .map(|event| event.kind)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+
+fn mcp_error_kind(error: &McpError) -> RuntimeDispatchErrorKind {
+    match error {
+        McpError::Resource(_) => RuntimeDispatchErrorKind::Resource,
+        McpError::Client { .. } => RuntimeDispatchErrorKind::Client,
+        McpError::UnsupportedTransport { .. } => RuntimeDispatchErrorKind::UnsupportedRunner,
+        McpError::ExtensionRuntimeMismatch { .. } => {
+            RuntimeDispatchErrorKind::ExtensionRuntimeMismatch
+        }
+        McpError::CapabilityNotDeclared { .. } => RuntimeDispatchErrorKind::UndeclaredCapability,
+        McpError::DescriptorMismatch { .. } => RuntimeDispatchErrorKind::Manifest,
+        McpError::InvalidInvocation { .. } => RuntimeDispatchErrorKind::InputEncode,
+        McpError::OutputLimitExceeded { .. } => RuntimeDispatchErrorKind::OutputTooLarge,
+    }
+}
+
+const MCP_MANIFEST: &str = r#"
+id = "github-mcp"
+name = "GitHub MCP"
+version = "0.1.0"
+description = "GitHub MCP adapter"
+trust = "third_party"
+
+[runtime]
+kind = "mcp"
+transport = "stdio"
+command = "github-mcp"
+args = ["--stdio"]
+
+[[capabilities]]
+id = "github-mcp.search"
+description = "Search GitHub"
+effects = ["network", "dispatch_capability"]
+default_permission = "ask"
+parameters_schema = { type = "object" }
+"#;

--- a/crates/ironclaw_scripts/Cargo.toml
+++ b/crates/ironclaw_scripts/Cargo.toml
@@ -12,4 +12,10 @@ serde_json = "1"
 thiserror = "2"
 
 [dev-dependencies]
+async-trait = "0.1"
+ironclaw_dispatcher = { path = "../ironclaw_dispatcher" }
+ironclaw_events = { path = "../ironclaw_events" }
+ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 rust_decimal_macros = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
+++ b/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
@@ -1,0 +1,351 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_dispatcher::{
+    RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
+};
+use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
+use ironclaw_extensions::{ExtensionManifest, ExtensionPackage};
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::*;
+use ironclaw_resources::*;
+use ironclaw_scripts::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn script_lane_dispatches_manifest_command_and_reconciles_through_dispatcher() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput {
+        exit_code: 0,
+        stdout: br#"{"message":"script ok"}"#.to_vec(),
+        stderr: Vec::new(),
+        wall_clock_ms: 11,
+    });
+    let adapter = Arc::new(ScriptRuntimeAdapter::new(backend.clone()));
+    let (dispatcher, governor, events, account) = dispatcher_with_script_adapter(adapter);
+
+    let result = dispatcher
+        .dispatch_json(dispatch_request(
+            json!({"message":"hello", "command":"ignored"}),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(result.runtime, RuntimeKind::Script);
+    assert_eq!(result.output, json!({"message":"script ok"}));
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(result.usage.process_count, 1);
+    assert_eq!(result.usage.wall_clock_ms, 11);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert!(governor.usage_for(&account).output_bytes > 0);
+
+    let requests = backend.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].runner, "docker");
+    assert_eq!(requests[0].image.as_deref(), Some("alpine:latest"));
+    assert_eq!(requests[0].command, "script-echo");
+    assert_eq!(requests[0].args, vec!["--json".to_string()]);
+    assert_eq!(
+        requests[0].stdin_json,
+        r#"{"command":"ignored","message":"hello"}"#
+    );
+
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+        ],
+    );
+}
+
+#[tokio::test]
+async fn script_lane_nonzero_exit_releases_reservation_and_emits_sanitized_failure() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput {
+        exit_code: 2,
+        stdout: Vec::new(),
+        stderr: b"raw backend detail".to_vec(),
+        wall_clock_ms: 3,
+    });
+    let adapter = Arc::new(ScriptRuntimeAdapter::new(backend));
+    let (dispatcher, governor, events, account) = dispatcher_with_script_adapter(adapter);
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request(json!({"message":"fail"})))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Script {
+            kind: RuntimeDispatchErrorKind::ExitFailure
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("exit_failure"));
+}
+
+#[tokio::test]
+async fn script_lane_invalid_json_releases_reservation_and_emits_output_decode_failure() {
+    let backend = RecordingScriptBackend::success(ScriptBackendOutput {
+        exit_code: 0,
+        stdout: b"not-json".to_vec(),
+        stderr: Vec::new(),
+        wall_clock_ms: 3,
+    });
+    let adapter = Arc::new(ScriptRuntimeAdapter::new(backend));
+    let (dispatcher, governor, events, account) = dispatcher_with_script_adapter(adapter);
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request(json!({"message":"bad-json"})))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Script {
+            kind: RuntimeDispatchErrorKind::OutputDecode
+        }
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("output_decode"));
+}
+
+#[derive(Clone)]
+struct ScriptRuntimeAdapter<B> {
+    runtime: ScriptRuntime<B>,
+}
+
+impl<B> ScriptRuntimeAdapter<B>
+where
+    B: ScriptBackend,
+{
+    fn new(backend: B) -> Self {
+        Self {
+            runtime: ScriptRuntime::new(ScriptRuntimeConfig::for_testing(), backend),
+        }
+    }
+}
+
+#[async_trait]
+impl<B> RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for ScriptRuntimeAdapter<B>
+where
+    B: ScriptBackend + Send + Sync,
+{
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        let execution = self
+            .runtime
+            .execute_extension_json(
+                request.governor,
+                ScriptExecutionRequest {
+                    package: request.package,
+                    capability_id: request.capability_id,
+                    scope: request.scope,
+                    estimate: request.estimate,
+                    resource_reservation: request.resource_reservation,
+                    invocation: ScriptInvocation {
+                        input: request.input,
+                    },
+                },
+            )
+            .map_err(|error| DispatchError::Script {
+                kind: script_error_kind(&error),
+            })?;
+
+        Ok(RuntimeAdapterResult {
+            output: execution.result.output,
+            usage: execution.result.usage,
+            receipt: execution.receipt,
+            output_bytes: execution.result.output_bytes,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct RecordingScriptBackend {
+    output: Arc<Mutex<Result<ScriptBackendOutput, String>>>,
+    requests: Arc<Mutex<Vec<ScriptBackendRequest>>>,
+}
+
+impl RecordingScriptBackend {
+    fn success(output: ScriptBackendOutput) -> Self {
+        Self {
+            output: Arc::new(Mutex::new(Ok(output))),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<ScriptBackendRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl ScriptBackend for RecordingScriptBackend {
+    fn execute(&self, request: ScriptBackendRequest) -> Result<ScriptBackendOutput, String> {
+        self.requests.lock().unwrap().push(request);
+        self.output.lock().unwrap().clone()
+    }
+}
+
+fn dispatcher_with_script_adapter<T>(
+    adapter: Arc<T>,
+) -> (
+    RuntimeDispatcher<'static, LocalFilesystem, InMemoryResourceGovernor>,
+    Arc<InMemoryResourceGovernor>,
+    InMemoryEventSink,
+    ResourceAccount,
+)
+where
+    T: RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> + 'static,
+{
+    let account = sample_account();
+    let registry = Arc::new(registry_with_package(SCRIPT_MANIFEST));
+    let filesystem = Arc::new(mounted_empty_extension_root());
+    let governor = Arc::new(governor_with_default_limit(account.clone()));
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, filesystem, Arc::clone(&governor))
+        .with_runtime_adapter_arc(RuntimeKind::Script, adapter)
+        .with_event_sink_arc(Arc::new(events.clone()));
+    (dispatcher, governor, events, account)
+}
+
+fn registry_with_package(manifest: &str) -> ironclaw_extensions::ExtensionRegistry {
+    let mut registry = ironclaw_extensions::ExtensionRegistry::new();
+    registry.insert(package_from_manifest(manifest)).unwrap();
+    registry
+}
+
+fn package_from_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn mounted_empty_extension_root() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
+}
+
+fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGovernor {
+    let governor = InMemoryResourceGovernor::new();
+    governor.set_limit(
+        account,
+        ResourceLimits {
+            max_concurrency_slots: Some(10),
+            max_process_count: Some(10),
+            max_output_bytes: Some(100_000),
+            ..ResourceLimits::default()
+        },
+    );
+    governor
+}
+
+fn dispatch_request(input: serde_json::Value) -> CapabilityDispatchRequest {
+    CapabilityDispatchRequest {
+        capability_id: CapabilityId::new("script.echo").unwrap(),
+        scope: sample_scope(),
+        estimate: ResourceEstimate {
+            concurrency_slots: Some(1),
+            process_count: Some(1),
+            output_bytes: Some(10_000),
+            ..ResourceEstimate::default()
+        },
+        mounts: None,
+        resource_reservation: None,
+        input,
+    }
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("user-a").unwrap(),
+        agent_id: Some(AgentId::new("agent-a").unwrap()),
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: Some(MissionId::new("mission-a").unwrap()),
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn sample_account() -> ResourceAccount {
+    ResourceAccount::tenant(TenantId::new("tenant-a").unwrap())
+}
+
+fn assert_event_kinds(events: &InMemoryEventSink, expected: &[RuntimeEventKind]) {
+    let actual = events
+        .events()
+        .into_iter()
+        .map(|event| event.kind)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+
+fn script_error_kind(error: &ScriptError) -> RuntimeDispatchErrorKind {
+    match error {
+        ScriptError::Resource(_) => RuntimeDispatchErrorKind::Resource,
+        ScriptError::Backend { .. } => RuntimeDispatchErrorKind::Backend,
+        ScriptError::UnsupportedRunner { .. } => RuntimeDispatchErrorKind::UnsupportedRunner,
+        ScriptError::ExtensionRuntimeMismatch { .. } => {
+            RuntimeDispatchErrorKind::ExtensionRuntimeMismatch
+        }
+        ScriptError::CapabilityNotDeclared { .. } => RuntimeDispatchErrorKind::UndeclaredCapability,
+        ScriptError::DescriptorMismatch { .. } => RuntimeDispatchErrorKind::Manifest,
+        ScriptError::InvalidInvocation { .. } => RuntimeDispatchErrorKind::InputEncode,
+        ScriptError::ExitFailure { .. } => RuntimeDispatchErrorKind::ExitFailure,
+        ScriptError::OutputLimitExceeded { .. } => RuntimeDispatchErrorKind::OutputTooLarge,
+        ScriptError::Timeout { .. } => RuntimeDispatchErrorKind::Executor,
+        ScriptError::InvalidOutput { .. } => RuntimeDispatchErrorKind::OutputDecode,
+    }
+}
+
+const SCRIPT_MANIFEST: &str = r#"
+id = "script"
+name = "Script Echo"
+version = "0.1.0"
+description = "Script integration extension"
+trust = "untrusted"
+
+[runtime]
+kind = "script"
+runner = "docker"
+image = "alpine:latest"
+command = "script-echo"
+args = ["--json"]
+
+[[capabilities]]
+id = "script.echo"
+description = "Echo through Script"
+effects = ["dispatch_capability", "execute_code"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;

--- a/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
+++ b/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
@@ -44,10 +44,8 @@ async fn script_lane_dispatches_manifest_command_and_reconciles_through_dispatch
     assert_eq!(requests[0].image.as_deref(), Some("alpine:latest"));
     assert_eq!(requests[0].command, "script-echo");
     assert_eq!(requests[0].args, vec!["--json".to_string()]);
-    assert_eq!(
-        requests[0].stdin_json,
-        r#"{"command":"ignored","message":"hello"}"#
-    );
+    let stdin_json: serde_json::Value = serde_json::from_str(&requests[0].stdin_json).unwrap();
+    assert_eq!(stdin_json, json!({"message":"hello", "command":"ignored"}));
 
     assert_event_kinds(
         &events,

--- a/crates/ironclaw_wasm/Cargo.toml
+++ b/crates/ironclaw_wasm/Cargo.toml
@@ -13,6 +13,14 @@ wasmtime = { version = "43.0.1", features = ["component-model"] }
 wasmtime-wasi = "43.0.1"
 
 [dev-dependencies]
+async-trait = "0.1"
+ironclaw_dispatcher = { path = "../ironclaw_dispatcher" }
+ironclaw_events = { path = "../ironclaw_events" }
+ironclaw_extensions = { path = "../ironclaw_extensions" }
+ironclaw_filesystem = { path = "../ironclaw_filesystem" }
+ironclaw_resources = { path = "../ironclaw_resources" }
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }
 wat = "1.245.1"
 wit-component = "0.245.1"
 wit-parser = "0.245.1"

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -1,4 +1,10 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use async_trait::async_trait;
 use ironclaw_dispatcher::{
@@ -9,7 +15,10 @@ use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRuntime}
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
-use ironclaw_wasm::{PreparedWitTool, WitToolHost, WitToolRequest, WitToolRuntime};
+use ironclaw_wasm::{
+    PreparedWitTool, RecordingWasmHostHttp, WasmHttpResponse, WitToolHost, WitToolRequest,
+    WitToolRuntime,
+};
 use serde_json::{Value, json};
 use wit_component::{ComponentEncoder, StringEncoding, embed_component_metadata};
 use wit_parser::Resolve;
@@ -21,8 +30,9 @@ async fn wasm_lane_loads_component_from_root_filesystem_and_uses_fresh_instances
     let registry = Arc::new(registry_with_package(WASM_MANIFEST));
     let governor = Arc::new(governor_with_default_limit(sample_account()));
     let events = InMemoryEventSink::new();
+    let adapter = Arc::new(WasmRuntimeAdapter::new());
     let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
-        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(WasmRuntimeAdapter::new()))
+        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(&adapter))
         .with_event_sink_arc(Arc::new(events.clone()));
 
     let first = dispatcher
@@ -43,6 +53,11 @@ async fn wasm_lane_loads_component_from_root_filesystem_and_uses_fresh_instances
     );
     assert_eq!(first.receipt.status, ReservationStatus::Reconciled);
     assert_eq!(second.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(
+        adapter.prepare_count(),
+        1,
+        "dispatcher smoke should reuse one prepared component while proving fresh execution instances"
+    );
     assert_eq!(
         governor.reserved_for(&sample_account()),
         ResourceTally::default()
@@ -104,16 +119,85 @@ async fn wasm_lane_guest_trap_releases_reservation_and_preserves_dispatch_failur
     assert_eq!(recorded[2].error_kind.as_deref(), Some("guest"));
 }
 
+#[tokio::test]
+async fn wasm_lane_execution_failure_reconciles_preserved_usage_from_runtime() {
+    let component = tool_component(&trap_after_http_wat());
+    let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/http-trap.wasm", &component).await;
+    let registry = Arc::new(registry_with_package(WASM_HTTP_TRAP_MANIFEST));
+    let governor = Arc::new(governor_with_default_limit(sample_account()));
+    let events = InMemoryEventSink::new();
+    let http = Arc::new(RecordingWasmHostHttp::ok(WasmHttpResponse {
+        status: 200,
+        headers_json: "{}".to_string(),
+        body: Vec::new(),
+    }));
+    let adapter = Arc::new(WasmRuntimeAdapter::with_host(
+        WitToolHost::deny_all().with_http(Arc::clone(&http)),
+    ));
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
+        .with_runtime_adapter_arc(RuntimeKind::Wasm, adapter)
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request(
+            "wasm-smoke.httptrap",
+            json!({"call":"http"}),
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::Guest
+        }
+    ));
+    assert_eq!(http.requests().unwrap().len(), 1);
+    assert_eq!(
+        governor.reserved_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_eq!(
+        governor.usage_for(&sample_account()).network_egress_bytes,
+        5,
+        "request-body egress preserved by WasmError::ExecutionFailed must be reconciled"
+    );
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("guest"));
+}
+
 struct WasmRuntimeAdapter {
     runtime: WitToolRuntime,
+    host: WitToolHost,
+    prepared: Mutex<HashMap<String, Arc<PreparedWitTool>>>,
+    prepare_count: AtomicUsize,
 }
 
 impl WasmRuntimeAdapter {
     fn new() -> Self {
+        Self::with_host(WitToolHost::deny_all())
+    }
+
+    fn with_host(host: WitToolHost) -> Self {
         Self {
             runtime: WitToolRuntime::new(ironclaw_wasm::WitToolRuntimeConfig::for_testing())
                 .unwrap(),
+            host,
+            prepared: Mutex::new(HashMap::new()),
+            prepare_count: AtomicUsize::new(0),
         }
+    }
+
+    fn prepare_count(&self) -> usize {
+        self.prepare_count.load(Ordering::SeqCst)
     }
 }
 
@@ -139,6 +223,15 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for WasmRuntimeAd
                 });
             }
         };
+        let cache_key = format!(
+            "{}:{}",
+            request.capability_id.as_str(),
+            module_path.as_str()
+        );
+        if let Some(prepared) = self.prepared.lock().unwrap().get(&cache_key).cloned() {
+            return execute_prepared_wasm(&self.runtime, &prepared, self.host.clone(), request);
+        }
+
         let wasm_bytes = request
             .filesystem
             .read_file(&module_path)
@@ -146,19 +239,31 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for WasmRuntimeAd
             .map_err(|_| DispatchError::Wasm {
                 kind: RuntimeDispatchErrorKind::FilesystemDenied,
             })?;
-        let prepared = self
-            .runtime
-            .prepare(request.capability_id.as_str(), &wasm_bytes)
-            .map_err(|error| DispatchError::Wasm {
-                kind: wasm_error_kind(&error),
-            })?;
-        execute_prepared_wasm(&self.runtime, &prepared, request)
+        let prepared = Arc::new(
+            self.runtime
+                .prepare(request.capability_id.as_str(), &wasm_bytes)
+                .map_err(|error| DispatchError::Wasm {
+                    kind: wasm_error_kind(&error),
+                })?,
+        );
+        let prepared = {
+            let mut prepared_cache = self.prepared.lock().unwrap();
+            if let Some(existing) = prepared_cache.get(&cache_key).cloned() {
+                existing
+            } else {
+                self.prepare_count.fetch_add(1, Ordering::SeqCst);
+                prepared_cache.insert(cache_key, Arc::clone(&prepared));
+                prepared
+            }
+        };
+        execute_prepared_wasm(&self.runtime, &prepared, self.host.clone(), request)
     }
 }
 
 fn execute_prepared_wasm(
     runtime: &WitToolRuntime,
     prepared: &PreparedWitTool,
+    host: WitToolHost,
     request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
 ) -> Result<RuntimeAdapterResult, DispatchError> {
     let input_json = serde_json::to_string(&request.input).map_err(|_| DispatchError::Wasm {
@@ -173,14 +278,19 @@ fn execute_prepared_wasm(
                 kind: RuntimeDispatchErrorKind::Resource,
             })?,
     };
-    let execution = match runtime.execute(
-        prepared,
-        WitToolHost::deny_all(),
-        WitToolRequest::new(input_json),
-    ) {
+    let execution = match runtime.execute(prepared, host, WitToolRequest::new(input_json)) {
         Ok(execution) => execution,
         Err(error) => {
-            release_wasm_reservation(request.governor, reservation.id);
+            if let Some(usage) = preserved_wasm_error_usage(&error) {
+                if request.governor.reconcile(reservation.id, usage).is_err() {
+                    release_wasm_reservation(request.governor, reservation.id);
+                    return Err(DispatchError::Wasm {
+                        kind: RuntimeDispatchErrorKind::Resource,
+                    });
+                }
+            } else {
+                release_wasm_reservation(request.governor, reservation.id);
+            }
             return Err(DispatchError::Wasm {
                 kind: wasm_error_kind(&error),
             });
@@ -232,6 +342,25 @@ fn release_wasm_reservation(
     reservation_id: ResourceReservationId,
 ) {
     let _ = governor.release(reservation_id);
+}
+
+fn preserved_wasm_error_usage(error: &ironclaw_wasm::WasmError) -> Option<ResourceUsage> {
+    if let ironclaw_wasm::WasmError::ExecutionFailed { usage, .. } = error
+        && has_accountable_effects(usage)
+    {
+        Some(usage.clone())
+    } else {
+        None
+    }
+}
+
+fn has_accountable_effects(usage: &ResourceUsage) -> bool {
+    usage.usd != Default::default()
+        || usage.input_tokens > 0
+        || usage.output_tokens > 0
+        || usage.output_bytes > 0
+        || usage.network_egress_bytes > 0
+        || usage.process_count > 0
 }
 
 fn registry_with_package(manifest: &str) -> ironclaw_extensions::ExtensionRegistry {
@@ -412,6 +541,101 @@ const COUNTER_TOOL_WAT: &str = r#"
 )
 "#;
 
+const HTTP_TOOL_WAT: &str = r#"
+(module
+  (type (;0;) (func (param i32 i32 i32)))
+  (type (;1;) (func (result i64)))
+  (type (;2;) (func (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+  (type (;3;) (func (param i32 i32 i32 i32 i32)))
+  (type (;4;) (func (param i32 i32) (result i32)))
+  (import "near:agent/host@0.3.0" "log" (func $log (type 0)))
+  (import "near:agent/host@0.3.0" "now-millis" (func $now (type 1)))
+  (import "near:agent/host@0.3.0" "workspace-read" (func $workspace_read (type 0)))
+  (import "near:agent/host@0.3.0" "http-request" (func $http_request (type 2)))
+  (import "near:agent/host@0.3.0" "tool-invoke" (func $tool_invoke (type 3)))
+  (import "near:agent/host@0.3.0" "secret-exists" (func $secret_exists (type 4)))
+  (memory (export "memory") 1)
+  (global $heap (mut i32) (i32.const 4096))
+  (data (i32.const 128) "POST")
+  (data (i32.const 160) "https://example.test/api")
+  (data (i32.const 224) "{}")
+  (data (i32.const 256) "hello")
+  (data (i32.const 1024) "{\22type\22:\22object\22}")
+  (data (i32.const 2048) "fixture description")
+  (data (i32.const 3072) "1")
+  (func $schema (result i32)
+    i32.const 16
+    i32.const 1024
+    i32.store
+    i32.const 20
+    i32.const 17
+    i32.store
+    i32.const 16)
+  (func $description (result i32)
+    i32.const 32
+    i32.const 2048
+    i32.store
+    i32.const 36
+    i32.const 19
+    i32.store
+    i32.const 32)
+  (func $execute (param i32 i32 i32 i32 i32) (result i32)
+    i32.const 128
+    i32.const 4
+    i32.const 160
+    i32.const 24
+    i32.const 224
+    i32.const 2
+    i32.const 1
+    i32.const 256
+    i32.const 5
+    i32.const 0
+    i32.const 0
+    i32.const 512
+    call $http_request
+
+    i32.const 48
+    i32.const 1
+    i32.store
+    i32.const 52
+    i32.const 3072
+    i32.store
+    i32.const 56
+    i32.const 1
+    i32.store
+    i32.const 60
+    i32.const 0
+    i32.store
+    i32.const 48)
+  (func $post (param i32))
+  (func $realloc (param $old i32) (param $old_align i32) (param $new_size i32) (param $new_align i32) (result i32)
+    (local $ret i32)
+    global.get $heap
+    local.set $ret
+    global.get $heap
+    local.get $new_size
+    i32.add
+    global.set $heap
+    local.get $ret)
+  (func $_initialize)
+  (export "near:agent/tool@0.3.0#execute" (func $execute))
+  (export "cabi_post_near:agent/tool@0.3.0#execute" (func $post))
+  (export "near:agent/tool@0.3.0#schema" (func $schema))
+  (export "cabi_post_near:agent/tool@0.3.0#schema" (func $post))
+  (export "near:agent/tool@0.3.0#description" (func $description))
+  (export "cabi_post_near:agent/tool@0.3.0#description" (func $post))
+  (export "cabi_realloc" (func $realloc))
+  (export "_initialize" (func $_initialize))
+)
+"#;
+
+fn trap_after_http_wat() -> String {
+    HTTP_TOOL_WAT.replace(
+        "i32.const 48\n    i32.const 1\n    i32.store",
+        "unreachable\n\n    i32.const 48\n    i32.const 1\n    i32.store",
+    )
+}
+
 const TRAP_TOOL_WAT: &str = r#"
 (module
   (memory (export "memory") 1)
@@ -484,6 +708,25 @@ module = "wasm/trap.wasm"
 id = "wasm-smoke.trap"
 description = "Trap through WASM"
 effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;
+
+const WASM_HTTP_TRAP_MANIFEST: &str = r#"
+id = "wasm-smoke"
+name = "WASM HTTP Trap"
+version = "0.1.0"
+description = "WASM runtime lane HTTP trap extension"
+trust = "untrusted"
+
+[runtime]
+kind = "wasm"
+module = "wasm/http-trap.wasm"
+
+[[capabilities]]
+id = "wasm-smoke.httptrap"
+description = "Trap after host HTTP through WASM"
+effects = ["dispatch_capability", "network"]
 default_permission = "allow"
 parameters_schema = { type = "object" }
 "#;

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -1,0 +1,489 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_dispatcher::{
+    RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
+};
+use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
+use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRuntime};
+use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
+use ironclaw_host_api::*;
+use ironclaw_resources::*;
+use ironclaw_wasm::{PreparedWitTool, WitToolHost, WitToolRequest, WitToolRuntime};
+use serde_json::{Value, json};
+use wit_component::{ComponentEncoder, StringEncoding, embed_component_metadata};
+use wit_parser::Resolve;
+
+#[tokio::test]
+async fn wasm_lane_loads_component_from_root_filesystem_and_uses_fresh_instances() {
+    let component = tool_component(COUNTER_TOOL_WAT);
+    let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/counter.wasm", &component).await;
+    let registry = Arc::new(registry_with_package(WASM_MANIFEST));
+    let governor = Arc::new(governor_with_default_limit(sample_account()));
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
+        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(WasmRuntimeAdapter::new()))
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let first = dispatcher
+        .dispatch_json(dispatch_request("wasm-smoke.count", json!({"call":1})))
+        .await
+        .unwrap();
+    let second = dispatcher
+        .dispatch_json(dispatch_request("wasm-smoke.count", json!({"call":2})))
+        .await
+        .unwrap();
+
+    assert_eq!(first.runtime, RuntimeKind::Wasm);
+    assert_eq!(first.output, json!(1));
+    assert_eq!(
+        second.output,
+        json!(1),
+        "fresh component instance per dispatch should reset guest globals"
+    );
+    assert_eq!(first.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(second.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(
+        governor.reserved_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert!(governor.usage_for(&sample_account()).output_bytes >= 2);
+
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+        ],
+    );
+}
+
+#[tokio::test]
+async fn wasm_lane_guest_trap_releases_reservation_and_preserves_dispatch_failure() {
+    let component = tool_component(TRAP_TOOL_WAT);
+    let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/trap.wasm", &component).await;
+    let registry = Arc::new(registry_with_package(WASM_TRAP_MANIFEST));
+    let governor = Arc::new(governor_with_default_limit(sample_account()));
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
+        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(WasmRuntimeAdapter::new()))
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request("wasm-smoke.trap", json!({"call":"trap"})))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::Guest
+        }
+    ));
+    assert_eq!(
+        governor.reserved_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_eq!(
+        governor.usage_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("guest"));
+}
+
+struct WasmRuntimeAdapter {
+    runtime: WitToolRuntime,
+}
+
+impl WasmRuntimeAdapter {
+    fn new() -> Self {
+        Self {
+            runtime: WitToolRuntime::new(ironclaw_wasm::WitToolRuntimeConfig::for_testing())
+                .unwrap(),
+        }
+    }
+}
+
+#[async_trait]
+impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for WasmRuntimeAdapter {
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        let module_path = match &request.package.manifest.runtime {
+            ExtensionRuntime::Wasm { module } => module
+                .resolve_under(&request.package.root)
+                .map_err(|_| DispatchError::Wasm {
+                    kind: RuntimeDispatchErrorKind::Manifest,
+                })?,
+            other => {
+                return Err(DispatchError::Wasm {
+                    kind: if other.kind() == RuntimeKind::Wasm {
+                        RuntimeDispatchErrorKind::Manifest
+                    } else {
+                        RuntimeDispatchErrorKind::ExtensionRuntimeMismatch
+                    },
+                });
+            }
+        };
+        let wasm_bytes = request
+            .filesystem
+            .read_file(&module_path)
+            .await
+            .map_err(|_| DispatchError::Wasm {
+                kind: RuntimeDispatchErrorKind::FilesystemDenied,
+            })?;
+        let prepared = self
+            .runtime
+            .prepare(request.capability_id.as_str(), &wasm_bytes)
+            .map_err(|error| DispatchError::Wasm {
+                kind: wasm_error_kind(&error),
+            })?;
+        execute_prepared_wasm(&self.runtime, &prepared, request)
+    }
+}
+
+fn execute_prepared_wasm(
+    runtime: &WitToolRuntime,
+    prepared: &PreparedWitTool,
+    request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+) -> Result<RuntimeAdapterResult, DispatchError> {
+    let input_json = serde_json::to_string(&request.input).map_err(|_| DispatchError::Wasm {
+        kind: RuntimeDispatchErrorKind::InputEncode,
+    })?;
+    let reservation = match request.resource_reservation {
+        Some(reservation) => reservation,
+        None => request
+            .governor
+            .reserve(request.scope, request.estimate)
+            .map_err(|_| DispatchError::Wasm {
+                kind: RuntimeDispatchErrorKind::Resource,
+            })?,
+    };
+    let execution = match runtime.execute(
+        prepared,
+        WitToolHost::deny_all(),
+        WitToolRequest::new(input_json),
+    ) {
+        Ok(execution) => execution,
+        Err(error) => {
+            release_wasm_reservation(request.governor, reservation.id);
+            return Err(DispatchError::Wasm {
+                kind: wasm_error_kind(&error),
+            });
+        }
+    };
+    if execution.error.is_some() {
+        release_wasm_reservation(request.governor, reservation.id);
+        return Err(DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::Guest,
+        });
+    }
+    let Some(output_json) = execution.output_json else {
+        release_wasm_reservation(request.governor, reservation.id);
+        return Err(DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::InvalidResult,
+        });
+    };
+    let output = match serde_json::from_str::<Value>(&output_json) {
+        Ok(output) => output,
+        Err(_) => {
+            release_wasm_reservation(request.governor, reservation.id);
+            return Err(DispatchError::Wasm {
+                kind: RuntimeDispatchErrorKind::OutputDecode,
+            });
+        }
+    };
+    let receipt = match request
+        .governor
+        .reconcile(reservation.id, execution.usage.clone())
+    {
+        Ok(receipt) => receipt,
+        Err(_) => {
+            release_wasm_reservation(request.governor, reservation.id);
+            return Err(DispatchError::Wasm {
+                kind: RuntimeDispatchErrorKind::Resource,
+            });
+        }
+    };
+    Ok(RuntimeAdapterResult {
+        output,
+        output_bytes: execution.usage.output_bytes,
+        usage: execution.usage,
+        receipt,
+    })
+}
+
+fn release_wasm_reservation(
+    governor: &InMemoryResourceGovernor,
+    reservation_id: ResourceReservationId,
+) {
+    let _ = governor.release(reservation_id);
+}
+
+fn registry_with_package(manifest: &str) -> ironclaw_extensions::ExtensionRegistry {
+    let mut registry = ironclaw_extensions::ExtensionRegistry::new();
+    registry.insert(package_from_manifest(manifest)).unwrap();
+    registry
+}
+
+fn package_from_manifest(manifest: &str) -> ExtensionPackage {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
+    ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn mounted_empty_extension_root() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
+}
+
+async fn filesystem_with_wasm_component(
+    extension_id: &str,
+    module_path: &str,
+    wasm_bytes: &[u8],
+) -> LocalFilesystem {
+    let fs = mounted_empty_extension_root();
+    let path =
+        VirtualPath::new(format!("/system/extensions/{extension_id}/{module_path}")).unwrap();
+    fs.write_file(&path, wasm_bytes).await.unwrap();
+    fs
+}
+
+fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGovernor {
+    let governor = InMemoryResourceGovernor::new();
+    governor.set_limit(
+        account,
+        ResourceLimits {
+            max_concurrency_slots: Some(10),
+            max_process_count: Some(10),
+            max_output_bytes: Some(100_000),
+            ..ResourceLimits::default()
+        },
+    );
+    governor
+}
+
+fn dispatch_request(capability: &str, input: Value) -> CapabilityDispatchRequest {
+    CapabilityDispatchRequest {
+        capability_id: CapabilityId::new(capability).unwrap(),
+        scope: sample_scope(),
+        estimate: ResourceEstimate {
+            concurrency_slots: Some(1),
+            process_count: Some(1),
+            output_bytes: Some(10_000),
+            ..ResourceEstimate::default()
+        },
+        mounts: None,
+        resource_reservation: None,
+        input,
+    }
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("user-a").unwrap(),
+        agent_id: Some(AgentId::new("agent-a").unwrap()),
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: Some(MissionId::new("mission-a").unwrap()),
+        thread_id: Some(ThreadId::new("thread-a").unwrap()),
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn sample_account() -> ResourceAccount {
+    ResourceAccount::tenant(TenantId::new("tenant-a").unwrap())
+}
+
+fn assert_event_kinds(events: &InMemoryEventSink, expected: &[RuntimeEventKind]) {
+    let actual = events
+        .events()
+        .into_iter()
+        .map(|event| event.kind)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+
+fn wasm_error_kind(error: &ironclaw_wasm::WasmError) -> RuntimeDispatchErrorKind {
+    match error {
+        ironclaw_wasm::WasmError::EngineCreationFailed(_) => RuntimeDispatchErrorKind::Executor,
+        ironclaw_wasm::WasmError::CompilationFailed(_) => RuntimeDispatchErrorKind::Manifest,
+        ironclaw_wasm::WasmError::StoreConfiguration(_) => RuntimeDispatchErrorKind::Executor,
+        ironclaw_wasm::WasmError::LinkerConfiguration(_) => RuntimeDispatchErrorKind::Executor,
+        ironclaw_wasm::WasmError::InstantiationFailed(_) => RuntimeDispatchErrorKind::MethodMissing,
+        ironclaw_wasm::WasmError::ExecutionFailed { .. } => RuntimeDispatchErrorKind::Guest,
+        ironclaw_wasm::WasmError::InvalidSchema(_) => RuntimeDispatchErrorKind::Manifest,
+    }
+}
+
+fn tool_component(wat_src: &str) -> Vec<u8> {
+    let mut module = wat::parse_str(wat_src).expect("fixture WAT must parse");
+    let mut resolve = Resolve::default();
+    let package = resolve
+        .push_str("tool.wit", include_str!("../../../wit/tool.wit"))
+        .expect("tool WIT must parse");
+    let world = resolve
+        .select_world(&[package], Some("sandboxed-tool"))
+        .expect("sandboxed-tool world must exist");
+
+    embed_component_metadata(&mut module, &resolve, world, StringEncoding::UTF8)
+        .expect("component metadata must embed");
+
+    let mut encoder = ComponentEncoder::default()
+        .module(&module)
+        .expect("fixture module must decode")
+        .validate(true);
+    encoder.encode().expect("component must encode")
+}
+
+const COUNTER_TOOL_WAT: &str = r#"
+(module
+  (memory (export "memory") 1)
+  (global $count (mut i32) (i32.const 0))
+  (data (i32.const 1024) "{\22type\22:\22object\22}")
+  (data (i32.const 2048) "counter fixture")
+  (data (i32.const 3072) "1")
+  (func $schema (result i32)
+    i32.const 16
+    i32.const 1024
+    i32.store
+    i32.const 20
+    i32.const 17
+    i32.store
+    i32.const 16)
+  (func $description (result i32)
+    i32.const 32
+    i32.const 2048
+    i32.store
+    i32.const 36
+    i32.const 15
+    i32.store
+    i32.const 32)
+  (func $execute (param i32 i32 i32 i32 i32) (result i32)
+    global.get $count
+    i32.const 1
+    i32.add
+    global.set $count
+    i32.const 48
+    i32.const 1
+    i32.store
+    i32.const 52
+    i32.const 3072
+    i32.store
+    i32.const 56
+    i32.const 1
+    i32.store
+    i32.const 60
+    i32.const 0
+    i32.store
+    i32.const 48)
+  (func $post (param i32))
+  (func $realloc (param $old i32) (param $old_align i32) (param $new_size i32) (param $new_align i32) (result i32)
+    i32.const 4096)
+  (func $_initialize)
+  (export "near:agent/tool@0.3.0#execute" (func $execute))
+  (export "cabi_post_near:agent/tool@0.3.0#execute" (func $post))
+  (export "near:agent/tool@0.3.0#schema" (func $schema))
+  (export "cabi_post_near:agent/tool@0.3.0#schema" (func $post))
+  (export "near:agent/tool@0.3.0#description" (func $description))
+  (export "cabi_post_near:agent/tool@0.3.0#description" (func $post))
+  (export "cabi_realloc" (func $realloc))
+  (export "_initialize" (func $_initialize))
+)
+"#;
+
+const TRAP_TOOL_WAT: &str = r#"
+(module
+  (memory (export "memory") 1)
+  (data (i32.const 1024) "{\22type\22:\22object\22}")
+  (data (i32.const 2048) "trap fixture")
+  (func $schema (result i32)
+    i32.const 16
+    i32.const 1024
+    i32.store
+    i32.const 20
+    i32.const 17
+    i32.store
+    i32.const 16)
+  (func $description (result i32)
+    i32.const 32
+    i32.const 2048
+    i32.store
+    i32.const 36
+    i32.const 12
+    i32.store
+    i32.const 32)
+  (func $execute (param i32 i32 i32 i32 i32) (result i32)
+    unreachable)
+  (func $post (param i32))
+  (func $realloc (param $old i32) (param $old_align i32) (param $new_size i32) (param $new_align i32) (result i32)
+    i32.const 4096)
+  (func $_initialize)
+  (export "near:agent/tool@0.3.0#execute" (func $execute))
+  (export "cabi_post_near:agent/tool@0.3.0#execute" (func $post))
+  (export "near:agent/tool@0.3.0#schema" (func $schema))
+  (export "cabi_post_near:agent/tool@0.3.0#schema" (func $post))
+  (export "near:agent/tool@0.3.0#description" (func $description))
+  (export "cabi_post_near:agent/tool@0.3.0#description" (func $post))
+  (export "cabi_realloc" (func $realloc))
+  (export "_initialize" (func $_initialize))
+)
+"#;
+
+const WASM_MANIFEST: &str = r#"
+id = "wasm-smoke"
+name = "WASM Smoke"
+version = "0.1.0"
+description = "WASM runtime lane smoke extension"
+trust = "untrusted"
+
+[runtime]
+kind = "wasm"
+module = "wasm/counter.wasm"
+
+[[capabilities]]
+id = "wasm-smoke.count"
+description = "Count through WASM"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;
+
+const WASM_TRAP_MANIFEST: &str = r#"
+id = "wasm-smoke"
+name = "WASM Trap"
+version = "0.1.0"
+description = "WASM runtime lane trap extension"
+trust = "untrusted"
+
+[runtime]
+kind = "wasm"
+module = "wasm/trap.wasm"
+
+[[capabilities]]
+id = "wasm-smoke.trap"
+description = "Trap through WASM"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object" }
+"#;


### PR DESCRIPTION
## Summary

Implements issue #3067 Phase 2 runtime-lane smoke coverage now that Script/MCP (#3027) and WIT WASM (#3097) are both on `reborn-integration`.

Adds caller-level tests that drive each real runtime lane through the public `RuntimeDispatcher` / `RuntimeAdapter` seam instead of only through crate-local runtime contracts:

- Script lane dispatch smoke in `crates/ironclaw_scripts/tests/script_dispatch_integration.rs`
  - manifest command/args are used
  - invocation input is passed as JSON stdin
  - success reconciles resources
  - non-zero exit and invalid JSON release reservations and emit sanitized dispatch failures
- MCP lane dispatch smoke in `crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs`
  - manifest transport/command/args are used
  - invocation input reaches the client adapter
  - success reconciles resources
  - client failure and output-limit failure release reservations and emit sanitized dispatch failures
- WASM lane dispatch smoke in `crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs`
  - component bytes are loaded through `RootFilesystem` virtual paths
  - canonical WIT/component-model exports are exercised
  - fresh instance per dispatch is proven
  - guest trap releases the reservation and emits sanitized dispatch failure

Also updates stale dispatcher test fixtures from obsolete `trust = "sandbox"` to `trust = "untrusted"`, matching the current manifest parser.

## Verification

```bash
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-integration-target cargo test -p ironclaw_dispatcher -p ironclaw_scripts -p ironclaw_mcp -p ironclaw_wasm
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-integration-target cargo clippy -q -p ironclaw_dispatcher -p ironclaw_scripts -p ironclaw_mcp -p ironclaw_wasm --all-targets -- -D warnings
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-integration-target cargo test -p ironclaw_architecture
python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD
bash scripts/pre-commit-safety.sh
git diff --check
```

## Links

- Tracks #3067 Phase 2
- Related tracker: #2987
