### PR TITLE
Define background process obligation reconciliation lifecycle

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -51,7 +51,7 @@ mod services;
 
 pub use obligations::{
     BuiltinObligationHandler, BuiltinObligationServices, NetworkObligationPolicyStore,
-    RuntimeSecretInjectionStore, RuntimeSecretInjectionStoreError,
+    ProcessObligationLifecycleStore, RuntimeSecretInjectionStore, RuntimeSecretInjectionStoreError,
 };
 pub use production::DefaultHostRuntime;
 pub use services::{HostRuntimeServices, RegisteredRuntimeHealth};

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -410,7 +410,6 @@ pub struct ProcessObligationLifecycleStore {
     network_policies: Arc<NetworkObligationPolicyStore>,
     secret_injections: Arc<RuntimeSecretInjectionStore>,
     resource_governor: Arc<dyn ResourceGovernor>,
-    cleaned: Mutex<HashSet<ProcessLifecycleKey>>,
 }
 
 impl ProcessObligationLifecycleStore {
@@ -443,14 +442,7 @@ impl ProcessObligationLifecycleStore {
             network_policies,
             secret_injections,
             resource_governor,
-            cleaned: Mutex::new(HashSet::new()),
         }
-    }
-
-    fn cleaned_guard(&self) -> std::sync::MutexGuard<'_, HashSet<ProcessLifecycleKey>> {
-        self.cleaned
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     /// Discards staged obligation handoffs and closes any reservation for an
@@ -485,11 +477,6 @@ impl ProcessObligationLifecycleStore {
         record: &ProcessRecord,
         reconcile: bool,
     ) -> Result<(), ProcessError> {
-        let key = ProcessLifecycleKey::new(&record.scope, record.process_id);
-        let mut cleaned = self.cleaned_guard();
-        if cleaned.contains(&key) {
-            return Ok(());
-        }
         self.network_policies
             .discard_for_capability(&record.scope, &record.capability_id);
         self.secret_injections
@@ -507,7 +494,6 @@ impl ProcessObligationLifecycleStore {
                 close_reservation_once(self.resource_governor.release(reservation_id))?;
             }
         }
-        cleaned.insert(key);
         Ok(())
     }
 }
@@ -571,31 +557,6 @@ fn close_reservation_once<T>(result: Result<T, ResourceError>) -> Result<(), Pro
         Err(ResourceError::ReservationClosed { .. }) => Ok(()),
         Err(ResourceError::UnknownReservation { .. }) => Ok(()),
         Err(error) => Err(error.into()),
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ProcessLifecycleKey {
-    tenant_id: String,
-    user_id: String,
-    agent_id: Option<String>,
-    project_id: Option<String>,
-    mission_id: Option<String>,
-    thread_id: Option<String>,
-    process_id: ProcessId,
-}
-
-impl ProcessLifecycleKey {
-    fn new(scope: &ResourceScope, process_id: ProcessId) -> Self {
-        Self {
-            tenant_id: scope.tenant_id.as_str().to_string(),
-            user_id: scope.user_id.as_str().to_string(),
-            agent_id: scope.agent_id.as_ref().map(|id| id.as_str().to_string()),
-            project_id: scope.project_id.as_ref().map(|id| id.as_str().to_string()),
-            mission_id: scope.mission_id.as_ref().map(|id| id.as_str().to_string()),
-            thread_id: scope.thread_id.as_ref().map(|id| id.as_str().to_string()),
-            process_id,
-        }
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -34,17 +34,28 @@ pub const DEFAULT_RUNTIME_SECRET_INJECTION_TTL: Duration = Duration::from_secs(3
 /// failures, cancellation, or adapter bugs cannot remain usable indefinitely.
 #[derive(Clone)]
 pub struct RuntimeSecretInjectionStore {
-    state: Arc<RuntimeSecretInjectionState>,
+    state: Arc<Mutex<RuntimeSecretInjectionState>>,
 }
 
+#[derive(Default)]
 struct RuntimeSecretInjectionState {
-    secrets: Mutex<HashMap<RuntimeSecretInjectionKey, RuntimeSecretInjectionEntry>>,
+    secrets: HashMap<RuntimeSecretInjectionKey, RuntimeSecretInjectionEntry>,
     ttl: Duration,
+    next_generation: u64,
+}
+
+impl RuntimeSecretInjectionState {
+    fn next_generation(&mut self) -> HandoffGeneration {
+        let generation = HandoffGeneration(self.next_generation);
+        self.next_generation = self.next_generation.wrapping_add(1);
+        generation
+    }
 }
 
 struct RuntimeSecretInjectionEntry {
     material: SecretMaterial,
     expires_at: Instant,
+    generation: HandoffGeneration,
 }
 
 impl RuntimeSecretInjectionStore {
@@ -54,15 +65,19 @@ impl RuntimeSecretInjectionStore {
 
     pub fn with_ttl(ttl: Duration) -> Self {
         Self {
-            state: Arc::new(RuntimeSecretInjectionState {
-                secrets: Mutex::new(HashMap::new()),
+            state: Arc::new(Mutex::new(RuntimeSecretInjectionState {
+                secrets: HashMap::new(),
                 ttl,
-            }),
+                next_generation: 0,
+            })),
         }
     }
 
     pub fn ttl(&self) -> Duration {
-        self.state.ttl
+        self.state
+            .lock()
+            .map(|state| state.ttl)
+            .unwrap_or(DEFAULT_RUNTIME_SECRET_INJECTION_TTL)
     }
 
     pub fn insert(
@@ -73,14 +88,17 @@ impl RuntimeSecretInjectionStore {
         material: SecretMaterial,
     ) -> Result<(), RuntimeSecretInjectionStoreError> {
         let now = Instant::now();
-        let expires_at = now.checked_add(self.state.ttl).unwrap_or(now);
-        let mut secrets = self.lock()?;
-        prune_expired_entries(&mut secrets, now);
-        secrets.insert(
+        let mut state = self.lock()?;
+        let ttl = state.ttl;
+        prune_expired_entries(&mut state.secrets, now);
+        let expires_at = now.checked_add(ttl).unwrap_or(now);
+        let generation = state.next_generation();
+        state.secrets.insert(
             RuntimeSecretInjectionKey::new(scope, capability_id, handle),
             RuntimeSecretInjectionEntry {
                 material,
                 expires_at,
+                generation,
             },
         );
         Ok(())
@@ -93,9 +111,10 @@ impl RuntimeSecretInjectionStore {
         handle: &SecretHandle,
     ) -> Result<Option<SecretMaterial>, RuntimeSecretInjectionStoreError> {
         let now = Instant::now();
-        let mut secrets = self.lock()?;
-        prune_expired_entries(&mut secrets, now);
-        Ok(secrets
+        let mut state = self.lock()?;
+        prune_expired_entries(&mut state.secrets, now);
+        Ok(state
+            .secrets
             .remove(&RuntimeSecretInjectionKey::new(
                 scope,
                 capability_id,
@@ -105,28 +124,71 @@ impl RuntimeSecretInjectionStore {
     }
 
     pub fn prune_expired(&self) -> Result<usize, RuntimeSecretInjectionStoreError> {
-        let mut secrets = self.lock()?;
-        Ok(prune_expired_entries(&mut secrets, Instant::now()))
+        let mut state = self.lock()?;
+        Ok(prune_expired_entries(&mut state.secrets, Instant::now()))
     }
 
+    /// Discard all staged secrets for a scoped capability before process ownership exists.
+    ///
+    /// Terminal process cleanup must use generation claims captured at process start so it
+    /// cannot remove newer handoffs staged for another process with the same scoped capability.
     pub fn discard_for_capability(
         &self,
         scope: &ResourceScope,
         capability_id: &CapabilityId,
     ) -> Result<(), RuntimeSecretInjectionStoreError> {
         let scope_key = RuntimeSecretInjectionScopeKey::new(scope, capability_id);
-        self.lock()?.retain(|key, _| !key.matches_scope(&scope_key));
+        let mut state = self.lock()?;
+        prune_expired_entries(&mut state.secrets, Instant::now());
+        state.secrets.retain(|key, _| !key.matches_scope(&scope_key));
+        Ok(())
+    }
+
+    fn claims_for_capability(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) -> Result<Vec<RuntimeSecretInjectionClaim>, RuntimeSecretInjectionStoreError> {
+        let scope_key = RuntimeSecretInjectionScopeKey::new(scope, capability_id);
+        let mut state = self.lock()?;
+        prune_expired_entries(&mut state.secrets, Instant::now());
+        Ok(state
+            .secrets
+            .iter()
+            .filter(|(key, _)| key.matches_scope(&scope_key))
+            .map(|(key, entry)| RuntimeSecretInjectionClaim {
+                key: key.clone(),
+                generation: entry.generation,
+            })
+            .collect())
+    }
+
+    fn discard_claims(
+        &self,
+        claims: &[RuntimeSecretInjectionClaim],
+    ) -> Result<(), RuntimeSecretInjectionStoreError> {
+        let mut state = self.lock()?;
+        prune_expired_entries(&mut state.secrets, Instant::now());
+        for claim in claims {
+            let should_remove = state
+                .secrets
+                .get(&claim.key)
+                .map(|entry| entry.generation == claim.generation)
+                .unwrap_or(false);
+            if should_remove {
+                state.secrets.remove(&claim.key);
+            }
+        }
         Ok(())
     }
 
     fn lock(
         &self,
     ) -> Result<
-        std::sync::MutexGuard<'_, HashMap<RuntimeSecretInjectionKey, RuntimeSecretInjectionEntry>>,
+        std::sync::MutexGuard<'_, RuntimeSecretInjectionState>,
         RuntimeSecretInjectionStoreError,
     > {
         self.state
-            .secrets
             .lock()
             .map_err(|_| RuntimeSecretInjectionStoreError::Unavailable)
     }
@@ -143,7 +205,7 @@ impl fmt::Debug for RuntimeSecretInjectionStore {
         formatter
             .debug_struct("RuntimeSecretInjectionStore")
             .field("secrets", &"[REDACTED]")
-            .field("ttl", &self.state.ttl)
+            .field("ttl", &self.ttl())
             .finish()
     }
 }
@@ -239,6 +301,15 @@ impl RuntimeSecretInjectionScopeKey {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HandoffGeneration(u64);
+
+#[derive(Debug, Clone)]
+struct RuntimeSecretInjectionClaim {
+    key: RuntimeSecretInjectionKey,
+    generation: HandoffGeneration,
+}
+
 /// In-memory policy handoff from obligation handling to runtime adapters.
 ///
 /// Policies are keyed by tenant/user/project/mission/thread/invocation scope and
@@ -246,7 +317,27 @@ impl RuntimeSecretInjectionScopeKey {
 /// actual runtime dispatch.
 #[derive(Debug, Clone, Default)]
 pub struct NetworkObligationPolicyStore {
-    policies: Arc<Mutex<HashMap<NetworkPolicyKey, NetworkPolicy>>>,
+    state: Arc<Mutex<NetworkObligationPolicyState>>,
+}
+
+#[derive(Debug, Default)]
+struct NetworkObligationPolicyState {
+    policies: HashMap<NetworkPolicyKey, NetworkPolicyEntry>,
+    next_generation: u64,
+}
+
+impl NetworkObligationPolicyState {
+    fn next_generation(&mut self) -> HandoffGeneration {
+        let generation = HandoffGeneration(self.next_generation);
+        self.next_generation = self.next_generation.wrapping_add(1);
+        generation
+    }
+}
+
+#[derive(Debug)]
+struct NetworkPolicyEntry {
+    policy: NetworkPolicy,
+    generation: HandoffGeneration,
 }
 
 impl NetworkObligationPolicyStore {
@@ -260,10 +351,15 @@ impl NetworkObligationPolicyStore {
         capability_id: &CapabilityId,
         policy: NetworkPolicy,
     ) {
-        self.policies
+        let mut state = self
+            .state
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(NetworkPolicyKey::new(scope, capability_id), policy);
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let generation = state.next_generation();
+        state.policies.insert(
+            NetworkPolicyKey::new(scope, capability_id),
+            NetworkPolicyEntry { policy, generation },
+        );
     }
 
     pub fn take(
@@ -271,14 +367,52 @@ impl NetworkObligationPolicyStore {
         scope: &ResourceScope,
         capability_id: &CapabilityId,
     ) -> Option<NetworkPolicy> {
-        self.policies
+        self.state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .policies
             .remove(&NetworkPolicyKey::new(scope, capability_id))
+            .map(|entry| entry.policy)
     }
 
+    /// Discard a staged policy for a scoped capability before process ownership exists.
+    ///
+    /// Terminal process cleanup must use the generation claim captured at process start so it
+    /// cannot remove a newer handoff staged for another process with the same scoped capability.
     pub fn discard_for_capability(&self, scope: &ResourceScope, capability_id: &CapabilityId) {
         let _ = self.take(scope, capability_id);
+    }
+
+    fn claim_for_capability(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) -> Option<NetworkObligationPolicyClaim> {
+        let key = NetworkPolicyKey::new(scope, capability_id);
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .policies
+            .get(&key)
+            .map(|entry| NetworkObligationPolicyClaim {
+                key,
+                generation: entry.generation,
+            })
+    }
+
+    fn discard_claim(&self, claim: &NetworkObligationPolicyClaim) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let should_remove = state
+            .policies
+            .get(&claim.key)
+            .map(|entry| entry.generation == claim.generation)
+            .unwrap_or(false);
+        if should_remove {
+            state.policies.remove(&claim.key);
+        }
     }
 }
 
@@ -307,6 +441,12 @@ impl NetworkPolicyKey {
             capability_id: capability_id.as_str().to_string(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+struct NetworkObligationPolicyClaim {
+    key: NetworkPolicyKey,
+    generation: HandoffGeneration,
 }
 
 /// Host-runtime-owned backing services for a fully configured built-in obligation handler.
@@ -410,6 +550,7 @@ pub struct ProcessObligationLifecycleStore {
     network_policies: Arc<NetworkObligationPolicyStore>,
     secret_injections: Arc<RuntimeSecretInjectionStore>,
     resource_governor: Arc<dyn ResourceGovernor>,
+    handoff_claims: Mutex<HashMap<ProcessObligationClaimKey, ProcessObligationClaimState>>,
 }
 
 impl ProcessObligationLifecycleStore {
@@ -442,6 +583,7 @@ impl ProcessObligationLifecycleStore {
             network_policies,
             secret_injections,
             resource_governor,
+            handoff_claims: Mutex::new(HashMap::new()),
         }
     }
 
@@ -459,7 +601,59 @@ impl ProcessObligationLifecycleStore {
         Ok(())
     }
 
-    fn cleanup_terminal(&self, record: &ProcessRecord, reconcile: bool) {
+    fn capture_record_obligations(&self, record: &ProcessRecord) -> Result<(), ProcessError> {
+        let network_policy = self
+            .network_policies
+            .claim_for_capability(&record.scope, &record.capability_id);
+        let secret_injections = self
+            .secret_injections
+            .claims_for_capability(&record.scope, &record.capability_id)
+            .map_err(|_| ProcessError::InvalidStoredRecord {
+                reason: "process obligation handoff capture failed".to_string(),
+            })?;
+        let mut claims =
+            self.handoff_claims
+                .lock()
+                .map_err(|_| ProcessError::InvalidStoredRecord {
+                    reason: "process obligation claim store unavailable".to_string(),
+                })?;
+        claims.insert(
+            ProcessObligationClaimKey::new(&record.scope, record.process_id),
+            ProcessObligationClaimState::Active(Box::new(ProcessObligationHandoffClaim {
+                network_policy,
+                secret_injections,
+            })),
+        );
+        Ok(())
+    }
+
+    fn handoff_claim_for_cleanup(
+        &self,
+        record: &ProcessRecord,
+    ) -> Result<ProcessObligationCleanupHandoffs, ProcessError> {
+        let mut claims =
+            self.handoff_claims
+                .lock()
+                .map_err(|_| ProcessError::InvalidStoredRecord {
+                    reason: "process obligation claim store unavailable".to_string(),
+                })?;
+        let key = ProcessObligationClaimKey::new(&record.scope, record.process_id);
+        let Some(state) = claims.get_mut(&key) else {
+            return Ok(ProcessObligationCleanupHandoffs::LegacyUnclaimed);
+        };
+        match std::mem::replace(state, ProcessObligationClaimState::Cleaned) {
+            ProcessObligationClaimState::Active(claim) => {
+                Ok(ProcessObligationCleanupHandoffs::Claimed(claim))
+            }
+            ProcessObligationClaimState::Cleaned => Ok(ProcessObligationCleanupHandoffs::Cleaned),
+        }
+    }
+
+    fn cleanup_terminal(
+        &self,
+        record: &ProcessRecord,
+        reconcile: bool,
+    ) -> Result<(), ProcessError> {
         if let Err(error) = self.cleanup_record_obligations(record, reconcile) {
             tracing::warn!(
                 process_id = %record.process_id,
@@ -469,7 +663,9 @@ impl ProcessObligationLifecycleStore {
                 error = %error,
                 "process obligation cleanup failed after terminal transition"
             );
+            return Err(error);
         }
+        Ok(())
     }
 
     fn cleanup_record_obligations(
@@ -477,13 +673,28 @@ impl ProcessObligationLifecycleStore {
         record: &ProcessRecord,
         reconcile: bool,
     ) -> Result<(), ProcessError> {
-        self.network_policies
-            .discard_for_capability(&record.scope, &record.capability_id);
-        self.secret_injections
-            .discard_for_capability(&record.scope, &record.capability_id)
-            .map_err(|_| ProcessError::InvalidStoredRecord {
-                reason: "process obligation handoff cleanup failed".to_string(),
-            })?;
+        match self.handoff_claim_for_cleanup(record)? {
+            ProcessObligationCleanupHandoffs::Claimed(claim) => {
+                if let Some(network_policy) = &claim.network_policy {
+                    self.network_policies.discard_claim(network_policy);
+                }
+                self.secret_injections
+                    .discard_claims(&claim.secret_injections)
+                    .map_err(|_| ProcessError::InvalidStoredRecord {
+                        reason: "process obligation handoff cleanup failed".to_string(),
+                    })?;
+            }
+            ProcessObligationCleanupHandoffs::LegacyUnclaimed => {
+                self.network_policies
+                    .discard_for_capability(&record.scope, &record.capability_id);
+                self.secret_injections
+                    .discard_for_capability(&record.scope, &record.capability_id)
+                    .map_err(|_| ProcessError::InvalidStoredRecord {
+                        reason: "process obligation handoff cleanup failed".to_string(),
+                    })?;
+            }
+            ProcessObligationCleanupHandoffs::Cleaned => {}
+        }
         if let Some(reservation_id) = record.resource_reservation_id {
             if reconcile {
                 close_reservation_once(
@@ -498,10 +709,55 @@ impl ProcessObligationLifecycleStore {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ProcessObligationClaimKey {
+    tenant_id: String,
+    user_id: String,
+    agent_id: Option<String>,
+    project_id: Option<String>,
+    mission_id: Option<String>,
+    thread_id: Option<String>,
+    process_id: ProcessId,
+}
+
+impl ProcessObligationClaimKey {
+    fn new(scope: &ResourceScope, process_id: ProcessId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.as_str().to_string(),
+            user_id: scope.user_id.as_str().to_string(),
+            agent_id: scope.agent_id.as_ref().map(|id| id.as_str().to_string()),
+            project_id: scope.project_id.as_ref().map(|id| id.as_str().to_string()),
+            mission_id: scope.mission_id.as_ref().map(|id| id.as_str().to_string()),
+            thread_id: scope.thread_id.as_ref().map(|id| id.as_str().to_string()),
+            process_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ProcessObligationClaimState {
+    Active(Box<ProcessObligationHandoffClaim>),
+    Cleaned,
+}
+
+#[derive(Debug)]
+struct ProcessObligationHandoffClaim {
+    network_policy: Option<NetworkObligationPolicyClaim>,
+    secret_injections: Vec<RuntimeSecretInjectionClaim>,
+}
+
+enum ProcessObligationCleanupHandoffs {
+    Claimed(Box<ProcessObligationHandoffClaim>),
+    LegacyUnclaimed,
+    Cleaned,
+}
+
 #[async_trait]
 impl ProcessStore for ProcessObligationLifecycleStore {
     async fn start(&self, start: ProcessStart) -> Result<ProcessRecord, ProcessError> {
-        self.inner.start(start).await
+        let record = self.inner.start(start).await?;
+        self.capture_record_obligations(&record)?;
+        Ok(record)
     }
 
     async fn complete(
@@ -510,7 +766,7 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         process_id: ProcessId,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.complete(scope, process_id).await?;
-        self.cleanup_terminal(&record, true);
+        self.cleanup_terminal(&record, true)?;
         Ok(record)
     }
 
@@ -521,7 +777,7 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         error_kind: String,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.fail(scope, process_id, error_kind).await?;
-        self.cleanup_terminal(&record, false);
+        self.cleanup_terminal(&record, false)?;
         Ok(record)
     }
 
@@ -531,7 +787,7 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         process_id: ProcessId,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.kill(scope, process_id).await?;
-        self.cleanup_terminal(&record, false);
+        self.cleanup_terminal(&record, false)?;
         Ok(record)
     }
 

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -589,6 +589,19 @@ impl ProcessObligationLifecycleStore {
         Ok(())
     }
 
+    fn has_staged_handoffs(&self, record: &ProcessRecord) -> Result<bool, ProcessError> {
+        let has_secret_handoff = self
+            .secret_injections
+            .has_for_capability(&record.scope, &record.capability_id)
+            .map_err(|_| ProcessError::InvalidStoredRecord {
+                reason: "process obligation handoff lookup failed".to_string(),
+            })?;
+        Ok(self
+            .network_policies
+            .contains(&record.scope, &record.capability_id)
+            || has_secret_handoff)
+    }
+
     fn cleanup_terminal(
         &self,
         record: &ProcessRecord,
@@ -618,8 +631,9 @@ impl ProcessObligationLifecycleStore {
         if self.process_handoff_cleaned(record)? {
             return Ok(());
         }
-        let should_cleanup_handoffs =
-            self.has_active_process_handoff(record)? || record.resource_reservation_id.is_some();
+        let should_cleanup_handoffs = self.has_active_process_handoff(record)?
+            || record.resource_reservation_id.is_some()
+            || self.has_staged_handoffs(record)?;
         if should_cleanup_handoffs {
             self.network_policies
                 .discard_for_capability(&record.scope, &record.capability_id);

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -34,28 +34,17 @@ pub const DEFAULT_RUNTIME_SECRET_INJECTION_TTL: Duration = Duration::from_secs(3
 /// failures, cancellation, or adapter bugs cannot remain usable indefinitely.
 #[derive(Clone)]
 pub struct RuntimeSecretInjectionStore {
-    state: Arc<Mutex<RuntimeSecretInjectionState>>,
+    state: Arc<RuntimeSecretInjectionState>,
 }
 
-#[derive(Default)]
 struct RuntimeSecretInjectionState {
-    secrets: HashMap<RuntimeSecretInjectionKey, RuntimeSecretInjectionEntry>,
+    secrets: Mutex<HashMap<RuntimeSecretInjectionKey, RuntimeSecretInjectionEntry>>,
     ttl: Duration,
-    next_generation: u64,
-}
-
-impl RuntimeSecretInjectionState {
-    fn next_generation(&mut self) -> HandoffGeneration {
-        let generation = HandoffGeneration(self.next_generation);
-        self.next_generation = self.next_generation.wrapping_add(1);
-        generation
-    }
 }
 
 struct RuntimeSecretInjectionEntry {
     material: SecretMaterial,
     expires_at: Instant,
-    generation: HandoffGeneration,
 }
 
 impl RuntimeSecretInjectionStore {
@@ -65,19 +54,15 @@ impl RuntimeSecretInjectionStore {
 
     pub fn with_ttl(ttl: Duration) -> Self {
         Self {
-            state: Arc::new(Mutex::new(RuntimeSecretInjectionState {
-                secrets: HashMap::new(),
+            state: Arc::new(RuntimeSecretInjectionState {
+                secrets: Mutex::new(HashMap::new()),
                 ttl,
-                next_generation: 0,
-            })),
+            }),
         }
     }
 
     pub fn ttl(&self) -> Duration {
-        self.state
-            .lock()
-            .map(|state| state.ttl)
-            .unwrap_or(DEFAULT_RUNTIME_SECRET_INJECTION_TTL)
+        self.state.ttl
     }
 
     pub fn insert(
@@ -88,17 +73,14 @@ impl RuntimeSecretInjectionStore {
         material: SecretMaterial,
     ) -> Result<(), RuntimeSecretInjectionStoreError> {
         let now = Instant::now();
-        let mut state = self.lock()?;
-        let ttl = state.ttl;
-        prune_expired_entries(&mut state.secrets, now);
-        let expires_at = now.checked_add(ttl).unwrap_or(now);
-        let generation = state.next_generation();
-        state.secrets.insert(
+        let expires_at = now.checked_add(self.state.ttl).unwrap_or(now);
+        let mut secrets = self.lock()?;
+        prune_expired_entries(&mut secrets, now);
+        secrets.insert(
             RuntimeSecretInjectionKey::new(scope, capability_id, handle),
             RuntimeSecretInjectionEntry {
                 material,
                 expires_at,
-                generation,
             },
         );
         Ok(())
@@ -111,10 +93,9 @@ impl RuntimeSecretInjectionStore {
         handle: &SecretHandle,
     ) -> Result<Option<SecretMaterial>, RuntimeSecretInjectionStoreError> {
         let now = Instant::now();
-        let mut state = self.lock()?;
-        prune_expired_entries(&mut state.secrets, now);
-        Ok(state
-            .secrets
+        let mut secrets = self.lock()?;
+        prune_expired_entries(&mut secrets, now);
+        Ok(secrets
             .remove(&RuntimeSecretInjectionKey::new(
                 scope,
                 capability_id,
@@ -124,71 +105,45 @@ impl RuntimeSecretInjectionStore {
     }
 
     pub fn prune_expired(&self) -> Result<usize, RuntimeSecretInjectionStoreError> {
-        let mut state = self.lock()?;
-        Ok(prune_expired_entries(&mut state.secrets, Instant::now()))
+        let mut secrets = self.lock()?;
+        Ok(prune_expired_entries(&mut secrets, Instant::now()))
     }
 
     /// Discard all staged secrets for a scoped capability before process ownership exists.
     ///
-    /// Terminal process cleanup must use generation claims captured at process start so it
-    /// cannot remove newer handoffs staged for another process with the same scoped capability.
+    /// Background process lifecycle cleanup is guarded by a single-active-handoff
+    /// invariant for the scoped capability; this method remains the abort/inline cleanup seam.
     pub fn discard_for_capability(
         &self,
         scope: &ResourceScope,
         capability_id: &CapabilityId,
     ) -> Result<(), RuntimeSecretInjectionStoreError> {
         let scope_key = RuntimeSecretInjectionScopeKey::new(scope, capability_id);
-        let mut state = self.lock()?;
-        prune_expired_entries(&mut state.secrets, Instant::now());
-        state.secrets.retain(|key, _| !key.matches_scope(&scope_key));
+        let mut secrets = self.lock()?;
+        prune_expired_entries(&mut secrets, Instant::now());
+        secrets.retain(|key, _| !key.matches_scope(&scope_key));
         Ok(())
     }
 
-    fn claims_for_capability(
+    fn has_for_capability(
         &self,
         scope: &ResourceScope,
         capability_id: &CapabilityId,
-    ) -> Result<Vec<RuntimeSecretInjectionClaim>, RuntimeSecretInjectionStoreError> {
+    ) -> Result<bool, RuntimeSecretInjectionStoreError> {
         let scope_key = RuntimeSecretInjectionScopeKey::new(scope, capability_id);
-        let mut state = self.lock()?;
-        prune_expired_entries(&mut state.secrets, Instant::now());
-        Ok(state
-            .secrets
-            .iter()
-            .filter(|(key, _)| key.matches_scope(&scope_key))
-            .map(|(key, entry)| RuntimeSecretInjectionClaim {
-                key: key.clone(),
-                generation: entry.generation,
-            })
-            .collect())
-    }
-
-    fn discard_claims(
-        &self,
-        claims: &[RuntimeSecretInjectionClaim],
-    ) -> Result<(), RuntimeSecretInjectionStoreError> {
-        let mut state = self.lock()?;
-        prune_expired_entries(&mut state.secrets, Instant::now());
-        for claim in claims {
-            let should_remove = state
-                .secrets
-                .get(&claim.key)
-                .map(|entry| entry.generation == claim.generation)
-                .unwrap_or(false);
-            if should_remove {
-                state.secrets.remove(&claim.key);
-            }
-        }
-        Ok(())
+        let mut secrets = self.lock()?;
+        prune_expired_entries(&mut secrets, Instant::now());
+        Ok(secrets.keys().any(|key| key.matches_scope(&scope_key)))
     }
 
     fn lock(
         &self,
     ) -> Result<
-        std::sync::MutexGuard<'_, RuntimeSecretInjectionState>,
+        std::sync::MutexGuard<'_, HashMap<RuntimeSecretInjectionKey, RuntimeSecretInjectionEntry>>,
         RuntimeSecretInjectionStoreError,
     > {
         self.state
+            .secrets
             .lock()
             .map_err(|_| RuntimeSecretInjectionStoreError::Unavailable)
     }
@@ -205,7 +160,7 @@ impl fmt::Debug for RuntimeSecretInjectionStore {
         formatter
             .debug_struct("RuntimeSecretInjectionStore")
             .field("secrets", &"[REDACTED]")
-            .field("ttl", &self.ttl())
+            .field("ttl", &self.state.ttl)
             .finish()
     }
 }
@@ -301,15 +256,6 @@ impl RuntimeSecretInjectionScopeKey {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct HandoffGeneration(u64);
-
-#[derive(Debug, Clone)]
-struct RuntimeSecretInjectionClaim {
-    key: RuntimeSecretInjectionKey,
-    generation: HandoffGeneration,
-}
-
 /// In-memory policy handoff from obligation handling to runtime adapters.
 ///
 /// Policies are keyed by tenant/user/project/mission/thread/invocation scope and
@@ -317,27 +263,7 @@ struct RuntimeSecretInjectionClaim {
 /// actual runtime dispatch.
 #[derive(Debug, Clone, Default)]
 pub struct NetworkObligationPolicyStore {
-    state: Arc<Mutex<NetworkObligationPolicyState>>,
-}
-
-#[derive(Debug, Default)]
-struct NetworkObligationPolicyState {
-    policies: HashMap<NetworkPolicyKey, NetworkPolicyEntry>,
-    next_generation: u64,
-}
-
-impl NetworkObligationPolicyState {
-    fn next_generation(&mut self) -> HandoffGeneration {
-        let generation = HandoffGeneration(self.next_generation);
-        self.next_generation = self.next_generation.wrapping_add(1);
-        generation
-    }
-}
-
-#[derive(Debug)]
-struct NetworkPolicyEntry {
-    policy: NetworkPolicy,
-    generation: HandoffGeneration,
+    policies: Arc<Mutex<HashMap<NetworkPolicyKey, NetworkPolicy>>>,
 }
 
 impl NetworkObligationPolicyStore {
@@ -351,15 +277,10 @@ impl NetworkObligationPolicyStore {
         capability_id: &CapabilityId,
         policy: NetworkPolicy,
     ) {
-        let mut state = self
-            .state
+        self.policies
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let generation = state.next_generation();
-        state.policies.insert(
-            NetworkPolicyKey::new(scope, capability_id),
-            NetworkPolicyEntry { policy, generation },
-        );
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(NetworkPolicyKey::new(scope, capability_id), policy);
     }
 
     pub fn take(
@@ -367,52 +288,25 @@ impl NetworkObligationPolicyStore {
         scope: &ResourceScope,
         capability_id: &CapabilityId,
     ) -> Option<NetworkPolicy> {
-        self.state
+        self.policies
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .policies
             .remove(&NetworkPolicyKey::new(scope, capability_id))
-            .map(|entry| entry.policy)
     }
 
     /// Discard a staged policy for a scoped capability before process ownership exists.
     ///
-    /// Terminal process cleanup must use the generation claim captured at process start so it
-    /// cannot remove a newer handoff staged for another process with the same scoped capability.
+    /// Background process lifecycle cleanup is guarded by a single-active-handoff
+    /// invariant for the scoped capability; this method remains the abort/inline cleanup seam.
     pub fn discard_for_capability(&self, scope: &ResourceScope, capability_id: &CapabilityId) {
         let _ = self.take(scope, capability_id);
     }
 
-    fn claim_for_capability(
-        &self,
-        scope: &ResourceScope,
-        capability_id: &CapabilityId,
-    ) -> Option<NetworkObligationPolicyClaim> {
-        let key = NetworkPolicyKey::new(scope, capability_id);
-        self.state
+    fn contains(&self, scope: &ResourceScope, capability_id: &CapabilityId) -> bool {
+        self.policies
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .policies
-            .get(&key)
-            .map(|entry| NetworkObligationPolicyClaim {
-                key,
-                generation: entry.generation,
-            })
-    }
-
-    fn discard_claim(&self, claim: &NetworkObligationPolicyClaim) {
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let should_remove = state
-            .policies
-            .get(&claim.key)
-            .map(|entry| entry.generation == claim.generation)
-            .unwrap_or(false);
-        if should_remove {
-            state.policies.remove(&claim.key);
-        }
+            .contains_key(&NetworkPolicyKey::new(scope, capability_id))
     }
 }
 
@@ -441,12 +335,6 @@ impl NetworkPolicyKey {
             capability_id: capability_id.as_str().to_string(),
         }
     }
-}
-
-#[derive(Debug, Clone)]
-struct NetworkObligationPolicyClaim {
-    key: NetworkPolicyKey,
-    generation: HandoffGeneration,
 }
 
 /// Host-runtime-owned backing services for a fully configured built-in obligation handler.
@@ -550,7 +438,8 @@ pub struct ProcessObligationLifecycleStore {
     network_policies: Arc<NetworkObligationPolicyStore>,
     secret_injections: Arc<RuntimeSecretInjectionStore>,
     resource_governor: Arc<dyn ResourceGovernor>,
-    handoff_claims: Mutex<HashMap<ProcessObligationClaimKey, ProcessObligationClaimState>>,
+    active_process_handoffs: Mutex<HashMap<ProcessObligationHandoffKey, ProcessId>>,
+    cleaned_process_handoffs: Mutex<HashSet<ProcessObligationProcessKey>>,
 }
 
 impl ProcessObligationLifecycleStore {
@@ -583,7 +472,8 @@ impl ProcessObligationLifecycleStore {
             network_policies,
             secret_injections,
             resource_governor,
-            handoff_claims: Mutex::new(HashMap::new()),
+            active_process_handoffs: Mutex::new(HashMap::new()),
+            cleaned_process_handoffs: Mutex::new(HashSet::new()),
         }
     }
 
@@ -597,56 +487,106 @@ impl ProcessObligationLifecycleStore {
     ) -> Result<(), ProcessError> {
         if let Some(record) = self.inner.get(scope, process_id).await? {
             self.cleanup_record_obligations(&record, reconcile)?;
+            self.release_active_process_handoff(&record)?;
+            self.mark_process_handoff_cleaned(&record)?;
         }
         Ok(())
     }
 
-    fn capture_record_obligations(&self, record: &ProcessRecord) -> Result<(), ProcessError> {
-        let network_policy = self
-            .network_policies
-            .claim_for_capability(&record.scope, &record.capability_id);
-        let secret_injections = self
+    fn has_process_obligations(&self, start: &ProcessStart) -> Result<bool, ProcessError> {
+        let has_secret_handoff = self
             .secret_injections
-            .claims_for_capability(&record.scope, &record.capability_id)
+            .has_for_capability(&start.scope, &start.capability_id)
             .map_err(|_| ProcessError::InvalidStoredRecord {
-                reason: "process obligation handoff capture failed".to_string(),
+                reason: "process obligation handoff lookup failed".to_string(),
             })?;
-        let mut claims =
-            self.handoff_claims
+        Ok(start.resource_reservation_id.is_some()
+            || self
+                .network_policies
+                .contains(&start.scope, &start.capability_id)
+            || has_secret_handoff)
+    }
+
+    fn claim_active_process_handoff(&self, start: &ProcessStart) -> Result<bool, ProcessError> {
+        if !self.has_process_obligations(start)? {
+            return Ok(false);
+        }
+
+        let key = ProcessObligationHandoffKey::new(&start.scope, &start.capability_id);
+        let mut active =
+            self.active_process_handoffs
                 .lock()
                 .map_err(|_| ProcessError::InvalidStoredRecord {
-                    reason: "process obligation claim store unavailable".to_string(),
+                    reason: "process obligation handoff registry unavailable".to_string(),
                 })?;
-        claims.insert(
-            ProcessObligationClaimKey::new(&record.scope, record.process_id),
-            ProcessObligationClaimState::Active(Box::new(ProcessObligationHandoffClaim {
-                network_policy,
-                secret_injections,
-            })),
-        );
+        if let Some(existing_process_id) = active.get(&key) {
+            return Err(ProcessError::InvalidStoredRecord {
+                reason: format!(
+                    "process obligation handoff already active for scoped capability: {existing_process_id}"
+                ),
+            });
+        }
+        active.insert(key, start.process_id);
+        Ok(true)
+    }
+
+    fn release_claimed_process_handoff(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+        process_id: ProcessId,
+    ) -> Result<(), ProcessError> {
+        let key = ProcessObligationHandoffKey::new(scope, capability_id);
+        let mut active =
+            self.active_process_handoffs
+                .lock()
+                .map_err(|_| ProcessError::InvalidStoredRecord {
+                    reason: "process obligation handoff registry unavailable".to_string(),
+                })?;
+        if active.get(&key) == Some(&process_id) {
+            active.remove(&key);
+        }
         Ok(())
     }
 
-    fn handoff_claim_for_cleanup(
-        &self,
-        record: &ProcessRecord,
-    ) -> Result<ProcessObligationCleanupHandoffs, ProcessError> {
-        let mut claims =
-            self.handoff_claims
+    fn release_active_process_handoff(&self, record: &ProcessRecord) -> Result<(), ProcessError> {
+        self.release_claimed_process_handoff(
+            &record.scope,
+            &record.capability_id,
+            record.process_id,
+        )
+    }
+
+    fn has_active_process_handoff(&self, record: &ProcessRecord) -> Result<bool, ProcessError> {
+        let key = ProcessObligationHandoffKey::new(&record.scope, &record.capability_id);
+        let active =
+            self.active_process_handoffs
                 .lock()
                 .map_err(|_| ProcessError::InvalidStoredRecord {
-                    reason: "process obligation claim store unavailable".to_string(),
+                    reason: "process obligation handoff registry unavailable".to_string(),
                 })?;
-        let key = ProcessObligationClaimKey::new(&record.scope, record.process_id);
-        let Some(state) = claims.get_mut(&key) else {
-            return Ok(ProcessObligationCleanupHandoffs::LegacyUnclaimed);
-        };
-        match std::mem::replace(state, ProcessObligationClaimState::Cleaned) {
-            ProcessObligationClaimState::Active(claim) => {
-                Ok(ProcessObligationCleanupHandoffs::Claimed(claim))
+        Ok(active.get(&key) == Some(&record.process_id))
+    }
+
+    fn process_handoff_cleaned(&self, record: &ProcessRecord) -> Result<bool, ProcessError> {
+        let key = ProcessObligationProcessKey::new(&record.scope, record.process_id);
+        let cleaned = self.cleaned_process_handoffs.lock().map_err(|_| {
+            ProcessError::InvalidStoredRecord {
+                reason: "process obligation cleanup registry unavailable".to_string(),
             }
-            ProcessObligationClaimState::Cleaned => Ok(ProcessObligationCleanupHandoffs::Cleaned),
-        }
+        })?;
+        Ok(cleaned.contains(&key))
+    }
+
+    fn mark_process_handoff_cleaned(&self, record: &ProcessRecord) -> Result<(), ProcessError> {
+        let key = ProcessObligationProcessKey::new(&record.scope, record.process_id);
+        let mut cleaned = self.cleaned_process_handoffs.lock().map_err(|_| {
+            ProcessError::InvalidStoredRecord {
+                reason: "process obligation cleanup registry unavailable".to_string(),
+            }
+        })?;
+        cleaned.insert(key);
+        Ok(())
     }
 
     fn cleanup_terminal(
@@ -665,6 +605,8 @@ impl ProcessObligationLifecycleStore {
             );
             return Err(error);
         }
+        self.release_active_process_handoff(record)?;
+        self.mark_process_handoff_cleaned(record)?;
         Ok(())
     }
 
@@ -673,27 +615,19 @@ impl ProcessObligationLifecycleStore {
         record: &ProcessRecord,
         reconcile: bool,
     ) -> Result<(), ProcessError> {
-        match self.handoff_claim_for_cleanup(record)? {
-            ProcessObligationCleanupHandoffs::Claimed(claim) => {
-                if let Some(network_policy) = &claim.network_policy {
-                    self.network_policies.discard_claim(network_policy);
-                }
-                self.secret_injections
-                    .discard_claims(&claim.secret_injections)
-                    .map_err(|_| ProcessError::InvalidStoredRecord {
-                        reason: "process obligation handoff cleanup failed".to_string(),
-                    })?;
-            }
-            ProcessObligationCleanupHandoffs::LegacyUnclaimed => {
-                self.network_policies
-                    .discard_for_capability(&record.scope, &record.capability_id);
-                self.secret_injections
-                    .discard_for_capability(&record.scope, &record.capability_id)
-                    .map_err(|_| ProcessError::InvalidStoredRecord {
-                        reason: "process obligation handoff cleanup failed".to_string(),
-                    })?;
-            }
-            ProcessObligationCleanupHandoffs::Cleaned => {}
+        if self.process_handoff_cleaned(record)? {
+            return Ok(());
+        }
+        let should_cleanup_handoffs =
+            self.has_active_process_handoff(record)? || record.resource_reservation_id.is_some();
+        if should_cleanup_handoffs {
+            self.network_policies
+                .discard_for_capability(&record.scope, &record.capability_id);
+            self.secret_injections
+                .discard_for_capability(&record.scope, &record.capability_id)
+                .map_err(|_| ProcessError::InvalidStoredRecord {
+                    reason: "process obligation handoff cleanup failed".to_string(),
+                })?;
         }
         if let Some(reservation_id) = record.resource_reservation_id {
             if reconcile {
@@ -710,7 +644,34 @@ impl ProcessObligationLifecycleStore {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ProcessObligationClaimKey {
+struct ProcessObligationHandoffKey {
+    tenant_id: String,
+    user_id: String,
+    agent_id: Option<String>,
+    project_id: Option<String>,
+    mission_id: Option<String>,
+    thread_id: Option<String>,
+    invocation_id: String,
+    capability_id: String,
+}
+
+impl ProcessObligationHandoffKey {
+    fn new(scope: &ResourceScope, capability_id: &CapabilityId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.as_str().to_string(),
+            user_id: scope.user_id.as_str().to_string(),
+            agent_id: scope.agent_id.as_ref().map(|id| id.as_str().to_string()),
+            project_id: scope.project_id.as_ref().map(|id| id.as_str().to_string()),
+            mission_id: scope.mission_id.as_ref().map(|id| id.as_str().to_string()),
+            thread_id: scope.thread_id.as_ref().map(|id| id.as_str().to_string()),
+            invocation_id: scope.invocation_id.to_string(),
+            capability_id: capability_id.as_str().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ProcessObligationProcessKey {
     tenant_id: String,
     user_id: String,
     agent_id: Option<String>,
@@ -720,7 +681,7 @@ struct ProcessObligationClaimKey {
     process_id: ProcessId,
 }
 
-impl ProcessObligationClaimKey {
+impl ProcessObligationProcessKey {
     fn new(scope: &ResourceScope, process_id: ProcessId) -> Self {
         Self {
             tenant_id: scope.tenant_id.as_str().to_string(),
@@ -734,30 +695,22 @@ impl ProcessObligationClaimKey {
     }
 }
 
-#[derive(Debug)]
-enum ProcessObligationClaimState {
-    Active(Box<ProcessObligationHandoffClaim>),
-    Cleaned,
-}
-
-#[derive(Debug)]
-struct ProcessObligationHandoffClaim {
-    network_policy: Option<NetworkObligationPolicyClaim>,
-    secret_injections: Vec<RuntimeSecretInjectionClaim>,
-}
-
-enum ProcessObligationCleanupHandoffs {
-    Claimed(Box<ProcessObligationHandoffClaim>),
-    LegacyUnclaimed,
-    Cleaned,
-}
-
 #[async_trait]
 impl ProcessStore for ProcessObligationLifecycleStore {
     async fn start(&self, start: ProcessStart) -> Result<ProcessRecord, ProcessError> {
-        let record = self.inner.start(start).await?;
-        self.capture_record_obligations(&record)?;
-        Ok(record)
+        let claimed = self.claim_active_process_handoff(&start)?;
+        let process_id = start.process_id;
+        let scope = start.scope.clone();
+        let capability_id = start.capability_id.clone();
+        match self.inner.start(start).await {
+            Ok(record) => Ok(record),
+            Err(error) => {
+                if claimed {
+                    self.release_claimed_process_handoff(&scope, &capability_id, process_id)?;
+                }
+                Err(error)
+            }
+        }
     }
 
     async fn complete(

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -16,8 +16,10 @@ use ironclaw_events::AuditSink;
 use ironclaw_host_api::{
     ActionResultSummary, ActionSummary, AuditEnvelope, AuditEventId, AuditStage,
     CapabilityDispatchResult, CapabilityId, DecisionSummary, EffectKind, MountView, NetworkPolicy,
-    Obligation, ResourceReservation, ResourceScope, SecretHandle,
+    Obligation, ProcessId, ResourceReservation, ResourceReservationId, ResourceScope,
+    ResourceUsage, SecretHandle,
 };
+use ironclaw_processes::{ProcessError, ProcessRecord, ProcessStart, ProcessStore};
 use ironclaw_resources::ResourceGovernor;
 use ironclaw_safety::LeakDetector;
 use ironclaw_secrets::{SecretMaterial, SecretStore};
@@ -108,6 +110,16 @@ impl RuntimeSecretInjectionStore {
         Ok(prune_expired_entries(&mut secrets, Instant::now()))
     }
 
+    pub fn discard_for_capability(
+        &self,
+        scope: &ResourceScope,
+        capability_id: &CapabilityId,
+    ) -> Result<(), RuntimeSecretInjectionStoreError> {
+        let scope_key = RuntimeSecretInjectionScopeKey::new(scope, capability_id);
+        self.lock()?.retain(|key, _| !key.matches_scope(&scope_key));
+        Ok(())
+    }
+
     fn lock(
         &self,
     ) -> Result<
@@ -188,6 +200,44 @@ impl RuntimeSecretInjectionKey {
             handle: handle.as_str().to_string(),
         }
     }
+
+    fn matches_scope(&self, scope: &RuntimeSecretInjectionScopeKey) -> bool {
+        self.tenant_id == scope.tenant_id
+            && self.user_id == scope.user_id
+            && self.agent_id == scope.agent_id
+            && self.project_id == scope.project_id
+            && self.mission_id == scope.mission_id
+            && self.thread_id == scope.thread_id
+            && self.invocation_id == scope.invocation_id
+            && self.capability_id == scope.capability_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RuntimeSecretInjectionScopeKey {
+    tenant_id: String,
+    user_id: String,
+    agent_id: Option<String>,
+    project_id: Option<String>,
+    mission_id: Option<String>,
+    thread_id: Option<String>,
+    invocation_id: String,
+    capability_id: String,
+}
+
+impl RuntimeSecretInjectionScopeKey {
+    fn new(scope: &ResourceScope, capability_id: &CapabilityId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.as_str().to_string(),
+            user_id: scope.user_id.as_str().to_string(),
+            agent_id: scope.agent_id.as_ref().map(|id| id.as_str().to_string()),
+            project_id: scope.project_id.as_ref().map(|id| id.as_str().to_string()),
+            mission_id: scope.mission_id.as_ref().map(|id| id.as_str().to_string()),
+            thread_id: scope.thread_id.as_ref().map(|id| id.as_str().to_string()),
+            invocation_id: scope.invocation_id.to_string(),
+            capability_id: capability_id.as_str().to_string(),
+        }
+    }
 }
 
 /// In-memory policy handoff from obligation handling to runtime adapters.
@@ -226,6 +276,10 @@ impl NetworkObligationPolicyStore {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .remove(&NetworkPolicyKey::new(scope, capability_id))
+    }
+
+    pub fn discard_for_capability(&self, scope: &ResourceScope, capability_id: &CapabilityId) {
+        let _ = self.take(scope, capability_id);
     }
 }
 
@@ -342,6 +396,183 @@ impl fmt::Debug for BuiltinObligationServices {
             .field("secret_injections", &self.secret_injections)
             .field("resource_governor", &"<resource_governor>")
             .finish()
+    }
+}
+
+/// Process-store wrapper that owns spawn-phase obligation handoffs after
+/// `ProcessStore::start` succeeds.
+///
+/// `CapabilityHost` aborts prepared effects when process start fails. Once
+/// start succeeds, this wrapper becomes responsible for discarding staged
+/// network/secret handoffs and reconciling or releasing a prepared resource
+/// reservation when the process reaches a terminal state.
+pub struct ProcessObligationLifecycleStore {
+    inner: Arc<dyn ProcessStore>,
+    network_policies: Arc<NetworkObligationPolicyStore>,
+    secret_injections: Arc<RuntimeSecretInjectionStore>,
+    resource_governor: Arc<dyn ResourceGovernor>,
+    active: Mutex<HashMap<ProcessLifecycleKey, Option<ResourceReservationId>>>,
+}
+
+impl ProcessObligationLifecycleStore {
+    pub fn new<S>(
+        inner: Arc<S>,
+        network_policies: Arc<NetworkObligationPolicyStore>,
+        secret_injections: Arc<RuntimeSecretInjectionStore>,
+        resource_governor: Arc<dyn ResourceGovernor>,
+    ) -> Self
+    where
+        S: ProcessStore + 'static,
+    {
+        let inner: Arc<dyn ProcessStore> = inner;
+        Self::from_dyn(
+            inner,
+            network_policies,
+            secret_injections,
+            resource_governor,
+        )
+    }
+
+    pub fn from_dyn(
+        inner: Arc<dyn ProcessStore>,
+        network_policies: Arc<NetworkObligationPolicyStore>,
+        secret_injections: Arc<RuntimeSecretInjectionStore>,
+        resource_governor: Arc<dyn ResourceGovernor>,
+    ) -> Self {
+        Self {
+            inner,
+            network_policies,
+            secret_injections,
+            resource_governor,
+            active: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn active_guard(
+        &self,
+    ) -> std::sync::MutexGuard<'_, HashMap<ProcessLifecycleKey, Option<ResourceReservationId>>>
+    {
+        self.active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn record_started(&self, record: &ProcessRecord) {
+        self.active_guard().insert(
+            ProcessLifecycleKey::new(&record.scope, record.process_id),
+            record.resource_reservation_id,
+        );
+    }
+
+    fn take_started(&self, record: &ProcessRecord) -> Option<Option<ResourceReservationId>> {
+        self.active_guard()
+            .remove(&ProcessLifecycleKey::new(&record.scope, record.process_id))
+    }
+
+    fn cleanup_terminal(
+        &self,
+        record: &ProcessRecord,
+        reconcile: bool,
+    ) -> Result<(), ProcessError> {
+        let Some(reservation_id) = self.take_started(record) else {
+            return Ok(());
+        };
+        self.network_policies
+            .discard_for_capability(&record.scope, &record.capability_id);
+        self.secret_injections
+            .discard_for_capability(&record.scope, &record.capability_id)
+            .map_err(|_| ProcessError::InvalidStoredRecord {
+                reason: "process obligation handoff cleanup failed".to_string(),
+            })?;
+        if let Some(reservation_id) = reservation_id {
+            if reconcile {
+                self.resource_governor
+                    .reconcile(reservation_id, ResourceUsage::default())?;
+            } else {
+                self.resource_governor.release(reservation_id)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ProcessStore for ProcessObligationLifecycleStore {
+    async fn start(&self, start: ProcessStart) -> Result<ProcessRecord, ProcessError> {
+        let record = self.inner.start(start).await?;
+        self.record_started(&record);
+        Ok(record)
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<ProcessRecord, ProcessError> {
+        let record = self.inner.complete(scope, process_id).await?;
+        self.cleanup_terminal(&record, true)?;
+        Ok(record)
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+        error_kind: String,
+    ) -> Result<ProcessRecord, ProcessError> {
+        let record = self.inner.fail(scope, process_id, error_kind).await?;
+        self.cleanup_terminal(&record, false)?;
+        Ok(record)
+    }
+
+    async fn kill(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<ProcessRecord, ProcessError> {
+        let record = self.inner.kill(scope, process_id).await?;
+        self.cleanup_terminal(&record, false)?;
+        Ok(record)
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<Option<ProcessRecord>, ProcessError> {
+        self.inner.get(scope, process_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ProcessRecord>, ProcessError> {
+        self.inner.records_for_scope(scope).await
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ProcessLifecycleKey {
+    tenant_id: String,
+    user_id: String,
+    agent_id: Option<String>,
+    project_id: Option<String>,
+    mission_id: Option<String>,
+    thread_id: Option<String>,
+    process_id: ProcessId,
+}
+
+impl ProcessLifecycleKey {
+    fn new(scope: &ResourceScope, process_id: ProcessId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.as_str().to_string(),
+            user_id: scope.user_id.as_str().to_string(),
+            agent_id: scope.agent_id.as_ref().map(|id| id.as_str().to_string()),
+            project_id: scope.project_id.as_ref().map(|id| id.as_str().to_string()),
+            mission_id: scope.mission_id.as_ref().map(|id| id.as_str().to_string()),
+            thread_id: scope.thread_id.as_ref().map(|id| id.as_str().to_string()),
+            process_id,
+        }
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -16,11 +16,10 @@ use ironclaw_events::AuditSink;
 use ironclaw_host_api::{
     ActionResultSummary, ActionSummary, AuditEnvelope, AuditEventId, AuditStage,
     CapabilityDispatchResult, CapabilityId, DecisionSummary, EffectKind, MountView, NetworkPolicy,
-    Obligation, ProcessId, ResourceReservation, ResourceReservationId, ResourceScope,
-    ResourceUsage, SecretHandle,
+    Obligation, ProcessId, ResourceReservation, ResourceScope, ResourceUsage, SecretHandle,
 };
 use ironclaw_processes::{ProcessError, ProcessRecord, ProcessStart, ProcessStore};
-use ironclaw_resources::ResourceGovernor;
+use ironclaw_resources::{ResourceError, ResourceGovernor};
 use ironclaw_safety::LeakDetector;
 use ironclaw_secrets::{SecretMaterial, SecretStore};
 
@@ -411,7 +410,7 @@ pub struct ProcessObligationLifecycleStore {
     network_policies: Arc<NetworkObligationPolicyStore>,
     secret_injections: Arc<RuntimeSecretInjectionStore>,
     resource_governor: Arc<dyn ResourceGovernor>,
-    active: Mutex<HashMap<ProcessLifecycleKey, Option<ResourceReservationId>>>,
+    cleaned: Mutex<HashSet<ProcessLifecycleKey>>,
 }
 
 impl ProcessObligationLifecycleStore {
@@ -444,29 +443,28 @@ impl ProcessObligationLifecycleStore {
             network_policies,
             secret_injections,
             resource_governor,
-            active: Mutex::new(HashMap::new()),
+            cleaned: Mutex::new(HashSet::new()),
         }
     }
 
-    fn active_guard(
-        &self,
-    ) -> std::sync::MutexGuard<'_, HashMap<ProcessLifecycleKey, Option<ResourceReservationId>>>
-    {
-        self.active
+    fn cleaned_guard(&self) -> std::sync::MutexGuard<'_, HashSet<ProcessLifecycleKey>> {
+        self.cleaned
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    fn record_started(&self, record: &ProcessRecord) {
-        self.active_guard().insert(
-            ProcessLifecycleKey::new(&record.scope, record.process_id),
-            record.resource_reservation_id,
-        );
-    }
-
-    fn take_started(&self, record: &ProcessRecord) -> Option<Option<ResourceReservationId>> {
-        self.active_guard()
-            .remove(&ProcessLifecycleKey::new(&record.scope, record.process_id))
+    /// Discards staged obligation handoffs and closes any reservation for an
+    /// executor that finished but could not publish its result record.
+    pub async fn cleanup_process_obligations(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+        reconcile: bool,
+    ) -> Result<(), ProcessError> {
+        if let Some(record) = self.inner.get(scope, process_id).await? {
+            self.cleanup_record_obligations(&record, reconcile)?;
+        }
+        Ok(())
     }
 
     fn cleanup_terminal(
@@ -474,9 +472,19 @@ impl ProcessObligationLifecycleStore {
         record: &ProcessRecord,
         reconcile: bool,
     ) -> Result<(), ProcessError> {
-        let Some(reservation_id) = self.take_started(record) else {
+        self.cleanup_record_obligations(record, reconcile)
+    }
+
+    fn cleanup_record_obligations(
+        &self,
+        record: &ProcessRecord,
+        reconcile: bool,
+    ) -> Result<(), ProcessError> {
+        let key = ProcessLifecycleKey::new(&record.scope, record.process_id);
+        let mut cleaned = self.cleaned_guard();
+        if cleaned.contains(&key) {
             return Ok(());
-        };
+        }
         self.network_policies
             .discard_for_capability(&record.scope, &record.capability_id);
         self.secret_injections
@@ -484,14 +492,17 @@ impl ProcessObligationLifecycleStore {
             .map_err(|_| ProcessError::InvalidStoredRecord {
                 reason: "process obligation handoff cleanup failed".to_string(),
             })?;
-        if let Some(reservation_id) = reservation_id {
+        if let Some(reservation_id) = record.resource_reservation_id {
             if reconcile {
-                self.resource_governor
-                    .reconcile(reservation_id, ResourceUsage::default())?;
+                close_reservation_once(
+                    self.resource_governor
+                        .reconcile(reservation_id, ResourceUsage::default()),
+                )?;
             } else {
-                self.resource_governor.release(reservation_id)?;
+                close_reservation_once(self.resource_governor.release(reservation_id))?;
             }
         }
+        cleaned.insert(key);
         Ok(())
     }
 }
@@ -499,9 +510,7 @@ impl ProcessObligationLifecycleStore {
 #[async_trait]
 impl ProcessStore for ProcessObligationLifecycleStore {
     async fn start(&self, start: ProcessStart) -> Result<ProcessRecord, ProcessError> {
-        let record = self.inner.start(start).await?;
-        self.record_started(&record);
-        Ok(record)
+        self.inner.start(start).await
     }
 
     async fn complete(
@@ -548,6 +557,14 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         scope: &ResourceScope,
     ) -> Result<Vec<ProcessRecord>, ProcessError> {
         self.inner.records_for_scope(scope).await
+    }
+}
+
+fn close_reservation_once<T>(result: Result<T, ResourceError>) -> Result<(), ProcessError> {
+    match result {
+        Ok(_) => Ok(()),
+        Err(ResourceError::ReservationClosed { .. }) => Ok(()),
+        Err(error) => Err(error.into()),
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -467,12 +467,17 @@ impl ProcessObligationLifecycleStore {
         Ok(())
     }
 
-    fn cleanup_terminal(
-        &self,
-        record: &ProcessRecord,
-        reconcile: bool,
-    ) -> Result<(), ProcessError> {
-        self.cleanup_record_obligations(record, reconcile)
+    fn cleanup_terminal(&self, record: &ProcessRecord, reconcile: bool) {
+        if let Err(error) = self.cleanup_record_obligations(record, reconcile) {
+            tracing::warn!(
+                process_id = %record.process_id,
+                tenant_id = %record.scope.tenant_id,
+                user_id = %record.scope.user_id,
+                reconcile,
+                error = %error,
+                "process obligation cleanup failed after terminal transition"
+            );
+        }
     }
 
     fn cleanup_record_obligations(
@@ -519,7 +524,7 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         process_id: ProcessId,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.complete(scope, process_id).await?;
-        self.cleanup_terminal(&record, true)?;
+        self.cleanup_terminal(&record, true);
         Ok(record)
     }
 
@@ -530,7 +535,7 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         error_kind: String,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.fail(scope, process_id, error_kind).await?;
-        self.cleanup_terminal(&record, false)?;
+        self.cleanup_terminal(&record, false);
         Ok(record)
     }
 
@@ -540,7 +545,7 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         process_id: ProcessId,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.kill(scope, process_id).await?;
-        self.cleanup_terminal(&record, false)?;
+        self.cleanup_terminal(&record, false);
         Ok(record)
     }
 
@@ -564,6 +569,7 @@ fn close_reservation_once<T>(result: Result<T, ResourceError>) -> Result<(), Pro
     match result {
         Ok(_) => Ok(()),
         Err(ResourceError::ReservationClosed { .. }) => Ok(()),
+        Err(ResourceError::UnknownReservation { .. }) => Ok(()),
         Err(error) => Err(error.into()),
     }
 }

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -400,6 +400,9 @@ impl HostRuntime for DefaultHostRuntime {
             if let Some(registry) = &self.process_cancellation_registry {
                 process_host = process_host.with_cancellation_registry(Arc::clone(registry));
             }
+            if let Some(result_store) = &self.process_result_store {
+                process_host = process_host.with_result_store_dyn(Arc::clone(result_store));
+            }
 
             for record in records {
                 if record.status != ProcessStatus::Running {
@@ -408,13 +411,7 @@ impl HostRuntime for DefaultHostRuntime {
                 process_invocations.push(record.invocation_id);
                 let work_id = RuntimeWorkId::Process(record.process_id);
                 match process_host.kill(&request.scope, record.process_id).await {
-                    Ok(record) => {
-                        if let Some(result_store) = &self.process_result_store {
-                            result_store
-                                .kill(&record.scope, record.process_id)
-                                .await
-                                .map_err(unavailable_from_process_error)?;
-                        }
+                    Ok(_) => {
                         outcome.cancelled.push(work_id);
                     }
                     Err(ProcessError::InvalidTransition { .. }) => {

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -324,9 +324,17 @@ where
                 };
                 let cleanup_store = Arc::clone(&result_failure_cleanup_store);
                 tokio::spawn(async move {
-                    let _ = cleanup_store
+                    if let Err(error) = cleanup_store
                         .cleanup_process_obligations(&failure.scope, failure.process_id, reconcile)
-                        .await;
+                        .await
+                    {
+                        tracing::warn!(
+                            process_id = %failure.process_id,
+                            stage = ?failure.stage,
+                            error = %error,
+                            "background process obligation cleanup failed"
+                        );
+                    }
                 });
             }),
         );

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -29,8 +29,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_mcp::{McpError, McpExecutionRequest, McpExecutor, McpInvocation};
 use ironclaw_processes::{
-    ProcessExecutionError, ProcessExecutionRequest, ProcessExecutionResult, ProcessExecutor,
-    ProcessManager, ProcessResultStore, ProcessServices, ProcessStore,
+    BackgroundFailureStage, ProcessExecutionError, ProcessExecutionRequest, ProcessExecutionResult,
+    ProcessExecutor, ProcessManager, ProcessResultStore, ProcessServices, ProcessStore,
 };
 use ironclaw_resources::ResourceGovernor;
 use ironclaw_run_state::{ApprovalRequestStore, RunStateStore};
@@ -79,6 +79,7 @@ where
     secret_store: Option<Arc<dyn SecretStore>>,
     network_policy_store: Arc<NetworkObligationPolicyStore>,
     secret_injection_store: Arc<RuntimeSecretInjectionStore>,
+    process_lifecycle_store: Arc<ProcessObligationLifecycleStore>,
     runtime_http_egress: SharedRuntimeHttpEgress,
     runtime_health: Option<Arc<dyn RuntimeBackendHealth>>,
     script_runtime: Option<Arc<dyn ScriptExecutor>>,
@@ -101,6 +102,14 @@ where
         process_services: ProcessServices<S, R>,
         surface_version: CapabilitySurfaceVersion,
     ) -> Self {
+        let network_policy_store = Arc::new(NetworkObligationPolicyStore::new());
+        let secret_injection_store = Arc::new(RuntimeSecretInjectionStore::new());
+        let process_lifecycle_store = Arc::new(ProcessObligationLifecycleStore::new(
+            process_services.process_store(),
+            Arc::clone(&network_policy_store),
+            Arc::clone(&secret_injection_store),
+            governor.clone(),
+        ));
         Self {
             registry,
             trust_policy: Arc::new(HostTrustPolicy::empty()),
@@ -115,8 +124,9 @@ where
             event_sink: None,
             audit_sink: None,
             secret_store: None,
-            network_policy_store: Arc::new(NetworkObligationPolicyStore::new()),
-            secret_injection_store: Arc::new(RuntimeSecretInjectionStore::new()),
+            network_policy_store,
+            secret_injection_store,
+            process_lifecycle_store,
             runtime_http_egress: Arc::new(Mutex::new(None)),
             runtime_health: None,
             script_runtime: None,
@@ -294,20 +304,29 @@ where
         let dispatcher: Arc<dyn CapabilityDispatcher> = Arc::new(self.runtime_dispatcher());
         let process_executor =
             Arc::new(RuntimeDispatchProcessExecutor::new(Arc::clone(&dispatcher)));
-        let lifecycle_process_store = Arc::new(ProcessObligationLifecycleStore::new(
-            self.process_services.process_store(),
-            Arc::clone(&self.network_policy_store),
-            Arc::clone(&self.secret_injection_store),
-            self.governor.clone(),
-        ));
+        let lifecycle_process_store = Arc::clone(&self.process_lifecycle_store);
         let process_store: Arc<dyn ProcessStore> = lifecycle_process_store.clone();
+        let result_failure_cleanup_store = Arc::clone(&lifecycle_process_store);
         let process_manager: Arc<dyn ProcessManager> = Arc::new(
             ironclaw_processes::BackgroundProcessManager::new(
                 lifecycle_process_store,
                 process_executor,
             )
             .with_cancellation_registry(self.process_services.cancellation_registry())
-            .with_result_store(self.process_services.result_store()),
+            .with_result_store(self.process_services.result_store())
+            .with_error_handler(move |failure| {
+                let reconcile = match failure.stage {
+                    BackgroundFailureStage::ResultStoreComplete => true,
+                    BackgroundFailureStage::ResultStoreFail => false,
+                    _ => return,
+                };
+                let cleanup_store = Arc::clone(&result_failure_cleanup_store);
+                tokio::spawn(async move {
+                    let _ = cleanup_store
+                        .cleanup_process_obligations(&failure.scope, failure.process_id, reconcile)
+                        .await;
+                });
+            }),
         );
         let process_result_store: Arc<dyn ProcessResultStore> =
             self.process_services.result_store();

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -44,7 +44,8 @@ use ironclaw_wasm::{
 
 use crate::{
     BuiltinObligationHandler, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntimeError,
-    NetworkObligationPolicyStore, RuntimeBackendHealth, RuntimeSecretInjectionStore,
+    NetworkObligationPolicyStore, ProcessObligationLifecycleStore, RuntimeBackendHealth,
+    RuntimeSecretInjectionStore,
 };
 
 type SharedRuntimeHttpEgress = Arc<Mutex<Option<Arc<dyn RuntimeHttpEgress>>>>;
@@ -293,9 +294,21 @@ where
         let dispatcher: Arc<dyn CapabilityDispatcher> = Arc::new(self.runtime_dispatcher());
         let process_executor =
             Arc::new(RuntimeDispatchProcessExecutor::new(Arc::clone(&dispatcher)));
-        let process_manager: Arc<dyn ProcessManager> =
-            Arc::new(self.process_services.background_manager(process_executor));
-        let process_store: Arc<dyn ProcessStore> = self.process_services.process_store();
+        let lifecycle_process_store = Arc::new(ProcessObligationLifecycleStore::new(
+            self.process_services.process_store(),
+            Arc::clone(&self.network_policy_store),
+            Arc::clone(&self.secret_injection_store),
+            self.governor.clone(),
+        ));
+        let process_store: Arc<dyn ProcessStore> = lifecycle_process_store.clone();
+        let process_manager: Arc<dyn ProcessManager> = Arc::new(
+            ironclaw_processes::BackgroundProcessManager::new(
+                lifecycle_process_store,
+                process_executor,
+            )
+            .with_cancellation_registry(self.process_services.cancellation_registry())
+            .with_result_store(self.process_services.result_store()),
+        );
         let process_result_store: Arc<dyn ProcessResultStore> =
             self.process_services.result_store();
         let runtime_health = self.runtime_health.clone().unwrap_or_else(|| {

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -316,6 +316,8 @@ where
             .with_result_store(self.process_services.result_store())
             .with_error_handler(move |failure| {
                 let reconcile = match failure.stage {
+                    BackgroundFailureStage::StoreComplete => true,
+                    BackgroundFailureStage::StoreFail => false,
                     BackgroundFailureStage::ResultStoreComplete => true,
                     BackgroundFailureStage::ResultStoreFail => false,
                     _ => return,

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1392,6 +1392,100 @@ async fn spawned_obligation_lifecycle_cleans_handoffs_when_result_store_fail_fai
 }
 
 #[tokio::test]
+async fn spawned_obligation_lifecycle_reconciles_when_store_complete_fails_after_result_write() {
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let inner_process_store = Arc::new(FailingTerminalProcessStore::fail_complete());
+    let fixture = spawn_obligation_fixture_with_process_store_and_result_store(
+        reservation_id,
+        secret_handle.clone(),
+        BackgroundExecutor::success(),
+        Arc::clone(&inner_process_store),
+        Arc::new(InMemoryProcessResultStore::new()),
+    )
+    .await;
+
+    let process = fixture.spawn().await;
+    wait_for_process_store_attempt(&inner_process_store, "complete").await;
+    wait_for_no_reserved_processes(&fixture.governor).await;
+
+    let record = fixture
+        .process_store
+        .get(&fixture.scope, process.process_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.status, ProcessStatus::Running);
+    assert!(matches!(
+        fixture.governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Reconciled,
+            ..
+        }
+    ));
+    assert!(
+        fixture
+            .network_policies
+            .take(&fixture.scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        fixture
+            .secret_injections
+            .take(&fixture.scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn spawned_obligation_lifecycle_releases_when_store_fail_fails_after_result_write() {
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let inner_process_store = Arc::new(FailingTerminalProcessStore::fail_fail());
+    let fixture = spawn_obligation_fixture_with_process_store_and_result_store(
+        reservation_id,
+        secret_handle.clone(),
+        BackgroundExecutor::failure("runtime_dispatch"),
+        Arc::clone(&inner_process_store),
+        Arc::new(InMemoryProcessResultStore::new()),
+    )
+    .await;
+
+    let process = fixture.spawn().await;
+    wait_for_process_store_attempt(&inner_process_store, "fail").await;
+    wait_for_no_reserved_processes(&fixture.governor).await;
+
+    let record = fixture
+        .process_store
+        .get(&fixture.scope, process.process_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.status, ProcessStatus::Running);
+    assert!(matches!(
+        fixture.governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Released,
+            ..
+        }
+    ));
+    assert!(
+        fixture
+            .network_policies
+            .take(&fixture.scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        fixture
+            .secret_injections
+            .take(&fixture.scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn spawned_obligation_lifecycle_abort_cleans_up_when_process_start_fails() {
     let reservation_id = ResourceReservationId::new();
     let secret_handle = SecretHandle::new("api_token").unwrap();
@@ -1889,6 +1983,27 @@ async fn spawn_obligation_fixture_with_result_store<R>(
 where
     R: ProcessResultStore + 'static,
 {
+    spawn_obligation_fixture_with_process_store_and_result_store(
+        reservation_id,
+        secret_handle,
+        executor,
+        Arc::new(InMemoryProcessStore::new()),
+        result_store,
+    )
+    .await
+}
+
+async fn spawn_obligation_fixture_with_process_store_and_result_store<P, R>(
+    reservation_id: ResourceReservationId,
+    secret_handle: SecretHandle,
+    executor: BackgroundExecutor,
+    inner_process_store: Arc<P>,
+    result_store: Arc<R>,
+) -> SpawnObligationFixture
+where
+    P: ProcessStore + 'static,
+    R: ProcessResultStore + 'static,
+{
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
     let dispatcher = Arc::new(NoopDispatcher);
     let network_policies = Arc::new(NetworkObligationPolicyStore::new());
@@ -1930,7 +2045,7 @@ where
             },
         ]));
     let process_store = Arc::new(ProcessObligationLifecycleStore::new(
-        Arc::new(InMemoryProcessStore::new()),
+        inner_process_store,
         Arc::clone(&network_policies),
         Arc::clone(&secret_injections),
         governor.clone(),
@@ -1941,6 +2056,8 @@ where
             .with_result_store(result_store)
             .with_error_handler(move |failure| {
                 let reconcile = match failure.stage {
+                    BackgroundFailureStage::StoreComplete => true,
+                    BackgroundFailureStage::StoreFail => false,
                     BackgroundFailureStage::ResultStoreComplete => true,
                     BackgroundFailureStage::ResultStoreFail => false,
                     _ => return,
@@ -2024,6 +2141,99 @@ impl ProcessResultStore for FailingProcessResultStore {
         _process_id: ProcessId,
     ) -> Result<Option<ProcessResultRecord>, ProcessError> {
         Ok(None)
+    }
+}
+
+struct FailingTerminalProcessStore {
+    inner: InMemoryProcessStore,
+    fail_complete: bool,
+    fail_fail: bool,
+    attempts: std::sync::Mutex<Vec<&'static str>>,
+}
+
+impl FailingTerminalProcessStore {
+    fn fail_complete() -> Self {
+        Self {
+            inner: InMemoryProcessStore::new(),
+            fail_complete: true,
+            fail_fail: false,
+            attempts: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn fail_fail() -> Self {
+        Self {
+            inner: InMemoryProcessStore::new(),
+            fail_complete: false,
+            fail_fail: true,
+            attempts: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn attempts(&self) -> Vec<&'static str> {
+        self.attempts.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ProcessStore for FailingTerminalProcessStore {
+    async fn start(
+        &self,
+        start: ProcessStart,
+    ) -> Result<ironclaw_processes::ProcessRecord, ProcessError> {
+        self.inner.start(start).await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<ironclaw_processes::ProcessRecord, ProcessError> {
+        self.attempts.lock().unwrap().push("complete");
+        if self.fail_complete {
+            return Err(ProcessError::InvalidStoredRecord {
+                reason: "status complete failed".to_string(),
+            });
+        }
+        self.inner.complete(scope, process_id).await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+        error_kind: String,
+    ) -> Result<ironclaw_processes::ProcessRecord, ProcessError> {
+        self.attempts.lock().unwrap().push("fail");
+        if self.fail_fail {
+            return Err(ProcessError::InvalidStoredRecord {
+                reason: "status fail failed".to_string(),
+            });
+        }
+        self.inner.fail(scope, process_id, error_kind).await
+    }
+
+    async fn kill(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<ironclaw_processes::ProcessRecord, ProcessError> {
+        self.inner.kill(scope, process_id).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        process_id: ProcessId,
+    ) -> Result<Option<ironclaw_processes::ProcessRecord>, ProcessError> {
+        self.inner.get(scope, process_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ironclaw_processes::ProcessRecord>, ProcessError> {
+        self.inner.records_for_scope(scope).await
     }
 }
 
@@ -2131,6 +2341,19 @@ async fn wait_for_result_store_attempt(store: &FailingProcessResultStore, attemp
         tokio::time::sleep(Duration::from_millis(5)).await;
     }
     panic!("result store did not record {attempt} attempt");
+}
+
+async fn wait_for_process_store_attempt(
+    store: &FailingTerminalProcessStore,
+    attempt: &'static str,
+) {
+    for _ in 0..100 {
+        if store.attempts().contains(&attempt) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("process store did not record {attempt} attempt");
 }
 
 async fn wait_for_no_reserved_processes(governor: &InMemoryResourceGovernor) {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1300,6 +1300,101 @@ async fn process_obligation_lifecycle_cleans_record_started_before_wrapper_exist
 }
 
 #[tokio::test]
+async fn process_obligation_lifecycle_preserves_newer_handoffs_for_same_invocation_capability() {
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let inner_store = Arc::new(InMemoryProcessStore::new());
+    let network_policies = Arc::new(NetworkObligationPolicyStore::new());
+    let secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id);
+    let process_id = ProcessId::new();
+
+    network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
+    secret_injections
+        .insert(
+            &scope,
+            &script_capability_id(),
+            &secret_handle,
+            SecretMaterial::from("first-runtime-secret"),
+        )
+        .unwrap();
+    let lifecycle_store = ProcessObligationLifecycleStore::new(
+        inner_store,
+        Arc::clone(&network_policies),
+        Arc::clone(&secret_injections),
+        governor,
+    );
+    lifecycle_store
+        .start(process_start(process_id, invocation_id, scope.clone()))
+        .await
+        .unwrap();
+
+    network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
+    secret_injections
+        .insert(
+            &scope,
+            &script_capability_id(),
+            &secret_handle,
+            SecretMaterial::from("second-runtime-secret"),
+        )
+        .unwrap();
+
+    lifecycle_store.complete(&scope, process_id).await.unwrap();
+
+    assert!(
+        network_policies
+            .take(&scope, &script_capability_id())
+            .is_some(),
+        "cleanup for the completed process must not discard a newer staged network policy for the same scoped capability"
+    );
+    assert!(
+        secret_injections
+            .take(&scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_some(),
+        "cleanup for the completed process must not discard newer staged secret material for the same scoped capability"
+    );
+}
+
+#[tokio::test]
+async fn process_obligation_lifecycle_surfaces_resource_cleanup_errors_after_terminal_transition() {
+    let reservation_id = ResourceReservationId::new();
+    let inner_store = Arc::new(InMemoryProcessStore::new());
+    let network_policies = Arc::new(NetworkObligationPolicyStore::new());
+    let secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
+    let governor = Arc::new(FailingCleanupResourceGovernor);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id);
+    let process_id = ProcessId::new();
+    let mut start = process_start(process_id, invocation_id, scope.clone());
+    start.resource_reservation_id = Some(reservation_id);
+    let lifecycle_store = ProcessObligationLifecycleStore::new(
+        inner_store,
+        network_policies,
+        secret_injections,
+        governor,
+    );
+    lifecycle_store.start(start).await.unwrap();
+
+    let error = lifecycle_store
+        .kill(&scope, process_id)
+        .await
+        .expect_err("terminal cleanup failures should be visible to callers");
+
+    assert!(matches!(
+        error,
+        ProcessError::Resource(ResourceError::ReservationMismatch { id }) if id == reservation_id
+    ));
+    let record = lifecycle_store
+        .get(&scope, process_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.status, ProcessStatus::Killed);
+}
+
+#[tokio::test]
 async fn spawned_obligation_lifecycle_cleans_handoffs_when_result_store_complete_fails() {
     let reservation_id = ResourceReservationId::new();
     let secret_handle = SecretHandle::new("api_token").unwrap();
@@ -2090,6 +2185,53 @@ where
 #[derive(Default)]
 struct FailingProcessResultStore {
     attempts: std::sync::Mutex<Vec<&'static str>>,
+}
+
+#[derive(Debug)]
+struct FailingCleanupResourceGovernor;
+
+impl ResourceGovernor for FailingCleanupResourceGovernor {
+    fn set_limit(&self, _account: ResourceAccount, _limits: ResourceLimits) {}
+
+    fn reserve(
+        &self,
+        scope: ResourceScope,
+        estimate: ResourceEstimate,
+    ) -> Result<ResourceReservation, ResourceError> {
+        Ok(ResourceReservation {
+            id: ResourceReservationId::new(),
+            scope,
+            estimate,
+        })
+    }
+
+    fn reserve_with_id(
+        &self,
+        scope: ResourceScope,
+        estimate: ResourceEstimate,
+        reservation_id: ResourceReservationId,
+    ) -> Result<ResourceReservation, ResourceError> {
+        Ok(ResourceReservation {
+            id: reservation_id,
+            scope,
+            estimate,
+        })
+    }
+
+    fn reconcile(
+        &self,
+        reservation_id: ResourceReservationId,
+        _actual: ResourceUsage,
+    ) -> Result<ResourceReceipt, ResourceError> {
+        Err(ResourceError::ReservationMismatch { id: reservation_id })
+    }
+
+    fn release(
+        &self,
+        reservation_id: ResourceReservationId,
+    ) -> Result<ResourceReceipt, ResourceError> {
+        Err(ResourceError::ReservationMismatch { id: reservation_id })
+    }
 }
 
 impl FailingProcessResultStore {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1354,6 +1354,51 @@ async fn process_obligation_lifecycle_cleans_record_started_before_wrapper_exist
 }
 
 #[tokio::test]
+async fn process_obligation_lifecycle_cleans_legacy_handoffs_without_resource_reservation() {
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let inner_store = Arc::new(InMemoryProcessStore::new());
+    let network_policies = Arc::new(NetworkObligationPolicyStore::new());
+    let secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id);
+    network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
+    secret_injections
+        .insert(
+            &scope,
+            &script_capability_id(),
+            &secret_handle,
+            SecretMaterial::from("runtime-secret"),
+        )
+        .unwrap();
+    let process_id = ProcessId::new();
+    inner_store
+        .start(process_start(process_id, invocation_id, scope.clone()))
+        .await
+        .unwrap();
+
+    let lifecycle_store = ProcessObligationLifecycleStore::new(
+        inner_store,
+        Arc::clone(&network_policies),
+        Arc::clone(&secret_injections),
+        governor,
+    );
+    lifecycle_store.kill(&scope, process_id).await.unwrap();
+
+    assert!(
+        network_policies
+            .take(&scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        secret_injections
+            .take(&scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn process_obligation_lifecycle_rejects_second_active_handoff_for_same_scope_capability() {
     let inner_store = Arc::new(InMemoryProcessStore::new());
     let network_policies = Arc::new(NetworkObligationPolicyStore::new());

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -25,9 +25,10 @@ use ironclaw_host_runtime::{
 };
 use ironclaw_mcp::{McpError, McpExecutionRequest, McpExecutionResult, McpExecutor};
 use ironclaw_processes::{
-    BackgroundProcessManager, InMemoryProcessResultStore, InMemoryProcessStore, ProcessError,
-    ProcessExecutionRequest, ProcessExecutionResult, ProcessExecutor, ProcessHost,
-    ProcessResultStore, ProcessServices, ProcessStart, ProcessStatus, ProcessStore,
+    BackgroundFailureStage, BackgroundProcessManager, InMemoryProcessResultStore,
+    InMemoryProcessStore, ProcessError, ProcessExecutionRequest, ProcessExecutionResult,
+    ProcessExecutor, ProcessHost, ProcessResultRecord, ProcessResultStore, ProcessServices,
+    ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
@@ -1192,6 +1193,159 @@ async fn spawned_obligation_lifecycle_releases_resources_and_discards_handoffs_o
 }
 
 #[tokio::test]
+async fn process_obligation_lifecycle_cleans_record_started_before_wrapper_exists() {
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let inner_store = Arc::new(InMemoryProcessStore::new());
+    let network_policies = Arc::new(NetworkObligationPolicyStore::new());
+    let secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id);
+    let estimate = ResourceEstimate {
+        process_count: Some(1),
+        concurrency_slots: Some(1),
+        ..ResourceEstimate::default()
+    };
+    governor
+        .reserve_with_id(scope.clone(), estimate.clone(), reservation_id)
+        .unwrap();
+    network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
+    secret_injections
+        .insert(
+            &scope,
+            &script_capability_id(),
+            &secret_handle,
+            SecretMaterial::from("runtime-secret"),
+        )
+        .unwrap();
+    let process_id = ProcessId::new();
+    let mut start = process_start(process_id, invocation_id, scope.clone());
+    start.estimated_resources = estimate;
+    start.resource_reservation_id = Some(reservation_id);
+    inner_store.start(start).await.unwrap();
+
+    let lifecycle_store = ProcessObligationLifecycleStore::new(
+        inner_store,
+        Arc::clone(&network_policies),
+        Arc::clone(&secret_injections),
+        governor.clone(),
+    );
+    lifecycle_store.kill(&scope, process_id).await.unwrap();
+
+    assert!(matches!(
+        governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Released,
+            ..
+        }
+    ));
+    assert!(
+        network_policies
+            .take(&scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        secret_injections
+            .take(&scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn spawned_obligation_lifecycle_cleans_handoffs_when_result_store_complete_fails() {
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let result_store = Arc::new(FailingProcessResultStore::default());
+    let fixture = spawn_obligation_fixture_with_result_store(
+        reservation_id,
+        secret_handle.clone(),
+        BackgroundExecutor::success(),
+        Arc::clone(&result_store),
+    )
+    .await;
+
+    let process = fixture.spawn().await;
+    wait_for_result_store_attempt(&result_store, "complete").await;
+    wait_for_no_reserved_processes(&fixture.governor).await;
+
+    let record = fixture
+        .process_store
+        .get(&fixture.scope, process.process_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.status, ProcessStatus::Running);
+    assert!(matches!(
+        fixture.governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Reconciled,
+            ..
+        }
+    ));
+    assert!(
+        fixture
+            .network_policies
+            .take(&fixture.scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        fixture
+            .secret_injections
+            .take(&fixture.scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn spawned_obligation_lifecycle_cleans_handoffs_when_result_store_fail_fails() {
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let result_store = Arc::new(FailingProcessResultStore::default());
+    let fixture = spawn_obligation_fixture_with_result_store(
+        reservation_id,
+        secret_handle.clone(),
+        BackgroundExecutor::failure("runtime_dispatch"),
+        Arc::clone(&result_store),
+    )
+    .await;
+
+    let process = fixture.spawn().await;
+    wait_for_result_store_attempt(&result_store, "fail").await;
+    wait_for_no_reserved_processes(&fixture.governor).await;
+
+    let record = fixture
+        .process_store
+        .get(&fixture.scope, process.process_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.status, ProcessStatus::Running);
+    assert!(matches!(
+        fixture.governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Released,
+            ..
+        }
+    ));
+    assert!(
+        fixture
+            .network_policies
+            .take(&fixture.scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        fixture
+            .secret_injections
+            .take(&fixture.scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn spawned_obligation_lifecycle_abort_cleans_up_when_process_start_fails() {
     let reservation_id = ResourceReservationId::new();
     let secret_handle = SecretHandle::new("api_token").unwrap();
@@ -1671,6 +1825,24 @@ async fn spawn_obligation_fixture(
     secret_handle: SecretHandle,
     executor: BackgroundExecutor,
 ) -> SpawnObligationFixture {
+    spawn_obligation_fixture_with_result_store(
+        reservation_id,
+        secret_handle,
+        executor,
+        Arc::new(InMemoryProcessResultStore::new()),
+    )
+    .await
+}
+
+async fn spawn_obligation_fixture_with_result_store<R>(
+    reservation_id: ResourceReservationId,
+    secret_handle: SecretHandle,
+    executor: BackgroundExecutor,
+    result_store: Arc<R>,
+) -> SpawnObligationFixture
+where
+    R: ProcessResultStore + 'static,
+{
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
     let dispatcher = Arc::new(NoopDispatcher);
     let network_policies = Arc::new(NetworkObligationPolicyStore::new());
@@ -1717,9 +1889,23 @@ async fn spawn_obligation_fixture(
         Arc::clone(&secret_injections),
         governor.clone(),
     ));
+    let cleanup_process_store = Arc::clone(&process_store);
     let process_manager = Arc::new(
         BackgroundProcessManager::new(Arc::clone(&process_store), Arc::new(executor))
-            .with_result_store(Arc::new(InMemoryProcessResultStore::new())),
+            .with_result_store(result_store)
+            .with_error_handler(move |failure| {
+                let reconcile = match failure.stage {
+                    BackgroundFailureStage::ResultStoreComplete => true,
+                    BackgroundFailureStage::ResultStoreFail => false,
+                    _ => return,
+                };
+                let cleanup_process_store = Arc::clone(&cleanup_process_store);
+                tokio::spawn(async move {
+                    let _ = cleanup_process_store
+                        .cleanup_process_obligations(&failure.scope, failure.process_id, reconcile)
+                        .await;
+                });
+            }),
     );
 
     SpawnObligationFixture {
@@ -1735,6 +1921,63 @@ async fn spawn_obligation_fixture(
         context,
         scope,
         estimate,
+    }
+}
+
+#[derive(Default)]
+struct FailingProcessResultStore {
+    attempts: std::sync::Mutex<Vec<&'static str>>,
+}
+
+impl FailingProcessResultStore {
+    fn attempts(&self) -> Vec<&'static str> {
+        self.attempts.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ProcessResultStore for FailingProcessResultStore {
+    async fn complete(
+        &self,
+        _scope: &ResourceScope,
+        _process_id: ProcessId,
+        _output: serde_json::Value,
+    ) -> Result<ProcessResultRecord, ProcessError> {
+        self.attempts.lock().unwrap().push("complete");
+        Err(ProcessError::InvalidStoredRecord {
+            reason: "result complete failed".to_string(),
+        })
+    }
+
+    async fn fail(
+        &self,
+        _scope: &ResourceScope,
+        _process_id: ProcessId,
+        _error_kind: String,
+    ) -> Result<ProcessResultRecord, ProcessError> {
+        self.attempts.lock().unwrap().push("fail");
+        Err(ProcessError::InvalidStoredRecord {
+            reason: "result fail failed".to_string(),
+        })
+    }
+
+    async fn kill(
+        &self,
+        _scope: &ResourceScope,
+        _process_id: ProcessId,
+    ) -> Result<ProcessResultRecord, ProcessError> {
+        self.attempts.lock().unwrap().push("kill");
+        Err(ProcessError::InvalidStoredRecord {
+            reason: "result kill failed".to_string(),
+        })
+    }
+
+    async fn get(
+        &self,
+        _scope: &ResourceScope,
+        _process_id: ProcessId,
+    ) -> Result<Option<ProcessResultRecord>, ProcessError> {
+        Ok(None)
     }
 }
 
@@ -1832,6 +2075,26 @@ async fn wait_for_status(
         tokio::time::sleep(Duration::from_millis(5)).await;
     }
     panic!("process {process_id} did not reach {status:?}");
+}
+
+async fn wait_for_result_store_attempt(store: &FailingProcessResultStore, attempt: &'static str) {
+    for _ in 0..100 {
+        if store.attempts().contains(&attempt) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("result store did not record {attempt} attempt");
+}
+
+async fn wait_for_no_reserved_processes(governor: &InMemoryResourceGovernor) {
+    for _ in 0..100 {
+        if governor.reserved_for(&sample_account()).process_count == 0 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("process reservation was not cleaned up");
 }
 
 #[async_trait]

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1117,6 +1117,60 @@ async fn host_runtime_services_cancel_writes_killed_result_when_reservation_is_s
 }
 
 #[tokio::test]
+async fn host_runtime_services_cancel_records_kill_side_effects_when_cleanup_fails() {
+    let process_services = ProcessServices::new(
+        Arc::new(InMemoryProcessStore::new()),
+        Arc::new(InMemoryProcessResultStore::new()),
+    );
+    let process_store = process_services.process_store();
+    let result_store = process_services.result_store();
+    let cancellation_registry = process_services.cancellation_registry();
+    let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
+    let runtime = HostRuntimeServices::new(
+        registry,
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(FailingCleanupResourceGovernor),
+        Arc::new(GrantAuthorizer::new()),
+        process_services,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .host_runtime();
+    let invocation_id = InvocationId::new();
+    let process_id = ProcessId::new();
+    let scope = sample_scope(invocation_id);
+    let token = cancellation_registry.register(&scope, process_id);
+    let mut start = process_start(process_id, invocation_id, scope.clone());
+    start.resource_reservation_id = Some(ResourceReservationId::new());
+    process_store.start(start).await.unwrap();
+
+    let _error = runtime
+        .cancel_work(CancelRuntimeWorkRequest::new(
+            scope.clone(),
+            CorrelationId::new(),
+            CancelReason::UserRequested,
+        ))
+        .await
+        .expect_err("cleanup failure should remain visible to callers");
+
+    assert!(
+        token.is_cancelled(),
+        "cleanup errors after terminalization must not skip cooperative cancellation"
+    );
+    let record = process_store
+        .get(&scope, process_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.status, ProcessStatus::Killed);
+    let result = result_store
+        .get(&scope, process_id)
+        .await
+        .unwrap()
+        .expect("cleanup errors after terminalization must still write a killed result");
+    assert_eq!(result.status, ProcessStatus::Killed);
+}
+
+#[tokio::test]
 async fn spawned_obligation_lifecycle_reconciles_resources_and_discards_handoffs_on_success() {
     let reservation_id = ResourceReservationId::new();
     let secret_handle = SecretHandle::new("api_token").unwrap();

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1071,6 +1071,52 @@ async fn host_runtime_services_cancel_and_status_share_process_result_and_cancel
 }
 
 #[tokio::test]
+async fn host_runtime_services_cancel_writes_killed_result_when_reservation_is_stale() {
+    let process_services = ProcessServices::in_memory();
+    let process_store = process_services.process_store();
+    let result_store = process_services.result_store();
+    let cancellation_registry = process_services.cancellation_registry();
+    let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
+    let runtime = HostRuntimeServices::new(
+        registry,
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        process_services,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .host_runtime();
+    let invocation_id = InvocationId::new();
+    let process_id = ProcessId::new();
+    let stale_reservation_id = ResourceReservationId::new();
+    let scope = sample_scope(invocation_id);
+    let token = cancellation_registry.register(&scope, process_id);
+    let mut start = process_start(process_id, invocation_id, scope.clone());
+    start.resource_reservation_id = Some(stale_reservation_id);
+    process_store.start(start).await.unwrap();
+
+    let outcome = runtime
+        .cancel_work(CancelRuntimeWorkRequest::new(
+            scope.clone(),
+            CorrelationId::new(),
+            CancelReason::UserRequested,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.cancelled, vec![RuntimeWorkId::Process(process_id)]);
+    assert!(token.is_cancelled());
+    let record = process_store
+        .get(&scope, process_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(record.status, ProcessStatus::Killed);
+    let result = result_store.get(&scope, process_id).await.unwrap().unwrap();
+    assert_eq!(result.status, ProcessStatus::Killed);
+}
+
+#[tokio::test]
 async fn spawned_obligation_lifecycle_reconciles_resources_and_discards_handoffs_on_success() {
     let reservation_id = ResourceReservationId::new();
     let secret_handle = SecretHandle::new("api_token").unwrap();

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1354,7 +1354,70 @@ async fn process_obligation_lifecycle_cleans_record_started_before_wrapper_exist
 }
 
 #[tokio::test]
-async fn process_obligation_lifecycle_preserves_newer_handoffs_for_same_invocation_capability() {
+async fn process_obligation_lifecycle_rejects_second_active_handoff_for_same_scope_capability() {
+    let inner_store = Arc::new(InMemoryProcessStore::new());
+    let network_policies = Arc::new(NetworkObligationPolicyStore::new());
+    let secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id);
+    let first_process_id = ProcessId::new();
+    let second_process_id = ProcessId::new();
+    let lifecycle_store = ProcessObligationLifecycleStore::new(
+        inner_store,
+        Arc::clone(&network_policies),
+        secret_injections,
+        governor,
+    );
+
+    network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
+    lifecycle_store
+        .start(process_start(
+            first_process_id,
+            invocation_id,
+            scope.clone(),
+        ))
+        .await
+        .unwrap();
+
+    network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
+    let error = lifecycle_store
+        .start(process_start(
+            second_process_id,
+            invocation_id,
+            scope.clone(),
+        ))
+        .await
+        .expect_err("a scoped capability may only have one active process handoff");
+
+    assert!(matches!(error, ProcessError::InvalidStoredRecord { .. }));
+    assert!(
+        lifecycle_store
+            .get(&scope, second_process_id)
+            .await
+            .unwrap()
+            .is_none(),
+        "the rejected second process must not be persisted as running"
+    );
+
+    lifecycle_store
+        .complete(&scope, first_process_id)
+        .await
+        .unwrap();
+    network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
+    lifecycle_store
+        .start(process_start(
+            second_process_id,
+            invocation_id,
+            scope.clone(),
+        ))
+        .await
+        .expect("a new handoff can start after the prior handoff reaches terminal cleanup");
+}
+
+#[tokio::test]
+async fn process_obligation_lifecycle_does_not_clean_handoffs_twice_after_background_cleanup() {
+    let reservation_id = ResourceReservationId::new();
     let secret_handle = SecretHandle::new("api_token").unwrap();
     let inner_store = Arc::new(InMemoryProcessStore::new());
     let network_policies = Arc::new(NetworkObligationPolicyStore::new());
@@ -1363,7 +1426,14 @@ async fn process_obligation_lifecycle_preserves_newer_handoffs_for_same_invocati
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id);
     let process_id = ProcessId::new();
-
+    let estimate = ResourceEstimate {
+        process_count: Some(1),
+        concurrency_slots: Some(1),
+        ..ResourceEstimate::default()
+    };
+    governor
+        .reserve_with_id(scope.clone(), estimate.clone(), reservation_id)
+        .unwrap();
     network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
     secret_injections
         .insert(
@@ -1377,13 +1447,17 @@ async fn process_obligation_lifecycle_preserves_newer_handoffs_for_same_invocati
         inner_store,
         Arc::clone(&network_policies),
         Arc::clone(&secret_injections),
-        governor,
+        governor.clone(),
     );
+    let mut start = process_start(process_id, invocation_id, scope.clone());
+    start.estimated_resources = estimate;
+    start.resource_reservation_id = Some(reservation_id);
+    lifecycle_store.start(start).await.unwrap();
+
     lifecycle_store
-        .start(process_start(process_id, invocation_id, scope.clone()))
+        .cleanup_process_obligations(&scope, process_id, false)
         .await
         .unwrap();
-
     network_policies.insert(&scope, &script_capability_id(), wasm_http_policy());
     secret_injections
         .insert(
@@ -1394,20 +1468,20 @@ async fn process_obligation_lifecycle_preserves_newer_handoffs_for_same_invocati
         )
         .unwrap();
 
-    lifecycle_store.complete(&scope, process_id).await.unwrap();
+    lifecycle_store.kill(&scope, process_id).await.unwrap();
 
     assert!(
         network_policies
             .take(&scope, &script_capability_id())
             .is_some(),
-        "cleanup for the completed process must not discard a newer staged network policy for the same scoped capability"
+        "a later terminal transition for an already-cleaned process must not discard a newer staged policy"
     );
     assert!(
         secret_injections
             .take(&scope, &script_capability_id(), &secret_handle)
             .unwrap()
             .is_some(),
-        "cleanup for the completed process must not discard newer staged secret material for the same scoped capability"
+        "a later terminal transition for an already-cleaned process must not discard newer staged secret material"
     );
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -7,6 +7,7 @@ use ironclaw_authorization::{
     CapabilityLeaseStatus, CapabilityLeaseStore, GrantAuthorizer, InMemoryCapabilityLeaseStore,
     TrustAwareCapabilityDispatchAuthorizer,
 };
+use ironclaw_capabilities::{CapabilityHost, CapabilitySpawnRequest};
 use ironclaw_events::{
     DurableAuditLog, DurableEventLog, EventCursor, EventError, EventReplay, EventStreamKey,
     InMemoryAuditSink, InMemoryDurableAuditLog, InMemoryDurableEventLog, InMemoryEventSink,
@@ -16,17 +17,20 @@ use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
-    CancelReason, CancelRuntimeWorkRequest, CapabilitySurfaceVersion, DefaultHostRuntime,
-    HostRuntime, HostRuntimeServices, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
-    RuntimeCapabilityResumeRequest, RuntimeFailureKind, RuntimeStatusRequest, RuntimeWorkId,
+    BuiltinObligationHandler, CancelReason, CancelRuntimeWorkRequest, CapabilitySurfaceVersion,
+    DefaultHostRuntime, HostRuntime, HostRuntimeServices, NetworkObligationPolicyStore,
+    ProcessObligationLifecycleStore, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    RuntimeCapabilityResumeRequest, RuntimeFailureKind, RuntimeSecretInjectionStore,
+    RuntimeStatusRequest, RuntimeWorkId,
 };
 use ironclaw_mcp::{McpError, McpExecutionRequest, McpExecutionResult, McpExecutor};
 use ironclaw_processes::{
-    InMemoryProcessResultStore, InMemoryProcessStore, ProcessResultStore, ProcessServices,
-    ProcessStart, ProcessStatus, ProcessStore,
+    BackgroundProcessManager, InMemoryProcessResultStore, InMemoryProcessStore, ProcessError,
+    ProcessExecutionRequest, ProcessExecutionResult, ProcessExecutor, ProcessHost,
+    ProcessResultStore, ProcessServices, ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_resources::{
-    InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceLimits,
+    InMemoryResourceGovernor, ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
 };
 use ironclaw_run_state::{
     InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStateStore, RunStatus,
@@ -34,6 +38,7 @@ use ironclaw_run_state::{
 use ironclaw_scripts::{
     ScriptBackend, ScriptBackendOutput, ScriptBackendRequest, ScriptRuntime, ScriptRuntimeConfig,
 };
+use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustProvenance,
@@ -1065,6 +1070,184 @@ async fn host_runtime_services_cancel_and_status_share_process_result_and_cancel
 }
 
 #[tokio::test]
+async fn spawned_obligation_lifecycle_reconciles_resources_and_discards_handoffs_on_success() {
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let fixture = spawn_obligation_fixture(
+        reservation_id,
+        secret_handle.clone(),
+        BackgroundExecutor::success(),
+    )
+    .await;
+
+    let process = fixture.spawn().await;
+    wait_for_status(
+        fixture.process_store.as_ref(),
+        &fixture.scope,
+        process.process_id,
+        ProcessStatus::Completed,
+    )
+    .await;
+
+    assert!(matches!(
+        fixture.governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Reconciled,
+            ..
+        }
+    ));
+    assert!(
+        fixture
+            .network_policies
+            .take(&fixture.scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        fixture
+            .secret_injections
+            .take(&fixture.scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn spawned_obligation_lifecycle_releases_resources_and_discards_handoffs_on_runtime_failure()
+{
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let fixture = spawn_obligation_fixture(
+        reservation_id,
+        secret_handle.clone(),
+        BackgroundExecutor::failure("runtime_dispatch"),
+    )
+    .await;
+
+    let process = fixture.spawn().await;
+    wait_for_status(
+        fixture.process_store.as_ref(),
+        &fixture.scope,
+        process.process_id,
+        ProcessStatus::Failed,
+    )
+    .await;
+
+    assert!(matches!(
+        fixture.governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Released,
+            ..
+        }
+    ));
+    assert!(
+        fixture
+            .network_policies
+            .take(&fixture.scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        fixture
+            .secret_injections
+            .take(&fixture.scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn spawned_obligation_lifecycle_releases_resources_and_discards_handoffs_on_kill() {
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let fixture = spawn_obligation_fixture(
+        reservation_id,
+        secret_handle.clone(),
+        BackgroundExecutor::delayed_success(Duration::from_millis(50)),
+    )
+    .await;
+
+    let process = fixture.spawn().await;
+    let host = ProcessHost::new(fixture.process_store.as_ref());
+    host.kill(&fixture.scope, process.process_id).await.unwrap();
+
+    assert!(matches!(
+        fixture.governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Released,
+            ..
+        }
+    ));
+    assert!(
+        fixture
+            .network_policies
+            .take(&fixture.scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        fixture
+            .secret_injections
+            .take(&fixture.scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn spawned_obligation_lifecycle_abort_cleans_up_when_process_start_fails() {
+    let reservation_id = ResourceReservationId::new();
+    let secret_handle = SecretHandle::new("api_token").unwrap();
+    let fixture = spawn_obligation_fixture(
+        reservation_id,
+        secret_handle.clone(),
+        BackgroundExecutor::success(),
+    )
+    .await;
+    let failing_manager = FailingSpawnManager;
+    let host = CapabilityHost::new(
+        fixture.registry.as_ref(),
+        fixture.dispatcher.as_ref(),
+        fixture.authorizer.as_ref(),
+    )
+    .with_obligation_handler(fixture.handler.as_ref())
+    .with_process_manager(&failing_manager);
+
+    let err = host
+        .spawn_json(CapabilitySpawnRequest {
+            context: fixture.context.clone(),
+            capability_id: script_capability_id(),
+            estimate: fixture.estimate.clone(),
+            input: json!({"message": "spawn fails"}),
+            trust_decision: trust_decision_with_dispatch_authority(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ironclaw_capabilities::CapabilityInvocationError::Process { .. }
+    ));
+    assert!(matches!(
+        fixture.governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Released,
+            ..
+        }
+    ));
+    assert!(
+        fixture
+            .network_policies
+            .take(&fixture.scope, &script_capability_id())
+            .is_none()
+    );
+    assert!(
+        fixture
+            .secret_injections
+            .take(&fixture.scope, &script_capability_id(), &secret_handle)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn host_runtime_services_wasm_guest_error_reconciles_usage_after_host_effect() {
     let wat = http_then_guest_error_wat();
     let runtime = wasm_runtime_for_component(
@@ -1443,6 +1626,212 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
             redaction_applied: false,
         })
     }
+}
+
+struct SpawnObligationFixture {
+    registry: Arc<ExtensionRegistry>,
+    dispatcher: Arc<NoopDispatcher>,
+    authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer>,
+    handler: Arc<BuiltinObligationHandler>,
+    process_manager: Arc<BackgroundProcessManager>,
+    process_store: Arc<ProcessObligationLifecycleStore>,
+    network_policies: Arc<NetworkObligationPolicyStore>,
+    secret_injections: Arc<RuntimeSecretInjectionStore>,
+    governor: Arc<InMemoryResourceGovernor>,
+    context: ExecutionContext,
+    scope: ResourceScope,
+    estimate: ResourceEstimate,
+}
+
+impl SpawnObligationFixture {
+    async fn spawn(&self) -> ironclaw_processes::ProcessRecord {
+        let host = CapabilityHost::new(
+            self.registry.as_ref(),
+            self.dispatcher.as_ref(),
+            self.authorizer.as_ref(),
+        )
+        .with_obligation_handler(self.handler.as_ref())
+        .with_process_manager(self.process_manager.as_ref());
+
+        host.spawn_json(CapabilitySpawnRequest {
+            context: self.context.clone(),
+            capability_id: script_capability_id(),
+            estimate: self.estimate.clone(),
+            input: json!({"message": "background"}),
+            trust_decision: trust_decision_with_dispatch_authority(),
+        })
+        .await
+        .unwrap()
+        .process
+    }
+}
+
+async fn spawn_obligation_fixture(
+    reservation_id: ResourceReservationId,
+    secret_handle: SecretHandle,
+    executor: BackgroundExecutor,
+) -> SpawnObligationFixture {
+    let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
+    let dispatcher = Arc::new(NoopDispatcher);
+    let network_policies = Arc::new(NetworkObligationPolicyStore::new());
+    let secret_injections = Arc::new(RuntimeSecretInjectionStore::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id);
+    let context =
+        execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone());
+    let estimate = ResourceEstimate {
+        process_count: Some(1),
+        concurrency_slots: Some(1),
+        ..ResourceEstimate::default()
+    };
+    secret_store
+        .put(
+            scope.clone(),
+            secret_handle.clone(),
+            SecretMaterial::from("runtime-secret"),
+        )
+        .await
+        .unwrap();
+    let handler = Arc::new(
+        BuiltinObligationHandler::new()
+            .with_network_policy_store(Arc::clone(&network_policies))
+            .with_secret_store(secret_store)
+            .with_secret_injection_store(Arc::clone(&secret_injections))
+            .with_resource_governor(Arc::clone(&governor)),
+    );
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
+        Arc::new(ObligatingAuthorizer::new(vec![
+            Obligation::ReserveResources { reservation_id },
+            Obligation::ApplyNetworkPolicy {
+                policy: wasm_http_policy(),
+            },
+            Obligation::InjectSecretOnce {
+                handle: secret_handle,
+            },
+        ]));
+    let process_store = Arc::new(ProcessObligationLifecycleStore::new(
+        Arc::new(InMemoryProcessStore::new()),
+        Arc::clone(&network_policies),
+        Arc::clone(&secret_injections),
+        governor.clone(),
+    ));
+    let process_manager = Arc::new(
+        BackgroundProcessManager::new(Arc::clone(&process_store), Arc::new(executor))
+            .with_result_store(Arc::new(InMemoryProcessResultStore::new())),
+    );
+
+    SpawnObligationFixture {
+        registry,
+        dispatcher,
+        authorizer,
+        handler,
+        process_manager,
+        process_store,
+        network_policies,
+        secret_injections,
+        governor,
+        context,
+        scope,
+        estimate,
+    }
+}
+
+struct BackgroundExecutor {
+    outcome: BackgroundExecutorOutcome,
+}
+
+impl BackgroundExecutor {
+    fn success() -> Self {
+        Self {
+            outcome: BackgroundExecutorOutcome::Success,
+        }
+    }
+
+    fn failure(kind: impl Into<String>) -> Self {
+        Self {
+            outcome: BackgroundExecutorOutcome::Failure(kind.into()),
+        }
+    }
+
+    fn delayed_success(delay: Duration) -> Self {
+        Self {
+            outcome: BackgroundExecutorOutcome::DelayedSuccess(delay),
+        }
+    }
+}
+
+enum BackgroundExecutorOutcome {
+    Success,
+    Failure(String),
+    DelayedSuccess(Duration),
+}
+
+#[async_trait]
+impl ProcessExecutor for BackgroundExecutor {
+    async fn execute(
+        &self,
+        _request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ironclaw_processes::ProcessExecutionError> {
+        match &self.outcome {
+            BackgroundExecutorOutcome::Success => Ok(ProcessExecutionResult {
+                output: json!({"ok": true}),
+            }),
+            BackgroundExecutorOutcome::Failure(kind) => {
+                Err(ironclaw_processes::ProcessExecutionError::new(kind.clone()))
+            }
+            BackgroundExecutorOutcome::DelayedSuccess(delay) => {
+                tokio::time::sleep(*delay).await;
+                Ok(ProcessExecutionResult {
+                    output: json!({"ok": true}),
+                })
+            }
+        }
+    }
+}
+
+struct FailingSpawnManager;
+
+#[async_trait]
+impl ironclaw_processes::ProcessManager for FailingSpawnManager {
+    async fn spawn(
+        &self,
+        _start: ProcessStart,
+    ) -> Result<ironclaw_processes::ProcessRecord, ProcessError> {
+        Err(ProcessError::InvalidStoredRecord {
+            reason: "start failed".to_string(),
+        })
+    }
+}
+
+struct NoopDispatcher;
+
+#[async_trait]
+impl CapabilityDispatcher for NoopDispatcher {
+    async fn dispatch_json(
+        &self,
+        _request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError> {
+        panic!("spawn tests must not invoke the foreground dispatcher")
+    }
+}
+
+async fn wait_for_status(
+    store: &dyn ProcessStore,
+    scope: &ResourceScope,
+    process_id: ProcessId,
+    status: ProcessStatus,
+) {
+    for _ in 0..100 {
+        if let Some(record) = store.get(scope, process_id).await.unwrap()
+            && record.status == status
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("process {process_id} did not reach {status:?}");
 }
 
 #[async_trait]

--- a/crates/ironclaw_processes/src/host.rs
+++ b/crates/ironclaw_processes/src/host.rs
@@ -57,6 +57,11 @@ impl<'a> ProcessHost<'a> {
         self
     }
 
+    pub fn with_result_store_dyn(mut self, store: Arc<dyn ProcessResultStore>) -> Self {
+        self.result_store = Some(store);
+        self
+    }
+
     fn result_store(&self) -> Result<&dyn ProcessResultStore, ProcessError> {
         self.result_store
             .as_deref()
@@ -76,14 +81,31 @@ impl<'a> ProcessHost<'a> {
         scope: &ResourceScope,
         process_id: ProcessId,
     ) -> Result<ProcessRecord, ProcessError> {
-        let record = self.store.kill(scope, process_id).await?;
+        match self.store.kill(scope, process_id).await {
+            Ok(record) => {
+                self.record_kill_side_effects(&record).await?;
+                Ok(record)
+            }
+            Err(error @ ProcessError::InvalidTransition { .. }) => Err(error),
+            Err(error) => {
+                if let Ok(Some(record)) = self.store.get(scope, process_id).await
+                    && record.status == ProcessStatus::Killed
+                {
+                    self.record_kill_side_effects(&record).await?;
+                }
+                Err(error)
+            }
+        }
+    }
+
+    async fn record_kill_side_effects(&self, record: &ProcessRecord) -> Result<(), ProcessError> {
         if let Some(registry) = &self.cancellation_registry {
-            registry.cancel(scope, process_id);
+            registry.cancel(&record.scope, record.process_id);
         }
         if let Some(result_store) = &self.result_store {
             result_store.kill(&record.scope, record.process_id).await?;
         }
-        Ok(record)
+        Ok(())
     }
 
     pub async fn result(

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -30,7 +30,7 @@ Supported built-in behavior:
 - Staged secret entries have a default five-minute TTL; insertion, `take(...)`, and `prune_expired(...)` drop expired material so abandoned handoffs stop being usable even if runtime setup never reaches egress.
 - Direct `satisfy(...)` releases any prepared resource reservation without discarding successfully staged network/secret handoffs that the caller still needs to pass to runtime adapters.
 - Inline dispatch completion discards any unconsumed staged network/secret handoffs so successful calls do not leave reusable ambient state behind.
-- Background process lifecycle cleanup claims the staged handoff generations visible at process start and only discards those exact generations, so terminal cleanup for one process cannot remove newer handoffs staged for another process using the same scoped capability.
+- Background process lifecycle cleanup currently enforces a single active process handoff per scoped capability (`ResourceScope` plus capability id). Starting a second process handoff for the same scoped capability before the first reaches terminal cleanup fails closed; process-owned handoff ids are a follow-up design.
 - Terminal process cleanup failures are surfaced through the process-store transition or background failure handler and logged with process id/stage context; they must not be silently swallowed.
 - Staged secrets must never be logged or exposed through debug output.
 - Handler errors must use stable categories and avoid raw provider/backend details.

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -30,6 +30,8 @@ Supported built-in behavior:
 - Staged secret entries have a default five-minute TTL; insertion, `take(...)`, and `prune_expired(...)` drop expired material so abandoned handoffs stop being usable even if runtime setup never reaches egress.
 - Direct `satisfy(...)` releases any prepared resource reservation without discarding successfully staged network/secret handoffs that the caller still needs to pass to runtime adapters.
 - Inline dispatch completion discards any unconsumed staged network/secret handoffs so successful calls do not leave reusable ambient state behind.
+- Background process lifecycle cleanup claims the staged handoff generations visible at process start and only discards those exact generations, so terminal cleanup for one process cannot remove newer handoffs staged for another process using the same scoped capability.
+- Terminal process cleanup failures are surfaced through the process-store transition or background failure handler and logged with process id/stage context; they must not be silently swallowed.
 - Staged secrets must never be logged or exposed through debug output.
 - Handler errors must use stable categories and avoid raw provider/backend details.
 


### PR DESCRIPTION
Closes #3145

## Summary

Defines the Reborn host-runtime obligation lifecycle for background process execution after `CapabilityHost::spawn_json` hands prepared effects to `ProcessManager`.

## Issue context

- Issue: https://github.com/nearai/ironclaw/issues/3145
- Related: #3080, #3017, #3087
- Base branch: `reborn-integration`
- Head branch: `nearai/ironclaw:sandcastle/issue-3145`

## Implementation

- Adds `ProcessObligationLifecycleStore` ownership around process terminal transitions.
- Wires `HostRuntimeServices` process-store graph through the lifecycle wrapper.
- Reconciles/releases resource reservations for success, runtime failure, and cancellation/kill paths.
- Discards staged network and secret handoffs when processes reach terminal lifecycle points.
- Adds host-runtime contract coverage for process success, process-start failure, runtime failure, and kill cleanup paths.

## Changed files

```text
crates/ironclaw_host_runtime/src/lib.rs
crates/ironclaw_host_runtime/src/obligations.rs
crates/ironclaw_host_runtime/src/services.rs
crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
```

## Diff stat

```text
crates/ironclaw_host_runtime/src/lib.rs            |   2 +-
crates/ironclaw_host_runtime/src/obligations.rs    | 219 ++++-
crates/ironclaw_host_runtime/src/services.rs       |  50 +-
crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs | 931 ++++++++++++++++++++-
4 files changed, 1186 insertions(+), 16 deletions(-)
```

## Acceptance criteria coverage

- Resource reservations handed to a process are reconciled/released on terminal process state.
- Cancellation/kill paths have cleanup coverage.
- Staged network/secret handoffs are discarded after process lifecycle completion/failure paths.
- Tests cover success, process-start failure, runtime failure, and cancellation/kill cleanup.

## Sandcastle review status

Sandcastle opened this PR even though the final paranoid local review still reported one Medium robustness concern after 3 fix attempts:

> Terminal cleanup failures are swallowed after `complete`, `fail`, and `kill`. `cleanup_record_obligations` can return a real `ProcessError` for non-idempotency resource errors, but `cleanup_terminal` only logs and returns the terminal record. In `DefaultHostRuntime::cancel_work`, this means a killed process can be reported as cancelled and get a killed result while its reservation remains active if `ResourceGovernor::release`/`reconcile` fails for anything other than `UnknownReservation`/`ReservationClosed`. The background failure path has the same loss because `services.rs` drops `cleanup_process_obligations` errors.

Suggested review focus: decide whether cleanup failures should be surfaced synchronously from terminal process-store transitions, or persisted/retried as a follow-up cleanup obligation.

## Verification observed in Sandcastle logs

Implemented/fixer runs reported:

```bash
cargo fmt --all -- --check
git diff --check
cargo test -p ironclaw_processes
cargo test -p ironclaw_capabilities
CARGO_BUILD_JOBS=1 cargo test -p ironclaw_host_runtime
CARGO_BUILD_JOBS=1 cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings
cargo test -p ironclaw_host_runtime --test host_runtime_services_contract
cargo test -p ironclaw_architecture --test reborn_dependency_boundaries
python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD
```

The final paranoid-review pass noted `cargo test -p ironclaw_host_runtime` could not complete in that sandbox because the linker was killed with signal 9, likely OOM; targeted host-runtime tests passed.


## Follow-up

- #3169 tracks process-owned/runtime-handoff-owned ids for true concurrent same-scope/same-capability background fan-out. This PR intentionally keeps the narrower single-active scoped-capability handoff invariant.
