### PR TITLE
feat(reborn): route MCP HTTP through shared egress

### DIFF
--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -289,6 +289,25 @@ struct McpHostHttpClientState {
     session_ids: Mutex<HashMap<McpHostHttpSessionKey, String>>,
 }
 
+struct McpHostHttpSessionCleanup {
+    state: Arc<McpHostHttpClientState>,
+    session_key: McpHostHttpSessionKey,
+}
+
+impl McpHostHttpSessionCleanup {
+    fn new(state: Arc<McpHostHttpClientState>, session_key: McpHostHttpSessionKey) -> Self {
+        Self { state, session_key }
+    }
+}
+
+impl Drop for McpHostHttpSessionCleanup {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.state.session_ids.lock() {
+            guard.remove(&self.session_key);
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct McpHostHttpSessionKey {
     tenant_id: String,
@@ -341,13 +360,13 @@ where
     fn send_json_rpc(
         &self,
         request: &McpClientRequest,
+        session_key: &McpHostHttpSessionKey,
         id: Option<u64>,
         method: &str,
         params: Option<Value>,
     ) -> Result<McpJsonRpcExchange, String> {
         let url = request.url.as_deref().ok_or_else(request_denied)?;
         let body = encode_json_rpc_request(id, method, params)?;
-        let session_key = McpHostHttpSessionKey::new(&request.scope, &request.provider, url);
         let mut headers = vec![
             ("Content-Type".to_string(), "application/json".to_string()),
             (
@@ -355,7 +374,7 @@ where
                 "application/json, text/event-stream".to_string(),
             ),
         ];
-        if let Some(session_id) = self.current_session_id(&session_key)? {
+        if let Some(session_id) = self.current_session_id(session_key)? {
             headers.push(("Mcp-Session-Id".to_string(), session_id));
         }
 
@@ -387,11 +406,15 @@ where
             })
             .map_err(mcp_client_http_error)?;
 
-        self.capture_session_id(&session_key, &response)?;
         let usage = ResourceUsage {
             network_egress_bytes: response.request_bytes,
             ..ResourceUsage::default()
         };
+
+        if !(200..300).contains(&response.status) {
+            return Err(response_error());
+        }
+        self.capture_session_id(session_key, &response)?;
 
         if response.status == 202 && id.is_none() {
             return Ok(McpJsonRpcExchange {
@@ -401,9 +424,6 @@ where
                 },
                 usage,
             });
-        }
-        if !(200..300).contains(&response.status) {
-            return Err(response_error());
         }
 
         Ok(McpJsonRpcExchange {
@@ -467,9 +487,15 @@ where
             return Err(request_denied());
         }
 
+        let url = request.url.as_deref().ok_or_else(request_denied)?;
+        let session_key = McpHostHttpSessionKey::new(&request.scope, &request.provider, url);
+        let _session_cleanup =
+            McpHostHttpSessionCleanup::new(Arc::clone(&self.state), session_key.clone());
+
         let mut usage = ResourceUsage::default();
         let initialize = self.send_json_rpc(
             &request,
+            &session_key,
             Some(self.next_request_id()),
             "initialize",
             Some(json_rpc_initialize_params()),
@@ -479,7 +505,13 @@ where
             return Err(response_error());
         }
 
-        let initialized = self.send_json_rpc(&request, None, "notifications/initialized", None)?;
+        let initialized = self.send_json_rpc(
+            &request,
+            &session_key,
+            None,
+            "notifications/initialized",
+            None,
+        )?;
         accumulate_usage(&mut usage, initialized.usage);
         if initialized.response.error {
             return Err(response_error());
@@ -488,6 +520,7 @@ where
         let tool_name = mcp_tool_name(&request.provider, &request.capability_id);
         let call = self.send_json_rpc(
             &request,
+            &session_key,
             Some(self.next_request_id()),
             "tools/call",
             Some(serde_json::json!({

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -608,8 +608,8 @@ fn parse_mcp_json_rpc_value(
     expected_id: Option<u64>,
 ) -> Result<McpJsonRpcResponse, String> {
     let parsed_id = json_rpc_id(value);
-    if let (Some(expected), Some(actual)) = (expected_id, parsed_id)
-        && expected != actual
+    if let Some(expected) = expected_id
+        && parsed_id != Some(expected)
     {
         return Err(response_error());
     }

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -5,12 +5,21 @@
 //! network authority; the host-selected client is the only integration point and
 //! resource accounting still happens through the host governor.
 
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
 use async_trait::async_trait;
 use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, ResourceEstimate, ResourceReservation, ResourceReservationId,
-    ResourceScope, ResourceUsage, RuntimeHttpEgress, RuntimeHttpEgressError,
-    RuntimeHttpEgressRequest, RuntimeHttpEgressResponse, RuntimeKind,
+    CapabilityId, ExtensionId, NetworkMethod, NetworkPolicy, ResourceEstimate, ResourceReservation,
+    ResourceReservationId, ResourceScope, ResourceUsage, RuntimeCredentialInjection,
+    RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    RuntimeKind,
 };
 use ironclaw_resources::{ResourceError, ResourceGovernor, ResourceReceipt};
 use serde_json::Value;
@@ -180,6 +189,480 @@ fn mcp_http_error(error: RuntimeHttpEgressError) -> McpHostHttpError {
     McpHostHttpError::Egress {
         reason: error.stable_runtime_reason().to_string(),
     }
+}
+
+pub trait McpHostHttp: Send + Sync {
+    fn request(&self, request: McpHostHttpRequest)
+    -> Result<McpHostHttpResponse, McpHostHttpError>;
+}
+
+impl<E> McpHostHttp for McpRuntimeHttpAdapter<E>
+where
+    E: RuntimeHttpEgress,
+{
+    fn request(
+        &self,
+        request: McpHostHttpRequest,
+    ) -> Result<McpHostHttpResponse, McpHostHttpError> {
+        McpRuntimeHttpAdapter::request(self, request)
+    }
+}
+
+impl<T> McpHostHttp for Arc<T>
+where
+    T: McpHostHttp + ?Sized,
+{
+    fn request(
+        &self,
+        request: McpHostHttpRequest,
+    ) -> Result<McpHostHttpResponse, McpHostHttpError> {
+        self.as_ref().request(request)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct McpHostHttpEgressPlan {
+    pub network_policy: NetworkPolicy,
+    pub credential_injections: Vec<RuntimeCredentialInjection>,
+    pub response_body_limit: Option<u64>,
+    pub timeout_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct McpHostHttpEgressPlanRequest<'a> {
+    pub provider: &'a ExtensionId,
+    pub capability_id: &'a CapabilityId,
+    pub scope: &'a ResourceScope,
+    pub transport: &'a str,
+    pub method: NetworkMethod,
+    pub url: &'a str,
+    pub headers: &'a [(String, String)],
+    pub body: &'a [u8],
+}
+
+/// Host-owned egress planner for MCP HTTP/SSE requests.
+///
+/// The planner is intentionally separate from [`McpClientRequest::input`]:
+/// runtime/plugin inputs can affect the JSON-RPC body, but only this host-owned
+/// planner can provide network policy, credential handles, response limits, and
+/// timeouts for the shared egress service.
+pub trait McpHostHttpEgressPlanner: Send + Sync {
+    fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan;
+}
+
+impl<T> McpHostHttpEgressPlanner for Arc<T>
+where
+    T: McpHostHttpEgressPlanner + ?Sized,
+{
+    fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan {
+        self.as_ref().plan(request)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StaticMcpHostHttpEgressPlanner {
+    plan: McpHostHttpEgressPlan,
+}
+
+impl StaticMcpHostHttpEgressPlanner {
+    pub fn new(plan: McpHostHttpEgressPlan) -> Self {
+        Self { plan }
+    }
+}
+
+impl McpHostHttpEgressPlanner for StaticMcpHostHttpEgressPlanner {
+    fn plan(&self, _request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan {
+        self.plan.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct McpHostHttpClient<H, P> {
+    http: H,
+    planner: P,
+    state: Arc<McpHostHttpClientState>,
+}
+
+#[derive(Debug)]
+struct McpHostHttpClientState {
+    next_id: AtomicU64,
+    session_ids: Mutex<HashMap<McpHostHttpSessionKey, String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct McpHostHttpSessionKey {
+    tenant_id: String,
+    user_id: String,
+    agent_id: Option<String>,
+    project_id: Option<String>,
+    mission_id: Option<String>,
+    thread_id: Option<String>,
+    invocation_id: String,
+    provider: String,
+    url: String,
+}
+
+impl McpHostHttpSessionKey {
+    fn new(scope: &ResourceScope, provider: &ExtensionId, url: &str) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.as_str().to_string(),
+            user_id: scope.user_id.as_str().to_string(),
+            agent_id: scope.agent_id.as_ref().map(|id| id.as_str().to_string()),
+            project_id: scope.project_id.as_ref().map(|id| id.as_str().to_string()),
+            mission_id: scope.mission_id.as_ref().map(|id| id.as_str().to_string()),
+            thread_id: scope.thread_id.as_ref().map(|id| id.as_str().to_string()),
+            invocation_id: scope.invocation_id.to_string(),
+            provider: provider.as_str().to_string(),
+            url: url.to_string(),
+        }
+    }
+}
+
+impl<H, P> McpHostHttpClient<H, P>
+where
+    H: McpHostHttp,
+    P: McpHostHttpEgressPlanner,
+{
+    pub fn new(http: H, planner: P) -> Self {
+        Self {
+            http,
+            planner,
+            state: Arc::new(McpHostHttpClientState {
+                next_id: AtomicU64::new(1),
+                session_ids: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    fn next_request_id(&self) -> u64 {
+        self.state.next_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn send_json_rpc(
+        &self,
+        request: &McpClientRequest,
+        id: Option<u64>,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<McpJsonRpcExchange, String> {
+        let url = request.url.as_deref().ok_or_else(request_denied)?;
+        let body = encode_json_rpc_request(id, method, params)?;
+        let session_key = McpHostHttpSessionKey::new(&request.scope, &request.provider, url);
+        let mut headers = vec![
+            ("Content-Type".to_string(), "application/json".to_string()),
+            (
+                "Accept".to_string(),
+                "application/json, text/event-stream".to_string(),
+            ),
+        ];
+        if let Some(session_id) = self.current_session_id(&session_key)? {
+            headers.push(("Mcp-Session-Id".to_string(), session_id));
+        }
+
+        let plan = self.planner.plan(McpHostHttpEgressPlanRequest {
+            provider: &request.provider,
+            capability_id: &request.capability_id,
+            scope: &request.scope,
+            transport: &request.transport,
+            method: NetworkMethod::Post,
+            url,
+            headers: &headers,
+            body: &body,
+        });
+
+        let response_body_limit =
+            effective_mcp_response_body_limit(plan.response_body_limit, request.max_output_bytes);
+        let response = self
+            .http
+            .request(McpHostHttpRequest {
+                scope: request.scope.clone(),
+                method: NetworkMethod::Post,
+                url: url.to_string(),
+                headers,
+                body,
+                network_policy: plan.network_policy,
+                credential_injections: plan.credential_injections,
+                response_body_limit,
+                timeout_ms: plan.timeout_ms,
+            })
+            .map_err(mcp_client_http_error)?;
+
+        self.capture_session_id(&session_key, &response)?;
+        let usage = ResourceUsage {
+            network_egress_bytes: response.request_bytes,
+            ..ResourceUsage::default()
+        };
+
+        if response.status == 202 && id.is_none() {
+            return Ok(McpJsonRpcExchange {
+                response: McpJsonRpcResponse {
+                    result: None,
+                    error: false,
+                },
+                usage,
+            });
+        }
+        if !(200..300).contains(&response.status) {
+            return Err(response_error());
+        }
+
+        Ok(McpJsonRpcExchange {
+            response: parse_mcp_response(&response, id)?,
+            usage,
+        })
+    }
+
+    fn current_session_id(
+        &self,
+        session_key: &McpHostHttpSessionKey,
+    ) -> Result<Option<String>, String> {
+        self.state
+            .session_ids
+            .lock()
+            .map(|guard| guard.get(session_key).cloned())
+            .map_err(|_| request_denied())
+    }
+
+    fn capture_session_id(
+        &self,
+        session_key: &McpHostHttpSessionKey,
+        response: &McpHostHttpResponse,
+    ) -> Result<(), String> {
+        let Some((_, value)) = response
+            .headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("Mcp-Session-Id"))
+        else {
+            return Ok(());
+        };
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Ok(());
+        }
+        if !is_safe_mcp_session_id(trimmed) {
+            return Err(response_error());
+        }
+        let mut guard = self
+            .state
+            .session_ids
+            .lock()
+            .map_err(|_| request_denied())?;
+        guard.insert(session_key.clone(), trimmed.to_string());
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<H, P> McpClient for McpHostHttpClient<H, P>
+where
+    H: McpHostHttp,
+    P: McpHostHttpEgressPlanner,
+{
+    fn uses_host_mediated_http_egress(&self) -> bool {
+        true
+    }
+
+    async fn call_tool(&self, request: McpClientRequest) -> Result<McpClientOutput, String> {
+        if !requires_host_http_egress(&request.transport) {
+            return Err(request_denied());
+        }
+
+        let mut usage = ResourceUsage::default();
+        let initialize = self.send_json_rpc(
+            &request,
+            Some(self.next_request_id()),
+            "initialize",
+            Some(json_rpc_initialize_params()),
+        )?;
+        accumulate_usage(&mut usage, initialize.usage);
+        if initialize.response.error {
+            return Err(response_error());
+        }
+
+        let initialized = self.send_json_rpc(&request, None, "notifications/initialized", None)?;
+        accumulate_usage(&mut usage, initialized.usage);
+        if initialized.response.error {
+            return Err(response_error());
+        }
+
+        let tool_name = mcp_tool_name(&request.provider, &request.capability_id);
+        let call = self.send_json_rpc(
+            &request,
+            Some(self.next_request_id()),
+            "tools/call",
+            Some(serde_json::json!({
+                "name": tool_name,
+                "arguments": request.input,
+            })),
+        )?;
+        accumulate_usage(&mut usage, call.usage);
+        if call.response.error {
+            return Err(response_error());
+        }
+        let output = call.response.result.ok_or_else(response_error)?;
+        let output_bytes = serde_json::to_vec(&output)
+            .map(|bytes| bytes.len() as u64)
+            .map_err(|_| response_error())?;
+        usage.output_bytes = usage.output_bytes.max(output_bytes);
+
+        Ok(McpClientOutput {
+            output,
+            usage,
+            output_bytes: Some(output_bytes),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct McpJsonRpcResponse {
+    result: Option<Value>,
+    error: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct McpJsonRpcExchange {
+    response: McpJsonRpcResponse,
+    usage: ResourceUsage,
+}
+
+fn mcp_client_http_error(error: McpHostHttpError) -> String {
+    match error {
+        McpHostHttpError::Egress { reason } => reason,
+    }
+}
+
+fn effective_mcp_response_body_limit(host_limit: Option<u64>, client_limit: u64) -> Option<u64> {
+    Some(match host_limit {
+        Some(limit) => limit.min(client_limit),
+        None => client_limit,
+    })
+}
+
+fn is_safe_mcp_session_id(value: &str) -> bool {
+    const MAX_MCP_SESSION_ID_BYTES: usize = 1024;
+    !value.is_empty()
+        && value.len() <= MAX_MCP_SESSION_ID_BYTES
+        && value.bytes().all(|byte| matches!(byte, 0x21..=0x7e))
+}
+
+fn encode_json_rpc_request(
+    id: Option<u64>,
+    method: &str,
+    params: Option<Value>,
+) -> Result<Vec<u8>, String> {
+    let mut object = serde_json::Map::new();
+    object.insert("jsonrpc".to_string(), Value::String("2.0".to_string()));
+    if let Some(id) = id {
+        object.insert(
+            "id".to_string(),
+            Value::Number(serde_json::Number::from(id)),
+        );
+    }
+    object.insert("method".to_string(), Value::String(method.to_string()));
+    if let Some(params) = params {
+        object.insert("params".to_string(), params);
+    }
+    serde_json::to_vec(&Value::Object(object)).map_err(|_| request_denied())
+}
+
+fn parse_mcp_response(
+    response: &McpHostHttpResponse,
+    expected_id: Option<u64>,
+) -> Result<McpJsonRpcResponse, String> {
+    if response_is_sse(response) {
+        parse_mcp_sse_response(&response.body, expected_id)
+    } else {
+        let value =
+            serde_json::from_slice::<Value>(&response.body).map_err(|_| response_error())?;
+        parse_mcp_json_rpc_value(&value, expected_id)
+    }
+}
+
+fn response_is_sse(response: &McpHostHttpResponse) -> bool {
+    response.headers.iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("content-type")
+            && value.to_ascii_lowercase().contains("text/event-stream")
+    })
+}
+
+fn parse_mcp_sse_response(
+    body: &[u8],
+    expected_id: Option<u64>,
+) -> Result<McpJsonRpcResponse, String> {
+    let text = std::str::from_utf8(body).map_err(|_| response_error())?;
+    for line in text.lines() {
+        let Some(payload) = line.strip_prefix("data:") else {
+            continue;
+        };
+        let value = serde_json::from_str::<Value>(payload.trim()).map_err(|_| response_error())?;
+        let parsed_id = json_rpc_id(&value);
+        if expected_id.is_none() || parsed_id == expected_id {
+            return parse_mcp_json_rpc_value(&value, expected_id);
+        }
+    }
+    Err(response_error())
+}
+
+fn parse_mcp_json_rpc_value(
+    value: &Value,
+    expected_id: Option<u64>,
+) -> Result<McpJsonRpcResponse, String> {
+    let parsed_id = json_rpc_id(value);
+    if let (Some(expected), Some(actual)) = (expected_id, parsed_id)
+        && expected != actual
+    {
+        return Err(response_error());
+    }
+    Ok(McpJsonRpcResponse {
+        result: value.get("result").cloned(),
+        error: value.get("error").is_some(),
+    })
+}
+
+fn json_rpc_id(value: &Value) -> Option<u64> {
+    match value.get("id") {
+        Some(Value::Number(number)) => number.as_u64(),
+        Some(Value::String(value)) => value.parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn json_rpc_initialize_params() -> Value {
+    serde_json::json!({
+        "protocolVersion": "2024-11-05",
+        "capabilities": {
+            "roots": { "listChanged": false },
+            "sampling": {}
+        },
+        "clientInfo": {
+            "name": "ironclaw",
+            "version": env!("CARGO_PKG_VERSION")
+        }
+    })
+}
+
+fn mcp_tool_name(provider: &ExtensionId, capability_id: &CapabilityId) -> String {
+    let prefix = format!("{}.", provider.as_str());
+    capability_id
+        .as_str()
+        .strip_prefix(&prefix)
+        .unwrap_or_else(|| capability_id.as_str())
+        .to_string()
+}
+
+fn accumulate_usage(total: &mut ResourceUsage, usage: ResourceUsage) {
+    total.network_egress_bytes = total
+        .network_egress_bytes
+        .saturating_add(usage.network_egress_bytes);
+    total.output_bytes = total.output_bytes.saturating_add(usage.output_bytes);
+}
+
+fn request_denied() -> String {
+    "request_denied".to_string()
+}
+
+fn response_error() -> String {
+    "response_error".to_string()
 }
 
 /// MCP runtime failures.

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -132,6 +132,313 @@ fn mcp_host_http_adapter_returns_sanitized_shared_egress_errors() {
 }
 
 #[tokio::test]
+async fn concrete_mcp_http_client_routes_json_rpc_through_shared_egress() {
+    let scope = sample_scope();
+    let plan = host_http_plan();
+    let egress = RecordingRuntimeEgress::json_rpc();
+    let planner = RecordingEgressPlanner::new(plan.clone());
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        planner.clone(),
+    );
+
+    assert!(client.uses_host_mediated_http_egress());
+
+    let output = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: scope.clone(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({
+                "query": "ironclaw",
+                "credential_injections": [{"handle": "evil-token"}]
+            }),
+            max_output_bytes: 4096,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        output.output,
+        json!({"content":[{"type":"text","text":"ok"}],"isError":false})
+    );
+
+    let requests = egress.requests();
+    assert_eq!(
+        requests.len(),
+        3,
+        "initialize, initialized notification, tools/call"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.runtime == RuntimeKind::Mcp)
+    );
+    assert!(requests.iter().all(|request| request.scope == scope));
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.network_policy == plan.network_policy)
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.credential_injections == plan.credential_injections)
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.response_body_limit == Some(4096))
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.timeout_ms == Some(2_500))
+    );
+    assert_eq!(json_rpc_method(&requests[0].body), "initialize");
+    assert_eq!(
+        json_rpc_method(&requests[1].body),
+        "notifications/initialized"
+    );
+    assert_eq!(json_rpc_method(&requests[2].body), "tools/call");
+    assert_eq!(json_rpc_param(&requests[2].body, "name"), json!("search"));
+    assert_eq!(
+        json_rpc_param(&requests[2].body, "arguments"),
+        json!({"query":"ironclaw","credential_injections":[{"handle":"evil-token"}]})
+    );
+    assert!(
+        requests[2]
+            .headers
+            .iter()
+            .any(|(name, value)| name == "Mcp-Session-Id" && value == "session-123")
+    );
+    assert!(requests.iter().all(|request| {
+        !request
+            .credential_injections
+            .iter()
+            .any(|injection| injection.handle.as_str() == "evil-token")
+    }));
+
+    let planner_calls = planner.calls();
+    assert_eq!(planner_calls.len(), 3);
+    assert!(planner_calls.iter().all(|call| call.scope == scope));
+    assert!(
+        planner_calls
+            .iter()
+            .all(|call| call.url == "https://mcp.example.test/mcp")
+    );
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_scopes_session_ids_per_invocation() {
+    let egress = ScopedSessionRuntimeEgress::new();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    for user in ["user1", "user2"] {
+        client
+            .call_tool(McpClientRequest {
+                provider: ExtensionId::new("github-mcp").unwrap(),
+                capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+                scope: sample_scope_for_user(user),
+                transport: "http".to_string(),
+                command: None,
+                args: vec![],
+                url: Some("https://mcp.example.test/mcp".to_string()),
+                input: json!({"query": user}),
+                max_output_bytes: 4096,
+            })
+            .await
+            .unwrap();
+    }
+
+    let requests = egress.requests();
+    let user2_requests = requests
+        .iter()
+        .filter(|request| request.scope.user_id.as_str() == "user2")
+        .collect::<Vec<_>>();
+    assert_eq!(user2_requests.len(), 3);
+    assert!(user2_requests.iter().all(|request| {
+        !request
+            .headers
+            .iter()
+            .any(|(_, value)| value == "session-user1")
+    }));
+    assert!(
+        user2_requests
+            .iter()
+            .filter(|request| json_rpc_method(&request.body) == "tools/call")
+            .all(|request| request
+                .headers
+                .iter()
+                .any(|(name, value)| name == "Mcp-Session-Id" && value == "session-user2"))
+    );
+}
+
+#[tokio::test]
+async fn mcp_runtime_with_concrete_http_client_consumes_shared_egress_end_to_end() {
+    let package = package_from_manifest(MCP_MANIFEST);
+    let egress = RecordingRuntimeEgress::json_rpc();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+    let runtime = McpRuntime::new(McpRuntimeConfig::for_testing(), client);
+    let governor = InMemoryResourceGovernor::new();
+
+    let result = runtime
+        .execute_extension_json(
+            &governor,
+            McpExecutionRequest {
+                package: &package,
+                capability_id: &CapabilityId::new("github-mcp.search").unwrap(),
+                scope: sample_scope(),
+                estimate: ResourceEstimate::default(),
+                resource_reservation: None,
+                invocation: McpInvocation {
+                    input: json!({"query": "ironclaw"}),
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.result.output,
+        json!({"content":[{"type":"text","text":"ok"}],"isError":false})
+    );
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 3);
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.runtime == RuntimeKind::Mcp)
+    );
+}
+
+#[tokio::test]
+async fn concrete_mcp_sse_client_parses_event_stream_through_shared_egress() {
+    let egress = RecordingRuntimeEgress::sse();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    let output = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "sse".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/sse".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        output.output,
+        json!({"content":[{"type":"text","text":"ok from sse"}],"isError":false})
+    );
+    assert_eq!(egress.requests().len(), 3);
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_caps_missing_plan_limit_to_client_output_limit() {
+    let mut plan = host_http_plan();
+    plan.response_body_limit = None;
+    let egress = RecordingRuntimeEgress::json_rpc();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        StaticMcpHostHttpEgressPlanner::new(plan),
+    );
+
+    client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 1_234,
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        egress
+            .requests()
+            .iter()
+            .all(|request| request.response_body_limit == Some(1_234))
+    );
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_rejects_invalid_session_id_before_reuse() {
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(InvalidSessionRuntimeEgress)),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    let error = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .expect_err("invalid upstream session ids must not be reused as request headers");
+
+    assert_eq!(error, "response_error");
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_sanitizes_shared_egress_failures() {
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(SecretEchoRuntimeEgress)),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    let error = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .expect_err("raw shared-egress errors must not leak through the MCP client");
+
+    assert_eq!(error, "network_error");
+    assert!(!error.contains("sk-test-secret"));
+    assert!(!error.contains("10.0.0.7"));
+}
+
+#[tokio::test]
 async fn mcp_runtime_fails_closed_for_external_stdio_process_egress() {
     let package = package_from_manifest(STDIO_MCP_MANIFEST);
     let client = RecordingMcpClient::new(Ok(McpClientOutput::json(json!({"ok": true}))));
@@ -488,6 +795,274 @@ impl McpClient for RecordingMcpClient {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordedResponseMode {
+    Json,
+    Sse,
+}
+
+#[derive(Debug, Clone)]
+struct RecordingRuntimeEgress {
+    mode: RecordedResponseMode,
+    requests: Arc<Mutex<Vec<RuntimeHttpEgressRequest>>>,
+}
+
+impl RecordingRuntimeEgress {
+    fn json_rpc() -> Self {
+        Self {
+            mode: RecordedResponseMode::Json,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn sse() -> Self {
+        Self {
+            mode: RecordedResponseMode::Sse,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<RuntimeHttpEgressRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl RuntimeHttpEgress for RecordingRuntimeEgress {
+    fn execute(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        let method = json_rpc_method(&request.body);
+        self.requests.lock().unwrap().push(request.clone());
+        match method.as_str() {
+            "initialize" => Ok(runtime_json_response(
+                Some(1),
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {"listChanged": false}},
+                    "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}
+                }),
+                vec![("Mcp-Session-Id".to_string(), "session-123".to_string())],
+            )),
+            "notifications/initialized" => Ok(RuntimeHttpEgressResponse {
+                status: 202,
+                headers: vec![],
+                body: vec![],
+                request_bytes: request.body.len() as u64,
+                response_bytes: 0,
+                redaction_applied: false,
+            }),
+            "tools/call" => {
+                let id = json_rpc_id(&request.body);
+                match self.mode {
+                    RecordedResponseMode::Json => Ok(runtime_json_response(
+                        id,
+                        json!({"content":[{"type":"text","text":"ok"}],"isError":false}),
+                        vec![],
+                    )),
+                    RecordedResponseMode::Sse => Ok(runtime_sse_response(
+                        id,
+                        json!({"content":[{"type":"text","text":"ok from sse"}],"isError":false}),
+                    )),
+                }
+            }
+            other => panic!("unexpected MCP JSON-RPC method {other}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecordedPlanCall {
+    scope: ResourceScope,
+    method: NetworkMethod,
+    url: String,
+}
+
+#[derive(Debug, Clone)]
+struct RecordingEgressPlanner {
+    plan: McpHostHttpEgressPlan,
+    calls: Arc<Mutex<Vec<RecordedPlanCall>>>,
+}
+
+impl RecordingEgressPlanner {
+    fn new(plan: McpHostHttpEgressPlan) -> Self {
+        Self {
+            plan,
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn calls(&self) -> Vec<RecordedPlanCall> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl McpHostHttpEgressPlanner for RecordingEgressPlanner {
+    fn plan(&self, request: McpHostHttpEgressPlanRequest<'_>) -> McpHostHttpEgressPlan {
+        self.calls.lock().unwrap().push(RecordedPlanCall {
+            scope: request.scope.clone(),
+            method: request.method,
+            url: request.url.to_string(),
+        });
+        self.plan.clone()
+    }
+}
+
+fn host_http_plan() -> McpHostHttpEgressPlan {
+    McpHostHttpEgressPlan {
+        network_policy: mcp_http_policy(),
+        credential_injections: vec![RuntimeCredentialInjection {
+            handle: SecretHandle::new("github-token").unwrap(),
+            target: RuntimeCredentialTarget::Header {
+                name: "Authorization".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            },
+            required: true,
+        }],
+        response_body_limit: Some(4096),
+        timeout_ms: Some(2_500),
+    }
+}
+
+fn json_rpc_method(body: &[u8]) -> String {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .unwrap()
+        .get("method")
+        .and_then(serde_json::Value::as_str)
+        .unwrap()
+        .to_string()
+}
+
+fn json_rpc_id(body: &[u8]) -> Option<u64> {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .unwrap()
+        .get("id")
+        .and_then(serde_json::Value::as_u64)
+}
+
+fn json_rpc_param(body: &[u8], key: &str) -> serde_json::Value {
+    serde_json::from_slice::<serde_json::Value>(body).unwrap()["params"][key].clone()
+}
+
+fn runtime_json_response(
+    id: Option<u64>,
+    result: serde_json::Value,
+    extra_headers: Vec<(String, String)>,
+) -> RuntimeHttpEgressResponse {
+    let mut headers = vec![("content-type".to_string(), "application/json".to_string())];
+    headers.extend(extra_headers);
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    }))
+    .unwrap();
+    RuntimeHttpEgressResponse {
+        status: 200,
+        headers,
+        response_bytes: body.len() as u64,
+        body,
+        request_bytes: 0,
+        redaction_applied: false,
+    }
+}
+
+fn runtime_sse_response(id: Option<u64>, result: serde_json::Value) -> RuntimeHttpEgressResponse {
+    let event = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    });
+    let body = format!("event: message\ndata: {event}\n\n").into_bytes();
+    RuntimeHttpEgressResponse {
+        status: 200,
+        headers: vec![("content-type".to_string(), "text/event-stream".to_string())],
+        response_bytes: body.len() as u64,
+        body,
+        request_bytes: 0,
+        redaction_applied: false,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ScopedSessionRuntimeEgress {
+    requests: Arc<Mutex<Vec<RuntimeHttpEgressRequest>>>,
+}
+
+impl ScopedSessionRuntimeEgress {
+    fn new() -> Self {
+        Self {
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<RuntimeHttpEgressRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl RuntimeHttpEgress for ScopedSessionRuntimeEgress {
+    fn execute(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        let method = json_rpc_method(&request.body);
+        self.requests.lock().unwrap().push(request.clone());
+        match method.as_str() {
+            "initialize" => Ok(runtime_json_response(
+                Some(json_rpc_id(&request.body).unwrap()),
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {"listChanged": false}},
+                    "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}
+                }),
+                vec![(
+                    "Mcp-Session-Id".to_string(),
+                    format!("session-{}", request.scope.user_id.as_str()),
+                )],
+            )),
+            "notifications/initialized" => Ok(RuntimeHttpEgressResponse {
+                status: 202,
+                headers: vec![],
+                body: vec![],
+                request_bytes: request.body.len() as u64,
+                response_bytes: 0,
+                redaction_applied: false,
+            }),
+            "tools/call" => Ok(runtime_json_response(
+                json_rpc_id(&request.body),
+                json!({"content":[{"type":"text","text":"ok"}],"isError":false}),
+                vec![],
+            )),
+            other => panic!("unexpected MCP JSON-RPC method {other}"),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct InvalidSessionRuntimeEgress;
+
+impl RuntimeHttpEgress for InvalidSessionRuntimeEgress {
+    fn execute(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        assert_eq!(json_rpc_method(&request.body), "initialize");
+        Ok(runtime_json_response(
+            Some(1),
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {"listChanged": false}},
+                "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}
+            }),
+            vec![(
+                "Mcp-Session-Id".to_string(),
+                "bad\r\nInjected: yes".to_string(),
+            )],
+        ))
+    }
+}
+
 #[derive(Debug)]
 struct SecretEchoRuntimeEgress;
 
@@ -570,6 +1145,13 @@ fn sample_scope() -> ResourceScope {
         thread_id: None,
         invocation_id: InvocationId::new(),
     }
+}
+
+fn sample_scope_for_user(user_id: &str) -> ResourceScope {
+    let mut scope = sample_scope();
+    scope.user_id = UserId::new(user_id).unwrap();
+    scope.invocation_id = InvocationId::new();
+    scope
 }
 
 fn mcp_http_policy() -> NetworkPolicy {

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -282,6 +282,124 @@ async fn concrete_mcp_http_client_scopes_session_ids_per_invocation() {
 }
 
 #[tokio::test]
+async fn concrete_mcp_http_client_clears_session_ids_between_calls() {
+    let egress = ScopedSessionRuntimeEgress::new();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+    let scope = sample_scope();
+
+    for query in ["first", "second"] {
+        client
+            .call_tool(McpClientRequest {
+                provider: ExtensionId::new("github-mcp").unwrap(),
+                capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+                scope: scope.clone(),
+                transport: "http".to_string(),
+                command: None,
+                args: vec![],
+                url: Some("https://mcp.example.test/mcp".to_string()),
+                input: json!({"query": query}),
+                max_output_bytes: 4096,
+            })
+            .await
+            .unwrap();
+    }
+
+    let requests = egress.requests();
+    let initialize_requests = requests
+        .iter()
+        .filter(|request| json_rpc_method(&request.body) == "initialize")
+        .collect::<Vec<_>>();
+    assert_eq!(initialize_requests.len(), 2);
+    assert!(initialize_requests.iter().all(|request| {
+        !request
+            .headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("Mcp-Session-Id"))
+    }));
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_does_not_reuse_session_from_failed_initialize() {
+    let egress = ErrorSessionRuntimeEgress::new();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+    let scope = sample_scope();
+
+    let error = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: scope.clone(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "first"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .expect_err("failed initialize responses must fail the call");
+    assert_eq!(error, "response_error");
+
+    client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope,
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "second"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .unwrap();
+
+    let requests = egress.requests();
+    let initialize_requests = requests
+        .iter()
+        .filter(|request| json_rpc_method(&request.body) == "initialize")
+        .collect::<Vec<_>>();
+    assert_eq!(initialize_requests.len(), 2);
+    assert!(initialize_requests.iter().all(|request| {
+        !request.headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("Mcp-Session-Id") && value == "session-from-error"
+        })
+    }));
+}
+
+#[tokio::test]
+async fn concrete_mcp_http_client_rejects_json_rpc_response_without_matching_id() {
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(MissingIdRuntimeEgress)),
+        StaticMcpHostHttpEgressPlanner::new(host_http_plan()),
+    );
+
+    let error = client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope: sample_scope(),
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .expect_err("ID-bearing JSON-RPC requests must reject missing response ids");
+
+    assert_eq!(error, "response_error");
+}
+
+#[tokio::test]
 async fn mcp_runtime_with_concrete_http_client_consumes_shared_egress_end_to_end() {
     let package = package_from_manifest(MCP_MANIFEST);
     let egress = RecordingRuntimeEgress::json_rpc();
@@ -1060,6 +1178,113 @@ impl RuntimeHttpEgress for InvalidSessionRuntimeEgress {
                 "bad\r\nInjected: yes".to_string(),
             )],
         ))
+    }
+}
+
+#[derive(Debug)]
+struct MissingIdRuntimeEgress;
+
+impl RuntimeHttpEgress for MissingIdRuntimeEgress {
+    fn execute(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        match json_rpc_method(&request.body).as_str() {
+            "initialize" => Ok(runtime_json_response(
+                json_rpc_id(&request.body),
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {"listChanged": false}},
+                    "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}
+                }),
+                vec![],
+            )),
+            "notifications/initialized" => Ok(RuntimeHttpEgressResponse {
+                status: 202,
+                headers: vec![],
+                body: vec![],
+                request_bytes: request.body.len() as u64,
+                response_bytes: 0,
+                redaction_applied: false,
+            }),
+            "tools/call" => Ok(runtime_json_response(
+                None,
+                json!({"content":[{"type":"text","text":"missing id"}],"isError":false}),
+                vec![],
+            )),
+            other => panic!("unexpected MCP JSON-RPC method {other}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ErrorSessionRuntimeEgress {
+    requests: Arc<Mutex<Vec<RuntimeHttpEgressRequest>>>,
+    initialize_count: Arc<Mutex<u32>>,
+}
+
+impl ErrorSessionRuntimeEgress {
+    fn new() -> Self {
+        Self {
+            requests: Arc::new(Mutex::new(Vec::new())),
+            initialize_count: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    fn requests(&self) -> Vec<RuntimeHttpEgressRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl RuntimeHttpEgress for ErrorSessionRuntimeEgress {
+    fn execute(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        let method = json_rpc_method(&request.body);
+        self.requests.lock().unwrap().push(request.clone());
+        match method.as_str() {
+            "initialize" => {
+                let mut initialize_count = self.initialize_count.lock().unwrap();
+                *initialize_count += 1;
+                if *initialize_count == 1 {
+                    return Ok(RuntimeHttpEgressResponse {
+                        status: 500,
+                        headers: vec![(
+                            "Mcp-Session-Id".to_string(),
+                            "session-from-error".to_string(),
+                        )],
+                        body: b"server error".to_vec(),
+                        request_bytes: request.body.len() as u64,
+                        response_bytes: "server error".len() as u64,
+                        redaction_applied: false,
+                    });
+                }
+                Ok(runtime_json_response(
+                    json_rpc_id(&request.body),
+                    json!({
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {"listChanged": false}},
+                        "serverInfo": {"name": "mock-mcp", "version": "1.0.0"}
+                    }),
+                    vec![("Mcp-Session-Id".to_string(), "session-good".to_string())],
+                ))
+            }
+            "notifications/initialized" => Ok(RuntimeHttpEgressResponse {
+                status: 202,
+                headers: vec![],
+                body: vec![],
+                request_bytes: request.body.len() as u64,
+                response_bytes: 0,
+                redaction_applied: false,
+            }),
+            "tools/call" => Ok(runtime_json_response(
+                json_rpc_id(&request.body),
+                json!({"content":[{"type":"text","text":"ok"}],"isError":false}),
+                vec![],
+            )),
+            other => panic!("unexpected MCP JSON-RPC method {other}"),
+        }
     }
 }
 

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -33,3 +33,5 @@ Supported built-in behavior:
 ## Runtime HTTP egress
 
 Runtime HTTP remains host-mediated through `RuntimeHttpEgress` and `HostHttpEgressService`. Runtime code must not perform ad-hoc DNS/private-IP checks or direct HTTP clients; `ironclaw_network` owns network policy enforcement and `ironclaw_secrets` owns secret lease/consume semantics.
+
+MCP HTTP/SSE follows the same rule through `ironclaw_mcp::McpHostHttpClient`: the host supplies an `McpRuntimeHttpAdapter<RuntimeHttpEgress>` and an egress planner for scoped network policy, credential injection handles, response body limits, and timeouts. Generic or direct-network MCP clients keep `uses_host_mediated_http_egress() == false`, so `McpRuntime` rejects HTTP/SSE manifests before any outbound attempt.

--- a/docs/reborn/contracts/network.md
+++ b/docs/reborn/contracts/network.md
@@ -134,7 +134,7 @@ This slice does not implement:
 - per-tenant persisted policy stores
 - OAuth/token refresh flows
 
-Those should be added as separate service/composition slices without moving runtime execution or product workflow semantics into this crate. Runtime adapters that wrap external protocol clients, such as MCP HTTP/SSE, must fail closed unless the host-selected client explicitly uses this host-mediated egress boundary rather than ambient direct HTTP.
+Those should be added as separate service/composition slices without moving runtime execution or product workflow semantics into this crate. Runtime adapters that wrap external protocol clients must fail closed unless the host-selected client explicitly uses this host-mediated egress boundary rather than ambient direct HTTP. Reborn MCP HTTP/SSE uses `ironclaw_mcp::McpHostHttpClient` with `McpRuntimeHttpAdapter<RuntimeHttpEgress>` plus a host-owned egress planner; only that fully host-mediated client may report `uses_host_mediated_http_egress() == true`.
 
 ---
 

--- a/src/tools/mcp/http_transport.rs
+++ b/src/tools/mcp/http_transport.rs
@@ -147,6 +147,13 @@ impl McpTransport for HttpMcpTransport {
                 .get("Mcp-Session-Id")
                 .and_then(|v| v.to_str().ok())
         {
+            let session_id = session_id.trim();
+            if !is_safe_mcp_session_id(session_id) {
+                return Err(ToolError::ExternalService(format!(
+                    "[{}] MCP server returned invalid session id",
+                    self.server_name
+                )));
+            }
             session_manager
                 .update_session_id(user_id, &self.server_name, Some(session_id.to_string()))
                 .await;
@@ -286,6 +293,13 @@ impl HttpMcpTransport {
 ///
 /// See #263 — raw HTML error pages were propagating through the error
 /// chain into the web UI, causing a white screen.
+fn is_safe_mcp_session_id(value: &str) -> bool {
+    const MAX_MCP_SESSION_ID_BYTES: usize = 1024;
+    !value.is_empty()
+        && value.len() <= MAX_MCP_SESSION_ID_BYTES
+        && value.bytes().all(|byte| matches!(byte, 0x21..=0x7e))
+}
+
 pub(crate) fn sanitize_error_body(body: &str) -> String {
     const MAX_CHARS: usize = 200;
 
@@ -558,6 +572,52 @@ mod tests {
     /// Regression test for #1436: 202 Accepted responses for notifications
     /// were parsed as JSON, causing "Failed to parse MCP response" errors
     /// that broke the MCP session handshake.
+    #[tokio::test]
+    async fn test_wire_rejects_invalid_session_id_before_storing() {
+        use axum::{Router, http::HeaderMap, response::IntoResponse, routing::post};
+        use tokio::net::TcpListener;
+
+        async fn invalid_session_response() -> impl IntoResponse {
+            let mut headers = HeaderMap::new();
+            headers.insert("Mcp-Session-Id", "bad session".parse().unwrap());
+            (
+                headers,
+                axum::Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {"listChanged": false}},
+                        "serverInfo": {"name": "mock", "version": "1"}
+                    }
+                })),
+            )
+        }
+
+        let app = Router::new().route("/", post(invalid_session_response));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://127.0.0.1:{}", addr.port());
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let session_manager = Arc::new(McpSessionManager::new());
+        let transport = HttpMcpTransport::new(&url, "invalidsession")
+            .with_session_manager(Arc::clone(&session_manager), "user-a");
+        let request = McpRequest::initialize(1);
+
+        let error = transport.send(&request, &HashMap::new()).await.unwrap_err();
+
+        assert!(error.to_string().contains("invalid session id"));
+        assert_eq!(
+            session_manager
+                .get_session_id("user-a", &McpServerName::new("invalidsession").unwrap())
+                .await,
+            None
+        );
+    }
+
     #[tokio::test]
     async fn test_wire_202_accepted_for_notification() {
         use axum::{Router, http::StatusCode, routing::post};

--- a/src/tools/mcp/http_transport.rs
+++ b/src/tools/mcp/http_transport.rs
@@ -135,7 +135,18 @@ impl McpTransport for HttpMcpTransport {
             ToolError::ExternalService(chain)
         })?;
 
-        // Extract session ID from response headers before consuming the body.
+        // Handle error status codes before accepting any session state from the response.
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            let sanitized = sanitize_error_body(&body);
+            return Err(ToolError::ExternalService(format!(
+                "[{}] MCP server returned status: {} - {}",
+                self.server_name, status, sanitized
+            )));
+        }
+
+        // Extract session ID from successful response headers before consuming the body.
         // Scope by `(session_user_id, server_name)` so a second user's
         // initialize handshake can't overwrite the first user's stored
         // session ID and silently redirect their subsequent requests to
@@ -157,17 +168,6 @@ impl McpTransport for HttpMcpTransport {
             session_manager
                 .update_session_id(user_id, &self.server_name, Some(session_id.to_string()))
                 .await;
-        }
-
-        // Handle error status codes.
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            let sanitized = sanitize_error_body(&body);
-            return Err(ToolError::ExternalService(format!(
-                "[{}] MCP server returned status: {} - {}",
-                self.server_name, status, sanitized
-            )));
         }
 
         // MCP notifications commonly acknowledge with 202 Accepted and no body.
@@ -614,6 +614,49 @@ mod tests {
             session_manager
                 .get_session_id("user-a", &McpServerName::new("invalidsession").unwrap())
                 .await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wire_does_not_store_session_id_from_error_status() {
+        use axum::{Router, response::IntoResponse, routing::post};
+        use tokio::net::TcpListener;
+
+        async fn error_session_response() -> impl IntoResponse {
+            let mut response = (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "server error",
+            )
+                .into_response();
+            response
+                .headers_mut()
+                .insert("Mcp-Session-Id", "session-from-error".parse().unwrap());
+            response
+        }
+
+        let app = Router::new().route("/", post(error_session_response));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://127.0.0.1:{}", addr.port());
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let session_manager = Arc::new(McpSessionManager::new());
+        let server_name = McpServerName::new("errorsession").unwrap();
+        session_manager
+            .get_or_create("user-a", &server_name, &url)
+            .await;
+        let transport = HttpMcpTransport::new(&url, "errorsession")
+            .with_session_manager(Arc::clone(&session_manager), "user-a");
+        let request = McpRequest::initialize(1);
+
+        let error = transport.send(&request, &HashMap::new()).await.unwrap_err();
+
+        assert!(error.to_string().contains("500"));
+        assert_eq!(
+            session_manager.get_session_id("user-a", &server_name).await,
             None
         );
     }


### PR DESCRIPTION
## Summary

- Adds a concrete Reborn `McpHostHttpClient` that implements `McpClient` for HTTP/SSE MCP transports by sending MCP JSON-RPC through `McpRuntimeHttpAdapter` / shared `RuntimeHttpEgress`.
- Adds a host-owned `McpHostHttpEgressPlanner` seam for per-request `ResourceScope`, `NetworkPolicy`, credential injection handles, response body limits, and timeouts; runtime/plugin input cannot invent secret handles.
- Keeps HTTP/SSE fail-closed for generic/direct clients and stdio/process transports; the new client is the only MCP client in this crate that reports `uses_host_mediated_http_egress() == true`.
- Parses JSON and SSE MCP responses with stable runtime-visible error categories, clamps missing host response limits to `max_output_bytes`, scopes MCP session ids by invocation/provider/url, and validates session ids before reuse.
- Hardens the legacy v1 `HttpMcpTransport` session-id capture with the same validation guard.

Closes #3137

## Verification

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-reborn-mcp-http-egress-target cargo test -p ironclaw_mcp`
- `CARGO_TARGET_DIR=/tmp/ironclaw-reborn-mcp-http-egress-target cargo test -p ironclaw --lib tools::mcp::http_transport`
- `CARGO_TARGET_DIR=/tmp/ironclaw-reborn-mcp-http-egress-target cargo clippy -q -p ironclaw_mcp --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-reborn-mcp-http-egress-target cargo clippy -q -p ironclaw --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-reborn-mcp-http-egress-target cargo test -p ironclaw_architecture`
- `git diff --check`

## Notes

- No direct HTTP/DNS/private-IP logic or HTTP client dependency was added to `ironclaw_mcp`; shared host egress and `ironclaw_network` remain the only network boundary.
- HTTP vs HTTPS remains governed by host-supplied `NetworkPolicy`; this PR does not change the manifest URL policy semantics.
