### PR TITLE
ci: trim wit_compat features, share WASM target dir, nextest main tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
             echo "has_web_risk=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if has_match '^(wit/|crates/ironclaw_common/|src/(channels/wasm|extensions|registry|tools/mcp|tools/wasm)/|channels-src/|tools-src/|registry/|scripts/build-wasm-extensions\.sh$|scripts/check-version-bumps\.sh$|tests/wit_compat\.rs$|tests/wasm_channel_integration\.rs$|tests/e2e_wasm_.*|Cargo\.toml$|Cargo\.lock$|\.github/workflows/test\.yml$)'; then
+          if has_match '^(wit/|crates/ironclaw_common/|src/(channels/wasm|tools/wasm)/|channels-src/|tools-src/|registry/|scripts/build-wasm-extensions\.sh$|scripts/check-version-bumps\.sh$|tests/wit_compat\.rs$|tests/wasm_channel_integration\.rs$|tests/e2e_wasm_.*|\.github/workflows/test\.yml$)'; then
             echo "has_wasm_abi_risk=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_wasm_abi_risk=false" >> "$GITHUB_OUTPUT"
@@ -181,12 +181,20 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-component
         uses: ./.github/actions/install-cargo-component
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # v2
+        with:
+          tool: cargo-nextest
       - name: Build WASM channels (for integration tests)
         run: ./scripts/build-wasm-extensions.sh --channels
       - name: Run Tests
         run: |
-          timeout --signal=INT --kill-after=30s 40m \
-            cargo test ${{ matrix.flags }} -- --nocapture
+          timeout --signal=INT --kill-after=30s 35m \
+            cargo nextest run --profile ci ${{ matrix.flags }}
+      - name: Run Doctests
+        run: |
+          timeout --signal=INT --kill-after=30s 10m \
+            cargo test --doc ${{ matrix.flags }}
 
   heavy-integration-tests:
     name: Heavy Integration Tests
@@ -366,6 +374,10 @@ jobs:
     env:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
+      # Share dep artifacts across the 18 cargo-component builds and the
+      # host wit_compat test build. tests/wit_compat.rs reads CARGO_TARGET_DIR
+      # at runtime to locate the produced .wasm artifacts.
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -391,8 +403,8 @@ jobs:
         run: ./scripts/build-wasm-extensions.sh
       - name: Instantiation test (host linker compatibility)
         run: |
-          timeout --signal=INT --kill-after=30s 20m \
-            cargo test --all-features --test wit_compat -- --nocapture
+          timeout --signal=INT --kill-after=30s 15m \
+            cargo test --no-default-features --features libsql --test wit_compat -- --nocapture
 
   bench-compile:
     name: Benchmark Compilation

--- a/scripts/build-wasm-extensions.sh
+++ b/scripts/build-wasm-extensions.sh
@@ -17,9 +17,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Share a single target dir across all extension builds so deps like
-# wit-bindgen, anyhow, serde compile once instead of 18 times.
-export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$(pwd)/target}"
+# Note: callers can `export CARGO_TARGET_DIR=...` to share dep artifacts
+# across all 18 builds. The wasm-wit-compat CI job does this. We do NOT
+# default it here: tests/slack_auth_integration.rs and telegram_auth_integration.rs
+# hardcode per-crate target paths and would break.
 
 BUILD_TOOLS=true
 BUILD_CHANNELS=true

--- a/scripts/build-wasm-extensions.sh
+++ b/scripts/build-wasm-extensions.sh
@@ -17,6 +17,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# Share a single target dir across all extension builds so deps like
+# wit-bindgen, anyhow, serde compile once instead of 18 times.
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$(pwd)/target}"
+
 BUILD_TOOLS=true
 BUILD_CHANNELS=true
 FAILED=()


### PR DESCRIPTION
## Summary

Speeds up PR CI by trimming the path filters and feature surface that drive the slowest jobs. Diagnosed from PR #3157, where `WASM WIT Compatibility` ran 14:36 and `Tests (all-features)` ran 13:57 on a Rust-engine-only PR.

- **wasm-abi risk regex**: drop `Cargo.toml$|Cargo.lock$` (and unrelated `src/extensions/`, `src/registry/`, `src/tools/mcp/`). Lock-file or dep churn no longer triggers the 14-min WIT compat job on PRs that have nothing to do with WASM ABI.
- **wit_compat features**: `--all-features` → `--no-default-features --features libsql`. The test imports only `wasmtime`/`wasmtime-wasi` (top-level deps, not behind any feature); cuts host build feature surface (drops postgres/bedrock/html-to-markdown/import).
- **Shared `CARGO_TARGET_DIR`**: all 18 cargo-component builds + the host wit_compat build now share dep artifacts (wit-bindgen, anyhow, serde compile once instead of 18×). `tests/wit_compat.rs:74` already reads `CARGO_TARGET_DIR` to locate the produced .wasm artifacts. Defaulted in `build-wasm-extensions.sh` for local-dev parity.
- **`cargo nextest` for main `tests` job**: per-binary parallelism. Doctests preserved via separate `cargo test --doc` step (nextest skips them by design).

## Expected impact

- Lock-file-only PRs: skip `WASM WIT Compatibility` entirely (~14 min off wall-clock when it was the longest job).
- WASM ABI PRs: wit_compat host-build is dramatically lighter (no AWS SDK / sqlx / html5ever); cargo-component builds share deps.
- Core-code PRs: nextest parallelism on the integration test suite.

## Test plan
- [ ] `WASM WIT Compatibility` is **skipped** on this PR (no WASM/wit/registry changes — should drop off the matrix entirely).
- [ ] `Tests (all-features)` runs via `cargo nextest`; check the step log for nextest output.
- [ ] `Run Doctests` step appears and passes.
- [ ] Verify total PR wall-clock improves vs comparable recent PRs.
- [ ] Watch first `push: main` after merge — confirms the wasm-extensions cache is reseeded with the new `CARGO_TARGET_DIR` layout.