### PR TITLE
[codex] Add NEAR Intents trading agent foundation

### DIFF
--- a/docs/plans/2026-05-02-intents-trading-agent.md
+++ b/docs/plans/2026-05-02-intents-trading-agent.md
@@ -1,0 +1,183 @@
+# Intents Trading Agent on IronClaw
+
+**Status**: prototype scaffold
+**Date**: 2026-05-02
+**Owner**: tbd
+
+## Goal
+
+Build a TradingAgents-style crypto trading workflow on top of IronClaw
+that can research multichain spot opportunities, debate bull and bear
+cases, apply deterministic risk gates, and produce unsigned NEAR Intent
+bundles for user review.
+
+The first version is intentionally conservative: paper mode by default,
+quote-only when explicitly requested, no private keys, no signing, and
+no raw chain transaction builders.
+
+## Existing IronClaw foundation
+
+IronClaw already has the right execution primitive in
+`tools-src/portfolio`:
+
+- `scan` discovers EVM and NEAR portfolio positions.
+- `propose` emits deterministic DeFi movement proposals from strategy
+  docs.
+- `build_intent` turns a `MovementPlan` into a `portfolio-intent/1`
+  unsigned intent bundle through fixture, replay, or live NEAR Intents
+  solver paths.
+- `backtest` runs deterministic long-only spot strategy tests over
+  caller-provided OHLCV candles before a trade idea is eligible for
+  intent construction.
+- `backtest_suite` ranks a menu of strategy candidates over the same
+  OHLCV episode so users can choose from tested alternatives.
+
+The new `skills/intents-trading-agent` skill is the orchestration layer
+above that tool.
+
+## TradingAgents role mapping
+
+| TradingAgents role | IronClaw prototype role | Output |
+|---|---|---|
+| Fundamentals analyst | Market data analyst | Trend, volume, volatility, liquidity context |
+| News analyst | News/sentiment analyst | Catalyst and risk event memo |
+| Technical analyst | Market data analyst | Setup, invalidation, regime notes |
+| Research bull | Bull memo | Best case for the trade |
+| Research bear | Bear memo | Best case against the trade |
+| Trader | Trader proposal | Direction, notional, route, expected output |
+| Risk manager | Risk analyst | Gate pass/fail table |
+| Portfolio manager | Manager synthesis | Final stance: skip, watch, paper-intent, quote-intent |
+
+## Open-source references
+
+The local implementation borrows design patterns from mature
+open-source trading frameworks without copying code:
+
+- [Freqtrade](https://github.com/freqtrade/freqtrade): dry-run first,
+  explicit backtesting, fee/slippage-aware reporting, strategy
+  discovery, hyperopt, and lookahead/recursive-analysis commands.
+- [Backtrader](https://www.backtrader.com/): strategy/analyzer split
+  and reusable metrics.
+- [Jesse](https://github.com/jesse-ai/jesse): crypto-native strategy
+  research, multi-symbol/timeframe discipline, risk helpers, metrics,
+  optimization, Monte Carlo analysis, and debug workflow.
+- [TradingAgents](https://github.com/TauricResearch/TradingAgents):
+  analyst, bull/bear debate, trader, risk, and portfolio manager role
+  decomposition.
+
+The code remains an IronClaw-native Rust/WASM tool path so licensing,
+audit boundaries, and unsigned-intent constraints stay simple.
+
+## Project layout
+
+The skill writes state under `projects/intents-trading-agent/`:
+
+```text
+projects/intents-trading-agent/
+|-- AGENTS.md
+|-- config.json
+|-- watchlist.md
+|-- addresses.md
+|-- .system/
+|   `-- widgets/
+|       `-- near-intents-console/
+|           |-- manifest.json
+|           |-- index.js
+|           `-- style.css
+|-- state/
+|   |-- latest.json
+|   `-- history/
+|-- research/
+|-- debates/
+|-- decisions/
+|-- risk/
+|-- backtests/
+|-- intents/
+|-- journal/
+`-- widgets/
+    `-- state.json
+```
+
+This is separate from the existing `portfolio` project so market
+research, trading theses, and intent artifacts are not mixed with the
+general DeFi portfolio keeper.
+
+## Execution model
+
+1. Load project config, watchlist, wallet addresses, recent decisions,
+   and pending intents.
+2. Scan wallet addresses through `portfolio.scan` when available.
+3. Run analyst memos for market data, onchain exposure, news/sentiment,
+   intents/liquidity, and risk.
+4. Run and rank a backtest suite when OHLCV candles are available.
+5. Write bull and bear cases, then a manager synthesis.
+6. If the stance is `paper-intent` or `quote-intent`, build a
+   `MovementPlan`.
+7. Apply risk gates.
+8. Call `portfolio.build_intent`.
+9. Call `portfolio.format_intents_widget`.
+10. Persist the unsigned bundle, widget state, and summarize what was built.
+
+## Modes
+
+| Mode | Solver | Intended use |
+|---|---|---|
+| `paper` | `fixture` | Local experiments, replayable tests, no live quote claims |
+| `quote` | `near-intents` | Live quote only, still unsigned |
+| `execution` | future wallet flow | Requires explicit user signing outside the agent |
+
+The default config sets `mode` to `paper`.
+
+## Risk gates
+
+A proposal cannot become an intent unless all configured gates pass:
+
+- notional <= `max_notional_usd`,
+- daily turnover <= `max_daily_turnover_usd`,
+- confidence >= `min_confidence`,
+- expected edge >= `min_expected_edge_bps`,
+- asset and chain allowlists,
+- slippage <= `max_slippage_bps`,
+- backtest return, drawdown, trade count, and alpha gates pass when
+  candles are available,
+- no stale data,
+- no unresolved security or exploit concern,
+- no conflicting pending intent.
+
+## M0 deliverables
+
+- `skills/intents-trading-agent/SKILL.md` defines the workflow.
+- `skills/intents-trading-agent/strategies/*.md` defines the first
+  spot strategy test corpus plus Hyperliquid signal/risk-gate notes.
+- `portfolio.backtest` evaluates `buy-hold`, `sma-cross`, `breakout`,
+  `momentum`, `mean-reversion`, and `rsi-mean-reversion` strategies
+  with fee/slippage, stop/take-profit, and lookahead-safe next-open
+  execution.
+- `portfolio.backtest_suite` evaluates a menu of candidates with common
+  assumptions, ranks them by a transparent selection score, and returns
+  basic gate pass/fail flags.
+- `tools-src/portfolio/scenarios/intents-trading-agent-backtest-*.yaml`
+  covers the strategy baselines and suite ranking in the replay suite.
+- `tools-src/portfolio/scenarios/intents-trading-agent-swap.yaml`
+  proves a swap-shaped trading plan can be converted into an unsigned
+  intent bundle in replay tests.
+- `portfolio.format_intents_widget` emits `intents-trading-widget/1`
+  state for the IronClaw Projects widget.
+- `skills/intents-trading-agent/widgets/near-intents-console/` provides
+  the project widget that renders ranked strategies, risk gates, and
+  unsigned NEAR Intents status.
+- `tools-src/portfolio/fixtures/solver/ita-swap-near-usdc-btc-near.json`
+  records the deterministic solver response for the scenario.
+
+## Next milestones
+
+1. Add a project widget that shows stance, backtest metrics, risk gates,
+   pending intents,
+   and recent paper PnL.
+2. Add a data-source adapter for token prices and volatility, keeping
+   it read-only.
+3. Add replay scenarios for cross-chain spot rotation and route refusal.
+4. Add walk-forward validation, parameter grids, and regime-split reports over
+   `state/history`, `journal`, and external candle files.
+5. Integrate a wallet-signing handoff only after the unsigned-artifact
+   flow is stable and auditable.

--- a/docs/plans/2026-05-02-intents-trading-research.md
+++ b/docs/plans/2026-05-02-intents-trading-research.md
@@ -1,0 +1,141 @@
+# Intents Trading Agent Research Notes
+
+**Date**: 2026-05-02
+**Purpose**: evaluate open-source trading/backtesting systems and
+IronClaw skills before expanding the intents trading agent beyond the
+initial scaffold.
+
+## Source Review
+
+| Project | What it contributes | What to avoid |
+|---|---|---|
+| [Freqtrade](https://github.com/freqtrade/freqtrade) | Mature crypto-bot lifecycle: data download, backtesting, backtest analysis, hyperopt, plotting, dry-run/live split, strategy listing, lookahead analysis, recursive analysis. | Do not import strategy code or live exchange execution. IronClaw should keep execution unsigned and wallet-mediated. |
+| [Freqtrade hyperopt docs](https://www.freqtrade.io/en/stable/hyperopt/) | Hyperparameter search is just repeated backtesting over historical data with explicit loss functions, min-trades, fee, timerange, pair, timeframe, and data-format controls. | Do not add heavy optimization dependencies into the WASM tool yet. Start with deterministic grid/replay hooks. |
+| [Freqtrade lookahead analysis](https://docs.freqtrade.io/en/latest/lookahead-analysis/) | Bias detection is a first-class command, not a footnote. Backtests must prove they do not use future candles. | Do not accept indicator code that only works because it saw the whole dataframe. |
+| [Jesse](https://github.com/jesse-ai/jesse) | Crypto-native research framework: simple strategy syntax, indicator library, multiple symbols/timeframes, risk helpers, metrics, debug mode, optimization, Monte Carlo, ML pipeline. | No leverage/shorts in v0. No partial-fill simulation until solver route and wallet handoff exist. |
+| [Backtrader](https://www.backtrader.com/) | Clear separation between strategy, data feeds, broker/store, observers, and analyzers. Reusable analyzers are the right mental model for metrics. | Backtrader is Python/process heavy; do not embed it in the sandbox path. Use its architecture pattern. |
+| [Backtrader analyzers](https://www.backtrader.com/docu/analyzers/analyzers/) | Analyzers evaluate one strategy's performance and return compact results after a run. This maps well to `portfolio.backtest` returning `metrics`, `trades`, and `equity_curve`. | Avoid opaque metrics without trade logs; every metric should be traceable to candles and fills. |
+| [Hummingbot](https://github.com/hummingbot/hummingbot) | Connector/strategy split, market-making posture, CEX+DEX venue abstraction, and bot config discipline. | Market making needs live order management, inventory controls, and cancel/replace mechanics; do not pretend NEAR Intent swaps are an order book maker. |
+| [Hummingbot perpetual market making](https://hummingbot.org/strategies/v1-strategies/perpetual-market-making/) | Funding-aware perp strategies, mid-price references, spreads, and position management are useful design references for future Hyperliquid research. | Perps/leverage stay out of v0; use HL only as a signal source until execution semantics are explicit. |
+| [CCXT](https://github.com/ccxt/ccxt) | Unified exchange market-data API across many venues; public endpoints include tickers, order books, trades, and OHLCV. | Private exchange trading APIs conflict with the unsigned-wallet constraint; do not route execution through API keys. |
+| [vectorbt](https://vectorbt.dev/) | Fast vectorized parameter sweeps and heatmaps; good mental model for running many strategy variants over the same series. | Python/numpy research can live outside the WASM boundary; production gates should remain deterministic and replayable. |
+| [TradingAgents](https://github.com/TauricResearch/TradingAgents) | Analyst team, bull/bear research debate, trader, risk management, and portfolio-management decomposition. | Do not let the debate layer bypass deterministic gates. LLM confidence is advisory, not execution authority. |
+
+## Crypto Portal / Data Source Inventory
+
+| Source | Useful data | Fit for IronClaw | Notes |
+|---|---|---|---|
+| [NEAR Intents solver relay](https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay) | Quote requests, signed-intent publishing, status checks. | Execution/quote path, but unsigned until user wallet signs. | `portfolio.build_intent` already models fixture/replay/live solver modes. |
+| [NEAR Intents chain/address support](https://docs.near-intents.org/near-intents/chain-address-support) | Supported signing standards, token support, chain support. | Capability discovery and route gating. | Use this before promising a multichain route. |
+| [Hyperliquid info endpoint](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint) | All mids, user fills, L2 book snapshots, candle snapshots. | Strong read-only signal source for Hyperliquid spot/perp market context. | Candle snapshots are capped; long history needs recording or external archives. |
+| [Hyperliquid funding docs](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/funding) | Hourly funding mechanics and premium/oracle relationship. | Signal source for perp/spot divergence and risk-on/risk-off regimes. | Funding/carry execution is not v0 because v0 stays spot-only. |
+| [Hyperliquid historical data](https://hyperliquid.gitbook.io/hyperliquid-docs/historical-data) | S3 archives for L2 books, asset contexts, fills, explorer blocks. | Backfill source for serious HL strategy research. | The docs warn archive timeliness/completeness is not guaranteed. |
+| [Dune Sim API](https://docs.sim.dune.com/) | Wallet balances, token metadata, activity, transactions across many chains. | Existing `portfolio.scan` EVM source. | Requires API key; read-only. |
+| [CoinGecko trading guide](https://docs.coingecko.com/trading) | Spot prices, OHLC candles, market chart ranges, onchain OHLCV. | Candidate market-data adapter for backtests. | Good enough for daily/hourly research; verify plan/rate limits before automation. |
+| [DefiLlama API](https://defillama.com/docs/api) | Protocol TVL, yields, unlocks, stablecoins, broader DeFi context. | Risk/catalyst context and yield comparison. | Great for gating and context, not execution. |
+| [CCXT](https://github.com/ccxt/ccxt) | Exchange OHLCV/order books/trades from many CEX venues. | Optional external research adapter. | Use public market data only unless user explicitly designs a separate API-key execution mode. |
+
+## Hyperliquid / "HL" Strategy Notes
+
+Assumption: "HL" means Hyperliquid. If the user meant another portal,
+rename this section and keep the same gate structure.
+
+| Strategy family | Signal inputs | Can intents execute it now? | Research decision |
+|---|---|---|---|
+| Perp funding/carry | Funding rate, oracle/perp premium, spot hedge availability. | No, because v0 is spot-only and NEAR Intents are swap/bridge oriented here. | Track as signal and future module; no autonomous perp execution. |
+| Perp momentum / breakout | HL candle snapshots, all mids, L2 liquidity, open interest context from external sources. | Partially: signal can map to spot token rotation through intents. | Candidate v1 signal source after candle ingestion exists. |
+| Order-book imbalance | HL L2 book snapshots, spread, depth, impact price. | No as a maker; maybe as a slippage/liquidity gate for taker intents. | Use for risk gates before trade selection, not as standalone execution. |
+| Liquidation / squeeze context | Funding, premium, order-book thinning, liquidation feeds from third-party portals. | Signal only. | Needs robust data provenance and false-positive controls. |
+| Vault/copy-trading | Public vault/user portfolio and fills data. | No direct copy execution. | Could become an analyst input after privacy and survivorship-bias review. |
+
+## Strategy Selection Model
+
+The local tool should expose two levels:
+
+1. `portfolio.backtest`: one strategy config over one OHLCV episode.
+2. `portfolio.backtest_suite`: many candidate configs over the same
+   episode, ranked by a transparent deterministic score.
+
+The suite is not optimizer magic. It is the minimum "people can choose
+from strategies" primitive:
+
+- all candidates share the same candles, fee, slippage, and starting cash,
+- each candidate may override size, stop-loss, and take-profit,
+- output includes metrics, warnings, `selection_score`, and
+  `passes_basic_gate`,
+- no intent can be built from the suite result unless the risk manager
+  still approves it.
+
+## IronClaw Skill Evaluation
+
+| Skill/tool | Use in framework | Decision |
+|---|---|---|
+| `portfolio` tool | Position scans, DeFi proposals, intent construction, now backtesting. | Core execution and research substrate. |
+| `portfolio` skill | Project bootstrap and portfolio keeper conventions. | Reuse file layout ideas; keep trading-agent state separate. |
+| `llm-council` | Optional multi-model bull/bear/manager review. | Advisory only; never a substitute for risk gates. |
+| `decision-capture` | Durable records for accepted/rejected trade decisions. | Companion skill, useful for trade journal and later outcome review. |
+| `trader-setup` | Existing equities/options commitment workflow. | Pattern reference only; crypto intents gets its own project and config. |
+| `commitment-*` skills | Missions, digests, follow-up reminders. | Useful after strategy/backtest corpus stabilizes; not required for M0. |
+
+## Strategy Families To Offer
+
+| Strategy | Kind | Best market | Primary gate |
+|---|---|---|---|
+| Buy and hold benchmark | `buy-hold` | Any candidate pair | Benchmark only |
+| SMA cross | `sma-cross` | Trending, liquid markets | Positive alpha vs buy-hold after costs |
+| Breakout | `breakout` | Strong trend continuation | Drawdown and false-breakout controls |
+| Momentum | `momentum` | Rotation/risk-on markets | Regime split and turnover cost |
+| Mean reversion | `mean-reversion` | Rangebound, deep-liquidity assets | Win rate and stop discipline |
+| RSI mean reversion | `rsi-mean-reversion` | Oversold but unimpaired large caps | Catalyst/security veto |
+
+## Backtest Requirements
+
+Minimum framework requirements before a strategy can build an intent:
+
+1. Historical candles are oldest-to-newest and pass OHLC consistency.
+2. Signals are computed on closed candles and executed at next open.
+3. Fees and slippage are explicit.
+4. Result includes trade log, equity curve, drawdown, win rate, profit
+   factor, exposure, average trade return, and buy-hold alpha.
+5. Strategy-specific minimums are enforced from the strategy doc.
+6. Any exploit/depeg/unlock/regulatory risk can veto an otherwise good
+   backtest.
+7. Strategy menus are evaluated via suite ranking before choosing a
+   paper-intent candidate.
+8. Walk-forward and out-of-sample splits are required before claiming a
+   strategy is robust rather than merely fit to one episode.
+
+## Near-Term Gaps
+
+- Live OHLCV ingestion is still missing.
+- Walk-forward and out-of-sample splits are still missing.
+- Hyperparameter search is not implemented yet.
+- Monte Carlo / trade-order shuffling is not implemented yet.
+- Solver-route replay and market-data replay are separate; they need a
+  shared episode format.
+- No widget yet for backtest/risk/intent status.
+
+## Implementation Slice From This Sprint
+
+- Added `portfolio.backtest` for long-only spot strategy replay.
+- Added `portfolio.backtest_suite` to rank a strategy menu over a common
+  candle episode.
+- Added replay scenarios for individual strategies, suite ranking, and
+  a swap-shaped unsigned intent bundle.
+- Added the first bundled strategy corpus:
+  `buy-hold`, `sma-cross`, `breakout`, `momentum`, `mean-reversion`,
+  and `rsi-mean-reversion`.
+- Added first Hyperliquid-specific docs as signal/risk inputs:
+  funding carry watch, book imbalance gate, and perp momentum signal.
+- Added `portfolio.format_intents_widget` and a NEAR Intents project
+  widget template so the workflow has an operator-facing IronClaw UI.
+
+## Multi-Day Roadmap
+
+| Phase | Work | Exit criteria |
+|---|---|---|
+| M1 data ingestion | CoinGecko/CCXT CSV import, Hyperliquid candle snapshot recorder, Dune/NEAR portfolio context. | Backtests can run from saved market-data episodes, not hand-written candles. |
+| M2 strategy lab | Parameter grids, walk-forward splits, regime splits, benchmark comparisons, strategy doc thresholds. | A strategy report shows train/test windows, drawdown, turnover, and rejection reasons. |
+| M3 risk/intent bridge | Map approved suite results to `MovementPlan`, quote replay, solver refusal tests, route expiry tests, widget state updates. | A paper-intent can be rebuilt deterministically from research + backtest + quote fixture and inspected in the Projects UI. |
+| M4 portals and HL signals | Hyperliquid funding/book/candle adapters, DefiLlama risk context, optional CoinGecko fallback. | HL data is used as signal/risk context without pretending to execute perps. |
+| M5 UI/mission | Widget for watchlist, ranked strategies, risk gates, pending intents, and paper PnL journal. | User can inspect the autonomous run without reading JSON. |

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -2,7 +2,7 @@
   "name": "portfolio",
   "display_name": "Portfolio",
   "kind": "tool",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "wit_version": "0.3.0",
   "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
   "keywords": [

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -4,7 +4,7 @@
   "kind": "tool",
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, and unsigned NEAR Intent construction. Single tool with three operations: scan, propose, build_intent.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
   "keywords": [
     "defi",
     "portfolio",
@@ -12,7 +12,9 @@
     "wallet",
     "rebalance",
     "near-intents",
-    "crypto"
+    "crypto",
+    "backtesting",
+    "trading"
   ],
   "source": {
     "dir": "tools-src/portfolio",

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: intents-trading-agent
+version: 0.1.0
+description: TradingAgents-style crypto trading workflow for IronClaw that researches multichain spot opportunities, debates bull/bear cases, applies risk gates, and builds unsigned NEAR Intent bundles through the portfolio tool.
+activation:
+  keywords:
+    - intents trading
+    - trading agent
+    - crypto trading agent
+    - autonomous crypto trading
+    - multichain trading
+    - near intents trading
+    - intent based trading
+    - rebalance into
+    - swap thesis
+    - token rotation
+  patterns:
+    - "(?i)(trade|swap|rotate|rebalance).*(NEAR Intents|intents|multichain|cross-chain)"
+    - "(?i)(autonomous|agentic).*(crypto|token|trading|portfolio)"
+    - "(?i)(build|try|prototype).*(TradingAgents|trading agents).*(IronClaw|intents)"
+  exclude_keywords:
+    - nft
+    - mint
+  tags:
+    - crypto
+    - trading
+    - finance
+    - intents
+  max_context_tokens: 5000
+requires:
+  skills:
+    - portfolio
+    - llm-council
+    - decision-capture
+---
+
+# Intents Trading Agent
+
+You run a TradingAgents-style crypto workflow on top of IronClaw.
+The goal is to turn market research into **unsigned NEAR Intent
+bundles** that the user can inspect and sign in their own wallet.
+
+This skill is a research and orchestration layer. It does not replace
+the `portfolio` WASM tool. Use `portfolio.scan`, `portfolio.propose`,
+and `portfolio.build_intent` for positions, deterministic DeFi
+proposals, and intent bundle construction.
+
+## Non-negotiables
+
+1. **No private keys.** Never ask for seed phrases, private keys, or
+   signing material. Never claim to have signed or submitted a trade.
+2. **Unsigned only.** The agent may autonomously research, rank, and
+   build unsigned intent artifacts. Signing is always a user-wallet
+   action outside this skill.
+3. **Paper mode by default.** Unless the user explicitly opts into live
+   quoting, use fixture/replay paths and mark all output as test or
+   paper. Do not present fixture bundles as executable quotes.
+4. **Spot only in v0.** Do not propose leverage, perps, borrowing, or
+   recursive collateral loops. Defensive deleveraging proposals from
+   `portfolio.propose` are allowed.
+5. **Risk gates before intents.** A trade idea becomes an intent only
+   after the risk manager approves it against project config.
+6. **Audit trail first.** Persist research, debate notes, risk checks,
+   decisions, and built intents under `projects/intents-trading-agent/`.
+
+## Project bootstrap
+
+If the project does not exist, create `projects/intents-trading-agent/`
+using workspace writes. Initialize:
+
+- `AGENTS.md` - operating principles and tool boundaries.
+- `config.json`:
+
+```json
+{
+  "mode": "paper",
+  "max_notional_usd": 100,
+  "max_daily_turnover_usd": 250,
+  "max_slippage_bps": 50,
+  "min_confidence": 0.72,
+  "min_expected_edge_bps": 75,
+  "cooldown_minutes": 240,
+  "allowed_chains": [],
+  "allowed_assets": ["NEAR", "USDC", "USDT", "BTC", "ETH"],
+  "disallowed_assets": [],
+  "require_user_approval": true
+}
+```
+
+- `watchlist.md` - token pairs, chains, and theses the user cares about.
+- `addresses.md` - optional wallet addresses to scan.
+- `state/latest.json` and `state/history/`.
+- `research/`, `debates/`, `decisions/`, `risk/`, `intents/`,
+  `journal/`, and `widgets/`.
+- `strategies/` - copy or reference the baseline strategy docs bundled
+  with this skill (`sma-cross-spot`, `breakout-spot`,
+  `momentum-spot`, `mean-reversion-spot`,
+  `rsi-mean-reversion-spot`, `buy-hold-benchmark`) plus signal/gate
+  docs such as `hyperliquid-funding-carry-watch`,
+  `hyperliquid-book-imbalance-gate`, and
+  `hyperliquid-perp-momentum-signal`.
+- `.system/widgets/near-intents-console/` - copy the bundled widget
+  files from `skills/intents-trading-agent/widgets/near-intents-console/`
+  so IronClaw Projects can render the NEAR Intents trading console.
+
+If a `portfolio` project already exists, read it for wallet/address
+context, but keep trading-agent research and decisions in
+`projects/intents-trading-agent/`.
+
+## Run procedure
+
+### 1. Load state
+
+Read config, watchlist, addresses, latest state, recent decisions, and
+open unsigned intents. If the user provides a wallet address, append it
+to `addresses.md` and scan it.
+
+If addresses are present, call:
+
+```json
+{
+  "action": "scan",
+  "addresses": ["<address>"],
+  "chains": "*",
+  "source": "auto"
+}
+```
+
+Save the returned positions exactly as `state/latest.json` and append a
+dated copy under `state/history/`.
+
+### 2. Analyst team
+
+Run the analysis as distinct roles. Keep each role short and evidence
+grounded.
+
+- **Market Data Analyst**: price trend, volume, volatility, liquidity,
+  and drawdown context for the watched pair. For Hyperliquid/HL ideas,
+  include funding, candle snapshot, all-mids, and L2 book context when
+  available, but treat those as signal/risk inputs unless execution
+  support is explicitly implemented.
+- **Onchain/Portfolio Analyst**: wallet exposure, idle balances,
+  concentration, chain exposure, and any deterministic proposals from
+  `portfolio.propose`.
+- **News/Sentiment Analyst**: recent catalysts, governance, listings,
+  exploits, unlocks, regulatory events, and social sentiment. Use web
+  search for current facts when available.
+- **Intents/Liquidity Analyst**: whether the move is suitable for
+  intent execution, likely source/destination chains, route complexity,
+  solver quote risk, slippage budget, and expiry risk.
+- **Risk Analyst**: position sizing, downside scenario, correlation,
+  liquidity, stale data, and whether the idea passes config gates.
+
+Write role outputs to
+`projects/intents-trading-agent/research/<YYYY-MM-DD>/<role>.md`.
+
+### 3. Strategy lab and backtest
+
+Before a strategy can become a trade proposal, run a deterministic
+backtest when historical OHLCV candles are available. Prefer
+`action="backtest_suite"` when evaluating a menu of strategies, and use
+`action="backtest"` only for a single focused strategy check.
+
+For a strategy menu, call `portfolio` with:
+
+- `candles`: oldest-to-newest OHLCV candles,
+- `candidates`: strategy configs with stable IDs,
+- common fees, slippage, and starting cash.
+
+Each candidate may include `max_position_pct`, `stop_loss_bps`, and
+`take_profit_bps`. Persist the returned ranked suite exactly as
+`projects/intents-trading-agent/backtests/<YYYY-MM-DDTHH-MM>-suite-<pair>.json`.
+
+For a single strategy, call `portfolio` with `action="backtest"` and
+pass:
+
+- `candles`: oldest-to-newest OHLCV candles,
+- `strategy`: one of `buy-hold`, `sma-cross`, `breakout`,
+  `momentum`, `mean-reversion`, `rsi-mean-reversion`,
+- fees, slippage, max position size, and optional stop/take-profit.
+
+The backtester is inspired by common open-source trading frameworks:
+dry-run/backtest-first workflow, explicit fee/slippage assumptions,
+lookahead-safe next-open execution, analyzers/metrics, and a
+buy-and-hold benchmark. Do not copy external strategy code into the
+workspace; use these as design patterns and keep the local implementation
+auditable.
+
+Persist reports to
+`projects/intents-trading-agent/backtests/<YYYY-MM-DDTHH-MM>-<strategy>-<pair>.json`.
+
+Reject or downgrade to `watch` if:
+
+- `lookahead_safe` is false,
+- no suite candidate passes `passes_basic_gate`,
+- completed trades are below the strategy doc minimum,
+- max drawdown exceeds project risk budget,
+- total return is negative after fees and slippage,
+- alpha versus buy-and-hold is negative for a trend-following strategy,
+- win rate or profit factor fails the strategy doc minimum,
+- the test sample is too small or excludes a relevant stress regime.
+
+Always run `buy-hold` as a benchmark when enough candles are available.
+Always present the top ranked suite candidates and rejected candidates
+separately so the user can see what was considered.
+
+### 4. Bull/bear debate
+
+Create two concise debate memos:
+
+- Bull case: why the trade should be considered now.
+- Bear case: why it should be skipped, sized down, or delayed.
+
+Then write a manager synthesis with:
+
+- consensus points,
+- unresolved disagreements,
+- key missing data,
+- confidence score from 0 to 1,
+- final stance: `skip`, `watch`, `paper-intent`, or `quote-intent`.
+
+Persist to `projects/intents-trading-agent/debates/<YYYY-MM-DDTHH-MM>-<pair>.md`.
+
+### 5. Trader proposal
+
+Only create a trade proposal when the manager stance is
+`paper-intent` or `quote-intent`.
+
+A proposal must include:
+
+- pair and direction,
+- source asset, destination asset, source chain, destination chain,
+- notional USD and token amount,
+- expected output and expected cost,
+- thesis,
+- invalidation condition,
+- expiry or review time,
+- confidence,
+- risk gates and their pass/fail result.
+
+The trade proposal is not executable by itself. It is a request for an
+unsigned intent bundle.
+
+### 6. Risk gates
+
+Reject or downgrade to `watch` if any gate fails:
+
+- `notional_usd <= max_notional_usd`
+- daily turnover including pending intents <= `max_daily_turnover_usd`
+- confidence >= `min_confidence`
+- expected edge >= `min_expected_edge_bps`
+- source and destination assets are allowed and not disallowed
+- slippage <= `max_slippage_bps`
+- data freshness is acceptable
+- no unresolved security/exploit concern
+- no existing conflicting pending intent
+- backtest gates pass when candles are available
+
+If `require_user_approval` is true, do not ask the user to sign; ask
+whether they want a live quote or want to keep it as paper.
+
+### 7. Build unsigned intent
+
+For an approved `paper-intent`, call `portfolio.build_intent` with
+`solver: "fixture"` so the output is clearly a deterministic test
+bundle.
+
+For an approved `quote-intent`, call `portfolio.build_intent` with
+`solver: "near-intents"` only if the user explicitly requested live
+quoting and the environment supports it. The returned bundle is still
+unsigned.
+
+Use a `MovementPlan` shaped like:
+
+```json
+{
+  "proposal_id": "ita-<YYYYMMDD>-<pair>-<slug>",
+  "legs": [
+    {
+      "kind": "swap",
+      "chain": "<source-chain>",
+      "from_token": {
+        "symbol": "<source-symbol>",
+        "address": null,
+        "chain": "<source-chain>",
+        "amount": "<amount>",
+        "value_usd": "<notional-usd>"
+      },
+      "to_token": {
+        "symbol": "<destination-symbol>",
+        "address": null,
+        "chain": "<destination-chain>",
+        "amount": "<expected-amount>",
+        "value_usd": "<expected-usd>"
+      },
+      "description": "Swap <source> to <destination> via NEAR Intents"
+    }
+  ],
+  "expected_out": {
+    "symbol": "<destination-symbol>",
+    "address": null,
+    "chain": "<destination-chain>",
+    "amount": "<expected-amount>",
+    "value_usd": "<expected-usd>"
+  },
+  "expected_cost_usd": "<max-cost-usd>"
+}
+```
+
+For cross-chain moves, use ordered `withdraw`, `bridge`, `swap`, and
+`deposit` legs as needed. Never hand-build a raw EVM transaction.
+
+Persist returned bundles to
+`projects/intents-trading-agent/intents/<YYYY-MM-DDTHH-MM>-<proposal_id>.json`.
+
+### 8. Format the project widget
+
+After every run, call `portfolio` with `action="format_intents_widget"`
+and pass the latest pair, stance, confidence, `backtest_suite`, risk
+gates, research sources, and optional unsigned `IntentBundle`.
+
+Persist the returned JSON exactly as:
+
+`projects/intents-trading-agent/widgets/state.json`
+
+The bundled project widget reads this file and renders ranked strategy
+candidates, risk gates, and unsigned NEAR Intents status inside the
+IronClaw Projects view. If the widget files are not installed yet, copy:
+
+- `skills/intents-trading-agent/widgets/near-intents-console/manifest.json`
+- `skills/intents-trading-agent/widgets/near-intents-console/index.js`
+- `skills/intents-trading-agent/widgets/near-intents-console/style.css`
+
+to:
+
+`projects/intents-trading-agent/.system/widgets/near-intents-console/`
+
+### 9. Response
+
+Respond with specifics:
+
+- stance and confidence,
+- top supporting and opposing evidence,
+- backtest summary versus buy-and-hold when available,
+- top strategy-suite candidates when available,
+- risk gate table,
+- proposed notional and route,
+- intent status: `none`, `paper-built`, `live-quote-built`, or
+  `blocked`,
+- widget status and state path,
+- exact project paths written.
+
+Make clear that this is research and unsigned intent construction, not
+financial advice or executed trading.
+
+## Recurring mission
+
+Offer, but do not auto-create, a mission:
+
+- `name`: `intents-trading-agent`
+- `project_id`: `intents-trading-agent`
+- `cadence`: `0 */4 * * *`
+- `goal`: "Run the intents trading workflow in paper mode for the
+  configured watchlist. Research current market/onchain/news context,
+  run and rank a strategy suite when candles are available, debate bull
+  and bear cases, apply risk gates, and build unsigned paper intent
+  bundles only when every gate passes. Never sign or submit trades."
+
+If the user later opts into live quotes, update the mission goal to say
+`live quote bundles are allowed, signing remains user-only`.

--- a/skills/intents-trading-agent/strategies/breakout-spot.md
+++ b/skills/intents-trading-agent/strategies/breakout-spot.md
@@ -1,0 +1,26 @@
+---
+id: breakout-spot
+version: 1
+kind: breakout
+timeframes: ["1h", "4h", "1d"]
+parameters:
+  lookback_window: 20
+  threshold_bps: 25
+  max_position_pct: 0.5
+risk:
+  stop_loss_bps: 1000
+  take_profit_bps: 1800
+  min_backtest_trades: 5
+  min_alpha_vs_buy_hold_pct: 0
+---
+
+# Breakout Spot Baseline
+
+Trend-continuation baseline for high-liquidity pairs. Enter when a
+closed candle breaks above the prior lookback high by the threshold;
+exit on a downside break, stop-loss, or take-profit.
+
+This is meant to catch strong directional moves while still being
+compatible with intent-based spot execution. Reject it when volume is
+thin, spreads are wide, or the projected route needs fragile
+cross-chain hops.

--- a/skills/intents-trading-agent/strategies/buy-hold-benchmark.md
+++ b/skills/intents-trading-agent/strategies/buy-hold-benchmark.md
@@ -1,0 +1,17 @@
+---
+id: buy-hold-benchmark
+version: 1
+kind: buy-hold
+timeframes: ["1h", "4h", "1d"]
+parameters:
+  max_position_pct: 1.0
+risk:
+  benchmark_only: true
+---
+
+# Buy and Hold Benchmark
+
+Baseline benchmark for alpha checks. The trading agent should compare
+active strategies against buy-and-hold after fees and slippage. A
+strategy that adds complexity but underperforms buy-and-hold should be
+rejected or downgraded to watch mode.

--- a/skills/intents-trading-agent/strategies/hyperliquid-book-imbalance-gate.md
+++ b/skills/intents-trading-agent/strategies/hyperliquid-book-imbalance-gate.md
@@ -1,0 +1,33 @@
+---
+id: hyperliquid-book-imbalance-gate
+version: 1
+kind: gate-hyperliquid-orderbook
+venue: hyperliquid
+status: risk-gate
+timeframes: ["1m", "5m", "15m"]
+data_sources:
+  - hyperliquid_l2_book
+  - hyperliquid_all_mids
+parameters:
+  depth_bps: 50
+  max_spread_bps: 20
+  min_bid_ask_depth_ratio: 0.65
+  max_bid_ask_depth_ratio: 1.55
+risk:
+  blocks_intent_when_book_thin: true
+  blocks_intent_when_spread_wide: true
+---
+
+# Hyperliquid Book Imbalance Gate
+
+Risk gate for checking whether a Hyperliquid market is too thin,
+one-sided, or wide-spread to support a spot intent thesis. This is not a
+market-making strategy. It should block or downsize trades when book
+conditions imply poor execution or fragile momentum.
+
+Pass only when the top-of-book spread is inside budget, depth near the
+intended route size is adequate, and bid/ask depth is not badly skewed.
+
+Fail the gate when a trade would be forced through a thin book, when
+spread exceeds the configured threshold, or when imbalance suggests the
+signal is already crowded.

--- a/skills/intents-trading-agent/strategies/hyperliquid-funding-carry-watch.md
+++ b/skills/intents-trading-agent/strategies/hyperliquid-funding-carry-watch.md
@@ -1,0 +1,35 @@
+---
+id: hyperliquid-funding-carry-watch
+version: 1
+kind: signal-hyperliquid-funding
+venue: hyperliquid
+status: signal-only
+timeframes: ["1h", "8h", "1d"]
+data_sources:
+  - hyperliquid_funding
+  - hyperliquid_all_mids
+  - spot_reference_price
+parameters:
+  min_abs_funding_apr_pct: 12
+  min_observation_hours: 24
+  max_premium_bps: 75
+risk:
+  no_perp_execution_in_v0: true
+  require_spot_liquidity_check: true
+  require_funding_reversal_check: true
+---
+
+# Hyperliquid Funding Carry Watch
+
+Signal-only strategy for identifying when perp funding is extreme
+enough to matter for spot positioning. The agent may use this as
+context for a spot rotation thesis, but v0 must not open perp positions
+or claim carry execution through NEAR Intents.
+
+Use the signal when funding is persistent across multiple observations,
+the perp premium is not already mean-reverting violently, and spot
+liquidity is deep enough for the candidate intent route.
+
+Reject the signal if funding flipped recently, market depth is thin,
+oracle/mark divergence is unstable, or the proposed trade only works
+because of leverage.

--- a/skills/intents-trading-agent/strategies/hyperliquid-perp-momentum-signal.md
+++ b/skills/intents-trading-agent/strategies/hyperliquid-perp-momentum-signal.md
@@ -1,0 +1,34 @@
+---
+id: hyperliquid-perp-momentum-signal
+version: 1
+kind: signal-hyperliquid-momentum
+venue: hyperliquid
+status: signal-only
+timeframes: ["15m", "1h", "4h"]
+data_sources:
+  - hyperliquid_candle_snapshot
+  - hyperliquid_l2_book
+  - hyperliquid_all_mids
+parameters:
+  lookback_window: 20
+  min_momentum_bps: 250
+  max_chase_distance_bps: 150
+risk:
+  require_spot_backtest_confirmation: true
+  require_book_gate: true
+  require_news_veto_check: true
+---
+
+# Hyperliquid Perp Momentum Signal
+
+Signal-only strategy for using Hyperliquid perp market structure as an
+early warning that a liquid asset may be entering a momentum regime. In
+v0, this can only support a spot intent candidate; it cannot authorize
+perp orders, leverage, or API-key execution.
+
+Promote the signal only when momentum persists beyond the lookback
+window, the current price is not too far from the breakout level, and a
+matching spot strategy also passes `portfolio.backtest_suite`.
+
+Reject or downgrade when the move is already extended, book depth is
+weak, funding is crowded, or the catalyst is unverifiable.

--- a/skills/intents-trading-agent/strategies/mean-reversion-spot.md
+++ b/skills/intents-trading-agent/strategies/mean-reversion-spot.md
@@ -1,0 +1,25 @@
+---
+id: mean-reversion-spot
+version: 1
+kind: mean-reversion
+timeframes: ["1h", "4h"]
+parameters:
+  lookback_window: 20
+  threshold_bps: 300
+  max_position_pct: 0.35
+risk:
+  stop_loss_bps: 800
+  min_backtest_trades: 8
+  min_win_rate_pct: 45
+---
+
+# Mean Reversion Spot Baseline
+
+Liquidity-reversion baseline for large-cap pairs. Enter when price
+closes materially below a moving average and exit when price reverts to
+the average.
+
+Use only on assets with deep liquidity and no obvious impairment
+catalyst. Do not use this to catch falling knives after hacks, token
+unlock shocks, depegs, regulatory events, or protocol insolvency
+rumors.

--- a/skills/intents-trading-agent/strategies/momentum-spot.md
+++ b/skills/intents-trading-agent/strategies/momentum-spot.md
@@ -1,0 +1,25 @@
+---
+id: momentum-spot
+version: 1
+kind: momentum
+timeframes: ["4h", "1d"]
+parameters:
+  lookback_window: 20
+  threshold_bps: 500
+  max_position_pct: 0.4
+risk:
+  stop_loss_bps: 1000
+  min_backtest_trades: 5
+  min_alpha_vs_buy_hold_pct: 0
+---
+
+# Momentum Spot Baseline
+
+Relative momentum baseline for liquid assets. Enter when trailing
+lookback return clears the threshold; exit when trailing momentum
+fades to zero or lower.
+
+Use this for rotation candidates where the thesis is continued strength
+rather than a single breakout candle. Reject when the asset is already
+extended into a known unlock, exploit, delisting, depeg, or governance
+risk window.

--- a/skills/intents-trading-agent/strategies/rsi-mean-reversion-spot.md
+++ b/skills/intents-trading-agent/strategies/rsi-mean-reversion-spot.md
@@ -1,0 +1,26 @@
+---
+id: rsi-mean-reversion-spot
+version: 1
+kind: rsi-mean-reversion
+timeframes: ["1h", "4h"]
+parameters:
+  lookback_window: 14
+  entry_threshold: 30
+  exit_threshold: 55
+  max_position_pct: 0.3
+risk:
+  stop_loss_bps: 700
+  min_backtest_trades: 8
+  min_win_rate_pct: 45
+---
+
+# RSI Mean Reversion Spot Baseline
+
+Oscillator-driven reversion baseline. Enter when RSI is oversold and
+exit when RSI normalizes. This is only appropriate for deep-liquidity
+assets where the move looks like flow exhaustion, not fundamental
+impairment.
+
+Reject the strategy during protocol exploit news, stablecoin depegs,
+forced unlocks, liquidation cascades, chain halts, or any case where
+the "oversold" move may be information rather than noise.

--- a/skills/intents-trading-agent/strategies/sma-cross-spot.md
+++ b/skills/intents-trading-agent/strategies/sma-cross-spot.md
@@ -1,0 +1,25 @@
+---
+id: sma-cross-spot
+version: 1
+kind: sma-cross
+timeframes: ["1h", "4h", "1d"]
+parameters:
+  fast_window: 8
+  slow_window: 21
+  max_position_pct: 0.5
+risk:
+  stop_loss_bps: 800
+  min_backtest_trades: 5
+  min_alpha_vs_buy_hold_pct: 0
+---
+
+# SMA Cross Spot Baseline
+
+Trend-following baseline for liquid spot pairs. Enter when the fast
+moving average crosses above the slow moving average; exit on the
+reverse cross or a stop-loss.
+
+Use this as a sanity benchmark, not a production strategy. It should
+only graduate to an intent candidate when the backtest shows enough
+trades, positive alpha after fees and slippage, and drawdown inside the
+project risk budget.

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -1,0 +1,202 @@
+var root = document.createElement('section');
+root.className = 'ita-console';
+container.appendChild(root);
+
+function itaEscape(value) {
+  var div = document.createElement('div');
+  div.textContent = value == null ? '' : String(value);
+  return div.innerHTML;
+}
+
+function itaSlugify(value) {
+  return String(value || 'intents-trading-agent')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || 'intents-trading-agent';
+}
+
+function itaPct(value) {
+  var n = Number(value || 0);
+  var sign = n > 0 ? '+' : '';
+  return sign + n.toFixed(2) + '%';
+}
+
+function itaScore(value) {
+  var n = Number(value || 0);
+  return n.toFixed(2);
+}
+
+function itaStatusClass(status) {
+  var s = String(status || 'unknown').toLowerCase();
+  if (s === 'pass' || s === 'paper-built' || s === 'live-quote-built') return 'is-pass';
+  if (s === 'warn' || s === 'awaiting-signature' || s === 'watch') return 'is-warn';
+  if (s === 'fail' || s === 'failed' || s === 'blocked') return 'is-fail';
+  return 'is-neutral';
+}
+
+function itaReadState(slug) {
+  var path = 'projects/' + slug + '/widgets/state.json';
+  return api.fetch('/api/memory/read?path=' + encodeURIComponent(path))
+    .then(function(res) {
+      if (!res.ok) throw new Error('state not found');
+      return res.json();
+    })
+    .then(function(doc) {
+      return JSON.parse(doc.content || '{}');
+    });
+}
+
+function itaLoadProjectSlug() {
+  return api.fetch('/api/engine/projects/' + encodeURIComponent(projectId))
+    .then(function(res) {
+      if (!res.ok) throw new Error('project not found');
+      return res.json();
+    })
+    .then(function(data) {
+      return itaSlugify(data && data.project && data.project.name);
+    })
+    .catch(function() {
+      return 'intents-trading-agent';
+    });
+}
+
+function itaCandidateRows(candidates) {
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    return '<div class="ita-empty-line">No ranked strategies yet.</div>';
+  }
+  return '<div class="ita-table" role="table" aria-label="Ranked strategy candidates">'
+    + candidates.map(function(c) {
+      return '<div class="ita-row" role="row">'
+        + '<div class="ita-rank">#' + itaEscape(c.rank || '-') + '</div>'
+        + '<div class="ita-strategy">'
+        + '<strong>' + itaEscape(c.id || 'candidate') + '</strong>'
+        + '<span>' + itaEscape(c.strategy_kind || 'strategy') + '</span>'
+        + '</div>'
+        + '<div class="ita-metric"><span>Score</span><strong>' + itaScore(c.selection_score) + '</strong></div>'
+        + '<div class="ita-metric"><span>Return</span><strong>' + itaPct(c.total_return_pct) + '</strong></div>'
+        + '<div class="ita-metric"><span>Alpha</span><strong>' + itaPct(c.alpha_vs_buy_hold_pct) + '</strong></div>'
+        + '<div class="ita-metric"><span>DD</span><strong>' + itaPct(-Math.abs(Number(c.max_drawdown_pct || 0))) + '</strong></div>'
+        + '<div class="ita-gate ' + (c.passes_basic_gate ? 'is-pass' : 'is-fail') + '">'
+        + (c.passes_basic_gate ? 'Gate pass' : 'Gate fail')
+        + '</div>'
+        + '</div>';
+    }).join('')
+    + '</div>';
+}
+
+function itaRiskGates(gates) {
+  if (!Array.isArray(gates) || gates.length === 0) {
+    return '<div class="ita-empty-line">No risk gates recorded.</div>';
+  }
+  return '<div class="ita-gates">'
+    + gates.map(function(gate) {
+      return '<div class="ita-gate-row">'
+        + '<span class="ita-gate-name">' + itaEscape(gate.name || 'gate') + '</span>'
+        + '<span class="ita-pill ' + itaStatusClass(gate.status) + '">' + itaEscape(gate.status || 'unknown') + '</span>'
+        + (gate.detail ? '<span class="ita-gate-detail">' + itaEscape(gate.detail) + '</span>' : '')
+        + '</div>';
+    }).join('')
+    + '</div>';
+}
+
+function itaIntent(intent) {
+  if (!intent) {
+    return '<div class="ita-intent-empty">No unsigned intent built for this run.</div>';
+  }
+  var minOut = Array.isArray(intent.min_out) ? intent.min_out : [];
+  return '<div class="ita-intent">'
+    + '<div class="ita-intent-main">'
+    + '<span class="ita-pill ' + itaStatusClass(intent.status) + '">' + itaEscape(intent.status || 'none') + '</span>'
+    + '<strong>' + itaEscape(intent.route_label || 'NEAR Intents route') + '</strong>'
+    + '<span>' + itaEscape(intent.quote_source || 'fixture') + ' quote source</span>'
+    + '</div>'
+    + '<div class="ita-intent-grid">'
+    + '<div><span>Bundle</span><strong>' + itaEscape(intent.id || '-') + '</strong></div>'
+    + '<div><span>Legs</span><strong>' + itaEscape(intent.legs || 0) + '</strong></div>'
+    + '<div><span>Cost</span><strong>$' + itaEscape(intent.total_cost_usd || '0.00') + '</strong></div>'
+    + '<div><span>Signer</span><strong>' + itaEscape(intent.signer_placeholder || '<signed-by-user>') + '</strong></div>'
+    + '</div>'
+    + (minOut.length ? '<div class="ita-minout">'
+      + minOut.map(function(token) {
+        return '<span>' + itaEscape(token.amount) + ' ' + itaEscape(token.symbol) + ' on ' + itaEscape(token.chain) + '</span>';
+      }).join('')
+      + '</div>' : '')
+    + '</div>';
+}
+
+function itaWritePrompt(kind, state) {
+  if (api && api.navigate) api.navigate('chat');
+  var input = document.getElementById('chat-input');
+  if (!input) return;
+  var pair = state && state.pair ? state.pair : 'the watched pair';
+  input.value = kind === 'quote'
+    ? 'For the Intents Trading Agent, request a live NEAR Intents quote for ' + pair + ' only if all current risk gates still pass. Keep it unsigned.'
+    : 'For the Intents Trading Agent, run the paper NEAR Intents workflow for ' + pair + ': research, backtest_suite, risk gates, and unsigned intent preview.';
+  input.focus();
+  if (typeof autoGrow === 'function') autoGrow(input);
+}
+
+function itaRender(state) {
+  var statusClass = itaStatusClass(state.stance);
+  root.innerHTML = '<div class="ita-head">'
+    + '<div>'
+    + '<div class="ita-kicker">NEAR Intents Trading Agent</div>'
+    + '<h3>' + itaEscape(state.pair || 'Watchlist') + '</h3>'
+    + '</div>'
+    + '<div class="ita-head-actions">'
+    + '<span class="ita-pill ' + statusClass + '">' + itaEscape(state.stance || 'watch') + '</span>'
+    + '<button type="button" data-action="ita-refresh">Refresh</button>'
+    + '</div>'
+    + '</div>'
+    + '<div class="ita-summary">'
+    + '<div><span>Mode</span><strong>' + itaEscape(state.mode || 'paper') + '</strong></div>'
+    + '<div><span>Confidence</span><strong>' + (state.confidence == null ? '-' : Math.round(Number(state.confidence) * 100) + '%') + '</strong></div>'
+    + '<div><span>Sources</span><strong>' + itaEscape(state.source_count || 0) + '</strong></div>'
+    + '<div><span>Updated</span><strong>' + itaEscape(state.generated_at || '-') + '</strong></div>'
+    + '</div>'
+    + '<div class="ita-body">'
+    + '<section><div class="ita-section-title">Strategy Suite</div>' + itaCandidateRows(state.top_candidates) + '</section>'
+    + '<section><div class="ita-section-title">Risk Gates</div>' + itaRiskGates(state.risk_gates) + '</section>'
+    + '<section><div class="ita-section-title">Unsigned Intent</div>' + itaIntent(state.intent) + '</section>'
+    + '</div>'
+    + (state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '')
+    + '<div class="ita-actions">'
+    + '<button type="button" data-action="ita-paper">Prepare Paper Run</button>'
+    + '<button type="button" data-action="ita-quote">Prepare Live Quote Request</button>'
+    + '</div>';
+
+  root.querySelector('[data-action="ita-refresh"]').addEventListener('click', itaLoad);
+  root.querySelector('[data-action="ita-paper"]').addEventListener('click', function() {
+    itaWritePrompt('paper', state);
+  });
+  root.querySelector('[data-action="ita-quote"]').addEventListener('click', function() {
+    itaWritePrompt('quote', state);
+  });
+}
+
+function itaRenderEmpty() {
+  root.innerHTML = '<div class="ita-empty">'
+    + '<div class="ita-kicker">NEAR Intents Trading Agent</div>'
+    + '<h3>No console state yet</h3>'
+    + '<p>Run the paper workflow to produce ranked strategies, risk gates, and an unsigned intent preview.</p>'
+    + '<button type="button" data-action="ita-paper-empty">Prepare Paper Run</button>'
+    + '</div>';
+  root.querySelector('[data-action="ita-paper-empty"]').addEventListener('click', function() {
+    itaWritePrompt('paper', { pair: 'the configured watchlist' });
+  });
+}
+
+function itaRenderLoading() {
+  root.innerHTML = '<div class="ita-loading">Loading NEAR Intents console...</div>';
+}
+
+function itaLoad() {
+  itaRenderLoading();
+  itaLoadProjectSlug()
+    .then(itaReadState)
+    .then(itaRender)
+    .catch(itaRenderEmpty);
+}
+
+itaLoad();

--- a/skills/intents-trading-agent/widgets/near-intents-console/manifest.json
+++ b/skills/intents-trading-agent/widgets/near-intents-console/manifest.json
@@ -1,0 +1,6 @@
+{
+  "id": "near-intents-console",
+  "name": "NEAR Intents Console",
+  "slot": "project_header",
+  "position": "before:missions"
+}

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -1,0 +1,300 @@
+.ita-console {
+  margin: 14px 0 18px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 92%, var(--accent-subtle) 8%);
+  color: var(--text);
+}
+
+.ita-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.ita-kicker {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.ita-head h3,
+.ita-empty h3 {
+  margin: 2px 0 0;
+  font-size: 22px;
+  line-height: 1.15;
+}
+
+.ita-head-actions,
+.ita-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.ita-console button {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-sm);
+  min-height: 32px;
+  padding: 6px 10px;
+}
+
+.ita-console button:hover {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.ita-pill,
+.ita-gate {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  justify-content: center;
+  min-height: 24px;
+  padding: 3px 9px;
+  text-transform: uppercase;
+}
+
+.ita-pill.is-pass,
+.ita-gate.is-pass {
+  border-color: color-mix(in srgb, var(--success) 45%, var(--border) 55%);
+  color: var(--success);
+}
+
+.ita-pill.is-warn {
+  border-color: color-mix(in srgb, var(--warning) 45%, var(--border) 55%);
+  color: var(--warning);
+}
+
+.ita-pill.is-fail,
+.ita-gate.is-fail {
+  border-color: color-mix(in srgb, var(--error) 45%, var(--border) 55%);
+  color: var(--error);
+}
+
+.ita-pill.is-neutral {
+  color: var(--text-secondary);
+}
+
+.ita-summary {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-bottom: 16px;
+}
+
+.ita-summary > div,
+.ita-intent-grid > div {
+  border-top: 1px solid var(--border);
+  padding-top: 8px;
+}
+
+.ita-summary span,
+.ita-intent-grid span,
+.ita-metric span {
+  color: var(--text-muted);
+  display: block;
+  font-size: var(--text-xs);
+}
+
+.ita-summary strong,
+.ita-intent-grid strong,
+.ita-metric strong {
+  color: var(--text);
+  display: block;
+  font-size: var(--text-sm);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-body {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.9fr);
+}
+
+.ita-body section:nth-child(3) {
+  grid-column: 1 / -1;
+}
+
+.ita-section-title {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.ita-table,
+.ita-gates {
+  display: grid;
+  gap: 6px;
+}
+
+.ita-row {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 42px minmax(120px, 1.3fr) repeat(4, minmax(66px, 0.55fr)) 86px;
+  min-height: 54px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.ita-rank {
+  color: var(--accent);
+  font-weight: 800;
+}
+
+.ita-strategy strong,
+.ita-strategy span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-strategy span {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  margin-top: 2px;
+}
+
+.ita-gate-row {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(120px, 1fr) auto;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.ita-gate-name {
+  font-weight: 700;
+}
+
+.ita-gate-detail {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  grid-column: 1 / -1;
+}
+
+.ita-intent {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.ita-intent-main {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.ita-intent-main > span:last-child,
+.ita-next,
+.ita-intent-empty,
+.ita-empty-line,
+.ita-loading {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.ita-intent-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ita-minout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.ita-minout span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  padding: 4px 8px;
+}
+
+.ita-next {
+  border-top: 1px solid var(--border);
+  margin-top: 14px;
+  padding-top: 10px;
+}
+
+.ita-actions {
+  margin-top: 12px;
+}
+
+.ita-empty {
+  padding: 8px 0;
+}
+
+.ita-empty p {
+  color: var(--text-secondary);
+  margin: 6px 0 12px;
+  max-width: 720px;
+}
+
+@media (max-width: 980px) {
+  .ita-summary,
+  .ita-body,
+  .ita-intent-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .ita-row {
+    grid-template-columns: 36px minmax(120px, 1fr) 76px;
+  }
+
+  .ita-row .ita-metric:nth-of-type(n + 3) {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .ita-console {
+    padding: 12px;
+  }
+
+  .ita-head,
+  .ita-intent-main {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .ita-summary,
+  .ita-body,
+  .ita-intent-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ita-row {
+    grid-template-columns: 32px minmax(0, 1fr);
+  }
+
+  .ita-row .ita-metric,
+  .ita-row .ita-gate {
+    grid-column: 2;
+    justify-self: start;
+  }
+}

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "intents-trading-widget/1",
+  "generated_at": "2026-05-02T16:30:00Z",
+  "project_id": "intents-trading-agent",
+  "mode": "paper",
+  "pair": "NEAR/BTC",
+  "stance": "paper-intent",
+  "confidence": 0.74,
+  "top_candidates": [
+    {
+      "rank": 1,
+      "id": "sma_cross_fast",
+      "strategy_kind": "sma-cross",
+      "selection_score": 18.5,
+      "passes_basic_gate": true,
+      "total_return_pct": 12.0,
+      "alpha_vs_buy_hold_pct": 3.0,
+      "max_drawdown_pct": 8.0,
+      "trades": 6
+    }
+  ],
+  "risk_gates": [
+    {
+      "name": "unsigned-only",
+      "status": "pass",
+      "detail": "Wallet signature required outside the agent."
+    },
+    {
+      "name": "live-quote",
+      "status": "warn",
+      "detail": "Live NEAR Intents quote requires explicit user approval."
+    }
+  ],
+  "intent": {
+    "id": "intent-widget-fixture",
+    "status": "paper-built",
+    "route_label": "NEAR -> BTC via NEAR Intents",
+    "quote_source": "fixture",
+    "schema_version": "portfolio-intent/1",
+    "legs": 1,
+    "total_cost_usd": "0.42",
+    "expires_at": 1775000000,
+    "signer_placeholder": "<signed-by-user>",
+    "min_out": [
+      {
+        "symbol": "BTC",
+        "chain": "near",
+        "amount": "0.001",
+        "value_usd": "70.00"
+      }
+    ]
+  },
+  "source_count": 2,
+  "research_sources": [
+    "https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay",
+    "https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint"
+  ],
+  "next_action": "Ask the user before requesting a live NEAR Intents quote."
+}

--- a/tools-src/portfolio/fixtures/solver/ita-swap-near-usdc-btc-near.json
+++ b/tools-src/portfolio/fixtures/solver/ita-swap-near-usdc-btc-near.json
@@ -1,0 +1,31 @@
+{
+  "quote_id": "q-ita-swap-near-usdc-btc-2026-05-02",
+  "quote_version": "near-intents/1",
+  "legs": [
+    {
+      "id": "swap-near-usdc-btc",
+      "kind": "swap",
+      "chain": "near",
+      "near_intent_payload": {
+        "op": "swap",
+        "from_chain": "near",
+        "to_chain": "near",
+        "from_asset": "USDC",
+        "to_asset": "BTC",
+        "amount_in": "100.00",
+        "min_amount_out": "0.00099500",
+        "paper_mode": true,
+        "source": "intents-trading-agent-smoke"
+      },
+      "min_out": {
+        "symbol": "BTC",
+        "chain": "near",
+        "amount": "0.00099500",
+        "value_usd": "98.01"
+      },
+      "quoted_by": "relay-solver/replay"
+    }
+  ],
+  "total_cost_usd": "1.50",
+  "expires_at_unix": 1800000000
+}

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, and unsigned NEAR Intent construction. Single tool with three operations: scan, propose, build_intent.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
   "discovery_summary": {
     "always_required": [
       "action"
@@ -9,11 +9,15 @@
     "conditional_requirements": [
       "`scan` requires `addresses` (list of wallet addresses).",
       "`propose` requires `positions` (output of `scan`). `strategies` is optional — defaults to the bundled strategies (stablecoin-yield-floor, lending-health-guard, lp-impermanent-loss-watch, near-staking-yield, near-lending-yield, near-lp-yield) when omitted or empty. `config` is optional.",
-      "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`."
+      "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`.",
+      "`backtest` requires oldest-to-newest OHLCV `candles` plus a long-only spot `strategy` (`buy-hold`, `sma-cross`, `breakout`, `mean-reversion`, `momentum`, or `rsi-mean-reversion`). Fees, slippage, position size, stop-loss, and take-profit are optional.",
+      "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
+      "`format_intents_widget` requires a `pair` and optional backtest-suite output, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -29,6 +33,25 @@
         "positions": [],
         "strategies": [],
         "config": { "floor_apy": 0.04, "max_risk_score": 3 }
+      },
+      {
+        "action": "backtest_suite",
+        "candles": [],
+        "candidates": [
+          { "id": "sma_5_20", "strategy": { "kind": "sma-cross", "fast_window": 5, "slow_window": 20 } },
+          { "id": "buy_hold", "strategy": { "kind": "buy-hold" } }
+        ],
+        "fee_bps": 10,
+        "slippage_bps": 5
+      },
+      {
+        "action": "format_intents_widget",
+        "pair": "NEAR/BTC",
+        "mode": "paper",
+        "stance": "watch",
+        "risk_gates": [
+          { "name": "unsigned-only", "status": "pass", "detail": "Wallet signature required outside the agent." }
+        ]
       }
     ]
   },

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-breakout.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-breakout.yaml
@@ -1,0 +1,33 @@
+id: intents-trading-agent-backtest-breakout
+description: |
+  Backtests a long-only breakout strategy with explicit fee/slippage
+  assumptions. This is the trend-following baseline in the strategy
+  test corpus.
+steps:
+  - name: backtest_breakout
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 0.75
+      take_profit_bps: 1800
+      strategy:
+        kind: breakout
+        lookback_window: 3
+        threshold_bps: 25
+      candles:
+        - {ts: "2026-02-01T00:00:00Z", open: 20.0, high: 20.3, low: 19.8, close: 20.0, volume: 900}
+        - {ts: "2026-02-02T00:00:00Z", open: 20.1, high: 20.4, low: 19.9, close: 20.1, volume: 900}
+        - {ts: "2026-02-03T00:00:00Z", open: 20.0, high: 20.3, low: 19.7, close: 20.0, volume: 900}
+        - {ts: "2026-02-04T00:00:00Z", open: 20.2, high: 20.5, low: 20.0, close: 20.2, volume: 950}
+        - {ts: "2026-02-05T00:00:00Z", open: 20.3, high: 21.2, low: 20.2, close: 21.1, volume: 1300}
+        - {ts: "2026-02-06T00:00:00Z", open: 21.2, high: 22.4, low: 21.0, close: 22.1, volume: 1500}
+        - {ts: "2026-02-07T00:00:00Z", open: 22.2, high: 23.5, low: 22.0, close: 23.2, volume: 1600}
+        - {ts: "2026-02-08T00:00:00Z", open: 23.3, high: 24.6, low: 23.0, close: 24.0, volume: 1700}
+        - {ts: "2026-02-09T00:00:00Z", open: 24.0, high: 24.4, low: 23.3, close: 23.8, volume: 1200}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 5
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-mean-reversion.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-mean-reversion.yaml
@@ -1,0 +1,34 @@
+id: intents-trading-agent-backtest-mean-reversion
+description: |
+  Backtests a liquidity-aware mean-reversion baseline. The strategy
+  buys a sharp discount to a short moving average and exits when
+  price normalizes.
+steps:
+  - name: backtest_mean_reversion
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 0.5
+      stop_loss_bps: 800
+      strategy:
+        kind: mean-reversion
+        lookback_window: 3
+        threshold_bps: 300
+      candles:
+        - {ts: "2026-03-01T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 2000}
+        - {ts: "2026-03-02T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 2000}
+        - {ts: "2026-03-03T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 2000}
+        - {ts: "2026-03-04T00:00:00Z", open: 98.0, high: 99.0, low: 93.0, close: 94.0, volume: 2600}
+        - {ts: "2026-03-05T00:00:00Z", open: 94.5, high: 96.0, low: 92.5, close: 93.0, volume: 2500}
+        - {ts: "2026-03-06T00:00:00Z", open: 93.5, high: 96.5, low: 93.0, close: 95.0, volume: 2300}
+        - {ts: "2026-03-07T00:00:00Z", open: 95.5, high: 99.0, low: 95.0, close: 98.0, volume: 2200}
+        - {ts: "2026-03-08T00:00:00Z", open: 98.5, high: 102.0, low: 98.0, close: 101.0, volume: 2200}
+        - {ts: "2026-03-09T00:00:00Z", open: 101.0, high: 102.0, low: 99.0, close: 100.0, volume: 1900}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 0
+      backtest_max_drawdown_le: 10
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-momentum.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-momentum.yaml
@@ -1,0 +1,33 @@
+id: intents-trading-agent-backtest-momentum
+description: |
+  Backtests a trailing-return momentum strategy. This expands the
+  strategy corpus beyond moving-average and breakout signals for
+  users who want rotation-style choices.
+steps:
+  - name: backtest_momentum
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 0.6
+      stop_loss_bps: 1000
+      strategy:
+        kind: momentum
+        lookback_window: 3
+        threshold_bps: 500
+      candles:
+        - {ts: "2026-04-01T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-04-02T00:00:00Z", open: 10.2, high: 10.4, low: 10.0, close: 10.2, volume: 1100}
+        - {ts: "2026-04-03T00:00:00Z", open: 10.4, high: 10.6, low: 10.2, close: 10.4, volume: 1200}
+        - {ts: "2026-04-04T00:00:00Z", open: 10.6, high: 10.8, low: 10.4, close: 10.6, volume: 1300}
+        - {ts: "2026-04-05T00:00:00Z", open: 11.2, high: 11.4, low: 11.0, close: 11.2, volume: 1600}
+        - {ts: "2026-04-06T00:00:00Z", open: 11.8, high: 12.0, low: 11.6, close: 11.8, volume: 1800}
+        - {ts: "2026-04-07T00:00:00Z", open: 12.4, high: 12.6, low: 12.1, close: 12.4, volume: 1900}
+        - {ts: "2026-04-08T00:00:00Z", open: 12.0, high: 12.2, low: 11.7, close: 12.0, volume: 1500}
+        - {ts: "2026-04-09T00:00:00Z", open: 11.5, high: 11.7, low: 11.2, close: 11.5, volume: 1300}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 0
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-rsi.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-rsi.yaml
@@ -1,0 +1,36 @@
+id: intents-trading-agent-backtest-rsi
+description: |
+  Backtests an RSI mean-reversion strategy. This gives users an
+  oscillator-style choice distinct from SMA, breakout, and momentum
+  strategies.
+steps:
+  - name: backtest_rsi_mean_reversion
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 0.4
+      stop_loss_bps: 700
+      strategy:
+        kind: rsi-mean-reversion
+        lookback_window: 5
+        entry_threshold: 25
+        exit_threshold: 55
+      candles:
+        - {ts: "2026-05-01T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 2000}
+        - {ts: "2026-05-02T00:00:00Z", open: 98.0, high: 99.0, low: 97.0, close: 98.0, volume: 2200}
+        - {ts: "2026-05-03T00:00:00Z", open: 96.0, high: 97.0, low: 95.0, close: 96.0, volume: 2400}
+        - {ts: "2026-05-04T00:00:00Z", open: 94.0, high: 95.0, low: 93.0, close: 94.0, volume: 2500}
+        - {ts: "2026-05-05T00:00:00Z", open: 92.0, high: 93.0, low: 91.0, close: 92.0, volume: 2600}
+        - {ts: "2026-05-06T00:00:00Z", open: 90.0, high: 91.0, low: 89.0, close: 90.0, volume: 2700}
+        - {ts: "2026-05-07T00:00:00Z", open: 91.0, high: 92.0, low: 90.0, close: 91.0, volume: 2500}
+        - {ts: "2026-05-08T00:00:00Z", open: 93.0, high: 94.0, low: 92.0, close: 93.0, volume: 2300}
+        - {ts: "2026-05-09T00:00:00Z", open: 95.0, high: 96.0, low: 94.0, close: 95.0, volume: 2200}
+        - {ts: "2026-05-10T00:00:00Z", open: 98.0, high: 99.0, low: 97.0, close: 98.0, volume: 2100}
+        - {ts: "2026-05-11T00:00:00Z", open: 101.0, high: 102.0, low: 100.0, close: 101.0, volume: 2000}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 0
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-sma.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-sma.yaml
@@ -1,0 +1,40 @@
+id: intents-trading-agent-backtest-sma
+description: |
+  Backtests an SMA crossover strategy before it is eligible for
+  intent construction. This mirrors the TradingAgents flow where
+  the trader must clear a historical sanity check before the risk
+  manager allows a paper intent.
+steps:
+  - name: backtest_sma_cross
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 1
+      stop_loss_bps: 1200
+      strategy:
+        kind: sma-cross
+        fast_window: 2
+        slow_window: 4
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 10.2, high: 10.7, low: 10.0, close: 10.5, volume: 1200}
+        - {ts: "2026-01-06T00:00:00Z", open: 10.6, high: 11.2, low: 10.5, close: 11.0, volume: 1300}
+        - {ts: "2026-01-07T00:00:00Z", open: 11.1, high: 12.1, low: 11.0, close: 12.0, volume: 1400}
+        - {ts: "2026-01-08T00:00:00Z", open: 12.1, high: 13.1, low: 12.0, close: 13.0, volume: 1500}
+        - {ts: "2026-01-09T00:00:00Z", open: 13.1, high: 14.1, low: 13.0, close: 14.0, volume: 1600}
+        - {ts: "2026-01-10T00:00:00Z", open: 13.8, high: 14.0, low: 12.8, close: 13.0, volume: 1500}
+        - {ts: "2026-01-11T00:00:00Z", open: 12.8, high: 13.0, low: 11.8, close: 12.0, volume: 1400}
+        - {ts: "2026-01-12T00:00:00Z", open: 11.8, high: 12.0, low: 10.8, close: 11.0, volume: 1300}
+        - {ts: "2026-01-13T00:00:00Z", open: 10.8, high: 11.0, low: 9.8, close: 10.0, volume: 1200}
+        - {ts: "2026-01-14T00:00:00Z", open: 9.8, high: 10.0, low: 8.8, close: 9.0, volume: 1100}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 10
+      backtest_max_drawdown_le: 20
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-suite.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-suite.yaml
@@ -1,0 +1,72 @@
+id: intents-trading-agent-backtest-suite
+description: |
+  Ranks a menu of deterministic spot strategies over the same candle
+  episode. This is the strategy-selection gate an autonomous intents
+  trading agent should clear before asking for any wallet-signed action.
+steps:
+  - name: rank_strategy_menu
+    action: backtest_suite
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      candidates:
+        - id: buy_hold_baseline
+          strategy:
+            kind: buy-hold
+        - id: sma_cross_fast
+          max_position_pct: 1
+          stop_loss_bps: 1200
+          strategy:
+            kind: sma-cross
+            fast_window: 2
+            slow_window: 4
+        - id: breakout_short
+          max_position_pct: 0.8
+          stop_loss_bps: 1000
+          strategy:
+            kind: breakout
+            lookback_window: 3
+            threshold_bps: 25
+        - id: momentum_rotation
+          max_position_pct: 0.8
+          stop_loss_bps: 1000
+          strategy:
+            kind: momentum
+            lookback_window: 3
+            threshold_bps: 500
+        - id: mean_reversion_range
+          max_position_pct: 0.5
+          stop_loss_bps: 700
+          strategy:
+            kind: mean-reversion
+            lookback_window: 3
+            threshold_bps: 300
+        - id: rsi_reversion
+          max_position_pct: 0.5
+          stop_loss_bps: 700
+          strategy:
+            kind: rsi-mean-reversion
+            lookback_window: 5
+            entry_threshold: 25
+            exit_threshold: 55
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 10.2, high: 10.7, low: 10.0, close: 10.5, volume: 1200}
+        - {ts: "2026-01-06T00:00:00Z", open: 10.6, high: 11.2, low: 10.5, close: 11.0, volume: 1300}
+        - {ts: "2026-01-07T00:00:00Z", open: 11.1, high: 12.1, low: 11.0, close: 12.0, volume: 1400}
+        - {ts: "2026-01-08T00:00:00Z", open: 12.1, high: 13.1, low: 12.0, close: 13.0, volume: 1500}
+        - {ts: "2026-01-09T00:00:00Z", open: 13.1, high: 14.1, low: 13.0, close: 14.0, volume: 1600}
+        - {ts: "2026-01-10T00:00:00Z", open: 13.8, high: 14.0, low: 12.8, close: 13.0, volume: 1500}
+        - {ts: "2026-01-11T00:00:00Z", open: 12.8, high: 13.0, low: 11.8, close: 12.0, volume: 1400}
+        - {ts: "2026-01-12T00:00:00Z", open: 11.8, high: 12.0, low: 10.8, close: 11.0, volume: 1300}
+        - {ts: "2026-01-13T00:00:00Z", open: 10.8, high: 11.0, low: 9.8, close: 10.0, volume: 1200}
+        - {ts: "2026-01-14T00:00:00Z", open: 9.8, high: 10.0, low: 8.8, close: 9.0, volume: 1100}
+    expect:
+      backtest_suite_schema_version: intents-backtest-suite/1
+      backtest_suite_ranked_min: 6
+      backtest_suite_top_trades_min: 1
+      backtest_suite_any_passes_basic_gate: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-swap.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-swap.yaml
@@ -1,0 +1,46 @@
+id: intents-trading-agent-swap
+description: |
+  Smoke test for the Intents Trading Agent skill. A paper-mode
+  TradingAgents-style workflow drafts a spot swap MovementPlan
+  (USDC -> BTC on NEAR) and asks portfolio.build_intent to turn it
+  into an unsigned portfolio-intent/1 bundle. The replay solver fixture
+  keeps the test deterministic while exercising the same parser and
+  bounded checks used by live solver responses.
+steps:
+  - name: build_paper_swap_intent
+    action: build_intent
+    params:
+      plan:
+        proposal_id: ita-swap-near-usdc-btc
+        legs:
+          - kind: swap
+            chain: near
+            from_token:
+              symbol: USDC
+              chain: near
+              amount: "100.00"
+              value_usd: "100.00"
+            to_token:
+              symbol: BTC
+              chain: near
+              amount: "0.00100000"
+              value_usd: "98.50"
+            description: Swap 100 USDC to BTC through a NEAR Intents route
+        expected_out:
+          symbol: BTC
+          chain: near
+          amount: "0.00100000"
+          value_usd: "98.50"
+        expected_cost_usd: "1.50"
+      config:
+        floor_apy: 0.04
+        max_risk_score: 3
+        notify_threshold_usd: 25
+        auto_intent_ceiling_usd: 100
+        max_slippage_bps: 50
+        allowed_chains: ["near"]
+      solver: replay
+    expect:
+      bundle_legs_min: 1
+      bundle_first_leg_kind: swap
+      bundle_schema_version: portfolio-intent/1

--- a/tools-src/portfolio/scenarios/intents-trading-agent-widget.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-widget.yaml
@@ -1,0 +1,74 @@
+id: intents-trading-agent-widget
+description: |
+  Formats the NEAR Intents trading console state consumed by the
+  project widget. The state is render-ready: ranked strategy choices,
+  risk gates, and unsigned intent preview in one payload.
+steps:
+  - name: format_console_state
+    action: format_intents_widget
+    params:
+      generated_at: "2026-05-02T16:30:00Z"
+      project_id: intents-trading-agent
+      mode: paper
+      pair: NEAR/BTC
+      stance: paper-intent
+      confidence: 0.74
+      backtest_suite:
+        schema_version: intents-backtest-suite/1
+        ranked:
+          - rank: 1
+            id: sma_cross_fast
+            strategy: {kind: sma-cross}
+            selection_score: 18.5
+            passes_basic_gate: true
+            metrics:
+              total_return_pct: 12.0
+              alpha_vs_buy_hold_pct: 3.0
+              max_drawdown_pct: 8.0
+              trades: 6
+          - rank: 2
+            id: buy_hold_baseline
+            strategy: {kind: buy-hold}
+            selection_score: 9.0
+            passes_basic_gate: true
+            metrics:
+              total_return_pct: 9.0
+              alpha_vs_buy_hold_pct: 0.0
+              max_drawdown_pct: 10.0
+              trades: 1
+      risk_gates:
+        - {name: unsigned-only, status: pass, detail: "Wallet signature required outside the agent."}
+        - {name: max-notional, status: pass, detail: "Paper notional is below config ceiling."}
+        - {name: live-quote, status: warn, detail: "Live NEAR Intents quote requires explicit user approval."}
+      intent:
+        status: paper-built
+        route_label: "NEAR -> BTC via NEAR Intents"
+        quote_source: fixture
+        bundle:
+          id: intent-widget-fixture
+          schema_version: portfolio-intent/1
+          total_cost_usd: "0.42"
+          expires_at: 1775000000
+          signer_placeholder: "<signed-by-user>"
+          bounded_checks:
+            max_slippage_bps: 50
+            solver_quote_version: fixture
+            min_out_per_leg:
+              - {symbol: BTC, address: null, chain: near, amount: "0.001", value_usd: "70.00"}
+          legs:
+            - id: leg-1
+              kind: swap
+              chain: near
+              depends_on: null
+              quoted_by: fixture
+              min_out: {symbol: BTC, address: null, chain: near, amount: "0.001", value_usd: "70.00"}
+              near_intent_payload:
+                intent: token_diff
+      research_sources:
+        - https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay
+        - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint
+      next_action: "Ask the user before requesting a live NEAR Intents quote."
+    expect:
+      intents_widget_schema_version: intents-trading-widget/1
+      intents_widget_top_candidates_min: 2
+      intents_widget_intent_status: paper-built

--- a/tools-src/portfolio/src/backtest.rs
+++ b/tools-src/portfolio/src/backtest.rs
@@ -1,0 +1,1179 @@
+//! Deterministic spot backtesting for the Intents Trading Agent.
+//!
+//! This is intentionally small and pure: no exchange adapters, no
+//! external market data fetches, and no live orders. The skill passes
+//! candle data in, this module evaluates long-only strategy rules, and
+//! returns metrics plus a trade log. Execution uses the next candle's
+//! open after a signal is formed on a closed candle, which keeps replay
+//! tests honest and avoids lookahead by construction.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BacktestInput {
+    pub candles: Vec<Candle>,
+    pub strategy: StrategyConfig,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+    #[serde(default = "default_fee_bps")]
+    pub fee_bps: f64,
+    #[serde(default = "default_slippage_bps")]
+    pub slippage_bps: f64,
+    #[serde(default = "default_max_position_pct")]
+    pub max_position_pct: f64,
+    #[serde(default)]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(default)]
+    pub take_profit_bps: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BacktestSuiteInput {
+    pub candles: Vec<Candle>,
+    pub candidates: Vec<BacktestCandidate>,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+    #[serde(default = "default_fee_bps")]
+    pub fee_bps: f64,
+    #[serde(default = "default_slippage_bps")]
+    pub slippage_bps: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BacktestCandidate {
+    pub id: String,
+    pub strategy: StrategyConfig,
+    #[serde(default)]
+    pub max_position_pct: Option<f64>,
+    #[serde(default)]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(default)]
+    pub take_profit_bps: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Candle {
+    pub ts: String,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    #[serde(default)]
+    pub volume: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StrategyConfig {
+    /// Supported values: "buy-hold", "sma-cross", "breakout",
+    /// "mean-reversion", "momentum", "rsi-mean-reversion".
+    pub kind: String,
+    #[serde(default)]
+    pub fast_window: Option<usize>,
+    #[serde(default)]
+    pub slow_window: Option<usize>,
+    #[serde(default)]
+    pub lookback_window: Option<usize>,
+    #[serde(default)]
+    pub threshold_bps: Option<f64>,
+    #[serde(default)]
+    pub entry_threshold: Option<f64>,
+    #[serde(default)]
+    pub exit_threshold: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BacktestOutput {
+    pub schema_version: &'static str,
+    pub strategy: StrategySummary,
+    pub metrics: BacktestMetrics,
+    pub trades: Vec<BacktestTrade>,
+    pub equity_curve: Vec<EquityPoint>,
+    pub warnings: Vec<String>,
+    pub lookahead_safe: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BacktestSuiteOutput {
+    pub schema_version: &'static str,
+    pub ranked: Vec<BacktestSuiteResult>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BacktestSuiteResult {
+    pub rank: usize,
+    pub id: String,
+    pub strategy: StrategySummary,
+    pub selection_score: f64,
+    pub passes_basic_gate: bool,
+    pub metrics: BacktestMetrics,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StrategySummary {
+    pub kind: String,
+    pub fast_window: Option<usize>,
+    pub slow_window: Option<usize>,
+    pub lookback_window: Option<usize>,
+    pub threshold_bps: Option<f64>,
+    pub entry_threshold: Option<f64>,
+    pub exit_threshold: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BacktestMetrics {
+    pub candles: usize,
+    pub trades: usize,
+    pub start_equity_usd: String,
+    pub end_equity_usd: String,
+    pub total_return_pct: f64,
+    pub buy_hold_return_pct: f64,
+    pub alpha_vs_buy_hold_pct: f64,
+    pub max_drawdown_pct: f64,
+    pub win_rate_pct: f64,
+    pub exposure_pct: f64,
+    pub profit_factor: f64,
+    pub average_trade_return_pct: f64,
+    pub return_stability: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BacktestTrade {
+    pub entry_index: usize,
+    pub exit_index: usize,
+    pub entry_ts: String,
+    pub exit_ts: String,
+    pub entry_price: String,
+    pub exit_price: String,
+    pub units: String,
+    pub gross_pnl_usd: String,
+    pub net_pnl_usd: String,
+    pub return_pct: f64,
+    pub exit_reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EquityPoint {
+    pub index: usize,
+    pub ts: String,
+    pub equity_usd: String,
+    pub in_position: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Signal {
+    Enter,
+    Exit,
+    Hold,
+}
+
+#[derive(Debug, Clone)]
+struct OpenTrade {
+    entry_index: usize,
+    entry_ts: String,
+    entry_price: f64,
+    units: f64,
+    entry_notional: f64,
+    entry_fee: f64,
+}
+
+fn default_initial_cash_usd() -> f64 {
+    10_000.0
+}
+
+fn default_fee_bps() -> f64 {
+    10.0
+}
+
+fn default_slippage_bps() -> f64 {
+    5.0
+}
+
+fn default_max_position_pct() -> f64 {
+    1.0
+}
+
+pub fn run(input: BacktestInput) -> Result<BacktestOutput, String> {
+    validate_input(&input)?;
+
+    let mut warnings = vec![
+        "Backtest is long-only spot and does not model funding, borrow, MEV, partial fills, solver expiry, or route refusal.".to_string(),
+        "Signals are generated on closed candles and executed at the next candle open to avoid lookahead.".to_string(),
+    ];
+
+    if input.candles.len() < 30 {
+        warnings.push("Small sample: fewer than 30 candles; metrics are fragile.".to_string());
+    }
+
+    let fee_rate = input.fee_bps / 10_000.0;
+    let slip_rate = input.slippage_bps / 10_000.0;
+    let max_position_pct = input.max_position_pct.clamp(0.0, 1.0);
+
+    let mut cash = input.initial_cash_usd;
+    let mut open: Option<OpenTrade> = None;
+    let mut trades = Vec::new();
+    let mut equity_curve = Vec::with_capacity(input.candles.len());
+    let mut periodic_returns = Vec::new();
+    let mut prior_equity: Option<f64> = None;
+    let mut exposure_count = 0usize;
+    let mut pending = if input.strategy.kind == "buy-hold" {
+        Signal::Enter
+    } else {
+        Signal::Hold
+    };
+
+    for idx in 0..input.candles.len() {
+        let candle = &input.candles[idx];
+
+        match pending {
+            Signal::Enter if open.is_none() => {
+                open = enter_trade(
+                    idx,
+                    candle,
+                    &mut cash,
+                    max_position_pct,
+                    fee_rate,
+                    slip_rate,
+                );
+            }
+            Signal::Exit if open.is_some() => {
+                exit_trade(
+                    idx,
+                    candle,
+                    candle.open * (1.0 - slip_rate),
+                    "signal",
+                    fee_rate,
+                    &mut cash,
+                    &mut open,
+                    &mut trades,
+                );
+            }
+            _ => {}
+        }
+        pending = Signal::Hold;
+
+        if let Some(active) = &open {
+            if let Some(stop_bps) = input.stop_loss_bps {
+                let stop_price = active.entry_price * (1.0 - stop_bps / 10_000.0);
+                if candle.low <= stop_price {
+                    exit_trade(
+                        idx,
+                        candle,
+                        stop_price * (1.0 - slip_rate),
+                        "stop-loss",
+                        fee_rate,
+                        &mut cash,
+                        &mut open,
+                        &mut trades,
+                    );
+                }
+            }
+        }
+
+        if let Some(active) = &open {
+            if let Some(tp_bps) = input.take_profit_bps {
+                let take_profit_price = active.entry_price * (1.0 + tp_bps / 10_000.0);
+                if candle.high >= take_profit_price {
+                    exit_trade(
+                        idx,
+                        candle,
+                        take_profit_price * (1.0 - slip_rate),
+                        "take-profit",
+                        fee_rate,
+                        &mut cash,
+                        &mut open,
+                        &mut trades,
+                    );
+                }
+            }
+        }
+
+        let equity = mark_equity(cash, open.as_ref(), candle.close);
+        if let Some(prev) = prior_equity {
+            if prev > 0.0 {
+                periodic_returns.push((equity / prev) - 1.0);
+            }
+        }
+        prior_equity = Some(equity);
+        if open.is_some() {
+            exposure_count += 1;
+        }
+        equity_curve.push(EquityPoint {
+            index: idx,
+            ts: candle.ts.clone(),
+            equity_usd: format!("{equity:.2}"),
+            in_position: open.is_some(),
+        });
+
+        if idx + 1 < input.candles.len() {
+            pending = signal_at(&input.candles, idx, &input.strategy, open.is_some())?;
+        }
+    }
+
+    if let Some(last) = input.candles.last() {
+        if open.is_some() {
+            let idx = input.candles.len() - 1;
+            exit_trade(
+                idx,
+                last,
+                last.close * (1.0 - slip_rate),
+                "end-of-test",
+                fee_rate,
+                &mut cash,
+                &mut open,
+                &mut trades,
+            );
+            if let Some(point) = equity_curve.last_mut() {
+                point.equity_usd = format!("{cash:.2}");
+                point.in_position = false;
+            }
+        }
+    }
+
+    if trades.is_empty() {
+        warnings.push("No completed trades; inspect strategy windows and thresholds.".to_string());
+    }
+
+    let metrics = compute_metrics(
+        input.initial_cash_usd,
+        cash,
+        &input.candles,
+        &trades,
+        &equity_curve,
+        &periodic_returns,
+        exposure_count,
+        slip_rate,
+    );
+
+    Ok(BacktestOutput {
+        schema_version: "intents-backtest/1",
+        strategy: StrategySummary {
+            kind: input.strategy.kind,
+            fast_window: input.strategy.fast_window,
+            slow_window: input.strategy.slow_window,
+            lookback_window: input.strategy.lookback_window,
+            threshold_bps: input.strategy.threshold_bps,
+            entry_threshold: input.strategy.entry_threshold,
+            exit_threshold: input.strategy.exit_threshold,
+        },
+        metrics,
+        trades,
+        equity_curve,
+        warnings,
+        lookahead_safe: true,
+    })
+}
+
+pub fn run_suite(input: BacktestSuiteInput) -> Result<BacktestSuiteOutput, String> {
+    validate_suite_input(&input)?;
+
+    let mut ranked = Vec::with_capacity(input.candidates.len());
+    for candidate in input.candidates {
+        let output = run(BacktestInput {
+            candles: input.candles.clone(),
+            strategy: candidate.strategy,
+            initial_cash_usd: input.initial_cash_usd,
+            fee_bps: input.fee_bps,
+            slippage_bps: input.slippage_bps,
+            max_position_pct: candidate
+                .max_position_pct
+                .unwrap_or_else(default_max_position_pct),
+            stop_loss_bps: candidate.stop_loss_bps,
+            take_profit_bps: candidate.take_profit_bps,
+        })?;
+
+        let selection_score = selection_score(&output.metrics);
+        let passes_basic_gate = passes_basic_gate(&output.metrics);
+
+        ranked.push(BacktestSuiteResult {
+            rank: 0,
+            id: candidate.id,
+            strategy: output.strategy,
+            selection_score,
+            passes_basic_gate,
+            metrics: output.metrics,
+            warnings: output.warnings,
+        });
+    }
+
+    ranked.sort_by(|a, b| {
+        b.selection_score
+            .partial_cmp(&a.selection_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    for (idx, result) in ranked.iter_mut().enumerate() {
+        result.rank = idx + 1;
+    }
+
+    Ok(BacktestSuiteOutput {
+        schema_version: "intents-backtest-suite/1",
+        ranked,
+        warnings: vec![
+            "Selection score is a deterministic paper-trading heuristic, not expected return."
+                .to_string(),
+            "Use out-of-sample, walk-forward, market-data replay, and solver-route replay before live wallet signing."
+                .to_string(),
+        ],
+    })
+}
+
+fn validate_suite_input(input: &BacktestSuiteInput) -> Result<(), String> {
+    if input.candidates.is_empty() {
+        return Err("backtest_suite requires at least one candidate".to_string());
+    }
+    if !input.initial_cash_usd.is_finite() || input.initial_cash_usd <= 0.0 {
+        return Err("initial_cash_usd must be > 0".to_string());
+    }
+    if !input.fee_bps.is_finite() || input.fee_bps < 0.0 {
+        return Err("fee_bps must be >= 0".to_string());
+    }
+    if !input.slippage_bps.is_finite() || input.slippage_bps < 0.0 {
+        return Err("slippage_bps must be >= 0".to_string());
+    }
+
+    let mut ids = std::collections::BTreeSet::new();
+    for candidate in &input.candidates {
+        if candidate.id.trim().is_empty() {
+            return Err("backtest_suite candidate id must be non-empty".to_string());
+        }
+        if !ids.insert(candidate.id.clone()) {
+            return Err(format!(
+                "backtest_suite candidate id '{}' is duplicated",
+                candidate.id
+            ));
+        }
+        let max_position_pct = candidate
+            .max_position_pct
+            .unwrap_or_else(default_max_position_pct);
+        validate_input(&BacktestInput {
+            candles: input.candles.clone(),
+            strategy: candidate.strategy.clone(),
+            initial_cash_usd: input.initial_cash_usd,
+            fee_bps: input.fee_bps,
+            slippage_bps: input.slippage_bps,
+            max_position_pct,
+            stop_loss_bps: candidate.stop_loss_bps,
+            take_profit_bps: candidate.take_profit_bps,
+        })?;
+    }
+
+    Ok(())
+}
+
+fn selection_score(metrics: &BacktestMetrics) -> f64 {
+    let trade_penalty = if metrics.trades == 0 { 25.0 } else { 0.0 };
+    let drawdown_penalty = metrics.max_drawdown_pct * 0.75;
+    let exposure_penalty = (metrics.exposure_pct - 85.0).max(0.0) * 0.05;
+    let profit_factor_bonus = metrics.profit_factor.clamp(0.0, 5.0) * 2.0;
+    let stability_bonus = metrics.return_stability.clamp(-5.0, 5.0) * 2.0;
+    let score = metrics.total_return_pct + metrics.alpha_vs_buy_hold_pct
+        - drawdown_penalty
+        - exposure_penalty
+        - trade_penalty
+        + (metrics.win_rate_pct * 0.05)
+        + profit_factor_bonus
+        + stability_bonus;
+
+    if score.is_finite() {
+        score
+    } else {
+        -1_000_000.0
+    }
+}
+
+fn passes_basic_gate(metrics: &BacktestMetrics) -> bool {
+    metrics.trades > 0
+        && metrics.total_return_pct > 0.0
+        && metrics.alpha_vs_buy_hold_pct >= -5.0
+        && metrics.max_drawdown_pct <= 35.0
+        && metrics.profit_factor >= 1.0
+}
+
+fn validate_input(input: &BacktestInput) -> Result<(), String> {
+    if input.candles.len() < 2 {
+        return Err("backtest requires at least 2 candles".to_string());
+    }
+    if !input.initial_cash_usd.is_finite() || input.initial_cash_usd <= 0.0 {
+        return Err("initial_cash_usd must be > 0".to_string());
+    }
+    if !input.fee_bps.is_finite() || input.fee_bps < 0.0 {
+        return Err("fee_bps must be >= 0".to_string());
+    }
+    if !input.slippage_bps.is_finite() || input.slippage_bps < 0.0 {
+        return Err("slippage_bps must be >= 0".to_string());
+    }
+    if !input.max_position_pct.is_finite()
+        || input.max_position_pct <= 0.0
+        || input.max_position_pct > 1.0
+    {
+        return Err("max_position_pct must be in (0, 1]".to_string());
+    }
+    for (idx, c) in input.candles.iter().enumerate() {
+        for (name, value) in [
+            ("open", c.open),
+            ("high", c.high),
+            ("low", c.low),
+            ("close", c.close),
+        ] {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(format!("candle {idx} {name} must be > 0"));
+            }
+        }
+        if c.high < c.low || c.high < c.open || c.high < c.close {
+            return Err(format!("candle {idx} high is inconsistent"));
+        }
+        if c.low > c.open || c.low > c.close {
+            return Err(format!("candle {idx} low is inconsistent"));
+        }
+    }
+
+    match input.strategy.kind.as_str() {
+        "buy-hold" => {}
+        "sma-cross" => {
+            let fast = input.strategy.fast_window.unwrap_or(5);
+            let slow = input.strategy.slow_window.unwrap_or(20);
+            if fast == 0 || slow == 0 || fast >= slow {
+                return Err("sma-cross requires 0 < fast_window < slow_window".to_string());
+            }
+        }
+        "breakout" => {
+            let lookback = input.strategy.lookback_window.unwrap_or(20);
+            if lookback == 0 {
+                return Err("breakout requires lookback_window > 0".to_string());
+            }
+        }
+        "mean-reversion" => {
+            let lookback = input.strategy.lookback_window.unwrap_or(20);
+            if lookback == 0 {
+                return Err("mean-reversion requires lookback_window > 0".to_string());
+            }
+        }
+        "momentum" => {
+            let lookback = input.strategy.lookback_window.unwrap_or(20);
+            if lookback == 0 {
+                return Err("momentum requires lookback_window > 0".to_string());
+            }
+        }
+        "rsi-mean-reversion" => {
+            let lookback = input.strategy.lookback_window.unwrap_or(14);
+            if lookback == 0 {
+                return Err("rsi-mean-reversion requires lookback_window > 0".to_string());
+            }
+        }
+        other => return Err(format!("unknown backtest strategy kind: {other}")),
+    }
+
+    Ok(())
+}
+
+fn enter_trade(
+    idx: usize,
+    candle: &Candle,
+    cash: &mut f64,
+    max_position_pct: f64,
+    fee_rate: f64,
+    slip_rate: f64,
+) -> Option<OpenTrade> {
+    if *cash <= 0.0 {
+        return None;
+    }
+    let execution_price = candle.open * (1.0 + slip_rate);
+    let notional = (*cash * max_position_pct) / (1.0 + fee_rate);
+    if notional <= 0.0 {
+        return None;
+    }
+    let fee = notional * fee_rate;
+    let units = notional / execution_price;
+    *cash -= notional + fee;
+    Some(OpenTrade {
+        entry_index: idx,
+        entry_ts: candle.ts.clone(),
+        entry_price: execution_price,
+        units,
+        entry_notional: notional,
+        entry_fee: fee,
+    })
+}
+
+fn exit_trade(
+    idx: usize,
+    candle: &Candle,
+    execution_price: f64,
+    reason: &str,
+    fee_rate: f64,
+    cash: &mut f64,
+    open: &mut Option<OpenTrade>,
+    trades: &mut Vec<BacktestTrade>,
+) {
+    let Some(active) = open.take() else {
+        return;
+    };
+    let exit_notional = active.units * execution_price;
+    let exit_fee = exit_notional * fee_rate;
+    *cash += exit_notional - exit_fee;
+
+    let gross_pnl = exit_notional - active.entry_notional;
+    let net_pnl = gross_pnl - active.entry_fee - exit_fee;
+    let denom = active.entry_notional + active.entry_fee;
+    let return_pct = if denom > 0.0 {
+        (net_pnl / denom) * 100.0
+    } else {
+        0.0
+    };
+
+    trades.push(BacktestTrade {
+        entry_index: active.entry_index,
+        exit_index: idx,
+        entry_ts: active.entry_ts,
+        exit_ts: candle.ts.clone(),
+        entry_price: format!("{:.8}", active.entry_price),
+        exit_price: format!("{execution_price:.8}"),
+        units: format!("{:.8}", active.units),
+        gross_pnl_usd: format!("{gross_pnl:.2}"),
+        net_pnl_usd: format!("{net_pnl:.2}"),
+        return_pct,
+        exit_reason: reason.to_string(),
+    });
+}
+
+fn mark_equity(cash: f64, open: Option<&OpenTrade>, close: f64) -> f64 {
+    cash + open.map(|t| t.units * close).unwrap_or(0.0)
+}
+
+fn signal_at(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    match strategy.kind.as_str() {
+        "buy-hold" => Ok(Signal::Hold),
+        "sma-cross" => sma_cross_signal(candles, idx, strategy, in_position),
+        "breakout" => breakout_signal(candles, idx, strategy, in_position),
+        "mean-reversion" => mean_reversion_signal(candles, idx, strategy, in_position),
+        "momentum" => momentum_signal(candles, idx, strategy, in_position),
+        "rsi-mean-reversion" => rsi_signal(candles, idx, strategy, in_position),
+        other => Err(format!("unknown backtest strategy kind: {other}")),
+    }
+}
+
+fn sma_cross_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let fast = strategy.fast_window.unwrap_or(5);
+    let slow = strategy.slow_window.unwrap_or(20);
+    if idx < slow {
+        return Ok(Signal::Hold);
+    }
+    let Some(fast_prev) = sma(candles, idx - 1, fast) else {
+        return Ok(Signal::Hold);
+    };
+    let Some(slow_prev) = sma(candles, idx - 1, slow) else {
+        return Ok(Signal::Hold);
+    };
+    let Some(fast_now) = sma(candles, idx, fast) else {
+        return Ok(Signal::Hold);
+    };
+    let Some(slow_now) = sma(candles, idx, slow) else {
+        return Ok(Signal::Hold);
+    };
+
+    if !in_position && fast_prev <= slow_prev && fast_now > slow_now {
+        Ok(Signal::Enter)
+    } else if in_position && fast_prev >= slow_prev && fast_now < slow_now {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn breakout_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let lookback = strategy.lookback_window.unwrap_or(20);
+    if idx < lookback {
+        return Ok(Signal::Hold);
+    }
+    let threshold = strategy.threshold_bps.unwrap_or(0.0) / 10_000.0;
+    let window = &candles[idx - lookback..idx];
+    let prior_high = window
+        .iter()
+        .map(|c| c.high)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let prior_low = window.iter().map(|c| c.low).fold(f64::INFINITY, f64::min);
+    let close = candles[idx].close;
+
+    if !in_position && close > prior_high * (1.0 + threshold) {
+        Ok(Signal::Enter)
+    } else if in_position && close < prior_low * (1.0 - threshold) {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn mean_reversion_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let lookback = strategy.lookback_window.unwrap_or(20);
+    let threshold = strategy.threshold_bps.unwrap_or(200.0) / 10_000.0;
+    let Some(avg) = sma(candles, idx, lookback) else {
+        return Ok(Signal::Hold);
+    };
+    let close = candles[idx].close;
+    if !in_position && close <= avg * (1.0 - threshold) {
+        Ok(Signal::Enter)
+    } else if in_position && close >= avg {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn momentum_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let lookback = strategy.lookback_window.unwrap_or(20);
+    if idx < lookback {
+        return Ok(Signal::Hold);
+    }
+    let threshold = strategy.threshold_bps.unwrap_or(200.0) / 10_000.0;
+    let prior = candles[idx - lookback].close;
+    let momentum = (candles[idx].close / prior) - 1.0;
+    if !in_position && momentum >= threshold {
+        Ok(Signal::Enter)
+    } else if in_position && momentum <= 0.0 {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn rsi_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let lookback = strategy.lookback_window.unwrap_or(14);
+    let Some(rsi) = rsi(candles, idx, lookback) else {
+        return Ok(Signal::Hold);
+    };
+    let entry = strategy.entry_threshold.unwrap_or(30.0);
+    let exit = strategy.exit_threshold.unwrap_or(50.0);
+    if !in_position && rsi <= entry {
+        Ok(Signal::Enter)
+    } else if in_position && rsi >= exit {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn sma(candles: &[Candle], end_idx: usize, window: usize) -> Option<f64> {
+    if window == 0 || end_idx + 1 < window {
+        return None;
+    }
+    let start = end_idx + 1 - window;
+    let sum: f64 = candles[start..=end_idx].iter().map(|c| c.close).sum();
+    Some(sum / window as f64)
+}
+
+fn rsi(candles: &[Candle], end_idx: usize, window: usize) -> Option<f64> {
+    if window == 0 || end_idx < window {
+        return None;
+    }
+    let start = end_idx + 1 - window;
+    let mut gains = 0.0;
+    let mut losses = 0.0;
+    for i in start..=end_idx {
+        let delta = candles[i].close - candles[i - 1].close;
+        if delta >= 0.0 {
+            gains += delta;
+        } else {
+            losses += delta.abs();
+        }
+    }
+    if losses == 0.0 {
+        Some(100.0)
+    } else {
+        let rs = gains / losses;
+        Some(100.0 - (100.0 / (1.0 + rs)))
+    }
+}
+
+fn compute_metrics(
+    initial_cash: f64,
+    end_cash: f64,
+    candles: &[Candle],
+    trades: &[BacktestTrade],
+    equity_curve: &[EquityPoint],
+    periodic_returns: &[f64],
+    exposure_count: usize,
+    slip_rate: f64,
+) -> BacktestMetrics {
+    let total_return_pct = pct_return(initial_cash, end_cash);
+    let first_buy = candles
+        .first()
+        .map(|c| c.open * (1.0 + slip_rate))
+        .unwrap_or(0.0);
+    let last_sell = candles
+        .last()
+        .map(|c| c.close * (1.0 - slip_rate))
+        .unwrap_or(0.0);
+    let buy_hold_return_pct = pct_return(first_buy, last_sell);
+
+    let wins = trades.iter().filter(|t| t.return_pct > 0.0).count();
+    let win_rate_pct = if trades.is_empty() {
+        0.0
+    } else {
+        wins as f64 / trades.len() as f64 * 100.0
+    };
+    let average_trade_return_pct = if trades.is_empty() {
+        0.0
+    } else {
+        trades.iter().map(|t| t.return_pct).sum::<f64>() / trades.len() as f64
+    };
+
+    let mut gross_wins = 0.0;
+    let mut gross_losses = 0.0;
+    for t in trades {
+        let pnl = parse_money(&t.net_pnl_usd);
+        if pnl >= 0.0 {
+            gross_wins += pnl;
+        } else {
+            gross_losses += pnl.abs();
+        }
+    }
+    let profit_factor = if gross_losses > 0.0 {
+        gross_wins / gross_losses
+    } else if gross_wins > 0.0 {
+        gross_wins
+    } else {
+        0.0
+    };
+
+    BacktestMetrics {
+        candles: candles.len(),
+        trades: trades.len(),
+        start_equity_usd: format!("{initial_cash:.2}"),
+        end_equity_usd: format!("{end_cash:.2}"),
+        total_return_pct,
+        buy_hold_return_pct,
+        alpha_vs_buy_hold_pct: total_return_pct - buy_hold_return_pct,
+        max_drawdown_pct: max_drawdown_pct(equity_curve),
+        win_rate_pct,
+        exposure_pct: exposure_count as f64 / candles.len() as f64 * 100.0,
+        profit_factor,
+        average_trade_return_pct,
+        return_stability: return_stability(periodic_returns),
+    }
+}
+
+fn pct_return(start: f64, end: f64) -> f64 {
+    if start > 0.0 {
+        ((end / start) - 1.0) * 100.0
+    } else {
+        0.0
+    }
+}
+
+fn max_drawdown_pct(equity_curve: &[EquityPoint]) -> f64 {
+    let mut peak = 0.0;
+    let mut max_dd = 0.0;
+    for point in equity_curve {
+        let equity = parse_money(&point.equity_usd);
+        if equity > peak {
+            peak = equity;
+        }
+        if peak > 0.0 {
+            let dd = (peak - equity) / peak * 100.0;
+            if dd > max_dd {
+                max_dd = dd;
+            }
+        }
+    }
+    max_dd
+}
+
+fn return_stability(returns: &[f64]) -> f64 {
+    if returns.len() < 2 {
+        return 0.0;
+    }
+    let mean = returns.iter().sum::<f64>() / returns.len() as f64;
+    let variance =
+        returns.iter().map(|r| (r - mean).powi(2)).sum::<f64>() / (returns.len() - 1) as f64;
+    let stddev = variance.sqrt();
+    if stddev > 0.0 {
+        mean / stddev
+    } else {
+        0.0
+    }
+}
+
+fn parse_money(s: &str) -> f64 {
+    s.parse::<f64>().unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candle(idx: usize, close: f64) -> Candle {
+        Candle {
+            ts: format!("2026-05-{idx:02}T00:00:00Z"),
+            open: close,
+            high: close * 1.01,
+            low: close * 0.99,
+            close,
+            volume: 1_000.0,
+        }
+    }
+
+    fn run_with(kind: &str, closes: &[f64], strategy: StrategyConfig) -> BacktestOutput {
+        let candles = closes
+            .iter()
+            .enumerate()
+            .map(|(idx, close)| candle(idx + 1, *close))
+            .collect();
+        run(BacktestInput {
+            candles,
+            strategy: StrategyConfig {
+                kind: kind.to_string(),
+                ..strategy
+            },
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            max_position_pct: 1.0,
+            stop_loss_bps: None,
+            take_profit_bps: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn buy_hold_enters_and_exits() {
+        let out = run_with(
+            "buy-hold",
+            &[100.0, 110.0, 120.0],
+            StrategyConfig {
+                kind: "buy-hold".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert_eq!(out.schema_version, "intents-backtest/1");
+        assert_eq!(out.metrics.trades, 1);
+        assert!(out.metrics.total_return_pct > 19.0);
+        assert!(out.lookahead_safe);
+    }
+
+    #[test]
+    fn suite_ranks_candidate_menu() {
+        let closes = [
+            10.0, 10.0, 10.0, 10.0, 10.5, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 16.0, 15.0,
+            14.0, 13.0, 12.0,
+        ];
+        let candles = closes
+            .iter()
+            .enumerate()
+            .map(|(idx, close)| candle(idx + 1, *close))
+            .collect();
+
+        let out = run_suite(BacktestSuiteInput {
+            candles,
+            candidates: vec![
+                BacktestCandidate {
+                    id: "buy_hold".to_string(),
+                    strategy: StrategyConfig {
+                        kind: "buy-hold".to_string(),
+                        fast_window: None,
+                        slow_window: None,
+                        lookback_window: None,
+                        threshold_bps: None,
+                        entry_threshold: None,
+                        exit_threshold: None,
+                    },
+                    max_position_pct: None,
+                    stop_loss_bps: None,
+                    take_profit_bps: None,
+                },
+                BacktestCandidate {
+                    id: "sma".to_string(),
+                    strategy: StrategyConfig {
+                        kind: "sma-cross".to_string(),
+                        fast_window: Some(2),
+                        slow_window: Some(4),
+                        lookback_window: None,
+                        threshold_bps: None,
+                        entry_threshold: None,
+                        exit_threshold: None,
+                    },
+                    max_position_pct: Some(1.0),
+                    stop_loss_bps: Some(1200.0),
+                    take_profit_bps: None,
+                },
+            ],
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+        })
+        .unwrap();
+
+        assert_eq!(out.schema_version, "intents-backtest-suite/1");
+        assert_eq!(out.ranked.len(), 2);
+        assert_eq!(out.ranked[0].rank, 1);
+        assert!(out.ranked.iter().any(|result| result.passes_basic_gate));
+    }
+
+    #[test]
+    fn sma_cross_produces_a_trade() {
+        let closes = [
+            10.0, 10.0, 10.0, 10.0, 10.0, 10.5, 11.0, 12.0, 13.0, 14.0, 13.0, 12.0, 11.0, 10.0, 9.0,
+        ];
+        let out = run_with(
+            "sma-cross",
+            &closes,
+            StrategyConfig {
+                kind: "sma-cross".to_string(),
+                fast_window: Some(2),
+                slow_window: Some(4),
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn breakout_produces_a_trade() {
+        let closes = [10.0, 10.1, 10.0, 10.2, 10.1, 11.0, 11.5, 12.0, 12.5, 13.0];
+        let out = run_with(
+            "breakout",
+            &closes,
+            StrategyConfig {
+                kind: "breakout".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: Some(3),
+                threshold_bps: Some(25.0),
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn mean_reversion_produces_a_trade() {
+        let closes = [100.0, 100.0, 100.0, 94.0, 93.0, 95.0, 98.0, 101.0, 100.0];
+        let out = run_with(
+            "mean-reversion",
+            &closes,
+            StrategyConfig {
+                kind: "mean-reversion".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: Some(3),
+                threshold_bps: Some(300.0),
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn momentum_produces_a_trade() {
+        let closes = [10.0, 10.2, 10.4, 10.6, 11.2, 11.8, 12.4, 12.0, 11.5];
+        let out = run_with(
+            "momentum",
+            &closes,
+            StrategyConfig {
+                kind: "momentum".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: Some(3),
+                threshold_bps: Some(500.0),
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn rsi_mean_reversion_produces_a_trade() {
+        let closes = [
+            100.0, 98.0, 96.0, 94.0, 92.0, 90.0, 91.0, 93.0, 95.0, 98.0, 101.0,
+        ];
+        let out = run_with(
+            "rsi-mean-reversion",
+            &closes,
+            StrategyConfig {
+                kind: "rsi-mean-reversion".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: Some(5),
+                threshold_bps: None,
+                entry_threshold: Some(25.0),
+                exit_threshold: Some(55.0),
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn invalid_ohlc_errors() {
+        let result = run(BacktestInput {
+            candles: vec![
+                Candle {
+                    ts: "a".to_string(),
+                    open: 10.0,
+                    high: 9.0,
+                    low: 8.0,
+                    close: 10.0,
+                    volume: 0.0,
+                },
+                candle(2, 10.0),
+            ],
+            strategy: StrategyConfig {
+                kind: "buy-hold".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            max_position_pct: 1.0,
+            stop_loss_bps: None,
+            take_profit_bps: None,
+        });
+        assert!(result.unwrap_err().contains("high"));
+    }
+}

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -5,7 +5,7 @@
 
 //! Portfolio WASM tool for IronClaw.
 //!
-//! Single tool with three operations:
+//! Single tool with multiple operations:
 //!
 //! - `scan` — discover positions across chains for one or more addresses
 //!   and classify them against the embedded protocol registry.
@@ -14,6 +14,12 @@
 //!   filter; LLM does the final ranking via the skill playbook).
 //! - `build_intent` — translate a movement plan into an unsigned NEAR
 //!   Intent bundle, applying bounded checks before returning.
+//! - `backtest` — run deterministic long-only spot strategy tests over
+//!   caller-provided OHLCV candles before any intent is built.
+//! - `backtest_suite` — rank several strategy candidates over the same
+//!   candle episode before any strategy is selected for paper intent work.
+//! - `format_intents_widget` — build the NEAR Intents trading console
+//!   view model consumed by the project widget.
 //!
 //! The agent never holds private keys. All output is read-only or
 //! unsigned.
@@ -27,7 +33,9 @@
 //! ├── indexer/            // scan: fetch + normalize raw positions
 //! ├── analyzer/           // classify raw positions via protocols/*.json
 //! ├── strategy/           // propose: parse strategy docs + filter
-//! └── intents/            // build_intent: solver call + bounded checks
+//! ├── intents/            // build_intent: solver call + bounded checks
+//! ├── backtest.rs         // paper strategy replay/ranking over OHLCV candles
+//! └── widget.rs           // web widget state formatters
 //! ```
 
 wit_bindgen::generate!({
@@ -38,6 +46,7 @@ wit_bindgen::generate!({
 use serde::{Deserialize, Serialize};
 
 mod analyzer;
+mod backtest;
 mod format;
 mod indexer;
 mod intents;
@@ -109,10 +118,28 @@ enum PortfolioAction {
     #[serde(rename = "progress")]
     Progress(format::ProgressInput),
 
+    /// Run deterministic long-only spot backtests over caller-provided
+    /// OHLCV candles. Used by the Intents Trading Agent before a
+    /// candidate trade is eligible for intent construction.
+    #[serde(rename = "backtest")]
+    Backtest(backtest::BacktestInput),
+
+    /// Run and rank several deterministic long-only spot strategy
+    /// candidates over the same OHLCV episode. Used to build a
+    /// menu of choices instead of blindly evaluating one strategy.
+    #[serde(rename = "backtest_suite")]
+    BacktestSuite(backtest::BacktestSuiteInput),
+
     /// Build the render-ready view model the web widget consumes.
     /// Writes to `projects/<id>/widgets/state.json`.
     #[serde(rename = "format_widget")]
     FormatWidget(widget::FormatWidgetInput),
+
+    /// Build the render-ready view model the Intents Trading Agent
+    /// project widget consumes. The caller persists it under
+    /// `projects/intents-trading-agent/widgets/state.json`.
+    #[serde(rename = "format_intents_widget")]
+    FormatIntentsWidget(widget::FormatIntentsTradingWidgetInput),
 }
 
 fn default_chains() -> ChainSelector {
@@ -184,7 +211,9 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
         "Cross-chain DeFi portfolio analyzer. Discovers positions across chains, \
          classifies them against an embedded protocol registry, generates ranked \
          rebalancing proposals from declarative strategy docs, and builds unsigned \
-         NEAR Intent bundles. Three operations: scan, propose, build_intent. \
+         NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
+         backtest, backtest_suite, format_suggestion, format_widget, \
+         format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
     }
@@ -272,10 +301,24 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = format::format_progress(input);
             serde_json::to_string(&output).map_err(|e| format!("Serialize progress response: {e}"))
         }
+        PortfolioAction::Backtest(input) => {
+            let output = backtest::run(input)?;
+            serde_json::to_string(&output).map_err(|e| format!("Serialize backtest response: {e}"))
+        }
+        PortfolioAction::BacktestSuite(input) => {
+            let output = backtest::run_suite(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize backtest_suite response: {e}"))
+        }
         PortfolioAction::FormatWidget(input) => {
             let output = widget::format_widget(input);
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize format_widget response: {e}"))
+        }
+        PortfolioAction::FormatIntentsWidget(input) => {
+            let output = widget::format_intents_trading_widget(input);
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize format_intents_widget response: {e}"))
         }
     }
 }

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -365,6 +365,180 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "bundle_first_leg_kind" => {
+                let kind = response
+                    .pointer("/bundle/legs/0/kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing /bundle/legs/0/kind", step.name)
+                    });
+                let want = expected.as_str().expect("bundle_first_leg_kind: string");
+                assert_eq!(
+                    kind, want,
+                    "[{path}] step '{}': first bundle leg kind mismatch",
+                    step.name
+                );
+            }
+            "backtest_schema_version" => {
+                let v = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected.as_str().expect("backtest_schema_version: string");
+                assert_eq!(
+                    v, want,
+                    "[{path}] step '{}': backtest schema mismatch",
+                    step.name
+                );
+            }
+            "backtest_trades_min" => {
+                let trades = response
+                    .pointer("/metrics/trades")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing /metrics/trades", step.name)
+                    });
+                let want = expected.as_u64().expect("backtest_trades_min: number");
+                assert!(
+                    trades >= want,
+                    "[{path}] step '{}': backtest trades {} < min {}",
+                    step.name,
+                    trades,
+                    want
+                );
+            }
+            "backtest_total_return_gt" => {
+                let value = response
+                    .pointer("/metrics/total_return_pct")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /metrics/total_return_pct",
+                            step.name
+                        )
+                    });
+                let want = expected.as_f64().expect("backtest_total_return_gt: number");
+                assert!(
+                    value > want,
+                    "[{path}] step '{}': total_return_pct {} <= {}",
+                    step.name,
+                    value,
+                    want
+                );
+            }
+            "backtest_max_drawdown_le" => {
+                let value = response
+                    .pointer("/metrics/max_drawdown_pct")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /metrics/max_drawdown_pct",
+                            step.name
+                        )
+                    });
+                let want = expected.as_f64().expect("backtest_max_drawdown_le: number");
+                assert!(
+                    value <= want,
+                    "[{path}] step '{}': max_drawdown_pct {} > {}",
+                    step.name,
+                    value,
+                    want
+                );
+            }
+            "backtest_lookahead_safe" => {
+                let value = response
+                    .get("lookahead_safe")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing lookahead_safe", step.name)
+                    });
+                let want = expected.as_bool().expect("backtest_lookahead_safe: bool");
+                assert_eq!(
+                    value, want,
+                    "[{path}] step '{}': lookahead_safe mismatch",
+                    step.name
+                );
+            }
+            "backtest_suite_schema_version" => {
+                let v = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("backtest_suite_schema_version: string");
+                assert_eq!(
+                    v, want,
+                    "[{path}] step '{}': backtest suite schema mismatch",
+                    step.name
+                );
+            }
+            "backtest_suite_ranked_min" => {
+                let ranked = response
+                    .get("ranked")
+                    .and_then(|v| v.as_array())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing ranked array", step.name)
+                    });
+                let want = expected
+                    .as_u64()
+                    .expect("backtest_suite_ranked_min: number")
+                    as usize;
+                assert!(
+                    ranked.len() >= want,
+                    "[{path}] step '{}': ranked candidates {} < min {}",
+                    step.name,
+                    ranked.len(),
+                    want
+                );
+            }
+            "backtest_suite_top_trades_min" => {
+                let trades = response
+                    .pointer("/ranked/0/metrics/trades")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /ranked/0/metrics/trades",
+                            step.name
+                        )
+                    });
+                let want = expected
+                    .as_u64()
+                    .expect("backtest_suite_top_trades_min: number");
+                assert!(
+                    trades >= want,
+                    "[{path}] step '{}': top-ranked trades {} < min {}",
+                    step.name,
+                    trades,
+                    want
+                );
+            }
+            "backtest_suite_any_passes_basic_gate" => {
+                let ranked = response
+                    .get("ranked")
+                    .and_then(|v| v.as_array())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing ranked array", step.name)
+                    });
+                let got = ranked.iter().any(|result| {
+                    result
+                        .get("passes_basic_gate")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false)
+                });
+                let want = expected
+                    .as_bool()
+                    .expect("backtest_suite_any_passes_basic_gate: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': basic-gate match mismatch",
+                    step.name
+                );
+            }
             "equal_to_step" => {
                 let other_step = expected.as_str().expect("equal_to_step: string");
                 let prior_resp = prior.get(other_step).unwrap_or_else(|| {
@@ -494,6 +668,54 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                 assert_eq!(
                     non_empty, want,
                     "[{path}] step '{}': widget_has_non_empty_totals mismatch",
+                    step.name
+                );
+            }
+            "intents_widget_schema_version" => {
+                let v = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("intents_widget_schema_version: string");
+                assert_eq!(
+                    v, want,
+                    "[{path}] step '{}': intents widget schema mismatch",
+                    step.name
+                );
+            }
+            "intents_widget_top_candidates_min" => {
+                let len = response
+                    .get("top_candidates")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("intents_widget_top_candidates_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': intents widget top candidates {len} < min {want}",
+                    step.name
+                );
+            }
+            "intents_widget_intent_status" => {
+                let got = response
+                    .pointer("/intent/status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing /intent/status", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("intents_widget_intent_status: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': intents widget intent status mismatch",
                     step.name
                 );
             }

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -109,6 +109,87 @@
     },
     {
       "properties": {
+        "action": { "const": "format_intents_widget" },
+        "generated_at": {
+          "type": "string",
+          "description": "ISO 8601 timestamp for the current strategy/intent report."
+        },
+        "project_id": {
+          "type": "string",
+          "description": "Project slug or id, usually intents-trading-agent."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["paper", "quote", "execution"],
+          "default": "paper",
+          "description": "Trading workflow mode. Execution remains future wallet-only plumbing."
+        },
+        "pair": {
+          "type": "string",
+          "description": "Watched pair, for example NEAR/BTC."
+        },
+        "stance": {
+          "type": "string",
+          "enum": ["skip", "watch", "paper-intent", "quote-intent", "blocked"],
+          "default": "watch"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "backtest_suite": {
+          "type": "object",
+          "description": "Output from backtest_suite. Top five ranked candidates are extracted for the widget."
+        },
+        "risk_gates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "status": {
+                "type": "string",
+                "enum": ["pass", "warn", "fail", "blocked", "unknown"]
+              },
+              "detail": { "type": "string" }
+            },
+            "required": ["name", "status"]
+          },
+          "default": []
+        },
+        "intent": {
+          "type": "object",
+          "description": "Optional unsigned NEAR Intent bundle preview.",
+          "properties": {
+            "bundle": {
+              "type": "object",
+              "description": "IntentBundle returned from build_intent."
+            },
+            "status": {
+              "type": "string",
+              "enum": ["none", "paper-built", "live-quote-built", "awaiting-signature", "submitted", "failed", "blocked"],
+              "default": "none"
+            },
+            "route_label": { "type": "string" },
+            "quote_source": { "type": "string" }
+          },
+          "required": ["bundle"]
+        },
+        "research_sources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "next_action": {
+          "type": "string",
+          "description": "Operator-facing next step shown in the widget."
+        }
+      },
+      "required": ["action", "pair"]
+    },
+    {
+      "properties": {
         "action": { "const": "progress" },
         "history": {
           "type": "array",
@@ -128,6 +209,110 @@
         }
       },
       "required": ["action", "history", "config"]
+    },
+    {
+      "properties": {
+        "action": { "const": "backtest" },
+        "candles": {
+          "type": "array",
+          "description": "OHLCV candles sorted oldest to newest. Signals are formed on candle close and executed at the next candle open.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ts": { "type": "string" },
+              "open": { "type": "number", "exclusiveMinimum": 0 },
+              "high": { "type": "number", "exclusiveMinimum": 0 },
+              "low": { "type": "number", "exclusiveMinimum": 0 },
+              "close": { "type": "number", "exclusiveMinimum": 0 },
+              "volume": { "type": "number" }
+            },
+            "required": ["ts", "open", "high", "low", "close"]
+          },
+          "minItems": 2
+        },
+        "strategy": {
+          "type": "object",
+          "description": "Long-only spot strategy config. Supported kinds: buy-hold, sma-cross, breakout, mean-reversion, momentum, rsi-mean-reversion.",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["buy-hold", "sma-cross", "breakout", "mean-reversion", "momentum", "rsi-mean-reversion"]
+            },
+            "fast_window": { "type": "integer", "minimum": 1 },
+            "slow_window": { "type": "integer", "minimum": 1 },
+            "lookback_window": { "type": "integer", "minimum": 1 },
+            "threshold_bps": { "type": "number", "minimum": 0 },
+            "entry_threshold": { "type": "number", "minimum": 0 },
+            "exit_threshold": { "type": "number", "minimum": 0 }
+          },
+          "required": ["kind"]
+        },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 },
+        "fee_bps": { "type": "number", "minimum": 0, "default": 10 },
+        "slippage_bps": { "type": "number", "minimum": 0, "default": 5 },
+        "max_position_pct": { "type": "number", "exclusiveMinimum": 0, "maximum": 1, "default": 1 },
+        "stop_loss_bps": { "type": "number", "minimum": 0 },
+        "take_profit_bps": { "type": "number", "minimum": 0 }
+      },
+      "required": ["action", "candles", "strategy"]
+    },
+    {
+      "properties": {
+        "action": { "const": "backtest_suite" },
+        "candles": {
+          "type": "array",
+          "description": "OHLCV candles sorted oldest to newest. Every candidate is evaluated against this same market episode.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ts": { "type": "string" },
+              "open": { "type": "number", "exclusiveMinimum": 0 },
+              "high": { "type": "number", "exclusiveMinimum": 0 },
+              "low": { "type": "number", "exclusiveMinimum": 0 },
+              "close": { "type": "number", "exclusiveMinimum": 0 },
+              "volume": { "type": "number" }
+            },
+            "required": ["ts", "open", "high", "low", "close"]
+          },
+          "minItems": 2
+        },
+        "candidates": {
+          "type": "array",
+          "description": "Strategy menu to rank. Each candidate may override position size, stop-loss, and take-profit.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "strategy": {
+                "type": "object",
+                "description": "Long-only spot strategy config. Supported kinds: buy-hold, sma-cross, breakout, mean-reversion, momentum, rsi-mean-reversion.",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": ["buy-hold", "sma-cross", "breakout", "mean-reversion", "momentum", "rsi-mean-reversion"]
+                  },
+                  "fast_window": { "type": "integer", "minimum": 1 },
+                  "slow_window": { "type": "integer", "minimum": 1 },
+                  "lookback_window": { "type": "integer", "minimum": 1 },
+                  "threshold_bps": { "type": "number", "minimum": 0 },
+                  "entry_threshold": { "type": "number", "minimum": 0 },
+                  "exit_threshold": { "type": "number", "minimum": 0 }
+                },
+                "required": ["kind"]
+              },
+              "max_position_pct": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+              "stop_loss_bps": { "type": "number", "minimum": 0 },
+              "take_profit_bps": { "type": "number", "minimum": 0 }
+            },
+            "required": ["id", "strategy"]
+          },
+          "minItems": 1
+        },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 },
+        "fee_bps": { "type": "number", "minimum": 0, "default": 10 },
+        "slippage_bps": { "type": "number", "minimum": 0, "default": 5 }
+      },
+      "required": ["action", "candles", "candidates"]
     },
     {
       "properties": {

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -34,9 +34,53 @@ pub struct FormatWidgetInput {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct FormatIntentsTradingWidgetInput {
+    #[serde(default)]
+    pub generated_at: Option<String>,
+    #[serde(default)]
+    pub project_id: Option<String>,
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    pub pair: String,
+    #[serde(default = "default_stance")]
+    pub stance: String,
+    #[serde(default)]
+    pub confidence: Option<f64>,
+    #[serde(default)]
+    pub backtest_suite: Option<serde_json::Value>,
+    #[serde(default)]
+    pub risk_gates: Vec<IntentsRiskGateInput>,
+    #[serde(default)]
+    pub intent: Option<IntentsIntentInput>,
+    #[serde(default)]
+    pub research_sources: Vec<String>,
+    #[serde(default)]
+    pub next_action: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct PendingIntentInput {
     pub bundle: IntentBundle,
     pub status: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IntentsRiskGateInput {
+    pub name: String,
+    pub status: String,
+    #[serde(default)]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IntentsIntentInput {
+    pub bundle: IntentBundle,
+    #[serde(default = "default_intent_status")]
+    pub status: String,
+    #[serde(default)]
+    pub route_label: Option<String>,
+    #[serde(default)]
+    pub quote_source: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -113,6 +157,83 @@ pub struct WidgetPendingIntent {
     pub expires_at: i64,
 }
 
+#[derive(Debug, Serialize)]
+pub struct IntentsTradingWidgetState {
+    pub schema_version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    pub mode: String,
+    pub pair: String,
+    pub stance: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+    pub top_candidates: Vec<IntentsStrategyCandidate>,
+    pub risk_gates: Vec<IntentsRiskGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intent: Option<IntentsIntentPreview>,
+    pub source_count: usize,
+    pub research_sources: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsStrategyCandidate {
+    pub rank: usize,
+    pub id: String,
+    pub strategy_kind: String,
+    pub selection_score: f64,
+    pub passes_basic_gate: bool,
+    pub total_return_pct: f64,
+    pub alpha_vs_buy_hold_pct: f64,
+    pub max_drawdown_pct: f64,
+    pub trades: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsRiskGate {
+    pub name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsIntentPreview {
+    pub id: String,
+    pub status: String,
+    pub route_label: String,
+    pub quote_source: String,
+    pub schema_version: String,
+    pub legs: usize,
+    pub total_cost_usd: String,
+    pub expires_at: i64,
+    pub signer_placeholder: String,
+    pub min_out: Vec<IntentMinOutPreview>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentMinOutPreview {
+    pub symbol: String,
+    pub chain: String,
+    pub amount: String,
+    pub value_usd: String,
+}
+
+fn default_mode() -> String {
+    "paper".to_string()
+}
+
+fn default_stance() -> String {
+    "watch".to_string()
+}
+
+fn default_intent_status() -> String {
+    "none".to_string()
+}
+
 pub fn format_widget(input: FormatWidgetInput) -> WidgetState {
     let totals = compute_totals(&input);
 
@@ -175,6 +296,115 @@ pub fn format_widget(input: FormatWidgetInput) -> WidgetState {
         pending_intents,
         next_mission_run: input.next_mission_run.clone(),
         progress_metric: input.progress.clone(),
+    }
+}
+
+pub fn format_intents_trading_widget(
+    input: FormatIntentsTradingWidgetInput,
+) -> IntentsTradingWidgetState {
+    let top_candidates = input
+        .backtest_suite
+        .as_ref()
+        .and_then(|suite| suite.get("ranked"))
+        .and_then(|ranked| ranked.as_array())
+        .into_iter()
+        .flatten()
+        .take(5)
+        .map(strategy_candidate_from_value)
+        .collect();
+
+    let risk_gates = input
+        .risk_gates
+        .into_iter()
+        .map(|gate| IntentsRiskGate {
+            name: gate.name,
+            status: gate.status,
+            detail: gate.detail,
+        })
+        .collect();
+
+    let intent = input.intent.map(|intent| {
+        let min_out = intent
+            .bundle
+            .bounded_checks
+            .min_out_per_leg
+            .iter()
+            .map(|token| IntentMinOutPreview {
+                symbol: token.symbol.clone(),
+                chain: token.chain.clone(),
+                amount: token.amount.clone(),
+                value_usd: token.value_usd.clone(),
+            })
+            .collect();
+        IntentsIntentPreview {
+            id: intent.bundle.id,
+            status: intent.status,
+            route_label: intent
+                .route_label
+                .unwrap_or_else(|| "NEAR Intents route".to_string()),
+            quote_source: intent.quote_source.unwrap_or_else(|| "fixture".to_string()),
+            schema_version: intent.bundle.schema_version,
+            legs: intent.bundle.legs.len(),
+            total_cost_usd: intent.bundle.total_cost_usd,
+            expires_at: intent.bundle.expires_at,
+            signer_placeholder: intent.bundle.signer_placeholder,
+            min_out,
+        }
+    });
+
+    IntentsTradingWidgetState {
+        schema_version: "intents-trading-widget/1",
+        generated_at: input.generated_at,
+        project_id: input.project_id,
+        mode: input.mode,
+        pair: input.pair,
+        stance: input.stance,
+        confidence: input.confidence,
+        top_candidates,
+        risk_gates,
+        intent,
+        source_count: input.research_sources.len(),
+        research_sources: input.research_sources,
+        next_action: input.next_action,
+    }
+}
+
+fn strategy_candidate_from_value(value: &serde_json::Value) -> IntentsStrategyCandidate {
+    let default_metrics = serde_json::Value::Null;
+    let metrics = value.get("metrics").unwrap_or(&default_metrics);
+    IntentsStrategyCandidate {
+        rank: value.get("rank").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
+        id: value
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("candidate")
+            .to_string(),
+        strategy_kind: value
+            .pointer("/strategy/kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string(),
+        selection_score: value
+            .get("selection_score")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        passes_basic_gate: value
+            .get("passes_basic_gate")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        total_return_pct: metrics
+            .get("total_return_pct")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        alpha_vs_buy_hold_pct: metrics
+            .get("alpha_vs_buy_hold_pct")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        max_drawdown_pct: metrics
+            .get("max_drawdown_pct")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        trades: metrics.get("trades").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
     }
 }
 
@@ -486,6 +716,83 @@ mod tests {
         assert_eq!(w.pending_intents[0].legs, 2);
         assert_eq!(w.pending_intents[0].total_cost_usd, "0.50");
         assert_eq!(w.pending_intents[0].expires_at, 1712345678);
+    }
+
+    #[test]
+    fn intents_trading_widget_summarizes_suite_and_intent() {
+        use crate::types::{BoundedChecks, IntentBundle, IntentLeg, TokenAmount};
+
+        let token = TokenAmount {
+            symbol: "BTC".into(),
+            address: None,
+            chain: "near".into(),
+            amount: "0.001".into(),
+            value_usd: "70.00".into(),
+        };
+
+        let w = format_intents_trading_widget(FormatIntentsTradingWidgetInput {
+            generated_at: Some("2026-05-02T16:00:00Z".to_string()),
+            project_id: Some("intents-trading-agent".to_string()),
+            mode: "paper".to_string(),
+            pair: "NEAR/BTC".to_string(),
+            stance: "paper-intent".to_string(),
+            confidence: Some(0.74),
+            backtest_suite: Some(serde_json::json!({
+                "schema_version": "intents-backtest-suite/1",
+                "ranked": [{
+                    "rank": 1,
+                    "id": "sma_cross_fast",
+                    "strategy": { "kind": "sma-cross" },
+                    "selection_score": 18.5,
+                    "passes_basic_gate": true,
+                    "metrics": {
+                        "total_return_pct": 12.0,
+                        "alpha_vs_buy_hold_pct": 3.0,
+                        "max_drawdown_pct": 8.0,
+                        "trades": 6
+                    }
+                }]
+            })),
+            risk_gates: vec![IntentsRiskGateInput {
+                name: "unsigned-only".to_string(),
+                status: "pass".to_string(),
+                detail: Some("Wallet signature required outside the agent.".to_string()),
+            }],
+            intent: Some(IntentsIntentInput {
+                bundle: IntentBundle {
+                    id: "intent-1".to_string(),
+                    legs: vec![IntentLeg {
+                        id: "leg-1".to_string(),
+                        kind: "swap".to_string(),
+                        chain: "near".to_string(),
+                        near_intent_payload: serde_json::json!({ "intent": "token_diff" }),
+                        depends_on: None,
+                        min_out: token.clone(),
+                        quoted_by: "fixture".to_string(),
+                    }],
+                    total_cost_usd: "0.42".to_string(),
+                    bounded_checks: BoundedChecks {
+                        min_out_per_leg: vec![token],
+                        max_slippage_bps: 50,
+                        solver_quote_version: "fixture".to_string(),
+                    },
+                    expires_at: 1_775_000_000,
+                    signer_placeholder: "<signed-by-user>".to_string(),
+                    schema_version: "portfolio-intent/1".to_string(),
+                },
+                status: "paper-built".to_string(),
+                route_label: Some("NEAR -> BTC via NEAR Intents".to_string()),
+                quote_source: Some("fixture".to_string()),
+            }),
+            research_sources: vec!["https://docs.near-intents.org/".to_string()],
+            next_action: Some("Request live quote only after user approval.".to_string()),
+        });
+
+        assert_eq!(w.schema_version, "intents-trading-widget/1");
+        assert_eq!(w.top_candidates.len(), 1);
+        assert!(w.top_candidates[0].passes_basic_gate);
+        assert_eq!(w.intent.unwrap().status, "paper-built");
+        assert_eq!(w.source_count, 1);
     }
 
     // ---- only ready proposals in suggestions ----


### PR DESCRIPTION
## Summary

Adds the first NEAR Intents-focused trading-agent foundation on top of the portfolio tool:

- introduces deterministic long-only spot backtesting plus `backtest_suite` strategy ranking
- adds an `intents-trading-agent` skill with research workflow, strategy corpus, Hyperliquid signal/gate notes, and project bootstrap guidance
- keeps NEAR Intents execution unsigned by routing approved ideas through `build_intent` paper/replay/live-quote modes
- adds `format_intents_widget` plus a project widget template for ranked strategies, risk gates, and unsigned intent status in the IronClaw Projects view
- expands replay coverage for strategy backtests, suite ranking, swap-shaped intent construction, and widget state formatting

## Why

The previous scaffold did not give users a credible way to compare strategies, inspect risk, or use the work inside IronClaw. This PR makes NEAR Intents the center of the workflow: strategy research feeds risk gates, risk gates feed unsigned intent artifacts, and the project widget exposes the result to operators.

## Validation

- `cargo test` in `tools-src/portfolio` — 206 passed, 10 ignored
- `cargo test -p ironclaw_gateway` — 60 unit tests + 1 doctest passed
- `cargo fmt --check` in `tools-src/portfolio`
- `node --check skills/intents-trading-agent/widgets/near-intents-console/index.js`
- JSON parse checks for portfolio schema/capabilities/registry/widget files
- YAML parse check for portfolio scenarios

## Follow-up PRs

- add CoinGecko/CCXT/Hyperliquid data ingestion episodes
- add walk-forward and parameter-grid reports
- wire live NEAR Intents quote review deeper into the project widget
- add browser screenshot coverage for the project widget once a sample project can be seeded automatically