### PR TITLE
fix(reborn): harden capability approval lifecycle

### DIFF
--- a/crates/ironclaw_approvals/src/lib.rs
+++ b/crates/ironclaw_approvals/src/lib.rs
@@ -7,8 +7,9 @@
 use ironclaw_authorization::{CapabilityLease, CapabilityLeaseError, CapabilityLeaseStore};
 use ironclaw_events::AuditSink;
 use ironclaw_host_api::{
-    Action, CapabilityGrant, CapabilityGrantId, EffectKind, GrantConstraints, MountView,
-    NetworkPolicy, Principal, ResourceCeiling, ResourceScope, SecretHandle, Timestamp,
+    Action, ApprovalRequestId, CapabilityGrant, CapabilityGrantId, CapabilityId, EffectKind,
+    GrantConstraints, MountView, NetworkPolicy, Principal, ResourceCeiling, ResourceScope,
+    SecretHandle, Timestamp,
 };
 use ironclaw_run_state::{ApprovalRecord, ApprovalRequestStore, ApprovalStatus, RunStateError};
 use thiserror::Error;
@@ -44,8 +45,34 @@ where
     pub async fn approve_dispatch(
         &self,
         scope: &ResourceScope,
-        request_id: ironclaw_host_api::ApprovalRequestId,
+        request_id: ApprovalRequestId,
         approval: LeaseApproval,
+    ) -> Result<CapabilityLease, ApprovalResolutionError> {
+        self.approve_capability_action(
+            scope,
+            request_id,
+            approval,
+            ApprovedCapabilityAction::Dispatch,
+        )
+        .await
+    }
+
+    pub async fn approve_spawn(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+        approval: LeaseApproval,
+    ) -> Result<CapabilityLease, ApprovalResolutionError> {
+        self.approve_capability_action(scope, request_id, approval, ApprovedCapabilityAction::Spawn)
+            .await
+    }
+
+    async fn approve_capability_action(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+        approval: LeaseApproval,
+        expected_action: ApprovedCapabilityAction,
     ) -> Result<CapabilityLease, ApprovalResolutionError> {
         let record = self
             .approvals
@@ -58,9 +85,8 @@ where
             });
         }
 
-        let Action::Dispatch { capability, .. } = record.request.action.as_ref() else {
-            return Err(ApprovalResolutionError::UnsupportedAction);
-        };
+        let capability = capability_for_action(record.request.action.as_ref(), expected_action)
+            .ok_or(ApprovalResolutionError::UnsupportedAction)?;
 
         let invocation_fingerprint = record
             .request
@@ -143,6 +169,25 @@ where
         if let Some(sink) = self.audit_sink {
             let _ = sink.emit_audit(record).await;
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApprovedCapabilityAction {
+    Dispatch,
+    Spawn,
+}
+
+fn capability_for_action(
+    action: &Action,
+    expected: ApprovedCapabilityAction,
+) -> Option<&CapabilityId> {
+    match (expected, action) {
+        (ApprovedCapabilityAction::Dispatch, Action::Dispatch { capability, .. })
+        | (ApprovedCapabilityAction::Spawn, Action::SpawnCapability { capability, .. }) => {
+            Some(capability)
+        }
+        _ => None,
     }
 }
 

--- a/crates/ironclaw_capabilities/src/helpers.rs
+++ b/crates/ironclaw_capabilities/src/helpers.rs
@@ -24,23 +24,65 @@ pub(crate) fn ensure_no_obligations(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CapabilityActionKind {
+    Dispatch,
+    Spawn,
+}
+
+pub(crate) fn invocation_fingerprint_for_kind(
+    kind: CapabilityActionKind,
+    scope: &ResourceScope,
+    capability_id: &CapabilityId,
+    estimate: &ResourceEstimate,
+    input: &serde_json::Value,
+) -> Result<InvocationFingerprint, ironclaw_host_api::HostApiError> {
+    match kind {
+        CapabilityActionKind::Dispatch => {
+            InvocationFingerprint::for_dispatch(scope, capability_id, estimate, input)
+        }
+        CapabilityActionKind::Spawn => {
+            InvocationFingerprint::for_spawn(scope, capability_id, estimate, input)
+        }
+    }
+}
+
 pub(crate) fn validate_approval_request_matches_invocation(
     approval: &ApprovalRequest,
     context: &ExecutionContext,
     capability_id: &CapabilityId,
     estimate: &ResourceEstimate,
+    expected_action: CapabilityActionKind,
 ) -> Result<(), CapabilityInvocationError> {
-    match approval.action.as_ref() {
-        Action::Dispatch {
-            capability,
-            estimated_resources,
-        } if capability == capability_id && estimated_resources == estimate => {}
-        _ => {
-            return Err(CapabilityInvocationError::ApprovalRequestMismatch {
-                capability: capability_id.clone(),
-                field: "action",
-            });
-        }
+    let action_matches = match (expected_action, approval.action.as_ref()) {
+        (
+            CapabilityActionKind::Dispatch,
+            Action::Dispatch {
+                capability,
+                estimated_resources,
+            },
+        )
+        | (
+            CapabilityActionKind::Spawn,
+            Action::SpawnCapability {
+                capability,
+                estimated_resources,
+            },
+        ) => capability == capability_id && estimated_resources == estimate,
+        _ => false,
+    };
+    if !action_matches {
+        return Err(CapabilityInvocationError::ApprovalRequestMismatch {
+            capability: capability_id.clone(),
+            field: "action",
+        });
+    }
+
+    if approval.correlation_id != context.correlation_id {
+        return Err(CapabilityInvocationError::ApprovalRequestMismatch {
+            capability: capability_id.clone(),
+            field: "correlation_id",
+        });
     }
 
     let expected_requester = Principal::Extension(context.extension_id.clone());

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -1,8 +1,7 @@
 use ironclaw_authorization::{CapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_host_api::{
-    CapabilityDispatchRequest, CapabilityDispatcher, Decision, DenyReason, InvocationFingerprint,
-    ProcessId,
+    CapabilityDispatchRequest, CapabilityDispatcher, Decision, DenyReason, ProcessId,
 };
 use ironclaw_processes::{ProcessManager, ProcessStart};
 use ironclaw_run_state::{
@@ -11,10 +10,11 @@ use ironclaw_run_state::{
 use tracing::warn;
 
 use crate::helpers::{
-    approval_not_approved_error_kind, capability_lease_error_kind,
+    CapabilityActionKind, approval_not_approved_error_kind, capability_lease_error_kind,
     claim_error_may_be_concurrent_resume, complete_run_after_side_effect, ensure_no_obligations,
-    fail_run_if_configured, matching_approval_lease, resume_context_mismatch_kind,
-    run_state_error_kind, validate_approval_request_matches_invocation,
+    fail_run_if_configured, invocation_fingerprint_for_kind, matching_approval_lease,
+    resume_context_mismatch_kind, run_state_error_kind,
+    validate_approval_request_matches_invocation,
 };
 use crate::{
     CapabilityInvocationError, CapabilityInvocationRequest, CapabilityInvocationResult,
@@ -116,7 +116,8 @@ where
             });
         }
 
-        let invocation_fingerprint = InvocationFingerprint::for_dispatch(
+        let invocation_fingerprint = invocation_fingerprint_for_kind(
+            CapabilityActionKind::Dispatch,
             &scope,
             &request.capability_id,
             &request.estimate,
@@ -190,6 +191,7 @@ where
                     &request.context,
                     &request.capability_id,
                     &request.estimate,
+                    CapabilityActionKind::Dispatch,
                 ) {
                     fail_run_if_configured(
                         self.run_state,
@@ -356,7 +358,8 @@ where
             });
         }
 
-        let invocation_fingerprint = InvocationFingerprint::for_dispatch(
+        let invocation_fingerprint = invocation_fingerprint_for_kind(
+            CapabilityActionKind::Dispatch,
             &scope,
             &request.capability_id,
             &request.estimate,
@@ -414,6 +417,22 @@ where
                 capability: request.capability_id,
                 status: approval.status,
             });
+        }
+        if let Err(error) = validate_approval_request_matches_invocation(
+            &approval.request,
+            &request.context,
+            &request.capability_id,
+            &request.estimate,
+            CapabilityActionKind::Dispatch,
+        ) {
+            fail_run_if_configured(
+                Some(run_state),
+                &scope,
+                invocation_id,
+                "ApprovalRequestMismatch",
+            )
+            .await;
+            return Err(error);
         }
         if approval.request.invocation_fingerprint.as_ref() != Some(&invocation_fingerprint) {
             fail_run_if_configured(
@@ -549,7 +568,21 @@ where
             Ok(dispatch) => dispatch,
             Err(error) => {
                 fail_run_if_configured(Some(run_state), &scope, invocation_id, "Dispatch").await;
-                return Err(CapabilityInvocationError::from(error));
+                let invocation_error = CapabilityInvocationError::from(error);
+                if let Err(revoke_error) = capability_leases
+                    .revoke(&scope, claimed_lease.grant.id)
+                    .await
+                {
+                    warn!(
+                        lease_id = %claimed_lease.grant.id,
+                        invocation_id = %invocation_id,
+                        capability_id = %capability_id,
+                        dispatch_error = %invocation_error,
+                        revoke_error_kind = capability_lease_error_kind(&revoke_error),
+                        "capability lease revoke failed after dispatch failure; lease may remain claimed",
+                    );
+                }
+                return Err(invocation_error);
             }
         };
 
@@ -577,6 +610,296 @@ where
         Ok(CapabilityInvocationResult { dispatch })
     }
 
+    pub async fn resume_spawn_json(
+        &self,
+        request: CapabilityResumeRequest,
+    ) -> Result<CapabilitySpawnResult, CapabilityInvocationError> {
+        let process_manager = self.process_manager.ok_or_else(|| {
+            CapabilityInvocationError::ProcessManagerMissing {
+                capability: request.capability_id.clone(),
+            }
+        })?;
+        let run_state =
+            self.run_state
+                .ok_or_else(|| CapabilityInvocationError::ResumeStoreMissing {
+                    capability: request.capability_id.clone(),
+                    store: "run_state",
+                })?;
+        let approval_requests = self.approval_requests.ok_or_else(|| {
+            CapabilityInvocationError::ResumeStoreMissing {
+                capability: request.capability_id.clone(),
+                store: "approval_requests",
+            }
+        })?;
+        let capability_leases = self.capability_leases.ok_or_else(|| {
+            CapabilityInvocationError::ResumeStoreMissing {
+                capability: request.capability_id.clone(),
+                store: "capability_leases",
+            }
+        })?;
+
+        let invocation_id = request.context.invocation_id;
+        let capability_id = request.capability_id.clone();
+        let scope = request.context.resource_scope.clone();
+        if request.context.validate().is_err() {
+            return Err(CapabilityInvocationError::AuthorizationDenied {
+                capability: request.capability_id,
+                reason: DenyReason::InternalInvariantViolation,
+            });
+        }
+
+        let invocation_fingerprint = invocation_fingerprint_for_kind(
+            CapabilityActionKind::Spawn,
+            &scope,
+            &request.capability_id,
+            &request.estimate,
+            &request.input,
+        )
+        .map_err(|source| CapabilityInvocationError::InvocationFingerprint {
+            capability: request.capability_id.clone(),
+            source,
+        })?;
+
+        let run_record = run_state
+            .get(&scope, invocation_id)
+            .await?
+            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+        if run_record.status != RunStatus::BlockedApproval {
+            return Err(CapabilityInvocationError::ResumeNotBlocked {
+                capability: request.capability_id,
+                status: run_record.status,
+            });
+        }
+        let capability_mismatch = run_record.capability_id != request.capability_id;
+        let approval_request_mismatch =
+            run_record.approval_request_id != Some(request.approval_request_id);
+        if capability_mismatch || approval_request_mismatch {
+            fail_run_if_configured(
+                Some(run_state),
+                &scope,
+                invocation_id,
+                "ResumeContextMismatch",
+            )
+            .await;
+            return Err(CapabilityInvocationError::ResumeContextMismatch {
+                capability: request.capability_id,
+                kind: resume_context_mismatch_kind(capability_mismatch, approval_request_mismatch),
+            });
+        }
+
+        let approval = approval_requests
+            .get(&scope, request.approval_request_id)
+            .await?
+            .ok_or(RunStateError::UnknownApprovalRequest {
+                request_id: request.approval_request_id,
+            })?;
+        if approval.status != ApprovalStatus::Approved {
+            if approval.status != ApprovalStatus::Pending {
+                fail_run_if_configured(
+                    Some(run_state),
+                    &scope,
+                    invocation_id,
+                    approval_not_approved_error_kind(approval.status),
+                )
+                .await;
+            }
+            return Err(CapabilityInvocationError::ApprovalNotApproved {
+                capability: request.capability_id,
+                status: approval.status,
+            });
+        }
+        if let Err(error) = validate_approval_request_matches_invocation(
+            &approval.request,
+            &request.context,
+            &request.capability_id,
+            &request.estimate,
+            CapabilityActionKind::Spawn,
+        ) {
+            fail_run_if_configured(
+                Some(run_state),
+                &scope,
+                invocation_id,
+                "ApprovalRequestMismatch",
+            )
+            .await;
+            return Err(error);
+        }
+        if approval.request.invocation_fingerprint.as_ref() != Some(&invocation_fingerprint) {
+            fail_run_if_configured(
+                Some(run_state),
+                &scope,
+                invocation_id,
+                "InvocationFingerprintMismatch",
+            )
+            .await;
+            return Err(CapabilityInvocationError::ApprovalFingerprintMismatch {
+                capability: request.capability_id,
+            });
+        }
+
+        let Some(descriptor) = self.registry.get_capability(&request.capability_id) else {
+            fail_run_if_configured(Some(run_state), &scope, invocation_id, "UnknownCapability")
+                .await;
+            return Err(CapabilityInvocationError::UnknownCapability {
+                capability: request.capability_id,
+            });
+        };
+
+        let Some(lease) = matching_approval_lease(
+            capability_leases,
+            &request.context,
+            &request.capability_id,
+            &invocation_fingerprint,
+        )
+        .await
+        else {
+            fail_run_if_configured(
+                Some(run_state),
+                &scope,
+                invocation_id,
+                "ApprovalLeaseMissing",
+            )
+            .await;
+            return Err(CapabilityInvocationError::ApprovalLeaseMissing {
+                capability: request.capability_id,
+            });
+        };
+        let mut authorized_context = request.context.clone();
+        authorized_context.grants.grants.push(lease.grant.clone());
+
+        match self
+            .authorizer
+            .authorize_spawn_with_trust(
+                &authorized_context,
+                descriptor,
+                &request.estimate,
+                &request.trust_decision,
+            )
+            .await
+        {
+            Decision::Allow { obligations } => {
+                if let Err(error) = ensure_no_obligations(&capability_id, obligations.into_vec()) {
+                    fail_run_if_configured(
+                        Some(run_state),
+                        &scope,
+                        invocation_id,
+                        "UnsupportedObligations",
+                    )
+                    .await;
+                    return Err(error);
+                }
+            }
+            Decision::Deny { reason } => {
+                fail_run_if_configured(
+                    Some(run_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationDenied",
+                )
+                .await;
+                return Err(CapabilityInvocationError::AuthorizationDenied {
+                    capability: request.capability_id,
+                    reason,
+                });
+            }
+            Decision::RequireApproval { .. } => {
+                fail_run_if_configured(
+                    Some(run_state),
+                    &scope,
+                    invocation_id,
+                    "AuthorizationRequiresApproval",
+                )
+                .await;
+                return Err(CapabilityInvocationError::AuthorizationRequiresApproval {
+                    capability: request.capability_id,
+                });
+            }
+        }
+
+        let claimed_lease = match capability_leases
+            .claim(&scope, lease.grant.id, &invocation_fingerprint)
+            .await
+        {
+            Ok(lease) => lease,
+            Err(error) => {
+                if claim_error_may_be_concurrent_resume(&error) {
+                    warn!(
+                        lease_id = %lease.grant.id,
+                        invocation_id = %invocation_id,
+                        capability_id = %capability_id,
+                        error_kind = capability_lease_error_kind(&error),
+                        "spawn approval lease claim lost to a concurrent resume; leaving run state unchanged",
+                    );
+                } else {
+                    fail_run_if_configured(
+                        Some(run_state),
+                        &scope,
+                        invocation_id,
+                        "ApprovalLeaseClaim",
+                    )
+                    .await;
+                }
+                return Err(CapabilityInvocationError::Lease(Box::new(error)));
+            }
+        };
+
+        let process = match process_manager
+            .spawn(ProcessStart {
+                process_id: ProcessId::new(),
+                parent_process_id: authorized_context.process_id,
+                invocation_id,
+                scope: scope.clone(),
+                extension_id: descriptor.provider.clone(),
+                capability_id: request.capability_id,
+                runtime: descriptor.runtime,
+                grants: authorized_context.grants,
+                mounts: authorized_context.mounts,
+                estimated_resources: request.estimate,
+                resource_reservation_id: None,
+                input: request.input,
+            })
+            .await
+        {
+            Ok(process) => process,
+            Err(error) => {
+                fail_run_if_configured(Some(run_state), &scope, invocation_id, "ProcessSpawn")
+                    .await;
+                let invocation_error = CapabilityInvocationError::from(error);
+                if let Err(revoke_error) = capability_leases
+                    .revoke(&scope, claimed_lease.grant.id)
+                    .await
+                {
+                    warn!(
+                        lease_id = %claimed_lease.grant.id,
+                        invocation_id = %invocation_id,
+                        capability_id = %capability_id,
+                        process_error = %invocation_error,
+                        revoke_error_kind = capability_lease_error_kind(&revoke_error),
+                        "capability lease revoke failed after process spawn failure; lease may remain claimed",
+                    );
+                }
+                return Err(invocation_error);
+            }
+        };
+
+        if let Err(error) = capability_leases
+            .consume(&scope, claimed_lease.grant.id)
+            .await
+        {
+            warn!(
+                lease_id = %claimed_lease.grant.id,
+                invocation_id = %invocation_id,
+                capability_id = %capability_id,
+                error_kind = capability_lease_error_kind(&error),
+                "capability lease consume failed after successful process spawn; lease left in claimed state",
+            );
+        }
+
+        complete_run_after_side_effect(run_state, &scope, invocation_id, &capability_id, "spawn")
+            .await;
+        Ok(CapabilitySpawnResult { process })
+    }
+
     pub async fn spawn_json(
         &self,
         request: CapabilitySpawnRequest,
@@ -595,6 +918,18 @@ where
                 reason: DenyReason::InternalInvariantViolation,
             });
         }
+
+        let invocation_fingerprint = invocation_fingerprint_for_kind(
+            CapabilityActionKind::Spawn,
+            &scope,
+            &request.capability_id,
+            &request.estimate,
+            &request.input,
+        )
+        .map_err(|source| CapabilityInvocationError::InvocationFingerprint {
+            capability: request.capability_id.clone(),
+            source,
+        })?;
 
         if let Some(run_state) = self.run_state {
             run_state
@@ -651,14 +986,109 @@ where
                     reason,
                 });
             }
-            Decision::RequireApproval { .. } => {
-                fail_run_if_configured(
-                    self.run_state,
-                    &scope,
-                    invocation_id,
-                    "AuthorizationRequiresApproval",
-                )
-                .await;
+            Decision::RequireApproval {
+                request: mut approval,
+            } => {
+                if let Err(error) = validate_approval_request_matches_invocation(
+                    &approval,
+                    &request.context,
+                    &request.capability_id,
+                    &request.estimate,
+                    CapabilityActionKind::Spawn,
+                ) {
+                    fail_run_if_configured(
+                        self.run_state,
+                        &scope,
+                        invocation_id,
+                        "ApprovalRequestMismatch",
+                    )
+                    .await;
+                    return Err(error);
+                }
+
+                if let Some(existing) = &approval.invocation_fingerprint {
+                    if existing != &invocation_fingerprint {
+                        fail_run_if_configured(
+                            self.run_state,
+                            &scope,
+                            invocation_id,
+                            "InvocationFingerprintMismatch",
+                        )
+                        .await;
+                        return Err(CapabilityInvocationError::ApprovalFingerprintMismatch {
+                            capability: request.capability_id,
+                        });
+                    }
+                } else {
+                    approval.invocation_fingerprint = Some(invocation_fingerprint);
+                }
+
+                match (self.run_state, self.approval_requests) {
+                    (Some(run_state), Some(approval_requests)) => {
+                        let approval_id = approval.id;
+                        if let Err(error) = approval_requests
+                            .save_pending(scope.clone(), approval.clone())
+                            .await
+                        {
+                            fail_run_if_configured(
+                                Some(run_state),
+                                &scope,
+                                invocation_id,
+                                "ApprovalStore",
+                            )
+                            .await;
+                            return Err(CapabilityInvocationError::from(error));
+                        }
+                        if let Err(error) = run_state
+                            .block_approval(&scope, invocation_id, approval)
+                            .await
+                        {
+                            if let Err(discard_error) =
+                                approval_requests.discard_pending(&scope, approval_id).await
+                            {
+                                warn!(
+                                    approval_request_id = %approval_id,
+                                    invocation_id = %invocation_id,
+                                    transition_error_kind = run_state_error_kind(&discard_error),
+                                    "approval rollback failed after spawn run-state block transition failed",
+                                );
+                            }
+                            fail_run_if_configured(
+                                Some(run_state),
+                                &scope,
+                                invocation_id,
+                                "ApprovalBlock",
+                            )
+                            .await;
+                            return Err(CapabilityInvocationError::from(error));
+                        }
+                    }
+                    (Some(run_state), None) => {
+                        fail_run_if_configured(
+                            Some(run_state),
+                            &scope,
+                            invocation_id,
+                            "ApprovalStoreMissing",
+                        )
+                        .await;
+                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
+                            capability: request.capability_id,
+                            store: "approval_requests",
+                        });
+                    }
+                    (None, Some(_)) => {
+                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
+                            capability: request.capability_id,
+                            store: "run_state",
+                        });
+                    }
+                    (None, None) => {
+                        return Err(CapabilityInvocationError::ApprovalStoreMissing {
+                            capability: request.capability_id,
+                            store: "run_state and approval_requests",
+                        });
+                    }
+                }
                 return Err(CapabilityInvocationError::AuthorizationRequiresApproval {
                     capability: request.capability_id,
                 });

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -146,6 +146,15 @@ async fn capability_host_rejects_authorizer_approval_with_mismatched_requested_b
     .await;
 }
 
+#[tokio::test]
+async fn capability_host_rejects_authorizer_approval_with_mismatched_correlation_id() {
+    assert_mismatched_approval_request_rejected(
+        ApprovalRequestMismatch::CorrelationId,
+        "correlation_id",
+    )
+    .await;
+}
+
 async fn assert_mismatched_approval_request_rejected(
     mismatch: ApprovalRequestMismatch,
     expected_field: &'static str,
@@ -684,6 +693,85 @@ async fn capability_host_denies_resume_when_trust_ceiling_omits_capability_effec
 }
 
 #[tokio::test]
+async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = FailingDispatcher;
+    let run_state = InMemoryRunStateStore::new();
+    let approval_requests = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let block_dispatcher = RecordingDispatcher::default();
+    let block_host = CapabilityHost::new(&registry, &block_dispatcher, &ApprovalAuthorizer)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "approved but dispatch fails"});
+
+    block_host
+        .invoke_json(CapabilityInvocationRequest {
+            context: context.clone(),
+            capability_id: capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+    let approval_id = run_state
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .approval_request_id
+        .unwrap();
+    let lease = ApprovalResolver::new(&approval_requests, &leases)
+        .approve_dispatch(
+            &scope,
+            approval_id,
+            LeaseApproval {
+                issued_by: Principal::HostRuntime,
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: MountView::default(),
+                network: NetworkPolicy::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+    let resume_authorizer = GrantAuthorizer::new();
+    let resume_host = CapabilityHost::new(&registry, &dispatcher, &resume_authorizer)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests)
+        .with_capability_leases(&leases);
+    let err = resume_host
+        .resume_json(CapabilityResumeRequest {
+            context,
+            approval_request_id: approval_id,
+            capability_id: capability_id(),
+            estimate,
+            input,
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::Dispatch { ref kind } if kind == "Backend"
+    ));
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    let revoked = leases.get(&scope, lease.grant.id).await.unwrap();
+    assert_eq!(revoked.status, CapabilityLeaseStatus::Revoked);
+}
+
+#[tokio::test]
 async fn capability_host_returns_dispatch_result_when_lease_consume_fails_after_dispatch() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
@@ -1057,6 +1145,21 @@ enum ApprovalRequestMismatch {
     Capability,
     Estimate,
     RequestedBy,
+    CorrelationId,
+}
+
+struct FailingDispatcher;
+
+#[async_trait]
+impl CapabilityDispatcher for FailingDispatcher {
+    async fn dispatch_json(
+        &self,
+        _request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        Err(DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::Backend,
+        })
+    }
 }
 
 struct MismatchedApprovalRequestAuthorizer {
@@ -1075,6 +1178,7 @@ impl TrustAwareCapabilityDispatchAuthorizer for MismatchedApprovalRequestAuthori
         let mut capability = capability_id();
         let mut estimated_resources = estimate.clone();
         let mut requested_by = Principal::Extension(context.extension_id.clone());
+        let mut correlation_id = context.correlation_id;
         match self.mismatch {
             ApprovalRequestMismatch::Capability => {
                 capability = CapabilityId::new("echo.other").unwrap();
@@ -1085,12 +1189,15 @@ impl TrustAwareCapabilityDispatchAuthorizer for MismatchedApprovalRequestAuthori
             ApprovalRequestMismatch::RequestedBy => {
                 requested_by = Principal::User(context.user_id.clone());
             }
+            ApprovalRequestMismatch::CorrelationId => {
+                correlation_id = CorrelationId::new();
+            }
         }
 
         Decision::RequireApproval {
             request: ApprovalRequest {
                 id: ApprovalRequestId::new(),
-                correlation_id: context.correlation_id,
+                correlation_id,
                 requested_by,
                 action: Box::new(Action::Dispatch {
                     capability,

--- a/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_spawn_contract.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 
 use async_trait::async_trait;
+use ironclaw_approvals::*;
 use ironclaw_authorization::*;
 use ironclaw_capabilities::*;
 use ironclaw_host_api::*;
@@ -10,6 +11,147 @@ use serde_json::json;
 
 mod support;
 use support::*;
+
+#[tokio::test]
+async fn capability_host_blocks_spawn_for_approval_without_starting_process() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let process_manager = RecordingProcessManager::default();
+    let run_state = InMemoryRunStateStore::new();
+    let approval_requests = InMemoryApprovalRequestStore::new();
+    let host = CapabilityHost::new(&registry, &dispatcher, &SpawnApprovalAuthorizer)
+        .with_process_manager(&process_manager)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "background approval"});
+
+    let err = host
+        .spawn_json(CapabilitySpawnRequest {
+            context,
+            capability_id: capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::AuthorizationRequiresApproval { .. }
+    ));
+    assert!(!dispatcher.has_request());
+    assert!(!process_manager.has_start());
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::BlockedApproval);
+    let approval_id = run.approval_request_id.unwrap();
+    let approval = approval_requests
+        .get(&scope, approval_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(approval.status, ApprovalStatus::Pending);
+    assert_eq!(
+        approval.request.invocation_fingerprint,
+        Some(
+            InvocationFingerprint::for_spawn(&scope, &capability_id(), &estimate, &input).unwrap()
+        )
+    );
+}
+
+#[tokio::test]
+async fn capability_host_resumes_approved_spawn_and_consumes_matching_lease() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let process_manager = RecordingProcessManager::default();
+    let run_state = InMemoryRunStateStore::new();
+    let approval_requests = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let block_host = CapabilityHost::new(&registry, &dispatcher, &SpawnApprovalAuthorizer)
+        .with_process_manager(&process_manager)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "approved background"});
+
+    block_host
+        .spawn_json(CapabilitySpawnRequest {
+            context: context.clone(),
+            capability_id: capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+    let approval_id = run_state
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .approval_request_id
+        .unwrap();
+    let lease = ApprovalResolver::new(&approval_requests, &leases)
+        .approve_spawn(
+            &scope,
+            approval_id,
+            LeaseApproval {
+                issued_by: Principal::HostRuntime,
+                allowed_effects: vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
+                mounts: MountView::default(),
+                network: NetworkPolicy::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+    let resume_authorizer = GrantAuthorizer::new();
+    let resume_host = CapabilityHost::new(&registry, &dispatcher, &resume_authorizer)
+        .with_process_manager(&process_manager)
+        .with_run_state(&run_state)
+        .with_approval_requests(&approval_requests)
+        .with_capability_leases(&leases);
+    let result = resume_host
+        .resume_spawn_json(CapabilityResumeRequest {
+            context: context.clone(),
+            approval_request_id: approval_id,
+            capability_id: capability_id(),
+            estimate,
+            input,
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap();
+
+    assert!(!dispatcher.has_request());
+    let start = process_manager.take_start();
+    assert_eq!(start.scope, context.resource_scope);
+    assert_eq!(start.capability_id, capability_id());
+    assert!(
+        start
+            .grants
+            .grants
+            .iter()
+            .any(|grant| grant.id == lease.grant.id),
+        "resumed spawned process must inherit the approved lease grant"
+    );
+    assert_eq!(result.process.process_id, start.process_id);
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Completed);
+    let consumed = leases.get(&scope, lease.grant.id).await.unwrap();
+    assert_eq!(consumed.status, CapabilityLeaseStatus::Consumed);
+}
 
 #[tokio::test]
 async fn capability_host_denies_spawn_when_trust_ceiling_omits_spawn_effect() {
@@ -227,6 +369,46 @@ impl ProcessManager for RecordingProcessManager {
             resource_reservation_id: start.resource_reservation_id,
             error_kind: None,
         })
+    }
+}
+
+struct SpawnApprovalAuthorizer;
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for SpawnApprovalAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        _context: &ExecutionContext,
+        _descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+        _trust_decision: &ironclaw_trust::TrustDecision,
+    ) -> Decision {
+        Decision::Deny {
+            reason: DenyReason::MissingGrant,
+        }
+    }
+
+    async fn authorize_spawn_with_trust(
+        &self,
+        context: &ExecutionContext,
+        _descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        _trust_decision: &ironclaw_trust::TrustDecision,
+    ) -> Decision {
+        Decision::RequireApproval {
+            request: ApprovalRequest {
+                id: ApprovalRequestId::new(),
+                correlation_id: context.correlation_id,
+                requested_by: Principal::Extension(context.extension_id.clone()),
+                action: Box::new(Action::SpawnCapability {
+                    capability: capability_id(),
+                    estimated_resources: estimate.clone(),
+                }),
+                invocation_fingerprint: None,
+                reason: "spawn approval required".to_string(),
+                reusable_scope: None,
+            },
+        }
     }
 }
 

--- a/crates/ironclaw_host_api/src/approval.rs
+++ b/crates/ironclaw_host_api/src/approval.rs
@@ -37,6 +37,25 @@ impl InvocationFingerprint {
         estimate: &ResourceEstimate,
         input: &serde_json::Value,
     ) -> Result<Self, HostApiError> {
+        Self::for_action("dispatch", scope, capability, estimate, input)
+    }
+
+    pub fn for_spawn(
+        scope: &ResourceScope,
+        capability: &CapabilityId,
+        estimate: &ResourceEstimate,
+        input: &serde_json::Value,
+    ) -> Result<Self, HostApiError> {
+        Self::for_action("spawn_capability", scope, capability, estimate, input)
+    }
+
+    fn for_action(
+        kind: &'static str,
+        scope: &ResourceScope,
+        capability: &CapabilityId,
+        estimate: &ResourceEstimate,
+        input: &serde_json::Value,
+    ) -> Result<Self, HostApiError> {
         #[derive(Serialize)]
         struct Payload<'a> {
             version: u8,
@@ -50,7 +69,7 @@ impl InvocationFingerprint {
         let canonical_input = canonical_json(input)?;
         let payload = Payload {
             version: 1,
-            kind: "dispatch",
+            kind,
             scope,
             capability,
             estimate,

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -468,6 +468,23 @@ fn invocation_fingerprint_is_stable_and_input_hashed() {
 }
 
 #[test]
+fn invocation_fingerprint_separates_dispatch_and_spawn_actions() {
+    let ctx = sample_context();
+    let capability = CapabilityId::new("echo.say").unwrap();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "same"});
+
+    let dispatch =
+        InvocationFingerprint::for_dispatch(&ctx.resource_scope, &capability, &estimate, &input)
+            .unwrap();
+    let spawn =
+        InvocationFingerprint::for_spawn(&ctx.resource_scope, &capability, &estimate, &input)
+            .unwrap();
+
+    assert_ne!(dispatch, spawn);
+}
+
+#[test]
 fn invocation_fingerprint_rejects_deeply_nested_input() {
     let ctx = sample_context();
     let capability = CapabilityId::new("echo.say").unwrap();

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -661,7 +661,11 @@ where
         let mut records = Vec::new();
         for entry in entries {
             if entry.name.ends_with(".json") {
-                let bytes = self.filesystem.read_file(&entry.path).await?;
+                let bytes = match self.filesystem.read_file(&entry.path).await {
+                    Ok(bytes) => bytes,
+                    Err(error) if is_not_found(&error) => continue,
+                    Err(error) => return Err(error.into()),
+                };
                 let record = deserialize::<RunRecord>(&bytes)?;
                 if same_scope_owner(&record.scope, scope) {
                     records.push(record);
@@ -819,7 +823,11 @@ where
         let mut records = Vec::new();
         for entry in entries {
             if entry.name.ends_with(".json") {
-                let bytes = self.filesystem.read_file(&entry.path).await?;
+                let bytes = match self.filesystem.read_file(&entry.path).await {
+                    Ok(bytes) => bytes,
+                    Err(error) if is_not_found(&error) => continue,
+                    Err(error) => return Err(error.into()),
+                };
                 let record = deserialize::<ApprovalRecord>(&bytes)?;
                 if same_scope_owner(&record.scope, scope) {
                     records.push(record);

--- a/crates/ironclaw_run_state/tests/run_state_contract.rs
+++ b/crates/ironclaw_run_state/tests/run_state_contract.rs
@@ -1,4 +1,9 @@
-use ironclaw_filesystem::LocalFilesystem;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use ironclaw_filesystem::{
+    DirEntry, FileStat, FilesystemError, FilesystemOperation, LocalFilesystem, RootFilesystem,
+};
 use ironclaw_host_api::*;
 use ironclaw_run_state::*;
 
@@ -342,6 +347,22 @@ async fn filesystem_approval_request_store_persists_pending_requests_under_tenan
 }
 
 #[tokio::test]
+async fn filesystem_approval_request_listing_ignores_records_deleted_after_list() {
+    let fs = DisappearingApprovalReadFilesystem::new(engine_filesystem());
+    let store = FilesystemApprovalRequestStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id);
+
+    store.save_pending(scope.clone(), approval).await.unwrap();
+    fs.fail_next_approval_read();
+
+    let records = store.records_for_scope(&scope).await.unwrap();
+
+    assert_eq!(records, Vec::new());
+}
+
+#[tokio::test]
 async fn in_memory_approval_request_store_discards_pending_request() {
     let store = InMemoryApprovalRequestStore::new();
     let invocation_id = InvocationId::new();
@@ -674,6 +695,64 @@ async fn filesystem_approval_request_store_isolates_records_by_project_scope() {
         Vec::new()
     );
     assert_eq!(store.records_for_scope(&project_a).await.unwrap().len(), 1);
+}
+
+struct DisappearingApprovalReadFilesystem {
+    inner: LocalFilesystem,
+    fail_next_approval_read: AtomicBool,
+}
+
+impl DisappearingApprovalReadFilesystem {
+    fn new(inner: LocalFilesystem) -> Self {
+        Self {
+            inner,
+            fail_next_approval_read: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_next_approval_read(&self) {
+        self.fail_next_approval_read.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for DisappearingApprovalReadFilesystem {
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        if path.as_str().contains("/approvals/")
+            && path.as_str().ends_with(".json")
+            && self.fail_next_approval_read.swap(false, Ordering::SeqCst)
+        {
+            return Err(FilesystemError::NotFound {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+            });
+        }
+        self.inner.read_file(path).await
+    }
+
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        self.inner.write_file(path, bytes).await
+    }
+
+    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        self.inner.append_file(path, bytes).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.create_dir_all(path).await
+    }
 }
 
 fn engine_filesystem() -> LocalFilesystem {


### PR DESCRIPTION
## Summary

Follow-up to #3071 after the capability-host base PR landed. Hardens the approval/run-state/lease lifecycle around the review findings:

- Persist spawn approval requests instead of failing terminally when `authorize_spawn_with_trust` returns `RequireApproval`.
- Add `CapabilityHost::resume_spawn_json` so approved spawn requests can claim the matching lease, start the process, consume the lease, and complete run state.
- Add spawn-specific invocation fingerprints so dispatch and spawn approvals cannot share the same replay fingerprint.
- Validate approval `correlation_id` in addition to action/requester/fingerprint before persisting or resuming approvals.
- Revoke a claimed approval lease when resumed dispatch fails after the claim but before successful runtime dispatch.
- Make filesystem run/approval listings tolerate records deleted after directory listing, preventing rollback/listing races from failing the whole list.

## Notes

- Still no concrete runtime/dispatcher/WASM dependency from `ironclaw_capabilities`.
- Existing dispatch approval path is preserved; `approve_dispatch` now delegates through a shared action-specific helper, and `approve_spawn` handles `Action::SpawnCapability`.
- I self-reviewed this diff directly; no review subagent was used.
- `skip-regression-check` label and `[skip-regression-check]` commit marker are applied because the workflow false-negatives on crate-local Rust test changes, even though this PR adds multiple regression tests.

## Verification

```bash
cargo test -p ironclaw_host_api
cargo test -p ironclaw_approvals
cargo test -p ironclaw_run_state
cargo test -p ironclaw_capabilities
cargo clippy -p ironclaw_host_api -p ironclaw_approvals -p ironclaw_run_state -p ironclaw_capabilities --all-targets -- -D warnings
cargo test -p ironclaw_architecture
cargo fmt --all -- --check
git diff --check
```

All passed locally.
