### PR TITLE
test(reborn): cover WASM runtime failure edges

### DIFF
--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -174,6 +174,154 @@ async fn wasm_lane_execution_failure_reconciles_preserved_usage_from_runtime() {
     assert_eq!(recorded[2].error_kind.as_deref(), Some("guest"));
 }
 
+#[tokio::test]
+async fn wasm_lane_missing_module_file_returns_sanitized_filesystem_error() {
+    let fs = mounted_empty_extension_root();
+    let registry = Arc::new(registry_with_package(WASM_MANIFEST));
+    let governor = Arc::new(governor_with_default_limit(sample_account()));
+    let events = InMemoryEventSink::new();
+    let adapter = Arc::new(WasmRuntimeAdapter::new());
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
+        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(&adapter))
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request(
+            "wasm-smoke.count",
+            json!({"call": "missing"}),
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::FilesystemDenied
+        }
+    ));
+    assert_eq!(adapter.prepare_count(), 0);
+    assert_eq!(
+        governor.reserved_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_eq!(
+        governor.usage_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("filesystem_denied"));
+}
+
+#[tokio::test]
+async fn wasm_lane_malformed_module_returns_sanitized_manifest_error() {
+    let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/counter.wasm", b"not wasm").await;
+    let registry = Arc::new(registry_with_package(WASM_MANIFEST));
+    let governor = Arc::new(governor_with_default_limit(sample_account()));
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
+        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(WasmRuntimeAdapter::new()))
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request(
+            "wasm-smoke.count",
+            json!({"call": "malformed"}),
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::Manifest
+        }
+    ));
+    assert_eq!(
+        governor.reserved_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_eq!(
+        governor.usage_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("manifest"));
+}
+
+#[tokio::test]
+async fn wasm_lane_invalid_output_json_returns_sanitized_output_error() {
+    let invalid_output_wat = COUNTER_TOOL_WAT
+        .replace(
+            r#"(data (i32.const 3072) "1")"#,
+            r#"(data (i32.const 3072) "not-json")"#,
+        )
+        .replace(
+            "i32.const 56\n    i32.const 1\n    i32.store",
+            "i32.const 56\n    i32.const 8\n    i32.store",
+        );
+    assert_ne!(
+        invalid_output_wat, COUNTER_TOOL_WAT,
+        "invalid output WAT mutation should match the fixture"
+    );
+    let component = tool_component(&invalid_output_wat);
+    let fs = filesystem_with_wasm_component("wasm-smoke", "wasm/counter.wasm", &component).await;
+    let registry = Arc::new(registry_with_package(WASM_MANIFEST));
+    let governor = Arc::new(governor_with_default_limit(sample_account()));
+    let events = InMemoryEventSink::new();
+    let dispatcher = RuntimeDispatcher::from_arcs(registry, Arc::new(fs), Arc::clone(&governor))
+        .with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::new(WasmRuntimeAdapter::new()))
+        .with_event_sink_arc(Arc::new(events.clone()));
+
+    let err = dispatcher
+        .dispatch_json(dispatch_request(
+            "wasm-smoke.count",
+            json!({"call": "invalid-output"}),
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::OutputDecode
+        }
+    ));
+    assert_eq!(
+        governor.reserved_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_eq!(
+        governor.usage_for(&sample_account()),
+        ResourceTally::default()
+    );
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+    let recorded = events.events();
+    assert_eq!(recorded[2].error_kind.as_deref(), Some("output_decode"));
+}
+
 struct WasmRuntimeAdapter {
     runtime: WitToolRuntime,
     host: WitToolHost,

--- a/crates/ironclaw_wasm/tests/wit_tool_runtime_contract.rs
+++ b/crates/ironclaw_wasm/tests/wit_tool_runtime_contract.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use ironclaw_wasm::{
-    DenyWasmHostHttp, RecordingWasmHostHttp, WasmHostHttp, WasmHttpRequest, WasmHttpResponse,
-    WitToolHost, WitToolRequest, WitToolRuntime, WitToolRuntimeConfig,
+    DenyWasmHostHttp, RecordingWasmHostHttp, WasmError, WasmHostHttp, WasmHttpRequest,
+    WasmHttpResponse, WitToolHost, WitToolRequest, WitToolRuntime, WitToolRuntimeConfig,
 };
 use serde_json::json;
 use wit_component::{ComponentEncoder, StringEncoding, embed_component_metadata};
@@ -210,6 +210,75 @@ fn prepares_metadata_from_wit_tool_component() {
     assert_eq!(prepared.name(), "counter");
     assert_eq!(prepared.description(), "fixture description");
     assert_eq!(prepared.schema(), &json!({ "type": "object" }));
+}
+
+#[test]
+fn malformed_component_bytes_are_rejected_as_compilation_failure() {
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+
+    let error = runtime
+        .prepare("malformed", b"not a wasm component")
+        .unwrap_err();
+
+    assert!(
+        matches!(error, WasmError::CompilationFailed(_)),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[test]
+fn core_wasm_module_bytes_are_rejected_as_compilation_failure() {
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+    let core_module = wat::parse_str("(module)").unwrap();
+
+    let error = runtime.prepare("core-module", &core_module).unwrap_err();
+
+    assert!(
+        matches!(error, WasmError::CompilationFailed(_)),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[test]
+fn unsupported_component_without_tool_exports_is_rejected_at_instantiation() {
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+    let component_without_tool_exports = wat::parse_str("(component)").unwrap();
+
+    let error = runtime
+        .prepare("unsupported", &component_without_tool_exports)
+        .unwrap_err();
+
+    assert!(
+        matches!(error, WasmError::InstantiationFailed(_)),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[test]
+fn schema_export_must_return_json_object() {
+    let runtime = WitToolRuntime::new(WitToolRuntimeConfig::for_testing()).unwrap();
+    let invalid_schema_wat = COUNTER_TOOL_WAT
+        .replace(
+            r#"(data (i32.const 1024) "{\22type\22:\22object\22}")"#,
+            r#"(data (i32.const 1024) "[1]")"#,
+        )
+        .replace(
+            "i32.const 17\n    i32.store\n    i32.const 16)\n  (func $description",
+            "i32.const 3\n    i32.store\n    i32.const 16)\n  (func $description",
+        );
+    assert_ne!(
+        invalid_schema_wat, COUNTER_TOOL_WAT,
+        "invalid schema WAT mutation should match the fixture"
+    );
+
+    let error = runtime
+        .prepare("invalid-schema", &tool_component(&invalid_schema_wat))
+        .unwrap_err();
+
+    assert!(
+        matches!(error, WasmError::InvalidSchema(_)),
+        "unexpected error: {error:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Test-only follow-up for #3086 to close the remaining explicit WASM runtime coverage gaps after #3097 and #3109 landed.

Adds coverage for:

- malformed non-WASM bytes rejected by `WitToolRuntime::prepare`
- valid core WASM module bytes rejected because they are not component-model tools
- component-model inputs without the required WIT tool exports
- invalid WIT schema exports that are not JSON objects
- missing WASM module files through the `RuntimeDispatcher` / `RuntimeAdapter` seam
- malformed module bytes through the dispatch seam as sanitized manifest errors
- invalid output JSON through the dispatch seam as sanitized output decode errors

No production code changes.

## Verification

```bash
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-wasm-coverage-target cargo test -p ironclaw_wasm
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-wasm-coverage-target cargo clippy -q -p ironclaw_wasm --all-targets -- -D warnings
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-wasm-coverage-target cargo test -p ironclaw_architecture
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-wasm-coverage-target cargo test -p ironclaw_dispatcher
git diff --check
```

## Links

Completes #3086.
Part of #2987.
