### PR TITLE
ci(docker): add linux/arm64 to image builds (#3168)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,6 +118,16 @@ jobs:
           username: ${{ vars.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
+      # QEMU enables cross-arch emulation on the amd64 runner so the
+      # arm64 image can be built without provisioning native arm64
+      # hardware. The arm64 build is roughly 2-3x slower than amd64
+      # under emulation; if CI minutes become a concern, swap this for
+      # a native arm64 runner once one is available.
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -130,7 +140,7 @@ jobs:
           target: ${{ steps.tags.outputs.target }}
           labels: |
             ironclaw.git.sha=${{ steps.source_sha.outputs.sha }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -143,7 +153,7 @@ jobs:
           tags: ${{ steps.tags.outputs.worker_tags }}
           labels: |
             ironclaw.git.sha=${{ steps.source_sha.outputs.sha }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker
 

--- a/.github/workflows/rebuild-release-image.yml
+++ b/.github/workflows/rebuild-release-image.yml
@@ -70,6 +70,14 @@ jobs:
         run: |
           echo "sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
+      # QEMU enables cross-arch emulation on the amd64 runner so the
+      # arm64 image can be rebuilt without provisioning native arm64
+      # hardware. Mirrors the setup in docker.yml.
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -96,7 +104,7 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ inputs.tag }}
           target: runtime
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -107,7 +115,7 @@ jobs:
           context: .
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ inputs.tag }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,13 @@
 # threading issues when statically linked against musl (segfault on
 # database reopen), so we use glibc.
 #
-# Build:
-#   docker build --platform linux/amd64 --target runtime -t ironclaw:latest .
+# Build (host arch — produces an image for whatever platform you're on):
+#   docker build --target runtime -t ironclaw:latest .
+#
+# Build (multi-arch — requires Buildx + QEMU):
+#   docker buildx build \
+#     --platform linux/amd64,linux/arm64 \
+#     --target runtime -t ironclaw:latest --push .
 #
 # Run:
 #   docker run --env-file .env -p 3000:3000 ironclaw:latest


### PR DESCRIPTION
## Summary

Closes #3168.

IronClaw ships only \`linux/amd64\` Docker images today, blocking native runs on Apple Silicon, AWS Graviton, Raspberry Pi 4/5, and the broader arm64 fleet. Cranelift (the WASM JIT) already supports \`aarch64\`, so the gap is purely in the publish matrix.

## What this changes

- **`.github/workflows/docker.yml`** — adds \`docker/setup-qemu-action\` (pinned by SHA) and switches both image builds (\`ironclaw\` + \`ironclaw-worker\`) to \`platforms: linux/amd64,linux/arm64\`.
- **`.github/workflows/rebuild-release-image.yml`** — same treatment for both build paths (\`runtime\` target + final-stage fallback).
- **`Dockerfile`** header — removed the \`--platform linux/amd64\` example (host-arch is the right default for a developer once the official images go multi-arch) and added a Buildx multi-arch example.

## Cost / risk

QEMU emulation on the amd64 runner adds roughly 2-3x to the arm64 build time vs amd64. If that bites CI minutes, the right next step is provisioning a native arm64 runner (the inline comment in both workflows points at this). Until then, emulation is the correct tradeoff for parity.

## Confirmation

@gcaguilar's PoC fork run already showed this works end-to-end: https://github.com/gcaguilar/ironclaw/actions/runs/25252983548. Only armv7 (32-bit) is blocked, which is tracked separately in #1339.

## Test plan

- [ ] Trigger \`docker.yml\` on this branch via \`workflow_dispatch\` (a Docker Hub login secret is required so I can't trigger it from a fork PR — needs a maintainer with publish rights to kick it off)
- [ ] Verify the resulting manifest list has both architectures: \`docker manifest inspect nearaidev/ironclaw:sha-<7chars>\`
- [ ] Smoke-test the arm64 image on an Apple Silicon machine: \`docker run --platform linux/arm64 --rm nearaidev/ironclaw:sha-<7chars> ironclaw --version\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)