### PR TITLE
fix(extensions): honor auth.optional so optional-creds tools stop showing Configure (#3081)

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -5404,6 +5404,16 @@ impl ExtensionManager {
                 return ToolAuthState::Ready;
             }
 
+            // Tools that mark their auth section `optional: true` work
+            // without credentials. Treating them as `NeedsSetup` causes
+            // the Settings UI to render a misleading "Configure" button
+            // for a tool that has nothing required to configure. See
+            // #3081 (Portfolio: Dune API key is optional, only enables
+            // the EVM scan path; NEAR scans work without it).
+            if auth.optional {
+                return ToolAuthState::Ready;
+            }
+
             return if auth.oauth.is_some() {
                 ToolAuthState::NeedsAuth
             } else {

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -652,6 +652,18 @@ pub struct AuthCapabilitySchema {
     /// Tool can specify an endpoint to call for validation.
     #[serde(default)]
     pub validation_endpoint: Option<ValidationEndpointSchema>,
+
+    /// Mark this auth section as optional — the tool works without
+    /// credentials but is enhanced by them. When set, `check_tool_auth_status`
+    /// returns `Ready` instead of `NeedsSetup` when no token is on file,
+    /// so the Settings UI does not render a misleading "Configure" button
+    /// for a tool that has nothing required to configure.
+    ///
+    /// Example: the Portfolio tool can scan NEAR addresses with no auth;
+    /// the optional Dune API key only enables the EVM scan path.
+    /// Resolves the misleading-Configure-button shape filed in #3081.
+    #[serde(default)]
+    pub optional: bool,
 }
 
 /// OAuth 2.0 configuration for browser-based login.
@@ -1092,6 +1104,31 @@ mod tests {
         assert_eq!(auth.secret_name, "my_api_key");
         assert!(auth.display_name.is_none());
         assert!(auth.setup_url.is_none());
+        // `optional` defaults to false when absent — auth is required
+        // unless the manifest explicitly opts out.
+        assert!(!auth.optional, "auth.optional must default to false");
+    }
+
+    /// Regression: #3081. Tools that mark their auth `optional: true`
+    /// (e.g. Portfolio's Dune API key, which only enables the EVM scan
+    /// path) must round-trip the flag through deserialization. The
+    /// extension-manager honors this in `check_tool_auth_status` to
+    /// avoid the misleading "Configure" button on cards that have
+    /// nothing required to configure.
+    #[test]
+    fn test_parse_auth_optional_flag() {
+        let json = r#"{
+            "auth": {
+                "secret_name": "dune_api_key",
+                "display_name": "Dune Analytics",
+                "instructions": "Optional — only needed for EVM scans.",
+                "optional": true
+            }
+        }"#;
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let auth = caps.auth.expect("auth should parse");
+        assert_eq!(auth.secret_name, "dune_api_key");
+        assert!(auth.optional, "auth.optional must round-trip as true");
     }
 
     // ── Category 1: Header field name alias ─────────────────────────────


### PR DESCRIPTION
## Summary

Closes #3081.

The Portfolio extension's settings card showed a misleading \"Configure\" button alongside a \"No configuration needed for portfolio\" toast (the original report shows the toast firing 4x as the user clicked four times). The button was visually inviting but opened a dead-end modal.

## Root cause

\`AuthCapabilitySchema\` had no \`optional\` field, so the \`\"optional\": true\` flag in [\`tools-src/portfolio/portfolio-tool.capabilities.json\`](https://github.com/nearai/ironclaw/blob/main/tools-src/portfolio/portfolio-tool.capabilities.json) was silently dropped at deserialization. \`check_tool_auth_status\` then treated the (effectively optional) Dune API key as required, returned \`ToolAuthState::NeedsSetup\`, and \`InstalledExtension.needs_setup\` propagated to the frontend, which dutifully rendered the Configure button (\`crates/ironclaw_gateway/static/js/surfaces/extensions.js:362\`).

## Fix

1. Add \`pub optional: bool\` (defaults to false via \`#[serde(default)]\`) to \`AuthCapabilitySchema\`. Documented inline with a pointer back to #3081 and the Portfolio example.

2. In \`check_tool_auth_status\` (\`src/extensions/manager.rs\`), when the auth section has no managed token and no env var, return \`Ready\` instead of \`NeedsSetup\` if the auth is marked optional. Existing behavior for required auth (\`NeedsAuth\` for OAuth, \`NeedsSetup\` for manual) is unchanged.

## Effect on the bug

- Portfolio's \`needs_setup\` now resolves to \`false\`.
- The Configure button stops rendering on the card.
- The misleading toast is no longer reachable from the card.
- Required-auth tools (every other extension shipping today) keep their Configure button as before.

## Tests

- \`test_parse_auth_minimal\` — extended to assert \`auth.optional\` defaults to false when absent, pinning the safe default so a future regression that flips it is caught.
- \`test_parse_auth_optional_flag\` — new, mirrors the Portfolio JSON shape (\`\"optional\": true\` on a manual-token auth) and asserts the flag round-trips through deserialization.

3/3 pass on \`cargo test\`.

## Tools that benefit from this today

Any tool whose capability JSON sets \`\"optional\": true\` on its auth section. Portfolio is the immediate one; future tools that work without credentials but are *enhanced* by them (e.g., a search tool that uses a paid Tavily key but falls back to a free tier) get the same UX for free.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo test test_parse_auth\` — 3/3 pass
- [ ] Manual: open Settings → Extensions on a build with this PR → Portfolio card no longer shows Configure
- [ ] Manual regression: install a tool with required-auth (e.g. Notion, Gmail) → Configure button still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)