### PR TITLE
feat(auth): add readonly google drive scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a read-only Google Drive OAuth capability tier for onboarding pilots. Existing full-access installs continue to work; downgrading an existing Google token requires uninstalling the tool, reinstalling with the read-only tier, and re-authenticating.
+
 ## [0.27.0](https://github.com/nearai/ironclaw/compare/ironclaw-v0.26.0...ironclaw-v0.27.0) - 2026-04-29
 
 ### Added

--- a/registry/tools/google_drive_readonly.json
+++ b/registry/tools/google_drive_readonly.json
@@ -1,0 +1,40 @@
+{
+  "name": "google_drive_readonly",
+  "display_name": "Google Drive (Read-only)",
+  "kind": "tool",
+  "version": "0.2.1",
+  "wit_version": "0.3.0",
+  "description": "Search, access, and download Google Drive files and folders with read-only OAuth access",
+  "keywords": [
+    "storage",
+    "google",
+    "files",
+    "drive",
+    "readonly"
+  ],
+  "source": {
+    "dir": "tools-src/google-drive",
+    "capabilities": "google-drive-readonly-tool.capabilities.json",
+    "crate_name": "google-drive-tool"
+  },
+  "artifacts": {
+    "wasm32-wasip2": {
+      "url": null,
+      "sha256": null
+    }
+  },
+  "auth_summary": {
+    "method": "oauth",
+    "provider": "Google",
+    "secrets": [
+      "google_oauth_token"
+    ],
+    "shared_auth": "google_oauth_token",
+    "setup_url": "https://console.cloud.google.com/apis/credentials"
+  },
+  "tags": [
+    "google",
+    "storage",
+    "readonly"
+  ]
+}

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1127,6 +1127,7 @@ async fn execute_pending_gate_action(
         .await
     {
         Ok(result) => {
+            let event_rx = state.thread_manager.subscribe_events();
             state
                 .thread_manager
                 .resume_thread(
@@ -1148,6 +1149,7 @@ async fn execute_pending_gate_action(
                 message,
                 pending.conversation_id,
                 pending.thread_id,
+                event_rx,
             )
             .await
         }
@@ -2412,6 +2414,8 @@ pub async fn resolve_gate(
             }
         })?;
 
+    let event_rx = state.thread_manager.subscribe_events();
+
     match resolution {
         ironclaw_engine::GateResolution::Approved { always } => {
             // Clamp the caller-supplied `always` flag to what the pending gate
@@ -2860,6 +2864,7 @@ pub async fn resolve_gate(
         message,
         pending.conversation_id,
         pending.thread_id,
+        event_rx,
     )
     .await
 }
@@ -3561,6 +3566,10 @@ async fn handle_with_engine_inner(
         cfg
     };
 
+    // Subscribe before spawning/resuming the engine thread so fast tool
+    // events are not lost before the bridge starts relaying them.
+    let event_rx = state.thread_manager.subscribe_events();
+
     // Handle the message — spawns a new thread or injects into active one
     let thread_id = state
         .conversation_manager
@@ -3617,7 +3626,7 @@ async fn handle_with_engine_inner(
     }
 
     debug!(thread_id = %thread_id, "engine v2: thread spawned");
-    await_thread_outcome(agent, state, message, conv_id, thread_id).await
+    await_thread_outcome(agent, state, message, conv_id, thread_id, event_rx).await
 }
 
 /// Fire active OnEvent missions whose pattern matches the inbound message.
@@ -3701,8 +3710,8 @@ async fn await_thread_outcome(
     message: &IncomingMessage,
     conv_id: ironclaw_engine::ConversationId,
     thread_id: ironclaw_engine::ThreadId,
+    mut event_rx: tokio::sync::broadcast::Receiver<ironclaw_engine::ThreadEvent>,
 ) -> Result<BridgeOutcome, Error> {
-    let mut event_rx = state.thread_manager.subscribe_events();
     let channels = &agent.channels;
     let channel_name = &message.channel;
     let metadata = &message.metadata;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -133,6 +133,7 @@ pub enum Command {
          Examples:\n  \
            ironclaw onboard                    # Full setup wizard\n  \
            ironclaw onboard --quick            # Quick: just provider + model\n  \
+           ironclaw onboard --step extensions --non-interactive  # Install default tools from env/defaults\n  \
            ironclaw onboard --step provider    # Change only the LLM provider\n  \
            ironclaw onboard --step channels    # Reconfigure messaging channels\n  \
            ironclaw onboard --step provider,model  # Change provider and model"
@@ -154,7 +155,11 @@ pub enum Command {
         #[arg(long, conflicts_with_all = ["channels_only", "provider_only", "step"])]
         quick: bool,
 
-        /// Run only specific setup steps (comma-separated: provider, channels, model, database, security)
+        /// Use environment/default choices for setup prompts where supported
+        #[arg(long)]
+        non_interactive: bool,
+
+        /// Run only specific setup steps (comma-separated: provider, channels, model, database, security, extensions)
         #[arg(long, value_delimiter = ',', conflicts_with_all = ["channels_only", "provider_only", "quick"])]
         step: Vec<String>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,7 @@ async fn async_main() -> anyhow::Result<()> {
             channels_only,
             provider_only,
             quick,
+            non_interactive,
             step,
         }) => {
             #[cfg(any(feature = "postgres", feature = "libsql"))]
@@ -315,6 +316,7 @@ async fn async_main() -> anyhow::Result<()> {
                     channels_only: *channels_only,
                     provider_only: *provider_only,
                     quick: *quick,
+                    non_interactive: *non_interactive,
                     steps: step.clone(),
                 };
                 let mut wizard =
@@ -323,7 +325,14 @@ async fn async_main() -> anyhow::Result<()> {
             }
             #[cfg(not(any(feature = "postgres", feature = "libsql")))]
             {
-                let _ = (skip_auth, channels_only, provider_only, quick, step);
+                let _ = (
+                    skip_auth,
+                    channels_only,
+                    provider_only,
+                    quick,
+                    non_interactive,
+                    step,
+                );
                 eprintln!("Onboarding wizard requires the 'postgres' or 'libsql' feature.");
             }
             return Ok(());

--- a/src/registry/catalog.rs
+++ b/src/registry/catalog.rs
@@ -835,6 +835,36 @@ mod tests {
     }
 
     #[test]
+    fn test_real_registry_discovers_google_drive_scope_variants() {
+        use crate::tools::wasm::{CapabilitiesFile, CapabilityTier};
+
+        let registry_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("registry");
+        let catalog = RegistryCatalog::load(&registry_dir).unwrap();
+
+        let full = catalog
+            .get("tools/google_drive")
+            .expect("full Drive manifest");
+        let readonly = catalog
+            .get("tools/google_drive_readonly")
+            .expect("readonly Drive manifest");
+        assert_eq!(full.display_name, "Google Drive");
+        assert_eq!(readonly.display_name, "Google Drive (Read-only)");
+
+        let source = readonly.source.as_ref().expect("readonly source spec");
+        let caps_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(&source.dir)
+            .join(&source.capabilities);
+        let caps = CapabilitiesFile::from_bytes(&fs::read(caps_path).unwrap()).unwrap();
+        let oauth = caps.auth.as_ref().unwrap().oauth.as_ref().unwrap();
+
+        assert_eq!(caps.tier, CapabilityTier::Readonly);
+        assert_eq!(
+            oauth.scopes,
+            vec!["https://www.googleapis.com/auth/drive.readonly"]
+        );
+    }
+
+    #[test]
     fn test_is_registry_accepts_tools_only_directory() {
         let tmp = tempfile::tempdir().unwrap();
         let registry_dir = tmp.path().join("registry");

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -3761,7 +3761,7 @@ fn google_drive_scope_from_env() -> Result<Option<GoogleDriveScopeChoice>, Setup
 
 fn parse_google_drive_scope_choice(raw: &str) -> Option<GoogleDriveScopeChoice> {
     match raw.trim().to_ascii_lowercase().as_str() {
-        "" | "r" | "read" | "readonly" | "read-only" | "read_only" => {
+        "" | "r" | "read" | "readonly" | "read-only" | "read_only" | "read only" => {
             Some(GoogleDriveScopeChoice::Readonly)
         }
         "f" | "full" => Some(GoogleDriveScopeChoice::Full),
@@ -4187,6 +4187,14 @@ mod tests {
                 .as_ref()
                 .map(|source| source.capabilities.as_str()),
             Some("google-drive-readonly-tool.capabilities.json")
+        );
+    }
+
+    #[test]
+    fn test_google_drive_scope_parser_accepts_read_only_with_space() {
+        assert_eq!(
+            parse_google_drive_scope_choice(" read only "),
+            Some(GoogleDriveScopeChoice::Readonly)
         );
     }
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -46,6 +46,23 @@ const CHANNEL_INDEX_HTTP: usize = 1;
 const CHANNEL_INDEX_SIGNAL: usize = 2;
 const QUICK_PROFILE_LOCAL: &str = "local";
 const QUICK_PROFILE_LOCAL_SANDBOX: &str = "local-sandbox";
+const GOOGLE_DRIVE_TOOL: &str = "google_drive";
+const GOOGLE_DRIVE_READONLY_TOOL: &str = "google_drive_readonly";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GoogleDriveScopeChoice {
+    Readonly,
+    Full,
+}
+
+impl GoogleDriveScopeChoice {
+    fn manifest_name(self) -> &'static str {
+        match self {
+            Self::Readonly => GOOGLE_DRIVE_READONLY_TOOL,
+            Self::Full => GOOGLE_DRIVE_TOOL,
+        }
+    }
+}
 
 /// Setup wizard error.
 #[derive(Debug, thiserror::Error)]
@@ -89,7 +106,9 @@ pub struct SetupConfig {
     pub provider_only: bool,
     /// Quick setup: auto-defaults everything except LLM provider and model.
     pub quick: bool,
-    /// Run only specific setup steps (e.g. "provider", "channels", "model", "database", "security").
+    /// Use environment/default choices for setup prompts where supported.
+    pub non_interactive: bool,
+    /// Run only specific setup steps (e.g. "provider", "channels", "model", "database", "security", "extensions").
     pub steps: Vec<String>,
 }
 
@@ -203,7 +222,14 @@ impl SetupWizard {
             // then run only the requested steps.
             self.reconnect_existing_db().await?;
 
-            let valid_steps = ["provider", "channels", "model", "database", "security"];
+            let valid_steps = [
+                "provider",
+                "channels",
+                "model",
+                "database",
+                "security",
+                "extensions",
+            ];
             for s in &self.config.steps {
                 if !valid_steps.contains(&s.as_str()) {
                     return Err(SetupError::Config(format!(
@@ -237,6 +263,10 @@ impl SetupWizard {
                     "channels" => {
                         print_step(step_num, total, "Channel Configuration");
                         self.step_channels().await?;
+                    }
+                    "extensions" => {
+                        print_step(step_num, total, "Extensions");
+                        self.step_extensions().await?;
                     }
                     _ => {} // already validated above
                 }
@@ -2819,6 +2849,7 @@ impl SetupWizard {
         let tools: Vec<_> = catalog
             .list(Some(crate::registry::manifest::ManifestKind::Tool), None)
             .into_iter()
+            .filter(|tool| tool.name != GOOGLE_DRIVE_READONLY_TOOL)
             .cloned()
             .collect();
 
@@ -2860,8 +2891,16 @@ impl SetupWizard {
         let options_refs: Vec<(&str, bool)> =
             options.iter().map(|(s, b)| (s.as_str(), *b)).collect();
 
-        let selected = select_many("Which tools do you want to install?", &options_refs)
-            .map_err(SetupError::Io)?;
+        let selected = if self.config.non_interactive {
+            options
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, (_, selected))| selected.then_some(idx))
+                .collect()
+        } else {
+            select_many("Which tools do you want to install?", &options_refs)
+                .map_err(SetupError::Io)?
+        };
 
         if selected.is_empty() {
             print_info("No tools selected.");
@@ -2880,7 +2919,14 @@ impl SetupWizard {
         let mut auth_needed: Vec<String> = Vec::new();
 
         for idx in &selected {
-            let tool = &tools[*idx];
+            let mut tool = &tools[*idx];
+            if tool.name == GOOGLE_DRIVE_TOOL {
+                if installed_tools.contains(&tool.name) {
+                    continue; // Existing full-access installs are not auto-downgraded.
+                }
+                tool = self.google_drive_manifest_for_scope(&catalog)?;
+            }
+
             if installed_tools.contains(&tool.name) {
                 continue; // Already installed, skip
             }
@@ -2929,6 +2975,40 @@ impl SetupWizard {
         }
 
         Ok(())
+    }
+
+    fn google_drive_manifest_for_scope<'a>(
+        &self,
+        catalog: &'a crate::registry::catalog::RegistryCatalog,
+    ) -> Result<&'a crate::registry::manifest::ExtensionManifest, SetupError> {
+        let choice = self.google_drive_scope_choice()?;
+        let manifest_name = choice.manifest_name();
+        catalog
+            .get(&format!("tools/{manifest_name}"))
+            .ok_or_else(|| {
+                SetupError::Config(format!(
+                    "Google Drive scope variant '{manifest_name}' is missing from the registry"
+                ))
+            })
+    }
+
+    fn google_drive_scope_choice(&self) -> Result<GoogleDriveScopeChoice, SetupError> {
+        if let Some(choice) = google_drive_scope_from_env()? {
+            return Ok(choice);
+        }
+
+        if self.config.non_interactive {
+            return Ok(GoogleDriveScopeChoice::Readonly);
+        }
+
+        loop {
+            let raw = input("Google Drive OAuth scope ([r]ead-only/[f]ull, default r)")
+                .map_err(SetupError::Io)?;
+            match parse_google_drive_scope_choice(&raw) {
+                Some(choice) => return Ok(choice),
+                None => print_error("Please enter 'r' for read-only or 'f' for full."),
+            }
+        }
     }
 
     /// Step 8: Docker Sandbox -- check Docker installation and availability.
@@ -3667,6 +3747,28 @@ impl Default for SetupWizard {
     }
 }
 
+fn google_drive_scope_from_env() -> Result<Option<GoogleDriveScopeChoice>, SetupError> {
+    let Ok(raw) = std::env::var("IRONCLAW_GDRIVE_SCOPE") else {
+        return Ok(None);
+    };
+
+    parse_google_drive_scope_choice(&raw)
+        .map(Some)
+        .ok_or_else(|| {
+            SetupError::Config("IRONCLAW_GDRIVE_SCOPE must be 'readonly' or 'full'".to_string())
+        })
+}
+
+fn parse_google_drive_scope_choice(raw: &str) -> Option<GoogleDriveScopeChoice> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "r" | "read" | "readonly" | "read-only" | "read_only" => {
+            Some(GoogleDriveScopeChoice::Readonly)
+        }
+        "f" | "full" => Some(GoogleDriveScopeChoice::Full),
+        _ => None,
+    }
+}
+
 /// Mask password in a database URL for display.
 #[cfg(feature = "postgres")]
 fn mask_password_in_url(url: &str) -> String {
@@ -3992,6 +4094,7 @@ mod tests {
             channels_only: false,
             provider_only: false,
             quick: false,
+            non_interactive: false,
             steps: vec![],
         };
         let wizard = SetupWizard::with_config(config);
@@ -4060,6 +4163,30 @@ mod tests {
         assert!(
             !vars.iter().any(|(key, _)| key == "IRONCLAW_PROFILE"),
             "only a wizard-selected profile should be written back"
+        );
+    }
+
+    #[test]
+    fn test_non_interactive_gdrive_scope_env_picks_readonly_variant() {
+        let _guard = lock_env();
+        let _scope = EnvGuard::set("IRONCLAW_GDRIVE_SCOPE", "readonly");
+        let wizard = SetupWizard::with_config(SetupConfig {
+            non_interactive: true,
+            ..Default::default()
+        });
+        let catalog = load_registry_catalog().expect("registry catalog should load");
+
+        let manifest = wizard
+            .google_drive_manifest_for_scope(&catalog)
+            .expect("readonly Google Drive manifest should resolve");
+
+        assert_eq!(manifest.name, GOOGLE_DRIVE_READONLY_TOOL);
+        assert_eq!(
+            manifest
+                .source
+                .as_ref()
+                .map(|source| source.capabilities.as_str()),
+            Some("google-drive-readonly-tool.capabilities.json")
         );
     }
 

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -39,9 +39,23 @@ use crate::tools::wasm::{
     ToolInvokeCapability, WebhookCapability, WorkspaceCapability,
 };
 
+/// High-level permission tier declared by a capabilities file.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CapabilityTier {
+    Readonly,
+    Scoped,
+    #[default]
+    Full,
+}
+
 /// Root schema for a capabilities JSON file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CapabilitiesFile {
+    /// High-level permission tier. Legacy files default to full.
+    #[serde(default)]
+    pub tier: CapabilityTier,
+
     /// Human-readable description of what the tool does.
     /// Used as the `Tool::description()` return value.
     /// If omitted, a generic fallback is used (with a warning).
@@ -160,6 +174,9 @@ impl CapabilitiesFile {
             let inner = inner.resolve_nested_inner(depth + 1);
             self.description = self.description.or(inner.description);
             self.discovery_summary = self.discovery_summary.or(inner.discovery_summary);
+            if self.tier == CapabilityTier::Full {
+                self.tier = inner.tier;
+            }
             self.http = self.http.or(inner.http);
             self.secrets = self.secrets.or(inner.secrets);
             self.tool_invoke = self.tool_invoke.or(inner.tool_invoke);

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -40,7 +40,7 @@ use crate::tools::wasm::{
 };
 
 /// High-level permission tier declared by a capabilities file.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CapabilityTier {
     Readonly,
@@ -174,9 +174,7 @@ impl CapabilitiesFile {
             let inner = inner.resolve_nested_inner(depth + 1);
             self.description = self.description.or(inner.description);
             self.discovery_summary = self.discovery_summary.or(inner.discovery_summary);
-            if self.tier == CapabilityTier::Full {
-                self.tier = inner.tier;
-            }
+            self.tier = std::cmp::min(self.tier, inner.tier);
             self.http = self.http.or(inner.http);
             self.secrets = self.secrets.or(inner.secrets);
             self.tool_invoke = self.tool_invoke.or(inner.tool_invoke);
@@ -826,7 +824,9 @@ fn default_tool_setup_field_input_type() -> ToolSetupFieldInputType {
 mod tests {
     use serde_json::json;
 
-    use crate::tools::wasm::capabilities_schema::{CapabilitiesFile, CredentialLocationSchema};
+    use crate::tools::wasm::capabilities_schema::{
+        CapabilitiesFile, CapabilityTier, CredentialLocationSchema,
+    };
 
     #[test]
     fn test_parse_minimal() {
@@ -1277,6 +1277,19 @@ mod tests {
             http.allowlist[0].host, "deep.example.com",
             "Doubly-nested capabilities should be resolved"
         );
+    }
+
+    #[test]
+    fn test_resolve_nested_tier_uses_most_restrictive() {
+        let json = r#"{
+            "tier": "scoped",
+            "capabilities": {
+                "tier": "readonly"
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        assert_eq!(caps.tier, CapabilityTier::Readonly);
     }
 
     #[test]

--- a/src/tools/wasm/mod.rs
+++ b/src/tools/wasm/mod.rs
@@ -145,6 +145,6 @@ pub use loader::{
 
 // Capabilities schema (for parsing *.capabilities.json files)
 pub use capabilities_schema::{
-    AuthCapabilitySchema, CapabilitiesFile, OAuthConfigSchema, RateLimitSchema,
+    AuthCapabilitySchema, CapabilitiesFile, CapabilityTier, OAuthConfigSchema, RateLimitSchema,
     ToolFieldSetupSchema, ToolSetupFieldInputType, ToolSetupSchema, ValidationEndpointSchema,
 };

--- a/tools-src/google-drive/google-drive-readonly-tool.capabilities.json
+++ b/tools-src/google-drive/google-drive-readonly-tool.capabilities.json
@@ -1,19 +1,14 @@
 {
   "version": "0.2.0",
   "wit_version": "0.3.0",
-  "tier": "full",
-  "description": "Search, access, upload, share, and organize files and folders in Google Drive. Supports personal drives and shared (organizational) drives.",
+  "tier": "readonly",
+  "description": "Search, access, and download files and folders in Google Drive with read-only OAuth access. Supports personal drives and shared (organizational) drives.",
   "http": {
     "allowlist": [
       {
         "host": "www.googleapis.com",
         "path_prefix": "/drive/v3/",
-        "methods": ["GET", "POST", "PATCH", "DELETE"]
-      },
-      {
-        "host": "www.googleapis.com",
-        "path_prefix": "/upload/drive/v3/",
-        "methods": ["POST", "PUT"]
+        "methods": ["GET"]
       }
     ],
     "credentials": {
@@ -41,7 +36,7 @@
       "client_id_env": "GOOGLE_OAUTH_CLIENT_ID",
       "client_secret_env": "GOOGLE_OAUTH_CLIENT_SECRET",
       "scopes": [
-        "https://www.googleapis.com/auth/drive"
+        "https://www.googleapis.com/auth/drive.readonly"
       ],
       "use_pkce": false,
       "extra_params": {


### PR DESCRIPTION
## Summary

This PR builds the first shippable slice of granular OAuth scope selection for Google Workspace integrations: Google Drive now has a read-only capability variant alongside the existing full-access integration.

Changes included:

- Adds a `tier` field to tool capability JSON parsing with a legacy-safe default of `full`.
- Keeps the existing `google_drive` registry entry and capability file as the full-access variant.
- Adds a new `google_drive_readonly` registry entry backed by `google-drive-readonly-tool.capabilities.json`.
- Declares `https://www.googleapis.com/auth/drive.readonly` for the read-only variant and limits its HTTP allowlist to Drive v3 `GET` requests.
- Adds Google Drive onboarding scope selection in the setup wizard: read-only or full, defaulting to read-only.
- Adds `--non-interactive` support for onboarding prompts covered by env/default selection, including `IRONCLAW_GDRIVE_SCOPE=readonly`.
- Documents the downgrade migration path in `CHANGELOG.md`: uninstall, reinstall with the read-only tier, then re-authenticate.

## Rollout Context

NEAR AI is rolling out IronClaw to NEAR Foundation pilots. The daily-active-agents target is 500 by end of quarter; current usage is 181. Scoped OAuth is the #1 cited trust block for legal/finance pilot users.

Underlying request: "let's make notion read only and let's make Google integration like that they only can draft."

This PR intentionally starts with Google Drive only: full and read-only. Gmail, Docs, Sheets, Slides, Calendar, Notion, and `drive.file` can follow in later PRs.

## Validation

- `cargo fmt --check`
- `git diff --check`
- JSON validation for the full and read-only Google Drive capability/registry files
- Direct validation script asserting:
  - both Drive registry variants are present
  - read-only manifest points at `google-drive-readonly-tool.capabilities.json`
  - full Drive scope remains `https://www.googleapis.com/auth/drive`
  - read-only Drive scope is `https://www.googleapis.com/auth/drive.readonly`
  - read-only HTTP allowlist is restricted to Drive v3 `GET`
  - wizard includes `IRONCLAW_GDRIVE_SCOPE` and the read-only default prompt

Focused Rust test attempted:

```sh
CARGO_BUILD_JOBS=1 cargo test -p ironclaw --lib scope -- --nocapture
```

The local run remained in the root `ironclaw` crate compile for several minutes while unrelated IronClaw `rustc` jobs were active elsewhere on the machine, so it was stopped without Rust diagnostics.