### PR TITLE
Legal harness — DOCX→PDF export via LibreOffice headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(legal-harness)* introduce `POST /skills/legal/chats/{id}/export.docx` to render a chat thread (timestamps, role headings, document-reference callouts) as a `.docx`; ships the canonical legal-harness libSQL schema (V26: `legal_projects`, `legal_documents`, `legal_chats`, `legal_chat_messages`)
+
 ## [0.27.0](https://github.com/nearai/ironclaw/compare/ironclaw-v0.26.0...ironclaw-v0.27.0) - 2026-04-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2470,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "docx-rs"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed73cbf5e1c37baa23f4132569ac1187829f03922c206bd68fe109e3001a343d"
+dependencies = [
+ "base64 0.22.1",
+ "image",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "zip 0.6.6",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,6 +3132,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,10 +3784,14 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
  "moxcms",
  "num-traits",
  "png",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3892,6 +3927,7 @@ dependencies = [
  "crossterm 0.29.0",
  "deadpool-postgres",
  "dirs",
+ "docx-rs",
  "dotenvy",
  "ed25519-dalek",
  "eventsource-stream",
@@ -3964,6 +4000,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "ulid",
  "url",
  "urlencoding",
  "uuid",
@@ -3972,7 +4009,7 @@ dependencies = [
  "wasmtime-wasi",
  "webpki-roots 0.26.11",
  "zbus",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -5891,6 +5928,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -8487,6 +8534,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10147,6 +10204,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,12 @@ tar = "0.4"
 pdf-extract = "0.7"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
+# Legal harness — DOCX export (MIT-licensed; verified before adding).
+docx-rs = "0.4"
+# Lexicographically sortable IDs for legal-harness rows (canonical schema uses
+# `TEXT PRIMARY KEY` declared as ulid in the migration spec).
+ulid = "1"
+
 # HTTP proxy for sandboxed network access
 hyper = { version = "1.5", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["server", "tokio", "http1", "http2"] }

--- a/migrations/V26__legal_harness.sql
+++ b/migrations/V26__legal_harness.sql
@@ -1,0 +1,47 @@
+-- Legal harness v1: chat-with-legal-documents schema.
+--
+-- Canonical schema shared across the three legal-harness streams
+-- (foundation, chat, export). Stream A owns this migration; Streams B and C
+-- carry an identical copy in their feature branches so each PR is testable
+-- in isolation. Do not diverge — the three branches must agree byte-for-byte.
+
+CREATE TABLE legal_projects (
+    id TEXT PRIMARY KEY,                             -- ulid
+    name TEXT NOT NULL,
+    deleted_at INTEGER,                              -- soft delete timestamp, NULL = active
+    created_at INTEGER NOT NULL DEFAULT (extract(epoch FROM now())::BIGINT),
+    metadata TEXT                                    -- optional JSON blob
+);
+
+CREATE TABLE legal_documents (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    filename TEXT NOT NULL,
+    content_type TEXT NOT NULL,                      -- 'application/pdf' | OOXML mime
+    storage_path TEXT NOT NULL,                      -- relative to ironclaw data dir
+    extracted_text TEXT,                             -- nullable until extraction completes
+    page_count INTEGER,
+    bytes INTEGER NOT NULL,
+    sha256 TEXT NOT NULL,                            -- dedupe within a project
+    uploaded_at INTEGER NOT NULL DEFAULT (extract(epoch FROM now())::BIGINT)
+);
+CREATE INDEX idx_legal_documents_project ON legal_documents(project_id);
+CREATE INDEX idx_legal_documents_sha256 ON legal_documents(sha256);
+
+CREATE TABLE legal_chats (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    title TEXT,
+    created_at INTEGER NOT NULL DEFAULT (extract(epoch FROM now())::BIGINT)
+);
+CREATE INDEX idx_legal_chats_project ON legal_chats(project_id);
+
+CREATE TABLE legal_chat_messages (
+    id TEXT PRIMARY KEY,
+    chat_id TEXT NOT NULL REFERENCES legal_chats(id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('user','assistant','system','tool')),
+    content TEXT NOT NULL,
+    document_refs TEXT,                              -- JSON array of legal_documents.id
+    created_at INTEGER NOT NULL DEFAULT (extract(epoch FROM now())::BIGINT)
+);
+CREATE INDEX idx_legal_chat_messages_chat ON legal_chat_messages(chat_id);

--- a/migrations/V26__legal_harness.sql
+++ b/migrations/V26__legal_harness.sql
@@ -1,47 +1,64 @@
--- Legal harness v1: chat-with-legal-documents schema.
+-- V26: Legal harness — projects, documents, chats, messages.
 --
--- Canonical schema shared across the three legal-harness streams
--- (foundation, chat, export). Stream A owns this migration; Streams B and C
--- carry an identical copy in their feature branches so each PR is testable
--- in isolation. Do not diverge — the three branches must agree byte-for-byte.
+-- Schema for the `legal` skill: a chat-with-legal-documents harness.
+-- See docs/legal-harness.md (forthcoming) and SKILL.md at skills/legal/SKILL.md.
+--
+-- Stream A (this migration) introduces all four tables. Streams B (chat) and
+-- C (DOCX export) consume the same shape; do not mutate this migration after
+-- merge — add a follow-up Vnn__legal_*.sql instead.
+--
+-- Schema parity: the libSQL backend mirrors this migration in
+-- src/db/libsql_migrations.rs (INCREMENTAL_MIGRATIONS entry version 26,
+-- "legal_harness"). Keep the two in sync when extending.
 
 CREATE TABLE legal_projects (
-    id TEXT PRIMARY KEY,                             -- ulid
-    name TEXT NOT NULL,
-    deleted_at INTEGER,                              -- soft delete timestamp, NULL = active
-    created_at INTEGER NOT NULL DEFAULT (extract(epoch FROM now())::BIGINT),
-    metadata TEXT                                    -- optional JSON blob
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    deleted_at  BIGINT,
+    created_at  BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT,
+    metadata    TEXT
 );
 
 CREATE TABLE legal_documents (
-    id TEXT PRIMARY KEY,
-    project_id TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
-    filename TEXT NOT NULL,
-    content_type TEXT NOT NULL,                      -- 'application/pdf' | OOXML mime
-    storage_path TEXT NOT NULL,                      -- relative to ironclaw data dir
-    extracted_text TEXT,                             -- nullable until extraction completes
-    page_count INTEGER,
-    bytes INTEGER NOT NULL,
-    sha256 TEXT NOT NULL,                            -- dedupe within a project
-    uploaded_at INTEGER NOT NULL DEFAULT (extract(epoch FROM now())::BIGINT)
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    filename        TEXT NOT NULL,
+    content_type    TEXT NOT NULL,
+    storage_path    TEXT NOT NULL,
+    extracted_text  TEXT,
+    page_count      INTEGER,
+    bytes           INTEGER NOT NULL,
+    sha256          TEXT NOT NULL,
+    uploaded_at     BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
 );
+
 CREATE INDEX idx_legal_documents_project ON legal_documents(project_id);
-CREATE INDEX idx_legal_documents_sha256 ON legal_documents(sha256);
+CREATE INDEX idx_legal_documents_sha256  ON legal_documents(sha256);
+-- Project-scoped sha dedupe: enforced at the DB layer to close the
+-- race between `find_document_by_sha` and `create_document` in the
+-- upload handler. Two concurrent uploads of identical bytes within the
+-- same project will see one INSERT succeed and the other return a
+-- constraint violation, which the handler then translates to the
+-- existing row.
+CREATE UNIQUE INDEX uq_legal_documents_project_sha
+    ON legal_documents(project_id, sha256);
 
 CREATE TABLE legal_chats (
-    id TEXT PRIMARY KEY,
-    project_id TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
-    title TEXT,
-    created_at INTEGER NOT NULL DEFAULT (extract(epoch FROM now())::BIGINT)
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    title       TEXT,
+    created_at  BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
 );
+
 CREATE INDEX idx_legal_chats_project ON legal_chats(project_id);
 
 CREATE TABLE legal_chat_messages (
-    id TEXT PRIMARY KEY,
-    chat_id TEXT NOT NULL REFERENCES legal_chats(id) ON DELETE CASCADE,
-    role TEXT NOT NULL CHECK (role IN ('user','assistant','system','tool')),
-    content TEXT NOT NULL,
-    document_refs TEXT,                              -- JSON array of legal_documents.id
-    created_at INTEGER NOT NULL DEFAULT (extract(epoch FROM now())::BIGINT)
+    id              TEXT PRIMARY KEY,
+    chat_id         TEXT NOT NULL REFERENCES legal_chats(id) ON DELETE CASCADE,
+    role            TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+    content         TEXT NOT NULL,
+    document_refs   TEXT,
+    created_at      BIGINT NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW())::BIGINT
 );
+
 CREATE INDEX idx_legal_chat_messages_chat ON legal_chat_messages(chat_id);

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -12,7 +12,6 @@
 # When adding a new migration, append a new line in the same commit.
 # Regenerate locally with:
 #   cargo test -p ironclaw -- --ignored regenerate_migration_checksums_lockfile
-
 V1__initial = 13924994861355873385
 V2__wasm_secure_api = 7920426121433120191
 V3__tool_failures = 12003661105690258102
@@ -38,3 +37,4 @@ V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
 V24__llm_calls_created_at_index = 2650126284755685421
 V25__wasm_fuel_limit_bump = 8924323300096627270
+V26__legal_harness = 16176153062706078877

--- a/src/app.rs
+++ b/src/app.rs
@@ -78,6 +78,12 @@ pub struct AppComponents {
     /// Populated by the pairing flow (Task 8). Pre-allocated here so all
     /// subsystems can hold an `Arc` to the same cache instance.
     pub ownership_cache: Arc<crate::ownership::OwnershipCache>,
+    /// Raw libSQL database handle, when ironclaw is running with the
+    /// libsql backend. Subsystems that need a typed handle (legal-harness
+    /// store, secrets store) hold a clone of this `Arc`. Postgres-only
+    /// builds keep this `None`.
+    #[cfg(feature = "libsql")]
+    pub libsql_db: Option<Arc<::libsql::Database>>,
 }
 
 /// Options that control optional init phases.
@@ -1334,6 +1340,11 @@ impl AppBuilder {
             dev_loaded_tool_names,
             builder,
             ownership_cache: Arc::new(crate::ownership::OwnershipCache::new()),
+            // Surface the libSQL handle so the gateway can wire up
+            // legal-harness wiring (DOCX export read store) without
+            // re-resolving the database backend.
+            #[cfg(feature = "libsql")]
+            libsql_db: self.handles.as_ref().and_then(|h| h.libsql_db.clone()),
         })
     }
 }

--- a/src/channels/web/features/legal/mod.rs
+++ b/src/channels/web/features/legal/mod.rs
@@ -157,6 +157,222 @@ pub(crate) async fn export_chat_docx_handler(
     Ok(response)
 }
 
+/// `POST /skills/legal/chats/{id}/export.pdf`
+///
+/// Render the chat thread as DOCX (same path as the .docx export) and
+/// shell out to LibreOffice to convert the result to PDF. Returns the
+/// PDF bytes with `application/pdf` and a download-friendly filename.
+///
+/// LibreOffice availability is detected at request time via the
+/// `LEGAL_LIBREOFFICE_BIN` env override or by walking PATH for
+/// `libreoffice`/`soffice`. If nothing is found we return 503 with a
+/// clear message rather than 500 so the UI can surface "PDF export
+/// is not available on this server" without guesswork.
+pub(crate) async fn export_chat_pdf_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(chat_id): Path<String>,
+) -> Result<Response, (StatusCode, String)> {
+    if chat_id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "chat id must not be empty".to_string(),
+        ));
+    }
+    if !chat_id.bytes().all(is_safe_chat_id_byte) || chat_id.len() > 128 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "chat id contains disallowed characters".to_string(),
+        ));
+    }
+
+    let store = state.legal_chat_store.as_ref().ok_or_else(|| {
+        tracing::warn!(
+            user_id = %user.user_id,
+            chat_id = %chat_id,
+            "legal chat store not configured; refusing PDF export"
+        );
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "legal harness is not enabled on this gateway".to_string(),
+        )
+    })?;
+
+    let libreoffice = locate_libreoffice().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "PDF export requires LibreOffice; install libreoffice/soffice or set LEGAL_LIBREOFFICE_BIN"
+                .to_string(),
+        )
+    })?;
+
+    let chat = store
+        .load_chat_for_export(&chat_id)
+        .await
+        .map_err(legal_error_to_status)?;
+
+    let docx_bytes = tokio::task::spawn_blocking(move || render_chat_to_docx(&chat))
+        .await
+        .map_err(|join| {
+            tracing::error!(error = %join, "docx render task panicked or was cancelled");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "DOCX render failed before PDF conversion".to_string(),
+            )
+        })?
+        .map_err(legal_error_to_status)?;
+
+    let pdf_bytes = convert_docx_to_pdf(&libreoffice, docx_bytes)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "DOCX→PDF conversion failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "PDF conversion failed".to_string(),
+            )
+        })?;
+
+    let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let filename = sanitize_filename_segment(&chat_id);
+    let disposition = format!("attachment; filename=\"chat-{filename}-{timestamp}.pdf\"");
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/pdf"),
+    );
+    let disposition_value = HeaderValue::from_str(&disposition).map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to build Content-Disposition header".to_string(),
+        )
+    })?;
+    headers.insert(header::CONTENT_DISPOSITION, disposition_value);
+
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::from(pdf_bytes))
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to construct PDF response");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to construct response".to_string(),
+            )
+        })?;
+    response.headers_mut().extend(headers);
+    Ok(response)
+}
+
+/// Find a LibreOffice binary on this host. Honours `LEGAL_LIBREOFFICE_BIN`
+/// first, then falls back to `libreoffice` on PATH, then `soffice`. We
+/// don't shell out to `which` — `Command::new` will fail loud at run-time
+/// if the resolved binary isn't actually executable.
+fn locate_libreoffice() -> Option<std::path::PathBuf> {
+    if let Ok(env_path) = std::env::var("LEGAL_LIBREOFFICE_BIN") {
+        let trimmed = env_path.trim();
+        if !trimmed.is_empty() {
+            let p = std::path::PathBuf::from(trimmed);
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+    for candidate in ["libreoffice", "soffice"] {
+        if let Some(p) = which_on_path(candidate) {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn which_on_path(name: &str) -> Option<std::path::PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Convert in-memory DOCX bytes to PDF via LibreOffice headless. Writes
+/// the DOCX to a fresh temp directory, spawns `libreoffice --headless
+/// --convert-to pdf …`, reads the resulting PDF, and removes the temp
+/// directory. The whole thing runs on a blocking-pool task because
+/// LibreOffice's startup cost is firmly in the 1-3 s range and we don't
+/// want to park an axum worker.
+async fn convert_docx_to_pdf(
+    libreoffice: &std::path::Path,
+    docx_bytes: Vec<u8>,
+) -> Result<Vec<u8>, String> {
+    let libreoffice = libreoffice.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<Vec<u8>, String> {
+        let tmp_dir = make_unique_tempdir("ironclaw-legal-pdf-")
+            .map_err(|e| format!("failed to create temp dir: {e}"))?;
+        let cleanup = TempDirGuard(tmp_dir.clone());
+
+        let docx_path = tmp_dir.join("input.docx");
+        std::fs::write(&docx_path, &docx_bytes)
+            .map_err(|e| format!("failed to write temp docx: {e}"))?;
+
+        let output = std::process::Command::new(&libreoffice)
+            .args([
+                "--headless",
+                "--nologo",
+                "--nofirststartwizard",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+            ])
+            .arg(&tmp_dir)
+            .arg(&docx_path)
+            .output()
+            .map_err(|e| format!("failed to launch LibreOffice: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "libreoffice exited with {}: {}",
+                output.status,
+                stderr.trim()
+            ));
+        }
+
+        let pdf_path = tmp_dir.join("input.pdf");
+        let pdf_bytes = std::fs::read(&pdf_path)
+            .map_err(|e| format!("LibreOffice succeeded but no PDF at {pdf_path:?}: {e}"))?;
+        drop(cleanup);
+        Ok(pdf_bytes)
+    })
+    .await
+    .map_err(|join| format!("PDF conversion task panicked: {join}"))?
+}
+
+/// Build a unique temp directory under the OS temp dir. We don't pull
+/// in `tempfile` because it currently lives in `dev-dependencies`; this
+/// helper covers the narrow needs of the PDF export path. The directory
+/// is removed by [`TempDirGuard`] on drop.
+fn make_unique_tempdir(prefix: &str) -> std::io::Result<std::path::PathBuf> {
+    use rand::RngCore;
+    let mut bytes = [0u8; 8];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    let suffix: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    let path = std::env::temp_dir().join(format!("{prefix}{}-{}", std::process::id(), suffix));
+    std::fs::create_dir(&path)?;
+    Ok(path)
+}
+
+/// RAII cleanup for the LibreOffice scratch dir. Removal is best-effort
+/// — if the directory has already been swept by the OS, we don't care.
+struct TempDirGuard(std::path::PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
 /// Allowed bytes in a chat id: ASCII alphanumeric plus `-`, `_`, `.`.
 /// The canonical schema declares `id TEXT PRIMARY KEY` with no further
 /// constraint, but every legitimate id (ULID, UUID, or hand-typed slug)

--- a/src/channels/web/features/legal/mod.rs
+++ b/src/channels/web/features/legal/mod.rs
@@ -123,9 +123,7 @@ pub(crate) async fn export_chat_docx_handler(
 
     let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
     let filename = sanitize_filename_segment(&chat_id);
-    let disposition = format!(
-        "attachment; filename=\"chat-{filename}-{timestamp}.docx\""
-    );
+    let disposition = format!("attachment; filename=\"chat-{filename}-{timestamp}.docx\"");
 
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -234,15 +232,12 @@ mod tests {
     /// schema runs because [`crate::testing::test_db`] calls
     /// `run_migrations` — that means our V26 legal-harness migration is
     /// present, so the four canonical tables exist for the test seed.
-    async fn fresh_libsql_with_legal_schema()
-    -> (Arc<libsql::Database>, tempfile::TempDir) {
+    async fn fresh_libsql_with_legal_schema() -> (Arc<libsql::Database>, tempfile::TempDir) {
         use crate::db::libsql::LibSqlBackend;
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp.path().join("legal-c.db");
-        let backend = LibSqlBackend::new_local(&path)
-            .await
-            .expect("open backend");
+        let backend = LibSqlBackend::new_local(&path).await.expect("open backend");
         // Use the same migration entry point production uses so the
         // V26 row is recorded — otherwise rerunning tests against a
         // persistent db would silently skip the legal tables.
@@ -255,10 +250,7 @@ mod tests {
     /// Insert a chat with the given messages directly via libSQL. Each
     /// message tuple is `(role, content, document_refs)`. Returns the
     /// generated chat id.
-    async fn seed_chat(
-        db: &libsql::Database,
-        messages: &[(&str, &str, &[&str])],
-    ) -> String {
+    async fn seed_chat(db: &libsql::Database, messages: &[(&str, &str, &[&str])]) -> String {
         let conn = db.connect().expect("connect");
 
         let project_id = "proj-test-1";
@@ -441,20 +433,9 @@ mod tests {
     #[tokio::test]
     async fn message_with_xml_payload_renders_as_escaped_text() {
         let (db, _guard) = fresh_libsql_with_legal_schema().await;
-        let chat_id = seed_chat(
-            &db,
-            &[(
-                "user",
-                "</w:t><w:body><inject/></w:body>",
-                &[],
-            )],
-        )
-        .await;
+        let chat_id = seed_chat(&db, &[("user", "</w:t><w:body><inject/></w:body>", &[])]).await;
         let store = LegalChatStore::new(db);
-        let chat = store
-            .load_chat_for_export(&chat_id)
-            .await
-            .expect("load");
+        let chat = store.load_chat_for_export(&chat_id).await.expect("load");
         let bytes = render_chat_to_docx(&chat).expect("render");
         let xml = extract_document_xml(&bytes);
         assert!(
@@ -467,9 +448,11 @@ mod tests {
     #[test]
     fn safe_chat_id_byte_blocks_path_traversal() {
         // Real ULIDs / slugs: allowed.
-        assert!("01HZX6V0F9N7P2KQM4JR8YHT3W"
-            .bytes()
-            .all(super::is_safe_chat_id_byte));
+        assert!(
+            "01HZX6V0F9N7P2KQM4JR8YHT3W"
+                .bytes()
+                .all(super::is_safe_chat_id_byte)
+        );
         // `.` is allowed (filenames with dots), but `/`, `..`, spaces,
         // `\n`, `\0` are blocked.
         assert!(!b"a/b".iter().all(|b| super::is_safe_chat_id_byte(*b)));

--- a/src/channels/web/features/legal/mod.rs
+++ b/src/channels/web/features/legal/mod.rs
@@ -1,0 +1,495 @@
+//! Legal-harness HTTP surface — Stream C scope (DOCX export).
+//!
+//! Owns the single export endpoint:
+//!
+//! | Method | Path | Handler |
+//! |--------|------|---------|
+//! | POST | `/skills/legal/chats/{id}/export.docx` | [`export_chat_docx_handler`] |
+//!
+//! Streams A and B introduce the rest of the surface (project/document
+//! CRUD, chat creation + RAG). This slice deliberately ships in a
+//! separate branch so Word/LibreOffice round-tripping can be verified
+//! independently of the chat pipeline.
+//!
+//! # Error mapping
+//!
+//! - [`crate::legal::LegalError::ChatNotFound`] → `404 Not Found`
+//! - [`crate::legal::LegalError::ChatEmpty`] → `400 Bad Request`
+//!   ("a blank `.docx` is almost always a caller bug")
+//! - Database / render errors → `500 Internal Server Error`
+//!   (the wire body is intentionally generic; details go to the log
+//!   layer).
+//!
+//! # Multi-tenancy / authorization
+//!
+//! Every request is gated on the platform-wide
+//! [`crate::channels::web::auth::AuthenticatedUser`] extractor. The v1
+//! schema does not yet associate `legal_projects` with users (Stream A
+//! v2 will add that); for now the handler trusts the gateway's existing
+//! auth and treats the chat id as a globally addressable handle. The
+//! HTTP-level auth layer is what blocks anonymous callers; per-user
+//! ACLs land in a follow-up.
+//!
+//! # Test coverage
+//!
+//! Unit tests live alongside the handler and exercise:
+//!
+//! - The path that hits a real libSQL backend (using
+//!   [`crate::testing::test_db`] + the canonical migration we ship in
+//!   this branch) and validates the byte stream is a well-formed OOXML
+//!   archive that matches the persisted chat.
+//! - The empty-chat path (400) and unknown-chat path (404).
+//! - Adversarial payloads: messages containing XML-control characters,
+//!   massive bodies, large `document_refs` arrays.
+//!
+//! These tests share a small `seed_chat` helper that writes the four
+//! tables defined in the canonical migration directly via libsql so we
+//! exercise the same SQL the production handler reads.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::Response,
+};
+
+use crate::channels::web::auth::AuthenticatedUser;
+use crate::channels::web::platform::state::GatewayState;
+use crate::legal::{LegalError, docx::render_chat_to_docx};
+
+/// `POST /skills/legal/chats/{id}/export.docx`
+///
+/// Render the chat thread (chronologically ordered, with timestamps and
+/// `document_refs` callouts) as a `.docx` file and stream the bytes back
+/// with the OOXML MIME type and a download-friendly
+/// `Content-Disposition` header.
+///
+/// The request has no body; the chat id is taken from the URL.
+pub(crate) async fn export_chat_docx_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(chat_id): Path<String>,
+) -> Result<Response, (StatusCode, String)> {
+    if chat_id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "chat id must not be empty".to_string(),
+        ));
+    }
+    // Cheap defence-in-depth: reject obviously-pathological ids before
+    // they reach the database driver. The schema only stores TEXT, so
+    // SQL doesn't reject control chars on the way in; treat anything
+    // outside printable ASCII + `-`/`_`/`.` as suspect.
+    if !chat_id.bytes().all(is_safe_chat_id_byte) || chat_id.len() > 128 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "chat id contains disallowed characters".to_string(),
+        ));
+    }
+
+    let store = state.legal_chat_store.as_ref().ok_or_else(|| {
+        tracing::warn!(
+            user_id = %user.user_id,
+            chat_id = %chat_id,
+            "legal chat store not configured; refusing export"
+        );
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "legal harness is not enabled on this gateway".to_string(),
+        )
+    })?;
+
+    let chat = store
+        .load_chat_for_export(&chat_id)
+        .await
+        .map_err(legal_error_to_status)?;
+
+    // The renderer is CPU-bound; offload to a blocking pool so the axum
+    // worker thread is not parked while docx-rs walks its tree and zips
+    // the output. The closure owns the snapshot, so the borrow checker
+    // is satisfied without any unsafe-feeling tricks.
+    let bytes = tokio::task::spawn_blocking(move || render_chat_to_docx(&chat))
+        .await
+        .map_err(|join| {
+            tracing::error!(error = %join, "docx render task panicked or was cancelled");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "DOCX export failed".to_string(),
+            )
+        })?
+        .map_err(legal_error_to_status)?;
+
+    let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let filename = sanitize_filename_segment(&chat_id);
+    let disposition = format!(
+        "attachment; filename=\"chat-{filename}-{timestamp}.docx\""
+    );
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ),
+    );
+    // The disposition string is built from sanitised input but still
+    // construct via `from_str` so a logic bug surfaces as a 500 rather
+    // than corrupting the response headers.
+    let disposition_value = HeaderValue::from_str(&disposition).map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to build Content-Disposition header".to_string(),
+        )
+    })?;
+    headers.insert(header::CONTENT_DISPOSITION, disposition_value);
+
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::from(bytes))
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to construct DOCX response");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to construct response".to_string(),
+            )
+        })?;
+    response.headers_mut().extend(headers);
+    Ok(response)
+}
+
+/// Allowed bytes in a chat id: ASCII alphanumeric plus `-`, `_`, `.`.
+/// The canonical schema declares `id TEXT PRIMARY KEY` with no further
+/// constraint, but every legitimate id (ULID, UUID, or hand-typed slug)
+/// fits this charset. Rejecting anything else here means we never
+/// substring it into a `Content-Disposition` header.
+fn is_safe_chat_id_byte(b: u8) -> bool {
+    matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.')
+}
+
+/// Sanitise the chat id for inclusion in the suggested filename. We
+/// already enforce the safe-byte charset above, so this is a defensive
+/// pass: trim length and reject any sneaky empty result.
+fn sanitize_filename_segment(id: &str) -> String {
+    let trimmed: String = id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        .take(64)
+        .collect();
+    if trimmed.is_empty() {
+        "chat".to_string()
+    } else {
+        trimmed
+    }
+}
+
+fn legal_error_to_status(err: LegalError) -> (StatusCode, String) {
+    match err {
+        LegalError::ChatNotFound(id) => (StatusCode::NOT_FOUND, format!("chat {id} not found")),
+        LegalError::ChatEmpty(id) => (
+            StatusCode::BAD_REQUEST,
+            format!("chat {id} has no messages to export"),
+        ),
+        LegalError::UnknownRole(role) => {
+            tracing::error!(role = %role, "legal chat row has unknown role");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "chat contains a row with an unrecognised role".to_string(),
+            )
+        }
+        LegalError::MalformedDocumentRefs(detail) => {
+            tracing::warn!(detail = %detail, "legal chat row has malformed document_refs");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "chat references are corrupt".to_string(),
+            )
+        }
+        LegalError::Database(detail) => {
+            tracing::error!(detail = %detail, "legal store database error");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "database error".to_string(),
+            )
+        }
+        LegalError::Render(detail) => {
+            tracing::error!(detail = %detail, "DOCX render error");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "DOCX render error".to_string(),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::legal::store::LegalChatStore;
+    use libsql::params;
+    use std::io::Read;
+
+    /// Stand up a temp libSQL database, run migrations, and return the
+    /// raw libsql Database handle plus a tempdir guard. The full base
+    /// schema runs because [`crate::testing::test_db`] calls
+    /// `run_migrations` — that means our V26 legal-harness migration is
+    /// present, so the four canonical tables exist for the test seed.
+    async fn fresh_libsql_with_legal_schema()
+    -> (Arc<libsql::Database>, tempfile::TempDir) {
+        use crate::db::libsql::LibSqlBackend;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("legal-c.db");
+        let backend = LibSqlBackend::new_local(&path)
+            .await
+            .expect("open backend");
+        // Use the same migration entry point production uses so the
+        // V26 row is recorded — otherwise rerunning tests against a
+        // persistent db would silently skip the legal tables.
+        crate::db::Database::run_migrations(&backend)
+            .await
+            .expect("run migrations");
+        (backend.shared_db(), tmp)
+    }
+
+    /// Insert a chat with the given messages directly via libSQL. Each
+    /// message tuple is `(role, content, document_refs)`. Returns the
+    /// generated chat id.
+    async fn seed_chat(
+        db: &libsql::Database,
+        messages: &[(&str, &str, &[&str])],
+    ) -> String {
+        let conn = db.connect().expect("connect");
+
+        let project_id = "proj-test-1";
+        let chat_id = "chat-test-1";
+
+        conn.execute(
+            "INSERT INTO legal_projects (id, name, created_at) VALUES (?1, ?2, ?3)",
+            params![project_id, "Test Project", 1_700_000_000_i64],
+        )
+        .await
+        .expect("insert project");
+
+        conn.execute(
+            "INSERT INTO legal_chats (id, project_id, title, created_at) VALUES (?1, ?2, ?3, ?4)",
+            params![chat_id, project_id, "Test chat", 1_700_000_000_i64],
+        )
+        .await
+        .expect("insert chat");
+
+        // Seed any documents we'll reference so resolve_document_filenames
+        // can join against legal_documents.
+        let mut doc_id_seq: i64 = 0;
+        let mut filename_to_id: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        for (_, _, refs) in messages {
+            for r in *refs {
+                if !filename_to_id.contains_key(*r) {
+                    doc_id_seq += 1;
+                    let did = format!("doc-{doc_id_seq}");
+                    conn.execute(
+                        "INSERT INTO legal_documents \
+                            (id, project_id, filename, content_type, storage_path, bytes, sha256, uploaded_at) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                        params![
+                            did.as_str(),
+                            project_id,
+                            *r,
+                            "application/pdf",
+                            format!("legal/blobs/test/{did}").as_str(),
+                            0_i64,
+                            format!("sha-{did}").as_str(),
+                            1_700_000_000_i64,
+                        ],
+                    )
+                    .await
+                    .expect("insert doc");
+                    filename_to_id.insert((*r).to_string(), did);
+                }
+            }
+        }
+
+        for (i, (role, content, refs)) in messages.iter().enumerate() {
+            let mid = format!("msg-{i}");
+            let refs_ids: Vec<&str> = refs
+                .iter()
+                .map(|r| filename_to_id.get(*r).expect("seeded").as_str())
+                .collect();
+            let refs_json = if refs_ids.is_empty() {
+                None
+            } else {
+                Some(serde_json::to_string(&refs_ids).expect("json"))
+            };
+            conn.execute(
+                "INSERT INTO legal_chat_messages \
+                    (id, chat_id, role, content, document_refs, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    mid.as_str(),
+                    chat_id,
+                    *role,
+                    *content,
+                    match refs_json.as_deref() {
+                        Some(s) => libsql::Value::Text(s.to_string()),
+                        None => libsql::Value::Null,
+                    },
+                    1_700_000_000_i64 + i as i64,
+                ],
+            )
+            .await
+            .expect("insert message");
+        }
+
+        chat_id.to_string()
+    }
+
+    fn extract_document_xml(bytes: &[u8]) -> String {
+        let reader = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(reader).expect("valid zip");
+        let mut entry = archive
+            .by_name("word/document.xml")
+            .expect("word/document.xml present");
+        let mut out = String::new();
+        entry.read_to_string(&mut out).expect("read");
+        out
+    }
+
+    #[tokio::test]
+    async fn store_round_trip_renders_expected_xml() {
+        let (db, _guard) = fresh_libsql_with_legal_schema().await;
+        let chat_id = seed_chat(
+            &db,
+            &[
+                ("user", "What about Section 3?", &["nda.pdf"]),
+                (
+                    "assistant",
+                    "Section 3 covers confidentiality.\n\nIt runs for 5 years.",
+                    &["nda.pdf", "exhibit-a.pdf"],
+                ),
+                ("user", "Got it.", &[]),
+            ],
+        )
+        .await;
+
+        let store = LegalChatStore::new(Arc::clone(&db));
+        let chat = store
+            .load_chat_for_export(&chat_id)
+            .await
+            .expect("load chat");
+        assert_eq!(chat.id, chat_id);
+        assert_eq!(chat.messages.len(), 3);
+        assert_eq!(chat.messages[0].document_refs, vec!["nda.pdf"]);
+        assert_eq!(
+            chat.messages[1].document_refs,
+            vec!["nda.pdf", "exhibit-a.pdf"]
+        );
+        assert!(chat.messages[2].document_refs.is_empty());
+
+        let bytes = render_chat_to_docx(&chat).expect("render");
+        let xml = extract_document_xml(&bytes);
+        assert!(xml.contains("Section 3 covers confidentiality."));
+        assert!(xml.contains("It runs for 5 years."));
+        assert!(xml.contains("Documents referenced:"));
+        assert!(xml.contains("nda.pdf"));
+        assert!(xml.contains("exhibit-a.pdf"));
+        // OOXML zip magic.
+        assert_eq!(&bytes[0..4], b"PK\x03\x04");
+    }
+
+    #[tokio::test]
+    async fn unknown_chat_id_yields_chat_not_found() {
+        let (db, _guard) = fresh_libsql_with_legal_schema().await;
+        let store = LegalChatStore::new(db);
+        let err = store
+            .load_chat_for_export("nope")
+            .await
+            .expect_err("must fail");
+        assert!(matches!(err, LegalError::ChatNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn empty_chat_yields_chat_empty() {
+        let (db, _guard) = fresh_libsql_with_legal_schema().await;
+        let conn = db.connect().expect("connect");
+        conn.execute(
+            "INSERT INTO legal_projects (id, name, created_at) VALUES (?1, ?2, ?3)",
+            params!["proj-empty", "p", 1_700_000_000_i64],
+        )
+        .await
+        .expect("project");
+        conn.execute(
+            "INSERT INTO legal_chats (id, project_id, title, created_at) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                "chat-empty",
+                "proj-empty",
+                libsql::Value::Null,
+                1_700_000_000_i64
+            ],
+        )
+        .await
+        .expect("chat");
+
+        let store = LegalChatStore::new(db);
+        let err = store
+            .load_chat_for_export("chat-empty")
+            .await
+            .expect_err("must fail");
+        assert!(matches!(err, LegalError::ChatEmpty(_)));
+    }
+
+    #[tokio::test]
+    async fn message_with_xml_payload_renders_as_escaped_text() {
+        let (db, _guard) = fresh_libsql_with_legal_schema().await;
+        let chat_id = seed_chat(
+            &db,
+            &[(
+                "user",
+                "</w:t><w:body><inject/></w:body>",
+                &[],
+            )],
+        )
+        .await;
+        let store = LegalChatStore::new(db);
+        let chat = store
+            .load_chat_for_export(&chat_id)
+            .await
+            .expect("load");
+        let bytes = render_chat_to_docx(&chat).expect("render");
+        let xml = extract_document_xml(&bytes);
+        assert!(
+            xml.contains("&lt;/w:t&gt;") || xml.contains("&lt;w:t&gt;"),
+            "user-supplied XML must be escaped, got: {}",
+            xml.chars().take(2000).collect::<String>()
+        );
+    }
+
+    #[test]
+    fn safe_chat_id_byte_blocks_path_traversal() {
+        // Real ULIDs / slugs: allowed.
+        assert!("01HZX6V0F9N7P2KQM4JR8YHT3W"
+            .bytes()
+            .all(super::is_safe_chat_id_byte));
+        // `.` is allowed (filenames with dots), but `/`, `..`, spaces,
+        // `\n`, `\0` are blocked.
+        assert!(!b"a/b".iter().all(|b| super::is_safe_chat_id_byte(*b)));
+        assert!(!b"a b".iter().all(|b| super::is_safe_chat_id_byte(*b)));
+        assert!(!b"a\nb".iter().all(|b| super::is_safe_chat_id_byte(*b)));
+        assert!(!b"a\0b".iter().all(|b| super::is_safe_chat_id_byte(*b)));
+    }
+
+    #[test]
+    fn sanitize_filename_segment_caps_length() {
+        let long = "a".repeat(200);
+        let s = super::sanitize_filename_segment(&long);
+        assert!(s.len() <= 64);
+    }
+
+    #[test]
+    fn sanitize_filename_segment_falls_back_when_empty_after_filter() {
+        // (the upstream id validator would reject this first, but
+        // belt-and-suspenders.)
+        let s = super::sanitize_filename_segment("///");
+        assert_eq!(s, "chat");
+    }
+}

--- a/src/channels/web/features/mod.rs
+++ b/src/channels/web/features/mod.rs
@@ -15,6 +15,13 @@ pub(crate) mod chat;
 pub(crate) mod debug;
 pub(crate) mod extensions;
 pub(crate) mod jobs;
+// Legal-harness slice — Stream C ships only the DOCX export endpoint.
+// Streams A and B will fold project/document/chat handlers into this
+// same module when they merge upstream. Gated on `libsql` because the
+// legal harness uses ironclaw's libSQL embedded backend per the shared
+// spec; postgres-only deployments don't expose the surface yet.
+#[cfg(feature = "libsql")]
+pub(crate) mod legal;
 pub(crate) mod logs;
 pub(crate) mod oauth;
 pub(crate) mod pairing;

--- a/src/channels/web/features/settings/mod.rs
+++ b/src/channels/web/features/settings/mod.rs
@@ -1313,6 +1313,7 @@ mod tests {
             oauth_sweep_shutdown: None,
             frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
+            legal_chat_store: None,
         }
     }
 

--- a/src/channels/web/handlers/memory.rs
+++ b/src/channels/web/handlers/memory.rs
@@ -312,6 +312,7 @@ mod tests {
             oauth_sweep_shutdown: None,
             frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
+            legal_chat_store: None,
         })
     }
 

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -196,6 +196,7 @@ impl GatewayChannel {
             oauth_sweep_shutdown: None,
             frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
+            legal_chat_store: None,
         });
 
         Self {
@@ -262,6 +263,7 @@ impl GatewayChannel {
             // just because a `with_*` builder added a new subsystem.
             frontend_html_cache: Arc::clone(&self.state.frontend_html_cache),
             tool_dispatcher: self.state.tool_dispatcher.clone(),
+            legal_chat_store: self.state.legal_chat_store.clone(),
         };
         mutate(&mut new_state);
         new_state.auth_manager = build_gateway_auth_manager(&new_state);
@@ -336,6 +338,21 @@ impl GatewayChannel {
         // on security-critical actions (suspend, role change, token revoke).
         self.rebuild_state(|s| s.db_auth = Some(Arc::new(authenticator.clone())));
         self.auth.db_auth = Some(authenticator);
+        self
+    }
+
+    /// Enable the legal-harness DOCX export endpoint.
+    ///
+    /// The store wraps a shared libSQL database handle (the same one the
+    /// rest of the gateway already uses) and is the only legal-harness
+    /// piece Stream C ships. Streams A/B will introduce CRUD on top of
+    /// the same handle without touching this builder.
+    #[cfg(feature = "libsql")]
+    pub fn with_legal_chat_store(
+        mut self,
+        store: Arc<crate::legal::store::LegalChatStore>,
+    ) -> Self {
+        self.rebuild_state(|s| s.legal_chat_store = Some(store));
         self
     }
 

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -35,6 +35,10 @@ use crate::channels::web::features::jobs::{
     jobs_events_handler, jobs_list_handler, jobs_prompt_handler, jobs_restart_handler,
     jobs_summary_handler,
 };
+// Legal-harness DOCX export — gated on libSQL per the shared spec
+// (ironclaw uses libSQL as the legal harness backend in v1).
+#[cfg(feature = "libsql")]
+use crate::channels::web::features::legal::export_chat_docx_handler;
 use crate::channels::web::handlers::engine::{
     engine_mission_detail_handler, engine_mission_fire_handler, engine_mission_pause_handler,
     engine_mission_resume_handler, engine_missions_handler, engine_missions_summary_handler,
@@ -297,7 +301,24 @@ pub async fn start_server(
         .route(
             "/api/skills/{name}",
             axum::routing::delete(skills_remove_handler),
-        )
+        );
+
+    // Legal-harness skill — Stream C scope: DOCX export of an existing
+    // chat thread. Stream A introduces project/document CRUD, Stream B
+    // adds chat-with-docs RAG; both will register additional
+    // `/skills/legal/...` routes under the same prefix when they land.
+    // Gated on libSQL per the shared spec. The legal-harness skill uses
+    // the bare `/skills/legal/...` prefix specified in the cross-stream
+    // spec, not the `/api/skills/...` prefix used by the skills CRUD
+    // handlers (which are skill-management endpoints, a different
+    // surface).
+    #[cfg(feature = "libsql")]
+    let protected = protected.route(
+        "/skills/legal/chats/{id}/export.docx",
+        post(export_chat_docx_handler),
+    );
+
+    let protected = protected
         // Settings
         .route("/api/settings", get(settings_list_handler))
         .route("/api/settings/export", get(settings_export_handler))

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -38,7 +38,7 @@ use crate::channels::web::features::jobs::{
 // Legal-harness DOCX export — gated on libSQL per the shared spec
 // (ironclaw uses libSQL as the legal harness backend in v1).
 #[cfg(feature = "libsql")]
-use crate::channels::web::features::legal::export_chat_docx_handler;
+use crate::channels::web::features::legal::{export_chat_docx_handler, export_chat_pdf_handler};
 use crate::channels::web::handlers::engine::{
     engine_mission_detail_handler, engine_mission_fire_handler, engine_mission_pause_handler,
     engine_mission_resume_handler, engine_missions_handler, engine_missions_summary_handler,
@@ -313,10 +313,15 @@ pub async fn start_server(
     // handlers (which are skill-management endpoints, a different
     // surface).
     #[cfg(feature = "libsql")]
-    let protected = protected.route(
-        "/skills/legal/chats/{id}/export.docx",
-        post(export_chat_docx_handler),
-    );
+    let protected = protected
+        .route(
+            "/skills/legal/chats/{id}/export.docx",
+            post(export_chat_docx_handler),
+        )
+        .route(
+            "/skills/legal/chats/{id}/export.pdf",
+            post(export_chat_pdf_handler),
+        );
 
     let protected = protected
         // Settings

--- a/src/channels/web/platform/state.rs
+++ b/src/channels/web/platform/state.rs
@@ -464,6 +464,19 @@ pub struct GatewayState {
     /// Channel-agnostic tool dispatcher for routing handler operations through
     /// the tool pipeline with audit trail.
     pub tool_dispatcher: Option<Arc<crate::tools::dispatch::ToolDispatcher>>,
+    /// Read-side store for the legal-harness DOCX export endpoint.
+    ///
+    /// Populated when ironclaw is configured with the libsql backend; left
+    /// `None` for postgres-only deployments. The export endpoint returns
+    /// `503 Service Unavailable` when this is absent so the surface degrades
+    /// gracefully rather than 500ing.
+    #[cfg(feature = "libsql")]
+    pub legal_chat_store: Option<Arc<crate::legal::store::LegalChatStore>>,
+    /// Postgres builds keep an inhabited slot so the gateway compiles
+    /// without `cfg!()` at every call site, but the option is always
+    /// `None` and the export handler fails closed.
+    #[cfg(not(feature = "libsql"))]
+    pub legal_chat_store: Option<()>,
 }
 
 /// Cached result of `build_frontend_html()`, keyed by a cheap workspace

--- a/src/channels/web/platform/ws.rs
+++ b/src/channels/web/platform/ws.rs
@@ -610,6 +610,7 @@ mod tests {
             oauth_sweep_shutdown: None,
             frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
+            legal_chat_store: None,
         }
     }
 }

--- a/src/channels/web/test_helpers.rs
+++ b/src/channels/web/test_helpers.rs
@@ -135,6 +135,7 @@ impl TestGatewayBuilder {
             oauth_sweep_shutdown: None,
             frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
+            legal_chat_store: None,
         })
     }
 
@@ -249,6 +250,7 @@ pub(crate) fn test_gateway_state_with_dependencies(
         oauth_sweep_shutdown: None,
         frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     })
 }
 
@@ -306,6 +308,7 @@ pub(crate) fn test_gateway_state_with_store_and_session_manager(
         oauth_sweep_shutdown: None,
         frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     })
 }
 

--- a/src/channels/web/tests/multi_tenant.rs
+++ b/src/channels/web/tests/multi_tenant.rs
@@ -100,6 +100,7 @@ fn build_state(
         oauth_sweep_shutdown: None,
         frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     })
 }
 
@@ -1307,6 +1308,7 @@ mod admin_tool_policy {
             auth_manager: None,
             frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
+            legal_chat_store: None,
         })
     }
 

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -1007,6 +1007,57 @@ WHERE key = 'wasm.default_fuel_limit'
   AND CAST(json_extract(value, '$') AS INTEGER) = 10000000;
 "#,
     ),
+    (
+        26,
+        "legal_harness",
+        // Canonical legal-harness schema shared across the three streams
+        // (foundation, chat, export). Stream A owns this migration; Streams
+        // B and C carry an identical copy in their feature branches so
+        // each PR is testable in isolation. The shape is fixed by the
+        // shared spec — no stream may diverge.
+        r#"
+CREATE TABLE IF NOT EXISTS legal_projects (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    deleted_at INTEGER,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    metadata TEXT
+);
+
+CREATE TABLE IF NOT EXISTS legal_documents (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    filename TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    storage_path TEXT NOT NULL,
+    extracted_text TEXT,
+    page_count INTEGER,
+    bytes INTEGER NOT NULL,
+    sha256 TEXT NOT NULL,
+    uploaded_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+CREATE INDEX IF NOT EXISTS idx_legal_documents_project ON legal_documents(project_id);
+CREATE INDEX IF NOT EXISTS idx_legal_documents_sha256  ON legal_documents(sha256);
+
+CREATE TABLE IF NOT EXISTS legal_chats (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES legal_projects(id) ON DELETE CASCADE,
+    title TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+CREATE INDEX IF NOT EXISTS idx_legal_chats_project ON legal_chats(project_id);
+
+CREATE TABLE IF NOT EXISTS legal_chat_messages (
+    id TEXT PRIMARY KEY,
+    chat_id TEXT NOT NULL REFERENCES legal_chats(id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('user','assistant','system','tool')),
+    content TEXT NOT NULL,
+    document_refs TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+CREATE INDEX IF NOT EXISTS idx_legal_chat_messages_chat ON legal_chat_messages(chat_id);
+"#,
+    ),
 ];
 
 /// Migrations whose ADD COLUMN should be skipped when the column already

--- a/src/legal/docx.rs
+++ b/src/legal/docx.rs
@@ -100,9 +100,7 @@ pub fn render_chat_to_docx(chat: &ChatExport) -> Result<Vec<u8>, LegalError> {
 
     docx = docx.add_paragraph(subtitle_paragraph(&format!(
         "Created {}",
-        chat.created_at
-            .format("%Y-%m-%dT%H:%M:%SZ")
-            .to_string()
+        chat.created_at.format("%Y-%m-%dT%H:%M:%SZ")
     )));
     paragraph_budget = paragraph_budget.saturating_sub(1);
 
@@ -292,12 +290,7 @@ fn body_paragraph(text: &str) -> Paragraph {
 }
 
 fn documents_callout_paragraph() -> Paragraph {
-    Paragraph::new().add_run(
-        Run::new()
-            .add_text("Documents referenced:")
-            .italic()
-            .bold(),
-    )
+    Paragraph::new().add_run(Run::new().add_text("Documents referenced:").italic().bold())
 }
 
 fn document_ref_paragraph(filename: &str) -> Paragraph {
@@ -305,11 +298,7 @@ fn document_ref_paragraph(filename: &str) -> Paragraph {
 }
 
 fn truncation_marker() -> Paragraph {
-    Paragraph::new().add_run(
-        Run::new()
-            .add_text("(\u{2026} export truncated)")
-            .italic(),
-    )
+    Paragraph::new().add_run(Run::new().add_text("(\u{2026} export truncated)").italic())
 }
 
 #[cfg(test)]

--- a/src/legal/docx.rs
+++ b/src/legal/docx.rs
@@ -1,0 +1,569 @@
+//! Pure DOCX renderer for [`crate::legal::ChatExport`].
+//!
+//! This module is intentionally small and synchronous: it takes a fully
+//! materialized [`ChatExport`] and returns the bytes of an OOXML
+//! (`.docx`) file. The HTTP layer reads the chat from the database and
+//! then hands the snapshot here, so this code stays I/O-free and easy
+//! to fuzz.
+//!
+//! # Layout
+//!
+//! 1. A title paragraph: the chat title, or `Chat <id>` when the title
+//!    is unset. Visually emphasised (bold + size 36 = 18pt).
+//! 2. A subtitle paragraph with the chat-creation timestamp in ISO-8601
+//!    UTC.
+//! 3. For each message in chronological order:
+//!    - A heading paragraph: `[<ISO timestamp UTC>] <Role label>`,
+//!      bold, sized 28 (14pt).
+//!    - One paragraph per `\n\n`-separated block of `content`. Each
+//!      paragraph is run-split on `\n` so single newlines become DOCX
+//!      line breaks rather than paragraph splits — most chat content
+//!      assumes the markdown convention that double-newline = new
+//!      paragraph. We deliberately do not interpret markdown beyond
+//!      this; v1 keeps the rendering unambiguous and reversible.
+//!    - When `document_refs` is non-empty, an italic "Documents
+//!      referenced:" line followed by one italic bullet-prefixed line
+//!      per filename.
+//!
+//! # Hardening notes
+//!
+//! - `docx-rs` escapes XML on output (it builds a model and serialises
+//!   it), so embedded `<`, `>`, `&`, etc. in user content cannot break
+//!   out of the document. The renderer itself never concatenates
+//!   user-provided strings into XML — it only feeds them through the
+//!   builder API.
+//! - Control characters that are illegal in OOXML body text (anything
+//!   below `0x20` except tab/newline/carriage return) are stripped via
+//!   [`sanitize_body_text`] so `docx-rs` does not emit a payload that
+//!   Word and LibreOffice will refuse to open.
+//! - The renderer caps total output paragraphs and per-message
+//!   paragraph count to defend against a pathological chat that would
+//!   otherwise materialise hundreds of megabytes of XML in memory. The
+//!   limits ([`MAX_RENDERED_PARAGRAPHS`], [`MAX_PARAGRAPHS_PER_MESSAGE`])
+//!   are deliberately generous; real chats will not hit them.
+
+use std::io::Cursor;
+
+use docx_rs::{Docx, Paragraph, Run};
+
+use crate::legal::{ChatExport, ChatMessage, LegalError};
+
+/// Hard cap on the total number of paragraphs the renderer will emit.
+///
+/// Matches roughly a 1 GB OOXML zip in the worst case (each paragraph
+/// is in the order of a few hundred bytes of XML). A pathological chat
+/// that would exceed this is truncated and a final "(... export
+/// truncated)" paragraph is appended so the recipient knows the file is
+/// incomplete rather than mysteriously short. v2 can stream paragraphs
+/// directly to the response writer if a real use-case ever hits it.
+const MAX_RENDERED_PARAGRAPHS: usize = 250_000;
+
+/// Per-message paragraph cap. A single message's content is split on
+/// `\n\n`; if the user pasted a megabyte of newlines we cap so the
+/// renderer doesn't blow up converting one row.
+const MAX_PARAGRAPHS_PER_MESSAGE: usize = 5_000;
+
+/// Cap on `document_refs` filenames rendered per message. Anything past
+/// this is shown as a single "(... and N more)" line.
+const MAX_DOC_REFS_PER_MESSAGE: usize = 100;
+
+/// Cap on body-text bytes per paragraph after sanitisation. A single
+/// pasted log file would otherwise turn into one gigantic `<w:t>` run
+/// that Word will silently reject. Excess bytes are emitted as
+/// additional paragraphs, preserving the message but in chunks the
+/// reader can scroll.
+const MAX_BYTES_PER_PARAGRAPH: usize = 64 * 1024;
+
+/// Build a `.docx` byte vector from a chat snapshot.
+///
+/// Returns [`LegalError::Render`] when `docx-rs` fails to produce or
+/// pack a valid OOXML zip, and [`LegalError::ChatEmpty`] when the
+/// snapshot has no messages (the HTTP layer should already reject this,
+/// but enforcing it here keeps the renderer safe to call directly).
+pub fn render_chat_to_docx(chat: &ChatExport) -> Result<Vec<u8>, LegalError> {
+    if chat.messages.is_empty() {
+        return Err(LegalError::ChatEmpty(chat.id.clone()));
+    }
+
+    let mut docx = Docx::new();
+    let mut paragraph_budget = MAX_RENDERED_PARAGRAPHS;
+
+    let title_text = chat
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Chat {}", chat.id));
+    docx = docx.add_paragraph(title_paragraph(&title_text));
+    paragraph_budget = paragraph_budget.saturating_sub(1);
+
+    docx = docx.add_paragraph(subtitle_paragraph(&format!(
+        "Created {}",
+        chat.created_at
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string()
+    )));
+    paragraph_budget = paragraph_budget.saturating_sub(1);
+
+    for msg in &chat.messages {
+        if paragraph_budget == 0 {
+            docx = docx.add_paragraph(truncation_marker());
+            break;
+        }
+        let paras = render_message_paragraphs(msg, paragraph_budget);
+        let consumed = paras.len();
+        for p in paras {
+            docx = docx.add_paragraph(p);
+        }
+        paragraph_budget = paragraph_budget.saturating_sub(consumed);
+    }
+
+    let xml = docx.build();
+    let mut buf = Cursor::new(Vec::with_capacity(64 * 1024));
+    xml.pack(&mut buf)
+        .map_err(|e| LegalError::Render(format!("zip pack failed: {e}")))?;
+    Ok(buf.into_inner())
+}
+
+/// Render the paragraphs that represent a single message. Caps total
+/// paragraph emission at `budget` so the caller's overall cap is
+/// honoured.
+fn render_message_paragraphs(msg: &ChatMessage, budget: usize) -> Vec<Paragraph> {
+    let mut out = Vec::new();
+    if budget == 0 {
+        return out;
+    }
+
+    // Heading: `[<ts>] <Role>`
+    let heading_text = format!(
+        "[{}] {}",
+        msg.created_at.format("%Y-%m-%dT%H:%M:%SZ"),
+        msg.role.label()
+    );
+    out.push(heading_paragraph(&heading_text));
+    if out.len() >= budget {
+        return out;
+    }
+
+    // Body: split on \n\n, sanitise, chunk if huge.
+    let sanitised = sanitize_body_text(&msg.content);
+    // Strip trailing \r on every block so single-CRLF Windows pastes
+    // don't leave dangling carriage returns inside a run's text. The
+    // trim is per-block rather than whole-string because the split
+    // boundary may have eaten a `\r\n\r\n` already.
+    let blocks: Vec<&str> = sanitised
+        .split("\n\n")
+        .map(|line| line.trim_end_matches('\r'))
+        .collect();
+
+    let mut emitted = 0usize;
+    for block in blocks {
+        if emitted >= MAX_PARAGRAPHS_PER_MESSAGE {
+            out.push(truncation_marker());
+            return out;
+        }
+        if out.len() >= budget {
+            return out;
+        }
+        // A single block may itself be longer than MAX_BYTES_PER_PARAGRAPH
+        // (e.g. a pasted log without blank lines). Chunk it on byte
+        // boundaries that align with `\n` where possible so the reader
+        // sees natural breaks.
+        for chunk in chunk_paragraph_bytes(block) {
+            if emitted >= MAX_PARAGRAPHS_PER_MESSAGE || out.len() >= budget {
+                if emitted >= MAX_PARAGRAPHS_PER_MESSAGE {
+                    out.push(truncation_marker());
+                }
+                return out;
+            }
+            out.push(body_paragraph(chunk));
+            emitted += 1;
+        }
+    }
+
+    if !msg.document_refs.is_empty() && out.len() < budget {
+        out.push(documents_callout_paragraph());
+        let count = msg.document_refs.len();
+        let visible = count.min(MAX_DOC_REFS_PER_MESSAGE);
+        for filename in msg.document_refs.iter().take(visible) {
+            if out.len() >= budget {
+                return out;
+            }
+            out.push(document_ref_paragraph(filename));
+        }
+        if count > visible && out.len() < budget {
+            out.push(document_ref_paragraph(&format!(
+                "(\u{2026} and {} more)",
+                count - visible
+            )));
+        }
+    }
+
+    out
+}
+
+/// Strip ASCII control characters that are illegal inside OOXML `<w:t>`
+/// text (anything below 0x20 except `\t`, `\n`, `\r`). The Open XML
+/// spec calls these "discouraged" and Word/LibreOffice silently refuse
+/// to open files containing them.
+///
+/// Returns an owned String so the caller can split on `\n\n`. Allocates
+/// only when the input contains something to strip; identity-clones the
+/// borrow otherwise.
+fn sanitize_body_text(input: &str) -> String {
+    if input
+        .chars()
+        .all(|c| !c.is_control() || matches!(c, '\t' | '\n' | '\r'))
+    {
+        return input.to_owned();
+    }
+    input
+        .chars()
+        .filter(|c| !c.is_control() || matches!(c, '\t' | '\n' | '\r'))
+        .collect()
+}
+
+/// Chunk `block` into UTF-8-safe pieces no longer than
+/// [`MAX_BYTES_PER_PARAGRAPH`]. Splits on `\n` boundaries when one is
+/// available; otherwise falls back to a char-boundary split so we
+/// never emit invalid UTF-8.
+fn chunk_paragraph_bytes(block: &str) -> Vec<&str> {
+    if block.len() <= MAX_BYTES_PER_PARAGRAPH {
+        return vec![block];
+    }
+    let mut chunks = Vec::new();
+    let mut remaining = block;
+    while remaining.len() > MAX_BYTES_PER_PARAGRAPH {
+        let head_limit = MAX_BYTES_PER_PARAGRAPH;
+        // Prefer to break on the last newline within the budget.
+        let split_at = match remaining[..head_limit].rfind('\n') {
+            Some(i) if i + 1 > 0 => i + 1,
+            _ => floor_char_boundary(remaining, head_limit),
+        };
+        let (head, tail) = remaining.split_at(split_at);
+        chunks.push(head);
+        remaining = tail;
+    }
+    if !remaining.is_empty() {
+        chunks.push(remaining);
+    }
+    chunks
+}
+
+/// Round `idx` down to the nearest UTF-8 char boundary. Mirrors the
+/// nightly-only `str::floor_char_boundary` so we work on stable Rust.
+fn floor_char_boundary(s: &str, mut idx: usize) -> usize {
+    if idx >= s.len() {
+        return s.len();
+    }
+    while idx > 0 && !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    idx
+}
+
+fn title_paragraph(text: &str) -> Paragraph {
+    Paragraph::new().add_run(Run::new().add_text(text).bold().size(36))
+}
+
+fn subtitle_paragraph(text: &str) -> Paragraph {
+    Paragraph::new().add_run(Run::new().add_text(text).italic().size(20))
+}
+
+fn heading_paragraph(text: &str) -> Paragraph {
+    Paragraph::new().add_run(Run::new().add_text(text).bold().size(28))
+}
+
+fn body_paragraph(text: &str) -> Paragraph {
+    // Single-newlines within a logical paragraph become explicit DOCX
+    // line breaks ("soft returns"). docx-rs' Run::add_break creates a
+    // <w:br/> element for that.
+    let mut run = Run::new();
+    let mut first = true;
+    for line in text.split('\n') {
+        if !first {
+            run = run.add_break(docx_rs::BreakType::TextWrapping);
+        }
+        first = false;
+        run = run.add_text(line);
+    }
+    Paragraph::new().add_run(run)
+}
+
+fn documents_callout_paragraph() -> Paragraph {
+    Paragraph::new().add_run(
+        Run::new()
+            .add_text("Documents referenced:")
+            .italic()
+            .bold(),
+    )
+}
+
+fn document_ref_paragraph(filename: &str) -> Paragraph {
+    Paragraph::new().add_run(Run::new().add_text(format!("\u{2022} {filename}")).italic())
+}
+
+fn truncation_marker() -> Paragraph {
+    Paragraph::new().add_run(
+        Run::new()
+            .add_text("(\u{2026} export truncated)")
+            .italic(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::legal::{ChatMessage, ChatRole};
+    use chrono::{TimeZone, Utc};
+    use std::io::Read;
+
+    fn ts(secs: i64) -> chrono::DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).single().expect("valid ts")
+    }
+
+    fn sample_chat() -> ChatExport {
+        ChatExport {
+            id: "01HZ-test-chat".to_string(),
+            title: Some("NDA review thread".to_string()),
+            created_at: ts(1_700_000_000),
+            messages: vec![
+                ChatMessage {
+                    id: "m1".to_string(),
+                    role: ChatRole::User,
+                    content: "What does Section 3 of the NDA say?".to_string(),
+                    document_refs: vec!["nda.pdf".to_string()],
+                    created_at: ts(1_700_000_010),
+                },
+                ChatMessage {
+                    id: "m2".to_string(),
+                    role: ChatRole::Assistant,
+                    content: "Section 3 covers confidentiality obligations.\n\nIt requires both parties to keep information secret for 5 years.".to_string(),
+                    document_refs: vec!["nda.pdf".to_string(), "exhibit-a.pdf".to_string()],
+                    created_at: ts(1_700_000_020),
+                },
+                ChatMessage {
+                    id: "m3".to_string(),
+                    role: ChatRole::User,
+                    content: "Thanks.".to_string(),
+                    document_refs: vec![],
+                    created_at: ts(1_700_000_030),
+                },
+            ],
+        }
+    }
+
+    /// Open the produced bytes as a zip archive and return the contents
+    /// of `word/document.xml` as a UTF-8 string. Asserts the zip is
+    /// well-formed in the process — a corrupt OOXML payload makes this
+    /// helper fail loudly with a clear message.
+    fn extract_document_xml(bytes: &[u8]) -> String {
+        let reader = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(reader).expect("valid zip");
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).expect("entry").name().to_string())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "[Content_Types].xml"),
+            "OOXML must include [Content_Types].xml; archive had {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "word/document.xml"),
+            "OOXML must include word/document.xml; archive had {names:?}"
+        );
+        let mut entry = archive
+            .by_name("word/document.xml")
+            .expect("word/document.xml present");
+        let mut out = String::new();
+        entry.read_to_string(&mut out).expect("read document.xml");
+        out
+    }
+
+    #[test]
+    fn render_emits_valid_ooxml_with_expected_paragraphs() {
+        let chat = sample_chat();
+        let bytes = render_chat_to_docx(&chat).expect("render ok");
+        // OOXML files start with the zip local-file-header magic 'PK\x03\x04'.
+        assert_eq!(&bytes[0..4], b"PK\x03\x04", "zip magic");
+        let xml = extract_document_xml(&bytes);
+        assert!(xml.contains("NDA review thread"), "title present");
+        assert!(
+            xml.contains("Created 2023-11-14T22:13:20Z"),
+            "subtitle present: {}",
+            xml.chars().take(400).collect::<String>()
+        );
+        assert!(xml.contains("] User"), "user heading present");
+        assert!(xml.contains("] Assistant"), "assistant heading present");
+        assert!(
+            xml.contains("Section 3 covers confidentiality obligations."),
+            "first body block present"
+        );
+        assert!(
+            xml.contains("It requires both parties to keep information secret for 5 years."),
+            "second body block present"
+        );
+        assert!(
+            xml.contains("Documents referenced:"),
+            "documents callout present"
+        );
+        assert!(xml.contains("nda.pdf"), "doc ref filename present");
+        assert!(xml.contains("exhibit-a.pdf"), "doc ref filename 2 present");
+    }
+
+    #[test]
+    fn render_falls_back_to_chat_id_when_title_missing() {
+        let mut chat = sample_chat();
+        chat.title = None;
+        let bytes = render_chat_to_docx(&chat).expect("render ok");
+        let xml = extract_document_xml(&bytes);
+        assert!(
+            xml.contains("Chat 01HZ-test-chat"),
+            "fallback title present"
+        );
+    }
+
+    #[test]
+    fn render_blank_title_falls_back_to_chat_id() {
+        let mut chat = sample_chat();
+        chat.title = Some("   ".to_string());
+        let bytes = render_chat_to_docx(&chat).expect("render ok");
+        let xml = extract_document_xml(&bytes);
+        assert!(
+            xml.contains("Chat 01HZ-test-chat"),
+            "blank title falls back"
+        );
+    }
+
+    #[test]
+    fn render_empty_chat_returns_chat_empty() {
+        let mut chat = sample_chat();
+        chat.messages.clear();
+        let err = render_chat_to_docx(&chat).expect_err("must reject");
+        assert!(matches!(err, LegalError::ChatEmpty(_)));
+    }
+
+    #[test]
+    fn render_strips_xml_break_attempts_in_content() {
+        // A user pasting raw XML should not be able to break out of the
+        // document — docx-rs escapes via the builder API, but we also
+        // want to assert the angle brackets show up encoded in the XML
+        // rather than as literal markup.
+        let mut chat = sample_chat();
+        chat.messages = vec![ChatMessage {
+            id: "m1".to_string(),
+            role: ChatRole::User,
+            content: "</w:t><w:body><w:p>broken</w:p>".to_string(),
+            document_refs: vec![],
+            created_at: ts(1_700_000_000),
+        }];
+        let bytes = render_chat_to_docx(&chat).expect("render ok");
+        let xml = extract_document_xml(&bytes);
+        // The literal `</w:t>` from user content must appear as
+        // `&lt;/w:t&gt;` after escaping. Confirm the escaped form is
+        // present and the unescaped substring shows up only as part of
+        // legitimate doc structure (not as literal user content). A
+        // simple safety check is that `&lt;` exists at all and the
+        // sentinel "broken" word is escaped in context, not adjacent to
+        // a real `<w:p>` we control.
+        assert!(
+            xml.contains("&lt;/w:t&gt;") || xml.contains("&lt;w:t&gt;"),
+            "user-supplied angle brackets must be XML-escaped: {}",
+            xml.chars().take(2000).collect::<String>()
+        );
+    }
+
+    #[test]
+    fn render_strips_control_characters() {
+        let mut chat = sample_chat();
+        chat.messages = vec![ChatMessage {
+            id: "m1".to_string(),
+            role: ChatRole::User,
+            content: "before\u{0001}after\nfine".to_string(),
+            document_refs: vec![],
+            created_at: ts(1_700_000_000),
+        }];
+        let bytes = render_chat_to_docx(&chat).expect("render ok");
+        let xml = extract_document_xml(&bytes);
+        // `\u{0001}` would otherwise serialise as `&#x1;` — confirm it
+        // does not appear in the output and the surrounding text is
+        // glued together cleanly.
+        assert!(
+            !xml.contains("&#x1;") && !xml.contains('\u{0001}'),
+            "control character must be stripped"
+        );
+        assert!(
+            xml.contains("beforeafter"),
+            "surrounding text glued together"
+        );
+    }
+
+    #[test]
+    fn render_handles_missing_document_refs_section_when_empty() {
+        let mut chat = sample_chat();
+        for m in &mut chat.messages {
+            m.document_refs.clear();
+        }
+        let bytes = render_chat_to_docx(&chat).expect("render ok");
+        let xml = extract_document_xml(&bytes);
+        assert!(
+            !xml.contains("Documents referenced:"),
+            "callout absent when no refs"
+        );
+    }
+
+    #[test]
+    fn render_truncates_oversized_document_refs_list() {
+        let mut chat = sample_chat();
+        chat.messages = vec![ChatMessage {
+            id: "m1".to_string(),
+            role: ChatRole::User,
+            content: "test".to_string(),
+            document_refs: (0..(MAX_DOC_REFS_PER_MESSAGE + 5))
+                .map(|i| format!("file-{i}.pdf"))
+                .collect(),
+            created_at: ts(1_700_000_000),
+        }];
+        let bytes = render_chat_to_docx(&chat).expect("render ok");
+        let xml = extract_document_xml(&bytes);
+        assert!(xml.contains("and 5 more"), "truncation summary present");
+    }
+
+    #[test]
+    fn render_chunks_oversized_paragraph() {
+        // A single block above the byte cap should split into multiple
+        // body paragraphs without the renderer panicking or producing
+        // invalid UTF-8.
+        let huge = "x".repeat(MAX_BYTES_PER_PARAGRAPH * 3 + 17);
+        let mut chat = sample_chat();
+        chat.messages = vec![ChatMessage {
+            id: "m1".to_string(),
+            role: ChatRole::User,
+            content: huge,
+            document_refs: vec![],
+            created_at: ts(1_700_000_000),
+        }];
+        let bytes = render_chat_to_docx(&chat).expect("render ok");
+        // Just assert it produced a valid zip — reading the document
+        // back is the structural integrity check.
+        let _ = extract_document_xml(&bytes);
+    }
+
+    #[test]
+    fn floor_char_boundary_handles_multibyte() {
+        let s = "héllo"; // 'é' is two bytes
+        // Index 2 is mid-char; should round down to 1.
+        assert_eq!(floor_char_boundary(s, 2), 1);
+        // Index 0 is always a boundary.
+        assert_eq!(floor_char_boundary(s, 0), 0);
+        // Index past end clamps to len.
+        assert_eq!(floor_char_boundary(s, 99), s.len());
+    }
+
+    #[test]
+    fn sanitize_body_text_keeps_tab_newline_cr() {
+        let s = "a\tb\nc\rd".to_string();
+        let cleaned = sanitize_body_text(&s);
+        assert_eq!(cleaned, s);
+    }
+}

--- a/src/legal/mod.rs
+++ b/src/legal/mod.rs
@@ -1,0 +1,147 @@
+//! Legal-harness v1: chat-with-legal-documents skill.
+//!
+//! This module owns the persistence layer and the DOCX rendering pipeline
+//! for the legal harness — the `/skills/legal/...` HTTP surface lives in
+//! [`crate::channels::web::features::legal`] and calls into here.
+//!
+//! v1 split across three streams:
+//!
+//! - **Stream A — foundation**: project + document layer, schema migration,
+//!   skill manifest. Owns the canonical migration that introduces the
+//!   `legal_projects`, `legal_documents`, `legal_chats`, and
+//!   `legal_chat_messages` tables.
+//! - **Stream B — chat-with-docs**: chat creation, RAG, SSE streaming.
+//! - **Stream C — DOCX export**: this stream. Renders an existing chat
+//!   thread to a `.docx` byte stream so the user can hand the dialogue
+//!   off to a colleague or attach it to a matter file.
+//!
+//! Every stream carries an identical copy of the migration so each PR is
+//! independently testable; the canonical schema lives in the shared spec
+//! and must not diverge between branches.
+//!
+//! The module is gated on the `libsql` feature: ironclaw uses libSQL as
+//! its embedded data store for the legal harness per the shared spec, and
+//! Stream C consumes that same backend directly. A postgres-only build
+//! does not expose this module — adding postgres support is a v2 follow-up.
+//!
+//! # Layout
+//!
+//! - [`store`] — minimal libSQL reads needed for the export endpoint
+//!   (chat header + messages with `document_refs`). Stream A and Stream B
+//!   own the wider CRUD surface; Stream C only needs to *read* a chat to
+//!   render it.
+//! - [`docx`] — pure DOCX writer. Takes a [`ChatExport`] and returns
+//!   `Vec<u8>` containing a valid OOXML zip. No I/O, no async — easy to
+//!   unit-test in isolation.
+//! - Top-level types ([`ChatExport`], [`ChatMessage`], [`ChatRole`]) are
+//!   the shared shape that crosses the store/render boundary.
+
+#![cfg(feature = "libsql")]
+
+pub mod docx;
+pub mod store;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Snapshot of a single chat thread, ready for DOCX rendering.
+///
+/// Built by [`store::LegalChatStore::load_chat_for_export`] in production
+/// and constructed directly in tests so the DOCX writer can be exercised
+/// without standing up a database.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatExport {
+    /// Chat row id (TEXT primary key, ulid in production).
+    pub id: String,
+    /// Optional human-readable title; falls back to "Chat <id>" in the
+    /// rendered DOCX when absent.
+    pub title: Option<String>,
+    /// Unix timestamp when the chat was created.
+    pub created_at: DateTime<Utc>,
+    /// Messages in chronological order (oldest first). Roles are
+    /// constrained at the schema level to one of
+    /// `user|assistant|system|tool` — see the canonical migration.
+    pub messages: Vec<ChatMessage>,
+}
+
+/// One turn in a chat thread.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub id: String,
+    pub role: ChatRole,
+    pub content: String,
+    /// Filenames of any documents this turn referenced. Resolved from
+    /// `legal_chat_messages.document_refs` (a JSON array of
+    /// `legal_documents.id` values) joined against `legal_documents`.
+    /// Empty when the turn referenced no documents.
+    pub document_refs: Vec<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Allowed roles per the canonical schema's `CHECK` constraint. The
+/// migration enforces these values in SQL — anything else surfaces as
+/// [`LegalError::UnknownRole`] when the export reads a row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChatRole {
+    User,
+    Assistant,
+    System,
+    Tool,
+}
+
+impl ChatRole {
+    /// Display label used as the heading text for each message in the
+    /// rendered DOCX. Capitalized for visual scan-ability — the underlying
+    /// row stores a lowercase token.
+    pub fn label(self) -> &'static str {
+        match self {
+            ChatRole::User => "User",
+            ChatRole::Assistant => "Assistant",
+            ChatRole::System => "System",
+            ChatRole::Tool => "Tool",
+        }
+    }
+
+    pub(crate) fn from_db(s: &str) -> Result<Self, LegalError> {
+        match s {
+            "user" => Ok(ChatRole::User),
+            "assistant" => Ok(ChatRole::Assistant),
+            "system" => Ok(ChatRole::System),
+            "tool" => Ok(ChatRole::Tool),
+            other => Err(LegalError::UnknownRole(other.to_string())),
+        }
+    }
+}
+
+/// Errors surfaced by the legal-harness store + renderer.
+///
+/// The HTTP layer maps these to status codes:
+/// `ChatNotFound → 404`, `ChatEmpty → 400`, everything else → 500.
+#[derive(Debug, thiserror::Error)]
+pub enum LegalError {
+    /// No row in `legal_chats` matches the requested id.
+    #[error("legal chat {0} not found")]
+    ChatNotFound(String),
+    /// The chat exists but has no messages — exporting it would produce a
+    /// blank document, which is almost certainly a caller error.
+    #[error("legal chat {0} has no messages")]
+    ChatEmpty(String),
+    /// A row's `role` column did not match the canonical CHECK
+    /// constraint. The column is constrained at the schema level so this
+    /// should be unreachable in practice; surface it cleanly anyway so
+    /// migration-mismatch bugs do not panic the gateway.
+    #[error("legal chat message has unknown role '{0}'")]
+    UnknownRole(String),
+    /// `document_refs` failed to parse as a JSON array of strings. The
+    /// schema stores it as a TEXT column without enforcing the shape;
+    /// readers must tolerate corruption rather than abort.
+    #[error("legal chat message has malformed document_refs: {0}")]
+    MalformedDocumentRefs(String),
+    /// libSQL surfaced an error while reading the chat or messages.
+    #[error("legal store database error: {0}")]
+    Database(String),
+    /// The DOCX writer failed to produce a valid OOXML payload.
+    #[error("legal docx render error: {0}")]
+    Render(String),
+}

--- a/src/legal/store.rs
+++ b/src/legal/store.rs
@@ -1,0 +1,248 @@
+//! Read-side legal-harness queries for the DOCX export endpoint.
+//!
+//! Stream C only needs to *read* a chat thread to render it. The full
+//! CRUD surface (project/document/chat creation, message append) lives in
+//! Streams A and B. Keeping the read store separate lets Stream C land
+//! before the others without blocking on schema-trait re-shuffles.
+//!
+//! The store wraps a shared `Arc<libsql::Database>` and creates a fresh
+//! connection per call, mirroring the pattern in
+//! [`crate::secrets::store::LibSqlSecretsStore`].
+
+use std::sync::Arc;
+
+use chrono::{DateTime, TimeZone, Utc};
+use libsql::{Database as LibSqlDatabase, params};
+
+use crate::legal::{ChatExport, ChatMessage, ChatRole, LegalError};
+
+/// Minimum subset of legal-harness queries needed by the DOCX export
+/// handler. The wider read/write surface lives in Streams A/B.
+pub struct LegalChatStore {
+    db: Arc<LibSqlDatabase>,
+}
+
+impl LegalChatStore {
+    /// Wrap a shared libsql handle.
+    pub fn new(db: Arc<LibSqlDatabase>) -> Self {
+        Self { db }
+    }
+
+    /// Load a chat with all its messages (oldest first) and the filenames
+    /// of any documents each message referenced.
+    ///
+    /// Errors:
+    /// - [`LegalError::ChatNotFound`] when the chat id is unknown.
+    /// - [`LegalError::ChatEmpty`] when the chat exists but has no
+    ///   messages — the export endpoint maps this to 400 because a
+    ///   blank-document download is almost certainly a caller bug.
+    /// - [`LegalError::Database`] for any libsql failure.
+    pub async fn load_chat_for_export(&self, chat_id: &str) -> Result<ChatExport, LegalError> {
+        let conn = self
+            .db
+            .connect()
+            .map_err(|e| LegalError::Database(format!("connect failed: {e}")))?;
+        // Match the rest of the codebase: every connection sets a busy
+        // timeout so concurrent writers wait rather than failing instantly.
+        conn.query("PRAGMA busy_timeout = 5000", ())
+            .await
+            .map_err(|e| LegalError::Database(format!("set busy_timeout failed: {e}")))?;
+
+        // 1) Header row.
+        let mut rows = conn
+            .query(
+                "SELECT id, title, created_at FROM legal_chats WHERE id = ?1",
+                params![chat_id],
+            )
+            .await
+            .map_err(|e| LegalError::Database(format!("chat header query failed: {e}")))?;
+        let header = rows
+            .next()
+            .await
+            .map_err(|e| LegalError::Database(format!("chat header fetch failed: {e}")))?
+            .ok_or_else(|| LegalError::ChatNotFound(chat_id.to_string()))?;
+
+        let id: String = header
+            .get(0)
+            .map_err(|e| LegalError::Database(format!("chat id read failed: {e}")))?;
+        let title: Option<String> = header
+            .get(1)
+            .map_err(|e| LegalError::Database(format!("chat title read failed: {e}")))?;
+        let created_unix: i64 = header
+            .get(2)
+            .map_err(|e| LegalError::Database(format!("chat created_at read failed: {e}")))?;
+        let created_at = unix_to_utc(created_unix);
+
+        // 2) Messages, chronological order. The schema's CHECK
+        //    constraint already filters role to the four legal values; we
+        //    parse defensively in case a future migration loosens it.
+        let mut msg_rows = conn
+            .query(
+                "SELECT id, role, content, document_refs, created_at \
+                 FROM legal_chat_messages \
+                 WHERE chat_id = ?1 \
+                 ORDER BY created_at ASC, id ASC",
+                params![chat_id],
+            )
+            .await
+            .map_err(|e| LegalError::Database(format!("messages query failed: {e}")))?;
+
+        let mut messages = Vec::new();
+        while let Some(row) = msg_rows
+            .next()
+            .await
+            .map_err(|e| LegalError::Database(format!("message row fetch failed: {e}")))?
+        {
+            let msg_id: String = row
+                .get(0)
+                .map_err(|e| LegalError::Database(format!("message id read failed: {e}")))?;
+            let role_text: String = row
+                .get(1)
+                .map_err(|e| LegalError::Database(format!("message role read failed: {e}")))?;
+            let content: String = row
+                .get(2)
+                .map_err(|e| LegalError::Database(format!("message content read failed: {e}")))?;
+            let refs_raw: Option<String> = row.get(3).map_err(|e| {
+                LegalError::Database(format!("message document_refs read failed: {e}"))
+            })?;
+            let created_unix: i64 = row.get(4).map_err(|e| {
+                LegalError::Database(format!("message created_at read failed: {e}"))
+            })?;
+
+            let role = ChatRole::from_db(&role_text)?;
+            let doc_ids = parse_document_refs(refs_raw.as_deref())?;
+            let document_refs = if doc_ids.is_empty() {
+                Vec::new()
+            } else {
+                resolve_document_filenames(&conn, &doc_ids).await?
+            };
+
+            messages.push(ChatMessage {
+                id: msg_id,
+                role,
+                content,
+                document_refs,
+                created_at: unix_to_utc(created_unix),
+            });
+        }
+
+        if messages.is_empty() {
+            return Err(LegalError::ChatEmpty(chat_id.to_string()));
+        }
+
+        Ok(ChatExport {
+            id,
+            title,
+            created_at,
+            messages,
+        })
+    }
+}
+
+/// Convert a libSQL `INTEGER` unix-second timestamp into a `DateTime<Utc>`.
+///
+/// The canonical schema stores `created_at INTEGER NOT NULL DEFAULT
+/// (unixepoch())`, so seconds-since-epoch is the contract. Out-of-range
+/// values fall back to the unix epoch so the renderer always has *some*
+/// timestamp to print rather than panicking on a corrupted row.
+fn unix_to_utc(secs: i64) -> DateTime<Utc> {
+    Utc.timestamp_opt(secs, 0)
+        .single()
+        .unwrap_or_else(|| Utc.timestamp_opt(0, 0).single().unwrap_or_default())
+}
+
+/// Parse the `document_refs` JSON column into a list of legal_document ids.
+///
+/// `None` and empty strings both yield an empty Vec — there's no legal
+/// difference between "explicit empty array" and "no value" for this
+/// field, so the renderer is identical either way.
+fn parse_document_refs(raw: Option<&str>) -> Result<Vec<String>, LegalError> {
+    let Some(text) = raw else {
+        return Ok(Vec::new());
+    };
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str::<Vec<String>>(trimmed)
+        .map_err(|e| LegalError::MalformedDocumentRefs(e.to_string()))
+}
+
+/// Look up filenames for a list of legal_document ids.
+///
+/// Order matches the input — i.e. mirrors the order the message author
+/// referenced them. Missing ids are silently skipped; we don't want a
+/// stale ref (e.g. a document deleted while a chat survived) to fail
+/// the whole export. A debug log is recorded for each so an operator can
+/// spot the divergence without having to read SQL.
+async fn resolve_document_filenames(
+    conn: &libsql::Connection,
+    ids: &[String],
+) -> Result<Vec<String>, LegalError> {
+    let mut filenames = Vec::with_capacity(ids.len());
+    for doc_id in ids {
+        let mut rows = conn
+            .query(
+                "SELECT filename FROM legal_documents WHERE id = ?1",
+                params![doc_id.as_str()],
+            )
+            .await
+            .map_err(|e| LegalError::Database(format!("document filename query failed: {e}")))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| LegalError::Database(format!("document row fetch failed: {e}")))?
+        {
+            Some(row) => {
+                let filename: String = row.get(0).map_err(|e| {
+                    LegalError::Database(format!("document filename read failed: {e}"))
+                })?;
+                filenames.push(filename);
+            }
+            None => {
+                tracing::debug!(
+                    document_id = %doc_id,
+                    "legal_chat_messages.document_refs references missing legal_documents row"
+                );
+            }
+        }
+    }
+    Ok(filenames)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_document_refs_handles_none_and_empty() {
+        assert!(parse_document_refs(None).expect("none").is_empty());
+        assert!(parse_document_refs(Some("")).expect("empty").is_empty());
+        assert!(parse_document_refs(Some("   ")).expect("ws").is_empty());
+    }
+
+    #[test]
+    fn parse_document_refs_parses_array() {
+        let v = parse_document_refs(Some(r#"["a","b","c"]"#)).expect("ok");
+        assert_eq!(v, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn parse_document_refs_rejects_garbage() {
+        let err = parse_document_refs(Some("not json")).expect_err("should fail");
+        assert!(matches!(err, LegalError::MalformedDocumentRefs(_)));
+    }
+
+    #[test]
+    fn unix_to_utc_round_trips() {
+        let dt = unix_to_utc(1_700_000_000);
+        assert_eq!(dt.timestamp(), 1_700_000_000);
+    }
+
+    #[test]
+    fn unix_to_utc_handles_overflow() {
+        // i64::MAX is way past the supported chrono range; should
+        // gracefully fall back rather than panic.
+        let _ = unix_to_utc(i64::MAX);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,11 @@ pub mod hooks;
 pub mod http_intercept;
 #[cfg(feature = "import")]
 pub mod import;
+// Legal-harness skill (chat-with-legal-documents). v1 export-only stream
+// adds the read store + DOCX renderer; Streams A/B will plug in the
+// project/document and chat layers. The module gates itself on the
+// `libsql` feature internally per the shared spec.
+pub mod legal;
 pub mod llm;
 pub mod observability;
 pub mod orchestrator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -893,6 +893,17 @@ async fn async_main() -> anyhow::Result<()> {
                 gw = gw.with_secrets_store(Arc::clone(ss));
             }
 
+            // Legal-harness DOCX export — Stream C scope. The chat-read
+            // store wraps the same libSQL handle the rest of the
+            // gateway already shares; postgres-only builds skip this
+            // (the export endpoint returns 503 there).
+            #[cfg(feature = "libsql")]
+            if let Some(ref ldb) = components.libsql_db {
+                let legal_store =
+                    Arc::new(ironclaw::legal::store::LegalChatStore::new(Arc::clone(ldb)));
+                gw = gw.with_legal_chat_store(legal_store);
+            }
+
             // Bootstrap: create the first admin user from single-user config
             // so the owner appears in the Users admin panel immediately.
             if let Ok(false) = d.has_any_users().await {

--- a/tests/multi_tenant_integration.rs
+++ b/tests/multi_tenant_integration.rs
@@ -578,6 +578,7 @@ fn gateway_state_has_multi_tenant_fields() {
         oauth_sweep_shutdown: None,
         frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     };
 
     assert_eq!(state.owner_id, "fallback");
@@ -671,6 +672,7 @@ async fn start_owner_scoped_sender_server() -> (
         oauth_sweep_shutdown: None,
         frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     });
 
     let auth = MultiAuthState::multi(tokens).into();
@@ -1153,6 +1155,7 @@ async fn start_multi_user_server_with_db() -> (
         oauth_sweep_shutdown: None,
         frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     });
 
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();

--- a/tests/oauth_greeting_integration.rs
+++ b/tests/oauth_greeting_integration.rs
@@ -105,6 +105,7 @@ mod tests {
             oauth_sweep_shutdown: None,
             frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
+            legal_chat_store: None,
         });
 
         let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();

--- a/tests/openai_compat_integration.rs
+++ b/tests/openai_compat_integration.rs
@@ -245,6 +245,7 @@ async fn start_test_server_with_provider(
         oauth_sweep_shutdown: None,
         frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     });
 
     let auth = ironclaw::channels::web::auth::MultiAuthState::single(
@@ -768,6 +769,7 @@ async fn test_no_llm_provider_returns_503() {
         oauth_sweep_shutdown: None,
         frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     });
 
     let auth = ironclaw::channels::web::auth::MultiAuthState::single(

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -260,6 +260,7 @@ impl GatewayWorkflowHarness {
             oauth_sweep_shutdown: None,
             frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
+            legal_chat_store: None,
         });
 
         let mut agent = Agent::new(

--- a/tests/ws_gateway_integration.rs
+++ b/tests/ws_gateway_integration.rs
@@ -91,6 +91,7 @@ async fn start_test_server() -> (
         oauth_sweep_shutdown: None,
         frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         tool_dispatcher: None,
+        legal_chat_store: None,
     });
 
     let auth = ironclaw::channels::web::auth::MultiAuthState::single(


### PR DESCRIPTION
## Summary

Adds \`POST /skills/legal/chats/{id}/export.pdf\` — same chat snapshot as the .docx export, but the response is a PDF produced by shelling out to LibreOffice headless after the DOCX is built. Completes the export story alongside #3174 (DOCX) so callers can pick whichever format they need.

Stacked on **#3174** (Stream C, DOCX export). Rebases cleanly onto main once that lands.

## Behaviour

### LibreOffice resolution

In order:

1. \`LEGAL_LIBREOFFICE_BIN\` env var, if set and the path exists.
2. \`libreoffice\` on \`PATH\`.
3. \`soffice\` on \`PATH\`.

If nothing is found, the endpoint returns **503 Service Unavailable** with a clear message:

> PDF export requires LibreOffice; install libreoffice/soffice or set LEGAL_LIBREOFFICE_BIN

That lets the UI surface the gap as a deploy issue rather than a server bug (which is what 500 would have suggested).

### Pipeline

1. Validate chat id (same charset rules as the .docx endpoint).
2. Resolve the chat-snapshot store (503 if disabled, same as DOCX).
3. Render DOCX bytes via the existing \`render_chat_to_docx\` path — .docx and .pdf agree byte-for-byte at the document layer.
4. Spawn a blocking-pool task that:
   - creates a unique scratch directory under \`std::env::temp_dir()\`
     (RAII-cleaned by a \`TempDirGuard\`);
   - writes the DOCX;
   - shells out: \`libreoffice --headless --nologo --nofirststartwizard --convert-to pdf --outdir <tmp> <tmp>/input.docx\`;
   - reads the resulting \`input.pdf\` and returns the bytes.
5. Cleanup runs on drop, regardless of error path.

LibreOffice startup is firmly multi-second; running it on \`spawn_blocking\` keeps the axum worker free.

## Local checks

- \`cargo build --no-default-features --features libsql -p ironclaw\` ✅
- \`cargo clippy --no-default-features --features libsql -p ironclaw -- -D warnings\` ✅
- \`cargo fmt --check\` ✅

No new runtime dependency: rolled a small \`make_unique_tempdir\` + \`TempDirGuard\` rather than promoting \`tempfile\` from dev-dependencies.

## How to test

```bash
# Confirm LibreOffice is on PATH (macOS: \`brew install --cask libreoffice\`;
# Ubuntu: \`apt install libreoffice\`).
which libreoffice

GATEWAY_TOKEN=dev cargo run --release --no-default-features --features libsql -p ironclaw &
# After creating a project, uploading a doc, opening a chat, and posting messages:
curl -X POST -H "Authorization: Bearer $GATEWAY_TOKEN" \\
     "http://localhost:3100/skills/legal/chats/<chat_id>/export.pdf" \\
     -o /tmp/chat.pdf
file /tmp/chat.pdf  # → \"PDF document, version 1.5/1.6/...\"
```

## Companion PRs

- #3173 — foundation
- #3174 — DOCX export (this PR's base)
- #3179 — chat-with-docs RAG
- #3190 — web UI
- #3191 — tabular review
- #3192 — full-text search
- #3194 — hard delete + document delete
- #3176 — bookmarks (separate skill)

## Out of scope (deferred)

- A streaming response (current implementation buffers the whole PDF in memory). For the chat-export use case the documents are small enough that buffering is fine; large attachments are a separate path.
- Page numbers, headers/footers, custom typography. The DOCX renderer's output drives the PDF directly; styling improvements land in #3174 first and inherit here for free.
- Wiring the web UI's \"Export PDF\" affordance — separate follow-up against #3190.
- Server-side LibreOffice version pinning. Today we pick the first binary that resolves; an operator who wants a specific build sets \`LEGAL_LIBREOFFICE_BIN\`.