### PR TITLE
fix(reborn): move fallback runtime network policy

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -667,7 +667,7 @@ impl<N, S> HostHttpEgressService<N, S> {
 
     fn network_policy_for_request(
         &self,
-        request: &RuntimeHttpEgressRequest,
+        request: &mut RuntimeHttpEgressRequest,
     ) -> Result<NetworkPolicy, RuntimeHttpEgressError> {
         if let Some(store) = &self.network_policy_store {
             return store
@@ -685,7 +685,9 @@ impl<N, S> HostHttpEgressService<N, S> {
                 request_bytes: 0,
                 response_bytes: 0,
             }),
-            NetworkPolicySource::RequestPolicyFallback => Ok(request.network_policy.clone()),
+            NetworkPolicySource::RequestPolicyFallback => {
+                Ok(std::mem::take(&mut request.network_policy))
+            }
         }
     }
 }
@@ -699,7 +701,7 @@ where
         &self,
         mut request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
-        let network_policy = self.network_policy_for_request(&request)?;
+        let network_policy = self.network_policy_for_request(&mut request)?;
         validate_runtime_request(&request)?;
 
         let mut redaction_values = Vec::new();

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -701,8 +701,8 @@ where
         &self,
         mut request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
-        let network_policy = self.network_policy_for_request(&mut request)?;
         validate_runtime_request(&request)?;
+        let network_policy = self.network_policy_for_request(&mut request)?;
 
         let mut redaction_values = Vec::new();
         let mut credential_materials = Vec::new();


### PR DESCRIPTION
## Summary

- Address Gemini follow-up from #3149 by moving the request-policy fallback out of `RuntimeHttpEgressRequest` instead of cloning it.
- Keep staged `NetworkObligationPolicyStore` precedence unchanged while making the explicit test/legacy fallback consume the embedded policy.

## Verification

- `cargo test -q -p ironclaw_host_runtime --test runtime_http_egress_contract`
- `cargo clippy -q -p ironclaw_host_runtime --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Context

Follow-up to #3149 after it merged before the Gemini review nit could land on the PR branch.
