### PR TITLE
[codex] Add paid research layer for NEAR intents trading

### DIFF
--- a/docs/plans/2026-05-02-intents-trading-research.md
+++ b/docs/plans/2026-05-02-intents-trading-research.md
@@ -35,6 +35,17 @@ initial scaffold.
 | [DefiLlama API](https://defillama.com/docs/api) | Protocol TVL, yields, unlocks, stablecoins, broader DeFi context. | Risk/catalyst context and yield comparison. | Great for gating and context, not execution. |
 | [CCXT](https://github.com/ccxt/ccxt) | Exchange OHLCV/order books/trades from many CEX venues. | Optional external research adapter. | Use public market data only unless user explicitly designs a separate API-key execution mode. |
 
+## Paid Research / Agent Payment Inventory
+
+| Source | Useful data | Fit for IronClaw | Notes |
+|---|---|---|---|
+| [DripStack](https://dripstack.xyz) | Premium financial newsletter discovery and paid full-post access. | Pattern for a paid research layer before trading decisions. | Paid routes are MPP/x402 gated; use only through receipt-backed paid-source flows. |
+| [DripStack OpenAPI](https://dripstack.xyz/openapi.json) | Free catalog endpoints and paid post endpoint metadata with HTTP 402 challenges. | Candidate source discovery adapter. | Runtime 402 challenges are authoritative over static pricing. |
+| [MPP](https://mpp.dev/) | HTTP-native machine payments for API requests, tool calls, and content. | Payment rail for paid research, not a trading execution rail. | Treat as external until IronClaw has a payment-client boundary. |
+| [Payment Authentication specs](https://paymentauth.org/) | Payment HTTP auth scheme, charge intent, discovery, and JSON-RPC/MCP transport. | Shape for paid MCP/tool calls and source fetches. | Useful for future MCP paid-source implementation. |
+| [x402 docs](https://docs.x402.org/) | HTTP 402 payment standard for APIs/content without accounts or sessions. | Base-compatible paid-source rail. | Do not mix x402 payment with NEAR intent signing; keep each receipt explicit. |
+| [Cloudflare x402 docs](https://developers.cloudflare.com/agents/agentic-payments/x402/) | Concrete 402 challenge/retry flow for agents. | Reference for the payment-client boundary. | Portfolio tool should plan and attribute; a wallet/payment client handles signatures. |
+
 ## Hyperliquid / "HL" Strategy Notes
 
 Assumption: "HL" means Hyperliquid. If the user meant another portal,
@@ -120,6 +131,9 @@ Minimum framework requirements before a strategy can build an intent:
 - Added `portfolio.backtest` for long-only spot strategy replay.
 - Added `portfolio.backtest_suite` to rank a strategy menu over a common
   candle episode.
+- Added `portfolio.plan_paid_research` to budget and attribute premium
+  research sources before using paid newsletter/API content in a trading
+  decision.
 - Added replay scenarios for individual strategies, suite ranking, and
   a swap-shaped unsigned intent bundle.
 - Added the first bundled strategy corpus:
@@ -129,6 +143,9 @@ Minimum framework requirements before a strategy can build an intent:
   funding carry watch, book imbalance gate, and perp momentum signal.
 - Added `portfolio.format_intents_widget` and a NEAR Intents project
   widget template so the workflow has an operator-facing IronClaw UI.
+- Added paid research attribution to the widget so selected sources,
+  MPP/x402 rails, and NEAR funding-route hints are visible before any
+  unsigned intent is built.
 
 ## Multi-Day Roadmap
 

--- a/docs/plans/2026-05-02-intents-trading-research.md
+++ b/docs/plans/2026-05-02-intents-trading-research.md
@@ -133,7 +133,11 @@ Minimum framework requirements before a strategy can build an intent:
   candle episode.
 - Added `portfolio.plan_paid_research` to budget and attribute premium
   research sources before using paid newsletter/API content in a trading
-  decision.
+  decision, including source-trust gates, agent-wallet caps, and
+  MPP/x402 payment alternatives.
+- Added `portfolio.plan_dripstack_browse` to model topic →
+  publication → article → purchase-confirmation guided browse before a
+  selected article becomes a paid-source candidate.
 - Added replay scenarios for individual strategies, suite ranking, and
   a swap-shaped unsigned intent bundle.
 - Added the first bundled strategy corpus:

--- a/docs/plans/2026-05-02-paid-research-intents.md
+++ b/docs/plans/2026-05-02-paid-research-intents.md
@@ -1,0 +1,101 @@
+# Paid Research Layer For NEAR Intents Trading
+
+**Date**: 2026-05-02
+**Trigger**: Michael Blau's X post about DripStack described a chat UI
+over paid financial newsletters where writers are paid when their posts
+are used in answers, using MPP on Tempo and x402 on Base.
+
+## What The Post Changes
+
+This is not a trading strategy by itself. It is a missing research
+market layer for the trading agent:
+
+1. discover premium financial/crypto writers and paid research APIs,
+2. price which sources are worth buying for a specific trade question,
+3. pay or prepare payment through agent-native rails,
+4. attribute source usage in the answer,
+5. keep the NEAR Intents trade path gated by backtests and risk checks.
+
+DripStack's public site exposes the same shape: free publication and post
+discovery, plus paid full-post access. Its OpenAPI says paid post routes
+return HTTP 402 and can present both MPP and x402 payment challenges. Its
+agent skill says paid posts are gated by x402/MPP micropayments and that
+agents should fetch publication/post metadata before attempting a paid
+post.
+
+## Source Notes
+
+| Source | Relevant detail | Implementation decision |
+|---|---|---|
+| [DripStack](https://dripstack.xyz) | Landing page frames the product as premium financial-writer Q&A with source payment. | Use it as the target product pattern, not as a dependency. |
+| [DripStack SKILL.md](https://dripstack.xyz/SKILL.md) | Free catalog first, paid full post route later, payment-aware client required. | IronClaw should separate source discovery from paid content fetch. |
+| [DripStack OpenAPI](https://dripstack.xyz/openapi.json) | Paid full-post endpoint declares 402 responses with MPP `WWW-Authenticate` and x402 `PAYMENT-REQUIRED`. | Store payment rail metadata on candidate sources and require receipts before using paid text. |
+| [MPP](https://mpp.dev/) | Described as an open machine-to-machine payment protocol for API requests, tool calls, or content in the same HTTP call. | Model MPP as one paid-source rail. |
+| [MPP payment specs](https://paymentauth.org/) | Defines a Payment HTTP Authentication scheme, charge intent, service discovery, and JSON-RPC/MCP transport. | Treat paid tool/resource calls as a protocol-level challenge, not an ad hoc checkout. |
+| [Stripe MPP announcement](https://stripe.com/blog/machine-payments-protocol) | Agents request resources, services return payment requests, agents authorize payment, then resources are delivered. | Keep IronClaw's output as a payment plan until a wallet/payment client authorizes. |
+| [x402 docs](https://docs.x402.org/) | x402 uses HTTP 402 so clients can pay for APIs/content without accounts or sessions. | Model x402 as the Base-compatible paid-source rail. |
+| [Cloudflare x402 docs](https://developers.cloudflare.com/agents/agentic-payments/x402/) | Resource server replies with 402 and payment details, client retries with a payment payload. | Do not fetch paywalled content with plain HTTP; surface a payable plan first. |
+
+## Architecture
+
+```mermaid
+flowchart LR
+  A["Trade question"] --> B["Free source discovery"]
+  B --> C["portfolio.plan_paid_research"]
+  C --> D["Paid source plan"]
+  D --> E{"User/payment policy approves?"}
+  E -- no --> F["Free-source research only"]
+  E -- yes --> G["Payment-aware client handles MPP/x402/NEAR rail"]
+  G --> H["Receipt + paid evidence"]
+  H --> I["Analyst synthesis with source credits"]
+  I --> J["portfolio.backtest_suite"]
+  J --> K["Risk gates"]
+  K --> L["portfolio.build_intent unsigned NEAR Intent"]
+```
+
+## What Was Implemented In This Slice
+
+- `portfolio.plan_paid_research`
+  - ranks source candidates by relevance, trust, freshness, tag match,
+    and budget cost,
+  - selects sources under a dollar cap,
+  - emits source attribution IDs,
+  - summarizes MPP, x402, NEAR-native, subscription, manual, or free
+    rails,
+  - emits `near_funding_routes` so a NEAR treasury can prepare rail
+    funding through NEAR Intents before external MPP/x402 payment,
+  - emits policy gates for budget, receipts, attribution, payment
+    authorization, and the trading risk gate.
+
+- `portfolio.format_intents_widget`
+  - accepts `paid_research_plan`,
+  - exposes `paid_research` in the widget state,
+  - shows payable sources, allocated budget, rails, and NEAR funding
+    routes in the project widget.
+
+- `intents-trading-agent` skill
+  - adds paid research as a formal step before backtesting,
+  - stores plans under `projects/intents-trading-agent/paid-research/`,
+  - forbids paid text use without receipts,
+  - requires paid source credit IDs when paid evidence is used,
+  - keeps backtest/risk gates mandatory before any unsigned NEAR Intent.
+
+## Open Implementation Work
+
+| Next PR | What to build | Done when |
+|---|---|---|
+| Source discovery adapters | Parse MPP/OpenAPI `x-payment-info`, x402 discovery, DripStack catalogs, and local `sources/paid-research.json`. | Agent can populate candidate sources without manual JSON. |
+| Payment client boundary | Add a wallet/payment-client abstraction for MPP/x402 challenge handling with receipts, never private keys. | Paid content fetch returns receipt metadata and content only after approval. |
+| NEAR funding route builder | Convert `near_funding_routes` into unsigned NEAR Intent funding bundles for rail wallets. | User can inspect/sign a funding intent before MPP/x402 fetch. |
+| Evidence ledger | Persist paid source receipts, content hashes, quote snippets, and answer attribution. | A journal entry can prove which writer/source contributed to which answer. |
+| Research-to-backtest loop | Track whether paid evidence changed candidate strategies and compare outcomes. | Strategy reports show paid-source deltas vs free-source baseline. |
+
+## Hard Boundaries
+
+- Premium research is evidence, not execution authority.
+- Paid content must not be summarized, quoted, or used as a factual basis
+  before a receipt exists.
+- The agent does not sign MPP, x402, or NEAR payments.
+- NEAR Intents remain the preferred asset/treasury routing surface for
+  this project, but MPP/x402 paid content rails are external services
+  unless/until a NEAR-native paid-content rail exists.

--- a/docs/plans/2026-05-02-paid-research-intents.md
+++ b/docs/plans/2026-05-02-paid-research-intents.md
@@ -60,18 +60,34 @@ flowchart LR
     and budget cost,
   - selects sources under a dollar cap,
   - emits source attribution IDs,
+  - supports multiple payment options per source, so a DripStack article
+    can advertise both MPP on Tempo and x402 on Base,
   - summarizes MPP, x402, NEAR-native, subscription, manual, or free
     rails,
+  - applies basic agentic-SEO defenses through trust and source-risk
+    gates,
+  - models a small autonomous wallet policy, including per-article caps,
+    daily caps, default one-cent article math, and audit links,
   - emits `near_funding_routes` so a NEAR treasury can prepare rail
     funding through NEAR Intents before external MPP/x402 payment,
   - emits policy gates for budget, receipts, attribution, payment
     authorization, and the trading risk gate.
 
+- `portfolio.plan_dripstack_browse`
+  - models DripStack's guided browse flow from free metadata,
+  - returns `topic`, `publication`, `article`, or
+    `purchase-confirmation` checkpoints,
+  - shortlists publications from the user topic,
+  - shortlists post summaries for a chosen publication,
+  - converts one user-selected article into a paid-source candidate
+    without fetching the article body,
+  - includes both MPP and x402 payment options for the selected article.
+
 - `portfolio.format_intents_widget`
   - accepts `paid_research_plan`,
   - exposes `paid_research` in the widget state,
-  - shows payable sources, allocated budget, rails, and NEAR funding
-    routes in the project widget.
+  - shows payable sources, allocated budget, rails, NEAR funding routes,
+    autonomous-wallet caps, and audit links in the project widget.
 
 - `intents-trading-agent` skill
   - adds paid research as a formal step before backtesting,

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -17,7 +17,9 @@
     "trading",
     "paid-research",
     "x402",
-    "mpp"
+    "mpp",
+    "dripstack",
+    "agent-wallet"
   ],
   "source": {
     "dir": "tools-src/portfolio",

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -4,7 +4,7 @@
   "kind": "tool",
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, and NEAR Intents trading widget state.",
   "keywords": [
     "defi",
     "portfolio",
@@ -14,7 +14,10 @@
     "near-intents",
     "crypto",
     "backtesting",
-    "trading"
+    "trading",
+    "paid-research",
+    "x402",
+    "mpp"
   ],
   "source": {
     "dir": "tools-src/portfolio",

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -42,8 +42,9 @@ bundles** that the user can inspect and sign in their own wallet.
 
 This skill is a research and orchestration layer. It does not replace
 the `portfolio` WASM tool. Use `portfolio.scan`, `portfolio.propose`,
-and `portfolio.build_intent` for positions, deterministic DeFi
-proposals, and intent bundle construction.
+`portfolio.plan_paid_research`, and `portfolio.build_intent` for
+positions, deterministic DeFi proposals, paid-source budgeting, and
+intent bundle construction.
 
 ## Non-negotiables
 
@@ -62,6 +63,11 @@ proposals, and intent bundle construction.
    after the risk manager approves it against project config.
 6. **Audit trail first.** Persist research, debate notes, risk checks,
    decisions, and built intents under `projects/intents-trading-agent/`.
+7. **Paid content requires receipts.** Paywalled newsletters, APIs, or
+   premium posts can be planned and attributed before use, but their
+   actual text must not be quoted or relied on until a payment receipt
+   exists. Writers/source owners must be credited when their paid work
+   contributes to an answer.
 
 ## Project bootstrap
 
@@ -83,6 +89,9 @@ using workspace writes. Initialize:
   "allowed_chains": [],
   "allowed_assets": ["NEAR", "USDC", "USDT", "BTC", "ETH"],
   "disallowed_assets": [],
+  "paid_research_budget_usd": 0.25,
+  "paid_research_max_sources": 4,
+  "paid_research_mode": "plan-only",
   "require_user_approval": true
 }
 ```
@@ -90,8 +99,11 @@ using workspace writes. Initialize:
 - `watchlist.md` - token pairs, chains, and theses the user cares about.
 - `addresses.md` - optional wallet addresses to scan.
 - `state/latest.json` and `state/history/`.
+- `sources/paid-research.json` - optional candidate premium sources and
+  payment metadata discovered from MPP, x402, NEAR-native, newsletter, or
+  API catalogs.
 - `research/`, `debates/`, `decisions/`, `risk/`, `intents/`,
-  `journal/`, and `widgets/`.
+  `journal/`, `paid-research/`, and `widgets/`.
 - `strategies/` - copy or reference the baseline strategy docs bundled
   with this skill (`sma-cross-spot`, `breakout-spot`,
   `momentum-spot`, `mean-reversion-spot`,
@@ -154,7 +166,56 @@ grounded.
 Write role outputs to
 `projects/intents-trading-agent/research/<YYYY-MM-DD>/<role>.md`.
 
-### 3. Strategy lab and backtest
+### 3. Paid research planning
+
+When the run would benefit from premium newsletters, research APIs, or
+paid posts, create a source plan before reading paywalled content. This
+is the DripStack-style pattern: the agent can decide which sources are
+worth paying for, but payment and attribution are explicit.
+
+Candidate sources may come from:
+
+- `projects/intents-trading-agent/sources/paid-research.json`,
+- public MPP or x402 service discovery,
+- a user-provided source list,
+- free/public research already collected by the analyst team.
+
+Call `portfolio` with:
+
+```json
+{
+  "action": "plan_paid_research",
+  "query": "<specific question the trade needs answered>",
+  "pair": "<pair>",
+  "budget_usd": 0.25,
+  "max_sources": 4,
+  "spending_mode": "plan-only",
+  "near_funding_asset": "USDC.near",
+  "sources": []
+}
+```
+
+The returned `paid-research-plan/1` is a budget and attribution plan,
+not a content fetch. Persist it to:
+
+`projects/intents-trading-agent/paid-research/<YYYY-MM-DDTHH-MM>-<pair>.json`
+
+Use the plan as follows:
+
+- If `ready_for_paid_fetch` is false, continue with free sources only.
+- If selected sources require MPP on Tempo or x402 on Base, treat
+  `near_funding_routes` as hints for how a NEAR Intents-funded treasury
+  could fund the rail wallet. This does not authorize the actual paid
+  fetch.
+- Never include paid source text in the answer or research memo until
+  the payment client returns a receipt.
+- When paid source text is used, include source IDs from
+  `selected_sources[].attribution.credit_id` in the answer and journal.
+- Paid research can change the thesis or confidence, but it cannot
+  bypass the strategy suite, backtest gates, risk gates, or unsigned-only
+  NEAR Intent boundary.
+
+### 4. Strategy lab and backtest
 
 Before a strategy can become a trade proposal, run a deterministic
 backtest when historical OHLCV candles are available. Prefer
@@ -204,7 +265,7 @@ Always run `buy-hold` as a benchmark when enough candles are available.
 Always present the top ranked suite candidates and rejected candidates
 separately so the user can see what was considered.
 
-### 4. Bull/bear debate
+### 5. Bull/bear debate
 
 Create two concise debate memos:
 
@@ -221,7 +282,7 @@ Then write a manager synthesis with:
 
 Persist to `projects/intents-trading-agent/debates/<YYYY-MM-DDTHH-MM>-<pair>.md`.
 
-### 5. Trader proposal
+### 6. Trader proposal
 
 Only create a trade proposal when the manager stance is
 `paper-intent` or `quote-intent`.
@@ -236,12 +297,13 @@ A proposal must include:
 - invalidation condition,
 - expiry or review time,
 - confidence,
-- risk gates and their pass/fail result.
+- risk gates and their pass/fail result,
+- paid research source IDs used, if any.
 
 The trade proposal is not executable by itself. It is a request for an
 unsigned intent bundle.
 
-### 6. Risk gates
+### 7. Risk gates
 
 Reject or downgrade to `watch` if any gate fails:
 
@@ -255,11 +317,13 @@ Reject or downgrade to `watch` if any gate fails:
 - no unresolved security/exploit concern
 - no existing conflicting pending intent
 - backtest gates pass when candles are available
+- paid source text is not used without receipts
+- paid research spend is within `paid_research_budget_usd`
 
 If `require_user_approval` is true, do not ask the user to sign; ask
 whether they want a live quote or want to keep it as paper.
 
-### 7. Build unsigned intent
+### 8. Build unsigned intent
 
 For an approved `paper-intent`, call `portfolio.build_intent` with
 `solver: "fixture"` so the output is clearly a deterministic test
@@ -313,19 +377,21 @@ For cross-chain moves, use ordered `withdraw`, `bridge`, `swap`, and
 Persist returned bundles to
 `projects/intents-trading-agent/intents/<YYYY-MM-DDTHH-MM>-<proposal_id>.json`.
 
-### 8. Format the project widget
+### 9. Format the project widget
 
 After every run, call `portfolio` with `action="format_intents_widget"`
 and pass the latest pair, stance, confidence, `backtest_suite`, risk
-gates, research sources, and optional unsigned `IntentBundle`.
+gates, research sources, optional `paid_research_plan`, and optional
+unsigned `IntentBundle`.
 
 Persist the returned JSON exactly as:
 
 `projects/intents-trading-agent/widgets/state.json`
 
 The bundled project widget reads this file and renders ranked strategy
-candidates, risk gates, and unsigned NEAR Intents status inside the
-IronClaw Projects view. If the widget files are not installed yet, copy:
+candidates, paid source attribution, risk gates, and unsigned NEAR
+Intents status inside the IronClaw Projects view. If the widget files are
+not installed yet, copy:
 
 - `skills/intents-trading-agent/widgets/near-intents-console/manifest.json`
 - `skills/intents-trading-agent/widgets/near-intents-console/index.js`
@@ -335,12 +401,14 @@ to:
 
 `projects/intents-trading-agent/.system/widgets/near-intents-console/`
 
-### 9. Response
+### 10. Response
 
 Respond with specifics:
 
 - stance and confidence,
 - top supporting and opposing evidence,
+- paid source budget, selected sources, and receipt status if premium
+  research was planned or used,
 - backtest summary versus buy-and-hold when available,
 - top strategy-suite candidates when available,
 - risk gate table,

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -92,6 +92,11 @@ using workspace writes. Initialize:
   "paid_research_budget_usd": 0.25,
   "paid_research_max_sources": 4,
   "paid_research_mode": "plan-only",
+  "paid_research_agent_wallet_provider": "AgentCash",
+  "paid_research_default_article_price_usd": 0.01,
+  "paid_research_per_article_cap_usd": 0.05,
+  "paid_research_daily_cap_usd": 1.0,
+  "paid_research_max_wallet_balance_usd": 5.0,
   "require_user_approval": true
 }
 ```
@@ -177,8 +182,27 @@ Candidate sources may come from:
 
 - `projects/intents-trading-agent/sources/paid-research.json`,
 - public MPP or x402 service discovery,
+- DripStack guided browse results,
 - a user-provided source list,
 - free/public research already collected by the analyst team.
+
+For DripStack-style newsletter access, do not scrape or bulk-buy. Use
+the guided flow:
+
+1. Ask for a topic if none was provided.
+2. Use free catalog metadata to shortlist publications.
+3. Let the user choose one publication.
+4. Use free post summaries to shortlist articles.
+5. Let the user choose one article.
+6. Convert that article into a paid-source candidate.
+7. Only then pass the candidate to `plan_paid_research`.
+
+The deterministic helper for this is `portfolio.plan_dripstack_browse`.
+It accepts free publication/post metadata and returns one of these
+checkpoints: `topic`, `publication`, `article`, or
+`purchase-confirmation`. A `purchase-confirmation` output includes a
+`paid_source_candidate` with both MPP and x402 payment options when the
+article came from DripStack.
 
 Call `portfolio` with:
 
@@ -191,6 +215,16 @@ Call `portfolio` with:
   "max_sources": 4,
   "spending_mode": "plan-only",
   "near_funding_asset": "USDC.near",
+  "preferred_payment_protocols": ["mpp", "x402"],
+  "agent_wallet": {
+    "provider": "AgentCash",
+    "network": "base",
+    "balance_usd": 5.0,
+    "default_article_price_usd": 0.01,
+    "per_article_cap_usd": 0.05,
+    "daily_cap_usd": 1.0,
+    "max_wallet_balance_usd": 5.0
+  },
   "sources": []
 }
 ```
@@ -207,6 +241,15 @@ Use the plan as follows:
   `near_funding_routes` as hints for how a NEAR Intents-funded treasury
   could fund the rail wallet. This does not authorize the actual paid
   fetch.
+- For autonomous wallets, keep balances small. The default policy is
+  `$5` maximum wallet balance, `$0.05` per article, and `$1` daily
+  research spend. This mirrors the "small USDC balance" operating model:
+  enough for many one-cent articles, not enough to create a large blast
+  radius.
+- Record audit links such as `mppscan.com` and `x402scan.com` in the
+  paid-research plan or journal so spend can be reviewed after a run.
+- Treat highly optimized source metadata as an adversarial surface.
+  Reject or downgrade sources with low trust or high `seo_risk_score`.
 - Never include paid source text in the answer or research memo until
   the payment client returns a receipt.
 - When paid source text is used, include source IDs from

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -125,12 +125,61 @@ function itaIntent(intent) {
     + '</div>';
 }
 
+function itaMoney(value) {
+  var n = Number(value || 0);
+  return '$' + n.toFixed(n < 1 ? 4 : 2);
+}
+
+function itaPaidResearch(plan) {
+  if (!plan) {
+    return '<div class="ita-empty-line">No paid research plan recorded.</div>';
+  }
+  var sources = Array.isArray(plan.payable_sources) ? plan.payable_sources : [];
+  var rails = Array.isArray(plan.payment_rails) ? plan.payment_rails : [];
+  var routes = Array.isArray(plan.near_funding_routes) ? plan.near_funding_routes : [];
+  var gates = Array.isArray(plan.policy_gates) ? plan.policy_gates : [];
+  return '<div class="ita-paid">'
+    + '<div class="ita-paid-bar">'
+    + '<div><span>Budget</span><strong>' + itaMoney(plan.budget_usd) + '</strong></div>'
+    + '<div><span>Allocated</span><strong>' + itaMoney(plan.allocated_usd) + '</strong></div>'
+    + '<div><span>Unspent</span><strong>' + itaMoney(plan.unspent_usd) + '</strong></div>'
+    + '<div><span>Fetch</span><strong>' + (plan.ready_for_paid_fetch ? 'Ready' : 'Blocked') + '</strong></div>'
+    + '</div>'
+    + (plan.query ? '<div class="ita-paid-query">' + itaEscape(plan.query) + '</div>' : '')
+    + '<div class="ita-paid-lanes">'
+    + '<div>'
+    + '<div class="ita-subtitle">Payable Sources</div>'
+    + (sources.length ? sources.map(function(source) {
+      return '<div class="ita-source-line">'
+        + '<div><strong>' + itaEscape(source.title || source.id) + '</strong>'
+        + '<span>' + itaEscape(source.author || 'Unknown author') + ' · ' + itaEscape(source.protocol || 'manual') + ' / ' + itaEscape(source.network || 'manual') + '</span></div>'
+        + '<div class="ita-source-price">' + itaMoney(source.amount_usd) + '</div>'
+        + (source.receipt_required ? '<span class="ita-pill is-warn">Receipt</span>' : '<span class="ita-pill is-pass">Free</span>')
+        + '</div>';
+    }).join('') : '<div class="ita-empty-line">No payable sources selected.</div>')
+    + '</div>'
+    + '<div>'
+    + '<div class="ita-subtitle">Rails</div>'
+    + (rails.length ? rails.map(function(rail) {
+      return '<div class="ita-rail-line"><span>' + itaEscape(rail.protocol || 'manual') + '</span><strong>' + itaMoney(rail.allocated_usd) + '</strong></div>';
+    }).join('') : '<div class="ita-empty-line">No payment rails.</div>')
+    + (routes.length ? '<div class="ita-route-note">' + routes.map(function(route) {
+      return itaEscape(route.via || 'near-intents') + ' -> ' + itaEscape(route.target_protocol || 'rail') + ' ' + itaMoney(route.amount_usd);
+    }).join('<br>') + '</div>' : '')
+    + '</div>'
+    + '</div>'
+    + (gates.length ? '<div class="ita-paid-gates">' + itaRiskGates(gates) + '</div>' : '')
+    + '</div>';
+}
+
 function itaWritePrompt(kind, state) {
   if (api && api.navigate) api.navigate('chat');
   var input = document.getElementById('chat-input');
   if (!input) return;
   var pair = state && state.pair ? state.pair : 'the watched pair';
-  input.value = kind === 'quote'
+  input.value = kind === 'paid'
+    ? 'For the Intents Trading Agent, build a paid research plan for ' + pair + ' first: discover MPP/x402/NEAR payable sources, enforce the source budget, require receipts before use, then run backtest_suite and risk gates before any unsigned NEAR intent.'
+    : kind === 'quote'
     ? 'For the Intents Trading Agent, request a live NEAR Intents quote for ' + pair + ' only if all current risk gates still pass. Keep it unsigned.'
     : 'For the Intents Trading Agent, run the paper NEAR Intents workflow for ' + pair + ': research, backtest_suite, risk gates, and unsigned intent preview.';
   input.focus();
@@ -152,21 +201,26 @@ function itaRender(state) {
     + '<div class="ita-summary">'
     + '<div><span>Mode</span><strong>' + itaEscape(state.mode || 'paper') + '</strong></div>'
     + '<div><span>Confidence</span><strong>' + (state.confidence == null ? '-' : Math.round(Number(state.confidence) * 100) + '%') + '</strong></div>'
-    + '<div><span>Sources</span><strong>' + itaEscape(state.source_count || 0) + '</strong></div>'
+    + '<div><span>Sources</span><strong>' + itaEscape(state.paid_research ? state.paid_research.selected_count : state.source_count || 0) + '</strong></div>'
     + '<div><span>Updated</span><strong>' + itaEscape(state.generated_at || '-') + '</strong></div>'
     + '</div>'
     + '<div class="ita-body">'
+    + '<section><div class="ita-section-title">Paid Research</div>' + itaPaidResearch(state.paid_research) + '</section>'
     + '<section><div class="ita-section-title">Strategy Suite</div>' + itaCandidateRows(state.top_candidates) + '</section>'
     + '<section><div class="ita-section-title">Risk Gates</div>' + itaRiskGates(state.risk_gates) + '</section>'
     + '<section><div class="ita-section-title">Unsigned Intent</div>' + itaIntent(state.intent) + '</section>'
     + '</div>'
     + (state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '')
     + '<div class="ita-actions">'
+    + '<button type="button" data-action="ita-paid">Prepare Paid Research</button>'
     + '<button type="button" data-action="ita-paper">Prepare Paper Run</button>'
     + '<button type="button" data-action="ita-quote">Prepare Live Quote Request</button>'
     + '</div>';
 
   root.querySelector('[data-action="ita-refresh"]').addEventListener('click', itaLoad);
+  root.querySelector('[data-action="ita-paid"]').addEventListener('click', function() {
+    itaWritePrompt('paid', state);
+  });
   root.querySelector('[data-action="ita-paper"]').addEventListener('click', function() {
     itaWritePrompt('paper', state);
   });

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -138,6 +138,7 @@ function itaPaidResearch(plan) {
   var rails = Array.isArray(plan.payment_rails) ? plan.payment_rails : [];
   var routes = Array.isArray(plan.near_funding_routes) ? plan.near_funding_routes : [];
   var gates = Array.isArray(plan.policy_gates) ? plan.policy_gates : [];
+  var wallet = plan.wallet_policy || null;
   return '<div class="ita-paid">'
     + '<div class="ita-paid-bar">'
     + '<div><span>Budget</span><strong>' + itaMoney(plan.budget_usd) + '</strong></div>'
@@ -168,6 +169,17 @@ function itaPaidResearch(plan) {
     }).join('<br>') + '</div>' : '')
     + '</div>'
     + '</div>'
+    + (wallet ? '<div class="ita-wallet-line">'
+      + '<div><span>Agent Wallet</span><strong>' + itaEscape(wallet.provider || 'Agent wallet') + ' · ' + itaEscape(wallet.network || 'base') + '</strong></div>'
+      + '<div><span>Balance</span><strong>' + itaMoney(wallet.balance_usd) + '</strong></div>'
+      + '<div><span>Articles</span><strong>' + itaEscape(wallet.max_articles_at_default_price || 0) + '</strong></div>'
+      + '<span class="ita-pill ' + (wallet.safe_to_autopay ? 'is-pass' : 'is-warn') + '">' + (wallet.safe_to_autopay ? 'Policy OK' : 'Approval') + '</span>'
+      + '</div>'
+      + (Array.isArray(wallet.audit_urls) && wallet.audit_urls.length ? '<div class="ita-audit-links">'
+        + wallet.audit_urls.map(function(url) {
+          return '<a href="' + itaEscape(url) + '" target="_blank" rel="noreferrer">' + itaEscape(String(url).replace(/^https?:\/\//, '').replace(/\/$/, '')) + '</a>';
+        }).join('')
+        + '</div>' : '') : '')
     + (gates.length ? '<div class="ita-paid-gates">' + itaRiskGates(gates) + '</div>' : '')
     + '</div>';
 }

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -335,6 +335,41 @@
   margin-top: 12px;
 }
 
+.ita-wallet-line {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 84px 76px auto;
+  margin-top: 12px;
+  min-height: 48px;
+  padding-top: 8px;
+}
+
+.ita-wallet-line span,
+.ita-audit-links a {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.ita-wallet-line strong {
+  display: block;
+  font-size: var(--text-sm);
+  margin-top: 2px;
+}
+
+.ita-audit-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.ita-audit-links a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .ita-next {
   border-top: 1px solid var(--border);
   margin-top: 14px;
@@ -403,6 +438,10 @@
   }
 
   .ita-source-line {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ita-wallet-line {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -128,7 +128,8 @@
   grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.9fr);
 }
 
-.ita-body section:nth-child(3) {
+.ita-body section:first-child,
+.ita-body section:nth-child(4) {
   grid-column: 1 / -1;
 }
 
@@ -235,6 +236,105 @@
   padding: 4px 8px;
 }
 
+.ita-paid {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.ita-paid-bar {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ita-paid-bar > div {
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  padding-top: 8px;
+}
+
+.ita-paid-bar span,
+.ita-source-line span,
+.ita-subtitle {
+  color: var(--text-muted);
+  display: block;
+  font-size: var(--text-xs);
+}
+
+.ita-paid-bar strong,
+.ita-source-line strong,
+.ita-rail-line strong {
+  display: block;
+  font-size: var(--text-sm);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-paid-query {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  margin-top: 10px;
+}
+
+.ita-paid-lanes {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.25fr) minmax(220px, 0.75fr);
+  margin-top: 12px;
+}
+
+.ita-subtitle {
+  font-weight: 700;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+.ita-source-line {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 76px auto;
+  min-height: 48px;
+  padding: 8px 0;
+}
+
+.ita-source-price {
+  color: var(--accent);
+  font-size: var(--text-sm);
+  font-weight: 800;
+  text-align: right;
+}
+
+.ita-rail-line {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  min-height: 36px;
+}
+
+.ita-rail-line span {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.ita-route-note {
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  margin-top: 8px;
+  padding-top: 8px;
+}
+
+.ita-paid-gates {
+  margin-top: 12px;
+}
+
 .ita-next {
   border-top: 1px solid var(--border);
   margin-top: 14px;
@@ -258,6 +358,8 @@
 @media (max-width: 980px) {
   .ita-summary,
   .ita-body,
+  .ita-paid-bar,
+  .ita-paid-lanes,
   .ita-intent-grid {
     grid-template-columns: 1fr 1fr;
   }
@@ -284,6 +386,8 @@
 
   .ita-summary,
   .ita-body,
+  .ita-paid-bar,
+  .ita-paid-lanes,
   .ita-intent-grid {
     grid-template-columns: 1fr;
   }
@@ -296,5 +400,13 @@
   .ita-row .ita-gate {
     grid-column: 2;
     justify-self: start;
+  }
+
+  .ita-source-line {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ita-source-price {
+    text-align: left;
   }
 }

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -55,5 +55,76 @@
     "https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay",
     "https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint"
   ],
+  "paid_research": {
+    "schema_version": "paid-research-plan/1",
+    "query": "Should the NEAR/BTC paper intent use premium route and liquidity research before quoting?",
+    "budget_usd": 0.05,
+    "allocated_usd": 0.04,
+    "unspent_usd": 0.01,
+    "selected_count": 2,
+    "ready_for_paid_fetch": true,
+    "ready_for_trade_research": true,
+    "payment_rails": [
+      {
+        "protocol": "mpp",
+        "count": 1,
+        "allocated_usd": 0.02
+      },
+      {
+        "protocol": "x402",
+        "count": 1,
+        "allocated_usd": 0.02
+      }
+    ],
+    "payable_sources": [
+      {
+        "id": "premium-near-liquidity",
+        "title": "NEAR/BTC solver liquidity note",
+        "author": "Premium Macro Writer",
+        "protocol": "mpp",
+        "network": "tempo",
+        "amount_usd": 0.02,
+        "evidence_weight": 0.52,
+        "receipt_required": true
+      },
+      {
+        "id": "base-x402-route-risk",
+        "title": "Intent route risk memo",
+        "author": "Onchain Researcher",
+        "protocol": "x402",
+        "network": "base",
+        "amount_usd": 0.02,
+        "evidence_weight": 0.48,
+        "receipt_required": true
+      }
+    ],
+    "near_funding_routes": [
+      {
+        "target_protocol": "mpp",
+        "target_network": "tempo",
+        "amount_usd": 0.02,
+        "via": "near-intents"
+      },
+      {
+        "target_protocol": "x402",
+        "target_network": "base",
+        "amount_usd": 0.02,
+        "via": "near-intents"
+      }
+    ],
+    "policy_gates": [
+      {
+        "name": "receipt-before-use",
+        "status": "pass",
+        "detail": "Paywalled source text is used only after a payment receipt."
+      },
+      {
+        "name": "trade-gate",
+        "status": "pass",
+        "detail": "Premium research does not bypass backtest or risk gates."
+      }
+    ],
+    "warnings": []
+  },
   "next_action": "Ask the user before requesting a live NEAR Intents quote."
 }

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -124,6 +124,23 @@
         "detail": "Premium research does not bypass backtest or risk gates."
       }
     ],
+    "wallet_policy": {
+      "provider": "AgentCash",
+      "address": "0x3333333333333333333333333333333333333333",
+      "network": "base",
+      "balance_usd": 5.0,
+      "default_article_price_usd": 0.01,
+      "max_articles_at_default_price": 500,
+      "per_article_cap_usd": 0.05,
+      "daily_cap_usd": 1.0,
+      "max_wallet_balance_usd": 5.0,
+      "safe_to_autopay": true,
+      "audit_urls": [
+        "https://mppscan.com/",
+        "https://www.x402scan.com/"
+      ],
+      "warnings": []
+    },
     "warnings": []
   },
   "next_action": "Ask the user before requesting a live NEAR Intents quote."

--- a/tests/support/live_mission_helpers.rs
+++ b/tests/support/live_mission_helpers.rs
@@ -4,7 +4,6 @@
 //! (`tests/e2e_live_mission_gmail.rs`, etc.) can reuse the same approval
 //! responder and notification heuristics without copy-paste drift.
 
-#![cfg(feature = "libsql")]
 #![allow(dead_code)] // shared API; not every test uses every helper
 
 use std::collections::HashSet;

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, and NEAR Intents trading widget state.",
   "discovery_summary": {
     "always_required": [
       "action"
@@ -12,12 +12,13 @@
       "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`.",
       "`backtest` requires oldest-to-newest OHLCV `candles` plus a long-only spot `strategy` (`buy-hold`, `sma-cross`, `breakout`, `mean-reversion`, `momentum`, or `rsi-mean-reversion`). Fees, slippage, position size, stop-loss, and take-profit are optional.",
       "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
+      "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, policy gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
       "`format_intents_widget` requires a `pair` and optional backtest-suite output, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -51,6 +52,24 @@
         "stance": "watch",
         "risk_gates": [
           { "name": "unsigned-only", "status": "pass", "detail": "Wallet signature required outside the agent." }
+        ]
+      },
+      {
+        "action": "plan_paid_research",
+        "query": "Should the NEAR/BTC paper intent pay for premium source research before quoting?",
+        "pair": "NEAR/BTC",
+        "budget_usd": 0.05,
+        "spending_mode": "quote",
+        "sources": [
+          {
+            "id": "premium-route-risk",
+            "title": "Intent route risk memo",
+            "author": "Researcher",
+            "url": "https://example.com/route-risk",
+            "tags": ["near-intents", "btc"],
+            "price_usd": 0.02,
+            "payment": { "protocol": "x402", "network": "base", "asset": "USDC" }
+          }
         ]
       }
     ]

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -12,13 +12,14 @@
       "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`.",
       "`backtest` requires oldest-to-newest OHLCV `candles` plus a long-only spot `strategy` (`buy-hold`, `sma-cross`, `breakout`, `mean-reversion`, `momentum`, or `rsi-mean-reversion`). Fees, slippage, position size, stop-loss, and take-profit are optional.",
       "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
-      "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, policy gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
+      "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, autonomous-wallet policy gates, agentic-SEO trust gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
+      "`plan_dripstack_browse` models DripStack's guided topic → publication → article flow from free catalog/post metadata. A selected article becomes a paid-source candidate for `plan_paid_research`; the tool never buys or fetches article bodies.",
       "`format_intents_widget` requires a `pair` and optional backtest-suite output, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -69,6 +70,17 @@
             "tags": ["near-intents", "btc"],
             "price_usd": 0.02,
             "payment": { "protocol": "x402", "network": "base", "asset": "USDC" }
+          }
+        ]
+      },
+      {
+        "action": "plan_dripstack_browse",
+        "topic": "crypto market structure",
+        "publications": [
+          {
+            "slug": "premiumcrypto.substack.com",
+            "title": "Premium Crypto Notes",
+            "description": "Crypto market structure, liquidity, and onchain trading research."
           }
         ]
       }

--- a/tools-src/portfolio/scenarios/intents-trading-agent-dripstack-browse.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-dripstack-browse.yaml
@@ -1,0 +1,100 @@
+id: intents-trading-agent-dripstack-browse
+description: |
+  Models DripStack as a guided browse flow: topic shortlist, publication
+  choice, article choice, then a paid-source candidate with both MPP and
+  x402 options. The paid article body is never fetched by this tool.
+steps:
+  - name: ask_topic
+    action: plan_dripstack_browse
+    params: {}
+    expect:
+      dripstack_checkpoint: topic
+  - name: shortlist_publications
+    action: plan_dripstack_browse
+    params:
+      topic: "crypto market structure"
+      publications:
+        - slug: premiumcrypto.substack.com
+          title: "Premium Crypto Notes"
+          description: "Crypto market structure, liquidity, exchanges, stablecoins, and onchain trading research."
+          site_url: "https://premiumcrypto.substack.com"
+        - slug: culturesignals.substack.com
+          title: "Culture Signals"
+          description: "Culture, media, and technology essays."
+          site_url: "https://culturesignals.substack.com"
+    expect:
+      dripstack_checkpoint: publication
+      dripstack_publications_min: 1
+  - name: list_articles
+    action: plan_dripstack_browse
+    params:
+      topic: "crypto market structure"
+      selected_publication_slug: premiumcrypto.substack.com
+      publications:
+        - slug: premiumcrypto.substack.com
+          title: "Premium Crypto Notes"
+          description: "Crypto market structure, liquidity, exchanges, stablecoins, and onchain trading research."
+          site_url: "https://premiumcrypto.substack.com"
+      posts:
+        - slug: near-intents-liquidity
+          title: "NEAR Intents liquidity and solver-routing risk"
+          subtitle: "A short premium note on route expiry, taker depth, and BTC leg risk."
+          author: "Premium Crypto Writer"
+          price_usd: 0.01
+        - slug: exchange-fragmentation
+          title: "Exchange fragmentation and agent order flow"
+          subtitle: "How agent traffic changes exchange liquidity."
+          author: "Premium Crypto Writer"
+          price_usd: 0.02
+    expect:
+      dripstack_checkpoint: article
+      dripstack_posts_min: 2
+  - name: selected_article_candidate
+    action: plan_dripstack_browse
+    params:
+      topic: "crypto market structure"
+      selected_publication_slug: premiumcrypto.substack.com
+      selected_post_slug: near-intents-liquidity
+      publications:
+        - slug: premiumcrypto.substack.com
+          title: "Premium Crypto Notes"
+          description: "Crypto market structure, liquidity, exchanges, stablecoins, and onchain trading research."
+          site_url: "https://premiumcrypto.substack.com"
+      posts:
+        - slug: near-intents-liquidity
+          title: "NEAR Intents liquidity and solver-routing risk"
+          subtitle: "A short premium note on route expiry, taker depth, and BTC leg risk."
+          author: "Premium Crypto Writer"
+          price_usd: 0.01
+    capture:
+      dripstack_paid_source_var: drip_source
+    expect:
+      dripstack_checkpoint: purchase-confirmation
+      dripstack_has_paid_source_candidate: true
+  - name: plan_payment_for_selected_article
+    action: plan_paid_research
+    params:
+      query: "Use the selected DripStack article only if it clears wallet and receipt gates."
+      pair: NEAR/BTC
+      budget_usd: 0.05
+      max_sources: 1
+      min_relevance: 0.2
+      min_trust_score: 0.4
+      spending_mode: quote
+      preferred_payment_protocols: [mpp, x402]
+      agent_wallet:
+        provider: AgentCash
+        network: base
+        address: "0x3333333333333333333333333333333333333333"
+        balance_usd: 5.0
+        per_article_cap_usd: 0.05
+        daily_cap_usd: 1.0
+        max_wallet_balance_usd: 5.0
+      sources:
+        - "$drip_source"
+    expect:
+      paid_research_schema_version: paid-research-plan/1
+      paid_research_selected_min: 1
+      paid_research_allocated_le: 0.05
+      paid_research_has_rail: mpp
+      paid_research_near_funding_routes_min: 1

--- a/tools-src/portfolio/scenarios/intents-trading-agent-paid-research.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-paid-research.yaml
@@ -1,0 +1,132 @@
+id: intents-trading-agent-paid-research
+description: |
+  Plans a DripStack-style premium research query before using paid
+  source text in a NEAR Intents trading decision. The plan selects
+  payable MPP/x402 sources under budget, creates NEAR funding-route
+  hints, and feeds attribution into the project widget state.
+steps:
+  - name: paid_research_plan
+    action: plan_paid_research
+    params:
+      query: "Should the NEAR/BTC paper intent pay for premium solver liquidity and route risk research before requesting a quote?"
+      pair: NEAR/BTC
+      budget_usd: 0.05
+      max_sources: 3
+      min_relevance: 0.35
+      max_source_age_days: 14
+      spending_mode: quote
+      near_funding_asset: USDC.near
+      required_tags: [near-intents]
+      sources:
+        - id: premium-near-liquidity
+          title: "NEAR/BTC solver liquidity note"
+          author: "Premium Macro Writer"
+          publisher: "DripStack Research"
+          url: "https://example.com/near-btc-liquidity"
+          summary: "Premium note on NEAR Intents solver depth, BTC routing, slippage, and quote risk."
+          tags: [near-intents, btc, liquidity]
+          price_usd: 0.02
+          relevance: 0.92
+          trust_score: 0.82
+          freshness_score: 0.95
+          age_days: 1
+          payment:
+            protocol: mpp
+            network: tempo
+            asset: USDC
+            recipient: "0x1111111111111111111111111111111111111111"
+            endpoint: "https://example.com/near-btc-liquidity/pay"
+        - id: base-x402-route-risk
+          title: "Intent route risk memo"
+          author: "Onchain Researcher"
+          publisher: "Route Desk"
+          url: "https://example.com/intent-route-risk"
+          summary: "x402 paid memo covering Base, NEAR Intents, solver route expiry, and BTC destination risk."
+          tags: [near-intents, route-risk, btc]
+          price_usd: 0.02
+          relevance: 0.89
+          trust_score: 0.78
+          freshness_score: 0.9
+          age_days: 2
+          payment:
+            protocol: x402
+            network: base
+            asset: USDC
+            recipient: "0x2222222222222222222222222222222222222222"
+            endpoint: "https://example.com/intent-route-risk/pay"
+        - id: stale-alpha
+          title: "Old NEAR/BTC alpha note"
+          author: "Archive Writer"
+          publisher: "Old Desk"
+          url: "https://example.com/stale-alpha"
+          summary: "Old note on NEAR/BTC market structure."
+          tags: [near-intents, btc]
+          price_usd: 0.01
+          relevance: 0.7
+          trust_score: 0.5
+          freshness_score: 0.2
+          age_days: 60
+          payment:
+            protocol: x402
+            network: base
+            asset: USDC
+        - id: expensive-premium-pack
+          title: "Premium intent execution pack"
+          author: "Institutional Desk"
+          publisher: "Expensive Research"
+          url: "https://example.com/expensive-pack"
+          summary: "Broad premium pack on NEAR Intents and cross-chain execution."
+          tags: [near-intents, btc]
+          price_usd: 0.20
+          relevance: 0.95
+          trust_score: 0.9
+          freshness_score: 0.9
+          age_days: 1
+          payment:
+            protocol: mpp
+            network: tempo
+            asset: USDC
+    capture:
+      paid_research_plan_var: paid_plan
+    expect:
+      paid_research_schema_version: paid-research-plan/1
+      paid_research_selected_min: 2
+      paid_research_allocated_le: 0.05
+      paid_research_has_rail: x402
+      paid_research_near_funding_routes_min: 2
+  - name: format_console_state
+    action: format_intents_widget
+    params:
+      generated_at: "2026-05-02T19:15:00Z"
+      project_id: intents-trading-agent
+      mode: paper
+      pair: NEAR/BTC
+      stance: watch
+      confidence: 0.68
+      paid_research_plan: "$paid_plan"
+      backtest_suite:
+        schema_version: intents-backtest-suite/1
+        ranked:
+          - rank: 1
+            id: sma_cross_fast
+            strategy: {kind: sma-cross}
+            selection_score: 18.5
+            passes_basic_gate: true
+            metrics:
+              total_return_pct: 12.0
+              alpha_vs_buy_hold_pct: 3.0
+              max_drawdown_pct: 8.0
+              trades: 6
+      risk_gates:
+        - {name: receipt-before-use, status: pass, detail: "Paid source text is blocked until receipts exist."}
+        - {name: backtest-required, status: pass, detail: "Premium research cannot bypass the strategy suite."}
+      research_sources:
+        - https://dripstack.xyz
+        - https://mpp.dev
+        - https://docs.x402.org/
+      next_action: "Pay for selected sources only after user approval, then re-run research before building any unsigned intent."
+    expect:
+      intents_widget_schema_version: intents-trading-widget/1
+      intents_widget_top_candidates_min: 1
+      intents_widget_paid_sources_min: 2
+      intents_widget_paid_ready: true

--- a/tools-src/portfolio/src/backtest.rs
+++ b/tools-src/portfolio/src/backtest.rs
@@ -597,6 +597,7 @@ fn enter_trade(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn exit_trade(
     idx: usize,
     candle: &Candle,
@@ -816,6 +817,7 @@ fn rsi(candles: &[Candle], end_idx: usize, window: usize) -> Option<f64> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compute_metrics(
     initial_cash: f64,
     end_cash: f64,

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -20,6 +20,8 @@
 //!   candle episode before any strategy is selected for paper intent work.
 //! - `plan_paid_research` — rank paid/free research sources, budget a
 //!   premium-source query, and prepare attribution/payment gates.
+//! - `plan_dripstack_browse` — model DripStack's guided topic →
+//!   publication → article purchase flow without fetching paid content.
 //! - `format_intents_widget` — build the NEAR Intents trading console
 //!   view model consumed by the project widget.
 //!
@@ -141,6 +143,13 @@ enum PortfolioAction {
     #[serde(rename = "plan_paid_research")]
     PlanPaidResearch(research::PaidResearchPlanInput),
 
+    /// Plan the DripStack guided-browse flow. Free catalog/post-title
+    /// metadata goes in; a selected article becomes a paid-source
+    /// candidate for `plan_paid_research`. It never buys or fetches
+    /// article bodies.
+    #[serde(rename = "plan_dripstack_browse")]
+    PlanDripstackBrowse(research::DripstackBrowseInput),
+
     /// Build the render-ready view model the web widget consumes.
     /// Writes to `projects/<id>/widgets/state.json`.
     #[serde(rename = "format_widget")]
@@ -223,8 +232,8 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          classifies them against an embedded protocol registry, generates ranked \
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
-         backtest, backtest_suite, plan_paid_research, format_suggestion, \
-         format_widget, format_intents_widget. \
+         backtest, backtest_suite, plan_paid_research, plan_dripstack_browse, \
+         format_suggestion, format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
     }
@@ -325,6 +334,11 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = research::plan(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize plan_paid_research response: {e}"))
+        }
+        PortfolioAction::PlanDripstackBrowse(input) => {
+            let output = research::plan_dripstack_browse(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize plan_dripstack_browse response: {e}"))
         }
         PortfolioAction::FormatWidget(input) => {
             let output = widget::format_widget(input);

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -18,6 +18,8 @@
 //!   caller-provided OHLCV candles before any intent is built.
 //! - `backtest_suite` — rank several strategy candidates over the same
 //!   candle episode before any strategy is selected for paper intent work.
+//! - `plan_paid_research` — rank paid/free research sources, budget a
+//!   premium-source query, and prepare attribution/payment gates.
 //! - `format_intents_widget` — build the NEAR Intents trading console
 //!   view model consumed by the project widget.
 //!
@@ -35,6 +37,7 @@
 //! ├── strategy/           // propose: parse strategy docs + filter
 //! ├── intents/            // build_intent: solver call + bounded checks
 //! ├── backtest.rs         // paper strategy replay/ranking over OHLCV candles
+//! ├── research.rs         // paid research source budgeting/attribution
 //! └── widget.rs           // web widget state formatters
 //! ```
 
@@ -50,6 +53,7 @@ mod backtest;
 mod format;
 mod indexer;
 mod intents;
+mod research;
 mod strategy;
 mod types;
 mod widget;
@@ -129,6 +133,13 @@ enum PortfolioAction {
     /// menu of choices instead of blindly evaluating one strategy.
     #[serde(rename = "backtest_suite")]
     BacktestSuite(backtest::BacktestSuiteInput),
+
+    /// Plan a premium-source research query before fetching paywalled
+    /// content. This ranks candidate sources, enforces a budget, and
+    /// returns attribution/payment gates for MPP, x402, and NEAR
+    /// Intents-style rails. It never fetches paid content or signs.
+    #[serde(rename = "plan_paid_research")]
+    PlanPaidResearch(research::PaidResearchPlanInput),
 
     /// Build the render-ready view model the web widget consumes.
     /// Writes to `projects/<id>/widgets/state.json`.
@@ -212,8 +223,8 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          classifies them against an embedded protocol registry, generates ranked \
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
-         backtest, backtest_suite, format_suggestion, format_widget, \
-         format_intents_widget. \
+         backtest, backtest_suite, plan_paid_research, format_suggestion, \
+         format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
     }
@@ -309,6 +320,11 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = backtest::run_suite(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize backtest_suite response: {e}"))
+        }
+        PortfolioAction::PlanPaidResearch(input) => {
+            let output = research::plan(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize plan_paid_research response: {e}"))
         }
         PortfolioAction::FormatWidget(input) => {
             let output = widget::format_widget(input);

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -719,6 +719,115 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "paid_research_schema_version" => {
+                let v = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("paid_research_schema_version: string");
+                assert_eq!(
+                    v, want,
+                    "[{path}] step '{}': paid research schema mismatch",
+                    step.name
+                );
+            }
+            "paid_research_selected_min" => {
+                let len = response
+                    .get("selected_sources")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("paid_research_selected_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': paid research selected {len} < min {want}",
+                    step.name
+                );
+            }
+            "paid_research_allocated_le" => {
+                let allocated = response
+                    .get("allocated_usd")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing allocated_usd", step.name)
+                    });
+                let want = expected
+                    .as_f64()
+                    .expect("paid_research_allocated_le: number");
+                assert!(
+                    allocated <= want + f64::EPSILON,
+                    "[{path}] step '{}': paid research allocated {allocated} > {want}",
+                    step.name
+                );
+            }
+            "paid_research_has_rail" => {
+                let rail = expected.as_str().expect("paid_research_has_rail: string");
+                let rails = response
+                    .get("payment_rails")
+                    .and_then(|v| v.as_array())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing payment_rails", step.name)
+                    });
+                let found = rails
+                    .iter()
+                    .any(|item| item.get("protocol").and_then(|v| v.as_str()) == Some(rail));
+                assert!(
+                    found,
+                    "[{path}] step '{}': paid research rail '{rail}' not found",
+                    step.name
+                );
+            }
+            "paid_research_near_funding_routes_min" => {
+                let len = response
+                    .get("near_funding_routes")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("paid_research_near_funding_routes_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': NEAR funding routes {len} < min {want}",
+                    step.name
+                );
+            }
+            "intents_widget_paid_sources_min" => {
+                let len = response
+                    .pointer("/paid_research/payable_sources")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("intents_widget_paid_sources_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': intents widget paid sources {len} < min {want}",
+                    step.name
+                );
+            }
+            "intents_widget_paid_ready" => {
+                let got = response
+                    .pointer("/paid_research/ready_for_paid_fetch")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let want = expected.as_bool().expect("intents_widget_paid_ready: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': paid research ready mismatch",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name
@@ -738,6 +847,7 @@ fn capture_vars(path: &str, step: &Step, response: &Value, vars: &mut BTreeMap<S
                 .get("proposals")
                 .cloned()
                 .unwrap_or(Value::Array(Vec::new())),
+            "paid_research_plan_var" => response.clone(),
             "first_ready_plan_var" => response
                 .get("proposals")
                 .and_then(|v| v.as_array())

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -828,6 +828,58 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "dripstack_checkpoint" => {
+                let got = response
+                    .get("checkpoint")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| panic!("[{path}] step '{}': missing checkpoint", step.name));
+                let want = expected.as_str().expect("dripstack_checkpoint: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': dripstack checkpoint mismatch",
+                    step.name
+                );
+            }
+            "dripstack_publications_min" => {
+                let len = response
+                    .get("matched_publications")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("dripstack_publications_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': matched publications {len} < min {want}",
+                    step.name
+                );
+            }
+            "dripstack_posts_min" => {
+                let len = response
+                    .get("post_candidates")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected.as_u64().expect("dripstack_posts_min: number") as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': post candidates {len} < min {want}",
+                    step.name
+                );
+            }
+            "dripstack_has_paid_source_candidate" => {
+                let got = response.get("paid_source_candidate").is_some();
+                let want = expected
+                    .as_bool()
+                    .expect("dripstack_has_paid_source_candidate: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': paid source candidate presence mismatch",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name
@@ -848,6 +900,15 @@ fn capture_vars(path: &str, step: &Step, response: &Value, vars: &mut BTreeMap<S
                 .cloned()
                 .unwrap_or(Value::Array(Vec::new())),
             "paid_research_plan_var" => response.clone(),
+            "dripstack_paid_source_var" => response
+                .get("paid_source_candidate")
+                .cloned()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "[{path}] step '{}': missing paid_source_candidate to capture",
+                        step.name
+                    )
+                }),
             "first_ready_plan_var" => response
                 .get("proposals")
                 .and_then(|v| v.as_array())

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -12,6 +12,11 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
+// Paid research plans run in the WASM tool layer and use f64 only for
+// non-settlement ranking, budgeting, and policy hints. Settlement remains with
+// the payment rails; this tolerance avoids machine-epsilon threshold mistakes.
+const USD_TOLERANCE: f64 = 1e-6;
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct PaidResearchPlanInput {
     pub query: String,
@@ -416,7 +421,7 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
             rejected_sources.push(rejected(&candidate, "max-sources-reached"));
             continue;
         }
-        if candidate.price_usd > remaining_budget + f64::EPSILON {
+        if candidate.price_usd > remaining_budget + USD_TOLERANCE {
             rejected_sources.push(rejected(&candidate, "over-budget"));
             continue;
         }
@@ -447,7 +452,7 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
             rail_entry.0 += 1;
             rail_entry.1 += payment.amount_usd;
 
-            if payment.amount_usd > 0.0 && payment.protocol != "near-intents" {
+            if payment.amount_usd > 0.0 && matches!(payment.protocol.as_str(), "mpp" | "x402") {
                 let key = (
                     payment.protocol.clone(),
                     payment.network.clone(),
@@ -549,7 +554,7 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         max_selected_price_usd,
     );
     let ready_for_paid_fetch = !selected_sources.is_empty()
-        && allocated_usd <= budget_usd + f64::EPSILON
+        && allocated_usd <= budget_usd + USD_TOLERANCE
         && policy_gates.iter().all(|gate| gate.status != "fail");
     let ready_for_trade_research = ready_for_paid_fetch
         && selected_sources
@@ -951,7 +956,7 @@ fn policy_gates(
     let mut gates = vec![
         PaidResearchPolicyGate {
             name: "budget-cap".to_string(),
-            status: if allocated_usd <= budget_usd + f64::EPSILON {
+            status: if allocated_usd <= budget_usd + USD_TOLERANCE {
                 "pass"
             } else {
                 "fail"
@@ -1020,7 +1025,7 @@ fn policy_gates(
         });
         gates.push(PaidResearchPolicyGate {
             name: "per-article-cap".to_string(),
-            status: if max_selected_price_usd <= policy.per_article_cap_usd + f64::EPSILON {
+            status: if max_selected_price_usd <= policy.per_article_cap_usd + USD_TOLERANCE {
                 "pass"
             } else {
                 "fail"
@@ -1075,7 +1080,7 @@ fn agent_wallet_policy(
     if balance_usd > max_wallet_balance_usd {
         warnings.push("Agent wallet is over the configured autonomous balance cap.".to_string());
     }
-    if max_selected_price_usd > per_article_cap_usd + f64::EPSILON {
+    if max_selected_price_usd > per_article_cap_usd + USD_TOLERANCE {
         warnings.push("At least one selected source exceeds the per-article cap.".to_string());
     }
     let audit_urls = if input.audit_urls.is_empty() {
@@ -1097,8 +1102,8 @@ fn agent_wallet_policy(
         daily_cap_usd: round4(daily_cap_usd),
         max_wallet_balance_usd: round4(max_wallet_balance_usd),
         safe_to_autopay: balance_usd > 0.0
-            && balance_usd <= max_wallet_balance_usd + f64::EPSILON
-            && max_selected_price_usd <= per_article_cap_usd + f64::EPSILON,
+            && balance_usd <= max_wallet_balance_usd + USD_TOLERANCE
+            && max_selected_price_usd <= per_article_cap_usd + USD_TOLERANCE,
         audit_urls,
         warnings,
     })
@@ -1229,7 +1234,7 @@ fn tokenize(value: &str) -> BTreeSet<String> {
     value
         .split(|ch: char| !ch.is_ascii_alphanumeric())
         .map(normalize)
-        .filter(|token| token.len() > 2 && !is_stopword(token))
+        .filter(|token| token.len() > 1 && !is_stopword(token))
         .collect()
 }
 
@@ -1275,22 +1280,7 @@ fn default_network_for_protocol(protocol: &str) -> String {
 fn is_stopword(token: &str) -> bool {
     matches!(
         token,
-        "the"
-            | "and"
-            | "for"
-            | "with"
-            | "into"
-            | "from"
-            | "that"
-            | "this"
-            | "what"
-            | "when"
-            | "near"
-            | "price"
-            | "trade"
-            | "trading"
-            | "token"
-            | "crypto"
+        "the" | "and" | "for" | "with" | "into" | "from" | "that" | "this" | "what" | "when"
     )
 }
 
@@ -1433,5 +1423,56 @@ mod tests {
             .rejected_sources
             .iter()
             .any(|source| source.reason == "over-budget"));
+    }
+
+    #[test]
+    fn funding_routes_only_include_supported_crypto_native_rails() {
+        let plan = plan(PaidResearchPlanInput {
+            query: "NEAR price crypto research".to_string(),
+            pair: Some("NEAR/USDC".to_string()),
+            budget_usd: 0.09,
+            max_sources: 4,
+            min_relevance: 0.1,
+            min_trust_score: 0.4,
+            max_seo_risk_score: 0.65,
+            max_source_age_days: Some(7),
+            spending_mode: "quote".to_string(),
+            near_funding_asset: "USDC.near".to_string(),
+            preferred_payment_protocols: vec![],
+            default_article_price_usd: 0.01,
+            agent_wallet: None,
+            required_tags: vec![],
+            blocked_publishers: vec![],
+            sources: vec![
+                source("manual-source", 0.02, "manual", 0.95),
+                source("subscription-source", 0.02, "subscription", 0.9),
+                source("mpp-source", 0.02, "mpp", 0.85),
+                source("x402-source", 0.02, "x402", 0.8),
+            ],
+        })
+        .expect("plan");
+
+        let route_protocols: Vec<&str> = plan
+            .near_funding_routes
+            .iter()
+            .map(|route| route.target_protocol.as_str())
+            .collect();
+
+        assert_eq!(route_protocols, vec!["mpp", "x402"]);
+    }
+
+    #[test]
+    fn tokenize_preserves_two_letter_tickers_and_trading_terms() {
+        let tokens = tokenize("NEAR price for OP and AR crypto token trading");
+
+        assert!(tokens.contains("near"));
+        assert!(tokens.contains("price"));
+        assert!(tokens.contains("op"));
+        assert!(tokens.contains("ar"));
+        assert!(tokens.contains("crypto"));
+        assert!(tokens.contains("token"));
+        assert!(tokens.contains("trading"));
+        assert!(!tokens.contains("a"));
+        assert!(!tokens.contains("for"));
     }
 }

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -1010,9 +1010,9 @@ fn policy_gates(
     if let Some(policy) = wallet_policy {
         gates.push(PaidResearchPolicyGate {
             name: "agent-wallet-funded".to_string(),
-            status: if policy.balance_usd <= 0.0 {
-                "warn"
-            } else if policy.balance_usd > policy.max_wallet_balance_usd {
+            status: if policy.balance_usd <= 0.0
+                || policy.balance_usd > policy.max_wallet_balance_usd
+            {
                 "warn"
             } else {
                 "pass"

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -1,0 +1,797 @@
+//! Paid research planning for the Intents Trading Agent.
+//!
+//! This module models the "DripStack" pattern for IronClaw: an agent can
+//! discover premium research sources, budget a query, attribute which sources
+//! would be used in an answer, and prepare payment rails before any trading
+//! intent is built. It intentionally does not fetch paywalled content or sign
+//! payments. The output is a deterministic plan the skill can persist, show in
+//! the widget, and hand to a wallet/payment client after user approval.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PaidResearchPlanInput {
+    pub query: String,
+    #[serde(default)]
+    pub pair: Option<String>,
+    #[serde(default = "default_budget_usd")]
+    pub budget_usd: f64,
+    #[serde(default = "default_max_sources")]
+    pub max_sources: usize,
+    #[serde(default = "default_min_relevance")]
+    pub min_relevance: f64,
+    #[serde(default)]
+    pub max_source_age_days: Option<u32>,
+    #[serde(default = "default_spending_mode")]
+    pub spending_mode: String,
+    #[serde(default = "default_near_funding_asset")]
+    pub near_funding_asset: String,
+    #[serde(default)]
+    pub required_tags: Vec<String>,
+    #[serde(default)]
+    pub blocked_publishers: Vec<String>,
+    #[serde(default)]
+    pub sources: Vec<PaidResearchSourceInput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PaidResearchSourceInput {
+    pub id: String,
+    pub title: String,
+    pub author: String,
+    #[serde(default)]
+    pub publisher: Option<String>,
+    pub url: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub price_usd: Option<f64>,
+    #[serde(default)]
+    pub relevance: Option<f64>,
+    #[serde(default)]
+    pub trust_score: Option<f64>,
+    #[serde(default)]
+    pub freshness_score: Option<f64>,
+    #[serde(default)]
+    pub age_days: Option<u32>,
+    #[serde(default)]
+    pub payment: Option<PaidResearchPaymentInput>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PaidResearchPaymentInput {
+    #[serde(default = "default_payment_protocol")]
+    pub protocol: String,
+    #[serde(default)]
+    pub network: Option<String>,
+    #[serde(default)]
+    pub asset: Option<String>,
+    #[serde(default)]
+    pub recipient: Option<String>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaidResearchPlan {
+    pub schema_version: &'static str,
+    pub query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pair: Option<String>,
+    pub spending_mode: String,
+    pub budget_usd: f64,
+    pub allocated_usd: f64,
+    pub unspent_usd: f64,
+    pub selected_sources: Vec<SelectedPaidResearchSource>,
+    pub rejected_sources: Vec<RejectedPaidResearchSource>,
+    pub payment_rails: Vec<PaidResearchRailSummary>,
+    pub near_funding_routes: Vec<NearFundingRoute>,
+    pub policy_gates: Vec<PaidResearchPolicyGate>,
+    pub ready_for_paid_fetch: bool,
+    pub ready_for_trade_research: bool,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ScoredSource {
+    source: PaidResearchSourceInput,
+    relevance: f64,
+    trust_score: f64,
+    freshness_score: f64,
+    tag_score: f64,
+    selection_score: f64,
+    price_usd: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SelectedPaidResearchSource {
+    pub id: String,
+    pub title: String,
+    pub author: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publisher: Option<String>,
+    pub url: String,
+    pub tags: Vec<String>,
+    pub price_usd: f64,
+    pub relevance: f64,
+    pub trust_score: f64,
+    pub freshness_score: f64,
+    pub selection_score: f64,
+    pub evidence_weight: f64,
+    pub payment: PlannedResearchPayment,
+    pub attribution: ResearchAttribution,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PlannedResearchPayment {
+    pub protocol: String,
+    pub network: String,
+    pub asset: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recipient: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    pub amount_usd: f64,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResearchAttribution {
+    pub credit_id: String,
+    pub payable: bool,
+    pub receipt_required: bool,
+    pub answer_usage: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RejectedPaidResearchSource {
+    pub id: String,
+    pub title: String,
+    pub reason: String,
+    pub price_usd: f64,
+    pub relevance: f64,
+    pub selection_score: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaidResearchRailSummary {
+    pub protocol: String,
+    pub count: usize,
+    pub allocated_usd: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NearFundingRoute {
+    pub target_protocol: String,
+    pub target_network: String,
+    pub target_asset: String,
+    pub amount_usd: f64,
+    pub via: String,
+    pub note: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaidResearchPolicyGate {
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
+    if input.query.trim().is_empty() {
+        return Err("query is required for plan_paid_research".to_string());
+    }
+
+    let budget_usd = clean_nonnegative(input.budget_usd);
+    let max_sources = input.max_sources.max(1);
+    let min_relevance = clamp01(input.min_relevance);
+    let blocked = normalized_set(&input.blocked_publishers);
+    let required_tags = normalized_set(&input.required_tags);
+
+    let mut warnings = Vec::new();
+    if input.sources.is_empty() {
+        warnings.push("No candidate research sources were provided.".to_string());
+    }
+    if budget_usd == 0.0 {
+        warnings.push("Budget is zero; only free sources can be selected.".to_string());
+    }
+
+    let mut rejected_sources = Vec::new();
+    let mut candidates = Vec::new();
+    for source in input.sources {
+        let scored = score_source(source, &input.query, &required_tags, budget_usd);
+        if blocked.contains(&normalize(&scored.source.author))
+            || scored
+                .source
+                .publisher
+                .as_ref()
+                .map(|publisher| blocked.contains(&normalize(publisher)))
+                .unwrap_or(false)
+        {
+            rejected_sources.push(rejected(&scored, "blocked-publisher"));
+            continue;
+        }
+        if !required_tags.is_empty() && !source_has_required_tags(&scored.source, &required_tags) {
+            rejected_sources.push(rejected(&scored, "missing-required-tags"));
+            continue;
+        }
+        if let (Some(max_age), Some(age)) = (input.max_source_age_days, scored.source.age_days) {
+            if age > max_age {
+                rejected_sources.push(rejected(&scored, "stale-source"));
+                continue;
+            }
+        }
+        if scored.relevance < min_relevance {
+            rejected_sources.push(rejected(&scored, "below-min-relevance"));
+            continue;
+        }
+        candidates.push(scored);
+    }
+
+    candidates.sort_by(|a, b| {
+        b.selection_score
+            .partial_cmp(&a.selection_score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| {
+                a.price_usd
+                    .partial_cmp(&b.price_usd)
+                    .unwrap_or(Ordering::Equal)
+            })
+            .then_with(|| a.source.id.cmp(&b.source.id))
+    });
+
+    let mut selected_scored = Vec::new();
+    let mut remaining_budget = budget_usd;
+    for candidate in candidates {
+        if selected_scored.len() >= max_sources {
+            rejected_sources.push(rejected(&candidate, "max-sources-reached"));
+            continue;
+        }
+        if candidate.price_usd > remaining_budget + f64::EPSILON {
+            rejected_sources.push(rejected(&candidate, "over-budget"));
+            continue;
+        }
+        remaining_budget = (remaining_budget - candidate.price_usd).max(0.0);
+        selected_scored.push(candidate);
+    }
+
+    let allocated_usd: f64 = selected_scored.iter().map(|s| s.price_usd).sum();
+    let score_sum: f64 = selected_scored
+        .iter()
+        .map(|s| s.selection_score.max(0.0))
+        .sum();
+    let mut rail_totals: BTreeMap<String, (usize, f64)> = BTreeMap::new();
+    let mut funding_totals: BTreeMap<(String, String, String), f64> = BTreeMap::new();
+
+    let selected_sources: Vec<SelectedPaidResearchSource> = selected_scored
+        .into_iter()
+        .map(|scored| {
+            let payment = planned_payment(&scored, &input.spending_mode);
+            let rail_entry = rail_totals
+                .entry(payment.protocol.clone())
+                .or_insert((0, 0.0));
+            rail_entry.0 += 1;
+            rail_entry.1 += payment.amount_usd;
+
+            if payment.amount_usd > 0.0 && payment.protocol != "near-intents" {
+                let key = (
+                    payment.protocol.clone(),
+                    payment.network.clone(),
+                    payment.asset.clone(),
+                );
+                *funding_totals.entry(key).or_insert(0.0) += payment.amount_usd;
+            }
+
+            let evidence_weight = if score_sum > 0.0 {
+                round4(scored.selection_score.max(0.0) / score_sum)
+            } else {
+                0.0
+            };
+            let payable = payment.amount_usd > 0.0;
+            SelectedPaidResearchSource {
+                id: scored.source.id.clone(),
+                title: scored.source.title.clone(),
+                author: scored.source.author.clone(),
+                publisher: scored.source.publisher.clone(),
+                url: scored.source.url.clone(),
+                tags: scored.source.tags.clone(),
+                price_usd: round4(scored.price_usd),
+                relevance: round4(scored.relevance),
+                trust_score: round4(scored.trust_score),
+                freshness_score: round4(scored.freshness_score),
+                selection_score: round4(scored.selection_score),
+                evidence_weight,
+                payment,
+                attribution: ResearchAttribution {
+                    credit_id: format!("research-credit/{}", scored.source.id),
+                    payable,
+                    receipt_required: payable,
+                    answer_usage: if payable {
+                        "cite only after payment receipt, then credit this source in the answer"
+                            .to_string()
+                    } else {
+                        "free/public source can be cited with URL attribution".to_string()
+                    },
+                },
+            }
+        })
+        .collect();
+
+    let payment_rails = rail_totals
+        .into_iter()
+        .map(
+            |(protocol, (count, allocated_usd))| PaidResearchRailSummary {
+                protocol,
+                count,
+                allocated_usd: round4(allocated_usd),
+            },
+        )
+        .collect();
+
+    let near_funding_routes = funding_totals
+        .into_iter()
+        .map(
+            |((target_protocol, target_network, target_asset), amount_usd)| NearFundingRoute {
+                target_protocol: target_protocol.clone(),
+                target_network,
+                target_asset,
+                amount_usd: round4(amount_usd),
+                via: "near-intents".to_string(),
+                note: format!(
+                    "Use a NEAR Intents funding route from {} into the {} rail wallet before the paid fetch; this does not itself authorize the content payment.",
+                    input.near_funding_asset, target_protocol
+                ),
+            },
+        )
+        .collect();
+
+    if selected_sources.is_empty() && !rejected_sources.is_empty() {
+        warnings.push(
+            "All candidate paid research sources were rejected by budget or gates.".to_string(),
+        );
+    }
+
+    let paid_selected = selected_sources
+        .iter()
+        .filter(|source| source.payment.amount_usd > 0.0)
+        .count();
+    let policy_gates = policy_gates(
+        &input.spending_mode,
+        budget_usd,
+        allocated_usd,
+        paid_selected,
+    );
+    let ready_for_paid_fetch = !selected_sources.is_empty()
+        && allocated_usd <= budget_usd + f64::EPSILON
+        && policy_gates.iter().all(|gate| gate.status != "fail");
+    let ready_for_trade_research = ready_for_paid_fetch
+        && selected_sources
+            .iter()
+            .map(|source| source.evidence_weight)
+            .sum::<f64>()
+            > 0.0;
+
+    Ok(PaidResearchPlan {
+        schema_version: "paid-research-plan/1",
+        query: input.query,
+        pair: input.pair,
+        spending_mode: input.spending_mode,
+        budget_usd: round4(budget_usd),
+        allocated_usd: round4(allocated_usd),
+        unspent_usd: round4((budget_usd - allocated_usd).max(0.0)),
+        selected_sources,
+        rejected_sources,
+        payment_rails,
+        near_funding_routes,
+        policy_gates,
+        ready_for_paid_fetch,
+        ready_for_trade_research,
+        warnings,
+    })
+}
+
+fn score_source(
+    source: PaidResearchSourceInput,
+    query: &str,
+    required_tags: &BTreeSet<String>,
+    budget_usd: f64,
+) -> ScoredSource {
+    let text = format!(
+        "{} {} {} {}",
+        source.title,
+        source.author,
+        source.summary.as_deref().unwrap_or_default(),
+        source.tags.join(" ")
+    );
+    let lexical = lexical_relevance(query, &text);
+    let relevance = source
+        .relevance
+        .map(clamp01)
+        .unwrap_or(lexical)
+        .max(lexical * 0.9);
+    let trust_score = source.trust_score.map(clamp01).unwrap_or(0.6);
+    let freshness_score = source
+        .freshness_score
+        .map(clamp01)
+        .unwrap_or_else(|| age_freshness(source.age_days));
+    let tag_score = tag_score(&source, query, required_tags);
+    let price_usd = clean_nonnegative(source.price_usd.unwrap_or(0.0));
+    let cost_penalty = if budget_usd > 0.0 {
+        (price_usd / budget_usd).min(1.0) * 0.08
+    } else if price_usd > 0.0 {
+        0.25
+    } else {
+        0.0
+    };
+    let selection_score =
+        (relevance * 0.50) + (trust_score * 0.22) + (freshness_score * 0.18) + (tag_score * 0.10)
+            - cost_penalty;
+
+    ScoredSource {
+        source,
+        relevance,
+        trust_score,
+        freshness_score,
+        tag_score,
+        selection_score: selection_score.max(0.0),
+        price_usd,
+    }
+}
+
+fn planned_payment(scored: &ScoredSource, spending_mode: &str) -> PlannedResearchPayment {
+    let raw = scored
+        .source
+        .payment
+        .clone()
+        .unwrap_or(PaidResearchPaymentInput {
+            protocol: if scored.price_usd > 0.0 {
+                "manual".to_string()
+            } else {
+                "free".to_string()
+            },
+            network: None,
+            asset: None,
+            recipient: None,
+            endpoint: None,
+        });
+    let protocol = normalize_protocol(&raw.protocol, scored.price_usd);
+    let is_free = scored.price_usd == 0.0 || protocol == "free";
+    let network = raw
+        .network
+        .unwrap_or_else(|| default_network_for_protocol(&protocol));
+    let asset = raw.asset.unwrap_or_else(|| {
+        if is_free {
+            "none".to_string()
+        } else {
+            "USDC".to_string()
+        }
+    });
+    let status = if is_free {
+        "free".to_string()
+    } else if spending_mode == "autopay" {
+        "requires-policy-wallet".to_string()
+    } else {
+        "requires-user-approval".to_string()
+    };
+
+    PlannedResearchPayment {
+        protocol,
+        network,
+        asset,
+        recipient: raw.recipient,
+        endpoint: raw.endpoint,
+        amount_usd: round4(scored.price_usd),
+        status,
+    }
+}
+
+fn policy_gates(
+    spending_mode: &str,
+    budget_usd: f64,
+    allocated_usd: f64,
+    paid_selected: usize,
+) -> Vec<PaidResearchPolicyGate> {
+    let mut gates = vec![
+        PaidResearchPolicyGate {
+            name: "budget-cap".to_string(),
+            status: if allocated_usd <= budget_usd + f64::EPSILON {
+                "pass"
+            } else {
+                "fail"
+            }
+            .to_string(),
+            detail: format!(
+                "Allocated ${:.4} of the ${:.4} paid research budget.",
+                allocated_usd, budget_usd
+            ),
+        },
+        PaidResearchPolicyGate {
+            name: "receipt-before-use".to_string(),
+            status: "pass".to_string(),
+            detail:
+                "Paywalled source text must not be used in an answer until a payment receipt exists."
+                    .to_string(),
+        },
+        PaidResearchPolicyGate {
+            name: "citation-attribution".to_string(),
+            status: "pass".to_string(),
+            detail:
+                "Every answer using paid research must include source IDs so writers can be credited."
+                    .to_string(),
+        },
+        PaidResearchPolicyGate {
+            name: "trade-gate".to_string(),
+            status: "pass".to_string(),
+            detail:
+                "Paid research can influence the thesis, but backtest and risk gates still control NEAR intent construction."
+                    .to_string(),
+        },
+    ];
+
+    let approval_status = match spending_mode {
+        "plan-only" | "quote" => "pass",
+        "autopay" if paid_selected == 0 => "pass",
+        "autopay" => "warn",
+        _ => "warn",
+    };
+    gates.push(PaidResearchPolicyGate {
+        name: "payment-authorization".to_string(),
+        status: approval_status.to_string(),
+        detail: if spending_mode == "autopay" {
+            "Autopay requires a policy wallet with explicit source, amount, and cadence caps."
+                .to_string()
+        } else {
+            "Live source payments remain user-approved; this plan only prepares payable attribution."
+                .to_string()
+        },
+    });
+
+    gates
+}
+
+fn rejected(scored: &ScoredSource, reason: &str) -> RejectedPaidResearchSource {
+    RejectedPaidResearchSource {
+        id: scored.source.id.clone(),
+        title: scored.source.title.clone(),
+        reason: reason.to_string(),
+        price_usd: round4(scored.price_usd),
+        relevance: round4(scored.relevance),
+        selection_score: round4(scored.selection_score),
+    }
+}
+
+fn lexical_relevance(query: &str, text: &str) -> f64 {
+    let query_tokens = tokenize(query);
+    if query_tokens.is_empty() {
+        return 0.0;
+    }
+    let text_tokens = tokenize(text);
+    if text_tokens.is_empty() {
+        return 0.0;
+    }
+    let matches = query_tokens
+        .iter()
+        .filter(|token| text_tokens.contains(*token))
+        .count();
+    (matches as f64 / query_tokens.len() as f64).min(1.0)
+}
+
+fn tag_score(
+    source: &PaidResearchSourceInput,
+    query: &str,
+    required_tags: &BTreeSet<String>,
+) -> f64 {
+    let source_tags = normalized_set(&source.tags);
+    if source_tags.is_empty() {
+        return 0.0;
+    }
+    if !required_tags.is_empty() {
+        let hits = required_tags
+            .iter()
+            .filter(|tag| source_tags.contains(*tag))
+            .count();
+        return hits as f64 / required_tags.len() as f64;
+    }
+    let query_tokens = tokenize(query);
+    let hits = query_tokens
+        .iter()
+        .filter(|token| source_tags.contains(*token))
+        .count();
+    (hits as f64 / query_tokens.len().max(1) as f64).min(1.0)
+}
+
+fn source_has_required_tags(
+    source: &PaidResearchSourceInput,
+    required_tags: &BTreeSet<String>,
+) -> bool {
+    let source_tags = normalized_set(&source.tags);
+    required_tags.iter().all(|tag| source_tags.contains(tag))
+}
+
+fn age_freshness(age_days: Option<u32>) -> f64 {
+    match age_days {
+        Some(0..=1) => 1.0,
+        Some(2..=7) => 0.85,
+        Some(8..=30) => 0.65,
+        Some(31..=90) => 0.45,
+        Some(_) => 0.25,
+        None => 0.55,
+    }
+}
+
+fn tokenize(value: &str) -> BTreeSet<String> {
+    value
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .map(normalize)
+        .filter(|token| token.len() > 2 && !is_stopword(token))
+        .collect()
+}
+
+fn normalized_set(values: &[String]) -> BTreeSet<String> {
+    values
+        .iter()
+        .map(|value| normalize(value))
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn normalize_protocol(protocol: &str, price_usd: f64) -> String {
+    let protocol = normalize(protocol);
+    if price_usd == 0.0 {
+        return "free".to_string();
+    }
+    match protocol.as_str() {
+        "near" | "near_intents" | "near-intents" => "near-intents".to_string(),
+        "mpp" | "tempo" => "mpp".to_string(),
+        "x402" | "base-x402" => "x402".to_string(),
+        "subscription" => "subscription".to_string(),
+        "manual" => "manual".to_string(),
+        "free" => "free".to_string(),
+        _ => "manual".to_string(),
+    }
+}
+
+fn default_network_for_protocol(protocol: &str) -> String {
+    match protocol {
+        "near-intents" => "near".to_string(),
+        "mpp" => "tempo".to_string(),
+        "x402" => "base".to_string(),
+        "subscription" => "offchain".to_string(),
+        "free" => "none".to_string(),
+        _ => "manual".to_string(),
+    }
+}
+
+fn is_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "the"
+            | "and"
+            | "for"
+            | "with"
+            | "into"
+            | "from"
+            | "that"
+            | "this"
+            | "what"
+            | "when"
+            | "near"
+            | "price"
+            | "trade"
+            | "trading"
+            | "token"
+            | "crypto"
+    )
+}
+
+fn clean_nonnegative(value: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        0.0
+    }
+}
+
+fn clamp01(value: f64) -> f64 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    value.clamp(0.0, 1.0)
+}
+
+fn round4(value: f64) -> f64 {
+    (value * 10_000.0).round() / 10_000.0
+}
+
+fn default_budget_usd() -> f64 {
+    5.0
+}
+
+fn default_max_sources() -> usize {
+    4
+}
+
+fn default_min_relevance() -> f64 {
+    0.35
+}
+
+fn default_spending_mode() -> String {
+    "plan-only".to_string()
+}
+
+fn default_near_funding_asset() -> String {
+    "USDC.near".to_string()
+}
+
+fn default_payment_protocol() -> String {
+    "manual".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(id: &str, price_usd: f64, protocol: &str, relevance: f64) -> PaidResearchSourceInput {
+        PaidResearchSourceInput {
+            id: id.to_string(),
+            title: format!("{id} NEAR Intents research"),
+            author: "Writer".to_string(),
+            publisher: Some("Research Desk".to_string()),
+            url: format!("https://example.com/{id}"),
+            summary: Some("NEAR BTC liquidity, solver quality, and intent route risk.".to_string()),
+            tags: vec!["near-intents".to_string(), "btc".to_string()],
+            price_usd: Some(price_usd),
+            relevance: Some(relevance),
+            trust_score: Some(0.8),
+            freshness_score: Some(0.9),
+            age_days: Some(1),
+            payment: Some(PaidResearchPaymentInput {
+                protocol: protocol.to_string(),
+                network: None,
+                asset: Some("USDC".to_string()),
+                recipient: Some("0xmerchant".to_string()),
+                endpoint: Some(format!("https://example.com/{id}/paid")),
+            }),
+        }
+    }
+
+    #[test]
+    fn paid_research_plan_respects_budget_and_routes_external_rails() {
+        let plan = plan(PaidResearchPlanInput {
+            query: "NEAR BTC solver route risk".to_string(),
+            pair: Some("NEAR/BTC".to_string()),
+            budget_usd: 0.05,
+            max_sources: 3,
+            min_relevance: 0.2,
+            max_source_age_days: Some(7),
+            spending_mode: "quote".to_string(),
+            near_funding_asset: "USDC.near".to_string(),
+            required_tags: vec!["near-intents".to_string()],
+            blocked_publishers: vec![],
+            sources: vec![
+                source("mpp-source", 0.02, "mpp", 0.9),
+                source("x402-source", 0.02, "x402", 0.85),
+                source("too-expensive", 0.10, "x402", 0.95),
+            ],
+        })
+        .expect("plan");
+
+        assert_eq!(plan.schema_version, "paid-research-plan/1");
+        assert_eq!(plan.selected_sources.len(), 2);
+        assert!(plan.allocated_usd <= 0.05);
+        assert_eq!(plan.near_funding_routes.len(), 2);
+        assert!(plan
+            .rejected_sources
+            .iter()
+            .any(|source| source.reason == "over-budget"));
+    }
+}

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -23,12 +23,22 @@ pub struct PaidResearchPlanInput {
     pub max_sources: usize,
     #[serde(default = "default_min_relevance")]
     pub min_relevance: f64,
+    #[serde(default = "default_min_trust_score")]
+    pub min_trust_score: f64,
+    #[serde(default = "default_max_seo_risk_score")]
+    pub max_seo_risk_score: f64,
     #[serde(default)]
     pub max_source_age_days: Option<u32>,
     #[serde(default = "default_spending_mode")]
     pub spending_mode: String,
     #[serde(default = "default_near_funding_asset")]
     pub near_funding_asset: String,
+    #[serde(default)]
+    pub preferred_payment_protocols: Vec<String>,
+    #[serde(default = "default_article_price_usd")]
+    pub default_article_price_usd: f64,
+    #[serde(default)]
+    pub agent_wallet: Option<AgentWalletPolicyInput>,
     #[serde(default)]
     pub required_tags: Vec<String>,
     #[serde(default)]
@@ -37,7 +47,7 @@ pub struct PaidResearchPlanInput {
     pub sources: Vec<PaidResearchSourceInput>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PaidResearchSourceInput {
     pub id: String,
     pub title: String,
@@ -58,9 +68,13 @@ pub struct PaidResearchSourceInput {
     #[serde(default)]
     pub freshness_score: Option<f64>,
     #[serde(default)]
+    pub seo_risk_score: Option<f64>,
+    #[serde(default)]
     pub age_days: Option<u32>,
     #[serde(default)]
     pub payment: Option<PaidResearchPaymentInput>,
+    #[serde(default)]
+    pub payment_options: Vec<PaidResearchPaymentInput>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -75,6 +89,76 @@ pub struct PaidResearchPaymentInput {
     pub recipient: Option<String>,
     #[serde(default)]
     pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentWalletPolicyInput {
+    #[serde(default = "default_agent_wallet_provider")]
+    pub provider: String,
+    #[serde(default)]
+    pub address: Option<String>,
+    #[serde(default = "default_agent_wallet_network")]
+    pub network: String,
+    #[serde(default)]
+    pub balance_usd: Option<f64>,
+    #[serde(default = "default_article_price_usd")]
+    pub default_article_price_usd: f64,
+    #[serde(default = "default_per_article_cap_usd")]
+    pub per_article_cap_usd: f64,
+    #[serde(default = "default_daily_wallet_cap_usd")]
+    pub daily_cap_usd: f64,
+    #[serde(default = "default_max_wallet_balance_usd")]
+    pub max_wallet_balance_usd: f64,
+    #[serde(default)]
+    pub audit_urls: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DripstackBrowseInput {
+    #[serde(default)]
+    pub topic: Option<String>,
+    #[serde(default)]
+    pub selected_publication_slug: Option<String>,
+    #[serde(default)]
+    pub selected_post_slug: Option<String>,
+    #[serde(default)]
+    pub max_results: Option<usize>,
+    #[serde(default = "default_article_price_usd")]
+    pub default_price_usd: f64,
+    #[serde(default)]
+    pub publications: Vec<DripstackPublicationInput>,
+    #[serde(default)]
+    pub posts: Vec<DripstackPostInput>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DripstackPublicationInput {
+    pub slug: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "siteUrl")]
+    pub site_url: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "lastSyncedAt")]
+    pub last_synced_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DripstackPostInput {
+    pub slug: String,
+    pub title: String,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub author: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "publishedAt")]
+    pub published_at: Option<String>,
+    #[serde(default)]
+    pub price_usd: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -92,6 +176,8 @@ pub struct PaidResearchPlan {
     pub payment_rails: Vec<PaidResearchRailSummary>,
     pub near_funding_routes: Vec<NearFundingRoute>,
     pub policy_gates: Vec<PaidResearchPolicyGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wallet_policy: Option<AgentWalletPolicy>,
     pub ready_for_paid_fetch: bool,
     pub ready_for_trade_research: bool,
     pub warnings: Vec<String>,
@@ -106,6 +192,7 @@ struct ScoredSource {
     tag_score: f64,
     selection_score: f64,
     price_usd: f64,
+    seo_risk_score: f64,
 }
 
 #[derive(Debug, Serialize)]
@@ -121,13 +208,16 @@ pub struct SelectedPaidResearchSource {
     pub relevance: f64,
     pub trust_score: f64,
     pub freshness_score: f64,
+    pub seo_risk_score: f64,
     pub selection_score: f64,
     pub evidence_weight: f64,
     pub payment: PlannedResearchPayment,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub payment_options: Vec<PlannedResearchPayment>,
     pub attribution: ResearchAttribution,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PlannedResearchPayment {
     pub protocol: String,
     pub network: String,
@@ -182,6 +272,65 @@ pub struct PaidResearchPolicyGate {
     pub detail: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct AgentWalletPolicy {
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    pub network: String,
+    pub balance_usd: f64,
+    pub default_article_price_usd: f64,
+    pub max_articles_at_default_price: usize,
+    pub per_article_cap_usd: f64,
+    pub daily_cap_usd: f64,
+    pub max_wallet_balance_usd: f64,
+    pub safe_to_autopay: bool,
+    pub audit_urls: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DripstackBrowsePlan {
+    pub schema_version: &'static str,
+    pub checkpoint: String,
+    pub prompt: String,
+    pub matched_publications: Vec<DripstackPublicationMatch>,
+    pub post_candidates: Vec<DripstackPostCandidate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_article: Option<DripstackPostCandidate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paid_source_candidate: Option<PaidResearchSourceInput>,
+    pub guardrails: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DripstackPublicationMatch {
+    pub rank: usize,
+    pub slug: String,
+    pub title: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub site_url: Option<String>,
+    pub relevance: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DripstackPostCandidate {
+    pub rank: usize,
+    pub publication_slug: String,
+    pub slug: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subtitle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
+    pub price_usd: f64,
+    pub endpoint: String,
+}
+
 pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
     if input.query.trim().is_empty() {
         return Err("query is required for plan_paid_research".to_string());
@@ -190,8 +339,15 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
     let budget_usd = clean_nonnegative(input.budget_usd);
     let max_sources = input.max_sources.max(1);
     let min_relevance = clamp01(input.min_relevance);
+    let min_trust_score = clamp01(input.min_trust_score);
+    let max_seo_risk_score = clamp01(input.max_seo_risk_score);
     let blocked = normalized_set(&input.blocked_publishers);
     let required_tags = normalized_set(&input.required_tags);
+    let preferred_payment_protocols =
+        preferred_payment_protocols(&input.preferred_payment_protocols);
+    let spending_mode = input.spending_mode.clone();
+    let default_article_price_usd = clean_nonnegative(input.default_article_price_usd);
+    let agent_wallet = input.agent_wallet.clone();
 
     let mut warnings = Vec::new();
     if input.sources.is_empty() {
@@ -228,6 +384,14 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         }
         if scored.relevance < min_relevance {
             rejected_sources.push(rejected(&scored, "below-min-relevance"));
+            continue;
+        }
+        if scored.trust_score < min_trust_score {
+            rejected_sources.push(rejected(&scored, "below-min-trust"));
+            continue;
+        }
+        if scored.seo_risk_score > max_seo_risk_score {
+            rejected_sources.push(rejected(&scored, "seo-risk-too-high"));
             continue;
         }
         candidates.push(scored);
@@ -271,7 +435,12 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
     let selected_sources: Vec<SelectedPaidResearchSource> = selected_scored
         .into_iter()
         .map(|scored| {
-            let payment = planned_payment(&scored, &input.spending_mode);
+            let payment_options =
+                planned_payment_options(&scored, &spending_mode, &preferred_payment_protocols);
+            let payment = payment_options
+                .first()
+                .cloned()
+                .unwrap_or_else(|| planned_payment_default(&scored, &spending_mode));
             let rail_entry = rail_totals
                 .entry(payment.protocol.clone())
                 .or_insert((0, 0.0));
@@ -304,9 +473,11 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
                 relevance: round4(scored.relevance),
                 trust_score: round4(scored.trust_score),
                 freshness_score: round4(scored.freshness_score),
+                seo_risk_score: round4(scored.seo_risk_score),
                 selection_score: round4(scored.selection_score),
                 evidence_weight,
                 payment,
+                payment_options,
                 attribution: ResearchAttribution {
                     credit_id: format!("research-credit/{}", scored.source.id),
                     payable,
@@ -360,11 +531,22 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         .iter()
         .filter(|source| source.payment.amount_usd > 0.0)
         .count();
+    let max_selected_price_usd = selected_sources
+        .iter()
+        .map(|source| source.price_usd)
+        .fold(0.0, f64::max);
+    let wallet_policy = agent_wallet_policy(
+        agent_wallet.as_ref(),
+        max_selected_price_usd,
+        default_article_price_usd,
+    );
     let policy_gates = policy_gates(
-        &input.spending_mode,
+        &spending_mode,
         budget_usd,
         allocated_usd,
         paid_selected,
+        wallet_policy.as_ref(),
+        max_selected_price_usd,
     );
     let ready_for_paid_fetch = !selected_sources.is_empty()
         && allocated_usd <= budget_usd + f64::EPSILON
@@ -380,7 +562,7 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         schema_version: "paid-research-plan/1",
         query: input.query,
         pair: input.pair,
-        spending_mode: input.spending_mode,
+        spending_mode,
         budget_usd: round4(budget_usd),
         allocated_usd: round4(allocated_usd),
         unspent_usd: round4((budget_usd - allocated_usd).max(0.0)),
@@ -389,8 +571,220 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         payment_rails,
         near_funding_routes,
         policy_gates,
+        wallet_policy,
         ready_for_paid_fetch,
         ready_for_trade_research,
+        warnings,
+    })
+}
+
+pub fn plan_dripstack_browse(input: DripstackBrowseInput) -> Result<DripstackBrowsePlan, String> {
+    let guardrails = vec![
+        "Guided browse only: topic, publication, article, then explicit purchase approval."
+            .to_string(),
+        "Catalog and post-title routes are free; article body remains gated until 402 payment succeeds."
+            .to_string(),
+        "Never auto-buy: a selected article becomes a paid-source candidate, not fetched content."
+            .to_string(),
+        "Paid article text requires a receipt before it can be summarized, quoted, or used in a trade thesis."
+            .to_string(),
+    ];
+    let mut warnings = Vec::new();
+    let max_results = input.max_results.unwrap_or(5).clamp(1, 10);
+    let default_price_usd = clean_nonnegative(input.default_price_usd).max(0.01);
+
+    let topic = input
+        .topic
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let selected_publication_slug = input
+        .selected_publication_slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let selected_post_slug = input
+        .selected_post_slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    if topic.is_none() && selected_publication_slug.is_none() {
+        return Ok(DripstackBrowsePlan {
+            schema_version: "dripstack-browse-plan/1",
+            checkpoint: "topic".to_string(),
+            prompt: "Choose a topic first: finance, crypto, AI, tech, business, geopolitics, or culture.".to_string(),
+            matched_publications: Vec::new(),
+            post_candidates: Vec::new(),
+            selected_article: None,
+            paid_source_candidate: None,
+            guardrails,
+            warnings,
+        });
+    }
+
+    let matched_publications = if let Some(topic) = topic {
+        let mut scored: Vec<(f64, &DripstackPublicationInput)> = input
+            .publications
+            .iter()
+            .map(|publication| (publication_relevance(topic, publication), publication))
+            .filter(|(score, _)| *score > 0.0)
+            .collect();
+        scored.sort_by(|a, b| {
+            b.0.partial_cmp(&a.0)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.1.slug.cmp(&b.1.slug))
+        });
+        scored
+            .into_iter()
+            .take(max_results)
+            .enumerate()
+            .map(
+                |(idx, (relevance, publication))| DripstackPublicationMatch {
+                    rank: idx + 1,
+                    slug: publication.slug.clone(),
+                    title: publication
+                        .title
+                        .clone()
+                        .unwrap_or_else(|| publication.slug.clone()),
+                    description: publication.description.clone().unwrap_or_default(),
+                    site_url: publication.site_url.clone(),
+                    relevance: round4(relevance),
+                },
+            )
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    if selected_publication_slug.is_none() {
+        if input.publications.is_empty() {
+            warnings.push(
+                "No publication catalog was supplied. Fetch DripStack GET /api/v1/publications before this step."
+                    .to_string(),
+            );
+        }
+        return Ok(DripstackBrowsePlan {
+            schema_version: "dripstack-browse-plan/1",
+            checkpoint: "publication".to_string(),
+            prompt: "Pick one matched publication before listing articles.".to_string(),
+            matched_publications,
+            post_candidates: Vec::new(),
+            selected_article: None,
+            paid_source_candidate: None,
+            guardrails,
+            warnings,
+        });
+    }
+
+    let publication_slug = selected_publication_slug.unwrap();
+    let publication = input
+        .publications
+        .iter()
+        .find(|publication| publication.slug == publication_slug);
+    if publication.is_none() && !input.publications.is_empty() {
+        warnings.push(format!(
+            "Selected publication '{publication_slug}' was not found in the supplied catalog."
+        ));
+    }
+    let publication_title = publication
+        .and_then(|publication| publication.title.clone())
+        .unwrap_or_else(|| publication_slug.to_string());
+
+    let post_candidates: Vec<DripstackPostCandidate> = input
+        .posts
+        .iter()
+        .take(max_results)
+        .enumerate()
+        .map(|(idx, post)| post_candidate(idx + 1, publication_slug, post, default_price_usd))
+        .collect();
+
+    if selected_post_slug.is_none() {
+        if input.posts.is_empty() {
+            warnings.push(format!(
+                "No post summaries were supplied. Fetch DripStack GET /api/v1/publications/{publication_slug} before choosing an article."
+            ));
+        }
+        return Ok(DripstackBrowsePlan {
+            schema_version: "dripstack-browse-plan/1",
+            checkpoint: "article".to_string(),
+            prompt: format!(
+                "Pick one article from {publication_title}; no article body is fetched yet."
+            ),
+            matched_publications,
+            post_candidates,
+            selected_article: None,
+            paid_source_candidate: None,
+            guardrails,
+            warnings,
+        });
+    }
+
+    let selected_post_slug = selected_post_slug.unwrap();
+    let selected_post = input
+        .posts
+        .iter()
+        .find(|post| post.slug == selected_post_slug)
+        .ok_or_else(|| {
+            format!(
+                "Selected post '{selected_post_slug}' was not found in the supplied post summaries."
+            )
+        })?;
+    let selected_article = post_candidate(1, publication_slug, selected_post, default_price_usd);
+    let title = selected_article.title.clone();
+    let author = selected_article
+        .author
+        .clone()
+        .unwrap_or_else(|| publication_title.clone());
+    let paid_source_candidate = PaidResearchSourceInput {
+        id: format!("dripstack:{publication_slug}:{selected_post_slug}"),
+        title,
+        author,
+        publisher: Some(publication_title),
+        url: selected_article.endpoint.clone(),
+        summary: selected_article.subtitle.clone(),
+        tags: vec![
+            "dripstack".to_string(),
+            "paid-content".to_string(),
+            "financial-research".to_string(),
+        ],
+        price_usd: Some(selected_article.price_usd),
+        relevance: Some(0.75),
+        trust_score: Some(0.65),
+        freshness_score: selected_article.published_at.as_ref().map(|_| 0.75),
+        seo_risk_score: Some(0.35),
+        age_days: None,
+        payment: None,
+        payment_options: vec![
+            PaidResearchPaymentInput {
+                protocol: "mpp".to_string(),
+                network: Some("tempo".to_string()),
+                asset: Some("USDC".to_string()),
+                recipient: None,
+                endpoint: Some(selected_article.endpoint.clone()),
+            },
+            PaidResearchPaymentInput {
+                protocol: "x402".to_string(),
+                network: Some("base".to_string()),
+                asset: Some("USDC".to_string()),
+                recipient: None,
+                endpoint: Some(selected_article.endpoint.clone()),
+            },
+        ],
+    };
+
+    Ok(DripstackBrowsePlan {
+        schema_version: "dripstack-browse-plan/1",
+        checkpoint: "purchase-confirmation".to_string(),
+        prompt: format!(
+            "Confirm before paying for this article. The planned price is ${:.4}; article body remains locked until the payment-aware client returns a receipt.",
+            selected_article.price_usd
+        ),
+        matched_publications,
+        post_candidates,
+        selected_article: Some(selected_article),
+        paid_source_candidate: Some(paid_source_candidate),
+        guardrails,
         warnings,
     })
 }
@@ -419,6 +813,13 @@ fn score_source(
         .freshness_score
         .map(clamp01)
         .unwrap_or_else(|| age_freshness(source.age_days));
+    let seo_risk_score = source.seo_risk_score.map(clamp01).unwrap_or_else(|| {
+        if trust_score < 0.45 && relevance > 0.8 {
+            0.75
+        } else {
+            0.25
+        }
+    });
     let tag_score = tag_score(&source, query, required_tags);
     let price_usd = clean_nonnegative(source.price_usd.unwrap_or(0.0));
     let cost_penalty = if budget_usd > 0.0 {
@@ -440,15 +841,27 @@ fn score_source(
         tag_score,
         selection_score: selection_score.max(0.0),
         price_usd,
+        seo_risk_score,
     }
 }
 
-fn planned_payment(scored: &ScoredSource, spending_mode: &str) -> PlannedResearchPayment {
-    let raw = scored
-        .source
-        .payment
-        .clone()
-        .unwrap_or(PaidResearchPaymentInput {
+fn planned_payment_options(
+    scored: &ScoredSource,
+    spending_mode: &str,
+    preferred_protocols: &[String],
+) -> Vec<PlannedResearchPayment> {
+    let mut raw_options = if scored.source.payment_options.is_empty() {
+        scored
+            .source
+            .payment
+            .clone()
+            .into_iter()
+            .collect::<Vec<_>>()
+    } else {
+        scored.source.payment_options.clone()
+    };
+    if raw_options.is_empty() {
+        raw_options.push(PaidResearchPaymentInput {
             protocol: if scored.price_usd > 0.0 {
                 "manual".to_string()
             } else {
@@ -459,6 +872,43 @@ fn planned_payment(scored: &ScoredSource, spending_mode: &str) -> PlannedResearc
             recipient: None,
             endpoint: None,
         });
+    }
+
+    let mut options: Vec<PlannedResearchPayment> = raw_options
+        .into_iter()
+        .map(|raw| planned_payment_from_raw(scored, raw, spending_mode))
+        .collect();
+    options.sort_by(|a, b| {
+        payment_rank(&a.protocol, preferred_protocols)
+            .cmp(&payment_rank(&b.protocol, preferred_protocols))
+            .then_with(|| a.network.cmp(&b.network))
+    });
+    options
+}
+
+fn planned_payment_default(scored: &ScoredSource, spending_mode: &str) -> PlannedResearchPayment {
+    planned_payment_from_raw(
+        scored,
+        PaidResearchPaymentInput {
+            protocol: if scored.price_usd > 0.0 {
+                "manual".to_string()
+            } else {
+                "free".to_string()
+            },
+            network: None,
+            asset: None,
+            recipient: None,
+            endpoint: None,
+        },
+        spending_mode,
+    )
+}
+
+fn planned_payment_from_raw(
+    scored: &ScoredSource,
+    raw: PaidResearchPaymentInput,
+    spending_mode: &str,
+) -> PlannedResearchPayment {
     let protocol = normalize_protocol(&raw.protocol, scored.price_usd);
     let is_free = scored.price_usd == 0.0 || protocol == "free";
     let network = raw
@@ -495,6 +945,8 @@ fn policy_gates(
     budget_usd: f64,
     allocated_usd: f64,
     paid_selected: usize,
+    wallet_policy: Option<&AgentWalletPolicy>,
+    max_selected_price_usd: f64,
 ) -> Vec<PaidResearchPolicyGate> {
     let mut gates = vec![
         PaidResearchPolicyGate {
@@ -550,6 +1002,44 @@ fn policy_gates(
                 .to_string()
         },
     });
+    if let Some(policy) = wallet_policy {
+        gates.push(PaidResearchPolicyGate {
+            name: "agent-wallet-funded".to_string(),
+            status: if policy.balance_usd <= 0.0 {
+                "warn"
+            } else if policy.balance_usd > policy.max_wallet_balance_usd {
+                "warn"
+            } else {
+                "pass"
+            }
+            .to_string(),
+            detail: format!(
+                "{} wallet balance is ${:.2}; cap is ${:.2}.",
+                policy.provider, policy.balance_usd, policy.max_wallet_balance_usd
+            ),
+        });
+        gates.push(PaidResearchPolicyGate {
+            name: "per-article-cap".to_string(),
+            status: if max_selected_price_usd <= policy.per_article_cap_usd + f64::EPSILON {
+                "pass"
+            } else {
+                "fail"
+            }
+            .to_string(),
+            detail: format!(
+                "Highest selected source is ${:.4}; wallet per-article cap is ${:.4}.",
+                max_selected_price_usd, policy.per_article_cap_usd
+            ),
+        });
+    } else if paid_selected > 0 {
+        gates.push(PaidResearchPolicyGate {
+            name: "agent-wallet-configured".to_string(),
+            status: "warn".to_string(),
+            detail:
+                "No agent wallet policy was supplied; paid fetches must stay in explicit approval mode."
+                    .to_string(),
+        });
+    }
 
     gates
 }
@@ -563,6 +1053,81 @@ fn rejected(scored: &ScoredSource, reason: &str) -> RejectedPaidResearchSource {
         relevance: round4(scored.relevance),
         selection_score: round4(scored.selection_score),
     }
+}
+
+fn agent_wallet_policy(
+    input: Option<&AgentWalletPolicyInput>,
+    max_selected_price_usd: f64,
+    fallback_article_price_usd: f64,
+) -> Option<AgentWalletPolicy> {
+    let input = input?;
+    let balance_usd = clean_nonnegative(input.balance_usd.unwrap_or(0.0));
+    let default_article_price_usd = clean_nonnegative(input.default_article_price_usd)
+        .max(clean_nonnegative(fallback_article_price_usd))
+        .max(0.0001);
+    let per_article_cap_usd = clean_nonnegative(input.per_article_cap_usd);
+    let daily_cap_usd = clean_nonnegative(input.daily_cap_usd);
+    let max_wallet_balance_usd = clean_nonnegative(input.max_wallet_balance_usd);
+    let mut warnings = Vec::new();
+    if balance_usd == 0.0 {
+        warnings.push("Agent wallet has no declared USDC balance.".to_string());
+    }
+    if balance_usd > max_wallet_balance_usd {
+        warnings.push("Agent wallet is over the configured autonomous balance cap.".to_string());
+    }
+    if max_selected_price_usd > per_article_cap_usd + f64::EPSILON {
+        warnings.push("At least one selected source exceeds the per-article cap.".to_string());
+    }
+    let audit_urls = if input.audit_urls.is_empty() {
+        vec![
+            "https://mppscan.com/".to_string(),
+            "https://www.x402scan.com/".to_string(),
+        ]
+    } else {
+        input.audit_urls.clone()
+    };
+    Some(AgentWalletPolicy {
+        provider: input.provider.clone(),
+        address: input.address.clone(),
+        network: input.network.clone(),
+        balance_usd: round4(balance_usd),
+        default_article_price_usd: round4(default_article_price_usd),
+        max_articles_at_default_price: (balance_usd / default_article_price_usd).floor() as usize,
+        per_article_cap_usd: round4(per_article_cap_usd),
+        daily_cap_usd: round4(daily_cap_usd),
+        max_wallet_balance_usd: round4(max_wallet_balance_usd),
+        safe_to_autopay: balance_usd > 0.0
+            && balance_usd <= max_wallet_balance_usd + f64::EPSILON
+            && max_selected_price_usd <= per_article_cap_usd + f64::EPSILON,
+        audit_urls,
+        warnings,
+    })
+}
+
+fn preferred_payment_protocols(raw: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = raw
+        .iter()
+        .map(|protocol| normalize_protocol(protocol, 1.0))
+        .filter(|protocol| !protocol.is_empty())
+        .collect();
+    if out.is_empty() {
+        out = vec![
+            "near-intents".to_string(),
+            "mpp".to_string(),
+            "x402".to_string(),
+            "subscription".to_string(),
+            "manual".to_string(),
+            "free".to_string(),
+        ];
+    }
+    out
+}
+
+fn payment_rank(protocol: &str, preferred_protocols: &[String]) -> usize {
+    preferred_protocols
+        .iter()
+        .position(|candidate| candidate == protocol)
+        .unwrap_or(usize::MAX)
 }
 
 fn lexical_relevance(query: &str, text: &str) -> f64 {
@@ -579,6 +1144,42 @@ fn lexical_relevance(query: &str, text: &str) -> f64 {
         .filter(|token| text_tokens.contains(*token))
         .count();
     (matches as f64 / query_tokens.len() as f64).min(1.0)
+}
+
+fn publication_relevance(topic: &str, publication: &DripstackPublicationInput) -> f64 {
+    lexical_relevance(
+        topic,
+        &format!(
+            "{} {} {}",
+            publication.title.as_deref().unwrap_or_default(),
+            publication.description.as_deref().unwrap_or_default(),
+            publication.site_url.as_deref().unwrap_or_default()
+        ),
+    )
+}
+
+fn post_candidate(
+    rank: usize,
+    publication_slug: &str,
+    post: &DripstackPostInput,
+    default_price_usd: f64,
+) -> DripstackPostCandidate {
+    DripstackPostCandidate {
+        rank,
+        publication_slug: publication_slug.to_string(),
+        slug: post.slug.clone(),
+        title: post.title.clone(),
+        subtitle: post.subtitle.clone(),
+        author: post.author.clone(),
+        published_at: post.published_at.clone(),
+        price_usd: round4(clean_nonnegative(
+            post.price_usd.unwrap_or(default_price_usd),
+        )),
+        endpoint: format!(
+            "https://dripstack.xyz/api/v1/publications/{}/{}",
+            publication_slug, post.slug
+        ),
+    }
 }
 
 fn tag_score(
@@ -724,6 +1325,14 @@ fn default_min_relevance() -> f64 {
     0.35
 }
 
+fn default_min_trust_score() -> f64 {
+    0.45
+}
+
+fn default_max_seo_risk_score() -> f64 {
+    0.65
+}
+
 fn default_spending_mode() -> String {
     "plan-only".to_string()
 }
@@ -734,6 +1343,30 @@ fn default_near_funding_asset() -> String {
 
 fn default_payment_protocol() -> String {
     "manual".to_string()
+}
+
+fn default_agent_wallet_provider() -> String {
+    "AgentCash".to_string()
+}
+
+fn default_agent_wallet_network() -> String {
+    "base".to_string()
+}
+
+fn default_article_price_usd() -> f64 {
+    0.01
+}
+
+fn default_per_article_cap_usd() -> f64 {
+    0.05
+}
+
+fn default_daily_wallet_cap_usd() -> f64 {
+    1.0
+}
+
+fn default_max_wallet_balance_usd() -> f64 {
+    5.0
 }
 
 #[cfg(test)]
@@ -753,6 +1386,7 @@ mod tests {
             relevance: Some(relevance),
             trust_score: Some(0.8),
             freshness_score: Some(0.9),
+            seo_risk_score: Some(0.2),
             age_days: Some(1),
             payment: Some(PaidResearchPaymentInput {
                 protocol: protocol.to_string(),
@@ -761,6 +1395,7 @@ mod tests {
                 recipient: Some("0xmerchant".to_string()),
                 endpoint: Some(format!("https://example.com/{id}/paid")),
             }),
+            payment_options: Vec::new(),
         }
     }
 
@@ -772,9 +1407,14 @@ mod tests {
             budget_usd: 0.05,
             max_sources: 3,
             min_relevance: 0.2,
+            min_trust_score: 0.4,
+            max_seo_risk_score: 0.65,
             max_source_age_days: Some(7),
             spending_mode: "quote".to_string(),
             near_funding_asset: "USDC.near".to_string(),
+            preferred_payment_protocols: vec!["mpp".to_string(), "x402".to_string()],
+            default_article_price_usd: 0.01,
+            agent_wallet: None,
             required_tags: vec!["near-intents".to_string()],
             blocked_publishers: vec![],
             sources: vec![

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -349,6 +349,20 @@
           "default": 0.35,
           "description": "Minimum relevance gate after explicit and lexical scoring."
         },
+        "min_trust_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.45,
+          "description": "Minimum trust gate to reduce agentic-SEO manipulation."
+        },
+        "max_seo_risk_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.65,
+          "description": "Maximum accepted source-manipulation risk score."
+        },
         "max_source_age_days": {
           "type": "integer",
           "minimum": 0,
@@ -364,6 +378,36 @@
           "type": "string",
           "default": "USDC.near",
           "description": "NEAR-side asset to route from when funding external MPP/x402 rails through NEAR Intents."
+        },
+        "preferred_payment_protocols": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["near-intents", "mpp", "x402", "subscription", "manual", "free"]
+          },
+          "default": ["near-intents", "mpp", "x402", "subscription", "manual", "free"],
+          "description": "Payment rail preference order when a source supports more than one rail."
+        },
+        "default_article_price_usd": {
+          "type": "number",
+          "minimum": 0,
+          "default": 0.01,
+          "description": "Default article price used for wallet-cap math."
+        },
+        "agent_wallet": {
+          "type": "object",
+          "description": "Optional autonomous wallet policy. This is policy metadata only, not signing material.",
+          "properties": {
+            "provider": { "type": "string", "default": "AgentCash" },
+            "address": { "type": "string" },
+            "network": { "type": "string", "default": "base" },
+            "balance_usd": { "type": "number", "minimum": 0 },
+            "default_article_price_usd": { "type": "number", "minimum": 0, "default": 0.01 },
+            "per_article_cap_usd": { "type": "number", "minimum": 0, "default": 0.05 },
+            "daily_cap_usd": { "type": "number", "minimum": 0, "default": 1.0 },
+            "max_wallet_balance_usd": { "type": "number", "minimum": 0, "default": 5.0 },
+            "audit_urls": { "type": "array", "items": { "type": "string" }, "default": [] }
+          }
         },
         "required_tags": {
           "type": "array",
@@ -394,6 +438,7 @@
               "relevance": { "type": "number", "minimum": 0, "maximum": 1 },
               "trust_score": { "type": "number", "minimum": 0, "maximum": 1 },
               "freshness_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "seo_risk_score": { "type": "number", "minimum": 0, "maximum": 1 },
               "age_days": { "type": "integer", "minimum": 0 },
               "payment": {
                 "type": "object",
@@ -409,6 +454,25 @@
                   "recipient": { "type": "string" },
                   "endpoint": { "type": "string" }
                 }
+              },
+              "payment_options": {
+                "type": "array",
+                "description": "Alternative rails accepted by the same source, for example DripStack supporting both MPP and x402.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "protocol": {
+                      "type": "string",
+                      "enum": ["near-intents", "mpp", "x402", "subscription", "manual", "free"],
+                      "default": "manual"
+                    },
+                    "network": { "type": "string" },
+                    "asset": { "type": "string" },
+                    "recipient": { "type": "string" },
+                    "endpoint": { "type": "string" }
+                  }
+                },
+                "default": []
               }
             },
             "required": ["id", "title", "author", "url"]
@@ -417,6 +481,64 @@
         }
       },
       "required": ["action", "query"]
+    },
+    {
+      "properties": {
+        "action": { "const": "plan_dripstack_browse" },
+        "topic": {
+          "type": "string",
+          "description": "User topic. If absent, the output checkpoint asks for a topic before any catalog work."
+        },
+        "selected_publication_slug": {
+          "type": "string",
+          "description": "Publication slug selected by the user from a matched shortlist."
+        },
+        "selected_post_slug": {
+          "type": "string",
+          "description": "Post slug selected by the user from post summaries."
+        },
+        "max_results": { "type": "integer", "minimum": 1, "maximum": 10, "default": 5 },
+        "default_price_usd": {
+          "type": "number",
+          "minimum": 0,
+          "default": 0.01,
+          "description": "Default planned article price when a post-specific price is unavailable."
+        },
+        "publications": {
+          "type": "array",
+          "description": "Free DripStack publication catalog rows from GET /api/v1/publications.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": { "type": "string" },
+              "title": { "type": "string" },
+              "description": { "type": "string" },
+              "site_url": { "type": "string" },
+              "last_synced_at": { "type": "string" }
+            },
+            "required": ["slug"]
+          },
+          "default": []
+        },
+        "posts": {
+          "type": "array",
+          "description": "Free post summaries from GET /api/v1/publications/{publicationSlug}.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": { "type": "string" },
+              "title": { "type": "string" },
+              "subtitle": { "type": "string" },
+              "author": { "type": "string" },
+              "published_at": { "type": "string" },
+              "price_usd": { "type": "number", "minimum": 0 }
+            },
+            "required": ["slug", "title"]
+          },
+          "default": []
+        }
+      },
+      "required": ["action"]
     },
     {
       "properties": {

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -181,6 +181,10 @@
           "items": { "type": "string" },
           "default": []
         },
+        "paid_research_plan": {
+          "type": "object",
+          "description": "Optional output from plan_paid_research. The widget extracts budget, payable sources, rails, policy gates, and NEAR funding routes."
+        },
         "next_action": {
           "type": "string",
           "description": "Operator-facing next step shown in the widget."
@@ -313,6 +317,106 @@
         "slippage_bps": { "type": "number", "minimum": 0, "default": 5 }
       },
       "required": ["action", "candles", "candidates"]
+    },
+    {
+      "properties": {
+        "action": { "const": "plan_paid_research" },
+        "query": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Question or research task to answer before a trading decision."
+        },
+        "pair": {
+          "type": "string",
+          "description": "Optional watched pair, for example NEAR/BTC."
+        },
+        "budget_usd": {
+          "type": "number",
+          "minimum": 0,
+          "default": 5,
+          "description": "Maximum total spend across selected paid sources. Zero allows only free sources."
+        },
+        "max_sources": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 4,
+          "description": "Maximum number of sources to select."
+        },
+        "min_relevance": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.35,
+          "description": "Minimum relevance gate after explicit and lexical scoring."
+        },
+        "max_source_age_days": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional freshness gate for sources that include age_days."
+        },
+        "spending_mode": {
+          "type": "string",
+          "enum": ["plan-only", "quote", "autopay"],
+          "default": "plan-only",
+          "description": "plan-only and quote never authorize payment; autopay still requires a policy wallet outside this tool."
+        },
+        "near_funding_asset": {
+          "type": "string",
+          "default": "USDC.near",
+          "description": "NEAR-side asset to route from when funding external MPP/x402 rails through NEAR Intents."
+        },
+        "required_tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "All selected sources must include these tags when provided."
+        },
+        "blocked_publishers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Authors or publishers to exclude from selection."
+        },
+        "sources": {
+          "type": "array",
+          "description": "Candidate free or paid sources discovered from newsletters, APIs, x402/MPP discovery, or project config.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "title": { "type": "string" },
+              "author": { "type": "string" },
+              "publisher": { "type": "string" },
+              "url": { "type": "string" },
+              "summary": { "type": "string" },
+              "tags": { "type": "array", "items": { "type": "string" }, "default": [] },
+              "price_usd": { "type": "number", "minimum": 0 },
+              "relevance": { "type": "number", "minimum": 0, "maximum": 1 },
+              "trust_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "freshness_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "age_days": { "type": "integer", "minimum": 0 },
+              "payment": {
+                "type": "object",
+                "description": "Payment rail metadata. This is planning data only; no payment is signed.",
+                "properties": {
+                  "protocol": {
+                    "type": "string",
+                    "enum": ["near-intents", "mpp", "x402", "subscription", "manual", "free"],
+                    "default": "manual"
+                  },
+                  "network": { "type": "string" },
+                  "asset": { "type": "string" },
+                  "recipient": { "type": "string" },
+                  "endpoint": { "type": "string" }
+                }
+              }
+            },
+            "required": ["id", "title", "author", "url"]
+          },
+          "default": []
+        }
+      },
+      "required": ["action", "query"]
     },
     {
       "properties": {

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -240,6 +240,8 @@ pub struct IntentsPaidResearchSummary {
     pub payable_sources: Vec<IntentsPayableResearchSource>,
     pub near_funding_routes: Vec<IntentsPaidResearchFundingRoute>,
     pub policy_gates: Vec<IntentsRiskGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wallet_policy: Option<IntentsPaidResearchWalletPolicy>,
     pub warnings: Vec<String>,
 }
 
@@ -268,6 +270,20 @@ pub struct IntentsPaidResearchFundingRoute {
     pub target_network: String,
     pub amount_usd: f64,
     pub via: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPaidResearchWalletPolicy {
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    pub network: String,
+    pub balance_usd: f64,
+    pub max_articles_at_default_price: usize,
+    pub per_article_cap_usd: f64,
+    pub daily_cap_usd: f64,
+    pub safe_to_autopay: bool,
+    pub audit_urls: Vec<String>,
 }
 
 fn default_mode() -> String {
@@ -530,6 +546,34 @@ fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidRes
                 .map(|detail| detail.to_string()),
         })
         .collect();
+    let wallet_policy = value
+        .get("wallet_policy")
+        .map(|wallet| IntentsPaidResearchWalletPolicy {
+            provider: string_field(wallet, "provider", "AgentCash"),
+            address: wallet
+                .get("address")
+                .and_then(|address| address.as_str())
+                .map(|address| address.to_string()),
+            network: string_field(wallet, "network", "base"),
+            balance_usd: number_field(wallet, "balance_usd"),
+            max_articles_at_default_price: wallet
+                .get("max_articles_at_default_price")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as usize,
+            per_article_cap_usd: number_field(wallet, "per_article_cap_usd"),
+            daily_cap_usd: number_field(wallet, "daily_cap_usd"),
+            safe_to_autopay: wallet
+                .get("safe_to_autopay")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            audit_urls: wallet
+                .get("audit_urls")
+                .and_then(|urls| urls.as_array())
+                .into_iter()
+                .flatten()
+                .filter_map(|url| url.as_str().map(|url| url.to_string()))
+                .collect(),
+        });
 
     let warnings = value
         .get("warnings")
@@ -558,6 +602,7 @@ fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidRes
         payable_sources,
         near_funding_routes,
         policy_gates,
+        wallet_policy,
         warnings,
     }
 }

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -55,6 +55,8 @@ pub struct FormatIntentsTradingWidgetInput {
     #[serde(default)]
     pub research_sources: Vec<String>,
     #[serde(default)]
+    pub paid_research_plan: Option<serde_json::Value>,
+    #[serde(default)]
     pub next_action: Option<String>,
 }
 
@@ -176,6 +178,8 @@ pub struct IntentsTradingWidgetState {
     pub source_count: usize,
     pub research_sources: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub paid_research: Option<IntentsPaidResearchSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
 }
 
@@ -220,6 +224,50 @@ pub struct IntentMinOutPreview {
     pub chain: String,
     pub amount: String,
     pub value_usd: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPaidResearchSummary {
+    pub schema_version: String,
+    pub query: String,
+    pub budget_usd: f64,
+    pub allocated_usd: f64,
+    pub unspent_usd: f64,
+    pub selected_count: usize,
+    pub ready_for_paid_fetch: bool,
+    pub ready_for_trade_research: bool,
+    pub payment_rails: Vec<IntentsPaidResearchRail>,
+    pub payable_sources: Vec<IntentsPayableResearchSource>,
+    pub near_funding_routes: Vec<IntentsPaidResearchFundingRoute>,
+    pub policy_gates: Vec<IntentsRiskGate>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPaidResearchRail {
+    pub protocol: String,
+    pub count: usize,
+    pub allocated_usd: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPayableResearchSource {
+    pub id: String,
+    pub title: String,
+    pub author: String,
+    pub protocol: String,
+    pub network: String,
+    pub amount_usd: f64,
+    pub evidence_weight: f64,
+    pub receipt_required: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPaidResearchFundingRoute {
+    pub target_protocol: String,
+    pub target_network: String,
+    pub amount_usd: f64,
+    pub via: String,
 }
 
 fn default_mode() -> String {
@@ -351,6 +399,10 @@ pub fn format_intents_trading_widget(
             min_out,
         }
     });
+    let paid_research = input
+        .paid_research_plan
+        .as_ref()
+        .map(paid_research_summary_from_value);
 
     IntentsTradingWidgetState {
         schema_version: "intents-trading-widget/1",
@@ -365,6 +417,7 @@ pub fn format_intents_trading_widget(
         intent,
         source_count: input.research_sources.len(),
         research_sources: input.research_sources,
+        paid_research,
         next_action: input.next_action,
     }
 }
@@ -406,6 +459,119 @@ fn strategy_candidate_from_value(value: &serde_json::Value) -> IntentsStrategyCa
             .unwrap_or(0.0),
         trades: metrics.get("trades").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
     }
+}
+
+fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidResearchSummary {
+    let selected_sources = value
+        .get("selected_sources")
+        .and_then(|sources| sources.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let payable_sources = selected_sources
+        .iter()
+        .take(6)
+        .map(|source| {
+            let payment = source.get("payment").unwrap_or(&serde_json::Value::Null);
+            let attribution = source
+                .get("attribution")
+                .unwrap_or(&serde_json::Value::Null);
+            IntentsPayableResearchSource {
+                id: string_field(source, "id", "source"),
+                title: string_field(source, "title", "Untitled source"),
+                author: string_field(source, "author", "Unknown author"),
+                protocol: string_field(payment, "protocol", "manual"),
+                network: string_field(payment, "network", "manual"),
+                amount_usd: number_field(payment, "amount_usd"),
+                evidence_weight: number_field(source, "evidence_weight"),
+                receipt_required: attribution
+                    .get("receipt_required")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            }
+        })
+        .collect();
+
+    let payment_rails = value
+        .get("payment_rails")
+        .and_then(|rails| rails.as_array())
+        .into_iter()
+        .flatten()
+        .map(|rail| IntentsPaidResearchRail {
+            protocol: string_field(rail, "protocol", "manual"),
+            count: rail.get("count").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
+            allocated_usd: number_field(rail, "allocated_usd"),
+        })
+        .collect();
+
+    let near_funding_routes = value
+        .get("near_funding_routes")
+        .and_then(|routes| routes.as_array())
+        .into_iter()
+        .flatten()
+        .map(|route| IntentsPaidResearchFundingRoute {
+            target_protocol: string_field(route, "target_protocol", "manual"),
+            target_network: string_field(route, "target_network", "manual"),
+            amount_usd: number_field(route, "amount_usd"),
+            via: string_field(route, "via", "near-intents"),
+        })
+        .collect();
+
+    let policy_gates = value
+        .get("policy_gates")
+        .and_then(|gates| gates.as_array())
+        .into_iter()
+        .flatten()
+        .map(|gate| IntentsRiskGate {
+            name: string_field(gate, "name", "paid-research-gate"),
+            status: string_field(gate, "status", "unknown"),
+            detail: gate
+                .get("detail")
+                .and_then(|detail| detail.as_str())
+                .map(|detail| detail.to_string()),
+        })
+        .collect();
+
+    let warnings = value
+        .get("warnings")
+        .and_then(|warnings| warnings.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|warning| warning.as_str().map(|warning| warning.to_string()))
+        .collect();
+
+    IntentsPaidResearchSummary {
+        schema_version: string_field(value, "schema_version", "paid-research-plan/1"),
+        query: string_field(value, "query", ""),
+        budget_usd: number_field(value, "budget_usd"),
+        allocated_usd: number_field(value, "allocated_usd"),
+        unspent_usd: number_field(value, "unspent_usd"),
+        selected_count: selected_sources.len(),
+        ready_for_paid_fetch: value
+            .get("ready_for_paid_fetch")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        ready_for_trade_research: value
+            .get("ready_for_trade_research")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        payment_rails,
+        payable_sources,
+        near_funding_routes,
+        policy_gates,
+        warnings,
+    }
+}
+
+fn string_field(value: &serde_json::Value, field: &str, default: &str) -> String {
+    value
+        .get(field)
+        .and_then(|v| v.as_str())
+        .unwrap_or(default)
+        .to_string()
+}
+
+fn number_field(value: &serde_json::Value, field: &str) -> f64 {
+    value.get(field).and_then(|v| v.as_f64()).unwrap_or(0.0)
 }
 
 fn compute_totals(input: &FormatWidgetInput) -> WidgetTotals {
@@ -785,6 +951,46 @@ mod tests {
                 quote_source: Some("fixture".to_string()),
             }),
             research_sources: vec!["https://docs.near-intents.org/".to_string()],
+            paid_research_plan: Some(serde_json::json!({
+                "schema_version": "paid-research-plan/1",
+                "query": "NEAR/BTC route risk",
+                "budget_usd": 0.05,
+                "allocated_usd": 0.02,
+                "unspent_usd": 0.03,
+                "ready_for_paid_fetch": true,
+                "ready_for_trade_research": true,
+                "payment_rails": [{
+                    "protocol": "x402",
+                    "count": 1,
+                    "allocated_usd": 0.02
+                }],
+                "selected_sources": [{
+                    "id": "paid-alpha-1",
+                    "title": "NEAR/BTC route risk",
+                    "author": "Researcher",
+                    "evidence_weight": 1.0,
+                    "payment": {
+                        "protocol": "x402",
+                        "network": "base",
+                        "amount_usd": 0.02
+                    },
+                    "attribution": {
+                        "receipt_required": true
+                    }
+                }],
+                "near_funding_routes": [{
+                    "target_protocol": "x402",
+                    "target_network": "base",
+                    "amount_usd": 0.02,
+                    "via": "near-intents"
+                }],
+                "policy_gates": [{
+                    "name": "receipt-before-use",
+                    "status": "pass",
+                    "detail": "Receipt required."
+                }],
+                "warnings": []
+            })),
             next_action: Some("Request live quote only after user approval.".to_string()),
         });
 
@@ -793,6 +999,10 @@ mod tests {
         assert!(w.top_candidates[0].passes_basic_gate);
         assert_eq!(w.intent.unwrap().status, "paper-built");
         assert_eq!(w.source_count, 1);
+        let paid_research = w.paid_research.unwrap();
+        assert_eq!(paid_research.selected_count, 1);
+        assert_eq!(paid_research.payable_sources[0].protocol, "x402");
+        assert_eq!(paid_research.near_funding_routes[0].via, "near-intents");
     }
 
     // ---- only ready proposals in suggestions ----


### PR DESCRIPTION
## Summary
- add portfolio.plan_paid_research for DripStack-style premium research budgeting, source attribution, MPP/x402/NEAR rail metadata, and policy gates
- surface paid research plans in the NEAR Intents trading widget with payable sources, rails, and NEAR funding-route hints
- update the intents trading skill and research docs so paid source use requires receipts and cannot bypass backtesting or risk gates
- add a replay scenario covering paid-source planning into widget state

## Why
The linked DripStack example is not a trading signal; it is the paid research marketplace layer this trading agent needs. This PR makes premium newsletters/API sources explicit, attributable, budgeted, and approval-gated before their evidence can influence a NEAR Intents trade workflow.

## Validation
- cargo fmt --check in tools-src/portfolio
- cargo test in tools-src/portfolio: 207 passed, 10 ignored
- cargo test -p ironclaw_gateway: 60 passed + 1 doctest passed
- node --check skills/intents-trading-agent/widgets/near-intents-console/index.js
- python3 -m json.tool for portfolio schema/capabilities/registry and sample widget state

## Stack
Base PR: #3207
