### PR TITLE
docs(docker): fix Docker Hub image name to nearaidev/ironclaw (#2963)

### DIFF
--- a/docs/drafts/install/docker.mdx
+++ b/docs/drafts/install/docker.mdx
@@ -32,7 +32,7 @@ docker run -d \
   -p 3000:3000 \
   -p 8080:8080 \
   # Pin to a specific IronClaw version for reproducible, rollback-friendly deployments.
-  nearai/ironclaw:latest 
+  nearaidev/ironclaw:latest 
 ```
 
 ## Docker Compose
@@ -45,7 +45,7 @@ version: '3.8'
 services:
   ironclaw:
     # Pin to a specific IronClaw version for reproducible, rollback-friendly deployments.
-    image: nearai/ironclaw:latest
+    image: nearaidev/ironclaw:latest
     container_name: ironclaw
     restart: unless-stopped
 
@@ -121,7 +121,7 @@ docker run -d \
   -v ~/.ironclaw:/home/ironclaw/.ironclaw \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 3000:3000 \
-  nearai/ironclaw:latest
+  nearaidev/ironclaw:latest
 ```
 
 See [Configuration Reference](/setup/configuration) for all options.
@@ -195,7 +195,7 @@ server {
 
 ```bash
 # Pull latest image
-docker pull nearai/ironclaw:latest
+docker pull nearaidev/ironclaw:latest
 
 # Recreate container
 docker stop ironclaw
@@ -205,7 +205,7 @@ docker run -d \
   -v ~/.ironclaw:/home/ironclaw/.ironclaw \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 3000:3000 \
-  nearai/ironclaw:latest
+  nearaidev/ironclaw:latest
 
 # Or with docker compose
 docker compose pull

--- a/docs/drafts/install/uninstalling.mdx
+++ b/docs/drafts/install/uninstalling.mdx
@@ -51,7 +51,7 @@ brew services stop ironclaw    # Homebrew
     docker rm ironclaw
 
     # Remove image
-    docker rmi nearai/ironclaw:latest
+    docker rmi nearaidev/ironclaw:latest
     ```
   </Tab>
 </Tabs>

--- a/docs/drafts/install/updating.mdx
+++ b/docs/drafts/install/updating.mdx
@@ -43,7 +43,7 @@ ironclaw --version
   <Tab title="Docker">
     ```bash
     # Pull latest image
-    docker pull nearai/ironclaw:latest
+    docker pull nearaidev/ironclaw:latest
 
     # Recreate container
     docker stop ironclaw
@@ -115,7 +115,7 @@ If you need to rollback:
 curl -fsSL https://install.ironclaw.ai | bash -s -- --version 0.12.0
 
 # Docker
-docker pull nearai/ironclaw:v0.12.0
+docker pull nearaidev/ironclaw:v0.12.0
 ```
 
 <Warning>

--- a/docs/drafts/platforms/docker-compose.mdx
+++ b/docs/drafts/platforms/docker-compose.mdx
@@ -21,7 +21,7 @@ version: "3.9"
 
 services:
   ironclaw:
-    image: nearai/ironclaw:latest
+    image: nearaidev/ironclaw:latest
     container_name: ironclaw
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
## Summary

Closes #2963.

@magnusviri reported \`pull access denied for nearai/ironclaw, repository does not exist\` when following the install/docker.mdx guide. The actual Docker Hub repo is \`nearaidev/ironclaw\` — confirmed by:

1. \`.github/workflows/docker.yml\` line 32: \`IMAGE_NAME: nearaidev/ironclaw\` (the workflow that publishes the official image)
2. The public Docker Hub page: https://hub.docker.com/r/nearaidev/ironclaw

The \`nearai/ironclaw\` namespace was never the correct image and is not under our control. Anyone following the docs hits the squat / 401 immediately.

## Files updated (9 occurrences across 4 files)

- \`docs/drafts/install/docker.mdx\` (5 occurrences — \`docker run\`, Compose example, two more pull commands)
- \`docs/drafts/install/updating.mdx\` (2 occurrences — \`pull :latest\` and \`pull :v0.12.0\` example)
- \`docs/drafts/install/uninstalling.mdx\` (1 occurrence — \`docker rmi\`)
- \`docs/drafts/platforms/docker-compose.mdx\` (1 occurrence — Compose example)

## Out of scope

\`README.md\` references to \`nearai/ironclaw\` are gitcgr.com URLs to the source repository, not Docker Hub image pulls — those are correct as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)