### PR TITLE
fix(release): bump cargo-dist to 0.31.0 to fix installer (#2818)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ lto = "thin"
 # Config for 'dist'
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.3"
+cargo-dist-version = "0.31.0"
 # Ignore out-of-date generated CI so custom release.yml jobs are allowed
 allow-dirty = ["ci"]
 # CI backends to support


### PR DESCRIPTION
## Summary

Bumps cargo-dist from **0.30.3** to **0.31.0** in `Cargo.toml` and the bootstrap URL in `.github/workflows/release.yml`. Fixes #2818.

## Why

cargo-dist 0.30.3 generated broken installers for our namespaced release tags (\`ironclaw-v<version>\`):

1. **Wrong download URL**: hardcoded \`releases/download/v0.26.0\` instead of \`releases/download/ironclaw-v0.26.0\` → every artifact 404s.
2. **Missing target cases**: \`select_archive_for_arch\` and the \`\$platforms\` hashtable only contained Windows entries → installer errors out with \"there isn't a download for your platform x86_64-unknown-linux-gnu\" before it ever attempts a download.

Both bugs are reproducible in the published 0.26.0 and 0.27.0 installers (\`ironclaw-installer.sh\` line 38 and the \`select_archive_for_arch\` body).

## Verification

Ran cargo-dist 0.31.0 locally against this workspace:

\`\`\`
dist build --tag=ironclaw-v0.27.0 --artifacts=global --allow-dirty
\`\`\`

Produced an installer with:
- 4× \`releases/download/ironclaw-v0.27.0\` references in \`.sh\` and \`.ps1\`; **zero** stale \`v0.27.0\` URLs
- 11 cases in \`select_archive_for_arch\` (9 actual targets + 2 Windows fallbacks), with a \`check_glibc 2 31\` + musl fallback for Linux GNU
- 9 entries in the \`.ps1\` \`\$platforms\` hashtable

## Test plan

- [ ] Cut a test tag (e.g. \`ironclaw-v0.27.1-rc.1\`) on this branch and verify the resulting \`ironclaw-installer.sh\` contains \`releases/download/ironclaw-v0.27.1-rc.1\` and a case for \`x86_64-unknown-linux-gnu\`
- [ ] Run \`bash ironclaw-installer.sh\` on x86_64 glibc Linux end-to-end
- [ ] Smoke-check macOS (aarch64) and Windows installs still work