### PR TITLE
feat(reborn): evaluate host trust before capability dispatch

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -259,13 +259,14 @@ pub struct RuntimeCapabilityRequest {
     /// The host runtime still validates and forwards the key into
     /// observability spans for audit/tracing.
     pub idempotency_key: Option<IdempotencyKey>,
-    /// Host-controlled trust decision for the package providing this capability.
+    /// Legacy caller-supplied trust decision kept for transitional request-shape
+    /// compatibility.
     ///
-    /// The host evaluates trust against its own policy before constructing this
-    /// request — callers must not synthesize trust decisions or override the
-    /// host's policy. The decision flows through to the underlying capability
-    /// host so authorization, approval, and authority ceiling are derived from
-    /// the host-validated trust posture, not caller-asserted claims.
+    /// [`DefaultHostRuntime`](crate::DefaultHostRuntime) ignores this value: it
+    /// resolves the capability provider's package identity, evaluates the
+    /// host-owned policy, stamps the resulting effective trust onto the
+    /// execution context, and passes that host-owned decision to the capability
+    /// host. Callers must not rely on this field to widen or narrow authority.
     pub trust_decision: TrustDecision,
 }
 

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -31,10 +31,7 @@ use ironclaw_processes::{
     ProcessStatus, ProcessStore,
 };
 use ironclaw_run_state::{ApprovalRequestStore, RunStateError, RunStateStore, RunStatus};
-use ironclaw_trust::{
-    AuthorityCeiling, EffectiveTrustClass, HostTrustPolicy, TrustDecision, TrustError, TrustPolicy,
-    TrustProvenance,
-};
+use ironclaw_trust::{HostTrustPolicy, TrustDecision, TrustError, TrustPolicy, TrustProvenance};
 
 use crate::{
     BuiltinObligationHandler, BuiltinObligationServices, CancelRuntimeWorkOutcome,
@@ -247,8 +244,7 @@ impl HostRuntime for DefaultHostRuntime {
         }
 
         let trust_decision = match self.evaluate_invocation_trust(&capability_id) {
-            Ok(Some(host_decision)) => host_decision,
-            Ok(None) => unknown_capability_trust_decision(),
+            Ok(host_decision) => host_decision,
             Err(error) => {
                 tracing::debug!(
                     capability_id = %capability_id,
@@ -484,12 +480,13 @@ impl DefaultHostRuntime {
     fn evaluate_invocation_trust(
         &self,
         capability_id: &CapabilityId,
-    ) -> Result<Option<TrustDecision>, TrustEvaluationError> {
+    ) -> Result<TrustDecision, TrustEvaluationError> {
         let policy = self.trust_policy.as_ref();
 
-        let Some(descriptor) = self.registry.get_capability(capability_id) else {
-            return Ok(None);
-        };
+        let descriptor = self
+            .registry
+            .get_capability(capability_id)
+            .ok_or(TrustEvaluationError::UnknownCapability)?;
         let package = self
             .registry
             .get_extension(&descriptor.provider)
@@ -516,7 +513,7 @@ impl DefaultHostRuntime {
             }
         };
         trace_trust_decision(capability_id, &decision);
-        Ok(Some(decision))
+        Ok(decision)
     }
 
     async fn translate_invocation_error(
@@ -582,6 +579,7 @@ impl DefaultHostRuntime {
 
 #[derive(Debug, Clone, Copy)]
 enum TrustEvaluationError {
+    UnknownCapability,
     MissingPackage,
     StalePackageDescriptor,
     ConflictingPackageDescriptor,
@@ -592,6 +590,7 @@ enum TrustEvaluationError {
 impl TrustEvaluationError {
     const fn kind(self) -> &'static str {
         match self {
+            Self::UnknownCapability => "unknown_capability",
             Self::MissingPackage => "missing_package",
             Self::StalePackageDescriptor => "stale_package_descriptor",
             Self::ConflictingPackageDescriptor => "conflicting_package_descriptor",
@@ -602,6 +601,7 @@ impl TrustEvaluationError {
 
     const fn message(self) -> &'static str {
         match self {
+            Self::UnknownCapability => "unknown capability",
             Self::MissingPackage => "capability provider trust metadata is missing",
             Self::StalePackageDescriptor | Self::ConflictingPackageDescriptor => {
                 "capability provider trust metadata is stale"
@@ -656,24 +656,26 @@ fn trust_error_label(error: &TrustError) -> &'static str {
     }
 }
 
-fn unknown_capability_trust_decision() -> TrustDecision {
-    TrustDecision {
-        effective_trust: EffectiveTrustClass::sandbox(),
-        authority_ceiling: AuthorityCeiling::empty(),
-        provenance: TrustProvenance::Default,
-        evaluated_at: chrono::Utc::now(),
-    }
-}
-
 fn trust_evaluation_failure(
     capability_id: CapabilityId,
     error: TrustEvaluationError,
 ) -> RuntimeCapabilityOutcome {
     RuntimeCapabilityOutcome::Failed(RuntimeCapabilityFailure {
         capability_id,
-        kind: RuntimeFailureKind::Authorization,
+        kind: trust_evaluation_failure_kind(error),
         message: Some(error.message().to_string()),
     })
+}
+
+fn trust_evaluation_failure_kind(error: TrustEvaluationError) -> RuntimeFailureKind {
+    match error {
+        TrustEvaluationError::UnknownCapability => RuntimeFailureKind::MissingRuntime,
+        TrustEvaluationError::MissingPackage
+        | TrustEvaluationError::StalePackageDescriptor
+        | TrustEvaluationError::ConflictingPackageDescriptor
+        | TrustEvaluationError::TrustInput
+        | TrustEvaluationError::Policy => RuntimeFailureKind::Authorization,
+    }
 }
 
 /// Maps a [`RunStateError`] to a sanitized [`HostRuntimeError::Unavailable`].

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -7,8 +7,11 @@
 //! run-state and approval stores, capability-lease store, and process
 //! manager.
 //!
-//! Trust is not evaluated here: callers must supply a host-validated
-//! [`TrustDecision`](ironclaw_trust::TrustDecision) on each invocation.
+//! This layer evaluates the package's manifest-derived trust input immediately
+//! before invoking [`CapabilityHost`] so authorization consumes a host-owned
+//! [`TrustDecision`](ironclaw_trust::TrustDecision) instead of caller-supplied
+//! claims. The default empty policy fails closed until composition supplies a
+//! concrete host policy.
 
 use std::sync::Arc;
 
@@ -18,15 +21,20 @@ use ironclaw_capabilities::{
     CapabilityHost, CapabilityInvocationError, CapabilityInvocationRequest,
     CapabilityInvocationResult, CapabilityObligationHandler,
 };
-use ironclaw_extensions::ExtensionRegistry;
+use ironclaw_extensions::{ExtensionPackage, ExtensionRegistry};
 use ironclaw_host_api::{
-    ApprovalRequestId, CapabilityDispatcher, CapabilityId, InvocationId, ResourceScope, RuntimeKind,
+    ApprovalRequestId, CapabilityDispatcher, CapabilityId, InvocationId, PackageSource,
+    ResourceScope, RuntimeKind,
 };
 use ironclaw_processes::{
     ProcessCancellationRegistry, ProcessError, ProcessHost, ProcessManager, ProcessResultStore,
     ProcessStatus, ProcessStore,
 };
 use ironclaw_run_state::{ApprovalRequestStore, RunStateError, RunStateStore, RunStatus};
+use ironclaw_trust::{
+    AuthorityCeiling, EffectiveTrustClass, HostTrustPolicy, TrustDecision, TrustError, TrustPolicy,
+    TrustProvenance,
+};
 
 use crate::{
     BuiltinObligationHandler, BuiltinObligationServices, CancelRuntimeWorkOutcome,
@@ -42,6 +50,7 @@ pub struct DefaultHostRuntime {
     registry: Arc<ExtensionRegistry>,
     dispatcher: Arc<dyn CapabilityDispatcher>,
     authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer>,
+    trust_policy: Arc<dyn TrustPolicy>,
     run_state: Option<Arc<dyn RunStateStore>>,
     approval_requests: Option<Arc<dyn ApprovalRequestStore>>,
     capability_leases: Option<Arc<dyn CapabilityLeaseStore>>,
@@ -56,6 +65,10 @@ pub struct DefaultHostRuntime {
 
 impl DefaultHostRuntime {
     /// Constructs a default host runtime over the supplied kernel services.
+    ///
+    /// The runtime starts with an empty host trust policy, so capability
+    /// dispatch fails closed until composition attaches a concrete policy with
+    /// [`Self::with_trust_policy`] or [`Self::with_trust_policy_dyn`].
     ///
     /// Callers must additionally attach a run-state store and approval-
     /// request store via [`with_run_state`](Self::with_run_state) and
@@ -75,6 +88,7 @@ impl DefaultHostRuntime {
             registry,
             dispatcher,
             authorizer,
+            trust_policy: Arc::new(HostTrustPolicy::empty()),
             run_state: None,
             approval_requests: None,
             capability_leases: None,
@@ -86,6 +100,22 @@ impl DefaultHostRuntime {
             obligation_handler: None,
             surface_version,
         }
+    }
+
+    /// Attaches the host-owned trust policy used to evaluate each provider's
+    /// manifest-derived trust input immediately before capability dispatch.
+    pub fn with_trust_policy<T>(mut self, trust_policy: Arc<T>) -> Self
+    where
+        T: TrustPolicy + 'static,
+    {
+        self.trust_policy = trust_policy;
+        self
+    }
+
+    /// Attaches an already-erased host-owned trust policy.
+    pub fn with_trust_policy_dyn(mut self, trust_policy: Arc<dyn TrustPolicy>) -> Self {
+        self.trust_policy = trust_policy;
+        self
     }
 
     /// Attaches the run-state store used to record invocation lifecycle.
@@ -194,16 +224,20 @@ impl HostRuntime for DefaultHostRuntime {
         &self,
         request: RuntimeCapabilityRequest,
     ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
-        let scope = request.context.resource_scope.clone();
-        let invocation_id = request.context.invocation_id;
-        let capability_id = request.capability_id.clone();
+        let RuntimeCapabilityRequest {
+            mut context,
+            capability_id,
+            estimate,
+            input,
+            idempotency_key,
+            trust_decision: _caller_trust_decision,
+        } = request;
+        let scope = context.resource_scope.clone();
+        let invocation_id = context.invocation_id;
         // Forward the (currently advisory) idempotency key into spans for
         // audit/tracing only — dedupe enforcement is not yet implemented at
         // this layer (see `RuntimeCapabilityRequest::idempotency_key`).
-        let idempotency_key = request
-            .idempotency_key
-            .as_ref()
-            .map(|key| key.as_str().to_string());
+        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
         if let Some(key) = idempotency_key.as_deref() {
             tracing::debug!(
                 capability_id = %capability_id,
@@ -211,6 +245,20 @@ impl HostRuntime for DefaultHostRuntime {
                 "capability invocation accepted advisory idempotency key (not yet enforced)"
             );
         }
+
+        let trust_decision = match self.evaluate_invocation_trust(&capability_id) {
+            Ok(Some(host_decision)) => host_decision,
+            Ok(None) => unknown_capability_trust_decision(),
+            Err(error) => {
+                tracing::debug!(
+                    capability_id = %capability_id,
+                    trust_error_kind = error.kind(),
+                    "capability trust evaluation failed before dispatch"
+                );
+                return Ok(trust_evaluation_failure(capability_id, error));
+            }
+        };
+        context.trust = trust_decision.effective_trust.class();
 
         let mut host = CapabilityHost::new(
             self.registry.as_ref(),
@@ -234,11 +282,11 @@ impl HostRuntime for DefaultHostRuntime {
         }
 
         let invocation = CapabilityInvocationRequest {
-            context: request.context,
+            context,
             capability_id: capability_id.clone(),
-            estimate: request.estimate,
-            input: request.input,
-            trust_decision: request.trust_decision,
+            estimate,
+            input,
+            trust_decision,
         };
 
         match host.invoke_json(invocation).await {
@@ -433,6 +481,44 @@ impl HostRuntime for DefaultHostRuntime {
 }
 
 impl DefaultHostRuntime {
+    fn evaluate_invocation_trust(
+        &self,
+        capability_id: &CapabilityId,
+    ) -> Result<Option<TrustDecision>, TrustEvaluationError> {
+        let policy = self.trust_policy.as_ref();
+
+        let Some(descriptor) = self.registry.get_capability(capability_id) else {
+            return Ok(None);
+        };
+        let package = self
+            .registry
+            .get_extension(&descriptor.provider)
+            .ok_or(TrustEvaluationError::MissingPackage)?;
+        let package_descriptor = package
+            .capabilities
+            .iter()
+            .find(|candidate| candidate.id == *capability_id)
+            .ok_or(TrustEvaluationError::StalePackageDescriptor)?;
+        if package_descriptor != descriptor {
+            return Err(TrustEvaluationError::ConflictingPackageDescriptor);
+        }
+
+        let input = trust_policy_input_for_local_manifest(package)?;
+        let decision = match policy.evaluate(&input) {
+            Ok(decision) => decision,
+            Err(error) => {
+                tracing::debug!(
+                    capability_id = %capability_id,
+                    trust_policy_error_kind = trust_error_label(&error),
+                    "host trust policy evaluation returned an error"
+                );
+                return Err(TrustEvaluationError::Policy);
+            }
+        };
+        trace_trust_decision(capability_id, &decision);
+        Ok(Some(decision))
+    }
+
     async fn translate_invocation_error(
         &self,
         error: CapabilityInvocationError,
@@ -492,6 +578,102 @@ impl DefaultHostRuntime {
             .map_err(unavailable_from_run_state)?;
         Ok(record.and_then(|record| record.approval_request_id))
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TrustEvaluationError {
+    MissingPackage,
+    StalePackageDescriptor,
+    ConflictingPackageDescriptor,
+    TrustInput,
+    Policy,
+}
+
+impl TrustEvaluationError {
+    const fn kind(self) -> &'static str {
+        match self {
+            Self::MissingPackage => "missing_package",
+            Self::StalePackageDescriptor => "stale_package_descriptor",
+            Self::ConflictingPackageDescriptor => "conflicting_package_descriptor",
+            Self::TrustInput => "trust_input",
+            Self::Policy => "policy",
+        }
+    }
+
+    const fn message(self) -> &'static str {
+        match self {
+            Self::MissingPackage => "capability provider trust metadata is missing",
+            Self::StalePackageDescriptor | Self::ConflictingPackageDescriptor => {
+                "capability provider trust metadata is stale"
+            }
+            Self::TrustInput => "capability provider trust metadata is invalid",
+            Self::Policy => "capability provider trust policy evaluation failed",
+        }
+    }
+}
+
+fn trust_policy_input_for_local_manifest(
+    package: &ExtensionPackage,
+) -> Result<ironclaw_trust::TrustPolicyInput, TrustEvaluationError> {
+    package
+        .trust_policy_input(local_manifest_source(package), None, None)
+        .map_err(|_| TrustEvaluationError::TrustInput)
+}
+
+fn local_manifest_source(package: &ExtensionPackage) -> PackageSource {
+    PackageSource::LocalManifest {
+        path: format!(
+            "{}/manifest.toml",
+            package.root.as_str().trim_end_matches('/')
+        ),
+    }
+}
+
+fn trace_trust_decision(capability_id: &CapabilityId, decision: &TrustDecision) {
+    tracing::debug!(
+        capability_id = %capability_id,
+        effective_trust = ?decision.effective_trust.class(),
+        trust_provenance = trust_provenance_label(&decision.provenance),
+        trust_allowed_effect_count = decision.authority_ceiling.allowed_effects.len(),
+        trust_has_resource_ceiling = decision.authority_ceiling.max_resource_ceiling.is_some(),
+        "evaluated capability provider trust from host policy"
+    );
+}
+
+fn trust_provenance_label(provenance: &TrustProvenance) -> &'static str {
+    match provenance {
+        TrustProvenance::Default => "default",
+        TrustProvenance::Bundled => "bundled",
+        TrustProvenance::AdminConfig => "admin_config",
+        TrustProvenance::SignedRegistry { .. } => "signed_registry",
+        TrustProvenance::LocalManifest => "local_manifest",
+    }
+}
+
+fn trust_error_label(error: &TrustError) -> &'static str {
+    match error {
+        TrustError::InvariantViolation { .. } => "invariant_violation",
+    }
+}
+
+fn unknown_capability_trust_decision() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::sandbox(),
+        authority_ceiling: AuthorityCeiling::empty(),
+        provenance: TrustProvenance::Default,
+        evaluated_at: chrono::Utc::now(),
+    }
+}
+
+fn trust_evaluation_failure(
+    capability_id: CapabilityId,
+    error: TrustEvaluationError,
+) -> RuntimeCapabilityOutcome {
+    RuntimeCapabilityOutcome::Failed(RuntimeCapabilityFailure {
+        capability_id,
+        kind: RuntimeFailureKind::Authorization,
+        message: Some(error.message().to_string()),
+    })
 }
 
 /// Maps a [`RunStateError`] to a sanitized [`HostRuntimeError::Unavailable`].

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -34,6 +34,7 @@ use ironclaw_resources::ResourceGovernor;
 use ironclaw_run_state::{ApprovalRequestStore, RunStateStore};
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
 use ironclaw_secrets::SecretStore;
+use ironclaw_trust::{HostTrustPolicy, TrustPolicy};
 use ironclaw_wasm::{
     DenyWasmHostHttp, PreparedWitTool, WasmError, WasmRuntimeHttpAdapter, WitToolHost,
     WitToolRequest, WitToolRuntime, WitToolRuntimeConfig,
@@ -61,6 +62,7 @@ where
     R: ProcessResultStore + 'static,
 {
     registry: Arc<ExtensionRegistry>,
+    trust_policy: Arc<dyn TrustPolicy>,
     filesystem: Arc<F>,
     governor: Arc<G>,
     authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer>,
@@ -98,6 +100,7 @@ where
     ) -> Self {
         Self {
             registry,
+            trust_policy: Arc::new(HostTrustPolicy::empty()),
             filesystem,
             governor,
             authorizer,
@@ -117,6 +120,22 @@ where
             mcp_runtime: None,
             wasm_runtime: None,
         }
+    }
+
+    /// Attaches the host-owned trust policy used by the produced
+    /// [`DefaultHostRuntime`]. Without this, the service graph keeps the
+    /// default empty policy and capability dispatch fails closed.
+    pub fn with_trust_policy<T>(mut self, trust_policy: Arc<T>) -> Self
+    where
+        T: TrustPolicy + 'static,
+    {
+        self.trust_policy = trust_policy;
+        self
+    }
+
+    pub fn with_trust_policy_dyn(mut self, trust_policy: Arc<dyn TrustPolicy>) -> Self {
+        self.trust_policy = trust_policy;
+        self
     }
 
     pub fn with_run_state<T>(mut self, run_state: Arc<T>) -> Self
@@ -273,6 +292,7 @@ where
             Arc::clone(&self.authorizer),
             self.surface_version.clone(),
         )
+        .with_trust_policy_dyn(Arc::clone(&self.trust_policy))
         .with_process_manager(process_manager)
         .with_process_store(process_store)
         .with_process_result_store(process_result_store)

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -187,14 +187,17 @@ async fn default_runtime_returns_failed_for_unknown_capability() {
     let registry = Arc::new(ExtensionRegistry::new());
     let dispatcher = Arc::new(RecordingDispatcher::default());
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let run_state = Arc::new(InMemoryRunStateStore::new());
     let runtime = DefaultHostRuntime::new(
         registry,
-        dispatcher,
+        dispatcher.clone(),
         authorizer,
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
-    );
+    )
+    .with_run_state(run_state.clone());
 
     let context = execution_context_with_dispatch_grant();
+    let scope = context.resource_scope.clone();
     let request = RuntimeCapabilityRequest::new(
         context,
         capability_id(),
@@ -215,6 +218,18 @@ async fn default_runtime_returns_failed_for_unknown_capability() {
         }
         other => panic!("expected Failed outcome, got {:?}", other),
     }
+    assert!(
+        !dispatcher.has_request(),
+        "unknown capabilities must fail during trust evaluation before dispatch"
+    );
+    assert!(
+        run_state
+            .records_for_scope(&scope)
+            .await
+            .unwrap()
+            .is_empty(),
+        "unknown capabilities must fail before starting a capability-host run record"
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -20,7 +20,10 @@ use ironclaw_run_state::{
     InMemoryApprovalRequestStore, InMemoryRunStateStore, RunRecord, RunStart, RunStateError,
     RunStateStore,
 };
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+use ironclaw_trust::{
+    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
+    HostTrustPolicy, TrustDecision, TrustProvenance,
+};
 use serde_json::json;
 
 #[test]
@@ -56,6 +59,7 @@ async fn default_runtime_returns_completed_outcome_for_authorized_dispatch() {
         authorizer,
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
     .with_run_state(run_state.clone())
     .with_approval_requests(approval_requests.clone());
 
@@ -267,7 +271,8 @@ async fn default_runtime_idempotency_key_is_advisory_and_does_not_dedupe() {
         dispatcher.clone(),
         authorizer,
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
-    );
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()));
 
     let key = IdempotencyKey::new("turn-1/tool-1").unwrap();
 
@@ -1123,6 +1128,20 @@ fn execution_context_with_dispatch_grant() -> ExecutionContext {
         grants,
         MountView::default(),
     )
+    .unwrap()
+}
+
+fn local_manifest_trust_policy() -> HostTrustPolicy {
+    HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
+        AdminEntry::for_local_manifest(
+            PackageId::new("echo").unwrap(),
+            "/system/extensions/echo/manifest.toml".to_string(),
+            None,
+            HostTrustAssignment::user_trusted(),
+            vec![EffectKind::DispatchCapability],
+            None,
+        ),
+    ]))])
     .unwrap()
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -25,7 +25,10 @@ use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore};
 use ironclaw_scripts::{
     ScriptBackend, ScriptBackendOutput, ScriptBackendRequest, ScriptRuntime, ScriptRuntimeConfig,
 };
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+use ironclaw_trust::{
+    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
+    HostTrustPolicy, TrustDecision, TrustProvenance,
+};
 use ironclaw_wasm::{
     RecordingWasmHostHttp, WasmHostError, WasmHostHttp, WasmHttpRequest, WasmHttpResponse,
     WitToolHost, WitToolRuntimeConfig,
@@ -59,6 +62,10 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
         process_services,
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
     .with_run_state(run_state)
     .with_approval_requests(approval_requests)
     .with_capability_leases(capability_leases)
@@ -786,6 +793,23 @@ fn capability_grants(capability: CapabilityId) -> CapabilitySet {
         },
     });
     grants
+}
+
+fn local_manifest_trust_policy(
+    extension_id: &str,
+    allowed_effects: Vec<EffectKind>,
+) -> HostTrustPolicy {
+    HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
+        AdminEntry::for_local_manifest(
+            PackageId::new(extension_id).unwrap(),
+            format!("/system/extensions/{extension_id}/manifest.toml"),
+            None,
+            HostTrustAssignment::user_trusted(),
+            allowed_effects,
+            None,
+        ),
+    ]))])
+    .unwrap()
 }
 
 fn trust_decision_with_dispatch_authority() -> TrustDecision {

--- a/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/production_trust_contract.rs
@@ -1,0 +1,309 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
+use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry};
+use ironclaw_host_api::*;
+use ironclaw_host_runtime::{
+    CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime, RuntimeCapabilityOutcome,
+    RuntimeCapabilityRequest, RuntimeFailureKind,
+};
+use ironclaw_trust::{
+    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
+    HostTrustPolicy, InvalidationBus, TrustDecision, TrustPolicy, TrustPolicyInput,
+    TrustProvenance,
+};
+use serde_json::json;
+
+#[tokio::test]
+async fn production_runtime_ignores_caller_supplied_privileged_trust_decision() {
+    let registry = Arc::new(registry_with_manifest(FIRST_PARTY_REQUESTED_MANIFEST));
+    let dispatcher = Arc::new(CountingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let runtime = DefaultHostRuntime::new(
+        Arc::clone(&registry),
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+
+    let forged_decision = privileged_local_manifest_policy()
+        .evaluate(&trust_input_for_registry(&registry))
+        .unwrap();
+    let request = RuntimeCapabilityRequest::new(
+        execution_context_with_dispatch_grant(TrustClass::FirstParty),
+        capability_id(),
+        ResourceEstimate::default(),
+        json!({"message": "must not dispatch"}),
+        forged_decision,
+    );
+
+    let outcome = runtime.invoke_capability(request).await.unwrap();
+
+    assert_authorization_failed(outcome);
+    assert_eq!(
+        dispatcher.count(),
+        0,
+        "stale or caller-supplied privileged TrustDecision must not authorize dispatch"
+    );
+}
+
+#[tokio::test]
+async fn production_runtime_uses_host_policy_decision_instead_of_request_claims() {
+    let registry = Arc::new(registry_with_manifest(FIRST_PARTY_REQUESTED_MANIFEST));
+    let dispatcher = Arc::new(CountingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let runtime = DefaultHostRuntime::new(
+        Arc::clone(&registry),
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(privileged_local_manifest_policy()));
+
+    let request = RuntimeCapabilityRequest::new(
+        execution_context_with_dispatch_grant(TrustClass::Sandbox),
+        capability_id(),
+        ResourceEstimate::default(),
+        json!({"message": "host policy decides"}),
+        sandbox_caller_decision(),
+    );
+
+    let outcome = runtime.invoke_capability(request).await.unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.capability_id, capability_id());
+            assert_eq!(completed.output, json!({"ok": true}));
+        }
+        other => panic!("expected Completed outcome, got {other:?}"),
+    }
+    assert_eq!(
+        dispatcher.count(),
+        1,
+        "host-owned trust policy should supply the effective decision before authorization"
+    );
+}
+
+#[tokio::test]
+async fn trust_downgrade_denies_future_invocation_before_dispatch_side_effects() {
+    let registry = Arc::new(registry_with_manifest(FIRST_PARTY_REQUESTED_MANIFEST));
+    let dispatcher = Arc::new(CountingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(GrantAuthorizer);
+    let policy = Arc::new(privileged_local_manifest_policy());
+    let runtime = DefaultHostRuntime::new(
+        Arc::clone(&registry),
+        dispatcher.clone(),
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::clone(&policy));
+
+    let trusted_input = trust_input_for_registry(&registry);
+    let stale_privileged_decision = policy.evaluate(&trusted_input).unwrap();
+    let first = RuntimeCapabilityRequest::new(
+        execution_context_with_dispatch_grant(TrustClass::Sandbox),
+        capability_id(),
+        ResourceEstimate::default(),
+        json!({"message": "before downgrade"}),
+        sandbox_caller_decision(),
+    );
+    let first_outcome = runtime.invoke_capability(first).await.unwrap();
+    assert!(
+        matches!(first_outcome, RuntimeCapabilityOutcome::Completed(_)),
+        "first invocation should use the host policy's privileged decision"
+    );
+    assert_eq!(dispatcher.count(), 1);
+
+    policy
+        .mutate_with(
+            &InvalidationBus::new(),
+            trusted_input.identity.clone(),
+            trusted_input.requested_authority.clone(),
+            trusted_input.requested_trust,
+            |sources| {
+                sources.admin_remove(
+                    &trusted_input.identity.package_id,
+                    &trusted_input.identity.source,
+                )?;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+    let second = RuntimeCapabilityRequest::new(
+        execution_context_with_dispatch_grant(TrustClass::FirstParty),
+        capability_id(),
+        ResourceEstimate::default(),
+        json!({"message": "after downgrade"}),
+        stale_privileged_decision,
+    );
+    let second_outcome = runtime.invoke_capability(second).await.unwrap();
+
+    assert_authorization_failed(second_outcome);
+    assert_eq!(
+        dispatcher.count(),
+        1,
+        "downgraded trust must fail closed before any second dispatch side effect"
+    );
+}
+
+fn assert_authorization_failed(outcome: RuntimeCapabilityOutcome) {
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.capability_id, capability_id());
+            assert_eq!(failure.kind, RuntimeFailureKind::Authorization);
+        }
+        other => panic!("expected Failed(Authorization), got {other:?}"),
+    }
+}
+
+#[derive(Default)]
+struct CountingDispatcher {
+    count: Mutex<usize>,
+}
+
+impl CountingDispatcher {
+    fn count(&self) -> usize {
+        *self
+            .count
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[async_trait]
+impl CapabilityDispatcher for CountingDispatcher {
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        *self
+            .count
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) += 1;
+        Ok(CapabilityDispatchResult {
+            capability_id: request.capability_id,
+            provider: extension_id(),
+            runtime: RuntimeKind::Wasm,
+            output: json!({"ok": true}),
+            usage: ResourceUsage::default(),
+            receipt: ResourceReceipt {
+                id: ResourceReservationId::new(),
+                scope: request.scope,
+                status: ReservationStatus::Reconciled,
+                estimate: request.estimate,
+                actual: Some(ResourceUsage::default()),
+            },
+        })
+    }
+}
+
+fn registry_with_manifest(manifest: &str) -> ExtensionRegistry {
+    let manifest = ExtensionManifest::parse(manifest).unwrap();
+    let package = ExtensionPackage::from_manifest(
+        manifest,
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package).unwrap();
+    registry
+}
+
+fn trust_input_for_registry(registry: &ExtensionRegistry) -> TrustPolicyInput {
+    registry
+        .get_extension(&extension_id())
+        .unwrap()
+        .trust_policy_input(
+            PackageSource::LocalManifest {
+                path: local_manifest_path(),
+            },
+            None,
+            None,
+        )
+        .unwrap()
+}
+
+fn privileged_local_manifest_policy() -> HostTrustPolicy {
+    HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
+        AdminEntry::for_local_manifest(
+            PackageId::new("echo").unwrap(),
+            local_manifest_path(),
+            None,
+            HostTrustAssignment::first_party(),
+            vec![EffectKind::DispatchCapability],
+            None,
+        ),
+    ]))])
+    .unwrap()
+}
+
+fn execution_context_with_dispatch_grant(trust: TrustClass) -> ExecutionContext {
+    let mut grants = CapabilitySet::default();
+    grants.grants.push(CapabilityGrant {
+        id: CapabilityGrantId::new(),
+        capability: capability_id(),
+        grantee: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        issued_by: Principal::HostRuntime,
+        constraints: GrantConstraints {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            mounts: MountView::default(),
+            network: NetworkPolicy::default(),
+            secrets: Vec::new(),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
+    });
+    ExecutionContext::local_default(
+        UserId::new("user").unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::Wasm,
+        trust,
+        grants,
+        MountView::default(),
+    )
+    .unwrap()
+}
+
+fn sandbox_caller_decision() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::sandbox(),
+        authority_ceiling: AuthorityCeiling::empty(),
+        provenance: TrustProvenance::Default,
+        evaluated_at: Utc::now(),
+    }
+}
+
+fn capability_id() -> CapabilityId {
+    CapabilityId::new("echo.say").unwrap()
+}
+
+fn extension_id() -> ExtensionId {
+    ExtensionId::new("echo").unwrap()
+}
+
+fn local_manifest_path() -> String {
+    "/system/extensions/echo/manifest.toml".to_string()
+}
+
+const FIRST_PARTY_REQUESTED_MANIFEST: &str = r#"
+id = "echo"
+name = "Echo"
+version = "0.1.0"
+description = "Echo test extension"
+trust = "first_party_requested"
+
+[runtime]
+kind = "wasm"
+module = "echo.wasm"
+
+[[capabilities]]
+id = "echo.say"
+description = "Echoes input"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = {}
+"#;

--- a/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_invoke_vertical_slice.rs
@@ -21,7 +21,10 @@ use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceTally,
 };
 use ironclaw_run_state::{InMemoryRunStateStore, RunStateStore, RunStatus};
-use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+use ironclaw_trust::{
+    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
+    HostTrustPolicy, TrustDecision, TrustProvenance,
+};
 use serde_json::{Value, json};
 
 #[tokio::test]
@@ -37,6 +40,7 @@ async fn default_host_runtime_invokes_through_runtime_dispatcher_with_resources_
         authorizer.clone(),
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
     .with_run_state(run_state.clone());
     let context = execution_context(CapabilitySet {
         grants: vec![dispatch_grant()],
@@ -331,6 +335,20 @@ fn dispatch_grant() -> CapabilityGrant {
             max_invocations: None,
         },
     }
+}
+
+fn local_manifest_trust_policy() -> HostTrustPolicy {
+    HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
+        AdminEntry::for_local_manifest(
+            PackageId::new("echo").unwrap(),
+            "/system/extensions/echo/manifest.toml".to_string(),
+            None,
+            HostTrustAssignment::user_trusted(),
+            vec![EffectKind::DispatchCapability],
+            None,
+        ),
+    ]))])
+    .unwrap()
 }
 
 fn trust_decision() -> TrustDecision {


### PR DESCRIPTION
## Summary

- Evaluate provider trust inside `DefaultHostRuntime` before every capability invocation.
- Default host runtime and `HostRuntimeServices` now start with an empty fail-closed `HostTrustPolicy`; composition can attach a concrete host policy.
- Ignore caller-supplied `RuntimeCapabilityRequest.trust_decision` and overwrite `ExecutionContext.trust` with the host-evaluated effective trust before authorization.
- Add production trust regressions for forged/stale privileged trust, host-policy elevation, and downgrade/revocation fail-closed behavior.

Fixes #3146.

## Verification

```bash
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/ironclaw-issue-3146-target cargo test -p ironclaw_trust -p ironclaw_authorization -p ironclaw_extensions -p ironclaw_capabilities -p ironclaw_host_runtime
CARGO_TARGET_DIR=/tmp/ironclaw-issue-3146-target cargo clippy -q -p ironclaw_host_runtime -p ironclaw_trust -p ironclaw_authorization -p ironclaw_extensions --all-targets -- -D warnings
CARGO_TARGET_DIR=/tmp/ironclaw-issue-3146-target cargo test -p ironclaw_architecture
python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD
git diff --check
```

## Review evidence

- Claude read-only re-review after fixes found no remaining Critical/High/Medium correctness or security issues.
