### PR TITLE
fix(gemini-oauth): preserve thoughtSignature in Cloud Code SSE handler (#3214)

### DIFF
--- a/src/llm/gemini_oauth.rs
+++ b/src/llm/gemini_oauth.rs
@@ -162,6 +162,43 @@ fn supports_modern_features(model: &str) -> bool {
     model.contains("gemini-3")
 }
 
+/// Extract a `functionCall` part from a Cloud Code SSE candidate part,
+/// preserving the sibling `thoughtSignature` when present.
+///
+/// Returns `None` when the part does not contain a `functionCall` key.
+///
+/// **Why this exists:** Cloud Code SSE delivers `thoughtSignature` as a
+/// sibling key in the same part object as `functionCall`:
+///
+/// ```json
+/// {
+///   "functionCall": {"name": "list_dir", "args": {}},
+///   "thoughtSignature": "<base64 token from gemini>"
+/// }
+/// ```
+///
+/// The original SSE handler at the call site copied only `functionCall`,
+/// silently discarding `thoughtSignature`. The prior fixes #1565 + #1752
+/// added a roundtrip plus synthetic fallback at the request-builder layer,
+/// but the upstream SSE parser still dropped the real signature here, so
+/// the synthetic sentinel `"skip_thought_signature_validator"` got
+/// installed on every functionCall part. Gemini 3.x's INVALID_ARGUMENT
+/// validator then rejected the request with
+/// `Function call is missing a thought_signature in functionCall parts.`
+/// (issue #3214).
+///
+/// This helper preserves the real signature when present; the synthetic-
+/// fallback path in `ensure_thought_signatures()` remains for the
+/// no-signature case.
+fn extract_function_call_part(part: &serde_json::Value) -> Option<serde_json::Value> {
+    let fc = part.get("functionCall")?;
+    let mut part_obj = serde_json::json!({ "functionCall": fc });
+    if let Some(sig) = part.get("thoughtSignature") {
+        part_obj["thoughtSignature"] = sig.clone();
+    }
+    Some(part_obj)
+}
+
 /// Invalid stream error types mirroring the Gemini CLI.
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -1438,10 +1475,8 @@ impl GeminiOauthProvider {
                                         combined_text.push_str(text);
                                     }
                                 }
-                                if let Some(fc) = part.get("functionCall") {
-                                    tool_calls_parts.push(serde_json::json!({
-                                        "functionCall": fc
-                                    }));
+                                if let Some(part_obj) = extract_function_call_part(part) {
+                                    tool_calls_parts.push(part_obj);
                                 }
                             }
                         }
@@ -2664,6 +2699,75 @@ mod tests {
         assert_eq!(curated.len(), 2, "Invalid model turn should be dropped");
         assert_eq!(curated[0]["parts"][0]["text"], "hello");
         assert_eq!(curated[1]["parts"][0]["text"], "again");
+    }
+
+    /// Issue #3214 regression: when the Cloud Code SSE stream delivers a
+    /// `functionCall` with a sibling `thoughtSignature`, the SSE handler
+    /// must preserve the signature on the part object — otherwise the
+    /// roundtrip + synthetic fallback installed by #1565 + #1752 has
+    /// nothing real to capture, and the synthetic sentinel ends up on
+    /// every part. Gemini 3.x then 400s with `INVALID_ARGUMENT —
+    /// Function call is missing a thought_signature in functionCall parts.`
+    #[test]
+    fn test_extract_function_call_part_preserves_thought_signature() {
+        let part = serde_json::json!({
+            "functionCall": {
+                "name": "list_dir",
+                "args": { "path": "." }
+            },
+            "thoughtSignature": "REAL-SIG-FROM-GEMINI-abc123"
+        });
+
+        let extracted = super::extract_function_call_part(&part)
+            .expect("functionCall part must be extracted");
+
+        assert_eq!(
+            extracted.get("functionCall").and_then(|v| v.get("name")).and_then(|v| v.as_str()),
+            Some("list_dir"),
+            "functionCall payload must round-trip"
+        );
+        assert_eq!(
+            extracted.get("thoughtSignature").and_then(|v| v.as_str()),
+            Some("REAL-SIG-FROM-GEMINI-abc123"),
+            "thoughtSignature must be preserved on the part — this is the #3214 fix"
+        );
+    }
+
+    /// No regression for the no-signature case: when the SSE part has
+    /// only `functionCall`, the extractor returns the part unchanged
+    /// (no synthetic signature here — that gets injected later by
+    /// `ensure_thought_signatures` on the request side).
+    #[test]
+    fn test_extract_function_call_part_omits_signature_when_absent() {
+        let part = serde_json::json!({
+            "functionCall": {
+                "name": "list_dir",
+                "args": {}
+            }
+        });
+
+        let extracted = super::extract_function_call_part(&part)
+            .expect("functionCall part must be extracted");
+
+        assert!(
+            extracted.get("functionCall").is_some(),
+            "functionCall must round-trip"
+        );
+        assert!(
+            extracted.get("thoughtSignature").is_none(),
+            "no synthetic signature here — the request-side fallback handles that"
+        );
+    }
+
+    /// Defensive: a part without `functionCall` returns None so the
+    /// caller can skip cleanly without injecting an empty record.
+    #[test]
+    fn test_extract_function_call_part_returns_none_for_text_only_part() {
+        let part = serde_json::json!({ "text": "hello" });
+        assert!(
+            super::extract_function_call_part(&part).is_none(),
+            "text-only part must not be extracted as a functionCall"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #3214. Re-fixes the Gemini 3.x \`INVALID_ARGUMENT — Function call is missing a thought_signature in functionCall parts\` error that the prior fixes #1565 and #1752 were intended to address but did not, because both fixes worked on the request-builder layer while the upstream SSE parser was still dropping the real signature on the floor.

## Root cause (verbatim from the reporter)

> @thomasmaerz traced it to \`src/llm/gemini_oauth.rs\` lines 1441-1444, where the Cloud Code SSE part-extractor copied only \`functionCall\` and silently discarded \`thoughtSignature\` (which Gemini delivers as a sibling key). The synthetic sentinel \`\"skip_thought_signature_validator\"\` injected by \`ensure_thought_signatures()\` then replaced every real signature, and Gemini's INVALID_ARGUMENT validator rejected the request.

The SSE shape Cloud Code delivers:

\`\`\`json
{
  \"functionCall\": {\"name\": \"list_dir\", \"args\": {}},
  \"thoughtSignature\": \"<base64 token from gemini>\"
}
\`\`\`

## Fix

Extract \`thoughtSignature\` as a sibling of \`functionCall\` in the SSE part-handler. Refactored the inline extraction into a small helper \`extract_function_call_part\` so the contract is unit-testable without standing up a mock SSE stream.

The roundtrip + synthetic-fallback layers added by #1565 / #1752 are unchanged — they now have the real signature to work with for thinking-mode parts, and the synthetic fallback still applies when no signature was delivered.

## Tests

Three regression tests, all passing:

- \`test_extract_function_call_part_preserves_thought_signature\` — the #3214 happy path
- \`test_extract_function_call_part_omits_signature_when_absent\` — the no-signature case still works (request-side fallback handles it)
- \`test_extract_function_call_part_returns_none_for_text_only_part\` — defensive: text-only parts must not be misclassified as functionCall parts

## Test plan

- [x] \`cargo test test_extract_function_call_part\` — 3/3 pass
- [ ] Manual repro: install \`ironclaw-v0.27.0-8-g749fe9da\` (or HEAD with this PR), configure \`gemini_oauth\` provider with \`gemini-3-flash-preview\`, ask a question requiring a tool call (e.g. \`ls .\`). Pre-PR: HTTP 400 INVALID_ARGUMENT after the first tool call. Post-PR: tool calls succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Issue linkage audit

Closes #3214.

Note: #3214 is already closed as of this audit; keeping the closing reference here preserves traceability for the Cloud Code SSE thoughtSignature fix. Prior related fixes: #1565 and #1752.
