### PR TITLE
feat(cli): add `ironclaw import backup` for restoring backup archives

### DIFF
--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -162,12 +162,14 @@ pub async fn run_import_backup(archive: &Path, force: bool, dry_run: bool) -> Re
     // safe across binary updates: a backup taken on schema_version=25
     // restored onto a binary that expects 26 will catch up cleanly.
     #[cfg(feature = "libsql")]
-    apply_pending_migrations(&db_target).await.with_context(|| {
-        format!(
-            "running pending migrations on restored db {}",
-            db_target.display()
-        )
-    })?;
+    apply_pending_migrations(&db_target)
+        .await
+        .with_context(|| {
+            format!(
+                "running pending migrations on restored db {}",
+                db_target.display()
+            )
+        })?;
 
     println!();
     println!("Restore complete.");
@@ -229,7 +231,9 @@ fn read_manifest_from_zip(archive: &Path) -> Result<ImportManifest> {
         .by_name("manifest.json")
         .context("archive is missing manifest.json — not a recognized ironclaw backup")?;
     let mut buf = String::new();
-    entry.read_to_string(&mut buf).context("reading manifest.json bytes")?;
+    entry
+        .read_to_string(&mut buf)
+        .context("reading manifest.json bytes")?;
     let manifest: ImportManifest =
         serde_json::from_str(&buf).context("parsing manifest.json as JSON")?;
     Ok(manifest)
@@ -241,22 +245,18 @@ fn read_manifest_from_zip(archive: &Path) -> Result<ImportManifest> {
 /// 2. Move any pre-existing target out of the way (`<path>.pre-import-<ts>`).
 /// 3. Rename staging paths into place. If step 3 fails partway through,
 ///    restore the pre-existing files.
-fn extract_with_rollback(
-    archive: &Path,
-    db_target: &Path,
-    config_target: &Path,
-) -> Result<()> {
-    if let Some(parent) = db_target.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating parent dir {}", parent.display()))?;
-        }
+fn extract_with_rollback(archive: &Path, db_target: &Path, config_target: &Path) -> Result<()> {
+    if let Some(parent) = db_target.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dir {}", parent.display()))?;
     }
-    if let Some(parent) = config_target.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating parent dir {}", parent.display()))?;
-        }
+    if let Some(parent) = config_target.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dir {}", parent.display()))?;
     }
 
     let f = std::fs::File::open(archive)
@@ -272,8 +272,7 @@ fn extract_with_rollback(
 
     extract_entry(&mut zip, "data/ironclaw.db", &db_staged)
         .context("extracting data/ironclaw.db")?;
-    extract_entry(&mut zip, "config.toml", &config_staged)
-        .context("extracting config.toml")?;
+    extract_entry(&mut zip, "config.toml", &config_staged).context("extracting config.toml")?;
 
     let db_existed = db_target.exists();
     let config_existed = config_target.exists();
@@ -286,18 +285,16 @@ fn extract_with_rollback(
             )
         })?;
     }
-    if config_existed {
-        if let Err(e) = std::fs::rename(config_target, &config_backup) {
-            // Roll back the db rename to keep the on-disk state coherent.
-            if db_existed {
-                let _ = std::fs::rename(&db_backup, db_target);
-            }
-            return Err(anyhow::Error::from(e).context(format!(
-                "moving existing config aside: {} -> {}",
-                config_target.display(),
-                config_backup.display()
-            )));
+    if config_existed && let Err(e) = std::fs::rename(config_target, &config_backup) {
+        // Roll back the db rename to keep the on-disk state coherent.
+        if db_existed {
+            let _ = std::fs::rename(&db_backup, db_target);
         }
+        return Err(anyhow::Error::from(e).context(format!(
+            "moving existing config aside: {} -> {}",
+            config_target.display(),
+            config_backup.display()
+        )));
     }
 
     let promote = (|| -> std::io::Result<()> {
@@ -342,8 +339,7 @@ fn extract_entry(
     let mut entry = zip
         .by_name(name)
         .with_context(|| format!("archive is missing entry '{name}'"))?;
-    let f = std::fs::File::create(out)
-        .with_context(|| format!("creating {}", out.display()))?;
+    let f = std::fs::File::create(out).with_context(|| format!("creating {}", out.display()))?;
     let mut writer = io::BufWriter::with_capacity(64 * 1024, f);
     let mut buf = [0u8; 64 * 1024];
     loop {

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,8 +1,23 @@
-//! Import command for migrating data from other AI systems.
+//! `ironclaw import` — restore from `ironclaw backup` archives, plus
+//! migration paths from other AI systems.
+//!
+//! This module hosts two unrelated import flavors that share a common
+//! parent subcommand:
+//!
+//! - `ironclaw import backup <PATH>` — companion to `ironclaw backup`,
+//!   restoring a `--quick` archive (db + config + manifest) onto the
+//!   local IronClaw base dir. Always available.
+//! - `ironclaw import openclaw [--path …]` — migration from OpenClaw
+//!   (memory, history, settings, credentials). Gated behind the
+//!   `import` feature flag because it pulls in re-embedding deps.
 
-use std::path::PathBuf;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+#[cfg(feature = "import")]
 use std::sync::Arc;
 
+use anyhow::{Context, Result};
+use chrono::Utc;
 use clap::Subcommand;
 
 #[cfg(feature = "import")]
@@ -10,7 +25,8 @@ use crate::import::ImportOptions;
 #[cfg(feature = "import")]
 use crate::import::openclaw::OpenClawImporter;
 
-/// Import data from other AI systems.
+/// Import data into IronClaw. Currently supports restoring from a backup
+/// archive (always available) and migrating from OpenClaw (feature-gated).
 #[derive(Subcommand, Debug, Clone)]
 pub enum ImportCommand {
     /// Import from OpenClaw (memory, history, settings, credentials)
@@ -32,23 +48,334 @@ pub enum ImportCommand {
         #[arg(long)]
         user_id: Option<String>,
     },
+
+    /// Restore an `ironclaw backup` archive (currently `--quick` mode
+    /// only) onto the local IronClaw base dir. Existing files are
+    /// renamed to `<path>.pre-import-<ISO8601>` before replacement so
+    /// the operator can roll back manually if needed.
+    Backup {
+        /// Path to the backup zip (the file produced by
+        /// `ironclaw backup --quick`).
+        archive: PathBuf,
+
+        /// Bypass the major-version-skew safety check. Required when
+        /// the archive was produced by an `ironclaw` whose major
+        /// version differs from the running binary; defaults to the
+        /// safe rejection.
+        #[arg(long)]
+        force: bool,
+
+        /// Validate the archive and print the restore plan, but do
+        /// not modify any files.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 /// Run an import command.
-#[cfg(feature = "import")]
 pub async fn run_import_command(
     cmd: &ImportCommand,
     config: &crate::config::Config,
 ) -> anyhow::Result<()> {
     match cmd {
+        #[cfg(feature = "import")]
         ImportCommand::Openclaw {
             path,
             dry_run,
             re_embed,
             user_id,
         } => run_import_openclaw(config, path.clone(), *dry_run, *re_embed, user_id.clone()).await,
+
+        ImportCommand::Backup {
+            archive,
+            force,
+            dry_run,
+        } => {
+            // The backup-restore path operates on local files; it does
+            // not need a live database connection from `config`. We
+            // accept the param for signature symmetry with the
+            // openclaw arm.
+            let _ = config;
+            run_import_backup(archive, *force, *dry_run).await
+        }
     }
 }
+
+// =====================================================================
+// `ironclaw import backup` — always-on restore for the backup format.
+// =====================================================================
+
+/// Manifest header read from `manifest.json` at the top of the zip.
+/// Mirrors the shape that `ironclaw backup` writes.
+#[derive(Debug, serde::Deserialize)]
+struct ImportManifest {
+    ironclaw_version: String,
+    schema_version: i64,
+    #[allow(dead_code)]
+    created_at: String,
+    hostname: String,
+    label: Option<String>,
+    mode: String,
+    components: Vec<String>,
+}
+
+/// Top-level dispatch for `ironclaw import backup <PATH>`. Public so
+/// integration tests can drive it without faking a `Config`.
+pub async fn run_import_backup(archive: &Path, force: bool, dry_run: bool) -> Result<()> {
+    if !archive.exists() {
+        anyhow::bail!("archive not found at {}", archive.display());
+    }
+
+    let manifest = read_manifest_from_zip(archive)
+        .with_context(|| format!("reading manifest from {}", archive.display()))?;
+
+    validate_manifest(&manifest, force)?;
+
+    let base = crate::bootstrap::compute_ironclaw_base_dir();
+    let db_target = base.join("ironclaw.db");
+    let config_target = base.join("config.toml");
+
+    println!("ironclaw import — restore plan");
+    println!("  archive:           {}", archive.display());
+    println!("  ironclaw_version:  {}", manifest.ironclaw_version);
+    println!("  schema_version:    {}", manifest.schema_version);
+    println!("  hostname:          {}", manifest.hostname);
+    if let Some(label) = manifest.label.as_deref() {
+        println!("  label:             {label}");
+    }
+    println!("  components:        {}", manifest.components.join(","));
+    println!();
+    println!("  -> {}", db_target.display());
+    println!("  -> {}", config_target.display());
+
+    if dry_run {
+        println!();
+        println!("[DRY RUN] No files were modified.");
+        return Ok(());
+    }
+
+    extract_with_rollback(archive, &db_target, &config_target)
+        .with_context(|| format!("extracting {}", archive.display()))?;
+
+    // Re-open the restored libSQL db and apply any migrations newer
+    // than what the archive carried. This is what makes round-trip
+    // safe across binary updates: a backup taken on schema_version=25
+    // restored onto a binary that expects 26 will catch up cleanly.
+    #[cfg(feature = "libsql")]
+    apply_pending_migrations(&db_target).await.with_context(|| {
+        format!(
+            "running pending migrations on restored db {}",
+            db_target.display()
+        )
+    })?;
+
+    println!();
+    println!("Restore complete.");
+    Ok(())
+}
+
+/// Reject archives that were produced by an incompatible binary.
+///
+/// In this commit only `--quick` mode is restorable; later commits will
+/// add `--full`. Major-version skew is rejected without `--force`
+/// because the on-disk shape of the secrets store, the workspace
+/// document encoding, and the WASM channel layout can change between
+/// majors and we don't auto-rewrite them.
+fn validate_manifest(manifest: &ImportManifest, force: bool) -> Result<()> {
+    if manifest.mode != "quick" {
+        anyhow::bail!(
+            "archive mode is '{}'; only 'quick' is supported by this binary. \
+             Re-run `ironclaw backup --quick` on the source host.",
+            manifest.mode
+        );
+    }
+
+    let current = env!("CARGO_PKG_VERSION");
+    let current_major = major(current);
+    let archive_major = major(&manifest.ironclaw_version);
+
+    if current_major != archive_major && !force {
+        anyhow::bail!(
+            "archive was produced by ironclaw {}; current binary is {} (different major). \
+             Cross-major-version restore is risky and refused without --force.",
+            manifest.ironclaw_version,
+            current
+        );
+    }
+
+    Ok(())
+}
+
+/// Parse the leading numeric component of a SemVer-shaped version string.
+/// Returns 0 for unparseable input — over-permissive on purpose so a
+/// malformed manifest version does not crash the importer ahead of the
+/// `--force` gate that the operator can always reach for.
+fn major(version: &str) -> u32 {
+    version
+        .split('.')
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Read and parse `manifest.json` from the top of the archive.
+fn read_manifest_from_zip(archive: &Path) -> Result<ImportManifest> {
+    let f = std::fs::File::open(archive)
+        .with_context(|| format!("opening archive {}", archive.display()))?;
+    let mut zip = zip::ZipArchive::new(io::BufReader::new(f))
+        .with_context(|| format!("reading zip {}", archive.display()))?;
+
+    let mut entry = zip
+        .by_name("manifest.json")
+        .context("archive is missing manifest.json — not a recognized ironclaw backup")?;
+    let mut buf = String::new();
+    entry.read_to_string(&mut buf).context("reading manifest.json bytes")?;
+    let manifest: ImportManifest =
+        serde_json::from_str(&buf).context("parsing manifest.json as JSON")?;
+    Ok(manifest)
+}
+
+/// Extract the archive over the targets atomically-as-possible:
+///
+/// 1. Stream entries to sibling staging paths.
+/// 2. Move any pre-existing target out of the way (`<path>.pre-import-<ts>`).
+/// 3. Rename staging paths into place. If step 3 fails partway through,
+///    restore the pre-existing files.
+fn extract_with_rollback(
+    archive: &Path,
+    db_target: &Path,
+    config_target: &Path,
+) -> Result<()> {
+    if let Some(parent) = db_target.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating parent dir {}", parent.display()))?;
+        }
+    }
+    if let Some(parent) = config_target.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating parent dir {}", parent.display()))?;
+        }
+    }
+
+    let f = std::fs::File::open(archive)
+        .with_context(|| format!("opening archive {}", archive.display()))?;
+    let mut zip = zip::ZipArchive::new(io::BufReader::new(f))
+        .with_context(|| format!("reading zip {}", archive.display()))?;
+
+    let stamp = Utc::now().format("%Y-%m-%dT%H-%M-%SZ").to_string();
+    let db_staged = with_extension_suffix(db_target, ".restore-staged");
+    let config_staged = with_extension_suffix(config_target, ".restore-staged");
+    let db_backup = with_extension_suffix(db_target, &format!(".pre-import-{stamp}"));
+    let config_backup = with_extension_suffix(config_target, &format!(".pre-import-{stamp}"));
+
+    extract_entry(&mut zip, "data/ironclaw.db", &db_staged)
+        .context("extracting data/ironclaw.db")?;
+    extract_entry(&mut zip, "config.toml", &config_staged)
+        .context("extracting config.toml")?;
+
+    let db_existed = db_target.exists();
+    let config_existed = config_target.exists();
+    if db_existed {
+        std::fs::rename(db_target, &db_backup).with_context(|| {
+            format!(
+                "moving existing db aside: {} -> {}",
+                db_target.display(),
+                db_backup.display()
+            )
+        })?;
+    }
+    if config_existed {
+        if let Err(e) = std::fs::rename(config_target, &config_backup) {
+            // Roll back the db rename to keep the on-disk state coherent.
+            if db_existed {
+                let _ = std::fs::rename(&db_backup, db_target);
+            }
+            return Err(anyhow::Error::from(e).context(format!(
+                "moving existing config aside: {} -> {}",
+                config_target.display(),
+                config_backup.display()
+            )));
+        }
+    }
+
+    let promote = (|| -> std::io::Result<()> {
+        std::fs::rename(&db_staged, db_target)?;
+        std::fs::rename(&config_staged, config_target)?;
+        Ok(())
+    })();
+
+    if let Err(e) = promote {
+        // Best-effort rollback: clean up staged + restore originals.
+        let _ = std::fs::remove_file(&db_staged);
+        let _ = std::fs::remove_file(&config_staged);
+        if db_existed {
+            let _ = std::fs::rename(&db_backup, db_target);
+        }
+        if config_existed {
+            let _ = std::fs::rename(&config_backup, config_target);
+        }
+        return Err(anyhow::Error::from(e).context("promoting staged files"));
+    }
+
+    if db_existed {
+        println!("  pre-import db saved:     {}", db_backup.display());
+    }
+    if config_existed {
+        println!("  pre-import config saved: {}", config_backup.display());
+    }
+    Ok(())
+}
+
+fn with_extension_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(suffix);
+    PathBuf::from(s)
+}
+
+fn extract_entry(
+    zip: &mut zip::ZipArchive<io::BufReader<std::fs::File>>,
+    name: &str,
+    out: &Path,
+) -> Result<()> {
+    let mut entry = zip
+        .by_name(name)
+        .with_context(|| format!("archive is missing entry '{name}'"))?;
+    let f = std::fs::File::create(out)
+        .with_context(|| format!("creating {}", out.display()))?;
+    let mut writer = io::BufWriter::with_capacity(64 * 1024, f);
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = entry.read(&mut buf).context("reading zip entry")?;
+        if n == 0 {
+            break;
+        }
+        writer.write_all(&buf[..n]).context("writing staged file")?;
+    }
+    writer.flush().context("flushing staged file")?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn apply_pending_migrations(db_path: &Path) -> Result<()> {
+    // `run_migrations` is a method on the `Database` supertrait —
+    // bring it into scope at the call site so the trait method
+    // resolves on the concrete `LibSqlBackend`.
+    use crate::db::Database;
+    let backend = crate::db::libsql::LibSqlBackend::new_local(db_path)
+        .await
+        .with_context(|| format!("opening restored libSQL db at {}", db_path.display()))?;
+    backend
+        .run_migrations()
+        .await
+        .context("running pending migrations on restored db")?;
+    Ok(())
+}
+
+// =====================================================================
+// `ironclaw import openclaw` — feature-gated migration from OpenClaw.
+// =====================================================================
 
 /// Run the OpenClaw import.
 #[cfg(feature = "import")]
@@ -153,10 +480,68 @@ async fn run_import_openclaw(
     Ok(())
 }
 
-#[cfg(not(feature = "import"))]
-pub async fn run_import_command(
-    _cmd: &ImportCommand,
-    _config: &crate::config::Config,
-) -> anyhow::Result<()> {
-    anyhow::bail!("Import feature not enabled. Compile with --features import")
+// =====================================================================
+// Tests for the backup-restore path. The openclaw path has its own
+// integration tests under `tests/openclaw_*` that we don't duplicate here.
+// =====================================================================
+
+#[cfg(all(test, feature = "libsql"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn major_parses_leading_component() {
+        assert_eq!(major("0.27.0"), 0);
+        assert_eq!(major("1.2.3"), 1);
+        assert_eq!(major("12"), 12);
+        assert_eq!(major("garbage"), 0);
+        assert_eq!(major(""), 0);
+    }
+
+    #[test]
+    fn validate_rejects_non_quick_mode() {
+        let m = ImportManifest {
+            ironclaw_version: env!("CARGO_PKG_VERSION").to_string(),
+            schema_version: 25,
+            created_at: "2026-05-01T00:00:00Z".into(),
+            hostname: "h".into(),
+            label: None,
+            mode: "full".into(),
+            components: vec!["db".into(), "config".into(), "skills".into()],
+        };
+        let err = validate_manifest(&m, false).unwrap_err().to_string();
+        assert!(err.contains("'full'"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_cross_major_without_force() {
+        let m = ImportManifest {
+            // Deliberately use a major that won't match CARGO_PKG_VERSION.
+            ironclaw_version: "99.0.0".into(),
+            schema_version: 25,
+            created_at: "2026-05-01T00:00:00Z".into(),
+            hostname: "h".into(),
+            label: None,
+            mode: "quick".into(),
+            components: vec!["db".into(), "config".into()],
+        };
+        let err = validate_manifest(&m, false).unwrap_err().to_string();
+        assert!(err.contains("--force"), "{err}");
+        // With --force, the same manifest is accepted.
+        validate_manifest(&m, true).expect("force overrides version check");
+    }
+
+    #[test]
+    fn validate_accepts_same_major() {
+        let m = ImportManifest {
+            ironclaw_version: env!("CARGO_PKG_VERSION").to_string(),
+            schema_version: 25,
+            created_at: "2026-05-01T00:00:00Z".into(),
+            hostname: "h".into(),
+            label: None,
+            mode: "quick".into(),
+            components: vec!["db".into(), "config".into()],
+        };
+        validate_manifest(&m, false).expect("same-major archive is valid");
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,7 +22,10 @@ mod config;
 mod doctor;
 pub mod fmt;
 mod hooks;
-#[cfg(feature = "import")]
+// `import` is no longer feature-gated at the module level: the
+// `Backup` variant inside ImportCommand restores `ironclaw backup`
+// archives and is always available. The `Openclaw` variant inside
+// the same enum stays gated by `feature = "import"`.
 pub mod import;
 mod logs;
 mod mcp;
@@ -43,8 +46,10 @@ pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
 pub use doctor::run_doctor_command;
 pub use hooks::{HooksCommand, run_hooks_command};
-#[cfg(feature = "import")]
-pub use import::{ImportCommand, run_import_command};
+// ImportCommand + run_import_command are always available now that the
+// `Backup` variant (always-on, restores `ironclaw backup` archives)
+// lives alongside the openclaw migration variant (still feature-gated).
+pub use import::{ImportCommand, run_import_backup, run_import_command};
 pub use logs::{LogsCommand, run_logs_command};
 pub use mcp::{McpCommand, run_mcp_command};
 pub use memory::MemoryCommand;
@@ -312,11 +317,13 @@ pub enum Command {
     Completion(Completion),
 
     /// Import data from other AI systems
-    #[cfg(feature = "import")]
+    // The Import subcommand is always available — its `Backup`
+    // variant restores `ironclaw backup` archives. The `Openclaw`
+    // variant inside ImportCommand is still feature-gated.
     #[command(
         subcommand,
-        about = "Import from other AI systems",
-        long_about = "Migrate data from other AI assistants like OpenClaw.\nExample: ironclaw import openclaw"
+        about = "Import or restore data",
+        long_about = "Restore an `ironclaw backup` archive, or migrate from another AI system.\nExamples:\n  ironclaw import backup ./snap.zip\n  ironclaw import openclaw    # requires the `import` feature"
     )]
     Import(ImportCommand),
 

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
@@ -26,7 +26,7 @@ Commands:
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions
-  import      Import from other AI systems
+  import      Import or restore data
   login       Authenticate with a provider (re-login)
   acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -26,6 +26,7 @@ Commands:
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions
+  import      Import or restore data
   login       Authenticate with a provider (re-login)
   acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
@@ -40,7 +40,7 @@ Commands:
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions
-  import      Import from other AI systems
+  import      Import or restore data
   login       Authenticate with a provider (re-login)
   acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -40,6 +40,7 @@ Commands:
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions
+  import      Import or restore data
   login       Authenticate with a provider (re-login)
   acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,11 @@ async fn async_main() -> anyhow::Result<()> {
             init_cli_tracing();
             return completion.run();
         }
-        #[cfg(feature = "import")]
+        // The Import command is always wired now that the `Backup`
+        // variant (always-on, restores `ironclaw backup` archives)
+        // shares the parent subcommand with the feature-gated
+        // `Openclaw` migration. The dispatch into `run_import_command`
+        // ignores Config for the Backup arm.
         Some(Command::Import(import_cmd)) => {
             init_cli_tracing();
             let config = ironclaw::config::Config::from_env().await?;

--- a/tests/import_backup_integration.rs
+++ b/tests/import_backup_integration.rs
@@ -1,0 +1,399 @@
+//! Integration tests for `ironclaw import backup`.
+//!
+//! Drives the public entry point against synthetic backup archives that
+//! match the on-the-wire shape `ironclaw backup --quick` produces:
+//!   manifest.json + data/ironclaw.db + config.toml.
+//!
+//! Process-level state (env vars, the `IRONCLAW_BASE_DIR` LazyLock) is
+//! shared across all tests in this binary, so we serialize via
+//! `ENV_LOCK` and prefer test-scoped temp dirs piped through env vars.
+
+#![cfg(feature = "libsql")]
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::Utc;
+use ironclaw::cli::run_import_backup;
+// `Database` is brought in for the `run_migrations` trait method on
+// `LibSqlBackend`, which we use both to seed a real payload db inside
+// the synthetic archive and to reopen the restored snapshot for
+// content assertions.
+use ironclaw::db::Database;
+
+/// Serialize all tests that touch process env. Tests that do not touch
+/// env still take the lock to avoid interleaving with ones that do —
+/// cheaper than reasoning about which arms touch which keys.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII env override. Restores prior values on drop, panic-safe.
+struct EnvGuard {
+    entries: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    fn set(mut self, key: &'static str, val: impl AsRef<Path>) -> Self {
+        let prior = std::env::var_os(key);
+        // SAFETY: tests serialize via ENV_LOCK; no other thread
+        // mutates the environment concurrently.
+        unsafe {
+            std::env::set_var(key, val.as_ref());
+        }
+        self.entries.push((key, prior));
+        self
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, prior) in self.entries.drain(..) {
+            // SAFETY: same lock contract as `set`. Drop runs even on
+            // panic so the next test starts from a clean baseline.
+            unsafe {
+                match prior {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+/// Build a real (migrated) libSQL db at `db_path`. Used as the payload
+/// inside the synthetic archive.
+async fn build_real_libsql_db(db_path: &Path) {
+    let backend = ironclaw::db::libsql::LibSqlBackend::new_local(db_path)
+        .await
+        .expect("LibSqlBackend::new_local");
+    backend
+        .run_migrations()
+        .await
+        .expect("run_migrations on payload db");
+}
+
+/// Compose a synthetic backup archive at `archive_out` containing:
+///   - `manifest.json` (top of zip)
+///   - `data/ironclaw.db` (a real, migrated libSQL file)
+///   - `config.toml` (placeholder content)
+async fn build_archive(
+    archive_out: &Path,
+    payload_db: &Path,
+    payload_config: &str,
+    mode: &str,
+    version: &str,
+) {
+    build_real_libsql_db(payload_db).await;
+
+    let f = fs::File::create(archive_out).expect("create archive");
+    let mut zip = zip::ZipWriter::new(f);
+    let opts = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    // 1. manifest.json — pinned at index 0 to match the backup writer.
+    zip.start_file("manifest.json", opts).expect("start manifest.json");
+    let manifest = serde_json::json!({
+        "ironclaw_version": version,
+        "schema_version": 25,
+        "created_at": Utc::now().to_rfc3339(),
+        "hostname": "test-host",
+        "label": "import-integration",
+        "mode": mode,
+        "components": ["db", "config"],
+    });
+    zip.write_all(
+        serde_json::to_string_pretty(&manifest)
+            .expect("manifest serialize")
+            .as_bytes(),
+    )
+    .expect("write manifest");
+
+    // 2. data/ironclaw.db
+    zip.start_file("data/ironclaw.db", opts).expect("start db");
+    let db_bytes = fs::read(payload_db).expect("read payload db");
+    zip.write_all(&db_bytes).expect("write db bytes");
+
+    // 3. config.toml
+    zip.start_file("config.toml", opts).expect("start config.toml");
+    zip.write_all(payload_config.as_bytes()).expect("write config");
+
+    zip.finish().expect("finalize zip");
+}
+
+#[tokio::test]
+async fn dry_run_validates_and_does_not_write() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("ironclaw_base");
+    fs::create_dir_all(&base).unwrap();
+    let archive = tmp.path().join("snap.zip");
+    let payload_db = tmp.path().join("payload.db");
+
+    build_archive(
+        &archive,
+        &payload_db,
+        "[agent]\nname = \"from-archive\"\n",
+        "quick",
+        env!("CARGO_PKG_VERSION"),
+    )
+    .await;
+
+    let _guard = EnvGuard::new().set("IRONCLAW_BASE_DIR", &base);
+
+    run_import_backup(&archive, /* force */ false, /* dry_run */ true)
+        .await
+        .expect("dry run should succeed for a valid same-major archive");
+
+    // No write should land at the canonical paths under the base dir.
+    assert!(!base.join("ironclaw.db").exists(), "dry run wrote db");
+    assert!(
+        !base.join("config.toml").exists(),
+        "dry run wrote config"
+    );
+}
+
+#[tokio::test]
+async fn restore_lands_db_and_config_when_target_is_empty() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("ironclaw_base");
+    fs::create_dir_all(&base).unwrap();
+    let archive = tmp.path().join("snap.zip");
+    let payload_db = tmp.path().join("payload.db");
+
+    let archive_config = "[agent]\nname = \"from-archive\"\n";
+    build_archive(
+        &archive,
+        &payload_db,
+        archive_config,
+        "quick",
+        env!("CARGO_PKG_VERSION"),
+    )
+    .await;
+
+    let _guard = EnvGuard::new().set("IRONCLAW_BASE_DIR", &base);
+
+    run_import_backup(&archive, false, false)
+        .await
+        .expect("restore should succeed");
+
+    let restored_db = base.join("ironclaw.db");
+    let restored_cfg = base.join("config.toml");
+    assert!(restored_db.exists(), "restored db is missing at expected path");
+    assert!(
+        restored_cfg.exists(),
+        "restored config is missing at expected path"
+    );
+
+    // Config content survives the round trip verbatim.
+    let got = fs::read_to_string(&restored_cfg).unwrap();
+    assert_eq!(got, archive_config);
+
+    // The restored db has the seeded migrations table from
+    // `run_migrations` baked in. Sanity-check by reopening.
+    let backend = ironclaw::db::libsql::LibSqlBackend::new_local(&restored_db)
+        .await
+        .expect("open restored db");
+    let conn = backend.connect().await.expect("connect restored");
+    let mut rows = conn
+        .query("SELECT COUNT(*) FROM _migrations", ())
+        .await
+        .expect("read _migrations");
+    let row = rows
+        .next()
+        .await
+        .expect("rows.next")
+        .expect("at least one row");
+    let count: i64 = row.get(0).expect("count col");
+    assert!(count > 0, "restored db has no _migrations rows");
+
+    // No pre-import sidecar files exist when there was nothing to
+    // displace.
+    let sidecars: Vec<PathBuf> = fs::read_dir(&base)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.contains(".pre-import-"))
+                .unwrap_or(false)
+        })
+        .collect();
+    assert!(
+        sidecars.is_empty(),
+        "unexpected pre-import sidecars: {sidecars:?}"
+    );
+}
+
+#[tokio::test]
+async fn restore_renames_existing_files_aside() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("ironclaw_base");
+    fs::create_dir_all(&base).unwrap();
+    let archive = tmp.path().join("snap.zip");
+    let payload_db = tmp.path().join("payload.db");
+
+    build_archive(
+        &archive,
+        &payload_db,
+        "from-archive",
+        "quick",
+        env!("CARGO_PKG_VERSION"),
+    )
+    .await;
+
+    // Pre-create files at the targets so the importer must move them
+    // aside.
+    fs::write(base.join("ironclaw.db"), b"PRIOR DB CONTENT").unwrap();
+    fs::write(base.join("config.toml"), b"PRIOR CONFIG CONTENT").unwrap();
+
+    let _guard = EnvGuard::new().set("IRONCLAW_BASE_DIR", &base);
+
+    run_import_backup(&archive, false, false)
+        .await
+        .expect("restore over existing files should succeed");
+
+    // Canonical paths now hold the archive content.
+    assert_eq!(
+        fs::read_to_string(base.join("config.toml")).unwrap(),
+        "from-archive"
+    );
+
+    // Pre-import sidecars exist with the original content.
+    let entries: Vec<_> = fs::read_dir(&base)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .collect();
+    let pre_db_sidecar = entries
+        .iter()
+        .find(|p| {
+            let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            name.starts_with("ironclaw.db.pre-import-")
+        })
+        .expect("db pre-import sidecar must exist");
+    let pre_cfg_sidecar = entries
+        .iter()
+        .find(|p| {
+            let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            name.starts_with("config.toml.pre-import-")
+        })
+        .expect("config pre-import sidecar must exist");
+
+    assert_eq!(fs::read(pre_db_sidecar).unwrap(), b"PRIOR DB CONTENT");
+    assert_eq!(
+        fs::read(pre_cfg_sidecar).unwrap(),
+        b"PRIOR CONFIG CONTENT"
+    );
+}
+
+#[tokio::test]
+async fn rejects_cross_major_without_force() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("ironclaw_base");
+    fs::create_dir_all(&base).unwrap();
+    let archive = tmp.path().join("snap.zip");
+    let payload_db = tmp.path().join("payload.db");
+
+    // Force the archive to claim a major-version that cannot match the
+    // running binary regardless of CARGO_PKG_VERSION drift.
+    build_archive(&archive, &payload_db, "irrelevant", "quick", "99.0.0").await;
+
+    let _guard = EnvGuard::new().set("IRONCLAW_BASE_DIR", &base);
+
+    let err = run_import_backup(&archive, /* force */ false, false)
+        .await
+        .expect_err("must refuse cross-major restore without --force");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("--force"),
+        "error must mention --force escape hatch: {msg}"
+    );
+
+    // No files were written.
+    assert!(!base.join("ironclaw.db").exists());
+    assert!(!base.join("config.toml").exists());
+
+    // With --force, the same archive is accepted.
+    run_import_backup(&archive, /* force */ true, false)
+        .await
+        .expect("--force overrides cross-major check");
+    assert!(base.join("ironclaw.db").exists());
+    assert!(base.join("config.toml").exists());
+}
+
+#[tokio::test]
+async fn rejects_non_quick_mode_archive() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("ironclaw_base");
+    fs::create_dir_all(&base).unwrap();
+    let archive = tmp.path().join("snap.zip");
+    let payload_db = tmp.path().join("payload.db");
+
+    build_archive(
+        &archive,
+        &payload_db,
+        "irrelevant",
+        "full",
+        env!("CARGO_PKG_VERSION"),
+    )
+    .await;
+
+    let _guard = EnvGuard::new().set("IRONCLAW_BASE_DIR", &base);
+
+    let err = run_import_backup(&archive, false, false)
+        .await
+        .expect_err("must refuse non-quick archive in this commit");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("'full'") || msg.contains("only 'quick'"), "{msg}");
+}
+
+#[tokio::test]
+async fn rejects_archive_missing_required_entries() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let archive = tmp.path().join("incomplete.zip");
+
+    // Build a zip that only has manifest.json — no db, no config.
+    let f = fs::File::create(&archive).expect("create archive");
+    let mut zip = zip::ZipWriter::new(f);
+    let opts = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+    zip.start_file("manifest.json", opts).unwrap();
+    let m = serde_json::json!({
+        "ironclaw_version": env!("CARGO_PKG_VERSION"),
+        "schema_version": 25,
+        "created_at": Utc::now().to_rfc3339(),
+        "hostname": "h",
+        "label": null,
+        "mode": "quick",
+        "components": ["db", "config"],
+    });
+    zip.write_all(serde_json::to_string(&m).unwrap().as_bytes())
+        .unwrap();
+    zip.finish().unwrap();
+
+    let base = tmp.path().join("ironclaw_base");
+    fs::create_dir_all(&base).unwrap();
+    let _guard = EnvGuard::new().set("IRONCLAW_BASE_DIR", &base);
+
+    let err = run_import_backup(&archive, false, false)
+        .await
+        .expect_err("must refuse archive missing data/ironclaw.db");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("data/ironclaw.db") || msg.contains("missing entry"),
+        "error must mention the missing entry: {msg}"
+    );
+}

--- a/tests/import_backup_integration.rs
+++ b/tests/import_backup_integration.rs
@@ -9,6 +9,13 @@
 //! `ENV_LOCK` and prefer test-scoped temp dirs piped through env vars.
 
 #![cfg(feature = "libsql")]
+// ENV_LOCK is a process-wide std::sync::Mutex used to serialise env-var
+// mutations across these async integration tests. The lock IS held
+// across .await points (env state must stay pinned for the duration of
+// the test). An async Mutex wouldn't help because the contention is
+// between threads, not between async tasks. Same shape as the sibling
+// `tests/backup_integration.rs`.
+#![allow(clippy::await_holding_lock)]
 
 use std::ffi::OsString;
 use std::fs;

--- a/tests/import_backup_integration.rs
+++ b/tests/import_backup_integration.rs
@@ -99,7 +99,8 @@ async fn build_archive(
         .compression_method(zip::CompressionMethod::Deflated);
 
     // 1. manifest.json — pinned at index 0 to match the backup writer.
-    zip.start_file("manifest.json", opts).expect("start manifest.json");
+    zip.start_file("manifest.json", opts)
+        .expect("start manifest.json");
     let manifest = serde_json::json!({
         "ironclaw_version": version,
         "schema_version": 25,
@@ -122,8 +123,10 @@ async fn build_archive(
     zip.write_all(&db_bytes).expect("write db bytes");
 
     // 3. config.toml
-    zip.start_file("config.toml", opts).expect("start config.toml");
-    zip.write_all(payload_config.as_bytes()).expect("write config");
+    zip.start_file("config.toml", opts)
+        .expect("start config.toml");
+    zip.write_all(payload_config.as_bytes())
+        .expect("write config");
 
     zip.finish().expect("finalize zip");
 }
@@ -154,10 +157,7 @@ async fn dry_run_validates_and_does_not_write() {
 
     // No write should land at the canonical paths under the base dir.
     assert!(!base.join("ironclaw.db").exists(), "dry run wrote db");
-    assert!(
-        !base.join("config.toml").exists(),
-        "dry run wrote config"
-    );
+    assert!(!base.join("config.toml").exists(), "dry run wrote config");
 }
 
 #[tokio::test]
@@ -187,7 +187,10 @@ async fn restore_lands_db_and_config_when_target_is_empty() {
 
     let restored_db = base.join("ironclaw.db");
     let restored_cfg = base.join("config.toml");
-    assert!(restored_db.exists(), "restored db is missing at expected path");
+    assert!(
+        restored_db.exists(),
+        "restored db is missing at expected path"
+    );
     assert!(
         restored_cfg.exists(),
         "restored config is missing at expected path"
@@ -290,10 +293,7 @@ async fn restore_renames_existing_files_aside() {
         .expect("config pre-import sidecar must exist");
 
     assert_eq!(fs::read(pre_db_sidecar).unwrap(), b"PRIOR DB CONTENT");
-    assert_eq!(
-        fs::read(pre_cfg_sidecar).unwrap(),
-        b"PRIOR CONFIG CONTENT"
-    );
+    assert_eq!(fs::read(pre_cfg_sidecar).unwrap(), b"PRIOR CONFIG CONTENT");
 }
 
 #[tokio::test]
@@ -356,7 +356,10 @@ async fn rejects_non_quick_mode_archive() {
         .await
         .expect_err("must refuse non-quick archive in this commit");
     let msg = format!("{err:#}");
-    assert!(msg.contains("'full'") || msg.contains("only 'quick'"), "{msg}");
+    assert!(
+        msg.contains("'full'") || msg.contains("only 'quick'"),
+        "{msg}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Companion to `ironclaw backup --quick` (#3178). Adds a `Backup` variant to the existing `ironclaw import` subcommand that restores a backup zip onto the local IronClaw base dir. Closes the migration loop:

```
ironclaw backup --quick && scp && ironclaw import backup ./snap.zip
```

## What this adds

- **New `ironclaw import backup <PATH> [--force] [--dry-run]` subcommand.** Lives alongside the existing OpenClaw migration variant (which stays gated behind the `import` feature). The Backup arm is always available regardless of features.
- **Manifest validation** — `mode == "quick"`, archive's ironclaw major version matches the running binary. `--force` is the escape hatch for cross-major restores; safe-rejection is the default because the on-disk shape of secrets, workspace docs, and WASM channels can change between majors and we don't auto-rewrite them.
- **Atomic-as-possible restore** — each archive entry streams to a sibling `<path>.restore-staged` file, any pre-existing target is renamed to `<path>.pre-import-<ISO8601>`, then staged files rename into place. On rename failure mid-promotion, the originals are restored from the sidecars.
- **Migration replay** — libSQL builds re-open the restored db after extraction and apply pending migrations, so a snapshot taken on schema_version=N restored onto a binary expecting N+M catches up cleanly.
- **`--dry-run`** validates the archive and prints the restore plan without modifying any files.

## CLI ungating

The parent `Import` command + module + main.rs dispatch are no longer feature-gated, since the new `Backup` variant is always-on. Only the `Openclaw` arm and its helpers remain `#[cfg(feature = "import")]`.

## Test plan

- [x] `cargo check --tests` clean
- [x] `cargo test --test import_backup_integration` — 6 integration tests (dry-run, empty-target restore, existing-files-rename-aside with sidecar content assertions, cross-major refusal + `--force` override, non-quick mode rejection, missing-entry rejection)
- [x] `cargo test --lib import::tests` — 4 unit tests (major-version parsing, manifest validation arms)
- [ ] Manual: `ironclaw backup --quick && ironclaw import backup ~/ironclaw-backup-*.zip` round-trip on a real workspace

## Scope

This commit ships `Backup` mode end-to-end. Out of scope as follow-ups:

- `--full` mode restore (skill bundles, installed extensions, encrypted secrets — depends on `ironclaw backup --full` landing).
- Cross-machine secrets rewrap (irrelevant until --full carries secrets).
- Auto-detect-and-stop the running ironclaw service before restore. Today the operator stops the service themselves; the importer just writes files.
- Admin UI surface for uploading + restoring archives via the gateway.

## Why this matters

NEAR Foundation pilots are migrating from Railway to Crab Shack (per Tobias Holenstein's 2026-05-01 all-hands status). Without import, every migration is a manual sqlite dump + scp. This is the second half of the migration story — #3178 is the first half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)