### PR TITLE
fix(reborn): harden runtime network policy handoff

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -701,8 +701,8 @@ where
         &self,
         mut request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
-        validate_runtime_request(&request)?;
         let network_policy = self.network_policy_for_request(&mut request)?;
+        validate_runtime_request(&request)?;
 
         let mut redaction_values = Vec::new();
         let mut credential_materials = Vec::new();

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -12,13 +12,16 @@ use ironclaw_host_runtime::{
     BuiltinObligationHandler, HostHttpEgressService, NetworkObligationPolicyStore,
     RuntimeSecretInjectionStore,
 };
+use ironclaw_mcp::{McpHostHttpRequest, McpRuntimeHttpAdapter};
 use ironclaw_network::{
     NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
 };
+use ironclaw_scripts::{ScriptHostHttpRequest, ScriptRuntimeHttpAdapter};
 use ironclaw_secrets::{
     InMemorySecretStore, SecretLease, SecretLeaseId, SecretMaterial, SecretMetadata, SecretStore,
     SecretStoreError,
 };
+use ironclaw_wasm::{WasmHostHttp, WasmHttpRequest, WasmRuntimeHttpAdapter};
 use std::{
     sync::{Arc, Mutex},
     time::Duration,
@@ -1074,6 +1077,150 @@ fn host_http_egress_consumes_staged_network_policy_before_transport() {
         policy_store.take(&scope, &capability_id).is_none(),
         "runtime egress must consume staged policy exactly once"
     );
+}
+
+#[test]
+fn wasm_http_adapter_consumes_real_host_staged_network_policy() {
+    let network = RecordingNetwork::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![],
+        body: b"ok".to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 5,
+            response_bytes: 2,
+            resolved_ip: None,
+        },
+    });
+    let network_recorder = network.requests.clone();
+    let policy_store = Arc::new(NetworkObligationPolicyStore::new());
+    let scope = sample_scope();
+    let capability_id = sample_capability_id();
+    let staged_policy = sample_policy();
+    policy_store.insert(&scope, &capability_id, staged_policy.clone());
+    let service = HostHttpEgressService::new(network, InMemorySecretStore::new())
+        .with_network_policy_store(policy_store.clone());
+    let adapter = WasmRuntimeHttpAdapter::new(
+        Arc::new(service),
+        scope.clone(),
+        capability_id.clone(),
+        caller_supplied_policy(),
+    );
+
+    let response = adapter
+        .request(WasmHttpRequest {
+            method: "POST".to_string(),
+            url: "https://api.example.test/v1/run".to_string(),
+            headers_json: "{}".to_string(),
+            body: Some(b"hello".to_vec()),
+            timeout_ms: Some(1000),
+        })
+        .expect("WASM adapter should reach host egress using staged policy");
+
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, b"ok".to_vec());
+    let requests = network_recorder.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].policy, staged_policy);
+    assert_eq!(requests[0].url, "https://api.example.test/v1/run");
+    assert_eq!(requests[0].body, b"hello".to_vec());
+    drop(requests);
+    assert!(policy_store.take(&scope, &capability_id).is_none());
+}
+
+#[test]
+fn script_http_adapter_consumes_real_host_staged_network_policy() {
+    let network = RecordingNetwork::ok(NetworkHttpResponse {
+        status: 202,
+        headers: vec![],
+        body: b"script-ok".to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 5,
+            response_bytes: 9,
+            resolved_ip: None,
+        },
+    });
+    let network_recorder = network.requests.clone();
+    let policy_store = Arc::new(NetworkObligationPolicyStore::new());
+    let scope = sample_scope();
+    let capability_id = sample_capability_id();
+    let staged_policy = sample_policy();
+    policy_store.insert(&scope, &capability_id, staged_policy.clone());
+    let service = HostHttpEgressService::new(network, InMemorySecretStore::new())
+        .with_network_policy_store(policy_store.clone());
+    let adapter = ScriptRuntimeHttpAdapter::new(Arc::new(service));
+
+    let response = adapter
+        .request(ScriptHostHttpRequest {
+            scope: scope.clone(),
+            capability_id: capability_id.clone(),
+            method: NetworkMethod::Post,
+            url: "https://api.example.test/v1/run".to_string(),
+            headers: vec![],
+            body: b"hello".to_vec(),
+            network_policy: caller_supplied_policy(),
+            credential_injections: vec![],
+            response_body_limit: Some(4096),
+            timeout_ms: Some(1000),
+        })
+        .expect("script adapter should reach host egress using staged policy");
+
+    assert_eq!(response.status, 202);
+    assert_eq!(response.body, b"script-ok".to_vec());
+    let requests = network_recorder.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].policy, staged_policy);
+    assert_eq!(requests[0].url, "https://api.example.test/v1/run");
+    assert_eq!(requests[0].body, b"hello".to_vec());
+    drop(requests);
+    assert!(policy_store.take(&scope, &capability_id).is_none());
+}
+
+#[test]
+fn mcp_http_adapter_consumes_real_host_staged_network_policy() {
+    let network = RecordingNetwork::ok(NetworkHttpResponse {
+        status: 203,
+        headers: vec![],
+        body: b"mcp-ok".to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 5,
+            response_bytes: 6,
+            resolved_ip: None,
+        },
+    });
+    let network_recorder = network.requests.clone();
+    let policy_store = Arc::new(NetworkObligationPolicyStore::new());
+    let scope = sample_scope();
+    let capability_id = sample_capability_id();
+    let staged_policy = sample_policy();
+    policy_store.insert(&scope, &capability_id, staged_policy.clone());
+    let service = HostHttpEgressService::new(network, InMemorySecretStore::new())
+        .with_network_policy_store(policy_store.clone());
+    let adapter = McpRuntimeHttpAdapter::new(Arc::new(service));
+
+    let response = adapter
+        .request(McpHostHttpRequest {
+            scope: scope.clone(),
+            capability_id: capability_id.clone(),
+            method: NetworkMethod::Post,
+            url: "https://api.example.test/v1/run".to_string(),
+            headers: vec![],
+            body: b"hello".to_vec(),
+            network_policy: caller_supplied_policy(),
+            credential_injections: vec![],
+            response_body_limit: Some(4096),
+            timeout_ms: Some(1000),
+        })
+        .expect("MCP adapter should reach host egress using staged policy");
+
+    assert_eq!(response.status, 203);
+    assert_eq!(response.body, b"mcp-ok".to_vec());
+    let requests = network_recorder.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].policy, staged_policy);
+    assert_eq!(requests[0].url, "https://api.example.test/v1/run");
+    assert_eq!(requests[0].body, b"hello".to_vec());
+    drop(requests);
+    assert!(policy_store.take(&scope, &capability_id).is_none());
 }
 
 #[test]

--- a/crates/ironclaw_wasm/src/host.rs
+++ b/crates/ironclaw_wasm/src/host.rs
@@ -116,7 +116,6 @@ pub struct WasmRuntimeCredentialRequest {
     pub method: NetworkMethod,
     pub url: String,
     pub headers: Vec<(String, String)>,
-    pub network_policy: NetworkPolicy,
 }
 
 pub trait WasmRuntimeCredentialProvider: Send + Sync + std::fmt::Debug {
@@ -289,7 +288,6 @@ where
                 method,
                 url: request.url.clone(),
                 headers: headers.clone(),
-                network_policy: self.network_policy.clone(),
             })
             .map_err(wasm_credential_provider_error)?;
 

--- a/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
+++ b/crates/ironclaw_wasm/tests/wasm_http_adapter_contract.rs
@@ -579,7 +579,14 @@ impl WasmRuntimeCredentialProvider for DestinationCredentialProvider {
         &self,
         request: &WasmRuntimeCredentialRequest,
     ) -> Result<Vec<RuntimeCredentialInjection>, WasmHostError> {
-        if request.url == self.approved_url {
+        let WasmRuntimeCredentialRequest {
+            scope: _,
+            capability_id: _,
+            method: _,
+            url,
+            headers: _,
+        } = request;
+        if url == &self.approved_url {
             Ok(vec![self.injection.clone()])
         } else {
             Ok(Vec::new())


### PR DESCRIPTION
## Summary
- remove the stale `network_policy` field from `WasmRuntimeCredentialRequest` so credential providers cannot drift from the staged runtime policy handoff
- add WASM/script/MCP adapter composition coverage through real `HostHttpEgressService + NetworkObligationPolicyStore`
- restore staged policy consumption before request validation so one-shot policy handoffs cannot be reused after pre-transport request failures

## Verification
- `cargo fmt --check`
- `cargo test -p ironclaw_wasm --test wasm_http_adapter_contract`
- `cargo test -p ironclaw_host_runtime --test runtime_http_egress_contract`
- `cargo check -p ironclaw_host_runtime -p ironclaw_wasm -p ironclaw_scripts -p ironclaw_mcp --all-targets`
- `cargo clippy -p ironclaw_host_runtime -p ironclaw_wasm -p ironclaw_scripts -p ironclaw_mcp --all-targets -- -D warnings`
- `git diff --check`
