### PR TITLE
fix(mcp): lock env in refresh-direct test to fix #3197 merge queue flake

### DIFF
--- a/src/tools/mcp/auth.rs
+++ b/src/tools/mcp/auth.rs
@@ -2273,8 +2273,16 @@ mod tests {
         assert_ne!(state, state_2, "State must be unique per request");
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn test_refresh_access_token_direct_includes_stored_client_secret() {
+        // Serialize against any other test that mutates IRONCLAW_OAUTH_* env vars,
+        // and explicitly clear them so refresh_access_token takes the direct path
+        // instead of routing through whatever proxy URL a parallel test left set.
+        let _env_guard = lock_env();
+        let _proxy_url_guard = set_env_var("IRONCLAW_OAUTH_EXCHANGE_URL", None);
+        let _proxy_token_guard = set_env_var("IRONCLAW_OAUTH_PROXY_AUTH_TOKEN", None);
+
         let secrets = test_secrets_store();
         let user_id = "test-user";
         let Some((base_url, state)) = start_refresh_server().await else {


### PR DESCRIPTION
## Summary

- `tools::mcp::auth::tests::test_refresh_access_token_direct_includes_stored_client_secret` did not hold `lock_env()` and did not clear `IRONCLAW_OAUTH_EXCHANGE_URL` / `IRONCLAW_OAUTH_PROXY_AUTH_TOKEN`. When `test_refresh_access_token_uses_proxy_when_configured` ran in parallel and left those vars set inside *its* lock-protected window, the direct test routed through the proxy URL to the *proxy* test's mock server.
- The direct test's mock server then saw zero requests; the proxy test's mock server saw two. Both tests failed their `requests.len() == 1` assertion. This surfaced on the merge queue head for #3197 (run [25250915890](https://github.com/nearai/ironclaw/actions/runs/25250915890)) because parallel scheduling there happened to interleave them; PR CI scheduled them disjointly.
- Fix mirrors the already-correct `test_refresh_access_token_serializes_concurrent_refreshes`: acquire `lock_env()` and explicitly clear both env vars so the direct path is exercised regardless of what other tests left in the environment.

## Why this is its own PR (not a commit on #3197)

#3197 is a bridge-layer fix for engine-action param coercion — it doesn't touch `src/tools/mcp/auth.rs`. Bundling an unrelated test-infra fix would violate the PR scope rule in `.claude/rules/review-discipline.md`. Land this first; #3197 then re-enters the merge queue cleanly.

## Test plan

- [x] `cargo test --lib --features integration tools::mcp::auth::tests::test_refresh_access_token` — 3 passed (direct, proxy, serialized-concurrent).
- [x] Pattern matches existing `test_refresh_access_token_serializes_concurrent_refreshes`, which uses the same `lock_env()` + explicit clear of both env vars and has been stable.

`[skip-regression-check]` — test-only change fixing a flaky test; no production code changed.