### PR TITLE
feat(reborn): add host runtime approval resume

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -294,6 +294,50 @@ impl RuntimeCapabilityRequest {
     }
 }
 
+/// Request to resume one approval-blocked capability through the composed host runtime.
+///
+/// The shape mirrors [`RuntimeCapabilityRequest`] but additionally carries the
+/// approval request selected by an upper approval workflow. Like invoke requests,
+/// `trust_decision` is transitional compatibility data: the default host runtime
+/// evaluates provider trust itself before delegating to `CapabilityHost`.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct RuntimeCapabilityResumeRequest {
+    pub context: ExecutionContext,
+    pub approval_request_id: ApprovalRequestId,
+    pub capability_id: CapabilityId,
+    pub estimate: ResourceEstimate,
+    pub input: Value,
+    pub idempotency_key: Option<IdempotencyKey>,
+    pub trust_decision: TrustDecision,
+}
+
+impl RuntimeCapabilityResumeRequest {
+    pub fn new(
+        context: ExecutionContext,
+        approval_request_id: ApprovalRequestId,
+        capability_id: CapabilityId,
+        estimate: ResourceEstimate,
+        input: Value,
+        trust_decision: TrustDecision,
+    ) -> Self {
+        Self {
+            context,
+            approval_request_id,
+            capability_id,
+            estimate,
+            input,
+            idempotency_key: None,
+            trust_decision,
+        }
+    }
+
+    pub fn with_idempotency_key(mut self, key: IdempotencyKey) -> Self {
+        self.idempotency_key = Some(key);
+        self
+    }
+}
+
 /// Request to list host-filtered visible capabilities.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -553,6 +597,11 @@ pub trait HostRuntime: Send + Sync {
     async fn invoke_capability(
         &self,
         request: RuntimeCapabilityRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError>;
+
+    async fn resume_capability(
+        &self,
+        request: RuntimeCapabilityResumeRequest,
     ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError>;
 
     async fn visible_capabilities(

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use ironclaw_authorization::{CapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_capabilities::{
     CapabilityHost, CapabilityInvocationError, CapabilityInvocationRequest,
-    CapabilityInvocationResult, CapabilityObligationHandler,
+    CapabilityInvocationResult, CapabilityObligationHandler, CapabilityResumeRequest,
 };
 use ironclaw_extensions::{ExtensionPackage, ExtensionRegistry};
 use ironclaw_host_api::{
@@ -38,8 +38,9 @@ use crate::{
     CancelRuntimeWorkRequest, CapabilitySurfaceVersion, HostRuntime, HostRuntimeError,
     HostRuntimeHealth, HostRuntimeStatus, RuntimeApprovalGate, RuntimeBackendHealth,
     RuntimeBlockedReason, RuntimeCapabilityCompleted, RuntimeCapabilityFailure,
-    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind, RuntimeStatusRequest,
-    RuntimeWorkId, RuntimeWorkSummary, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeCapabilityResumeRequest,
+    RuntimeFailureKind, RuntimeStatusRequest, RuntimeWorkId, RuntimeWorkSummary,
+    VisibleCapabilityRequest, VisibleCapabilitySurface,
 };
 
 /// Default production wiring for [`HostRuntime`].
@@ -256,26 +257,7 @@ impl HostRuntime for DefaultHostRuntime {
         };
         context.trust = trust_decision.effective_trust.class();
 
-        let mut host = CapabilityHost::new(
-            self.registry.as_ref(),
-            self.dispatcher.as_ref(),
-            self.authorizer.as_ref(),
-        );
-        if let Some(run_state) = &self.run_state {
-            host = host.with_run_state(run_state.as_ref());
-        }
-        if let Some(approval_requests) = &self.approval_requests {
-            host = host.with_approval_requests(approval_requests.as_ref());
-        }
-        if let Some(capability_leases) = &self.capability_leases {
-            host = host.with_capability_leases(capability_leases.as_ref());
-        }
-        if let Some(process_manager) = &self.process_manager {
-            host = host.with_process_manager(process_manager.as_ref());
-        }
-        if let Some(obligation_handler) = &self.obligation_handler {
-            host = host.with_obligation_handler(obligation_handler.as_ref());
-        }
+        let host = self.capability_host();
 
         let invocation = CapabilityInvocationRequest {
             context,
@@ -298,6 +280,74 @@ impl HostRuntime for DefaultHostRuntime {
                 );
                 self.translate_invocation_error(error, capability_id, scope, invocation_id)
                     .await
+            }
+        }
+    }
+
+    async fn resume_capability(
+        &self,
+        request: RuntimeCapabilityResumeRequest,
+    ) -> Result<RuntimeCapabilityOutcome, HostRuntimeError> {
+        let RuntimeCapabilityResumeRequest {
+            mut context,
+            approval_request_id,
+            capability_id,
+            estimate,
+            input,
+            idempotency_key,
+            trust_decision: _caller_trust_decision,
+        } = request;
+        let idempotency_key = idempotency_key.map(|key| key.as_str().to_string());
+        if let Some(key) = idempotency_key.as_deref() {
+            tracing::debug!(
+                capability_id = %capability_id,
+                approval_request_id = %approval_request_id,
+                idempotency_key = %key,
+                "capability resume accepted advisory idempotency key (not yet enforced)"
+            );
+        }
+
+        let trust_decision = match self.evaluate_invocation_trust(&capability_id) {
+            Ok(host_decision) => host_decision,
+            Err(error) => {
+                tracing::debug!(
+                    capability_id = %capability_id,
+                    trust_error_kind = error.kind(),
+                    "capability trust evaluation failed before resume"
+                );
+                return Ok(trust_evaluation_failure(capability_id, error));
+            }
+        };
+        context.trust = trust_decision.effective_trust.class();
+
+        let host = self.capability_host();
+        let resume = CapabilityResumeRequest {
+            context,
+            approval_request_id,
+            capability_id: capability_id.clone(),
+            estimate,
+            input,
+            trust_decision,
+        };
+
+        match host.resume_json(resume).await {
+            Ok(result) => Ok(RuntimeCapabilityOutcome::Completed(Box::new(
+                completed_outcome_from(result, capability_id),
+            ))),
+            // Resume must not start a second approval loop: if the lower layer ever returns
+            // AuthorizationRequiresApproval here, surface it as a failed resume instead of
+            // translating it back into RuntimeCapabilityOutcome::ApprovalRequired.
+            Err(error) => {
+                tracing::debug!(
+                    capability_id = %capability_id,
+                    error_kind = failure_kind_from(&error).as_str(),
+                    idempotency_key = idempotency_key.as_deref().unwrap_or(""),
+                    "capability resume failed"
+                );
+                Ok(RuntimeCapabilityOutcome::Failed(failure_from(
+                    error,
+                    capability_id,
+                )))
             }
         }
     }
@@ -477,6 +527,30 @@ impl HostRuntime for DefaultHostRuntime {
 }
 
 impl DefaultHostRuntime {
+    fn capability_host(&self) -> CapabilityHost<'_, dyn CapabilityDispatcher> {
+        let mut host = CapabilityHost::new(
+            self.registry.as_ref(),
+            self.dispatcher.as_ref(),
+            self.authorizer.as_ref(),
+        );
+        if let Some(run_state) = &self.run_state {
+            host = host.with_run_state(run_state.as_ref());
+        }
+        if let Some(approval_requests) = &self.approval_requests {
+            host = host.with_approval_requests(approval_requests.as_ref());
+        }
+        if let Some(capability_leases) = &self.capability_leases {
+            host = host.with_capability_leases(capability_leases.as_ref());
+        }
+        if let Some(process_manager) = &self.process_manager {
+            host = host.with_process_manager(process_manager.as_ref());
+        }
+        if let Some(obligation_handler) = &self.obligation_handler {
+            host = host.with_obligation_handler(obligation_handler.as_ref());
+        }
+        host
+    }
+
     fn evaluate_invocation_trust(
         &self,
         capability_id: &CapabilityId,

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -315,6 +315,13 @@ impl HostRuntime for DefaultHostRuntime {
                     trust_error_kind = error.kind(),
                     "capability trust evaluation failed before resume"
                 );
+                self.fail_matching_blocked_resume_on_preflight_error(
+                    &context,
+                    &capability_id,
+                    approval_request_id,
+                    error.kind(),
+                )
+                .await;
                 return Ok(trust_evaluation_failure(capability_id, error));
             }
         };
@@ -588,6 +595,56 @@ impl DefaultHostRuntime {
         };
         trace_trust_decision(capability_id, &decision);
         Ok(decision)
+    }
+
+    async fn fail_matching_blocked_resume_on_preflight_error(
+        &self,
+        context: &ironclaw_host_api::ExecutionContext,
+        capability_id: &CapabilityId,
+        approval_request_id: ApprovalRequestId,
+        error_kind: &'static str,
+    ) {
+        if context.validate().is_err() {
+            return;
+        }
+        let Some(run_state) = self.run_state.as_ref() else {
+            return;
+        };
+        let scope = &context.resource_scope;
+        let invocation_id = context.invocation_id;
+        let record = match run_state.get(scope, invocation_id).await {
+            Ok(Some(record)) => record,
+            Ok(None) => return,
+            Err(error) => {
+                tracing::warn!(
+                    invocation_id = %invocation_id,
+                    capability_id = %capability_id,
+                    preflight_error_kind = error_kind,
+                    transition_error = %unavailable_from_run_state(error),
+                    "blocked resume preflight failed, but run-state lookup failed; leaving run state unchanged",
+                );
+                return;
+            }
+        };
+        if record.status != RunStatus::BlockedApproval
+            || &record.capability_id != capability_id
+            || record.approval_request_id != Some(approval_request_id)
+        {
+            return;
+        }
+        if let Err(error) = run_state
+            .fail(scope, invocation_id, error_kind.to_string())
+            .await
+        {
+            tracing::warn!(
+                invocation_id = %invocation_id,
+                capability_id = %capability_id,
+                approval_request_id = %approval_request_id,
+                preflight_error_kind = error_kind,
+                transition_error = %unavailable_from_run_state(error),
+                "blocked resume preflight failed, but run-state fail transition failed; original failure is returned to caller",
+            );
+        }
     }
 
     async fn translate_invocation_error(

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1,9 +1,11 @@
 use std::{sync::Arc, thread, time::Duration};
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{Duration as ChronoDuration, Utc};
+use ironclaw_approvals::LeaseApproval;
 use ironclaw_authorization::{
-    GrantAuthorizer, InMemoryCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
+    CapabilityLeaseStatus, CapabilityLeaseStore, GrantAuthorizer, InMemoryCapabilityLeaseStore,
+    TrustAwareCapabilityDispatchAuthorizer,
 };
 use ironclaw_events::{
     DurableAuditLog, DurableEventLog, EventCursor, EventError, EventReplay, EventStreamKey,
@@ -16,16 +18,19 @@ use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CancelReason, CancelRuntimeWorkRequest, CapabilitySurfaceVersion, DefaultHostRuntime,
     HostRuntime, HostRuntimeServices, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
-    RuntimeFailureKind, RuntimeStatusRequest, RuntimeWorkId,
+    RuntimeCapabilityResumeRequest, RuntimeFailureKind, RuntimeStatusRequest, RuntimeWorkId,
 };
 use ironclaw_mcp::{McpError, McpExecutionRequest, McpExecutionResult, McpExecutor};
 use ironclaw_processes::{
-    ProcessResultStore, ProcessServices, ProcessStart, ProcessStatus, ProcessStore,
+    InMemoryProcessResultStore, InMemoryProcessStore, ProcessResultStore, ProcessServices,
+    ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceLimits,
 };
-use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore};
+use ironclaw_run_state::{
+    InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStateStore, RunStatus,
+};
 use ironclaw_scripts::{
     ScriptBackend, ScriptBackendOutput, ScriptBackendRequest, ScriptRuntime, ScriptRuntimeConfig,
 };
@@ -210,6 +215,260 @@ async fn host_runtime_services_writes_runtime_events_to_durable_event_log_metada
     assert!(serialized.contains("script.echo"));
     assert!(serialized.contains("dispatch_requested"));
     assert!(serialized.contains("dispatch_succeeded"));
+}
+
+#[tokio::test]
+async fn host_runtime_services_resumes_approved_capability_and_consumes_lease_once() {
+    let fixture = approval_resume_fixture();
+    let runtime = fixture.services.host_runtime();
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "approval resume"});
+
+    let gate = block_for_approval(&runtime, context.clone(), estimate.clone(), input.clone()).await;
+    let lease =
+        approve_dispatch_for_services(&fixture.services, &scope, gate.approval_request_id, None)
+            .await;
+
+    let resumed = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            context.clone(),
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate.clone(),
+            input.clone(),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match resumed {
+        RuntimeCapabilityOutcome::Completed(completed) => {
+            assert_eq!(completed.capability_id, script_capability_id());
+            assert_eq!(completed.output, input);
+        }
+        other => panic!("expected completed resume outcome, got {other:?}"),
+    }
+    assert_eq!(
+        fixture
+            .capability_leases
+            .get(&scope, lease.grant.id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Consumed
+    );
+    let kinds = fixture
+        .events
+        .events()
+        .into_iter()
+        .map(|event| event.kind)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+        ]
+    );
+
+    let second = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            context,
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate,
+            input,
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    assert_failed_outcome(second, RuntimeFailureKind::Authorization);
+    assert_eq!(
+        fixture.events.events().len(),
+        3,
+        "second resume must fail before a second dispatch"
+    );
+}
+
+#[tokio::test]
+async fn host_runtime_services_resume_changed_input_fails_before_lease_claim_or_dispatch() {
+    let fixture = approval_resume_fixture();
+    let runtime = fixture.services.host_runtime();
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let estimate = ResourceEstimate::default();
+    let original_input = json!({"message": "original"});
+
+    let gate =
+        block_for_approval(&runtime, context.clone(), estimate.clone(), original_input).await;
+    let lease =
+        approve_dispatch_for_services(&fixture.services, &scope, gate.approval_request_id, None)
+            .await;
+
+    let outcome = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            context,
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate,
+            json!({"message": "changed"}),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    assert_failed_outcome(outcome, RuntimeFailureKind::Authorization);
+    assert!(fixture.events.events().is_empty());
+    // The approval request stores the original invocation fingerprint; changed input
+    // computes a different resume fingerprint, so no matching lease is claimable.
+    assert_eq!(
+        fixture
+            .capability_leases
+            .get(&scope, lease.grant.id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active,
+        "fingerprint mismatch must fail before lease claim/consume"
+    );
+}
+
+#[tokio::test]
+async fn host_runtime_services_resume_wrong_user_scope_is_hidden_before_dispatch() {
+    let fixture = approval_resume_fixture();
+    let runtime = fixture.services.host_runtime();
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "wrong user"});
+
+    let gate = block_for_approval(&runtime, context.clone(), estimate.clone(), input.clone()).await;
+    let lease =
+        approve_dispatch_for_services(&fixture.services, &scope, gate.approval_request_id, None)
+            .await;
+    let wrong_scope = ResourceScope {
+        user_id: UserId::new("other-user").unwrap(),
+        ..scope.clone()
+    };
+    let wrong_context =
+        execution_context_with_dispatch_grant_for_scope(script_capability_id(), wrong_scope);
+
+    let outcome = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            wrong_context,
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate,
+            input,
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    assert_failed_outcome(outcome, RuntimeFailureKind::Backend);
+    assert!(fixture.events.events().is_empty());
+    let original_run = fixture
+        .run_state
+        .get(&scope, context.invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(original_run.status, RunStatus::BlockedApproval);
+    assert_eq!(
+        original_run.approval_request_id,
+        Some(gate.approval_request_id)
+    );
+    assert_eq!(
+        fixture
+            .capability_leases
+            .get(&scope, lease.grant.id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active
+    );
+}
+
+#[tokio::test]
+async fn host_runtime_services_resume_expired_lease_fails_before_dispatch() {
+    let fixture = approval_resume_fixture();
+    let runtime = fixture.services.host_runtime();
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "expired"});
+
+    let gate = block_for_approval(&runtime, context.clone(), estimate.clone(), input.clone()).await;
+    let lease = approve_dispatch_for_services(
+        &fixture.services,
+        &scope,
+        gate.approval_request_id,
+        Some(Utc::now() - ChronoDuration::seconds(1)),
+    )
+    .await;
+
+    let outcome = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            context,
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate,
+            input,
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    assert_failed_outcome(outcome, RuntimeFailureKind::Authorization);
+    assert!(fixture.events.events().is_empty());
+    assert_eq!(
+        fixture
+            .capability_leases
+            .get(&scope, lease.grant.id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active
+    );
+}
+
+#[tokio::test]
+async fn host_runtime_services_resume_without_backing_stores_fails_closed() {
+    let runtime = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ApprovalThenGrantAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )))
+    .host_runtime();
+
+    let outcome = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            execution_context_without_grants(),
+            ApprovalRequestId::new(),
+            script_capability_id(),
+            ResourceEstimate::default(),
+            json!({"message": "missing stores"}),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    assert_failed_outcome(outcome, RuntimeFailureKind::Backend);
 }
 
 #[tokio::test]
@@ -840,6 +1099,137 @@ fn assert_completed_outcome(outcome: RuntimeCapabilityOutcome, expected_capabili
     }
 }
 
+type InMemoryHostRuntimeServices = HostRuntimeServices<
+    LocalFilesystem,
+    InMemoryResourceGovernor,
+    InMemoryProcessStore,
+    InMemoryProcessResultStore,
+>;
+
+struct ApprovalResumeFixture {
+    services: InMemoryHostRuntimeServices,
+    run_state: Arc<InMemoryRunStateStore>,
+    capability_leases: Arc<InMemoryCapabilityLeaseStore>,
+    events: InMemoryEventSink,
+}
+
+fn approval_resume_fixture() -> ApprovalResumeFixture {
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let events = InMemoryEventSink::new();
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ApprovalThenGrantAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
+    .with_run_state(Arc::clone(&run_state))
+    .with_approval_requests(Arc::new(InMemoryApprovalRequestStore::new()))
+    .with_capability_leases(Arc::clone(&capability_leases))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )))
+    .with_event_sink(Arc::new(events.clone()));
+
+    ApprovalResumeFixture {
+        services,
+        run_state,
+        capability_leases,
+        events,
+    }
+}
+
+async fn block_for_approval(
+    runtime: &impl HostRuntime,
+    context: ExecutionContext,
+    estimate: ResourceEstimate,
+    input: serde_json::Value,
+) -> ironclaw_host_runtime::RuntimeApprovalGate {
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            script_capability_id(),
+            estimate,
+            input,
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::ApprovalRequired(gate) => gate,
+        other => panic!("expected approval gate, got {other:?}"),
+    }
+}
+
+async fn approve_dispatch_for_services(
+    services: &InMemoryHostRuntimeServices,
+    scope: &ResourceScope,
+    approval_request_id: ApprovalRequestId,
+    expires_at: Option<Timestamp>,
+) -> ironclaw_authorization::CapabilityLease {
+    services
+        .approval_resolver()
+        .expect("approval resolver should be configured")
+        .approve_dispatch(
+            scope,
+            approval_request_id,
+            LeaseApproval {
+                issued_by: Principal::HostRuntime,
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: MountView::default(),
+                network: NetworkPolicy::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap()
+}
+
+struct ApprovalThenGrantAuthorizer;
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for ApprovalThenGrantAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        trust_decision: &TrustDecision,
+    ) -> Decision {
+        if context.grants.grants.is_empty() {
+            Decision::RequireApproval {
+                request: ApprovalRequest {
+                    id: ApprovalRequestId::new(),
+                    correlation_id: context.correlation_id,
+                    requested_by: Principal::Extension(context.extension_id.clone()),
+                    action: Box::new(Action::Dispatch {
+                        capability: descriptor.id.clone(),
+                        estimated_resources: estimate.clone(),
+                    }),
+                    invocation_fingerprint: None,
+                    reason: "approval required".to_string(),
+                    reusable_scope: None,
+                },
+            }
+        } else {
+            GrantAuthorizer::new()
+                .authorize_dispatch_with_trust(context, descriptor, estimate, trust_decision)
+                .await
+        }
+    }
+}
+
 struct EchoScriptBackend;
 
 impl ScriptBackend for EchoScriptBackend {
@@ -996,6 +1386,18 @@ fn registry_with_manifests(manifests: &[&str]) -> ExtensionRegistry {
         registry.insert(package).unwrap();
     }
     registry
+}
+
+fn execution_context_without_grants() -> ExecutionContext {
+    ExecutionContext::local_default(
+        UserId::new("user").unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::Script,
+        TrustClass::UserTrusted,
+        CapabilitySet::default(),
+        MountView::default(),
+    )
+    .unwrap()
 }
 
 fn execution_context_with_dispatch_grant(capability: CapabilityId) -> ExecutionContext {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -437,6 +437,103 @@ async fn host_runtime_services_resume_expired_lease_fails_before_dispatch() {
 }
 
 #[tokio::test]
+async fn host_runtime_services_resume_trust_preflight_failure_fails_only_matching_blocked_run() {
+    let fixture = approval_resume_fixture();
+    let runtime = fixture.services.host_runtime();
+    let context = execution_context_without_grants();
+    let scope = context.resource_scope.clone();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "stale trust metadata"});
+
+    let gate = block_for_approval(&runtime, context.clone(), estimate.clone(), input.clone()).await;
+    let lease =
+        approve_dispatch_for_services(&fixture.services, &scope, gate.approval_request_id, None)
+            .await;
+    let broken_runtime = resume_runtime_with_empty_registry(&fixture);
+
+    let wrong_scope = ResourceScope {
+        user_id: UserId::new("other-user").unwrap(),
+        ..scope.clone()
+    };
+    let wrong_context = execution_context_without_grants_for_scope(wrong_scope);
+    let wrong_scope_outcome = broken_runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            wrong_context,
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate.clone(),
+            input.clone(),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+    assert_failed_outcome(wrong_scope_outcome, RuntimeFailureKind::MissingRuntime);
+    assert_blocked_approval_run(
+        &fixture,
+        &scope,
+        context.invocation_id,
+        gate.approval_request_id,
+    )
+    .await;
+
+    let mut invalid_context = context.clone();
+    invalid_context.user_id = UserId::new("tampered-user").unwrap();
+    let invalid_context_outcome = broken_runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            invalid_context,
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate.clone(),
+            input.clone(),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+    assert_failed_outcome(invalid_context_outcome, RuntimeFailureKind::MissingRuntime);
+    assert_blocked_approval_run(
+        &fixture,
+        &scope,
+        context.invocation_id,
+        gate.approval_request_id,
+    )
+    .await;
+
+    let matching_outcome = broken_runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            context.clone(),
+            gate.approval_request_id,
+            script_capability_id(),
+            estimate,
+            input,
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+    assert_failed_outcome(matching_outcome, RuntimeFailureKind::MissingRuntime);
+
+    let failed_run = fixture
+        .run_state
+        .get(&scope, context.invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(failed_run.status, RunStatus::Failed);
+    assert_eq!(failed_run.approval_request_id, None);
+    assert_eq!(failed_run.error_kind.as_deref(), Some("unknown_capability"));
+    assert_eq!(
+        fixture
+            .capability_leases
+            .get(&scope, lease.grant.id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active,
+        "trust preflight failure must not claim or consume the approval lease"
+    );
+    assert!(fixture.events.events().is_empty());
+}
+
+#[tokio::test]
 async fn host_runtime_services_resume_without_backing_stores_fails_closed() {
     let runtime = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -1109,12 +1206,14 @@ type InMemoryHostRuntimeServices = HostRuntimeServices<
 struct ApprovalResumeFixture {
     services: InMemoryHostRuntimeServices,
     run_state: Arc<InMemoryRunStateStore>,
+    approval_requests: Arc<InMemoryApprovalRequestStore>,
     capability_leases: Arc<InMemoryCapabilityLeaseStore>,
     events: InMemoryEventSink,
 }
 
 fn approval_resume_fixture() -> ApprovalResumeFixture {
     let run_state = Arc::new(InMemoryRunStateStore::new());
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
     let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
     let events = InMemoryEventSink::new();
     let services = HostRuntimeServices::new(
@@ -1130,7 +1229,7 @@ fn approval_resume_fixture() -> ApprovalResumeFixture {
         vec![EffectKind::DispatchCapability],
     )))
     .with_run_state(Arc::clone(&run_state))
-    .with_approval_requests(Arc::new(InMemoryApprovalRequestStore::new()))
+    .with_approval_requests(Arc::clone(&approval_requests))
     .with_capability_leases(Arc::clone(&capability_leases))
     .with_script_runtime(Arc::new(ScriptRuntime::new(
         ScriptRuntimeConfig::for_testing(),
@@ -1141,9 +1240,50 @@ fn approval_resume_fixture() -> ApprovalResumeFixture {
     ApprovalResumeFixture {
         services,
         run_state,
+        approval_requests,
         capability_leases,
         events,
     }
+}
+
+fn resume_runtime_with_empty_registry(fixture: &ApprovalResumeFixture) -> DefaultHostRuntime {
+    HostRuntimeServices::new(
+        Arc::new(ExtensionRegistry::new()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ApprovalThenGrantAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
+    .with_run_state(Arc::clone(&fixture.run_state))
+    .with_approval_requests(Arc::clone(&fixture.approval_requests))
+    .with_capability_leases(Arc::clone(&fixture.capability_leases))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )))
+    .host_runtime()
+}
+
+async fn assert_blocked_approval_run(
+    fixture: &ApprovalResumeFixture,
+    scope: &ResourceScope,
+    invocation_id: InvocationId,
+    approval_request_id: ApprovalRequestId,
+) {
+    let run = fixture
+        .run_state
+        .get(scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, RunStatus::BlockedApproval);
+    assert_eq!(run.approval_request_id, Some(approval_request_id));
+    assert_eq!(run.error_kind, None);
 }
 
 async fn block_for_approval(
@@ -1398,6 +1538,29 @@ fn execution_context_without_grants() -> ExecutionContext {
         MountView::default(),
     )
     .unwrap()
+}
+
+fn execution_context_without_grants_for_scope(scope: ResourceScope) -> ExecutionContext {
+    let context = ExecutionContext {
+        invocation_id: scope.invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: scope.mission_id.clone(),
+        thread_id: scope.thread_id.clone(),
+        extension_id: ExtensionId::new("caller").unwrap(),
+        runtime: RuntimeKind::Script,
+        trust: TrustClass::UserTrusted,
+        grants: CapabilitySet::default(),
+        mounts: MountView::default(),
+        resource_scope: scope,
+    };
+    context.validate().unwrap();
+    context
 }
 
 fn execution_context_with_dispatch_grant(capability: CapabilityId) -> ExecutionContext {


### PR DESCRIPTION
## Summary

Adds the small HostRuntime approval-resume facade needed for #3067 Phase 3b coverage.

New API:

- `RuntimeCapabilityResumeRequest`
- `HostRuntime::resume_capability(...)`
- `DefaultHostRuntime::resume_capability(...)`, delegating through `CapabilityHost::resume_json(...)`

Behavior:

- re-evaluates host-owned provider trust at resume time
- stamps effective trust onto the resume context
- ignores caller-supplied transitional `trust_decision`, matching invoke behavior
- uses the same configured run-state, approval-request, capability-lease, process, and obligation services graph
- maps resume failures to sanitized `RuntimeCapabilityOutcome::Failed(...)` outcomes instead of starting a second approval loop

## Tests

Adds caller-level `HostRuntimeServices` coverage for:

- approval resume happy path
- lease consumed after successful resume
- second resume fails before second dispatch
- changed input/fingerprint mismatch fails before lease claim or dispatch
- wrong user/scope fails without consuming the original lease or dispatching
- expired lease fails before dispatch
- missing resume backing stores fail closed as backend failure

## Related

- Tracks #3067 Phase 3b approval-resume coverage.

## Verification

```bash
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-resume-target cargo test -q -p ironclaw_host_runtime
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-resume-target cargo clippy -q -p ironclaw_host_runtime --all-targets -- -D warnings
CARGO_TARGET_DIR=/tmp/ironclaw-reborn-resume-target cargo test -q -p ironclaw_architecture
cargo fmt --all -- --check
git diff --check origin/reborn-integration...HEAD
python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD
bash scripts/pre-commit-safety.sh
```
