### PR TITLE
feat(reborn): compose built-in obligation services

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -48,8 +48,8 @@ mod obligations;
 mod production;
 
 pub use obligations::{
-    BuiltinObligationHandler, NetworkObligationPolicyStore, RuntimeSecretInjectionStore,
-    RuntimeSecretInjectionStoreError,
+    BuiltinObligationHandler, BuiltinObligationServices, NetworkObligationPolicyStore,
+    RuntimeSecretInjectionStore, RuntimeSecretInjectionStoreError,
 };
 pub use production::DefaultHostRuntime;
 

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -193,6 +193,95 @@ impl NetworkPolicyKey {
     }
 }
 
+/// Host-runtime-owned backing services for a fully configured built-in obligation handler.
+///
+/// This value is the production composition seam for obligation handling. It
+/// keeps the in-memory network-policy and runtime-secret handoff stores alive
+/// outside the handler so runtime adapters can consume the exact staged state
+/// that [`BuiltinObligationHandler`] prepares before dispatch.
+#[derive(Clone)]
+pub struct BuiltinObligationServices {
+    audit_sink: Arc<dyn AuditSink>,
+    network_policies: Arc<NetworkObligationPolicyStore>,
+    secret_store: Arc<dyn SecretStore>,
+    secret_injections: Arc<RuntimeSecretInjectionStore>,
+    resource_governor: Arc<dyn ResourceGovernor>,
+}
+
+impl BuiltinObligationServices {
+    pub fn new(
+        audit_sink: Arc<dyn AuditSink>,
+        secret_store: Arc<dyn SecretStore>,
+        resource_governor: Arc<dyn ResourceGovernor>,
+    ) -> Self {
+        Self::with_handoff_stores(
+            audit_sink,
+            Arc::new(NetworkObligationPolicyStore::new()),
+            secret_store,
+            Arc::new(RuntimeSecretInjectionStore::new()),
+            resource_governor,
+        )
+    }
+
+    pub fn with_handoff_stores(
+        audit_sink: Arc<dyn AuditSink>,
+        network_policies: Arc<NetworkObligationPolicyStore>,
+        secret_store: Arc<dyn SecretStore>,
+        secret_injections: Arc<RuntimeSecretInjectionStore>,
+        resource_governor: Arc<dyn ResourceGovernor>,
+    ) -> Self {
+        Self {
+            audit_sink,
+            network_policies,
+            secret_store,
+            secret_injections,
+            resource_governor,
+        }
+    }
+
+    pub fn audit_sink(&self) -> Arc<dyn AuditSink> {
+        self.audit_sink.clone()
+    }
+
+    pub fn network_policy_store(&self) -> Arc<NetworkObligationPolicyStore> {
+        self.network_policies.clone()
+    }
+
+    pub fn secret_store(&self) -> Arc<dyn SecretStore> {
+        self.secret_store.clone()
+    }
+
+    pub fn secret_injection_store(&self) -> Arc<RuntimeSecretInjectionStore> {
+        self.secret_injections.clone()
+    }
+
+    pub fn resource_governor(&self) -> Arc<dyn ResourceGovernor> {
+        self.resource_governor.clone()
+    }
+
+    pub fn obligation_handler(&self) -> BuiltinObligationHandler {
+        BuiltinObligationHandler::new()
+            .with_audit_sink_dyn(self.audit_sink.clone())
+            .with_network_policy_store(self.network_policies.clone())
+            .with_secret_store_dyn(self.secret_store.clone())
+            .with_secret_injection_store(self.secret_injections.clone())
+            .with_resource_governor_dyn(self.resource_governor.clone())
+    }
+}
+
+impl fmt::Debug for BuiltinObligationServices {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BuiltinObligationServices")
+            .field("audit_sink", &"<audit_sink>")
+            .field("network_policies", &self.network_policies)
+            .field("secret_store", &"[REDACTED]")
+            .field("secret_injections", &self.secret_injections)
+            .field("resource_governor", &"<resource_governor>")
+            .finish()
+    }
+}
+
 /// Built-in obligation handler for the current host-runtime slice.
 #[derive(Clone, Default)]
 pub struct BuiltinObligationHandler {

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -29,12 +29,12 @@ use ironclaw_processes::{
 use ironclaw_run_state::{ApprovalRequestStore, RunStateError, RunStateStore, RunStatus};
 
 use crate::{
-    BuiltinObligationHandler, CancelRuntimeWorkOutcome, CancelRuntimeWorkRequest,
-    CapabilitySurfaceVersion, HostRuntime, HostRuntimeError, HostRuntimeHealth, HostRuntimeStatus,
-    RuntimeApprovalGate, RuntimeBackendHealth, RuntimeBlockedReason, RuntimeCapabilityCompleted,
-    RuntimeCapabilityFailure, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
-    RuntimeFailureKind, RuntimeStatusRequest, RuntimeWorkId, RuntimeWorkSummary,
-    VisibleCapabilityRequest, VisibleCapabilitySurface,
+    BuiltinObligationHandler, BuiltinObligationServices, CancelRuntimeWorkOutcome,
+    CancelRuntimeWorkRequest, CapabilitySurfaceVersion, HostRuntime, HostRuntimeError,
+    HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalGate, RuntimeBackendHealth,
+    RuntimeBlockedReason, RuntimeCapabilityCompleted, RuntimeCapabilityFailure,
+    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind, RuntimeStatusRequest,
+    RuntimeWorkId, RuntimeWorkSummary, VisibleCapabilityRequest, VisibleCapabilitySurface,
 };
 
 /// Default production wiring for [`HostRuntime`].
@@ -168,10 +168,21 @@ impl DefaultHostRuntime {
         self
     }
 
+    /// Installs a fully configured built-in obligation handler using the shared
+    /// service graph supplied by host-runtime composition.
+    ///
+    /// The `services` value owns the handoff stores that runtime adapters and
+    /// HTTP egress wiring will consume, while the installed handler receives
+    /// clones of the same stores for staging obligations before dispatch.
+    pub fn with_builtin_obligation_services(self, services: &BuiltinObligationServices) -> Self {
+        self.with_obligation_handler(Arc::new(services.obligation_handler()))
+    }
+
     /// Installs the default built-in obligation handler with no optional backing
     /// stores. Obligations requiring audit/network/secret/resource backing still
     /// fail closed until the caller supplies a fully configured handler through
-    /// [`Self::with_obligation_handler`] or [`Self::with_obligation_handler_dyn`].
+    /// [`Self::with_builtin_obligation_services`], [`Self::with_obligation_handler`],
+    /// or [`Self::with_obligation_handler_dyn`].
     pub fn with_builtin_obligation_handler(self) -> Self {
         self.with_obligation_handler(Arc::new(BuiltinObligationHandler::new()))
     }

--- a/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/obligation_services_composition_contract.rs
@@ -1,0 +1,282 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_authorization::TrustAwareCapabilityDispatchAuthorizer;
+use ironclaw_events::InMemoryAuditSink;
+use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry};
+use ironclaw_host_api::*;
+use ironclaw_host_runtime::{
+    BuiltinObligationServices, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime,
+    NetworkObligationPolicyStore, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    RuntimeSecretInjectionStore,
+};
+use ironclaw_resources::{InMemoryResourceGovernor, ResourceGovernor};
+use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
+use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+use secrecy::ExposeSecret;
+use serde_json::json;
+
+#[tokio::test]
+async fn default_runtime_installs_configured_builtin_obligation_services() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let audit_sink = Arc::new(InMemoryAuditSink::new());
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let resource_governor = Arc::new(InMemoryResourceGovernor::new());
+    let services = BuiltinObligationServices::new(
+        audit_sink.clone(),
+        secret_store.clone(),
+        resource_governor.clone(),
+    );
+
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let expected_policy = NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "api.example.com".to_string(),
+            port: Some(443),
+        }],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(2048),
+    };
+    let reservation_id = ResourceReservationId::new();
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
+        Arc::new(ObligatingAuthorizer {
+            policy: expected_policy.clone(),
+            secret_handle: secret_handle.clone(),
+            reservation_id,
+        });
+    let dispatcher = Arc::new(ObligationAwareDispatcher::new(
+        services.network_policy_store(),
+        services.secret_injection_store(),
+        resource_governor.clone(),
+        expected_policy,
+        secret_handle.clone(),
+    ));
+
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_builtin_obligation_services(&services);
+
+    let context = execution_context_with_dispatch_grant();
+    secret_store
+        .put(
+            context.resource_scope.clone(),
+            secret_handle,
+            SecretMaterial::from("runtime-secret"),
+        )
+        .await
+        .unwrap();
+
+    let request = RuntimeCapabilityRequest::new(
+        context,
+        capability_id(),
+        ResourceEstimate::default(),
+        json!({"message": "hello"}),
+        trust_decision_with_dispatch_authority(),
+    );
+
+    let outcome = runtime.invoke_capability(request).await.unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.capability_id, capability_id());
+            assert_eq!(completed.output, json!({"ok": true}));
+        }
+        other => panic!("expected completed outcome, got {other:?}"),
+    }
+    assert!(dispatcher.dispatched_with_staged_handoffs());
+    assert_eq!(audit_sink.records().len(), 1);
+    assert_eq!(audit_sink.records()[0].stage, AuditStage::Before);
+}
+
+struct ObligatingAuthorizer {
+    policy: NetworkPolicy,
+    secret_handle: SecretHandle,
+    reservation_id: ResourceReservationId,
+}
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for ObligatingAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        _context: &ExecutionContext,
+        _descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+        _trust_decision: &TrustDecision,
+    ) -> Decision {
+        Decision::Allow {
+            obligations: Obligations::new(vec![
+                Obligation::AuditBefore,
+                Obligation::ReserveResources {
+                    reservation_id: self.reservation_id,
+                },
+                Obligation::ApplyNetworkPolicy {
+                    policy: self.policy.clone(),
+                },
+                Obligation::InjectSecretOnce {
+                    handle: self.secret_handle.clone(),
+                },
+            ])
+            .unwrap(),
+        }
+    }
+}
+
+struct ObligationAwareDispatcher {
+    network_policies: Arc<NetworkObligationPolicyStore>,
+    secret_injections: Arc<RuntimeSecretInjectionStore>,
+    resource_governor: Arc<InMemoryResourceGovernor>,
+    expected_policy: NetworkPolicy,
+    secret_handle: SecretHandle,
+    dispatched: Mutex<bool>,
+}
+
+impl ObligationAwareDispatcher {
+    fn new(
+        network_policies: Arc<NetworkObligationPolicyStore>,
+        secret_injections: Arc<RuntimeSecretInjectionStore>,
+        resource_governor: Arc<InMemoryResourceGovernor>,
+        expected_policy: NetworkPolicy,
+        secret_handle: SecretHandle,
+    ) -> Self {
+        Self {
+            network_policies,
+            secret_injections,
+            resource_governor,
+            expected_policy,
+            secret_handle,
+            dispatched: Mutex::new(false),
+        }
+    }
+
+    fn dispatched_with_staged_handoffs(&self) -> bool {
+        *self
+            .dispatched
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+#[async_trait]
+impl CapabilityDispatcher for ObligationAwareDispatcher {
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        let policy = self
+            .network_policies
+            .take(&request.scope, &request.capability_id)
+            .expect("configured obligation store should stage network policy");
+        assert_eq!(policy, self.expected_policy);
+
+        let material = self
+            .secret_injections
+            .take(&request.scope, &request.capability_id, &self.secret_handle)
+            .unwrap()
+            .expect("configured obligation store should stage one-shot secret material");
+        assert_eq!(material.expose_secret(), "runtime-secret");
+
+        let reservation = request
+            .resource_reservation
+            .as_ref()
+            .expect("configured resource governor should reserve before dispatch");
+        let receipt = self.resource_governor.release(reservation.id).unwrap();
+        *self
+            .dispatched
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+
+        Ok(CapabilityDispatchResult {
+            capability_id: request.capability_id,
+            provider: extension_id(),
+            runtime: RuntimeKind::Wasm,
+            output: json!({"ok": true}),
+            usage: ResourceUsage::default(),
+            receipt,
+        })
+    }
+}
+
+fn registry_with_echo_capability() -> ExtensionRegistry {
+    let manifest = ExtensionManifest::parse(ECHO_MANIFEST).unwrap();
+    let package = ExtensionPackage::from_manifest(
+        manifest,
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package).unwrap();
+    registry
+}
+
+fn execution_context_with_dispatch_grant() -> ExecutionContext {
+    let mut grants = CapabilitySet::default();
+    grants.grants.push(CapabilityGrant {
+        id: CapabilityGrantId::new(),
+        capability: capability_id(),
+        grantee: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        issued_by: Principal::HostRuntime,
+        constraints: GrantConstraints {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            mounts: MountView::default(),
+            network: NetworkPolicy::default(),
+            secrets: Vec::new(),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
+    });
+    ExecutionContext::local_default(
+        UserId::new("user").unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::Wasm,
+        TrustClass::UserTrusted,
+        grants,
+        MountView::default(),
+    )
+    .unwrap()
+}
+
+fn trust_decision_with_dispatch_authority() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::user_trusted(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            max_resource_ceiling: None,
+        },
+        provenance: TrustProvenance::Default,
+        evaluated_at: Utc::now(),
+    }
+}
+
+fn capability_id() -> CapabilityId {
+    CapabilityId::new("echo.say").unwrap()
+}
+
+fn extension_id() -> ExtensionId {
+    ExtensionId::new("echo").unwrap()
+}
+
+const ECHO_MANIFEST: &str = r#"
+id = "echo"
+name = "Echo"
+version = "0.1.0"
+description = "Echo test extension"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "echo.wasm"
+
+[[capabilities]]
+id = "echo.say"
+description = "Echoes input"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = {}
+"#;

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -6,7 +6,9 @@
 
 `DefaultHostRuntime` may be configured with a `CapabilityObligationHandler` through `with_obligation_handler(...)`. It forwards the handler into `CapabilityHost` for capability invocations.
 
-`BuiltinObligationHandler` is the default host-owned implementation for current V1 obligations. It is deliberately fail-closed: obligations that require backing services fail unless the corresponding store/sink/governor is configured.
+Production/service-graph construction should prefer `BuiltinObligationServices` plus `DefaultHostRuntime::with_builtin_obligation_services(...)`. `BuiltinObligationServices` requires an audit sink, secret store, and resource governor at construction time, creates the network-policy and runtime-secret handoff stores, and exposes cloned store handles for runtime adapters/HTTP egress to consume the exact state staged by the handler.
+
+`BuiltinObligationHandler` is the default host-owned implementation for current V1 obligations. It is deliberately fail-closed: obligations that require backing services fail unless the corresponding store/sink/governor is configured. The convenience `with_builtin_obligation_handler()` installs an explicit empty/dev handler and keeps those obligations fail-closed until a fully configured services value is supplied.
 
 Supported built-in behavior:
 


### PR DESCRIPTION
## Summary

- add `BuiltinObligationServices` as the host-runtime-owned service graph for configured obligation handling
- wire `DefaultHostRuntime::with_builtin_obligation_services(...)` to install a handler backed by shared audit/network/secret/resource services
- add a caller-level host-runtime test proving staged network policy, one-shot secret material, resource reservation, and audit flow through the configured handler
- document the production composition seam and explicit empty/dev fallback

Closes #3143.

## Verification

- `cargo test -p ironclaw_host_runtime --test obligation_services_composition_contract`
- `cargo test -p ironclaw_host_runtime`
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings`
- `python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
- `git diff --check`
