### PR TITLE
fix(reborn): make host runtime cancel and health real

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -513,6 +513,21 @@ pub struct HostRuntimeHealth {
     pub missing_runtime_backends: Vec<RuntimeKind>,
 }
 
+/// Backend health probe for concrete runtime implementations.
+///
+/// The host runtime asks this port about the runtime kinds required by the
+/// current visible capability registry. Implementations should return the
+/// subset of `required` that is not currently available. Callers must treat a
+/// missing probe as "unknown/unready" whenever the registry requires at least
+/// one runtime backend.
+#[async_trait]
+pub trait RuntimeBackendHealth: Send + Sync {
+    async fn missing_runtime_backends(
+        &self,
+        required: &[RuntimeKind],
+    ) -> Result<Vec<RuntimeKind>, HostRuntimeError>;
+}
+
 /// Contract for the Reborn host runtime facade.
 #[async_trait]
 pub trait HostRuntime: Send + Sync {

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -20,17 +20,21 @@ use ironclaw_capabilities::{
 };
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_host_api::{
-    ApprovalRequestId, CapabilityDispatcher, CapabilityId, InvocationId, ResourceScope,
+    ApprovalRequestId, CapabilityDispatcher, CapabilityId, InvocationId, ResourceScope, RuntimeKind,
 };
-use ironclaw_processes::ProcessManager;
+use ironclaw_processes::{
+    ProcessCancellationRegistry, ProcessError, ProcessHost, ProcessManager, ProcessStatus,
+    ProcessStore,
+};
 use ironclaw_run_state::{ApprovalRequestStore, RunStateError, RunStateStore, RunStatus};
 
 use crate::{
     CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest, CapabilitySurfaceVersion, HostRuntime,
     HostRuntimeError, HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalGate,
-    RuntimeBlockedReason, RuntimeCapabilityCompleted, RuntimeCapabilityFailure,
-    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind, RuntimeStatusRequest,
-    RuntimeWorkId, RuntimeWorkSummary, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    RuntimeBackendHealth, RuntimeBlockedReason, RuntimeCapabilityCompleted,
+    RuntimeCapabilityFailure, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    RuntimeFailureKind, RuntimeStatusRequest, RuntimeWorkId, RuntimeWorkSummary,
+    VisibleCapabilityRequest, VisibleCapabilitySurface,
 };
 
 /// Default production wiring for [`HostRuntime`].
@@ -42,6 +46,9 @@ pub struct DefaultHostRuntime {
     approval_requests: Option<Arc<dyn ApprovalRequestStore>>,
     capability_leases: Option<Arc<dyn CapabilityLeaseStore>>,
     process_manager: Option<Arc<dyn ProcessManager>>,
+    process_store: Option<Arc<dyn ProcessStore>>,
+    process_cancellation_registry: Option<Arc<ProcessCancellationRegistry>>,
+    runtime_health: Option<Arc<dyn RuntimeBackendHealth>>,
     surface_version: CapabilitySurfaceVersion,
 }
 
@@ -70,6 +77,9 @@ impl DefaultHostRuntime {
             approval_requests: None,
             capability_leases: None,
             process_manager: None,
+            process_store: None,
+            process_cancellation_registry: None,
+            runtime_health: None,
             surface_version,
         }
     }
@@ -101,6 +111,28 @@ impl DefaultHostRuntime {
     /// Attaches the process manager used by future spawn paths.
     pub fn with_process_manager(mut self, process_manager: Arc<dyn ProcessManager>) -> Self {
         self.process_manager = Some(process_manager);
+        self
+    }
+
+    /// Attaches the process store used for status and cancellation fanout.
+    pub fn with_process_store(mut self, process_store: Arc<dyn ProcessStore>) -> Self {
+        self.process_store = Some(process_store);
+        self
+    }
+
+    /// Attaches the process cancellation registry used to notify running
+    /// background executors when `cancel_work` kills a process record.
+    pub fn with_process_cancellation_registry(
+        mut self,
+        registry: Arc<ProcessCancellationRegistry>,
+    ) -> Self {
+        self.process_cancellation_registry = Some(registry);
+        self
+    }
+
+    /// Attaches the backend health probe for concrete runtime implementations.
+    pub fn with_runtime_health(mut self, health: Arc<dyn RuntimeBackendHealth>) -> Self {
+        self.runtime_health = Some(health);
         self
     }
 }
@@ -184,19 +216,67 @@ impl HostRuntime for DefaultHostRuntime {
         })
     }
 
-    /// Best-effort cancellation fanout.
+    /// Best-effort cancellation fanout for active work in one scope.
     ///
-    /// This implementation is a deliberate stub at this layer: the underlying
-    /// [`CapabilityHost`] does not yet expose a cancellation port, so we always
-    /// return an empty outcome. Upper services must not treat an empty result
-    /// as confirmation that work was cancelled — it is `unknown`/`no-op` until
-    /// a richer cancellation contract lands.
+    /// Background processes can be terminalized through the process store and
+    /// cooperative cancellation registry. Inline capability invocations do not
+    /// yet expose a cancellation token through [`CapabilityHost`], so active
+    /// invocation records are returned as `unsupported` instead of silently
+    /// disappearing behind an empty outcome.
     async fn cancel_work(
         &self,
         request: CancelRuntimeWorkRequest,
     ) -> Result<CancelRuntimeWorkOutcome, HostRuntimeError> {
-        let _ = request;
-        Ok(CancelRuntimeWorkOutcome::default())
+        tracing::debug!(
+            correlation_id = %request.correlation_id,
+            reason = ?request.reason,
+            "host runtime cancellation requested"
+        );
+
+        let mut outcome = CancelRuntimeWorkOutcome::default();
+        let mut process_invocations = Vec::new();
+
+        if let Some(process_store) = &self.process_store {
+            let records = process_store
+                .records_for_scope(&request.scope)
+                .await
+                .map_err(unavailable_from_process_error)?;
+            let mut process_host = ProcessHost::new(process_store.as_ref());
+            if let Some(registry) = &self.process_cancellation_registry {
+                process_host = process_host.with_cancellation_registry(Arc::clone(registry));
+            }
+
+            for record in records {
+                if record.status != ProcessStatus::Running {
+                    continue;
+                }
+                process_invocations.push(record.invocation_id);
+                let work_id = RuntimeWorkId::Process(record.process_id);
+                match process_host.kill(&request.scope, record.process_id).await {
+                    Ok(_) => outcome.cancelled.push(work_id),
+                    Err(ProcessError::InvalidTransition { .. }) => {
+                        outcome.already_terminal.push(work_id);
+                    }
+                    Err(error) => return Err(unavailable_from_process_error(error)),
+                }
+            }
+        }
+
+        if let Some(run_state) = &self.run_state {
+            let records = run_state
+                .records_for_scope(&request.scope)
+                .await
+                .map_err(unavailable_from_run_state)?;
+            outcome.unsupported.extend(
+                records
+                    .into_iter()
+                    .filter(|record| record.status == RunStatus::Running)
+                    .filter(|record| !process_invocations.contains(&record.invocation_id))
+                    .map(|record| RuntimeWorkId::Invocation(record.invocation_id)),
+            );
+        }
+
+        Ok(outcome)
     }
 
     /// Snapshot of active host runtime work for one scope.
@@ -209,45 +289,71 @@ impl HostRuntime for DefaultHostRuntime {
         &self,
         request: RuntimeStatusRequest,
     ) -> Result<HostRuntimeStatus, HostRuntimeError> {
-        let Some(run_state) = &self.run_state else {
-            return Ok(HostRuntimeStatus::default());
-        };
+        let mut active_work = Vec::new();
 
-        let records = run_state
-            .records_for_scope(&request.scope)
-            .await
-            .map_err(unavailable_from_run_state)?;
+        if let Some(run_state) = &self.run_state {
+            let records = run_state
+                .records_for_scope(&request.scope)
+                .await
+                .map_err(unavailable_from_run_state)?;
 
-        let active_work = records
-            .into_iter()
-            .filter(|record| record.status == RunStatus::Running)
-            .map(|record| {
-                let runtime = self
-                    .registry
-                    .get_capability(&record.capability_id)
-                    .map(|descriptor| descriptor.runtime);
-                RuntimeWorkSummary {
-                    work_id: RuntimeWorkId::Invocation(record.invocation_id),
-                    capability_id: Some(record.capability_id),
-                    runtime,
-                }
-            })
-            .collect();
+            active_work.extend(
+                records
+                    .into_iter()
+                    .filter(|record| record.status == RunStatus::Running)
+                    .map(|record| {
+                        let runtime = self
+                            .registry
+                            .get_capability(&record.capability_id)
+                            .map(|descriptor| descriptor.runtime);
+                        RuntimeWorkSummary {
+                            work_id: RuntimeWorkId::Invocation(record.invocation_id),
+                            capability_id: Some(record.capability_id),
+                            runtime,
+                        }
+                    }),
+            );
+        }
+
+        if let Some(process_store) = &self.process_store {
+            let records = process_store
+                .records_for_scope(&request.scope)
+                .await
+                .map_err(unavailable_from_process_error)?;
+            active_work.extend(
+                records
+                    .into_iter()
+                    .filter(|record| record.status == ProcessStatus::Running)
+                    .map(|record| RuntimeWorkSummary {
+                        work_id: RuntimeWorkId::Process(record.process_id),
+                        capability_id: Some(record.capability_id),
+                        runtime: Some(record.runtime),
+                    }),
+            );
+        }
 
         Ok(HostRuntimeStatus { active_work })
     }
 
-    /// Returns a coarse readiness signal for the composed host runtime.
-    ///
-    /// This is a deliberate stub at this layer: the underlying capability
-    /// host does not yet expose backend-level health probes, so we always
-    /// report `ready = true` with no missing backends. Upper services must not
-    /// rely on this for liveness — richer health surfaces will land alongside
-    /// the runtime registry.
+    /// Returns readiness for runtime backends required by registered capabilities.
     async fn health(&self) -> Result<HostRuntimeHealth, HostRuntimeError> {
+        let required = required_runtime_backends(&self.registry);
+        if required.is_empty() {
+            return Ok(HostRuntimeHealth {
+                ready: true,
+                missing_runtime_backends: Vec::new(),
+            });
+        }
+
+        let missing_runtime_backends = if let Some(health) = &self.runtime_health {
+            let reported = health.missing_runtime_backends(&required).await?;
+            normalize_missing_runtime_backends(&required, reported)
+        } else {
+            required
+        };
         Ok(HostRuntimeHealth {
-            ready: true,
-            missing_runtime_backends: Vec::new(),
+            ready: missing_runtime_backends.is_empty(),
+            missing_runtime_backends,
         })
     }
 }
@@ -333,6 +439,67 @@ fn unavailable_from_run_state(error: RunStateError) -> HostRuntimeError {
         RunStateError::Deserialization(_) => "run-state deserialization failed",
     };
     HostRuntimeError::unavailable(reason)
+}
+
+/// Maps a [`ProcessError`] to a sanitized [`HostRuntimeError::Unavailable`].
+fn unavailable_from_process_error(error: ProcessError) -> HostRuntimeError {
+    let reason = match error {
+        ProcessError::UnknownProcess { .. } => "process record not found",
+        ProcessError::ProcessAlreadyExists { .. } => "process record already exists",
+        ProcessError::InvalidTransition { .. } => "process lifecycle transition invalid",
+        ProcessError::ResourceReservationMismatch { .. } => "process resource reservation mismatch",
+        ProcessError::ResourceReservationAlreadyAssigned { .. } => {
+            "process resource reservation already assigned"
+        }
+        ProcessError::ResourceReservationNotOwned { .. } => {
+            "process resource reservation not owned"
+        }
+        ProcessError::Resource(_) => "process resource lifecycle failed",
+        ProcessError::ResourceCleanupFailed { .. } => "process resource cleanup failed",
+        ProcessError::ProcessResultStoreUnavailable => "process result store unavailable",
+        ProcessError::ProcessResultUnavailable { .. } => "process result unavailable",
+        ProcessError::InvalidStoredRecord { .. } => "process stored record invalid",
+        ProcessError::InvalidPath(_) => "process storage path invalid",
+        ProcessError::Filesystem(_) => "process filesystem unavailable",
+        ProcessError::Serialization(_) => "process serialization failed",
+        ProcessError::Deserialization(_) => "process deserialization failed",
+    };
+    HostRuntimeError::unavailable(reason)
+}
+
+fn required_runtime_backends(registry: &ExtensionRegistry) -> Vec<RuntimeKind> {
+    let mut required = Vec::new();
+    for descriptor in registry.capabilities() {
+        if !required.contains(&descriptor.runtime) {
+            required.push(descriptor.runtime);
+        }
+    }
+    required.sort_by_key(|runtime| runtime_kind_rank(*runtime));
+    required
+}
+
+fn normalize_missing_runtime_backends(
+    required: &[RuntimeKind],
+    reported: Vec<RuntimeKind>,
+) -> Vec<RuntimeKind> {
+    let mut missing = Vec::new();
+    for runtime in reported {
+        if required.contains(&runtime) && !missing.contains(&runtime) {
+            missing.push(runtime);
+        }
+    }
+    missing.sort_by_key(|runtime| runtime_kind_rank(*runtime));
+    missing
+}
+
+fn runtime_kind_rank(runtime: RuntimeKind) -> u8 {
+    match runtime {
+        RuntimeKind::Wasm => 0,
+        RuntimeKind::Mcp => 1,
+        RuntimeKind::Script => 2,
+        RuntimeKind::FirstParty => 3,
+        RuntimeKind::System => 4,
+    }
 }
 
 fn completed_outcome_from(
@@ -669,6 +836,35 @@ mod tests {
                     "sanitized reason must not leak filesystem paths, got {reason:?}"
                 );
                 assert_eq!(reason, "run-state filesystem unavailable");
+            }
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unavailable_from_process_error_uses_redacted_reasons() {
+        let error = ProcessError::InvalidPath("/private/users/secret/processes".to_string());
+        let host_error = unavailable_from_process_error(error);
+        match host_error {
+            HostRuntimeError::Unavailable { reason } => {
+                assert!(
+                    !reason.contains("/private/"),
+                    "sanitized reason must not leak filesystem paths, got {reason:?}"
+                );
+                assert_eq!(reason, "process storage path invalid");
+            }
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+
+        let error = ProcessError::Filesystem("connection refused at /tmp/processes.db".to_string());
+        let host_error = unavailable_from_process_error(error);
+        match host_error {
+            HostRuntimeError::Unavailable { reason } => {
+                assert!(
+                    !reason.contains("/tmp"),
+                    "sanitized reason must not leak filesystem paths, got {reason:?}"
+                );
+                assert_eq!(reason, "process filesystem unavailable");
             }
             other => panic!("expected Unavailable, got {other:?}"),
         }

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -23,8 +23,8 @@ use ironclaw_host_api::{
     ApprovalRequestId, CapabilityDispatcher, CapabilityId, InvocationId, ResourceScope, RuntimeKind,
 };
 use ironclaw_processes::{
-    ProcessCancellationRegistry, ProcessError, ProcessHost, ProcessManager, ProcessStatus,
-    ProcessStore,
+    ProcessCancellationRegistry, ProcessError, ProcessHost, ProcessManager, ProcessResultStore,
+    ProcessStatus, ProcessStore,
 };
 use ironclaw_run_state::{ApprovalRequestStore, RunStateError, RunStateStore, RunStatus};
 
@@ -47,6 +47,7 @@ pub struct DefaultHostRuntime {
     capability_leases: Option<Arc<dyn CapabilityLeaseStore>>,
     process_manager: Option<Arc<dyn ProcessManager>>,
     process_store: Option<Arc<dyn ProcessStore>>,
+    process_result_store: Option<Arc<dyn ProcessResultStore>>,
     process_cancellation_registry: Option<Arc<ProcessCancellationRegistry>>,
     runtime_health: Option<Arc<dyn RuntimeBackendHealth>>,
     surface_version: CapabilitySurfaceVersion,
@@ -78,6 +79,7 @@ impl DefaultHostRuntime {
             capability_leases: None,
             process_manager: None,
             process_store: None,
+            process_result_store: None,
             process_cancellation_registry: None,
             runtime_health: None,
             surface_version,
@@ -117,6 +119,15 @@ impl DefaultHostRuntime {
     /// Attaches the process store used for status and cancellation fanout.
     pub fn with_process_store(mut self, process_store: Arc<dyn ProcessStore>) -> Self {
         self.process_store = Some(process_store);
+        self
+    }
+
+    /// Attaches the process result store used to persist cancellation results.
+    pub fn with_process_result_store(
+        mut self,
+        process_result_store: Arc<dyn ProcessResultStore>,
+    ) -> Self {
+        self.process_result_store = Some(process_result_store);
         self
     }
 
@@ -253,7 +264,15 @@ impl HostRuntime for DefaultHostRuntime {
                 process_invocations.push(record.invocation_id);
                 let work_id = RuntimeWorkId::Process(record.process_id);
                 match process_host.kill(&request.scope, record.process_id).await {
-                    Ok(_) => outcome.cancelled.push(work_id),
+                    Ok(record) => {
+                        if let Some(result_store) = &self.process_result_store {
+                            result_store
+                                .kill(&record.scope, record.process_id)
+                                .await
+                                .map_err(unavailable_from_process_error)?;
+                        }
+                        outcome.cancelled.push(work_id);
+                    }
                     Err(ProcessError::InvalidTransition { .. }) => {
                         outcome.already_terminal.push(work_id);
                     }
@@ -320,16 +339,28 @@ impl HostRuntime for DefaultHostRuntime {
                 .records_for_scope(&request.scope)
                 .await
                 .map_err(unavailable_from_process_error)?;
+            let mut process_invocations = Vec::new();
             active_work.extend(
                 records
                     .into_iter()
                     .filter(|record| record.status == ProcessStatus::Running)
-                    .map(|record| RuntimeWorkSummary {
-                        work_id: RuntimeWorkId::Process(record.process_id),
-                        capability_id: Some(record.capability_id),
-                        runtime: Some(record.runtime),
+                    .map(|record| {
+                        process_invocations.push(record.invocation_id);
+                        RuntimeWorkSummary {
+                            work_id: RuntimeWorkId::Process(record.process_id),
+                            capability_id: Some(record.capability_id),
+                            runtime: Some(record.runtime),
+                        }
                     }),
             );
+            if !process_invocations.is_empty() {
+                active_work.retain(|summary| match &summary.work_id {
+                    RuntimeWorkId::Invocation(invocation_id) => {
+                        !process_invocations.contains(invocation_id)
+                    }
+                    RuntimeWorkId::Process(_) | RuntimeWorkId::Gate(_) => true,
+                });
+            }
         }
 
         Ok(HostRuntimeStatus { active_work })

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -13,7 +13,8 @@ use ironclaw_host_runtime::{
     RuntimeStatusRequest, RuntimeWorkId, SurfaceKind, VisibleCapabilityRequest,
 };
 use ironclaw_processes::{
-    InMemoryProcessStore, ProcessCancellationRegistry, ProcessStart, ProcessStatus, ProcessStore,
+    InMemoryProcessResultStore, InMemoryProcessStore, ProcessCancellationRegistry,
+    ProcessResultStore, ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_run_state::{
     InMemoryApprovalRequestStore, InMemoryRunStateStore, RunRecord, RunStart, RunStateError,
@@ -645,6 +646,99 @@ async fn default_runtime_status_includes_running_processes_from_process_store() 
     );
     assert_eq!(status.active_work[0].capability_id, Some(capability_id()));
     assert_eq!(status.active_work[0].runtime, Some(RuntimeKind::Wasm));
+}
+
+#[tokio::test]
+async fn default_runtime_cancel_writes_killed_process_result_record() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let process_store = Arc::new(InMemoryProcessStore::new());
+    let result_store = Arc::new(InMemoryProcessResultStore::new());
+    let cancellation_registry = Arc::new(ProcessCancellationRegistry::new());
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher,
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_process_store(process_store.clone())
+    .with_process_result_store(result_store.clone())
+    .with_process_cancellation_registry(cancellation_registry.clone());
+
+    let context = execution_context_with_dispatch_grant();
+    let process_id = ProcessId::new();
+    process_store
+        .start(process_start(&context, process_id))
+        .await
+        .unwrap();
+    cancellation_registry.register(&context.resource_scope, process_id);
+
+    let outcome = runtime
+        .cancel_work(CancelRuntimeWorkRequest::new(
+            context.resource_scope.clone(),
+            context.correlation_id,
+            CancelReason::TurnCancelled,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.cancelled, vec![RuntimeWorkId::Process(process_id)]);
+    let result = result_store
+        .get(&context.resource_scope, process_id)
+        .await
+        .unwrap()
+        .expect("killed process result should be persisted");
+    assert_eq!(result.status, ProcessStatus::Killed);
+    assert_eq!(result.output, None);
+    assert_eq!(result.output_ref, None);
+    assert_eq!(result.error_kind, None);
+}
+
+#[tokio::test]
+async fn default_runtime_status_does_not_duplicate_process_backed_invocations() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let process_store = Arc::new(InMemoryProcessStore::new());
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher,
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_run_state(run_state.clone())
+    .with_process_store(process_store.clone());
+
+    let context = execution_context_with_dispatch_grant();
+    let process_id = ProcessId::new();
+    run_state
+        .start(RunStart {
+            invocation_id: context.invocation_id,
+            capability_id: capability_id(),
+            scope: context.resource_scope.clone(),
+        })
+        .await
+        .unwrap();
+    process_store
+        .start(process_start(&context, process_id))
+        .await
+        .unwrap();
+
+    let status = runtime
+        .runtime_status(RuntimeStatusRequest::new(
+            context.resource_scope,
+            context.correlation_id,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(status.active_work.len(), 1);
+    assert_eq!(
+        status.active_work[0].work_id,
+        RuntimeWorkId::Process(process_id)
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -9,8 +9,11 @@ use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CancelReason, CancelRuntimeWorkRequest, CapabilitySurfaceVersion, DefaultHostRuntime,
-    HostRuntime, IdempotencyKey, RuntimeCapabilityRequest, RuntimeStatusRequest, RuntimeWorkId,
-    SurfaceKind, VisibleCapabilityRequest,
+    HostRuntime, HostRuntimeError, IdempotencyKey, RuntimeBackendHealth, RuntimeCapabilityRequest,
+    RuntimeStatusRequest, RuntimeWorkId, SurfaceKind, VisibleCapabilityRequest,
+};
+use ironclaw_processes::{
+    InMemoryProcessStore, ProcessCancellationRegistry, ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_run_state::{
     InMemoryApprovalRequestStore, InMemoryRunStateStore, RunRecord, RunStart, RunStateError,
@@ -521,18 +524,29 @@ async fn default_runtime_status_reports_running_invocations_only() {
 }
 
 #[tokio::test]
-async fn default_runtime_cancel_returns_empty_outcome_when_unsupported() {
-    let registry = Arc::new(ExtensionRegistry::new());
+async fn default_runtime_cancel_reports_running_invocations_as_unsupported() {
+    let registry = Arc::new(registry_with_echo_capability());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let run_state = Arc::new(InMemoryRunStateStore::new());
     let runtime = DefaultHostRuntime::new(
         registry,
         dispatcher,
         authorizer,
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
-    );
+    )
+    .with_run_state(run_state.clone());
 
     let context = execution_context_with_dispatch_grant();
+    run_state
+        .start(RunStart {
+            invocation_id: context.invocation_id,
+            capability_id: capability_id(),
+            scope: context.resource_scope.clone(),
+        })
+        .await
+        .unwrap();
+
     let outcome = runtime
         .cancel_work(CancelRuntimeWorkRequest::new(
             context.resource_scope,
@@ -544,11 +558,97 @@ async fn default_runtime_cancel_returns_empty_outcome_when_unsupported() {
 
     assert!(outcome.cancelled.is_empty());
     assert!(outcome.already_terminal.is_empty());
-    assert!(outcome.unsupported.is_empty());
+    assert_eq!(
+        outcome.unsupported,
+        vec![RuntimeWorkId::Invocation(context.invocation_id)]
+    );
 }
 
 #[tokio::test]
-async fn default_runtime_health_reports_ready_with_no_missing_backends() {
+async fn default_runtime_cancel_kills_running_processes_and_cancels_tokens() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let process_store = Arc::new(InMemoryProcessStore::new());
+    let cancellation_registry = Arc::new(ProcessCancellationRegistry::new());
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher,
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_process_store(process_store.clone())
+    .with_process_cancellation_registry(cancellation_registry.clone());
+
+    let context = execution_context_with_dispatch_grant();
+    let process_id = ProcessId::new();
+    process_store
+        .start(process_start(&context, process_id))
+        .await
+        .unwrap();
+    let cancellation_token = cancellation_registry.register(&context.resource_scope, process_id);
+
+    let outcome = runtime
+        .cancel_work(CancelRuntimeWorkRequest::new(
+            context.resource_scope.clone(),
+            context.correlation_id,
+            CancelReason::TurnCancelled,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.cancelled, vec![RuntimeWorkId::Process(process_id)]);
+    assert!(outcome.already_terminal.is_empty());
+    assert!(outcome.unsupported.is_empty());
+    assert!(cancellation_token.is_cancelled());
+    let record = process_store
+        .get(&context.resource_scope, process_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.status, ProcessStatus::Killed);
+}
+
+#[tokio::test]
+async fn default_runtime_status_includes_running_processes_from_process_store() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let process_store = Arc::new(InMemoryProcessStore::new());
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher,
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_process_store(process_store.clone());
+
+    let context = execution_context_with_dispatch_grant();
+    let process_id = ProcessId::new();
+    process_store
+        .start(process_start(&context, process_id))
+        .await
+        .unwrap();
+
+    let status = runtime
+        .runtime_status(RuntimeStatusRequest::new(
+            context.resource_scope,
+            context.correlation_id,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(status.active_work.len(), 1);
+    assert_eq!(
+        status.active_work[0].work_id,
+        RuntimeWorkId::Process(process_id)
+    );
+    assert_eq!(status.active_work[0].capability_id, Some(capability_id()));
+    assert_eq!(status.active_work[0].runtime, Some(RuntimeKind::Wasm));
+}
+
+#[tokio::test]
+async fn default_runtime_health_reports_ready_when_registry_requires_no_backends() {
     let registry = Arc::new(ExtensionRegistry::new());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
@@ -560,8 +660,75 @@ async fn default_runtime_health_reports_ready_with_no_missing_backends() {
     );
 
     let health = runtime.health().await.unwrap();
+
     assert!(health.ready);
     assert!(health.missing_runtime_backends.is_empty());
+}
+
+#[tokio::test]
+async fn default_runtime_health_without_probe_reports_required_runtimes_missing() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher,
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+
+    let health = runtime.health().await.unwrap();
+
+    assert!(!health.ready);
+    assert_eq!(health.missing_runtime_backends, vec![RuntimeKind::Wasm]);
+}
+
+#[tokio::test]
+async fn default_runtime_health_uses_configured_backend_probe() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher,
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_runtime_health(Arc::new(HealthyRuntimeProbe));
+
+    let health = runtime.health().await.unwrap();
+
+    assert!(health.ready);
+    assert!(health.missing_runtime_backends.is_empty());
+}
+
+struct HealthyRuntimeProbe;
+
+#[async_trait]
+impl RuntimeBackendHealth for HealthyRuntimeProbe {
+    async fn missing_runtime_backends(
+        &self,
+        _required: &[RuntimeKind],
+    ) -> Result<Vec<RuntimeKind>, HostRuntimeError> {
+        Ok(Vec::new())
+    }
+}
+
+fn process_start(context: &ExecutionContext, process_id: ProcessId) -> ProcessStart {
+    ProcessStart {
+        process_id,
+        parent_process_id: context.process_id,
+        invocation_id: context.invocation_id,
+        scope: context.resource_scope.clone(),
+        extension_id: extension_id(),
+        capability_id: capability_id(),
+        runtime: RuntimeKind::Wasm,
+        grants: context.grants.clone(),
+        mounts: context.mounts.clone(),
+        estimated_resources: ResourceEstimate::default(),
+        resource_reservation_id: None,
+        input: json!({"message": "background"}),
+    }
 }
 
 /// Wraps an [`InMemoryRunStateStore`] but fails every `records_for_scope`


### PR DESCRIPTION
## Summary
- replace the DefaultHostRuntime cancel_work stub with real process cancellation and explicit unsupported reporting for inline invocations
- include running process records in runtime_status
- replace the always-ready health stub with a RuntimeBackendHealth probe and required-runtime missing-backend reporting
- add regression coverage for cancellation, process status, health, and sanitized process-store errors

## Verification
- cargo test -p ironclaw_host_runtime
- cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings
- cargo test -p ironclaw_architecture
- cargo fmt --all -- --check
- git diff --check

Base: reborn-integration
Depends on: #3095 merged into reborn-integration