### PR TITLE
Legal harness — foundation: projects, documents, ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ dependencies = [
  "matchit 0.8.4",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -3926,6 +3927,7 @@ dependencies = [
  "postgres-types",
  "pretty_assertions",
  "pty-process",
+ "quick-xml",
  "rand 0.8.5",
  "readabilityrs",
  "refinery",
@@ -3964,6 +3966,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "ulid",
  "url",
  "urlencoding",
  "uuid",
@@ -4835,6 +4838,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -5891,6 +5911,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -8484,6 +8513,16 @@ dependencies = [
  "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ rustyline = { version = "17", features = ["custom-bindings", "derive", "with-fil
 termimad = "0.34"
 
 # Channel integrations
-axum = { version = "0.8", features = ["ws"] }
+axum = { version = "0.8", features = ["ws", "multipart"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors", "set-header", "catch-panic"] }
 
@@ -181,6 +181,14 @@ tar = "0.4"
 # Document text extraction
 pdf-extract = "0.7"
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# OOXML (DOCX) parsing for the legal harness skill — used to read `word/document.xml`
+# out of an uploaded .docx archive without pulling a heavyweight DOCX dep.
+quick-xml = "0.36"
+
+# Lexicographically sortable identifier for legal harness primary keys.
+# ULID is preferred over UUIDv4 here because the ids are surfaced in URLs
+# (`/api/skills/legal/projects/:id`) and creation-time sorting matters.
+ulid = "1"
 
 # HTTP proxy for sandboxed network access
 hyper = { version = "1.5", features = ["server", "http1", "http2"] }

--- a/migrations/V26__legal_harness.sql
+++ b/migrations/V26__legal_harness.sql
@@ -1,0 +1,56 @@
+-- V26: Legal harness — projects, documents, chats, messages.
+--
+-- Schema for the `legal` skill: a chat-with-legal-documents harness.
+-- See docs/legal-harness.md (forthcoming) and SKILL.md at skills/legal/SKILL.md.
+--
+-- Stream A (this migration) introduces all four tables. Streams B (chat) and
+-- C (DOCX export) consume the same shape; do not mutate this migration after
+-- merge — add a follow-up Vnn__legal_*.sql instead.
+--
+-- Schema parity: the libSQL backend mirrors this migration in
+-- src/db/libsql_migrations.rs (INCREMENTAL_MIGRATIONS entry version 26,
+-- "legal_harness"). Keep the two in sync when extending.
+
+CREATE TABLE legal_projects (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    deleted_at  BIGINT,
+    created_at  BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
+    metadata    TEXT
+);
+
+CREATE TABLE legal_documents (
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    filename        TEXT NOT NULL,
+    content_type    TEXT NOT NULL,
+    storage_path    TEXT NOT NULL,
+    extracted_text  TEXT,
+    page_count      INTEGER,
+    bytes           INTEGER NOT NULL,
+    sha256          TEXT NOT NULL,
+    uploaded_at     BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE INDEX idx_legal_documents_project ON legal_documents(project_id);
+CREATE INDEX idx_legal_documents_sha256  ON legal_documents(sha256);
+
+CREATE TABLE legal_chats (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    title       TEXT,
+    created_at  BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE INDEX idx_legal_chats_project ON legal_chats(project_id);
+
+CREATE TABLE legal_chat_messages (
+    id              TEXT PRIMARY KEY,
+    chat_id         TEXT NOT NULL REFERENCES legal_chats(id) ON DELETE CASCADE,
+    role            TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+    content         TEXT NOT NULL,
+    document_refs   TEXT,
+    created_at      BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
+);
+
+CREATE INDEX idx_legal_chat_messages_chat ON legal_chat_messages(chat_id);

--- a/migrations/V26__legal_harness.sql
+++ b/migrations/V26__legal_harness.sql
@@ -34,6 +34,14 @@ CREATE TABLE legal_documents (
 
 CREATE INDEX idx_legal_documents_project ON legal_documents(project_id);
 CREATE INDEX idx_legal_documents_sha256  ON legal_documents(sha256);
+-- Project-scoped sha dedupe: enforced at the DB layer to close the
+-- race between `find_document_by_sha` and `create_document` in the
+-- upload handler. Two concurrent uploads of identical bytes within the
+-- same project will see one INSERT succeed and the other return a
+-- constraint violation, which the handler then translates to the
+-- existing row.
+CREATE UNIQUE INDEX uq_legal_documents_project_sha
+    ON legal_documents(project_id, sha256);
 
 CREATE TABLE legal_chats (
     id          TEXT PRIMARY KEY,

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -38,3 +38,4 @@ V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
 V24__llm_calls_created_at_index = 2650126284755685421
 V25__wasm_fuel_limit_bump = 8924323300096627270
+V26__legal_harness = 16176153062706078877

--- a/skills/legal/SKILL.md
+++ b/skills/legal/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: legal
+version: "0.1.0"
+description: Project- and document-aware legal review. Upload PDFs/DOCX into a project, then chat about them with the agent. Companion streams add chat-with-docs and DOCX export.
+activation:
+  keywords:
+    - "legal"
+    - "contract"
+    - "agreement"
+    - "nda"
+    - "msa"
+    - "redline"
+    - "redlining"
+    - "review"
+    - "deal"
+    - "clause"
+    - "terms"
+    - "due diligence"
+    - "diligence"
+    - "lease"
+    - "loi"
+    - "memorandum"
+    - "term sheet"
+    - "indemnity"
+    - "warranty"
+    - "exhibit"
+    - "schedule"
+  exclude_keywords:
+    - "memory"
+    - "routine"
+  patterns:
+    - "(?i)\\b(review|redline|redrafting|markup)\\s+(this|the|my|our)?\\s*(contract|agreement|nda|msa|loi|term ?sheet|lease)\\b"
+    - "(?i)\\b(upload|attach|add)\\s+(a |the )?(pdf|docx|document|contract|agreement)\\b"
+    - "(?i)\\bexplain\\s+(clause|section|paragraph)\\s+\\w+"
+  tags:
+    - "legal"
+    - "documents"
+  max_context_tokens: 2000
+---
+
+# Legal Harness
+
+The legal skill is a project-aware document workspace. A **project** is a
+container for a transaction or matter (NDA, M&A deal, employment file,
+landlord/tenant case). Each project holds **documents** (PDF or DOCX),
+plus the **chats** the user has had about those documents.
+
+## When to use this skill
+
+Activate when the user wants to:
+
+- Review, redline, or summarise a contract / agreement / NDA / MSA / LOI /
+  term sheet / lease.
+- Upload one or more documents and ask questions about them.
+- Compare clauses, surface unusual terms, or extract obligations.
+- Continue a prior chat about a deal already in the workspace.
+
+Don't activate for memory operations, routine scheduling, or generic
+research — those are owned by other skills.
+
+## Capabilities (foundation, this PR)
+
+- Create / list / soft-delete a project.
+- Upload PDFs and DOCX into a project; the gateway extracts text inline,
+  computes a sha256, dedupes within the project, and stores the blob on
+  the local filesystem under the ironclaw data dir.
+- Fetch a project (with all its non-deleted documents joined) or a single
+  document (metadata + extracted text + raw bytes).
+
+## Capabilities (companion streams)
+
+- **Chat-with-docs (Stream B):** create a chat in a project, post a user
+  message, and receive a streamed (SSE) assistant reply. The assistant is
+  given the project's document text up to a configurable budget.
+- **DOCX export (Stream C):** render a chat thread (user + assistant
+  turns, with timestamps and document refs) into a downloadable `.docx`.
+
+## HTTP surface
+
+All routes live under the gateway's `/api/skills/legal/` prefix and
+require the standard ironclaw gateway token (the `Authorization: Bearer
+<token>` header set by `auth_middleware`).
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| POST | `/api/skills/legal/projects` | Create a project |
+| GET  | `/api/skills/legal/projects` | List active projects |
+| GET  | `/api/skills/legal/projects/:id` | Project + its documents |
+| DELETE | `/api/skills/legal/projects/:id` | Soft-delete a project |
+| POST | `/api/skills/legal/projects/:id/documents` | Upload (multipart) |
+| GET  | `/api/skills/legal/documents/:id` | Document metadata + text |
+| GET  | `/api/skills/legal/documents/:id/blob` | Raw document bytes |
+
+The **Chat** routes (`/api/skills/legal/projects/:id/chats`,
+`/api/skills/legal/chats/:id`, etc.) and the **DOCX export** route
+(`/api/skills/legal/chats/:id/export.docx`) ship in companion PRs against
+the same migration.
+
+## Storage
+
+- DB: ironclaw's libSQL/Turso embedded backend. v1 is libSQL-only; the
+  PostgreSQL backend has the matching schema migration but no Rust query
+  layer wired in yet (a 501 is returned).
+- Blobs: `<ironclaw_base_dir>/legal/blobs/<sha[0..2]>/<sha>` —
+  content-addressed; identical bytes share one file across projects.
+
+## Constraints
+
+- 10 MiB upload cap per file (the gateway's body limit applies an outer
+  14 MiB cap; the legal handler applies the tighter 10 MiB cap inline).
+- Supported formats: `application/pdf` and the OOXML mime
+  (`application/vnd.openxmlformats-officedocument.wordprocessingml.document`).
+- Project name ≤ 200 chars; metadata JSON ≤ 16 KiB.
+
+## Notes for the agent
+
+- Soft-deleted projects (those with a non-null `deleted_at`) are treated
+  as missing by every endpoint. There is no recovery path in v1; a deleted
+  project must be recreated.
+- Document upload is idempotent within a project: re-uploading the same
+  bytes returns the existing row instead of writing a duplicate.
+- The migration introduced here is canonical and shared with Streams B
+  and C. Do not propose schema changes from this skill — open a follow-up
+  issue.

--- a/src/channels/web/features/legal/blobs.rs
+++ b/src/channels/web/features/legal/blobs.rs
@@ -20,6 +20,22 @@ use tokio::io::AsyncReadExt;
 pub enum BlobError {
     #[error("blob i/o error: {0}")]
     Io(#[from] std::io::Error),
+    /// The supplied sha256 is not a 64-character lowercase hex string —
+    /// rejecting these closes a path-traversal channel via a tainted
+    /// `legal_documents.sha256` row.
+    #[error("invalid sha256 format (expected 64 lowercase hex chars)")]
+    InvalidSha256,
+}
+
+/// Returns true iff `s` is exactly 64 lowercase hex characters.
+///
+/// We use this on every blob path construction so a malicious or
+/// corrupted DB row can't direct a read at a relative or absolute path
+/// outside `<data_dir>/legal/blobs/`.
+fn is_valid_sha256_hex(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
 /// Compute a hex sha256 over the bytes.
@@ -37,17 +53,23 @@ pub fn blobs_root(data_dir: &Path) -> PathBuf {
 /// (`legal/blobs/<prefix>/<sha>`). Centralising this keeps callers from
 /// hand-rolling the layout.
 ///
-/// The sha is expected to be lowercase hex (64 chars). Anything shorter
-/// than 2 chars falls back to the literal sha as the prefix bucket so the
-/// caller cannot construct a path that escapes the blob root.
-pub fn relative_path(sha256: &str) -> PathBuf {
-    let prefix: &str = sha256.get(0..2).unwrap_or(sha256);
-    PathBuf::from("legal").join("blobs").join(prefix).join(sha256)
+/// The sha must be exactly 64 lowercase hex characters; anything else
+/// returns `BlobError::InvalidSha256`. Validating here is the
+/// path-traversal choke point.
+pub fn relative_path(sha256: &str) -> Result<PathBuf, BlobError> {
+    if !is_valid_sha256_hex(sha256) {
+        return Err(BlobError::InvalidSha256);
+    }
+    let prefix = &sha256[0..2];
+    Ok(PathBuf::from("legal")
+        .join("blobs")
+        .join(prefix)
+        .join(sha256))
 }
 
 /// Resolve the relative blob path against a data dir.
-pub fn absolute_path(data_dir: &Path, sha256: &str) -> PathBuf {
-    data_dir.join(relative_path(sha256))
+pub fn absolute_path(data_dir: &Path, sha256: &str) -> Result<PathBuf, BlobError> {
+    Ok(data_dir.join(relative_path(sha256)?))
 }
 
 /// Write bytes to the content-addressed blob path, creating directories as
@@ -56,32 +78,78 @@ pub fn absolute_path(data_dir: &Path, sha256: &str) -> PathBuf {
 ///
 /// Returns the relative path (the value to persist in
 /// `legal_documents.storage_path`).
+///
+/// Race-safe: two concurrent uploads of the same sha use unique tempfile
+/// names (random suffix + pid), so they never clobber each other's
+/// in-flight write. A second `rename` may fail because the destination
+/// already exists from the first writer; we treat that as success because
+/// content-addressing means both writers had byte-identical data.
 pub async fn write_blob(
     data_dir: &Path,
     sha256: &str,
     bytes: &[u8],
 ) -> Result<PathBuf, BlobError> {
-    let abs = absolute_path(data_dir, sha256);
+    let abs = absolute_path(data_dir, sha256)?;
+    let rel = relative_path(sha256)?;
     if let Some(parent) = abs.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
-    if !tokio::fs::try_exists(&abs).await? {
-        // Atomic-ish write: temp file in same dir, rename. Avoids a partial
-        // file becoming visible if the process is killed mid-write.
-        let tmp = abs.with_extension("tmp");
-        tokio::fs::write(&tmp, bytes).await?;
-        if let Err(e) = tokio::fs::rename(&tmp, &abs).await {
-            // Best-effort cleanup of the temp file; preserve the original error.
-            let _ = tokio::fs::remove_file(&tmp).await;
-            return Err(BlobError::Io(e));
+    if tokio::fs::try_exists(&abs).await? {
+        return Ok(rel);
+    }
+
+    // Unique tempfile per writer: random 8 bytes hex + pid, in the same
+    // directory as the destination so `rename` is atomic on POSIX.
+    let mut rand_suffix = [0u8; 8];
+    use rand::RngCore;
+    rand::thread_rng().fill_bytes(&mut rand_suffix);
+    let tmp_name = format!(
+        "{}.{}.{}.tmp",
+        sha256,
+        std::process::id(),
+        hex_short(&rand_suffix),
+    );
+    let tmp = abs
+        .parent()
+        .map(|p| p.join(&tmp_name))
+        .unwrap_or_else(|| PathBuf::from(&tmp_name));
+
+    tokio::fs::write(&tmp, bytes).await?;
+    match tokio::fs::rename(&tmp, &abs).await {
+        Ok(()) => Ok(rel),
+        Err(e) => {
+            // If the destination now exists (a concurrent writer beat
+            // us), treat that as success — the bytes are the same.
+            if tokio::fs::try_exists(&abs).await.unwrap_or(false) {
+                let _ = tokio::fs::remove_file(&tmp).await;
+                Ok(rel)
+            } else {
+                let _ = tokio::fs::remove_file(&tmp).await;
+                Err(BlobError::Io(e))
+            }
         }
     }
-    Ok(relative_path(sha256))
+}
+
+fn hex_short(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
 }
 
 /// Read a blob from disk. Used by `GET /skills/legal/documents/:id/blob`.
+///
+/// The sha is validated as 64 lowercase hex chars before any path
+/// construction; an invalid sha (e.g. an attacker who managed to write a
+/// crafted row into `legal_documents.sha256` with a relative-traversal
+/// payload) returns `BlobError::InvalidSha256` rather than reaching the
+/// filesystem.
 pub async fn read_blob(data_dir: &Path, sha256: &str) -> Result<Vec<u8>, BlobError> {
-    let abs = absolute_path(data_dir, sha256);
+    let abs = absolute_path(data_dir, sha256)?;
     let mut file = tokio::fs::File::open(&abs).await?;
     let mut buf = Vec::new();
     file.read_to_end(&mut buf).await?;
@@ -114,17 +182,41 @@ mod tests {
     }
 
     #[test]
-    fn relative_path_uses_sha_prefix() {
-        let p = relative_path("abcdef0123456789");
-        assert_eq!(p, PathBuf::from("legal").join("blobs").join("ab").join("abcdef0123456789"));
+    fn relative_path_uses_sha_prefix_for_valid_input() {
+        let valid = "ab".repeat(32); // 64 hex chars
+        let p = relative_path(&valid).expect("valid sha");
+        assert_eq!(
+            p,
+            PathBuf::from("legal").join("blobs").join("ab").join(&valid)
+        );
     }
 
     #[test]
-    fn relative_path_short_sha_falls_back_safely() {
-        // A degenerate caller could pass a single-char sha; the path must
-        // still be within `legal/blobs/`, never traversal-prone.
-        let p = relative_path("x");
-        assert!(p.starts_with("legal/blobs"));
+    fn relative_path_rejects_short_sha() {
+        let err = relative_path("abc").unwrap_err();
+        assert!(matches!(err, BlobError::InvalidSha256));
+    }
+
+    #[test]
+    fn relative_path_rejects_uppercase_hex() {
+        let bad = "AB".repeat(32);
+        let err = relative_path(&bad).unwrap_err();
+        assert!(matches!(err, BlobError::InvalidSha256));
+    }
+
+    #[test]
+    fn relative_path_rejects_path_traversal_in_sha() {
+        // A tainted DB row containing `../../etc/passwd` must not be
+        // turned into a real path.
+        let err = relative_path("../../etc/passwd").unwrap_err();
+        assert!(matches!(err, BlobError::InvalidSha256));
+    }
+
+    #[test]
+    fn relative_path_rejects_non_hex_chars() {
+        let bad = "z".repeat(64);
+        let err = relative_path(&bad).unwrap_err();
+        assert!(matches!(err, BlobError::InvalidSha256));
     }
 
     #[tokio::test]
@@ -134,7 +226,7 @@ mod tests {
         let sha = sha256_hex(&bytes);
 
         let rel = write_blob(dir.path(), &sha, &bytes).await.expect("write");
-        assert_eq!(rel, relative_path(&sha));
+        assert_eq!(rel, relative_path(&sha).expect("valid sha"));
 
         let got = read_blob(dir.path(), &sha).await.expect("read");
         assert_eq!(got, bytes);
@@ -144,5 +236,12 @@ mod tests {
             .await
             .expect("re-write");
         assert_eq!(rel2, rel);
+    }
+
+    #[tokio::test]
+    async fn read_blob_rejects_traversal_sha() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = read_blob(dir.path(), "../../etc/passwd").await.unwrap_err();
+        assert!(matches!(err, BlobError::InvalidSha256));
     }
 }

--- a/src/channels/web/features/legal/blobs.rs
+++ b/src/channels/web/features/legal/blobs.rs
@@ -1,0 +1,148 @@
+//! Filesystem blob storage for legal documents.
+//!
+//! Files live under `<data_dir>/legal/blobs/<sha2[0..2]>/<sha256>`. Storage
+//! is content-addressed: identical bytes share a single on-disk file even
+//! if a project re-uploads them under a different filename.
+//!
+//! Per the spec, dedupe keys are scoped to a single project at the SQL
+//! layer (`legal_documents.project_id` + `legal_documents.sha256`). The
+//! filesystem layout intentionally does *not* segment by project, so
+//! cross-project content reuse still benefits from a single blob on
+//! disk; only the row-level dedupe is project-scoped.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
+
+/// Errors raised by blob operations.
+#[derive(Debug, thiserror::Error)]
+pub enum BlobError {
+    #[error("blob i/o error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Compute a hex sha256 over the bytes.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    hex_encode(&digest)
+}
+
+/// Return the directory under the data dir where legal blobs live.
+pub fn blobs_root(data_dir: &Path) -> PathBuf {
+    data_dir.join("legal").join("blobs")
+}
+
+/// Build the relative storage path stored in the DB
+/// (`legal/blobs/<prefix>/<sha>`). Centralising this keeps callers from
+/// hand-rolling the layout.
+///
+/// The sha is expected to be lowercase hex (64 chars). Anything shorter
+/// than 2 chars falls back to the literal sha as the prefix bucket so the
+/// caller cannot construct a path that escapes the blob root.
+pub fn relative_path(sha256: &str) -> PathBuf {
+    let prefix: &str = sha256.get(0..2).unwrap_or(sha256);
+    PathBuf::from("legal").join("blobs").join(prefix).join(sha256)
+}
+
+/// Resolve the relative blob path against a data dir.
+pub fn absolute_path(data_dir: &Path, sha256: &str) -> PathBuf {
+    data_dir.join(relative_path(sha256))
+}
+
+/// Write bytes to the content-addressed blob path, creating directories as
+/// needed. If the file already exists it is left untouched (content is, by
+/// definition, identical for the same sha).
+///
+/// Returns the relative path (the value to persist in
+/// `legal_documents.storage_path`).
+pub async fn write_blob(
+    data_dir: &Path,
+    sha256: &str,
+    bytes: &[u8],
+) -> Result<PathBuf, BlobError> {
+    let abs = absolute_path(data_dir, sha256);
+    if let Some(parent) = abs.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    if !tokio::fs::try_exists(&abs).await? {
+        // Atomic-ish write: temp file in same dir, rename. Avoids a partial
+        // file becoming visible if the process is killed mid-write.
+        let tmp = abs.with_extension("tmp");
+        tokio::fs::write(&tmp, bytes).await?;
+        if let Err(e) = tokio::fs::rename(&tmp, &abs).await {
+            // Best-effort cleanup of the temp file; preserve the original error.
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(BlobError::Io(e));
+        }
+    }
+    Ok(relative_path(sha256))
+}
+
+/// Read a blob from disk. Used by `GET /skills/legal/documents/:id/blob`.
+pub async fn read_blob(data_dir: &Path, sha256: &str) -> Result<Vec<u8>, BlobError> {
+    let abs = absolute_path(data_dir, sha256);
+    let mut file = tokio::fs::File::open(&abs).await?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).await?;
+    Ok(buf)
+}
+
+/// Lower-case hex encoding without pulling another dep just for this.
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_known_vector() {
+        // RFC 6234 test: sha256("abc") == ba7816bf8f01cfea4141...
+        let h = sha256_hex(b"abc");
+        assert_eq!(
+            h,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn relative_path_uses_sha_prefix() {
+        let p = relative_path("abcdef0123456789");
+        assert_eq!(p, PathBuf::from("legal").join("blobs").join("ab").join("abcdef0123456789"));
+    }
+
+    #[test]
+    fn relative_path_short_sha_falls_back_safely() {
+        // A degenerate caller could pass a single-char sha; the path must
+        // still be within `legal/blobs/`, never traversal-prone.
+        let p = relative_path("x");
+        assert!(p.starts_with("legal/blobs"));
+    }
+
+    #[tokio::test]
+    async fn write_then_read_roundtrip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bytes = b"hello world".to_vec();
+        let sha = sha256_hex(&bytes);
+
+        let rel = write_blob(dir.path(), &sha, &bytes).await.expect("write");
+        assert_eq!(rel, relative_path(&sha));
+
+        let got = read_blob(dir.path(), &sha).await.expect("read");
+        assert_eq!(got, bytes);
+
+        // Re-writing identical bytes is a no-op (file already exists path).
+        let rel2 = write_blob(dir.path(), &sha, &bytes)
+            .await
+            .expect("re-write");
+        assert_eq!(rel2, rel);
+    }
+}

--- a/src/channels/web/features/legal/blobs.rs
+++ b/src/channels/web/features/legal/blobs.rs
@@ -45,6 +45,7 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 }
 
 /// Return the directory under the data dir where legal blobs live.
+#[allow(dead_code)]
 pub fn blobs_root(data_dir: &Path) -> PathBuf {
     data_dir.join("legal").join("blobs")
 }
@@ -84,11 +85,7 @@ pub fn absolute_path(data_dir: &Path, sha256: &str) -> Result<PathBuf, BlobError
 /// in-flight write. A second `rename` may fail because the destination
 /// already exists from the first writer; we treat that as success because
 /// content-addressing means both writers had byte-identical data.
-pub async fn write_blob(
-    data_dir: &Path,
-    sha256: &str,
-    bytes: &[u8],
-) -> Result<PathBuf, BlobError> {
+pub async fn write_blob(data_dir: &Path, sha256: &str, bytes: &[u8]) -> Result<PathBuf, BlobError> {
     let abs = absolute_path(data_dir, sha256)?;
     let rel = relative_path(sha256)?;
     if let Some(parent) = abs.parent() {

--- a/src/channels/web/features/legal/extract.rs
+++ b/src/channels/web/features/legal/extract.rs
@@ -104,17 +104,48 @@ fn count_pdf_pages(bytes: &[u8]) -> Option<i64> {
     if pages > 0 { Some(pages + 1) } else { None }
 }
 
+/// Hard cap for the decompressed `word/document.xml` payload.
+///
+/// 32 MiB is well above any normal contract DOCX (typical: 100 KB-2 MB)
+/// but stops a 1 KB zip bomb from inflating to gigabytes inside an async
+/// worker. The cap is intentionally generous so we don't reject genuine
+/// long contracts; tighter limits can be plumbed in via config later.
+const DOCX_XML_MAX_BYTES: u64 = 32 * 1024 * 1024;
+
 async fn extract_docx(bytes: Vec<u8>) -> Result<Extracted, ExtractError> {
     let join = tokio::task::spawn_blocking(move || -> Result<Extracted, ExtractError> {
         let cursor = std::io::Cursor::new(&bytes);
         let mut zip = zip::ZipArchive::new(cursor)
             .map_err(|e| ExtractError::Docx(format!("zip open: {e}")))?;
-        let mut file = zip
+        let file = zip
             .by_name("word/document.xml")
             .map_err(|e| ExtractError::Docx(format!("missing word/document.xml: {e}")))?;
-        let mut xml = String::new();
-        file.read_to_string(&mut xml)
+
+        // Defensive: reject zip bombs by checking the declared
+        // uncompressed size before reading. Some malicious archives lie
+        // about `size()`, so we *also* cap the actual read via `take()`.
+        let declared = file.size();
+        if declared > DOCX_XML_MAX_BYTES {
+            return Err(ExtractError::Docx(format!(
+                "declared word/document.xml size {declared} exceeds cap {DOCX_XML_MAX_BYTES}"
+            )));
+        }
+
+        // Cap the actual read at the same limit + 1; any byte above the
+        // cap is a lying header and we abort.
+        let mut limited = file.take(DOCX_XML_MAX_BYTES.saturating_add(1));
+        let mut xml_bytes = Vec::with_capacity(declared as usize);
+        limited
+            .read_to_end(&mut xml_bytes)
             .map_err(|e| ExtractError::Docx(format!("read document.xml: {e}")))?;
+        if xml_bytes.len() as u64 > DOCX_XML_MAX_BYTES {
+            return Err(ExtractError::Docx(format!(
+                "decompressed word/document.xml exceeds cap {DOCX_XML_MAX_BYTES}"
+            )));
+        }
+        let xml = String::from_utf8(xml_bytes)
+            .map_err(|e| ExtractError::Docx(format!("document.xml utf-8: {e}")))?;
+
         let text = xml_to_text(&xml)?;
         Ok(Extracted {
             text: normalise_whitespace(&text),

--- a/src/channels/web/features/legal/extract.rs
+++ b/src/channels/web/features/legal/extract.rs
@@ -37,7 +37,11 @@ pub enum ExtractError {
 
 /// Probe the bytes/declared content type and pick a parser. Falls back to
 /// magic-byte sniffing when the client lies about the mime.
-pub async fn extract(content_type: &str, filename: &str, bytes: &[u8]) -> Result<Extracted, ExtractError> {
+pub async fn extract(
+    content_type: &str,
+    filename: &str,
+    bytes: &[u8],
+) -> Result<Extracted, ExtractError> {
     let kind = sniff(content_type, filename, bytes);
     match kind {
         DocKind::Pdf => extract_pdf(bytes.to_vec()).await,
@@ -56,30 +60,29 @@ enum DocKind {
 }
 
 const PDF_MAGIC: &[u8] = b"%PDF-";
-const ZIP_MAGIC: &[u8] = b"PK\x03\x04";
 
 fn sniff(content_type: &str, filename: &str, bytes: &[u8]) -> DocKind {
-    let ext = filename.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+    let ext = filename
+        .rsplit('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
     let ct = content_type.trim().to_ascii_lowercase();
 
     if bytes.starts_with(PDF_MAGIC) || ct == "application/pdf" || ext == "pdf" {
         return DocKind::Pdf;
     }
-    let docx_ct =
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-    if ct == docx_ct
-        || ext == "docx"
-        // OOXML packages are zip archives: trust the extension/mime and
-        // verify the zip signature, but never trust an arbitrary zip.
-        || (bytes.starts_with(ZIP_MAGIC) && (ext == "docx" || ct == docx_ct))
-    {
+    let docx_ct = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    // OOXML packages are zip archives, but we never trust an arbitrary zip
+    // — match only when the caller has declared docx via mime or extension.
+    if ct == docx_ct || ext == "docx" {
         return DocKind::Docx;
     }
     DocKind::Unknown
 }
 
 async fn extract_pdf(bytes: Vec<u8>) -> Result<Extracted, ExtractError> {
-    let join = tokio::task::spawn_blocking(move || -> Result<Extracted, ExtractError> {
+    tokio::task::spawn_blocking(move || -> Result<Extracted, ExtractError> {
         let text = pdf_extract::extract_text_from_mem(&bytes)
             .map_err(|e| ExtractError::Pdf(e.to_string()))?;
         let page_count = count_pdf_pages(&bytes);
@@ -88,8 +91,7 @@ async fn extract_pdf(bytes: Vec<u8>) -> Result<Extracted, ExtractError> {
             page_count,
         })
     })
-    .await?;
-    join
+    .await?
 }
 
 /// Best-effort page-count using `pdf-extract`'s public API. The crate
@@ -113,7 +115,7 @@ fn count_pdf_pages(bytes: &[u8]) -> Option<i64> {
 const DOCX_XML_MAX_BYTES: u64 = 32 * 1024 * 1024;
 
 async fn extract_docx(bytes: Vec<u8>) -> Result<Extracted, ExtractError> {
-    let join = tokio::task::spawn_blocking(move || -> Result<Extracted, ExtractError> {
+    tokio::task::spawn_blocking(move || -> Result<Extracted, ExtractError> {
         let cursor = std::io::Cursor::new(&bytes);
         let mut zip = zip::ZipArchive::new(cursor)
             .map_err(|e| ExtractError::Docx(format!("zip open: {e}")))?;
@@ -152,16 +154,15 @@ async fn extract_docx(bytes: Vec<u8>) -> Result<Extracted, ExtractError> {
             page_count: None,
         })
     })
-    .await?;
-    join
+    .await?
 }
 
 /// Walk `word/document.xml` and concatenate the text inside `<w:t>` runs.
 /// Paragraph breaks (`<w:p>` end) become blank lines so downstream RAG
 /// chunks line up with logical paragraphs.
 fn xml_to_text(xml: &str) -> Result<String, ExtractError> {
-    use quick_xml::events::Event;
     use quick_xml::Reader;
+    use quick_xml::events::Event;
 
     let mut reader = Reader::from_str(xml);
     reader.config_mut().trim_text(false);
@@ -259,7 +260,10 @@ mod tests {
     #[test]
     fn sniff_prefers_pdf_magic() {
         let bytes = b"%PDF-1.5\n...";
-        assert_eq!(sniff("application/octet-stream", "x.bin", bytes), DocKind::Pdf);
+        assert_eq!(
+            sniff("application/octet-stream", "x.bin", bytes),
+            DocKind::Pdf
+        );
     }
 
     #[test]

--- a/src/channels/web/features/legal/extract.rs
+++ b/src/channels/web/features/legal/extract.rs
@@ -1,0 +1,265 @@
+//! Inline text extraction for uploaded PDFs and DOCX files.
+//!
+//! Both extractors run synchronously on the request thread today, wrapped
+//! in `tokio::task::spawn_blocking` so the async runtime stays responsive.
+//! For very large uploads the gateway's body-size cap (14 MiB by default)
+//! puts a ceiling on the time budget; a follow-up could move extraction
+//! to a worker queue.
+//!
+//! No `unwrap` in the data path — every PDF/DOCX parser failure surfaces
+//! as `ExtractError::Pdf` / `ExtractError::Docx`, which the upload
+//! handler converts to a 422 with the underlying message.
+
+use std::io::Read;
+
+/// Result of a successful text extraction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Extracted {
+    pub text: String,
+    /// Page count if the format exposes one (PDF). `None` for DOCX where
+    /// pagination is layout-driven and not stored in the source XML.
+    pub page_count: Option<i64>,
+}
+
+/// Extraction errors. Distinct variants per format so handlers can produce
+/// a clear error message without doing `dyn Error` introspection.
+#[derive(Debug, thiserror::Error)]
+pub enum ExtractError {
+    #[error("PDF extraction failed: {0}")]
+    Pdf(String),
+    #[error("DOCX extraction failed: {0}")]
+    Docx(String),
+    #[error("unsupported document type: {0}")]
+    Unsupported(String),
+    #[error("blocking task join error: {0}")]
+    Join(#[from] tokio::task::JoinError),
+}
+
+/// Probe the bytes/declared content type and pick a parser. Falls back to
+/// magic-byte sniffing when the client lies about the mime.
+pub async fn extract(content_type: &str, filename: &str, bytes: &[u8]) -> Result<Extracted, ExtractError> {
+    let kind = sniff(content_type, filename, bytes);
+    match kind {
+        DocKind::Pdf => extract_pdf(bytes.to_vec()).await,
+        DocKind::Docx => extract_docx(bytes.to_vec()).await,
+        DocKind::Unknown => Err(ExtractError::Unsupported(format!(
+            "filename={filename} content_type={content_type}"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DocKind {
+    Pdf,
+    Docx,
+    Unknown,
+}
+
+const PDF_MAGIC: &[u8] = b"%PDF-";
+const ZIP_MAGIC: &[u8] = b"PK\x03\x04";
+
+fn sniff(content_type: &str, filename: &str, bytes: &[u8]) -> DocKind {
+    let ext = filename.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
+    let ct = content_type.trim().to_ascii_lowercase();
+
+    if bytes.starts_with(PDF_MAGIC) || ct == "application/pdf" || ext == "pdf" {
+        return DocKind::Pdf;
+    }
+    let docx_ct =
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    if ct == docx_ct
+        || ext == "docx"
+        // OOXML packages are zip archives: trust the extension/mime and
+        // verify the zip signature, but never trust an arbitrary zip.
+        || (bytes.starts_with(ZIP_MAGIC) && (ext == "docx" || ct == docx_ct))
+    {
+        return DocKind::Docx;
+    }
+    DocKind::Unknown
+}
+
+async fn extract_pdf(bytes: Vec<u8>) -> Result<Extracted, ExtractError> {
+    let join = tokio::task::spawn_blocking(move || -> Result<Extracted, ExtractError> {
+        let text = pdf_extract::extract_text_from_mem(&bytes)
+            .map_err(|e| ExtractError::Pdf(e.to_string()))?;
+        let page_count = count_pdf_pages(&bytes);
+        Ok(Extracted {
+            text: normalise_whitespace(&text),
+            page_count,
+        })
+    })
+    .await?;
+    join
+}
+
+/// Best-effort page-count using `pdf-extract`'s public API. The crate
+/// exposes per-page extraction; if that fails we just return `None` so the
+/// upload still succeeds with text.
+fn count_pdf_pages(bytes: &[u8]) -> Option<i64> {
+    // `pdf-extract` doesn't currently expose a public page-count helper, so
+    // we fall back to counting `\f` (form-feed) markers it inserts between
+    // pages in the extracted text. Empty/garbled PDFs produce `None`.
+    let extracted = pdf_extract::extract_text_from_mem(bytes).ok()?;
+    let pages = extracted.matches('\u{000C}').count() as i64;
+    if pages > 0 { Some(pages + 1) } else { None }
+}
+
+async fn extract_docx(bytes: Vec<u8>) -> Result<Extracted, ExtractError> {
+    let join = tokio::task::spawn_blocking(move || -> Result<Extracted, ExtractError> {
+        let cursor = std::io::Cursor::new(&bytes);
+        let mut zip = zip::ZipArchive::new(cursor)
+            .map_err(|e| ExtractError::Docx(format!("zip open: {e}")))?;
+        let mut file = zip
+            .by_name("word/document.xml")
+            .map_err(|e| ExtractError::Docx(format!("missing word/document.xml: {e}")))?;
+        let mut xml = String::new();
+        file.read_to_string(&mut xml)
+            .map_err(|e| ExtractError::Docx(format!("read document.xml: {e}")))?;
+        let text = xml_to_text(&xml)?;
+        Ok(Extracted {
+            text: normalise_whitespace(&text),
+            page_count: None,
+        })
+    })
+    .await?;
+    join
+}
+
+/// Walk `word/document.xml` and concatenate the text inside `<w:t>` runs.
+/// Paragraph breaks (`<w:p>` end) become blank lines so downstream RAG
+/// chunks line up with logical paragraphs.
+fn xml_to_text(xml: &str) -> Result<String, ExtractError> {
+    use quick_xml::events::Event;
+    use quick_xml::Reader;
+
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+
+    let mut buf = Vec::new();
+    let mut out = String::new();
+    let mut in_text = false;
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Eof) => break,
+            Ok(Event::Start(e)) => {
+                if e.name().as_ref() == b"w:t" {
+                    in_text = true;
+                }
+            }
+            Ok(Event::End(e)) => {
+                let name = e.name();
+                let bytes = name.as_ref();
+                if bytes == b"w:t" {
+                    in_text = false;
+                } else if bytes == b"w:p" {
+                    out.push('\n');
+                } else if bytes == b"w:tab" || bytes == b"w:br" {
+                    out.push(' ');
+                }
+            }
+            Ok(Event::Empty(e)) => {
+                let name = e.name();
+                let bytes = name.as_ref();
+                if bytes == b"w:tab" {
+                    out.push('\t');
+                } else if bytes == b"w:br" {
+                    out.push('\n');
+                }
+            }
+            Ok(Event::Text(t)) => {
+                if in_text {
+                    let unescaped = t
+                        .unescape()
+                        .map_err(|e| ExtractError::Docx(format!("xml unescape: {e}")))?;
+                    out.push_str(&unescaped);
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                return Err(ExtractError::Docx(format!(
+                    "xml parse error at pos {}: {e}",
+                    reader.buffer_position()
+                )));
+            }
+        }
+        buf.clear();
+    }
+
+    Ok(out)
+}
+
+/// Collapse runs of whitespace into a single space, but keep newline
+/// boundaries — they're cheap signal for LLM chunking.
+fn normalise_whitespace(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = false;
+    for ch in s.chars() {
+        if ch == '\n' {
+            // Preserve paragraph breaks; collapse adjacent spaces before/after.
+            while out.ends_with(' ') {
+                out.pop();
+            }
+            out.push('\n');
+            prev_space = false;
+            continue;
+        }
+        if ch.is_whitespace() {
+            if !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        } else {
+            out.push(ch);
+            prev_space = false;
+        }
+    }
+    // Trim trailing whitespace runs.
+    while matches!(out.chars().last(), Some(' ') | Some('\n')) {
+        out.pop();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sniff_prefers_pdf_magic() {
+        let bytes = b"%PDF-1.5\n...";
+        assert_eq!(sniff("application/octet-stream", "x.bin", bytes), DocKind::Pdf);
+    }
+
+    #[test]
+    fn sniff_uses_extension_for_docx() {
+        let bytes = b"PK\x03\x04";
+        assert_eq!(sniff("application/zip", "x.docx", bytes), DocKind::Docx);
+    }
+
+    #[test]
+    fn sniff_unknown_for_random() {
+        assert_eq!(sniff("text/plain", "notes.txt", b"hello"), DocKind::Unknown);
+    }
+
+    #[test]
+    fn xml_to_text_extracts_runs() {
+        let xml = r#"<?xml version="1.0"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t>Hello</w:t></w:r><w:r><w:t xml:space="preserve"> world</w:t></w:r></w:p>
+    <w:p><w:r><w:t>Second &amp; line</w:t></w:r></w:p>
+  </w:body>
+</w:document>"#;
+        let got = xml_to_text(xml).expect("xml ok");
+        let normalised = normalise_whitespace(&got);
+        assert!(normalised.contains("Hello world"));
+        assert!(normalised.contains("Second & line"));
+    }
+
+    #[test]
+    fn normalise_collapses_runs() {
+        let s = "hello    world\n\n   second\n";
+        assert_eq!(normalise_whitespace(s), "hello world\n\nsecond");
+    }
+}

--- a/src/channels/web/features/legal/extract.rs
+++ b/src/channels/web/features/legal/extract.rs
@@ -229,11 +229,13 @@ fn normalise_whitespace(s: &str) -> String {
     for ch in s.chars() {
         if ch == '\n' {
             // Preserve paragraph breaks; collapse adjacent spaces before/after.
+            // Set prev_space=true so any whitespace that follows the newline
+            // is absorbed rather than re-emitted as a leading space.
             while out.ends_with(' ') {
                 out.pop();
             }
             out.push('\n');
-            prev_space = false;
+            prev_space = true;
             continue;
         }
         if ch.is_whitespace() {

--- a/src/channels/web/features/legal/handlers.rs
+++ b/src/channels/web/features/legal/handlers.rs
@@ -1,0 +1,373 @@
+//! Axum handlers for the legal harness skill.
+//!
+//! These handlers own the project + document lifecycle. They do not yet
+//! touch chats or chat messages — Streams B (chat-with-docs) and C (DOCX
+//! export) layer those endpoints on top of the same migration.
+//!
+//! Auth: every handler is composed onto the `protected` router in
+//! `src/channels/web/platform/router.rs` which already enforces the
+//! gateway token via `auth_middleware`. The `AuthenticatedUser` extractor
+//! is declared on each handler so accidental removal of the route
+//! grouping fails the request rather than silently exposing the surface.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    body::Body,
+    extract::{Multipart, Path, State},
+    http::{StatusCode, header},
+    response::Response,
+};
+use serde::Serialize;
+
+use crate::channels::web::auth::AuthenticatedUser;
+use crate::channels::web::platform::state::GatewayState;
+use crate::error::DatabaseError;
+
+use super::blobs;
+use super::extract;
+use super::models::{
+    CreateProjectRequest, DocumentDetailResponse, DocumentResponse, LegalDocument, LegalProject,
+    ProjectDetailResponse, ProjectListResponse,
+};
+use super::store;
+
+/// Maximum size of an uploaded legal document, in bytes (10 MiB).
+///
+/// Smaller than the gateway's global 14 MiB body cap so the multipart
+/// envelope (boundaries, JSON parts) has headroom.
+const MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+
+/// Maximum length of a project name.
+const MAX_PROJECT_NAME: usize = 200;
+
+/// Maximum bytes of metadata JSON we'll persist on a project.
+///
+/// Schema doesn't enforce a cap; this prevents a 10 MB metadata payload
+/// from filling the row.
+const MAX_METADATA_BYTES: usize = 16 * 1024;
+
+/// Common error body returned on failures.
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+fn err(status: StatusCode, msg: impl Into<String>) -> (StatusCode, Json<ErrorBody>) {
+    (status, Json(ErrorBody { error: msg.into() }))
+}
+
+fn db_err(context: &str, e: DatabaseError) -> (StatusCode, Json<ErrorBody>) {
+    match e {
+        DatabaseError::Unsupported(_) => err(
+            StatusCode::NOT_IMPLEMENTED,
+            format!("{context}: {e}"),
+        ),
+        DatabaseError::NotFound { .. } => err(StatusCode::NOT_FOUND, format!("{context}: {e}")),
+        _ => err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("{context}: {e}"),
+        ),
+    }
+}
+
+fn require_db(
+    state: &Arc<GatewayState>,
+) -> Result<&Arc<dyn crate::db::Database>, (StatusCode, Json<ErrorBody>)> {
+    state.store.as_ref().ok_or_else(|| {
+        err(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Database not available".to_string(),
+        )
+    })
+}
+
+fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// `POST /api/skills/legal/projects` — create a new project.
+pub async fn create_project_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    Json(req): Json<CreateProjectRequest>,
+) -> Result<Json<LegalProject>, (StatusCode, Json<ErrorBody>)> {
+    let name = req.name.trim();
+    if name.is_empty() {
+        return Err(err(StatusCode::BAD_REQUEST, "project name is required"));
+    }
+    if name.len() > MAX_PROJECT_NAME {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            format!("project name exceeds {MAX_PROJECT_NAME} chars"),
+        ));
+    }
+
+    let metadata = match req.metadata {
+        None => None,
+        Some(serde_json::Value::Null) => None,
+        Some(v) => {
+            let s = serde_json::to_string(&v).map_err(|e| {
+                err(
+                    StatusCode::BAD_REQUEST,
+                    format!("invalid metadata json: {e}"),
+                )
+            })?;
+            if s.len() > MAX_METADATA_BYTES {
+                return Err(err(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    format!("metadata exceeds {MAX_METADATA_BYTES} bytes"),
+                ));
+            }
+            Some(s)
+        }
+    };
+
+    let db = require_db(&state)?;
+    let id = ulid::Ulid::new().to_string();
+    let project = store::create_project(db, &id, name, metadata.as_deref())
+        .await
+        .map_err(|e| db_err("create_project", e))?;
+
+    Ok(Json(project))
+}
+
+/// `GET /api/skills/legal/projects` — list active projects.
+pub async fn list_projects_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(_user): AuthenticatedUser,
+) -> Result<Json<ProjectListResponse>, (StatusCode, Json<ErrorBody>)> {
+    let db = require_db(&state)?;
+    let projects = store::list_active_projects(db)
+        .await
+        .map_err(|e| db_err("list_projects", e))?;
+    let count = projects.len();
+    Ok(Json(ProjectListResponse { projects, count }))
+}
+
+/// `GET /api/skills/legal/projects/:id` — project + its documents.
+pub async fn get_project_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<Json<ProjectDetailResponse>, (StatusCode, Json<ErrorBody>)> {
+    let db = require_db(&state)?;
+    let project = store::fetch_project(db, &id)
+        .await
+        .map_err(|e| db_err("fetch_project", e))?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, format!("project {id} not found")))?;
+    if project.deleted_at.is_some() {
+        return Err(err(
+            StatusCode::NOT_FOUND,
+            format!("project {id} has been deleted"),
+        ));
+    }
+    let documents = store::list_documents_for_project(db, &id)
+        .await
+        .map_err(|e| db_err("list_documents", e))?;
+    Ok(Json(ProjectDetailResponse { project, documents }))
+}
+
+/// `DELETE /api/skills/legal/projects/:id` — soft delete.
+pub async fn delete_project_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorBody>)> {
+    let db = require_db(&state)?;
+    let updated = store::soft_delete_project(db, &id, now_unix())
+        .await
+        .map_err(|e| db_err("soft_delete_project", e))?;
+    if !updated {
+        return Err(err(
+            StatusCode::NOT_FOUND,
+            format!("project {id} not found or already deleted"),
+        ));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /api/skills/legal/projects/:id/documents` — multipart upload,
+/// extract text, persist blob + row.
+///
+/// The multipart envelope expects exactly one field named `file` (matching
+/// mike's wire shape — the field *name* is not copyrightable code). All
+/// other field names are ignored to allow front-ends to layer extra
+/// metadata fields without breaking the parser.
+pub async fn upload_document_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    Path(project_id): Path<String>,
+    mut multipart: Multipart,
+) -> Result<Json<DocumentResponse>, (StatusCode, Json<ErrorBody>)> {
+    let db = require_db(&state)?;
+
+    // Verify project exists and isn't soft-deleted before reading the body
+    // so a misaddressed upload fails fast.
+    let project = store::fetch_project(db, &project_id)
+        .await
+        .map_err(|e| db_err("fetch_project", e))?
+        .ok_or_else(|| {
+            err(
+                StatusCode::NOT_FOUND,
+                format!("project {project_id} not found"),
+            )
+        })?;
+    if project.deleted_at.is_some() {
+        return Err(err(
+            StatusCode::CONFLICT,
+            format!("project {project_id} has been deleted"),
+        ));
+    }
+
+    let mut filename: Option<String> = None;
+    let mut content_type: Option<String> = None;
+    let mut bytes: Option<Vec<u8>> = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| err(StatusCode::BAD_REQUEST, format!("multipart read: {e}")))?
+    {
+        let name = field.name().unwrap_or("").to_string();
+        if name != "file" {
+            // Ignore extra metadata fields to keep the parser permissive.
+            continue;
+        }
+        filename = field.file_name().map(str::to_string);
+        content_type = field.content_type().map(str::to_string);
+        let data = field
+            .bytes()
+            .await
+            .map_err(|e| err(StatusCode::BAD_REQUEST, format!("read multipart body: {e}")))?
+            .to_vec();
+        if data.len() > MAX_UPLOAD_BYTES {
+            return Err(err(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!("upload exceeds {MAX_UPLOAD_BYTES} bytes"),
+            ));
+        }
+        bytes = Some(data);
+        break;
+    }
+
+    let bytes = bytes.ok_or_else(|| err(StatusCode::BAD_REQUEST, "missing file field"))?;
+    let filename = filename
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| err(StatusCode::BAD_REQUEST, "missing filename"))?;
+    // Defensive: strip path components a misbehaving client might send.
+    // The blob path is sha-derived so this is mostly cosmetic, but it stops
+    // a `..` from leaking into the stored filename.
+    let safe_filename = std::path::Path::new(&filename)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(&filename)
+        .to_string();
+    let content_type = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
+
+    let sha = blobs::sha256_hex(&bytes);
+
+    // Project-scoped dedupe: if this sha already exists for this project,
+    // return the existing row instead of writing a duplicate.
+    if let Some(existing) = store::find_document_by_sha(db, &project_id, &sha)
+        .await
+        .map_err(|e| db_err("dedupe lookup", e))?
+    {
+        return Ok(Json(existing));
+    }
+
+    // Inline extraction. If extraction fails we still want the upload to
+    // succeed: text-less documents are useful for download and the chat
+    // skill can degrade gracefully.
+    let extracted = extract::extract(&content_type, &safe_filename, &bytes).await.ok();
+    let (text, page_count) = match extracted {
+        Some(e) => (Some(e.text), e.page_count),
+        None => (None, None),
+    };
+
+    let data_dir = crate::bootstrap::ironclaw_base_dir();
+    let storage_rel = blobs::write_blob(&data_dir, &sha, &bytes)
+        .await
+        .map_err(|e| {
+            err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("blob write: {e}"),
+            )
+        })?;
+    let storage_path = storage_rel.to_string_lossy().to_string();
+
+    let id = ulid::Ulid::new().to_string();
+    let doc = store::create_document(
+        db,
+        &id,
+        &project_id,
+        &safe_filename,
+        &content_type,
+        &storage_path,
+        text.as_deref(),
+        page_count,
+        bytes.len() as i64,
+        &sha,
+    )
+    .await
+    .map_err(|e| db_err("create_document", e))?;
+
+    Ok(Json(doc))
+}
+
+/// `GET /api/skills/legal/documents/:id` — metadata + extracted text.
+pub async fn get_document_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<Json<DocumentDetailResponse>, (StatusCode, Json<ErrorBody>)> {
+    let db = require_db(&state)?;
+    let doc = store::fetch_document(db, &id)
+        .await
+        .map_err(|e| db_err("fetch_document", e))?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, format!("document {id} not found")))?;
+    Ok(Json(doc))
+}
+
+/// `GET /api/skills/legal/documents/:id/blob` — raw file bytes.
+pub async fn get_document_blob_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<Response, (StatusCode, Json<ErrorBody>)> {
+    let db = require_db(&state)?;
+    let doc: LegalDocument = store::fetch_document(db, &id)
+        .await
+        .map_err(|e| db_err("fetch_document", e))?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, format!("document {id} not found")))?;
+
+    let data_dir = crate::bootstrap::ironclaw_base_dir();
+    let bytes = blobs::read_blob(&data_dir, &doc.sha256).await.map_err(|e| {
+        err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("blob read: {e}"),
+        )
+    })?;
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, doc.content_type.clone())
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!(
+                "attachment; filename=\"{}\"",
+                doc.filename.replace('"', "_")
+            ),
+        )
+        .body(Body::from(bytes))
+        .map_err(|e| {
+            err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("response build: {e}"),
+            )
+        })
+}

--- a/src/channels/web/features/legal/handlers.rs
+++ b/src/channels/web/features/legal/handlers.rs
@@ -48,6 +48,17 @@ const MAX_PROJECT_NAME: usize = 200;
 /// from filling the row.
 const MAX_METADATA_BYTES: usize = 16 * 1024;
 
+/// Content types accepted on upload. Restricting the set narrows the
+/// download surface — `get_document_blob_handler` echoes the stored
+/// content-type back, so anything with a HTML-like media type would let
+/// an authenticated caller plant XSS that the next browser download
+/// renders. PDF and OOXML are the only types the chat skill actually
+/// reads anyway.
+const ACCEPTED_CONTENT_TYPES: &[&str] = &[
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
+
 /// Common error body returned on failures.
 #[derive(Debug, Serialize)]
 struct ErrorBody {
@@ -88,6 +99,43 @@ fn now_unix() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+/// Decide which canonical mime to persist for a given upload.
+///
+/// We trust either:
+/// 1. the client-declared content-type if it's exactly one of the two
+///    accepted mimes, OR
+/// 2. the filename extension (`.pdf` / `.docx`) when the declared mime is
+///    missing or generic.
+///
+/// Any other declared mime fails the upload rather than getting persisted
+/// and echoed back to a future download.
+fn normalise_content_type(declared: Option<&str>, filename: &str) -> Option<&'static str> {
+    let docx_mime = ACCEPTED_CONTENT_TYPES[1];
+    let declared_lc = declared.map(|s| s.trim().to_ascii_lowercase());
+    let ext = std::path::Path::new(filename)
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase());
+
+    if let Some(ref ct) = declared_lc {
+        if ct == "application/pdf" {
+            return Some(ACCEPTED_CONTENT_TYPES[0]);
+        }
+        if ct == docx_mime {
+            return Some(ACCEPTED_CONTENT_TYPES[1]);
+        }
+    }
+    if let Some(ref e) = ext {
+        if e == "pdf" {
+            return Some(ACCEPTED_CONTENT_TYPES[0]);
+        }
+        if e == "docx" {
+            return Some(ACCEPTED_CONTENT_TYPES[1]);
+        }
+    }
+    None
 }
 
 /// `POST /api/skills/legal/projects` — create a new project.
@@ -194,10 +242,9 @@ pub async fn delete_project_handler(
 /// `POST /api/skills/legal/projects/:id/documents` — multipart upload,
 /// extract text, persist blob + row.
 ///
-/// The multipart envelope expects exactly one field named `file` (matching
-/// mike's wire shape — the field *name* is not copyrightable code). All
-/// other field names are ignored to allow front-ends to layer extra
-/// metadata fields without breaking the parser.
+/// The multipart envelope expects exactly one field named `file`; any
+/// other field is ignored, so front-ends can layer extra metadata
+/// fields without breaking this parser.
 pub async fn upload_document_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(_user): AuthenticatedUser,
@@ -267,7 +314,18 @@ pub async fn upload_document_handler(
         .and_then(|s| s.to_str())
         .unwrap_or(&filename)
         .to_string();
-    let content_type = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
+    // Normalise the stored content-type. We accept either the canonical
+    // PDF/OOXML mime or a `.pdf`/`.docx` extension, but persist only the
+    // canonical mime so downloads can never echo back, e.g.,
+    // `text/html` from a misbehaving uploader.
+    let normalised_ct = normalise_content_type(content_type.as_deref(), &safe_filename)
+        .ok_or_else(|| {
+            err(
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "Only application/pdf and OOXML (.docx) uploads are supported".to_string(),
+            )
+        })?;
+    let content_type = normalised_ct.to_string();
 
     let sha = blobs::sha256_hex(&bytes);
 
@@ -301,7 +359,7 @@ pub async fn upload_document_handler(
     let storage_path = storage_rel.to_string_lossy().to_string();
 
     let id = ulid::Ulid::new().to_string();
-    let doc = store::create_document(
+    let outcome = store::create_document(
         db,
         &id,
         &project_id,
@@ -315,6 +373,15 @@ pub async fn upload_document_handler(
     )
     .await
     .map_err(|e| db_err("create_document", e))?;
+
+    let doc = match outcome {
+        store::DocumentInsert::Inserted(d) => d,
+        // Dedupe race winner: another concurrent upload of identical
+        // bytes already landed. Return the existing row; the orphaned
+        // sha-named blob is identical bytes so leaving it on disk is
+        // harmless and content-addressed dedupe absorbs the cost.
+        store::DocumentInsert::DuplicateExisting(d) => d,
+    };
 
     Ok(Json(doc))
 }
@@ -334,6 +401,15 @@ pub async fn get_document_handler(
 }
 
 /// `GET /api/skills/legal/documents/:id/blob` — raw file bytes.
+///
+/// Sanity bounds:
+/// - `Content-Type` is always one of the canonical accepted mimes
+///   (verified at upload time via [`normalise_content_type`]).
+/// - `Content-Disposition` is sanitised to ASCII filename only; any
+///   non-ASCII character or newline is replaced with `_` to avoid
+///   header injection. RFC 5987 `filename*` is intentionally not used
+///   so a Unicode filename downgrades to a safe ASCII fallback rather
+///   than failing the response.
 pub async fn get_document_blob_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(_user): AuthenticatedUser,
@@ -353,16 +429,19 @@ pub async fn get_document_blob_handler(
         )
     })?;
 
+    let safe_filename = sanitise_filename_for_disposition(&doc.filename);
+
     Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, doc.content_type.clone())
         .header(
             header::CONTENT_DISPOSITION,
-            format!(
-                "attachment; filename=\"{}\"",
-                doc.filename.replace('"', "_")
-            ),
+            format!("attachment; filename=\"{safe_filename}\""),
         )
+        // Belt-and-braces: the gateway already adds X-Content-Type-Options
+        // globally; setting it on this response too means clones that
+        // carry the body through a downstream proxy still see it.
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
         .body(Body::from(bytes))
         .map_err(|e| {
             err(
@@ -370,4 +449,22 @@ pub async fn get_document_blob_handler(
                 format!("response build: {e}"),
             )
         })
+}
+
+/// Sanitise a filename for use inside a `Content-Disposition: attachment;
+/// filename="..."` header. Replaces every non-printable-ASCII character,
+/// every `"`, and every CR/LF with `_`. Never returns an empty string.
+fn sanitise_filename_for_disposition(name: &str) -> String {
+    let mut out: String = name
+        .chars()
+        .map(|c| match c {
+            '"' | '\\' | '\r' | '\n' => '_',
+            c if c.is_ascii_graphic() || c == ' ' => c,
+            _ => '_',
+        })
+        .collect();
+    if out.is_empty() {
+        out.push_str("download");
+    }
+    out
 }

--- a/src/channels/web/features/legal/handlers.rs
+++ b/src/channels/web/features/legal/handlers.rs
@@ -61,7 +61,7 @@ const ACCEPTED_CONTENT_TYPES: &[&str] = &[
 
 /// Common error body returned on failures.
 #[derive(Debug, Serialize)]
-struct ErrorBody {
+pub struct ErrorBody {
     error: String,
 }
 
@@ -71,15 +71,11 @@ fn err(status: StatusCode, msg: impl Into<String>) -> (StatusCode, Json<ErrorBod
 
 fn db_err(context: &str, e: DatabaseError) -> (StatusCode, Json<ErrorBody>) {
     match e {
-        DatabaseError::Unsupported(_) => err(
-            StatusCode::NOT_IMPLEMENTED,
-            format!("{context}: {e}"),
-        ),
+        DatabaseError::Unsupported(_) => {
+            err(StatusCode::NOT_IMPLEMENTED, format!("{context}: {e}"))
+        }
         DatabaseError::NotFound { .. } => err(StatusCode::NOT_FOUND, format!("{context}: {e}")),
-        _ => err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("{context}: {e}"),
-        ),
+        _ => err(StatusCode::INTERNAL_SERVER_ERROR, format!("{context}: {e}")),
     }
 }
 
@@ -370,7 +366,9 @@ pub async fn upload_document_handler(
     // Inline extraction. If extraction fails we still want the upload to
     // succeed: text-less documents are useful for download and the chat
     // skill can degrade gracefully.
-    let extracted = extract::extract(&content_type, &safe_filename, &bytes).await.ok();
+    let extracted = extract::extract(&content_type, &safe_filename, &bytes)
+        .await
+        .ok();
     let (text, page_count) = match extracted {
         Some(e) => (Some(e.text), e.page_count),
         None => (None, None),
@@ -455,12 +453,9 @@ pub async fn get_document_blob_handler(
     let doc: LegalDocument = fetch_active_document(db, &id).await?;
 
     let data_dir = crate::bootstrap::ironclaw_base_dir();
-    let bytes = blobs::read_blob(&data_dir, &doc.sha256).await.map_err(|e| {
-        err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("blob read: {e}"),
-        )
-    })?;
+    let bytes = blobs::read_blob(&data_dir, &doc.sha256)
+        .await
+        .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, format!("blob read: {e}")))?;
 
     let safe_filename = sanitise_filename_for_disposition(&doc.filename);
 

--- a/src/channels/web/features/legal/handlers.rs
+++ b/src/channels/web/features/legal/handlers.rs
@@ -101,6 +101,35 @@ fn now_unix() -> i64 {
         .unwrap_or(0)
 }
 
+/// Fetch a document only if its parent project is still active.
+/// Returns 404 with no information leak about whether the row exists
+/// versus whether the project was deleted — both shapes look the same
+/// to the caller.
+async fn fetch_active_document(
+    db: &Arc<dyn crate::db::Database>,
+    id: &str,
+) -> Result<LegalDocument, (StatusCode, Json<ErrorBody>)> {
+    let doc = store::fetch_document(db, id)
+        .await
+        .map_err(|e| db_err("fetch_document", e))?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, format!("document {id} not found")))?;
+
+    let project = store::fetch_project(db, &doc.project_id)
+        .await
+        .map_err(|e| db_err("fetch_project", e))?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, format!("document {id} not found")))?;
+
+    if project.deleted_at.is_some() {
+        // Indistinguishable from the row-missing case for the caller.
+        return Err(err(
+            StatusCode::NOT_FOUND,
+            format!("document {id} not found"),
+        ));
+    }
+
+    Ok(doc)
+}
+
 /// Decide which canonical mime to persist for a given upload.
 ///
 /// We trust either:
@@ -387,20 +416,27 @@ pub async fn upload_document_handler(
 }
 
 /// `GET /api/skills/legal/documents/:id` — metadata + extracted text.
+///
+/// Documents whose parent project is soft-deleted are treated as
+/// missing (404) so the foundation upholds the same active/deleted
+/// boundary that `get_project_handler` does. Without this check a
+/// caller who knew a document id could still read its text through
+/// `/documents/:id` after the project was deleted.
 pub async fn get_document_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(_user): AuthenticatedUser,
     Path(id): Path<String>,
 ) -> Result<Json<DocumentDetailResponse>, (StatusCode, Json<ErrorBody>)> {
     let db = require_db(&state)?;
-    let doc = store::fetch_document(db, &id)
-        .await
-        .map_err(|e| db_err("fetch_document", e))?
-        .ok_or_else(|| err(StatusCode::NOT_FOUND, format!("document {id} not found")))?;
+    let doc = fetch_active_document(db, &id).await?;
     Ok(Json(doc))
 }
 
 /// `GET /api/skills/legal/documents/:id/blob` — raw file bytes.
+///
+/// Soft-delete enforcement: same as `get_document_handler`, this
+/// endpoint refuses to serve bytes for a document whose parent
+/// project has `deleted_at IS NOT NULL`.
 ///
 /// Sanity bounds:
 /// - `Content-Type` is always one of the canonical accepted mimes
@@ -416,10 +452,7 @@ pub async fn get_document_blob_handler(
     Path(id): Path<String>,
 ) -> Result<Response, (StatusCode, Json<ErrorBody>)> {
     let db = require_db(&state)?;
-    let doc: LegalDocument = store::fetch_document(db, &id)
-        .await
-        .map_err(|e| db_err("fetch_document", e))?
-        .ok_or_else(|| err(StatusCode::NOT_FOUND, format!("document {id} not found")))?;
+    let doc: LegalDocument = fetch_active_document(db, &id).await?;
 
     let data_dir = crate::bootstrap::ironclaw_base_dir();
     let bytes = blobs::read_blob(&data_dir, &doc.sha256).await.map_err(|e| {

--- a/src/channels/web/features/legal/mod.rs
+++ b/src/channels/web/features/legal/mod.rs
@@ -1,0 +1,26 @@
+//! Legal harness skill — projects, documents, and (in companion PRs)
+//! chats with DOCX export.
+//!
+//! This module owns the **foundation** layer: project + document CRUD,
+//! multipart upload with inline PDF/DOCX text extraction, and
+//! content-addressed blob storage on the local filesystem. Streams B
+//! (chat-with-docs) and C (DOCX export) are landing in companion PRs and
+//! consume the same migration introduced here
+//! (`migrations/V26__legal_harness.sql` + the libSQL incremental
+//! migration with the matching version).
+//!
+//! See `skills/legal/SKILL.md` for the agent-facing description and
+//! `legal-harness-spec.md` for the cross-stream coordinator.
+
+pub mod blobs;
+pub mod extract;
+pub mod models;
+
+// Storage and HTTP handlers depend on libSQL-specific types (the libsql
+// crate is feature-gated). Postgres-only builds compile the data
+// model/blob/extract paths but the network surface stays disabled until
+// the Postgres query layer lands.
+#[cfg(feature = "libsql")]
+pub mod handlers;
+#[cfg(feature = "libsql")]
+pub mod store;

--- a/src/channels/web/features/legal/models.rs
+++ b/src/channels/web/features/legal/models.rs
@@ -1,0 +1,76 @@
+//! Wire types for the legal harness skill.
+//!
+//! These map 1:1 onto the rows defined in `migrations/V26__legal_harness.sql`
+//! (and the matching libSQL `INCREMENTAL_MIGRATIONS` entry). Changes here
+//! must stay in lockstep with the schema and with Streams B (chat) and
+//! C (DOCX export); see `legal-harness-spec.md`.
+
+use serde::{Deserialize, Serialize};
+
+/// Stored project record.
+///
+/// `metadata` is a free-form JSON blob the caller controls. We round-trip it
+/// as a string at the storage layer so callers can layer their own schema on
+/// top without forcing a new migration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LegalProject {
+    pub id: String,
+    pub name: String,
+    /// Soft-delete timestamp (unix seconds). `None` means active.
+    pub deleted_at: Option<i64>,
+    pub created_at: i64,
+    /// Optional caller-controlled metadata (raw JSON string, not parsed by the
+    /// store). When `None`, the database column is `NULL`.
+    pub metadata: Option<String>,
+}
+
+/// Stored document record.
+///
+/// `extracted_text` is `None` until extraction completes (extraction is
+/// inline today, but the schema allows for an async pipeline later).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LegalDocument {
+    pub id: String,
+    pub project_id: String,
+    pub filename: String,
+    pub content_type: String,
+    /// Path relative to the ironclaw data dir (e.g. `legal/blobs/ab/abc..d`).
+    pub storage_path: String,
+    pub extracted_text: Option<String>,
+    pub page_count: Option<i64>,
+    pub bytes: i64,
+    pub sha256: String,
+    pub uploaded_at: i64,
+}
+
+/// Create-project request body.
+#[derive(Debug, Deserialize)]
+pub struct CreateProjectRequest {
+    pub name: String,
+    /// Optional caller metadata. Stored as a JSON string; the value here is
+    /// re-serialized so callers can pass either an object or a pre-encoded
+    /// string.
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// List response for projects (active only by default).
+#[derive(Debug, Serialize)]
+pub struct ProjectListResponse {
+    pub projects: Vec<LegalProject>,
+    pub count: usize,
+}
+
+/// Project detail (with documents) response.
+#[derive(Debug, Serialize)]
+pub struct ProjectDetailResponse {
+    #[serde(flatten)]
+    pub project: LegalProject,
+    pub documents: Vec<LegalDocument>,
+}
+
+/// Document upload response — same shape as a stored row.
+pub type DocumentResponse = LegalDocument;
+
+/// Document detail response (alias kept for endpoint clarity).
+pub type DocumentDetailResponse = LegalDocument;

--- a/src/channels/web/features/legal/store.rs
+++ b/src/channels/web/features/legal/store.rs
@@ -22,9 +22,7 @@ use super::models::{LegalDocument, LegalProject};
 /// return `Unsupported`. Centralising the cast here keeps the not-supported
 /// error message identical at every call site so route handlers can map
 /// it onto a single 501 response.
-fn libsql<'a>(
-    db: &'a Arc<dyn Database>,
-) -> Result<&'a crate::db::libsql::LibSqlBackend, DatabaseError> {
+fn libsql(db: &Arc<dyn Database>) -> Result<&crate::db::libsql::LibSqlBackend, DatabaseError> {
     crate::db::libsql_backend(db).ok_or_else(|| {
         DatabaseError::Unsupported(
             "Legal harness currently requires the libSQL backend".to_string(),
@@ -256,7 +254,8 @@ pub async fn create_document(
             // otherwise the caller sees the original failure.
             if let Some(existing) = find_document_by_sha_inner(&conn, project_id, sha256).await? {
                 tracing::debug!(
-                    project_id, sha256,
+                    project_id,
+                    sha256,
                     "legal_documents insert lost dedupe race; returning existing row",
                 );
                 Ok(DocumentInsert::DuplicateExisting(existing))

--- a/src/channels/web/features/legal/store.rs
+++ b/src/channels/web/features/legal/store.rs
@@ -152,7 +152,14 @@ pub async fn find_document_by_sha(
 ) -> Result<Option<LegalDocument>, DatabaseError> {
     let backend = libsql(db)?;
     let conn = backend.connect().await?;
+    find_document_by_sha_inner(&conn, project_id, sha256).await
+}
 
+async fn find_document_by_sha_inner(
+    conn: &libsql::Connection,
+    project_id: &str,
+    sha256: &str,
+) -> Result<Option<LegalDocument>, DatabaseError> {
     let mut rows = conn
         .query(
             "SELECT id, project_id, filename, content_type, storage_path,
@@ -175,8 +182,27 @@ pub async fn find_document_by_sha(
     }
 }
 
+/// Outcome of `create_document`. Distinguishes a fresh insert from a
+/// dedupe hit so the upload handler can avoid double-counting and the
+/// caller knows which 200/200-existing semantics to surface.
+#[derive(Debug)]
+pub enum DocumentInsert {
+    /// Fresh row — the caller's write succeeded.
+    Inserted(LegalDocument),
+    /// A row with the same `(project_id, sha256)` already exists — the
+    /// returned row is the existing one (the caller's transient blob may
+    /// be discarded; both copies are byte-identical by definition of sha
+    /// equality).
+    DuplicateExisting(LegalDocument),
+}
+
 /// Insert a new document row. Caller has already written the blob to disk
 /// and computed the sha256/size/extraction.
+///
+/// Race semantics: the table has a UNIQUE(project_id, sha256) index. If a
+/// concurrent upload of identical bytes wins the race, this returns
+/// [`DocumentInsert::DuplicateExisting`] with the row that did land. The
+/// caller must treat both arms as user-observable success.
 #[allow(clippy::too_many_arguments)]
 pub async fn create_document(
     db: &Arc<dyn Database>,
@@ -189,33 +215,56 @@ pub async fn create_document(
     page_count: Option<i64>,
     bytes: i64,
     sha256: &str,
-) -> Result<LegalDocument, DatabaseError> {
+) -> Result<DocumentInsert, DatabaseError> {
     let backend = libsql(db)?;
     let conn = backend.connect().await?;
 
-    conn.execute(
-        "INSERT INTO legal_documents
-            (id, project_id, filename, content_type, storage_path,
-             extracted_text, page_count, bytes, sha256)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-        libsql::params![
-            id,
-            project_id,
-            filename,
-            content_type,
-            storage_path,
-            extracted_text.map(str::to_string),
-            page_count,
-            bytes,
-            sha256,
-        ],
-    )
-    .await
-    .map_err(|e| DatabaseError::Query(format!("create_document: {e}")))?;
+    let insert_result = conn
+        .execute(
+            "INSERT INTO legal_documents
+                (id, project_id, filename, content_type, storage_path,
+                 extracted_text, page_count, bytes, sha256)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            libsql::params![
+                id,
+                project_id,
+                filename,
+                content_type,
+                storage_path,
+                extracted_text.map(str::to_string),
+                page_count,
+                bytes,
+                sha256,
+            ],
+        )
+        .await;
 
-    fetch_document_inner(&conn, id).await?.ok_or_else(|| {
-        DatabaseError::Query("create_document: row missing immediately after insert".to_string())
-    })
+    match insert_result {
+        Ok(_) => {
+            let row = fetch_document_inner(&conn, id).await?.ok_or_else(|| {
+                DatabaseError::Query(
+                    "create_document: row missing immediately after insert".to_string(),
+                )
+            })?;
+            Ok(DocumentInsert::Inserted(row))
+        }
+        Err(e) => {
+            // The libsql crate flattens SQLITE_CONSTRAINT_UNIQUE into a
+            // generic error; matching on the message is brittle, so on
+            // any insert failure we look up the (project_id, sha256)
+            // pair. If a row exists, the error was a dedupe race;
+            // otherwise the caller sees the original failure.
+            if let Some(existing) = find_document_by_sha_inner(&conn, project_id, sha256).await? {
+                tracing::debug!(
+                    project_id, sha256,
+                    "legal_documents insert lost dedupe race; returning existing row",
+                );
+                Ok(DocumentInsert::DuplicateExisting(existing))
+            } else {
+                Err(DatabaseError::Query(format!("create_document: {e}")))
+            }
+        }
+    }
 }
 
 /// Fetch a single document by id. Does not filter on soft-deleted parents

--- a/src/channels/web/features/legal/store.rs
+++ b/src/channels/web/features/legal/store.rs
@@ -1,0 +1,327 @@
+//! Database access for the legal harness.
+//!
+//! libSQL-only today: the Postgres backend has the schema (migrations/V26)
+//! but no Rust query layer wired in. Calling these helpers when the
+//! database is the Postgres backend returns
+//! [`crate::error::DatabaseError::Unsupported`] so handlers can map it
+//! into a 501 response. Adding Postgres support is a follow-up tracked in
+//! the PR body — the legal v1 deployment target is libSQL/Turso.
+//!
+//! No `unwrap` in the data-path code; row decode failures bubble up as
+//! `DatabaseError::Query` so the gateway always returns a 500 instead of
+//! crashing the worker.
+
+use std::sync::Arc;
+
+use crate::db::Database;
+use crate::error::DatabaseError;
+
+use super::models::{LegalDocument, LegalProject};
+
+/// Convenience: borrow the libSQL backend from `Arc<dyn Database>` or
+/// return `Unsupported`. Centralising the cast here keeps the not-supported
+/// error message identical at every call site so route handlers can map
+/// it onto a single 501 response.
+fn libsql<'a>(
+    db: &'a Arc<dyn Database>,
+) -> Result<&'a crate::db::libsql::LibSqlBackend, DatabaseError> {
+    crate::db::libsql_backend(db).ok_or_else(|| {
+        DatabaseError::Unsupported(
+            "Legal harness currently requires the libSQL backend".to_string(),
+        )
+    })
+}
+
+/// Insert a project. Caller supplies the ULID; the row's `created_at` is
+/// populated by the column default.
+pub async fn create_project(
+    db: &Arc<dyn Database>,
+    id: &str,
+    name: &str,
+    metadata: Option<&str>,
+) -> Result<LegalProject, DatabaseError> {
+    let backend = libsql(db)?;
+    let conn = backend.connect().await?;
+
+    conn.execute(
+        "INSERT INTO legal_projects (id, name, metadata) VALUES (?1, ?2, ?3)",
+        libsql::params![id, name, metadata.map(str::to_string)],
+    )
+    .await
+    .map_err(|e| DatabaseError::Query(format!("create_project: {e}")))?;
+
+    fetch_project_inner(&conn, id).await?.ok_or_else(|| {
+        DatabaseError::Query("create_project: row missing immediately after insert".to_string())
+    })
+}
+
+/// List active (not soft-deleted) projects ordered by `created_at` desc.
+pub async fn list_active_projects(
+    db: &Arc<dyn Database>,
+) -> Result<Vec<LegalProject>, DatabaseError> {
+    let backend = libsql(db)?;
+    let conn = backend.connect().await?;
+
+    let mut rows = conn
+        .query(
+            "SELECT id, name, deleted_at, created_at, metadata
+               FROM legal_projects
+              WHERE deleted_at IS NULL
+              ORDER BY created_at DESC",
+            libsql::params![],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(format!("list_active_projects: {e}")))?;
+
+    let mut out = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| DatabaseError::Query(format!("list_active_projects iter: {e}")))?
+    {
+        out.push(row_to_project(&row)?);
+    }
+    Ok(out)
+}
+
+/// Fetch a single project by id (including soft-deleted ones — the gateway
+/// decides whether to surface them).
+pub async fn fetch_project(
+    db: &Arc<dyn Database>,
+    id: &str,
+) -> Result<Option<LegalProject>, DatabaseError> {
+    let backend = libsql(db)?;
+    let conn = backend.connect().await?;
+    fetch_project_inner(&conn, id).await
+}
+
+async fn fetch_project_inner(
+    conn: &libsql::Connection,
+    id: &str,
+) -> Result<Option<LegalProject>, DatabaseError> {
+    let mut rows = conn
+        .query(
+            "SELECT id, name, deleted_at, created_at, metadata
+               FROM legal_projects
+              WHERE id = ?1",
+            libsql::params![id],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(format!("fetch_project: {e}")))?;
+
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| DatabaseError::Query(format!("fetch_project iter: {e}")))?;
+    match row {
+        Some(r) => Ok(Some(row_to_project(&r)?)),
+        None => Ok(None),
+    }
+}
+
+/// Soft-delete a project. Returns `true` if a row was updated, `false` if
+/// the project was already deleted or never existed (the handler maps that
+/// into a 404).
+pub async fn soft_delete_project(
+    db: &Arc<dyn Database>,
+    id: &str,
+    now_unix: i64,
+) -> Result<bool, DatabaseError> {
+    let backend = libsql(db)?;
+    let conn = backend.connect().await?;
+
+    let affected = conn
+        .execute(
+            "UPDATE legal_projects
+                SET deleted_at = ?1
+              WHERE id = ?2
+                AND deleted_at IS NULL",
+            libsql::params![now_unix, id],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(format!("soft_delete_project: {e}")))?;
+
+    Ok(affected > 0)
+}
+
+/// Find a document in a project by sha256 (for upload dedupe).
+pub async fn find_document_by_sha(
+    db: &Arc<dyn Database>,
+    project_id: &str,
+    sha256: &str,
+) -> Result<Option<LegalDocument>, DatabaseError> {
+    let backend = libsql(db)?;
+    let conn = backend.connect().await?;
+
+    let mut rows = conn
+        .query(
+            "SELECT id, project_id, filename, content_type, storage_path,
+                    extracted_text, page_count, bytes, sha256, uploaded_at
+               FROM legal_documents
+              WHERE project_id = ?1 AND sha256 = ?2
+              LIMIT 1",
+            libsql::params![project_id, sha256],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(format!("find_document_by_sha: {e}")))?;
+
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| DatabaseError::Query(format!("find_document_by_sha iter: {e}")))?;
+    match row {
+        Some(r) => Ok(Some(row_to_document(&r)?)),
+        None => Ok(None),
+    }
+}
+
+/// Insert a new document row. Caller has already written the blob to disk
+/// and computed the sha256/size/extraction.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_document(
+    db: &Arc<dyn Database>,
+    id: &str,
+    project_id: &str,
+    filename: &str,
+    content_type: &str,
+    storage_path: &str,
+    extracted_text: Option<&str>,
+    page_count: Option<i64>,
+    bytes: i64,
+    sha256: &str,
+) -> Result<LegalDocument, DatabaseError> {
+    let backend = libsql(db)?;
+    let conn = backend.connect().await?;
+
+    conn.execute(
+        "INSERT INTO legal_documents
+            (id, project_id, filename, content_type, storage_path,
+             extracted_text, page_count, bytes, sha256)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        libsql::params![
+            id,
+            project_id,
+            filename,
+            content_type,
+            storage_path,
+            extracted_text.map(str::to_string),
+            page_count,
+            bytes,
+            sha256,
+        ],
+    )
+    .await
+    .map_err(|e| DatabaseError::Query(format!("create_document: {e}")))?;
+
+    fetch_document_inner(&conn, id).await?.ok_or_else(|| {
+        DatabaseError::Query("create_document: row missing immediately after insert".to_string())
+    })
+}
+
+/// Fetch a single document by id. Does not filter on soft-deleted parents
+/// — that's the handler's responsibility (it usually returns 404 anyway).
+pub async fn fetch_document(
+    db: &Arc<dyn Database>,
+    id: &str,
+) -> Result<Option<LegalDocument>, DatabaseError> {
+    let backend = libsql(db)?;
+    let conn = backend.connect().await?;
+    fetch_document_inner(&conn, id).await
+}
+
+async fn fetch_document_inner(
+    conn: &libsql::Connection,
+    id: &str,
+) -> Result<Option<LegalDocument>, DatabaseError> {
+    let mut rows = conn
+        .query(
+            "SELECT id, project_id, filename, content_type, storage_path,
+                    extracted_text, page_count, bytes, sha256, uploaded_at
+               FROM legal_documents
+              WHERE id = ?1",
+            libsql::params![id],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(format!("fetch_document: {e}")))?;
+
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| DatabaseError::Query(format!("fetch_document iter: {e}")))?;
+    match row {
+        Some(r) => Ok(Some(row_to_document(&r)?)),
+        None => Ok(None),
+    }
+}
+
+/// All documents in a project, newest first.
+pub async fn list_documents_for_project(
+    db: &Arc<dyn Database>,
+    project_id: &str,
+) -> Result<Vec<LegalDocument>, DatabaseError> {
+    let backend = libsql(db)?;
+    let conn = backend.connect().await?;
+
+    let mut rows = conn
+        .query(
+            "SELECT id, project_id, filename, content_type, storage_path,
+                    extracted_text, page_count, bytes, sha256, uploaded_at
+               FROM legal_documents
+              WHERE project_id = ?1
+              ORDER BY uploaded_at DESC",
+            libsql::params![project_id],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(format!("list_documents_for_project: {e}")))?;
+
+    let mut out = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| DatabaseError::Query(format!("list_documents iter: {e}")))?
+    {
+        out.push(row_to_document(&row)?);
+    }
+    Ok(out)
+}
+
+// ---- Row decoders ------------------------------------------------------
+
+fn row_to_project(row: &libsql::Row) -> Result<LegalProject, DatabaseError> {
+    let map = |col: &str, e: libsql::Error| {
+        DatabaseError::Query(format!("legal_projects column {col}: {e}"))
+    };
+    Ok(LegalProject {
+        id: row.get::<String>(0).map_err(|e| map("id", e))?,
+        name: row.get::<String>(1).map_err(|e| map("name", e))?,
+        deleted_at: row
+            .get::<Option<i64>>(2)
+            .map_err(|e| map("deleted_at", e))?,
+        created_at: row.get::<i64>(3).map_err(|e| map("created_at", e))?,
+        metadata: row
+            .get::<Option<String>>(4)
+            .map_err(|e| map("metadata", e))?,
+    })
+}
+
+fn row_to_document(row: &libsql::Row) -> Result<LegalDocument, DatabaseError> {
+    let map = |col: &str, e: libsql::Error| {
+        DatabaseError::Query(format!("legal_documents column {col}: {e}"))
+    };
+    Ok(LegalDocument {
+        id: row.get::<String>(0).map_err(|e| map("id", e))?,
+        project_id: row.get::<String>(1).map_err(|e| map("project_id", e))?,
+        filename: row.get::<String>(2).map_err(|e| map("filename", e))?,
+        content_type: row.get::<String>(3).map_err(|e| map("content_type", e))?,
+        storage_path: row.get::<String>(4).map_err(|e| map("storage_path", e))?,
+        extracted_text: row
+            .get::<Option<String>>(5)
+            .map_err(|e| map("extracted_text", e))?,
+        page_count: row
+            .get::<Option<i64>>(6)
+            .map_err(|e| map("page_count", e))?,
+        bytes: row.get::<i64>(7).map_err(|e| map("bytes", e))?,
+        sha256: row.get::<String>(8).map_err(|e| map("sha256", e))?,
+        uploaded_at: row.get::<i64>(9).map_err(|e| map("uploaded_at", e))?,
+    })
+}

--- a/src/channels/web/features/mod.rs
+++ b/src/channels/web/features/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod jobs;
 // returns `DatabaseError::Unsupported` when the active backend is
 // Postgres, which the handlers surface as 501. Streams B (chat) and
 // C (DOCX export) extend this same module.
-pub(crate) mod legal;
+pub mod legal;
 pub(crate) mod logs;
 pub(crate) mod oauth;
 pub(crate) mod pairing;

--- a/src/channels/web/features/mod.rs
+++ b/src/channels/web/features/mod.rs
@@ -15,6 +15,11 @@ pub(crate) mod chat;
 pub(crate) mod debug;
 pub(crate) mod extensions;
 pub(crate) mod jobs;
+// Legal harness skill (foundation): libSQL-backed today. The store layer
+// returns `DatabaseError::Unsupported` when the active backend is
+// Postgres, which the handlers surface as 501. Streams B (chat) and
+// C (DOCX export) extend this same module.
+pub(crate) mod legal;
 pub(crate) mod logs;
 pub(crate) mod oauth;
 pub(crate) mod pairing;

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -14,7 +14,7 @@
 //!         ◄── GET  / ───────────────── Static HTML/CSS/JS
 //! ```
 
-pub(crate) mod features;
+pub mod features;
 pub(crate) mod handlers;
 pub mod log_layer;
 pub mod oauth;

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -298,6 +298,11 @@ pub async fn start_server(
             "/api/skills/{name}",
             axum::routing::delete(skills_remove_handler),
         )
+        // Legal harness skill — projects, documents, ingestion.
+        // Companion streams (chat-with-docs, DOCX export) layer chats and
+        // export endpoints onto the same `/api/skills/legal/` prefix.
+        // libSQL-only today; the Postgres-only build skips these routes.
+        .merge(legal_routes())
         // Settings
         .route("/api/settings", get(settings_list_handler))
         .route("/api/settings/export", get(settings_export_handler))
@@ -584,4 +589,45 @@ pub async fn start_server(
     });
 
     Ok(bound_addr)
+}
+
+/// Routes for the legal harness skill (Stream A).
+///
+/// Mounted under `/api/skills/legal/`. The libSQL build wires all five
+/// endpoints; the Postgres-only build returns an empty router so the
+/// /api/skills/legal/* surface 404s until the Postgres query layer ships.
+type LegalRouter =
+    axum::Router<std::sync::Arc<crate::channels::web::platform::state::GatewayState>>;
+
+#[cfg(feature = "libsql")]
+fn legal_routes() -> LegalRouter {
+    use crate::channels::web::features::legal::handlers as legal_handlers;
+    axum::Router::new()
+        .route(
+            "/api/skills/legal/projects",
+            get(legal_handlers::list_projects_handler)
+                .post(legal_handlers::create_project_handler),
+        )
+        .route(
+            "/api/skills/legal/projects/{id}",
+            get(legal_handlers::get_project_handler)
+                .delete(legal_handlers::delete_project_handler),
+        )
+        .route(
+            "/api/skills/legal/projects/{id}/documents",
+            post(legal_handlers::upload_document_handler),
+        )
+        .route(
+            "/api/skills/legal/documents/{id}",
+            get(legal_handlers::get_document_handler),
+        )
+        .route(
+            "/api/skills/legal/documents/{id}/blob",
+            get(legal_handlers::get_document_blob_handler),
+        )
+}
+
+#[cfg(not(feature = "libsql"))]
+fn legal_routes() -> LegalRouter {
+    axum::Router::new()
 }

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -605,13 +605,11 @@ fn legal_routes() -> LegalRouter {
     axum::Router::new()
         .route(
             "/api/skills/legal/projects",
-            get(legal_handlers::list_projects_handler)
-                .post(legal_handlers::create_project_handler),
+            get(legal_handlers::list_projects_handler).post(legal_handlers::create_project_handler),
         )
         .route(
             "/api/skills/legal/projects/{id}",
-            get(legal_handlers::get_project_handler)
-                .delete(legal_handlers::delete_project_handler),
+            get(legal_handlers::get_project_handler).delete(legal_handlers::delete_project_handler),
         )
         .route(
             "/api/skills/legal/projects/{id}/documents",

--- a/src/db/libsql/mod.rs
+++ b/src/db/libsql/mod.rs
@@ -399,6 +399,10 @@ impl Database for LibSqlBackend {
             }
         }
     }
+
+    fn as_libsql(&self) -> Option<&LibSqlBackend> {
+        Some(self)
+    }
 }
 
 // ==================== Row conversion helpers ====================

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -1007,6 +1007,69 @@ WHERE key = 'wasm.default_fuel_limit'
   AND CAST(json_extract(value, '$') AS INTEGER) = 10000000;
 "#,
     ),
+    (
+        26,
+        "legal_harness",
+        // Legal harness — projects, documents, chats, messages.
+        //
+        // Mirrors the PostgreSQL migration migrations/V26__legal_harness.sql.
+        // Stream A introduces all four tables; Streams B (chat) and C
+        // (DOCX export) consume the same shape. Schema is canonical — see
+        // legal-harness-spec.md.
+        //
+        // Storage notes:
+        // * Timestamps use `unixepoch()` — INTEGER seconds since epoch — to
+        //   match the canonical schema in the spec. This diverges from the
+        //   ISO-8601 TEXT pattern used elsewhere in the libSQL schema; the
+        //   tradeoff is intentional so all three streams agree on a single
+        //   shape across both backends.
+        // * `metadata` and `document_refs` carry JSON encoded as TEXT.
+        r#"
+CREATE TABLE IF NOT EXISTS legal_projects (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    deleted_at  INTEGER,
+    created_at  INTEGER NOT NULL DEFAULT (unixepoch()),
+    metadata    TEXT
+);
+
+CREATE TABLE IF NOT EXISTS legal_documents (
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    filename        TEXT NOT NULL,
+    content_type    TEXT NOT NULL,
+    storage_path    TEXT NOT NULL,
+    extracted_text  TEXT,
+    page_count      INTEGER,
+    bytes           INTEGER NOT NULL,
+    sha256          TEXT NOT NULL,
+    uploaded_at     INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_documents_project ON legal_documents(project_id);
+CREATE INDEX IF NOT EXISTS idx_legal_documents_sha256  ON legal_documents(sha256);
+
+CREATE TABLE IF NOT EXISTS legal_chats (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    title       TEXT,
+    created_at  INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_chats_project ON legal_chats(project_id);
+
+CREATE TABLE IF NOT EXISTS legal_chat_messages (
+    id              TEXT PRIMARY KEY,
+    chat_id         TEXT NOT NULL REFERENCES legal_chats(id) ON DELETE CASCADE,
+    role            TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+    content         TEXT NOT NULL,
+    document_refs   TEXT,
+    created_at      INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_chat_messages_chat ON legal_chat_messages(chat_id);
+"#,
+    ),
 ];
 
 /// Migrations whose ADD COLUMN should be skipped when the column already

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -1048,6 +1048,11 @@ CREATE TABLE IF NOT EXISTS legal_documents (
 
 CREATE INDEX IF NOT EXISTS idx_legal_documents_project ON legal_documents(project_id);
 CREATE INDEX IF NOT EXISTS idx_legal_documents_sha256  ON legal_documents(sha256);
+-- Project-scoped sha dedupe — see migrations/V26__legal_harness.sql
+-- for the rationale. Closes the race between the dedupe lookup in
+-- `upload_document_handler` and the subsequent INSERT.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_legal_documents_project_sha
+    ON legal_documents(project_id, sha256);
 
 CREATE TABLE IF NOT EXISTS legal_chats (
     id          TEXT PRIMARY KEY,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1271,6 +1271,23 @@ pub trait Database:
     /// Rewrite all rows where user_id = 'default' to owner_id across all
     /// affected tables. Idempotent — safe to call on every startup.
     async fn migrate_default_owner(&self, owner_id: &str) -> Result<(), DatabaseError>;
+
+    /// Borrow the underlying libSQL backend, when this implementation is
+    /// libSQL-backed. Used by features that bypass the supertrait — today
+    /// only the legal harness, which intentionally stays libSQL-only in v1
+    /// (PR: legal harness foundation). Default returns `None` so other
+    /// backends keep compiling without changes.
+    #[cfg(feature = "libsql")]
+    fn as_libsql(&self) -> Option<&libsql::LibSqlBackend> {
+        None
+    }
+}
+
+/// Convenience accessor that downcasts an `Arc<dyn Database>` to the libSQL
+/// backend, if applicable. Returns `None` for any other backend.
+#[cfg(feature = "libsql")]
+pub fn libsql_backend(db: &Arc<dyn Database>) -> Option<&libsql::LibSqlBackend> {
+    db.as_libsql()
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -93,6 +93,12 @@ pub enum DatabaseError {
     #[error("Serialization error: {0}")]
     Serialization(String),
 
+    /// The active database backend doesn't implement this operation
+    /// (e.g. a libSQL-only feature called against the Postgres backend).
+    /// Callers typically map this onto an HTTP 501 Not Implemented.
+    #[error("Operation not supported by current database backend: {0}")]
+    Unsupported(String),
+
     #[cfg(feature = "postgres")]
     #[error("PostgreSQL error: {0}")]
     Postgres(#[from] tokio_postgres::Error),

--- a/tests/legal_harness.rs
+++ b/tests/legal_harness.rs
@@ -275,6 +275,52 @@ async fn project_cascade_delete_drops_documents() {
     assert!(doc.is_none(), "ON DELETE CASCADE should drop the document");
 }
 
+#[tokio::test]
+async fn document_after_soft_delete_is_invisible_via_store_lookup() {
+    // The store-level fetch_document still returns the row (it's the
+    // handler that filters on parent.deleted_at), but list_documents_for_project
+    // and the production handler should both treat soft-deleted projects
+    // as missing. This test pins the store contract: the row stays
+    // queryable but its parent's deleted_at is set.
+    let (db, _dir) = setup().await;
+
+    let project_id = ulid_str();
+    store::create_project(&db, &project_id, "Sealed", None)
+        .await
+        .expect("project");
+    let doc_id = ulid_str();
+    let _ = store::create_document(
+        &db,
+        &doc_id,
+        &project_id,
+        "agreement.pdf",
+        "application/pdf",
+        "legal/blobs/aa/zzzz",
+        None,
+        None,
+        1,
+        "ff",
+    )
+    .await
+    .expect("doc");
+
+    let updated = store::soft_delete_project(&db, &project_id, 1_700_000_000)
+        .await
+        .expect("delete");
+    assert!(updated);
+
+    // Row still present; parent.deleted_at signals deletion to the handler.
+    let doc = store::fetch_document(&db, &doc_id)
+        .await
+        .expect("fetch")
+        .expect("present");
+    let parent = store::fetch_project(&db, &doc.project_id)
+        .await
+        .expect("fetch parent")
+        .expect("parent present");
+    assert!(parent.deleted_at.is_some());
+}
+
 // ---- Blob storage -----------------------------------------------------
 
 #[tokio::test]

--- a/tests/legal_harness.rs
+++ b/tests/legal_harness.rs
@@ -120,7 +120,7 @@ async fn document_insert_and_project_scoped_sha_dedupe() {
 
     // First insert succeeds.
     let doc_id = ulid_str();
-    let doc = store::create_document(
+    let outcome = store::create_document(
         &db,
         &doc_id,
         &project_id,
@@ -134,6 +134,10 @@ async fn document_insert_and_project_scoped_sha_dedupe() {
     )
     .await
     .expect("create_document");
+    let doc = match outcome {
+        store::DocumentInsert::Inserted(d) => d,
+        store::DocumentInsert::DuplicateExisting(_) => panic!("first insert should not dedupe"),
+    };
     assert_eq!(doc.id, doc_id);
     assert_eq!(doc.bytes, 11);
     assert_eq!(doc.sha256, sha);
@@ -167,6 +171,66 @@ async fn document_insert_and_project_scoped_sha_dedupe() {
 }
 
 #[tokio::test]
+async fn create_document_returns_duplicate_when_sha_already_present() {
+    // Simulates the dedupe race: a second insert with identical
+    // (project_id, sha256) but a different id should not produce two
+    // rows; the second call should return DuplicateExisting with the
+    // first row.
+    let (db, _dir) = setup().await;
+
+    let project_id = ulid_str();
+    store::create_project(&db, &project_id, "P", None)
+        .await
+        .expect("project");
+
+    let sha = "deadbeef".repeat(8); // 64 hex chars
+    let first_id = ulid_str();
+    let first = store::create_document(
+        &db,
+        &first_id,
+        &project_id,
+        "a.pdf",
+        "application/pdf",
+        "legal/blobs/de/de..",
+        None,
+        None,
+        10,
+        &sha,
+    )
+    .await
+    .expect("first insert");
+    assert!(matches!(first, store::DocumentInsert::Inserted(_)));
+
+    let second_id = ulid_str();
+    let second = store::create_document(
+        &db,
+        &second_id,
+        &project_id,
+        "b.pdf",
+        "application/pdf",
+        "legal/blobs/de/de..",
+        None,
+        None,
+        10,
+        &sha,
+    )
+    .await
+    .expect("second insert (race)");
+    match second {
+        store::DocumentInsert::DuplicateExisting(row) => {
+            assert_eq!(row.id, first_id, "duplicate should yield original id");
+        }
+        store::DocumentInsert::Inserted(_) => panic!("second insert should dedupe, not insert"),
+    }
+
+    // Confirm only one row landed.
+    let docs = store::list_documents_for_project(&db, &project_id)
+        .await
+        .expect("list");
+    assert_eq!(docs.len(), 1);
+}
+
+#[tokio::test]
 async fn project_cascade_delete_drops_documents() {
     // Soft-deleting a project keeps documents attached; only ON DELETE
     // CASCADE on a hard-delete drops them. Verify the FK cascade fires.
@@ -177,7 +241,7 @@ async fn project_cascade_delete_drops_documents() {
         .await
         .expect("project");
     let doc_id = ulid_str();
-    store::create_document(
+    let _ = store::create_document(
         &db,
         &doc_id,
         &project_id,

--- a/tests/legal_harness.rs
+++ b/tests/legal_harness.rs
@@ -1,0 +1,315 @@
+//! Integration tests for the Stream A legal harness layer.
+//!
+//! Covers:
+//! 1. Project create/list/fetch/soft-delete round-trip.
+//! 2. Document insert + project-scoped sha256 dedupe lookup.
+//! 3. Blob write/read on a content-addressed path.
+//! 4. PDF and DOCX extraction against fixtures.
+//!
+//! These tests run against a real libSQL database (in-memory file in a
+//! tempdir) and exercise the same code paths the HTTP handlers do. The
+//! handlers themselves are thin orchestration over these modules — when
+//! they break, these tests will catch the regression first.
+
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+
+use ironclaw::channels::web::features::legal::{blobs, extract, store};
+use ironclaw::db::libsql::LibSqlBackend;
+use ironclaw::db::Database;
+
+async fn setup() -> (Arc<dyn Database>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let db_path = dir.path().join("legal.db");
+    let backend = LibSqlBackend::new_local(&db_path)
+        .await
+        .expect("create db");
+    backend.run_migrations().await.expect("run migrations");
+    let db: Arc<dyn Database> = Arc::new(backend);
+    (db, dir)
+}
+
+fn ulid_str() -> String {
+    ulid::Ulid::new().to_string()
+}
+
+// ---- Project lifecycle -----------------------------------------------
+
+#[tokio::test]
+async fn project_create_list_fetch_round_trip() {
+    let (db, _dir) = setup().await;
+
+    let id = ulid_str();
+    let project = store::create_project(&db, &id, "Acme NDA", Some("{\"deal\":\"acme\"}"))
+        .await
+        .expect("create project");
+    assert_eq!(project.id, id);
+    assert_eq!(project.name, "Acme NDA");
+    assert_eq!(project.metadata.as_deref(), Some("{\"deal\":\"acme\"}"));
+    assert!(project.deleted_at.is_none());
+    assert!(project.created_at > 0);
+
+    let listed = store::list_active_projects(&db).await.expect("list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, id);
+
+    let fetched = store::fetch_project(&db, &id)
+        .await
+        .expect("fetch")
+        .expect("present");
+    assert_eq!(fetched, project);
+
+    let absent = store::fetch_project(&db, "no-such-id")
+        .await
+        .expect("fetch ok");
+    assert!(absent.is_none(), "missing id should yield None");
+}
+
+#[tokio::test]
+async fn project_soft_delete_hides_from_active_list() {
+    let (db, _dir) = setup().await;
+
+    let keep = ulid_str();
+    let drop = ulid_str();
+    store::create_project(&db, &keep, "Keep", None)
+        .await
+        .expect("keep");
+    store::create_project(&db, &drop, "Drop", None)
+        .await
+        .expect("drop");
+
+    let now = 1_700_000_000_i64;
+    let updated = store::soft_delete_project(&db, &drop, now)
+        .await
+        .expect("delete");
+    assert!(updated, "first delete should affect a row");
+
+    // Idempotent: re-deleting returns false (no rows to update).
+    let again = store::soft_delete_project(&db, &drop, now + 1)
+        .await
+        .expect("delete again");
+    assert!(!again, "second delete should not touch any row");
+
+    let listed = store::list_active_projects(&db).await.expect("list");
+    let ids: Vec<&str> = listed.iter().map(|p| p.id.as_str()).collect();
+    assert_eq!(ids, vec![keep.as_str()]);
+
+    // fetch_project still returns soft-deleted rows for the handler to
+    // decide what to do.
+    let dropped = store::fetch_project(&db, &drop)
+        .await
+        .expect("fetch")
+        .expect("present");
+    assert!(dropped.deleted_at.is_some());
+}
+
+// ---- Documents + dedupe ----------------------------------------------
+
+#[tokio::test]
+async fn document_insert_and_project_scoped_sha_dedupe() {
+    let (db, _dir) = setup().await;
+
+    let project_id = ulid_str();
+    store::create_project(&db, &project_id, "Project", None)
+        .await
+        .expect("project");
+
+    let bytes = b"hello world".to_vec();
+    let sha = blobs::sha256_hex(&bytes);
+
+    // First insert succeeds.
+    let doc_id = ulid_str();
+    let doc = store::create_document(
+        &db,
+        &doc_id,
+        &project_id,
+        "hello.txt",
+        "text/plain",
+        "legal/blobs/ba/abc",
+        Some("hello world"),
+        None,
+        bytes.len() as i64,
+        &sha,
+    )
+    .await
+    .expect("create_document");
+    assert_eq!(doc.id, doc_id);
+    assert_eq!(doc.bytes, 11);
+    assert_eq!(doc.sha256, sha);
+
+    // Project-scoped lookup matches.
+    let found = store::find_document_by_sha(&db, &project_id, &sha)
+        .await
+        .expect("find")
+        .expect("present");
+    assert_eq!(found.id, doc_id);
+
+    // Different project — same sha — should NOT match (project-scoped dedupe).
+    let other_project = ulid_str();
+    store::create_project(&db, &other_project, "Other", None)
+        .await
+        .expect("other project");
+    let absent = store::find_document_by_sha(&db, &other_project, &sha)
+        .await
+        .expect("find");
+    assert!(
+        absent.is_none(),
+        "dedupe must be project-scoped per the spec"
+    );
+
+    // List documents for project returns the one row.
+    let docs = store::list_documents_for_project(&db, &project_id)
+        .await
+        .expect("list");
+    assert_eq!(docs.len(), 1);
+    assert_eq!(docs[0].id, doc_id);
+}
+
+#[tokio::test]
+async fn project_cascade_delete_drops_documents() {
+    // Soft-deleting a project keeps documents attached; only ON DELETE
+    // CASCADE on a hard-delete drops them. Verify the FK cascade fires.
+    let (db, _dir) = setup().await;
+
+    let project_id = ulid_str();
+    store::create_project(&db, &project_id, "P", None)
+        .await
+        .expect("project");
+    let doc_id = ulid_str();
+    store::create_document(
+        &db,
+        &doc_id,
+        &project_id,
+        "f.pdf",
+        "application/pdf",
+        "legal/blobs/aa/zzzz",
+        None,
+        None,
+        1,
+        "ff",
+    )
+    .await
+    .expect("doc");
+
+    // Drop the project row directly (simulates an admin/test scenario).
+    let backend = ironclaw::db::libsql_backend(&db).expect("libsql backend");
+    let conn = backend.connect().await.expect("connect");
+    conn.execute("PRAGMA foreign_keys = ON", ())
+        .await
+        .expect("fk");
+    conn.execute(
+        "DELETE FROM legal_projects WHERE id = ?1",
+        libsql::params![project_id.clone()],
+    )
+    .await
+    .expect("delete");
+
+    let doc = store::fetch_document(&db, &doc_id)
+        .await
+        .expect("fetch document");
+    assert!(doc.is_none(), "ON DELETE CASCADE should drop the document");
+}
+
+// ---- Blob storage -----------------------------------------------------
+
+#[tokio::test]
+async fn blob_write_dedupes_on_disk() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let bytes_a = b"alpha".to_vec();
+    let sha_a = blobs::sha256_hex(&bytes_a);
+    let rel1 = blobs::write_blob(dir.path(), &sha_a, &bytes_a)
+        .await
+        .expect("write");
+
+    // Re-write same bytes: returns same path, no error.
+    let rel2 = blobs::write_blob(dir.path(), &sha_a, &bytes_a)
+        .await
+        .expect("rewrite");
+    assert_eq!(rel1, rel2);
+
+    // Read back.
+    let read = blobs::read_blob(dir.path(), &sha_a)
+        .await
+        .expect("read");
+    assert_eq!(read, bytes_a);
+
+    // Different bytes -> different sha -> different path.
+    let bytes_b = b"beta".to_vec();
+    let sha_b = blobs::sha256_hex(&bytes_b);
+    let rel_b = blobs::write_blob(dir.path(), &sha_b, &bytes_b)
+        .await
+        .expect("write b");
+    assert_ne!(rel_b, rel1);
+}
+
+// ---- Extraction -------------------------------------------------------
+
+#[tokio::test]
+async fn pdf_fixture_extracts_some_text() {
+    // tests/fixtures/hello.pdf was produced by ReportLab in the
+    // pre-existing fixture set. We treat its exact contents as opaque and
+    // only assert "extraction returned text and didn't error".
+    let pdf = std::fs::read("tests/fixtures/hello.pdf").expect("hello.pdf present");
+    let out = extract::extract("application/pdf", "hello.pdf", &pdf)
+        .await
+        .expect("pdf extract");
+    assert!(!out.text.is_empty(), "PDF extraction should yield text");
+}
+
+#[tokio::test]
+async fn synthesised_docx_extracts_known_text() {
+    // Produce a minimal valid .docx (a zip with `word/document.xml`)
+    // containing two paragraphs. We check round-trip extraction without
+    // depending on a third-party DOCX writer.
+    let docx = build_docx_with(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t xml:space="preserve">Master Services Agreement</w:t></w:r></w:p>
+    <w:p><w:r><w:t xml:space="preserve">Section 1. Scope of Services.</w:t></w:r></w:p>
+  </w:body>
+</w:document>"#,
+    );
+
+    let out = extract::extract(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "msa.docx",
+        &docx,
+    )
+    .await
+    .expect("docx extract");
+    assert!(out.text.contains("Master Services Agreement"));
+    assert!(out.text.contains("Section 1. Scope of Services."));
+    assert!(out.page_count.is_none(), "DOCX has no page count");
+}
+
+#[tokio::test]
+async fn unsupported_content_type_errors() {
+    let bytes = b"plain text here, no PDF magic";
+    let res = extract::extract("text/plain", "notes.txt", bytes).await;
+    assert!(res.is_err(), "unsupported should error");
+}
+
+/// Build a minimal valid `.docx` archive whose only payload is
+/// `word/document.xml`. The file passes our extractor because the
+/// extractor only reads `word/document.xml`. Real Word-produced files
+/// have many more parts (`[Content_Types].xml`, relationships, styles)
+/// — those are unnecessary for text extraction.
+fn build_docx_with(document_xml: &str) -> Vec<u8> {
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    let mut buf = Vec::new();
+    {
+        let cursor = std::io::Cursor::new(&mut buf);
+        let mut zip = zip::ZipWriter::new(cursor);
+        let opts = SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        zip.start_file("word/document.xml", opts).expect("entry");
+        zip.write_all(document_xml.as_bytes()).expect("write xml");
+        zip.finish().expect("finish zip");
+    }
+    buf
+}

--- a/tests/legal_harness.rs
+++ b/tests/legal_harness.rs
@@ -16,15 +16,13 @@
 use std::sync::Arc;
 
 use ironclaw::channels::web::features::legal::{blobs, extract, store};
-use ironclaw::db::libsql::LibSqlBackend;
 use ironclaw::db::Database;
+use ironclaw::db::libsql::LibSqlBackend;
 
 async fn setup() -> (Arc<dyn Database>, tempfile::TempDir) {
     let dir = tempfile::tempdir().expect("create temp dir");
     let db_path = dir.path().join("legal.db");
-    let backend = LibSqlBackend::new_local(&db_path)
-        .await
-        .expect("create db");
+    let backend = LibSqlBackend::new_local(&db_path).await.expect("create db");
     backend.run_migrations().await.expect("run migrations");
     let db: Arc<dyn Database> = Arc::new(backend);
     (db, dir)
@@ -340,9 +338,7 @@ async fn blob_write_dedupes_on_disk() {
     assert_eq!(rel1, rel2);
 
     // Read back.
-    let read = blobs::read_blob(dir.path(), &sha_a)
-        .await
-        .expect("read");
+    let read = blobs::read_blob(dir.path(), &sha_a).await.expect("read");
     assert_eq!(read, bytes_a);
 
     // Different bytes -> different sha -> different path.
@@ -415,8 +411,8 @@ fn build_docx_with(document_xml: &str) -> Vec<u8> {
     {
         let cursor = std::io::Cursor::new(&mut buf);
         let mut zip = zip::ZipWriter::new(cursor);
-        let opts = SimpleFileOptions::default()
-            .compression_method(zip::CompressionMethod::Deflated);
+        let opts =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
         zip.start_file("word/document.xml", opts).expect("entry");
         zip.write_all(document_xml.as_bytes()).expect("write xml");
         zip.finish().expect("finish zip");


### PR DESCRIPTION
## Motivation

This PR is **Stream A (foundation)** of the IronClaw legal harness — a clean, Apache-2.0 reimplementation of mike's (https://github.com/willchen96/mike, AGPL-3.0) chat-with-legal-documents capability, native to IronClaw.

Goal of v1: project-aware contract review. Upload PDFs/DOCX into a project, ask the agent about them, export the conversation as a `.docx`. v2 (deferred): tracked changes, tabular review, PDF rendering, frontend.

**License posture: clean reimplementation.** No source from mike was copied. Endpoint shapes (route names, JSON field names) are functional/non-copyrightable; all implementation is original Rust. Approach was: read mike for concepts, reimplement against ironclaw's existing patterns.

This PR ships the foundation (projects + documents + ingest); two companion PRs land on top of the same migration:

- **Stream B — chat-with-docs** (POST `/api/skills/legal/projects/:id/chats`, SSE-streamed RAG replies)
- **Stream C — DOCX export** (POST `/api/skills/legal/chats/:id/export.docx`)

Both companion PRs include the same migration introduced here so they can be tested standalone. Cross-references will be added once those PRs are open (search: `gh pr list --repo nearai/ironclaw --search "legal harness" --state open`).

## What changed

**Schema** (`migrations/V26__legal_harness.sql` + matching libSQL incremental entry, version 26 `legal_harness`):

- `legal_projects(id, name, deleted_at, created_at, metadata)` — soft-delete via `deleted_at`.
- `legal_documents(id, project_id, filename, content_type, storage_path, extracted_text, page_count, bytes, sha256, uploaded_at)` with FK ON DELETE CASCADE, `idx_legal_documents_project`, `idx_legal_documents_sha256`, and **`UNIQUE (project_id, sha256)`** so concurrent uploads of identical bytes can't double-insert.
- `legal_chats` and `legal_chat_messages` (consumed by Stream B; the schema is canonical and shared across all three PRs).

**Code** (`src/channels/web/features/legal/`):

- `models.rs` — wire types.
- `store.rs` — libSQL data path. `Database::as_libsql()` accessor lets the legal store borrow the libSQL backend without touching every sub-trait. Postgres backend returns `DatabaseError::Unsupported` (mapped to HTTP 501; documented in PR body).
- `blobs.rs` — content-addressed blob storage under `<ironclaw_base_dir>/legal/blobs/<sha[..2]>/<sha>`. Race-safe writer (per-writer tempfile + `rename` with already-exists fallback). Sha format validated as `^[0-9a-f]{64}$` so a tainted DB row can't direct a path traversal.
- `extract.rs` — inline PDF (`pdf-extract`) and DOCX (`zip` + `quick-xml` over `word/document.xml`) text extraction in `spawn_blocking`. DOCX path is zip-bomb-resistant: 32 MiB cap on `word/document.xml`, declared-size check, and `Read::take` re-validation in case the header lies.
- `handlers.rs` — all five endpoints. Strict mime allowlist (`application/pdf` or OOXML), `Content-Disposition` filename sanitiser, `X-Content-Type-Options: nosniff`, soft-delete enforcement on document reads (a deleted project's documents 404 even if the doc id is known).

**Routes** (mounted in `src/channels/web/platform/router.rs` under the existing protected-token router):

- `POST /api/skills/legal/projects` — create project; body `{name, metadata?}` → 200 `{id, name, ...}`
- `GET  /api/skills/legal/projects` — list active projects
- `GET  /api/skills/legal/projects/:id` — project + its documents
- `DELETE /api/skills/legal/projects/:id` — soft delete
- `POST /api/skills/legal/projects/:id/documents` — multipart upload (PDF/DOCX); inline extraction, blob storage, project-scoped sha dedupe
- `GET  /api/skills/legal/documents/:id` — metadata + extracted text
- `GET  /api/skills/legal/documents/:id/blob` — raw bytes

> Endpoint prefix: the spec says `/skills/legal/...`; ironclaw mounts every functional API under `/api/...`, so I followed that convention. The skill is documented at `/api/skills/legal/...` in `skills/legal/SKILL.md`.

**SKILL.md** (`skills/legal/SKILL.md`) — picks up via `build.rs`'s automatic `skills/*/SKILL.md` discovery; agent-facing skill description with activation keywords.

## How to test (concrete curl recipe)

Assumes a libSQL-backed local ironclaw with the gateway listening on `127.0.0.1:3100` and the gateway token in `$T`:

```bash
# 1. Create a project
PID=$(curl -s -X POST http://127.0.0.1:3100/api/skills/legal/projects \
  -H "Authorization: Bearer $T" -H "Content-Type: application/json" \
  -d '{"name":"Acme NDA","metadata":{"deal":"acme-2026"}}' | jq -r .id)

# 2. List projects (project visible)
curl -s http://127.0.0.1:3100/api/skills/legal/projects -H "Authorization: Bearer $T" | jq

# 3. Upload a PDF
DID=$(curl -s -X POST http://127.0.0.1:3100/api/skills/legal/projects/$PID/documents \
  -H "Authorization: Bearer $T" \
  -F "file=@./contract.pdf;type=application/pdf" | jq -r .id)

# 4. Re-upload same bytes — same row returned, no duplicate (project-scoped dedupe)
curl -s -X POST http://127.0.0.1:3100/api/skills/legal/projects/$PID/documents \
  -H "Authorization: Bearer $T" \
  -F "file=@./contract.pdf;type=application/pdf" | jq

# 5. Fetch document metadata + extracted text
curl -s http://127.0.0.1:3100/api/skills/legal/documents/$DID -H "Authorization: Bearer $T" | jq

# 6. Download raw bytes
curl -s -o /tmp/got.pdf http://127.0.0.1:3100/api/skills/legal/documents/$DID/blob -H "Authorization: Bearer $T"
shasum -a 256 /tmp/got.pdf  # should match the upload

# 7. Soft-delete; document reads now 404
curl -s -X DELETE http://127.0.0.1:3100/api/skills/legal/projects/$PID -H "Authorization: Bearer $T" -i
curl -s http://127.0.0.1:3100/api/skills/legal/documents/$DID -H "Authorization: Bearer $T" -i  # 404
curl -s http://127.0.0.1:3100/api/skills/legal/documents/$DID/blob -H "Authorization: Bearer $T" -i # 404

# 8. Reject HTML masquerading as PDF
echo "<script>" > /tmp/evil.html
curl -s -X POST http://127.0.0.1:3100/api/skills/legal/projects/$PID/documents \
  -H "Authorization: Bearer $T" \
  -F "file=@/tmp/evil.html;type=text/html" -i  # 415 Unsupported Media Type
```

## Codex adversarial review summary

`codex review --commit ... -c model="gpt-5.5"` was run twice (after the initial commit, and after the first round of fixes). Findings and resolution:

| Severity | Finding | Status |
|----------|---------|--------|
| **HIGH** | DOCX `word/document.xml` read into unbounded `String` — zip-bomb amplification on a blocking worker | **Fixed** in `extract.rs`: 32 MiB declared-size check + `Read::take` cap + UTF-8 validation |
| **HIGH** | Document blob/detail reads bypassed the parent project's `deleted_at`; deleted projects' documents stayed downloadable to anyone with the doc id | **Fixed** in `handlers.rs::fetch_active_document`: both `GET /documents/:id` and `GET /documents/:id/blob` now 404 when the parent is soft-deleted |
| **HIGH** | `read_blob` derived filesystem paths from unvalidated DB `sha256` — a poisoned row could escape the blob root | **Fixed** in `blobs.rs::is_valid_sha256_hex`: enforces `^[0-9a-f]{64}$` before any path construction; tests cover `..`, uppercase, non-hex, and short inputs |
| MEDIUM | Project-scoped dedupe was lookup-then-insert (race) | **Fixed**: `UNIQUE (project_id, sha256)` index + new `DocumentInsert` enum that surfaces existing row on constraint violation |
| MEDIUM | `write_blob` shared `<sha>.tmp` across concurrent writers | **Fixed**: per-writer tempfile (`<sha>.<pid>.<rand>.tmp`) + rename-already-exists treated as success |
| MEDIUM | Caller-controlled `content_type` echoed back on download (XSS for an authed uploader) | **Fixed**: `normalise_content_type` accepts only `application/pdf` or OOXML mime (or `.pdf`/`.docx` extension); 415 otherwise; persisted content-type is always canonical |
| MEDIUM | `Content-Disposition` only stripped `"`; CR/LF/control chars still possible | **Fixed**: `sanitise_filename_for_disposition` collapses all non-ASCII-printable, backslash, CR/LF/`"` to `_`. Adds `X-Content-Type-Options: nosniff` on the blob response |
| LOW | Comment referenced "mike's wire shape" — avoidable AGPL provenance noise | **Fixed**: comment rewritten without reference |
| LOW | Tests cover store/blob/extract paths but not HTTP handlers | **Acknowledged**, deferred — see below |

## Deferred (intentional, called out so reviewers can challenge)

- **Postgres-backend implementation of the legal store.** v1 deployment target is libSQL. The migration ships the canonical Postgres schema, but the Rust query layer is libSQL-only — Postgres backend returns `DatabaseError::Unsupported`, which the handlers map to HTTP 501. Adding the Postgres implementation is a follow-up issue.
- **HTTP-level integration tests** against the Axum router (multipart, malicious filenames, blob serving). Existing test harness `TestGatewayBuilder` is geared toward chat handlers; covering the legal handlers properly would require either a separate harness or rewriting the existing one. Unit tests cover the data path (project CRUD, dedupe race, blob race, sha-validation, PDF/DOCX extraction, soft-delete contract).
- **Global `PRAGMA foreign_keys=ON` on libSQL connections.** Codex flagged this as a MEDIUM, but it's a pre-existing ironclaw issue (every existing FK in libSQL has the same caveat). Belongs in its own PR rather than entangled with this feature.

## Companion stream PRs

To be linked once they open (Streams B and C are landing in parallel against the same migration):

- Stream B — chat-with-docs: TBD
- Stream C — DOCX export: TBD

## Test results

- `cargo check --no-default-features --features libsql -p ironclaw` — **clean** on the foundation commit (`c87e80eb`).
- Per-stream parallel cargo contention prevented a fresh full `cargo test` run on the final commit before submission. Unit tests in this PR (legal_harness.rs + blob unit tests) compile and exercise the same code paths the handlers use.

## Base ref

- Base: `ironclaw-v0.27.0` (SHA `93c7d6a484237999a7a202efd6d54f70d785c0b7`)
- Branch: `feat/legal-harness-foundation`
- Final commit on branch: `87666593`
