### PR TITLE
feat(cli): add `ironclaw insights` for usage analytics

### DIFF
--- a/migrations/V26__routine_runs_created_at_index.sql
+++ b/migrations/V26__routine_runs_created_at_index.sql
@@ -1,0 +1,18 @@
+-- Add index on routine_runs.created_at to speed up the time-window
+-- aggregation used by `ironclaw insights`.
+--
+-- V6 created indexes on routine_id and status but not created_at, so the
+-- insights query (`SELECT COUNT(*) FROM routine_runs WHERE created_at >=
+-- $1 AND created_at < $2`) was a full-table scan on deployments with
+-- meaningful routine_runs history. Mirrors the pattern of V24, which
+-- added the same kind of index to llm_calls for the admin usage summary.
+--
+-- WARNING: This takes a full table lock on routine_runs. For large
+-- deployments with millions of rows, this could block writes for several
+-- seconds to minutes. Refinery wraps migrations in a transaction, which
+-- prevents using CREATE INDEX CONCURRENTLY. If this is a concern, apply
+-- the index manually outside the migration framework first:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_routine_runs_created
+--       ON routine_runs(created_at);
+CREATE INDEX IF NOT EXISTS idx_routine_runs_created ON routine_runs(created_at);

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -38,3 +38,4 @@ V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
 V24__llm_calls_created_at_index = 2650126284755685421
 V25__wasm_fuel_limit_bump = 8924323300096627270
+V26__routine_runs_created_at_index = 16310507478302332026

--- a/src/cli/insights.rs
+++ b/src/cli/insights.rs
@@ -102,10 +102,7 @@ pub async fn run_insights_command(
 
 /// Run insights with an injected database. Used by tests to avoid touching
 /// `Config::from_env`.
-pub async fn run_insights_with_db(
-    args: InsightsArgs,
-    db: Arc<dyn Database>,
-) -> anyhow::Result<()> {
+pub async fn run_insights_with_db(args: InsightsArgs, db: Arc<dyn Database>) -> anyhow::Result<()> {
     let resolved = resolve_window(args.days);
     if resolved.clamped {
         eprintln!(

--- a/src/cli/insights.rs
+++ b/src/cli/insights.rs
@@ -141,20 +141,20 @@ fn emit_json(agg: &InsightsAggregate, window_days: u32) -> anyhow::Result<()> {
         "top_tools": agg.top_tools,
         "daily_activity": agg.daily_activity,
     });
-    println!("{}", serde_json::to_string_pretty(&payload)?);
+    let body = serde_json::to_string_pretty(&payload)?;
+    println!("{body}");
     Ok(())
 }
 
 fn emit_table(agg: &InsightsAggregate, window_days: u32) {
     if agg.total_jobs == 0 && agg.total_routine_runs == 0 {
         println!(
-            "No agent activity in the last {} day(s). Run `ironclaw run` to start the agent.",
-            window_days
+            "No agent activity in the last {window_days} day(s). Run `ironclaw run` to start the agent."
         );
         return;
     }
 
-    println!("IronClaw insights — last {} day(s)\n", window_days);
+    println!("IronClaw insights — last {window_days} day(s)\n");
 
     println!(
         "  jobs:           {}\n  routine runs:   {}\n  tokens used:    {}",

--- a/src/cli/insights.rs
+++ b/src/cli/insights.rs
@@ -115,9 +115,10 @@ pub async fn run_insights_with_db(
         );
     }
 
-    let since = Utc::now() - Duration::days(resolved.days as i64);
+    let until = Utc::now();
+    let since = until - Duration::days(resolved.days as i64);
     let aggregate = db
-        .aggregate_insights(since, TOP_TOOLS_LIMIT)
+        .aggregate_insights(since, until, TOP_TOOLS_LIMIT)
         .await
         .map_err(|e| anyhow::anyhow!("aggregate_insights failed: {e}"))?;
 

--- a/src/cli/insights.rs
+++ b/src/cli/insights.rs
@@ -1,0 +1,248 @@
+//! `ironclaw insights` — usage analytics over the local IronClaw database.
+//!
+//! Reads aggregates already collected by the agent (agent_jobs, routine_runs,
+//! job_actions). Operators previously tailed logs to track adoption; this
+//! subcommand surfaces the same numbers without scraping.
+//!
+//! First-commit scope:
+//!   - Time window aggregates only (`--days <N>`, default 30, capped at 90).
+//!   - Token + job counts, top-N tool frequency, daily activity histogram.
+//!   - Pretty table by default, structured JSON behind `--json`.
+//!
+//! Out of scope (follow-up PRs): per-call USD cost rollup, `--source` /
+//! `--user-id` filters, average turns/session.
+//!
+//! Hermes parity is intentionally partial: this is the CLI surface NEAR
+//! Foundation operators need today, not the full Hermes UI.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use clap::Args;
+
+use crate::db::{Database, InsightsAggregate};
+
+/// Default window in days when `--days` is not provided.
+pub const DEFAULT_INSIGHTS_DAYS: u32 = 30;
+/// Hard cap on `--days`. Larger values fall back to this and emit a warning.
+/// Aggregations beyond ~90 days have not been validated against real-world
+/// libSQL files and can produce surprising numbers when the schema changes.
+pub const MAX_INSIGHTS_DAYS: u32 = 90;
+/// Number of tool rows shown in pretty output and emitted in JSON.
+pub const TOP_TOOLS_LIMIT: i64 = 10;
+
+#[derive(Args, Debug, Clone)]
+pub struct InsightsArgs {
+    /// Time window in days (default 30). Capped at 90; values above the cap
+    /// are clamped and a warning is printed to stderr.
+    #[arg(long, default_value_t = DEFAULT_INSIGHTS_DAYS)]
+    pub days: u32,
+
+    /// Emit machine-readable JSON instead of a human-readable table.
+    /// The schema is additive — consumers should ignore unknown fields.
+    #[arg(long)]
+    pub json: bool,
+}
+
+impl Default for InsightsArgs {
+    fn default() -> Self {
+        Self {
+            days: DEFAULT_INSIGHTS_DAYS,
+            json: false,
+        }
+    }
+}
+
+/// Result of normalizing a user-supplied `--days` value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedWindow {
+    pub days: u32,
+    pub clamped: bool,
+}
+
+/// Clamp `--days` into `[1, MAX_INSIGHTS_DAYS]` and report whether clamping
+/// happened, so the caller can warn on stderr without re-doing the math.
+pub fn resolve_window(requested: u32) -> ResolvedWindow {
+    if requested == 0 {
+        // Treat 0 as "default window" rather than empty; insights with a
+        // zero-second window are useless and almost certainly a typo.
+        return ResolvedWindow {
+            days: DEFAULT_INSIGHTS_DAYS,
+            clamped: true,
+        };
+    }
+    if requested > MAX_INSIGHTS_DAYS {
+        return ResolvedWindow {
+            days: MAX_INSIGHTS_DAYS,
+            clamped: true,
+        };
+    }
+    ResolvedWindow {
+        days: requested,
+        clamped: false,
+    }
+}
+
+/// Top-level entry point used by `main.rs`. Loads config and connects to the
+/// configured database (libSQL or Postgres), then delegates to
+/// [`run_insights_with_db`] for testability.
+pub async fn run_insights_command(
+    args: InsightsArgs,
+    config_path: Option<&Path>,
+) -> anyhow::Result<()> {
+    let config = crate::config::Config::from_env_with_toml(config_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:#}"))?;
+    let db: Arc<dyn Database> = crate::db::connect_from_config(&config.database)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e:#}"))?;
+    run_insights_with_db(args, db).await
+}
+
+/// Run insights with an injected database. Used by tests to avoid touching
+/// `Config::from_env`.
+pub async fn run_insights_with_db(
+    args: InsightsArgs,
+    db: Arc<dyn Database>,
+) -> anyhow::Result<()> {
+    let resolved = resolve_window(args.days);
+    if resolved.clamped {
+        eprintln!(
+            "warning: requested window {} day(s) clamped to {} (max). \
+             Wider windows are not supported in this release.",
+            args.days, resolved.days
+        );
+    }
+
+    let since = Utc::now() - Duration::days(resolved.days as i64);
+    let aggregate = db
+        .aggregate_insights(since, TOP_TOOLS_LIMIT)
+        .await
+        .map_err(|e| anyhow::anyhow!("aggregate_insights failed: {e}"))?;
+
+    if args.json {
+        emit_json(&aggregate, resolved.days)?;
+    } else {
+        emit_table(&aggregate, resolved.days);
+    }
+    Ok(())
+}
+
+fn emit_json(agg: &InsightsAggregate, window_days: u32) -> anyhow::Result<()> {
+    // `version` lets dashboards detect breaking schema changes without sniffing
+    // optional fields. Bump it on rename/removal, never on additions.
+    let payload = serde_json::json!({
+        "version": 1,
+        "window_days": window_days,
+        "total_jobs": agg.total_jobs,
+        "total_routine_runs": agg.total_routine_runs,
+        "total_tokens_used": agg.total_tokens_used,
+        "top_tools": agg.top_tools,
+        "daily_activity": agg.daily_activity,
+    });
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+    Ok(())
+}
+
+fn emit_table(agg: &InsightsAggregate, window_days: u32) {
+    if agg.total_jobs == 0 && agg.total_routine_runs == 0 {
+        println!(
+            "No agent activity in the last {} day(s). Run `ironclaw run` to start the agent.",
+            window_days
+        );
+        return;
+    }
+
+    println!("IronClaw insights — last {} day(s)\n", window_days);
+
+    println!(
+        "  jobs:           {}\n  routine runs:   {}\n  tokens used:    {}",
+        agg.total_jobs, agg.total_routine_runs, agg.total_tokens_used,
+    );
+
+    if !agg.top_tools.is_empty() {
+        println!("\n  Top tools by invocation:");
+        let max_tool_len = agg
+            .top_tools
+            .iter()
+            .map(|t| t.tool_name.chars().count())
+            .max()
+            .unwrap_or(8)
+            .max(8);
+        for tool in &agg.top_tools {
+            println!(
+                "    {:<width$}  {:>6}",
+                tool.tool_name,
+                tool.invocations,
+                width = max_tool_len,
+            );
+        }
+    }
+
+    if !agg.daily_activity.is_empty() {
+        println!("\n  Daily activity:");
+        for day in &agg.daily_activity {
+            println!("    {}  {:>6}", day.date, day.jobs);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_window_default_clamps_zero() {
+        let r = resolve_window(0);
+        assert_eq!(r.days, DEFAULT_INSIGHTS_DAYS);
+        assert!(r.clamped);
+    }
+
+    #[test]
+    fn resolve_window_caps_at_max() {
+        let r = resolve_window(365);
+        assert_eq!(r.days, MAX_INSIGHTS_DAYS);
+        assert!(r.clamped);
+    }
+
+    #[test]
+    fn resolve_window_passes_through_in_range() {
+        let r = resolve_window(7);
+        assert_eq!(r.days, 7);
+        assert!(!r.clamped);
+    }
+
+    #[test]
+    fn resolve_window_passes_through_at_boundary() {
+        let r = resolve_window(MAX_INSIGHTS_DAYS);
+        assert_eq!(r.days, MAX_INSIGHTS_DAYS);
+        assert!(!r.clamped);
+    }
+
+    #[test]
+    fn json_is_stable_for_empty_aggregate() {
+        let agg = InsightsAggregate::default();
+        let payload = serde_json::json!({
+            "version": 1,
+            "window_days": 30,
+            "total_jobs": agg.total_jobs,
+            "total_routine_runs": agg.total_routine_runs,
+            "total_tokens_used": agg.total_tokens_used,
+            "top_tools": agg.top_tools,
+            "daily_activity": agg.daily_activity,
+        });
+        // Snapshot fixture: this is the canonical empty-data JSON shape.
+        // If this test fails, dashboards consuming the JSON will break too.
+        let expected = serde_json::json!({
+            "version": 1,
+            "window_days": 30,
+            "total_jobs": 0,
+            "total_routine_runs": 0,
+            "total_tokens_used": 0,
+            "top_tools": [],
+            "daily_activity": [],
+        });
+        assert_eq!(payload, expected);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,7 @@ pub mod fmt;
 mod hooks;
 #[cfg(feature = "import")]
 pub mod import;
+pub mod insights;
 mod logs;
 mod mcp;
 pub mod memory;
@@ -45,6 +46,7 @@ pub use doctor::run_doctor_command;
 pub use hooks::{HooksCommand, run_hooks_command};
 #[cfg(feature = "import")]
 pub use import::{ImportCommand, run_import_command};
+pub use insights::{InsightsArgs, run_insights_command, run_insights_with_db};
 pub use logs::{LogsCommand, run_logs_command};
 pub use mcp::{McpCommand, run_mcp_command};
 pub use memory::MemoryCommand;
@@ -255,6 +257,20 @@ pub enum Command {
         long_about = "List, search, and inspect SKILL.md-based skills.\nExamples:\n  ironclaw skills list\n  ironclaw skills search 'writing'\n  ironclaw skills info my-skill"
     )]
     Skills(SkillsCommand),
+
+    /// Show usage analytics (jobs, tokens, top tools)
+    #[command(
+        about = "Show usage analytics for the local agent",
+        long_about = "Aggregates agent_jobs, routine_runs, and job_actions over a time \
+                      window so operators can track adoption without tailing logs.\n\n\
+                      Default window is 30 days. Capped at 90 days; larger requests are \
+                      clamped with a warning.\n\n\
+                      Examples:\n  \
+                        ironclaw insights                # last 30 days, table\n  \
+                        ironclaw insights --days 7       # last week\n  \
+                        ironclaw insights --json         # machine-readable JSON"
+    )]
+    Insights(InsightsArgs),
 
     /// Manage lifecycle hooks
     #[command(

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
@@ -20,6 +20,7 @@ Commands:
   profile     Manage deployment profiles
   service     Manage OS service
   skills      Manage skills
+  insights    Show usage analytics for the local agent
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics (check if everything is configured correctly)

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -20,6 +20,7 @@ Commands:
   profile     Manage deployment profiles
   service     Manage OS service
   skills      Manage skills
+  insights    Show usage analytics for the local agent
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics (check if everything is configured correctly)

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
@@ -34,6 +34,7 @@ Commands:
   profile     Manage deployment profiles
   service     Manage OS service
   skills      Manage skills
+  insights    Show usage analytics for the local agent
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics (check if everything is configured correctly)

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -34,6 +34,7 @@ Commands:
   profile     Manage deployment profiles
   service     Manage OS service
   skills      Manage skills
+  insights    Show usage analytics for the local agent
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics (check if everything is configured correctly)

--- a/src/db/libsql/insights.rs
+++ b/src/db/libsql/insights.rs
@@ -1,0 +1,138 @@
+//! Aggregate usage analytics for the `ironclaw insights` CLI (libSQL backend).
+//!
+//! All queries are bounded by `agent_jobs.created_at >= ?since` so the work
+//! scales with the time window, not the table size. Tool frequency joins
+//! `job_actions` to `agent_jobs` so we don't aggregate actions whose parent
+//! job falls outside the window.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use libsql::params;
+
+use super::{LibSqlBackend, fmt_ts, get_i64, get_text};
+use crate::db::{DailyActivity, InsightsAggregate, InsightsStore, ToolFrequency};
+use crate::error::DatabaseError;
+
+#[async_trait]
+impl InsightsStore for LibSqlBackend {
+    async fn aggregate_insights(
+        &self,
+        since: DateTime<Utc>,
+        top_tools_limit: i64,
+    ) -> Result<InsightsAggregate, DatabaseError> {
+        let since_text = fmt_ts(&since);
+        let conn = self.connect().await?;
+
+        // Single round-trip per metric. Each query uses the
+        // `idx_agent_jobs_created` index for the time-window scan.
+
+        // Total jobs and total tokens used in the window.
+        let mut row = conn
+            .query(
+                r#"
+                SELECT
+                    COUNT(*) AS total_jobs,
+                    COALESCE(SUM(total_tokens_used), 0) AS total_tokens
+                FROM agent_jobs
+                WHERE created_at >= ?1
+                "#,
+                params![since_text.clone()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let (total_jobs, total_tokens_used) = match row
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            Some(r) => (get_i64(&r, 0).max(0) as u64, get_i64(&r, 1).max(0) as u64),
+            None => (0, 0),
+        };
+
+        // Total routine runs in the window (use created_at to align with jobs).
+        let mut row = conn
+            .query(
+                "SELECT COUNT(*) FROM routine_runs WHERE created_at >= ?1",
+                params![since_text.clone()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        let total_routine_runs = match row
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            Some(r) => get_i64(&r, 0).max(0) as u64,
+            None => 0,
+        };
+
+        // Top tools by invocation count, joined to agent_jobs so the time
+        // window applies. `top_tools_limit` is clamped to >=1 to avoid a
+        // zero/negative LIMIT producing surprises.
+        let limit = top_tools_limit.max(1);
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT ja.tool_name, COUNT(*) AS invocations
+                FROM job_actions ja
+                INNER JOIN agent_jobs aj ON aj.id = ja.job_id
+                WHERE aj.created_at >= ?1
+                GROUP BY ja.tool_name
+                ORDER BY invocations DESC, ja.tool_name ASC
+                LIMIT ?2
+                "#,
+                params![since_text.clone(), limit],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let mut top_tools = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            top_tools.push(ToolFrequency {
+                tool_name: get_text(&row, 0),
+                invocations: get_i64(&row, 1).max(0) as u64,
+            });
+        }
+
+        // Daily activity histogram. SQLite's `substr(created_at, 1, 10)` works
+        // because created_at is an RFC 3339 ISO string starting with the date.
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT substr(created_at, 1, 10) AS day, COUNT(*) AS jobs
+                FROM agent_jobs
+                WHERE created_at >= ?1
+                GROUP BY day
+                ORDER BY day ASC
+                "#,
+                params![since_text],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let mut daily_activity = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            daily_activity.push(DailyActivity {
+                date: get_text(&row, 0),
+                jobs: get_i64(&row, 1).max(0) as u64,
+            });
+        }
+
+        Ok(InsightsAggregate {
+            total_jobs,
+            total_routine_runs,
+            total_tokens_used,
+            top_tools,
+            daily_activity,
+        })
+    }
+}

--- a/src/db/libsql/insights.rs
+++ b/src/db/libsql/insights.rs
@@ -1,9 +1,11 @@
 //! Aggregate usage analytics for the `ironclaw insights` CLI (libSQL backend).
 //!
-//! All queries are bounded by `agent_jobs.created_at >= ?since` so the work
-//! scales with the time window, not the table size. Tool frequency joins
-//! `job_actions` to `agent_jobs` so we don't aggregate actions whose parent
-//! job falls outside the window.
+//! All queries are bounded by the closed-open interval `[since, until)`
+//! so the work scales with the time window, not the table size, AND
+//! future-dated rows (clock skew, manual seeds, replay tooling) cannot
+//! leak into the totals. Tool frequency joins `job_actions` to
+//! `agent_jobs` so we don't aggregate actions whose parent job falls
+//! outside the window.
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -18,13 +20,16 @@ impl InsightsStore for LibSqlBackend {
     async fn aggregate_insights(
         &self,
         since: DateTime<Utc>,
+        until: DateTime<Utc>,
         top_tools_limit: i64,
     ) -> Result<InsightsAggregate, DatabaseError> {
         let since_text = fmt_ts(&since);
+        let until_text = fmt_ts(&until);
         let conn = self.connect().await?;
 
         // Single round-trip per metric. Each query uses the
-        // `idx_agent_jobs_created` index for the time-window scan.
+        // `idx_agent_jobs_created` and `idx_routine_runs_created` indexes
+        // for the time-window scan.
 
         // Total jobs and total tokens used in the window.
         let mut row = conn
@@ -34,9 +39,9 @@ impl InsightsStore for LibSqlBackend {
                     COUNT(*) AS total_jobs,
                     COALESCE(SUM(total_tokens_used), 0) AS total_tokens
                 FROM agent_jobs
-                WHERE created_at >= ?1
+                WHERE created_at >= ?1 AND created_at < ?2
                 "#,
-                params![since_text.clone()],
+                params![since_text.clone(), until_text.clone()],
             )
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
@@ -53,8 +58,8 @@ impl InsightsStore for LibSqlBackend {
         // Total routine runs in the window (use created_at to align with jobs).
         let mut row = conn
             .query(
-                "SELECT COUNT(*) FROM routine_runs WHERE created_at >= ?1",
-                params![since_text.clone()],
+                "SELECT COUNT(*) FROM routine_runs WHERE created_at >= ?1 AND created_at < ?2",
+                params![since_text.clone(), until_text.clone()],
             )
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
@@ -77,12 +82,12 @@ impl InsightsStore for LibSqlBackend {
                 SELECT ja.tool_name, COUNT(*) AS invocations
                 FROM job_actions ja
                 INNER JOIN agent_jobs aj ON aj.id = ja.job_id
-                WHERE aj.created_at >= ?1
+                WHERE aj.created_at >= ?1 AND aj.created_at < ?2
                 GROUP BY ja.tool_name
                 ORDER BY invocations DESC, ja.tool_name ASC
-                LIMIT ?2
+                LIMIT ?3
                 "#,
-                params![since_text.clone(), limit],
+                params![since_text.clone(), until_text.clone(), limit],
             )
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
@@ -106,11 +111,11 @@ impl InsightsStore for LibSqlBackend {
                 r#"
                 SELECT substr(created_at, 1, 10) AS day, COUNT(*) AS jobs
                 FROM agent_jobs
-                WHERE created_at >= ?1
+                WHERE created_at >= ?1 AND created_at < ?2
                 GROUP BY day
                 ORDER BY day ASC
                 "#,
-                params![since_text],
+                params![since_text, until_text],
             )
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;

--- a/src/db/libsql/mod.rs
+++ b/src/db/libsql/mod.rs
@@ -8,6 +8,7 @@
 
 mod conversations;
 mod identities;
+mod insights;
 mod jobs;
 mod pairing;
 mod routines;

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -499,6 +499,7 @@ CREATE TABLE IF NOT EXISTS routine_runs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_routine_runs_routine ON routine_runs(routine_id);
+CREATE INDEX IF NOT EXISTS idx_routine_runs_created ON routine_runs(created_at);
 
 -- ==================== Settings ====================
 
@@ -1005,6 +1006,19 @@ CREATE INDEX IF NOT EXISTS idx_llm_calls_created_at ON llm_calls(created_at);
 DELETE FROM settings
 WHERE key = 'wasm.default_fuel_limit'
   AND CAST(json_extract(value, '$') AS INTEGER) = 10000000;
+"#,
+    ),
+    (
+        26,
+        "routine_runs_created_at_index",
+        // The `ironclaw insights` aggregation filters routine_runs by
+        // created_at over the [since, until) window. V6 created indexes
+        // on routine_id and status but not created_at, so the insights
+        // query was a full-table scan on busy deployments. Add the
+        // missing index here for existing libSQL databases; fresh
+        // databases pick it up via the consolidated SCHEMA above.
+        r#"
+CREATE INDEX IF NOT EXISTS idx_routine_runs_created ON routine_runs(created_at);
 "#,
     ),
 ];

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1285,13 +1285,20 @@ pub struct DailyActivity {
 
 #[async_trait]
 pub trait InsightsStore: Send + Sync {
-    /// Aggregate usage stats over the window `[since, now)`.
+    /// Aggregate usage stats over the window `[since, until)`.
+    ///
+    /// The closed-open `[since, until)` interval is enforced in SQL so
+    /// future-dated rows (clock skew, manual seeds, replay tooling) and
+    /// rows committed mid-aggregation cannot leak into the totals. The
+    /// caller is expected to pass `until = Utc::now()` for the live CLI
+    /// path; tests pin a fixed `until` to make assertions deterministic.
     ///
     /// `top_tools_limit` caps the number of tool rows returned. Backends must
     /// compute aggregates server-side (no streaming all rows to the CLI).
     async fn aggregate_insights(
         &self,
         since: DateTime<Utc>,
+        until: DateTime<Utc>,
         top_tools_limit: i64,
     ) -> Result<InsightsAggregate, DatabaseError>;
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1246,6 +1246,56 @@ pub trait IdentityStore: Send + Sync {
     ) -> Result<(), DatabaseError>;
 }
 
+/// Aggregate usage metrics over a time window for the `ironclaw insights` CLI.
+///
+/// All counts cover the half-open interval `[since, now)` where `since` is the
+/// `created_at` lower bound. The struct is deliberately additive — new fields
+/// must be appended (not reordered) so JSON output stays backward compatible.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InsightsAggregate {
+    /// Total agent_jobs rows with `created_at >= since`. Includes all sources
+    /// (`direct`, `sandbox`, `system`) so the operator sees full activity.
+    pub total_jobs: u64,
+    /// Total routine_runs rows with `created_at >= since`.
+    pub total_routine_runs: u64,
+    /// Sum of `agent_jobs.total_tokens_used` over the window.
+    pub total_tokens_used: u64,
+    /// Top tools by invocation count from `job_actions`, joined to `agent_jobs`
+    /// so the time window is enforced via `agent_jobs.created_at`.
+    /// Already truncated to the requested limit, ordered desc.
+    pub top_tools: Vec<ToolFrequency>,
+    /// Daily activity buckets ordered ascending by date (UTC, `YYYY-MM-DD`).
+    /// One row per calendar day that has at least one job; empty days are
+    /// omitted to keep the payload bounded.
+    pub daily_activity: Vec<DailyActivity>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ToolFrequency {
+    pub tool_name: String,
+    pub invocations: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DailyActivity {
+    /// UTC calendar day formatted as `YYYY-MM-DD`.
+    pub date: String,
+    pub jobs: u64,
+}
+
+#[async_trait]
+pub trait InsightsStore: Send + Sync {
+    /// Aggregate usage stats over the window `[since, now)`.
+    ///
+    /// `top_tools_limit` caps the number of tool rows returned. Backends must
+    /// compute aggregates server-side (no streaming all rows to the CLI).
+    async fn aggregate_insights(
+        &self,
+        since: DateTime<Utc>,
+        top_tools_limit: i64,
+    ) -> Result<InsightsAggregate, DatabaseError>;
+}
+
 /// Backend-agnostic database supertrait.
 ///
 /// Combines all sub-traits into one. Existing `Arc<dyn Database>` consumers
@@ -1262,6 +1312,7 @@ pub trait Database:
     + UserStore
     + ChannelPairingStore
     + IdentityStore
+    + InsightsStore
     + Send
     + Sync
 {

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -16,9 +16,10 @@ use crate::agent::routine::{Routine, RoutineRun, RunStatus};
 use crate::config::DatabaseConfig;
 use crate::context::{ActionRecord, JobContext, JobState};
 use crate::db::{
-    ApiTokenRecord, ChannelPairingStore, ConversationStore, Database, IdentityStore, JobStore,
-    PairingRequestRecord, RoutineStore, SandboxStore, SettingsStore, ToolFailureStore,
-    UserIdentityRecord, UserRecord, UserStore, WorkspaceStore,
+    ApiTokenRecord, ChannelPairingStore, ConversationStore, DailyActivity, Database, IdentityStore,
+    InsightsAggregate, InsightsStore, JobStore, PairingRequestRecord, RoutineStore, SandboxStore,
+    SettingsStore, ToolFailureStore, ToolFrequency, UserIdentityRecord, UserRecord, UserStore,
+    WorkspaceStore,
 };
 use crate::error::{DatabaseError, WorkspaceError};
 use crate::history::{
@@ -1649,5 +1650,85 @@ impl IdentityStore for PgBackend {
 
         tx.commit().await?;
         Ok(())
+    }
+}
+
+// ==================== InsightsStore ====================
+
+#[async_trait]
+impl InsightsStore for PgBackend {
+    async fn aggregate_insights(
+        &self,
+        since: DateTime<Utc>,
+        top_tools_limit: i64,
+    ) -> Result<InsightsAggregate, DatabaseError> {
+        let conn = self.store.pool().get().await?;
+        let limit = top_tools_limit.max(1);
+
+        // Combined jobs + tokens query (single round-trip for the most-used aggregate).
+        let job_row = conn
+            .query_one(
+                "SELECT COUNT(*)::BIGINT AS total_jobs, \
+                 COALESCE(SUM(total_tokens_used), 0)::BIGINT AS total_tokens \
+                 FROM agent_jobs WHERE created_at >= $1",
+                &[&since],
+            )
+            .await?;
+        let total_jobs: i64 = job_row.get("total_jobs");
+        let total_tokens: i64 = job_row.get("total_tokens");
+
+        let runs_row = conn
+            .query_one(
+                "SELECT COUNT(*)::BIGINT AS cnt FROM routine_runs WHERE created_at >= $1",
+                &[&since],
+            )
+            .await?;
+        let total_routine_runs: i64 = runs_row.get("cnt");
+
+        let tool_rows = conn
+            .query(
+                "SELECT ja.tool_name, COUNT(*)::BIGINT AS invocations \
+                 FROM job_actions ja \
+                 INNER JOIN agent_jobs aj ON aj.id = ja.job_id \
+                 WHERE aj.created_at >= $1 \
+                 GROUP BY ja.tool_name \
+                 ORDER BY invocations DESC, ja.tool_name ASC \
+                 LIMIT $2",
+                &[&since, &limit],
+            )
+            .await?;
+        let top_tools = tool_rows
+            .iter()
+            .map(|r| ToolFrequency {
+                tool_name: r.get::<_, String>("tool_name"),
+                invocations: r.get::<_, i64>("invocations").max(0) as u64,
+            })
+            .collect();
+
+        let day_rows = conn
+            .query(
+                "SELECT to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day, \
+                        COUNT(*)::BIGINT AS jobs \
+                 FROM agent_jobs WHERE created_at >= $1 \
+                 GROUP BY day \
+                 ORDER BY day ASC",
+                &[&since],
+            )
+            .await?;
+        let daily_activity = day_rows
+            .iter()
+            .map(|r| DailyActivity {
+                date: r.get::<_, String>("day"),
+                jobs: r.get::<_, i64>("jobs").max(0) as u64,
+            })
+            .collect();
+
+        Ok(InsightsAggregate {
+            total_jobs: total_jobs.max(0) as u64,
+            total_routine_runs: total_routine_runs.max(0) as u64,
+            total_tokens_used: total_tokens.max(0) as u64,
+            top_tools,
+            daily_activity,
+        })
     }
 }

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1660,18 +1660,24 @@ impl InsightsStore for PgBackend {
     async fn aggregate_insights(
         &self,
         since: DateTime<Utc>,
+        until: DateTime<Utc>,
         top_tools_limit: i64,
     ) -> Result<InsightsAggregate, DatabaseError> {
         let conn = self.store.pool().get().await?;
         let limit = top_tools_limit.max(1);
+
+        // Closed-open interval [since, until) so future-dated rows (clock
+        // skew, replay tooling, manual seeds) and rows committed mid-
+        // aggregation cannot leak into the totals. The agent_jobs and
+        // routine_runs `created_at` indexes carry the time-window scan.
 
         // Combined jobs + tokens query (single round-trip for the most-used aggregate).
         let job_row = conn
             .query_one(
                 "SELECT COUNT(*)::BIGINT AS total_jobs, \
                  COALESCE(SUM(total_tokens_used), 0)::BIGINT AS total_tokens \
-                 FROM agent_jobs WHERE created_at >= $1",
-                &[&since],
+                 FROM agent_jobs WHERE created_at >= $1 AND created_at < $2",
+                &[&since, &until],
             )
             .await?;
         let total_jobs: i64 = job_row.get("total_jobs");
@@ -1679,8 +1685,9 @@ impl InsightsStore for PgBackend {
 
         let runs_row = conn
             .query_one(
-                "SELECT COUNT(*)::BIGINT AS cnt FROM routine_runs WHERE created_at >= $1",
-                &[&since],
+                "SELECT COUNT(*)::BIGINT AS cnt FROM routine_runs \
+                 WHERE created_at >= $1 AND created_at < $2",
+                &[&since, &until],
             )
             .await?;
         let total_routine_runs: i64 = runs_row.get("cnt");
@@ -1690,11 +1697,11 @@ impl InsightsStore for PgBackend {
                 "SELECT ja.tool_name, COUNT(*)::BIGINT AS invocations \
                  FROM job_actions ja \
                  INNER JOIN agent_jobs aj ON aj.id = ja.job_id \
-                 WHERE aj.created_at >= $1 \
+                 WHERE aj.created_at >= $1 AND aj.created_at < $2 \
                  GROUP BY ja.tool_name \
                  ORDER BY invocations DESC, ja.tool_name ASC \
-                 LIMIT $2",
-                &[&since, &limit],
+                 LIMIT $3",
+                &[&since, &until, &limit],
             )
             .await?;
         let top_tools = tool_rows
@@ -1709,10 +1716,10 @@ impl InsightsStore for PgBackend {
             .query(
                 "SELECT to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day, \
                         COUNT(*)::BIGINT AS jobs \
-                 FROM agent_jobs WHERE created_at >= $1 \
+                 FROM agent_jobs WHERE created_at >= $1 AND created_at < $2 \
                  GROUP BY day \
                  ORDER BY day ASC",
-                &[&since],
+                &[&since, &until],
             )
             .await?;
         let daily_activity = day_rows

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,14 @@ async fn async_main() -> anyhow::Result<()> {
             return ironclaw::cli::run_skills_command(skills_cmd.clone(), cli.config.as_deref())
                 .await;
         }
+        Some(Command::Insights(insights_args)) => {
+            init_cli_tracing();
+            return ironclaw::cli::run_insights_command(
+                insights_args.clone(),
+                cli.config.as_deref(),
+            )
+            .await;
+        }
         Some(Command::Hooks(hooks_cmd)) => {
             init_cli_tracing();
             return ironclaw::cli::run_hooks_command(hooks_cmd.clone(), cli.config.as_deref())

--- a/tests/insights_integration.rs
+++ b/tests/insights_integration.rs
@@ -134,7 +134,7 @@ async fn aggregate_counts_jobs_and_top_tools_in_window() {
 
     let since = now - Duration::days(7);
     let agg = db
-        .aggregate_insights(since, 10)
+        .aggregate_insights(since, now, 10)
         .await
         .expect("aggregate_insights");
 
@@ -173,7 +173,7 @@ async fn json_payload_for_seeded_data_matches_fixture_shape() {
     seed_action(&db_path, &job, 1, "shell").await;
 
     let agg = db
-        .aggregate_insights(now - Duration::days(7), 10)
+        .aggregate_insights(now - Duration::days(7), now, 10)
         .await
         .expect("aggregate_insights");
 
@@ -203,8 +203,9 @@ async fn json_payload_for_seeded_data_matches_fixture_shape() {
 #[tokio::test]
 async fn empty_database_returns_zero_aggregate() {
     let (db, _tmp) = create_test_db().await;
+    let now = Utc::now();
     let agg = db
-        .aggregate_insights(Utc::now() - Duration::days(30), 10)
+        .aggregate_insights(now - Duration::days(30), now, 10)
         .await
         .expect("aggregate_insights");
 
@@ -235,7 +236,7 @@ async fn time_window_excludes_old_rows() {
 
     // Window: last 7 days.
     let agg = db
-        .aggregate_insights(now - Duration::days(7), 10)
+        .aggregate_insights(now - Duration::days(7), now, 10)
         .await
         .expect("aggregate_insights");
 
@@ -277,12 +278,64 @@ async fn aggregate_counts_routine_runs_in_window_only() {
     seed_job(&db_path, &job, "alice", now - Duration::days(1), 1).await;
 
     let agg = db
-        .aggregate_insights(now - Duration::days(7), 10)
+        .aggregate_insights(now - Duration::days(7), now, 10)
         .await
         .expect("aggregate_insights");
 
     assert_eq!(
         agg.total_routine_runs, 2,
         "expected exactly two recent routine_runs (the 60-day-old one is outside the window)"
+    );
+}
+
+/// Future-dated rows must NOT leak into the totals. Clock skew, replay
+/// tooling, or rows committed in another tick after `until` is captured
+/// would otherwise inflate the aggregate.
+#[tokio::test]
+async fn time_window_excludes_future_rows() {
+    let (db, tmp) = create_test_db().await;
+    let db_path = tmp.path().join("insights.db");
+
+    let now = Utc::now();
+    let recent_job = uuid::Uuid::new_v4().to_string();
+    let future_job = uuid::Uuid::new_v4().to_string();
+
+    seed_job(&db_path, &recent_job, "alice", now - Duration::days(1), 100).await;
+    // Stamped after `until` — must NOT be counted.
+    seed_job(&db_path, &future_job, "alice", now + Duration::days(2), 9_999).await;
+    seed_action(&db_path, &recent_job, 1, "shell").await;
+    seed_action(&db_path, &future_job, 1, "shell").await;
+    seed_action(&db_path, &future_job, 2, "shell").await;
+    seed_routine_run(&db_path, "alice", now - Duration::days(1)).await;
+    seed_routine_run(&db_path, "alice", now + Duration::days(2)).await;
+
+    // until is pinned at `now` so the future-dated rows are unambiguously
+    // outside the window.
+    let agg = db
+        .aggregate_insights(now - Duration::days(7), now, 10)
+        .await
+        .expect("aggregate_insights");
+
+    assert_eq!(
+        agg.total_jobs, 1,
+        "future_job is past the until bound and must not be counted"
+    );
+    assert_eq!(
+        agg.total_tokens_used, 100,
+        "tokens from future_job must not leak in"
+    );
+    assert_eq!(
+        agg.total_routine_runs, 1,
+        "future-dated routine_run must not be counted"
+    );
+    let shell_count = agg
+        .top_tools
+        .iter()
+        .find(|t| t.tool_name == "shell")
+        .map(|t| t.invocations)
+        .unwrap_or(0);
+    assert_eq!(
+        shell_count, 1,
+        "tool frequency must respect the upper bound via the agent_jobs join"
     );
 }

--- a/tests/insights_integration.rs
+++ b/tests/insights_integration.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use chrono::{Duration, Utc};
-use ironclaw::db::{Database, InsightsStore};
+use ironclaw::db::Database;
 use ironclaw::db::libsql::LibSqlBackend;
 
 async fn create_test_db() -> (Arc<dyn Database>, tempfile::TempDir) {

--- a/tests/insights_integration.rs
+++ b/tests/insights_integration.rs
@@ -38,9 +38,7 @@ async fn seed_job(
     created_at: chrono::DateTime<chrono::Utc>,
     tokens_used: u64,
 ) {
-    let backend = LibSqlBackend::new_local(db_path)
-        .await
-        .expect("seed open");
+    let backend = LibSqlBackend::new_local(db_path).await.expect("seed open");
     let conn = backend.connect().await.expect("seed conn");
     conn.execute(
         "INSERT INTO agent_jobs (id, title, description, status, source, user_id, \
@@ -57,15 +55,8 @@ async fn seed_job(
     .expect("seed insert job");
 }
 
-async fn seed_action(
-    db_path: &std::path::Path,
-    job_id: &str,
-    seq: i64,
-    tool_name: &str,
-) {
-    let backend = LibSqlBackend::new_local(db_path)
-        .await
-        .expect("seed open");
+async fn seed_action(db_path: &std::path::Path, job_id: &str, seq: i64, tool_name: &str) {
+    let backend = LibSqlBackend::new_local(db_path).await.expect("seed open");
     let conn = backend.connect().await.expect("seed conn");
     let action_id = uuid::Uuid::new_v4().to_string();
     conn.execute(
@@ -85,9 +76,7 @@ async fn seed_routine_run(
     user_id: &str,
     created_at: chrono::DateTime<chrono::Utc>,
 ) {
-    let backend = LibSqlBackend::new_local(db_path)
-        .await
-        .expect("seed open");
+    let backend = LibSqlBackend::new_local(db_path).await.expect("seed open");
     let conn = backend.connect().await.expect("seed conn");
     let routine_id = uuid::Uuid::new_v4().to_string();
     let run_id = uuid::Uuid::new_v4().to_string();
@@ -302,7 +291,14 @@ async fn time_window_excludes_future_rows() {
 
     seed_job(&db_path, &recent_job, "alice", now - Duration::days(1), 100).await;
     // Stamped after `until` — must NOT be counted.
-    seed_job(&db_path, &future_job, "alice", now + Duration::days(2), 9_999).await;
+    seed_job(
+        &db_path,
+        &future_job,
+        "alice",
+        now + Duration::days(2),
+        9_999,
+    )
+    .await;
     seed_action(&db_path, &recent_job, 1, "shell").await;
     seed_action(&db_path, &future_job, 1, "shell").await;
     seed_action(&db_path, &future_job, 2, "shell").await;

--- a/tests/insights_integration.rs
+++ b/tests/insights_integration.rs
@@ -78,6 +78,41 @@ async fn seed_action(
     .expect("seed insert action");
 }
 
+/// Insert a routine + a single routine_run at a given timestamp.
+/// Used to verify `total_routine_runs` aggregation respects the time window.
+async fn seed_routine_run(
+    db_path: &std::path::Path,
+    user_id: &str,
+    created_at: chrono::DateTime<chrono::Utc>,
+) {
+    let backend = LibSqlBackend::new_local(db_path)
+        .await
+        .expect("seed open");
+    let conn = backend.connect().await.expect("seed conn");
+    let routine_id = uuid::Uuid::new_v4().to_string();
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let stamp = created_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    conn.execute(
+        "INSERT INTO routines (id, name, description, user_id, trigger_type, \
+         trigger_config, action_type, action_config) VALUES \
+         (?1, ?2, '', ?3, 'cron', '{}', 'job', '{}')",
+        libsql::params![
+            routine_id.clone(),
+            format!("test-{}", &routine_id[..8]),
+            user_id.to_string(),
+        ],
+    )
+    .await
+    .expect("seed insert routine");
+    conn.execute(
+        "INSERT INTO routine_runs (id, routine_id, trigger_type, status, created_at, started_at) \
+         VALUES (?1, ?2, 'cron', 'completed', ?3, ?3)",
+        libsql::params![run_id, routine_id, stamp],
+    )
+    .await
+    .expect("seed insert routine_run");
+}
+
 #[tokio::test]
 async fn aggregate_counts_jobs_and_top_tools_in_window() {
     let (db, tmp) = create_test_db().await;
@@ -222,5 +257,32 @@ async fn time_window_excludes_old_rows() {
     assert_eq!(
         shell_count, 1,
         "tool frequency must respect the time window via the agent_jobs join"
+    );
+}
+
+#[tokio::test]
+async fn aggregate_counts_routine_runs_in_window_only() {
+    let (db, tmp) = create_test_db().await;
+    let db_path = tmp.path().join("insights.db");
+
+    let now = Utc::now();
+    // Two recent runs (must count), one ancient run (must not).
+    seed_routine_run(&db_path, "alice", now - Duration::days(1)).await;
+    seed_routine_run(&db_path, "alice", now - Duration::days(3)).await;
+    seed_routine_run(&db_path, "alice", now - Duration::days(60)).await;
+
+    // Sanity: also seed a job so the empty-table path doesn't accidentally
+    // skip the routine_runs query.
+    let job = uuid::Uuid::new_v4().to_string();
+    seed_job(&db_path, &job, "alice", now - Duration::days(1), 1).await;
+
+    let agg = db
+        .aggregate_insights(now - Duration::days(7), 10)
+        .await
+        .expect("aggregate_insights");
+
+    assert_eq!(
+        agg.total_routine_runs, 2,
+        "expected exactly two recent routine_runs (the 60-day-old one is outside the window)"
     );
 }

--- a/tests/insights_integration.rs
+++ b/tests/insights_integration.rs
@@ -1,0 +1,226 @@
+//! Integration tests for `ironclaw insights` aggregation against a real
+//! libSQL database.
+//!
+//! Covers the four scopes called out in the PR spec:
+//!   1. Seed jobs + routine_runs in a temp libSQL, run insights, assert counts.
+//!   2. `--json` output matches a snapshot fixture for the seeded data.
+//!   3. Zero-data case prints / serializes an empty-state payload.
+//!   4. Tool frequency aggregation respects the time window (rows older than
+//!      the window must not appear).
+
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use ironclaw::db::{Database, InsightsStore};
+use ironclaw::db::libsql::LibSqlBackend;
+
+async fn create_test_db() -> (Arc<dyn Database>, tempfile::TempDir) {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let db_path = temp_dir.path().join("insights.db");
+    let backend = LibSqlBackend::new_local(&db_path)
+        .await
+        .expect("LibSqlBackend");
+    backend.run_migrations().await.expect("migrations");
+    let db: Arc<dyn Database> = Arc::new(backend);
+    (db, temp_dir)
+}
+
+/// Insert a row directly into agent_jobs at a given timestamp.
+/// Goes through raw SQL on a fresh libSQL connection because the
+/// public `save_job` helper would stamp `created_at` to "now",
+/// and we need precise control for the time-window test.
+async fn seed_job(
+    db_path: &std::path::Path,
+    id: &str,
+    user_id: &str,
+    created_at: chrono::DateTime<chrono::Utc>,
+    tokens_used: u64,
+) {
+    let backend = LibSqlBackend::new_local(db_path)
+        .await
+        .expect("seed open");
+    let conn = backend.connect().await.expect("seed conn");
+    conn.execute(
+        "INSERT INTO agent_jobs (id, title, description, status, source, user_id, \
+         repair_attempts, max_tokens, total_tokens_used, created_at) \
+         VALUES (?1, 'seed', '', 'completed', 'direct', ?2, 0, 0, ?3, ?4)",
+        libsql::params![
+            id.to_string(),
+            user_id.to_string(),
+            tokens_used as i64,
+            created_at.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        ],
+    )
+    .await
+    .expect("seed insert job");
+}
+
+async fn seed_action(
+    db_path: &std::path::Path,
+    job_id: &str,
+    seq: i64,
+    tool_name: &str,
+) {
+    let backend = LibSqlBackend::new_local(db_path)
+        .await
+        .expect("seed open");
+    let conn = backend.connect().await.expect("seed conn");
+    let action_id = uuid::Uuid::new_v4().to_string();
+    conn.execute(
+        "INSERT INTO job_actions (id, job_id, sequence_num, tool_name, input, \
+         success, created_at) \
+         VALUES (?1, ?2, ?3, ?4, '{}', 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        libsql::params![action_id, job_id.to_string(), seq, tool_name.to_string()],
+    )
+    .await
+    .expect("seed insert action");
+}
+
+#[tokio::test]
+async fn aggregate_counts_jobs_and_top_tools_in_window() {
+    let (db, tmp) = create_test_db().await;
+    let db_path = tmp.path().join("insights.db");
+
+    let now = Utc::now();
+    let inside = now - Duration::days(2);
+    let job1 = uuid::Uuid::new_v4().to_string();
+    let job2 = uuid::Uuid::new_v4().to_string();
+    seed_job(&db_path, &job1, "alice", inside, 1_000).await;
+    seed_job(&db_path, &job2, "bob", inside, 500).await;
+
+    // alice's job has 3 shell calls + 1 read_file. bob's job has 1 shell.
+    seed_action(&db_path, &job1, 1, "shell").await;
+    seed_action(&db_path, &job1, 2, "shell").await;
+    seed_action(&db_path, &job1, 3, "shell").await;
+    seed_action(&db_path, &job1, 4, "read_file").await;
+    seed_action(&db_path, &job2, 1, "shell").await;
+
+    let since = now - Duration::days(7);
+    let agg = db
+        .aggregate_insights(since, 10)
+        .await
+        .expect("aggregate_insights");
+
+    assert_eq!(agg.total_jobs, 2, "should count both seeded jobs");
+    assert_eq!(agg.total_tokens_used, 1_500, "should sum total_tokens_used");
+    assert_eq!(
+        agg.top_tools.first().map(|t| t.tool_name.as_str()),
+        Some("shell"),
+        "shell should be the top tool"
+    );
+    assert_eq!(
+        agg.top_tools.first().map(|t| t.invocations),
+        Some(4),
+        "shell should be invoked 4 times across both jobs"
+    );
+    // top_tools is sorted desc by invocations, and the second entry must
+    // exist: read_file was called once.
+    assert_eq!(
+        agg.top_tools.get(1).map(|t| t.tool_name.as_str()),
+        Some("read_file"),
+    );
+    assert!(
+        !agg.daily_activity.is_empty(),
+        "daily_activity should have at least one bucket"
+    );
+}
+
+#[tokio::test]
+async fn json_payload_for_seeded_data_matches_fixture_shape() {
+    let (db, tmp) = create_test_db().await;
+    let db_path = tmp.path().join("insights.db");
+
+    let now = Utc::now();
+    let job = uuid::Uuid::new_v4().to_string();
+    seed_job(&db_path, &job, "alice", now - Duration::days(1), 42).await;
+    seed_action(&db_path, &job, 1, "shell").await;
+
+    let agg = db
+        .aggregate_insights(now - Duration::days(7), 10)
+        .await
+        .expect("aggregate_insights");
+
+    // Build the same payload the CLI emits, then strip volatile fields
+    // (daily_activity dates depend on wall clock) before comparing.
+    let payload = serde_json::json!({
+        "version": 1,
+        "window_days": 7,
+        "total_jobs": agg.total_jobs,
+        "total_routine_runs": agg.total_routine_runs,
+        "total_tokens_used": agg.total_tokens_used,
+        "top_tools": agg.top_tools,
+    });
+    let expected = serde_json::json!({
+        "version": 1,
+        "window_days": 7,
+        "total_jobs": 1,
+        "total_routine_runs": 0,
+        "total_tokens_used": 42,
+        "top_tools": [
+            { "tool_name": "shell", "invocations": 1 }
+        ],
+    });
+    assert_eq!(payload, expected, "JSON shape regression");
+}
+
+#[tokio::test]
+async fn empty_database_returns_zero_aggregate() {
+    let (db, _tmp) = create_test_db().await;
+    let agg = db
+        .aggregate_insights(Utc::now() - Duration::days(30), 10)
+        .await
+        .expect("aggregate_insights");
+
+    assert_eq!(agg.total_jobs, 0);
+    assert_eq!(agg.total_routine_runs, 0);
+    assert_eq!(agg.total_tokens_used, 0);
+    assert!(agg.top_tools.is_empty());
+    assert!(agg.daily_activity.is_empty());
+}
+
+#[tokio::test]
+async fn time_window_excludes_old_rows() {
+    let (db, tmp) = create_test_db().await;
+    let db_path = tmp.path().join("insights.db");
+
+    let now = Utc::now();
+    let recent_job = uuid::Uuid::new_v4().to_string();
+    let old_job = uuid::Uuid::new_v4().to_string();
+
+    seed_job(&db_path, &recent_job, "alice", now - Duration::days(2), 100).await;
+    // Older than the window — must NOT be counted.
+    seed_job(&db_path, &old_job, "alice", now - Duration::days(60), 9_999).await;
+
+    seed_action(&db_path, &recent_job, 1, "shell").await;
+    seed_action(&db_path, &old_job, 1, "shell").await;
+    seed_action(&db_path, &old_job, 2, "shell").await;
+    seed_action(&db_path, &old_job, 3, "shell").await;
+
+    // Window: last 7 days.
+    let agg = db
+        .aggregate_insights(now - Duration::days(7), 10)
+        .await
+        .expect("aggregate_insights");
+
+    assert_eq!(
+        agg.total_jobs, 1,
+        "old_job is outside the window and must not be counted"
+    );
+    assert_eq!(
+        agg.total_tokens_used, 100,
+        "tokens from old_job must not leak in"
+    );
+    // shell from old_job (3 invocations) must not appear; only the 1 from recent_job.
+    let shell_count = agg
+        .top_tools
+        .iter()
+        .find(|t| t.tool_name == "shell")
+        .map(|t| t.invocations)
+        .unwrap_or(0);
+    assert_eq!(
+        shell_count, 1,
+        "tool frequency must respect the time window via the agent_jobs join"
+    );
+}


### PR DESCRIPTION
## Summary

New `ironclaw insights [--days N] [--json]` subcommand that surfaces existing `agent_jobs`, `routine_runs`, and `job_actions` aggregates without log-scraping. Hermes parity for `hermes insights`.

- `--days` defaults to 30, capped at 90 with a stderr warning above the cap. `0` is treated as "default window".
- Default output is a human-readable table; `--json` emits a versioned, additive payload (`version: 1`) for dashboards.
- Both libSQL and Postgres backends ship `aggregate_insights` impls; queries are bounded by `agent_jobs.created_at >= since` and joined with `job_actions` for tool frequency, so the window is enforced consistently.

## Scope

First commit. Out of scope, called out as follow-ups in the second commit message:
- USD cost rollup (uses existing `src/llm/costs.rs` and `estimation_snapshots`)
- `--source` / `--user-id` filters
- `idx_routine_runs_created_at` migrations on libSQL + Postgres (perf — flagged by review)
- Tighten the SQL window to a closed `[since, until)` interval to keep clock-skew or future-dated rows out (correctness — flagged by review)

## Test plan

- [x] `cargo check --tests` clean
- [x] `cargo test --test insights_integration` — 5 tests pass: in-window job aggregation, JSON shape, empty DB, time-window exclusion, routine_runs window
- [x] `cargo test --lib cli::insights::tests` — 5 unit tests pass: `resolve_window` clamping (default/cap/in-range/at-boundary) plus JSON empty-state shape
- [ ] Manual: run \`ironclaw insights\` and \`ironclaw insights --json --days 7\` against a populated \`~/.ironclaw/ironclaw.db\`

## Why this matters

NEAR Foundation pilots (5 currently) need adoption visibility — operators are tailing logs to track token usage today. KPI: 181 → 500 daily active agents by quarter end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)