### PR TITLE
Add native autoverify command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ integrations/abound/tests/source_env_vars.sh
 # Sidecar tool data
 .sidecar/
 .todos/
+.autoverify.state.json
 
 target/
 

--- a/.ironclaw-verify.json
+++ b/.ironclaw-verify.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "tiers": [
+    {
+      "name": "smoke",
+      "timeout_s": 240,
+      "commands": [
+        {
+          "name": "fmt",
+          "run": "cargo fmt --all --check"
+        },
+        {
+          "name": "verify-unit",
+          "run": "cargo test -p ironclaw --lib cli::verify::tests"
+        }
+      ]
+    },
+    {
+      "name": "replay",
+      "timeout_s": 600,
+      "commands": [
+        {
+          "name": "engine-v2-single-tool-replay",
+          "run": "cargo test --test e2e_engine_v2 --features replay -- --list | grep '^engine_v2_tests::snapshot_single_tool_echo: test$' >/dev/null && cargo test --test e2e_engine_v2 --features replay engine_v2_tests::snapshot_single_tool_echo -- --exact"
+        }
+      ]
+    }
+  ]
+}

--- a/.ironclaw-verify.json
+++ b/.ironclaw-verify.json
@@ -12,6 +12,10 @@
         {
           "name": "verify-unit",
           "run": "cargo test -p ironclaw --lib cli::verify::tests"
+        },
+        {
+          "name": "audit-unit",
+          "run": "cargo test -p ironclaw --lib cli::audit::tests"
         }
       ]
     },

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -179,6 +179,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `sandbox` | ✅ | ✅ | - | WASM sandbox |
 | `doctor` | ✅ | 🚧 | P2 | 16 subsystem checks |
 | `logs` | ✅ | 🚧 | P3 | `logs` (gateway.log tail), `--follow` (SSE live stream), `--level` (get/set). No DB-persisted log history. |
+| `verify` / autoverify | ✅ | ✅ | P2 | Native layered verification tiers (`.ironclaw-verify.json`) with Hermes-compatible `.autoverify.json` fallback, structured JSON verdicts, retry/flaky handling, and persisted `.autoverify.state.json`. |
 | `update` | ✅ | ❌ | P3 | Self-update |
 | `completion` | ✅ | ✅ | - | Shell completion |
 | `/subagents spawn` | ✅ | ❌ | P3 | Spawn subagents from chat |

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -180,6 +180,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `doctor` | ✅ | 🚧 | P2 | 16 subsystem checks |
 | `logs` | ✅ | 🚧 | P3 | `logs` (gateway.log tail), `--follow` (SSE live stream), `--level` (get/set). No DB-persisted log history. |
 | `verify` / autoverify | ✅ | ✅ | P2 | Native layered verification tiers (`.ironclaw-verify.json`) with Hermes-compatible `.autoverify.json` fallback, structured JSON verdicts, retry/flaky handling, and persisted `.autoverify.state.json`. |
+| `audit` / auto-audit | ✅ | ✅ | P2 | Deterministic ship-readiness audit over latest verify state, git status/diff, and PR checks via `gh`. |
 | `update` | ✅ | ❌ | P3 | Self-update |
 | `completion` | ✅ | ✅ | - | Shell completion |
 | `/subagents spawn` | ✅ | ❌ | P3 | Spawn subagents from chat |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ cargo test
 
 # Run the layered verification harness
 ironclaw verify --tier smoke
+
+# Inspect configured verification tiers
+ironclaw verify --list
 ```
 
 For **full release** (after modifying channel sources), run `./scripts/build-all.sh` to rebuild channels first.
@@ -320,6 +323,9 @@ cargo test
 
 # Run the repo's autonomous verification tiers
 cargo run --bin ironclaw -- verify --tier smoke
+
+# Inspect the repo verification plan
+cargo run --bin ironclaw -- verify --list
 
 # Run specific test
 cargo test test_name

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ cargo build --release
 
 # Run tests
 cargo test
+
+# Run the layered verification harness
+ironclaw verify --tier smoke
 ```
 
 For **full release** (after modifying channel sources), run `./scripts/build-all.sh` to rebuild channels first.
@@ -314,6 +317,9 @@ cargo clippy --all --benches --tests --examples --all-features
 # Run tests
 createdb ironclaw_test
 cargo test
+
+# Run the repo's autonomous verification tiers
+cargo run --bin ironclaw -- verify --tier smoke
 
 # Run specific test
 cargo test test_name

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ ironclaw verify --tier smoke
 
 # Inspect configured verification tiers
 ironclaw verify --list
+
+# Audit verification state, git diff, and PR checks before shipping
+ironclaw audit --compact
 ```
 
 For **full release** (after modifying channel sources), run `./scripts/build-all.sh` to rebuild channels first.
@@ -326,6 +329,9 @@ cargo run --bin ironclaw -- verify --tier smoke
 
 # Inspect the repo verification plan
 cargo run --bin ironclaw -- verify --list
+
+# Audit the current branch before shipping
+cargo run --bin ironclaw -- audit --compact
 
 # Run specific test
 cargo test test_name

--- a/skills/auto-audit/SKILL.md
+++ b/skills/auto-audit/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: auto-audit
+version: 0.1.0
+description: Deterministic ship-readiness audit for autonomous coding work. Combines the latest ironclaw verify state, local git diff/status, and GitHub PR checks into a clear ship/no-ship verdict.
+activation:
+  keywords:
+    - auto-audit
+    - audit my work
+    - ship readiness
+    - ready to ship
+    - PR audit
+    - review readiness
+    - can I merge
+    - autonomous PR review
+  patterns:
+    - "(?i)(audit|review).*(work|changes|PR|pull request)"
+    - "(?i)(ready|safe).*(ship|merge)"
+    - "(?i)(ship|merge).*(audit|check|readiness)"
+  tags:
+    - developer
+    - verification
+    - review
+  max_context_tokens: 1600
+requires:
+  bins:
+    - git
+    - gh
+---
+
+# Auto Audit
+
+Use this skill when autonomous work needs a final ship/no-ship gate after tests have run. The core command is:
+
+```bash
+ironclaw audit --target <repo> --compact
+```
+
+`ironclaw audit` reads `.autoverify.state.json`, checks that the recorded `git_head` matches the current HEAD, checks the current git status and diff against a base revision, confirms the PR head matches local HEAD, and inspects GitHub PR checks when `gh` is available. Its verdicts are:
+
+- `ship`: verification passed, the worktree is clean, diff checks pass, and PR checks are green
+- `needs_review`: no blocker, but a warning remains, such as pending checks or unavailable PR metadata
+- `blocked`: verification failed or is missing, the worktree is dirty, diff checks failed, the PR is draft/closed, or checks failed
+
+## Operating Loop
+
+1. Run the meaningful verification tier first:
+
+```bash
+ironclaw verify --target . --upto replay --compact
+```
+
+2. Commit the verified tree, then audit it:
+
+```bash
+ironclaw audit --target . --compact
+```
+
+3. Use strict mode before declaring the PR ready:
+
+```bash
+ironclaw audit --target . --strict
+```
+
+4. If GitHub metadata is intentionally unavailable, run a local-only audit and state the limitation:
+
+```bash
+ironclaw audit --target . --no-checks --compact
+```
+
+Do not treat `needs_review` as green. Either wait for pending checks to finish, fix the warning, or clearly record why a human should make the final call.

--- a/skills/autoverify/SKILL.md
+++ b/skills/autoverify/SKILL.md
@@ -35,7 +35,7 @@ Use this skill when autonomous coding work needs evidence before it is called do
 ironclaw verify --target <repo> --tier smoke --compact
 ```
 
-IronClaw reads `.ironclaw-verify.json` first and falls back to Hermes-compatible `.autoverify.json`. The command runs named tiers in order, writes `.autoverify.state.json`, and emits a structured verdict:
+IronClaw reads `.ironclaw-verify.json` first and falls back to Hermes-compatible `.autoverify.json`. The command runs named tiers in order, writes `.autoverify.state.json`, and emits a structured verdict with attempt metadata:
 
 - `pass`: the requested tiers passed
 - `flaky`: a retry passed after an initial failure; rerun or investigate before trusting it
@@ -49,17 +49,23 @@ IronClaw reads `.ironclaw-verify.json` first and falls back to Hermes-compatible
 ironclaw verify --target . --tier smoke --compact
 ```
 
-2. Before shipping a PR, run all tiers needed for the touched surface:
+2. If you are unsure what the repo defines, inspect the plan without running commands:
+
+```bash
+ironclaw verify --target . --list
+```
+
+3. Before shipping a PR, run all tiers needed for the touched surface:
 
 ```bash
 ironclaw verify --target . --upto replay --compact
 ```
 
-3. If `verdict` is `flaky`, do not hand-wave it. Rerun the same tier. If it flakes again, inspect the failing command and either fix the flake or record it as an explicit risk.
+4. If `verdict` is `flaky`, do not hand-wave it. Rerun the same tier. If it flakes again, inspect the failing command and either fix the flake or record it as an explicit risk.
 
-4. If `verdict` is `fail`, fix the cause and rerun the smallest tier that proves the fix. Then rerun the ship tier before committing.
+5. If `verdict` is `fail`, fix the cause and rerun the smallest tier that proves the fix. Then rerun the ship tier before committing.
 
-5. After committing, rerun at least `smoke` against the committed tree so the final state, not an intermediate edit, is what passed.
+6. After committing, rerun at least `smoke` against the committed tree so the final state, not an intermediate edit, is what passed.
 
 ## Config Shape
 

--- a/skills/autoverify/SKILL.md
+++ b/skills/autoverify/SKILL.md
@@ -35,7 +35,7 @@ Use this skill when autonomous coding work needs evidence before it is called do
 ironclaw verify --target <repo> --tier smoke --compact
 ```
 
-IronClaw reads `.ironclaw-verify.json` first and falls back to Hermes-compatible `.autoverify.json`. The command runs named tiers in order, writes `.autoverify.state.json`, and emits a structured verdict with attempt metadata:
+IronClaw reads `.ironclaw-verify.json` first and falls back to Hermes-compatible `.autoverify.json`. The command runs named tiers in order, writes `.autoverify.state.json`, records the verified `git_head` when available, and emits a structured verdict with attempt metadata:
 
 - `pass`: the requested tiers passed
 - `flaky`: a retry passed after an initial failure; rerun or investigate before trusting it

--- a/skills/autoverify/SKILL.md
+++ b/skills/autoverify/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: autoverify
+version: 0.1.0
+description: Layered self-verification harness for autonomous coding work. Runs ironclaw verify tiers after changes, records machine-readable verdicts, and treats flaky results as unresolved until rerun or fixed.
+activation:
+  keywords:
+    - autoverify
+    - verify my work
+    - prove it works
+    - backtest
+    - autonomous verification
+    - overnight
+    - ship PR
+    - test tiers
+  patterns:
+    - "(?i)(prove|verify|test|backtest).*(work|change|PR|feature)"
+    - "(?i)(ship|merge).*(after|with).*(tests|verification|backtest)"
+    - "(?i)run .*verify"
+  tags:
+    - developer
+    - testing
+    - verification
+  max_context_tokens: 1800
+requires:
+  bins:
+    - git
+    - cargo
+---
+
+# Autoverify
+
+Use this skill when autonomous coding work needs evidence before it is called done. The core command is:
+
+```bash
+ironclaw verify --target <repo> --tier smoke --compact
+```
+
+IronClaw reads `.ironclaw-verify.json` first and falls back to Hermes-compatible `.autoverify.json`. The command runs named tiers in order, writes `.autoverify.state.json`, and emits a structured verdict:
+
+- `pass`: the requested tiers passed
+- `flaky`: a retry passed after an initial failure; rerun or investigate before trusting it
+- `fail`: at least one command failed, timed out, or could not start
+
+## Operating Loop
+
+1. After each code change, run the fastest meaningful tier:
+
+```bash
+ironclaw verify --target . --tier smoke --compact
+```
+
+2. Before shipping a PR, run all tiers needed for the touched surface:
+
+```bash
+ironclaw verify --target . --upto replay --compact
+```
+
+3. If `verdict` is `flaky`, do not hand-wave it. Rerun the same tier. If it flakes again, inspect the failing command and either fix the flake or record it as an explicit risk.
+
+4. If `verdict` is `fail`, fix the cause and rerun the smallest tier that proves the fix. Then rerun the ship tier before committing.
+
+5. After committing, rerun at least `smoke` against the committed tree so the final state, not an intermediate edit, is what passed.
+
+## Config Shape
+
+```json
+{
+  "version": 1,
+  "tiers": [
+    {
+      "name": "smoke",
+      "timeout_s": 60,
+      "retry_on_fail": true,
+      "commands": [
+        { "name": "fmt", "run": "cargo fmt --all --check" },
+        { "name": "unit", "run": "cargo test -p ironclaw_skills" }
+      ]
+    }
+  ]
+}
+```
+
+Keep tiers short and evidence-focused. A good suite has a cheap `smoke` tier, a targeted `unit` or `integration` tier, and a replay/backtest tier for behavior that could regress without compiler errors.

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -1,0 +1,859 @@
+//! Deterministic pre-ship audit command.
+//!
+//! `ironclaw audit` consumes local verification state, git state, and optional
+//! GitHub PR checks to produce a machine-readable ship/no-ship signal.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, bail};
+use clap::Args;
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_STATE_FILE: &str = ".autoverify.state.json";
+
+#[derive(Args, Debug, Clone)]
+pub struct AuditCommand {
+    /// Project directory to audit
+    #[arg(long, default_value = ".")]
+    pub target: PathBuf,
+
+    /// Git base for diff checks. Defaults to origin/main, main, then HEAD~1.
+    #[arg(long)]
+    pub base: Option<String>,
+
+    /// Verification state file. Relative paths are resolved from --target.
+    #[arg(long, default_value = DEFAULT_STATE_FILE)]
+    pub state: PathBuf,
+
+    /// Skip GitHub PR check inspection
+    #[arg(long)]
+    pub no_checks: bool,
+
+    /// Print a compact single-line JSON audit result
+    #[arg(long)]
+    pub compact: bool,
+
+    /// Return a non-zero exit code unless the audit verdict is ship
+    #[arg(long)]
+    pub strict: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum AuditVerdict {
+    Ship,
+    NeedsReview,
+    Blocked,
+}
+
+impl fmt::Display for AuditVerdict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuditVerdict::Ship => f.write_str("ship"),
+            AuditVerdict::NeedsReview => f.write_str("needs_review"),
+            AuditVerdict::Blocked => f.write_str("blocked"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum FindingLevel {
+    Info,
+    Warning,
+    Blocker,
+}
+
+impl fmt::Display for FindingLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FindingLevel::Info => f.write_str("info"),
+            FindingLevel::Warning => f.write_str("warning"),
+            FindingLevel::Blocker => f.write_str("blocker"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AuditFinding {
+    level: FindingLevel,
+    code: &'static str,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AuditOutput {
+    verdict: AuditVerdict,
+    target: String,
+    git: GitAudit,
+    verify: VerifyAudit,
+    checks: Option<ChecksAudit>,
+    findings: Vec<AuditFinding>,
+    started_at: String,
+    finished_at: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct GitAudit {
+    branch: Option<String>,
+    base: Option<String>,
+    dirty: bool,
+    changed_files: Vec<String>,
+    shortstat: Option<String>,
+    diff_check_pass: Option<bool>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct VerifyAudit {
+    state_path: String,
+    found: bool,
+    verdict: Option<String>,
+    git_head: Option<String>,
+    current_git_head: Option<String>,
+    target_matches: Option<bool>,
+    tiers_requested: Vec<String>,
+    finished_at: Option<String>,
+    summary: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct ChecksAudit {
+    pr_number: Option<u64>,
+    pr_url: Option<String>,
+    pr_state: Option<String>,
+    is_draft: Option<bool>,
+    head_ref_oid: Option<String>,
+    total: usize,
+    pass: usize,
+    fail: usize,
+    pending: usize,
+    skipping: usize,
+    cancel: usize,
+    unavailable: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPrView {
+    number: Option<u64>,
+    url: Option<String>,
+    state: Option<String>,
+    is_draft: Option<bool>,
+    head_ref_oid: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhCheck {
+    bucket: Option<String>,
+}
+
+struct ProcessOutput {
+    code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+pub async fn run_audit_command(cmd: AuditCommand) -> anyhow::Result<()> {
+    let started_at = chrono::Utc::now();
+    let target = cmd
+        .target
+        .canonicalize()
+        .with_context(|| format!("target does not exist: {}", cmd.target.display()))?;
+
+    let mut findings = Vec::new();
+    let git = audit_git(&target, cmd.base.as_deref(), &mut findings);
+    let verify = audit_verify(&target, &cmd.state, &mut findings);
+    let checks = if cmd.no_checks {
+        findings.push(AuditFinding {
+            level: FindingLevel::Info,
+            code: "checks_skipped",
+            message: "GitHub PR checks were skipped by --no-checks".to_string(),
+        });
+        None
+    } else {
+        Some(audit_checks(&target, &mut findings))
+    };
+
+    let verdict = decide_verdict(&findings);
+    let output = AuditOutput {
+        verdict,
+        target: target.display().to_string(),
+        git,
+        verify,
+        checks,
+        findings,
+        started_at: started_at.to_rfc3339(),
+        finished_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    render_output(&output, cmd.compact)?;
+
+    if cmd.strict && output.verdict != AuditVerdict::Ship {
+        bail!("audit verdict is {}", output.verdict);
+    }
+
+    Ok(())
+}
+
+fn audit_git(
+    target: &Path,
+    requested_base: Option<&str>,
+    findings: &mut Vec<AuditFinding>,
+) -> GitAudit {
+    let mut audit = GitAudit::default();
+
+    match run_process(target, "git", &["status", "--porcelain=v1", "--branch"]) {
+        Ok(output) if output.code == Some(0) => {
+            let mut lines = output.stdout.lines();
+            if let Some(first) = lines.next() {
+                audit.branch = parse_branch(first);
+            }
+            let dirty_entries: Vec<_> = lines.filter(|line| !line.trim().is_empty()).collect();
+            audit.dirty = !dirty_entries.is_empty();
+            if audit.dirty {
+                findings.push(AuditFinding {
+                    level: FindingLevel::Blocker,
+                    code: "git_dirty",
+                    message: format!(
+                        "worktree has {} uncommitted status entr{}",
+                        dirty_entries.len(),
+                        if dirty_entries.len() == 1 { "y" } else { "ies" }
+                    ),
+                });
+            }
+        }
+        Ok(output) => findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "git_status_failed",
+            message: command_failure_message("git status", &output),
+        }),
+        Err(error) => findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "git_status_failed",
+            message: error.to_string(),
+        }),
+    }
+
+    let base = requested_base
+        .map(ToOwned::to_owned)
+        .or_else(|| first_valid_revision(target, &["origin/main", "main", "HEAD~1"]));
+    audit.base = base.clone();
+
+    let Some(base) = base else {
+        findings.push(AuditFinding {
+            level: FindingLevel::Warning,
+            code: "git_base_missing",
+            message: "could not resolve a base revision for diff checks".to_string(),
+        });
+        return audit;
+    };
+
+    let range = format!("{base}...HEAD");
+    match run_process(target, "git", &["diff", "--name-only", &range]) {
+        Ok(output) if output.code == Some(0) => {
+            audit.changed_files = output
+                .stdout
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .map(ToOwned::to_owned)
+                .collect();
+            if audit.changed_files.is_empty() {
+                findings.push(AuditFinding {
+                    level: FindingLevel::Warning,
+                    code: "diff_empty",
+                    message: format!("no changed files found against {base}"),
+                });
+            }
+        }
+        Ok(output) => findings.push(AuditFinding {
+            level: FindingLevel::Warning,
+            code: "diff_name_failed",
+            message: command_failure_message("git diff --name-only", &output),
+        }),
+        Err(error) => findings.push(AuditFinding {
+            level: FindingLevel::Warning,
+            code: "diff_name_failed",
+            message: error.to_string(),
+        }),
+    }
+
+    if let Ok(output) = run_process(target, "git", &["diff", "--shortstat", &range])
+        && output.code == Some(0)
+    {
+        let stat = output.stdout.trim();
+        if !stat.is_empty() {
+            audit.shortstat = Some(stat.to_string());
+        }
+    }
+
+    match run_process(target, "git", &["diff", "--check", &range]) {
+        Ok(output) if output.code == Some(0) => {
+            audit.diff_check_pass = Some(true);
+        }
+        Ok(output) => {
+            audit.diff_check_pass = Some(false);
+            findings.push(AuditFinding {
+                level: FindingLevel::Blocker,
+                code: "diff_check_failed",
+                message: command_failure_message("git diff --check", &output),
+            });
+        }
+        Err(error) => findings.push(AuditFinding {
+            level: FindingLevel::Warning,
+            code: "diff_check_failed",
+            message: error.to_string(),
+        }),
+    }
+
+    audit
+}
+
+fn audit_verify(target: &Path, state: &Path, findings: &mut Vec<AuditFinding>) -> VerifyAudit {
+    let state_path = if state.is_absolute() {
+        state.to_path_buf()
+    } else {
+        target.join(state)
+    };
+    let mut audit = VerifyAudit {
+        state_path: state_path.display().to_string(),
+        ..VerifyAudit::default()
+    };
+
+    let raw = match std::fs::read_to_string(&state_path) {
+        Ok(raw) => raw,
+        Err(error) => {
+            findings.push(AuditFinding {
+                level: FindingLevel::Blocker,
+                code: "verify_state_missing",
+                message: format!("could not read {}: {error}", state_path.display()),
+            });
+            return audit;
+        }
+    };
+
+    audit.found = true;
+    let parsed: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(error) => {
+            findings.push(AuditFinding {
+                level: FindingLevel::Blocker,
+                code: "verify_state_invalid",
+                message: format!("could not parse {}: {error}", state_path.display()),
+            });
+            return audit;
+        }
+    };
+
+    audit.verdict = parsed
+        .get("verdict")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    audit.finished_at = parsed
+        .get("finished_at")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    audit.git_head = parsed
+        .get("git_head")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    audit.tiers_requested = parsed
+        .get("tiers_requested")
+        .and_then(serde_json::Value::as_array)
+        .map(|tiers| {
+            tiers
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default();
+    audit.summary = parsed.get("summary").cloned();
+    audit_verify_git_head(&mut audit, current_git_head(target), findings);
+
+    match audit.verdict.as_deref() {
+        Some("pass") => {}
+        Some(other) => findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "verify_not_pass",
+            message: format!("latest verification verdict is {other}"),
+        }),
+        None => findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "verify_verdict_missing",
+            message: "verification state has no verdict".to_string(),
+        }),
+    }
+
+    if let Some(state_target) = parsed.get("target").and_then(serde_json::Value::as_str) {
+        let target_matches = state_target == target.display().to_string();
+        audit.target_matches = Some(target_matches);
+        if !target_matches {
+            findings.push(AuditFinding {
+                level: FindingLevel::Blocker,
+                code: "verify_target_mismatch",
+                message: format!(
+                    "verification state target is {state_target}, expected {}",
+                    target.display()
+                ),
+            });
+        }
+    } else {
+        findings.push(AuditFinding {
+            level: FindingLevel::Warning,
+            code: "verify_target_missing",
+            message: "verification state has no target field".to_string(),
+        });
+    }
+
+    audit
+}
+
+fn audit_verify_git_head(
+    audit: &mut VerifyAudit,
+    current_head: Option<String>,
+    findings: &mut Vec<AuditFinding>,
+) {
+    audit.current_git_head = current_head.clone();
+    let Some(current_head) = current_head else {
+        return;
+    };
+
+    match audit.git_head.as_deref() {
+        Some(state_head) if state_head == current_head => {}
+        Some(state_head) => findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "verify_state_stale",
+            message: format!(
+                "verification state was written for git head {state_head}, current head is {current_head}"
+            ),
+        }),
+        None => findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "verify_git_head_missing",
+            message: "verification state has no git_head; rerun `ironclaw verify`".to_string(),
+        }),
+    }
+}
+
+fn current_git_head(target: &Path) -> Option<String> {
+    let output = run_process(target, "git", &["rev-parse", "HEAD"]).ok()?;
+    if output.code != Some(0) {
+        return None;
+    }
+
+    let head = output.stdout.trim();
+    if head.is_empty() {
+        None
+    } else {
+        Some(head.to_string())
+    }
+}
+
+fn audit_checks(target: &Path, findings: &mut Vec<AuditFinding>) -> ChecksAudit {
+    let mut audit = ChecksAudit::default();
+
+    let pr = match run_process(
+        target,
+        "gh",
+        &[
+            "pr",
+            "view",
+            "--json",
+            "number,url,state,isDraft,headRefOid",
+        ],
+    ) {
+        Ok(output) if output.code == Some(0) => {
+            match serde_json::from_str::<GhPrView>(&output.stdout) {
+                Ok(pr) => pr,
+                Err(error) => {
+                    audit.unavailable = true;
+                    findings.push(AuditFinding {
+                        level: FindingLevel::Warning,
+                        code: "pr_view_invalid",
+                        message: format!("could not parse gh pr view output: {error}"),
+                    });
+                    return audit;
+                }
+            }
+        }
+        Ok(output) => {
+            audit.unavailable = true;
+            findings.push(AuditFinding {
+                level: FindingLevel::Warning,
+                code: "pr_unavailable",
+                message: command_failure_message("gh pr view", &output),
+            });
+            return audit;
+        }
+        Err(error) => {
+            audit.unavailable = true;
+            findings.push(AuditFinding {
+                level: FindingLevel::Warning,
+                code: "pr_unavailable",
+                message: error.to_string(),
+            });
+            return audit;
+        }
+    };
+
+    audit.pr_number = pr.number;
+    audit.pr_url = pr.url;
+    audit.pr_state = pr.state;
+    audit.is_draft = pr.is_draft;
+    audit.head_ref_oid = pr.head_ref_oid;
+
+    if let Some(local_head) = current_git_head(target) {
+        match audit.head_ref_oid.as_deref() {
+            Some(pr_head) if pr_head == local_head => {}
+            Some(pr_head) => findings.push(AuditFinding {
+                level: FindingLevel::Blocker,
+                code: "pr_head_mismatch",
+                message: format!("pull request head is {pr_head}, local HEAD is {local_head}"),
+            }),
+            None => findings.push(AuditFinding {
+                level: FindingLevel::Warning,
+                code: "pr_head_missing",
+                message: "pull request metadata did not include headRefOid".to_string(),
+            }),
+        }
+    }
+
+    if audit.is_draft == Some(true) {
+        findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "pr_draft",
+            message: "pull request is still a draft".to_string(),
+        });
+    }
+    if !matches!(audit.pr_state.as_deref(), Some("OPEN") | Some("open")) {
+        findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "pr_not_open",
+            message: format!(
+                "pull request state is {}",
+                audit.pr_state.as_deref().unwrap_or("unknown")
+            ),
+        });
+    }
+
+    let checks = match run_process(
+        target,
+        "gh",
+        &["pr", "checks", "--json", "name,state,bucket,link,workflow"],
+    ) {
+        Ok(output) if matches!(output.code, Some(0) | Some(8)) => {
+            match serde_json::from_str::<Vec<GhCheck>>(&output.stdout) {
+                Ok(checks) => checks,
+                Err(error) => {
+                    audit.unavailable = true;
+                    findings.push(AuditFinding {
+                        level: FindingLevel::Warning,
+                        code: "checks_invalid",
+                        message: format!("could not parse gh pr checks output: {error}"),
+                    });
+                    return audit;
+                }
+            }
+        }
+        Ok(output) => {
+            audit.unavailable = true;
+            findings.push(AuditFinding {
+                level: FindingLevel::Warning,
+                code: "checks_unavailable",
+                message: command_failure_message("gh pr checks", &output),
+            });
+            return audit;
+        }
+        Err(error) => {
+            audit.unavailable = true;
+            findings.push(AuditFinding {
+                level: FindingLevel::Warning,
+                code: "checks_unavailable",
+                message: error.to_string(),
+            });
+            return audit;
+        }
+    };
+
+    audit.total = checks.len();
+    let mut unknown = 0;
+    for check in checks {
+        match check.bucket.as_deref() {
+            Some("pass") => audit.pass += 1,
+            Some("fail") => audit.fail += 1,
+            Some("pending") => audit.pending += 1,
+            Some("skipping") => audit.skipping += 1,
+            Some("cancel") => audit.cancel += 1,
+            _ => {
+                audit.unavailable = true;
+                unknown += 1;
+            }
+        }
+    }
+
+    if audit.total == 0 {
+        findings.push(AuditFinding {
+            level: FindingLevel::Warning,
+            code: "checks_empty",
+            message: "no GitHub PR checks were reported".to_string(),
+        });
+    }
+    if unknown > 0 {
+        findings.push(AuditFinding {
+            level: FindingLevel::Warning,
+            code: "checks_unknown",
+            message: format!("{unknown} PR check bucket(s) had an unknown status"),
+        });
+    }
+    if audit.fail > 0 || audit.cancel > 0 {
+        findings.push(AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "checks_failed",
+            message: format!(
+                "{} failing and {} canceled PR check bucket(s)",
+                audit.fail, audit.cancel
+            ),
+        });
+    }
+    if audit.pending > 0 {
+        findings.push(AuditFinding {
+            level: FindingLevel::Warning,
+            code: "checks_pending",
+            message: format!("{} PR check bucket(s) still pending", audit.pending),
+        });
+    }
+
+    audit
+}
+
+fn render_output(output: &AuditOutput, compact: bool) -> anyhow::Result<()> {
+    if compact {
+        println!("{}", serde_json::to_string(output)?);
+        return Ok(());
+    }
+
+    println!("IronClaw audit: {}", output.verdict);
+    println!("target: {}", output.target);
+    if let Some(branch) = &output.git.branch {
+        println!("branch: {branch}");
+    }
+    if let Some(base) = &output.git.base {
+        println!("base: {base}");
+    }
+    if let Some(shortstat) = &output.git.shortstat {
+        println!("diff: {shortstat}");
+    }
+    println!(
+        "verify: {}",
+        output.verify.verdict.as_deref().unwrap_or("missing")
+    );
+    if let Some(checks) = &output.checks
+        && !checks.unavailable
+    {
+        println!(
+            "checks: {} pass, {} pending, {} fail, {} cancel, {} skipped",
+            checks.pass, checks.pending, checks.fail, checks.cancel, checks.skipping
+        );
+    }
+    for finding in &output.findings {
+        println!("- {} {}: {}", finding.level, finding.code, finding.message);
+    }
+
+    Ok(())
+}
+
+fn decide_verdict(findings: &[AuditFinding]) -> AuditVerdict {
+    if findings
+        .iter()
+        .any(|finding| finding.level == FindingLevel::Blocker)
+    {
+        return AuditVerdict::Blocked;
+    }
+    if findings
+        .iter()
+        .any(|finding| finding.level == FindingLevel::Warning)
+    {
+        return AuditVerdict::NeedsReview;
+    }
+    AuditVerdict::Ship
+}
+
+fn parse_branch(status_header: &str) -> Option<String> {
+    let branch = status_header.strip_prefix("## ")?;
+    let current = match branch.split("...").next() {
+        Some(value) => value,
+        None => branch,
+    };
+    Some(current.to_string())
+}
+
+fn first_valid_revision(target: &Path, candidates: &[&str]) -> Option<String> {
+    candidates.iter().find_map(|candidate| {
+        let output = run_process(target, "git", &["rev-parse", "--verify", candidate]).ok()?;
+        if output.code == Some(0) {
+            Some((*candidate).to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn run_process(target: &Path, program: &str, args: &[&str]) -> anyhow::Result<ProcessOutput> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(target)
+        .output()
+        .with_context(|| format!("failed to run {program} {}", args.join(" ")))?;
+
+    Ok(ProcessOutput {
+        code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn command_failure_message(command: &str, output: &ProcessOutput) -> String {
+    let detail = if output.stderr.trim().is_empty() {
+        output.stdout.trim()
+    } else {
+        output.stderr.trim()
+    };
+    if detail.is_empty() {
+        format!("{command} exited with {:?}", output.code)
+    } else {
+        format!("{command} exited with {:?}: {detail}", output.code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decide_verdict_blocks_on_blocker() {
+        let findings = vec![AuditFinding {
+            level: FindingLevel::Blocker,
+            code: "x",
+            message: "blocked".into(),
+        }];
+
+        assert_eq!(decide_verdict(&findings), AuditVerdict::Blocked);
+    }
+
+    #[test]
+    fn decide_verdict_needs_review_on_warning() {
+        let findings = vec![AuditFinding {
+            level: FindingLevel::Warning,
+            code: "x",
+            message: "review".into(),
+        }];
+
+        assert_eq!(decide_verdict(&findings), AuditVerdict::NeedsReview);
+    }
+
+    #[test]
+    fn parse_branch_strips_upstream_suffix() {
+        assert_eq!(
+            parse_branch("## codex/native-autoverify...origin/codex/native-autoverify"),
+            Some("codex/native-autoverify".to_string())
+        );
+    }
+
+    #[test]
+    fn audit_verify_blocks_missing_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut findings = Vec::new();
+
+        let audit = audit_verify(temp.path(), Path::new(DEFAULT_STATE_FILE), &mut findings);
+
+        assert!(!audit.found);
+        assert_eq!(decide_verdict(&findings), AuditVerdict::Blocked);
+        assert_eq!(findings[0].code, "verify_state_missing");
+    }
+
+    #[test]
+    fn audit_verify_accepts_pass_state_for_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = serde_json::json!({
+            "verdict": "pass",
+            "target": temp.path().display().to_string(),
+            "tiers_requested": ["smoke"],
+            "summary": {"pass": 1},
+            "finished_at": "2026-05-02T00:00:00Z"
+        });
+        std::fs::write(
+            temp.path().join(DEFAULT_STATE_FILE),
+            serde_json::to_string(&state).expect("serialize state"),
+        )
+        .expect("write state");
+        let mut findings = Vec::new();
+
+        let audit = audit_verify(temp.path(), Path::new(DEFAULT_STATE_FILE), &mut findings);
+
+        assert!(audit.found);
+        assert_eq!(audit.verdict.as_deref(), Some("pass"));
+        assert_eq!(audit.target_matches, Some(true));
+        assert_eq!(decide_verdict(&findings), AuditVerdict::Ship);
+    }
+
+    #[test]
+    fn audit_verify_blocks_missing_git_head_when_current_head_exists() {
+        let mut audit = VerifyAudit::default();
+        let mut findings = Vec::new();
+
+        audit_verify_git_head(&mut audit, Some("abc123".to_string()), &mut findings);
+
+        assert_eq!(audit.current_git_head.as_deref(), Some("abc123"));
+        assert_eq!(decide_verdict(&findings), AuditVerdict::Blocked);
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.code == "verify_git_head_missing")
+        );
+    }
+
+    #[test]
+    fn audit_verify_blocks_stale_git_head() {
+        let mut audit = VerifyAudit {
+            git_head: Some("old".to_string()),
+            ..VerifyAudit::default()
+        };
+        let mut findings = Vec::new();
+
+        audit_verify_git_head(&mut audit, Some("new".to_string()), &mut findings);
+
+        assert_eq!(decide_verdict(&findings), AuditVerdict::Blocked);
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.code == "verify_state_stale")
+        );
+    }
+
+    #[test]
+    fn audit_verify_blocks_non_pass_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = serde_json::json!({
+            "verdict": "fail",
+            "target": temp.path().display().to_string()
+        });
+        std::fs::write(
+            temp.path().join(DEFAULT_STATE_FILE),
+            serde_json::to_string(&state).expect("serialize state"),
+        )
+        .expect("write state");
+        let mut findings = Vec::new();
+
+        let audit = audit_verify(temp.path(), Path::new(DEFAULT_STATE_FILE), &mut findings);
+
+        assert_eq!(audit.verdict.as_deref(), Some("fail"));
+        assert_eq!(decide_verdict(&findings), AuditVerdict::Blocked);
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.code == "verify_not_pass")
+        );
+    }
+}

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -538,34 +538,12 @@ fn audit_checks(target: &Path, findings: &mut Vec<AuditFinding>) -> ChecksAudit 
         });
     }
 
-    let checks = match run_process(
+    let checks_output = match run_process(
         target,
         "gh",
         &["pr", "checks", "--json", "name,state,bucket,link,workflow"],
     ) {
-        Ok(output) if matches!(output.code, Some(0) | Some(8)) => {
-            match serde_json::from_str::<Vec<GhCheck>>(&output.stdout) {
-                Ok(checks) => checks,
-                Err(error) => {
-                    audit.unavailable = true;
-                    findings.push(AuditFinding {
-                        level: FindingLevel::Warning,
-                        code: "checks_invalid",
-                        message: format!("could not parse gh pr checks output: {error}"),
-                    });
-                    return audit;
-                }
-            }
-        }
-        Ok(output) => {
-            audit.unavailable = true;
-            findings.push(AuditFinding {
-                level: FindingLevel::Warning,
-                code: "checks_unavailable",
-                message: command_failure_message("gh pr checks", &output),
-            });
-            return audit;
-        }
+        Ok(output) => output,
         Err(error) => {
             audit.unavailable = true;
             findings.push(AuditFinding {
@@ -577,6 +555,32 @@ fn audit_checks(target: &Path, findings: &mut Vec<AuditFinding>) -> ChecksAudit 
         }
     };
 
+    let checks = match serde_json::from_str::<Vec<GhCheck>>(&checks_output.stdout) {
+        Ok(checks) => checks,
+        Err(error) => {
+            audit.unavailable = true;
+            findings.push(AuditFinding {
+                level: FindingLevel::Warning,
+                code: "checks_invalid",
+                message: format!(
+                    "could not parse gh pr checks output: {error}; {}",
+                    command_failure_message("gh pr checks", &checks_output)
+                ),
+            });
+            return audit;
+        }
+    };
+
+    audit_check_buckets(&checks, &mut audit, findings);
+
+    audit
+}
+
+fn audit_check_buckets(
+    checks: &[GhCheck],
+    audit: &mut ChecksAudit,
+    findings: &mut Vec<AuditFinding>,
+) {
     audit.total = checks.len();
     let mut unknown = 0;
     for check in checks {
@@ -624,8 +628,6 @@ fn audit_checks(target: &Path, findings: &mut Vec<AuditFinding>) -> ChecksAudit 
             message: format!("{} PR check bucket(s) still pending", audit.pending),
         });
     }
-
-    audit
 }
 
 fn render_output(output: &AuditOutput, compact: bool) -> anyhow::Result<()> {
@@ -854,6 +856,51 @@ mod tests {
             findings
                 .iter()
                 .any(|finding| finding.code == "verify_not_pass")
+        );
+    }
+
+    #[test]
+    fn audit_check_buckets_blocks_failed_checks() {
+        let checks = vec![
+            GhCheck {
+                bucket: Some("pass".to_string()),
+            },
+            GhCheck {
+                bucket: Some("fail".to_string()),
+            },
+        ];
+        let mut audit = ChecksAudit::default();
+        let mut findings = Vec::new();
+
+        audit_check_buckets(&checks, &mut audit, &mut findings);
+
+        assert_eq!(audit.total, 2);
+        assert_eq!(audit.pass, 1);
+        assert_eq!(audit.fail, 1);
+        assert_eq!(decide_verdict(&findings), AuditVerdict::Blocked);
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.code == "checks_failed")
+        );
+    }
+
+    #[test]
+    fn audit_check_buckets_warns_on_unknown_status() {
+        let checks = vec![GhCheck {
+            bucket: Some("mystery".to_string()),
+        }];
+        let mut audit = ChecksAudit::default();
+        let mut findings = Vec::new();
+
+        audit_check_buckets(&checks, &mut audit, &mut findings);
+
+        assert!(audit.unavailable);
+        assert_eq!(decide_verdict(&findings), AuditVerdict::NeedsReview);
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.code == "checks_unknown")
         );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,9 +14,11 @@
 //! - Active health diagnostics (`doctor`)
 //! - Viewing gateway logs (`logs`)
 //! - Running project verification tiers (`verify`)
+//! - Auditing verification, git diff, and PR checks before shipping (`audit`)
 //! - Checking system health (`status`)
 
 pub mod acp;
+mod audit;
 mod channels;
 mod completion;
 mod config;
@@ -40,6 +42,7 @@ mod tool;
 mod verify;
 
 pub use acp::{AcpCommand, run_acp_command};
+pub use audit::{AuditCommand, run_audit_command};
 pub use channels::{ChannelsCommand, run_channels_command};
 pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
@@ -295,6 +298,17 @@ pub enum Command {
            ironclaw verify --target ../my-project --loop --interval 30 --max 20"
     )]
     Verify(VerifyCommand),
+
+    /// Audit verifier state, git diff, and PR checks before shipping
+    #[command(
+        about = "Audit ship readiness",
+        long_about = "Combines the latest `ironclaw verify` state, git status/diff, and optional GitHub PR checks into a deterministic ship/no-ship verdict.\n\n\
+         Examples:\n  \
+           ironclaw audit --compact\n  \
+           ironclaw audit --strict\n  \
+           ironclaw audit --no-checks --base origin/main"
+    )]
+    Audit(AuditCommand),
 
     /// Probe external dependencies and validate configuration
     #[command(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -289,6 +289,7 @@ pub enum Command {
         long_about = "Runs machine-readable verification tiers from .ironclaw-verify.json or the Hermes-compatible .autoverify.json.\n\n\
          Use this after code changes and before shipping autonomous work.\n\n\
          Examples:\n  \
+           ironclaw verify --list\n  \
            ironclaw verify --tier smoke --compact\n  \
            ironclaw verify --upto integration\n  \
            ironclaw verify --target ../my-project --loop --interval 30 --max 20"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,6 +13,7 @@
 //! - Listing deployment profiles (`profile list`)
 //! - Active health diagnostics (`doctor`)
 //! - Viewing gateway logs (`logs`)
+//! - Running project verification tiers (`verify`)
 //! - Checking system health (`status`)
 
 pub mod acp;
@@ -36,6 +37,7 @@ mod service;
 mod skills;
 pub mod status;
 mod tool;
+mod verify;
 
 pub use acp::{AcpCommand, run_acp_command};
 pub use channels::{ChannelsCommand, run_channels_command};
@@ -58,6 +60,7 @@ pub use service::{ServiceCommand, run_service_command};
 pub use skills::{SkillsCommand, run_skills_command};
 pub use status::run_status_command;
 pub use tool::{ToolCommand, run_tool_command};
+pub use verify::{VerifyCommand, run_verify_command};
 
 use std::sync::Arc;
 
@@ -279,6 +282,18 @@ pub enum Command {
            ironclaw models set-provider ollama --model llama3  # Switch to local Ollama"
     )]
     Models(ModelsCommand),
+
+    /// Run layered verification tiers from .ironclaw-verify.json or .autoverify.json
+    #[command(
+        about = "Run layered project verification",
+        long_about = "Runs machine-readable verification tiers from .ironclaw-verify.json or the Hermes-compatible .autoverify.json.\n\n\
+         Use this after code changes and before shipping autonomous work.\n\n\
+         Examples:\n  \
+           ironclaw verify --tier smoke --compact\n  \
+           ironclaw verify --upto integration\n  \
+           ironclaw verify --target ../my-project --loop --interval 30 --max 20"
+    )]
+    Verify(VerifyCommand),
 
     /// Probe external dependencies and validate configuration
     #[command(

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
@@ -22,6 +22,7 @@ Commands:
   skills      Manage skills
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
+  verify      Run layered project verification
   doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
@@ -23,6 +23,7 @@ Commands:
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   verify      Run layered project verification
+  audit       Audit ship readiness
   doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -22,6 +22,7 @@ Commands:
   skills      Manage skills
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
+  verify      Run layered project verification
   doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -23,6 +23,7 @@ Commands:
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   verify      Run layered project verification
+  audit       Audit ship readiness
   doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
@@ -37,6 +37,7 @@ Commands:
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   verify      Run layered project verification
+  audit       Audit ship readiness
   doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
@@ -36,6 +36,7 @@ Commands:
   skills      Manage skills
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
+  verify      Run layered project verification
   doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -37,6 +37,7 @@ Commands:
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   verify      Run layered project verification
+  audit       Audit ship readiness
   doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -36,6 +36,7 @@ Commands:
   skills      Manage skills
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
+  verify      Run layered project verification
   doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -4,6 +4,8 @@
 //! `.autoverify.json` shape used by Hermes while adding a native Rust runner
 //! and structured state file for IronClaw agents.
 
+use std::collections::HashSet;
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
@@ -42,6 +44,10 @@ pub struct VerifyCommand {
     #[arg(long)]
     pub compact: bool,
 
+    /// List configured tiers without running commands
+    #[arg(long)]
+    pub list: bool,
+
     /// Repeat verification until it passes or --max attempts is reached
     #[arg(long)]
     pub r#loop: bool,
@@ -59,13 +65,13 @@ pub struct VerifyCommand {
     pub state: Option<PathBuf>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 struct VerifyConfig {
     version: u32,
     tiers: Vec<VerifyTier>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 struct VerifyTier {
     name: String,
     #[serde(default = "default_timeout_secs")]
@@ -77,7 +83,7 @@ struct VerifyTier {
     commands: Vec<VerifyCommandSpec>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 struct VerifyCommandSpec {
     name: String,
     run: String,
@@ -91,11 +97,12 @@ enum Verdict {
     Fail,
 }
 
-impl Verdict {
-    fn exit_code(self) -> i32 {
+impl fmt::Display for Verdict {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Verdict::Pass => 0,
-            Verdict::Flaky | Verdict::Fail => 1,
+            Verdict::Pass => f.write_str("pass"),
+            Verdict::Flaky => f.write_str("flaky"),
+            Verdict::Fail => f.write_str("fail"),
         }
     }
 }
@@ -108,6 +115,18 @@ enum CommandStatus {
     Fail,
     Timeout,
     Error,
+}
+
+impl fmt::Display for CommandStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CommandStatus::Pass => f.write_str("pass"),
+            CommandStatus::Flaky => f.write_str("flaky"),
+            CommandStatus::Fail => f.write_str("fail"),
+            CommandStatus::Timeout => f.write_str("timeout"),
+            CommandStatus::Error => f.write_str("error"),
+        }
+    }
 }
 
 impl CommandStatus {
@@ -124,6 +143,8 @@ struct VerifyOutput {
     verdict: Verdict,
     target: String,
     config: String,
+    attempt: u32,
+    max_attempts: u32,
     tiers_requested: Vec<String>,
     commands: Vec<CommandOutcome>,
     summary: VerifySummary,
@@ -153,6 +174,13 @@ struct VerifySummary {
     total_duration_ms: u128,
 }
 
+#[derive(Debug, Serialize)]
+struct VerifyListing<'a> {
+    target: String,
+    config: String,
+    tiers: Vec<&'a VerifyTier>,
+}
+
 fn default_timeout_secs() -> u64 {
     DEFAULT_TIMEOUT_SECS
 }
@@ -167,11 +195,16 @@ pub async fn run_verify_command(cmd: VerifyCommand) -> anyhow::Result<()> {
     let config = load_config(&config_path)?;
     let tiers = select_tiers(&config, cmd.tier.as_deref(), cmd.upto.as_deref())?;
 
+    if cmd.list {
+        render_listing(&target, &config_path, &tiers, cmd.compact)?;
+        return Ok(());
+    }
+
     let max_attempts = if cmd.r#loop { cmd.max.max(1) } else { 1 };
     let mut last_output = None;
 
     for attempt in 1..=max_attempts {
-        let output = run_once(&target, &config_path, &tiers).await;
+        let output = run_once(&target, &config_path, &tiers, attempt, max_attempts).await;
         write_state(&state_path, &output)?;
         render_output(&output, cmd.compact, attempt, max_attempts)?;
 
@@ -187,7 +220,15 @@ pub async fn run_verify_command(cmd: VerifyCommand) -> anyhow::Result<()> {
     if let Some(output) = last_output
         && output.verdict != Verdict::Pass
     {
-        std::process::exit(output.verdict.exit_code());
+        bail!(
+            "verification {} ({} pass, {} flaky, {} fail, {} timeout, {} error)",
+            output.verdict,
+            output.summary.pass,
+            output.summary.flaky,
+            output.summary.fail,
+            output.summary.timeout,
+            output.summary.error
+        );
     }
 
     Ok(())
@@ -243,16 +284,31 @@ fn load_config(path: &Path) -> anyhow::Result<VerifyConfig> {
     if config.tiers.is_empty() {
         bail!("verification config has no tiers");
     }
+    let mut tier_names = HashSet::new();
     for tier in &config.tiers {
         if tier.name.trim().is_empty() {
             bail!("verification tier name may not be empty");
         }
+        if !tier_names.insert(tier.name.as_str()) {
+            bail!("duplicate verification tier '{}'", tier.name);
+        }
+        if tier.timeout_s == 0 {
+            bail!("verification tier '{}' must have timeout_s > 0", tier.name);
+        }
         if tier.commands.is_empty() {
             bail!("verification tier '{}' has no commands", tier.name);
         }
+        let mut command_names = HashSet::new();
         for command in &tier.commands {
             if command.name.trim().is_empty() {
                 bail!("verification tier '{}' has an unnamed command", tier.name);
+            }
+            if !command_names.insert(command.name.as_str()) {
+                bail!(
+                    "duplicate verification command '{}:{}'",
+                    tier.name,
+                    command.name
+                );
             }
             if command.run.trim().is_empty() {
                 bail!(
@@ -277,7 +333,7 @@ fn select_tiers<'a>(
             .tiers
             .iter()
             .find(|candidate| candidate.name == name)
-            .ok_or_else(|| anyhow!("unknown verification tier: {name}"))?;
+            .ok_or_else(|| unknown_tier_error(config, name))?;
         return Ok(vec![selected]);
     }
 
@@ -286,14 +342,32 @@ fn select_tiers<'a>(
             .tiers
             .iter()
             .position(|candidate| candidate.name == name)
-            .ok_or_else(|| anyhow!("unknown verification tier: {name}"))?;
+            .ok_or_else(|| unknown_tier_error(config, name))?;
         return Ok(config.tiers.iter().take(index + 1).collect());
     }
 
     Ok(config.tiers.iter().collect())
 }
 
-async fn run_once(target: &Path, config_path: &Path, tiers: &[&VerifyTier]) -> VerifyOutput {
+fn unknown_tier_error(config: &VerifyConfig, name: &str) -> anyhow::Error {
+    anyhow!(
+        "unknown verification tier: {name} (available: {})",
+        config
+            .tiers
+            .iter()
+            .map(|tier| tier.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+async fn run_once(
+    target: &Path,
+    config_path: &Path,
+    tiers: &[&VerifyTier],
+    attempt: u32,
+    max_attempts: u32,
+) -> VerifyOutput {
     let started_at = chrono::Utc::now();
     let mut commands = Vec::new();
 
@@ -328,6 +402,8 @@ async fn run_once(target: &Path, config_path: &Path, tiers: &[&VerifyTier]) -> V
         verdict,
         target: target.display().to_string(),
         config: config_path.display().to_string(),
+        attempt,
+        max_attempts,
         tiers_requested: tiers.iter().map(|tier| tier.name.clone()).collect(),
         commands,
         summary,
@@ -489,7 +565,7 @@ fn render_output(
     }
 
     println!(
-        "IronClaw verify attempt {attempt}/{max_attempts}: {:?}",
+        "IronClaw verify attempt {attempt}/{max_attempts}: {}",
         output.verdict
     );
     println!("target: {}", output.target);
@@ -508,11 +584,44 @@ fn render_output(
 
     for command in &output.commands {
         println!(
-            "- {}:{} {:?} ({}ms, attempts={})",
+            "- {}:{} {} ({}ms, attempts={})",
             command.tier, command.name, command.status, command.duration_ms, command.attempts
         );
         if command.status != CommandStatus::Pass && !command.tail.trim().is_empty() {
             println!("{}", indent_tail(&command.tail));
+        }
+    }
+
+    Ok(())
+}
+
+fn render_listing(
+    target: &Path,
+    config_path: &Path,
+    tiers: &[&VerifyTier],
+    compact: bool,
+) -> anyhow::Result<()> {
+    let listing = VerifyListing {
+        target: target.display().to_string(),
+        config: config_path.display().to_string(),
+        tiers: tiers.to_vec(),
+    };
+
+    if compact {
+        println!("{}", serde_json::to_string(&listing)?);
+        return Ok(());
+    }
+
+    println!("IronClaw verify tiers");
+    println!("target: {}", listing.target);
+    println!("config: {}", listing.config);
+    for tier in tiers {
+        println!(
+            "- {} (timeout={}s, retry_on_fail={}, continue_on_fail={})",
+            tier.name, tier.timeout_s, tier.retry_on_fail, tier.continue_on_fail
+        );
+        for command in &tier.commands {
+            println!("  - {}: {}", command.name, command.run);
         }
     }
 
@@ -544,6 +653,21 @@ fn indent_tail(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn verify_cmd(target: &Path) -> VerifyCommand {
+        VerifyCommand {
+            target: target.to_path_buf(),
+            config: None,
+            tier: None,
+            upto: None,
+            compact: true,
+            list: false,
+            r#loop: false,
+            interval: DEFAULT_INTERVAL_SECS,
+            max: DEFAULT_MAX_ATTEMPTS,
+            state: None,
+        }
+    }
 
     fn write_config(dir: &Path, body: &str) -> PathBuf {
         let path = dir.join(".autoverify.json");
@@ -599,9 +723,11 @@ mod tests {
         let config = load_config(&config_path).expect("load config");
         let tiers = select_tiers(&config, None, None).expect("select tiers");
 
-        let output = run_once(temp.path(), &config_path, &tiers).await;
+        let output = run_once(temp.path(), &config_path, &tiers, 1, 1).await;
 
         assert_eq!(output.verdict, Verdict::Pass);
+        assert_eq!(output.attempt, 1);
+        assert_eq!(output.max_attempts, 1);
         assert_eq!(output.summary.pass, 1);
         assert_eq!(output.commands[0].tail, "done");
     }
@@ -629,7 +755,7 @@ mod tests {
         let config = load_config(&config_path).expect("load config");
         let tiers = select_tiers(&config, None, None).expect("select tiers");
 
-        let output = run_once(temp.path(), &config_path, &tiers).await;
+        let output = run_once(temp.path(), &config_path, &tiers, 1, 1).await;
 
         assert_eq!(output.verdict, Verdict::Flaky);
         assert_eq!(output.summary.flaky, 1);
@@ -652,10 +778,145 @@ mod tests {
         let config = load_config(&config_path).expect("load config");
         let tiers = select_tiers(&config, None, None).expect("select tiers");
 
-        let output = run_once(temp.path(), &config_path, &tiers).await;
+        let output = run_once(temp.path(), &config_path, &tiers, 1, 1).await;
 
         assert_eq!(output.verdict, Verdict::Fail);
         assert_eq!(output.commands.len(), 1);
         assert_eq!(output.commands[0].exit, Some(9));
+    }
+
+    #[test]
+    fn resolve_config_prefers_ironclaw_verify_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join(".autoverify.json"), "{}").expect("write fallback");
+        std::fs::write(temp.path().join(".ironclaw-verify.json"), "{}")
+            .expect("write native config");
+
+        let selected = resolve_config_path(temp.path(), None).expect("resolve config");
+
+        assert_eq!(selected, temp.path().join(".ironclaw-verify.json"));
+    }
+
+    #[test]
+    fn load_config_rejects_duplicate_tiers() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = write_config(
+            temp.path(),
+            r#"{
+              "version": 1,
+              "tiers": [
+                {"name": "smoke", "commands": [{"name": "a", "run": "true"}]},
+                {"name": "smoke", "commands": [{"name": "b", "run": "true"}]}
+              ]
+            }"#,
+        );
+
+        let error = load_config(&config_path).expect_err("duplicate tiers should fail");
+
+        assert!(error.to_string().contains("duplicate verification tier"));
+    }
+
+    #[test]
+    fn load_config_rejects_duplicate_commands() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = write_config(
+            temp.path(),
+            r#"{
+              "version": 1,
+              "tiers": [
+                {"name": "smoke", "commands": [
+                  {"name": "same", "run": "true"},
+                  {"name": "same", "run": "true"}
+                ]}
+              ]
+            }"#,
+        );
+
+        let error = load_config(&config_path).expect_err("duplicate commands should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate verification command 'smoke:same'")
+        );
+    }
+
+    #[test]
+    fn select_unknown_tier_lists_available_tiers() {
+        let config = VerifyConfig {
+            version: 1,
+            tiers: vec![VerifyTier {
+                name: "smoke".into(),
+                timeout_s: 1,
+                retry_on_fail: false,
+                continue_on_fail: false,
+                commands: vec![VerifyCommandSpec {
+                    name: "a".into(),
+                    run: "true".into(),
+                }],
+            }],
+        };
+
+        let error = select_tiers(&config, Some("missing"), None).expect_err("unknown tier");
+
+        assert!(
+            error
+                .to_string()
+                .contains("unknown verification tier: missing (available: smoke)")
+        );
+    }
+
+    #[tokio::test]
+    async fn run_verify_command_returns_error_on_failure_without_exiting() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_config(
+            temp.path(),
+            r#"{
+              "version": 1,
+              "tiers": [
+                {"name": "smoke", "timeout_s": 5, "commands": [{"name": "fail", "run": "exit 7"}]}
+              ]
+            }"#,
+        );
+
+        let error = run_verify_command(verify_cmd(temp.path()))
+            .await
+            .expect_err("failing verification should return an error");
+        let state = std::fs::read_to_string(temp.path().join(DEFAULT_STATE_FILE))
+            .expect("state file should be written");
+        let state: serde_json::Value = serde_json::from_str(&state).expect("parse state");
+
+        assert!(error.to_string().contains("verification fail"));
+        assert_eq!(state["verdict"], "fail");
+        assert_eq!(state["attempt"], 1);
+        assert_eq!(state["commands"][0]["exit"], 7);
+    }
+
+    #[tokio::test]
+    async fn list_mode_does_not_run_commands_or_write_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let marker = temp.path().join("marker");
+        write_config(
+            temp.path(),
+            &format!(
+                r#"{{
+                  "version": 1,
+                  "tiers": [
+                    {{"name": "smoke", "commands": [{{"name": "touch", "run": "touch {}"}}]}}
+                  ]
+                }}"#,
+                marker.display()
+            ),
+        );
+        let mut cmd = verify_cmd(temp.path());
+        cmd.list = true;
+
+        run_verify_command(cmd).await.expect("list tiers");
+
+        assert!(!marker.exists(), "list mode should not run commands");
+        assert!(
+            !temp.path().join(DEFAULT_STATE_FILE).exists(),
+            "list mode should not write verifier state"
+        );
     }
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -1,0 +1,661 @@
+//! Layered project verification command.
+//!
+//! `ironclaw verify` is intentionally compatible with the lightweight
+//! `.autoverify.json` shape used by Hermes while adding a native Rust runner
+//! and structured state file for IronClaw agents.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, anyhow, bail};
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+const DEFAULT_CONFIG_FILES: &[&str] = &[".ironclaw-verify.json", ".autoverify.json"];
+const DEFAULT_STATE_FILE: &str = ".autoverify.state.json";
+const DEFAULT_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_INTERVAL_SECS: u64 = 60;
+const DEFAULT_MAX_ATTEMPTS: u32 = 1;
+const OUTPUT_TAIL_CHARS: usize = 4000;
+
+#[derive(Args, Debug, Clone)]
+pub struct VerifyCommand {
+    /// Project directory containing the verification config
+    #[arg(long, default_value = ".")]
+    pub target: PathBuf,
+
+    /// Explicit config file path. Defaults to .ironclaw-verify.json, then .autoverify.json.
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Run one tier by name
+    #[arg(long, conflicts_with = "upto")]
+    pub tier: Option<String>,
+
+    /// Run tiers from the beginning through this tier name
+    #[arg(long)]
+    pub upto: Option<String>,
+
+    /// Print a compact single-line JSON verdict
+    #[arg(long)]
+    pub compact: bool,
+
+    /// Repeat verification until it passes or --max attempts is reached
+    #[arg(long)]
+    pub r#loop: bool,
+
+    /// Seconds between loop attempts
+    #[arg(long, default_value_t = DEFAULT_INTERVAL_SECS)]
+    pub interval: u64,
+
+    /// Maximum attempts when --loop is set
+    #[arg(long, default_value_t = DEFAULT_MAX_ATTEMPTS)]
+    pub max: u32,
+
+    /// Override the state file path. Relative paths are resolved from --target.
+    #[arg(long)]
+    pub state: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct VerifyConfig {
+    version: u32,
+    tiers: Vec<VerifyTier>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct VerifyTier {
+    name: String,
+    #[serde(default = "default_timeout_secs")]
+    timeout_s: u64,
+    #[serde(default)]
+    retry_on_fail: bool,
+    #[serde(default)]
+    continue_on_fail: bool,
+    commands: Vec<VerifyCommandSpec>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct VerifyCommandSpec {
+    name: String,
+    run: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Verdict {
+    Pass,
+    Flaky,
+    Fail,
+}
+
+impl Verdict {
+    fn exit_code(self) -> i32 {
+        match self {
+            Verdict::Pass => 0,
+            Verdict::Flaky | Verdict::Fail => 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CommandStatus {
+    Pass,
+    Flaky,
+    Fail,
+    Timeout,
+    Error,
+}
+
+impl CommandStatus {
+    fn is_terminal_failure(self) -> bool {
+        matches!(
+            self,
+            CommandStatus::Fail | CommandStatus::Timeout | CommandStatus::Error
+        )
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct VerifyOutput {
+    verdict: Verdict,
+    target: String,
+    config: String,
+    tiers_requested: Vec<String>,
+    commands: Vec<CommandOutcome>,
+    summary: VerifySummary,
+    started_at: String,
+    finished_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CommandOutcome {
+    tier: String,
+    name: String,
+    status: CommandStatus,
+    exit: Option<i32>,
+    duration_ms: u128,
+    attempts: u8,
+    tail: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct VerifySummary {
+    total: usize,
+    pass: usize,
+    fail: usize,
+    flaky: usize,
+    timeout: usize,
+    error: usize,
+    total_duration_ms: u128,
+}
+
+fn default_timeout_secs() -> u64 {
+    DEFAULT_TIMEOUT_SECS
+}
+
+pub async fn run_verify_command(cmd: VerifyCommand) -> anyhow::Result<()> {
+    let target = cmd
+        .target
+        .canonicalize()
+        .with_context(|| format!("target does not exist: {}", cmd.target.display()))?;
+    let config_path = resolve_config_path(&target, cmd.config.as_deref())?;
+    let state_path = resolve_state_path(&target, cmd.state.as_deref());
+    let config = load_config(&config_path)?;
+    let tiers = select_tiers(&config, cmd.tier.as_deref(), cmd.upto.as_deref())?;
+
+    let max_attempts = if cmd.r#loop { cmd.max.max(1) } else { 1 };
+    let mut last_output = None;
+
+    for attempt in 1..=max_attempts {
+        let output = run_once(&target, &config_path, &tiers).await;
+        write_state(&state_path, &output)?;
+        render_output(&output, cmd.compact, attempt, max_attempts)?;
+
+        let verdict = output.verdict;
+        last_output = Some(output);
+        if verdict == Verdict::Pass || !cmd.r#loop || attempt == max_attempts {
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_secs(cmd.interval)).await;
+    }
+
+    if let Some(output) = last_output
+        && output.verdict != Verdict::Pass
+    {
+        std::process::exit(output.verdict.exit_code());
+    }
+
+    Ok(())
+}
+
+fn resolve_config_path(target: &Path, explicit: Option<&Path>) -> anyhow::Result<PathBuf> {
+    if let Some(path) = explicit {
+        let resolved = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            target.join(path)
+        };
+        if resolved.is_file() {
+            return Ok(resolved);
+        }
+        bail!("verification config not found: {}", resolved.display());
+    }
+
+    for name in DEFAULT_CONFIG_FILES {
+        let candidate = target.join(name);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+
+    bail!(
+        "no verification config found in {} (looked for {})",
+        target.display(),
+        DEFAULT_CONFIG_FILES.join(", ")
+    )
+}
+
+fn resolve_state_path(target: &Path, explicit: Option<&Path>) -> PathBuf {
+    match explicit {
+        Some(path) if path.is_absolute() => path.to_path_buf(),
+        Some(path) => target.join(path),
+        None => target.join(DEFAULT_STATE_FILE),
+    }
+}
+
+fn load_config(path: &Path) -> anyhow::Result<VerifyConfig> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let config: VerifyConfig = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    if config.version != 1 {
+        bail!(
+            "unsupported verification config version: {}",
+            config.version
+        );
+    }
+    if config.tiers.is_empty() {
+        bail!("verification config has no tiers");
+    }
+    for tier in &config.tiers {
+        if tier.name.trim().is_empty() {
+            bail!("verification tier name may not be empty");
+        }
+        if tier.commands.is_empty() {
+            bail!("verification tier '{}' has no commands", tier.name);
+        }
+        for command in &tier.commands {
+            if command.name.trim().is_empty() {
+                bail!("verification tier '{}' has an unnamed command", tier.name);
+            }
+            if command.run.trim().is_empty() {
+                bail!(
+                    "verification command '{}:{}' has an empty run string",
+                    tier.name,
+                    command.name
+                );
+            }
+        }
+    }
+
+    Ok(config)
+}
+
+fn select_tiers<'a>(
+    config: &'a VerifyConfig,
+    tier: Option<&str>,
+    upto: Option<&str>,
+) -> anyhow::Result<Vec<&'a VerifyTier>> {
+    if let Some(name) = tier {
+        let selected = config
+            .tiers
+            .iter()
+            .find(|candidate| candidate.name == name)
+            .ok_or_else(|| anyhow!("unknown verification tier: {name}"))?;
+        return Ok(vec![selected]);
+    }
+
+    if let Some(name) = upto {
+        let index = config
+            .tiers
+            .iter()
+            .position(|candidate| candidate.name == name)
+            .ok_or_else(|| anyhow!("unknown verification tier: {name}"))?;
+        return Ok(config.tiers.iter().take(index + 1).collect());
+    }
+
+    Ok(config.tiers.iter().collect())
+}
+
+async fn run_once(target: &Path, config_path: &Path, tiers: &[&VerifyTier]) -> VerifyOutput {
+    let started_at = chrono::Utc::now();
+    let mut commands = Vec::new();
+
+    for tier in tiers {
+        let mut tier_failed = false;
+        for spec in &tier.commands {
+            let outcome = run_command_with_retry(target, tier, spec).await;
+            if outcome.status.is_terminal_failure() {
+                tier_failed = true;
+            }
+            commands.push(outcome);
+
+            if tier_failed && !tier.continue_on_fail {
+                break;
+            }
+        }
+        if tier_failed && !tier.continue_on_fail {
+            break;
+        }
+    }
+
+    let summary = summarize(&commands);
+    let verdict = if summary.fail > 0 || summary.timeout > 0 || summary.error > 0 {
+        Verdict::Fail
+    } else if summary.flaky > 0 {
+        Verdict::Flaky
+    } else {
+        Verdict::Pass
+    };
+
+    VerifyOutput {
+        verdict,
+        target: target.display().to_string(),
+        config: config_path.display().to_string(),
+        tiers_requested: tiers.iter().map(|tier| tier.name.clone()).collect(),
+        commands,
+        summary,
+        started_at: started_at.to_rfc3339(),
+        finished_at: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
+async fn run_command_with_retry(
+    target: &Path,
+    tier: &VerifyTier,
+    spec: &VerifyCommandSpec,
+) -> CommandOutcome {
+    let first = run_command_once(target, tier, spec).await;
+    if !tier.retry_on_fail || first.status == CommandStatus::Pass {
+        return first;
+    }
+
+    let retry = run_command_once(target, tier, spec).await;
+    if retry.status == CommandStatus::Pass {
+        CommandOutcome {
+            status: CommandStatus::Flaky,
+            attempts: 2,
+            duration_ms: first.duration_ms + retry.duration_ms,
+            tail: format!(
+                "first attempt failed:\n{}\n\nretry passed:\n{}",
+                first.tail, retry.tail
+            ),
+            exit: retry.exit,
+            tier: retry.tier,
+            name: retry.name,
+        }
+    } else {
+        CommandOutcome {
+            attempts: 2,
+            duration_ms: first.duration_ms + retry.duration_ms,
+            tail: format!(
+                "first attempt:\n{}\n\nretry attempt:\n{}",
+                first.tail, retry.tail
+            ),
+            ..retry
+        }
+    }
+}
+
+async fn run_command_once(
+    target: &Path,
+    tier: &VerifyTier,
+    spec: &VerifyCommandSpec,
+) -> CommandOutcome {
+    let start = Instant::now();
+    let mut command = shell_command(&spec.run);
+    command
+        .current_dir(target)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let result =
+        tokio::time::timeout(Duration::from_secs(tier.timeout_s.max(1)), command.output()).await;
+
+    match result {
+        Ok(Ok(output)) => {
+            let mut combined = String::new();
+            combined.push_str(&String::from_utf8_lossy(&output.stdout));
+            if !output.stderr.is_empty() {
+                if !combined.is_empty() {
+                    combined.push_str("\n--- stderr ---\n");
+                }
+                combined.push_str(&String::from_utf8_lossy(&output.stderr));
+            }
+            let success = output.status.success();
+            CommandOutcome {
+                tier: tier.name.clone(),
+                name: spec.name.clone(),
+                status: if success {
+                    CommandStatus::Pass
+                } else {
+                    CommandStatus::Fail
+                },
+                exit: output.status.code(),
+                duration_ms: start.elapsed().as_millis(),
+                attempts: 1,
+                tail: tail(&combined),
+            }
+        }
+        Ok(Err(error)) => CommandOutcome {
+            tier: tier.name.clone(),
+            name: spec.name.clone(),
+            status: CommandStatus::Error,
+            exit: None,
+            duration_ms: start.elapsed().as_millis(),
+            attempts: 1,
+            tail: tail(&error.to_string()),
+        },
+        Err(_) => CommandOutcome {
+            tier: tier.name.clone(),
+            name: spec.name.clone(),
+            status: CommandStatus::Timeout,
+            exit: None,
+            duration_ms: start.elapsed().as_millis(),
+            attempts: 1,
+            tail: format!("timed out after {}s", tier.timeout_s.max(1)),
+        },
+    }
+}
+
+#[cfg(windows)]
+fn shell_command(script: &str) -> Command {
+    let mut command = Command::new("cmd");
+    command.arg("/C").arg(script);
+    command
+}
+
+#[cfg(not(windows))]
+fn shell_command(script: &str) -> Command {
+    let mut command = Command::new("sh");
+    command.arg("-lc").arg(script);
+    command
+}
+
+fn summarize(commands: &[CommandOutcome]) -> VerifySummary {
+    let mut summary = VerifySummary {
+        total: commands.len(),
+        ..VerifySummary::default()
+    };
+    for command in commands {
+        summary.total_duration_ms += command.duration_ms;
+        match command.status {
+            CommandStatus::Pass => summary.pass += 1,
+            CommandStatus::Fail => summary.fail += 1,
+            CommandStatus::Flaky => summary.flaky += 1,
+            CommandStatus::Timeout => summary.timeout += 1,
+            CommandStatus::Error => summary.error += 1,
+        }
+    }
+    summary
+}
+
+fn write_state(path: &Path, output: &VerifyOutput) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let body = serde_json::to_string_pretty(output)?;
+    std::fs::write(path, body).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn render_output(
+    output: &VerifyOutput,
+    compact: bool,
+    attempt: u32,
+    max_attempts: u32,
+) -> anyhow::Result<()> {
+    if compact {
+        println!("{}", serde_json::to_string(output)?);
+        return Ok(());
+    }
+
+    println!(
+        "IronClaw verify attempt {attempt}/{max_attempts}: {:?}",
+        output.verdict
+    );
+    println!("target: {}", output.target);
+    println!("config: {}", output.config);
+    println!("tiers: {}", output.tiers_requested.join(", "));
+    println!(
+        "summary: {} pass, {} flaky, {} fail, {} timeout, {} error ({} commands, {}ms)",
+        output.summary.pass,
+        output.summary.flaky,
+        output.summary.fail,
+        output.summary.timeout,
+        output.summary.error,
+        output.summary.total,
+        output.summary.total_duration_ms
+    );
+
+    for command in &output.commands {
+        println!(
+            "- {}:{} {:?} ({}ms, attempts={})",
+            command.tier, command.name, command.status, command.duration_ms, command.attempts
+        );
+        if command.status != CommandStatus::Pass && !command.tail.trim().is_empty() {
+            println!("{}", indent_tail(&command.tail));
+        }
+    }
+
+    Ok(())
+}
+
+fn tail(text: &str) -> String {
+    if text.chars().count() <= OUTPUT_TAIL_CHARS {
+        return text.trim().to_string();
+    }
+    let tail: String = text
+        .chars()
+        .rev()
+        .take(OUTPUT_TAIL_CHARS)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    format!("[truncated]\n{}", tail.trim())
+}
+
+fn indent_tail(text: &str) -> String {
+    text.lines()
+        .map(|line| format!("    {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_config(dir: &Path, body: &str) -> PathBuf {
+        let path = dir.join(".autoverify.json");
+        std::fs::write(&path, body).expect("write config");
+        path
+    }
+
+    #[test]
+    fn select_tier_by_name() {
+        let config = VerifyConfig {
+            version: 1,
+            tiers: vec![
+                VerifyTier {
+                    name: "smoke".into(),
+                    timeout_s: 1,
+                    retry_on_fail: false,
+                    continue_on_fail: false,
+                    commands: vec![VerifyCommandSpec {
+                        name: "a".into(),
+                        run: "true".into(),
+                    }],
+                },
+                VerifyTier {
+                    name: "unit".into(),
+                    timeout_s: 1,
+                    retry_on_fail: false,
+                    continue_on_fail: false,
+                    commands: vec![VerifyCommandSpec {
+                        name: "b".into(),
+                        run: "true".into(),
+                    }],
+                },
+            ],
+        };
+
+        let selected = select_tiers(&config, Some("unit"), None).expect("select tier");
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].name, "unit");
+    }
+
+    #[tokio::test]
+    async fn run_once_marks_success_pass() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = write_config(
+            temp.path(),
+            r#"{
+              "version": 1,
+              "tiers": [
+                {"name": "smoke", "timeout_s": 5, "commands": [{"name": "ok", "run": "printf done"}]}
+              ]
+            }"#,
+        );
+        let config = load_config(&config_path).expect("load config");
+        let tiers = select_tiers(&config, None, None).expect("select tiers");
+
+        let output = run_once(temp.path(), &config_path, &tiers).await;
+
+        assert_eq!(output.verdict, Verdict::Pass);
+        assert_eq!(output.summary.pass, 1);
+        assert_eq!(output.commands[0].tail, "done");
+    }
+
+    #[tokio::test]
+    async fn retry_pass_is_flaky() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let marker = temp.path().join("marker");
+        let command = format!(
+            "if [ -f {0} ]; then exit 0; else touch {0}; exit 1; fi",
+            marker.display()
+        );
+        let config_path = write_config(
+            temp.path(),
+            &format!(
+                r#"{{
+                  "version": 1,
+                  "tiers": [
+                    {{"name": "smoke", "timeout_s": 5, "retry_on_fail": true, "commands": [{{"name": "eventual", "run": "{}"}}]}}
+                  ]
+                }}"#,
+                command.replace('\\', "\\\\").replace('"', "\\\"")
+            ),
+        );
+        let config = load_config(&config_path).expect("load config");
+        let tiers = select_tiers(&config, None, None).expect("select tiers");
+
+        let output = run_once(temp.path(), &config_path, &tiers).await;
+
+        assert_eq!(output.verdict, Verdict::Flaky);
+        assert_eq!(output.summary.flaky, 1);
+        assert_eq!(output.commands[0].attempts, 2);
+    }
+
+    #[tokio::test]
+    async fn stops_after_failing_tier_by_default() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = write_config(
+            temp.path(),
+            r#"{
+              "version": 1,
+              "tiers": [
+                {"name": "smoke", "timeout_s": 5, "commands": [{"name": "fail", "run": "exit 9"}]},
+                {"name": "unit", "timeout_s": 5, "commands": [{"name": "should-not-run", "run": "printf nope"}]}
+              ]
+            }"#,
+        );
+        let config = load_config(&config_path).expect("load config");
+        let tiers = select_tiers(&config, None, None).expect("select tiers");
+
+        let output = run_once(temp.path(), &config_path, &tiers).await;
+
+        assert_eq!(output.verdict, Verdict::Fail);
+        assert_eq!(output.commands.len(), 1);
+        assert_eq!(output.commands[0].exit, Some(9));
+    }
+}

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -143,6 +143,7 @@ struct VerifyOutput {
     verdict: Verdict,
     target: String,
     config: String,
+    git_head: Option<String>,
     attempt: u32,
     max_attempts: u32,
     tiers_requested: Vec<String>,
@@ -402,6 +403,7 @@ async fn run_once(
         verdict,
         target: target.display().to_string(),
         config: config_path.display().to_string(),
+        git_head: current_git_head(target),
         attempt,
         max_attempts,
         tiers_requested: tiers.iter().map(|tier| tier.name.clone()).collect(),
@@ -410,6 +412,20 @@ async fn run_once(
         started_at: started_at.to_rfc3339(),
         finished_at: chrono::Utc::now().to_rfc3339(),
     }
+}
+
+fn current_git_head(target: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(target)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if head.is_empty() { None } else { Some(head) }
 }
 
 async fn run_command_with_retry(

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,10 @@ async fn async_main() -> anyhow::Result<()> {
             init_cli_tracing();
             return ironclaw::cli::run_verify_command(verify_cmd.clone()).await;
         }
+        Some(Command::Audit(audit_cmd)) => {
+            init_cli_tracing();
+            return ironclaw::cli::run_audit_command(audit_cmd.clone()).await;
+        }
         Some(Command::Doctor) => {
             init_cli_tracing();
             return ironclaw::cli::run_doctor_command().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,10 @@ async fn async_main() -> anyhow::Result<()> {
             return ironclaw::cli::run_models_command(models_cmd.clone(), cli.config.as_deref())
                 .await;
         }
+        Some(Command::Verify(verify_cmd)) => {
+            init_cli_tracing();
+            return ironclaw::cli::run_verify_command(verify_cmd.clone()).await;
+        }
         Some(Command::Doctor) => {
             init_cli_tracing();
             return ironclaw::cli::run_doctor_command().await;


### PR DESCRIPTION
## Summary
- add `ironclaw verify` for layered project verification from `.ironclaw-verify.json` with `.autoverify.json` fallback
- add repo smoke/replay tiers and an `autoverify` skill so autonomous work can prove itself before shipping
- harden verifier state with `git_head` so post-commit audit can reject stale verification
- add `ironclaw audit` and an `auto-audit` skill for deterministic ship readiness across verify state, git status/diff, PR head, and GitHub checks
- harden audit check parsing so failed `gh pr checks --json` payloads are classified as blockers even when `gh` exits non-zero
- update docs, feature parity, CLI help snapshots, and ignore generated verifier state

## Validation
- `cargo test -p ironclaw --lib cli::verify::tests` -> 10 verifier tests passing
- `cargo test -p ironclaw --lib cli::audit::tests` -> 10 audit tests passing
- `cargo test -p ironclaw --lib cli::tests::test_`
- `cargo test -p ironclaw --lib cli::tests::test_ --features import`
- `cargo test -p ironclaw_skills` -> 176 tests passing
- `cargo clippy -p ironclaw --lib -- -D warnings`
- `cargo run --bin ironclaw -- verify --upto replay --compact` -> `verdict: pass` with 4/4 commands passing on `7e6f3c2a33e6b88d05c1f9295bfc5771d6cf5b0e`, including audit-unit and `engine_v2_tests::snapshot_single_tool_echo`
- `target/debug/ironclaw audit --compact` -> `verdict: ship` after the final push, with 20 passing GitHub check buckets, 0 failing, 0 pending, and 11 skipped
- GitHub checks passed on the final push: regression enforcement, formatting/style, clippy all-features, cargo-deny, no-panics, heavy integration tests, Telegram integration shards, and tests all-features

## Notes
- Gemini currently has no actionable review feedback on this PR; the only Gemini comments are quota warnings.
- Ready for review after autonomous local verification, replay backtest, native audit, and CI pass.
