### PR TITLE
feat(reborn): wire obligation audit to durable sinks

### DIFF
--- a/crates/ironclaw_events/CLAUDE.md
+++ b/crates/ironclaw_events/CLAUDE.md
@@ -14,7 +14,8 @@ crates use to record what happened. It defines:
   alter runtime/control-plane outcomes;
 - explicit-error [`DurableEventLog`] / [`DurableAuditLog`] traits with a
   monotonic per-scope cursor envelope and replay-after semantics;
-- in-memory durable backends used by tests and reference loops.
+- in-memory durable backends used by tests and reference loops;
+- `DurableEventSink` / `DurableAuditSink` adapters that let service composition pass durable logs where producer crates expect live sink traits.
 
 Filesystem-backed JSONL durable backends and PostgreSQL/libSQL backends are
 deliberately deferred. They live in later grouped Reborn PRs that depend on

--- a/crates/ironclaw_events/src/lib.rs
+++ b/crates/ironclaw_events/src/lib.rs
@@ -694,6 +694,70 @@ pub trait DurableAuditLog: Send + Sync {
     ) -> Result<EventReplay<AuditEnvelope>, EventError>;
 }
 
+/// [`EventSink`] adapter that appends each emitted runtime event to a durable log.
+#[derive(Clone)]
+pub struct DurableEventSink {
+    log: Arc<dyn DurableEventLog>,
+}
+
+impl DurableEventSink {
+    pub fn new(log: Arc<dyn DurableEventLog>) -> Self {
+        Self { log }
+    }
+
+    pub fn log(&self) -> Arc<dyn DurableEventLog> {
+        Arc::clone(&self.log)
+    }
+}
+
+impl std::fmt::Debug for DurableEventSink {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DurableEventSink")
+            .field("log", &"<durable_event_log>")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl EventSink for DurableEventSink {
+    async fn emit(&self, event: RuntimeEvent) -> Result<(), EventError> {
+        self.log.append(event).await.map(|_| ())
+    }
+}
+
+/// [`AuditSink`] adapter that appends each emitted audit envelope to a durable log.
+#[derive(Clone)]
+pub struct DurableAuditSink {
+    log: Arc<dyn DurableAuditLog>,
+}
+
+impl DurableAuditSink {
+    pub fn new(log: Arc<dyn DurableAuditLog>) -> Self {
+        Self { log }
+    }
+
+    pub fn log(&self) -> Arc<dyn DurableAuditLog> {
+        Arc::clone(&self.log)
+    }
+}
+
+impl std::fmt::Debug for DurableAuditSink {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DurableAuditSink")
+            .field("log", &"<durable_audit_log>")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl AuditSink for DurableAuditSink {
+    async fn emit_audit(&self, record: AuditEnvelope) -> Result<(), EventError> {
+        self.log.append(record).await.map(|_| ())
+    }
+}
+
 // -----------------------------------------------------------------------------
 // In-memory best-effort sinks
 // -----------------------------------------------------------------------------

--- a/crates/ironclaw_events/tests/durable_log_contract.rs
+++ b/crates/ironclaw_events/tests/durable_log_contract.rs
@@ -6,10 +6,10 @@
 //! constructors, and best-effort sink delivery.
 
 use ironclaw_events::{
-    AuditSink, DurableAuditLog, DurableEventLog, EventCursor, EventError, EventSink,
-    EventStreamKey, InMemoryAuditSink, InMemoryDurableAuditLog, InMemoryDurableEventLog,
-    InMemoryEventSink, ReadScope, RuntimeEvent, RuntimeEventKind, parse_jsonl, replay_jsonl,
-    sanitize_error_kind,
+    AuditSink, DurableAuditLog, DurableAuditSink, DurableEventLog, DurableEventSink, EventCursor,
+    EventError, EventSink, EventStreamKey, InMemoryAuditSink, InMemoryDurableAuditLog,
+    InMemoryDurableEventLog, InMemoryEventSink, ReadScope, RuntimeEvent, RuntimeEventKind,
+    parse_jsonl, replay_jsonl, sanitize_error_kind,
 };
 use ironclaw_host_api::{
     Action, ActionSummary, AgentId, ApprovalRequest, ApprovalRequestId, AuditEnvelope,
@@ -550,6 +550,36 @@ async fn best_effort_event_sink_records_emit_calls() {
 }
 
 #[tokio::test]
+async fn durable_event_sink_appends_emit_calls_to_durable_log() {
+    let log = std::sync::Arc::new(InMemoryDurableEventLog::new());
+    let sink = DurableEventSink::new(log.clone());
+    let scope = local_scope("alice", Some("default"));
+
+    sink.emit(RuntimeEvent::dispatch_requested(
+        scope.clone(),
+        capability_id(),
+    ))
+    .await
+    .expect("emit through durable sink");
+
+    let replay = log
+        .read_after_cursor(
+            &EventStreamKey::from_scope(&scope),
+            &ReadScope::any(),
+            None,
+            10,
+        )
+        .await
+        .expect("replay durable event sink append");
+    assert_eq!(replay.entries.len(), 1);
+    assert_eq!(replay.entries[0].cursor, EventCursor::new(1));
+    assert_eq!(
+        replay.entries[0].record.kind,
+        RuntimeEventKind::DispatchRequested
+    );
+}
+
+#[tokio::test]
 async fn durable_audit_log_appends_and_replays() {
     let log = InMemoryDurableAuditLog::new();
     let scope = local_scope("alice", Some("default"));
@@ -728,6 +758,48 @@ async fn best_effort_audit_sink_captures_records() {
     sink.emit_audit(record).await.expect("audit emit");
 
     assert_eq!(sink.records().len(), 1);
+}
+
+#[tokio::test]
+async fn durable_audit_sink_appends_records_to_durable_log() {
+    let log = std::sync::Arc::new(InMemoryDurableAuditLog::new());
+    let sink = DurableAuditSink::new(log.clone());
+    let scope = local_scope("alice", Some("default"));
+    let ctx = ExecutionContext::local_default(
+        scope.user_id.clone(),
+        extension_id(),
+        RuntimeKind::Wasm,
+        ironclaw_host_api::TrustClass::FirstParty,
+        Default::default(),
+        MountView::default(),
+    )
+    .expect("local default execution context");
+    let record = AuditEnvelope::denied(
+        &ctx,
+        ironclaw_host_api::AuditStage::Denied,
+        ActionSummary::from_action(&Action::Dispatch {
+            capability: capability_id(),
+            estimated_resources: ResourceEstimate::default(),
+        }),
+        DenyReason::PolicyDenied,
+    );
+
+    sink.emit_audit(record)
+        .await
+        .expect("audit emit through durable sink");
+
+    let replay = log
+        .read_after_cursor(
+            &EventStreamKey::from_scope(&scope),
+            &ReadScope::any(),
+            None,
+            10,
+        )
+        .await
+        .expect("replay durable audit sink append");
+    assert_eq!(replay.entries.len(), 1);
+    assert_eq!(replay.entries[0].cursor, EventCursor::new(1));
+    assert_eq!(replay.entries[0].record.decision.kind, "deny");
 }
 
 #[tokio::test]

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -17,7 +17,9 @@ use ironclaw_authorization::{CapabilityLeaseStore, TrustAwareCapabilityDispatchA
 use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
 };
-use ironclaw_events::{AuditSink, EventSink};
+use ironclaw_events::{
+    AuditSink, DurableAuditLog, DurableAuditSink, DurableEventLog, DurableEventSink, EventSink,
+};
 use ironclaw_extensions::{ExtensionRegistry, ExtensionRuntime};
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
@@ -151,12 +153,28 @@ where
         self
     }
 
+    pub fn with_durable_event_log<T>(self, event_log: Arc<T>) -> Self
+    where
+        T: DurableEventLog + 'static,
+    {
+        let event_log: Arc<dyn DurableEventLog> = event_log;
+        self.with_event_sink(Arc::new(DurableEventSink::new(event_log)))
+    }
+
     pub fn with_audit_sink<T>(mut self, audit_sink: Arc<T>) -> Self
     where
         T: AuditSink + 'static,
     {
         self.audit_sink = Some(audit_sink);
         self
+    }
+
+    pub fn with_durable_audit_log<T>(self, audit_log: Arc<T>) -> Self
+    where
+        T: DurableAuditLog + 'static,
+    {
+        let audit_log: Arc<dyn DurableAuditLog> = audit_log;
+        self.with_audit_sink(Arc::new(DurableAuditSink::new(audit_log)))
     }
 
     pub fn with_secret_store<T>(mut self, secret_store: Arc<T>) -> Self

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -6,8 +6,9 @@ use ironclaw_authorization::{
     GrantAuthorizer, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
 };
 use ironclaw_events::{
-    DurableAuditLog, EventCursor, EventError, EventReplay, EventStreamKey, InMemoryAuditSink,
-    InMemoryDurableAuditLog, InMemoryEventSink, ReadScope, RuntimeEventKind,
+    DurableAuditLog, DurableEventLog, EventCursor, EventError, EventReplay, EventStreamKey,
+    InMemoryAuditSink, InMemoryDurableAuditLog, InMemoryDurableEventLog, InMemoryEventSink,
+    ReadScope, RuntimeEventKind,
 };
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry};
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
@@ -106,6 +107,98 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
             RuntimeEventKind::DispatchSucceeded,
         ]
     );
+}
+
+#[tokio::test]
+async fn host_runtime_services_writes_runtime_events_to_durable_event_log_metadata_only() {
+    let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
+    let filesystem = Arc::new(LocalFilesystem::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
+        Arc::new(GrantAuthorizer::new());
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    let script_runtime = Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    ));
+    let services = HostRuntimeServices::new(
+        registry,
+        filesystem,
+        governor,
+        authorizer,
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_durable_event_log(Arc::clone(&event_log))
+    .with_script_runtime(script_runtime);
+    let scope = sample_scope(InvocationId::new());
+    let payload = json!({
+        "message": "RAW_EVENT_INPUT_SENTINEL_3147 /tmp/private-event-path",
+        "secret": "SECRET_EVENT_SENTINEL_3147_sk_live_secret",
+        "output": "RUNTIME_EVENT_OUTPUT_SENTINEL_3147",
+    });
+
+    let outcome = services
+        .host_runtime()
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
+            script_capability_id(),
+            ResourceEstimate::default(),
+            payload.clone(),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.output, payload);
+        }
+        other => panic!("expected completed outcome, got {other:?}"),
+    }
+
+    let replay = event_log
+        .read_after_cursor(
+            &EventStreamKey::from_scope(&scope),
+            &ReadScope::any(),
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+    let kinds = replay
+        .entries
+        .iter()
+        .map(|entry| entry.record.kind)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+        ]
+    );
+    assert_eq!(
+        replay.entries[2].record.output_bytes,
+        Some(serde_json::to_vec(&payload).unwrap().len() as u64)
+    );
+
+    let serialized = serde_json::to_string(&replay).unwrap();
+    for forbidden in [
+        "RAW_EVENT_INPUT_SENTINEL_3147",
+        "/tmp/private-event-path",
+        "SECRET_EVENT_SENTINEL_3147",
+        "RUNTIME_EVENT_OUTPUT_SENTINEL_3147",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "durable runtime event replay leaked {forbidden}: {serialized}"
+        );
+    }
+    assert!(serialized.contains("script.echo"));
+    assert!(serialized.contains("dispatch_requested"));
+    assert!(serialized.contains("dispatch_succeeded"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -5,7 +5,10 @@ use chrono::Utc;
 use ironclaw_authorization::{
     GrantAuthorizer, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
 };
-use ironclaw_events::{InMemoryAuditSink, InMemoryEventSink, RuntimeEventKind};
+use ironclaw_events::{
+    DurableAuditLog, EventCursor, EventError, EventReplay, EventStreamKey, InMemoryAuditSink,
+    InMemoryDurableAuditLog, InMemoryEventSink, ReadScope, RuntimeEventKind,
+};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry};
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
@@ -201,6 +204,142 @@ async fn host_runtime_services_installs_builtin_obligation_handler_with_audit_si
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].stage, AuditStage::Before);
     assert_eq!(records[0].action.target.as_deref(), Some("script.echo"));
+}
+
+#[tokio::test]
+async fn host_runtime_services_writes_obligation_audit_records_to_durable_log_metadata_only() {
+    let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
+    let filesystem = Arc::new(LocalFilesystem::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let audit_log = Arc::new(InMemoryDurableAuditLog::new());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
+        Arc::new(ObligatingAuthorizer::new(vec![
+            Obligation::AuditBefore,
+            Obligation::AuditAfter,
+        ]));
+    let script_runtime = Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    ));
+    let services = HostRuntimeServices::new(
+        registry,
+        filesystem,
+        governor,
+        authorizer,
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_durable_audit_log(Arc::clone(&audit_log))
+    .with_script_runtime(script_runtime);
+    let scope = sample_scope(InvocationId::new());
+    let payload = json!({
+        "message": "RAW_INPUT_SENTINEL_3147 /tmp/private-host-path",
+        "secret": "SECRET_SENTINEL_3147_sk_live_secret",
+        "output": "RUNTIME_OUTPUT_SENTINEL_3147",
+    });
+
+    let outcome = services
+        .host_runtime()
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
+            script_capability_id(),
+            ResourceEstimate::default(),
+            payload.clone(),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.output, payload);
+        }
+        other => panic!("expected completed outcome, got {other:?}"),
+    }
+    let replay = audit_log
+        .read_after_cursor(
+            &EventStreamKey::from_scope(&scope),
+            &ReadScope::any(),
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay.entries.len(), 2);
+    assert_eq!(replay.entries[0].record.stage, AuditStage::Before);
+    assert_eq!(replay.entries[1].record.stage, AuditStage::After);
+    assert_eq!(
+        replay.entries[1]
+            .record
+            .result
+            .as_ref()
+            .and_then(|result| result.output_bytes),
+        Some(serde_json::to_vec(&payload).unwrap().len() as u64)
+    );
+
+    let serialized = serde_json::to_string(&replay).unwrap();
+    for forbidden in [
+        "RAW_INPUT_SENTINEL_3147",
+        "/tmp/private-host-path",
+        "SECRET_SENTINEL_3147",
+        "RUNTIME_OUTPUT_SENTINEL_3147",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "durable obligation audit replay leaked {forbidden}: {serialized}"
+        );
+    }
+    assert!(serialized.contains("script.echo"));
+    assert!(serialized.contains("audit_before"));
+    assert!(serialized.contains("audit_after"));
+}
+
+#[tokio::test]
+async fn host_runtime_services_fails_closed_when_durable_obligation_audit_append_fails() {
+    let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
+    let filesystem = Arc::new(LocalFilesystem::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
+        Arc::new(ObligatingAuthorizer::new(vec![Obligation::AuditBefore]));
+    let script_runtime = Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    ));
+    let services = HostRuntimeServices::new(
+        registry,
+        filesystem,
+        governor,
+        authorizer,
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_durable_audit_log(Arc::new(FailingDurableAuditLog))
+    .with_script_runtime(script_runtime);
+
+    let outcome = services
+        .host_runtime()
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context_with_dispatch_grant(script_capability_id()),
+            script_capability_id(),
+            ResourceEstimate::default(),
+            json!({"message": "must not dispatch after audit append failure"}),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.kind, RuntimeFailureKind::Backend);
+            let message = failure.message.unwrap_or_default();
+            assert!(message.contains("obligation handling failed: Audit"));
+            assert!(
+                !message.contains("/tmp/audit-backend-secret"),
+                "audit backend details must remain sanitized: {message}"
+            );
+        }
+        other => panic!("expected failed outcome, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -603,6 +742,32 @@ impl ScriptBackend for EchoScriptBackend {
     fn execute(&self, request: ScriptBackendRequest) -> Result<ScriptBackendOutput, String> {
         let value = serde_json::from_str(&request.stdin_json).map_err(|error| error.to_string())?;
         Ok(ScriptBackendOutput::json(value))
+    }
+}
+
+struct FailingDurableAuditLog;
+
+#[async_trait]
+impl DurableAuditLog for FailingDurableAuditLog {
+    async fn append(
+        &self,
+        _record: AuditEnvelope,
+    ) -> Result<ironclaw_events::EventLogEntry<AuditEnvelope>, EventError> {
+        Err(EventError::DurableLog {
+            reason: "simulated audit backend failure at /tmp/audit-backend-secret".to_string(),
+        })
+    }
+
+    async fn read_after_cursor(
+        &self,
+        _stream: &EventStreamKey,
+        _filter: &ReadScope,
+        _after: Option<EventCursor>,
+        _limit: usize,
+    ) -> Result<EventReplay<AuditEnvelope>, EventError> {
+        Err(EventError::DurableLog {
+            reason: "simulated audit replay failure".to_string(),
+        })
     }
 }
 

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -6,7 +6,7 @@
 
 `DefaultHostRuntime` may be configured with a `CapabilityObligationHandler` through `with_obligation_handler(...)`. It forwards the handler into `CapabilityHost` for capability invocations.
 
-Production/service-graph construction should prefer `BuiltinObligationServices` plus `DefaultHostRuntime::with_builtin_obligation_services(...)`. `BuiltinObligationServices` requires an audit sink, secret store, and resource governor at construction time, creates the network-policy and runtime-secret handoff stores, and exposes cloned store handles for runtime adapters/HTTP egress to consume the exact state staged by the handler.
+Production/service-graph construction should prefer `BuiltinObligationServices` plus `DefaultHostRuntime::with_builtin_obligation_services(...)`. `BuiltinObligationServices` requires an audit sink, secret store, and resource governor at construction time, creates the network-policy and runtime-secret handoff stores, and exposes cloned store handles for runtime adapters/HTTP egress to consume the exact state staged by the handler. `HostRuntimeServices` can also adapt durable event/audit logs with `with_durable_event_log(...)` and `with_durable_audit_log(...)`; the latter is the production path for built-in obligation audit records that must be replayable through the Reborn event substrate.
 
 `BuiltinObligationHandler` is the default host-owned implementation for current V1 obligations. It is deliberately fail-closed: obligations that require backing services fail unless the corresponding store/sink/governor is configured. The convenience `with_builtin_obligation_handler()` installs an explicit empty/dev handler and keeps those obligations fail-closed until a fully configured services value is supplied.
 


### PR DESCRIPTION
## Summary

- add durable event/audit sink adapters that append live sink calls into durable logs
- add HostRuntimeServices durable event/audit log wiring, including the production path for built-in obligation audit records
- cover AuditBefore/AuditAfter durable replay, metadata-only/no-exposure guarantees, and durable audit append failure classification

Closes #3147.

## Verification

- `cargo test -p ironclaw_events`
- `cargo test -p ironclaw_host_runtime`
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `cargo clippy -p ironclaw_events -p ironclaw_host_runtime --all-targets -- -D warnings`
- `python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
- `git diff --check`
