### PR TITLE
fix(bridge): coerce engine action params per schema (#3132)

### DIFF
--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -1230,20 +1230,21 @@ impl EffectBridgeAdapter {
         //
         // Engine actions (`mission_*`, routine aliases, `tool_info`) and
         // host tools both declare JSON Schemas for their parameters. Run
-        // both kinds through the same coercion the dispatcher path uses
-        // (`prepare_params_for_schema`) so the LLM can pass stringified
-        // scalars (`"120"` for an integer field) without breaking the
-        // handler. Schema sources, in order: orchestrator-populated
-        // action snapshot, bridge-known engine action defs, host tool
-        // registry. Coercion is idempotent for already-typed inputs, so
-        // tools whose downstream path runs `prepare_tool_params` again
-        // see the same shape.
+        // both kinds through the same coercion that `prepare_tool_params`
+        // applies for the v1 path so the LLM can pass stringified scalars
+        // (`"120"` for an integer field) without breaking the handler.
+        // Schema sources, in order: orchestrator-populated action
+        // snapshot, bridge-known engine action defs, host tool registry
+        // (via `discovery_schema()` to match `prepare_tool_params`).
+        // Once this runs, downstream sites in this method (sandbox-path
+        // validator, `execute_tool_with_safety`'s second `prepare_tool_params`)
+        // see already-coerced input — the second pass is idempotent.
         let action_schema = context
             .available_actions_snapshot
             .as_ref()
             .and_then(|snapshot| {
                 ActionDiscovery::resolve(snapshot.as_ref(), canonical_action_name)
-                    .map(|action| action.parameters_schema.clone())
+                    .map(|action| action.discovery_schema().clone())
             })
             .or_else(|| engine_action_schema(canonical_action_name));
         let action_schema = match action_schema {
@@ -1252,7 +1253,7 @@ impl EffectBridgeAdapter {
                 .tools
                 .get(&lookup_name)
                 .await
-                .map(|tool| tool.parameters_schema()),
+                .map(|tool| tool.discovery_schema()),
         };
         let parameters = match action_schema {
             Some(schema) => crate::tools::prepare_params_for_schema(&parameters, &schema),
@@ -1571,15 +1572,10 @@ impl EffectBridgeAdapter {
         // prompt-injection / param validation must run).
         let mounts_snapshot = self.workspace_mounts.read().await.as_ref().map(Arc::clone);
         let sandbox_result = if let Some(mounts) = mounts_snapshot {
-            // Normalize parameters the same way the host path does
-            // (`execute_tool_with_safety` → `prepare_tool_params`) so
-            // validation sees consistent types (e.g. string "true" → bool).
-            let normalized = if let Some(tool) = self.tools.get(&lookup_name).await {
-                crate::tools::prepare_tool_params(tool.as_ref(), &parameters)
-            } else {
-                parameters.clone()
-            };
-            let validation = self.safety.validator().validate_tool_params(&normalized);
+            // `parameters` was already coerced by the schema-guided
+            // pre-amble above; both the validator and the mount backend
+            // see the same shape that `execute_tool_with_safety` would.
+            let validation = self.safety.validator().validate_tool_params(&parameters);
             if !validation.is_valid {
                 let details = validation
                     .errors
@@ -1594,7 +1590,7 @@ impl EffectBridgeAdapter {
                     },
                 )))
             } else {
-                match maybe_intercept(&lookup_name, &normalized, context.project_id, &mounts).await
+                match maybe_intercept(&lookup_name, &parameters, context.project_id, &mounts).await
                 {
                     Ok(InterceptOutcome::Handled(s)) => Some(Ok(s)),
                     Ok(InterceptOutcome::FellThrough) => None,

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -1226,6 +1226,39 @@ impl EffectBridgeAdapter {
             .unwrap_or(canonical_action_name)
             .to_string();
 
+        // ── Schema-guided parameter coercion ──
+        //
+        // Engine actions (`mission_*`, routine aliases, `tool_info`) and
+        // host tools both declare JSON Schemas for their parameters. Run
+        // both kinds through the same coercion the dispatcher path uses
+        // (`prepare_params_for_schema`) so the LLM can pass stringified
+        // scalars (`"120"` for an integer field) without breaking the
+        // handler. Schema sources, in order: orchestrator-populated
+        // action snapshot, bridge-known engine action defs, host tool
+        // registry. Coercion is idempotent for already-typed inputs, so
+        // tools whose downstream path runs `prepare_tool_params` again
+        // see the same shape.
+        let action_schema = context
+            .available_actions_snapshot
+            .as_ref()
+            .and_then(|snapshot| {
+                ActionDiscovery::resolve(snapshot.as_ref(), canonical_action_name)
+                    .map(|action| action.parameters_schema.clone())
+            })
+            .or_else(|| engine_action_schema(canonical_action_name));
+        let action_schema = match action_schema {
+            Some(schema) => Some(schema),
+            None => self
+                .tools
+                .get(&lookup_name)
+                .await
+                .map(|tool| tool.parameters_schema()),
+        };
+        let parameters = match action_schema {
+            Some(schema) => crate::tools::prepare_params_for_schema(&parameters, &schema),
+            None => parameters,
+        };
+
         // ── Per-step call limit (prevent amplification loops) ──
         const MAX_CALLS_PER_STEP: u32 = 50;
         let count = self
@@ -2712,6 +2745,22 @@ fn extract_credential_name(error_msg: &str) -> Option<String> {
             .map(String::from);
     }
     None
+}
+
+/// Look up the parameter schema for a known engine-native action by name.
+///
+/// Engine actions (`mission_*`, `routine_*` aliases, `tool_info`) are not
+/// in the host `ToolRegistry` — they are handled directly inside the
+/// bridge. This helper provides the canonical schema for those actions so
+/// they get the same schema-guided parameter coercion that registered
+/// tools get via `prepare_tool_params`. The orchestrator-populated
+/// `available_actions_snapshot` takes precedence; this is the fallback
+/// for callers (and tests) that do not populate it.
+fn engine_action_schema(action_name: &str) -> Option<serde_json::Value> {
+    crate::bridge::engine_actions::mission_capability_actions()
+        .into_iter()
+        .find(|action| action.matches_name(action_name))
+        .map(|action| action.parameters_schema)
 }
 
 pub(crate) fn is_v1_only_tool(name: &str) -> bool {
@@ -4687,9 +4736,14 @@ mod tests {
 
     #[test]
     fn extract_guardrails_rejects_string_typed_integers() {
-        // Regression: LLMs pass numeric params as strings (e.g. cooldown_secs="0").
-        // The old code silently ignored the wrong type, so mission_update
-        // returned {"status":"updated"} but changed nothing in the database.
+        // Defense-in-depth: this helper is called directly on the raw
+        // params object and is the last line of defense if some future
+        // code path bypasses the schema-guided coercion that
+        // `execute_action_internal` now runs. A string-typed integer
+        // here means coercion didn't happen — fail loudly rather than
+        // silently dropping the value (the bug shape from before #2630).
+        // End-to-end coercion of `cooldown_secs="120"` is covered by
+        // `mission_create_string_guardrails_coerced_via_execute_action`.
         let params = serde_json::json!({"cooldown_secs": "0", "max_concurrent": "2"});
         let mut updates = ironclaw_engine::MissionUpdate::default();
         let err = extract_guardrails(&params, &mut updates).unwrap_err();
@@ -7303,10 +7357,57 @@ Use this skill to set up a Pika meeting.
         );
     }
 
-    /// Regression: mission_create with string-typed guardrails (e.g.
-    /// cooldown_secs="0") must be caught before creating the mission.
+    /// Regression for #3132: string-typed guardrails (e.g.
+    /// `cooldown_secs="120"`) must be coerced to integers per the action's
+    /// JSON Schema before reaching the handler. Previously rejected with
+    /// `'cooldown_secs' must be an integer, got "120"`.
     #[tokio::test]
-    async fn mission_create_string_guardrails_rejected_via_execute_action() {
+    async fn mission_create_string_guardrails_coerced_via_execute_action() {
+        let (adapter, _store, dyn_store) =
+            make_adapter_with_missions_and_store(Arc::new(ToolRegistry::new())).await;
+        let result = adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "test",
+                    "goal": "do stuff",
+                    "cadence": "manual",
+                    "cooldown_secs": "120",
+                    "max_concurrent": "2",
+                    "dedup_window_secs": "30",
+                    "max_threads_per_day": "5",
+                }),
+                &lease(),
+                &exec_ctx(ironclaw_engine::ThreadId::new(), Some("c3")),
+            )
+            .await
+            .expect("string-typed guardrails should be coerced and succeed");
+
+        assert!(!result.is_error, "got error: {}", result.output);
+        let mission_id_str = result
+            .output
+            .get("mission_id")
+            .and_then(|v| v.as_str())
+            .expect("should have mission_id");
+        let mission_id =
+            ironclaw_engine::MissionId(uuid::Uuid::parse_str(mission_id_str).expect("uuid"));
+        let mission = dyn_store
+            .load_mission(mission_id)
+            .await
+            .expect("load_mission")
+            .expect("mission persisted");
+        assert_eq!(mission.cooldown_secs, 120);
+        assert_eq!(mission.max_concurrent, 2);
+        assert_eq!(mission.dedup_window_secs, 30);
+        assert_eq!(mission.max_threads_per_day, 5);
+    }
+
+    /// Non-coercible strings (e.g. `cooldown_secs="abc"`) still surface as
+    /// a clean error rather than being silently dropped. Coercion leaves
+    /// the value unchanged when it can't parse to the target type, and
+    /// `extract_guardrails`'s strict check then rejects loudly.
+    #[tokio::test]
+    async fn mission_create_non_coercible_string_guardrail_returns_error() {
         let adapter = make_adapter_with_missions().await;
         let result = adapter
             .execute_action(
@@ -7315,10 +7416,10 @@ Use this skill to set up a Pika meeting.
                     "name": "test",
                     "goal": "do stuff",
                     "cadence": "manual",
-                    "cooldown_secs": "300"
+                    "cooldown_secs": "abc",
                 }),
                 &lease(),
-                &exec_ctx(ironclaw_engine::ThreadId::new(), Some("c3")),
+                &exec_ctx(ironclaw_engine::ThreadId::new(), Some("c3b")),
             )
             .await
             .expect("should return Ok with is_error=true");
@@ -7367,11 +7468,13 @@ Use this skill to set up a Pika meeting.
         );
     }
 
-    /// Regression: mission_update with string-typed guardrails must be
-    /// caught at the execute_action level, not silently ignored.
+    /// Regression for #3132: `mission_update` with string-typed guardrails
+    /// must be coerced (not rejected) so LLM calls passing `"5"` for an
+    /// integer parameter succeed and persist the new value.
     #[tokio::test]
-    async fn mission_update_string_guardrails_rejected_via_execute_action() {
-        let adapter = make_adapter_with_missions().await;
+    async fn mission_update_string_guardrails_coerced_via_execute_action() {
+        let (adapter, _store, dyn_store) =
+            make_adapter_with_missions_and_store(Arc::new(ToolRegistry::new())).await;
         let ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("u1"));
 
         // First create a mission to get an ID.
@@ -7389,40 +7492,39 @@ Use this skill to set up a Pika meeting.
             .await
             .expect("create should succeed");
         assert!(!create_result.is_error);
-        let mission_id = create_result
+        let mission_id_str = create_result
             .output
             .get("mission_id")
             .and_then(|v| v.as_str())
             .expect("should have mission_id");
 
-        // Now update with string-typed guardrails — should fail.
+        // Update with a string-typed integer — should be coerced and applied.
         let update_result = adapter
             .execute_action(
                 "mission_update",
                 serde_json::json!({
-                    "id": mission_id,
+                    "id": mission_id_str,
                     "max_concurrent": "5"
                 }),
                 &lease(),
                 &ctx,
             )
             .await
-            .expect("should return Ok with is_error=true");
+            .expect("string-typed guardrails should be coerced and succeed");
 
         assert!(
-            update_result.is_error,
-            "string guardrails should fail: {}",
+            !update_result.is_error,
+            "update should succeed after coercion: {}",
             update_result.output
         );
-        assert!(
-            update_result
-                .output
-                .get("error")
-                .and_then(|v| v.as_str())
-                .is_some_and(|s| s.contains("must be an integer")),
-            "got: {}",
-            update_result.output
-        );
+        let mission_id =
+            ironclaw_engine::MissionId(uuid::Uuid::parse_str(mission_id_str).expect("uuid"));
+        let mission = dyn_store
+            .load_mission(mission_id)
+            .await
+            .expect("load_mission")
+            .expect("mission persisted");
+        assert_eq!(mission.max_concurrent, 5);
     }
 
     /// Verify system_event cadence round-trips through mission_list.

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -1247,17 +1247,12 @@ impl EffectBridgeAdapter {
                     .map(|action| action.discovery_schema().clone())
             })
             .or_else(|| engine_action_schema(canonical_action_name));
-        let action_schema = match action_schema {
-            Some(schema) => Some(schema),
-            None => self
-                .tools
-                .get(&lookup_name)
-                .await
-                .map(|tool| tool.discovery_schema()),
-        };
-        let parameters = match action_schema {
-            Some(schema) => crate::tools::prepare_params_for_schema(&parameters, &schema),
-            None => parameters,
+        let parameters = if let Some(schema) = action_schema {
+            crate::tools::prepare_params_for_schema(&parameters, &schema)
+        } else if let Some(tool) = self.tools.get(&lookup_name).await {
+            crate::tools::prepare_params_for_schema(&parameters, &tool.discovery_schema())
+        } else {
+            parameters
         };
 
         // ── Per-step call limit (prevent amplification loops) ──
@@ -2743,15 +2738,24 @@ fn extract_credential_name(error_msg: &str) -> Option<String> {
     None
 }
 
-/// Look up the parameter schema for a known engine-native action by name.
+/// Look up the bridge-canonical schema for `mission_*` actions, the only
+/// engine-native action category that has no corresponding host `Tool`
+/// registration. `routine_*` (legacy v1 host tools, intercepted by the
+/// alias path before they execute) and `tool_info` (a v1/v2 host tool)
+/// are present in the host `ToolRegistry`, so they reach
+/// `execute_action_internal`'s registry branch directly and don't need
+/// this helper. Used in two places:
 ///
-/// Engine actions (`mission_*`, `routine_*` aliases, `tool_info`) are not
-/// in the host `ToolRegistry` — they are handled directly inside the
-/// bridge. This helper provides the canonical schema for those actions so
-/// they get the same schema-guided parameter coercion that registered
-/// tools get via `prepare_tool_params`. The orchestrator-populated
-/// `available_actions_snapshot` takes precedence; this is the fallback
-/// for callers (and tests) that do not populate it.
+/// 1. As a fallback in `execute_action_internal` when the orchestrator
+///    has not populated `available_actions_snapshot` — primarily tests
+///    that drive `execute_action` without setting up the snapshot.
+/// 2. To stay coupled to the `mission_capability_actions()` definitions
+///    so coercion in #1 always uses the same JSON Schema the engine
+///    advertises to the LLM.
+///
+/// In production paths the orchestrator always populates the snapshot,
+/// so the snapshot branch wins and this helper is a defense-in-depth
+/// fallback.
 fn engine_action_schema(action_name: &str) -> Option<serde_json::Value> {
     crate::bridge::engine_actions::mission_capability_actions()
         .into_iter()

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -33,7 +33,7 @@ pub use builder::{
     LlmSoftwareBuilder, SoftwareBuilder, SoftwareType, Template, TemplateEngine, TemplateType,
     TestCase, TestHarness, TestResult, TestSuite, ValidationError, ValidationResult, WasmValidator,
 };
-pub(crate) use coercion::prepare_tool_params;
+pub(crate) use coercion::{prepare_params_for_schema, prepare_tool_params};
 pub use rate_limiter::RateLimiter;
 pub use registry::{ToolRegistry, is_protected_tool_name};
 pub use tool::{


### PR DESCRIPTION
## Summary

- `mission_create` and `mission_update` rejected `cooldown_secs="120"` with `'cooldown_secs' must be an integer, got "120"` when the LLM passed integer guardrails as JSON strings (issue #3132).
- Root cause was a pipeline split: host tools coerce stringified scalars against their JSON Schema in `ToolDispatcher::dispatch` → `prepare_tool_params`, but engine actions (`mission_*`, `routine_*` aliases, `tool_info`) are intercepted in `effect_adapter::execute_action_internal` *before* that coercion runs.
- Lift schema-guided coercion to the engine-action dispatch boundary so both pipelines share the same input pre-amble. Schema sources, in order: orchestrator-populated `available_actions_snapshot`, bridge-known mission action defs (`mission_capability_actions()`), host tool registry. Idempotent — host-tool path sees unchanged shape since `prepare_tool_params` runs again downstream.
- `extract_guardrails` / `strict_u64` stay strict as defense in depth: if a future code path bypasses the new pre-amble, it still fails loudly rather than silently dropping the value (the bug shape from before #2630).

## Why this approach over making engine actions into Tools

Engine actions are engine-runtime operations on `MissionManager` / `Store` / `LeaseManager`. They take `ThreadExecutionContext` (step_id, current_call_id, available_actions_snapshot, user_timezone, thread_goal), not `JobContext`; they are gated by `CapabilityLease`+`EffectType` rather than `requires_approval`/rate-limit; and they belong to the engine crate, which has no host dependency. Engine v2's design direction is the opposite — `Capability/ActionDef` replacing `Tool`. Forcing engine actions through `Tool` would re-introduce a circular dependency, force the wrong context type, and double up on gating semantics. The right fix is to share the parts of the pipeline that should be shared (coercion, validation, redaction, sanitization), not to merge the abstractions.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib` — 5598 passed, 0 failed
- [x] `mission_create_string_guardrails_coerced_via_execute_action` — drives `execute_action` with all four guardrail params (`cooldown_secs`, `max_concurrent`, `dedup_window_secs`, `max_threads_per_day`) as strings; asserts the values persist correctly to the mission row in the backing store.
- [x] `mission_update_string_guardrails_coerced_via_execute_action` — same coverage for the update path.
- [x] `mission_create_non_coercible_string_guardrail_returns_error` — `cooldown_secs="abc"` still surfaces a clean error.
- [x] Existing `extract_guardrails_rejects_string_typed_integers` continues to pass; doc comment updated to reflect its defense-in-depth role.

Resolves #3132.