### PR TITLE
fix(admin-ui): debounce New User submit to stop duplicate creates (#3083)

### DIFF
--- a/crates/ironclaw_gateway/static/admin/admin.js
+++ b/crates/ironclaw_gateway/static/admin/admin.js
@@ -790,11 +790,25 @@
       alert('Display name is required');
       return;
     }
+
+    // Issue #3083: prevent rapid double/triple click from firing N
+    // parallel POSTs (which would create N duplicate user records).
+    // Disable + busy-flag the submit button on entry; restore in
+    // .finally so a validation/server error reopens the form cleanly.
+    var formEl = document.getElementById('create-user-form');
+    var submitBtn = formEl ? formEl.querySelector('[data-action="create-user"]') : null;
+    if (submitBtn) {
+      if (submitBtn.disabled) return;
+      submitBtn.disabled = true;
+      submitBtn.setAttribute('aria-busy', 'true');
+    }
+    var originalSubmitText = submitBtn ? submitBtn.textContent : null;
+    if (submitBtn) submitBtn.textContent = 'Creating…';
+
     var body = { display_name: nameEl.value.trim(), role: roleEl ? roleEl.value : 'member' };
     if (emailEl && emailEl.value.trim()) body.email = emailEl.value.trim();
 
     apiFetch('/api/admin/users', { method: 'POST', body: body }).then(function (res) {
-      var formEl = document.getElementById('create-user-form');
       if (formEl) formEl.style.display = 'none';
       if (nameEl) nameEl.value = '';
       if (emailEl) emailEl.value = '';
@@ -810,6 +824,12 @@
       });
     }).catch(function (err) {
       alert('Failed to create user: ' + err.message);
+    }).finally(function () {
+      if (submitBtn) {
+        submitBtn.disabled = false;
+        submitBtn.removeAttribute('aria-busy');
+        if (originalSubmitText !== null) submitBtn.textContent = originalSubmitText;
+      }
     });
   }
 

--- a/crates/ironclaw_gateway/static/js/surfaces/users.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/users.js
@@ -131,10 +131,22 @@ document.getElementById('users-create-cancel')?.addEventListener('click', functi
 });
 
 document.getElementById('users-create-submit')?.addEventListener('click', function() {
+  var submitBtn = this;
+  // Issue #3083: guard against a fast double/triple click that would
+  // otherwise fire N parallel POSTs and create N duplicate user
+  // records. Disable + show progress on entry; restore on completion
+  // so a validation or server error reopens the form cleanly.
+  if (submitBtn.disabled) return;
+
   var displayName = document.getElementById('user-display-name').value.trim();
   var email = document.getElementById('user-email').value.trim();
   var role = document.getElementById('user-role').value;
   if (!displayName) { alert(I18n.t('users.displayNameRequired')); return; }
+
+  var originalText = submitBtn.textContent;
+  submitBtn.disabled = true;
+  submitBtn.setAttribute('aria-busy', 'true');
+  submitBtn.textContent = I18n.t('users.creating') || 'Creating…';
 
   apiFetch('/api/admin/users', {
     method: 'POST',
@@ -152,7 +164,13 @@ document.getElementById('users-create-submit')?.addEventListener('click', functi
       showTokenBanner(data.token, I18n.t('users.userCreated'));
     }
     loadUsers();
-  }).catch(function(e) { alert(I18n.t('users.failedCreate') + ': ' + e.message); });
+  }).catch(function(e) {
+    alert(I18n.t('users.failedCreate') + ': ' + e.message);
+  }).finally(function() {
+    submitBtn.disabled = false;
+    submitBtn.removeAttribute('aria-busy');
+    submitBtn.textContent = originalText;
+  });
 });
 
 // --- Gateway status widget ---


### PR DESCRIPTION
## Summary

Closes #3083.

The User Management create form had no submit-button gating, so a fast triple-click while the POST was in flight fired three POSTs and produced three duplicate user records (the original report showed \"Ekiko\" landing 3x with different IDs). Bug bash flagged it P2 with security implications.

Both UI surfaces shipping today have the same shape and both got the same fix:

- \`crates/ironclaw_gateway/static/js/surfaces/users.js\` — the new admin Users tab (\`#users-create-submit\`)
- \`crates/ironclaw_gateway/static/admin/admin.js\` — the legacy admin (\`[data-action=\"create-user\"]\`)

## What changed

- **Disable on entry.** The submit button is set to \`disabled=true\` immediately after the input-validation check. A no-op early-return on already-disabled provides defense in depth in case the listener fires twice.
- **Screen-reader feedback.** \`aria-busy=\"true\"\` is set so assistive tech announces the in-flight state.
- **Visible progress.** Button text becomes \"Creating…\" so a sighted user sees something happening instead of an unresponsive button.
- **Clean restore on failure.** All three (\`disabled\`, \`aria-busy\`, original text) are restored in \`.finally\` so a server or validation error reopens the form cleanly — no permanently-stuck button.

## Out of scope

Backend idempotency tokens. The frontend debounce closes the immediate UX hole this issue described; a follow-up PR can layer an \`Idempotency-Key\` header on \`POST /api/admin/users\` for non-browser clients (or browser clients that bypass this code path).

## Test plan

- [ ] Manual repro of the original bug: open Users tab → New User → submit → triple-click before the POST returns. Pre-PR: 3 duplicate users. Post-PR: 1 user.
- [ ] Server error path (e.g., trigger 500 by killing the gateway briefly): confirm the button re-enables and the form reopens.
- [ ] Validation error path (empty Display Name): confirm the button doesn't get stuck disabled (early-return before the disable).
- [ ] Screen-reader test: VoiceOver / NVDA announces \"busy\" while the request is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)