### PR TITLE
fix(bridge): mission_* tools accept name; resolves #2583

### DIFF
--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -85,7 +85,7 @@ pub use runtime::conversation::ConversationManager;
 pub use runtime::manager::ThreadManager;
 pub use runtime::messaging::ThreadOutcome;
 pub use runtime::mission::{
-    BudgetGate, FireRateLimit, MissionManager, MissionNotification, MissionUpdate,
+    BudgetGate, FireRateLimit, MissionGateInfo, MissionManager, MissionNotification, MissionUpdate,
 };
 pub use runtime::tree::ThreadTree;
 

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -136,8 +136,23 @@ pub struct MissionGateInfo {
     /// `name` param, which has higher precedence than the credential
     /// fallback.
     pub parameters: serde_json::Value,
-    /// Engine-side `call_id` used to resume.
-    pub request_id: String,
+    /// Engine-side LLM tool-call id (e.g. `call_657a9167...`). This is
+    /// the identifier the engine needs to inject the resolved action
+    /// result back onto a paused thread when half-2 of #3133 wires up
+    /// auto-resume. **Not** what the user-facing auth tray sees — that
+    /// is `gate_request_id` below. (Per Copilot review on #3155: the
+    /// gateway parses the channel-side `request_id` as a UUID, so
+    /// forwarding the LLM call_id there would 400 every resolve POST.)
+    pub call_id: String,
+    /// Freshly-generated UUID identifying this surfaced gate to the
+    /// user. Forwarded by the bridge into
+    /// `StatusUpdate::AuthRequired.request_id` /
+    /// `StatusUpdate::ApprovalNeeded.request_id` so the gateway UI
+    /// can render the auth-tray entry and the resolve POST handler
+    /// (which `Uuid::parse_str`'s its input) accepts the response.
+    /// Mapping back to the engine `call_id` for half-2 auto-resume is
+    /// out of scope for this PR (#3166).
+    pub gate_request_id: uuid::Uuid,
     /// What kind of resolution unblocks this gate.
     pub resume_kind: crate::gate::ResumeKind,
 }
@@ -2445,7 +2460,8 @@ async fn process_mission_outcome_and_notify(
                 gate_name: gate_name.clone(),
                 action_name: action_name.clone(),
                 parameters: parameters.clone(),
-                request_id: call_id.clone(),
+                call_id: call_id.clone(),
+                gate_request_id: uuid::Uuid::new_v4(),
                 resume_kind: resume_kind.clone(),
             });
         }
@@ -4239,7 +4255,17 @@ mod tests {
             .as_ref()
             .expect("notification must carry MissionGateInfo for GatePaused");
         assert_eq!(gate.action_name, "tool_activate");
-        assert_eq!(gate.request_id, "call-gmail-1");
+        // call_id round-trips the engine's LLM tool-call id verbatim —
+        // the bridge keeps it for half-2 auto-resume but does NOT
+        // surface it to the channel.
+        assert_eq!(gate.call_id, "call-gmail-1");
+        // gate_request_id is a freshly-generated UUID. The bridge
+        // forwards this (not call_id) to StatusUpdate.request_id so
+        // the gateway resolve handler's UUID parse doesn't 400.
+        assert!(
+            !gate.gate_request_id.is_nil(),
+            "gate_request_id must be a freshly-generated UUID"
+        );
         assert_eq!(
             gate.parameters.get("name").and_then(|v| v.as_str()),
             Some("gmail"),

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -101,6 +101,45 @@ pub struct MissionNotification {
     pub response: Option<String>,
     /// True if the thread failed.
     pub is_error: bool,
+    /// When the mission's child thread paused on an unresolved gate
+    /// (auth, approval, or external callback) instead of completing,
+    /// the bridge translates this into a channel-side `AuthRequired` /
+    /// `ApprovalNeeded` status so the user's auth tray surfaces the
+    /// prompt. `None` for normal completions and failures.
+    ///
+    /// Pinned by issue #3133: previously the `_ => {}` arm in
+    /// `process_mission_outcome_and_notify` swallowed `GatePaused`
+    /// outcomes, leaving the user with no actionable signal and the
+    /// cron scheduler re-firing the same broken mission every tick.
+    pub gate: Option<MissionGateInfo>,
+}
+
+/// Gate metadata carried alongside a `MissionNotification` when the
+/// mission's child thread paused on an unresolved gate.
+///
+/// The bridge translates this into a `StatusUpdate::AuthRequired`
+/// (or `ApprovalNeeded`) so the user-facing auth tray (gateway UI) /
+/// chat-channel auth prompt fires for the mission, the same way it
+/// fires for foreground threads. The mission itself is moved to
+/// `MissionStatus::Paused` so the cron scheduler stops re-firing
+/// until the gate is resolved.
+#[derive(Debug, Clone)]
+pub struct MissionGateInfo {
+    /// Engine-side gate name (e.g., `auth_required`, `approval_required`).
+    pub gate_name: String,
+    /// Action that paused (e.g., `tool_activate`, `gmail`, `http`).
+    pub action_name: String,
+    /// Original action parameters at the time of the pause. The bridge
+    /// needs these to run the canonical extension-name resolver
+    /// (`AuthManager::resolve_extension_name_for_auth_flow`) — for
+    /// `tool_activate(name="gmail")` the resolver reads the explicit
+    /// `name` param, which has higher precedence than the credential
+    /// fallback.
+    pub parameters: serde_json::Value,
+    /// Engine-side `call_id` used to resume.
+    pub request_id: String,
+    /// What kind of resolution unblocks this gate.
+    pub resume_kind: crate::gate::ResumeKind,
 }
 
 /// Optional updates to apply to a mission via [`MissionManager::update_mission`].
@@ -2247,6 +2286,11 @@ async fn process_mission_outcome_and_notify(
     // Build notification fields while processing the outcome.
     let mut notify_response: Option<String> = None;
     let mut is_error = false;
+    // Gate metadata when the child thread paused waiting for the user.
+    // The bridge translates this into a channel-side AuthRequired /
+    // ApprovalNeeded status update so the auth tray fires for the user.
+    // See `MissionGateInfo` and #3133.
+    let mut gate_info: Option<MissionGateInfo> = None;
 
     match outcome {
         ThreadOutcome::Completed {
@@ -2322,6 +2366,58 @@ async fn process_mission_outcome_and_notify(
             notify_response = Some("Mission thread hit max iterations without completing".into());
             is_error = true;
         }
+        ThreadOutcome::GatePaused {
+            gate_name,
+            action_name,
+            call_id,
+            parameters,
+            resume_kind,
+            ..
+        } => {
+            // Pause the mission so the cron scheduler stops re-firing the
+            // same gate over and over. Until the gate resolves (user
+            // approves, provides a credential, etc.) the mission has nothing
+            // useful to do — pausing avoids the ghost-fire pattern reported
+            // in #3133 where a 3-minute cron kept re-tripping the same
+            // missing-credential gate without ever surfacing it to the user.
+            mission.status = MissionStatus::Paused;
+
+            // Friendly text the user will see in their notify_channels.
+            // Each ResumeKind has its own prompt shape; the bridge
+            // additionally fires a structured StatusUpdate (auth tray)
+            // alongside this text so the gateway UI's auth prompt opens.
+            let nudge = match &resume_kind {
+                crate::gate::ResumeKind::Authentication { instructions, .. } => format!(
+                    "Mission '{}' is paused: it needs authorization to use \
+                     '{action_name}'. Open the auth tray to grant access. \
+                     ({instructions})",
+                    mission.name
+                ),
+                crate::gate::ResumeKind::Approval { .. } => format!(
+                    "Mission '{}' is paused: approval required to run \
+                     '{action_name}'. Approve or deny in the auth tray.",
+                    mission.name
+                ),
+                crate::gate::ResumeKind::External { .. } => format!(
+                    "Mission '{}' is paused: waiting for an external \
+                     response on '{action_name}'.",
+                    mission.name
+                ),
+            };
+            mission.approach_history.push(format!(
+                "PAUSED: gate '{gate_name}' on action '{action_name}' \
+                 awaiting {kind}",
+                kind = resume_kind.kind_name()
+            ));
+            notify_response = Some(nudge);
+            gate_info = Some(MissionGateInfo {
+                gate_name: gate_name.clone(),
+                action_name: action_name.clone(),
+                parameters: parameters.clone(),
+                request_id: call_id.clone(),
+                resume_kind: resume_kind.clone(),
+            });
+        }
         _ => {}
     }
 
@@ -2342,6 +2438,7 @@ async fn process_mission_outcome_and_notify(
             notify_user: mission.notify_user.clone(),
             response,
             is_error,
+            gate: gate_info,
         };
         // Best-effort: ignore send errors (no subscribers = no problem).
         let _ = notification_tx.send(notification);
@@ -3948,6 +4045,160 @@ mod tests {
         assert!(
             refire.is_some(),
             "explicit resume should make failed missions fireable again"
+        );
+    }
+
+    /// Regression for #3133. When a mission's child thread emits
+    /// `ThreadOutcome::GatePaused` (e.g. the inner `tool_activate(gmail)`
+    /// triggered an OAuth gate), the previous `_ => {}` arm in
+    /// `process_mission_outcome_and_notify` swallowed it: the mission
+    /// stayed `Active` and the cron scheduler kept re-firing the same
+    /// broken mission every tick without surfacing anything to the user.
+    ///
+    /// This test pins the new behaviour:
+    ///   1. mission.status transitions to `Paused` (so cron stops firing).
+    ///   2. A `MissionNotification` is emitted with `gate: Some(...)`
+    ///      carrying the gate metadata the bridge needs to fire an
+    ///      `AuthRequired` status update on the user's auth tray.
+    ///   3. The notification's `response` text reads as a user-facing
+    ///      "mission paused, here's what to do" nudge — not bare
+    ///      orchestrator wording.
+    ///   4. Subsequent `fire_mission` calls return `None` (the same
+    ///      block-refire-until-resumed contract that `Failed` and
+    ///      `MaxIterations` already use).
+    #[tokio::test]
+    async fn gate_paused_pauses_mission_and_emits_gate_notification() {
+        use crate::gate::ResumeKind;
+        use ironclaw_common::CredentialName;
+
+        let store = Arc::new(TestStore::new());
+        let store_dyn = Arc::clone(&store) as Arc<dyn Store>;
+        let mgr = make_mission_manager(Arc::clone(&store_dyn));
+        let project_id = ProjectId::new();
+
+        let id = mgr
+            .create_mission(
+                project_id,
+                "test-user",
+                "Gmail Drafter",
+                "Create a Gmail draft on every tick",
+                MissionCadence::Cron {
+                    expression: "*/3 * * * *".into(),
+                    timezone: None,
+                },
+                vec!["gateway".to_string()],
+            )
+            .await
+            .unwrap();
+
+        // Subscribe BEFORE running the outcome processor so the broadcast
+        // channel captures the emitted notification.
+        let (notification_tx, mut notification_rx) =
+            tokio::sync::broadcast::channel::<MissionNotification>(8);
+
+        let outcome = ThreadOutcome::GatePaused {
+            gate_name: "auth_required".into(),
+            action_name: "tool_activate".into(),
+            call_id: "call-gmail-1".into(),
+            parameters: serde_json::json!({"name": "gmail"}),
+            resume_kind: ResumeKind::Authentication {
+                credential_name: CredentialName::new("google_oauth_token").unwrap(),
+                instructions: "Sign in with Google to grant Gmail access.".into(),
+                auth_url: Some("https://accounts.google.com/o/oauth2/auth?...".into()),
+            },
+            resume_output: None,
+            paused_lease: None,
+        };
+
+        process_mission_outcome_and_notify(
+            &store_dyn,
+            None,
+            id,
+            ThreadId::new(),
+            &outcome,
+            &notification_tx,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // (1) Mission transitioned to Paused.
+        let mission = mgr.get_mission(id).await.unwrap().unwrap();
+        assert_eq!(
+            mission.status,
+            MissionStatus::Paused,
+            "GatePaused outcome must transition mission to Paused; got {:?}",
+            mission.status
+        );
+
+        // (2) Notification was emitted with gate info.
+        let notif = notification_rx
+            .try_recv()
+            .expect("a MissionNotification must be emitted for GatePaused");
+        let gate = notif
+            .gate
+            .as_ref()
+            .expect("notification must carry MissionGateInfo for GatePaused");
+        assert_eq!(gate.action_name, "tool_activate");
+        assert_eq!(gate.request_id, "call-gmail-1");
+        assert_eq!(
+            gate.parameters.get("name").and_then(|v| v.as_str()),
+            Some("gmail"),
+            "parameters must round-trip so the bridge resolver can pick \
+             up the explicit `name` arg"
+        );
+        match &gate.resume_kind {
+            ResumeKind::Authentication {
+                credential_name,
+                auth_url,
+                ..
+            } => {
+                assert_eq!(credential_name.as_str(), "google_oauth_token");
+                assert!(
+                    auth_url.is_some(),
+                    "auth_url must round-trip so the bridge can include it \
+                     in StatusUpdate::AuthRequired"
+                );
+            }
+            other => panic!("expected Authentication ResumeKind, got {other:?}"),
+        }
+
+        // (3) Friendly user-facing text.
+        let response = notif
+            .response
+            .as_ref()
+            .expect("notification must carry a friendly response text");
+        assert!(
+            response.to_lowercase().contains("paused"),
+            "response should call out that the mission is paused; got: {response}"
+        );
+        assert!(
+            response.to_lowercase().contains("auth"),
+            "response should mention auth/authorization; got: {response}"
+        );
+
+        // Approach history records the structured pause.
+        assert!(
+            mission
+                .approach_history
+                .iter()
+                .any(|entry| entry.contains("PAUSED") && entry.contains("authentication")),
+            "approach_history should record the pause and the gate kind: {:?}",
+            mission.approach_history
+        );
+
+        // (4) Cron tick stops re-firing while the mission is Paused.
+        // The cron tick path filters by `MissionStatus::Active`
+        // (mission.rs lines 1058 / 1131 / 1194 / 1781), so a Paused
+        // mission cannot be picked up by the scheduler. Manual
+        // `fire_mission` is still allowed — users can explicitly
+        // override a Paused state, mirroring how `pause_mission` /
+        // `resume_mission` work today.
+        assert_ne!(
+            mission.status,
+            MissionStatus::Active,
+            "cron tick filters by Active; pausing on a gate must take \
+             the mission off the active path"
         );
     }
 

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -1039,6 +1039,37 @@ impl MissionManager {
         self.store.load_mission(id).await
     }
 
+    /// Find a mission by name, scoped to `(project_id, user_id)`.
+    ///
+    /// This is the typed lookup used by every name-keyed `mission_*`
+    /// dispatch path. Returns `Ok(None)` when no mission with that name
+    /// exists for the user (including shared missions, mirroring
+    /// `list_missions_with_shared`'s scope).
+    ///
+    /// Implementation note: today this scans `list_missions_with_shared`
+    /// and filters in-memory. That's O(N) per call against the user's
+    /// full mission set, including completed/archived. For accounts
+    /// with hundreds of missions and a high-frequency cron, this is the
+    /// hot path of every fire and is the perf concern flagged on
+    /// PR #3155 (serrrfirat). The right next step is a `Store`-level
+    /// `find_mission_by_name(project_id, user_id, name)` method that
+    /// pushes the predicate to the backend (an indexed SQL query for
+    /// PostgreSQL/libSQL). Adding it later is non-breaking — every
+    /// caller already goes through this method, so the optimisation
+    /// drops in without churn at the call sites.
+    pub async fn find_by_name(
+        &self,
+        project_id: ProjectId,
+        user_id: &str,
+        name: &str,
+    ) -> Result<Option<Mission>, EngineError> {
+        let missions = self
+            .store
+            .list_missions_with_shared(project_id, user_id)
+            .await?;
+        Ok(missions.into_iter().find(|m| m.name == name))
+    }
+
     /// Fire all active `OnSystemEvent` missions whose source and event_type match.
     ///
     /// The optional `payload` is forwarded as `trigger_payload` to each mission's
@@ -3635,6 +3666,74 @@ mod tests {
         assert_eq!(mission.goal, "do the thing");
         assert_eq!(mission.status, MissionStatus::Active);
         assert_eq!(mission.project_id, project_id);
+    }
+
+    #[tokio::test]
+    async fn find_by_name_round_trips_through_store() {
+        let store = Arc::new(TestStore::new());
+        let mgr = make_mission_manager(Arc::clone(&store) as Arc<dyn Store>);
+        let project_id = ProjectId::new();
+
+        // Round-trip the name used at create time. This is the hot
+        // path every mission_* handler hits when the LLM provides a
+        // name (which is what it always provides — UUIDs only show up
+        // in legacy/programmatic callers).
+        let id = mgr
+            .create_mission(
+                project_id,
+                "alice",
+                "find-me",
+                "round trip",
+                MissionCadence::Manual,
+                Vec::new(),
+            )
+            .await
+            .unwrap();
+
+        let found = mgr
+            .find_by_name(project_id, "alice", "find-me")
+            .await
+            .unwrap()
+            .expect("mission must be findable by its create-time name");
+        assert_eq!(found.id, id);
+        assert_eq!(found.name, "find-me");
+        assert_eq!(found.user_id, "alice");
+    }
+
+    #[tokio::test]
+    async fn find_by_name_returns_none_for_unknown() {
+        let store = Arc::new(TestStore::new());
+        let mgr = make_mission_manager(Arc::clone(&store) as Arc<dyn Store>);
+        let project_id = ProjectId::new();
+
+        // Empty store — no missions, no matches.
+        assert!(
+            mgr.find_by_name(project_id, "alice", "no-such-mission")
+                .await
+                .unwrap()
+                .is_none(),
+            "empty store must return None, not error"
+        );
+
+        // Mission exists for a different user — the per-user scope
+        // must not leak.
+        mgr.create_mission(
+            project_id,
+            "bob",
+            "bobs-mission",
+            "bob's work",
+            MissionCadence::Manual,
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            mgr.find_by_name(project_id, "alice", "bobs-mission")
+                .await
+                .unwrap()
+                .is_none(),
+            "per-user scope must filter out other users' missions"
+        );
     }
 
     #[tokio::test]

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -922,12 +922,22 @@ impl EffectBridgeAdapter {
                         Ok(Some(mission)) => {
                             // Ownership check: only the mission owner can
                             // retrieve its details (mirrors fire/pause/resume).
+                            //
+                            // Don't echo the foreign mission's id back to the
+                            // LLM — that would confirm the existence of a
+                            // mission the caller has no claim to, and the LLM
+                            // can't act on a UUID it doesn't own. Internal
+                            // diagnostics still get the id via tracing.
                             if mission.user_id != context.user_id {
+                                tracing::debug!(
+                                    target = "bridge::effect_adapter",
+                                    mission_id = %mission.id,
+                                    user_id = %context.user_id,
+                                    owner = %mission.user_id,
+                                    "rejected mission_get for foreign mission",
+                                );
                                 return Some(Err(EngineError::Effect {
-                                    reason: format!(
-                                        "mission {} belongs to another user",
-                                        mission.id
-                                    ),
+                                    reason: "mission belongs to another user".to_string(),
                                 }));
                             }
                             // Load recent threads (last 5) to show results
@@ -970,10 +980,13 @@ impl EffectBridgeAdapter {
                             }))
                         }
                         Ok(None) => Err(EngineError::Effect {
-                            // We resolved the id via name lookup, so this
-                            // should be unreachable in practice (the lookup
-                            // already proved the mission exists). Keep the
-                            // arm so the match is exhaustive.
+                            // Reachable when the caller passed an explicit
+                            // UUID `id` for a mission that was deleted, never
+                            // existed, or belongs to another project. Names
+                            // that didn't match are caught earlier by
+                            // `resolve_mission_id` with a more useful error;
+                            // by the time we hit this arm we have a parsed
+                            // UUID that the store doesn't recognise.
                             reason: format!("mission not found: {id}"),
                         }),
                         Err(e) => Err(e),
@@ -1030,19 +1043,54 @@ impl EffectBridgeAdapter {
                 }
             }
             "mission_update" => {
-                let id =
-                    resolve_mission_id(mgr.as_ref(), context.project_id, &context.user_id, params)
-                        .await;
+                // `mission_update` is the only handler where `name` can
+                // legitimately mean the *new* name rather than the lookup
+                // key. Pre-PR callers used `{id: <uuid>, name: <new>}` to
+                // rename. To keep that shape working without confusing
+                // the resolver's id/name conflict guard, detect the
+                // legacy shape up front and pass the resolver a params
+                // view that only contains the id — the resolver then
+                // never sees the would-be-rename `name` and never
+                // mistakes it for a lookup target.
+                let new_name_param = params.get("new_name").and_then(|v| v.as_str());
+                let id_uuid = params
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .and_then(|s| uuid::Uuid::parse_str(s).ok());
+                let legacy_name_for_rename = match (new_name_param, id_uuid) {
+                    (None, Some(_)) => params.get("name").and_then(|v| v.as_str()),
+                    _ => None,
+                };
+                let resolver_params = if legacy_name_for_rename.is_some()
+                    && let Some(obj) = params.as_object()
+                {
+                    let mut view = obj.clone();
+                    view.remove("name");
+                    serde_json::Value::Object(view)
+                } else {
+                    params.clone()
+                };
+
+                let id = resolve_mission_id(
+                    mgr.as_ref(),
+                    context.project_id,
+                    &context.user_id,
+                    &resolver_params,
+                )
+                .await;
                 match id {
                     Ok(id) => {
                         let mut updates = ironclaw_engine::MissionUpdate::default();
-                        // Renames use `new_name`. The legacy `name` field is
-                        // now the lookup key (consumed by `resolve_mission_id`),
-                        // not the rename target — see the schema in
-                        // `engine_actions.rs` and the migration note in the
-                        // helper docs above.
-                        if let Some(new_name) = params.get("new_name").and_then(|v| v.as_str()) {
-                            updates.name = Some(new_name.to_string());
+                        // Rename target priority:
+                        //   1. `new_name` (canonical post-PR field).
+                        //   2. Legacy `{id, name}` shape — `name` was the
+                        //      pre-PR rename target. Preserved only when
+                        //      `id` is a valid UUID and `new_name` is
+                        //      absent (handled above by removing `name`
+                        //      from the resolver view).
+                        if let Some(rename_target) = new_name_param.or(legacy_name_for_rename) {
+                            updates.name = Some(rename_target.to_string());
                         }
                         if let Some(goal) = params.get("goal").and_then(|v| v.as_str()) {
                             updates.goal = Some(goal.to_string());
@@ -2140,54 +2188,66 @@ fn parse_cadence(
 
 /// Resolve a mission identifier from action params.
 ///
-/// Mission/routine actions accept either an explicit `id` (a UUID, kept for
-/// backward compatibility and for callers that already hold one) or a
-/// human-readable `name`. The LLM-facing surface is name-first because
-/// (a) routines were originally keyed by name and the alias path
-/// (`routine_to_mission_alias`) preserves that, and (b) the agent rarely
-/// has a UUID at hand — forcing it to guess one was the root cause of
-/// #2583, where `routine_fire(name=...)` translated to `mission_fire`
-/// with a `name` field that the handler never read, then the handler
-/// parsed an empty `id` as UUID and rejected with "invalid length 0".
+/// Mission/routine actions accept either an explicit `id` (a UUID, kept
+/// for backward compatibility and for callers that already hold one) or
+/// a human-readable `name`. The LLM-facing surface is name-first because
+/// the agent rarely has a UUID at hand — forcing it to guess one was the
+/// root cause of #2583, where `routine_fire(name=...)` translated to
+/// `mission_fire` with a `name` field the handler never read, then the
+/// handler parsed an empty `id` as UUID and rejected with
+/// "invalid length 0".
 ///
-/// Resolution order (first match wins):
-///   1. `params.id` — if present and a valid UUID, use directly.
-///   2. `params.name` — look up `(project_id, user_id, name)` via
-///      `MissionManager::list_missions`. The same identifier used in
-///      `mission_create` is what we resolve back here.
-///   3. `params._args[0]` — positional fallback used by some Tier-0
-///      tool-call shapes; tried as UUID first, then as name.
+/// Resolution order (first match wins, then conflict-checked):
+///   1. `params.id` — if present and a valid UUID, the canonical id.
+///   2. `params.name` — looked up via [`MissionManager::find_by_name`]
+///      (typed, indexed lookup; same identifier used at create time).
+///   3. `params.id` *as a name* — backward compat for legacy
+///      `mission_complete({id: "<routine-name>"})` callers that
+///      conflated the slots.
+///   4. `params._args[0]` — Tier-0 positional fallback. Tried as a name
+///      *only*; positional UUIDs aren't honoured here because they
+///      can't carry a typed contract and would silently override an
+///      explicit `name` field. (This was the inversion serrrfirat
+///      flagged on PR #3155.)
 ///
-/// A non-UUID `id` value is treated as a name (some callers conflate the
-/// two), which keeps backward compat for `mission_complete`'s historical
-/// "name in the id slot" behaviour.
+/// **Conflict guard.** If both `id` (UUID) and a `name` are supplied
+/// AND the name resolves to a *different* mission than the id
+/// identifies, this returns an error. Silently preferring the UUID
+/// (the previous behaviour) was a foot-gun: a mistyped name would
+/// rename the wrong mission.
 async fn resolve_mission_id(
     mgr: &ironclaw_engine::MissionManager,
     project_id: ironclaw_engine::ProjectId,
     user_id: &str,
     params: &serde_json::Value,
 ) -> Result<ironclaw_engine::MissionId, EngineError> {
-    // 1. Explicit id field, if it's a valid UUID.
-    if let Some(s) = params
+    // Pull out the explicit id (only if it parses as a UUID).
+    let id_uuid: Option<ironclaw_engine::MissionId> = params
         .get("id")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
-        && let Ok(uuid) = uuid::Uuid::parse_str(s)
-    {
-        return Ok(ironclaw_engine::MissionId(uuid));
-    }
+        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+        .map(ironclaw_engine::MissionId);
 
-    // 2/3. Collect every candidate string we might still try as a name.
-    // Order: explicit name, then id-as-name (legacy mission_complete
-    // behaviour), then positional arg.
-    let mut name_candidates: Vec<&str> = Vec::new();
-    for key in ["name", "id"] {
+    // Collect candidate name strings in resolution order. We retain
+    // each candidate so we can emit a useful "tried these names" error
+    // and so the conflict guard knows which name was supplied.
+    let mut name_candidates: Vec<String> = Vec::new();
+    for key in &["name", "id"] {
         if let Some(s) = params
-            .get(key)
+            .get(*key)
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
         {
-            name_candidates.push(s);
+            // Skip the `id` slot when it's already been consumed as a
+            // UUID by the typed branch above — otherwise we'd double-
+            // try the same UUID-shaped string as a name.
+            if *key == "id" && uuid::Uuid::parse_str(s).is_ok() {
+                continue;
+            }
+            if !name_candidates.iter().any(|c| c == s) {
+                name_candidates.push(s.to_string());
+            }
         }
     }
     if let Some(s) = params
@@ -2195,39 +2255,73 @@ async fn resolve_mission_id(
         .and_then(|a| a.get(0))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
+        && !name_candidates.iter().any(|c| c == s)
     {
-        // Positional arg may be a UUID — try parsing first.
-        if let Ok(uuid) = uuid::Uuid::parse_str(s) {
-            return Ok(ironclaw_engine::MissionId(uuid));
-        }
-        name_candidates.push(s);
+        // Positional `_args[0]` is treated as a name — never as a
+        // UUID. A positional UUID would silently override an explicit
+        // `name` field if we honoured it, which is the worst-of-both
+        // ordering serrrfirat flagged.
+        name_candidates.push(s.to_string());
     }
 
-    if name_candidates.is_empty() {
-        return Err(EngineError::Effect {
-            reason: "mission identifier missing: provide 'name' (preferred) \
-                     or 'id' (UUID)"
-                .to_string(),
-        });
+    // (1) Only id provided.
+    if let Some(id) = id_uuid
+        && name_candidates.is_empty()
+    {
+        return Ok(id);
     }
 
-    // De-duplicate while preserving order.
-    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    name_candidates.retain(|s| seen.insert(*s));
-
-    let missions = mgr.list_missions(project_id, user_id).await?;
+    // (2/3/4) Name(s) provided. Resolve via the typed helper.
+    let mut resolved_by_name: Option<ironclaw_engine::MissionId> = None;
     for candidate in &name_candidates {
-        if let Some(m) = missions.iter().find(|m| m.name == *candidate) {
-            return Ok(m.id);
+        if let Some(m) = mgr.find_by_name(project_id, user_id, candidate).await? {
+            resolved_by_name = Some(m.id);
+            break;
         }
     }
 
-    Err(EngineError::Effect {
-        reason: format!(
-            "mission not found by name: tried {name_candidates:?} for user '{user_id}'. \
-             Use mission_list to see available missions."
-        ),
-    })
+    match (id_uuid, resolved_by_name) {
+        (Some(id), Some(by_name)) if id == by_name => Ok(id),
+        (Some(id), Some(by_name)) => Err(EngineError::Effect {
+            reason: format!(
+                "both id and name provided but they identify different \
+                 missions: id={id} vs name={name_candidates:?} → {by_name}. \
+                 Provide only one — or fix the name to match the id."
+            ),
+        }),
+        (Some(id), None) => {
+            // Name(s) supplied but none resolved. The id is still
+            // valid; warn through the error if name was clearly
+            // intended (non-empty candidate list).
+            if !name_candidates.is_empty() {
+                return Err(EngineError::Effect {
+                    reason: format!(
+                        "name {name_candidates:?} did not match any mission \
+                         (id was also provided as {id}). Remove the stale \
+                         name, or fix it to match the id."
+                    ),
+                });
+            }
+            Ok(id)
+        }
+        (None, Some(by_name)) => Ok(by_name),
+        (None, None) => {
+            if name_candidates.is_empty() {
+                Err(EngineError::Effect {
+                    reason: "mission identifier missing: provide 'name' \
+                             (preferred) or 'id' (UUID)"
+                        .to_string(),
+                })
+            } else {
+                Err(EngineError::Effect {
+                    reason: format!(
+                        "mission not found by name: tried {name_candidates:?}. \
+                         Use mission_list to see available missions."
+                    ),
+                })
+            }
+        }
+    }
 }
 
 /// Translation result from a `routine_*` call into mission_* dispatch.
@@ -7761,6 +7855,326 @@ Use this skill to set up a Pika meeting.
         assert!(
             s.contains("mission_list"),
             "error should hint at mission_list for discovery; got: {s}"
+        );
+    }
+
+    /// `mission_get` resolves by `name`. Pinning the name path here
+    /// closes the test gap flagged on PR #3155: every migrated
+    /// handler routes through `resolve_mission_id`, but only
+    /// `mission_fire` had a by-name regression before this.
+    #[tokio::test]
+    async fn mission_get_resolves_by_name() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("get-by-name-1"));
+
+        adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "lookup-target-get",
+                    "goal": "exists for mission_get",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create should succeed");
+
+        let got = adapter
+            .execute_action(
+                "mission_get",
+                serde_json::json!({"name": "lookup-target-get"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("mission_get by name should succeed");
+        assert!(!got.is_error, "mission_get by name failed: {}", got.output);
+        assert_eq!(
+            got.output.get("name").and_then(|v| v.as_str()),
+            Some("lookup-target-get"),
+            "mission_get must echo the same name back"
+        );
+    }
+
+    /// `mission_complete` resolves by `name`.
+    #[tokio::test]
+    async fn mission_complete_resolves_by_name() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("complete-by-name-1"));
+
+        adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "complete-target",
+                    "goal": "exists for mission_complete",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create should succeed");
+
+        let res = adapter
+            .execute_action(
+                "mission_complete",
+                serde_json::json!({"name": "complete-target"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("mission_complete by name should succeed");
+        assert!(!res.is_error, "complete failed: {}", res.output);
+        assert_eq!(
+            res.output.get("status").and_then(|v| v.as_str()),
+            Some("completed")
+        );
+    }
+
+    /// `mission_pause` and `mission_resume` round-trip by `name`.
+    #[tokio::test]
+    async fn mission_pause_and_resume_resolve_by_name() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(
+            ironclaw_engine::ThreadId::new(),
+            Some("pause-resume-name-1"),
+        );
+
+        adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "pause-target",
+                    "goal": "exists for pause/resume",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create should succeed");
+
+        let pause = adapter
+            .execute_action(
+                "mission_pause",
+                serde_json::json!({"name": "pause-target"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("pause by name should succeed");
+        assert!(!pause.is_error, "pause failed: {}", pause.output);
+
+        let resume = adapter
+            .execute_action(
+                "mission_resume",
+                serde_json::json!({"name": "pause-target"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("resume by name should succeed");
+        assert!(!resume.is_error, "resume failed: {}", resume.output);
+    }
+
+    /// Conflict guard: if `id` and `name` are both supplied AND they
+    /// identify *different* missions, the resolver must error rather
+    /// than silently preferring one. Silently preferring the UUID was
+    /// the foot-gun serrrfirat flagged on PR #3155 — a mistyped
+    /// `name` would rename the wrong mission.
+    #[tokio::test]
+    async fn mission_resolver_errors_when_id_and_name_disagree() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("conflict-1"));
+
+        // Create two distinct missions: A (the one our id refers to)
+        // and B (the one our `name` refers to). They are different.
+        let create_a = adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "mission-A",
+                    "goal": "the real target",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create A should succeed");
+        let id_a = create_a
+            .output
+            .get("mission_id")
+            .and_then(|v| v.as_str())
+            .expect("mission_id present")
+            .to_string();
+        adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "mission-B",
+                    "goal": "the wrong target",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create B should succeed");
+
+        // mission_fire with id=A but name=B — they identify different
+        // missions. Must error, not silently fire either one.
+        let res = adapter
+            .execute_action(
+                "mission_fire",
+                serde_json::json!({"id": id_a, "name": "mission-B"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("conflict should produce an ActionResult, not panic");
+        assert!(
+            res.is_error,
+            "id/name conflict must be flagged as is_error: {res:?}"
+        );
+        let err_text = res
+            .output
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            err_text.contains("different missions") || err_text.contains("identify different"),
+            "error must explain the conflict; got: {err_text}"
+        );
+    }
+
+    /// Backwards-compat: pre-PR callers renamed via
+    /// `mission_update({id: <uuid>, name: <new>})`. After the PR,
+    /// `name` became the lookup key and `new_name` is the rename
+    /// target — but a caller still passing the old shape must keep
+    /// renaming, not silently no-op. The handler preserves the legacy
+    /// shape only when `id` is the explicit lookup AND `new_name` is
+    /// absent.
+    #[tokio::test]
+    async fn mission_update_preserves_legacy_id_plus_name_rename() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("legacy-rename-1"));
+
+        let create = adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "old-name",
+                    "goal": "test legacy rename shape",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create should succeed");
+        let mission_id = create
+            .output
+            .get("mission_id")
+            .and_then(|v| v.as_str())
+            .expect("create must return mission_id")
+            .to_string();
+
+        // Legacy shape: id-as-lookup + name-as-rename-target.
+        let update = adapter
+            .execute_action(
+                "mission_update",
+                serde_json::json!({
+                    "id": mission_id,
+                    "name": "new-name-via-legacy-shape"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("legacy mission_update must succeed");
+        assert!(
+            !update.is_error,
+            "legacy update must succeed: {}",
+            update.output
+        );
+
+        // Verify the rename actually happened (not just a returned
+        // status). mission_list reflects the persisted name.
+        let list = adapter
+            .execute_action("mission_list", serde_json::json!({}), &lease(), &ctx)
+            .await
+            .expect("list should succeed");
+        let missions = list.output.as_array().expect("array");
+        let entry = missions
+            .iter()
+            .find(|m| m.get("id").and_then(|v| v.as_str()) == Some(mission_id.as_str()))
+            .expect("renamed mission must still be in list");
+        assert_eq!(
+            entry.get("name").and_then(|v| v.as_str()),
+            Some("new-name-via-legacy-shape"),
+            "legacy {{id, name}} update shape must rename the mission, \
+             not silently no-op"
+        );
+    }
+
+    /// Canonical post-PR rename via `new_name`. Pins that the new
+    /// schema field is honoured and that `name` (when also present
+    /// AND `new_name` is set) acts as the lookup key, NOT a second
+    /// rename source.
+    #[tokio::test]
+    async fn mission_update_renames_via_new_name_and_uses_name_as_lookup() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("new-name-1"));
+
+        adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "lookup-target",
+                    "goal": "test new_name rename",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create should succeed");
+
+        let update = adapter
+            .execute_action(
+                "mission_update",
+                serde_json::json!({
+                    "name": "lookup-target",
+                    "new_name": "renamed-via-new_name"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("new_name update should succeed");
+        assert!(!update.is_error, "update failed: {}", update.output);
+
+        let list = adapter
+            .execute_action("mission_list", serde_json::json!({}), &lease(), &ctx)
+            .await
+            .expect("list should succeed");
+        let missions = list.output.as_array().expect("array");
+        // Old name must no longer be present (it was renamed).
+        assert!(
+            !missions
+                .iter()
+                .any(|m| m.get("name").and_then(|v| v.as_str()) == Some("lookup-target")),
+            "old name must not survive a rename"
+        );
+        assert!(
+            missions
+                .iter()
+                .any(|m| m.get("name").and_then(|v| v.as_str()) == Some("renamed-via-new_name")),
+            "renamed mission must appear under its new name in mission_list"
         );
     }
 

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -914,17 +914,9 @@ impl EffectBridgeAdapter {
                 Err(e) => Err(e),
             },
             "mission_get" => {
-                let id_str = params
-                    .get("id")
-                    .or_else(|| params.get("name"))
-                    .or_else(|| params.get("_args").and_then(|a| a.get(0)))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let id = uuid::Uuid::parse_str(id_str)
-                    .map(ironclaw_engine::MissionId)
-                    .map_err(|e| EngineError::Effect {
-                        reason: format!("invalid mission id: {e}"),
-                    });
+                let id =
+                    resolve_mission_id(mgr.as_ref(), context.project_id, &context.user_id, params)
+                        .await;
                 match id {
                     Ok(id) => match mgr.get_mission(id).await {
                         Ok(Some(mission)) => {
@@ -932,7 +924,10 @@ impl EffectBridgeAdapter {
                             // retrieve its details (mirrors fire/pause/resume).
                             if mission.user_id != context.user_id {
                                 return Some(Err(EngineError::Effect {
-                                    reason: format!("mission {id_str} belongs to another user"),
+                                    reason: format!(
+                                        "mission {} belongs to another user",
+                                        mission.id
+                                    ),
                                 }));
                             }
                             // Load recent threads (last 5) to show results
@@ -975,7 +970,11 @@ impl EffectBridgeAdapter {
                             }))
                         }
                         Ok(None) => Err(EngineError::Effect {
-                            reason: format!("mission not found: {id_str}"),
+                            // We resolved the id via name lookup, so this
+                            // should be unreachable in practice (the lookup
+                            // already proved the mission exists). Keep the
+                            // arm so the match is exhaustive.
+                            reason: format!("mission not found: {id}"),
                         }),
                         Err(e) => Err(e),
                     },
@@ -983,16 +982,9 @@ impl EffectBridgeAdapter {
                 }
             }
             "mission_fire" => {
-                let id_str = params
-                    .get("id")
-                    .or_else(|| params.get("_args").and_then(|a| a.get(0)))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let id = uuid::Uuid::parse_str(id_str)
-                    .map(ironclaw_engine::MissionId)
-                    .map_err(|e| EngineError::Effect {
-                        reason: format!("invalid mission id: {e}"),
-                    });
+                let id =
+                    resolve_mission_id(mgr.as_ref(), context.project_id, &context.user_id, params)
+                        .await;
                 match id {
                     Ok(id) => match mgr.fire_mission(id, &context.user_id, None).await {
                         Ok(Some(tid)) => {
@@ -1007,16 +999,9 @@ impl EffectBridgeAdapter {
                 }
             }
             "mission_pause" | "mission_resume" => {
-                let id_str = params
-                    .get("id")
-                    .or_else(|| params.get("_args").and_then(|a| a.get(0)))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let id = uuid::Uuid::parse_str(id_str)
-                    .map(ironclaw_engine::MissionId)
-                    .map_err(|e| EngineError::Effect {
-                        reason: format!("invalid mission id: {e}"),
-                    });
+                let id =
+                    resolve_mission_id(mgr.as_ref(), context.project_id, &context.user_id, params)
+                        .await;
                 match id {
                     Ok(id) => {
                         let res = if action_name == "mission_pause" {
@@ -1033,17 +1018,9 @@ impl EffectBridgeAdapter {
                 }
             }
             "mission_complete" => {
-                let id_str = params
-                    .get("id")
-                    .or_else(|| params.get("name")) // routine_delete uses "name" param
-                    .or_else(|| params.get("_args").and_then(|a| a.get(0)))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let id = uuid::Uuid::parse_str(id_str)
-                    .map(ironclaw_engine::MissionId)
-                    .map_err(|e| EngineError::Effect {
-                        reason: format!("invalid mission id: {e}"),
-                    });
+                let id =
+                    resolve_mission_id(mgr.as_ref(), context.project_id, &context.user_id, params)
+                        .await;
                 match id {
                     Ok(id) => match mgr.complete_mission(id).await {
                         Ok(()) => Ok(serde_json::json!({"status": "completed"})),
@@ -1053,21 +1030,19 @@ impl EffectBridgeAdapter {
                 }
             }
             "mission_update" => {
-                let id_str = params
-                    .get("id")
-                    .or_else(|| params.get("_args").and_then(|a| a.get(0)))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let id = uuid::Uuid::parse_str(id_str)
-                    .map(ironclaw_engine::MissionId)
-                    .map_err(|e| EngineError::Effect {
-                        reason: format!("invalid mission id: {e}"),
-                    });
+                let id =
+                    resolve_mission_id(mgr.as_ref(), context.project_id, &context.user_id, params)
+                        .await;
                 match id {
                     Ok(id) => {
                         let mut updates = ironclaw_engine::MissionUpdate::default();
-                        if let Some(name) = params.get("name").and_then(|v| v.as_str()) {
-                            updates.name = Some(name.to_string());
+                        // Renames use `new_name`. The legacy `name` field is
+                        // now the lookup key (consumed by `resolve_mission_id`),
+                        // not the rename target — see the schema in
+                        // `engine_actions.rs` and the migration note in the
+                        // helper docs above.
+                        if let Some(new_name) = params.get("new_name").and_then(|v| v.as_str()) {
+                            updates.name = Some(new_name.to_string());
                         }
                         if let Some(goal) = params.get("goal").and_then(|v| v.as_str()) {
                             updates.goal = Some(goal.to_string());
@@ -2161,6 +2136,98 @@ fn parse_cadence(
              (e.g. 'event:telegram:.*'), or 'webhook:<path>'"
         ))
     }
+}
+
+/// Resolve a mission identifier from action params.
+///
+/// Mission/routine actions accept either an explicit `id` (a UUID, kept for
+/// backward compatibility and for callers that already hold one) or a
+/// human-readable `name`. The LLM-facing surface is name-first because
+/// (a) routines were originally keyed by name and the alias path
+/// (`routine_to_mission_alias`) preserves that, and (b) the agent rarely
+/// has a UUID at hand — forcing it to guess one was the root cause of
+/// #2583, where `routine_fire(name=...)` translated to `mission_fire`
+/// with a `name` field that the handler never read, then the handler
+/// parsed an empty `id` as UUID and rejected with "invalid length 0".
+///
+/// Resolution order (first match wins):
+///   1. `params.id` — if present and a valid UUID, use directly.
+///   2. `params.name` — look up `(project_id, user_id, name)` via
+///      `MissionManager::list_missions`. The same identifier used in
+///      `mission_create` is what we resolve back here.
+///   3. `params._args[0]` — positional fallback used by some Tier-0
+///      tool-call shapes; tried as UUID first, then as name.
+///
+/// A non-UUID `id` value is treated as a name (some callers conflate the
+/// two), which keeps backward compat for `mission_complete`'s historical
+/// "name in the id slot" behaviour.
+async fn resolve_mission_id(
+    mgr: &ironclaw_engine::MissionManager,
+    project_id: ironclaw_engine::ProjectId,
+    user_id: &str,
+    params: &serde_json::Value,
+) -> Result<ironclaw_engine::MissionId, EngineError> {
+    // 1. Explicit id field, if it's a valid UUID.
+    if let Some(s) = params
+        .get("id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        && let Ok(uuid) = uuid::Uuid::parse_str(s)
+    {
+        return Ok(ironclaw_engine::MissionId(uuid));
+    }
+
+    // 2/3. Collect every candidate string we might still try as a name.
+    // Order: explicit name, then id-as-name (legacy mission_complete
+    // behaviour), then positional arg.
+    let mut name_candidates: Vec<&str> = Vec::new();
+    for key in ["name", "id"] {
+        if let Some(s) = params
+            .get(key)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            name_candidates.push(s);
+        }
+    }
+    if let Some(s) = params
+        .get("_args")
+        .and_then(|a| a.get(0))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        // Positional arg may be a UUID — try parsing first.
+        if let Ok(uuid) = uuid::Uuid::parse_str(s) {
+            return Ok(ironclaw_engine::MissionId(uuid));
+        }
+        name_candidates.push(s);
+    }
+
+    if name_candidates.is_empty() {
+        return Err(EngineError::Effect {
+            reason: "mission identifier missing: provide 'name' (preferred) \
+                     or 'id' (UUID)"
+                .to_string(),
+        });
+    }
+
+    // De-duplicate while preserving order.
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    name_candidates.retain(|s| seen.insert(*s));
+
+    let missions = mgr.list_missions(project_id, user_id).await?;
+    for candidate in &name_candidates {
+        if let Some(m) = missions.iter().find(|m| m.name == *candidate) {
+            return Ok(m.id);
+        }
+    }
+
+    Err(EngineError::Effect {
+        reason: format!(
+            "mission not found by name: tried {name_candidates:?} for user '{user_id}'. \
+             Use mission_list to see available missions."
+        ),
+    })
 }
 
 /// Translation result from a `routine_*` call into mission_* dispatch.
@@ -7510,6 +7577,190 @@ Use this skill to set up a Pika meeting.
         assert!(
             uuid::Uuid::parse_str(thread_id).is_ok(),
             "thread_id must be a valid UUID, got {thread_id:?}",
+        );
+    }
+
+    /// Regression for #2583: `mission_fire` must accept a `name` parameter
+    /// and resolve it to the mission's id internally. Before this fix the
+    /// handler hard-required a UUID `id`, the `routine_fire` alias path
+    /// passed through the agent's `name=...` unchanged, and the resulting
+    /// "invalid mission id: invalid length 0" loop was the actual root
+    /// cause of the bug bash failure (not the budget-rework hypothesis in
+    /// the linked #2843).
+    #[tokio::test]
+    async fn mission_fire_resolves_by_name_when_id_absent() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("name-fire-1"));
+
+        adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "fire-by-name",
+                    "goal": "verify name-based fire",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create should succeed");
+
+        let fire = adapter
+            .execute_action(
+                "mission_fire",
+                serde_json::json!({"name": "fire-by-name"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("fire by name should succeed");
+
+        assert!(!fire.is_error, "fire by name failed: {}", fire.output);
+        assert_eq!(
+            fire.output.get("status").and_then(|v| v.as_str()),
+            Some("fired"),
+            "name-based fire should produce 'fired' status, got: {}",
+            fire.output
+        );
+        assert!(
+            fire.output
+                .get("thread_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| uuid::Uuid::parse_str(s).is_ok()),
+            "fired response must include a UUID thread_id"
+        );
+    }
+
+    /// Calling the LLM-facing `routine_fire` alias with a `name` parameter
+    /// must resolve through the bridge's mission_fire handler. This is the
+    /// exact path that #2583 reproduces — the agent calls
+    /// `routine_fire(name="bitcoin_price_checker")` and the handler
+    /// previously rejected with "invalid mission id" because it tried to
+    /// parse the routine name as a UUID.
+    #[tokio::test]
+    async fn routine_fire_alias_resolves_by_name_through_mission_fire() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("alias-name-fire-1"));
+
+        adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "bitcoin_price_checker",
+                    "goal": "fetch BTC price",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create should succeed");
+
+        let fire = adapter
+            .execute_action(
+                "routine_fire",
+                serde_json::json!({"name": "bitcoin_price_checker"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("routine_fire alias should dispatch through mission_fire");
+
+        assert!(
+            !fire.is_error,
+            "routine_fire by name failed: {}",
+            fire.output
+        );
+        assert_eq!(
+            fire.output.get("status").and_then(|v| v.as_str()),
+            Some("fired"),
+            "routine_fire alias should produce 'fired' status, got: {}",
+            fire.output
+        );
+    }
+
+    /// Calling `mission_fire` with neither `id` nor `name` must surface a
+    /// clear, actionable error rather than an empty-UUID parse failure.
+    /// The previous error message ("invalid mission id: invalid length:
+    /// expected length 32 for simple format, found 0") leaked the internal
+    /// validation noise to the LLM and contributed to retry loops.
+    #[tokio::test]
+    async fn mission_fire_errors_when_neither_id_nor_name_provided() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("no-id-no-name-1"));
+
+        let res = adapter
+            .execute_action("mission_fire", serde_json::json!({}), &lease(), &ctx)
+            .await
+            .expect("missing-id-and-name should produce an ActionResult, not panic");
+        assert!(
+            res.is_error,
+            "ActionResult must be flagged is_error when params are missing: {res:?}"
+        );
+        let s = res
+            .output
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            s.contains("name") && s.contains("id"),
+            "error message must mention both 'name' and 'id' so the LLM knows \
+             what to do; got: {s}"
+        );
+    }
+
+    /// Calling `mission_fire` with a `name` that doesn't exist must error
+    /// with a message that names the missing mission and points at
+    /// `mission_list` for discovery. The previous "invalid mission id" leak
+    /// was actively misleading — the mission existed under a different id.
+    #[tokio::test]
+    async fn mission_fire_errors_with_helpful_message_when_name_not_found() {
+        let adapter = make_adapter_with_missions().await;
+        let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("name-not-found-1"));
+
+        // Create a mission with a different name so we know the mission
+        // store is reachable; this isolates the failure to "name lookup
+        // didn't match" rather than "no missions exist for user".
+        adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "real-mission",
+                    "goal": "exists",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("create should succeed");
+
+        let res = adapter
+            .execute_action(
+                "mission_fire",
+                serde_json::json!({"name": "no-such-mission"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("unknown-name fire should produce an ActionResult, not panic");
+        assert!(
+            res.is_error,
+            "ActionResult must be flagged is_error when name lookup fails: {res:?}"
+        );
+        let s = res
+            .output
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            s.contains("no-such-mission"),
+            "error must echo the missing name; got: {s}"
+        );
+        assert!(
+            s.contains("mission_list"),
+            "error should hint at mission_list for discovery; got: {s}"
         );
     }
 

--- a/src/bridge/engine_actions.rs
+++ b/src/bridge/engine_actions.rs
@@ -155,7 +155,11 @@ pub(crate) fn mission_capability_actions() -> Vec<ActionDef> {
             Some(action_discovery_summary(
                 &[],
                 &[
-                    "Identify the mission to update with `name` (preferred) or `id` — exactly one is required.",
+                    "Identify the mission with `name` (preferred) or `id` (UUID). \
+                     If both are provided they must identify the same mission, or use \
+                     the legacy `{id, name}` rename shape (where `name` is the new \
+                     name) — otherwise the resolver errors with \
+                     'identify different missions'.",
                     "Only include the fields you want to change; omitted fields keep their existing values.",
                     "When renaming, set `new_name` (not `name`); `name` remains the lookup key.",
                     "When updating cadence, keep timezone aligned with cron-based schedules.",

--- a/src/bridge/engine_actions.rs
+++ b/src/bridge/engine_actions.rs
@@ -86,60 +86,61 @@ pub(crate) fn mission_capability_actions() -> Vec<ActionDef> {
         ),
         mission_action(
             "mission_get",
-            "Get detailed status and results of a specific mission or routine. Returns the mission state, approach history, and recent thread outputs. Use when the user asks about mission results, outcome, or progress.",
+            "Get detailed status and results of a specific mission or routine. Returns the mission state, approach history, and recent thread outputs. Use when the user asks about mission results, outcome, or progress. Provide either `name` (preferred — the same name used at create time) or `id` (UUID).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "id": {"type": "string", "description": "Mission/routine ID to retrieve"}
-                },
-                "required": ["id"]
+                    "name": {"type": "string", "description": "Mission/routine name to retrieve (preferred — the same name used at create time)"},
+                    "id": {"type": "string", "description": "Mission/routine UUID (legacy alternative; only needed if you already hold a UUID)"}
+                }
             }),
             None,
         ),
         mission_action(
             "mission_fire",
-            "Manually trigger a mission or routine to run immediately.",
+            "Manually trigger a mission or routine to run immediately. Provide either `name` (preferred — the same name used at create time) or `id` (UUID).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "id": {"type": "string", "description": "Mission/routine ID to trigger"}
-                },
-                "required": ["id"]
+                    "name": {"type": "string", "description": "Mission/routine name to trigger (preferred — the same name used at create time)"},
+                    "id": {"type": "string", "description": "Mission/routine UUID (legacy alternative; only needed if you already hold a UUID)"}
+                }
             }),
             None,
         ),
         mission_action(
             "mission_pause",
-            "Pause a running mission or routine.",
+            "Pause a running mission or routine. Provide either `name` (preferred) or `id` (UUID).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "id": {"type": "string", "description": "Mission/routine ID to pause"}
-                },
-                "required": ["id"]
+                    "name": {"type": "string", "description": "Mission/routine name to pause (preferred)"},
+                    "id": {"type": "string", "description": "Mission/routine UUID (legacy alternative)"}
+                }
             }),
             None,
         ),
         mission_action(
             "mission_resume",
-            "Resume a paused mission or routine.",
+            "Resume a paused mission or routine. Provide either `name` (preferred) or `id` (UUID).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "id": {"type": "string", "description": "Mission/routine ID to resume"}
-                },
-                "required": ["id"]
+                    "name": {"type": "string", "description": "Mission/routine name to resume (preferred)"},
+                    "id": {"type": "string", "description": "Mission/routine UUID (legacy alternative)"}
+                }
             }),
             None,
         ),
         mission_action(
             "mission_update",
-            "Update an existing mission or routine. Only include fields you want to change; omitted fields remain unchanged.",
+            "Update an existing mission or routine. Only include fields you want to change; omitted fields remain unchanged. Identify the target by `name` (preferred) or `id` (UUID).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "id": {"type": "string", "description": "Mission/routine ID to update"},
-                    "name": {"type": "string", "description": "New display name"},
+                    "name": {"type": "string", "description": "Mission/routine name to update (preferred). When also setting `new_name`, this is the lookup key."},
+                    "id": {"type": "string", "description": "Mission/routine UUID (legacy alternative)"},
+                    "new_name": {"type": "string", "description": "New display name (use this when renaming; the existing `name` field is the lookup key)"},
                     "goal": {"type": "string", "description": "New mission goal"},
                     "cadence": {"type": "string", "description": "New cadence: manual, cron, event:<channel>:<pattern>, or webhook:<path>"},
                     "timezone": {"type": "string", "description": "IANA timezone for cron scheduling"},
@@ -149,13 +150,14 @@ pub(crate) fn mission_capability_actions() -> Vec<ActionDef> {
                     "dedup_window_secs": {"type": "integer", "minimum": 0, "description": "Duplicate event suppression window"},
                     "max_threads_per_day": {"type": "integer", "minimum": 0, "description": "Daily thread budget"},
                     "success_criteria": {"type": "string", "description": "Completion criteria"}
-                },
-                "required": ["id"]
+                }
             }),
             Some(action_discovery_summary(
-                &["id"],
+                &[],
                 &[
+                    "Identify the mission to update with `name` (preferred) or `id` — exactly one is required.",
                     "Only include the fields you want to change; omitted fields keep their existing values.",
+                    "When renaming, set `new_name` (not `name`); `name` remains the lookup key.",
                     "When updating cadence, keep timezone aligned with cron-based schedules.",
                 ],
                 &[
@@ -165,13 +167,13 @@ pub(crate) fn mission_capability_actions() -> Vec<ActionDef> {
         ),
         mission_action(
             "mission_complete",
-            "Mark a mission or routine complete.",
+            "Mark a mission or routine complete. Provide either `name` (preferred) or `id` (UUID).",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "id": {"type": "string", "description": "Mission/routine ID to complete"}
-                },
-                "required": ["id"]
+                    "name": {"type": "string", "description": "Mission/routine name to complete (preferred)"},
+                    "id": {"type": "string", "description": "Mission/routine UUID (legacy alternative)"}
+                }
             }),
             None,
         ),

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4184,17 +4184,30 @@ pub(crate) async fn handle_mission_notification(
                         &notif.user_id,
                     )
                     .await;
+                    // Forward `gate_request_id` (a freshly-generated
+                    // UUID), NOT the engine `call_id`. The gateway's
+                    // gate-resolve handler at
+                    // `channels/web/features/chat/mod.rs:183` (and the
+                    // WS handler at `platform/ws.rs:236`) call
+                    // `Uuid::parse_str` on the inbound `request_id` and
+                    // 400 on non-UUIDs — `call_id` ("call_xyz...") would
+                    // make the auth-tray entry unresolvable. Engine
+                    // `call_id` is preserved on `MissionGateInfo` for
+                    // half-2 auto-resume (#3166).
                     StatusUpdate::AuthRequired {
                         extension_name,
                         instructions: Some(instructions.clone()),
                         auth_url: auth_url.clone(),
                         setup_url: None,
-                        request_id: Some(gate.request_id.clone()),
+                        request_id: Some(gate.gate_request_id.to_string()),
                     }
                 }
                 ironclaw_engine::ResumeKind::Approval { allow_always } => {
                     StatusUpdate::ApprovalNeeded {
-                        request_id: gate.request_id.clone(),
+                        // See the AuthRequired arm above for why we
+                        // forward `gate_request_id` rather than the
+                        // engine `call_id`.
+                        request_id: gate.gate_request_id.to_string(),
                         tool_name: gate.action_name.clone(),
                         description: format!(
                             "Mission '{}' is waiting for approval to run '{}'.",

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1760,6 +1760,9 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
         let sse_ref = agent.deps.sse_tx.clone();
         let db_ref = agent.deps.store.clone();
         let conv_mgr_ref = Arc::clone(&conversation_manager);
+        let auth_mgr_ref = agent.deps.auth_manager.clone();
+        let tools_ref = Arc::clone(&agent.deps.tools);
+        let ext_mgr_ref = agent.deps.extension_manager.clone();
         tokio::spawn(async move {
             loop {
                 match notification_rx.recv().await {
@@ -1770,6 +1773,9 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
                             sse_ref.as_ref(),
                             db_ref.as_ref(),
                             Some(conv_mgr_ref.as_ref()),
+                            auth_mgr_ref.as_deref(),
+                            Some(&tools_ref),
+                            ext_mgr_ref.as_deref(),
                         )
                         .await;
                     }
@@ -4128,18 +4134,91 @@ fn interpret_message_event(role: &str, content_preview: &str) -> Option<&'static
 ///    consistent with what the user actually saw.
 // pub(crate) for #[cfg(test)] re-export in mod.rs; the module itself
 // is private so this has no production visibility beyond router.rs.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_mission_notification(
     notif: &ironclaw_engine::MissionNotification,
     channels: &std::sync::Arc<crate::channels::ChannelManager>,
     sse: Option<&Arc<SseManager>>,
     db: Option<&Arc<dyn Database>>,
     conv_mgr: Option<&ironclaw_engine::ConversationManager>,
+    auth_manager: Option<&AuthManager>,
+    tools: Option<&Arc<crate::tools::ToolRegistry>>,
+    extension_manager: Option<&crate::extensions::ExtensionManager>,
 ) {
     let Some(ref text) = notif.response else {
         return;
     };
 
     let full_text = format!("**[{}]** {text}", notif.mission_name);
+
+    // If the mission paused on a gate (auth, approval, external), surface
+    // the gate on every notify_channel via a structured StatusUpdate. This
+    // is what lights up the gateway UI's auth tray (or the equivalent in
+    // chat-only channels). The friendly text response below is still
+    // delivered alongside so the user sees the prompt in chat history.
+    //
+    // Pinned by issue #3133: previously a mission's child thread that
+    // paused on Gmail OAuth would emit no channel signal at all — the
+    // user got nothing actionable, the cron would re-fire on the same
+    // gate, and the LLM eventually narrated "Status: None Error: None"
+    // when its `http` fallback failed. The mission is now Paused
+    // (engine-side) AND the user gets an auth-tray entry to resolve.
+    if let Some(gate) = &notif.gate
+        && let Some(tools) = tools
+    {
+        for channel_name in &notif.notify_channels {
+            let metadata = serde_json::json!({"user_id": notif.user_id});
+            let status = match &gate.resume_kind {
+                ironclaw_engine::ResumeKind::Authentication {
+                    credential_name,
+                    instructions,
+                    auth_url,
+                } => {
+                    let extension_name = resolve_extension_for_action(
+                        auth_manager,
+                        extension_manager,
+                        tools,
+                        &gate.action_name,
+                        &gate.parameters,
+                        credential_name.as_str(),
+                        &notif.user_id,
+                    )
+                    .await;
+                    StatusUpdate::AuthRequired {
+                        extension_name,
+                        instructions: Some(instructions.clone()),
+                        auth_url: auth_url.clone(),
+                        setup_url: None,
+                        request_id: Some(gate.request_id.clone()),
+                    }
+                }
+                ironclaw_engine::ResumeKind::Approval { allow_always } => {
+                    StatusUpdate::ApprovalNeeded {
+                        request_id: gate.request_id.clone(),
+                        tool_name: gate.action_name.clone(),
+                        description: format!(
+                            "Mission '{}' is waiting for approval to run '{}'.",
+                            notif.mission_name, gate.action_name
+                        ),
+                        parameters: gate.parameters.clone(),
+                        allow_always: *allow_always,
+                    }
+                }
+                // External callbacks (webhooks etc.) don't have a
+                // user-facing tray entry — there's nothing the user can do
+                // beyond wait for the external system to reply. The text
+                // response still tells them what's pending.
+                ironclaw_engine::ResumeKind::External { .. } => continue,
+            };
+            if let Err(e) = channels.send_status(channel_name, status, &metadata).await {
+                debug!(
+                    channel = %channel_name,
+                    mission = %notif.mission_name,
+                    "failed to surface mission gate status: {e}"
+                );
+            }
+        }
+    }
 
     // `notify_user` takes precedence over the mission owner's user_id when
     // set — it lets a routine/mission deliver to a specific recipient

--- a/src/channels/web/tests/no_silent_drop.rs
+++ b/src/channels/web/tests/no_silent_drop.rs
@@ -211,12 +211,22 @@ async fn mission_notification_cross_user_does_not_leak_owner_thread_id() {
         notify_user: Some("other-user".to_string()),
         response: Some("mission result".to_string()),
         is_error: false,
+        gate: None,
     };
 
     let owner_thread_id = notif.thread_id.to_string();
 
-    crate::bridge::handle_mission_notification(&notif, &channels, Some(&sse), Some(&store), None)
-        .await;
+    crate::bridge::handle_mission_notification(
+        &notif,
+        &channels,
+        Some(&sse),
+        Some(&store),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     // The recipient should get an event with a thread_id that is NOT the
     // owner's mission thread — it should be their own assistant thread.
@@ -286,12 +296,22 @@ async fn mission_notification_same_user_attaches_owner_thread_id() {
         notify_user: None, // owner IS the recipient
         response: Some("mission result".to_string()),
         is_error: false,
+        gate: None,
     };
 
     let owner_thread_id = notif.thread_id.to_string();
 
-    crate::bridge::handle_mission_notification(&notif, &channels, Some(&sse), Some(&store), None)
-        .await;
+    crate::bridge::handle_mission_notification(
+        &notif,
+        &channels,
+        Some(&sse),
+        Some(&store),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     // The owner should receive two events:
     // 1. From GatewayChannel::broadcast() (channel path)
@@ -354,12 +374,22 @@ async fn mission_notification_explicit_same_user_attaches_owner_thread_id() {
         notify_user: Some("test-user".to_string()),
         response: Some("mission result".to_string()),
         is_error: false,
+        gate: None,
     };
 
     let owner_thread_id = notif.thread_id.to_string();
 
-    crate::bridge::handle_mission_notification(&notif, &channels, Some(&sse), Some(&store), None)
-        .await;
+    crate::bridge::handle_mission_notification(
+        &notif,
+        &channels,
+        Some(&sse),
+        Some(&store),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
 
     let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
         .await

--- a/tests/e2e_live_mission_gmail.rs
+++ b/tests/e2e_live_mission_gmail.rs
@@ -1,0 +1,324 @@
+//! Live end-to-end test for issue #3133 — "Mission to send an email failed".
+//!
+//! The bug report shows a mission firing every 3 minutes whose child
+//! thread bails with the FINAL() body:
+//!
+//!   "Failed to send email. Status: None Error: None
+//!    Next focus: Debug Gmail authentication or try alternative email method."
+//!
+//! The "Status: None Error: None" wording is not from any of our Rust
+//! code — it's the LLM looking at a tool response (probably the `http`
+//! tool's reply shape, possibly a Gmail tool error path) where it
+//! expected populated `status` and `error` fields and found neither.
+//! Three plausible origins:
+//!
+//!   1. The agent fell back to an `http` POST to Gmail's REST API after
+//!      the WASM `gmail` tool call did not resolve cleanly.
+//!   2. The Gmail OAuth token was not seeded for the mission's child
+//!      thread, so the tool errored "Google OAuth token not configured…"
+//!      and the model paraphrased it.
+//!   3. The mission's lease did not include `gmail`, so the call never
+//!      reached the WASM tool at all.
+//!
+//! This test drives a verbatim-flavoured prompt through engine v2 with
+//! Gmail OAuth credentials seeded, and asserts that:
+//!
+//!   1. The agent invoked `mission_create` and `mission_fire`
+//!      (or the routine_* aliases that resolve to the same handlers).
+//!   2. The mission's child thread invoked the `gmail` tool — proving
+//!      the tool was discoverable and the lease covered it.
+//!   3. The notification carries a `**[<mission-name>]**` marker, the
+//!      same structural signal `e2e_live_routine.rs` uses.
+//!   4. The notification body does NOT contain the
+//!      "Status: None Error: None" pattern that #3133 reports — that's
+//!      the regression marker.
+//!   5. The orchestrator never emits "<N> consecutive code errors"
+//!      (sanity check shared with #2583).
+//!
+//! Why drafts, not sends: the bug reproduces equally on `gmail.create_draft`
+//! (which lands in the OAuth account's Drafts folder, no email actually
+//! delivered) as on `gmail.send_message`. Drafts have minimal blast
+//! radius — no real email goes out, and the resulting draft is easy to
+//! delete by id from the test owner's Gmail. Switching the prompt to
+//! "create a draft" instead of "send an email" preserves the auth /
+//! tool-discovery / lease paths the bug actually exercises.
+//!
+//! Run live (records a trace fixture):
+//! ```bash
+//! IRONCLAW_LIVE_TEST=1 cargo test --features libsql --test e2e_live_mission_gmail -- --ignored
+//! ```
+//!
+//! Replay (deterministic, after a fixture has been recorded):
+//! ```bash
+//! cargo test --features libsql --test e2e_live_mission_gmail -- --ignored
+//! ```
+//!
+//! Live mode requires Gmail OAuth credentials in the developer's
+//! `~/.ironclaw/ironclaw.db` under the names declared in `with_secrets`
+//! below. The test rig seeds *only* those rows into its temporary
+//! database; nothing else (workspace memory, conversation history, other
+//! secrets) crosses the boundary. See `tests/support/LIVE_TESTING.md`.
+
+#[cfg(feature = "libsql")]
+mod support;
+
+#[cfg(feature = "libsql")]
+mod live_mission_gmail_tests {
+    use std::time::{Duration, Instant};
+
+    use crate::support::live_harness::{LiveTestHarnessBuilder, TestMode};
+    use crate::support::live_mission_helpers::{
+        ApprovalAutoResponder, looks_like_routine_notification, tool_is, wait_for_response_matching,
+    };
+    use crate::support::test_rig::TestRig;
+
+    /// Channel name to use for the rig — mirrors the real "gateway" channel
+    /// so mission notifications route back the same way they do in production.
+    const CHANNEL: &str = "gateway";
+
+    /// User prompt that reproduces the #3133 flow. We deliberately ask for
+    /// drafts (not sends) so the test has minimal external blast radius.
+    /// "Trigger it once right now" is required to get a synchronous fire
+    /// the test can observe — the `every three minutes` cron alone wouldn't
+    /// fire within the test window.
+    const USER_PROMPT: &str = "Create a mission that creates a Gmail draft \
+        every three minutes. The draft should go to the user's own Gmail \
+        address (whichever account the OAuth token belongs to), with subject \
+        \"Test mission #3133\" and body \"This is a test draft from the \
+        IronClaw mission system.\" Trigger it once right now and report \
+        whether the draft was created.";
+
+    /// The orchestrator's "consecutive code errors" failure surface — same
+    /// regression marker the routine test guards against. Source:
+    /// `crates/ironclaw_engine/orchestrator/default.py:1003`.
+    const CONSECUTIVE_ERRORS_MARKER: &str = "consecutive code errors";
+
+    /// The exact #3133 regression marker. The model wrote "Status: None
+    /// Error: None" verbatim into FINAL() because it inspected a tool
+    /// response shape with `status` and `error` keys that were both
+    /// `None`. If that pattern shows up in the captured notification,
+    /// the bug is back.
+    const STATUS_NONE_MARKER: &str = "Status: None";
+    const ERROR_NONE_MARKER: &str = "Error: None";
+
+    fn init_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+            )
+            .with_test_writer()
+            .try_init();
+    }
+
+    /// Engine v2's mission_create matches; the bridge alias path also
+    /// translates `routine_create`. Accept either.
+    fn used_create(tools: &[String]) -> bool {
+        tools
+            .iter()
+            .any(|t| tool_is(t, "mission_create") || tool_is(t, "routine_create"))
+    }
+
+    /// Same dual-name acceptance for fire.
+    fn used_fire(tools: &[String]) -> bool {
+        tools
+            .iter()
+            .any(|t| tool_is(t, "mission_fire") || tool_is(t, "routine_fire"))
+    }
+
+    /// Did the mission's child thread actually invoke the Gmail WASM tool?
+    /// Tool name on the wire is `gmail`; arguments may be folded in as
+    /// `gmail(create_draft)` via `format_action_display_name`.
+    fn used_gmail(tools: &[String]) -> bool {
+        tools.iter().any(|t| tool_is(t, "gmail"))
+    }
+
+    /// Assert no captured response contains the #3133 regression marker.
+    /// The check is structural — we look for both "Status: None" AND
+    /// "Error: None" in the same response, since either alone could appear
+    /// in unrelated narration; the dual presence is the bug fingerprint.
+    async fn assert_no_status_none_failure(rig: &TestRig, where_in_test: &str) {
+        let responses = rig.wait_for_responses(0, Duration::from_millis(0)).await;
+        for r in &responses {
+            let has_status = r.content.contains(STATUS_NONE_MARKER);
+            let has_error = r.content.contains(ERROR_NONE_MARKER);
+            assert!(
+                !(has_status && has_error),
+                "[{where_in_test}] regression: response carried both \
+                 '{STATUS_NONE_MARKER}' and '{ERROR_NONE_MARKER}' — the \
+                 #3133 fingerprint of a Gmail mission FINAL() that bailed \
+                 with no useful diagnosis. Full response: {}",
+                r.content
+            );
+        }
+    }
+
+    /// Assert no captured response contains the orchestrator's consecutive-
+    /// errors failure surface (mirrors the #2583 sanity check).
+    async fn assert_no_consecutive_errors(rig: &TestRig, where_in_test: &str) {
+        let responses = rig.wait_for_responses(0, Duration::from_millis(0)).await;
+        for r in &responses {
+            assert!(
+                !r.content.to_lowercase().contains(CONSECUTIVE_ERRORS_MARKER),
+                "[{where_in_test}] regression: response carried the \
+                 '{CONSECUTIVE_ERRORS_MARKER}' failure surface from #2583. \
+                 Full response: {}",
+                r.content
+            );
+        }
+    }
+
+    #[test]
+    fn assert_no_status_none_failure_helper_recognises_pattern() {
+        // Dual-marker presence is the regression fingerprint. Single-marker
+        // presence in narration is fine and shouldn't trip the assertion.
+        let bug_text = "Failed to send email. Status: None Error: None\n\
+                        Next focus: Debug Gmail authentication.";
+        assert!(
+            bug_text.contains("Status: None") && bug_text.contains("Error: None"),
+            "the regression fingerprint must be both substrings present in \
+             the same response (the helper wires this together with an &&)"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore] // Live tier: requires Gmail OAuth in ~/.ironclaw/ironclaw.db.
+    // Records/replays from
+    // tests/fixtures/llm_traces/live/mission_gmail_draft_3133.json.
+    async fn mission_gmail_draft_3133() {
+        init_tracing();
+
+        // auto_approve_tools is intentionally OFF for the same reason as
+        // the routine test: administrative actions (mission_create /
+        // mission_fire) and write-effect actions (gmail.create_draft) are
+        // expected to surface ApprovalNeeded gates, and we want the
+        // responder to round-trip them. If the gates never fire, that's
+        // logged as a separate concern (parked under #2583's open items).
+        let harness = LiveTestHarnessBuilder::new("mission_gmail_draft_3133")
+            .with_engine_v2(true)
+            .with_max_tool_iterations(40)
+            .with_auto_approve_tools(false)
+            .with_channel_name(CHANNEL)
+            .with_secrets([
+                "google_oauth_token",
+                "google_oauth_token_refresh_token",
+                "google_oauth_token_scopes",
+            ])
+            .build()
+            .await;
+
+        let rig = harness.rig();
+        let approver = ApprovalAutoResponder::spawn(rig.channel_handle());
+
+        rig.send_message(USER_PROMPT).await;
+
+        // Wait for the mission's child thread to deliver a notification.
+        // Same `**[name]**` anchor the routine test uses — proves the
+        // mission_fire path itself works end-to-end.
+        let setup_deadline = Instant::now() + Duration::from_secs(900);
+        let notification_text =
+            match wait_for_response_matching(rig, looks_like_routine_notification, setup_deadline)
+                .await
+            {
+                Some(text) => text,
+                None => {
+                    let captured: Vec<String> = rig
+                        .wait_for_responses(0, Duration::from_millis(0))
+                        .await
+                        .iter()
+                        .map(|r| r.content.clone())
+                        .collect();
+                    let tools = rig.tool_calls_started();
+                    approver.shutdown();
+                    panic!(
+                        "no mission notification (with **[name]** marker) arrived \
+                     within 15 minutes — the mission did not deliver output \
+                     via the channel. Tool calls observed: {tools:?}. \
+                     Captured responses: {captured:#?}"
+                    );
+                }
+            };
+        eprintln!(
+            "[GmailMissionTest] Notification preview: {}",
+            notification_text.chars().take(400).collect::<String>()
+        );
+
+        // The agent must have invoked mission/routine creation + fire.
+        let tools = rig.tool_calls_started();
+        eprintln!("[GmailMissionTest] Tools observed: {tools:?}");
+        assert!(
+            used_create(&tools),
+            "expected agent to call mission_create or routine_create after \
+             prompt; got tools: {tools:?}"
+        );
+        assert!(
+            used_fire(&tools),
+            "expected agent to fire the newly-created mission for the \
+             'trigger it once right now' clause; got tools: {tools:?}"
+        );
+
+        // Did the Gmail tool actually run? If not, either:
+        //   - the lease/capability path didn't include gmail (real bug), or
+        //   - the agent "tried" via some other route (http fallback).
+        // In either case the FINAL() narration is suspect — emit a
+        // diagnostic warning, but don't fail the test on this alone since
+        // the structural notification check + Status:None check below are
+        // the actual regression guards.
+        if !used_gmail(&tools) {
+            eprintln!(
+                "[GmailMissionTest] WARNING: the gmail WASM tool was not \
+                 invoked even though the prompt asked for a Gmail draft. \
+                 The mission's child thread likely fell back to `http` or \
+                 narrated 'I would call gmail' without actually doing so. \
+                 This is one of the candidate root causes for #3133."
+            );
+        }
+
+        // The hard regression guard for #3133.
+        assert_no_status_none_failure(rig, "after mission notification").await;
+
+        // Sanity: the #2583 fix must still hold — no `consecutive code
+        // errors` should surface. If a fresh path triggers them, that's a
+        // signal the mission_* alias regression is back.
+        assert_no_consecutive_errors(rig, "after mission notification").await;
+
+        // ── Approval-gate observation (warning-only, parked under #2583) ──
+        let approved = approver.approved_tools().await;
+        eprintln!(
+            "[GmailMissionTest] Approvals captured ({}): {approved:?}",
+            approved.len()
+        );
+        if approved.is_empty() {
+            eprintln!(
+                "[GmailMissionTest] WARNING: auto_approve was OFF and zero \
+                 ApprovalNeeded gates were observed. Administrative tools \
+                 (mission_create / mission_fire) and the write-effect \
+                 gmail tool ran without prompting. This is the same parked \
+                 concern from the #2583 PR — track separately."
+            );
+        }
+
+        // Live mode only: surface unexpected tool failures in the captured
+        // trace so a maintainer reviewing a fixture diff sees them.
+        if harness.mode() == TestMode::Live {
+            let trace_errors = harness.collect_trace_errors();
+            if !trace_errors.is_empty() {
+                eprintln!(
+                    "[GmailMissionTest] WARNING: trace contained tool errors \
+                     (not failing the test, but worth investigating): \
+                     {trace_errors:?}"
+                );
+            }
+        }
+
+        approver.shutdown();
+
+        let all_text: Vec<String> = rig
+            .wait_for_responses(0, Duration::from_millis(0))
+            .await
+            .iter()
+            .map(|r| r.content.clone())
+            .collect();
+        harness.finish(USER_PROMPT, &all_text).await;
+    }
+}

--- a/tests/e2e_live_routine.rs
+++ b/tests/e2e_live_routine.rs
@@ -1,0 +1,596 @@
+//! Live end-to-end test for routine creation via engine v2.
+//!
+//! Reproduces the user-reported flow from issue #2583:
+//!
+//!   "Create basic routine for checking price of Bitcoin every five minutes
+//!    and send me test request right now."
+//!
+//! The original report observed the agent failing with "5 consecutive code
+//! errors" after the first one or two BTC price checks. This test drives the
+//! same prompt through engine v2 against a real LLM and asserts:
+//!
+//!   1. The agent invokes a routine/mission creation tool (engine v2 maps
+//!      `routine_create` to `mission_create` via the bridge alias path, so
+//!      either name is accepted).
+//!   2. The agent fires the routine immediately (the "test request right now"
+//!      part) and a notification carrying BTC price content arrives on the
+//!      gateway channel.
+//!   3. A second user turn ("fire the routine again now") triggers another
+//!      successful run that also delivers BTC price content.
+//!   4. No turn ends with the orchestrator's
+//!      "<N> consecutive code errors" failure surface — that string is the
+//!      exact symptom of #2583 and a regression must fail the test loudly.
+//!
+//! Run live (records a trace fixture):
+//! ```bash
+//! IRONCLAW_LIVE_TEST=1 cargo test --features libsql --test e2e_live_routine -- --ignored
+//! ```
+//!
+//! Replay (deterministic, after a fixture has been recorded):
+//! ```bash
+//! cargo test --features libsql --test e2e_live_routine -- --ignored
+//! ```
+
+#[cfg(feature = "libsql")]
+mod support;
+
+#[cfg(feature = "libsql")]
+mod live_routine_tests {
+    use std::collections::HashSet;
+    use std::time::{Duration, Instant};
+
+    use ironclaw::channels::{IncomingMessage, StatusUpdate};
+    use uuid::Uuid;
+
+    use crate::support::live_harness::{LiveTestHarnessBuilder, TestMode};
+    use crate::support::test_channel::TestChannel;
+    use crate::support::test_rig::TestRig;
+
+    /// Channel name to use for the rig — mirrors the real "gateway" channel
+    /// so routine notifications route back the same way they do in production.
+    const CHANNEL: &str = "gateway";
+
+    /// The user-reported prompt verbatim (issue #2583).
+    const USER_PROMPT: &str = "Create basic routine for checking price of Bitcoin \
+        every five minutes and send me test request right now.";
+
+    /// Second-turn prompt that asks the agent to re-fire the routine it just
+    /// created. Phrased loosely so it works whether the agent created a
+    /// "routine" (engine v1 vocabulary) or a "mission" (engine v2 vocabulary).
+    const REFIRE_PROMPT: &str = "Trigger that Bitcoin price routine you just \
+        created one more time right now and report back the price it returns.";
+
+    /// The exact orchestrator failure string the bug reproduces. If this
+    /// substring appears anywhere in the captured responses, the regression
+    /// is back. Source: `crates/ironclaw_engine/orchestrator/default.py:1003`.
+    const CONSECUTIVE_ERRORS_MARKER: &str = "consecutive code errors";
+
+    fn init_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+            )
+            .with_test_writer()
+            .try_init();
+    }
+
+    /// Returns true if `tool` is the bare action name `expected` or carries
+    /// the same name with a parenthesised argument suffix
+    /// (e.g. `routine_create(name)` from `format_action_display_name`).
+    fn tool_is(tool: &str, expected: &str) -> bool {
+        tool == expected
+            || tool
+                .strip_prefix(expected)
+                .is_some_and(|rest| rest.starts_with('('))
+    }
+
+    /// Engine v2 surfaces `mission_create`; the bridge alias path also lets
+    /// the LLM call `routine_create` and translates it. Accept either.
+    fn used_create(tools: &[String]) -> bool {
+        tools
+            .iter()
+            .any(|t| tool_is(t, "mission_create") || tool_is(t, "routine_create"))
+    }
+
+    /// Same dual-name acceptance for fire.
+    fn used_fire(tools: &[String]) -> bool {
+        tools
+            .iter()
+            .any(|t| tool_is(t, "mission_fire") || tool_is(t, "routine_fire"))
+    }
+
+    /// Anchor for "the routine actually fired and delivered output via
+    /// the notification channel" — independent of the formatting quality
+    /// of that output. Mirrors `e2e_live_mission.rs`'s `**[name]**`
+    /// marker check: engine v2 mission fires (which is what
+    /// `routine_fire` becomes via the bridge alias) wrap their
+    /// notifications with `**[<mission-name>]**` so the channel can
+    /// distinguish the fire output from the agent's foreground reply.
+    ///
+    /// Used as the primary gate for the #2583 regression test. The
+    /// secondary `looks_like_btc_price` heuristic checks output *quality*,
+    /// but a poorly-formatted notification still proves the fire path
+    /// itself worked — which is what #2583 was actually about.
+    fn looks_like_routine_notification(text: &str) -> bool {
+        // The marker is `**[<name>]**` — two `**` delimiters around a
+        // bracketed name. Any name shape is accepted because the agent
+        // chooses it.
+        if let Some(open) = text.find("**[")
+            && let Some(close_rel) = text[open + 3..].find("]**")
+        {
+            // Reject empty names (`**[]**`) — that's not a real marker.
+            return close_rel > 0;
+        }
+        false
+    }
+
+    #[test]
+    fn looks_like_routine_notification_accepts_marker() {
+        assert!(looks_like_routine_notification(
+            "**[bitcoin_price_checker]** ## Bitcoin Price Check Results\nPrice: $76,182"
+        ));
+    }
+
+    #[test]
+    fn looks_like_routine_notification_rejects_foreground_reply() {
+        // The agent's foreground confirmation has no `**[name]**` marker.
+        assert!(!looks_like_routine_notification(
+            "## Bitcoin Price Checker Routine Created ✅\nSchedule: */5 * * * *"
+        ));
+    }
+
+    /// Heuristic: a response counts as carrying real BTC price *output*
+    /// (not the foreground "I created the routine" reply) when:
+    ///
+    /// 1. It mentions Bitcoin or BTC, AND
+    /// 2. It contains a USD-shaped numeric price token — `$<digits>` with
+    ///    optional thousands separators and an optional decimal — like
+    ///    `$76,182`, `$76,182.45`, or `$1,234,567.89`. The captured digits
+    ///    must total at least 3 to filter out stray "$5" tokens that show
+    ///    up in free-form text.
+    ///
+    /// This is the *quality* signal, used for warnings and the LLM judge.
+    /// The structural "did the fire happen?" check is
+    /// `looks_like_routine_notification`.
+    fn looks_like_btc_price(text: &str) -> bool {
+        use std::sync::OnceLock;
+        static PRICE_RE: OnceLock<regex::Regex> = OnceLock::new();
+        // Match `$<digits>(,<digits>)*(\.<digits>+)?`. The `re.find_iter`
+        // pass below filters captured tokens by total digit count.
+        let re = PRICE_RE.get_or_init(|| {
+            regex::Regex::new(r"\$(\d+(?:,\d+)*(?:\.\d+)?)").expect("BTC price regex must compile")
+        });
+
+        let lower = text.to_lowercase();
+        if !(lower.contains("bitcoin") || lower.contains("btc")) {
+            return false;
+        }
+        re.captures_iter(text).any(|c| {
+            let digits = c
+                .get(1)
+                .map(|m| m.as_str())
+                .unwrap_or("")
+                .chars()
+                .filter(|c| c.is_ascii_digit())
+                .count();
+            digits >= 3
+        })
+    }
+
+    #[test]
+    fn looks_like_btc_price_rejects_creation_confirmation() {
+        // The exact false-positive observed during the first live run of
+        // this test: the agent's foreground reply confirming routine
+        // creation. It mentions Bitcoin and has a 4-digit-style cron
+        // literal but no dollar-prefixed price.
+        let text = "## Bitcoin Price Checker Routine Created ✅\n\
+                    Schedule: */5 * * * *";
+        assert!(
+            !looks_like_btc_price(text),
+            "creation-confirmation message must not pass the BTC-price heuristic"
+        );
+    }
+
+    #[test]
+    fn looks_like_btc_price_accepts_real_price_notification() {
+        let text = "**[bitcoin_price_checker]** ## Bitcoin Price Check Results\n\
+                    Current price: $76,182.45 USD";
+        assert!(
+            looks_like_btc_price(text),
+            "real price notification must pass the heuristic"
+        );
+    }
+
+    #[test]
+    fn looks_like_btc_price_accepts_simple_dollar_price() {
+        // Lower-budget shape: just `$<n>,<nnn>` with no decimal.
+        assert!(looks_like_btc_price("BTC is at $76,166 right now"));
+    }
+
+    #[test]
+    fn looks_like_btc_price_rejects_dollarless_text() {
+        assert!(!looks_like_btc_price(
+            "I will create a Bitcoin routine that checks every 5 minutes"
+        ));
+    }
+
+    /// Background approval auto-responder.
+    ///
+    /// Polls the `TestChannel`'s captured status events every 500ms and
+    /// resolves each `StatusUpdate::ApprovalNeeded` it has not already seen
+    /// by injecting a `Submission::ExecApproval { approved: true,
+    /// always: false }` back into the channel. Per-call approval is
+    /// deliberate — we want every fire to round-trip through the gate so a
+    /// regression that breaks the second gate (e.g. session-state leakage
+    /// between fires) shows up.
+    ///
+    /// Holds an `Arc<TestChannel>` rather than `&TestRig` so it can outlive
+    /// any individual borrow on the rig.
+    struct ApprovalAutoResponder {
+        approved: std::sync::Arc<tokio::sync::Mutex<Vec<(String, Uuid)>>>,
+        handle: tokio::task::JoinHandle<()>,
+    }
+
+    impl ApprovalAutoResponder {
+        fn spawn(channel: std::sync::Arc<TestChannel>) -> Self {
+            let approved =
+                std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<(String, Uuid)>::new()));
+            let approved_for_task = approved.clone();
+            let handle = tokio::spawn(async move {
+                let mut seen: HashSet<Uuid> = HashSet::new();
+                loop {
+                    for event in channel.captured_status_events() {
+                        if let StatusUpdate::ApprovalNeeded {
+                            request_id,
+                            tool_name,
+                            ..
+                        } = event
+                        {
+                            let Ok(rid) = Uuid::parse_str(&request_id) else {
+                                continue;
+                            };
+                            if seen.insert(rid) {
+                                eprintln!(
+                                    "[RoutineTest] Auto-approving '{tool_name}' \
+                                     (request_id={rid})"
+                                );
+                                let submission =
+                                    ironclaw::agent::submission::Submission::ExecApproval {
+                                        request_id: rid,
+                                        approved: true,
+                                        always: false,
+                                    };
+                                let msg = IncomingMessage::new(
+                                    channel.channel_name(),
+                                    channel.user_id(),
+                                    "",
+                                )
+                                .with_structured_submission(submission);
+                                channel.send_incoming(msg).await;
+                                approved_for_task.lock().await.push((tool_name, rid));
+                            }
+                        }
+                    }
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            });
+            Self { approved, handle }
+        }
+
+        async fn approved_tools(&self) -> Vec<(String, Uuid)> {
+            self.approved.lock().await.clone()
+        }
+
+        fn shutdown(self) {
+            self.handle.abort();
+        }
+    }
+
+    /// Wait until at least one captured response satisfies `predicate`,
+    /// polling every 500ms until `deadline`. Returns the first match.
+    async fn wait_for_response_matching<F>(
+        rig: &TestRig,
+        predicate: F,
+        deadline: Instant,
+    ) -> Option<String>
+    where
+        F: Fn(&str) -> bool,
+    {
+        loop {
+            let responses = rig.wait_for_responses(0, Duration::from_millis(0)).await;
+            if let Some(r) = responses.iter().find(|r| predicate(&r.content)) {
+                return Some(r.content.clone());
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Assert no captured response contains the orchestrator's consecutive-
+    /// errors failure surface. This is the exact regression #2583 reports.
+    async fn assert_no_consecutive_errors(rig: &TestRig, where_in_test: &str) {
+        let responses = rig.wait_for_responses(0, Duration::from_millis(0)).await;
+        for r in &responses {
+            assert!(
+                !r.content.to_lowercase().contains(CONSECUTIVE_ERRORS_MARKER),
+                "[{where_in_test}] regression: response carried the \
+                 '{CONSECUTIVE_ERRORS_MARKER}' failure surface from #2583. \
+                 Full response: {}",
+                r.content
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[ignore] // Live tier: requires LLM API keys. Records/replays from
+    // tests/fixtures/llm_traces/live/routine_btc_create_test_and_refire.json.
+    async fn routine_btc_create_test_and_refire() {
+        init_tracing();
+
+        // NOTE: auto_approve_tools is intentionally OFF. Routine/mission
+        // create + fire are administrative tools that surface
+        // `ApprovalNeeded` gates; one hypothesis for #2583 is that those
+        // gates are misbehaving (failing to surface, looping, or timing
+        // out). The test resolves each gate on its own via an
+        // `ApprovalAutoResponder` background task and asserts gates were
+        // observed, so a missing gate is a test failure rather than a
+        // silently-skipped path.
+        let harness = LiveTestHarnessBuilder::new("routine_btc_create_test_and_refire")
+            .with_engine_v2(true)
+            .with_max_tool_iterations(40)
+            .with_auto_approve_tools(false)
+            .with_channel_name(CHANNEL)
+            .build()
+            .await;
+
+        let rig = harness.rig();
+        // Spawn the approval auto-responder against a cloned channel handle.
+        // The rig keeps ownership of the channel; the responder's Arc is an
+        // additional reference, not a duplication of the rig.
+        let approver = ApprovalAutoResponder::spawn(rig.channel_handle());
+
+        // ── Turn 1: send the user prompt verbatim ─────────────────────────
+        rig.send_message(USER_PROMPT).await;
+
+        // The setup turn produces multiple captured responses on the gateway
+        // channel: the foreground agent reply ("I created a routine and fired
+        // a test run for you") and the routine's notification carrying the
+        // actual BTC price digest. The fire path produces a notification with
+        // a `**[<routine-name>]**` marker — that's the structural signal that
+        // routine_fire (the #2583 path) executed end-to-end. Output quality
+        // (whether the lightweight LLM produced a clean price string) is a
+        // separate concern verified by the LLM judge and a soft warning
+        // below; failing the test on quality alone would mask the true
+        // regression we're guarding against.
+        let setup_deadline = Instant::now() + Duration::from_secs(900);
+        let setup_notification_text =
+            match wait_for_response_matching(rig, looks_like_routine_notification, setup_deadline)
+                .await
+            {
+                Some(text) => text,
+                None => {
+                    let captured: Vec<String> = rig
+                        .wait_for_responses(0, Duration::from_millis(0))
+                        .await
+                        .iter()
+                        .map(|r| r.content.clone())
+                        .collect();
+                    let tools = rig.tool_calls_started();
+                    panic!(
+                        "no routine notification (with **[name]** marker) arrived \
+                     within 15 minutes — routine_fire did not deliver output \
+                     via the channel. Tool calls observed: {tools:?}. \
+                     Captured responses: {captured:#?}"
+                    );
+                }
+            };
+        eprintln!(
+            "[RoutineTest] Setup routine notification preview: {}",
+            setup_notification_text
+                .chars()
+                .take(400)
+                .collect::<String>()
+        );
+        if !looks_like_btc_price(&setup_notification_text) {
+            eprintln!(
+                "[RoutineTest] WARNING: setup notification does not contain a \
+                 USD-shaped price token — the mission fire ran (the child \
+                 thread spawned by `MissionManager::fire_mission` produced \
+                 a notification) but its FINAL() body did not include the \
+                 actual price the user asked for. This is a separate \
+                 quality issue from #2583 and is not test-failing on its own."
+            );
+        }
+
+        // The agent must have actually invoked routine/mission creation.
+        // The bug reproduces in CodeAct: the agent kept retrying creation
+        // calls and the orchestrator killed the thread at 5 consecutive
+        // failures. If creation never appears in tool calls, we have a
+        // different (and equally-bad) regression.
+        let setup_tools = rig.tool_calls_started();
+        eprintln!("[RoutineTest] Tools after setup turn: {setup_tools:?}");
+        assert!(
+            used_create(&setup_tools),
+            "expected agent to call mission_create or routine_create after \
+             prompt; got tools: {setup_tools:?}"
+        );
+        // The "send me test request right now" clause obliges a fire. If
+        // the agent silently dropped it, the routine is created-but-unverified
+        // and the user request was not honoured.
+        assert!(
+            used_fire(&setup_tools),
+            "expected agent to fire the newly-created routine for the 'test \
+             request right now' clause; got tools: {setup_tools:?}"
+        );
+
+        // The exact #2583 regression marker.
+        assert_no_consecutive_errors(rig, "after setup turn").await;
+
+        // ── Turn 2: ask the agent to refire the routine ───────────────────
+        // Snapshot the response count BEFORE sending so we can wait for new
+        // ones — `wait_for_responses(n, …)` returns once at least `n` total
+        // responses have been seen.
+        let baseline = rig
+            .wait_for_responses(0, Duration::from_millis(0))
+            .await
+            .len();
+        let baseline_fire_count = setup_tools
+            .iter()
+            .filter(|t| tool_is(t, "mission_fire") || tool_is(t, "routine_fire"))
+            .count();
+
+        rig.send_message(REFIRE_PROMPT).await;
+
+        let refire_deadline = Instant::now() + Duration::from_secs(900);
+        // Wait for at least one new response.
+        let after_refire = rig
+            .wait_for_responses(baseline + 1, Duration::from_secs(900))
+            .await;
+        assert!(
+            after_refire.len() > baseline,
+            "expected at least one new response after refire prompt; \
+             baseline={baseline}, total={}",
+            after_refire.len()
+        );
+        // Wait specifically for a routine-notification response that
+        // wasn't already there before turn 2 — the agent's foreground reply
+        // alone (the "I fired it" confirmation) doesn't carry the
+        // `**[name]**` marker, so it's filtered automatically.
+        let new_notification_text = match wait_for_response_matching(
+            rig,
+            |c| looks_like_routine_notification(c) && c != setup_notification_text.as_str(),
+            refire_deadline,
+        )
+        .await
+        {
+            Some(text) => text,
+            None => {
+                let captured: Vec<String> = rig
+                    .wait_for_responses(0, Duration::from_millis(0))
+                    .await
+                    .iter()
+                    .map(|r| r.content.clone())
+                    .collect();
+                let tools = rig.tool_calls_started();
+                panic!(
+                    "no second routine-notification response (with **[name]** \
+                     marker) arrived within 15 minutes after refire prompt — \
+                     the second routine_fire did not deliver fresh output. \
+                     Tool calls so far: {tools:?}. Captured responses: \
+                     {captured:#?}"
+                );
+            }
+        };
+        eprintln!(
+            "[RoutineTest] Refire routine notification preview: {}",
+            new_notification_text.chars().take(400).collect::<String>()
+        );
+        if !looks_like_btc_price(&new_notification_text) {
+            eprintln!(
+                "[RoutineTest] WARNING: refire notification does not contain a \
+                 USD-shaped price token (separate quality issue from #2583)."
+            );
+        }
+
+        // The agent must have invoked fire again on the second turn.
+        let total_tools = rig.tool_calls_started();
+        let total_fire_count = total_tools
+            .iter()
+            .filter(|t| tool_is(t, "mission_fire") || tool_is(t, "routine_fire"))
+            .count();
+        assert!(
+            total_fire_count > baseline_fire_count,
+            "expected at least one additional mission_fire/routine_fire on \
+             refire turn; baseline_fire_count={baseline_fire_count}, \
+             total_fire_count={total_fire_count}, all tools: {total_tools:?}"
+        );
+
+        assert_no_consecutive_errors(rig, "after refire turn").await;
+
+        // ── Optional semantic check via LLM judge ─────────────────────────
+        // Both notifications should read like Bitcoin price answers, not
+        // refusals or routing errors. Live mode only; replay returns None.
+        let criteria = "Each response is a Bitcoin price update. It mentions \
+            Bitcoin or BTC and contains a numeric price (with a dollar sign \
+            or a price-shaped number). It does NOT report failure, refusal, \
+            or '5 consecutive code errors' / similar orchestrator error \
+            wording.";
+        let combined = vec![
+            setup_notification_text.clone(),
+            new_notification_text.clone(),
+        ];
+        if let Some(verdict) = harness.judge(&combined, criteria).await {
+            assert!(
+                verdict.pass,
+                "LLM judge rejected the routine output: {}",
+                verdict.reasoning
+            );
+        }
+
+        // Live mode only: surface unexpected tool failures in the captured
+        // trace. `finish` (non-strict) records the fixture without panicking
+        // on benign warnings; we intentionally don't use `finish_strict` here
+        // because a transient HTTP error from the public BTC price source
+        // would otherwise mask the real result.
+        if harness.mode() == TestMode::Live {
+            let trace_errors = harness.collect_trace_errors();
+            if !trace_errors.is_empty() {
+                eprintln!(
+                    "[RoutineTest] WARNING: trace contained tool errors \
+                     (not failing the test, but worth investigating): \
+                     {trace_errors:?}"
+                );
+            }
+        }
+
+        // ── Approval-gate observation (warning-only) ──────────────────────
+        // `auto_approve_tools(false)` was set so routine/mission lifecycle
+        // actions *should* surface `ApprovalNeeded` gates that the
+        // background responder resolves. Empirically (verified by the live
+        // run that proved the #2583 fix landed) engine v2 currently runs
+        // these administrative tools without firing a gate — the
+        // `AUTONOMOUS_TOOL_DENYLIST` classification in
+        // `crates/ironclaw_engine/src/gate/tool_tier.rs` does not appear
+        // to trigger an `ApprovalNeeded` emission on the channel side.
+        //
+        // That's a real concern (administrative tools running unprompted
+        // when auto-approve is OFF), but it's a *separate* root cause from
+        // #2583 and the user explicitly asked to keep it parked as its
+        // own issue. We log it as a warning here so the next maintainer
+        // looking at this test sees the symptom and can file/investigate
+        // independently, but we do NOT fail the test — failing here would
+        // mask the fact that the actual #2583 fix is verified passing.
+        let approved = approver.approved_tools().await;
+        eprintln!(
+            "[RoutineTest] Approvals captured ({}): {approved:?}",
+            approved.len()
+        );
+        if approved.is_empty() {
+            eprintln!(
+                "[RoutineTest] WARNING: auto_approve was OFF and zero \
+                 ApprovalNeeded gates were observed. Administrative tools \
+                 (mission_create / routine_create / mission_fire / \
+                 routine_fire) ran without prompting. This is a separate \
+                 concern from the #2583 fix this test guards — file/track \
+                 it as its own issue."
+            );
+        } else {
+            let approved_names: Vec<&str> =
+                approved.iter().map(|(name, _)| name.as_str()).collect();
+            eprintln!("[RoutineTest] Approval gates surfaced for: {approved_names:?}");
+        }
+
+        approver.shutdown();
+
+        let all_text: Vec<String> = rig
+            .wait_for_responses(0, Duration::from_millis(0))
+            .await
+            .iter()
+            .map(|r| r.content.clone())
+            .collect();
+        harness.finish(USER_PROMPT, &all_text).await;
+    }
+}

--- a/tests/e2e_live_routine.rs
+++ b/tests/e2e_live_routine.rs
@@ -36,14 +36,12 @@ mod support;
 
 #[cfg(feature = "libsql")]
 mod live_routine_tests {
-    use std::collections::HashSet;
     use std::time::{Duration, Instant};
 
-    use ironclaw::channels::{IncomingMessage, StatusUpdate};
-    use uuid::Uuid;
-
     use crate::support::live_harness::{LiveTestHarnessBuilder, TestMode};
-    use crate::support::test_channel::TestChannel;
+    use crate::support::live_mission_helpers::{
+        ApprovalAutoResponder, looks_like_routine_notification, tool_is, wait_for_response_matching,
+    };
     use crate::support::test_rig::TestRig;
 
     /// Channel name to use for the rig — mirrors the real "gateway" channel
@@ -75,16 +73,6 @@ mod live_routine_tests {
             .try_init();
     }
 
-    /// Returns true if `tool` is the bare action name `expected` or carries
-    /// the same name with a parenthesised argument suffix
-    /// (e.g. `routine_create(name)` from `format_action_display_name`).
-    fn tool_is(tool: &str, expected: &str) -> bool {
-        tool == expected
-            || tool
-                .strip_prefix(expected)
-                .is_some_and(|rest| rest.starts_with('('))
-    }
-
     /// Engine v2 surfaces `mission_create`; the bridge alias path also lets
     /// the LLM call `routine_create` and translates it. Accept either.
     fn used_create(tools: &[String]) -> bool {
@@ -98,46 +86,6 @@ mod live_routine_tests {
         tools
             .iter()
             .any(|t| tool_is(t, "mission_fire") || tool_is(t, "routine_fire"))
-    }
-
-    /// Anchor for "the routine actually fired and delivered output via
-    /// the notification channel" — independent of the formatting quality
-    /// of that output. Mirrors `e2e_live_mission.rs`'s `**[name]**`
-    /// marker check: engine v2 mission fires (which is what
-    /// `routine_fire` becomes via the bridge alias) wrap their
-    /// notifications with `**[<mission-name>]**` so the channel can
-    /// distinguish the fire output from the agent's foreground reply.
-    ///
-    /// Used as the primary gate for the #2583 regression test. The
-    /// secondary `looks_like_btc_price` heuristic checks output *quality*,
-    /// but a poorly-formatted notification still proves the fire path
-    /// itself worked — which is what #2583 was actually about.
-    fn looks_like_routine_notification(text: &str) -> bool {
-        // The marker is `**[<name>]**` — two `**` delimiters around a
-        // bracketed name. Any name shape is accepted because the agent
-        // chooses it.
-        if let Some(open) = text.find("**[")
-            && let Some(close_rel) = text[open + 3..].find("]**")
-        {
-            // Reject empty names (`**[]**`) — that's not a real marker.
-            return close_rel > 0;
-        }
-        false
-    }
-
-    #[test]
-    fn looks_like_routine_notification_accepts_marker() {
-        assert!(looks_like_routine_notification(
-            "**[bitcoin_price_checker]** ## Bitcoin Price Check Results\nPrice: $76,182"
-        ));
-    }
-
-    #[test]
-    fn looks_like_routine_notification_rejects_foreground_reply() {
-        // The agent's foreground confirmation has no `**[name]**` marker.
-        assert!(!looks_like_routine_notification(
-            "## Bitcoin Price Checker Routine Created ✅\nSchedule: */5 * * * *"
-        ));
     }
 
     /// Heuristic: a response counts as carrying real BTC price *output*
@@ -213,100 +161,6 @@ mod live_routine_tests {
         assert!(!looks_like_btc_price(
             "I will create a Bitcoin routine that checks every 5 minutes"
         ));
-    }
-
-    /// Background approval auto-responder.
-    ///
-    /// Polls the `TestChannel`'s captured status events every 500ms and
-    /// resolves each `StatusUpdate::ApprovalNeeded` it has not already seen
-    /// by injecting a `Submission::ExecApproval { approved: true,
-    /// always: false }` back into the channel. Per-call approval is
-    /// deliberate — we want every fire to round-trip through the gate so a
-    /// regression that breaks the second gate (e.g. session-state leakage
-    /// between fires) shows up.
-    ///
-    /// Holds an `Arc<TestChannel>` rather than `&TestRig` so it can outlive
-    /// any individual borrow on the rig.
-    struct ApprovalAutoResponder {
-        approved: std::sync::Arc<tokio::sync::Mutex<Vec<(String, Uuid)>>>,
-        handle: tokio::task::JoinHandle<()>,
-    }
-
-    impl ApprovalAutoResponder {
-        fn spawn(channel: std::sync::Arc<TestChannel>) -> Self {
-            let approved =
-                std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<(String, Uuid)>::new()));
-            let approved_for_task = approved.clone();
-            let handle = tokio::spawn(async move {
-                let mut seen: HashSet<Uuid> = HashSet::new();
-                loop {
-                    for event in channel.captured_status_events() {
-                        if let StatusUpdate::ApprovalNeeded {
-                            request_id,
-                            tool_name,
-                            ..
-                        } = event
-                        {
-                            let Ok(rid) = Uuid::parse_str(&request_id) else {
-                                continue;
-                            };
-                            if seen.insert(rid) {
-                                eprintln!(
-                                    "[RoutineTest] Auto-approving '{tool_name}' \
-                                     (request_id={rid})"
-                                );
-                                let submission =
-                                    ironclaw::agent::submission::Submission::ExecApproval {
-                                        request_id: rid,
-                                        approved: true,
-                                        always: false,
-                                    };
-                                let msg = IncomingMessage::new(
-                                    channel.channel_name(),
-                                    channel.user_id(),
-                                    "",
-                                )
-                                .with_structured_submission(submission);
-                                channel.send_incoming(msg).await;
-                                approved_for_task.lock().await.push((tool_name, rid));
-                            }
-                        }
-                    }
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                }
-            });
-            Self { approved, handle }
-        }
-
-        async fn approved_tools(&self) -> Vec<(String, Uuid)> {
-            self.approved.lock().await.clone()
-        }
-
-        fn shutdown(self) {
-            self.handle.abort();
-        }
-    }
-
-    /// Wait until at least one captured response satisfies `predicate`,
-    /// polling every 500ms until `deadline`. Returns the first match.
-    async fn wait_for_response_matching<F>(
-        rig: &TestRig,
-        predicate: F,
-        deadline: Instant,
-    ) -> Option<String>
-    where
-        F: Fn(&str) -> bool,
-    {
-        loop {
-            let responses = rig.wait_for_responses(0, Duration::from_millis(0)).await;
-            if let Some(r) = responses.iter().find(|r| predicate(&r.content)) {
-                return Some(r.content.clone());
-            }
-            if Instant::now() >= deadline {
-                return None;
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
     }
 
     /// Assert no captured response contains the orchestrator's consecutive-

--- a/tests/fixtures/llm_traces/live/routine_btc_create_test_and_refire.json
+++ b/tests/fixtures/llm_traces/live/routine_btc_create_test_and_refire.json
@@ -1,0 +1,941 @@
+{
+  "model_name": "live-routine_btc_create_test_and_refire",
+  "http_exchanges": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+      },
+      "response": {
+        "status": 200,
+        "headers": [
+          [
+            "content-type",
+            "application/json; charset=utf-8"
+          ],
+          [
+            "access-control-request-method",
+            "*"
+          ],
+          [
+            "x-xss-protection",
+            "0"
+          ],
+          [
+            "access-control-allow-origin",
+            "*"
+          ],
+          [
+            "x-permitted-cross-domain-policies",
+            "none"
+          ],
+          [
+            "x-frame-options",
+            "SAMEORIGIN"
+          ],
+          [
+            "server",
+            "cloudflare"
+          ],
+          [
+            "date",
+            "Fri, 01 May 2026 10:08:42 GMT"
+          ],
+          [
+            "cache-control",
+            "max-age=30, public, must-revalidate, s-maxage=60"
+          ],
+          [
+            "access-control-allow-methods",
+            "POST, PUT, DELETE, GET, OPTIONS"
+          ],
+          [
+            "referrer-policy",
+            "strict-origin-when-cross-origin"
+          ],
+          [
+            "access-control-expose-headers",
+            "link, per-page, total"
+          ],
+          [
+            "x-content-type-options",
+            "nosniff"
+          ],
+          [
+            "vary",
+            "Accept-Encoding, Origin"
+          ],
+          [
+            "x-request-id",
+            "ca203e91-e2e6-4942-a4a5-4abcf5fc70da"
+          ],
+          [
+            "alternate-protocol",
+            "443:npn-spdy/2"
+          ],
+          [
+            "strict-transport-security",
+            "max-age=15724800; includeSubdomains"
+          ],
+          [
+            "etag",
+            "W/\"ea3f8b2ec1d662f71d842ecfa132afb0\""
+          ],
+          [
+            "x-runtime",
+            "0.005202"
+          ],
+          [
+            "content-security-policy-report-only",
+            "script-src https://accounts.google.com/gsi/client; frame-src https://accounts.google.com/gsi/; connect-src https://accounts.google.com/gsi/;"
+          ],
+          [
+            "cf-cache-status",
+            "HIT"
+          ],
+          [
+            "cf-ray",
+            "9f4dfc895926fcce-FUK"
+          ],
+          [
+            "alt-svc",
+            "h3=\":443\"; ma=86400"
+          ],
+          [
+            "access-control-allow-headers",
+            "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+          ]
+        ],
+        "body": "{\"bitcoin\":{\"usd\":77213}}"
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+      },
+      "response": {
+        "status": 200,
+        "headers": [
+          [
+            "vary",
+            "Accept-Encoding, Origin"
+          ],
+          [
+            "x-xss-protection",
+            "0"
+          ],
+          [
+            "date",
+            "Fri, 01 May 2026 10:08:54 GMT"
+          ],
+          [
+            "cache-control",
+            "max-age=30, public, must-revalidate, s-maxage=60"
+          ],
+          [
+            "x-runtime",
+            "0.005202"
+          ],
+          [
+            "x-content-type-options",
+            "nosniff"
+          ],
+          [
+            "cf-cache-status",
+            "HIT"
+          ],
+          [
+            "strict-transport-security",
+            "max-age=15724800; includeSubdomains"
+          ],
+          [
+            "cf-ray",
+            "9f4dfcd49cb3fcd2-FUK"
+          ],
+          [
+            "access-control-allow-headers",
+            "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+          ],
+          [
+            "alternate-protocol",
+            "443:npn-spdy/2"
+          ],
+          [
+            "etag",
+            "W/\"ea3f8b2ec1d662f71d842ecfa132afb0\""
+          ],
+          [
+            "x-request-id",
+            "ca203e91-e2e6-4942-a4a5-4abcf5fc70da"
+          ],
+          [
+            "x-permitted-cross-domain-policies",
+            "none"
+          ],
+          [
+            "referrer-policy",
+            "strict-origin-when-cross-origin"
+          ],
+          [
+            "access-control-request-method",
+            "*"
+          ],
+          [
+            "access-control-allow-origin",
+            "*"
+          ],
+          [
+            "content-security-policy-report-only",
+            "script-src https://accounts.google.com/gsi/client; frame-src https://accounts.google.com/gsi/; connect-src https://accounts.google.com/gsi/;"
+          ],
+          [
+            "age",
+            "16"
+          ],
+          [
+            "server",
+            "cloudflare"
+          ],
+          [
+            "alt-svc",
+            "h3=\":443\"; ma=86400"
+          ],
+          [
+            "access-control-allow-methods",
+            "POST, PUT, DELETE, GET, OPTIONS"
+          ],
+          [
+            "access-control-expose-headers",
+            "link, per-page, total"
+          ],
+          [
+            "content-type",
+            "application/json; charset=utf-8"
+          ],
+          [
+            "x-frame-options",
+            "SAMEORIGIN"
+          ]
+        ],
+        "body": "{\"bitcoin\":{\"usd\":77213}}"
+      }
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+      },
+      "response": {
+        "status": 200,
+        "headers": [
+          [
+            "x-xss-protection",
+            "0"
+          ],
+          [
+            "content-security-policy-report-only",
+            "script-src https://accounts.google.com/gsi/client; frame-src https://accounts.google.com/gsi/; connect-src https://accounts.google.com/gsi/;"
+          ],
+          [
+            "cf-ray",
+            "9f4dfd134a65fccf-FUK"
+          ],
+          [
+            "access-control-allow-headers",
+            "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+          ],
+          [
+            "x-request-id",
+            "ca203e91-e2e6-4942-a4a5-4abcf5fc70da"
+          ],
+          [
+            "etag",
+            "W/\"ea3f8b2ec1d662f71d842ecfa132afb0\""
+          ],
+          [
+            "x-runtime",
+            "0.005202"
+          ],
+          [
+            "server",
+            "cloudflare"
+          ],
+          [
+            "alternate-protocol",
+            "443:npn-spdy/2"
+          ],
+          [
+            "vary",
+            "Accept-Encoding, Origin"
+          ],
+          [
+            "access-control-request-method",
+            "*"
+          ],
+          [
+            "date",
+            "Fri, 01 May 2026 10:09:04 GMT"
+          ],
+          [
+            "strict-transport-security",
+            "max-age=15724800; includeSubdomains"
+          ],
+          [
+            "cache-control",
+            "max-age=30, public, must-revalidate, s-maxage=60"
+          ],
+          [
+            "access-control-allow-methods",
+            "POST, PUT, DELETE, GET, OPTIONS"
+          ],
+          [
+            "alt-svc",
+            "h3=\":443\"; ma=86400"
+          ],
+          [
+            "content-type",
+            "application/json; charset=utf-8"
+          ],
+          [
+            "age",
+            "26"
+          ],
+          [
+            "x-content-type-options",
+            "nosniff"
+          ],
+          [
+            "x-permitted-cross-domain-policies",
+            "none"
+          ],
+          [
+            "cf-cache-status",
+            "HIT"
+          ],
+          [
+            "x-frame-options",
+            "SAMEORIGIN"
+          ],
+          [
+            "access-control-expose-headers",
+            "link, per-page, total"
+          ],
+          [
+            "referrer-policy",
+            "strict-origin-when-cross-origin"
+          ],
+          [
+            "access-control-allow-origin",
+            "*"
+          ]
+        ],
+        "body": "{\"bitcoin\":{\"usd\":77213}}"
+      }
+    }
+  ],
+  "steps": [
+    {
+      "response": {
+        "type": "user_input",
+        "content": "Create basic routine for checking price of Bitcoin every five minutes and send me test request right now."
+      }
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 2
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_657a9167a2d74cdd88556b34",
+            "name": "routine_create",
+            "arguments": {
+              "cron": "*/5 * * * *",
+              "description": "Check Bitcoin price every 5 minutes",
+              "enabled": "True",
+              "name": "bitcoin-price-check",
+              "prompt": "Fetch the current Bitcoin price from a public API and report it. Use the web_search tool to find the current BTC/USD price, or make an HTTP request to a price API like https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd. Report the price clearly.",
+              "timezone": "UTC",
+              "trigger_type": "cron"
+            }
+          }
+        ],
+        "input_tokens": 9383,
+        "output_tokens": 222
+      }
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 4
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_b4d5b1ea6b4b4d3184b1d227",
+            "name": "routine_fire",
+            "arguments": {
+              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+            }
+          }
+        ],
+        "input_tokens": 9571,
+        "output_tokens": 48
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_657a9167a2d74cdd88556b34",
+          "name": "mission_create",
+          "content": "{'mission_id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'name': 'bitcoin-price-check', 'status': 'created'}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 6
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_7febebee51a647b38f1187a2",
+            "name": "routine_history",
+            "arguments": {
+              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+            }
+          }
+        ],
+        "input_tokens": 9651,
+        "output_tokens": 71
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_b4d5b1ea6b4b4d3184b1d227",
+          "name": "mission_fire",
+          "content": "{'status': 'fired', 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71'}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 8
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_23968adef6b64abb9ccd2090",
+            "name": "job_status",
+            "arguments": {
+              "job_id": "{{call_b4d5b1ea6b4b4d3184b1d227.thread_id}}"
+            }
+          }
+        ],
+        "input_tokens": 9993,
+        "output_tokens": 91
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_657a9167a2d74cdd88556b34",
+          "name": "mission_create",
+          "content": "{'mission_id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'name': 'bitcoin-price-check', 'status': 'created'}"
+        },
+        {
+          "tool_call_id": "call_b4d5b1ea6b4b4d3184b1d227",
+          "name": "mission_fire",
+          "content": "{'status': 'fired', 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71'}"
+        },
+        {
+          "tool_call_id": "call_7febebee51a647b38f1187a2",
+          "name": "mission_get",
+          "content": "{'approach_history': [], 'cadence': 'Manual', 'current_focus': None, 'goal': 'Fetch the current Bitcoin price from a public API and report it. Use the web_search tool to find the current BTC/USD price, or make an HTTP request to a price API like https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd. Report the price clearly.', 'id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'last_fire_at': '2026-05-01T10:08:31.354856+00:00', 'name': 'bitcoin-price-check', 'next_fire_at': None, 'recent_threads': [{'completed_at': None, 'created_at': '2026-05-01T10:08:31.303792+00:00', 'result': None, 'state': 'Running', 'steps': 0, 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71', 'tokens_used': 0}], 'status': 'Active', 'success_criteria': None, 'total_threads': 1}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 10
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_4d907b74c6b04b5bbd759005",
+            "name": "tool_activate",
+            "arguments": {
+              "name": "web_search"
+            }
+          }
+        ],
+        "input_tokens": 10101,
+        "output_tokens": 80
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_23968adef6b64abb9ccd2090",
+          "name": "job_status",
+          "content": "{'error': 'Job not found: Job 6d4fae13-fb42-4845-b4ec-a785b136aa71 not found'}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "# Mission: bitcoin-price-check\n\nGoal: Fetch the current Bitcoin price from a pub",
+        "min_message_count": 2
+      },
+      "response": {
+        "type": "text",
+        "content": "\n\n```repl\n# Fetch Bitcoin price from CoinGecko API\nimport json\n\ntry:\n    # Try CoinGecko API first\n    result = await http(\n        method=\"GET\",\n        url=\"https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd\",\n        timeout_secs=10\n    )\n    \n    if result and \"bitcoin\" in result:\n        btc_price = result[\"bitcoin\"][\"usd\"]\n        FINAL(f\"## Bitcoin Price Report\\n\\n**Current BTC/USD Price: ${btc_price:,}**\\n\\n*Fetched from CoinGecko API*\\n\\n---\\n\\n**Mission Status:** Complete for this run. The price check was successful.\")\n    else:\n        raise Exception(\"Invalid API response\")\n        \nexcept Exception as e:\n    # Fallback to web_search if API fails\n    try:\n        search_result = await web_search(query=\"Bitcoin price USD today current\", count=3)\n        \n        # Parse price from search results\n        import re\n        price_match = None\n        for item in search_result.get(\"results\", []):\n            content = item.get(\"title\", \"\") + \" \" + item.get(\"snippet\", \"\")\n            # Look for patterns like $45,000 or $45,000.00\n            matches = re.findall(r'\\$(\\d{1,3}(?:,\\d{3})*(?:\\.\\d{2})?)', content)\n            if matches:\n                price_match = matches[0].replace(\",\", \"\")\n                break\n        \n        if price_match:\n            FINAL(f\"## Bitcoin Price Report\\n\\n**Current BTC/USD Price: ${price_match}**\\n\\n*Price found via web search (CoinGecko API unavailable)*\\n\\n---\\n\\n**Mission Status:** Complete for this run.\")\n        else:\n            FINAL(f\"## Bitcoin Price Report\\n\\n**Status:** Unable to fetch current Bitcoin price.\\n\\n**Attempted Methods:**\\n1. CoinGecko API - Failed\\n2. Web Search - No clear price found\\n\\n**Error:** {str(e)}\\n\\n**Next Steps:** Please try again in a few minutes or check the price manually at coingecko.com or coinmarketcap.com\")\n            \n    except Exception as search_error:\n        FINAL(f\"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: {str(e)}\\n- Search: {str(search_error)}\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\")\n```",
+        "input_tokens": 9704,
+        "output_tokens": 654
+      }
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 13
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_4e9e7350c1f84d73b3b2baee",
+            "name": "routine_history",
+            "arguments": {
+              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+            }
+          }
+        ],
+        "input_tokens": 10248,
+        "output_tokens": 66
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_4d907b74c6b04b5bbd759005",
+          "name": "tool_activate",
+          "content": "[no output]"
+        },
+        {
+          "tool_call_id": "call_4d907b74c6b04b5bbd759005",
+          "name": "tool_activate",
+          "content": "{\n  \"kind\": \"wasm_tool\",\n  \"message\": \"Extension 'web_search' is ready.\",\n  \"name\": \"web_search\",\n  \"phase\": \"ready\",\n  \"status\": \"ready\"\n}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 15
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_69b042732bfe447c8d0e44b2",
+            "name": "tool_activate",
+            "arguments": {
+              "name": "http"
+            }
+          }
+        ],
+        "input_tokens": 10753,
+        "output_tokens": 82
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_4e9e7350c1f84d73b3b2baee",
+          "name": "mission_get",
+          "content": "{'approach_history': [\"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\"], 'cadence': 'Manual', 'current_focus': None, 'goal': 'Fetch the current Bitcoin price from a public API and report it. Use the web_search tool to find the current BTC/USD price, or make an HTTP request to a price API like https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd. Report the price clearly.', 'id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'last_fire_at': '2026-05-01T10:08:31.354856+00:00', 'name': 'bitcoin-price-check', 'next_fire_at': None, 'recent_threads': [{'completed_at': '2026-05-01T10:08:42.565898+00:00', 'created_at': '2026-05-01T10:08:31.303792+00:00', 'result': \"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\", 'state': 'Done', 'steps': 1, 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71', 'tokens_used': 10358}], 'status': 'Active', 'success_criteria': None, 'total_threads': 1}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 17
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_b3ac6430a5154168b5e1fde7",
+            "name": "tool_list",
+            "arguments": {
+              "kind": "builtin"
+            }
+          }
+        ],
+        "input_tokens": 10824,
+        "output_tokens": 59
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_69b042732bfe447c8d0e44b2",
+          "name": "tool_activate",
+          "content": "[ACTION FAILED] tool_activate: {'error': \"Tool 'tool_activate' failed: Tool error: Tool tool_activate execution failed: Execution failed: Extension not installed: http\"}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 19
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_81b424003cef45e9be61c621",
+            "name": "tool_activate",
+            "arguments": {
+              "name": "http"
+            }
+          }
+        ],
+        "input_tokens": 14823,
+        "output_tokens": 78
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_b3ac6430a5154168b5e1fde7",
+          "name": "tool_list",
+          "content": "{'builtin_count': 47, 'builtins': [{'default_state': 'always_allow', 'description': 'Search for available extensions to add new capabilities. Extensions include channels (Telegram, Slack, Discord — connect messaging platforms so IronClaw can receive and reply there), tools, and MCP servers. Use `tool_install` for explicit installation, then call `tool_activate(name=\"...\")` to make a discovered integration usable. Use the `message` tool for proactive outbound sends. Use discover:true to search online if the built-in registry has no results.', 'locked': False, 'locked_reason': None, 'name': 'tool_search', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Permanently remove an installed extension (channel, tool, or MCP server) from disk. This action cannot be undone — the WASM binary and configuration files will be deleted.', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'tool_remove', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Write content to a file on the LOCAL FILESYSTEM. **Only use for creating new files or complete rewrites.** For targeted edits, use apply_patch instead — it's safer and more efficient. NOT for workspace memory (use memory_write for that). Creates parent directories automatically.\", 'locked': False, 'locked_reason': None, 'name': 'write_file', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Search past memories, decisions, and context. MUST be called before answering questions about prior work, decisions, dates, people, preferences, or todos. Returns relevant snippets with relevance scores.', 'locked': False, 'locked_reason': None, 'name': 'memory_search', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'List contents of a directory on the LOCAL FILESYSTEM. NOT for workspace memory (use memory_tree for that). Shows files and subdirectories with their sizes.', 'locked': False, 'locked_reason': None, 'name': 'list_dir', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Show detailed information about an installed extension, including version and WIT version compatibility.', 'locked': False, 'locked_reason': None, 'name': 'extension_info', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Check the status and details of a specific job by its ID.', 'locked': False, 'locked_reason': None, 'name': 'job_status', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Update the plan progress checklist displayed to the user. Call this when creating a plan, starting execution, completing a step, or when the plan fails. The UI renders this as a live checklist. Always send the FULL list of steps (not incremental diffs).', 'locked': False, 'locked_reason': None, 'name': 'plan_update', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all routines with their status, trigger info, and next fire time.', 'locked': False, 'locked_reason': None, 'name': 'routine_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Manually trigger a routine to run immediately, bypassing schedule, trigger type, and cooldown.', 'locked': False, 'locked_reason': None, 'name': 'routine_fire', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all registered tools with names and descriptions', 'locked': False, 'locked_reason': None, 'name': 'system_tools_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Get or set the permission state for a tool. Use to view current permissions or propose a change (requires user approval). States: always_allow (no prompt), ask_each_time (approval required), disabled (tool hidden from LLM).', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'tool_permission_set', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Install an extension (channel, tool, or MCP server). Use the name from tool_search results, or provide an explicit URL. Also discovers tool source code in the working directory (tools-src/, tool-src/, or direct subdirectories with Cargo.toml).', 'locked': False, 'locked_reason': None, 'name': 'tool_install', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Echoes back the input message. Useful for testing tool execution.', 'locked': False, 'locked_reason': None, 'name': 'echo', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Read the event log for a sandbox job. Shows messages, tool calls, results, and status changes from the container. Use this to check what Claude Code or a worker sub-agent has been doing.', 'locked': False, 'locked_reason': None, 'name': 'job_events', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'View the execution history of a routine. Shows recent runs with status, duration, and results.', 'locked': False, 'locked_reason': None, 'name': 'routine_history', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Emit a structured system event to routines with a system_event trigger. Use this to trigger routines from tool workflows without waiting for cron.', 'locked': False, 'locked_reason': None, 'name': 'event_emit', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'View the workspace memory structure as a tree (database-backed storage). Use this to discover valid workspace paths before calling memory_read or memory_write. The workspace is separate from the local filesystem; use memory_read for files shown here, NOT read_file.', 'locked': False, 'locked_reason': None, 'name': 'memory_tree', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': \"Read a file from the workspace memory (database-backed storage). Use this to read files shown by memory_tree or to inspect a document before patching it with memory_write. NOT for local filesystem files (use read_file for those). If a workspace file does not exist yet, expect a not-found error and then create it with memory_write. Do not pass absolute paths like '/Users/...' or 'C:\\\\...'. Works with identity files, heartbeat checklist, memory, daily logs, or any custom workspace path.\", 'locked': False, 'locked_reason': None, 'name': 'memory_read', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Analyze an image using a vision-capable AI model. Provide a workspace path to the image and an optional analysis question.', 'locked': False, 'locked_reason': None, 'name': 'image_analyze', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': \"Write to persistent memory (database-backed, NOT the local filesystem). Use for important facts, decisions, preferences, workflow docs, or other workspace files that should live in memory rather than on disk. Targets: 'memory' for curated long-term facts, 'daily_log' for timestamped session notes, 'heartbeat' for the periodic checklist (HEARTBEAT.md), 'bootstrap' to clear the first-run ritual file, or a custom workspace path like 'projects/alpha/notes.md'. Prefer normal writes with 'content' unless you have just read the file and know the exact text to patch with 'old_string'/'new_string'. Never pass absolute filesystem paths like '/Users/...' or 'C:\\\\...'.\", 'locked': False, 'locked_reason': None, 'name': 'memory_write', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Generate an image from a text prompt using an AI image generation model (e.g., FLUX). Returns the generated image data.', 'locked': False, 'locked_reason': None, 'name': 'image_generate', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Create a new job or task for the agent to work on. Use this when the user wants you to do something substantial that should be tracked as a separate job.', 'locked': False, 'locked_reason': None, 'name': 'create_job', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Read a file from the LOCAL FILESYSTEM. **Always read a file before editing it.** NOT for workspace memory paths (use memory_read for those). Returns content with line numbers. Default limit is 2000 lines. For large files, use offset and limit for partial reads.', 'locked': False, 'locked_reason': None, 'name': 'read_file', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Search file contents using regex patterns. Powered by ripgrep. Three output modes: content (matching lines with context), files_with_matches (file paths only, default), count (match counts per file). Use this instead of shell with 'grep' or 'rg'.\", 'locked': False, 'locked_reason': None, 'name': 'grep', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Make HTTP requests to external APIs. Supports GET, POST, PUT, DELETE methods. Use save_to to download binary files (images, PDFs, etc.) to a local path, e.g. {\"method\":\"GET\",\"url\":\"https://picsum.photos/800/600\",\"save_to\":\"/tmp/photo.jpg\"}.', 'locked': False, 'locked_reason': None, 'name': 'http', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'List extensions and built-in tools with their authentication, activation, and permission status. Set include_available:true to also show registry entries not yet installed. Use kind=\"builtin\" to list only built-in Rust tools.', 'locked': False, 'locked_reason': None, 'name': 'tool_list', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Get info about any tool: description, parameter names, curated summary guidance, or full discovery schema.', 'locked': False, 'locked_reason': None, 'name': 'tool_info', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Get the agent version and build information', 'locked': False, 'locked_reason': None, 'name': 'system_version', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Execute shell commands. Use for running builds, tests, git operations, and other CLI tasks. Commands run in a subprocess with captured output. Long-running commands have a timeout. When Docker sandbox is enabled, commands run in isolated containers for security.', 'locked': False, 'locked_reason': None, 'name': 'shell', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Undo the most recent modification to a file by restoring its previous content. Only works for changes made by apply_patch or write_file in the current session.', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'file_undo', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Apply targeted edits to a file using search/replace. **Prefer this over write_file** for modifying existing files — it sends only the changed portion. The old_string must match exactly (including whitespace and indentation). The edit will FAIL if old_string is not unique — provide more context to make it unique, or set replace_all=true. **You must read_file before editing.** When editing text from read_file output, preserve the exact indentation (tabs/spaces) as it appears after the line number prefix.', 'locked': False, 'locked_reason': None, 'name': 'apply_patch', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Upgrade installed WASM extensions (channels and tools) to match the current host WIT version. If name is omitted, checks and upgrades all installed WASM extensions. Authentication and secrets are preserved.', 'locked': False, 'locked_reason': None, 'name': 'tool_upgrade', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'List all jobs or filter by status. Shows job IDs, titles, and current status.', 'locked': False, 'locked_reason': None, 'name': 'list_jobs', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Permanently delete a stored secret by name. This cannot be undone.', 'locked': False, 'locked_reason': None, 'name': 'secret_delete', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Edit an existing image using an AI model. Provide the workspace path to the source image and a text prompt describing the desired edits.', 'locked': False, 'locked_reason': None, 'name': 'image_edit', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Update an existing routine. Can change prompt, description, enabled state, cron schedule/timezone, Pass the routine name and only the fields you want to change. This does not convert trigger types. Behavior-changing edits should leave the routine marked unverified until it is tested again.', 'locked': False, 'locked_reason': None, 'name': 'routine_update', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Get current time, parse or format timestamps, convert timezones, or calculate time differences.', 'locked': False, 'locked_reason': None, 'name': 'time', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Fast file pattern matching. Find files by glob pattern (e.g. `**/*.rs`, `src/**/*.ts`). Results sorted by modification time (newest first). Use this instead of shell with `find` or `ls -R`.', 'locked': False, 'locked_reason': None, 'name': 'glob', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all stored secrets by name. Never returns values — only names and optional provider metadata. Use this to check what credentials are available before attempting a task that requires them.', 'locked': False, 'locked_reason': None, 'name': 'secret_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Create a new routine (scheduled or event-driven task). Supports cron schedules, event pattern matching, system events, and manual triggers. Use this when the user wants something to happen periodically or reactively. Do not use this for immediate one-shot requests like 'do it now', 'right now', or 'immediately'; complete those in the current thread. Creation saves the routine, but does not verify that it will execute successfully.\", 'locked': False, 'locked_reason': None, 'name': 'routine_create', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': \"Send a proactive message to a channel. Use normal assistant output to reply in the active conversation; use this tool for proactive notifications, routine/background follow-ups, attachments, or sending to a different channel/recipient. If channel/target are omitted, reuses the current conversation's channel and sender/group when available. If you provide `target` without `channel` and no scoped channel can be resolved, the message may be broadcast across connected channels instead of sent to just one. Supports file attachments: first download the file with the http tool using save_to (e.g., http GET https://picsum.photos/800/600 save_to=/tmp/photo.jpg), then pass the file path in the attachments array. Images are sent as photos on Telegram. - Signal: target accepts E.164 (+1234567890) or group ID - Telegram: target accepts username or chat ID - Slack: target accepts channel ID (C0...) or user ID (U0...)\", 'locked': False, 'locked_reason': None, 'name': 'message', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Delete a routine permanently. This also removes all run history.', 'locked': False, 'locked_reason': None, 'name': 'routine_delete', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Cancel a running or pending job. The job will be marked as cancelled and stopped.', 'locked': False, 'locked_reason': None, 'name': 'cancel_job', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Parse, query, and transform JSON data. Supports JSONPath-like queries. Use `source_tool_call_id` to reference the full output of a previous tool call (avoids truncation issues with large responses).', 'locked': False, 'locked_reason': None, 'name': 'json', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Initiate authentication for an extension. For OAuth, returns a URL. For manual auth, returns instructions. The user provides their token through a secure channel, never through this tool.', 'locked': False, 'locked_reason': None, 'name': 'tool_auth', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Make an integration usable. This may install, authenticate, and activate it as needed before loading tools, starting channels, or connecting to MCP servers.', 'locked': False, 'locked_reason': None, 'name': 'tool_activate', 'permission_state': 'always_allow'}]}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 21
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_08b42248eedb43e7b02e5518",
+            "name": "http",
+            "arguments": {
+              "method": "GET",
+              "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+            }
+          }
+        ],
+        "input_tokens": 14894,
+        "output_tokens": 113
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_81b424003cef45e9be61c621",
+          "name": "tool_activate",
+          "content": "[ACTION FAILED] tool_activate: {'error': \"Tool 'tool_activate' failed: Tool error: Tool tool_activate execution failed: Execution failed: Extension not installed: http\"}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 23
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_a3f00734525c4707a0edbfdc",
+            "name": "routine_update",
+            "arguments": {
+              "name": "{{call_4e9e7350c1f84d73b3b2baee.name}}",
+              "prompt": "Fetch the current Bitcoin price using the http tool. Call: http(method=\"GET\", url=\"https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd\"). Parse the response to extract the bitcoin.usd price and report it clearly in a formatted message like \"Bitcoin Price: $XXX,XXX USD\"."
+            }
+          }
+        ],
+        "input_tokens": 15409,
+        "output_tokens": 302
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_08b42248eedb43e7b02e5518",
+          "name": "http",
+          "content": "{'body': {'bitcoin': {'usd': 77213}}, 'headers': {'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, Authorization', 'access-control-allow-methods': 'POST, PUT, DELETE, GET, OPTIONS', 'access-control-allow-origin': '*', 'access-control-expose-headers': 'link, per-page, total', 'access-control-request-method': '*', 'age': '16', 'alt-svc': 'h3=\":443\"; ma=86400', 'alternate-protocol': '443:npn-spdy/2', 'cache-control': 'max-age=30, public, must-revalidate, s-maxage=60', 'cf-cache-status': 'HIT', 'cf-ray': '9f4dfcd49cb3fcd2-FUK', 'content-security-policy-report-only': 'script-src https://accounts.google.com/gsi/client; frame-src https://accounts.google.com/gsi/; connect-src https://accounts.google.com/gsi/;', 'content-type': 'application/json; charset=utf-8', 'date': 'Fri, 01 May 2026 10:08:54 GMT', 'etag': 'W/\"ea3f8b2ec1d662f71d842ecfa132afb0\"', 'referrer-policy': 'strict-origin-when-cross-origin', 'server': 'cloudflare', 'strict-transport-security': 'max-age=15724800; includeSubdomains', 'vary': 'Accept-Encoding, Origin', 'x-content-type-options': 'nosniff', 'x-frame-options': 'SAMEORIGIN', 'x-permitted-cross-domain-policies': 'none', 'x-request-id': 'ca203e91-e2e6-4942-a4a5-4abcf5fc70da', 'x-runtime': '0.005202', 'x-xss-protection': '0'}, 'status': 200}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 25
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_05c529ff62ea4620aeca7165",
+            "name": "routine_fire",
+            "arguments": {
+              "name": "{{call_4e9e7350c1f84d73b3b2baee.name}}"
+            }
+          }
+        ],
+        "input_tokens": 15592,
+        "output_tokens": 55
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_a3f00734525c4707a0edbfdc",
+          "name": "mission_update",
+          "content": "{'status': 'updated'}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 27
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_17e42824f0994356914beb8f",
+            "name": "routine_history",
+            "arguments": {
+              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+            }
+          }
+        ],
+        "input_tokens": 15675,
+        "output_tokens": 50
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_05c529ff62ea4620aeca7165",
+          "name": "mission_fire",
+          "content": "{'status': 'fired', 'thread_id': '3b3b6f86-7f0b-4d7b-ae8a-88ed4bfc8487'}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "# Mission: bitcoin-price-check\n\nGoal: Fetch the current Bitcoin price using the ",
+        "min_message_count": 2
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_ddabbb02263745438709ddf1",
+            "name": "http",
+            "arguments": {
+              "method": "GET",
+              "url": "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+            }
+          }
+        ],
+        "input_tokens": 9798,
+        "output_tokens": 88
+      }
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 29
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_ac9051b4a2ed4d6ba6e0c5eb",
+            "name": "job_status",
+            "arguments": {
+              "job_id": "{{call_05c529ff62ea4620aeca7165.thread_id}}"
+            }
+          }
+        ],
+        "input_tokens": 16294,
+        "output_tokens": 85
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_657a9167a2d74cdd88556b34",
+          "name": "mission_create",
+          "content": "{'mission_id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'name': 'bitcoin-price-check', 'status': 'created'}"
+        },
+        {
+          "tool_call_id": "call_b4d5b1ea6b4b4d3184b1d227",
+          "name": "mission_fire",
+          "content": "{'status': 'fired', 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71'}"
+        },
+        {
+          "tool_call_id": "call_7febebee51a647b38f1187a2",
+          "name": "mission_get",
+          "content": "{'approach_history': [], 'cadence': 'Manual', 'current_focus': None, 'goal': 'Fetch the current Bitcoin price from a public API and report it. Use the web_search tool to find the current BTC/USD price, or make an HTTP request to a price API like https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd. Report the price clearly.', 'id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'last_fire_at': '2026-05-01T10:08:31.354856+00:00', 'name': 'bitcoin-price-check', 'next_fire_at': None, 'recent_threads': [{'completed_at': None, 'created_at': '2026-05-01T10:08:31.303792+00:00', 'result': None, 'state': 'Running', 'steps': 0, 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71', 'tokens_used': 0}], 'status': 'Active', 'success_criteria': None, 'total_threads': 1}"
+        },
+        {
+          "tool_call_id": "call_23968adef6b64abb9ccd2090",
+          "name": "job_status",
+          "content": "{'error': 'Job not found: Job 6d4fae13-fb42-4845-b4ec-a785b136aa71 not found'}"
+        },
+        {
+          "tool_call_id": "call_4d907b74c6b04b5bbd759005",
+          "name": "tool_activate",
+          "content": "[no output]"
+        },
+        {
+          "tool_call_id": "call_4d907b74c6b04b5bbd759005",
+          "name": "tool_activate",
+          "content": "{\n  \"kind\": \"wasm_tool\",\n  \"message\": \"Extension 'web_search' is ready.\",\n  \"name\": \"web_search\",\n  \"phase\": \"ready\",\n  \"status\": \"ready\"\n}"
+        },
+        {
+          "tool_call_id": "call_4e9e7350c1f84d73b3b2baee",
+          "name": "mission_get",
+          "content": "{'approach_history': [\"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\"], 'cadence': 'Manual', 'current_focus': None, 'goal': 'Fetch the current Bitcoin price from a public API and report it. Use the web_search tool to find the current BTC/USD price, or make an HTTP request to a price API like https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd. Report the price clearly.', 'id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'last_fire_at': '2026-05-01T10:08:31.354856+00:00', 'name': 'bitcoin-price-check', 'next_fire_at': None, 'recent_threads': [{'completed_at': '2026-05-01T10:08:42.565898+00:00', 'created_at': '2026-05-01T10:08:31.303792+00:00', 'result': \"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\", 'state': 'Done', 'steps': 1, 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71', 'tokens_used': 10358}], 'status': 'Active', 'success_criteria': None, 'total_threads': 1}"
+        },
+        {
+          "tool_call_id": "call_69b042732bfe447c8d0e44b2",
+          "name": "tool_activate",
+          "content": "[ACTION FAILED] tool_activate: {'error': \"Tool 'tool_activate' failed: Tool error: Tool tool_activate execution failed: Execution failed: Extension not installed: http\"}"
+        },
+        {
+          "tool_call_id": "call_b3ac6430a5154168b5e1fde7",
+          "name": "tool_list",
+          "content": "{'builtin_count': 47, 'builtins': [{'default_state': 'always_allow', 'description': 'Search for available extensions to add new capabilities. Extensions include channels (Telegram, Slack, Discord — connect messaging platforms so IronClaw can receive and reply there), tools, and MCP servers. Use `tool_install` for explicit installation, then call `tool_activate(name=\"...\")` to make a discovered integration usable. Use the `message` tool for proactive outbound sends. Use discover:true to search online if the built-in registry has no results.', 'locked': False, 'locked_reason': None, 'name': 'tool_search', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Permanently remove an installed extension (channel, tool, or MCP server) from disk. This action cannot be undone — the WASM binary and configuration files will be deleted.', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'tool_remove', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Write content to a file on the LOCAL FILESYSTEM. **Only use for creating new files or complete rewrites.** For targeted edits, use apply_patch instead — it's safer and more efficient. NOT for workspace memory (use memory_write for that). Creates parent directories automatically.\", 'locked': False, 'locked_reason': None, 'name': 'write_file', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Search past memories, decisions, and context. MUST be called before answering questions about prior work, decisions, dates, people, preferences, or todos. Returns relevant snippets with relevance scores.', 'locked': False, 'locked_reason': None, 'name': 'memory_search', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'List contents of a directory on the LOCAL FILESYSTEM. NOT for workspace memory (use memory_tree for that). Shows files and subdirectories with their sizes.', 'locked': False, 'locked_reason': None, 'name': 'list_dir', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Show detailed information about an installed extension, including version and WIT version compatibility.', 'locked': False, 'locked_reason': None, 'name': 'extension_info', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Check the status and details of a specific job by its ID.', 'locked': False, 'locked_reason': None, 'name': 'job_status', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Update the plan progress checklist displayed to the user. Call this when creating a plan, starting execution, completing a step, or when the plan fails. The UI renders this as a live checklist. Always send the FULL list of steps (not incremental diffs).', 'locked': False, 'locked_reason': None, 'name': 'plan_update', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all routines with their status, trigger info, and next fire time.', 'locked': False, 'locked_reason': None, 'name': 'routine_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Manually trigger a routine to run immediately, bypassing schedule, trigger type, and cooldown.', 'locked': False, 'locked_reason': None, 'name': 'routine_fire', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all registered tools with names and descriptions', 'locked': False, 'locked_reason': None, 'name': 'system_tools_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Get or set the permission state for a tool. Use to view current permissions or propose a change (requires user approval). States: always_allow (no prompt), ask_each_time (approval required), disabled (tool hidden from LLM).', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'tool_permission_set', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Install an extension (channel, tool, or MCP server). Use the name from tool_search results, or provide an explicit URL. Also discovers tool source code in the working directory (tools-src/, tool-src/, or direct subdirectories with Cargo.toml).', 'locked': False, 'locked_reason': None, 'name': 'tool_install', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Echoes back the input message. Useful for testing tool execution.', 'locked': False, 'locked_reason': None, 'name': 'echo', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Read the event log for a sandbox job. Shows messages, tool calls, results, and status changes from the container. Use this to check what Claude Code or a worker sub-agent has been doing.', 'locked': False, 'locked_reason': None, 'name': 'job_events', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'View the execution history of a routine. Shows recent runs with status, duration, and results.', 'locked': False, 'locked_reason': None, 'name': 'routine_history', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Emit a structured system event to routines with a system_event trigger. Use this to trigger routines from tool workflows without waiting for cron.', 'locked': False, 'locked_reason': None, 'name': 'event_emit', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'View the workspace memory structure as a tree (database-backed storage). Use this to discover valid workspace paths before calling memory_read or memory_write. The workspace is separate from the local filesystem; use memory_read for files shown here, NOT read_file.', 'locked': False, 'locked_reason': None, 'name': 'memory_tree', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': \"Read a file from the workspace memory (database-backed storage). Use this to read files shown by memory_tree or to inspect a document before patching it with memory_write. NOT for local filesystem files (use read_file for those). If a workspace file does not exist yet, expect a not-found error and then create it with memory_write. Do not pass absolute paths like '/Users/...' or 'C:\\\\...'. Works with identity files, heartbeat checklist, memory, daily logs, or any custom workspace path.\", 'locked': False, 'locked_reason': None, 'name': 'memory_read', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Analyze an image using a vision-capable AI model. Provide a workspace path to the image and an optional analysis question.', 'locked': False, 'locked_reason': None, 'name': 'image_analyze', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': \"Write to persistent memory (database-backed, NOT the local filesystem). Use for important facts, decisions, preferences, workflow docs, or other workspace files that should live in memory rather than on disk. Targets: 'memory' for curated long-term facts, 'daily_log' for timestamped session notes, 'heartbeat' for the periodic checklist (HEARTBEAT.md), 'bootstrap' to clear the first-run ritual file, or a custom workspace path like 'projects/alpha/notes.md'. Prefer normal writes with 'content' unless you have just read the file and know the exact text to patch with 'old_string'/'new_string'. Never pass absolute filesystem paths like '/Users/...' or 'C:\\\\...'.\", 'locked': False, 'locked_reason': None, 'name': 'memory_write', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Generate an image from a text prompt using an AI image generation model (e.g., FLUX). Returns the generated image data.', 'locked': False, 'locked_reason': None, 'name': 'image_generate', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Create a new job or task for the agent to work on. Use this when the user wants you to do something substantial that should be tracked as a separate job.', 'locked': False, 'locked_reason': None, 'name': 'create_job', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Read a file from the LOCAL FILESYSTEM. **Always read a file before editing it.** NOT for workspace memory paths (use memory_read for those). Returns content with line numbers. Default limit is 2000 lines. For large files, use offset and limit for partial reads.', 'locked': False, 'locked_reason': None, 'name': 'read_file', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Search file contents using regex patterns. Powered by ripgrep. Three output modes: content (matching lines with context), files_with_matches (file paths only, default), count (match counts per file). Use this instead of shell with 'grep' or 'rg'.\", 'locked': False, 'locked_reason': None, 'name': 'grep', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Make HTTP requests to external APIs. Supports GET, POST, PUT, DELETE methods. Use save_to to download binary files (images, PDFs, etc.) to a local path, e.g. {\"method\":\"GET\",\"url\":\"https://picsum.photos/800/600\",\"save_to\":\"/tmp/photo.jpg\"}.', 'locked': False, 'locked_reason': None, 'name': 'http', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'List extensions and built-in tools with their authentication, activation, and permission status. Set include_available:true to also show registry entries not yet installed. Use kind=\"builtin\" to list only built-in Rust tools.', 'locked': False, 'locked_reason': None, 'name': 'tool_list', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Get info about any tool: description, parameter names, curated summary guidance, or full discovery schema.', 'locked': False, 'locked_reason': None, 'name': 'tool_info', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Get the agent version and build information', 'locked': False, 'locked_reason': None, 'name': 'system_version', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Execute shell commands. Use for running builds, tests, git operations, and other CLI tasks. Commands run in a subprocess with captured output. Long-running commands have a timeout. When Docker sandbox is enabled, commands run in isolated containers for security.', 'locked': False, 'locked_reason': None, 'name': 'shell', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Undo the most recent modification to a file by restoring its previous content. Only works for changes made by apply_patch or write_file in the current session.', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'file_undo', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Apply targeted edits to a file using search/replace. **Prefer this over write_file** for modifying existing files — it sends only the changed portion. The old_string must match exactly (including whitespace and indentation). The edit will FAIL if old_string is not unique — provide more context to make it unique, or set replace_all=true. **You must read_file before editing.** When editing text from read_file output, preserve the exact indentation (tabs/spaces) as it appears after the line number prefix.', 'locked': False, 'locked_reason': None, 'name': 'apply_patch', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Upgrade installed WASM extensions (channels and tools) to match the current host WIT version. If name is omitted, checks and upgrades all installed WASM extensions. Authentication and secrets are preserved.', 'locked': False, 'locked_reason': None, 'name': 'tool_upgrade', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'List all jobs or filter by status. Shows job IDs, titles, and current status.', 'locked': False, 'locked_reason': None, 'name': 'list_jobs', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Permanently delete a stored secret by name. This cannot be undone.', 'locked': False, 'locked_reason': None, 'name': 'secret_delete', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Edit an existing image using an AI model. Provide the workspace path to the source image and a text prompt describing the desired edits.', 'locked': False, 'locked_reason': None, 'name': 'image_edit', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Update an existing routine. Can change prompt, description, enabled state, cron schedule/timezone, Pass the routine name and only the fields you want to change. This does not convert trigger types. Behavior-changing edits should leave the routine marked unverified until it is tested again.', 'locked': False, 'locked_reason': None, 'name': 'routine_update', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Get current time, parse or format timestamps, convert timezones, or calculate time differences.', 'locked': False, 'locked_reason': None, 'name': 'time', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Fast file pattern matching. Find files by glob pattern (e.g. `**/*.rs`, `src/**/*.ts`). Results sorted by modification time (newest first). Use this instead of shell with `find` or `ls -R`.', 'locked': False, 'locked_reason': None, 'name': 'glob', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all stored secrets by name. Never returns values — only names and optional provider metadata. Use this to check what credentials are available before attempting a task that requires them.', 'locked': False, 'locked_reason': None, 'name': 'secret_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Create a new routine (scheduled or event-driven task). Supports cron schedules, event pattern matching, system events, and manual triggers. Use this when the user wants something to happen periodically or reactively. Do not use this for immediate one-shot requests like 'do it now', 'right now', or 'immediately'; complete those in the current thread. Creation saves the routine, but does not verify that it will execute successfully.\", 'locked': False, 'locked_reason': None, 'name': 'routine_create', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': \"Send a proactive message to a channel. Use normal assistant output to reply in the active conversation; use this tool for proactive notifications, routine/background follow-ups, attachments, or sending to a different channel/recipient. If channel/target are omitted, reuses the current conversation's channel and sender/group when available. If you provide `target` without `channel` and no scoped channel can be resolved, the message may be broadcast across connected channels instead of sent to just one. Supports file attachments: first download the file with the http tool using save_to (e.g., http GET https://picsum.photos/800/600 save_to=/tmp/photo.jpg), then pass the file path in the attachments array. Images are sent as photos on Telegram. - Signal: target accepts E.164 (+1234567890) or group ID - Telegram: target accepts username or chat ID - Slack: target accepts channel ID (C0...) or user ID (U0...)\", 'locked': False, 'locked_reason': None, 'name': 'message', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Delete a routine permanently. This also removes all run history.', 'locked': False, 'locked_reason': None, 'name': 'routine_delete', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Cancel a running or pending job. The job will be marked as cancelled and stopped.', 'locked': False, 'locked_reason': None, 'name': 'cancel_job', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Parse, query, and transform JSON data. Supports JSONPath-like queries. Use `source_tool_call_id` to reference the full output of a previous tool call (avoids truncation issues with large responses).', 'locked': False, 'locked_reason': None, 'name': 'json', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Initiate authentication for an extension. For OAuth, returns a URL. For manual auth, returns instructions. The user provides their token through a secure channel, never through this tool.', 'locked': False, 'locked_reason': None, 'name': 'tool_auth', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Make an integration usable. This may install, authenticate, and activate it as needed before loading tools, starting channels, or connecting to MCP servers.', 'locked': False, 'locked_reason': None, 'name': 'tool_activate', 'permission_state': 'always_allow'}]}"
+        },
+        {
+          "tool_call_id": "call_81b424003cef45e9be61c621",
+          "name": "tool_activate",
+          "content": "[ACTION FAILED] tool_activate: {'error': \"Tool 'tool_activate' failed: Tool error: Tool tool_activate execution failed: Execution failed: Extension not installed: http\"}"
+        },
+        {
+          "tool_call_id": "call_08b42248eedb43e7b02e5518",
+          "name": "http",
+          "content": "{'body': {'bitcoin': {'usd': 77213}}, 'headers': {'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, Authorization', 'access-control-allow-methods': 'POST, PUT, DELETE, GET, OPTIONS', 'access-control-allow-origin': '*', 'access-control-expose-headers': 'link, per-page, total', 'access-control-request-method': '*', 'age': '16', 'alt-svc': 'h3=\":443\"; ma=86400', 'alternate-protocol': '443:npn-spdy/2', 'cache-control': 'max-age=30, public, must-revalidate, s-maxage=60', 'cf-cache-status': 'HIT', 'cf-ray': '9f4dfcd49cb3fcd2-FUK', 'content-security-policy-report-only': 'script-src https://accounts.google.com/gsi/client; frame-src https://accounts.google.com/gsi/; connect-src https://accounts.google.com/gsi/;', 'content-type': 'application/json; charset=utf-8', 'date': 'Fri, 01 May 2026 10:08:54 GMT', 'etag': 'W/\"ea3f8b2ec1d662f71d842ecfa132afb0\"', 'referrer-policy': 'strict-origin-when-cross-origin', 'server': 'cloudflare', 'strict-transport-security': 'max-age=15724800; includeSubdomains', 'vary': 'Accept-Encoding, Origin', 'x-content-type-options': 'nosniff', 'x-frame-options': 'SAMEORIGIN', 'x-permitted-cross-domain-policies': 'none', 'x-request-id': 'ca203e91-e2e6-4942-a4a5-4abcf5fc70da', 'x-runtime': '0.005202', 'x-xss-protection': '0'}, 'status': 200}"
+        },
+        {
+          "tool_call_id": "call_a3f00734525c4707a0edbfdc",
+          "name": "mission_update",
+          "content": "{'status': 'updated'}"
+        },
+        {
+          "tool_call_id": "call_05c529ff62ea4620aeca7165",
+          "name": "mission_fire",
+          "content": "{'status': 'fired', 'thread_id': '3b3b6f86-7f0b-4d7b-ae8a-88ed4bfc8487'}"
+        },
+        {
+          "tool_call_id": "call_17e42824f0994356914beb8f",
+          "name": "mission_get",
+          "content": "{'approach_history': [\"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\"], 'cadence': 'Manual', 'current_focus': None, 'goal': 'Fetch the current Bitcoin price using the http tool. Call: http(method=\"GET\", url=\"https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd\"). Parse the response to extract the bitcoin.usd price and report it clearly in a formatted message like \"Bitcoin Price: $XXX,XXX USD\".', 'id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'last_fire_at': '2026-05-01T10:09:01.302229+00:00', 'name': 'bitcoin-price-check', 'next_fire_at': None, 'recent_threads': [{'completed_at': None, 'created_at': '2026-05-01T10:09:01.256384+00:00', 'result': None, 'state': 'Running', 'steps': 0, 'thread_id': '3b3b6f86-7f0b-4d7b-ae8a-88ed4bfc8487', 'tokens_used': 0}, {'completed_at': '2026-05-01T10:08:42.565898+00:00', 'created_at': '2026-05-01T10:08:31.303792+00:00', 'result': \"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\", 'state': 'Done', 'steps': 1, 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71', 'tokens_used': 10358}], 'status': 'Active', 'success_criteria': None, 'total_threads': 2}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "Create basic routine for checking price of Bitcoin every five minutes and send m",
+        "min_message_count": 31
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_e023cfbd1ff94b33968678ef",
+            "name": "routine_history",
+            "arguments": {
+              "name": "{{call_657a9167a2d74cdd88556b34.name}}"
+            }
+          }
+        ],
+        "input_tokens": 16408,
+        "output_tokens": 58
+      },
+      "expected_tool_results": [
+        {
+          "tool_call_id": "call_b4d5b1ea6b4b4d3184b1d227",
+          "name": "mission_fire",
+          "content": "{'status': 'fired', 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71'}"
+        },
+        {
+          "tool_call_id": "call_7febebee51a647b38f1187a2",
+          "name": "mission_get",
+          "content": "{'approach_history': [], 'cadence': 'Manual', 'current_focus': None, 'goal': 'Fetch the current Bitcoin price from a public API and report it. Use the web_search tool to find the current BTC/USD price, or make an HTTP request to a price API like https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd. Report the price clearly.', 'id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'last_fire_at': '2026-05-01T10:08:31.354856+00:00', 'name': 'bitcoin-price-check', 'next_fire_at': None, 'recent_threads': [{'completed_at': None, 'created_at': '2026-05-01T10:08:31.303792+00:00', 'result': None, 'state': 'Running', 'steps': 0, 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71', 'tokens_used': 0}], 'status': 'Active', 'success_criteria': None, 'total_threads': 1}"
+        },
+        {
+          "tool_call_id": "call_23968adef6b64abb9ccd2090",
+          "name": "job_status",
+          "content": "{'error': 'Job not found: Job 6d4fae13-fb42-4845-b4ec-a785b136aa71 not found'}"
+        },
+        {
+          "tool_call_id": "call_4d907b74c6b04b5bbd759005",
+          "name": "tool_activate",
+          "content": "[no output]"
+        },
+        {
+          "tool_call_id": "call_4d907b74c6b04b5bbd759005",
+          "name": "tool_activate",
+          "content": "{\n  \"kind\": \"wasm_tool\",\n  \"message\": \"Extension 'web_search' is ready.\",\n  \"name\": \"web_search\",\n  \"phase\": \"ready\",\n  \"status\": \"ready\"\n}"
+        },
+        {
+          "tool_call_id": "call_4e9e7350c1f84d73b3b2baee",
+          "name": "mission_get",
+          "content": "{'approach_history': [\"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\"], 'cadence': 'Manual', 'current_focus': None, 'goal': 'Fetch the current Bitcoin price from a public API and report it. Use the web_search tool to find the current BTC/USD price, or make an HTTP request to a price API like https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd. Report the price clearly.', 'id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'last_fire_at': '2026-05-01T10:08:31.354856+00:00', 'name': 'bitcoin-price-check', 'next_fire_at': None, 'recent_threads': [{'completed_at': '2026-05-01T10:08:42.565898+00:00', 'created_at': '2026-05-01T10:08:31.303792+00:00', 'result': \"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\", 'state': 'Done', 'steps': 1, 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71', 'tokens_used': 10358}], 'status': 'Active', 'success_criteria': None, 'total_threads': 1}"
+        },
+        {
+          "tool_call_id": "call_69b042732bfe447c8d0e44b2",
+          "name": "tool_activate",
+          "content": "[ACTION FAILED] tool_activate: {'error': \"Tool 'tool_activate' failed: Tool error: Tool tool_activate execution failed: Execution failed: Extension not installed: http\"}"
+        },
+        {
+          "tool_call_id": "call_b3ac6430a5154168b5e1fde7",
+          "name": "tool_list",
+          "content": "{'builtin_count': 47, 'builtins': [{'default_state': 'always_allow', 'description': 'Search for available extensions to add new capabilities. Extensions include channels (Telegram, Slack, Discord — connect messaging platforms so IronClaw can receive and reply there), tools, and MCP servers. Use `tool_install` for explicit installation, then call `tool_activate(name=\"...\")` to make a discovered integration usable. Use the `message` tool for proactive outbound sends. Use discover:true to search online if the built-in registry has no results.', 'locked': False, 'locked_reason': None, 'name': 'tool_search', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Permanently remove an installed extension (channel, tool, or MCP server) from disk. This action cannot be undone — the WASM binary and configuration files will be deleted.', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'tool_remove', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Write content to a file on the LOCAL FILESYSTEM. **Only use for creating new files or complete rewrites.** For targeted edits, use apply_patch instead — it's safer and more efficient. NOT for workspace memory (use memory_write for that). Creates parent directories automatically.\", 'locked': False, 'locked_reason': None, 'name': 'write_file', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Search past memories, decisions, and context. MUST be called before answering questions about prior work, decisions, dates, people, preferences, or todos. Returns relevant snippets with relevance scores.', 'locked': False, 'locked_reason': None, 'name': 'memory_search', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'List contents of a directory on the LOCAL FILESYSTEM. NOT for workspace memory (use memory_tree for that). Shows files and subdirectories with their sizes.', 'locked': False, 'locked_reason': None, 'name': 'list_dir', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Show detailed information about an installed extension, including version and WIT version compatibility.', 'locked': False, 'locked_reason': None, 'name': 'extension_info', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Check the status and details of a specific job by its ID.', 'locked': False, 'locked_reason': None, 'name': 'job_status', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Update the plan progress checklist displayed to the user. Call this when creating a plan, starting execution, completing a step, or when the plan fails. The UI renders this as a live checklist. Always send the FULL list of steps (not incremental diffs).', 'locked': False, 'locked_reason': None, 'name': 'plan_update', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all routines with their status, trigger info, and next fire time.', 'locked': False, 'locked_reason': None, 'name': 'routine_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Manually trigger a routine to run immediately, bypassing schedule, trigger type, and cooldown.', 'locked': False, 'locked_reason': None, 'name': 'routine_fire', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all registered tools with names and descriptions', 'locked': False, 'locked_reason': None, 'name': 'system_tools_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Get or set the permission state for a tool. Use to view current permissions or propose a change (requires user approval). States: always_allow (no prompt), ask_each_time (approval required), disabled (tool hidden from LLM).', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'tool_permission_set', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Install an extension (channel, tool, or MCP server). Use the name from tool_search results, or provide an explicit URL. Also discovers tool source code in the working directory (tools-src/, tool-src/, or direct subdirectories with Cargo.toml).', 'locked': False, 'locked_reason': None, 'name': 'tool_install', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Echoes back the input message. Useful for testing tool execution.', 'locked': False, 'locked_reason': None, 'name': 'echo', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Read the event log for a sandbox job. Shows messages, tool calls, results, and status changes from the container. Use this to check what Claude Code or a worker sub-agent has been doing.', 'locked': False, 'locked_reason': None, 'name': 'job_events', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'View the execution history of a routine. Shows recent runs with status, duration, and results.', 'locked': False, 'locked_reason': None, 'name': 'routine_history', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Emit a structured system event to routines with a system_event trigger. Use this to trigger routines from tool workflows without waiting for cron.', 'locked': False, 'locked_reason': None, 'name': 'event_emit', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'View the workspace memory structure as a tree (database-backed storage). Use this to discover valid workspace paths before calling memory_read or memory_write. The workspace is separate from the local filesystem; use memory_read for files shown here, NOT read_file.', 'locked': False, 'locked_reason': None, 'name': 'memory_tree', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': \"Read a file from the workspace memory (database-backed storage). Use this to read files shown by memory_tree or to inspect a document before patching it with memory_write. NOT for local filesystem files (use read_file for those). If a workspace file does not exist yet, expect a not-found error and then create it with memory_write. Do not pass absolute paths like '/Users/...' or 'C:\\\\...'. Works with identity files, heartbeat checklist, memory, daily logs, or any custom workspace path.\", 'locked': False, 'locked_reason': None, 'name': 'memory_read', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Analyze an image using a vision-capable AI model. Provide a workspace path to the image and an optional analysis question.', 'locked': False, 'locked_reason': None, 'name': 'image_analyze', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': \"Write to persistent memory (database-backed, NOT the local filesystem). Use for important facts, decisions, preferences, workflow docs, or other workspace files that should live in memory rather than on disk. Targets: 'memory' for curated long-term facts, 'daily_log' for timestamped session notes, 'heartbeat' for the periodic checklist (HEARTBEAT.md), 'bootstrap' to clear the first-run ritual file, or a custom workspace path like 'projects/alpha/notes.md'. Prefer normal writes with 'content' unless you have just read the file and know the exact text to patch with 'old_string'/'new_string'. Never pass absolute filesystem paths like '/Users/...' or 'C:\\\\...'.\", 'locked': False, 'locked_reason': None, 'name': 'memory_write', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Generate an image from a text prompt using an AI image generation model (e.g., FLUX). Returns the generated image data.', 'locked': False, 'locked_reason': None, 'name': 'image_generate', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Create a new job or task for the agent to work on. Use this when the user wants you to do something substantial that should be tracked as a separate job.', 'locked': False, 'locked_reason': None, 'name': 'create_job', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Read a file from the LOCAL FILESYSTEM. **Always read a file before editing it.** NOT for workspace memory paths (use memory_read for those). Returns content with line numbers. Default limit is 2000 lines. For large files, use offset and limit for partial reads.', 'locked': False, 'locked_reason': None, 'name': 'read_file', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Search file contents using regex patterns. Powered by ripgrep. Three output modes: content (matching lines with context), files_with_matches (file paths only, default), count (match counts per file). Use this instead of shell with 'grep' or 'rg'.\", 'locked': False, 'locked_reason': None, 'name': 'grep', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Make HTTP requests to external APIs. Supports GET, POST, PUT, DELETE methods. Use save_to to download binary files (images, PDFs, etc.) to a local path, e.g. {\"method\":\"GET\",\"url\":\"https://picsum.photos/800/600\",\"save_to\":\"/tmp/photo.jpg\"}.', 'locked': False, 'locked_reason': None, 'name': 'http', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'List extensions and built-in tools with their authentication, activation, and permission status. Set include_available:true to also show registry entries not yet installed. Use kind=\"builtin\" to list only built-in Rust tools.', 'locked': False, 'locked_reason': None, 'name': 'tool_list', 'permission_state': 'always_allow'}, {'default_state': 'always_allow', 'description': 'Get info about any tool: description, parameter names, curated summary guidance, or full discovery schema.', 'locked': False, 'locked_reason': None, 'name': 'tool_info', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Get the agent version and build information', 'locked': False, 'locked_reason': None, 'name': 'system_version', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Execute shell commands. Use for running builds, tests, git operations, and other CLI tasks. Commands run in a subprocess with captured output. Long-running commands have a timeout. When Docker sandbox is enabled, commands run in isolated containers for security.', 'locked': False, 'locked_reason': None, 'name': 'shell', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Undo the most recent modification to a file by restoring its previous content. Only works for changes made by apply_patch or write_file in the current session.', 'locked': True, 'locked_reason': 'This tool always requires explicit approval and cannot be set to always_allow.', 'name': 'file_undo', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Apply targeted edits to a file using search/replace. **Prefer this over write_file** for modifying existing files — it sends only the changed portion. The old_string must match exactly (including whitespace and indentation). The edit will FAIL if old_string is not unique — provide more context to make it unique, or set replace_all=true. **You must read_file before editing.** When editing text from read_file output, preserve the exact indentation (tabs/spaces) as it appears after the line number prefix.', 'locked': False, 'locked_reason': None, 'name': 'apply_patch', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Upgrade installed WASM extensions (channels and tools) to match the current host WIT version. If name is omitted, checks and upgrades all installed WASM extensions. Authentication and secrets are preserved.', 'locked': False, 'locked_reason': None, 'name': 'tool_upgrade', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'List all jobs or filter by status. Shows job IDs, titles, and current status.', 'locked': False, 'locked_reason': None, 'name': 'list_jobs', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Permanently delete a stored secret by name. This cannot be undone.', 'locked': False, 'locked_reason': None, 'name': 'secret_delete', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Edit an existing image using an AI model. Provide the workspace path to the source image and a text prompt describing the desired edits.', 'locked': False, 'locked_reason': None, 'name': 'image_edit', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Update an existing routine. Can change prompt, description, enabled state, cron schedule/timezone, Pass the routine name and only the fields you want to change. This does not convert trigger types. Behavior-changing edits should leave the routine marked unverified until it is tested again.', 'locked': False, 'locked_reason': None, 'name': 'routine_update', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Get current time, parse or format timestamps, convert timezones, or calculate time differences.', 'locked': False, 'locked_reason': None, 'name': 'time', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Fast file pattern matching. Find files by glob pattern (e.g. `**/*.rs`, `src/**/*.ts`). Results sorted by modification time (newest first). Use this instead of shell with `find` or `ls -R`.', 'locked': False, 'locked_reason': None, 'name': 'glob', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'List all stored secrets by name. Never returns values — only names and optional provider metadata. Use this to check what credentials are available before attempting a task that requires them.', 'locked': False, 'locked_reason': None, 'name': 'secret_list', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': \"Create a new routine (scheduled or event-driven task). Supports cron schedules, event pattern matching, system events, and manual triggers. Use this when the user wants something to happen periodically or reactively. Do not use this for immediate one-shot requests like 'do it now', 'right now', or 'immediately'; complete those in the current thread. Creation saves the routine, but does not verify that it will execute successfully.\", 'locked': False, 'locked_reason': None, 'name': 'routine_create', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': \"Send a proactive message to a channel. Use normal assistant output to reply in the active conversation; use this tool for proactive notifications, routine/background follow-ups, attachments, or sending to a different channel/recipient. If channel/target are omitted, reuses the current conversation's channel and sender/group when available. If you provide `target` without `channel` and no scoped channel can be resolved, the message may be broadcast across connected channels instead of sent to just one. Supports file attachments: first download the file with the http tool using save_to (e.g., http GET https://picsum.photos/800/600 save_to=/tmp/photo.jpg), then pass the file path in the attachments array. Images are sent as photos on Telegram. - Signal: target accepts E.164 (+1234567890) or group ID - Telegram: target accepts username or chat ID - Slack: target accepts channel ID (C0...) or user ID (U0...)\", 'locked': False, 'locked_reason': None, 'name': 'message', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Delete a routine permanently. This also removes all run history.', 'locked': False, 'locked_reason': None, 'name': 'routine_delete', 'permission_state': 'ask_each_time'}, {'default_state': 'ask_each_time', 'description': 'Cancel a running or pending job. The job will be marked as cancelled and stopped.', 'locked': False, 'locked_reason': None, 'name': 'cancel_job', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Parse, query, and transform JSON data. Supports JSONPath-like queries. Use `source_tool_call_id` to reference the full output of a previous tool call (avoids truncation issues with large responses).', 'locked': False, 'locked_reason': None, 'name': 'json', 'permission_state': 'always_allow'}, {'default_state': 'ask_each_time', 'description': 'Initiate authentication for an extension. For OAuth, returns a URL. For manual auth, returns instructions. The user provides their token through a secure channel, never through this tool.', 'locked': False, 'locked_reason': None, 'name': 'tool_auth', 'permission_state': 'ask_each_time'}, {'default_state': 'always_allow', 'description': 'Make an integration usable. This may install, authenticate, and activate it as needed before loading tools, starting channels, or connecting to MCP servers.', 'locked': False, 'locked_reason': None, 'name': 'tool_activate', 'permission_state': 'always_allow'}]}"
+        },
+        {
+          "tool_call_id": "call_81b424003cef45e9be61c621",
+          "name": "tool_activate",
+          "content": "[ACTION FAILED] tool_activate: {'error': \"Tool 'tool_activate' failed: Tool error: Tool tool_activate execution failed: Execution failed: Extension not installed: http\"}"
+        },
+        {
+          "tool_call_id": "call_08b42248eedb43e7b02e5518",
+          "name": "http",
+          "content": "{'body': {'bitcoin': {'usd': 77213}}, 'headers': {'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, Authorization', 'access-control-allow-methods': 'POST, PUT, DELETE, GET, OPTIONS', 'access-control-allow-origin': '*', 'access-control-expose-headers': 'link, per-page, total', 'access-control-request-method': '*', 'age': '16', 'alt-svc': 'h3=\":443\"; ma=86400', 'alternate-protocol': '443:npn-spdy/2', 'cache-control': 'max-age=30, public, must-revalidate, s-maxage=60', 'cf-cache-status': 'HIT', 'cf-ray': '9f4dfcd49cb3fcd2-FUK', 'content-security-policy-report-only': 'script-src https://accounts.google.com/gsi/client; frame-src https://accounts.google.com/gsi/; connect-src https://accounts.google.com/gsi/;', 'content-type': 'application/json; charset=utf-8', 'date': 'Fri, 01 May 2026 10:08:54 GMT', 'etag': 'W/\"ea3f8b2ec1d662f71d842ecfa132afb0\"', 'referrer-policy': 'strict-origin-when-cross-origin', 'server': 'cloudflare', 'strict-transport-security': 'max-age=15724800; includeSubdomains', 'vary': 'Accept-Encoding, Origin', 'x-content-type-options': 'nosniff', 'x-frame-options': 'SAMEORIGIN', 'x-permitted-cross-domain-policies': 'none', 'x-request-id': 'ca203e91-e2e6-4942-a4a5-4abcf5fc70da', 'x-runtime': '0.005202', 'x-xss-protection': '0'}, 'status': 200}"
+        },
+        {
+          "tool_call_id": "call_a3f00734525c4707a0edbfdc",
+          "name": "mission_update",
+          "content": "{'status': 'updated'}"
+        },
+        {
+          "tool_call_id": "call_05c529ff62ea4620aeca7165",
+          "name": "mission_fire",
+          "content": "{'status': 'fired', 'thread_id': '3b3b6f86-7f0b-4d7b-ae8a-88ed4bfc8487'}"
+        },
+        {
+          "tool_call_id": "call_17e42824f0994356914beb8f",
+          "name": "mission_get",
+          "content": "{'approach_history': [\"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\"], 'cadence': 'Manual', 'current_focus': None, 'goal': 'Fetch the current Bitcoin price using the http tool. Call: http(method=\"GET\", url=\"https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd\"). Parse the response to extract the bitcoin.usd price and report it clearly in a formatted message like \"Bitcoin Price: $XXX,XXX USD\".', 'id': 'f705bc52-e598-4c30-be86-eb0bb223244e', 'last_fire_at': '2026-05-01T10:09:01.302229+00:00', 'name': 'bitcoin-price-check', 'next_fire_at': None, 'recent_threads': [{'completed_at': None, 'created_at': '2026-05-01T10:09:01.256384+00:00', 'result': None, 'state': 'Running', 'steps': 0, 'thread_id': '3b3b6f86-7f0b-4d7b-ae8a-88ed4bfc8487', 'tokens_used': 0}, {'completed_at': '2026-05-01T10:08:42.565898+00:00', 'created_at': '2026-05-01T10:08:31.303792+00:00', 'result': \"## Bitcoin Price Report\\n\\n**Status:** Failed to fetch Bitcoin price.\\n\\n**Errors:**\\n- API: Invalid API response\\n- Search: action 'web_search' is not callable in this execution context\\n\\n**Recommendation:** Try again later or check https://www.coingecko.com manually\", 'state': 'Done', 'steps': 1, 'thread_id': '6d4fae13-fb42-4845-b4ec-a785b136aa71', 'tokens_used': 10358}], 'status': 'Active', 'success_criteria': None, 'total_threads': 2}"
+        },
+        {
+          "tool_call_id": "call_ac9051b4a2ed4d6ba6e0c5eb",
+          "name": "job_status",
+          "content": "{'error': 'Job not found: Job 3b3b6f86-7f0b-4d7b-ae8a-88ed4bfc8487 not found'}"
+        }
+      ]
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "# Mission: bitcoin-price-check\n\nGoal: Fetch the current Bitcoin price using the ",
+        "min_message_count": 4
+      },
+      "response": {
+        "type": "text",
+        "content": "\n\n```repl\n# Bitcoin price successfully fetched from CoinGecko API\nbitcoin_price = 77213\n\n# Format the price with proper currency formatting\nformatted_price = f\"${bitcoin_price:,}\"\n\n# Create the report\nreport = f\"\"\"\n## Bitcoin Price Report\n\n**Current Price:** {formatted_price} USD\n\n**Source:** CoinGecko API (https://api.coingecko.com/api/v3/simple/price)\n\n**Timestamp:** 2026-05-01 10:09:04 GMT\n\n---\n\n### Next Focus (for next thread)\n- Continue monitoring Bitcoin price every 5 minutes as scheduled\n- Track price changes and trends over time\n- Set up alerts if price deviates significantly from current value\n\n### Goal Status\n**Achieved:** Yes - Successfully fetched and reported Bitcoin price\n\"\"\"\n\nFINAL(report)\n```",
+        "input_tokens": 10313,
+        "output_tokens": 293
+      }
+    }
+  ]
+}

--- a/tests/support/live_mission_helpers.rs
+++ b/tests/support/live_mission_helpers.rs
@@ -1,0 +1,167 @@
+//! Shared helpers for live tests that drive engine v2 missions/routines.
+//!
+//! Extracted from `tests/e2e_live_routine.rs` so additional scenarios
+//! (`tests/e2e_live_mission_gmail.rs`, etc.) can reuse the same approval
+//! responder and notification heuristics without copy-paste drift.
+
+#![cfg(feature = "libsql")]
+#![allow(dead_code)] // shared API; not every test uses every helper
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ironclaw::channels::{IncomingMessage, StatusUpdate};
+use uuid::Uuid;
+
+use crate::support::test_channel::TestChannel;
+use crate::support::test_rig::TestRig;
+
+/// Returns true if `tool` is the bare action name `expected` or carries
+/// the same name with a parenthesised argument suffix
+/// (e.g. `routine_create(name)` from `format_action_display_name`).
+pub fn tool_is(tool: &str, expected: &str) -> bool {
+    tool == expected
+        || tool
+            .strip_prefix(expected)
+            .is_some_and(|rest| rest.starts_with('('))
+}
+
+/// Anchor for "the routine/mission actually fired and delivered output via
+/// the notification channel" — independent of the formatting quality of
+/// that output. Engine v2 mission fires (which is what `routine_fire`
+/// becomes via the bridge alias) wrap their notifications with
+/// `**[<mission-name>]**` so the channel can distinguish the fire output
+/// from the agent's foreground reply.
+pub fn looks_like_routine_notification(text: &str) -> bool {
+    if let Some(open) = text.find("**[")
+        && let Some(close_rel) = text[open + 3..].find("]**")
+    {
+        // Reject empty names (`**[]**`) — that's not a real marker.
+        return close_rel > 0;
+    }
+    false
+}
+
+/// Wait until at least one captured response satisfies `predicate`,
+/// polling every 500ms until `deadline`. Returns the first match.
+pub async fn wait_for_response_matching<F>(
+    rig: &TestRig,
+    predicate: F,
+    deadline: Instant,
+) -> Option<String>
+where
+    F: Fn(&str) -> bool,
+{
+    loop {
+        let responses = rig.wait_for_responses(0, Duration::from_millis(0)).await;
+        if let Some(r) = responses.iter().find(|r| predicate(&r.content)) {
+            return Some(r.content.clone());
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Background approval auto-responder.
+///
+/// Polls the `TestChannel`'s captured status events every 500ms and
+/// resolves each `StatusUpdate::ApprovalNeeded` it has not already seen
+/// by injecting a `Submission::ExecApproval { approved: true,
+/// always: false }` back into the channel. Per-call approval is
+/// deliberate — every fire round-trips through the gate so a regression
+/// that breaks the second gate (e.g. session-state leakage between
+/// fires) shows up.
+///
+/// Holds an `Arc<TestChannel>` rather than `&TestRig` so it can outlive
+/// any individual borrow on the rig.
+pub struct ApprovalAutoResponder {
+    approved: Arc<tokio::sync::Mutex<Vec<(String, Uuid)>>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl ApprovalAutoResponder {
+    pub fn spawn(channel: Arc<TestChannel>) -> Self {
+        let approved = Arc::new(tokio::sync::Mutex::new(Vec::<(String, Uuid)>::new()));
+        let approved_for_task = approved.clone();
+        let handle = tokio::spawn(async move {
+            let mut seen: HashSet<Uuid> = HashSet::new();
+            loop {
+                for event in channel.captured_status_events() {
+                    if let StatusUpdate::ApprovalNeeded {
+                        request_id,
+                        tool_name,
+                        ..
+                    } = event
+                    {
+                        let Ok(rid) = Uuid::parse_str(&request_id) else {
+                            continue;
+                        };
+                        if seen.insert(rid) {
+                            eprintln!(
+                                "[ApprovalAutoResponder] Auto-approving '{tool_name}' \
+                                 (request_id={rid})"
+                            );
+                            let submission =
+                                ironclaw::agent::submission::Submission::ExecApproval {
+                                    request_id: rid,
+                                    approved: true,
+                                    always: false,
+                                };
+                            let msg =
+                                IncomingMessage::new(channel.channel_name(), channel.user_id(), "")
+                                    .with_structured_submission(submission);
+                            channel.send_incoming(msg).await;
+                            approved_for_task.lock().await.push((tool_name, rid));
+                        }
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        });
+        Self { approved, handle }
+    }
+
+    pub async fn approved_tools(&self) -> Vec<(String, Uuid)> {
+        self.approved.lock().await.clone()
+    }
+
+    pub fn shutdown(self) {
+        self.handle.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn looks_like_routine_notification_accepts_marker() {
+        assert!(looks_like_routine_notification(
+            "**[bitcoin_price_checker]** Some output\nbody body body"
+        ));
+    }
+
+    #[test]
+    fn looks_like_routine_notification_rejects_foreground_reply() {
+        // Foreground replies have no marker.
+        assert!(!looks_like_routine_notification(
+            "## Bitcoin Price Checker Routine Created ✅\nSchedule: */5 * * * *"
+        ));
+    }
+
+    #[test]
+    fn looks_like_routine_notification_rejects_empty_marker() {
+        assert!(!looks_like_routine_notification("**[]** empty name"));
+    }
+
+    #[test]
+    fn tool_is_matches_bare_and_parenthesised() {
+        assert!(tool_is("mission_fire", "mission_fire"));
+        assert!(tool_is("mission_fire(abc)", "mission_fire"));
+        assert!(!tool_is("mission_fired", "mission_fire"));
+        assert!(!tool_is("other_mission_fire", "mission_fire"));
+    }
+}

--- a/tests/support/live_mission_helpers.rs
+++ b/tests/support/live_mission_helpers.rs
@@ -133,6 +133,19 @@ impl ApprovalAutoResponder {
     }
 }
 
+impl Drop for ApprovalAutoResponder {
+    fn drop(&mut self) {
+        // Defensive abort: if the test panics or returns before
+        // calling `shutdown()`, the background task would otherwise
+        // keep polling the channel for the lifetime of the test
+        // process and bleed into subsequent tests on the same tokio
+        // runtime. Calling `abort()` here is idempotent — a task
+        // already aborted by an explicit `shutdown()` call simply
+        // ignores it.
+        self.handle.abort();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -5,6 +5,8 @@ pub mod gateway_workflow_harness;
 pub mod instrumented_llm;
 #[cfg(feature = "libsql")]
 pub mod live_harness;
+#[cfg(feature = "libsql")]
+pub mod live_mission_helpers;
 pub mod metrics;
 pub mod mock_mcp_server;
 pub mod mock_openai_server;

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -267,6 +267,35 @@ impl TestRig {
         self.channel.send_incoming(msg).await;
     }
 
+    /// Cloneable handle to the underlying `TestChannel`. Used by tests that
+    /// need to spawn background helpers (e.g. an approval auto-responder)
+    /// without taking a reference to `TestRig` itself, which is not cloneable
+    /// (it owns the agent `JoinHandle` and a temp-dir guard).
+    pub fn channel_handle(&self) -> std::sync::Arc<crate::support::test_channel::TestChannel> {
+        self.channel.clone()
+    }
+
+    /// Resolve a tool-execution approval gate by submitting a typed
+    /// `Submission::ExecApproval`.
+    ///
+    /// The `request_id` must be a `Uuid` matching the `request_id` field on
+    /// a previously-emitted `StatusUpdate::ApprovalNeeded`. Tests usually
+    /// pull it from `captured_status_events()` after waiting for the gate.
+    pub async fn send_exec_approval(&self, request_id: uuid::Uuid, approved: bool, always: bool) {
+        let submission = ironclaw::agent::submission::Submission::ExecApproval {
+            request_id,
+            approved,
+            always,
+        };
+        let msg = ironclaw::channels::IncomingMessage::new(
+            self.channel.channel_name(),
+            self.channel.user_id(),
+            "",
+        )
+        .with_structured_submission(submission);
+        self.channel.send_incoming(msg).await;
+    }
+
     /// Resolve an OAuth-style gate by submitting a typed
     /// `Submission::ExternalCallback`.
     pub async fn send_external_callback(&self, request_id: uuid::Uuid) {


### PR DESCRIPTION
## Summary

- Fixes #2583 — routine creation hitting `5 consecutive code errors`. The actual root cause was much smaller than the linked #2843 epic suggested: every `mission_*` handler in the bridge required an `id` UUID, but the LLM and the `routine_*` alias path naturally pass `name`. Each call collapsed to `invalid mission id: invalid length 0`, retried 4–5×, and tripped the orchestrator's consecutive-error guard.
- Mission/routine tools now accept `name` (preferred) with `id` UUID retained as a legacy fallback; UUIDs stay internal.
- Adds a live regression test that drives the exact bug-bash prompt through engine v2 and verifies the fix end-to-end.

## What changed

| File | Change |
|---|---|
| `src/bridge/effect_adapter.rs` | New `resolve_mission_id` helper. Handlers `mission_get`, `mission_fire`, `mission_pause`, `mission_resume`, `mission_complete`, `mission_update` migrated. `mission_update` renames via `new_name`; legacy `name`-as-rename-target preserved only when a UUID `id` is also passed. Four new unit tests. |
| `src/bridge/engine_actions.rs` | Mission tool schemas advertise `name` as primary, `id` as legacy alternative. Neither field is `required`. `mission_update` documents `new_name` for renames. |
| `tests/support/test_rig.rs` | Adds `channel_handle()` accessor and `send_exec_approval` for the live test's approval responder. |
| `tests/e2e_live_routine.rs` | New live regression. Drives the issue's exact prompt; asserts no `invalid mission id` or `consecutive code errors`; verifies `**[name]**` notifications on both fire and refire. |
| `tests/fixtures/llm_traces/live/routine_btc_create_test_and_refire.json` | Recorded trace for deterministic replay (live run scrub-checked — no PII). |

## How the fix was found

Driving the issue's verbatim prompt through engine v2 with a real LLM (the new test) reproduced the failure on first run. The trace showed:

```
tool 'routine_fire(bitcoin_price_checker)' failed: effect execution error:
  invalid mission id: invalid length: expected length 32 for simple format, found 0
  ... (× 4)
```

`routine_fire` translates to `mission_fire` via `routine_to_mission_alias`, which passes `params.clone()` unchanged. The `mission_fire` handler then tried to parse the routine *name* as a UUID and failed. Five errors in a row → orchestrator killed the thread → \"5 consecutive code errors\" symptom.

## Verification

- `cargo test --features libsql --lib bridge::effect_adapter` — all 113 effect-adapter tests pass, including 4 new ones for the helper / handler / alias paths.
- `cargo test --features libsql --test e2e_live_routine -- --skip routine_btc` — heuristic + structural unit tests pass.
- `IRONCLAW_LIVE_TEST=1 cargo test --features libsql --test e2e_live_routine -- --ignored routine_btc_create_test_and_refire --nocapture` — passes in 49s. Tools observed: `[\"routine_create(*/5 * * * *)\", \"routine_fire(bitcoin-price-check)\", \"routine_history(bitcoin-price-check)\", \"job_status(...)\"]`. No `invalid mission id`. No `consecutive code errors`. Notifications delivered on both the initial fire and the second-turn refire.
- Replay mode (no `IRONCLAW_LIVE_TEST`) loads the committed fixture and runs deterministically.

## Out of scope (parked for separate follow-ups)

The live test surfaced two further observations that are independent of this fix and not test-failing:

1. **Administrative-tool approval gates not surfacing.** Even with `auto_approve_tools=false`, `mission_create / routine_create / mission_fire / routine_fire` (all classified `Administrative` per `crates/ironclaw_engine/src/gate/tool_tier.rs`) ran without firing a single `StatusUpdate::ApprovalNeeded`. Logged as a warning in the test.
2. **Mission-fire child thread sometimes returns narration instead of data.** `build_meta_prompt` (`crates/ironclaw_engine/src/runtime/mission.rs:2132–2139`) instructs the child to FINAL() with \"1. What you accomplished / 2. Next focus / 3. Goal achieved\" — meta-prose. For \"fetch X and surface it\" routines the user actually wants the data. Logged as a warning in the test.

Both warrant their own issues; flagging here so they're not lost.

## Test plan

- [ ] CI green on the new unit tests
- [ ] CI green on the live test in replay mode (uses committed fixture)
- [ ] Manual: bug-bash redo of the original report on staging — confirm no \"5 consecutive code errors\" surface