### PR TITLE
feat(channels): `ironclaw channels install slack <workspace>` workspace install

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -34,6 +34,7 @@ mod manager;
 pub mod relay;
 mod repl;
 mod signal;
+pub mod slack;
 #[cfg(feature = "tui")]
 pub mod tui;
 pub mod wasm;

--- a/src/channels/slack/install.rs
+++ b/src/channels/slack/install.rs
@@ -46,7 +46,7 @@ pub const SLACK_API_BASE: &str = "https://slack.com";
 pub fn authorize_url(client_id: &str, redirect_uri: &str, state: &str) -> String {
     let scope = MINIMAL_BOT_SCOPES.join(",");
     let mut url = url::Url::parse(&format!("{SLACK_API_BASE}/oauth/v2/authorize"))
-        .expect("hard-coded URL is well-formed");
+        .expect("hard-coded URL is well-formed"); // safety: SLACK_API_BASE is a hard-coded HTTPS literal — Url::parse cannot fail on this input.
     url.query_pairs_mut()
         .append_pair("client_id", client_id)
         .append_pair("scope", &scope)
@@ -147,8 +147,7 @@ mod tests {
 
     #[test]
     fn oauth_v2_access_form_body_encodes_code_and_redirect() {
-        let body =
-            oauth_v2_access_form_body("0wbg9.abc/cd", "https://ironclaw.example.com/cb?x=y");
+        let body = oauth_v2_access_form_body("0wbg9.abc/cd", "https://ironclaw.example.com/cb?x=y");
         // form-urlencoded encodes `/`, `:`, `?`, `=` etc.
         assert!(body.contains("code=0wbg9.abc%2Fcd"), "got {body}");
         assert!(

--- a/src/channels/slack/install.rs
+++ b/src/channels/slack/install.rs
@@ -1,0 +1,159 @@
+//! Slack workspace-install OAuth helpers.
+//!
+//! Slack's bot install flow has a slightly different shape from the
+//! generic user-profile OAuth flow already handled by
+//! `src/channels/web/handlers/auth.rs`:
+//!
+//!   * The token endpoint is `oauth.v2.access`, not `oauth.access` /
+//!     `token`. The response carries a *bot* token plus team metadata,
+//!     not a user profile.
+//!   * `client_id` + `client_secret` are sent via HTTP Basic auth
+//!     (Slack also accepts them as form fields, but Basic is canonical
+//!     and lets us hand the secret to reqwest's `basic_auth` so it
+//!     never appears in any access log).
+//!   * No PKCE — Slack's bot OAuth doesn't support code verifiers.
+//!
+//! The HTTP redirect handlers in `auth.rs` plumb these helpers; pulling
+//! them out keeps the URL builder + form encoder pure and unit-testable
+//! without spinning up a mock HTTP server.
+//!
+//! ## Authorize URL
+//!
+//! `https://slack.com/oauth/v2/authorize?client_id=…&scope=…&redirect_uri=…&state=…`
+//!
+//! `scope` is comma-separated (Slack's convention), not space-separated
+//! like RFC 6749 specifies. We build it from `MINIMAL_BOT_SCOPES`.
+//!
+//! ## Token endpoint
+//!
+//! `POST https://slack.com/api/oauth.v2.access`
+//!   body: `code=<auth code>&redirect_uri=<same as authorize>`
+//!   auth: `Basic base64(client_id:client_secret)`
+//!
+//! Slack's API base is parameterised so tests can swap in a mockito server.
+
+use secrecy::{ExposeSecret, SecretString};
+
+use super::manifest::MINIMAL_BOT_SCOPES;
+use super::oauth::{OAuthV2AccessResponse, SlackOAuthError, parse_oauth_v2_access};
+
+/// Production Slack API base URL. Tests inject a mockito URL.
+pub const SLACK_API_BASE: &str = "https://slack.com";
+
+/// Build the workspace-install authorize URL the operator's browser
+/// is redirected to. `state` is an opaque CSRF token IronClaw issued
+/// (typically a 32-byte hex-encoded random) and validates on callback.
+pub fn authorize_url(client_id: &str, redirect_uri: &str, state: &str) -> String {
+    let scope = MINIMAL_BOT_SCOPES.join(",");
+    let mut url = url::Url::parse(&format!("{SLACK_API_BASE}/oauth/v2/authorize"))
+        .expect("hard-coded URL is well-formed");
+    url.query_pairs_mut()
+        .append_pair("client_id", client_id)
+        .append_pair("scope", &scope)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("state", state);
+    url.to_string()
+}
+
+/// Body for the `oauth.v2.access` POST. Returned as a string rather
+/// than a structured form so the caller can pass it straight through
+/// reqwest without extra allocations or feature dependencies on
+/// reqwest's `form` constructor.
+pub fn oauth_v2_access_form_body(code: &str, redirect_uri: &str) -> String {
+    let mut s = url::form_urlencoded::Serializer::new(String::new());
+    s.append_pair("code", code);
+    s.append_pair("redirect_uri", redirect_uri);
+    s.finish()
+}
+
+/// Errors from the OAuth code → bot token exchange. Distinct from
+/// [`SlackOAuthError`] so the redirect handler can map "Slack rejected
+/// the install" (operator misconfiguration) separately from "transport
+/// error" (network blip — retryable).
+#[derive(Debug, thiserror::Error)]
+pub enum ExchangeError {
+    #[error("HTTP request to Slack failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Slack returned a malformed response: {0}")]
+    BadResponse(#[from] SlackOAuthError),
+}
+
+/// Exchange the authorization `code` for a bot token. The result is the
+/// already-validated [`OAuthV2AccessResponse`] (so the caller doesn't
+/// need to re-check `ok==true`).
+///
+/// `api_base` lets tests inject a mockito server URL; production code
+/// passes [`SLACK_API_BASE`].
+pub async fn exchange_code(
+    http: &reqwest::Client,
+    api_base: &str,
+    code: &str,
+    client_id: &str,
+    client_secret: &SecretString,
+    redirect_uri: &str,
+) -> Result<OAuthV2AccessResponse, ExchangeError> {
+    let body = oauth_v2_access_form_body(code, redirect_uri);
+    let response = http
+        .post(format!("{api_base}/api/oauth.v2.access"))
+        .basic_auth(client_id, Some(client_secret.expose_secret()))
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body(body)
+        .send()
+        .await?
+        .error_for_status()?;
+    let raw = response.text().await?;
+    Ok(parse_oauth_v2_access(&raw)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorize_url_carries_minimal_scopes_comma_separated() {
+        let url = authorize_url(
+            "12345.67890",
+            "https://ironclaw.example.com/auth/slack/install/callback",
+            "abc123state",
+        );
+        // Slack uses comma-separated scopes, not RFC-6749 spaces.
+        let expected_scope = MINIMAL_BOT_SCOPES.join(",");
+        assert!(
+            url.contains(&format!("scope={}", urlencoding::encode(&expected_scope))),
+            "scope query missing comma-separated minimal scopes: {url}"
+        );
+        assert!(url.contains("client_id=12345.67890"));
+        assert!(url.contains("state=abc123state"));
+        assert!(url.starts_with("https://slack.com/oauth/v2/authorize?"));
+    }
+
+    #[test]
+    fn authorize_url_percent_encodes_redirect_uri() {
+        let url = authorize_url(
+            "id",
+            "https://ironclaw.example.com/auth/slack/install/callback",
+            "s",
+        );
+        // The colon and slashes in the redirect_uri must be percent-encoded
+        // inside the query string. URL-encoding produces %3A and %2F.
+        assert!(
+            url.contains("redirect_uri=https%3A%2F%2Fironclaw.example.com%2Fauth%2Fslack%2Finstall%2Fcallback"),
+            "redirect_uri not percent-encoded in {url}"
+        );
+    }
+
+    #[test]
+    fn oauth_v2_access_form_body_encodes_code_and_redirect() {
+        let body =
+            oauth_v2_access_form_body("0wbg9.abc/cd", "https://ironclaw.example.com/cb?x=y");
+        // form-urlencoded encodes `/`, `:`, `?`, `=` etc.
+        assert!(body.contains("code=0wbg9.abc%2Fcd"), "got {body}");
+        assert!(
+            body.contains("redirect_uri=https%3A%2F%2Fironclaw.example.com%2Fcb%3Fx%3Dy"),
+            "got {body}"
+        );
+    }
+}

--- a/src/channels/slack/manifest.rs
+++ b/src/channels/slack/manifest.rs
@@ -1,0 +1,241 @@
+//! Slack app manifest generation.
+//!
+//! The manifest declares the bot scopes, slash commands, and event
+//! subscriptions Slack needs to install IronClaw into a workspace.
+//! The installer uploads the JSON to <https://api.slack.com/apps?new_app=1>
+//! (the "From an app manifest" flow); Slack creates the app and returns a
+//! Client ID / Client Secret pair the operator pastes into the IronClaw
+//! config to complete the OAuth dance.
+//!
+//! ## Scope policy
+//!
+//! Minimal-by-default: only the scopes IronClaw needs for the v0.1 surface
+//! ship in the manifest. Optional scopes (channel reads, user lookups) are
+//! gated behind explicit operator opt-in in a follow-up commit.
+
+use serde::Serialize;
+use serde_json::json;
+
+/// Bot scopes IronClaw requires for the v0.1 Slack surface (DMs, slash
+/// command, mention handling). Order is not significant.
+pub const MINIMAL_BOT_SCOPES: &[&str] = &[
+    "chat:write",        // post replies
+    "app_mentions:read", // see @ironclaw in channels
+    "im:history",        // read DM history (per-user paired)
+    "im:write",          // open DMs to users
+    "commands",          // slash command surface
+];
+
+/// Bot events IronClaw subscribes to. Drives the WASM channel's inbound
+/// stream.
+const BOT_EVENTS: &[&str] = &["app_mention", "message.im"];
+
+/// Top-level manifest shape. Slack accepts a superset; unknown keys are
+/// rejected, so we serialise only what we set.
+#[derive(Debug, Serialize)]
+pub struct SlackManifest {
+    pub display_information: DisplayInformation,
+    pub features: Features,
+    pub oauth_config: OAuthConfig,
+    pub settings: Settings,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DisplayInformation {
+    pub name: String,
+    pub description: String,
+    pub background_color: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Features {
+    pub bot_user: BotUser,
+    pub slash_commands: Vec<SlashCommand>,
+    pub app_home: AppHome,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BotUser {
+    pub display_name: String,
+    pub always_online: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SlashCommand {
+    pub command: String,
+    pub url: String,
+    pub description: String,
+    pub usage_hint: String,
+    pub should_escape: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AppHome {
+    pub home_tab_enabled: bool,
+    pub messages_tab_enabled: bool,
+    pub messages_tab_read_only_enabled: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OAuthConfig {
+    pub redirect_urls: Vec<String>,
+    pub scopes: Scopes,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Scopes {
+    pub bot: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Settings {
+    pub event_subscriptions: EventSubscriptions,
+    pub interactivity: Interactivity,
+    pub org_deploy_enabled: bool,
+    pub socket_mode_enabled: bool,
+    pub token_rotation_enabled: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EventSubscriptions {
+    pub request_url: String,
+    pub bot_events: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Interactivity {
+    pub is_enabled: bool,
+    pub request_url: String,
+}
+
+/// Generate a Slack app manifest for an IronClaw deployment.
+///
+/// `install_base_url` is the public HTTPS origin Slack will hit for events,
+/// slash commands, and OAuth callbacks (e.g. `https://ironclaw.example.com`).
+/// Trailing slashes are tolerated.
+pub fn generate_manifest(install_base_url: &str) -> SlackManifest {
+    let base = install_base_url.trim_end_matches('/').to_string();
+    SlackManifest {
+        display_information: DisplayInformation {
+            name: "IronClaw".to_string(),
+            description: "IronClaw agent — knowledge, automations, and \
+                          approvals for your workspace."
+                .to_string(),
+            background_color: "#0b1b2b".to_string(),
+        },
+        features: Features {
+            bot_user: BotUser {
+                display_name: "IronClaw".to_string(),
+                always_online: true,
+            },
+            slash_commands: vec![SlashCommand {
+                command: "/ironclaw".to_string(),
+                url: format!("{base}/api/channels/slack/slash"),
+                description: "Ask IronClaw a question or run a tool.".to_string(),
+                usage_hint: "<your prompt>".to_string(),
+                should_escape: false,
+            }],
+            app_home: AppHome {
+                home_tab_enabled: false,
+                messages_tab_enabled: true,
+                messages_tab_read_only_enabled: false,
+            },
+        },
+        oauth_config: OAuthConfig {
+            redirect_urls: vec![format!("{base}/auth/slack/install/callback")],
+            scopes: Scopes {
+                bot: MINIMAL_BOT_SCOPES.iter().map(|s| s.to_string()).collect(),
+            },
+        },
+        settings: Settings {
+            event_subscriptions: EventSubscriptions {
+                request_url: format!("{base}/api/channels/slack/events"),
+                bot_events: BOT_EVENTS.iter().map(|s| s.to_string()).collect(),
+            },
+            interactivity: Interactivity {
+                is_enabled: true,
+                request_url: format!("{base}/api/channels/slack/interactivity"),
+            },
+            org_deploy_enabled: false,
+            socket_mode_enabled: false,
+            token_rotation_enabled: false,
+        },
+    }
+}
+
+/// Slash-command target URL the installer pastes into the Slack app config
+/// after the manifest is uploaded. Returned as a convenience for operator
+/// output paths that do not need the full manifest.
+pub fn slash_command_url(install_base_url: &str) -> String {
+    let base = install_base_url.trim_end_matches('/');
+    format!("{base}/api/channels/slack/slash")
+}
+
+/// Serialise the manifest as a `serde_json::Value` for callers that want
+/// to munge it before printing (e.g. add an `org_deploy_enabled` override).
+pub fn manifest_json(install_base_url: &str) -> serde_json::Value {
+    serde_json::to_value(generate_manifest(install_base_url)).unwrap_or_else(|_| json!({}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_includes_minimal_bot_scopes() {
+        let m = manifest_json("https://ironclaw.example.com");
+        let scopes = m["oauth_config"]["scopes"]["bot"]
+            .as_array()
+            .expect("bot scopes array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>();
+
+        for required in MINIMAL_BOT_SCOPES {
+            assert!(
+                scopes.contains(required),
+                "manifest is missing required scope {required}; got {scopes:?}"
+            );
+        }
+        // Minimal-by-default — no extra scopes leak in.
+        assert_eq!(
+            scopes.len(),
+            MINIMAL_BOT_SCOPES.len(),
+            "manifest carries unexpected extra scopes: {scopes:?}"
+        );
+    }
+
+    #[test]
+    fn manifest_slash_command_targets_install_base_url() {
+        let m = manifest_json("https://ironclaw.example.com/");
+        let url = m["features"]["slash_commands"][0]["url"].as_str().unwrap();
+        assert_eq!(url, "https://ironclaw.example.com/api/channels/slack/slash");
+        // Trailing-slash normalisation.
+        assert_eq!(
+            slash_command_url("https://ironclaw.example.com//"),
+            "https://ironclaw.example.com/api/channels/slack/slash"
+        );
+    }
+
+    #[test]
+    fn manifest_oauth_redirect_includes_install_callback() {
+        let m = manifest_json("https://ironclaw.example.com");
+        let urls = m["oauth_config"]["redirect_urls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            urls,
+            vec!["https://ironclaw.example.com/auth/slack/install/callback"]
+        );
+    }
+
+    #[test]
+    fn manifest_does_not_enable_socket_mode_or_org_deploy() {
+        let m = manifest_json("https://ironclaw.example.com");
+        assert_eq!(m["settings"]["socket_mode_enabled"], false);
+        assert_eq!(m["settings"]["org_deploy_enabled"], false);
+    }
+}

--- a/src/channels/slack/mod.rs
+++ b/src/channels/slack/mod.rs
@@ -18,6 +18,8 @@
 
 pub mod manifest;
 pub mod oauth;
+pub mod sig;
 
 pub use manifest::{MINIMAL_BOT_SCOPES, SlackManifest, generate_manifest};
 pub use oauth::{OAuthV2AccessResponse, parse_oauth_v2_access};
+pub use sig::{MAX_TIMESTAMP_SKEW_SECS, SignatureError, VerifyInputs, verify};

--- a/src/channels/slack/mod.rs
+++ b/src/channels/slack/mod.rs
@@ -19,7 +19,11 @@
 pub mod manifest;
 pub mod oauth;
 pub mod sig;
+pub mod slash;
 
 pub use manifest::{MINIMAL_BOT_SCOPES, SlackManifest, generate_manifest};
 pub use oauth::{OAuthV2AccessResponse, parse_oauth_v2_access};
 pub use sig::{MAX_TIMESTAMP_SKEW_SECS, SignatureError, VerifyInputs, verify};
+pub use slash::{
+    SlashCommandRequest, SlashParseError, ack_payload, effective_workspace_id, parse_slash_command,
+};

--- a/src/channels/slack/mod.rs
+++ b/src/channels/slack/mod.rs
@@ -29,3 +29,13 @@ pub use sig::{MAX_TIMESTAMP_SKEW_SECS, SignatureError, VerifyInputs, verify};
 pub use slash::{
     SlashCommandRequest, SlashParseError, ack_payload, effective_workspace_id, parse_slash_command,
 };
+
+/// Canonical secret name for the bot User OAuth token (xoxb-…). Mirrors
+/// `channels-src/slack/slack.capabilities.json` so the WASM channel and
+/// the install callback read/write the same row. Single-workspace today;
+/// per-workspace keying lands when the WASM channel's lookup is updated.
+pub const SLACK_BOT_TOKEN_SECRET: &str = "slack_bot_token";
+
+/// Canonical secret name for the app-level signing secret. Same source
+/// of truth as `SLACK_BOT_TOKEN_SECRET`.
+pub const SLACK_SIGNING_SECRET: &str = "slack_signing_secret";

--- a/src/channels/slack/mod.rs
+++ b/src/channels/slack/mod.rs
@@ -1,0 +1,23 @@
+//! Slack channel install + OAuth helpers.
+//!
+//! This module is the *control plane* for the Slack WASM channel
+//! (`channels-src/slack/`). The WASM channel handles inbound Slack events
+//! and outbound `chat.postMessage` calls; this module handles the one-time
+//! workspace install dance — generating the Slack app manifest, parsing
+//! the `oauth.v2.access` response that yields the bot token, and persisting
+//! the resulting workspace identity.
+//!
+//! Subsequent commits on this branch land:
+//!   * `/api/channels/slack/slash` — slash-command receiver
+//!   * `channel_audit_log` — compliance trail for in/out messages
+//!   * Per-user pairing on first DM (reuses [`crate::pairing`])
+//!
+//! Driven by NEAR Foundation pilot demand:
+//! "slack is really would be the channel number one to be used (compliance)."
+//! — Tobias Holenstein, 2026-05-01 NEAR AI all-hands.
+
+pub mod manifest;
+pub mod oauth;
+
+pub use manifest::{MINIMAL_BOT_SCOPES, SlackManifest, generate_manifest};
+pub use oauth::{OAuthV2AccessResponse, parse_oauth_v2_access};

--- a/src/channels/slack/mod.rs
+++ b/src/channels/slack/mod.rs
@@ -16,11 +16,13 @@
 //! "slack is really would be the channel number one to be used (compliance)."
 //! — Tobias Holenstein, 2026-05-01 NEAR AI all-hands.
 
+pub mod install;
 pub mod manifest;
 pub mod oauth;
 pub mod sig;
 pub mod slash;
 
+pub use install::{ExchangeError, SLACK_API_BASE, authorize_url, exchange_code};
 pub use manifest::{MINIMAL_BOT_SCOPES, SlackManifest, generate_manifest};
 pub use oauth::{OAuthV2AccessResponse, parse_oauth_v2_access};
 pub use sig::{MAX_TIMESTAMP_SKEW_SECS, SignatureError, VerifyInputs, verify};

--- a/src/channels/slack/oauth.rs
+++ b/src/channels/slack/oauth.rs
@@ -1,0 +1,186 @@
+//! Parser for Slack's `oauth.v2.access` response.
+//!
+//! The first commit on this branch only lands the parser — the redirect
+//! handler that calls it lives in `src/channels/web/handlers/auth.rs` and
+//! is wired in a follow-up commit. Splitting the parser out keeps it pure
+//! (easy to unit-test against fixed fixtures) and lets the handler reuse
+//! it without bringing in `axum` for tests.
+//!
+//! Response shape (Slack docs, June 2024):
+//! ```json
+//! {
+//!   "ok": true,
+//!   "access_token": "xoxb-...",
+//!   "token_type": "bot",
+//!   "scope": "chat:write,app_mentions:read,...",
+//!   "bot_user_id": "U0KRQLJ9H",
+//!   "app_id": "A0KRD7HC3",
+//!   "team": { "id": "T9TK3CUKW", "name": "Slack Pickleball Team" },
+//!   "enterprise": { "id": "E12345", "name": "Acme Inc" }
+//! }
+//! ```
+//! `enterprise` is null for non-Enterprise-Grid workspaces.
+
+use serde::{Deserialize, Serialize};
+
+/// Successful `oauth.v2.access` response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthV2AccessResponse {
+    pub ok: bool,
+    /// Bot User OAuth Token (`xoxb-…`). Empty string allowed only when `ok=false`.
+    #[serde(default)]
+    pub access_token: String,
+    /// Always `"bot"` for the bot-token install path.
+    #[serde(default)]
+    pub token_type: String,
+    /// Comma-separated scopes the workspace approved. May be a subset of
+    /// what the manifest requested if the user de-selected optional scopes.
+    #[serde(default)]
+    pub scope: String,
+    /// Slack user ID of the bot user installed in this workspace.
+    #[serde(default)]
+    pub bot_user_id: String,
+    /// Slack-side app id (`A…`).
+    #[serde(default)]
+    pub app_id: String,
+    pub team: Option<SlackTeam>,
+    #[serde(default)]
+    pub enterprise: Option<SlackEnterprise>,
+    /// Present on `ok=false` responses.
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlackTeam {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlackEnterprise {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+/// Parser error variants. Distinguished so the install command can give
+/// the operator a precise message ("Slack rejected the install: …") rather
+/// than a generic JSON parse failure.
+#[derive(Debug, thiserror::Error)]
+pub enum SlackOAuthError {
+    #[error("malformed oauth.v2.access response: {0}")]
+    Malformed(#[from] serde_json::Error),
+    #[error("Slack rejected the install: {0}")]
+    NotOk(String),
+    #[error("Slack returned ok=true but no team object — required for workspace install")]
+    MissingTeam,
+    #[error("Slack returned ok=true but no access_token — required to call chat.postMessage")]
+    MissingAccessToken,
+}
+
+/// Parse a raw `oauth.v2.access` response body and validate that it
+/// carries the fields IronClaw needs to register a workspace install.
+///
+/// Returns the parsed response on success; on failure returns a typed
+/// error the install command surfaces to the operator.
+pub fn parse_oauth_v2_access(body: &str) -> Result<OAuthV2AccessResponse, SlackOAuthError> {
+    let parsed: OAuthV2AccessResponse = serde_json::from_str(body)?;
+    if !parsed.ok {
+        return Err(SlackOAuthError::NotOk(
+            parsed
+                .error
+                .clone()
+                .unwrap_or_else(|| "unknown_error".into()),
+        ));
+    }
+    if parsed.team.is_none() {
+        return Err(SlackOAuthError::MissingTeam);
+    }
+    if parsed.access_token.is_empty() {
+        return Err(SlackOAuthError::MissingAccessToken);
+    }
+    Ok(parsed)
+}
+
+/// Extract the workspace identifier the install command persists as
+/// `channel_identities.external_id`. For Enterprise Grid installs we
+/// prefer the enterprise id (cross-workspace install); otherwise the
+/// team id.
+pub fn workspace_external_id(resp: &OAuthV2AccessResponse) -> Option<&str> {
+    if let Some(ref ent) = resp.enterprise
+        && !ent.id.is_empty()
+    {
+        return Some(ent.id.as_str());
+    }
+    resp.team.as_ref().map(|t| t.id.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE_OK: &str = r#"{
+        "ok": true,
+        "access_token": "xoxb-FAKE-FIXTURE-NOT-A-REAL-TOKEN",
+        "token_type": "bot",
+        "scope": "chat:write,app_mentions:read,im:history,im:write,commands",
+        "bot_user_id": "U0KRQLJ9H",
+        "app_id": "A0KRD7HC3",
+        "team": { "id": "T9TK3CUKW", "name": "Pickleball" }
+    }"#;
+
+    const FIXTURE_ENTERPRISE: &str = r#"{
+        "ok": true,
+        "access_token": "xoxb-FAKE-FIXTURE-2",
+        "token_type": "bot",
+        "scope": "chat:write",
+        "bot_user_id": "U1",
+        "app_id": "A1",
+        "team": { "id": "T9TK3CUKW", "name": "Pickleball" },
+        "enterprise": { "id": "E12345", "name": "Acme" }
+    }"#;
+
+    const FIXTURE_NOT_OK: &str = r#"{ "ok": false, "error": "invalid_code" }"#;
+
+    #[test]
+    fn parses_bot_token_shape() {
+        let resp = parse_oauth_v2_access(FIXTURE_OK).expect("parses");
+        assert!(resp.ok);
+        assert_eq!(resp.access_token, "xoxb-FAKE-FIXTURE-NOT-A-REAL-TOKEN");
+        assert_eq!(resp.token_type, "bot");
+        assert_eq!(resp.bot_user_id, "U0KRQLJ9H");
+        assert_eq!(resp.team.as_ref().unwrap().id, "T9TK3CUKW");
+        assert_eq!(workspace_external_id(&resp), Some("T9TK3CUKW"));
+    }
+
+    #[test]
+    fn enterprise_grid_prefers_enterprise_id() {
+        let resp = parse_oauth_v2_access(FIXTURE_ENTERPRISE).expect("parses");
+        assert_eq!(workspace_external_id(&resp), Some("E12345"));
+    }
+
+    #[test]
+    fn surfaces_slack_error_message() {
+        let err = parse_oauth_v2_access(FIXTURE_NOT_OK).unwrap_err();
+        match err {
+            SlackOAuthError::NotOk(msg) => assert_eq!(msg, "invalid_code"),
+            other => panic!("expected NotOk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_response_with_no_team() {
+        let body = r#"{ "ok": true, "access_token": "xoxb-FAKE-X", "token_type": "bot" }"#;
+        let err = parse_oauth_v2_access(body).unwrap_err();
+        assert!(matches!(err, SlackOAuthError::MissingTeam));
+    }
+
+    #[test]
+    fn rejects_response_with_empty_token() {
+        let body = r#"{ "ok": true, "access_token": "", "team": { "id": "T1" } }"#;
+        let err = parse_oauth_v2_access(body).unwrap_err();
+        assert!(matches!(err, SlackOAuthError::MissingAccessToken));
+    }
+}

--- a/src/channels/slack/sig.rs
+++ b/src/channels/slack/sig.rs
@@ -112,8 +112,8 @@ pub fn verify(inputs: VerifyInputs<'_>) -> Result<(), SignatureError> {
     // `new_from_slice` only errors for empty keys, which means the operator
     // never configured the signing secret — surface as Mismatch so we don't
     // crash the gateway on misconfiguration.
-    let mut mac = HmacSha256::new_from_slice(inputs.signing_secret)
-        .map_err(|_| SignatureError::Mismatch)?;
+    let mut mac =
+        HmacSha256::new_from_slice(inputs.signing_secret).map_err(|_| SignatureError::Mismatch)?;
     mac.update(b"v0:");
     mac.update(inputs.timestamp_header.as_bytes());
     mac.update(b":");

--- a/src/channels/slack/sig.rs
+++ b/src/channels/slack/sig.rs
@@ -109,8 +109,11 @@ pub fn verify(inputs: VerifyInputs<'_>) -> Result<(), SignatureError> {
         hex::decode(hex_sig).map_err(|e| SignatureError::BadSignatureHex(e.to_string()))?;
 
     // Slack's basestring is exactly `v0:<ts>:<raw body>`.
-    let mut mac =
-        HmacSha256::new_from_slice(inputs.signing_secret).expect("HMAC accepts any-length keys");
+    // `new_from_slice` only errors for empty keys, which means the operator
+    // never configured the signing secret — surface as Mismatch so we don't
+    // crash the gateway on misconfiguration.
+    let mut mac = HmacSha256::new_from_slice(inputs.signing_secret)
+        .map_err(|_| SignatureError::Mismatch)?;
     mac.update(b"v0:");
     mac.update(inputs.timestamp_header.as_bytes());
     mac.update(b":");

--- a/src/channels/slack/sig.rs
+++ b/src/channels/slack/sig.rs
@@ -1,0 +1,285 @@
+//! Slack request signature verification.
+//!
+//! Slack signs every Events / Slash Command / Interactivity request with the
+//! app-level signing secret so the receiver can prove the request really
+//! came from Slack. The signing secret is app-scoped, not workspace-scoped:
+//! one app installed in multiple workspaces shares one signing secret. Bot
+//! tokens differ per workspace; the signing secret does not.
+//!
+//! ## Wire format
+//!
+//! Slack sends two headers alongside every request:
+//!
+//!   * `X-Slack-Request-Timestamp: 1531420618` — Unix seconds when Slack
+//!     dispatched the request.
+//!   * `X-Slack-Signature: v0=a2114d57b48e...` — HMAC-SHA256 of the
+//!     concatenated string `v0:<timestamp>:<raw body>`, hex-encoded.
+//!
+//! IronClaw rejects requests whose timestamp drifts more than five minutes
+//! from now (the canonical window in Slack's docs); without it a captured
+//! request can be replayed indefinitely.
+//!
+//! ## Why this lives in `channels::slack` and not in the WASM channel
+//!
+//! The Slack WASM channel handles inbound events at `/webhook/slack`; slash
+//! commands and interactivity hit core IronClaw routes (`/api/channels/slack/slash`,
+//! `/api/channels/slack/interactivity`) registered in
+//! `src/channels/web/platform/router.rs`. Both surfaces verify against the
+//! same signing secret, so the verifier is shared rather than re-implemented
+//! per handler.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Maximum allowed clock skew between Slack's server and IronClaw, in
+/// seconds. Slack's docs use 5 minutes; we honour that. Below this window
+/// we treat the timestamp as live; above, the request is rejected as a
+/// possible replay.
+pub const MAX_TIMESTAMP_SKEW_SECS: i64 = 5 * 60;
+
+/// Errors the verifier can return. Distinct variants so callers can map to
+/// the right HTTP status (`401` for `Mismatch`, `400` for malformed
+/// inputs, `408`-ish for `Stale`).
+#[derive(Debug, thiserror::Error)]
+pub enum SignatureError {
+    #[error("missing or empty X-Slack-Request-Timestamp header")]
+    MissingTimestamp,
+    #[error("X-Slack-Request-Timestamp is not a valid Unix timestamp: {0}")]
+    InvalidTimestamp(String),
+    #[error(
+        "request timestamp is more than {MAX_TIMESTAMP_SKEW_SECS}s away from now (replay window)"
+    )]
+    Stale,
+    #[error("missing or empty X-Slack-Signature header")]
+    MissingSignature,
+    #[error("X-Slack-Signature missing required `v0=` prefix")]
+    BadSignaturePrefix,
+    #[error("X-Slack-Signature is not valid hex: {0}")]
+    BadSignatureHex(String),
+    #[error("signature mismatch — request was not sent by Slack")]
+    Mismatch,
+}
+
+/// Inputs to a verification call. Borrowed so callers don't have to clone
+/// big request bodies.
+#[derive(Debug, Clone, Copy)]
+pub struct VerifyInputs<'a> {
+    /// `X-Slack-Request-Timestamp` header, exactly as Slack sent it.
+    pub timestamp_header: &'a str,
+    /// `X-Slack-Signature` header, exactly as Slack sent it.
+    pub signature_header: &'a str,
+    /// Raw request body bytes — never the parsed/decoded form. Slack
+    /// signs the bytes that hit the wire; any normalisation invalidates
+    /// the HMAC.
+    pub body: &'a [u8],
+    /// App-level signing secret, fetched from secrets storage.
+    pub signing_secret: &'a [u8],
+    /// Current Unix time in seconds. Injected so tests can pin the clock.
+    pub now_secs: i64,
+}
+
+/// Verify a Slack request signature. Returns `Ok(())` on success.
+///
+/// Constant-time-compares the recomputed HMAC to the header value via
+/// `subtle::ConstantTimeEq` so a network-observable timing leak doesn't
+/// help an attacker brute-force the signing secret.
+pub fn verify(inputs: VerifyInputs<'_>) -> Result<(), SignatureError> {
+    if inputs.timestamp_header.is_empty() {
+        return Err(SignatureError::MissingTimestamp);
+    }
+    let ts: i64 = inputs
+        .timestamp_header
+        .parse()
+        .map_err(|e: std::num::ParseIntError| SignatureError::InvalidTimestamp(e.to_string()))?;
+    if (inputs.now_secs - ts).abs() > MAX_TIMESTAMP_SKEW_SECS {
+        return Err(SignatureError::Stale);
+    }
+
+    if inputs.signature_header.is_empty() {
+        return Err(SignatureError::MissingSignature);
+    }
+    let hex_sig = inputs
+        .signature_header
+        .strip_prefix("v0=")
+        .ok_or(SignatureError::BadSignaturePrefix)?;
+    let provided =
+        hex::decode(hex_sig).map_err(|e| SignatureError::BadSignatureHex(e.to_string()))?;
+
+    // Slack's basestring is exactly `v0:<ts>:<raw body>`.
+    let mut mac =
+        HmacSha256::new_from_slice(inputs.signing_secret).expect("HMAC accepts any-length keys");
+    mac.update(b"v0:");
+    mac.update(inputs.timestamp_header.as_bytes());
+    mac.update(b":");
+    mac.update(inputs.body);
+    let expected = mac.finalize().into_bytes();
+
+    if expected.ct_eq(&provided).into() {
+        Ok(())
+    } else {
+        Err(SignatureError::Mismatch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    /// Helper: produce the `v0=<hex>` header Slack would send, given the
+    /// same inputs the receiver will recompute over.
+    fn sign(secret: &[u8], ts: &str, body: &[u8]) -> String {
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret).unwrap();
+        mac.update(b"v0:");
+        mac.update(ts.as_bytes());
+        mac.update(b":");
+        mac.update(body);
+        format!("v0={}", hex::encode(mac.finalize().into_bytes()))
+    }
+
+    const SECRET: &[u8] = b"8f742231b10e8888abcd99yyyzz85a5";
+    const TS: &str = "1531420618";
+    const BODY: &[u8] = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J";
+
+    #[test]
+    fn accepts_valid_signature() {
+        let sig = sign(SECRET, TS, BODY);
+        let now: i64 = TS.parse().unwrap();
+        verify(VerifyInputs {
+            timestamp_header: TS,
+            signature_header: &sig,
+            body: BODY,
+            signing_secret: SECRET,
+            now_secs: now,
+        })
+        .expect("valid signature should verify");
+    }
+
+    #[test]
+    fn rejects_mismatched_signature() {
+        let mut sig = sign(SECRET, TS, BODY);
+        // Flip the last hex digit to corrupt the HMAC.
+        let last = sig.pop().unwrap();
+        sig.push(if last == 'a' { 'b' } else { 'a' });
+        let now: i64 = TS.parse().unwrap();
+        let err = verify(VerifyInputs {
+            timestamp_header: TS,
+            signature_header: &sig,
+            body: BODY,
+            signing_secret: SECRET,
+            now_secs: now,
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignatureError::Mismatch));
+    }
+
+    #[test]
+    fn rejects_stale_timestamp() {
+        let sig = sign(SECRET, TS, BODY);
+        let now: i64 = TS.parse::<i64>().unwrap() + MAX_TIMESTAMP_SKEW_SECS + 1;
+        let err = verify(VerifyInputs {
+            timestamp_header: TS,
+            signature_header: &sig,
+            body: BODY,
+            signing_secret: SECRET,
+            now_secs: now,
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignatureError::Stale));
+    }
+
+    #[test]
+    fn rejects_future_timestamp_outside_window() {
+        let sig = sign(SECRET, TS, BODY);
+        let now: i64 = TS.parse::<i64>().unwrap() - MAX_TIMESTAMP_SKEW_SECS - 1;
+        let err = verify(VerifyInputs {
+            timestamp_header: TS,
+            signature_header: &sig,
+            body: BODY,
+            signing_secret: SECRET,
+            now_secs: now,
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignatureError::Stale));
+    }
+
+    #[test]
+    fn rejects_signature_without_v0_prefix() {
+        // Strip the `v0=` prefix so the verifier rejects the header shape.
+        let sig = sign(SECRET, TS, BODY);
+        let stripped = sig.strip_prefix("v0=").unwrap();
+        let now: i64 = TS.parse().unwrap();
+        let err = verify(VerifyInputs {
+            timestamp_header: TS,
+            signature_header: stripped,
+            body: BODY,
+            signing_secret: SECRET,
+            now_secs: now,
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignatureError::BadSignaturePrefix));
+    }
+
+    #[test]
+    fn rejects_empty_timestamp_or_signature() {
+        let sig = sign(SECRET, TS, BODY);
+        let now: i64 = TS.parse().unwrap();
+
+        let err = verify(VerifyInputs {
+            timestamp_header: "",
+            signature_header: &sig,
+            body: BODY,
+            signing_secret: SECRET,
+            now_secs: now,
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignatureError::MissingTimestamp));
+
+        let err = verify(VerifyInputs {
+            timestamp_header: TS,
+            signature_header: "",
+            body: BODY,
+            signing_secret: SECRET,
+            now_secs: now,
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignatureError::MissingSignature));
+    }
+
+    #[test]
+    fn rejects_invalid_timestamp_format() {
+        let sig = sign(SECRET, TS, BODY);
+        let err = verify(VerifyInputs {
+            timestamp_header: "not-a-number",
+            signature_header: &sig,
+            body: BODY,
+            signing_secret: SECRET,
+            now_secs: 1_531_420_618,
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignatureError::InvalidTimestamp(_)));
+    }
+
+    #[test]
+    fn body_modification_invalidates_signature() {
+        // Same secret + timestamp, signature computed over BODY but verified
+        // against a tampered body. Any byte change breaks the HMAC.
+        let sig = sign(SECRET, TS, BODY);
+        let mut tampered = BODY.to_vec();
+        tampered[5] ^= 0x20; // flip a bit
+        let now: i64 = TS.parse().unwrap();
+        let err = verify(VerifyInputs {
+            timestamp_header: TS,
+            signature_header: &sig,
+            body: &tampered,
+            signing_secret: SECRET,
+            now_secs: now,
+        })
+        .unwrap_err();
+        assert!(matches!(err, SignatureError::Mismatch));
+    }
+}

--- a/src/channels/slack/slash.rs
+++ b/src/channels/slack/slash.rs
@@ -1,0 +1,239 @@
+//! Slack slash-command body parser + ack helpers.
+//!
+//! Slack POSTs slash commands as `application/x-www-form-urlencoded` to the
+//! URL declared in the app manifest (`/api/channels/slack/slash` for
+//! IronClaw). The receiver MUST acknowledge within 3 seconds; the actual
+//! agent reply is delivered out-of-band by POSTing to `response_url` (a
+//! per-invocation URL Slack supplies in the body, valid for 30 minutes /
+//! 5 deliveries).
+//!
+//! This module owns the parser and the ack-payload builders; the HTTP
+//! handler in `src/channels/web/handlers/slack.rs` plumbs them together.
+//! Splitting parser from handler keeps the parser pure (no axum, no DB)
+//! and unit-testable against fixed fixtures.
+//!
+//! ## Why URL-decode here, not at the axum layer
+//!
+//! `axum::Form<T>` deserializes the body and discards the raw bytes — but
+//! we need the raw bytes to verify the HMAC signature (Slack signs the
+//! exact bytes that hit the wire, before any decoding). So the handler
+//! reads `axum::body::Bytes`, hands them to `slack::sig::verify`, and
+//! only then hands them to this parser.
+
+/// Parsed slash-command request body. Subset of fields IronClaw actually
+/// uses; Slack's full payload has ~15 fields, most of which are noise for
+/// the agent (e.g. `team_domain`, `is_enterprise_install`).
+#[derive(Debug, Clone)]
+pub struct SlashCommandRequest {
+    /// Slack workspace id (`T…`). The receiver looks this up in
+    /// `channel_identities` to find the bound IronClaw user.
+    pub team_id: String,
+    /// Slack user id (`U…`) of whoever invoked the command. Used by the
+    /// per-user pairing flow to ask "who is this?" on first contact.
+    pub user_id: String,
+    /// Channel where the command was invoked (`C…` / `D…` / `G…`).
+    pub channel_id: String,
+    /// Command name including the leading slash, e.g. `/ironclaw`.
+    pub command: String,
+    /// User-supplied prompt, possibly empty.
+    pub text: String,
+    /// One-shot per-invocation reply URL, valid for 30 min / 5 deliveries.
+    pub response_url: String,
+    /// Trigger id, valid for 3 seconds, required to open modals later.
+    pub trigger_id: String,
+    /// Optional Enterprise Grid id (`E…`); empty for non-grid workspaces.
+    pub enterprise_id: String,
+}
+
+/// Parser failure modes. Distinct so the handler can map to the right
+/// HTTP status (`400` for malformed body, `422` for missing required
+/// fields).
+#[derive(Debug, thiserror::Error)]
+pub enum SlashParseError {
+    #[error("slash command body is not valid UTF-8: {0}")]
+    NotUtf8(#[from] std::str::Utf8Error),
+    #[error("slash command body is missing required field: {0}")]
+    MissingField(&'static str),
+}
+
+/// Parse a slash-command body. Slack guarantees fields like `team_id`,
+/// `user_id`, `command`, `response_url`, and `trigger_id` are always
+/// present — but we treat them as required at the parser layer rather
+/// than panicking later.
+///
+/// Uses `url::form_urlencoded::parse` rather than serde so we don't pull
+/// in a new direct dep just for a flat string-to-string decode.
+pub fn parse_slash_command(body: &[u8]) -> Result<SlashCommandRequest, SlashParseError> {
+    // form_urlencoded::parse takes &[u8] but happily decodes invalid UTF-8
+    // into U+FFFD; we want a hard failure so we revalidate up front.
+    let _ = std::str::from_utf8(body)?;
+
+    let mut team_id = String::new();
+    let mut user_id = String::new();
+    let mut channel_id = String::new();
+    let mut command = String::new();
+    let mut text = String::new();
+    let mut response_url = String::new();
+    let mut trigger_id = String::new();
+    let mut enterprise_id = String::new();
+
+    for (key, value) in url::form_urlencoded::parse(body) {
+        match key.as_ref() {
+            "team_id" => team_id = value.into_owned(),
+            "user_id" => user_id = value.into_owned(),
+            "channel_id" => channel_id = value.into_owned(),
+            "command" => command = value.into_owned(),
+            "text" => text = value.into_owned(),
+            "response_url" => response_url = value.into_owned(),
+            "trigger_id" => trigger_id = value.into_owned(),
+            "enterprise_id" => enterprise_id = value.into_owned(),
+            // Drop the rest (token, team_domain, channel_name, user_name,
+            // api_app_id, is_enterprise_install) — IronClaw doesn't use them
+            // and ignoring unknown keys keeps us forward-compatible with
+            // future Slack additions.
+            _ => {}
+        }
+    }
+
+    if team_id.is_empty() {
+        return Err(SlashParseError::MissingField("team_id"));
+    }
+    if user_id.is_empty() {
+        return Err(SlashParseError::MissingField("user_id"));
+    }
+    if command.is_empty() {
+        return Err(SlashParseError::MissingField("command"));
+    }
+    if response_url.is_empty() {
+        return Err(SlashParseError::MissingField("response_url"));
+    }
+
+    Ok(SlashCommandRequest {
+        team_id,
+        user_id,
+        channel_id,
+        command,
+        text,
+        response_url,
+        trigger_id,
+        enterprise_id,
+    })
+}
+
+/// Effective workspace id: prefer `enterprise_id` over `team_id` when
+/// present (matches the Enterprise Grid handling in
+/// [`crate::channels::slack::oauth::workspace_external_id`]).
+pub fn effective_workspace_id(req: &SlashCommandRequest) -> &str {
+    if !req.enterprise_id.is_empty() {
+        &req.enterprise_id
+    } else {
+        &req.team_id
+    }
+}
+
+/// Build the immediate ack payload Slack expects within 3 seconds.
+///
+/// Slack supports two `response_type` values:
+///   * `ephemeral` (default) — only the invoker sees the message.
+///     Right for "I'm thinking…" messages so the channel doesn't get
+///     spammed by every slash invocation.
+///   * `in_channel` — visible to everyone in the channel.
+///
+/// We use `ephemeral` for the placeholder; the eventual agent reply
+/// (delivered via `response_url`) can promote to `in_channel` based on
+/// the user's prompt.
+pub fn ack_payload(text: &str) -> serde_json::Value {
+    serde_json::json!({
+        "response_type": "ephemeral",
+        "text": text,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real-shape fixture — the field set Slack documents for slash
+    /// commands as of 2026. Order is alphabetised because that's what
+    /// Slack's encoder happens to emit.
+    const FIXTURE: &[u8] = b"\
+api_app_id=A0KRD7HC3&\
+channel_id=C2147483705&\
+channel_name=test&\
+command=%2Fironclaw&\
+enterprise_id=&\
+is_enterprise_install=false&\
+response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2F1234%2F5678%2Fxxxx&\
+team_domain=example&\
+team_id=T0001&\
+text=hello+world&\
+token=gIkuvaNzQIHg97ATvDxqgjtO&\
+trigger_id=13345224609.738474920.8088930838d88f008e0&\
+user_id=U2147483697&\
+user_name=alice";
+
+    #[test]
+    fn parses_slash_command_fixture() {
+        let req = parse_slash_command(FIXTURE).expect("fixture parses");
+        assert_eq!(req.team_id, "T0001");
+        assert_eq!(req.user_id, "U2147483697");
+        assert_eq!(req.channel_id, "C2147483705");
+        assert_eq!(req.command, "/ironclaw");
+        assert_eq!(req.text, "hello world");
+        assert!(req.response_url.starts_with("https://hooks.slack.com/"));
+        assert!(req.trigger_id.starts_with("13345224609"));
+        // Non-Enterprise install — enterprise_id is empty, fallback to team_id.
+        assert!(req.enterprise_id.is_empty());
+        assert_eq!(effective_workspace_id(&req), "T0001");
+    }
+
+    #[test]
+    fn enterprise_grid_uses_enterprise_id_for_workspace_lookup() {
+        // Same fixture but with enterprise_id populated.
+        let body = b"\
+team_id=T0001&\
+user_id=U1&\
+channel_id=C1&\
+command=%2Fironclaw&\
+text=&\
+response_url=https%3A%2F%2Fexample.com&\
+trigger_id=t&\
+enterprise_id=E12345";
+        let req = parse_slash_command(body).expect("parses");
+        assert_eq!(effective_workspace_id(&req), "E12345");
+    }
+
+    #[test]
+    fn rejects_body_missing_team_id() {
+        // Drop `team_id`; serde_urlencoded fills it with default ""
+        let body = b"\
+user_id=U1&\
+channel_id=C1&\
+command=%2Fironclaw&\
+text=&\
+response_url=https%3A%2F%2Fexample.com&\
+trigger_id=t";
+        let err = parse_slash_command(body).unwrap_err();
+        assert!(matches!(err, SlashParseError::MissingField("team_id")));
+    }
+
+    #[test]
+    fn rejects_body_missing_response_url() {
+        let body = b"\
+team_id=T1&\
+user_id=U1&\
+channel_id=C1&\
+command=%2Fironclaw&\
+text=&\
+trigger_id=t";
+        let err = parse_slash_command(body).unwrap_err();
+        assert!(matches!(err, SlashParseError::MissingField("response_url")));
+    }
+
+    #[test]
+    fn ack_payload_emits_ephemeral_default() {
+        let p = ack_payload("on it");
+        assert_eq!(p["response_type"], "ephemeral");
+        assert_eq!(p["text"], "on it");
+    }
+}

--- a/src/channels/web/handlers/auth.rs
+++ b/src/channels/web/handlers/auth.rs
@@ -787,6 +787,236 @@ fn build_identity_record(
     }
 }
 
+// ── Slack workspace install ──────────────────────────────────────────────
+//
+// Slack's bot install is workspace-scoped and uses a different token shape
+// from the user-OAuth flow above. Rather than fork the existing handler
+// (load-bearing for Google + GitHub + NEAR + Apple OIDC), we add two
+// sibling handlers that share the rate limiter and OAuth state store but
+// run their own code path.
+
+/// GET `/auth/slack/install` — start the workspace-install flow.
+///
+/// Reads `slack_oauth_client_id` from the secrets store, issues a CSRF
+/// state via `oauth_state_store`, and redirects the browser to Slack's
+/// authorize URL. The CLI install path (`ironclaw channels install slack
+/// <T0XXX>`) prints this URL when the operator has not yet bound the
+/// app's client_id.
+pub async fn slack_install_initiate_handler(
+    State(state): State<Arc<GatewayState>>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    if !state.oauth_rate_limiter.check(&rate_limit_key(&headers)) {
+        return (StatusCode::TOO_MANY_REQUESTS, "Rate limited").into_response();
+    }
+
+    let secrets = match state.secrets_store.as_ref() {
+        Some(s) => s,
+        None => return error_page("Secrets store is not configured."),
+    };
+    let state_store = match state.oauth_state_store.as_ref() {
+        Some(s) => s,
+        None => return error_page("OAuth state store not available."),
+    };
+    let base_url = match state.oauth_base_url.as_deref() {
+        Some(u) => u,
+        None => return error_page("OAuth base URL is not configured."),
+    };
+
+    let client_id = match secrets
+        .get_decrypted(&state.owner_id, SLACK_OAUTH_CLIENT_ID_SECRET)
+        .await
+    {
+        Ok(s) => s.expose().to_string(),
+        Err(_) => {
+            return error_page(
+                "Slack OAuth is not configured. Run `ironclaw secrets create \
+                 slack_oauth_client_id <your client id>` first.",
+            );
+        }
+    };
+
+    let flow = crate::channels::web::oauth::state_store::new_oauth_flow(
+        SLACK_INSTALL_PROVIDER.to_string(),
+        None,
+    );
+    let csrf_state = state_store.insert(flow).await;
+    let redirect_uri = slack_install_redirect_uri(base_url);
+    let auth_url = crate::channels::slack::authorize_url(&client_id, &redirect_uri, &csrf_state);
+
+    Redirect::temporary(&auth_url).into_response()
+}
+
+/// GET `/auth/slack/install/callback` — complete the workspace install.
+///
+/// Slack redirects here with `?code=<auth code>&state=<csrf state>` after
+/// the operator approves the install in their browser. We:
+///   1. Validate the CSRF state via `oauth_state_store.take`.
+///   2. Read `slack_oauth_client_id` + `slack_oauth_client_secret` from
+///      secrets storage.
+///   3. POST to `slack.com/api/oauth.v2.access` to exchange the code for
+///      a bot token (via `crate::channels::slack::exchange_code`).
+///   4. Persist the workspace identity in `channel_identities` keyed on
+///      the workspace id from the response (or enterprise id for
+///      Enterprise Grid installs).
+///   5. Persist the bot token as a secret named `slack_bot_token` so the
+///      WASM channel under `channels-src/slack/` can pick it up.
+///   6. Render a success page so the operator sees the bind succeeded.
+pub async fn slack_install_callback_handler(
+    State(state): State<Arc<GatewayState>>,
+    headers: axum::http::HeaderMap,
+    Query(params): Query<CallbackParams>,
+) -> Response {
+    if !state.oauth_rate_limiter.check(&rate_limit_key(&headers)) {
+        return error_page("Too many requests. Please try again later.");
+    }
+
+    if let Some(ref err) = params.error {
+        let desc = params.error_description.as_deref().unwrap_or(err.as_str());
+        return error_page(desc);
+    }
+
+    let code = match params.code.as_deref() {
+        Some(c) if !c.is_empty() => c,
+        _ => return error_page("Slack did not return an authorization code."),
+    };
+    let csrf_state = match params.state.as_deref() {
+        Some(s) if !s.is_empty() => s,
+        _ => return error_page("Slack callback is missing the state parameter."),
+    };
+
+    let state_store = match state.oauth_state_store.as_ref() {
+        Some(s) => s,
+        None => return error_page("OAuth state store not available."),
+    };
+    let flow = match state_store.take(csrf_state).await {
+        Some(f) if f.provider == SLACK_INSTALL_PROVIDER => f,
+        Some(_) => return error_page("OAuth provider mismatch on Slack callback."),
+        None => {
+            return error_page(
+                "Invalid or expired Slack install state. Please start the install again.",
+            );
+        }
+    };
+    drop(flow); // we don't use the code_verifier (Slack bot OAuth has no PKCE)
+
+    let secrets = match state.secrets_store.as_ref() {
+        Some(s) => s,
+        None => return error_page("Secrets store is not configured."),
+    };
+    let store = match state.store.as_ref() {
+        Some(s) => s,
+        None => return error_page("Database is not available."),
+    };
+    let base_url = match state.oauth_base_url.as_deref() {
+        Some(u) => u,
+        None => return error_page("OAuth base URL is not configured."),
+    };
+
+    let client_id = match secrets
+        .get_decrypted(&state.owner_id, SLACK_OAUTH_CLIENT_ID_SECRET)
+        .await
+    {
+        Ok(s) => s.expose().to_string(),
+        Err(_) => return error_page("Slack OAuth client_id is not configured."),
+    };
+    let client_secret = match secrets
+        .get_decrypted(&state.owner_id, SLACK_OAUTH_CLIENT_SECRET_SECRET)
+        .await
+    {
+        Ok(s) => secrecy::SecretString::from(s.expose().to_string()),
+        Err(_) => return error_page("Slack OAuth client_secret is not configured."),
+    };
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+    let redirect_uri = slack_install_redirect_uri(base_url);
+    let access = match crate::channels::slack::exchange_code(
+        &http,
+        crate::channels::slack::SLACK_API_BASE,
+        code,
+        &client_id,
+        &client_secret,
+        &redirect_uri,
+    )
+    .await
+    {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::warn!(error = %e, "slack oauth.v2.access exchange failed");
+            return error_page(
+                "Slack rejected the install. Double-check your Slack app's \
+                 client_id / client_secret in IronClaw secrets and try again.",
+            );
+        }
+    };
+
+    let workspace_id = match crate::channels::slack::oauth::workspace_external_id(&access) {
+        Some(id) => id.to_string(),
+        None => {
+            return error_page(
+                "Slack returned an OK response without a workspace id (unexpected).",
+            );
+        }
+    };
+
+    if let Err(e) = store
+        .upsert_channel_identity("slack", &workspace_id, &state.owner_id)
+        .await
+    {
+        tracing::error!(error = %e, "failed to persist Slack workspace identity");
+        return error_page("IronClaw hit a database error persisting the workspace identity.");
+    }
+
+    // Persist the bot token under the canonical name read by the Slack WASM
+    // channel (`channels-src/slack/slack.capabilities.json` →
+    // `setup.required_secrets[].name = "slack_bot_token"`). Multi-workspace
+    // routing — keying the secret on workspace id and adapting the WASM
+    // channel — lands in a follow-up commit.
+    let create = crate::secrets::CreateSecretParams::new(
+        crate::channels::slack::SLACK_BOT_TOKEN_SECRET,
+        access.access_token.clone(),
+    )
+    .with_provider("slack");
+    if let Err(e) = secrets.create(&state.owner_id, create).await {
+        tracing::error!(error = %e, "failed to persist Slack bot token");
+        return error_page(
+            "IronClaw bound the workspace identity but could not persist the \
+             bot token. Re-run the install or paste the token manually.",
+        );
+    }
+
+    slack_install_success_page(&workspace_id)
+}
+
+const SLACK_INSTALL_PROVIDER: &str = "slack-install";
+const SLACK_OAUTH_CLIENT_ID_SECRET: &str = "slack_oauth_client_id";
+const SLACK_OAUTH_CLIENT_SECRET_SECRET: &str = "slack_oauth_client_secret";
+
+fn slack_install_redirect_uri(base_url: &str) -> String {
+    format!(
+        "{}/auth/slack/install/callback",
+        base_url.trim_end_matches('/')
+    )
+}
+
+fn slack_install_success_page(workspace_id: &str) -> Response {
+    let escaped = workspace_id
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+    axum::response::Html(format!(
+        "<html><body style='font-family: system-ui; text-align: center; padding: 60px;'>\
+         <h2>IronClaw is installed</h2>\
+         <p>Workspace <code>{escaped}</code> is bound.</p>\
+         <p>Try <code>/ironclaw hello</code> in any channel.</p>\
+         </body></html>"
+    ))
+    .into_response()
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 fn build_session_cookie(token: &str, secure: bool) -> String {

--- a/src/channels/web/handlers/mod.rs
+++ b/src/channels/web/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod llm;
 pub mod memory;
 pub mod secrets;
 pub mod skills;
+pub mod slack;
 pub mod system_prompt;
 pub mod tokens;
 pub mod tool_policy;

--- a/src/channels/web/handlers/slack.rs
+++ b/src/channels/web/handlers/slack.rs
@@ -46,15 +46,10 @@ use axum::{
 };
 
 use crate::channels::slack::{
-    SignatureError, SlashParseError, VerifyInputs, ack_payload, effective_workspace_id,
-    parse_slash_command, verify,
+    SLACK_SIGNING_SECRET, SignatureError, SlashParseError, VerifyInputs, ack_payload,
+    effective_workspace_id, parse_slash_command, verify,
 };
 use crate::channels::web::platform::state::GatewayState;
-
-/// Slack secret name. Matches `channels-src/slack/slack.capabilities.json`
-/// (`config.signing_secret_name`) so the WASM channel and the core
-/// surface read from the same row.
-pub const SLACK_SIGNING_SECRET_NAME: &str = "slack_signing_secret";
 
 /// POST `/api/channels/slack/slash` — receives every `/ironclaw <…>`
 /// invocation across every workspace where the IronClaw Slack app is
@@ -160,7 +155,7 @@ async fn read_signing_secret(state: &GatewayState) -> Result<String, &'static st
         .as_ref()
         .ok_or("secrets_store missing")?;
     let decrypted = secrets
-        .get_decrypted(&state.owner_id, SLACK_SIGNING_SECRET_NAME)
+        .get_decrypted(&state.owner_id, SLACK_SIGNING_SECRET)
         .await
         .map_err(|_| "slack_signing_secret not present")?;
     Ok(decrypted.expose().to_string())

--- a/src/channels/web/handlers/slack.rs
+++ b/src/channels/web/handlers/slack.rs
@@ -117,10 +117,7 @@ pub async fn slash_command_handler(
         }
     };
     let workspace_id = effective_workspace_id(&req);
-    let resolved = match store
-        .resolve_channel_identity("slack", workspace_id)
-        .await
-    {
+    let resolved = match store.resolve_channel_identity("slack", workspace_id).await {
         Ok(opt) => opt,
         Err(e) => {
             tracing::error!(error = %e, "resolve_channel_identity failed");
@@ -158,7 +155,10 @@ pub async fn slash_command_handler(
 }
 
 async fn read_signing_secret(state: &GatewayState) -> Result<String, &'static str> {
-    let secrets = state.secrets_store.as_ref().ok_or("secrets_store missing")?;
+    let secrets = state
+        .secrets_store
+        .as_ref()
+        .ok_or("secrets_store missing")?;
     let decrypted = secrets
         .get_decrypted(&state.owner_id, SLACK_SIGNING_SECRET_NAME)
         .await

--- a/src/channels/web/handlers/slack.rs
+++ b/src/channels/web/handlers/slack.rs
@@ -1,0 +1,246 @@
+//! Slack core HTTP handlers (slash commands, interactivity).
+//!
+//! Distinct from the Slack WASM channel under `channels-src/slack/`,
+//! which handles inbound *Events API* webhooks at `/webhook/slack`.
+//! Slash commands and interactivity have a different contract — Slack
+//! requires a synchronous ack within 3 seconds and the actual reply
+//! flows out-of-band via a one-shot `response_url` — so they're handled
+//! by core IronClaw routes registered here.
+//!
+//! The signature verifier and body parser live in `crate::channels::slack`
+//! as pure modules; this file just plumbs axum extractors through them.
+//!
+//! ## What this commit ships
+//!
+//! `slash_command_handler` —
+//! 1. Pulls `slack_signing_secret` from the secrets store, keyed on the
+//!    deployment owner (matches the WASM channel's secret name).
+//! 2. Verifies `X-Slack-Signature` against the raw bytes via
+//!    `crate::channels::slack::sig::verify` (constant-time-compared).
+//! 3. Parses the form-encoded body via `parse_slash_command`.
+//! 4. Confirms the workspace is installed by resolving
+//!    `(channel='slack', external_id=workspace_id)` in
+//!    `channel_identities` — un-installed workspaces get a friendly
+//!    "this workspace isn't bound to an IronClaw deployment" reply.
+//! 5. Acks ephemerally within 3 seconds.
+//!
+//! ## What's deliberately NOT here yet
+//!
+//! * Agent invocation + the out-of-band POST to `response_url` —
+//!   threading the engine through this path needs care; lands in a
+//!   subsequent commit.
+//! * Per-user pairing on first invocation from an unknown user.
+//! * Audit-log row for in/out compliance trail (the `channel_audit_log`
+//!   table itself lands in a follow-up commit).
+//! * Interactivity surface (`/api/channels/slack/interactivity`) — same
+//!   verifier, different body shape; one commit at a time.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+
+use crate::channels::slack::{
+    SignatureError, SlashParseError, VerifyInputs, ack_payload, effective_workspace_id,
+    parse_slash_command, verify,
+};
+use crate::channels::web::platform::state::GatewayState;
+
+/// Slack secret name. Matches `channels-src/slack/slack.capabilities.json`
+/// (`config.signing_secret_name`) so the WASM channel and the core
+/// surface read from the same row.
+pub const SLACK_SIGNING_SECRET_NAME: &str = "slack_signing_secret";
+
+/// POST `/api/channels/slack/slash` — receives every `/ironclaw <…>`
+/// invocation across every workspace where the IronClaw Slack app is
+/// installed.
+pub async fn slash_command_handler(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let now_secs = chrono::Utc::now().timestamp();
+
+    // 1. Pull signing secret. If unset, the gateway is misconfigured —
+    //    surface a 503 so the operator notices, not 500.
+    let signing_secret = match read_signing_secret(&state).await {
+        Ok(s) => s,
+        Err(reason) => {
+            tracing::warn!(
+                reason,
+                "slash command rejected: signing secret not available"
+            );
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Slack channel is not configured on this deployment.",
+            )
+                .into_response();
+        }
+    };
+
+    // 2. Verify signature against raw bytes (Slack signs the wire bytes,
+    //    NOT any decoded form).
+    let timestamp_header = header_str(&headers, "x-slack-request-timestamp");
+    let signature_header = header_str(&headers, "x-slack-signature");
+    if let Err(err) = verify(VerifyInputs {
+        timestamp_header,
+        signature_header,
+        body: body.as_ref(),
+        signing_secret: signing_secret.as_bytes(),
+        now_secs,
+    }) {
+        return signature_error_response(err);
+    }
+
+    // 3. Parse the form-encoded body.
+    let req = match parse_slash_command(body.as_ref()) {
+        Ok(r) => r,
+        Err(err) => return parse_error_response(err),
+    };
+
+    // 4. Resolve workspace identity. Lack of a row means the workspace
+    //    never ran `ironclaw channels install slack <team>` — friendly
+    //    self-service hint rather than a vague 4xx.
+    let store = match state.store.as_ref() {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "IronClaw database is not available.",
+            )
+                .into_response();
+        }
+    };
+    let workspace_id = effective_workspace_id(&req);
+    let resolved = match store
+        .resolve_channel_identity("slack", workspace_id)
+        .await
+    {
+        Ok(opt) => opt,
+        Err(e) => {
+            tracing::error!(error = %e, "resolve_channel_identity failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ack_payload(
+                    "IronClaw hit a database error resolving this workspace. Please try again.",
+                )),
+            )
+                .into_response();
+        }
+    };
+    if resolved.is_none() {
+        // Slack wants 200 with `response_type=ephemeral` here so the user
+        // sees the message instead of a generic Slack error.
+        return (
+            StatusCode::OK,
+            Json(ack_payload(&format!(
+                "This Slack workspace ({workspace_id}) is not bound to an IronClaw deployment yet. \
+                 Run `ironclaw channels install slack {workspace_id}` against the IronClaw \
+                 instance you want to bind to this workspace."
+            ))),
+        )
+            .into_response();
+    }
+
+    // 5. Ack within 3s. The actual agent reply lands later via response_url
+    //    (next commit on this branch).
+    let placeholder = if req.text.trim().is_empty() {
+        "On it. (Empty prompt — IronClaw will ignore this invocation.)".to_string()
+    } else {
+        format!("On it: \"{}\"", truncate_for_display(&req.text, 120))
+    };
+    (StatusCode::OK, Json(ack_payload(&placeholder))).into_response()
+}
+
+async fn read_signing_secret(state: &GatewayState) -> Result<String, &'static str> {
+    let secrets = state.secrets_store.as_ref().ok_or("secrets_store missing")?;
+    let decrypted = secrets
+        .get_decrypted(&state.owner_id, SLACK_SIGNING_SECRET_NAME)
+        .await
+        .map_err(|_| "slack_signing_secret not present")?;
+    Ok(decrypted.expose().to_string())
+}
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+}
+
+fn signature_error_response(err: SignatureError) -> Response {
+    // Distinguish replay / mismatch (401) from operator-controllable
+    // misconfiguration so logs are useful but the wire stays terse.
+    let status = match err {
+        SignatureError::Stale => StatusCode::REQUEST_TIMEOUT,
+        SignatureError::MissingTimestamp
+        | SignatureError::MissingSignature
+        | SignatureError::InvalidTimestamp(_)
+        | SignatureError::BadSignaturePrefix
+        | SignatureError::BadSignatureHex(_) => StatusCode::BAD_REQUEST,
+        SignatureError::Mismatch => StatusCode::UNAUTHORIZED,
+    };
+    tracing::warn!(error = %err, "slash command signature check failed");
+    (status, "Slack signature check failed").into_response()
+}
+
+fn parse_error_response(err: SlashParseError) -> Response {
+    let status = match err {
+        SlashParseError::NotUtf8(_) => StatusCode::BAD_REQUEST,
+        SlashParseError::MissingField(_) => StatusCode::UNPROCESSABLE_ENTITY,
+    };
+    tracing::warn!(error = %err, "slash command body invalid");
+    (status, "Slack slash-command body could not be parsed").into_response()
+}
+
+/// Truncate a string at `max_chars` *characters* (not bytes). Used only
+/// for placeholder text echoed back to the user; not security-critical.
+fn truncate_for_display(s: &str, max_chars: usize) -> String {
+    let mut out = String::with_capacity(s.len().min(max_chars));
+    for (i, ch) in s.chars().enumerate() {
+        if i >= max_chars {
+            out.push('…');
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_str_returns_empty_for_missing_header() {
+        let h = HeaderMap::new();
+        assert_eq!(header_str(&h, "x-slack-signature"), "");
+    }
+
+    #[test]
+    fn header_str_returns_value_for_present_header() {
+        let mut h = HeaderMap::new();
+        h.insert("x-slack-signature", "v0=abcd".parse().unwrap());
+        assert_eq!(header_str(&h, "x-slack-signature"), "v0=abcd");
+    }
+
+    #[test]
+    fn truncate_for_display_appends_ellipsis_above_limit() {
+        assert_eq!(truncate_for_display("abcdef", 3), "abc…");
+        assert_eq!(truncate_for_display("abc", 3), "abc");
+        assert_eq!(truncate_for_display("ab", 3), "ab");
+    }
+
+    #[test]
+    fn truncate_handles_multibyte_chars_without_panic() {
+        // 5 multibyte chars; truncation at 3 must not panic on byte boundaries.
+        let s = "αβγδε";
+        let out = truncate_for_display(s, 3);
+        assert_eq!(out, "αβγ…");
+    }
+}

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -157,6 +157,13 @@ pub async fn start_server(
             "/auth/logout",
             post(crate::channels::web::handlers::auth::logout_handler),
         )
+        // Slack slash-command surface. Public (Slack hits it directly with
+        // its own signed request); the handler verifies the HMAC before
+        // acting. See `crate::channels::slack::sig`.
+        .route(
+            "/api/channels/slack/slash",
+            post(crate::channels::web::handlers::slack::slash_command_handler),
+        )
         // NEAR wallet auth (challenge-response, not OAuth redirect)
         .route(
             "/auth/near/challenge",

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -164,6 +164,17 @@ pub async fn start_server(
             "/api/channels/slack/slash",
             post(crate::channels::web::handlers::slack::slash_command_handler),
         )
+        // Slack workspace-install OAuth flow. Public — the operator's
+        // browser is redirected to Slack and back; CSRF state validated
+        // via `oauth_state_store`. See `crate::channels::slack::install`.
+        .route(
+            "/auth/slack/install",
+            get(crate::channels::web::handlers::auth::slack_install_initiate_handler),
+        )
+        .route(
+            "/auth/slack/install/callback",
+            get(crate::channels::web::handlers::auth::slack_install_callback_handler),
+        )
         // NEAR wallet auth (challenge-response, not OAuth redirect)
         .route(
             "/auth/near/challenge",

--- a/src/cli/channels.rs
+++ b/src/cli/channels.rs
@@ -32,6 +32,33 @@ pub enum ChannelsCommand {
         #[arg(long)]
         json: bool,
     },
+
+    /// Install IronClaw into a workspace channel (currently: `slack`).
+    ///
+    /// Prints the Slack app manifest to upload at api.slack.com/apps,
+    /// persists the workspace identity, and prints the slash-command
+    /// target URL the installer pastes into the Slack app config.
+    ///
+    /// Example: `ironclaw channels install slack T0XXXX --base-url https://ironclaw.example.com`
+    Install {
+        /// Channel name. Currently only `slack` is supported.
+        #[arg(required = true)]
+        channel: String,
+
+        /// Slack workspace/team id (`T…`) or Enterprise Grid id (`E…`).
+        #[arg(required = true)]
+        workspace_id: String,
+
+        /// Public HTTPS origin Slack will reach for events, slash commands,
+        /// and the OAuth install callback. No trailing slash required.
+        #[arg(long)]
+        base_url: String,
+
+        /// Emit only the manifest JSON to stdout (for piping into `jq` or
+        /// saving). Suppresses the "next steps" banner.
+        #[arg(long, default_value_t = false)]
+        manifest_only: bool,
+    },
 }
 
 /// Run the channels CLI subcommand.
@@ -45,7 +72,133 @@ pub async fn run_channels_command(
 
     match cmd {
         ChannelsCommand::List { verbose, json } => cmd_list(&config.channels, verbose, json).await,
+        ChannelsCommand::Install {
+            channel,
+            workspace_id,
+            base_url,
+            manifest_only,
+        } => {
+            // Only `slack` lands in this commit. `telegram`/`signal` go through
+            // the existing onboard wizard and don't yet have a workspace-scoped
+            // install path. Reject other channel names so callers get a clear
+            // error rather than a silently-wrong manifest.
+            let channel_norm = channel.to_ascii_lowercase();
+            if channel_norm != "slack" {
+                anyhow::bail!(
+                    "install: channel '{channel}' is not supported. Currently only 'slack' \
+                     supports `channels install`; other channels are configured via \
+                     `ironclaw onboard --step channels`."
+                );
+            }
+            cmd_install_slack(&config, &workspace_id, &base_url, manifest_only).await
+        }
     }
+}
+
+/// Install the Slack channel for a workspace.
+///
+/// Workflow:
+///   1. Ensure the deployment owner user row exists (FK requirement on
+///      `channel_identities.owner_id`).
+///   2. Idempotently upsert `(channel='slack', external_id=workspace_id,
+///      owner_id=deployment_owner)` into `channel_identities`.
+///   3. Generate the Slack app manifest with minimal scopes.
+///   4. Print operator-facing instructions: upload manifest, complete OAuth,
+///      paste the slash-command URL into the Slack app config.
+///
+/// `--manifest-only` short-circuits steps (1)-(2) and emits only the JSON,
+/// for piping into another tool.
+async fn cmd_install_slack(
+    config: &crate::config::Config,
+    workspace_id: &str,
+    base_url: &str,
+    manifest_only: bool,
+) -> anyhow::Result<()> {
+    use crate::channels::slack::{generate_manifest, manifest::slash_command_url};
+
+    let workspace_id = workspace_id.trim();
+    if workspace_id.is_empty() {
+        anyhow::bail!("install slack: workspace_id is required");
+    }
+    // Slack team ids start with `T`, Enterprise Grid ids with `E`. Catch the
+    // "ABC123" / numeric typo before we write a junk row to the DB.
+    let first = workspace_id.chars().next().unwrap_or('?');
+    if first != 'T' && first != 'E' {
+        anyhow::bail!(
+            "install slack: workspace_id '{workspace_id}' does not look like a Slack \
+             team id (expected `T…`) or Enterprise Grid id (expected `E…`)"
+        );
+    }
+
+    let manifest = generate_manifest(base_url);
+    let manifest_json = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| anyhow::anyhow!("failed to serialize manifest: {e}"))?;
+
+    if manifest_only {
+        println!("{manifest_json}");
+        return Ok(());
+    }
+
+    // Persist workspace identity. Mirror the pairing CLI's approach: ensure
+    // the deployment-owner user row exists first (FK on channel_identities).
+    let db = crate::db::connect_from_config(&config.database)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to connect to database: {e}"))?;
+
+    db.get_or_create_user(crate::db::UserRecord {
+        id: config.owner_id.clone(),
+        role: crate::ownership::UserRole::Owner.as_db_role().to_string(),
+        display_name: "Owner".to_string(),
+        status: "active".to_string(),
+        email: None,
+        last_login_at: None,
+        created_by: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        metadata: serde_json::Value::Object(Default::default()),
+    })
+    .await
+    .ok();
+
+    let was_new = db
+        .upsert_channel_identity("slack", workspace_id, &config.owner_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to persist workspace identity: {e}"))?;
+
+    let slash_url = slash_command_url(base_url);
+    let install_url = format!(
+        "{}/auth/slack/install/callback",
+        base_url.trim_end_matches('/')
+    );
+
+    println!("Slack workspace install for {workspace_id}");
+    println!(
+        "  identity:    {}",
+        if was_new {
+            "registered (new)"
+        } else {
+            "already registered (owner refreshed)"
+        }
+    );
+    println!("  owner:       {}", config.owner_id);
+    println!();
+    println!("Next steps:");
+    println!("  1. Open https://api.slack.com/apps?new_app=1 and choose \"From an app manifest\".");
+    println!("  2. Paste the manifest below into the workspace of your choice.");
+    println!(
+        "  3. After Slack creates the app, install it. Slack will redirect to:\n     {install_url}"
+    );
+    println!("  4. The bot token will be captured by the redirect handler. Subsequent");
+    println!("     follow-up commits on this branch land the slash-command surface and");
+    println!("     audit log; this commit ships the install path only.");
+    println!();
+    println!("Slash-command URL (paste into Slack app config):");
+    println!("  {slash_url}");
+    println!();
+    println!("Manifest JSON:");
+    println!("{manifest_json}");
+
+    Ok(())
 }
 
 /// Channel entry for display.

--- a/src/db/libsql/pairing.rs
+++ b/src/db/libsql/pairing.rs
@@ -462,6 +462,78 @@ impl ChannelPairingStore for LibSqlBackend {
         .map_err(|e| DatabaseError::Query(e.to_string()))?;
         Ok(())
     }
+
+    async fn upsert_channel_identity(
+        &self,
+        channel: &str,
+        external_id: &str,
+        owner_id: &str,
+    ) -> Result<bool, DatabaseError> {
+        let channel = crate::pairing::normalize_channel_name(channel);
+        let conn = self.connect().await?;
+
+        // SELECT-then-INSERT/UPDATE so we can report inserted-vs-updated to
+        // the operator. Wrapped in IMMEDIATE so a concurrent install of the
+        // same workspace can't race us into a duplicate row.
+        conn.execute("BEGIN IMMEDIATE", ())
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let result = async {
+            let mut rows = conn
+                .query(
+                    "SELECT owner_id FROM channel_identities
+                     WHERE channel = ?1 AND external_id = ?2 LIMIT 1",
+                    params![channel.as_str(), external_id],
+                )
+                .await
+                .map_err(|e| DatabaseError::Query(e.to_string()))?;
+            let existing = rows
+                .next()
+                .await
+                .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+            if existing.is_some() {
+                conn.execute(
+                    "UPDATE channel_identities SET owner_id = ?1
+                     WHERE channel = ?2 AND external_id = ?3",
+                    params![owner_id, channel.as_str(), external_id],
+                )
+                .await
+                .map_err(|e| DatabaseError::Query(e.to_string()))?;
+                Ok::<bool, DatabaseError>(false)
+            } else {
+                let identity_id = uuid::Uuid::new_v4().to_string();
+                conn.execute(
+                    "INSERT INTO channel_identities (id, owner_id, channel, external_id)
+                     VALUES (?1, ?2, ?3, ?4)",
+                    params![
+                        identity_id.as_str(),
+                        owner_id,
+                        channel.as_str(),
+                        external_id
+                    ],
+                )
+                .await
+                .map_err(|e| DatabaseError::Query(e.to_string()))?;
+                Ok(true)
+            }
+        }
+        .await;
+
+        match result {
+            Ok(was_new) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| DatabaseError::Query(e.to_string()))?;
+                Ok(was_new)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1192,6 +1192,28 @@ pub trait ChannelPairingStore: Send + Sync {
         channel: &str,
         external_id: &str,
     ) -> Result<(), DatabaseError>;
+
+    /// Persist a workspace-level channel identity directly, without going
+    /// through per-user pairing. Used by `ironclaw channels install slack
+    /// <team_id>` and equivalent admin-driven workspace installs — the
+    /// install binds the deployment owner to the workspace; per-user
+    /// pairing happens later on first DM (see [`upsert_pairing_request`]
+    /// / [`approve_pairing`]).
+    ///
+    /// Idempotent. If `(channel, external_id)` already exists, the
+    /// existing row's `owner_id` is overwritten (matches the pairing
+    /// approve semantics). Returns `true` if a new row was inserted,
+    /// `false` if an existing row was updated — useful for operator
+    /// output ("registered" vs "owner refreshed").
+    ///
+    /// [`upsert_pairing_request`]: ChannelPairingStore::upsert_pairing_request
+    /// [`approve_pairing`]: ChannelPairingStore::approve_pairing
+    async fn upsert_channel_identity(
+        &self,
+        channel: &str,
+        external_id: &str,
+        owner_id: &str,
+    ) -> Result<bool, DatabaseError>;
 }
 
 /// Generates an 8-character pairing code from an unambiguous alphabet.

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1467,6 +1467,43 @@ impl ChannelPairingStore for PgBackend {
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
         Ok(())
     }
+
+    async fn upsert_channel_identity(
+        &self,
+        channel: &str,
+        external_id: &str,
+        owner_id: &str,
+    ) -> Result<bool, DatabaseError> {
+        let channel = crate::pairing::normalize_channel_name(channel);
+        let mut client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        // `xmax = 0` is true exactly when this row was inserted by THIS statement
+        // (no prior tuple to mark as updated) — the canonical Postgres trick for
+        // detecting INSERT-vs-UPDATE inside an UPSERT. Cheaper than SELECT-then-write.
+        let row = tx
+            .query_one(
+                "INSERT INTO channel_identities (id, owner_id, channel, external_id)
+                 VALUES (gen_random_uuid(), $1, $2, $3)
+                 ON CONFLICT (channel, external_id) DO UPDATE SET owner_id = $1
+                 RETURNING (xmax = 0) AS inserted",
+                &[&owner_id, &channel, &external_id],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        let inserted: bool = row.get("inserted");
+        tx.commit()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(inserted)
+    }
 }
 
 // ==================== IdentityStore ====================

--- a/tests/slack_install.rs
+++ b/tests/slack_install.rs
@@ -1,0 +1,165 @@
+//! Integration tests for the `ironclaw channels install slack` workflow.
+//!
+//! Covers the four checks called out in the install-path spec:
+//!   (a) manifest JSON has minimal scopes
+//!   (b) OAuth callback for the bot-token shape parses the response
+//!   (c) workspace identity write hits `channel_identities` with the team id
+//!   (d) duplicate install of the same workspace id reuses the existing identity
+//!
+//! Uses libSQL file-backed tempdir for isolation, mirroring `tests/pairing_integration.rs`.
+
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+
+use ironclaw::channels::slack::{
+    MINIMAL_BOT_SCOPES, manifest::manifest_json, parse_oauth_v2_access,
+};
+use ironclaw::db::libsql::LibSqlBackend;
+use ironclaw::db::{Database, UserRecord, UserStore};
+
+async fn setup_db_with_owner(owner_id: &str) -> (Arc<dyn Database>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("slack_install_test.db");
+    let db = LibSqlBackend::new_local(&db_path).await.unwrap();
+    db.run_migrations().await.unwrap();
+    db.get_or_create_user(UserRecord {
+        id: owner_id.to_string(),
+        role: "owner".to_string(),
+        display_name: owner_id.to_string(),
+        status: "active".to_string(),
+        email: None,
+        last_login_at: None,
+        created_by: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        metadata: serde_json::Value::Null,
+    })
+    .await
+    .unwrap();
+    (Arc::new(db), dir)
+}
+
+// (a) manifest JSON has minimal scopes
+#[test]
+fn manifest_json_carries_minimal_bot_scopes() {
+    let m = manifest_json("https://ironclaw.example.com");
+    let scopes: Vec<&str> = m["oauth_config"]["scopes"]["bot"]
+        .as_array()
+        .expect("scopes.bot is an array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+
+    let expected: Vec<&str> = MINIMAL_BOT_SCOPES.to_vec();
+    let mut got_sorted = scopes.clone();
+    got_sorted.sort();
+    let mut want_sorted = expected.clone();
+    want_sorted.sort();
+    assert_eq!(
+        got_sorted, want_sorted,
+        "manifest.oauth_config.scopes.bot must equal MINIMAL_BOT_SCOPES exactly; got {scopes:?}"
+    );
+
+    // Slash command must point at the deployment's install base URL.
+    let slash_url = m["features"]["slash_commands"][0]["url"]
+        .as_str()
+        .expect("slash command url");
+    assert_eq!(
+        slash_url,
+        "https://ironclaw.example.com/api/channels/slack/slash"
+    );
+}
+
+// (b) OAuth callback for the bot-token shape parses the response
+#[test]
+fn parses_oauth_v2_access_bot_token_response() {
+    // Real-shape fixture from Slack's docs (June 2024).
+    let body = r#"{
+        "ok": true,
+        "access_token": "xoxb-FAKE-FIXTURE-FOR-INTEGRATION-TEST",
+        "token_type": "bot",
+        "scope": "chat:write,app_mentions:read,im:history,im:write,commands",
+        "bot_user_id": "U0KRQLJ9H",
+        "app_id": "A0KRD7HC3",
+        "team": { "id": "T9TK3CUKW", "name": "Slack Pickleball Team" }
+    }"#;
+
+    let resp = parse_oauth_v2_access(body).expect("bot-token response parses");
+    assert!(resp.ok);
+    assert_eq!(resp.token_type, "bot");
+    assert!(resp.access_token.starts_with("xoxb-"));
+    assert_eq!(resp.team.as_ref().unwrap().id, "T9TK3CUKW");
+    // The captured token must carry every minimal scope. The manifest is
+    // declarative; the response is the proof Slack actually granted them.
+    let granted: Vec<&str> = resp.scope.split(',').collect();
+    for required in MINIMAL_BOT_SCOPES {
+        assert!(
+            granted.contains(required),
+            "captured response is missing required scope {required}; got {granted:?}"
+        );
+    }
+}
+
+// (c) workspace identity write hits channel_identities with the team id
+#[tokio::test]
+async fn install_persists_workspace_identity_with_team_id() {
+    let (db, _dir) = setup_db_with_owner("owner_alpha").await;
+
+    let was_new = db
+        .upsert_channel_identity("slack", "T9TK3CUKW", "owner_alpha")
+        .await
+        .expect("upsert succeeds");
+    assert!(
+        was_new,
+        "first call must report inserted=true so the operator sees \"registered (new)\""
+    );
+
+    // Resolve must round-trip the deployment owner.
+    let resolved = db
+        .resolve_channel_identity("slack", "T9TK3CUKW")
+        .await
+        .expect("resolve succeeds")
+        .expect("identity exists after install");
+    assert_eq!(resolved.as_str(), "owner_alpha");
+
+    // Channel name is normalised to lowercase per the table CHECK constraint.
+    let resolved_lower = db
+        .resolve_channel_identity("SLACK", "T9TK3CUKW")
+        .await
+        .expect("resolve succeeds for case-variant input")
+        .expect("identity is found regardless of channel-name case");
+    assert_eq!(resolved_lower.as_str(), "owner_alpha");
+}
+
+// (d) duplicate install of the same workspace id reuses the existing identity
+#[tokio::test]
+async fn install_is_idempotent_for_duplicate_workspace_id() {
+    let (db, _dir) = setup_db_with_owner("owner_beta").await;
+
+    let first = db
+        .upsert_channel_identity("slack", "T0DUP", "owner_beta")
+        .await
+        .unwrap();
+    assert!(first, "first install reports inserted=true");
+
+    let second = db
+        .upsert_channel_identity("slack", "T0DUP", "owner_beta")
+        .await
+        .unwrap();
+    assert!(
+        !second,
+        "duplicate install must report inserted=false (existing row reused), got true"
+    );
+
+    // No phantom second row was written. The UNIQUE (channel, external_id)
+    // constraint would have errored anyway — this assertion catches the
+    // regression where we would have INSERT'd to a different unique key
+    // (e.g. forgetting to lowercase the channel column).
+    let resolved = db
+        .resolve_channel_identity("slack", "T0DUP")
+        .await
+        .unwrap()
+        .expect("identity still resolves after duplicate install");
+    assert_eq!(resolved.as_str(), "owner_beta");
+}

--- a/tests/support/live_mission_helpers.rs
+++ b/tests/support/live_mission_helpers.rs
@@ -3,8 +3,11 @@
 //! Extracted from `tests/e2e_live_routine.rs` so additional scenarios
 //! (`tests/e2e_live_mission_gmail.rs`, etc.) can reuse the same approval
 //! responder and notification heuristics without copy-paste drift.
+//!
+//! The `feature = "libsql"` gate lives on the `mod live_mission_helpers;`
+//! line in `tests/support/mod.rs`; declaring it here too triggers
+//! `clippy::duplicated_attributes` under clippy 1.93+.
 
-#![cfg(feature = "libsql")]
 #![allow(dead_code)] // shared API; not every test uses every helper
 
 use std::collections::HashSet;


### PR DESCRIPTION
## Summary

- Adds `ironclaw channels install slack <T0XXX> --base-url <https-origin>` — a workspace-scoped install path that generates a minimal-scope Slack app manifest, persists the workspace identity, and prints the slash-command target URL. NEAR Foundation pilots rate Slack as the #1 enterprise channel for compliance reasons (per Tobias Holenstein's 2026-05-01 all-hands status: *"slack is really would be the channel number one to be used (compliance)."*); today every pilot is a manual bot-token paste + manifest copy.
- Extracts a small `crate::channels::slack` module — pure `manifest.rs` (Slack rejects unknown keys, so we serialise only what we set) and pure `oauth.rs` parser for the `oauth.v2.access` bot-token shape, with a typed error surface (`SlackOAuthError::{Malformed, NotOk, MissingTeam, MissingAccessToken}`). Handles Enterprise Grid (prefers enterprise id over team id when present).
- Adds `ChannelPairingStore::upsert_channel_identity(channel, external_id, owner_id) -> Result<bool>` for workspace-level installs that don't go through per-user pairing. Idempotent; returns inserted-vs-updated so the operator output reads `registered (new)` vs `owner refreshed`. Implemented for both libSQL and Postgres (Postgres uses the `xmax = 0` upsert trick; libSQL uses BEGIN IMMEDIATE + SELECT-then-write).
- This is the **first commit** on a multi-commit branch. Slash-command surface (`/api/channels/slack/slash`), the redirect handler that extends `src/channels/web/handlers/auth.rs` for the bot-token shape (`/auth/slack/install/callback`), the `channel_audit_log` table, and per-user pairing on first DM all land in subsequent commits on this same branch.

## Change Type

- [x] New feature

## Linked Issue

Related: NEAR Foundation pilot rollout for Slack (cited by Tobias Holenstein at the 2026-05-01 all-hands as the #1 enterprise compliance channel). DAU target: 181 → 500 by quarter end.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass:
    - `tests/slack_install.rs` — 4 integration tests:
        - `manifest_json_carries_minimal_bot_scopes`
        - `parses_oauth_v2_access_bot_token_response`
        - `install_persists_workspace_identity_with_team_id`
        - `install_is_idempotent_for_duplicate_workspace_id`
    - `src/channels/slack/manifest.rs` — 4 unit tests
    - `src/channels/slack/oauth.rs` — 5 unit tests
- [x] Manual testing: ran `ironclaw channels install slack T0FAKE --base-url https://ironclaw.example.com` against a libSQL deployment; verified the workspace identity row, manifest JSON shape, and slash-command URL output.

## Security Impact

- New code path persists a `(channel, external_id, owner_id)` row mapping a Slack workspace id to the deployment owner. The deployment owner is the same identity that approves per-user pairings today; no new privilege escalation.
- The OAuth parser only accepts responses with `ok=true` AND a non-empty `access_token` AND a `team` object — eagerly rejects degenerate responses that could bind a workspace to an empty token.
- Workspace id format is validated (`T…` or `E…` only) before any DB write to avoid persisting junk that could confuse the resolve path.
- No bot-token persistence in this commit; that lives behind the redirect handler that follows in the next commit on this branch.

## Database Impact

- No schema migration. Reuses the existing `channel_identities` table (V19) and its `UNIQUE (channel, external_id)` constraint.
- New trait method `upsert_channel_identity` implemented for both libSQL and Postgres backends. Postgres uses an `INSERT … ON CONFLICT DO UPDATE … RETURNING (xmax = 0) AS inserted` to detect insert-vs-update in one round trip; libSQL uses a `BEGIN IMMEDIATE` + SELECT-then-write transaction (libSQL's `RETURNING` doesn't surface conflict tuple state).

## Blast Radius

- New CLI subcommand (`channels install`) — additive, no behaviour change to existing `channels list` path.
- New trait method on `ChannelPairingStore` — implemented in both backends. No change to existing trait methods.
- New top-level module `crate::channels::slack` — control-plane only, distinct from the WASM Slack channel under `channels-src/slack/` which continues to handle inbound events.
- The existing `ironclaw onboard --step channels` Slack setup path is untouched.

## Rollback Plan

- Revert this commit (no migration to undo). The `channel_identities` rows written by this command are byte-identical to rows written by the per-user pairing flow, so they are safe to leave in place across revert/replay; or `DELETE FROM channel_identities WHERE channel = 'slack' AND external_id = '<workspace_id>'` to remove a specific workspace install.

## Review Follow-Through

- Subsequent commits on this same branch land:
    1. `/api/channels/slack/slash` slash-command receiver (Slack ack < 3s, real reply via `chat.postMessage` to the originating thread). Cross-channel hijack guard from #2444 must apply: an approval issued on Slack cannot be resolved from Telegram. Threading uses the `thread_ts` propagation fix from #2349.
    2. Redirect handler `/auth/slack/install/callback` that extends (does not fork) `src/channels/web/handlers/auth.rs` per the constraint that auth.rs is load-bearing for Google + GitHub + NEAR + Apple OIDC.
    3. New `channel_audit_log` table modelled on `secret_usage_log`'s pattern, with `audit.slack_retention_days` (default 90) — compliance pilots want this.
    4. Per-user pairing on first DM (reuses `crate::pairing` — the pairing CLI is already channel-generic, so no CLI change is needed).

---

**Review track**: C (database trait extension + new CLI surface)
