### PR TITLE
[codex] Add nominal NEAR intents trial mode

### DIFF
--- a/crates/ironclaw_gateway/src/assets.rs
+++ b/crates/ironclaw_gateway/src/assets.rs
@@ -172,3 +172,16 @@ pub const ADMIN_CSS: &str = include_str!("../static/admin/admin.css");
 
 /// Admin panel JavaScript.
 pub const ADMIN_JS: &str = include_str!("../static/admin/admin.js");
+
+// ==================== Public Experiments ====================
+
+/// Standalone NEAR Intents public experiment.
+pub const NEAR_INTENTS_EXPERIMENT_HTML: &str =
+    include_str!("../static/experiments/near-intents.html");
+
+/// Styles for the standalone NEAR Intents public experiment.
+pub const NEAR_INTENTS_EXPERIMENT_CSS: &str =
+    include_str!("../static/experiments/near-intents.css");
+
+/// JavaScript for the standalone NEAR Intents public experiment.
+pub const NEAR_INTENTS_EXPERIMENT_JS: &str = include_str!("../static/experiments/near-intents.js");

--- a/crates/ironclaw_gateway/static/experiments/near-intents.css
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.css
@@ -79,6 +79,12 @@ a {
   min-height: 100svh;
 }
 
+#live,
+#studio,
+#signals {
+  scroll-margin-top: 88px;
+}
+
 .vibe-nav {
   position: sticky;
   z-index: 30;
@@ -408,6 +414,66 @@ a {
   white-space: nowrap;
 }
 
+.starter-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  padding: 1px;
+  background: var(--line);
+}
+
+.starter-steps div {
+  min-width: 0;
+  min-height: 106px;
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  padding: 16px;
+  background: rgba(8, 11, 10, 0.92);
+}
+
+.starter-steps span {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 820;
+}
+
+.starter-steps strong {
+  font-size: 14px;
+}
+
+.starter-steps p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.38;
+}
+
+.starter-steps .is-active,
+.starter-steps .is-done {
+  background: rgba(146, 246, 189, 0.1);
+}
+
+.starter-steps .is-active span,
+.starter-steps .is-done span {
+  border-color: rgba(146, 246, 189, 0.58);
+  color: var(--accent);
+}
+
+.starter-steps .is-done strong::after {
+  content: " done";
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 760;
+}
+
 .live-steps {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -443,9 +509,70 @@ a {
   color: var(--red);
 }
 
+.live-summary {
+  min-height: 82px;
+  margin: 18px 18px 0;
+  display: grid;
+  align-content: center;
+  border: 1px solid rgba(146, 246, 189, 0.26);
+  border-radius: var(--radius-sm);
+  background: rgba(146, 246, 189, 0.08);
+  color: var(--ink);
+  padding: 16px;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.live-summary.is-warn {
+  border-color: rgba(243, 200, 107, 0.32);
+  background: var(--amber-soft);
+}
+
+.live-summary.is-error {
+  border-color: rgba(255, 116, 111, 0.38);
+  background: var(--red-soft);
+}
+
+.receipt-drawer {
+  margin: 12px 18px 18px;
+}
+
+.receipt-drawer summary,
+.inline-advanced summary,
+.advanced-settings summary {
+  position: relative;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 760;
+  list-style: none;
+  padding-right: 22px;
+}
+
+.receipt-drawer summary::-webkit-details-marker,
+.inline-advanced summary::-webkit-details-marker,
+.advanced-settings summary::-webkit-details-marker {
+  display: none;
+}
+
+.receipt-drawer summary::after,
+.inline-advanced summary::after,
+.advanced-settings summary::after {
+  content: "+";
+  position: absolute;
+  top: 0;
+  right: 0;
+  color: var(--accent);
+}
+
+.receipt-drawer[open] summary::after,
+.inline-advanced[open] summary::after,
+.advanced-settings[open] summary::after {
+  content: "-";
+}
+
 .terminal-pane,
-.code-pane,
-.core-preview pre {
+.code-pane {
   margin: 0;
   overflow: auto;
   border: 1px solid var(--line);
@@ -459,9 +586,9 @@ a {
 }
 
 .terminal-pane {
-  min-height: 230px;
+  min-height: 184px;
   max-height: 420px;
-  margin: 18px;
+  margin-top: 10px;
   padding: 16px;
 }
 
@@ -475,7 +602,6 @@ a {
 .core-preview article {
   min-width: 0;
   display: grid;
-  grid-template-rows: auto minmax(116px, 1fr);
   gap: 16px;
   border-radius: 24px;
   padding: 20px;
@@ -492,11 +618,6 @@ a {
   color: var(--soft);
   font-size: 14px;
   line-height: 1.5;
-}
-
-.core-preview pre {
-  min-height: 116px;
-  padding: 14px;
 }
 
 .studio-grid {
@@ -584,6 +705,22 @@ select option {
   color: #101412;
 }
 
+.inline-advanced {
+  margin-top: 12px;
+}
+
+.inline-advanced textarea {
+  margin-top: 10px;
+}
+
+.live-cap-label input {
+  min-height: 54px;
+  border-color: rgba(146, 246, 189, 0.44);
+  background: rgba(146, 246, 189, 0.075);
+  font-size: 20px;
+  font-weight: 820;
+}
+
 .dual-input {
   gap: 10px;
 }
@@ -651,6 +788,72 @@ select option {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
+}
+
+.action-grid-simple {
+  margin-top: 4px;
+}
+
+.safety-list {
+  display: grid;
+  gap: 10px;
+}
+
+.safety-list div {
+  min-height: 62px;
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(245, 247, 239, 0.04);
+  padding: 12px;
+}
+
+.safety-list strong {
+  font-size: 18px;
+}
+
+.safety-list span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.advanced-settings {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(245, 247, 239, 0.035);
+}
+
+.advanced-settings summary {
+  min-height: 58px;
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  padding: 12px 34px 12px 12px;
+}
+
+.advanced-settings summary::after {
+  top: 18px;
+  right: 12px;
+}
+
+.advanced-settings summary small {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 620;
+}
+
+.advanced-body {
+  padding: 0 12px 14px;
+}
+
+.advanced-body h3 {
+  margin: 18px 0 12px;
+  color: var(--ink);
+  font-size: 12px;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
 
 .primary-action,
@@ -1046,6 +1249,7 @@ tbody tr:last-child td {
   }
 
   .feature-strip,
+  .starter-steps,
   .wallet-card,
   .live-steps,
   .metric-strip,

--- a/crates/ironclaw_gateway/static/experiments/near-intents.css
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.css
@@ -1,26 +1,28 @@
 :root {
   color-scheme: dark;
-  --bg: #070807;
-  --surface: #0d100f;
-  --surface-2: #121514;
-  --surface-3: #171918;
-  --ink: #f6f4ed;
-  --muted: #9da59f;
-  --soft: rgba(246, 244, 237, 0.72);
-  --line: rgba(246, 244, 237, 0.13);
-  --line-strong: rgba(246, 244, 237, 0.24);
-  --accent: #82f6b8;
-  --cyan: #73d5ff;
-  --amber: #f4c76a;
-  --red: #ff766f;
-  --green-soft: rgba(130, 246, 184, 0.12);
-  --cyan-soft: rgba(115, 213, 255, 0.12);
-  --amber-soft: rgba(244, 199, 106, 0.13);
-  --red-soft: rgba(255, 118, 111, 0.13);
-  --shadow: rgba(0, 0, 0, 0.38);
-  --rail-left: 344px;
-  --rail-right: 388px;
-  --topbar: 78px;
+  --bg: #050606;
+  --bg-2: #080b0a;
+  --surface: #0c100f;
+  --surface-2: #111615;
+  --surface-3: #171c1b;
+  --ink: #f5f7ef;
+  --muted: #8f9a94;
+  --soft: rgba(245, 247, 239, 0.76);
+  --line: rgba(245, 247, 239, 0.12);
+  --line-strong: rgba(245, 247, 239, 0.22);
+  --accent: #92f6bd;
+  --cyan: #84dbff;
+  --blue: #7aa6ff;
+  --amber: #f3c86b;
+  --red: #ff746f;
+  --green-soft: rgba(146, 246, 189, 0.12);
+  --cyan-soft: rgba(132, 219, 255, 0.11);
+  --amber-soft: rgba(243, 200, 107, 0.13);
+  --red-soft: rgba(255, 116, 111, 0.13);
+  --shadow: rgba(0, 0, 0, 0.42);
+  --radius: 18px;
+  --radius-sm: 8px;
+  --control: 42px;
 }
 
 * {
@@ -29,6 +31,7 @@
 
 html {
   min-width: 320px;
+  scroll-behavior: smooth;
   background: var(--bg);
 }
 
@@ -37,8 +40,9 @@ body {
   min-width: 320px;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background:
-    linear-gradient(120deg, rgba(130, 246, 184, 0.08), transparent 32rem),
-    linear-gradient(180deg, #070807 0%, #0c0d0c 54%, #11100e 100%);
+    radial-gradient(circle at 18% 4%, rgba(146, 246, 189, 0.13), transparent 30rem),
+    radial-gradient(circle at 82% 12%, rgba(132, 219, 255, 0.11), transparent 28rem),
+    linear-gradient(180deg, #050606 0%, #07100d 48%, #0b0b0a 100%);
   color: var(--ink);
 }
 
@@ -66,126 +70,458 @@ p {
   margin-top: 0;
 }
 
-.studio-shell {
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
   min-height: 100svh;
 }
 
-.topbar {
+.vibe-nav {
   position: sticky;
-  z-index: 10;
+  z-index: 30;
   top: 0;
-  min-height: var(--topbar);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  padding: 14px 22px;
-  border-bottom: 1px solid var(--line);
-  background: rgba(7, 8, 7, 0.86);
-  backdrop-filter: blur(18px);
-}
-
-.eyebrow {
-  margin: 0 0 6px;
-  color: var(--accent);
-  font-size: 11px;
-  font-weight: 780;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.topbar h1 {
-  margin: 0;
-  font-size: clamp(25px, 3vw, 38px);
-  line-height: 0.96;
-  letter-spacing: 0;
-}
-
-.topbar-controls {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 14px;
-}
-
-.topbar-status {
+  min-height: 72px;
   display: grid;
-  gap: 4px;
-  min-width: 180px;
-  text-align: right;
+  grid-template-columns: minmax(190px, 1fr) auto minmax(190px, 1fr);
+  align-items: center;
+  gap: 20px;
+  padding: 14px clamp(18px, 4vw, 54px);
+  border-bottom: 1px solid var(--line);
+  background: rgba(5, 6, 6, 0.82);
+  backdrop-filter: blur(20px);
 }
 
-.topbar-status span {
-  color: var(--muted);
+.brand-lockup,
+.nav-actions,
+.hero-actions,
+.section-heading,
+.table-heading,
+.chart-header,
+.stage-toolbar,
+.pipeline,
+.dual-input,
+.copy-row {
+  display: flex;
+  align-items: center;
+}
+
+.brand-lockup {
+  gap: 10px;
+  min-width: 0;
+  font-weight: 820;
+}
+
+.brand-mark {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: #0a0d0c;
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--line-strong);
   font-size: 12px;
+  letter-spacing: 0;
 }
 
-.topbar-status strong {
-  font-size: 16px;
+.vibe-nav nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(245, 247, 239, 0.045);
 }
 
-.top-run {
-  min-height: 42px;
+.vibe-nav nav a {
+  min-height: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  padding: 0 16px;
-  background: var(--accent);
-  color: #07110d;
-  cursor: pointer;
-  font-weight: 780;
+  padding: 0 12px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 680;
   white-space: nowrap;
-  transition: transform 160ms ease, opacity 160ms ease;
 }
 
-.top-run:hover {
+.vibe-nav nav a:hover {
+  background: rgba(245, 247, 239, 0.07);
+  color: var(--ink);
+}
+
+.nav-actions {
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: 0;
+}
+
+.wallet-pill {
+  min-height: 34px;
+  max-width: 210px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0 12px;
+  color: var(--muted);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wallet-pill.is-connected {
+  border-color: rgba(146, 246, 189, 0.48);
+  background: var(--green-soft);
+  color: var(--accent);
+}
+
+.connect-btn,
+.hero-primary,
+.hero-secondary,
+.console-run,
+.top-run,
+.primary-action,
+.secondary-action {
+  min-height: var(--control);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-weight: 780;
+  letter-spacing: 0;
+  transition: transform 160ms ease, opacity 160ms ease, border-color 160ms ease, background-color 160ms ease;
+}
+
+.connect-btn,
+.hero-primary,
+.console-run,
+.top-run,
+.primary-action {
+  border-radius: 999px;
+  background: var(--accent);
+  color: #07110d;
+}
+
+.connect-btn {
+  padding: 0 18px;
+}
+
+.hero-primary,
+.hero-secondary {
+  min-height: 50px;
+  padding: 0 22px;
+}
+
+.hero-secondary,
+.secondary-action {
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  background: rgba(245, 247, 239, 0.055);
+  color: var(--ink);
+}
+
+.connect-btn:hover,
+.hero-primary:hover,
+.hero-secondary:hover,
+.console-run:hover,
+.top-run:hover,
+.primary-action:hover,
+.secondary-action:hover {
   transform: translateY(-1px);
 }
 
-.top-run:disabled {
+.connect-btn:disabled,
+.hero-primary:disabled,
+.hero-secondary:disabled,
+.console-run:disabled,
+.top-run:disabled,
+.primary-action:disabled,
+.secondary-action:disabled {
   cursor: not-allowed;
   opacity: 0.58;
   transform: none;
 }
 
+.hero {
+  min-height: calc(100svh - 150px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(340px, 0.72fr);
+  align-items: center;
+  gap: clamp(26px, 5vw, 72px);
+  padding: clamp(38px, 6vw, 74px) clamp(18px, 4vw, 54px) 28px;
+}
+
+.hero-copy {
+  max-width: 900px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 820;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  max-width: 920px;
+  margin: 0;
+  background: linear-gradient(92deg, #f7fbf1 0%, #c8f9dc 38%, #93e7ff 72%, #8ea9ff 100%);
+  background-clip: text;
+  color: transparent;
+  font-size: clamp(50px, 8vw, 112px);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+
+.hero-subtitle {
+  max-width: 760px;
+  margin: 20px 0 0;
+  color: var(--soft);
+  font-size: clamp(17px, 2vw, 21px);
+  line-height: 1.48;
+}
+
+.hero-actions {
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 30px;
+}
+
+.feature-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  max-width: 820px;
+  margin-top: 30px;
+}
+
+.feature-strip div,
+.agent-console,
+.core-preview article,
+.control-panel,
+.main-stage,
+.inspector-rail,
+.chart-section,
+.trade-table-wrap,
+.event-log {
+  border: 1px solid var(--line);
+  background: rgba(12, 16, 15, 0.76);
+  box-shadow: 0 24px 90px var(--shadow);
+}
+
+.feature-strip div {
+  min-height: 86px;
+  display: grid;
+  align-content: center;
+  gap: 6px;
+  border-radius: var(--radius-sm);
+  padding: 16px;
+}
+
+.feature-strip strong {
+  font-size: 14px;
+}
+
+.feature-strip span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.agent-console {
+  min-width: 0;
+  border-radius: 26px;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(146, 246, 189, 0.11), transparent 34%),
+    rgba(10, 13, 12, 0.88);
+}
+
+.console-header {
+  min-height: 82px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.console-header span,
+.wallet-card span,
+.topbar-status span,
+.pipeline-step span,
+.metric-strip span,
+.table-heading span,
+.preview-copy span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.console-header strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 18px;
+}
+
+.console-run {
+  min-height: 44px;
+  padding: 0 16px;
+}
+
+.wallet-card {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  padding: 1px;
+  background: var(--line);
+}
+
+.wallet-card div {
+  min-width: 0;
+  min-height: 92px;
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  padding: 16px;
+  background: rgba(7, 9, 8, 0.9);
+}
+
+.wallet-card strong {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.live-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  padding: 1px;
+  background: var(--line);
+}
+
+.live-steps span {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(14, 18, 17, 0.94);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 760;
+  text-align: center;
+}
+
+.live-steps span.is-active {
+  background: var(--green-soft);
+  color: var(--accent);
+}
+
+.live-steps span.is-warn {
+  background: var(--amber-soft);
+  color: var(--amber);
+}
+
+.live-steps span.is-error {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.terminal-pane,
+.code-pane,
+.core-preview pre {
+  margin: 0;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: #050606;
+  color: #e8eee9;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 11px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.terminal-pane {
+  min-height: 230px;
+  max-height: 420px;
+  margin: 18px;
+  padding: 16px;
+}
+
+.core-preview {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  padding: 0 clamp(18px, 4vw, 54px) 54px;
+}
+
+.core-preview article {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto minmax(116px, 1fr);
+  gap: 16px;
+  border-radius: 24px;
+  padding: 20px;
+}
+
+.preview-copy h2 {
+  margin: 8px 0 8px;
+  font-size: 28px;
+  line-height: 1;
+}
+
+.preview-copy p {
+  margin-bottom: 0;
+  color: var(--soft);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.core-preview pre {
+  min-height: 116px;
+  padding: 14px;
+}
+
 .studio-grid {
   display: grid;
-  grid-template-columns: var(--rail-left) minmax(0, 1fr) var(--rail-right);
-  min-height: calc(100svh - var(--topbar));
+  grid-template-columns: minmax(310px, 360px) minmax(0, 1fr) minmax(320px, 390px);
+  gap: 18px;
+  padding: 0 clamp(18px, 4vw, 54px) 54px;
 }
 
-.left-rail,
-.right-rail {
+.control-panel,
+.main-stage,
+.inspector-rail {
   min-width: 0;
-  background: rgba(13, 16, 15, 0.76);
+  border-radius: 24px;
+  overflow: hidden;
+  background: rgba(10, 13, 12, 0.78);
 }
 
-.left-rail {
-  border-right: 1px solid var(--line);
-}
-
-.right-rail {
-  border-left: 1px solid var(--line);
-}
-
-.rail-section {
+.panel-section {
   padding: 20px;
   border-bottom: 1px solid var(--line);
 }
 
-.rail-section:last-child {
+.panel-section:last-child {
   border-bottom: 0;
-}
-
-.section-heading,
-.table-heading,
-.chart-header,
-.pipeline,
-.metric-strip,
-.dual-input {
-  display: flex;
-  align-items: center;
 }
 
 .section-heading {
@@ -194,16 +530,16 @@ p {
 }
 
 .section-heading span {
-  width: 22px;
-  height: 22px;
+  min-width: 28px;
+  height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--line-strong);
   border-radius: 999px;
   color: var(--accent);
-  font-size: 12px;
-  font-weight: 760;
+  font-size: 11px;
+  font-weight: 820;
 }
 
 .section-heading h2,
@@ -226,16 +562,16 @@ input,
 select {
   width: 100%;
   border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  background: rgba(246, 244, 237, 0.055);
+  border-radius: var(--radius-sm);
+  background: rgba(245, 247, 239, 0.055);
   color: var(--ink);
 }
 
 textarea {
-  min-height: 118px;
+  min-height: 122px;
   resize: vertical;
   padding: 12px;
-  line-height: 1.42;
+  line-height: 1.44;
 }
 
 input,
@@ -254,6 +590,7 @@ select option {
 
 .dual-input label {
   flex: 1;
+  min-width: 0;
 }
 
 .strategy-deck {
@@ -264,32 +601,29 @@ select option {
 
 .strategy-option {
   width: 100%;
-  min-height: 78px;
+  min-height: 76px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;
   gap: 10px;
   padding: 12px;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: rgba(246, 244, 237, 0.045);
+  border-radius: var(--radius-sm);
+  background: rgba(245, 247, 239, 0.045);
   color: var(--ink);
   cursor: pointer;
   text-align: left;
-  transition:
-    transform 160ms ease,
-    border-color 160ms ease,
-    background-color 160ms ease;
+  transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
 }
 
 .strategy-option:hover {
   transform: translateY(-1px);
   border-color: var(--line-strong);
-  background: rgba(246, 244, 237, 0.07);
+  background: rgba(245, 247, 239, 0.07);
 }
 
 .strategy-option[aria-checked="true"] {
-  border-color: rgba(130, 246, 184, 0.7);
+  border-color: rgba(146, 246, 189, 0.68);
   background: var(--green-soft);
 }
 
@@ -313,67 +647,61 @@ select option {
   white-space: nowrap;
 }
 
-.action-section {
+.action-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
 }
 
 .primary-action,
 .secondary-action {
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  padding: 0 15px;
-  cursor: pointer;
-  font-weight: 760;
-  transition:
-    transform 160ms ease,
-    background-color 160ms ease,
-    border-color 160ms ease,
-    opacity 160ms ease;
-}
-
-.primary-action {
-  background: var(--accent);
-  color: #07110d;
-}
-
-.secondary-action {
-  border: 1px solid var(--line-strong);
-  background: rgba(246, 244, 237, 0.055);
-  color: var(--ink);
-}
-
-.primary-action:hover,
-.secondary-action:hover {
-  transform: translateY(-1px);
-}
-
-.primary-action:disabled,
-.secondary-action:disabled {
-  cursor: not-allowed;
-  opacity: 0.58;
-  transform: none;
+  width: 100%;
+  min-height: 42px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
 }
 
 .main-stage {
-  min-width: 0;
   padding: 20px;
-  background:
-    radial-gradient(circle at 70% 0%, rgba(115, 213, 255, 0.08), transparent 28rem),
-    rgba(7, 8, 7, 0.48);
+}
+
+.stage-toolbar {
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.stage-toolbar h2 {
+  margin: 0;
+  font-size: clamp(28px, 4vw, 52px);
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.topbar-status {
+  display: grid;
+  gap: 4px;
+  min-width: 164px;
+  text-align: right;
+}
+
+.topbar-status strong {
+  font-size: 16px;
+}
+
+.top-run {
+  padding: 0 16px;
+  white-space: nowrap;
 }
 
 .pipeline {
   gap: 1px;
   min-height: 66px;
   border: 1px solid var(--line);
+  border-radius: 14px;
   background: var(--line);
   overflow: hidden;
-  border-radius: 10px;
 }
 
 .pipeline-step {
@@ -388,18 +716,11 @@ select option {
   transition: background-color 180ms ease;
 }
 
-.pipeline-step span,
-.metric-strip span,
-.table-heading span {
-  color: var(--muted);
-  font-size: 12px;
-}
-
 .pipeline-step strong {
-  font-size: 13px;
-  white-space: nowrap;
   overflow: hidden;
+  font-size: 13px;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pipeline-step.is-active {
@@ -420,7 +741,7 @@ select option {
   gap: 1px;
   margin-top: 16px;
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: 14px;
   background: var(--line);
   overflow: hidden;
 }
@@ -454,10 +775,7 @@ select option {
 
 .chart-section {
   margin-top: 16px;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  background: rgba(13, 16, 15, 0.78);
-  box-shadow: 0 22px 80px var(--shadow);
+  border-radius: 16px;
   overflow: hidden;
 }
 
@@ -469,7 +787,7 @@ select option {
 
 .chart-header h2 {
   margin: 0;
-  font-size: clamp(24px, 4vw, 42px);
+  font-size: clamp(25px, 4vw, 46px);
   line-height: 1;
   letter-spacing: 0;
 }
@@ -504,8 +822,8 @@ select option {
 canvas {
   display: block;
   width: 100%;
-  height: clamp(360px, 52vh, 680px);
-  background: #080908;
+  height: clamp(350px, 50vh, 620px);
+  background: #050606;
 }
 
 .lower-grid {
@@ -518,9 +836,7 @@ canvas {
 .trade-table-wrap,
 .event-log {
   min-width: 0;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  background: rgba(13, 16, 15, 0.78);
+  border-radius: 16px;
   overflow: hidden;
 }
 
@@ -548,16 +864,19 @@ td {
 
 th {
   color: var(--muted);
-  font-weight: 620;
+  font-weight: 640;
 }
 
 td {
+  overflow: hidden;
   color: var(--soft);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 td:nth-child(2),
 td:nth-child(5) {
-  font-weight: 760;
+  font-weight: 780;
 }
 
 tbody tr:last-child td {
@@ -588,7 +907,7 @@ tbody tr:last-child td {
 
 .inspector-top h2 {
   margin-bottom: 10px;
-  font-size: clamp(28px, 4vw, 54px);
+  font-size: clamp(30px, 4vw, 60px);
   line-height: 0.95;
   letter-spacing: 0;
 }
@@ -634,30 +953,38 @@ tbody tr:last-child td {
 }
 
 .code-pane {
-  margin: 0;
-  max-height: 310px;
-  min-height: 166px;
-  overflow: auto;
+  max-height: 320px;
+  min-height: 168px;
   padding: 13px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: #070807;
-  color: #e5ede8;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 11px;
-  line-height: 1.55;
-  white-space: pre-wrap;
 }
 
-.copy-action {
-  width: 100%;
+.copy-row {
+  gap: 10px;
   margin-top: 10px;
 }
 
-@media (max-width: 1320px) {
-  :root {
-    --rail-left: 320px;
-    --rail-right: 340px;
+.copy-action {
+  flex: 1;
+}
+
+@media (max-width: 1440px) {
+  .studio-grid {
+    grid-template-columns: 330px minmax(0, 1fr);
+  }
+
+  .inspector-rail {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: 0.9fr 1fr 1fr 1fr;
+  }
+
+  .inspector-rail .panel-section {
+    border-right: 1px solid var(--line);
+    border-bottom: 0;
+  }
+
+  .inspector-rail .panel-section:last-child {
+    border-right: 0;
   }
 
   .metric-strip {
@@ -665,95 +992,95 @@ tbody tr:last-child td {
   }
 }
 
-@media (max-width: 1120px) {
-  .studio-grid {
-    grid-template-columns: 300px minmax(0, 1fr);
+@media (max-width: 1100px) {
+  .vibe-nav {
+    grid-template-columns: 1fr auto;
   }
 
-  .right-rail {
-    grid-column: 1 / -1;
-    border-left: 0;
-    border-top: 1px solid var(--line);
+  .vibe-nav nav {
+    display: none;
   }
 
-  .right-rail {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .right-rail .rail-section {
-    border-right: 1px solid var(--line);
-  }
-
-  .right-rail .rail-section:last-child {
-    border-right: 0;
-  }
-}
-
-@media (max-width: 900px) {
-  .topbar {
-    position: relative;
-  }
-
+  .hero,
+  .core-preview,
   .studio-grid,
-  .right-rail,
+  .inspector-rail,
   .lower-grid {
     grid-template-columns: 1fr;
   }
 
-  .left-rail,
-  .right-rail {
-    border: 0;
+  .hero {
+    min-height: auto;
+    align-items: start;
+  }
+
+  .inspector-rail .panel-section {
+    border-right: 0;
     border-bottom: 1px solid var(--line);
   }
 
-  .right-rail .rail-section {
-    border-right: 0;
-  }
-
-  .main-stage {
-    padding: 14px;
+  .inspector-rail .panel-section:last-child {
+    border-bottom: 0;
   }
 }
 
-@media (max-width: 620px) {
-  .topbar {
-    align-items: flex-start;
-    flex-direction: column;
+@media (max-width: 760px) {
+  .vibe-nav {
+    position: relative;
+    grid-template-columns: 1fr;
+    justify-items: stretch;
   }
 
-  .topbar-controls {
-    width: 100%;
-    align-items: stretch;
+  .nav-actions {
     justify-content: space-between;
   }
 
+  .wallet-pill {
+    max-width: none;
+    flex: 1;
+  }
+
+  .hero h1 {
+    max-width: 100%;
+    font-size: clamp(38px, 12.5vw, 50px);
+  }
+
+  .feature-strip,
+  .wallet-card,
+  .live-steps,
+  .metric-strip,
+  .pipeline,
+  .dual-input,
+  .stage-toolbar {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .stage-toolbar,
+  .chart-header {
+    align-items: flex-start;
+  }
+
   .topbar-status {
+    min-width: 0;
     text-align: left;
   }
 
-  .pipeline,
-  .metric-strip {
+  .console-header {
     grid-template-columns: 1fr;
-    display: grid;
   }
 
-  .pipeline-step,
-  .metric-strip div {
-    min-height: 62px;
+  .action-grid {
+    grid-template-columns: 1fr;
   }
 
-  .dual-input {
+  .hero-actions {
     display: grid;
+    grid-template-columns: 1fr;
   }
 
   th:nth-child(4),
   td:nth-child(4) {
     display: none;
-  }
-
-  .chart-header {
-    align-items: flex-start;
-    flex-direction: column;
   }
 }

--- a/crates/ironclaw_gateway/static/experiments/near-intents.css
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.css
@@ -1,16 +1,26 @@
 :root {
   color-scheme: dark;
-  --bg: #080a0c;
-  --ink: #f3f6f0;
-  --muted: #9aa69c;
-  --line: rgba(243, 246, 240, 0.14);
-  --line-strong: rgba(243, 246, 240, 0.24);
-  --panel: rgba(19, 24, 24, 0.82);
-  --panel-strong: rgba(27, 34, 33, 0.96);
-  --accent: #6ef0b0;
-  --accent-2: #f4c46b;
-  --danger: #ff7a7a;
-  --shadow: rgba(0, 0, 0, 0.34);
+  --bg: #070807;
+  --surface: #0d100f;
+  --surface-2: #121514;
+  --surface-3: #171918;
+  --ink: #f6f4ed;
+  --muted: #9da59f;
+  --soft: rgba(246, 244, 237, 0.72);
+  --line: rgba(246, 244, 237, 0.13);
+  --line-strong: rgba(246, 244, 237, 0.24);
+  --accent: #82f6b8;
+  --cyan: #73d5ff;
+  --amber: #f4c76a;
+  --red: #ff766f;
+  --green-soft: rgba(130, 246, 184, 0.12);
+  --cyan-soft: rgba(115, 213, 255, 0.12);
+  --amber-soft: rgba(244, 199, 106, 0.13);
+  --red-soft: rgba(255, 118, 111, 0.13);
+  --shadow: rgba(0, 0, 0, 0.38);
+  --rail-left: 344px;
+  --rail-right: 388px;
+  --topbar: 78px;
 }
 
 * {
@@ -18,7 +28,8 @@
 }
 
 html {
-  scroll-behavior: smooth;
+  min-width: 320px;
+  background: var(--bg);
 }
 
 body {
@@ -26,474 +37,722 @@ body {
   min-width: 320px;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background:
-    radial-gradient(circle at 18% 12%, rgba(110, 240, 176, 0.12), transparent 26rem),
-    linear-gradient(140deg, #080a0c 0%, #0e1412 42%, #171314 100%);
+    linear-gradient(120deg, rgba(130, 246, 184, 0.08), transparent 32rem),
+    linear-gradient(180deg, #070807 0%, #0c0d0c 54%, #11100e 100%);
   color: var(--ink);
 }
 
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
 }
 
 button,
 select,
 input,
-a {
+textarea {
   outline-color: var(--accent);
 }
 
-.lab-shell {
-  min-height: 100svh;
-}
-
-.hero {
-  min-height: 84svh;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  align-items: end;
-  padding: clamp(28px, 5vw, 72px);
-  position: relative;
-  overflow: hidden;
-  border-bottom: 1px solid var(--line);
-}
-
-.hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background:
-    linear-gradient(90deg, rgba(8, 10, 12, 0.98), rgba(8, 10, 12, 0.58) 52%, rgba(8, 10, 12, 0.94)),
-    url("data:image/svg+xml,%3Csvg width='1400' height='900' viewBox='0 0 1400 900' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1400' height='900' fill='%230b1110'/%3E%3Cg fill='none' stroke='%236ef0b0' stroke-opacity='.20'%3E%3Cpath d='M0 610 C190 550 250 450 410 484 C560 516 620 698 780 650 C930 604 960 360 1120 332 C1240 312 1300 400 1400 382' stroke-width='3'/%3E%3Cpath d='M0 690 C210 632 280 596 436 610 C590 625 668 760 820 736 C1000 708 1036 470 1190 448 C1274 436 1330 472 1400 458' stroke-width='2'/%3E%3Cpath d='M0 524 C160 490 250 330 390 360 C560 396 604 552 760 506 C930 456 984 250 1140 228 C1250 212 1308 276 1400 250' stroke-width='2'/%3E%3C/g%3E%3Cg fill='%236ef0b0' fill-opacity='.35'%3E%3Ccircle cx='410' cy='484' r='5'/%3E%3Ccircle cx='780' cy='650' r='5'/%3E%3Ccircle cx='1120' cy='332' r='5'/%3E%3Ccircle cx='820' cy='736' r='4'/%3E%3Ccircle cx='760' cy='506' r='4'/%3E%3C/g%3E%3Cg fill='%23f4c46b' fill-opacity='.28'%3E%3Crect x='1020' y='140' width='230' height='34' rx='4'/%3E%3Crect x='1060' y='190' width='180' height='18' rx='3'/%3E%3Crect x='940' y='740' width='290' height='26' rx='3'/%3E%3C/g%3E%3C/svg%3E");
-  background-size: cover;
-  background-position: center;
-  transform: scale(1.02);
-  animation: heroDrift 900ms ease-out both;
-}
-
-.hero-copy {
-  position: relative;
-  z-index: 1;
-  width: min(760px, 100%);
-  padding-bottom: clamp(58px, 8vh, 100px);
-  animation: riseIn 520ms ease-out both;
-}
-
-.eyebrow,
-.section-kicker {
-  margin: 0 0 12px;
-  color: var(--accent);
-  font-size: 12px;
-  font-weight: 760;
-  letter-spacing: 0;
-  text-transform: uppercase;
+button {
+  border: 0;
 }
 
 h1,
 h2,
-h3,
 p {
   margin-top: 0;
 }
 
-h1 {
-  margin-bottom: 18px;
-  max-width: 720px;
-  font-size: clamp(48px, 10vw, 118px);
-  line-height: 0.9;
+.studio-shell {
+  min-height: 100svh;
+}
+
+.topbar {
+  position: sticky;
+  z-index: 10;
+  top: 0;
+  min-height: var(--topbar);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(7, 8, 7, 0.86);
+  backdrop-filter: blur(18px);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 780;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: clamp(25px, 3vw, 38px);
+  line-height: 0.96;
   letter-spacing: 0;
 }
 
-.lede {
-  max-width: 610px;
-  color: rgba(243, 246, 240, 0.82);
-  font-size: clamp(18px, 2vw, 24px);
-  line-height: 1.38;
-}
-
-.hero-actions,
-.console-toolbar {
+.topbar-controls {
   display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.primary-action,
-.secondary-action,
-.console-toolbar button,
-.strategy-list button {
-  min-height: 44px;
-  border: 1px solid var(--line-strong);
-  color: var(--ink);
-  background: rgba(243, 246, 240, 0.08);
-  cursor: pointer;
-  text-decoration: none;
-  transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease;
-}
-
-.primary-action,
-.secondary-action,
-.console-toolbar button {
-  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 0 18px;
-  border-radius: 6px;
+  justify-content: flex-end;
+  gap: 14px;
 }
 
-.primary-action {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #06100b;
-  font-weight: 780;
-}
-
-.primary-action:hover,
-.secondary-action:hover,
-.console-toolbar button:hover,
-.strategy-list button:hover {
-  transform: translateY(-1px);
-  border-color: var(--accent);
-}
-
-.market-strip {
-  position: absolute;
-  z-index: 1;
-  right: clamp(22px, 5vw, 72px);
-  bottom: clamp(22px, 5vw, 72px);
-  width: min(580px, calc(100% - 44px));
+.topbar-status {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  border: 1px solid var(--line);
-  background: rgba(8, 10, 12, 0.62);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 20px 70px var(--shadow);
+  gap: 4px;
+  min-width: 180px;
+  text-align: right;
 }
 
-.market-strip div,
-.metrics-row div {
-  padding: 16px;
-  border-right: 1px solid var(--line);
-}
-
-.market-strip div:last-child,
-.metrics-row div:last-child {
-  border-right: 0;
-}
-
-.market-strip span,
-.metrics-row span {
-  display: block;
-  margin-bottom: 7px;
+.topbar-status span {
   color: var(--muted);
   font-size: 12px;
 }
 
-.market-strip strong,
-.metrics-row strong {
-  font-size: clamp(18px, 2vw, 24px);
+.topbar-status strong {
+  font-size: 16px;
 }
 
-.workspace {
+.top-run {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0 16px;
+  background: var(--accent);
+  color: #07110d;
+  cursor: pointer;
+  font-weight: 780;
+  white-space: nowrap;
+  transition: transform 160ms ease, opacity 160ms ease;
+}
+
+.top-run:hover {
+  transform: translateY(-1px);
+}
+
+.top-run:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+  transform: none;
+}
+
+.studio-grid {
   display: grid;
-  grid-template-columns: 340px minmax(0, 1fr);
-  min-height: 820px;
-  border-bottom: 1px solid var(--line);
+  grid-template-columns: var(--rail-left) minmax(0, 1fr) var(--rail-right);
+  min-height: calc(100svh - var(--topbar));
 }
 
-.controls {
-  padding: 26px;
+.left-rail,
+.right-rail {
+  min-width: 0;
+  background: rgba(13, 16, 15, 0.76);
+}
+
+.left-rail {
   border-right: 1px solid var(--line);
-  background: rgba(8, 10, 12, 0.44);
 }
 
-.control-block {
-  padding: 22px 0;
+.right-rail {
+  border-left: 1px solid var(--line);
+}
+
+.rail-section {
+  padding: 20px;
   border-bottom: 1px solid var(--line);
 }
 
-.control-block:first-child {
-  padding-top: 0;
+.rail-section:last-child {
+  border-bottom: 0;
 }
 
-.control-block:last-child {
-  border-bottom: 0;
+.section-heading,
+.table-heading,
+.chart-header,
+.pipeline,
+.metric-strip,
+.dual-input {
+  display: flex;
+  align-items: center;
+}
+
+.section-heading {
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.section-heading span {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.section-heading h2,
+.table-heading h2 {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0;
 }
 
 label {
   display: grid;
   gap: 8px;
-  margin-bottom: 14px;
+  margin-bottom: 13px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 12px;
+}
+
+textarea,
+input,
+select {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: rgba(246, 244, 237, 0.055);
+  color: var(--ink);
+}
+
+textarea {
+  min-height: 118px;
+  resize: vertical;
+  padding: 12px;
+  line-height: 1.42;
 }
 
 input,
 select {
-  width: 100%;
   min-height: 42px;
-  border: 1px solid var(--line-strong);
-  border-radius: 6px;
   padding: 0 12px;
-  background: rgba(243, 246, 240, 0.06);
-  color: var(--ink);
 }
 
 select option {
-  color: #07110d;
+  color: #101412;
 }
 
-.strategy-list {
-  display: grid;
+.dual-input {
   gap: 10px;
 }
 
-.strategy-list button {
-  border-radius: 6px;
-  padding: 13px 14px;
+.dual-input label {
+  flex: 1;
+}
+
+.strategy-deck {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.strategy-option {
+  width: 100%;
+  min-height: 78px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(246, 244, 237, 0.045);
+  color: var(--ink);
+  cursor: pointer;
   text-align: left;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease;
 }
 
-.strategy-list button[aria-checked="true"] {
-  border-color: var(--accent);
-  background: rgba(110, 240, 176, 0.12);
+.strategy-option:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+  background: rgba(246, 244, 237, 0.07);
 }
 
-.strategy-list strong {
+.strategy-option[aria-checked="true"] {
+  border-color: rgba(130, 246, 184, 0.7);
+  background: var(--green-soft);
+}
+
+.strategy-option strong {
   display: block;
-  margin-bottom: 4px;
+  margin-bottom: 5px;
+  font-size: 13px;
 }
 
-.strategy-list span {
+.strategy-option span {
+  display: block;
   color: var(--muted);
   font-size: 12px;
-  line-height: 1.4;
+  line-height: 1.36;
 }
 
-.live-panel {
-  padding: clamp(24px, 4vw, 44px);
-  background: linear-gradient(180deg, rgba(243, 246, 240, 0.03), rgba(243, 246, 240, 0.01));
+.strategy-option em {
+  font-style: normal;
+  color: var(--cyan);
+  font-size: 11px;
+  white-space: nowrap;
 }
 
-.panel-header,
-.console-toolbar {
-  display: flex;
-  justify-content: space-between;
+.action-section {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.primary-action,
+.secondary-action {
+  min-height: 44px;
+  display: inline-flex;
   align-items: center;
-  gap: 16px;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 0 15px;
+  cursor: pointer;
+  font-weight: 760;
+  transition:
+    transform 160ms ease,
+    background-color 160ms ease,
+    border-color 160ms ease,
+    opacity 160ms ease;
 }
 
-.panel-header h2,
-.paper-copy h2 {
-  margin-bottom: 0;
-  font-size: clamp(30px, 5vw, 58px);
+.primary-action {
+  background: var(--accent);
+  color: #07110d;
+}
+
+.secondary-action {
+  border: 1px solid var(--line-strong);
+  background: rgba(246, 244, 237, 0.055);
+  color: var(--ink);
+}
+
+.primary-action:hover,
+.secondary-action:hover {
+  transform: translateY(-1px);
+}
+
+.primary-action:disabled,
+.secondary-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+  transform: none;
+}
+
+.main-stage {
+  min-width: 0;
+  padding: 20px;
+  background:
+    radial-gradient(circle at 70% 0%, rgba(115, 213, 255, 0.08), transparent 28rem),
+    rgba(7, 8, 7, 0.48);
+}
+
+.pipeline {
+  gap: 1px;
+  min-height: 66px;
+  border: 1px solid var(--line);
+  background: var(--line);
+  overflow: hidden;
+  border-radius: 10px;
+}
+
+.pipeline-step {
+  flex: 1;
+  min-width: 0;
+  align-self: stretch;
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  padding: 14px;
+  background: rgba(13, 16, 15, 0.94);
+  transition: background-color 180ms ease;
+}
+
+.pipeline-step span,
+.metric-strip span,
+.table-heading span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.pipeline-step strong {
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pipeline-step.is-active {
+  background: linear-gradient(90deg, var(--green-soft), rgba(13, 16, 15, 0.94));
+}
+
+.pipeline-step.is-warn {
+  background: linear-gradient(90deg, var(--amber-soft), rgba(13, 16, 15, 0.94));
+}
+
+.pipeline-step.is-error {
+  background: linear-gradient(90deg, var(--red-soft), rgba(13, 16, 15, 0.94));
+}
+
+.metric-strip {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--line);
+  overflow: hidden;
+}
+
+.metric-strip div {
+  min-height: 82px;
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  padding: 14px;
+  background: rgba(13, 16, 15, 0.9);
+}
+
+.metric-strip strong {
+  font-size: clamp(18px, 2vw, 26px);
+}
+
+.metric-strip strong.good,
+.signal-buy {
+  color: var(--accent);
+}
+
+.metric-strip strong.bad,
+.signal-sell {
+  color: var(--red);
+}
+
+.signal-hold {
+  color: var(--amber);
+}
+
+.chart-section {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(13, 16, 15, 0.78);
+  box-shadow: 0 22px 80px var(--shadow);
+  overflow: hidden;
+}
+
+.chart-header {
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px 18px 12px;
+}
+
+.chart-header h2 {
+  margin: 0;
+  font-size: clamp(24px, 4vw, 42px);
   line-height: 1;
   letter-spacing: 0;
 }
 
-.status-pill {
-  border: 1px solid var(--line-strong);
-  border-radius: 999px;
-  padding: 9px 14px;
-  color: var(--accent);
-  background: rgba(110, 240, 176, 0.08);
-  font-size: 13px;
-  white-space: nowrap;
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 12px;
 }
 
-.status-pill.warn {
-  color: var(--accent-2);
-  background: rgba(244, 196, 107, 0.08);
+.chart-legend span::before {
+  content: "";
+  width: 18px;
+  height: 2px;
+  display: inline-block;
+  margin-right: 7px;
+  vertical-align: middle;
+  background: var(--accent);
 }
 
-.status-pill.danger {
-  color: var(--danger);
-  background: rgba(255, 122, 122, 0.08);
+.chart-legend .legend-equity::before {
+  background: var(--cyan);
 }
 
-.chart-wrap {
-  margin-top: 28px;
-  border: 1px solid var(--line);
-  background: rgba(8, 10, 12, 0.52);
-  min-height: 330px;
+.chart-legend .legend-trades::before {
+  background: var(--amber);
 }
 
 canvas {
   display: block;
   width: 100%;
-  height: min(48vh, 520px);
+  height: clamp(360px, 52vh, 680px);
+  background: #080908;
 }
 
-.metrics-row {
+.lower-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1.15fr) minmax(260px, 0.85fr);
+  gap: 16px;
   margin-top: 16px;
-  border: 1px solid var(--line);
-  background: rgba(8, 10, 12, 0.36);
 }
 
-.decision-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1px;
-  margin-top: 28px;
-  background: var(--line);
-  border: 1px solid var(--line);
-}
-
-.decision-grid > div {
-  padding: 22px;
-  background: rgba(8, 10, 12, 0.58);
-}
-
-.decision-copy {
-  margin: 0;
-  color: rgba(243, 246, 240, 0.76);
-  line-height: 1.55;
-}
-
-.paper-band {
-  display: grid;
-  grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.28fr);
-  gap: clamp(24px, 4vw, 54px);
-  padding: clamp(30px, 5vw, 76px);
-  background: #0b0e10;
-}
-
-.paper-copy p:last-child {
-  max-width: 560px;
-  color: rgba(243, 246, 240, 0.75);
-  line-height: 1.55;
-}
-
-.intent-console {
+.trade-table-wrap,
+.event-log {
   min-width: 0;
   border: 1px solid var(--line);
-  background: #080a0c;
-  box-shadow: 0 20px 70px var(--shadow);
+  border-radius: 12px;
+  background: rgba(13, 16, 15, 0.78);
+  overflow: hidden;
 }
 
-.console-toolbar {
-  padding: 14px;
+.table-heading {
+  justify-content: space-between;
+  gap: 14px;
+  min-height: 54px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--line);
 }
 
-.console-toolbar button {
-  min-width: 136px;
+table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
 }
 
-pre {
-  margin: 0;
-  min-height: 360px;
-  max-height: 560px;
-  overflow: auto;
-  padding: 18px;
-  color: #dce7df;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+th,
+td {
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
   font-size: 12px;
+}
+
+th {
+  color: var(--muted);
+  font-weight: 620;
+}
+
+td {
+  color: var(--soft);
+}
+
+td:nth-child(2),
+td:nth-child(5) {
+  font-weight: 760;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.empty-row td {
+  color: var(--muted);
+}
+
+.event-log ol {
+  max-height: 318px;
+  margin: 0;
+  padding: 6px 16px 16px 34px;
+  overflow: auto;
+}
+
+.event-log li {
+  margin: 10px 0;
+  color: var(--soft);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.event-log li::marker {
+  color: var(--accent);
+}
+
+.inspector-top h2 {
+  margin-bottom: 10px;
+  font-size: clamp(28px, 4vw, 54px);
+  line-height: 0.95;
+  letter-spacing: 0;
+}
+
+.inspector-top p:last-child {
+  margin-bottom: 0;
+  color: var(--soft);
+  line-height: 1.5;
+}
+
+.validation-list {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.validation-list li {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr);
+  gap: 9px;
+  color: var(--soft);
+  font-size: 12px;
+  line-height: 1.42;
+}
+
+.validation-list li::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.validation-list li.warn::before {
+  background: var(--amber);
+}
+
+.validation-list li.error::before {
+  background: var(--red);
+}
+
+.code-pane {
+  margin: 0;
+  max-height: 310px;
+  min-height: 166px;
+  overflow: auto;
+  padding: 13px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #070807;
+  color: #e5ede8;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 11px;
   line-height: 1.55;
   white-space: pre-wrap;
 }
 
-@keyframes riseIn {
-  from {
-    opacity: 0;
-    transform: translateY(18px);
+.copy-action {
+  width: 100%;
+  margin-top: 10px;
+}
+
+@media (max-width: 1320px) {
+  :root {
+    --rail-left: 320px;
+    --rail-right: 340px;
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+
+  .metric-strip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
-@keyframes heroDrift {
-  from {
-    opacity: 0.7;
-    transform: scale(1.06);
+@media (max-width: 1120px) {
+  .studio-grid {
+    grid-template-columns: 300px minmax(0, 1fr);
   }
-  to {
-    opacity: 1;
-    transform: scale(1.02);
+
+  .right-rail {
+    grid-column: 1 / -1;
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+
+  .right-rail {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .right-rail .rail-section {
+    border-right: 1px solid var(--line);
+  }
+
+  .right-rail .rail-section:last-child {
+    border-right: 0;
   }
 }
 
-@media (max-width: 960px) {
-  .hero {
-    min-height: 760px;
+@media (max-width: 900px) {
+  .topbar {
+    position: relative;
   }
 
-  .market-strip,
-  .workspace,
-  .paper-band,
-  .decision-grid {
+  .studio-grid,
+  .right-rail,
+  .lower-grid {
     grid-template-columns: 1fr;
   }
 
-  .market-strip {
-    left: 22px;
-    right: 22px;
-  }
-
-  .workspace {
-    min-height: auto;
-  }
-
-  .controls {
-    border-right: 0;
+  .left-rail,
+  .right-rail {
+    border: 0;
     border-bottom: 1px solid var(--line);
   }
 
-  .metrics-row {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .metrics-row div:nth-child(2) {
+  .right-rail .rail-section {
     border-right: 0;
   }
 
-  .metrics-row div:nth-child(-n + 2) {
-    border-bottom: 1px solid var(--line);
+  .main-stage {
+    padding: 14px;
   }
 }
 
 @media (max-width: 620px) {
-  .hero {
-    padding: 22px;
-    min-height: 720px;
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
-  .hero-copy {
-    padding-bottom: 230px;
+  .topbar-controls {
+    width: 100%;
+    align-items: stretch;
+    justify-content: space-between;
   }
 
-  .market-strip {
+  .topbar-status {
+    text-align: left;
+  }
+
+  .pipeline,
+  .metric-strip {
     grid-template-columns: 1fr;
+    display: grid;
   }
 
-  .market-strip div {
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
+  .pipeline-step,
+  .metric-strip div {
+    min-height: 62px;
   }
 
-  .market-strip div:last-child {
-    border-bottom: 0;
+  .dual-input {
+    display: grid;
   }
 
-  .metrics-row {
-    grid-template-columns: 1fr;
+  th:nth-child(4),
+  td:nth-child(4) {
+    display: none;
   }
 
-  .metrics-row div {
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
-  }
-
-  .metrics-row div:last-child {
-    border-bottom: 0;
-  }
-
-  .panel-header {
+  .chart-header {
     align-items: flex-start;
     flex-direction: column;
   }

--- a/crates/ironclaw_gateway/static/experiments/near-intents.css
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.css
@@ -1,0 +1,500 @@
+:root {
+  color-scheme: dark;
+  --bg: #080a0c;
+  --ink: #f3f6f0;
+  --muted: #9aa69c;
+  --line: rgba(243, 246, 240, 0.14);
+  --line-strong: rgba(243, 246, 240, 0.24);
+  --panel: rgba(19, 24, 24, 0.82);
+  --panel-strong: rgba(27, 34, 33, 0.96);
+  --accent: #6ef0b0;
+  --accent-2: #f4c46b;
+  --danger: #ff7a7a;
+  --shadow: rgba(0, 0, 0, 0.34);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(110, 240, 176, 0.12), transparent 26rem),
+    linear-gradient(140deg, #080a0c 0%, #0e1412 42%, #171314 100%);
+  color: var(--ink);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+select,
+input,
+a {
+  outline-color: var(--accent);
+}
+
+.lab-shell {
+  min-height: 100svh;
+}
+
+.hero {
+  min-height: 84svh;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: end;
+  padding: clamp(28px, 5vw, 72px);
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid var(--line);
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(8, 10, 12, 0.98), rgba(8, 10, 12, 0.58) 52%, rgba(8, 10, 12, 0.94)),
+    url("data:image/svg+xml,%3Csvg width='1400' height='900' viewBox='0 0 1400 900' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1400' height='900' fill='%230b1110'/%3E%3Cg fill='none' stroke='%236ef0b0' stroke-opacity='.20'%3E%3Cpath d='M0 610 C190 550 250 450 410 484 C560 516 620 698 780 650 C930 604 960 360 1120 332 C1240 312 1300 400 1400 382' stroke-width='3'/%3E%3Cpath d='M0 690 C210 632 280 596 436 610 C590 625 668 760 820 736 C1000 708 1036 470 1190 448 C1274 436 1330 472 1400 458' stroke-width='2'/%3E%3Cpath d='M0 524 C160 490 250 330 390 360 C560 396 604 552 760 506 C930 456 984 250 1140 228 C1250 212 1308 276 1400 250' stroke-width='2'/%3E%3C/g%3E%3Cg fill='%236ef0b0' fill-opacity='.35'%3E%3Ccircle cx='410' cy='484' r='5'/%3E%3Ccircle cx='780' cy='650' r='5'/%3E%3Ccircle cx='1120' cy='332' r='5'/%3E%3Ccircle cx='820' cy='736' r='4'/%3E%3Ccircle cx='760' cy='506' r='4'/%3E%3C/g%3E%3Cg fill='%23f4c46b' fill-opacity='.28'%3E%3Crect x='1020' y='140' width='230' height='34' rx='4'/%3E%3Crect x='1060' y='190' width='180' height='18' rx='3'/%3E%3Crect x='940' y='740' width='290' height='26' rx='3'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: cover;
+  background-position: center;
+  transform: scale(1.02);
+  animation: heroDrift 900ms ease-out both;
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+  width: min(760px, 100%);
+  padding-bottom: clamp(58px, 8vh, 100px);
+  animation: riseIn 520ms ease-out both;
+}
+
+.eyebrow,
+.section-kicker {
+  margin: 0 0 12px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 760;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  max-width: 720px;
+  font-size: clamp(48px, 10vw, 118px);
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+.lede {
+  max-width: 610px;
+  color: rgba(243, 246, 240, 0.82);
+  font-size: clamp(18px, 2vw, 24px);
+  line-height: 1.38;
+}
+
+.hero-actions,
+.console-toolbar {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.primary-action,
+.secondary-action,
+.console-toolbar button,
+.strategy-list button {
+  min-height: 44px;
+  border: 1px solid var(--line-strong);
+  color: var(--ink);
+  background: rgba(243, 246, 240, 0.08);
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease;
+}
+
+.primary-action,
+.secondary-action,
+.console-toolbar button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 18px;
+  border-radius: 6px;
+}
+
+.primary-action {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #06100b;
+  font-weight: 780;
+}
+
+.primary-action:hover,
+.secondary-action:hover,
+.console-toolbar button:hover,
+.strategy-list button:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent);
+}
+
+.market-strip {
+  position: absolute;
+  z-index: 1;
+  right: clamp(22px, 5vw, 72px);
+  bottom: clamp(22px, 5vw, 72px);
+  width: min(580px, calc(100% - 44px));
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--line);
+  background: rgba(8, 10, 12, 0.62);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 20px 70px var(--shadow);
+}
+
+.market-strip div,
+.metrics-row div {
+  padding: 16px;
+  border-right: 1px solid var(--line);
+}
+
+.market-strip div:last-child,
+.metrics-row div:last-child {
+  border-right: 0;
+}
+
+.market-strip span,
+.metrics-row span {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.market-strip strong,
+.metrics-row strong {
+  font-size: clamp(18px, 2vw, 24px);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 340px minmax(0, 1fr);
+  min-height: 820px;
+  border-bottom: 1px solid var(--line);
+}
+
+.controls {
+  padding: 26px;
+  border-right: 1px solid var(--line);
+  background: rgba(8, 10, 12, 0.44);
+}
+
+.control-block {
+  padding: 22px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.control-block:first-child {
+  padding-top: 0;
+}
+
+.control-block:last-child {
+  border-bottom: 0;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 14px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  padding: 0 12px;
+  background: rgba(243, 246, 240, 0.06);
+  color: var(--ink);
+}
+
+select option {
+  color: #07110d;
+}
+
+.strategy-list {
+  display: grid;
+  gap: 10px;
+}
+
+.strategy-list button {
+  border-radius: 6px;
+  padding: 13px 14px;
+  text-align: left;
+}
+
+.strategy-list button[aria-checked="true"] {
+  border-color: var(--accent);
+  background: rgba(110, 240, 176, 0.12);
+}
+
+.strategy-list strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.strategy-list span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.live-panel {
+  padding: clamp(24px, 4vw, 44px);
+  background: linear-gradient(180deg, rgba(243, 246, 240, 0.03), rgba(243, 246, 240, 0.01));
+}
+
+.panel-header,
+.console-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.panel-header h2,
+.paper-copy h2 {
+  margin-bottom: 0;
+  font-size: clamp(30px, 5vw, 58px);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.status-pill {
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  padding: 9px 14px;
+  color: var(--accent);
+  background: rgba(110, 240, 176, 0.08);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.status-pill.warn {
+  color: var(--accent-2);
+  background: rgba(244, 196, 107, 0.08);
+}
+
+.status-pill.danger {
+  color: var(--danger);
+  background: rgba(255, 122, 122, 0.08);
+}
+
+.chart-wrap {
+  margin-top: 28px;
+  border: 1px solid var(--line);
+  background: rgba(8, 10, 12, 0.52);
+  min-height: 330px;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: min(48vh, 520px);
+}
+
+.metrics-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  background: rgba(8, 10, 12, 0.36);
+}
+
+.decision-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 28px;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+
+.decision-grid > div {
+  padding: 22px;
+  background: rgba(8, 10, 12, 0.58);
+}
+
+.decision-copy {
+  margin: 0;
+  color: rgba(243, 246, 240, 0.76);
+  line-height: 1.55;
+}
+
+.paper-band {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.28fr);
+  gap: clamp(24px, 4vw, 54px);
+  padding: clamp(30px, 5vw, 76px);
+  background: #0b0e10;
+}
+
+.paper-copy p:last-child {
+  max-width: 560px;
+  color: rgba(243, 246, 240, 0.75);
+  line-height: 1.55;
+}
+
+.intent-console {
+  min-width: 0;
+  border: 1px solid var(--line);
+  background: #080a0c;
+  box-shadow: 0 20px 70px var(--shadow);
+}
+
+.console-toolbar {
+  padding: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.console-toolbar button {
+  min-width: 136px;
+}
+
+pre {
+  margin: 0;
+  min-height: 360px;
+  max-height: 560px;
+  overflow: auto;
+  padding: 18px;
+  color: #dce7df;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@keyframes riseIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes heroDrift {
+  from {
+    opacity: 0.7;
+    transform: scale(1.06);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1.02);
+  }
+}
+
+@media (max-width: 960px) {
+  .hero {
+    min-height: 760px;
+  }
+
+  .market-strip,
+  .workspace,
+  .paper-band,
+  .decision-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .market-strip {
+    left: 22px;
+    right: 22px;
+  }
+
+  .workspace {
+    min-height: auto;
+  }
+
+  .controls {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .metrics-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metrics-row div:nth-child(2) {
+    border-right: 0;
+  }
+
+  .metrics-row div:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 620px) {
+  .hero {
+    padding: 22px;
+    min-height: 720px;
+  }
+
+  .hero-copy {
+    padding-bottom: 230px;
+  }
+
+  .market-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .market-strip div {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .market-strip div:last-child {
+    border-bottom: 0;
+  }
+
+  .metrics-row {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics-row div {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .metrics-row div:last-child {
+    border-bottom: 0;
+  }
+
+  .panel-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/crates/ironclaw_gateway/static/experiments/near-intents.html
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>NEAR Intents Strategy Lab</title>
+  <link rel="stylesheet" href="/experiments/near-intents.css">
+</head>
+<body>
+  <main class="lab-shell">
+    <section class="hero">
+      <div class="hero-copy">
+        <p class="eyebrow">Public experiment</p>
+        <h1>NEAR Intents Strategy Lab</h1>
+        <p class="lede">Run live-data paper strategies, inspect the signal, and produce an unsigned direct NEAR Intents trial payload.</p>
+        <div class="hero-actions">
+          <button id="runLiveBtn" class="primary-action" type="button">Run live strategy</button>
+          <a class="secondary-action" href="#paper">View paper intent</a>
+        </div>
+      </div>
+      <div class="market-strip" aria-label="Market snapshot">
+        <div>
+          <span>Source</span>
+          <strong id="sourceLabel">Waiting</strong>
+        </div>
+        <div>
+          <span id="priceCaption">Last price</span>
+          <strong id="priceLabel">-</strong>
+        </div>
+        <div>
+          <span>Signal</span>
+          <strong id="signalLabel">Idle</strong>
+        </div>
+      </div>
+    </section>
+
+    <section class="workspace" aria-label="Strategy workspace">
+      <aside class="controls" aria-label="Experiment controls">
+        <div class="control-block">
+          <p class="section-kicker">Market</p>
+          <label>
+            Pair
+            <select id="pairSelect">
+              <option value="NEAR-USD" selected>NEAR / USD</option>
+              <option value="BTC-USD">BTC / USD</option>
+              <option value="ETH-USD">ETH / USD</option>
+              <option value="SOL-USD">SOL / USD</option>
+            </select>
+          </label>
+          <label>
+            Lookback
+            <select id="lookbackSelect">
+              <option value="30" selected>30 days</option>
+              <option value="14">14 days</option>
+              <option value="7">7 days</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="control-block">
+          <p class="section-kicker">Strategy</p>
+          <div id="strategyList" class="strategy-list" role="radiogroup" aria-label="Strategy"></div>
+        </div>
+
+        <div class="control-block">
+          <p class="section-kicker">Trial ticket</p>
+          <label>
+            NEAR account
+            <input id="accountInput" type="text" placeholder="small-test.near" autocomplete="off">
+          </label>
+          <label>
+            Paper budget, USD
+            <input id="budgetInput" type="number" min="0.01" step="0.01" value="0.25">
+          </label>
+          <label>
+            Max trade, USD
+            <input id="tradeCapInput" type="number" min="0.01" step="0.01" value="0.05">
+          </label>
+          <label>
+            Slippage, bps
+            <input id="slippageInput" type="number" min="1" max="500" step="1" value="50">
+          </label>
+        </div>
+      </aside>
+
+      <section class="live-panel" aria-label="Live strategy output">
+        <div class="panel-header">
+          <div>
+            <p class="section-kicker">Live paper run</p>
+            <h2 id="strategyTitle">SMA Cross</h2>
+          </div>
+          <div id="statusPill" class="status-pill">Idle</div>
+        </div>
+
+        <div class="chart-wrap">
+          <canvas id="priceCanvas" width="1200" height="520" aria-label="Price chart"></canvas>
+        </div>
+
+        <div class="metrics-row" aria-label="Backtest metrics">
+          <div>
+            <span>Return</span>
+            <strong id="returnMetric">-</strong>
+          </div>
+          <div>
+            <span>Max drawdown</span>
+            <strong id="drawdownMetric">-</strong>
+          </div>
+          <div>
+            <span>Trades</span>
+            <strong id="tradesMetric">-</strong>
+          </div>
+          <div>
+            <span>Confidence</span>
+            <strong id="confidenceMetric">-</strong>
+          </div>
+        </div>
+
+        <div class="decision-grid">
+          <div>
+            <p class="section-kicker">Signal note</p>
+            <p id="signalNote" class="decision-copy">Run the strategy to load recent candles and generate a paper decision.</p>
+          </div>
+          <div>
+            <p class="section-kicker">Risk boundary</p>
+            <p class="decision-copy">This page never signs or broadcasts. It only creates an unsigned trial payload for review.</p>
+          </div>
+        </div>
+      </section>
+    </section>
+
+    <section id="paper" class="paper-band" aria-label="Paper intent">
+      <div class="paper-copy">
+        <p class="section-kicker">Unsigned NEAR Intents draft</p>
+        <h2>Show the strategy, not a custody flow.</h2>
+        <p>External viewers can see live data, the strategy decision, sizing, and the exact unsigned direct-intent payload. A wallet signature remains a separate explicit step.</p>
+      </div>
+      <div class="intent-console">
+        <div class="console-toolbar">
+          <button id="buildIntentBtn" type="button">Build paper intent</button>
+          <button id="copyIntentBtn" type="button">Copy JSON</button>
+        </div>
+        <pre id="intentOutput">Run a strategy to prepare an unsigned payload.</pre>
+      </div>
+    </section>
+  </main>
+  <script src="/experiments/near-intents.js"></script>
+</body>
+</html>

--- a/crates/ironclaw_gateway/static/experiments/near-intents.html
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.html
@@ -29,23 +29,23 @@
       <div class="hero-copy">
         <p class="eyebrow">NEAR Intents strategy agent</p>
         <h1>Run autonomous trading strategies through intents.</h1>
-        <p class="hero-subtitle">Backtest on live market data, ask solvers for a quote, sign with your NEAR wallet, and only publish when you explicitly run the live step.</p>
+        <p class="hero-subtitle">Pick a strategy, preview the next move, then connect your wallet only when you are ready to try a tiny live run.</p>
         <div class="hero-actions">
-          <button id="heroRunBtn" class="hero-primary" type="button">Start Vibe Trading</button>
+          <button id="heroRunBtn" class="hero-primary" type="button">Preview strategy</button>
           <button id="heroConnectBtn" class="hero-secondary" type="button">Connect wallet</button>
         </div>
         <div class="feature-strip" aria-label="Agent capabilities">
           <div>
-            <strong>Risk-aware</strong>
-            <span>Caps every live signal</span>
+            <strong>Try first</strong>
+            <span>No wallet for previews</span>
           </div>
           <div>
-            <strong>Data-driven</strong>
-            <span>CoinGecko + strategy tape</span>
+            <strong>Tiny by default</strong>
+            <span>$5 live cap</span>
           </div>
           <div>
-            <strong>Intent-native</strong>
-            <span>Quote, sign, publish</span>
+            <strong>Manual send</strong>
+            <span>Wallet signs every run</span>
           </div>
         </div>
       </div>
@@ -56,7 +56,24 @@
             <span>Live execution</span>
             <strong id="liveModeLabel">Dry run ready</strong>
           </div>
-          <button id="runLiveBtn" class="console-run" type="button">Run live once</button>
+          <button id="runLiveBtn" class="console-run" type="button">Run tiny live trade</button>
+        </div>
+        <div class="starter-steps" aria-label="Guided setup">
+          <div id="guideStepPreview" class="is-active">
+            <span>1</span>
+            <strong>Preview</strong>
+            <p>Run the strategy with live market data.</p>
+          </div>
+          <div id="guideStepWallet">
+            <span>2</span>
+            <strong>Connect</strong>
+            <p>Use your NEAR wallet when you want to try it.</p>
+          </div>
+          <div id="guideStepRun">
+            <span>3</span>
+            <strong>Run</strong>
+            <p>Sign one tiny intent, then submit.</p>
+          </div>
         </div>
         <div class="wallet-card">
           <div>
@@ -73,43 +90,40 @@
           </div>
         </div>
         <div class="live-steps" aria-label="Execution phases">
-          <span id="liveStepBacktest" class="is-active">Backtest</span>
+          <span id="liveStepBacktest" class="is-active">Preview</span>
           <span id="liveStepQuote">Quote</span>
           <span id="liveStepSign">Sign</span>
-          <span id="liveStepPublish">Publish</span>
+          <span id="liveStepPublish">Submit</span>
         </div>
-        <pre id="liveExecutionOutput" class="terminal-pane">Connect a NEAR wallet, run a strategy, then execute a tiny signed intent when you are ready.</pre>
+        <p id="liveSummaryText" class="live-summary">Start with a strategy preview. Nothing is signed or submitted until you connect a wallet and approve it.</p>
+        <details class="receipt-drawer">
+          <summary>Technical receipt</summary>
+          <pre id="liveExecutionOutput" class="terminal-pane">Strategy receipts, quote requests, and signed payloads will appear here.</pre>
+        </details>
       </section>
     </section>
 
-    <section class="core-preview" aria-label="Core features">
+    <section class="core-preview" aria-label="Simple workflow">
       <article>
         <div class="preview-copy">
-          <span>Vibe Agent</span>
-          <h2>Strategy agent</h2>
-          <p>Pick a strategy, tune risk, and let the agent turn the latest signal into an execution plan.</p>
+          <span>Step 1</span>
+          <h2>Choose</h2>
+          <p>Select a strategy and market. Defaults are already filled in for NEAR.</p>
         </div>
-        <pre>signal = agent.evaluate("NEAR", "1h")
-if signal.side != "hold":
-    intent = build_token_diff(signal)</pre>
       </article>
       <article>
         <div class="preview-copy">
-          <span>Vibe Studio</span>
-          <h2>NEAR Intents</h2>
-          <p>Use deposited Intents balances directly. Edit asset IDs and decimals instead of forcing one wrapped route.</p>
+          <span>Step 2</span>
+          <h2>Preview</h2>
+          <p>See return, drawdown, latest signal, and a quote preview before using funds.</p>
         </div>
-        <pre>quote -> nep413_sign -> publish_intent
-venue = "intents.near"</pre>
       </article>
       <article>
         <div class="preview-copy">
-          <span>Backtest</span>
-          <h2>Live guardrails</h2>
-          <p>Every live run inherits the same caps, slippage, and confidence checks that shaped the paper run.</p>
+          <span>Step 3</span>
+          <h2>Run</h2>
+          <p>Connect a wallet and approve one tiny intent when the preview looks good.</p>
         </div>
-        <pre>max_trade_usd = 5.00
-mode = "manual_signature_required"</pre>
       </article>
     </section>
 
@@ -118,16 +132,19 @@ mode = "manual_signature_required"</pre>
         <section class="panel-section">
           <div class="section-heading">
             <span>01</span>
-            <h2>Strategy</h2>
+            <h2>Choose a strategy</h2>
           </div>
-          <textarea id="strategyPrompt" rows="5" spellcheck="false">NEAR spot momentum using SMA confirmation, RSI guardrail, 1.0% take profit, 0.6% stop, and small paper sizing.</textarea>
           <div id="strategyDeck" class="strategy-deck" role="radiogroup" aria-label="Strategy template"></div>
+          <details class="inline-advanced">
+            <summary>Edit strategy prompt</summary>
+            <textarea id="strategyPrompt" rows="5" spellcheck="false">NEAR spot momentum using SMA confirmation, RSI guardrail, 1.0% take profit, 0.6% stop, and small paper sizing.</textarea>
+          </details>
         </section>
 
         <section class="panel-section">
           <div class="section-heading">
             <span>02</span>
-            <h2>Market</h2>
+            <h2>Set up the run</h2>
           </div>
           <label>
             Pair
@@ -138,131 +155,155 @@ mode = "manual_signature_required"</pre>
               <option value="SOL-USD">SOL / USD</option>
             </select>
           </label>
-          <label>
-            Lookback
-            <select id="lookbackSelect">
-              <option value="7">7 days</option>
-              <option value="14">14 days</option>
-              <option value="30" selected>30 days</option>
-              <option value="60">60 days</option>
-            </select>
+          <label class="live-cap-label">
+            Tiny live cap, USD
+            <input id="liveAmountUsdInput" type="number" min="0.01" step="0.01" value="5">
           </label>
-          <div class="dual-input">
-            <label>
-              Starting cash, USD
-              <input id="balanceInput" type="number" min="10" step="10" value="1000">
-            </label>
-            <label>
-              Live cap, USD
-              <input id="liveAmountUsdInput" type="number" min="0.01" step="0.01" value="5">
-            </label>
+          <label>
+            NEAR account for previews
+            <input id="accountInput" type="text" placeholder="optional: viewer.near" autocomplete="off">
+          </label>
+          <div class="action-grid action-grid-simple">
+            <button id="runBacktestBtn" class="primary-action" type="button">Preview strategy</button>
+            <button id="dryQuoteBtn" class="secondary-action" type="button">Preview quote</button>
           </div>
-          <label>
-            NEAR account
-            <input id="accountInput" type="text" placeholder="viewer.near" autocomplete="off">
-          </label>
         </section>
 
-        <section class="panel-section">
+        <section class="panel-section simple-safety">
           <div class="section-heading">
             <span>03</span>
-            <h2>Risk</h2>
+            <h2>Safety defaults</h2>
           </div>
-          <label>
-            Max trade, USD
-            <input id="maxTradeInput" type="number" min="0.01" step="0.01" value="25">
-          </label>
-          <label>
-            Risk per signal, %
-            <input id="riskPctInput" type="number" min="0.1" max="100" step="0.1" value="5">
-          </label>
-          <div class="dual-input">
-            <label>
-              Fee, bps
-              <input id="feeBpsInput" type="number" min="0" max="200" step="1" value="8">
-            </label>
-            <label>
-              Slippage, bps
-              <input id="slippageInput" type="number" min="0" max="500" step="1" value="12">
-            </label>
+          <div class="safety-list">
+            <div>
+              <strong>$5</strong>
+              <span>Default live cap</span>
+            </div>
+            <div>
+              <strong>Manual</strong>
+              <span>Wallet approval required</span>
+            </div>
+            <div>
+              <strong>Quote preview</strong>
+              <span>Preview before signing</span>
+            </div>
           </div>
         </section>
 
         <section class="panel-section">
-          <div class="section-heading">
-            <span>04</span>
-            <h2>Assets</h2>
-          </div>
-          <label>
-            Base asset ID
-            <input id="baseAssetInput" list="assetIdList" type="text" value="nep141:wrap.near" autocomplete="off">
-          </label>
-          <label>
-            Quote / funding asset ID
-            <input id="quoteAssetInput" list="assetIdList" type="text" value="nep141:usdt.tether-token.near" autocomplete="off">
-          </label>
-          <datalist id="assetIdList"></datalist>
-          <div class="dual-input">
-            <label>
-              Base decimals
-              <input id="baseDecimalsInput" type="number" min="0" max="30" step="1" value="24">
-            </label>
-            <label>
-              Quote decimals
-              <input id="quoteDecimalsInput" type="number" min="0" max="30" step="1" value="6">
-            </label>
-          </div>
+          <details class="advanced-settings">
+            <summary>
+              <span>Advanced settings</span>
+              <small>Risk, asset routes, and developer keys</small>
+            </summary>
+            <div class="advanced-body">
+              <h3>Backtest assumptions</h3>
+              <label>
+                Lookback
+                <select id="lookbackSelect">
+                  <option value="7">7 days</option>
+                  <option value="14">14 days</option>
+                  <option value="30" selected>30 days</option>
+                  <option value="60">60 days</option>
+                </select>
+              </label>
+              <div class="dual-input">
+                <label>
+                  Starting cash, USD
+                  <input id="balanceInput" type="number" min="10" step="10" value="1000">
+                </label>
+                <label>
+                  Max trade, USD
+                  <input id="maxTradeInput" type="number" min="0.01" step="0.01" value="25">
+                </label>
+              </div>
+              <div class="dual-input">
+                <label>
+                  Risk per signal, %
+                  <input id="riskPctInput" type="number" min="0.1" max="100" step="0.1" value="5">
+                </label>
+                <label>
+                  Slippage, bps
+                  <input id="slippageInput" type="number" min="0" max="500" step="1" value="12">
+                </label>
+              </div>
+              <label>
+                Fee, bps
+                <input id="feeBpsInput" type="number" min="0" max="200" step="1" value="8">
+              </label>
+
+              <h3>Intent route</h3>
+              <label>
+                Base asset ID
+                <input id="baseAssetInput" list="assetIdList" type="text" value="nep141:wrap.near" autocomplete="off">
+              </label>
+              <label>
+                Quote / funding asset ID
+                <input id="quoteAssetInput" list="assetIdList" type="text" value="nep141:usdt.tether-token.near" autocomplete="off">
+              </label>
+              <datalist id="assetIdList"></datalist>
+              <div class="dual-input">
+                <label>
+                  Base decimals
+                  <input id="baseDecimalsInput" type="number" min="0" max="30" step="1" value="24">
+                </label>
+                <label>
+                  Quote decimals
+                  <input id="quoteDecimalsInput" type="number" min="0" max="30" step="1" value="6">
+                </label>
+              </div>
+
+              <h3>Live execution</h3>
+              <label>
+                Network
+                <select id="networkSelect">
+                  <option value="mainnet" selected>Mainnet</option>
+                  <option value="testnet">Testnet wallet only</option>
+                </select>
+              </label>
+              <label>
+                Side override
+                <select id="sideOverrideSelect">
+                  <option value="auto" selected>Use latest signal</option>
+                  <option value="buy">Force tiny buy</option>
+                  <option value="sell">Force tiny sell</option>
+                  <option value="hold">Force hold</option>
+                </select>
+              </label>
+              <form class="key-form" autocomplete="off">
+                <label>
+                  Solver relay JWT
+                  <input id="solverApiKeyInput" type="password" placeholder="Required to publish signed token_diff" autocomplete="off">
+                </label>
+                <label>
+                  1Click JWT (optional)
+                  <input id="oneClickApiKeyInput" type="password" placeholder="Optional quote auth" autocomplete="off">
+                </label>
+              </form>
+            </div>
+          </details>
         </section>
 
         <section class="panel-section">
-          <div class="section-heading">
-            <span>05</span>
-            <h2>Execution</h2>
-          </div>
-          <label>
-            Network
-            <select id="networkSelect">
-              <option value="mainnet" selected>Mainnet</option>
-              <option value="testnet">Testnet wallet only</option>
-            </select>
-          </label>
-          <label>
-            Side override
-            <select id="sideOverrideSelect">
-              <option value="auto" selected>Use latest signal</option>
-              <option value="buy">Force tiny buy</option>
-              <option value="sell">Force tiny sell</option>
-              <option value="hold">Force hold</option>
-            </select>
-          </label>
-          <label>
-            Solver relay JWT
-            <input id="solverApiKeyInput" type="password" placeholder="Required to publish signed token_diff">
-          </label>
-          <label>
-            1Click JWT (optional)
-            <input id="oneClickApiKeyInput" type="password" placeholder="Optional quote auth">
-          </label>
           <div class="action-grid">
-            <button id="runBacktestBtn" class="primary-action" type="button">Run backtest</button>
-            <button id="dryQuoteBtn" class="secondary-action" type="button">Dry quote</button>
-            <button id="buildIntentBtn" class="secondary-action" type="button">Build intent</button>
-            <button id="fetchBalancesBtn" class="secondary-action" type="button">Balances</button>
+            <button id="fetchBalancesBtn" class="secondary-action" type="button">Check balances</button>
+            <button id="buildIntentBtn" class="secondary-action" type="button">Build receipt</button>
           </div>
         </section>
+
       </aside>
 
       <section class="main-stage" id="signals" aria-label="Backtest output">
         <div class="stage-toolbar">
           <div>
             <p class="eyebrow">Agent run</p>
-            <h2>Signals, fills, and intent guardrails</h2>
+            <h2>Preview result</h2>
           </div>
           <div class="topbar-status" aria-label="Run status">
             <span id="dataSourceLabel">No data</span>
             <strong id="runStateLabel">Ready</strong>
           </div>
-          <button id="topRunBtn" class="top-run" type="button">Run backtest</button>
+          <button id="topRunBtn" class="top-run" type="button">Refresh preview</button>
         </div>
 
         <div class="pipeline" aria-label="Pipeline">

--- a/crates/ironclaw_gateway/static/experiments/near-intents.html
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.html
@@ -3,39 +3,130 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NEAR Intents Strategy Studio</title>
+  <title>IronClaw Intents Trading Agent</title>
+  <link rel="icon" href="data:,">
   <link rel="stylesheet" href="near-intents.css">
 </head>
 <body>
-  <main class="studio-shell">
-    <header class="topbar">
-      <div>
-        <p class="eyebrow">NEAR Intents</p>
-        <h1>Strategy Studio</h1>
-      </div>
-      <div class="topbar-controls">
-        <div class="topbar-status" aria-label="Run status">
-          <span id="dataSourceLabel">No data</span>
-          <strong id="runStateLabel">Ready</strong>
-        </div>
-        <button id="topRunBtn" class="top-run" type="button">Run backtest</button>
+  <main class="app-shell">
+    <header class="vibe-nav">
+      <a class="brand-lockup" href="#studio" aria-label="IronClaw Intents">
+        <span class="brand-mark">IC</span>
+        <span>IronClaw Intents</span>
+      </a>
+      <nav aria-label="Experiment navigation">
+        <a href="#signals">Signals</a>
+        <a href="#studio">Studio</a>
+        <a href="#live">Live</a>
+      </nav>
+      <div class="nav-actions">
+        <span id="walletPill" class="wallet-pill">Wallet offline</span>
+        <button id="connectWalletBtn" class="connect-btn" type="button">Connect</button>
       </div>
     </header>
 
-    <section class="studio-grid" aria-label="Trading strategy workspace">
-      <aside class="left-rail" aria-label="Strategy controls">
-        <section class="rail-section">
+    <section class="hero" id="live" aria-label="Live trading agent">
+      <div class="hero-copy">
+        <p class="eyebrow">NEAR Intents strategy agent</p>
+        <h1>Run autonomous trading strategies through intents.</h1>
+        <p class="hero-subtitle">Backtest on live market data, ask solvers for a quote, sign with your NEAR wallet, and only publish when you explicitly run the live step.</p>
+        <div class="hero-actions">
+          <button id="heroRunBtn" class="hero-primary" type="button">Start Vibe Trading</button>
+          <button id="heroConnectBtn" class="hero-secondary" type="button">Connect wallet</button>
+        </div>
+        <div class="feature-strip" aria-label="Agent capabilities">
+          <div>
+            <strong>Risk-aware</strong>
+            <span>Caps every live signal</span>
+          </div>
+          <div>
+            <strong>Data-driven</strong>
+            <span>CoinGecko + strategy tape</span>
+          </div>
+          <div>
+            <strong>Intent-native</strong>
+            <span>Quote, sign, publish</span>
+          </div>
+        </div>
+      </div>
+
+      <section class="agent-console" aria-label="Wallet and live execution">
+        <div class="console-header">
+          <div>
+            <span>Live execution</span>
+            <strong id="liveModeLabel">Dry run ready</strong>
+          </div>
+          <button id="runLiveBtn" class="console-run" type="button">Run live once</button>
+        </div>
+        <div class="wallet-card">
+          <div>
+            <span>Wallet</span>
+            <strong id="walletStatusLabel">Not connected</strong>
+          </div>
+          <div>
+            <span>Account</span>
+            <strong id="walletAccountLabel">-</strong>
+          </div>
+          <div>
+            <span>Intents balance</span>
+            <strong id="walletBalanceLabel">Connect to query</strong>
+          </div>
+        </div>
+        <div class="live-steps" aria-label="Execution phases">
+          <span id="liveStepBacktest" class="is-active">Backtest</span>
+          <span id="liveStepQuote">Quote</span>
+          <span id="liveStepSign">Sign</span>
+          <span id="liveStepPublish">Publish</span>
+        </div>
+        <pre id="liveExecutionOutput" class="terminal-pane">Connect a NEAR wallet, run a strategy, then execute a tiny signed intent when you are ready.</pre>
+      </section>
+    </section>
+
+    <section class="core-preview" aria-label="Core features">
+      <article>
+        <div class="preview-copy">
+          <span>Vibe Agent</span>
+          <h2>Strategy agent</h2>
+          <p>Pick a strategy, tune risk, and let the agent turn the latest signal into an execution plan.</p>
+        </div>
+        <pre>signal = agent.evaluate("NEAR", "1h")
+if signal.side != "hold":
+    intent = build_token_diff(signal)</pre>
+      </article>
+      <article>
+        <div class="preview-copy">
+          <span>Vibe Studio</span>
+          <h2>NEAR Intents</h2>
+          <p>Use deposited Intents balances directly. Edit asset IDs and decimals instead of forcing one wrapped route.</p>
+        </div>
+        <pre>quote -> nep413_sign -> publish_intent
+venue = "intents.near"</pre>
+      </article>
+      <article>
+        <div class="preview-copy">
+          <span>Backtest</span>
+          <h2>Live guardrails</h2>
+          <p>Every live run inherits the same caps, slippage, and confidence checks that shaped the paper run.</p>
+        </div>
+        <pre>max_trade_usd = 5.00
+mode = "manual_signature_required"</pre>
+      </article>
+    </section>
+
+    <section class="studio-grid" id="studio" aria-label="Trading strategy workspace">
+      <aside class="control-panel" aria-label="Strategy controls">
+        <section class="panel-section">
           <div class="section-heading">
-            <span>1</span>
+            <span>01</span>
             <h2>Strategy</h2>
           </div>
           <textarea id="strategyPrompt" rows="5" spellcheck="false">NEAR spot momentum using SMA confirmation, RSI guardrail, 1.0% take profit, 0.6% stop, and small paper sizing.</textarea>
           <div id="strategyDeck" class="strategy-deck" role="radiogroup" aria-label="Strategy template"></div>
         </section>
 
-        <section class="rail-section">
+        <section class="panel-section">
           <div class="section-heading">
-            <span>2</span>
+            <span>02</span>
             <h2>Market</h2>
           </div>
           <label>
@@ -56,19 +147,25 @@
               <option value="60">60 days</option>
             </select>
           </label>
-          <label>
-            Starting cash, USD
-            <input id="balanceInput" type="number" min="10" step="10" value="1000">
-          </label>
+          <div class="dual-input">
+            <label>
+              Starting cash, USD
+              <input id="balanceInput" type="number" min="10" step="10" value="1000">
+            </label>
+            <label>
+              Live cap, USD
+              <input id="liveAmountUsdInput" type="number" min="0.01" step="0.01" value="5">
+            </label>
+          </div>
           <label>
             NEAR account
             <input id="accountInput" type="text" placeholder="viewer.near" autocomplete="off">
           </label>
         </section>
 
-        <section class="rail-section">
+        <section class="panel-section">
           <div class="section-heading">
-            <span>3</span>
+            <span>03</span>
             <h2>Risk</h2>
           </div>
           <label>
@@ -91,13 +188,83 @@
           </div>
         </section>
 
-        <section class="rail-section action-section">
-          <button id="runBacktestBtn" class="primary-action" type="button">Run backtest</button>
-          <button id="buildIntentBtn" class="secondary-action" type="button">Build intent draft</button>
+        <section class="panel-section">
+          <div class="section-heading">
+            <span>04</span>
+            <h2>Assets</h2>
+          </div>
+          <label>
+            Base asset ID
+            <input id="baseAssetInput" list="assetIdList" type="text" value="nep141:wrap.near" autocomplete="off">
+          </label>
+          <label>
+            Quote / funding asset ID
+            <input id="quoteAssetInput" list="assetIdList" type="text" value="nep141:usdt.tether-token.near" autocomplete="off">
+          </label>
+          <datalist id="assetIdList"></datalist>
+          <div class="dual-input">
+            <label>
+              Base decimals
+              <input id="baseDecimalsInput" type="number" min="0" max="30" step="1" value="24">
+            </label>
+            <label>
+              Quote decimals
+              <input id="quoteDecimalsInput" type="number" min="0" max="30" step="1" value="6">
+            </label>
+          </div>
+        </section>
+
+        <section class="panel-section">
+          <div class="section-heading">
+            <span>05</span>
+            <h2>Execution</h2>
+          </div>
+          <label>
+            Network
+            <select id="networkSelect">
+              <option value="mainnet" selected>Mainnet</option>
+              <option value="testnet">Testnet wallet only</option>
+            </select>
+          </label>
+          <label>
+            Side override
+            <select id="sideOverrideSelect">
+              <option value="auto" selected>Use latest signal</option>
+              <option value="buy">Force tiny buy</option>
+              <option value="sell">Force tiny sell</option>
+              <option value="hold">Force hold</option>
+            </select>
+          </label>
+          <label>
+            Solver relay JWT
+            <input id="solverApiKeyInput" type="password" placeholder="Required to publish signed token_diff">
+          </label>
+          <label>
+            1Click JWT (optional)
+            <input id="oneClickApiKeyInput" type="password" placeholder="Optional quote auth">
+          </label>
+          <div class="action-grid">
+            <button id="runBacktestBtn" class="primary-action" type="button">Run backtest</button>
+            <button id="dryQuoteBtn" class="secondary-action" type="button">Dry quote</button>
+            <button id="buildIntentBtn" class="secondary-action" type="button">Build intent</button>
+            <button id="fetchBalancesBtn" class="secondary-action" type="button">Balances</button>
+          </div>
         </section>
       </aside>
 
-      <section class="main-stage" aria-label="Backtest output">
+      <section class="main-stage" id="signals" aria-label="Backtest output">
+        <div class="stage-toolbar">
+          <div>
+            <p class="eyebrow">Agent run</p>
+            <h2>Signals, fills, and intent guardrails</h2>
+          </div>
+          <div class="topbar-status" aria-label="Run status">
+            <span id="dataSourceLabel">No data</span>
+            <strong id="runStateLabel">Ready</strong>
+          </div>
+          <button id="topRunBtn" class="top-run" type="button">Run backtest</button>
+        </div>
+
         <div class="pipeline" aria-label="Pipeline">
           <div class="pipeline-step is-active" data-phase="describe">
             <span>Describe</span>
@@ -189,36 +356,39 @@
         </section>
       </section>
 
-      <aside class="right-rail" aria-label="Intent inspector">
-        <section class="rail-section inspector-top">
+      <aside class="inspector-rail" aria-label="Intent inspector">
+        <section class="panel-section inspector-top">
           <p class="eyebrow">Signal</p>
           <h2 id="signalTitle">No run yet</h2>
           <p id="signalSummary">Select a strategy and run a paper backtest.</p>
         </section>
 
-        <section class="rail-section">
+        <section class="panel-section">
           <div class="section-heading">
-            <span>4</span>
+            <span>06</span>
             <h2>Validation</h2>
           </div>
           <ul id="validationList" class="validation-list"></ul>
         </section>
 
-        <section class="rail-section">
+        <section class="panel-section">
           <div class="section-heading">
-            <span>5</span>
+            <span>07</span>
             <h2>Generated Strategy</h2>
           </div>
           <pre id="strategyCode" class="code-pane">Run a strategy to generate code.</pre>
         </section>
 
-        <section class="rail-section">
+        <section class="panel-section">
           <div class="section-heading">
-            <span>6</span>
-            <h2>Unsigned Intent</h2>
+            <span>08</span>
+            <h2>Signed / Draft Intent</h2>
           </div>
           <pre id="intentOutput" class="code-pane">Run a strategy to prepare a NEAR Intents draft.</pre>
-          <button id="copyIntentBtn" class="secondary-action copy-action" type="button">Copy JSON</button>
+          <div class="copy-row">
+            <button id="copyIntentBtn" class="secondary-action copy-action" type="button">Copy JSON</button>
+            <button id="copySignedBtn" class="secondary-action copy-action" type="button">Copy signed</button>
+          </div>
         </section>
       </aside>
     </section>

--- a/crates/ironclaw_gateway/static/experiments/near-intents.html
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.html
@@ -3,41 +3,41 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NEAR Intents Strategy Lab</title>
-  <link rel="stylesheet" href="/experiments/near-intents.css">
+  <title>NEAR Intents Strategy Studio</title>
+  <link rel="stylesheet" href="near-intents.css">
 </head>
 <body>
-  <main class="lab-shell">
-    <section class="hero">
-      <div class="hero-copy">
-        <p class="eyebrow">Public experiment</p>
-        <h1>NEAR Intents Strategy Lab</h1>
-        <p class="lede">Run live-data paper strategies, inspect the signal, and produce an unsigned direct NEAR Intents trial payload.</p>
-        <div class="hero-actions">
-          <button id="runLiveBtn" class="primary-action" type="button">Run live strategy</button>
-          <a class="secondary-action" href="#paper">View paper intent</a>
-        </div>
+  <main class="studio-shell">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">NEAR Intents</p>
+        <h1>Strategy Studio</h1>
       </div>
-      <div class="market-strip" aria-label="Market snapshot">
-        <div>
-          <span>Source</span>
-          <strong id="sourceLabel">Waiting</strong>
+      <div class="topbar-controls">
+        <div class="topbar-status" aria-label="Run status">
+          <span id="dataSourceLabel">No data</span>
+          <strong id="runStateLabel">Ready</strong>
         </div>
-        <div>
-          <span id="priceCaption">Last price</span>
-          <strong id="priceLabel">-</strong>
-        </div>
-        <div>
-          <span>Signal</span>
-          <strong id="signalLabel">Idle</strong>
-        </div>
+        <button id="topRunBtn" class="top-run" type="button">Run backtest</button>
       </div>
-    </section>
+    </header>
 
-    <section class="workspace" aria-label="Strategy workspace">
-      <aside class="controls" aria-label="Experiment controls">
-        <div class="control-block">
-          <p class="section-kicker">Market</p>
+    <section class="studio-grid" aria-label="Trading strategy workspace">
+      <aside class="left-rail" aria-label="Strategy controls">
+        <section class="rail-section">
+          <div class="section-heading">
+            <span>1</span>
+            <h2>Strategy</h2>
+          </div>
+          <textarea id="strategyPrompt" rows="5" spellcheck="false">NEAR spot momentum using SMA confirmation, RSI guardrail, 1.0% take profit, 0.6% stop, and small paper sizing.</textarea>
+          <div id="strategyDeck" class="strategy-deck" role="radiogroup" aria-label="Strategy template"></div>
+        </section>
+
+        <section class="rail-section">
+          <div class="section-heading">
+            <span>2</span>
+            <h2>Market</h2>
+          </div>
           <label>
             Pair
             <select id="pairSelect">
@@ -50,99 +50,179 @@
           <label>
             Lookback
             <select id="lookbackSelect">
-              <option value="30" selected>30 days</option>
-              <option value="14">14 days</option>
               <option value="7">7 days</option>
+              <option value="14">14 days</option>
+              <option value="30" selected>30 days</option>
+              <option value="60">60 days</option>
             </select>
           </label>
-        </div>
-
-        <div class="control-block">
-          <p class="section-kicker">Strategy</p>
-          <div id="strategyList" class="strategy-list" role="radiogroup" aria-label="Strategy"></div>
-        </div>
-
-        <div class="control-block">
-          <p class="section-kicker">Trial ticket</p>
+          <label>
+            Starting cash, USD
+            <input id="balanceInput" type="number" min="10" step="10" value="1000">
+          </label>
           <label>
             NEAR account
-            <input id="accountInput" type="text" placeholder="small-test.near" autocomplete="off">
+            <input id="accountInput" type="text" placeholder="viewer.near" autocomplete="off">
           </label>
-          <label>
-            Paper budget, USD
-            <input id="budgetInput" type="number" min="0.01" step="0.01" value="0.25">
-          </label>
+        </section>
+
+        <section class="rail-section">
+          <div class="section-heading">
+            <span>3</span>
+            <h2>Risk</h2>
+          </div>
           <label>
             Max trade, USD
-            <input id="tradeCapInput" type="number" min="0.01" step="0.01" value="0.05">
+            <input id="maxTradeInput" type="number" min="0.01" step="0.01" value="25">
           </label>
           <label>
-            Slippage, bps
-            <input id="slippageInput" type="number" min="1" max="500" step="1" value="50">
+            Risk per signal, %
+            <input id="riskPctInput" type="number" min="0.1" max="100" step="0.1" value="5">
           </label>
-        </div>
+          <div class="dual-input">
+            <label>
+              Fee, bps
+              <input id="feeBpsInput" type="number" min="0" max="200" step="1" value="8">
+            </label>
+            <label>
+              Slippage, bps
+              <input id="slippageInput" type="number" min="0" max="500" step="1" value="12">
+            </label>
+          </div>
+        </section>
+
+        <section class="rail-section action-section">
+          <button id="runBacktestBtn" class="primary-action" type="button">Run backtest</button>
+          <button id="buildIntentBtn" class="secondary-action" type="button">Build intent draft</button>
+        </section>
       </aside>
 
-      <section class="live-panel" aria-label="Live strategy output">
-        <div class="panel-header">
-          <div>
-            <p class="section-kicker">Live paper run</p>
-            <h2 id="strategyTitle">SMA Cross</h2>
+      <section class="main-stage" aria-label="Backtest output">
+        <div class="pipeline" aria-label="Pipeline">
+          <div class="pipeline-step is-active" data-phase="describe">
+            <span>Describe</span>
+            <strong id="describeStatus">Prompt ready</strong>
           </div>
-          <div id="statusPill" class="status-pill">Idle</div>
+          <div class="pipeline-step" data-phase="validate">
+            <span>Validate</span>
+            <strong id="validateStatus">Pending</strong>
+          </div>
+          <div class="pipeline-step" data-phase="backtest">
+            <span>Backtest</span>
+            <strong id="backtestStatus">Pending</strong>
+          </div>
+          <div class="pipeline-step" data-phase="intent">
+            <span>Intent</span>
+            <strong id="intentStatus">Unsigned</strong>
+          </div>
         </div>
 
-        <div class="chart-wrap">
-          <canvas id="priceCanvas" width="1200" height="520" aria-label="Price chart"></canvas>
-        </div>
-
-        <div class="metrics-row" aria-label="Backtest metrics">
+        <section class="metric-strip" aria-label="Backtest metrics">
           <div>
-            <span>Return</span>
+            <span>Total return</span>
             <strong id="returnMetric">-</strong>
+          </div>
+          <div>
+            <span>Sharpe</span>
+            <strong id="sharpeMetric">-</strong>
           </div>
           <div>
             <span>Max drawdown</span>
             <strong id="drawdownMetric">-</strong>
           </div>
           <div>
-            <span>Trades</span>
-            <strong id="tradesMetric">-</strong>
+            <span>Win rate</span>
+            <strong id="winRateMetric">-</strong>
           </div>
           <div>
-            <span>Confidence</span>
-            <strong id="confidenceMetric">-</strong>
+            <span>Profit factor</span>
+            <strong id="profitMetric">-</strong>
           </div>
-        </div>
+          <div>
+            <span>Latest signal</span>
+            <strong id="signalMetric">-</strong>
+          </div>
+        </section>
 
-        <div class="decision-grid">
-          <div>
-            <p class="section-kicker">Signal note</p>
-            <p id="signalNote" class="decision-copy">Run the strategy to load recent candles and generate a paper decision.</p>
+        <section class="chart-section" aria-label="Equity and price chart">
+          <div class="chart-header">
+            <div>
+              <p class="eyebrow">Paper simulation</p>
+              <h2 id="chartTitle">Awaiting run</h2>
+            </div>
+            <div class="chart-legend" aria-label="Chart legend">
+              <span class="legend-price">Price</span>
+              <span class="legend-equity">Equity</span>
+              <span class="legend-trades">Trades</span>
+            </div>
           </div>
-          <div>
-            <p class="section-kicker">Risk boundary</p>
-            <p class="decision-copy">This page never signs or broadcasts. It only creates an unsigned trial payload for review.</p>
+          <canvas id="chartCanvas" width="1600" height="760" aria-label="Backtest chart"></canvas>
+        </section>
+
+        <section class="lower-grid">
+          <div class="trade-table-wrap" aria-label="Trade blotter">
+            <div class="table-heading">
+              <h2>Trades</h2>
+              <span id="tradeCountLabel">0 fills</span>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Side</th>
+                  <th>Price</th>
+                  <th>Size</th>
+                  <th>PnL</th>
+                </tr>
+              </thead>
+              <tbody id="tradeTableBody"></tbody>
+            </table>
           </div>
-        </div>
+
+          <div class="event-log" aria-label="Strategy event log">
+            <div class="table-heading">
+              <h2>Run Tape</h2>
+              <span id="tapeSummary">Idle</span>
+            </div>
+            <ol id="eventTape"></ol>
+          </div>
+        </section>
       </section>
-    </section>
 
-    <section id="paper" class="paper-band" aria-label="Paper intent">
-      <div class="paper-copy">
-        <p class="section-kicker">Unsigned NEAR Intents draft</p>
-        <h2>Show the strategy, not a custody flow.</h2>
-        <p>External viewers can see live data, the strategy decision, sizing, and the exact unsigned direct-intent payload. A wallet signature remains a separate explicit step.</p>
-      </div>
-      <div class="intent-console">
-        <div class="console-toolbar">
-          <button id="buildIntentBtn" type="button">Build paper intent</button>
-          <button id="copyIntentBtn" type="button">Copy JSON</button>
-        </div>
-        <pre id="intentOutput">Run a strategy to prepare an unsigned payload.</pre>
-      </div>
+      <aside class="right-rail" aria-label="Intent inspector">
+        <section class="rail-section inspector-top">
+          <p class="eyebrow">Signal</p>
+          <h2 id="signalTitle">No run yet</h2>
+          <p id="signalSummary">Select a strategy and run a paper backtest.</p>
+        </section>
+
+        <section class="rail-section">
+          <div class="section-heading">
+            <span>4</span>
+            <h2>Validation</h2>
+          </div>
+          <ul id="validationList" class="validation-list"></ul>
+        </section>
+
+        <section class="rail-section">
+          <div class="section-heading">
+            <span>5</span>
+            <h2>Generated Strategy</h2>
+          </div>
+          <pre id="strategyCode" class="code-pane">Run a strategy to generate code.</pre>
+        </section>
+
+        <section class="rail-section">
+          <div class="section-heading">
+            <span>6</span>
+            <h2>Unsigned Intent</h2>
+          </div>
+          <pre id="intentOutput" class="code-pane">Run a strategy to prepare a NEAR Intents draft.</pre>
+          <button id="copyIntentBtn" class="secondary-action copy-action" type="button">Copy JSON</button>
+        </section>
+      </aside>
     </section>
   </main>
-  <script src="/experiments/near-intents.js"></script>
+  <script src="near-intents.js"></script>
 </body>
 </html>

--- a/crates/ironclaw_gateway/static/experiments/near-intents.js
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.js
@@ -120,7 +120,11 @@
     walletAccountLabel: document.getElementById('walletAccountLabel'),
     walletBalanceLabel: document.getElementById('walletBalanceLabel'),
     liveModeLabel: document.getElementById('liveModeLabel'),
+    liveSummaryText: document.getElementById('liveSummaryText'),
     liveExecutionOutput: document.getElementById('liveExecutionOutput'),
+    guideStepPreview: document.getElementById('guideStepPreview'),
+    guideStepWallet: document.getElementById('guideStepWallet'),
+    guideStepRun: document.getElementById('guideStepRun'),
     liveStepBacktest: document.getElementById('liveStepBacktest'),
     liveStepQuote: document.getElementById('liveStepQuote'),
     liveStepSign: document.getElementById('liveStepSign'),
@@ -356,6 +360,34 @@
     els.liveModeLabel.textContent = text;
   }
 
+  function setLiveSummary(text, tone) {
+    els.liveSummaryText.textContent = text;
+    els.liveSummaryText.className = 'live-summary' + (tone ? ' is-' + tone : '');
+  }
+
+  function updateGuideState(activeStep) {
+    var hasPreview = Boolean(state.result && !state.isStale);
+    var hasWallet = Boolean(state.wallet.accountId);
+    [
+      els.guideStepPreview,
+      els.guideStepWallet,
+      els.guideStepRun
+    ].forEach(function (el) {
+      el.classList.remove('is-active', 'is-done');
+    });
+    if (hasPreview) els.guideStepPreview.classList.add('is-done');
+    if (hasWallet) els.guideStepWallet.classList.add('is-done');
+    if (activeStep === 'sign' || activeStep === 'publish') {
+      els.guideStepRun.classList.add('is-active');
+    } else if (!hasPreview) {
+      els.guideStepPreview.classList.add('is-active');
+    } else if (!hasWallet) {
+      els.guideStepWallet.classList.add('is-active');
+    } else {
+      els.guideStepRun.classList.add('is-active');
+    }
+  }
+
   function setLiveStep(activeStep, tone) {
     var steps = {
       backtest: els.liveStepBacktest,
@@ -369,10 +401,34 @@
       el.classList.toggle('is-warn', key === activeStep && tone === 'warn');
       el.classList.toggle('is-error', key === activeStep && tone === 'error');
     });
+    updateGuideState(activeStep);
   }
 
   function writeLiveOutput(value) {
     els.liveExecutionOutput.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+    if (typeof value === 'string') {
+      if (value.toLowerCase().indexOf('failed') >= 0) {
+        setLiveSummary(value, 'error');
+      } else if (value.toLowerCase().indexOf('connect') >= 0) {
+        setLiveSummary(value);
+      }
+      return;
+    }
+    if (value && value.status === 'hold') {
+      setLiveSummary('The strategy says HOLD right now. You can still preview a tiny buy or sell from Advanced settings.', 'warn');
+    } else if (value && value.mode === 'one_click_dry_quote') {
+      setLiveSummary('Quote preview is ready. No wallet signature was requested and no trade was submitted.');
+    } else if (value && value.mode === 'dry_quote_only') {
+      setLiveSummary('Quote preview is ready. Add a solver relay JWT in Advanced settings when you want to sign and submit.', 'warn');
+    } else if (value && value.mode === 'signed_nep413') {
+      setLiveSummary('Wallet signature captured. Submitting the signed intent through the solver relay.');
+    } else if (value && value.mode === 'published') {
+      setLiveSummary('Intent submitted. Check balances again after settlement.');
+    } else if (value && value.balances) {
+      setLiveSummary('Balances loaded from intents.near for the selected assets.');
+    } else if (value && value.status === 'ready_to_quote') {
+      setLiveSummary('Execution plan is ready. Preview a quote before signing.');
+    }
   }
 
   function updateWalletUi() {
@@ -384,6 +440,7 @@
     els.connectWalletBtn.textContent = accountId ? 'Connected' : 'Connect';
     els.heroConnectBtn.textContent = accountId ? 'Wallet connected' : 'Connect wallet';
     if (accountId) els.accountInput.value = accountId;
+    updateGuideState('wallet');
   }
 
   function renderStrategies() {
@@ -536,7 +593,7 @@
       state.wallet.accountId = state.wallet.accounts[0].accountId;
       updateWalletUi();
       setLiveMode('Wallet connected');
-      writeLiveOutput('Wallet connected: ' + state.wallet.accountId + '\nRun a backtest, then click Run live once to quote and sign.');
+      writeLiveOutput('Wallet connected: ' + state.wallet.accountId + '\nPreview the strategy, then use Run tiny live trade when you want to sign.');
       fetchBalances();
       return state.wallet.accountId;
     } catch (err) {
@@ -1487,7 +1544,7 @@
     if (!result || !result.equity.length) {
       ctx.fillStyle = '#9da59f';
       ctx.font = '28px system-ui';
-      ctx.fillText('Run backtest to render price, equity, and fills', pad.left, height / 2);
+      ctx.fillText('Preview a strategy to render price, equity, and fills', pad.left, height / 2);
       return;
     }
 
@@ -1580,6 +1637,8 @@
     els.intentOutput.textContent = 'Run a strategy to prepare a NEAR Intents draft.';
     els.strategyCode.textContent = 'Run a strategy to generate code.';
     setLiveMode('Dry run ready');
+    setLiveSummary('Start with a strategy preview. Nothing is signed or submitted until you connect a wallet and approve it.');
+    els.liveExecutionOutput.textContent = 'Strategy receipts, quote requests, and signed payloads will appear here.';
     setLiveStep('backtest');
     updateWalletUi();
     drawChart(null);
@@ -1590,6 +1649,7 @@
     setRunState('Ready');
     setPhase('describe');
     setLiveMode('Strategy edited');
+    setLiveSummary('Strategy settings changed. Preview again before requesting a quote.');
     setLiveStep('backtest');
     els.describeStatus.textContent = 'Edited';
     els.validateStatus.textContent = 'Pending';
@@ -1634,6 +1694,7 @@
   async function runDryQuote() {
     setLiveStep('quote');
     setLiveMode('Preparing quote');
+    setLiveSummary('Building a quote preview. This does not require a wallet signature.');
     els.dryQuoteBtn.disabled = true;
     try {
       var result = await ensureBacktest();
@@ -1649,7 +1710,7 @@
         mode: 'one_click_dry_quote',
         plan: plan,
         quote: dryQuote,
-        note: 'This validates a deposited Intents-balance swap path. Use Run live once with a solver relay JWT to sign/publish token_diff.'
+        note: 'This validates a deposited Intents-balance swap path. Use Run tiny live trade with a solver relay JWT to sign and submit.'
       });
     } catch (err) {
       setLiveStep('quote', 'error');
@@ -1663,6 +1724,7 @@
   async function runLiveOnce() {
     els.runLiveBtn.disabled = true;
     setLiveMode('Running live once');
+    setLiveSummary('Preparing one tiny live run. Your wallet will still ask before anything is signed.');
     setLiveStep('backtest');
     try {
       if (!state.wallet.accountId) {
@@ -1744,6 +1806,7 @@
     var validations = validateRun(input);
     renderValidation(validations);
     setRunState('Loading data');
+    setLiveSummary('Loading market data and checking the strategy.');
     setPhase('validate');
     els.validateStatus.textContent = validations.some(function (item) { return item.tone === 'warn'; }) ? 'Warnings' : 'Valid';
     els.describeStatus.textContent = 'Captured';
@@ -1774,6 +1837,7 @@
       setPhase('intent', state.dataSource === 'Sample fallback' ? { backtest: 'warn' } : {});
       setRunState(state.dataSource === 'Sample fallback' ? 'Sample run' : 'Live data run');
       setLiveMode('Strategy ready');
+      setLiveSummary('Preview ready. Review the latest signal, then preview a quote or connect your wallet for a tiny live run.');
       setLiveStep('quote');
     } catch (err) {
       setRunState('Run failed');
@@ -1855,6 +1919,12 @@
     els.buildIntentBtn.addEventListener('click', buildIntentFromCurrent);
     els.copyIntentBtn.addEventListener('click', copyIntent);
     els.copySignedBtn.addEventListener('click', copySigned);
+    var keyForm = document.querySelector('.key-form');
+    if (keyForm) {
+      keyForm.addEventListener('submit', function (event) {
+        event.preventDefault();
+      });
+    }
     els.pairSelect.addEventListener('change', function () {
       updateAssetDefaults();
       markStale();

--- a/crates/ironclaw_gateway/static/experiments/near-intents.js
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.js
@@ -1,0 +1,528 @@
+(function () {
+  'use strict';
+
+  var strategies = [
+    {
+      id: 'sma_cross',
+      name: 'SMA Cross',
+      copy: 'Trend-following spot strategy using 12h and 48h moving averages.'
+    },
+    {
+      id: 'mean_reversion',
+      name: 'Mean Reversion',
+      copy: 'Range strategy using a 20h z-score and volatility-aware exits.'
+    },
+    {
+      id: 'breakout',
+      name: 'Breakout',
+      copy: 'Momentum strategy that reacts to 24h channel breaks.'
+    },
+    {
+      id: 'hl_momentum_watch',
+      name: 'HL Momentum Watch',
+      copy: 'Hyperliquid-style momentum watcher with spot-only NEAR Intents output.'
+    }
+  ];
+
+  var state = {
+    candles: [],
+    pair: 'NEAR-USD',
+    source: 'Waiting',
+    selectedStrategy: 'sma_cross',
+    result: null,
+    lastIntent: null
+  };
+
+  var els = {
+    runLiveBtn: document.getElementById('runLiveBtn'),
+    pairSelect: document.getElementById('pairSelect'),
+    lookbackSelect: document.getElementById('lookbackSelect'),
+    strategyList: document.getElementById('strategyList'),
+    accountInput: document.getElementById('accountInput'),
+    budgetInput: document.getElementById('budgetInput'),
+    tradeCapInput: document.getElementById('tradeCapInput'),
+    slippageInput: document.getElementById('slippageInput'),
+    sourceLabel: document.getElementById('sourceLabel'),
+    priceCaption: document.getElementById('priceCaption'),
+    priceLabel: document.getElementById('priceLabel'),
+    signalLabel: document.getElementById('signalLabel'),
+    strategyTitle: document.getElementById('strategyTitle'),
+    statusPill: document.getElementById('statusPill'),
+    priceCanvas: document.getElementById('priceCanvas'),
+    returnMetric: document.getElementById('returnMetric'),
+    drawdownMetric: document.getElementById('drawdownMetric'),
+    tradesMetric: document.getElementById('tradesMetric'),
+    confidenceMetric: document.getElementById('confidenceMetric'),
+    signalNote: document.getElementById('signalNote'),
+    buildIntentBtn: document.getElementById('buildIntentBtn'),
+    copyIntentBtn: document.getElementById('copyIntentBtn'),
+    intentOutput: document.getElementById('intentOutput')
+  };
+
+  function fmtUsd(n) {
+    if (!Number.isFinite(n)) return '-';
+    return '$' + n.toLocaleString(undefined, {
+      minimumFractionDigits: n < 10 ? 4 : 2,
+      maximumFractionDigits: n < 10 ? 4 : 2
+    });
+  }
+
+  function fmtPct(n) {
+    if (!Number.isFinite(n)) return '-';
+    var sign = n > 0 ? '+' : '';
+    return sign + (n * 100).toFixed(2) + '%';
+  }
+
+  function clamp(n, min, max) {
+    return Math.max(min, Math.min(max, n));
+  }
+
+  function average(values) {
+    if (!values.length) return 0;
+    return values.reduce(function (sum, value) { return sum + value; }, 0) / values.length;
+  }
+
+  function stdev(values) {
+    if (values.length < 2) return 0;
+    var mean = average(values);
+    var variance = average(values.map(function (value) {
+      return Math.pow(value - mean, 2);
+    }));
+    return Math.sqrt(variance);
+  }
+
+  function movingAverage(candles, end, period) {
+    if (end + 1 < period) return null;
+    var slice = candles.slice(end + 1 - period, end + 1).map(function (c) { return c.close; });
+    return average(slice);
+  }
+
+  function setStatus(text, tone) {
+    els.statusPill.textContent = text;
+    els.statusPill.className = 'status-pill' + (tone ? ' ' + tone : '');
+  }
+
+  function selectedStrategy() {
+    return strategies.find(function (strategy) {
+      return strategy.id === state.selectedStrategy;
+    }) || strategies[0];
+  }
+
+  function renderStrategies() {
+    els.strategyList.innerHTML = '';
+    strategies.forEach(function (strategy) {
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.setAttribute('role', 'radio');
+      button.setAttribute('aria-checked', strategy.id === state.selectedStrategy ? 'true' : 'false');
+      button.innerHTML = '<strong>' + strategy.name + '</strong><span>' + strategy.copy + '</span>';
+      button.addEventListener('click', function () {
+        state.selectedStrategy = strategy.id;
+        renderStrategies();
+        els.strategyTitle.textContent = strategy.name;
+        if (state.candles.length) runStrategy();
+      });
+      els.strategyList.appendChild(button);
+    });
+  }
+
+  async function fetchCoinbaseCandles(pair, days) {
+    var end = Math.floor(Date.now() / 1000);
+    var start = end - Number(days) * 24 * 60 * 60;
+    var url = 'https://api.exchange.coinbase.com/products/' + encodeURIComponent(pair) +
+      '/candles?granularity=3600&start=' + new Date(start * 1000).toISOString() +
+      '&end=' + new Date(end * 1000).toISOString();
+    var res = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!res.ok) throw new Error('Coinbase candles failed: ' + res.status);
+    var rows = await res.json();
+    if (!Array.isArray(rows) || rows.length < 24) throw new Error('Coinbase returned too few candles');
+    return rows.map(function (row) {
+      return {
+        time: row[0] * 1000,
+        low: Number(row[1]),
+        high: Number(row[2]),
+        open: Number(row[3]),
+        close: Number(row[4]),
+        volume: Number(row[5])
+      };
+    }).sort(function (a, b) { return a.time - b.time; });
+  }
+
+  async function fetchCoingeckoNear(days) {
+    var url = 'https://api.coingecko.com/api/v3/coins/near/market_chart?vs_currency=usd&days=' +
+      encodeURIComponent(days) + '&interval=hourly';
+    var res = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!res.ok) throw new Error('CoinGecko failed: ' + res.status);
+    var body = await res.json();
+    if (!body.prices || body.prices.length < 24) throw new Error('CoinGecko returned too few prices');
+    return body.prices.map(function (row) {
+      var price = Number(row[1]);
+      return {
+        time: Number(row[0]),
+        low: price,
+        high: price,
+        open: price,
+        close: price,
+        volume: 0
+      };
+    });
+  }
+
+  async function fetchCandles() {
+    var pair = els.pairSelect.value;
+    var days = els.lookbackSelect.value;
+    state.pair = pair;
+    try {
+      state.source = 'Coinbase hourly';
+      return await fetchCoinbaseCandles(pair, days);
+    } catch (err) {
+      if (pair !== 'NEAR-USD') throw err;
+      state.source = 'CoinGecko hourly';
+      return fetchCoingeckoNear(days);
+    }
+  }
+
+  function syntheticFallbackCandles(pair, days) {
+    var count = Number(days) * 24;
+    var baseByPair = {
+      'NEAR-USD': 1.28,
+      'BTC-USD': 94500,
+      'ETH-USD': 1820,
+      'SOL-USD': 126
+    };
+    var base = baseByPair[pair] || 1;
+    var candles = [];
+    var now = Date.now();
+    var drift = pair === 'BTC-USD' ? 0.00008 : 0.00018;
+
+    for (var i = 0; i < count; i += 1) {
+      var wave = Math.sin(i / 9) * 0.016 + Math.cos(i / 31) * 0.026;
+      var shock = Math.sin(i / 3.7) * 0.005;
+      var trend = (i - count / 2) * drift;
+      var close = base * (1 + trend + wave + shock);
+      candles.push({
+        time: now - (count - i) * 60 * 60 * 1000,
+        low: close * 0.994,
+        high: close * 1.006,
+        open: close * (1 - shock / 2),
+        close: close,
+        volume: 0
+      });
+    }
+
+    state.source = 'Sample fallback';
+    return candles;
+  }
+
+  function signalAt(candles, index, strategyId) {
+    var candle = candles[index];
+    if (!candle) return { side: 'hold', score: 0, reason: 'No candle' };
+
+    if (strategyId === 'sma_cross') {
+      var fast = movingAverage(candles, index, 12);
+      var slow = movingAverage(candles, index, 48);
+      if (!fast || !slow) return { side: 'hold', score: 0, reason: 'Waiting for SMA warmup' };
+      var spread = (fast - slow) / slow;
+      if (spread > 0.006) return { side: 'buy', score: clamp(spread * 900, 0.15, 0.92), reason: 'Fast average is above slow average.' };
+      if (spread < -0.006) return { side: 'sell', score: clamp(Math.abs(spread) * 900, 0.15, 0.92), reason: 'Fast average is below slow average.' };
+      return { side: 'hold', score: 0.34, reason: 'Averages are compressed.' };
+    }
+
+    if (strategyId === 'mean_reversion') {
+      if (index < 20) return { side: 'hold', score: 0, reason: 'Waiting for range warmup' };
+      var window = candles.slice(index - 19, index + 1).map(function (c) { return c.close; });
+      var mean = average(window);
+      var sigma = stdev(window);
+      var z = sigma > 0 ? (candle.close - mean) / sigma : 0;
+      if (z < -1.15) return { side: 'buy', score: clamp(Math.abs(z) / 2.8, 0.22, 0.88), reason: 'Price is below its local range.' };
+      if (z > 1.15) return { side: 'sell', score: clamp(Math.abs(z) / 2.8, 0.22, 0.88), reason: 'Price is above its local range.' };
+      return { side: 'hold', score: 0.36, reason: 'Price is near fair range.' };
+    }
+
+    if (strategyId === 'breakout') {
+      if (index < 24) return { side: 'hold', score: 0, reason: 'Waiting for channel warmup' };
+      var channel = candles.slice(index - 24, index);
+      var high = Math.max.apply(null, channel.map(function (c) { return c.high; }));
+      var low = Math.min.apply(null, channel.map(function (c) { return c.low; }));
+      if (candle.close > high) return { side: 'buy', score: 0.78, reason: 'Price cleared the 24h channel high.' };
+      if (candle.close < low) return { side: 'sell', score: 0.78, reason: 'Price lost the 24h channel low.' };
+      return { side: 'hold', score: 0.31, reason: 'Price remains inside the channel.' };
+    }
+
+    if (index < 12) return { side: 'hold', score: 0, reason: 'Waiting for momentum warmup' };
+    var prior = candles[index - 12].close;
+    var momentum = prior > 0 ? (candle.close - prior) / prior : 0;
+    if (momentum > 0.025) return { side: 'buy', score: clamp(momentum * 10, 0.24, 0.86), reason: '12h momentum is positive; paper-only spot route.' };
+    if (momentum < -0.025) return { side: 'sell', score: clamp(Math.abs(momentum) * 10, 0.24, 0.86), reason: '12h momentum is negative; paper-only de-risk route.' };
+    return { side: 'hold', score: 0.35, reason: 'Momentum is not decisive.' };
+  }
+
+  function backtest(candles, strategyId) {
+    var equity = 1;
+    var peak = 1;
+    var maxDrawdown = 0;
+    var position = 0;
+    var trades = 0;
+    var curve = [];
+
+    for (var i = 1; i < candles.length; i += 1) {
+      var signal = signalAt(candles, i - 1, strategyId);
+      var nextPosition = signal.side === 'buy' ? 1 : signal.side === 'sell' ? 0 : position;
+      if (nextPosition !== position) trades += 1;
+      position = nextPosition;
+      var ret = candles[i - 1].close > 0 ? (candles[i].close - candles[i - 1].close) / candles[i - 1].close : 0;
+      equity *= 1 + position * ret;
+      peak = Math.max(peak, equity);
+      maxDrawdown = Math.max(maxDrawdown, peak > 0 ? (peak - equity) / peak : 0);
+      curve.push(equity);
+    }
+
+    var latest = signalAt(candles, candles.length - 1, strategyId);
+    var totalReturn = equity - 1;
+    var confidence = clamp(0.45 + latest.score * 0.42 + Math.min(Math.max(totalReturn, -0.15), 0.25), 0.05, 0.93);
+    return {
+      latest: latest,
+      totalReturn: totalReturn,
+      maxDrawdown: maxDrawdown,
+      trades: trades,
+      confidence: confidence,
+      curve: curve
+    };
+  }
+
+  function drawChart() {
+    var canvas = els.priceCanvas;
+    var ctx = canvas.getContext('2d');
+    var width = canvas.width;
+    var height = canvas.height;
+    var candles = state.candles;
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = '#080a0c';
+    ctx.fillRect(0, 0, width, height);
+
+    if (!candles.length) {
+      ctx.fillStyle = '#9aa69c';
+      ctx.font = '28px system-ui';
+      ctx.fillText('Run live strategy to draw recent candles', 44, height / 2);
+      return;
+    }
+
+    var closes = candles.map(function (c) { return c.close; });
+    var min = Math.min.apply(null, closes);
+    var max = Math.max.apply(null, closes);
+    var pad = Math.max((max - min) * 0.12, max * 0.01);
+    var lo = min - pad;
+    var hi = max + pad;
+
+    function x(i) {
+      return candles.length <= 1 ? 0 : (i / (candles.length - 1)) * width;
+    }
+
+    function y(price) {
+      return height - ((price - lo) / (hi - lo)) * height;
+    }
+
+    ctx.strokeStyle = 'rgba(243, 246, 240, 0.08)';
+    ctx.lineWidth = 1;
+    for (var g = 1; g < 5; g += 1) {
+      ctx.beginPath();
+      ctx.moveTo(0, (height / 5) * g);
+      ctx.lineTo(width, (height / 5) * g);
+      ctx.stroke();
+    }
+
+    var gradient = ctx.createLinearGradient(0, 0, 0, height);
+    gradient.addColorStop(0, 'rgba(110, 240, 176, 0.32)');
+    gradient.addColorStop(1, 'rgba(110, 240, 176, 0)');
+    ctx.beginPath();
+    closes.forEach(function (close, i) {
+      if (i === 0) ctx.moveTo(x(i), y(close));
+      else ctx.lineTo(x(i), y(close));
+    });
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height);
+    ctx.closePath();
+    ctx.fillStyle = gradient;
+    ctx.fill();
+
+    ctx.beginPath();
+    closes.forEach(function (close, i) {
+      if (i === 0) ctx.moveTo(x(i), y(close));
+      else ctx.lineTo(x(i), y(close));
+    });
+    ctx.strokeStyle = '#6ef0b0';
+    ctx.lineWidth = 3;
+    ctx.stroke();
+
+    if (state.result && state.result.curve.length > 2) {
+      var curve = state.result.curve;
+      var cMin = Math.min.apply(null, curve);
+      var cMax = Math.max.apply(null, curve);
+      ctx.beginPath();
+      curve.forEach(function (point, i) {
+        var px = (i / (curve.length - 1)) * width;
+        var py = height - ((point - cMin) / Math.max(cMax - cMin, 0.0001)) * height;
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      });
+      ctx.strokeStyle = 'rgba(244, 196, 107, 0.72)';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+  }
+
+  function updateMetrics() {
+    var last = state.candles[state.candles.length - 1];
+    els.sourceLabel.textContent = state.source;
+    els.priceCaption.textContent = 'Last ' + state.pair.replace('-USD', '');
+    els.priceLabel.textContent = last ? fmtUsd(last.close) : '-';
+
+    if (!state.result) {
+      els.signalLabel.textContent = 'Idle';
+      els.returnMetric.textContent = '-';
+      els.drawdownMetric.textContent = '-';
+      els.tradesMetric.textContent = '-';
+      els.confidenceMetric.textContent = '-';
+      return;
+    }
+
+    var latest = state.result.latest;
+    els.signalLabel.textContent = latest.side.toUpperCase();
+    els.returnMetric.textContent = fmtPct(state.result.totalReturn);
+    els.drawdownMetric.textContent = fmtPct(-state.result.maxDrawdown);
+    els.tradesMetric.textContent = String(state.result.trades);
+    els.confidenceMetric.textContent = Math.round(state.result.confidence * 100) + '%';
+    els.signalNote.textContent = latest.reason + ' Latest paper decision: ' + latest.side.toUpperCase() + ' with ' + Math.round(state.result.confidence * 100) + '% confidence.';
+
+    if (latest.side === 'buy') setStatus('Paper buy', '');
+    else if (latest.side === 'sell') setStatus('Paper sell', 'warn');
+    else setStatus('Hold', 'warn');
+  }
+
+  async function runLive() {
+    setStatus('Loading candles', 'warn');
+    els.runLiveBtn.disabled = true;
+    try {
+      state.candles = await fetchCandles();
+      runStrategy();
+    } catch (err) {
+      state.candles = syntheticFallbackCandles(els.pairSelect.value, els.lookbackSelect.value);
+      runStrategy();
+      setStatus('Sample data', 'warn');
+      els.signalNote.textContent = 'Live data failed, so this run is using deterministic sample candles. The page is still safe; no funds or signatures are touched.';
+    } finally {
+      els.runLiveBtn.disabled = false;
+    }
+  }
+
+  function runStrategy() {
+    var strategy = selectedStrategy();
+    els.strategyTitle.textContent = strategy.name;
+    state.result = backtest(state.candles, strategy.id);
+    updateMetrics();
+    drawChart();
+    buildIntent();
+  }
+
+  function tokenForPair(pair) {
+    if (pair.indexOf('NEAR') === 0) return 'wrap.near';
+    if (pair.indexOf('BTC') === 0) return 'btc.omft.near';
+    if (pair.indexOf('ETH') === 0) return 'eth.omft.near';
+    if (pair.indexOf('SOL') === 0) return 'sol.omft.near';
+    return 'wrap.near';
+  }
+
+  function buildIntent() {
+    var last = state.candles[state.candles.length - 1];
+    var strategy = selectedStrategy();
+    var latest = state.result ? state.result.latest : { side: 'hold', reason: 'No signal yet' };
+    var budgetUsd = Number(els.budgetInput.value || 0);
+    var tradeCapUsd = Number(els.tradeCapInput.value || 0);
+    var slippageBps = Number(els.slippageInput.value || 0);
+    var safeTradeUsd = Math.max(0, Math.min(budgetUsd, tradeCapUsd));
+    var side = latest.side;
+    var account = els.accountInput.value.trim() || '<viewer-provided-account.near>';
+    var minOutUsd = safeTradeUsd * (1 - slippageBps / 10000);
+    var quoteRequest = side === 'hold' ? null : {
+      sell: side === 'buy'
+        ? { token: 'usdc.near', amount_usd_estimate: Number(safeTradeUsd.toFixed(6)) }
+        : { token: tokenForPair(state.pair), amount_usd_estimate: Number(safeTradeUsd.toFixed(6)) },
+      buy: side === 'buy'
+        ? { token: tokenForPair(state.pair), min_amount_usd: Number(minOutUsd.toFixed(6)) }
+        : { token: 'usdc.near', min_amount_usd: Number(minOutUsd.toFixed(6)) },
+      slippage_bps: slippageBps
+    };
+
+    state.lastIntent = {
+      schema: 'near-intents-public-experiment/1',
+      mode: 'paper',
+      public_demo: true,
+      execution_boundary: 'unsigned-only',
+      created_at: new Date().toISOString(),
+      account_id: account,
+      market: {
+        pair: state.pair.replace('-', '/'),
+        source: state.source,
+        last_price_usd: last ? Number(last.close.toFixed(8)) : null
+      },
+      strategy: {
+        id: strategy.id,
+        name: strategy.name,
+        decision: side,
+        confidence: state.result ? Number(state.result.confidence.toFixed(4)) : null,
+        note: latest.reason
+      },
+      risk: {
+        nominal_budget_usd: budgetUsd,
+        max_trade_usd: safeTradeUsd,
+        slippage_bps: slippageBps,
+        funding_asset_hint: 'any_near_intents_supported_deposit_asset',
+        no_auto_signing: true,
+        no_broadcast: true
+      },
+      draft_intent: {
+        venue: 'near_intents',
+        deposit_model: 'direct_near_intents_balance_or_any_supported_asset',
+        solver_quote_required: true,
+        decision: side,
+        quote_request: quoteRequest,
+        hold_reason: side === 'hold' ? latest.reason : null,
+        expires_in_seconds: 120
+      }
+    };
+    els.intentOutput.textContent = JSON.stringify(state.lastIntent, null, 2);
+  }
+
+  function copyIntent() {
+    var text = els.intentOutput.textContent || '';
+    if (!text || text.indexOf('{') !== 0) return;
+    navigator.clipboard.writeText(text).then(function () {
+      els.copyIntentBtn.textContent = 'Copied';
+      setTimeout(function () {
+        els.copyIntentBtn.textContent = 'Copy JSON';
+      }, 1200);
+    }).catch(function () {
+      els.copyIntentBtn.textContent = 'Copy failed';
+      setTimeout(function () {
+        els.copyIntentBtn.textContent = 'Copy JSON';
+      }, 1200);
+    });
+  }
+
+  function bind() {
+    renderStrategies();
+    drawChart();
+    els.runLiveBtn.addEventListener('click', runLive);
+    els.pairSelect.addEventListener('change', runLive);
+    els.lookbackSelect.addEventListener('change', runLive);
+    els.buildIntentBtn.addEventListener('click', buildIntent);
+    els.copyIntentBtn.addEventListener('click', copyIntent);
+    [els.accountInput, els.budgetInput, els.tradeCapInput, els.slippageInput].forEach(function (input) {
+      input.addEventListener('input', buildIntent);
+    });
+    window.addEventListener('resize', drawChart);
+    setTimeout(runLive, 250);
+  }
+
+  bind();
+}());

--- a/crates/ironclaw_gateway/static/experiments/near-intents.js
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.js
@@ -1,481 +1,839 @@
 (function () {
   'use strict';
 
-  var strategies = [
+  var COINGECKO_IDS = {
+    'NEAR-USD': 'near',
+    'BTC-USD': 'bitcoin',
+    'ETH-USD': 'ethereum',
+    'SOL-USD': 'solana'
+  };
+
+  var TOKEN_BY_PAIR = {
+    'NEAR-USD': 'wrap.near',
+    'BTC-USD': 'btc.omft.near',
+    'ETH-USD': 'eth.omft.near',
+    'SOL-USD': 'sol.omft.near'
+  };
+
+  var STRATEGIES = [
     {
-      id: 'sma_cross',
-      name: 'SMA Cross',
-      copy: 'Trend-following spot strategy using 12h and 48h moving averages.'
+      id: 'momentum',
+      name: 'Momentum',
+      badge: 'SMA + RSI',
+      copy: 'Trend entry when fast SMA leads slow SMA with RSI guardrails.',
+      prompt: 'NEAR spot momentum using SMA confirmation, RSI guardrail, 1.0% take profit, 0.6% stop, and small paper sizing.'
     },
     {
       id: 'mean_reversion',
       name: 'Mean Reversion',
-      copy: 'Range strategy using a 20h z-score and volatility-aware exits.'
+      badge: 'Bands',
+      copy: 'Bollinger lower-band entries with mean exit and hard stop.',
+      prompt: 'Mean reversion on NEAR: buy lower Bollinger Band with RSI below 38, exit near the mean, cap losses quickly.'
     },
     {
       id: 'breakout',
       name: 'Breakout',
-      copy: 'Momentum strategy that reacts to 24h channel breaks.'
+      badge: 'Channel',
+      copy: 'Trades fresh range expansion after a quiet channel.',
+      prompt: 'Breakout strategy that buys a 24 hour channel break, exits on channel failure, with realistic fees and slippage.'
     },
     {
-      id: 'hl_momentum_watch',
+      id: 'grid',
+      name: 'Spot Grid',
+      badge: 'Range',
+      copy: 'Rebalances around a moving center to harvest oscillation.',
+      prompt: 'Spot grid for NEAR with tight levels, small order size, and automatic recentering when the range drifts.'
+    },
+    {
+      id: 'dca',
+      name: 'DCA Rebalance',
+      badge: 'Steady',
+      copy: 'Buys on cadence and exits only after cumulative profit target.',
+      prompt: 'DCA into NEAR with a small recurring buy, then take profit when the basket is materially above cost.'
+    },
+    {
+      id: 'hl_momentum',
       name: 'HL Momentum Watch',
-      copy: 'Hyperliquid-style momentum watcher with spot-only NEAR Intents output.'
+      badge: 'Perp style',
+      copy: 'Hyperliquid-style momentum watcher constrained to spot intents.',
+      prompt: 'Hyperliquid-style momentum watch for NEAR, but produce spot-only NEAR Intents drafts with no leverage.'
     }
   ];
 
   var state = {
+    selectedStrategy: 'momentum',
     candles: [],
-    pair: 'NEAR-USD',
-    source: 'Waiting',
-    selectedStrategy: 'sma_cross',
     result: null,
-    lastIntent: null
+    latestIntent: null,
+    dataSource: 'No data',
+    lastRunAt: null
   };
 
   var els = {
-    runLiveBtn: document.getElementById('runLiveBtn'),
+    dataSourceLabel: document.getElementById('dataSourceLabel'),
+    runStateLabel: document.getElementById('runStateLabel'),
+    strategyPrompt: document.getElementById('strategyPrompt'),
+    strategyDeck: document.getElementById('strategyDeck'),
     pairSelect: document.getElementById('pairSelect'),
     lookbackSelect: document.getElementById('lookbackSelect'),
-    strategyList: document.getElementById('strategyList'),
+    balanceInput: document.getElementById('balanceInput'),
     accountInput: document.getElementById('accountInput'),
-    budgetInput: document.getElementById('budgetInput'),
-    tradeCapInput: document.getElementById('tradeCapInput'),
+    maxTradeInput: document.getElementById('maxTradeInput'),
+    riskPctInput: document.getElementById('riskPctInput'),
+    feeBpsInput: document.getElementById('feeBpsInput'),
     slippageInput: document.getElementById('slippageInput'),
-    sourceLabel: document.getElementById('sourceLabel'),
-    priceCaption: document.getElementById('priceCaption'),
-    priceLabel: document.getElementById('priceLabel'),
-    signalLabel: document.getElementById('signalLabel'),
-    strategyTitle: document.getElementById('strategyTitle'),
-    statusPill: document.getElementById('statusPill'),
-    priceCanvas: document.getElementById('priceCanvas'),
-    returnMetric: document.getElementById('returnMetric'),
-    drawdownMetric: document.getElementById('drawdownMetric'),
-    tradesMetric: document.getElementById('tradesMetric'),
-    confidenceMetric: document.getElementById('confidenceMetric'),
-    signalNote: document.getElementById('signalNote'),
+    topRunBtn: document.getElementById('topRunBtn'),
+    runBacktestBtn: document.getElementById('runBacktestBtn'),
     buildIntentBtn: document.getElementById('buildIntentBtn'),
     copyIntentBtn: document.getElementById('copyIntentBtn'),
+    describeStatus: document.getElementById('describeStatus'),
+    validateStatus: document.getElementById('validateStatus'),
+    backtestStatus: document.getElementById('backtestStatus'),
+    intentStatus: document.getElementById('intentStatus'),
+    returnMetric: document.getElementById('returnMetric'),
+    sharpeMetric: document.getElementById('sharpeMetric'),
+    drawdownMetric: document.getElementById('drawdownMetric'),
+    winRateMetric: document.getElementById('winRateMetric'),
+    profitMetric: document.getElementById('profitMetric'),
+    signalMetric: document.getElementById('signalMetric'),
+    chartTitle: document.getElementById('chartTitle'),
+    chartCanvas: document.getElementById('chartCanvas'),
+    tradeCountLabel: document.getElementById('tradeCountLabel'),
+    tradeTableBody: document.getElementById('tradeTableBody'),
+    tapeSummary: document.getElementById('tapeSummary'),
+    eventTape: document.getElementById('eventTape'),
+    signalTitle: document.getElementById('signalTitle'),
+    signalSummary: document.getElementById('signalSummary'),
+    validationList: document.getElementById('validationList'),
+    strategyCode: document.getElementById('strategyCode'),
     intentOutput: document.getElementById('intentOutput')
   };
 
-  function fmtUsd(n) {
-    if (!Number.isFinite(n)) return '-';
-    return '$' + n.toLocaleString(undefined, {
-      minimumFractionDigits: n < 10 ? 4 : 2,
-      maximumFractionDigits: n < 10 ? 4 : 2
-    });
+  function strategyById(id) {
+    return STRATEGIES.find(function (strategy) {
+      return strategy.id === id;
+    }) || STRATEGIES[0];
   }
 
-  function fmtPct(n) {
-    if (!Number.isFinite(n)) return '-';
-    var sign = n > 0 ? '+' : '';
-    return sign + (n * 100).toFixed(2) + '%';
+  function params() {
+    return {
+      pair: els.pairSelect.value,
+      lookbackDays: Number(els.lookbackSelect.value),
+      initialCash: Math.max(10, Number(els.balanceInput.value || 0)),
+      maxTradeUsd: Math.max(0.01, Number(els.maxTradeInput.value || 0)),
+      riskPct: Math.max(0.001, Number(els.riskPctInput.value || 0) / 100),
+      feeBps: Math.max(0, Number(els.feeBpsInput.value || 0)),
+      slippageBps: Math.max(0, Number(els.slippageInput.value || 0)),
+      accountId: els.accountInput.value.trim() || '<viewer-provided-account.near>',
+      prompt: els.strategyPrompt.value.trim(),
+      strategy: strategyById(state.selectedStrategy)
+    };
   }
 
-  function clamp(n, min, max) {
-    return Math.max(min, Math.min(max, n));
+  function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
   }
 
   function average(values) {
     if (!values.length) return 0;
-    return values.reduce(function (sum, value) { return sum + value; }, 0) / values.length;
+    return values.reduce(function (sum, value) {
+      return sum + value;
+    }, 0) / values.length;
   }
 
-  function stdev(values) {
+  function stddev(values) {
     if (values.length < 2) return 0;
     var mean = average(values);
-    var variance = average(values.map(function (value) {
-      return Math.pow(value - mean, 2);
-    }));
-    return Math.sqrt(variance);
+    var variance = values.reduce(function (sum, value) {
+      return sum + Math.pow(value - mean, 2);
+    }, 0) / (values.length - 1);
+    return Math.sqrt(Math.max(0, variance));
   }
 
-  function movingAverage(candles, end, period) {
-    if (end + 1 < period) return null;
-    var slice = candles.slice(end + 1 - period, end + 1).map(function (c) { return c.close; });
-    return average(slice);
+  function fmtUsd(value) {
+    if (!Number.isFinite(value)) return '-';
+    var decimals = Math.abs(value) < 10 ? 4 : 2;
+    return '$' + value.toLocaleString(undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals
+    });
   }
 
-  function setStatus(text, tone) {
-    els.statusPill.textContent = text;
-    els.statusPill.className = 'status-pill' + (tone ? ' ' + tone : '');
+  function fmtPct(value) {
+    if (!Number.isFinite(value)) return '-';
+    var sign = value > 0 ? '+' : '';
+    return sign + (value * 100).toFixed(2) + '%';
   }
 
-  function selectedStrategy() {
-    return strategies.find(function (strategy) {
-      return strategy.id === state.selectedStrategy;
-    }) || strategies[0];
+  function fmtNum(value, decimals) {
+    if (!Number.isFinite(value)) return '-';
+    return value.toFixed(decimals);
+  }
+
+  function fmtDate(timestamp) {
+    var date = new Date(timestamp);
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
+      ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  }
+
+  function hashText(text) {
+    var hash = 2166136261;
+    for (var i = 0; i < text.length; i += 1) {
+      hash ^= text.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0).toString(16);
+  }
+
+  function setRunState(text) {
+    els.runStateLabel.textContent = text;
+  }
+
+  function setPhase(activePhase, tones) {
+    var toneMap = tones || {};
+    Array.prototype.forEach.call(document.querySelectorAll('.pipeline-step'), function (step) {
+      var phase = step.getAttribute('data-phase');
+      step.classList.toggle('is-active', phase === activePhase);
+      step.classList.toggle('is-warn', toneMap[phase] === 'warn');
+      step.classList.toggle('is-error', toneMap[phase] === 'error');
+    });
   }
 
   function renderStrategies() {
-    els.strategyList.innerHTML = '';
-    strategies.forEach(function (strategy) {
+    els.strategyDeck.innerHTML = '';
+    STRATEGIES.forEach(function (strategy) {
       var button = document.createElement('button');
       button.type = 'button';
+      button.className = 'strategy-option';
       button.setAttribute('role', 'radio');
       button.setAttribute('aria-checked', strategy.id === state.selectedStrategy ? 'true' : 'false');
-      button.innerHTML = '<strong>' + strategy.name + '</strong><span>' + strategy.copy + '</span>';
+      button.innerHTML = '<div><strong>' + strategy.name + '</strong><span>' +
+        strategy.copy + '</span></div><em>' + strategy.badge + '</em>';
       button.addEventListener('click', function () {
         state.selectedStrategy = strategy.id;
+        els.strategyPrompt.value = strategy.prompt;
         renderStrategies();
-        els.strategyTitle.textContent = strategy.name;
-        if (state.candles.length) runStrategy();
+        markStale();
       });
-      els.strategyList.appendChild(button);
+      els.strategyDeck.appendChild(button);
     });
   }
 
-  async function fetchCoinbaseCandles(pair, days) {
-    var end = Math.floor(Date.now() / 1000);
-    var start = end - Number(days) * 24 * 60 * 60;
-    var url = 'https://api.exchange.coinbase.com/products/' + encodeURIComponent(pair) +
-      '/candles?granularity=3600&start=' + new Date(start * 1000).toISOString() +
-      '&end=' + new Date(end * 1000).toISOString();
-    var res = await fetch(url, { headers: { Accept: 'application/json' } });
-    if (!res.ok) throw new Error('Coinbase candles failed: ' + res.status);
-    var rows = await res.json();
-    if (!Array.isArray(rows) || rows.length < 24) throw new Error('Coinbase returned too few candles');
-    return rows.map(function (row) {
-      return {
-        time: row[0] * 1000,
-        low: Number(row[1]),
-        high: Number(row[2]),
-        open: Number(row[3]),
-        close: Number(row[4]),
-        volume: Number(row[5])
-      };
-    }).sort(function (a, b) { return a.time - b.time; });
+  function validateRun(input) {
+    var messages = [];
+    var minWarmup = input.strategy.id === 'momentum' ? 48 : input.strategy.id === 'mean_reversion' ? 24 : 18;
+    if (input.prompt.length < 24) {
+      messages.push({ tone: 'warn', text: 'Strategy prompt is short; template defaults will carry most behavior.' });
+    } else {
+      messages.push({ tone: 'ok', text: 'Prompt captured for strategy metadata and run hash.' });
+    }
+    if (input.lookbackDays * 24 < minWarmup + 10) {
+      messages.push({ tone: 'warn', text: 'Lookback barely covers indicator warmup; metrics may be noisy.' });
+    } else {
+      messages.push({ tone: 'ok', text: 'Lookback covers indicator warmup.' });
+    }
+    if (input.maxTradeUsd > input.initialCash * 0.5) {
+      messages.push({ tone: 'warn', text: 'Max trade is large versus paper balance.' });
+    } else {
+      messages.push({ tone: 'ok', text: 'Sizing is bounded by cash, risk percent, and max trade.' });
+    }
+    if (input.feeBps + input.slippageBps <= 0) {
+      messages.push({ tone: 'warn', text: 'Fees and slippage are zero; fills may look too optimistic.' });
+    } else {
+      messages.push({ tone: 'ok', text: 'Costs are included in every paper fill.' });
+    }
+    messages.push({ tone: 'ok', text: 'Execution boundary is unsigned preview only; no wallet call is made.' });
+    return messages;
   }
 
-  async function fetchCoingeckoNear(days) {
-    var url = 'https://api.coingecko.com/api/v3/coins/near/market_chart?vs_currency=usd&days=' +
-      encodeURIComponent(days) + '&interval=hourly';
+  function renderValidation(messages) {
+    els.validationList.innerHTML = '';
+    messages.forEach(function (message) {
+      var item = document.createElement('li');
+      item.className = message.tone === 'ok' ? '' : message.tone;
+      item.textContent = message.text;
+      els.validationList.appendChild(item);
+    });
+  }
+
+  function closeSeries(candles) {
+    return candles.map(function (candle) {
+      return candle.close;
+    });
+  }
+
+  function smaAt(values, index, period) {
+    if (index + 1 < period) return null;
+    return average(values.slice(index + 1 - period, index + 1));
+  }
+
+  function stdevAt(values, index, period) {
+    if (index + 1 < period) return null;
+    return stddev(values.slice(index + 1 - period, index + 1));
+  }
+
+  function rsiAt(values, index, period) {
+    if (index < period) return null;
+    var gains = [];
+    var losses = [];
+    for (var i = index - period + 1; i <= index; i += 1) {
+      var delta = values[i] - values[i - 1];
+      if (delta >= 0) gains.push(delta);
+      else losses.push(Math.abs(delta));
+    }
+    var avgGain = average(gains);
+    var avgLoss = average(losses);
+    if (avgLoss === 0) return 100;
+    var rs = avgGain / avgLoss;
+    return 100 - (100 / (1 + rs));
+  }
+
+  function atrAt(candles, index, period) {
+    if (index < period) return null;
+    var ranges = [];
+    for (var i = index - period + 1; i <= index; i += 1) {
+      var prevClose = candles[i - 1] ? candles[i - 1].close : candles[i].close;
+      var highLow = candles[i].high - candles[i].low;
+      var highClose = Math.abs(candles[i].high - prevClose);
+      var lowClose = Math.abs(candles[i].low - prevClose);
+      ranges.push(Math.max(highLow, highClose, lowClose));
+    }
+    return average(ranges);
+  }
+
+  function signal(strategyId, candles, index, simState) {
+    var values = closeSeries(candles);
+    var candle = candles[index];
+    var price = candle.close;
+    var hasPosition = simState.qty > 0.00000001;
+    var avgEntry = simState.qty > 0 ? simState.entryCost / simState.qty : 0;
+
+    if (strategyId === 'momentum') {
+      var fast = smaAt(values, index, 12);
+      var slow = smaAt(values, index, 48);
+      var rsi = rsiAt(values, index, 14);
+      if (!fast || !slow || rsi === null) return { side: 'hold', confidence: 0.12, reason: 'warming up indicators' };
+      if (hasPosition) {
+        var pnl = avgEntry > 0 ? (price - avgEntry) / avgEntry : 0;
+        if (pnl >= 0.01) return { side: 'sell', confidence: 0.77, reason: 'take profit threshold reached' };
+        if (pnl <= -0.006) return { side: 'sell', confidence: 0.82, reason: 'stop loss threshold reached' };
+        if (fast < slow || rsi > 82) return { side: 'sell', confidence: 0.64, reason: 'trend guard turned defensive' };
+      }
+      if (!hasPosition && fast > slow && rsi < 74) {
+        return { side: 'buy', confidence: clamp(0.48 + ((fast - slow) / slow) * 18, 0.5, 0.91), reason: 'fast SMA leads slow SMA with RSI below overbought' };
+      }
+      return { side: 'hold', confidence: 0.34, reason: 'momentum is not actionable' };
+    }
+
+    if (strategyId === 'mean_reversion') {
+      var mean = smaAt(values, index, 20);
+      var sigma = stdevAt(values, index, 20);
+      var bandRsi = rsiAt(values, index, 14);
+      if (!mean || !sigma || bandRsi === null) return { side: 'hold', confidence: 0.12, reason: 'warming up bands' };
+      var lower = mean - 2 * sigma;
+      if (hasPosition) {
+        var mrPnl = avgEntry > 0 ? (price - avgEntry) / avgEntry : 0;
+        if (price >= mean || mrPnl >= 0.012) return { side: 'sell', confidence: 0.73, reason: 'price reverted toward mean' };
+        if (mrPnl <= -0.008) return { side: 'sell', confidence: 0.79, reason: 'mean reversion stop triggered' };
+      }
+      if (!hasPosition && price < lower && bandRsi < 42) {
+        return { side: 'buy', confidence: clamp((mean - price) / Math.max(sigma, 0.00001) / 3, 0.52, 0.9), reason: 'price below lower band with weak RSI' };
+      }
+      return { side: 'hold', confidence: 0.31, reason: 'price remains inside range' };
+    }
+
+    if (strategyId === 'breakout') {
+      if (index < 28) return { side: 'hold', confidence: 0.12, reason: 'warming up channel' };
+      var channel = candles.slice(index - 24, index);
+      var high = Math.max.apply(null, channel.map(function (c) { return c.high; }));
+      var low = Math.min.apply(null, channel.map(function (c) { return c.low; }));
+      var atr = atrAt(candles, index, 14) || price * 0.01;
+      if (hasPosition) {
+        if (price < low || price < avgEntry - atr * 1.7) return { side: 'sell', confidence: 0.76, reason: 'channel failed or ATR stop hit' };
+      }
+      if (!hasPosition && price > high) {
+        return { side: 'buy', confidence: 0.78, reason: 'price cleared 24 hour channel high' };
+      }
+      return { side: 'hold', confidence: 0.33, reason: 'no channel break' };
+    }
+
+    if (strategyId === 'grid') {
+      if (!simState.gridCenter) simState.gridCenter = price;
+      var spacing = 0.008;
+      var drift = Math.abs(price - simState.gridCenter) / price;
+      if (drift > spacing * 3) simState.gridCenter = price;
+      if (price <= simState.gridCenter * (1 - spacing) && simState.cash > 1) {
+        simState.gridCenter = price;
+        return { side: 'buy', confidence: 0.58, reason: 'price moved into lower grid level' };
+      }
+      if (hasPosition && price >= avgEntry * (1 + spacing * 1.4)) {
+        simState.gridCenter = price;
+        return { side: 'sell', confidence: 0.62, reason: 'grid take profit level reached' };
+      }
+      return { side: 'hold', confidence: 0.4, reason: 'grid remains centered' };
+    }
+
+    if (strategyId === 'dca') {
+      if (hasPosition) {
+        var dcaPnl = avgEntry > 0 ? (price - avgEntry) / avgEntry : 0;
+        if (dcaPnl >= 0.045) return { side: 'sell', confidence: 0.74, reason: 'DCA basket reached profit target' };
+      }
+      if (index % 24 === 0 && simState.cash > 1) {
+        return { side: 'buy', confidence: 0.5, reason: 'scheduled DCA interval' };
+      }
+      return { side: 'hold', confidence: 0.35, reason: 'waiting for next DCA interval' };
+    }
+
+    if (index < 24) return { side: 'hold', confidence: 0.12, reason: 'warming up momentum window' };
+    var ret12 = (price - candles[index - 12].close) / candles[index - 12].close;
+    var ret24 = (price - candles[index - 24].close) / candles[index - 24].close;
+    if (hasPosition && ret12 < -0.012) return { side: 'sell', confidence: 0.74, reason: '12 hour momentum flipped negative' };
+    if (!hasPosition && ret12 > 0.012 && ret24 > 0.018) return { side: 'buy', confidence: clamp(0.5 + ret24 * 5, 0.52, 0.86), reason: '12 hour and 24 hour momentum align' };
+    return { side: 'hold', confidence: 0.34, reason: 'momentum watch is neutral' };
+  }
+
+  async function fetchCoingeckoCandles(pair, days) {
+    var id = COINGECKO_IDS[pair];
+    if (!id) throw new Error('Unsupported market');
+    var url = 'https://api.coingecko.com/api/v3/coins/' + encodeURIComponent(id) +
+      '/market_chart?vs_currency=usd&days=' + encodeURIComponent(days) + '&interval=hourly';
     var res = await fetch(url, { headers: { Accept: 'application/json' } });
-    if (!res.ok) throw new Error('CoinGecko failed: ' + res.status);
+    if (!res.ok) throw new Error('CoinGecko ' + res.status);
     var body = await res.json();
-    if (!body.prices || body.prices.length < 24) throw new Error('CoinGecko returned too few prices');
-    return body.prices.map(function (row) {
-      var price = Number(row[1]);
+    if (!body.prices || body.prices.length < 24) throw new Error('Too few prices');
+    return body.prices.map(function (row, index, rows) {
+      var close = Number(row[1]);
+      var prev = rows[index - 1] ? Number(rows[index - 1][1]) : close;
+      var high = Math.max(close, prev) * 1.002;
+      var low = Math.min(close, prev) * 0.998;
       return {
         time: Number(row[0]),
-        low: price,
-        high: price,
-        open: price,
-        close: price,
-        volume: 0
+        open: prev,
+        high: high,
+        low: low,
+        close: close,
+        volume: body.total_volumes && body.total_volumes[index] ? Number(body.total_volumes[index][1]) : 0
       };
     });
   }
 
-  async function fetchCandles() {
-    var pair = els.pairSelect.value;
-    var days = els.lookbackSelect.value;
-    state.pair = pair;
-    try {
-      state.source = 'Coinbase hourly';
-      return await fetchCoinbaseCandles(pair, days);
-    } catch (err) {
-      if (pair !== 'NEAR-USD') throw err;
-      state.source = 'CoinGecko hourly';
-      return fetchCoingeckoNear(days);
-    }
-  }
-
-  function syntheticFallbackCandles(pair, days) {
-    var count = Number(days) * 24;
-    var baseByPair = {
+  function syntheticCandles(pair, days) {
+    var count = Math.max(120, Number(days) * 24);
+    var bases = {
       'NEAR-USD': 1.28,
       'BTC-USD': 94500,
       'ETH-USD': 1820,
       'SOL-USD': 126
     };
-    var base = baseByPair[pair] || 1;
-    var candles = [];
+    var base = bases[pair] || 1;
     var now = Date.now();
-    var drift = pair === 'BTC-USD' ? 0.00008 : 0.00018;
-
+    var seed = pair.split('').reduce(function (sum, char) {
+      return sum + char.charCodeAt(0);
+    }, 0);
+    var candles = [];
     for (var i = 0; i < count; i += 1) {
-      var wave = Math.sin(i / 9) * 0.016 + Math.cos(i / 31) * 0.026;
-      var shock = Math.sin(i / 3.7) * 0.005;
-      var trend = (i - count / 2) * drift;
-      var close = base * (1 + trend + wave + shock);
+      var trend = (i - count / 2) * 0.00018;
+      var cycle = Math.sin((i + seed) / 13) * 0.025;
+      var micro = Math.cos((i + seed) / 5.5) * 0.009;
+      var close = base * (1 + trend + cycle + micro);
+      var open = i > 0 ? candles[i - 1].close : close * 0.997;
       candles.push({
         time: now - (count - i) * 60 * 60 * 1000,
-        low: close * 0.994,
-        high: close * 1.006,
-        open: close * (1 - shock / 2),
+        open: open,
+        high: Math.max(open, close) * 1.004,
+        low: Math.min(open, close) * 0.996,
         close: close,
         volume: 0
       });
     }
-
-    state.source = 'Sample fallback';
     return candles;
   }
 
-  function signalAt(candles, index, strategyId) {
-    var candle = candles[index];
-    if (!candle) return { side: 'hold', score: 0, reason: 'No candle' };
-
-    if (strategyId === 'sma_cross') {
-      var fast = movingAverage(candles, index, 12);
-      var slow = movingAverage(candles, index, 48);
-      if (!fast || !slow) return { side: 'hold', score: 0, reason: 'Waiting for SMA warmup' };
-      var spread = (fast - slow) / slow;
-      if (spread > 0.006) return { side: 'buy', score: clamp(spread * 900, 0.15, 0.92), reason: 'Fast average is above slow average.' };
-      if (spread < -0.006) return { side: 'sell', score: clamp(Math.abs(spread) * 900, 0.15, 0.92), reason: 'Fast average is below slow average.' };
-      return { side: 'hold', score: 0.34, reason: 'Averages are compressed.' };
-    }
-
-    if (strategyId === 'mean_reversion') {
-      if (index < 20) return { side: 'hold', score: 0, reason: 'Waiting for range warmup' };
-      var window = candles.slice(index - 19, index + 1).map(function (c) { return c.close; });
-      var mean = average(window);
-      var sigma = stdev(window);
-      var z = sigma > 0 ? (candle.close - mean) / sigma : 0;
-      if (z < -1.15) return { side: 'buy', score: clamp(Math.abs(z) / 2.8, 0.22, 0.88), reason: 'Price is below its local range.' };
-      if (z > 1.15) return { side: 'sell', score: clamp(Math.abs(z) / 2.8, 0.22, 0.88), reason: 'Price is above its local range.' };
-      return { side: 'hold', score: 0.36, reason: 'Price is near fair range.' };
-    }
-
-    if (strategyId === 'breakout') {
-      if (index < 24) return { side: 'hold', score: 0, reason: 'Waiting for channel warmup' };
-      var channel = candles.slice(index - 24, index);
-      var high = Math.max.apply(null, channel.map(function (c) { return c.high; }));
-      var low = Math.min.apply(null, channel.map(function (c) { return c.low; }));
-      if (candle.close > high) return { side: 'buy', score: 0.78, reason: 'Price cleared the 24h channel high.' };
-      if (candle.close < low) return { side: 'sell', score: 0.78, reason: 'Price lost the 24h channel low.' };
-      return { side: 'hold', score: 0.31, reason: 'Price remains inside the channel.' };
-    }
-
-    if (index < 12) return { side: 'hold', score: 0, reason: 'Waiting for momentum warmup' };
-    var prior = candles[index - 12].close;
-    var momentum = prior > 0 ? (candle.close - prior) / prior : 0;
-    if (momentum > 0.025) return { side: 'buy', score: clamp(momentum * 10, 0.24, 0.86), reason: '12h momentum is positive; paper-only spot route.' };
-    if (momentum < -0.025) return { side: 'sell', score: clamp(Math.abs(momentum) * 10, 0.24, 0.86), reason: '12h momentum is negative; paper-only de-risk route.' };
-    return { side: 'hold', score: 0.35, reason: 'Momentum is not decisive.' };
-  }
-
-  function backtest(candles, strategyId) {
-    var equity = 1;
-    var peak = 1;
-    var maxDrawdown = 0;
-    var position = 0;
-    var trades = 0;
-    var curve = [];
-
-    for (var i = 1; i < candles.length; i += 1) {
-      var signal = signalAt(candles, i - 1, strategyId);
-      var nextPosition = signal.side === 'buy' ? 1 : signal.side === 'sell' ? 0 : position;
-      if (nextPosition !== position) trades += 1;
-      position = nextPosition;
-      var ret = candles[i - 1].close > 0 ? (candles[i].close - candles[i - 1].close) / candles[i - 1].close : 0;
-      equity *= 1 + position * ret;
-      peak = Math.max(peak, equity);
-      maxDrawdown = Math.max(maxDrawdown, peak > 0 ? (peak - equity) / peak : 0);
-      curve.push(equity);
-    }
-
-    var latest = signalAt(candles, candles.length - 1, strategyId);
-    var totalReturn = equity - 1;
-    var confidence = clamp(0.45 + latest.score * 0.42 + Math.min(Math.max(totalReturn, -0.15), 0.25), 0.05, 0.93);
-    return {
-      latest: latest,
-      totalReturn: totalReturn,
-      maxDrawdown: maxDrawdown,
-      trades: trades,
-      confidence: confidence,
-      curve: curve
-    };
-  }
-
-  function drawChart() {
-    var canvas = els.priceCanvas;
-    var ctx = canvas.getContext('2d');
-    var width = canvas.width;
-    var height = canvas.height;
-    var candles = state.candles;
-    ctx.clearRect(0, 0, width, height);
-    ctx.fillStyle = '#080a0c';
-    ctx.fillRect(0, 0, width, height);
-
-    if (!candles.length) {
-      ctx.fillStyle = '#9aa69c';
-      ctx.font = '28px system-ui';
-      ctx.fillText('Run live strategy to draw recent candles', 44, height / 2);
-      return;
-    }
-
-    var closes = candles.map(function (c) { return c.close; });
-    var min = Math.min.apply(null, closes);
-    var max = Math.max.apply(null, closes);
-    var pad = Math.max((max - min) * 0.12, max * 0.01);
-    var lo = min - pad;
-    var hi = max + pad;
-
-    function x(i) {
-      return candles.length <= 1 ? 0 : (i / (candles.length - 1)) * width;
-    }
-
-    function y(price) {
-      return height - ((price - lo) / (hi - lo)) * height;
-    }
-
-    ctx.strokeStyle = 'rgba(243, 246, 240, 0.08)';
-    ctx.lineWidth = 1;
-    for (var g = 1; g < 5; g += 1) {
-      ctx.beginPath();
-      ctx.moveTo(0, (height / 5) * g);
-      ctx.lineTo(width, (height / 5) * g);
-      ctx.stroke();
-    }
-
-    var gradient = ctx.createLinearGradient(0, 0, 0, height);
-    gradient.addColorStop(0, 'rgba(110, 240, 176, 0.32)');
-    gradient.addColorStop(1, 'rgba(110, 240, 176, 0)');
-    ctx.beginPath();
-    closes.forEach(function (close, i) {
-      if (i === 0) ctx.moveTo(x(i), y(close));
-      else ctx.lineTo(x(i), y(close));
-    });
-    ctx.lineTo(width, height);
-    ctx.lineTo(0, height);
-    ctx.closePath();
-    ctx.fillStyle = gradient;
-    ctx.fill();
-
-    ctx.beginPath();
-    closes.forEach(function (close, i) {
-      if (i === 0) ctx.moveTo(x(i), y(close));
-      else ctx.lineTo(x(i), y(close));
-    });
-    ctx.strokeStyle = '#6ef0b0';
-    ctx.lineWidth = 3;
-    ctx.stroke();
-
-    if (state.result && state.result.curve.length > 2) {
-      var curve = state.result.curve;
-      var cMin = Math.min.apply(null, curve);
-      var cMax = Math.max.apply(null, curve);
-      ctx.beginPath();
-      curve.forEach(function (point, i) {
-        var px = (i / (curve.length - 1)) * width;
-        var py = height - ((point - cMin) / Math.max(cMax - cMin, 0.0001)) * height;
-        if (i === 0) ctx.moveTo(px, py);
-        else ctx.lineTo(px, py);
-      });
-      ctx.strokeStyle = 'rgba(244, 196, 107, 0.72)';
-      ctx.lineWidth = 2;
-      ctx.stroke();
-    }
-  }
-
-  function updateMetrics() {
-    var last = state.candles[state.candles.length - 1];
-    els.sourceLabel.textContent = state.source;
-    els.priceCaption.textContent = 'Last ' + state.pair.replace('-USD', '');
-    els.priceLabel.textContent = last ? fmtUsd(last.close) : '-';
-
-    if (!state.result) {
-      els.signalLabel.textContent = 'Idle';
-      els.returnMetric.textContent = '-';
-      els.drawdownMetric.textContent = '-';
-      els.tradesMetric.textContent = '-';
-      els.confidenceMetric.textContent = '-';
-      return;
-    }
-
-    var latest = state.result.latest;
-    els.signalLabel.textContent = latest.side.toUpperCase();
-    els.returnMetric.textContent = fmtPct(state.result.totalReturn);
-    els.drawdownMetric.textContent = fmtPct(-state.result.maxDrawdown);
-    els.tradesMetric.textContent = String(state.result.trades);
-    els.confidenceMetric.textContent = Math.round(state.result.confidence * 100) + '%';
-    els.signalNote.textContent = latest.reason + ' Latest paper decision: ' + latest.side.toUpperCase() + ' with ' + Math.round(state.result.confidence * 100) + '% confidence.';
-
-    if (latest.side === 'buy') setStatus('Paper buy', '');
-    else if (latest.side === 'sell') setStatus('Paper sell', 'warn');
-    else setStatus('Hold', 'warn');
-  }
-
-  async function runLive() {
-    setStatus('Loading candles', 'warn');
-    els.runLiveBtn.disabled = true;
+  async function loadCandles(input) {
     try {
-      state.candles = await fetchCandles();
-      runStrategy();
+      var candles = await fetchCoingeckoCandles(input.pair, input.lookbackDays);
+      state.dataSource = 'CoinGecko hourly';
+      return candles;
     } catch (err) {
-      state.candles = syntheticFallbackCandles(els.pairSelect.value, els.lookbackSelect.value);
-      runStrategy();
-      setStatus('Sample data', 'warn');
-      els.signalNote.textContent = 'Live data failed, so this run is using deterministic sample candles. The page is still safe; no funds or signatures are touched.';
-    } finally {
-      els.runLiveBtn.disabled = false;
+      state.dataSource = 'Sample fallback';
+      return syntheticCandles(input.pair, input.lookbackDays);
     }
   }
 
-  function runStrategy() {
-    var strategy = selectedStrategy();
-    els.strategyTitle.textContent = strategy.name;
-    state.result = backtest(state.candles, strategy.id);
-    updateMetrics();
-    drawChart();
-    buildIntent();
-  }
-
-  function tokenForPair(pair) {
-    if (pair.indexOf('NEAR') === 0) return 'wrap.near';
-    if (pair.indexOf('BTC') === 0) return 'btc.omft.near';
-    if (pair.indexOf('ETH') === 0) return 'eth.omft.near';
-    if (pair.indexOf('SOL') === 0) return 'sol.omft.near';
-    return 'wrap.near';
-  }
-
-  function buildIntent() {
-    var last = state.candles[state.candles.length - 1];
-    var strategy = selectedStrategy();
-    var latest = state.result ? state.result.latest : { side: 'hold', reason: 'No signal yet' };
-    var budgetUsd = Number(els.budgetInput.value || 0);
-    var tradeCapUsd = Number(els.tradeCapInput.value || 0);
-    var slippageBps = Number(els.slippageInput.value || 0);
-    var safeTradeUsd = Math.max(0, Math.min(budgetUsd, tradeCapUsd));
-    var side = latest.side;
-    var account = els.accountInput.value.trim() || '<viewer-provided-account.near>';
-    var minOutUsd = safeTradeUsd * (1 - slippageBps / 10000);
-    var quoteRequest = side === 'hold' ? null : {
-      sell: side === 'buy'
-        ? { token: 'usdc.near', amount_usd_estimate: Number(safeTradeUsd.toFixed(6)) }
-        : { token: tokenForPair(state.pair), amount_usd_estimate: Number(safeTradeUsd.toFixed(6)) },
-      buy: side === 'buy'
-        ? { token: tokenForPair(state.pair), min_amount_usd: Number(minOutUsd.toFixed(6)) }
-        : { token: 'usdc.near', min_amount_usd: Number(minOutUsd.toFixed(6)) },
-      slippage_bps: slippageBps
+  function executeBuy(sim, candle, input, reason) {
+    var spend = Math.min(sim.cash, input.maxTradeUsd, input.initialCash * input.riskPct);
+    if (spend < 0.01) return null;
+    var executionPrice = candle.close * (1 + input.slippageBps / 10000);
+    var fee = spend * input.feeBps / 10000;
+    var netSpend = Math.max(0, spend - fee);
+    var qty = netSpend / executionPrice;
+    sim.cash -= spend;
+    sim.qty += qty;
+    sim.entryCost += netSpend;
+    sim.fees += fee;
+    return {
+      time: candle.time,
+      side: 'BUY',
+      price: executionPrice,
+      qty: qty,
+      notional: spend,
+      fee: fee,
+      pnl: null,
+      reason: reason
     };
+  }
 
-    state.lastIntent = {
-      schema: 'near-intents-public-experiment/1',
+  function executeSell(sim, candle, input, reason) {
+    if (sim.qty <= 0) return null;
+    var sellQty = sim.qty;
+    var executionPrice = candle.close * (1 - input.slippageBps / 10000);
+    var gross = sellQty * executionPrice;
+    var fee = gross * input.feeBps / 10000;
+    var proceeds = gross - fee;
+    var costBasis = sim.entryCost;
+    var pnl = proceeds - costBasis;
+    sim.cash += proceeds;
+    sim.qty = 0;
+    sim.entryCost = 0;
+    sim.fees += fee;
+    return {
+      time: candle.time,
+      side: 'SELL',
+      price: executionPrice,
+      qty: sellQty,
+      notional: proceeds,
+      fee: fee,
+      pnl: pnl,
+      reason: reason
+    };
+  }
+
+  function runSimulation(candles, input) {
+    var sim = {
+      cash: input.initialCash,
+      qty: 0,
+      entryCost: 0,
+      fees: 0,
+      gridCenter: 0
+    };
+    var equity = [];
+    var trades = [];
+    var events = [];
+    var lastSignal = { side: 'hold', confidence: 0, reason: 'not run' };
+
+    for (var i = 0; i < candles.length; i += 1) {
+      var candle = candles[i];
+      var currentSignal = signal(input.strategy.id, candles, i, sim);
+      var trade = null;
+      if (currentSignal.side === 'buy') {
+        trade = executeBuy(sim, candle, input, currentSignal.reason);
+      } else if (currentSignal.side === 'sell') {
+        trade = executeSell(sim, candle, input, currentSignal.reason);
+      }
+      if (trade) {
+        trades.push(trade);
+        events.push(trade.side + ' at ' + fmtUsd(trade.price) + ': ' + trade.reason);
+      }
+      lastSignal = currentSignal;
+      equity.push({
+        time: candle.time,
+        price: candle.close,
+        value: sim.cash + sim.qty * candle.close,
+        cash: sim.cash,
+        qty: sim.qty
+      });
+    }
+
+    var latest = candles[candles.length - 1];
+    lastSignal = signal(input.strategy.id, candles, candles.length - 1, sim);
+    var metrics = calculateMetrics(equity, trades, input, sim.fees);
+    var status = sim.qty > 0 ? 'holding spot exposure' : 'flat';
+    if (!events.length) events.push('No fills. Latest signal: ' + lastSignal.side.toUpperCase() + ' - ' + lastSignal.reason + '.');
+    events.unshift(input.strategy.name + ' completed on ' + candles.length + ' hourly candles; account is ' + status + '.');
+
+    return {
+      input: input,
+      candles: candles,
+      equity: equity,
+      trades: trades,
+      events: events.slice(-24),
+      metrics: metrics,
+      latestSignal: lastSignal,
+      latestPrice: latest ? latest.close : null,
+      finalCash: sim.cash,
+      finalQty: sim.qty,
+      fees: sim.fees
+    };
+  }
+
+  function calculateMetrics(equity, trades, input, totalFees) {
+    if (equity.length < 2) {
+      return emptyMetrics(totalFees);
+    }
+    var values = equity.map(function (point) { return point.value; });
+    var returns = [];
+    for (var i = 1; i < values.length; i += 1) {
+      returns.push(values[i - 1] > 0 ? (values[i] - values[i - 1]) / values[i - 1] : 0);
+    }
+    var totalReturn = input.initialCash > 0 ? (values[values.length - 1] - input.initialCash) / input.initialCash : 0;
+    var days = Math.max(1, (equity[equity.length - 1].time - equity[0].time) / (24 * 60 * 60 * 1000));
+    var years = days / 365;
+    var cagr = years > 0 && values[values.length - 1] > 0 ? Math.pow(values[values.length - 1] / input.initialCash, 1 / years) - 1 : 0;
+    var mean = average(returns);
+    var vol = stddev(returns);
+    var downside = returns.filter(function (r) { return r < 0; });
+    var downsideVol = Math.sqrt(average(downside.map(function (r) { return r * r; })));
+    var sharpe = vol > 0 ? mean / vol * Math.sqrt(365 * 24) : 0;
+    var sortino = downsideVol > 0 ? mean / downsideVol * Math.sqrt(365 * 24) : 0;
+    var drawdown = maxDrawdown(values);
+    var calmar = drawdown < 0 ? cagr / Math.abs(drawdown) : 0;
+    var sellTrades = trades.filter(function (trade) {
+      return trade.side === 'SELL' && Number.isFinite(trade.pnl);
+    });
+    var wins = sellTrades.filter(function (trade) { return trade.pnl > 0; });
+    var losses = sellTrades.filter(function (trade) { return trade.pnl < 0; });
+    var grossProfit = wins.reduce(function (sum, trade) { return sum + trade.pnl; }, 0);
+    var grossLoss = Math.abs(losses.reduce(function (sum, trade) { return sum + trade.pnl; }, 0));
+    var profitFactor = grossLoss > 0 ? grossProfit / grossLoss : grossProfit > 0 ? 100 : 0;
+    var winRate = sellTrades.length ? wins.length / sellTrades.length : 0;
+    var expectancy = sellTrades.length
+      ? sellTrades.reduce(function (sum, trade) { return sum + trade.pnl; }, 0) / sellTrades.length
+      : 0;
+
+    return {
+      totalReturn: totalReturn,
+      cagr: cagr,
+      sharpe: sharpe,
+      sortino: sortino,
+      calmar: calmar,
+      maxDrawdown: drawdown,
+      winRate: winRate,
+      profitFactor: profitFactor,
+      expectancy: expectancy,
+      totalTrades: trades.length,
+      closedTrades: sellTrades.length,
+      totalFees: totalFees,
+      endingValue: values[values.length - 1]
+    };
+  }
+
+  function emptyMetrics(totalFees) {
+    return {
+      totalReturn: 0,
+      cagr: 0,
+      sharpe: 0,
+      sortino: 0,
+      calmar: 0,
+      maxDrawdown: 0,
+      winRate: 0,
+      profitFactor: 0,
+      expectancy: 0,
+      totalTrades: 0,
+      closedTrades: 0,
+      totalFees: totalFees || 0,
+      endingValue: 0
+    };
+  }
+
+  function maxDrawdown(values) {
+    var peak = values[0] || 0;
+    var drawdown = 0;
+    values.forEach(function (value) {
+      peak = Math.max(peak, value);
+      if (peak > 0) drawdown = Math.min(drawdown, (value - peak) / peak);
+    });
+    return drawdown;
+  }
+
+  function buildStrategyCode(input) {
+    var asset = input.pair.replace('-USD', '');
+    var interval = '1h';
+    if (input.strategy.id === 'momentum') {
+      return [
+        'from vibetrading import vibe, get_spot_price, get_futures_ohlcv, buy, sell, my_spot_balance',
+        '',
+        'ASSET = "' + asset + '"',
+        'SMA_FAST = 12',
+        'SMA_SLOW = 48',
+        'RSI_PERIOD = 14',
+        'TP_PCT = 0.010',
+        'SL_PCT = 0.006',
+        '',
+        '@vibe(interval="' + interval + '")',
+        'def near_intents_momentum():',
+        '    price = get_spot_price(ASSET)',
+        '    ohlcv = get_futures_ohlcv(ASSET, "' + interval + '", 72)',
+        '    fast = ohlcv["close"].rolling(SMA_FAST).mean().iloc[-1]',
+        '    slow = ohlcv["close"].rolling(SMA_SLOW).mean().iloc[-1]',
+        '    rsi = compute_rsi(ohlcv["close"], RSI_PERIOD).iloc[-1]',
+        '    if fast > slow and rsi < 74:',
+        '        buy(ASSET, sized_usd_order(), price, order_type="market")',
+        '    elif trend_guard_failed():',
+        '        sell(ASSET, current_position(), price, order_type="market")'
+      ].join('\n');
+    }
+    if (input.strategy.id === 'mean_reversion') {
+      return [
+        'from vibetrading import vibe, get_spot_price, get_futures_ohlcv, buy, sell',
+        '',
+        'ASSET = "' + asset + '"',
+        'BB_PERIOD = 20',
+        'BB_STD = 2.0',
+        'RSI_ENTRY = 42',
+        '',
+        '@vibe(interval="' + interval + '")',
+        'def near_intents_mean_reversion():',
+        '    price = get_spot_price(ASSET)',
+        '    bars = get_futures_ohlcv(ASSET, "' + interval + '", 40)',
+        '    middle = bars["close"].rolling(BB_PERIOD).mean().iloc[-1]',
+        '    sigma = bars["close"].rolling(BB_PERIOD).std().iloc[-1]',
+        '    lower = middle - BB_STD * sigma',
+        '    rsi = compute_rsi(bars["close"], 14).iloc[-1]',
+        '    if price < lower and rsi < RSI_ENTRY:',
+        '        buy(ASSET, sized_usd_order(), price, order_type="market")',
+        '    elif price >= middle or stop_loss_hit():',
+        '        sell(ASSET, current_position(), price, order_type="market")'
+      ].join('\n');
+    }
+    if (input.strategy.id === 'grid') {
+      return [
+        'from vibetrading import vibe, get_spot_price, buy, sell, my_spot_balance',
+        '',
+        'ASSET = "' + asset + '"',
+        'GRID_SPACING_PCT = 0.008',
+        '',
+        '@vibe(interval="' + interval + '")',
+        'def near_intents_spot_grid():',
+        '    price = get_spot_price(ASSET)',
+        '    center = load_grid_center(ASSET) or price',
+        '    if price <= center * (1 - GRID_SPACING_PCT):',
+        '        buy(ASSET, sized_usd_order(), price, order_type="market")',
+        '        save_grid_center(ASSET, price)',
+        '    elif price >= avg_entry(ASSET) * (1 + GRID_SPACING_PCT * 1.4):',
+        '        sell(ASSET, current_position(), price, order_type="market")',
+        '        save_grid_center(ASSET, price)'
+      ].join('\n');
+    }
+    if (input.strategy.id === 'dca') {
+      return [
+        'from vibetrading import vibe, get_spot_price, buy, sell',
+        '',
+        'ASSET = "' + asset + '"',
+        'TAKE_PROFIT = 0.045',
+        '',
+        '@vibe(interval="' + interval + '")',
+        'def near_intents_dca_rebalance():',
+        '    price = get_spot_price(ASSET)',
+        '    if basket_return(ASSET) >= TAKE_PROFIT:',
+        '        sell(ASSET, current_position(), price, order_type="market")',
+        '    elif cadence_due("daily"):',
+        '        buy(ASSET, sized_usd_order(), price, order_type="market")'
+      ].join('\n');
+    }
+    if (input.strategy.id === 'breakout') {
+      return [
+        'from vibetrading import vibe, get_spot_price, get_futures_ohlcv, buy, sell',
+        '',
+        'ASSET = "' + asset + '"',
+        'CHANNEL = 24',
+        '',
+        '@vibe(interval="' + interval + '")',
+        'def near_intents_breakout():',
+        '    price = get_spot_price(ASSET)',
+        '    bars = get_futures_ohlcv(ASSET, "' + interval + '", CHANNEL + 6)',
+        '    channel_high = bars["high"].iloc[-CHANNEL:-1].max()',
+        '    channel_low = bars["low"].iloc[-CHANNEL:-1].min()',
+        '    if price > channel_high:',
+        '        buy(ASSET, sized_usd_order(), price, order_type="market")',
+        '    elif price < channel_low or atr_stop_hit():',
+        '        sell(ASSET, current_position(), price, order_type="market")'
+      ].join('\n');
+    }
+    return [
+      'from vibetrading import vibe, get_spot_price, get_futures_ohlcv, buy, sell',
+      '',
+      'ASSET = "' + asset + '"',
+      '',
+      '@vibe(interval="' + interval + '")',
+      'def near_intents_hl_momentum_watch():',
+      '    price = get_spot_price(ASSET)',
+      '    bars = get_futures_ohlcv(ASSET, "' + interval + '", 30)',
+      '    ret_12h = bars["close"].iloc[-1] / bars["close"].iloc[-12] - 1',
+      '    ret_24h = bars["close"].iloc[-1] / bars["close"].iloc[-24] - 1',
+      '    if ret_12h > 0.012 and ret_24h > 0.018:',
+      '        buy(ASSET, sized_usd_order(), price, order_type="market")',
+      '    elif ret_12h < -0.012:',
+      '        sell(ASSET, current_position(), price, order_type="market")'
+    ].join('\n');
+  }
+
+  function buildIntentDraft(result) {
+    if (!result) return null;
+    var input = result.input;
+    var side = result.latestSignal.side;
+    var token = TOKEN_BY_PAIR[input.pair] || 'wrap.near';
+    var maxUsd = Math.min(input.maxTradeUsd, input.initialCash * input.riskPct);
+    var quoteRequest = null;
+    if (side === 'buy') {
+      quoteRequest = {
+        sell: { asset: 'usdc.near', amount_usd_estimate: Number(maxUsd.toFixed(6)) },
+        buy: { asset: token, min_amount_usd: Number((maxUsd * (1 - input.slippageBps / 10000)).toFixed(6)) },
+        route_preference: 'best_solver_quote'
+      };
+    } else if (side === 'sell') {
+      quoteRequest = {
+        sell: { asset: token, amount_usd_estimate: Number(maxUsd.toFixed(6)) },
+        buy: { asset: 'usdc.near', min_amount_usd: Number((maxUsd * (1 - input.slippageBps / 10000)).toFixed(6)) },
+        route_preference: 'best_solver_quote'
+      };
+    }
+    var runHash = hashText(JSON.stringify({
+      strategy: input.strategy.id,
+      pair: input.pair,
+      prompt: input.prompt,
+      metrics: result.metrics,
+      latest: result.latestSignal
+    }));
+    return {
+      schema: 'near-intents-vibetrading-lab/1',
       mode: 'paper',
-      public_demo: true,
-      execution_boundary: 'unsigned-only',
+      run_hash: runHash,
       created_at: new Date().toISOString(),
-      account_id: account,
+      source: 'VibeTrading-inspired client backtest',
+      execution_boundary: 'unsigned_preview_only',
+      account_id: input.accountId,
       market: {
-        pair: state.pair.replace('-', '/'),
-        source: state.source,
-        last_price_usd: last ? Number(last.close.toFixed(8)) : null
+        pair: input.pair.replace('-', '/'),
+        token: token,
+        data_source: state.dataSource,
+        last_price_usd: result.latestPrice ? Number(result.latestPrice.toFixed(8)) : null
       },
       strategy: {
-        id: strategy.id,
-        name: strategy.name,
-        decision: side,
-        confidence: state.result ? Number(state.result.confidence.toFixed(4)) : null,
-        note: latest.reason
+        id: input.strategy.id,
+        name: input.strategy.name,
+        prompt: input.prompt,
+        generated_code_hash: hashText(buildStrategyCode(input)),
+        latest_signal: side,
+        confidence: Number(result.latestSignal.confidence.toFixed(4)),
+        reason: result.latestSignal.reason
+      },
+      backtest: {
+        lookback_days: input.lookbackDays,
+        starting_cash_usd: input.initialCash,
+        ending_value_usd: Number(result.metrics.endingValue.toFixed(6)),
+        total_return: Number(result.metrics.totalReturn.toFixed(6)),
+        sharpe: Number(result.metrics.sharpe.toFixed(4)),
+        max_drawdown: Number(result.metrics.maxDrawdown.toFixed(6)),
+        win_rate: Number(result.metrics.winRate.toFixed(4)),
+        profit_factor: Number(result.metrics.profitFactor.toFixed(4)),
+        total_trades: result.metrics.totalTrades,
+        total_fees_usd: Number(result.metrics.totalFees.toFixed(6))
       },
       risk: {
-        nominal_budget_usd: budgetUsd,
-        max_trade_usd: safeTradeUsd,
-        slippage_bps: slippageBps,
+        max_trade_usd: Number(input.maxTradeUsd.toFixed(6)),
+        risk_per_signal_pct: Number((input.riskPct * 100).toFixed(4)),
+        fee_bps: input.feeBps,
+        slippage_bps: input.slippageBps,
         funding_asset_hint: 'any_near_intents_supported_deposit_asset',
         no_auto_signing: true,
         no_broadcast: true
@@ -483,19 +841,257 @@
       draft_intent: {
         venue: 'near_intents',
         deposit_model: 'direct_near_intents_balance_or_any_supported_asset',
-        solver_quote_required: true,
+        solver_quote_required: side !== 'hold',
         decision: side,
         quote_request: quoteRequest,
-        hold_reason: side === 'hold' ? latest.reason : null,
+        hold_reason: side === 'hold' ? result.latestSignal.reason : null,
         expires_in_seconds: 120
       }
     };
-    els.intentOutput.textContent = JSON.stringify(state.lastIntent, null, 2);
+  }
+
+  function renderMetrics(result) {
+    var metrics = result.metrics;
+    els.returnMetric.textContent = fmtPct(metrics.totalReturn);
+    els.returnMetric.className = metrics.totalReturn >= 0 ? 'good' : 'bad';
+    els.sharpeMetric.textContent = fmtNum(metrics.sharpe, 2);
+    els.drawdownMetric.textContent = fmtPct(metrics.maxDrawdown);
+    els.drawdownMetric.className = metrics.maxDrawdown < -0.08 ? 'bad' : '';
+    els.winRateMetric.textContent = metrics.closedTrades ? (metrics.winRate * 100).toFixed(2) + '%' : '-';
+    els.profitMetric.textContent = metrics.closedTrades ? fmtNum(metrics.profitFactor, 2) : '-';
+    els.signalMetric.textContent = result.latestSignal.side.toUpperCase();
+    els.signalMetric.className = 'signal-' + result.latestSignal.side;
+    els.chartTitle.textContent = result.input.strategy.name + ' on ' + result.input.pair.replace('-', ' / ');
+    els.dataSourceLabel.textContent = state.dataSource;
+  }
+
+  function renderSignal(result) {
+    var signalText = result.latestSignal.side.toUpperCase();
+    els.signalTitle.textContent = signalText;
+    els.signalTitle.className = 'signal-' + result.latestSignal.side;
+    els.signalSummary.textContent = result.latestSignal.reason + '. Confidence ' +
+      Math.round(result.latestSignal.confidence * 100) + '%. Ending value ' +
+      fmtUsd(result.metrics.endingValue) + ' after ' + result.trades.length + ' paper fills.';
+  }
+
+  function renderTrades(trades) {
+    els.tradeTableBody.innerHTML = '';
+    els.tradeCountLabel.textContent = trades.length + (trades.length === 1 ? ' fill' : ' fills');
+    if (!trades.length) {
+      var empty = document.createElement('tr');
+      empty.className = 'empty-row';
+      empty.innerHTML = '<td colspan="5">No fills in this run.</td>';
+      els.tradeTableBody.appendChild(empty);
+      return;
+    }
+    trades.slice(-12).reverse().forEach(function (trade) {
+      var row = document.createElement('tr');
+      row.innerHTML = '<td>' + fmtDate(trade.time) + '</td>' +
+        '<td class="' + (trade.side === 'BUY' ? 'signal-buy' : 'signal-sell') + '">' + trade.side + '</td>' +
+        '<td>' + fmtUsd(trade.price) + '</td>' +
+        '<td>' + fmtNum(trade.qty, 6) + '</td>' +
+        '<td class="' + (trade.pnl >= 0 ? 'signal-buy' : 'signal-sell') + '">' +
+        (trade.pnl === null ? '-' : fmtUsd(trade.pnl)) + '</td>';
+      els.tradeTableBody.appendChild(row);
+    });
+  }
+
+  function renderTape(events) {
+    els.eventTape.innerHTML = '';
+    els.tapeSummary.textContent = events.length + ' events';
+    events.slice(-14).reverse().forEach(function (event) {
+      var item = document.createElement('li');
+      item.textContent = event;
+      els.eventTape.appendChild(item);
+    });
+  }
+
+  function renderIntent(result) {
+    var draft = buildIntentDraft(result);
+    state.latestIntent = draft;
+    els.intentOutput.textContent = JSON.stringify(draft, null, 2);
+    els.intentStatus.textContent = draft.draft_intent.decision.toUpperCase();
+  }
+
+  function renderCode(input) {
+    els.strategyCode.textContent = buildStrategyCode(input);
+  }
+
+  function drawChart(result) {
+    var canvas = els.chartCanvas;
+    var ctx = canvas.getContext('2d');
+    var width = canvas.width;
+    var height = canvas.height;
+    var pad = { left: 54, right: 28, top: 26, bottom: 42 };
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = '#080908';
+    ctx.fillRect(0, 0, width, height);
+
+    if (!result || !result.equity.length) {
+      ctx.fillStyle = '#9da59f';
+      ctx.font = '28px system-ui';
+      ctx.fillText('Run backtest to render price, equity, and fills', pad.left, height / 2);
+      return;
+    }
+
+    var equity = result.equity;
+    var values = equity.map(function (point) { return point.value; });
+    var prices = equity.map(function (point) { return point.price; });
+    var minValue = Math.min.apply(null, values);
+    var maxValue = Math.max.apply(null, values);
+    var minPrice = Math.min.apply(null, prices);
+    var maxPrice = Math.max.apply(null, prices);
+    var plotW = width - pad.left - pad.right;
+    var plotH = height - pad.top - pad.bottom;
+
+    function x(index) {
+      return pad.left + (equity.length <= 1 ? 0 : (index / (equity.length - 1)) * plotW);
+    }
+
+    function yNorm(value, min, max) {
+      var span = Math.max(max - min, Math.abs(max) * 0.001, 0.000001);
+      return pad.top + plotH - ((value - min) / span) * plotH;
+    }
+
+    ctx.strokeStyle = 'rgba(246, 244, 237, 0.08)';
+    ctx.lineWidth = 1;
+    for (var g = 0; g <= 5; g += 1) {
+      var gy = pad.top + (plotH / 5) * g;
+      ctx.beginPath();
+      ctx.moveTo(pad.left, gy);
+      ctx.lineTo(width - pad.right, gy);
+      ctx.stroke();
+    }
+
+    ctx.fillStyle = '#6f7771';
+    ctx.font = '18px system-ui';
+    ctx.fillText(fmtUsd(maxValue), 10, pad.top + 10);
+    ctx.fillText(fmtUsd(minValue), 10, height - pad.bottom);
+
+    ctx.beginPath();
+    prices.forEach(function (price, index) {
+      var px = x(index);
+      var py = yNorm(price, minPrice, maxPrice);
+      if (index === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    });
+    ctx.strokeStyle = '#82f6b8';
+    ctx.lineWidth = 2.5;
+    ctx.stroke();
+
+    ctx.beginPath();
+    values.forEach(function (value, index) {
+      var px = x(index);
+      var py = yNorm(value, minValue, maxValue);
+      if (index === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    });
+    ctx.strokeStyle = '#73d5ff';
+    ctx.lineWidth = 2.5;
+    ctx.stroke();
+
+    result.trades.forEach(function (trade) {
+      var idx = equity.findIndex(function (point) {
+        return point.time >= trade.time;
+      });
+      if (idx < 0) return;
+      var tx = x(idx);
+      var ty = yNorm(equity[idx].price, minPrice, maxPrice);
+      ctx.beginPath();
+      ctx.arc(tx, ty, 6, 0, Math.PI * 2);
+      ctx.fillStyle = trade.side === 'BUY' ? '#82f6b8' : '#ff766f';
+      ctx.fill();
+      ctx.strokeStyle = '#080908';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    });
+  }
+
+  function resetMetrics() {
+    [els.returnMetric, els.sharpeMetric, els.drawdownMetric, els.winRateMetric, els.profitMetric, els.signalMetric].forEach(function (el) {
+      el.textContent = '-';
+      el.className = '';
+    });
+    els.chartTitle.textContent = 'Awaiting run';
+    els.signalTitle.textContent = 'No run yet';
+    els.signalTitle.className = '';
+    els.signalSummary.textContent = 'Select a strategy and run a paper backtest.';
+    els.tradeCountLabel.textContent = '0 fills';
+    els.tradeTableBody.innerHTML = '<tr class="empty-row"><td colspan="5">Run a strategy to populate fills.</td></tr>';
+    els.tapeSummary.textContent = 'Idle';
+    els.eventTape.innerHTML = '';
+    els.intentOutput.textContent = 'Run a strategy to prepare a NEAR Intents draft.';
+    els.strategyCode.textContent = 'Run a strategy to generate code.';
+    drawChart(null);
+  }
+
+  function markStale() {
+    setRunState('Ready');
+    setPhase('describe');
+    els.describeStatus.textContent = 'Edited';
+    els.validateStatus.textContent = 'Pending';
+    els.backtestStatus.textContent = 'Pending';
+    els.intentStatus.textContent = 'Unsigned';
+  }
+
+  async function runBacktest() {
+    var input = params();
+    var validations = validateRun(input);
+    renderValidation(validations);
+    setRunState('Loading data');
+    setPhase('validate');
+    els.validateStatus.textContent = validations.some(function (item) { return item.tone === 'warn'; }) ? 'Warnings' : 'Valid';
+    els.describeStatus.textContent = 'Captured';
+    els.runBacktestBtn.disabled = true;
+    els.topRunBtn.disabled = true;
+    els.buildIntentBtn.disabled = true;
+
+    try {
+      var candles = await loadCandles(input);
+      state.candles = candles;
+      els.dataSourceLabel.textContent = state.dataSource;
+      setRunState('Backtesting');
+      setPhase('backtest');
+      els.backtestStatus.textContent = candles.length + ' candles';
+      await new Promise(function (resolve) { setTimeout(resolve, 70); });
+      var result = runSimulation(candles, input);
+      state.result = result;
+      state.lastRunAt = new Date();
+      renderMetrics(result);
+      renderSignal(result);
+      renderTrades(result.trades);
+      renderTape(result.events);
+      renderCode(input);
+      renderIntent(result);
+      drawChart(result);
+      setPhase('intent', state.dataSource === 'Sample fallback' ? { backtest: 'warn' } : {});
+      setRunState(state.dataSource === 'Sample fallback' ? 'Sample run' : 'Live data run');
+    } catch (err) {
+      setRunState('Run failed');
+      setPhase('backtest', { backtest: 'error' });
+      els.backtestStatus.textContent = 'Failed';
+      els.signalTitle.textContent = 'Run failed';
+      els.signalSummary.textContent = err.message || String(err);
+    } finally {
+      els.runBacktestBtn.disabled = false;
+      els.topRunBtn.disabled = false;
+      els.buildIntentBtn.disabled = false;
+    }
+  }
+
+  function buildIntentFromCurrent() {
+    if (!state.result) {
+      runBacktest();
+      return;
+    }
+    renderIntent(state.result);
+    setPhase('intent');
+    setRunState('Intent drafted');
   }
 
   function copyIntent() {
     var text = els.intentOutput.textContent || '';
-    if (!text || text.indexOf('{') !== 0) return;
+    if (text.indexOf('{') !== 0) return;
     navigator.clipboard.writeText(text).then(function () {
       els.copyIntentBtn.textContent = 'Copied';
       setTimeout(function () {
@@ -511,17 +1107,20 @@
 
   function bind() {
     renderStrategies();
-    drawChart();
-    els.runLiveBtn.addEventListener('click', runLive);
-    els.pairSelect.addEventListener('change', runLive);
-    els.lookbackSelect.addEventListener('change', runLive);
-    els.buildIntentBtn.addEventListener('click', buildIntent);
+    resetMetrics();
+    renderValidation(validateRun(params()));
+    els.runBacktestBtn.addEventListener('click', runBacktest);
+    els.topRunBtn.addEventListener('click', runBacktest);
+    els.buildIntentBtn.addEventListener('click', buildIntentFromCurrent);
     els.copyIntentBtn.addEventListener('click', copyIntent);
-    [els.accountInput, els.budgetInput, els.tradeCapInput, els.slippageInput].forEach(function (input) {
-      input.addEventListener('input', buildIntent);
+    [els.strategyPrompt, els.pairSelect, els.lookbackSelect, els.balanceInput, els.accountInput, els.maxTradeInput, els.riskPctInput, els.feeBpsInput, els.slippageInput].forEach(function (el) {
+      el.addEventListener('input', markStale);
+      el.addEventListener('change', markStale);
     });
-    window.addEventListener('resize', drawChart);
-    setTimeout(runLive, 250);
+    window.addEventListener('resize', function () {
+      drawChart(state.result);
+    });
+    setTimeout(runBacktest, 250);
   }
 
   bind();

--- a/crates/ironclaw_gateway/static/experiments/near-intents.js
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.js
@@ -8,12 +8,20 @@
     'SOL-USD': 'solana'
   };
 
-  var TOKEN_BY_PAIR = {
-    'NEAR-USD': 'wrap.near',
-    'BTC-USD': 'btc.omft.near',
-    'ETH-USD': 'eth.omft.near',
-    'SOL-USD': 'sol.omft.near'
+  var ASSET_BY_PAIR = {
+    'NEAR-USD': { base: 'nep141:wrap.near', baseDecimals: 24, quote: 'nep141:usdt.tether-token.near', quoteDecimals: 6 },
+    'BTC-USD': { base: 'nep141:btc.omft.near', baseDecimals: 8, quote: 'nep141:usdt.tether-token.near', quoteDecimals: 6 },
+    'ETH-USD': { base: 'nep141:eth.omft.near', baseDecimals: 18, quote: 'nep141:usdt.tether-token.near', quoteDecimals: 6 },
+    'SOL-USD': { base: 'nep141:sol.omft.near', baseDecimals: 9, quote: 'nep141:usdt.tether-token.near', quoteDecimals: 6 }
   };
+
+  var INTENTS_CONTRACT = 'intents.near';
+  var NEAR_RPC = {
+    mainnet: 'https://rpc.mainnet.near.org',
+    testnet: 'https://rpc.testnet.near.org'
+  };
+  var SOLVER_RELAY_URL = 'https://solver-relay-v2.chaindefuser.com/rpc';
+  var ONE_CLICK_URL = 'https://1click.chaindefuser.com/v0';
 
   var STRATEGIES = [
     {
@@ -65,6 +73,18 @@
     candles: [],
     result: null,
     latestIntent: null,
+    latestLivePlan: null,
+    latestSignedIntent: null,
+    isStale: true,
+    nearConnectorModule: null,
+    wallet: {
+      connector: null,
+      instance: null,
+      accountId: '',
+      accounts: [],
+      network: 'mainnet'
+    },
+    supportedTokens: [],
     dataSource: 'No data',
     lastRunAt: null
   };
@@ -72,20 +92,47 @@
   var els = {
     dataSourceLabel: document.getElementById('dataSourceLabel'),
     runStateLabel: document.getElementById('runStateLabel'),
+    walletPill: document.getElementById('walletPill'),
+    connectWalletBtn: document.getElementById('connectWalletBtn'),
+    heroRunBtn: document.getElementById('heroRunBtn'),
+    heroConnectBtn: document.getElementById('heroConnectBtn'),
     strategyPrompt: document.getElementById('strategyPrompt'),
     strategyDeck: document.getElementById('strategyDeck'),
     pairSelect: document.getElementById('pairSelect'),
     lookbackSelect: document.getElementById('lookbackSelect'),
     balanceInput: document.getElementById('balanceInput'),
+    liveAmountUsdInput: document.getElementById('liveAmountUsdInput'),
     accountInput: document.getElementById('accountInput'),
     maxTradeInput: document.getElementById('maxTradeInput'),
     riskPctInput: document.getElementById('riskPctInput'),
     feeBpsInput: document.getElementById('feeBpsInput'),
     slippageInput: document.getElementById('slippageInput'),
+    baseAssetInput: document.getElementById('baseAssetInput'),
+    quoteAssetInput: document.getElementById('quoteAssetInput'),
+    assetIdList: document.getElementById('assetIdList'),
+    baseDecimalsInput: document.getElementById('baseDecimalsInput'),
+    quoteDecimalsInput: document.getElementById('quoteDecimalsInput'),
+    networkSelect: document.getElementById('networkSelect'),
+    sideOverrideSelect: document.getElementById('sideOverrideSelect'),
+    solverApiKeyInput: document.getElementById('solverApiKeyInput'),
+    oneClickApiKeyInput: document.getElementById('oneClickApiKeyInput'),
+    walletStatusLabel: document.getElementById('walletStatusLabel'),
+    walletAccountLabel: document.getElementById('walletAccountLabel'),
+    walletBalanceLabel: document.getElementById('walletBalanceLabel'),
+    liveModeLabel: document.getElementById('liveModeLabel'),
+    liveExecutionOutput: document.getElementById('liveExecutionOutput'),
+    liveStepBacktest: document.getElementById('liveStepBacktest'),
+    liveStepQuote: document.getElementById('liveStepQuote'),
+    liveStepSign: document.getElementById('liveStepSign'),
+    liveStepPublish: document.getElementById('liveStepPublish'),
+    runLiveBtn: document.getElementById('runLiveBtn'),
+    dryQuoteBtn: document.getElementById('dryQuoteBtn'),
+    fetchBalancesBtn: document.getElementById('fetchBalancesBtn'),
     topRunBtn: document.getElementById('topRunBtn'),
     runBacktestBtn: document.getElementById('runBacktestBtn'),
     buildIntentBtn: document.getElementById('buildIntentBtn'),
     copyIntentBtn: document.getElementById('copyIntentBtn'),
+    copySignedBtn: document.getElementById('copySignedBtn'),
     describeStatus: document.getElementById('describeStatus'),
     validateStatus: document.getElementById('validateStatus'),
     backtestStatus: document.getElementById('backtestStatus'),
@@ -116,15 +163,25 @@
   }
 
   function params() {
+    var pairAssets = ASSET_BY_PAIR[els.pairSelect.value] || ASSET_BY_PAIR['NEAR-USD'];
     return {
       pair: els.pairSelect.value,
       lookbackDays: Number(els.lookbackSelect.value),
       initialCash: Math.max(10, Number(els.balanceInput.value || 0)),
       maxTradeUsd: Math.max(0.01, Number(els.maxTradeInput.value || 0)),
+      liveAmountUsd: Math.max(0.01, Number(els.liveAmountUsdInput.value || els.maxTradeInput.value || 0)),
       riskPct: Math.max(0.001, Number(els.riskPctInput.value || 0) / 100),
       feeBps: Math.max(0, Number(els.feeBpsInput.value || 0)),
       slippageBps: Math.max(0, Number(els.slippageInput.value || 0)),
       accountId: els.accountInput.value.trim() || '<viewer-provided-account.near>',
+      baseAsset: (els.baseAssetInput.value || pairAssets.base).trim(),
+      quoteAsset: (els.quoteAssetInput.value || pairAssets.quote).trim(),
+      baseDecimals: clamp(Math.round(Number(els.baseDecimalsInput.value || pairAssets.baseDecimals)), 0, 30),
+      quoteDecimals: clamp(Math.round(Number(els.quoteDecimalsInput.value || pairAssets.quoteDecimals)), 0, 30),
+      network: els.networkSelect.value || 'mainnet',
+      sideOverride: els.sideOverrideSelect.value || 'auto',
+      solverApiKey: els.solverApiKeyInput.value.trim(),
+      oneClickApiKey: els.oneClickApiKeyInput.value.trim(),
       prompt: els.strategyPrompt.value.trim(),
       strategy: strategyById(state.selectedStrategy)
     };
@@ -185,6 +242,102 @@
     return (hash >>> 0).toString(16);
   }
 
+  function shortAccount(accountId) {
+    if (!accountId) return '-';
+    if (accountId.length <= 22) return accountId;
+    return accountId.slice(0, 10) + '...' + accountId.slice(-8);
+  }
+
+  function effectiveSide(result) {
+    var input = result ? result.input : params();
+    if (input.sideOverride && input.sideOverride !== 'auto') return input.sideOverride;
+    return result && result.latestSignal ? result.latestSignal.side : 'hold';
+  }
+
+  function priceForAsset(assetId, fallbackPrice) {
+    var token = state.supportedTokens.find(function (candidate) {
+      return candidate.assetId === assetId;
+    });
+    if (token && Number.isFinite(Number(token.price)) && Number(token.price) > 0) {
+      return Number(token.price);
+    }
+    if (assetId.indexOf('usdc') >= 0 || assetId.indexOf('usdt') >= 0 || assetId.indexOf('usd') >= 0) {
+      return 1;
+    }
+    return Number.isFinite(fallbackPrice) && fallbackPrice > 0 ? fallbackPrice : 1;
+  }
+
+  function decimalToAtomic(value, decimals) {
+    var safeDecimals = clamp(Math.round(Number(decimals) || 0), 0, 30);
+    var numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= 0) return '0';
+    var fixed = numeric.toFixed(Math.min(safeDecimals, 24));
+    var parts = fixed.split('.');
+    var whole = parts[0] || '0';
+    var frac = (parts[1] || '').padEnd(safeDecimals, '0').slice(0, safeDecimals);
+    var base = BigInt(10) ** BigInt(safeDecimals);
+    return (BigInt(whole) * base + BigInt(frac || '0')).toString();
+  }
+
+  function atomicToDecimalText(value, decimals) {
+    var safeDecimals = clamp(Math.round(Number(decimals) || 0), 0, 30);
+    var raw = String(value || '0').replace(/^-/, '');
+    if (!/^\d+$/.test(raw)) return String(value || '0');
+    if (safeDecimals === 0) return raw;
+    var padded = raw.padStart(safeDecimals + 1, '0');
+    var whole = padded.slice(0, -safeDecimals) || '0';
+    var frac = padded.slice(-safeDecimals).replace(/0+$/, '');
+    return frac ? whole + '.' + frac : whole;
+  }
+
+  function bytesToBase64(bytes) {
+    var binary = '';
+    bytes.forEach(function (byte) {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary);
+  }
+
+  function hexToBytes(hex) {
+    var clean = String(hex || '').replace(/^0x/, '').replace(/[^a-fA-F0-9]/g, '');
+    var bytes = new Uint8Array(clean.length / 2);
+    for (var i = 0; i < bytes.length; i += 1) {
+      bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+    }
+    return bytes;
+  }
+
+  function jsonToBase64(value) {
+    var text = JSON.stringify(value || {});
+    var bytes = new TextEncoder().encode(text);
+    return bytesToBase64(bytes);
+  }
+
+  function decodeNearViewResult(result) {
+    var bytes = new Uint8Array(result && result.result ? result.result : []);
+    var text = new TextDecoder().decode(bytes);
+    try {
+      return JSON.parse(text);
+    } catch (err) {
+      return text;
+    }
+  }
+
+  function normalizeWalletSignature(signed) {
+    var publicKey = signed.publicKey || signed.public_key || signed.publicKeyString || '';
+    var signature = signed.signature || '';
+    if (publicKey && typeof publicKey !== 'string' && publicKey.toString) {
+      publicKey = publicKey.toString();
+    }
+    if (signature && typeof signature !== 'string' && signature.toString) {
+      signature = signature.toString();
+    }
+    return {
+      publicKey: String(publicKey || ''),
+      signature: String(signature || '')
+    };
+  }
+
   function setRunState(text) {
     els.runStateLabel.textContent = text;
   }
@@ -197,6 +350,40 @@
       step.classList.toggle('is-warn', toneMap[phase] === 'warn');
       step.classList.toggle('is-error', toneMap[phase] === 'error');
     });
+  }
+
+  function setLiveMode(text) {
+    els.liveModeLabel.textContent = text;
+  }
+
+  function setLiveStep(activeStep, tone) {
+    var steps = {
+      backtest: els.liveStepBacktest,
+      quote: els.liveStepQuote,
+      sign: els.liveStepSign,
+      publish: els.liveStepPublish
+    };
+    Object.keys(steps).forEach(function (key) {
+      var el = steps[key];
+      el.classList.toggle('is-active', key === activeStep);
+      el.classList.toggle('is-warn', key === activeStep && tone === 'warn');
+      el.classList.toggle('is-error', key === activeStep && tone === 'error');
+    });
+  }
+
+  function writeLiveOutput(value) {
+    els.liveExecutionOutput.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  }
+
+  function updateWalletUi() {
+    var accountId = state.wallet.accountId;
+    els.walletPill.textContent = accountId ? shortAccount(accountId) : 'Wallet offline';
+    els.walletPill.classList.toggle('is-connected', Boolean(accountId));
+    els.walletStatusLabel.textContent = accountId ? 'Connected' : 'Not connected';
+    els.walletAccountLabel.textContent = accountId ? accountId : '-';
+    els.connectWalletBtn.textContent = accountId ? 'Connected' : 'Connect';
+    els.heroConnectBtn.textContent = accountId ? 'Wallet connected' : 'Connect wallet';
+    if (accountId) els.accountInput.value = accountId;
   }
 
   function renderStrategies() {
@@ -217,6 +404,360 @@
       });
       els.strategyDeck.appendChild(button);
     });
+  }
+
+  function updateAssetDefaults() {
+    var defaults = ASSET_BY_PAIR[els.pairSelect.value] || ASSET_BY_PAIR['NEAR-USD'];
+    els.baseAssetInput.value = defaults.base;
+    els.quoteAssetInput.value = defaults.quote;
+    els.baseDecimalsInput.value = defaults.baseDecimals;
+    els.quoteDecimalsInput.value = defaults.quoteDecimals;
+    applyKnownTokenMetadata(defaults.base, defaults.quote);
+  }
+
+  function applyKnownTokenMetadata(baseAsset, quoteAsset) {
+    if (!state.supportedTokens.length) return;
+    var base = state.supportedTokens.find(function (token) { return token.assetId === baseAsset; });
+    var quote = state.supportedTokens.find(function (token) { return token.assetId === quoteAsset; });
+    if (base && Number.isFinite(Number(base.decimals))) els.baseDecimalsInput.value = Number(base.decimals);
+    if (quote && Number.isFinite(Number(quote.decimals))) els.quoteDecimalsInput.value = Number(quote.decimals);
+  }
+
+  async function loadSupportedTokens() {
+    try {
+      var res = await fetch(ONE_CLICK_URL + '/tokens', { headers: { Accept: 'application/json' } });
+      if (!res.ok) throw new Error('1Click tokens ' + res.status);
+      var tokens = await res.json();
+      if (!Array.isArray(tokens)) return;
+      state.supportedTokens = tokens;
+      els.assetIdList.innerHTML = '';
+      tokens.slice(0, 450).forEach(function (token) {
+        if (!token.assetId) return;
+        var option = document.createElement('option');
+        option.value = token.assetId;
+        option.label = [token.symbol, token.blockchain, token.decimals + ' decimals'].filter(Boolean).join(' · ');
+        els.assetIdList.appendChild(option);
+      });
+      applyKnownTokenMetadata(els.baseAssetInput.value, els.quoteAssetInput.value);
+    } catch (err) {
+      writeLiveOutput('Token catalog unavailable from 1Click for now. You can still paste any NEAR Intents asset ID manually.');
+    }
+  }
+
+  async function nearRpcView(methodName, args) {
+    var network = els.networkSelect.value || 'mainnet';
+    var rpcUrl = NEAR_RPC[network] || NEAR_RPC.mainnet;
+    var res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'ironclaw-' + Date.now(),
+        method: 'query',
+        params: {
+          request_type: 'call_function',
+          finality: 'final',
+          account_id: INTENTS_CONTRACT,
+          method_name: methodName,
+          args_base64: jsonToBase64(args || {})
+        }
+      })
+    });
+    if (!res.ok) throw new Error('NEAR RPC ' + res.status);
+    var body = await res.json();
+    if (body.error) throw new Error(body.error.message || 'NEAR RPC error');
+    return decodeNearViewResult(body.result);
+  }
+
+  async function fetchCurrentSalt() {
+    var salt = await nearRpcView('current_salt', {});
+    var saltText = String(salt || '').replace(/^"|"$/g, '');
+    var bytes = hexToBytes(saltText);
+    if (bytes.length !== 4) throw new Error('Verifier returned invalid current_salt');
+    return bytes;
+  }
+
+  async function fetchBalances() {
+    var accountId = state.wallet.accountId || els.accountInput.value.trim();
+    if (!accountId) {
+      els.walletBalanceLabel.textContent = 'Connect first';
+      writeLiveOutput('Connect a NEAR wallet or enter a NEAR account to query Intents balances.');
+      return null;
+    }
+    try {
+      els.walletBalanceLabel.textContent = 'Querying...';
+      var input = params();
+      var balances = await nearRpcView('mt_batch_balance_of', {
+        account_id: accountId,
+        token_ids: [input.baseAsset, input.quoteAsset]
+      });
+      var baseBalance = balances && balances[0] ? balances[0] : '0';
+      var quoteBalance = balances && balances[1] ? balances[1] : '0';
+      els.walletBalanceLabel.textContent = atomicToDecimalText(baseBalance, input.baseDecimals) + ' base / ' +
+        atomicToDecimalText(quoteBalance, input.quoteDecimals) + ' quote';
+      writeLiveOutput({
+        account_id: accountId,
+        verifier_contract: INTENTS_CONTRACT,
+        balances: [
+          { asset_id: input.baseAsset, raw: baseBalance, display: atomicToDecimalText(baseBalance, input.baseDecimals) },
+          { asset_id: input.quoteAsset, raw: quoteBalance, display: atomicToDecimalText(quoteBalance, input.quoteDecimals) }
+        ]
+      });
+      return balances;
+    } catch (err) {
+      els.walletBalanceLabel.textContent = 'Balance query failed';
+      writeLiveOutput('Balance query failed: ' + (err.message || String(err)));
+      return null;
+    }
+  }
+
+  async function loadNearConnector() {
+    if (!state.nearConnectorModule) {
+      state.nearConnectorModule = await import('https://esm.sh/@hot-labs/near-connect@0.11');
+    }
+    return state.nearConnectorModule;
+  }
+
+  async function connectWallet() {
+    var network = els.networkSelect.value || 'mainnet';
+    els.connectWalletBtn.disabled = true;
+    els.heroConnectBtn.disabled = true;
+    setLiveMode('Connecting wallet');
+    writeLiveOutput('Opening NEAR wallet connector for ' + network + '.');
+    try {
+      var mod = await loadNearConnector();
+      if (!state.wallet.connector || state.wallet.network !== network) {
+        state.wallet.connector = new mod.NearConnector({ network: network });
+      }
+      state.wallet.network = network;
+      state.wallet.instance = await state.wallet.connector.connect();
+      state.wallet.accounts = await state.wallet.instance.getAccounts();
+      if (!state.wallet.accounts || !state.wallet.accounts.length) throw new Error('No NEAR account returned by wallet');
+      state.wallet.accountId = state.wallet.accounts[0].accountId;
+      updateWalletUi();
+      setLiveMode('Wallet connected');
+      writeLiveOutput('Wallet connected: ' + state.wallet.accountId + '\nRun a backtest, then click Run live once to quote and sign.');
+      fetchBalances();
+      return state.wallet.accountId;
+    } catch (err) {
+      setLiveMode('Wallet failed');
+      writeLiveOutput('Wallet connection failed: ' + (err.message || String(err)));
+      throw err;
+    } finally {
+      els.connectWalletBtn.disabled = false;
+      els.heroConnectBtn.disabled = false;
+    }
+  }
+
+  function buildLivePlan(result) {
+    if (!result) throw new Error('Run a strategy before building a live plan');
+    var input = result.input;
+    var side = effectiveSide(result);
+    if (side === 'hold') {
+      return {
+        side: 'hold',
+        reason: result.latestSignal.reason,
+        account_id: state.wallet.accountId || input.accountId,
+        strategy: input.strategy.name
+      };
+    }
+    var liveUsd = Math.min(input.liveAmountUsd, input.maxTradeUsd, input.initialCash * input.riskPct);
+    var basePrice = priceForAsset(input.baseAsset, result.latestPrice);
+    var quotePrice = priceForAsset(input.quoteAsset, 1);
+    var amountInDecimal;
+    var amountOutEstimateDecimal;
+    var assetIn;
+    var assetOut;
+    var decimalsIn;
+    var decimalsOut;
+    if (side === 'buy') {
+      assetIn = input.quoteAsset;
+      assetOut = input.baseAsset;
+      decimalsIn = input.quoteDecimals;
+      decimalsOut = input.baseDecimals;
+      amountInDecimal = liveUsd / quotePrice;
+      amountOutEstimateDecimal = (liveUsd / basePrice) * (1 - input.slippageBps / 10000);
+    } else {
+      assetIn = input.baseAsset;
+      assetOut = input.quoteAsset;
+      decimalsIn = input.baseDecimals;
+      decimalsOut = input.quoteDecimals;
+      amountInDecimal = liveUsd / basePrice;
+      amountOutEstimateDecimal = (liveUsd / quotePrice) * (1 - input.slippageBps / 10000);
+    }
+    return {
+      side: side,
+      side_source: input.sideOverride === 'auto' ? 'latest_strategy_signal' : 'manual_override',
+      account_id: state.wallet.accountId || input.accountId,
+      strategy: input.strategy.name,
+      reason: result.latestSignal.reason,
+      confidence: result.latestSignal.confidence,
+      live_cap_usd: Number(liveUsd.toFixed(6)),
+      asset_in: assetIn,
+      asset_out: assetOut,
+      decimals_in: decimalsIn,
+      decimals_out: decimalsOut,
+      amount_in_decimal: Number(amountInDecimal.toFixed(decimalsIn > 8 ? 8 : decimalsIn)),
+      amount_out_estimate_decimal: Number(amountOutEstimateDecimal.toFixed(decimalsOut > 8 ? 8 : decimalsOut)),
+      amount_in: decimalToAtomic(amountInDecimal, decimalsIn),
+      min_amount_out_estimate: decimalToAtomic(amountOutEstimateDecimal, decimalsOut),
+      slippage_bps: input.slippageBps,
+      pair: input.pair,
+      latest_price_usd: result.latestPrice
+    };
+  }
+
+  async function requestSolverQuote(plan) {
+    var apiKey = els.solverApiKeyInput.value.trim();
+    if (!apiKey) throw new Error('Solver relay JWT required for low-level quote/publish');
+    var request = {
+      id: 'ironclaw-' + Date.now(),
+      jsonrpc: '2.0',
+      method: 'quote',
+      params: [
+        {
+          defuse_asset_identifier_in: plan.asset_in,
+          defuse_asset_identifier_out: plan.asset_out,
+          exact_amount_in: plan.amount_in,
+          min_deadline_ms: 60000
+        }
+      ]
+    };
+    var res = await fetch(SOLVER_RELAY_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey
+      },
+      body: JSON.stringify(request)
+    });
+    if (!res.ok) throw new Error('Solver relay quote ' + res.status);
+    var body = await res.json();
+    if (body.error) throw new Error(body.error.message || 'Solver relay quote error');
+    var quotes = Array.isArray(body.result) ? body.result : [];
+    if (!quotes.length) throw new Error('No solver quotes returned');
+    quotes.sort(function (a, b) {
+      var aOut = BigInt(a.amount_out || '0');
+      var bOut = BigInt(b.amount_out || '0');
+      if (aOut === bOut) return 0;
+      return aOut > bOut ? -1 : 1;
+    });
+    return {
+      request: request,
+      selected: quotes[0],
+      quotes: quotes
+    };
+  }
+
+  async function requestOneClickQuote(plan, dry) {
+    var input = params();
+    var accountId = state.wallet.accountId || input.accountId;
+    if (!accountId || accountId.indexOf('<') === 0) throw new Error('Connect wallet or enter a recipient account first');
+    var headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    };
+    if (input.oneClickApiKey) headers.Authorization = 'Bearer ' + input.oneClickApiKey;
+    var request = {
+      dry: dry !== false,
+      swapType: 'EXACT_INPUT',
+      slippageTolerance: input.slippageBps,
+      originAsset: plan.asset_in,
+      depositType: 'INTENTS',
+      destinationAsset: plan.asset_out,
+      amount: plan.amount_in,
+      recipient: accountId,
+      recipientType: 'INTENTS',
+      refundTo: accountId,
+      refundType: 'INTENTS',
+      deadline: new Date(Date.now() + 5 * 60 * 1000).toISOString()
+    };
+    var res = await fetch(ONE_CLICK_URL + '/quote', {
+      method: 'POST',
+      headers: headers,
+      body: JSON.stringify(request)
+    });
+    var body = await res.json().catch(function () { return {}; });
+    if (!res.ok) throw new Error(body.message || body.error || '1Click quote ' + res.status);
+    return {
+      request: request,
+      response: body
+    };
+  }
+
+  async function signLiveIntent(plan, quote) {
+    if (!state.wallet.instance || !state.wallet.accountId) throw new Error('Connect a NEAR wallet before signing');
+    var salt = await fetchCurrentSalt();
+    var nonceBytes = new Uint8Array(32);
+    nonceBytes.set(salt, 0);
+    crypto.getRandomValues(nonceBytes.subarray(4));
+    var amountOut = quote && quote.selected && quote.selected.amount_out
+      ? quote.selected.amount_out
+      : plan.min_amount_out_estimate;
+    var message = {
+      signer_id: state.wallet.accountId,
+      deadline: new Date(Date.now() + 2 * 60 * 1000).toISOString(),
+      intents: [
+        {
+          intent: 'token_diff',
+          diff: {},
+          memo: 'ironclaw-intents-strategy:' + plan.strategy,
+          referral: 'ironclaw.near'
+        }
+      ]
+    };
+    message.intents[0].diff[plan.asset_in] = '-' + plan.amount_in;
+    message.intents[0].diff[plan.asset_out] = amountOut;
+    var payloadMessage = JSON.stringify(message);
+    var signed = await state.wallet.instance.signMessage({
+      message: payloadMessage,
+      recipient: INTENTS_CONTRACT,
+      nonce: nonceBytes
+    });
+    var normalized = normalizeWalletSignature(signed);
+    if (!normalized.signature || !normalized.publicKey) throw new Error('Wallet did not return a NEP-413 signature/public key');
+    return {
+      standard: 'nep413',
+      payload: {
+        recipient: INTENTS_CONTRACT,
+        nonce: bytesToBase64(nonceBytes),
+        message: payloadMessage
+      },
+      public_key: normalized.publicKey,
+      signature: normalized.signature
+    };
+  }
+
+  async function publishSignedIntent(signedData, quote) {
+    var apiKey = els.solverApiKeyInput.value.trim();
+    if (!apiKey) throw new Error('Solver relay JWT required to publish');
+    if (!quote || !quote.selected || !quote.selected.quote_hash) throw new Error('Solver quote hash required to publish');
+    var request = {
+      id: 'ironclaw-' + Date.now(),
+      jsonrpc: '2.0',
+      method: 'publish_intent',
+      params: [
+        {
+          quote_hashes: [quote.selected.quote_hash],
+          signed_data: signedData
+        }
+      ]
+    };
+    var res = await fetch(SOLVER_RELAY_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey
+      },
+      body: JSON.stringify(request)
+    });
+    if (!res.ok) throw new Error('Solver relay publish ' + res.status);
+    var body = await res.json();
+    if (body.error) throw new Error(body.error.message || 'Solver relay publish error');
+    return {
+      request: request,
+      response: body
+    };
   }
 
   function validateRun(input) {
@@ -242,7 +783,14 @@
     } else {
       messages.push({ tone: 'ok', text: 'Costs are included in every paper fill.' });
     }
-    messages.push({ tone: 'ok', text: 'Execution boundary is unsigned preview only; no wallet call is made.' });
+    if (!input.baseAsset || !input.quoteAsset) {
+      messages.push({ tone: 'error', text: 'Base and quote asset IDs are required for live NEAR Intents execution.' });
+    } else {
+      messages.push({ tone: 'ok', text: 'Live path can quote, sign NEP-413, and publish through the solver relay when a JWT is provided.' });
+    }
+    if (input.network !== 'mainnet') {
+      messages.push({ tone: 'warn', text: 'NEAR Intents verifier is mainnet-first; testnet wallet mode is only for connector testing.' });
+    }
     return messages;
   }
 
@@ -770,21 +1318,24 @@
   function buildIntentDraft(result) {
     if (!result) return null;
     var input = result.input;
-    var side = result.latestSignal.side;
-    var token = TOKEN_BY_PAIR[input.pair] || 'wrap.near';
-    var maxUsd = Math.min(input.maxTradeUsd, input.initialCash * input.riskPct);
+    var side = effectiveSide(result);
+    var token = input.baseAsset;
+    var quote = input.quoteAsset;
+    var maxUsd = Math.min(input.liveAmountUsd, input.maxTradeUsd, input.initialCash * input.riskPct);
     var quoteRequest = null;
     if (side === 'buy') {
       quoteRequest = {
-        sell: { asset: 'usdc.near', amount_usd_estimate: Number(maxUsd.toFixed(6)) },
-        buy: { asset: token, min_amount_usd: Number((maxUsd * (1 - input.slippageBps / 10000)).toFixed(6)) },
-        route_preference: 'best_solver_quote'
+        sell: { asset_id: quote, amount_usd_estimate: Number(maxUsd.toFixed(6)) },
+        buy: { asset_id: token, min_amount_usd: Number((maxUsd * (1 - input.slippageBps / 10000)).toFixed(6)) },
+        route_preference: 'best_solver_quote',
+        solver_method: 'quote'
       };
     } else if (side === 'sell') {
       quoteRequest = {
-        sell: { asset: token, amount_usd_estimate: Number(maxUsd.toFixed(6)) },
-        buy: { asset: 'usdc.near', min_amount_usd: Number((maxUsd * (1 - input.slippageBps / 10000)).toFixed(6)) },
-        route_preference: 'best_solver_quote'
+        sell: { asset_id: token, amount_usd_estimate: Number(maxUsd.toFixed(6)) },
+        buy: { asset_id: quote, min_amount_usd: Number((maxUsd * (1 - input.slippageBps / 10000)).toFixed(6)) },
+        route_preference: 'best_solver_quote',
+        solver_method: 'quote'
       };
     }
     var runHash = hashText(JSON.stringify({
@@ -796,15 +1347,16 @@
     }));
     return {
       schema: 'near-intents-vibetrading-lab/1',
-      mode: 'paper',
+      mode: 'paper_plus_live_execution',
       run_hash: runHash,
       created_at: new Date().toISOString(),
       source: 'VibeTrading-inspired client backtest',
-      execution_boundary: 'unsigned_preview_only',
+      execution_boundary: 'manual_wallet_signature_required',
       account_id: input.accountId,
       market: {
         pair: input.pair.replace('-', '/'),
-        token: token,
+        base_asset_id: token,
+        quote_asset_id: quote,
         data_source: state.dataSource,
         last_price_usd: result.latestPrice ? Number(result.latestPrice.toFixed(8)) : null
       },
@@ -831,18 +1383,23 @@
       },
       risk: {
         max_trade_usd: Number(input.maxTradeUsd.toFixed(6)),
+        live_cap_usd: Number(input.liveAmountUsd.toFixed(6)),
         risk_per_signal_pct: Number((input.riskPct * 100).toFixed(4)),
         fee_bps: input.feeBps,
         slippage_bps: input.slippageBps,
-        funding_asset_hint: 'any_near_intents_supported_deposit_asset',
+        funding_asset_id: quote,
+        base_decimals: input.baseDecimals,
+        quote_decimals: input.quoteDecimals,
         no_auto_signing: true,
-        no_broadcast: true
+        publish_requires_solver_jwt: true
       },
       draft_intent: {
         venue: 'near_intents',
-        deposit_model: 'direct_near_intents_balance_or_any_supported_asset',
+        verifier_contract: INTENTS_CONTRACT,
+        deposit_model: 'direct_near_intents_balance',
         solver_quote_required: side !== 'hold',
         decision: side,
+        side_source: input.sideOverride === 'auto' ? 'latest_strategy_signal' : 'manual_override',
         quote_request: quoteRequest,
         hold_reason: side === 'hold' ? result.latestSignal.reason : null,
         expires_in_seconds: 120
@@ -1022,16 +1579,164 @@
     els.eventTape.innerHTML = '';
     els.intentOutput.textContent = 'Run a strategy to prepare a NEAR Intents draft.';
     els.strategyCode.textContent = 'Run a strategy to generate code.';
+    setLiveMode('Dry run ready');
+    setLiveStep('backtest');
+    updateWalletUi();
     drawChart(null);
   }
 
   function markStale() {
+    state.isStale = true;
     setRunState('Ready');
     setPhase('describe');
+    setLiveMode('Strategy edited');
+    setLiveStep('backtest');
     els.describeStatus.textContent = 'Edited';
     els.validateStatus.textContent = 'Pending';
     els.backtestStatus.textContent = 'Pending';
     els.intentStatus.textContent = 'Unsigned';
+  }
+
+  async function ensureBacktest() {
+    if (state.result && !state.isStale) return state.result;
+    await runBacktest();
+    if (!state.result) throw new Error('Backtest did not produce a result');
+    return state.result;
+  }
+
+  function renderLivePlan(plan) {
+    state.latestLivePlan = plan;
+    if (plan.side === 'hold') {
+      writeLiveOutput({
+        status: 'hold',
+        reason: plan.reason,
+        next_step: 'No live order will be built unless you override the side.'
+      });
+      return;
+    }
+    writeLiveOutput({
+      status: 'ready_to_quote',
+      side: plan.side,
+      source: plan.side_source,
+      strategy: plan.strategy,
+      reason: plan.reason,
+      confidence: Number(plan.confidence.toFixed(4)),
+      live_cap_usd: plan.live_cap_usd,
+      quote_request: {
+        defuse_asset_identifier_in: plan.asset_in,
+        defuse_asset_identifier_out: plan.asset_out,
+        exact_amount_in: plan.amount_in,
+        human_amount_in: plan.amount_in_decimal
+      }
+    });
+  }
+
+  async function runDryQuote() {
+    setLiveStep('quote');
+    setLiveMode('Preparing quote');
+    els.dryQuoteBtn.disabled = true;
+    try {
+      var result = await ensureBacktest();
+      var plan = buildLivePlan(result);
+      renderLivePlan(plan);
+      if (plan.side === 'hold') {
+        setLiveMode('Hold signal');
+        return;
+      }
+      var dryQuote = await requestOneClickQuote(plan, true);
+      setLiveMode('1Click dry quote ready');
+      writeLiveOutput({
+        mode: 'one_click_dry_quote',
+        plan: plan,
+        quote: dryQuote,
+        note: 'This validates a deposited Intents-balance swap path. Use Run live once with a solver relay JWT to sign/publish token_diff.'
+      });
+    } catch (err) {
+      setLiveStep('quote', 'error');
+      setLiveMode('Quote failed');
+      writeLiveOutput('Dry quote failed: ' + (err.message || String(err)));
+    } finally {
+      els.dryQuoteBtn.disabled = false;
+    }
+  }
+
+  async function runLiveOnce() {
+    els.runLiveBtn.disabled = true;
+    setLiveMode('Running live once');
+    setLiveStep('backtest');
+    try {
+      if (!state.wallet.accountId) {
+        await connectWallet();
+      }
+      var result = await ensureBacktest();
+      var plan = buildLivePlan(result);
+      renderLivePlan(plan);
+      if (plan.side === 'hold') {
+        setLiveMode('Hold signal');
+        return;
+      }
+
+      var solverQuote = null;
+      setLiveStep('quote');
+      if (els.solverApiKeyInput.value.trim()) {
+        solverQuote = await requestSolverQuote(plan);
+        writeLiveOutput({
+          mode: 'solver_quote_ready',
+          plan: plan,
+          selected_quote: solverQuote.selected,
+          quote_count: solverQuote.quotes.length
+        });
+      } else {
+        var dryQuote = await requestOneClickQuote(plan, true);
+        setLiveStep('quote', 'warn');
+        writeLiveOutput({
+          mode: 'dry_quote_only',
+          plan: plan,
+          one_click_quote: dryQuote,
+          blocked_before_signature: 'Paste a solver relay JWT to request a low-level quote_hash and publish a signed token_diff intent.'
+        });
+        setLiveMode('JWT needed to publish');
+        return;
+      }
+
+      setLiveStep('sign');
+      setLiveMode('Wallet signature required');
+      var signedIntent = await signLiveIntent(plan, solverQuote);
+      state.latestSignedIntent = signedIntent;
+      state.latestIntent = {
+        plan: plan,
+        quote: solverQuote.selected,
+        signed_data: signedIntent
+      };
+      els.intentOutput.textContent = JSON.stringify(state.latestIntent, null, 2);
+      els.intentStatus.textContent = 'SIGNED';
+      writeLiveOutput({
+        mode: 'signed_nep413',
+        signed_data: signedIntent,
+        quote_hash: solverQuote.selected.quote_hash,
+        next_step: 'Publishing through solver relay.'
+      });
+
+      setLiveStep('publish');
+      setLiveMode('Publishing intent');
+      var published = await publishSignedIntent(signedIntent, solverQuote);
+      state.latestIntent.publish = published;
+      els.intentOutput.textContent = JSON.stringify(state.latestIntent, null, 2);
+      setLiveMode('Intent submitted');
+      writeLiveOutput({
+        mode: 'published',
+        plan: plan,
+        quote: solverQuote.selected,
+        publish: published
+      });
+      fetchBalances();
+    } catch (err) {
+      setLiveStep('publish', 'error');
+      setLiveMode('Live run failed');
+      writeLiveOutput('Live run failed: ' + (err.message || String(err)));
+    } finally {
+      els.runLiveBtn.disabled = false;
+    }
   }
 
   async function runBacktest() {
@@ -1044,6 +1749,7 @@
     els.describeStatus.textContent = 'Captured';
     els.runBacktestBtn.disabled = true;
     els.topRunBtn.disabled = true;
+    els.heroRunBtn.disabled = true;
     els.buildIntentBtn.disabled = true;
 
     try {
@@ -1056,6 +1762,7 @@
       await new Promise(function (resolve) { setTimeout(resolve, 70); });
       var result = runSimulation(candles, input);
       state.result = result;
+      state.isStale = false;
       state.lastRunAt = new Date();
       renderMetrics(result);
       renderSignal(result);
@@ -1066,21 +1773,25 @@
       drawChart(result);
       setPhase('intent', state.dataSource === 'Sample fallback' ? { backtest: 'warn' } : {});
       setRunState(state.dataSource === 'Sample fallback' ? 'Sample run' : 'Live data run');
+      setLiveMode('Strategy ready');
+      setLiveStep('quote');
     } catch (err) {
       setRunState('Run failed');
       setPhase('backtest', { backtest: 'error' });
+      setLiveStep('backtest', 'error');
       els.backtestStatus.textContent = 'Failed';
       els.signalTitle.textContent = 'Run failed';
       els.signalSummary.textContent = err.message || String(err);
     } finally {
       els.runBacktestBtn.disabled = false;
       els.topRunBtn.disabled = false;
+      els.heroRunBtn.disabled = false;
       els.buildIntentBtn.disabled = false;
     }
   }
 
   function buildIntentFromCurrent() {
-    if (!state.result) {
+    if (!state.result || state.isStale) {
       runBacktest();
       return;
     }
@@ -1105,21 +1816,63 @@
     });
   }
 
+  function copySigned() {
+    if (!state.latestSignedIntent) {
+      els.copySignedBtn.textContent = 'No signature';
+      setTimeout(function () {
+        els.copySignedBtn.textContent = 'Copy signed';
+      }, 1200);
+      return;
+    }
+    navigator.clipboard.writeText(JSON.stringify(state.latestSignedIntent, null, 2)).then(function () {
+      els.copySignedBtn.textContent = 'Copied';
+      setTimeout(function () {
+        els.copySignedBtn.textContent = 'Copy signed';
+      }, 1200);
+    }).catch(function () {
+      els.copySignedBtn.textContent = 'Copy failed';
+      setTimeout(function () {
+        els.copySignedBtn.textContent = 'Copy signed';
+      }, 1200);
+    });
+  }
+
   function bind() {
     renderStrategies();
     resetMetrics();
     renderValidation(validateRun(params()));
     els.runBacktestBtn.addEventListener('click', runBacktest);
     els.topRunBtn.addEventListener('click', runBacktest);
+    els.heroRunBtn.addEventListener('click', function () {
+      document.getElementById('studio').scrollIntoView({ behavior: 'smooth', block: 'start' });
+      runBacktest();
+    });
+    els.connectWalletBtn.addEventListener('click', connectWallet);
+    els.heroConnectBtn.addEventListener('click', connectWallet);
+    els.runLiveBtn.addEventListener('click', runLiveOnce);
+    els.dryQuoteBtn.addEventListener('click', runDryQuote);
+    els.fetchBalancesBtn.addEventListener('click', fetchBalances);
     els.buildIntentBtn.addEventListener('click', buildIntentFromCurrent);
     els.copyIntentBtn.addEventListener('click', copyIntent);
-    [els.strategyPrompt, els.pairSelect, els.lookbackSelect, els.balanceInput, els.accountInput, els.maxTradeInput, els.riskPctInput, els.feeBpsInput, els.slippageInput].forEach(function (el) {
+    els.copySignedBtn.addEventListener('click', copySigned);
+    els.pairSelect.addEventListener('change', function () {
+      updateAssetDefaults();
+      markStale();
+    });
+    [els.strategyPrompt, els.lookbackSelect, els.balanceInput, els.liveAmountUsdInput, els.accountInput, els.maxTradeInput, els.riskPctInput, els.feeBpsInput, els.slippageInput, els.baseAssetInput, els.quoteAssetInput, els.baseDecimalsInput, els.quoteDecimalsInput, els.networkSelect, els.sideOverrideSelect].forEach(function (el) {
       el.addEventListener('input', markStale);
       el.addEventListener('change', markStale);
+    });
+    [els.baseAssetInput, els.quoteAssetInput].forEach(function (el) {
+      el.addEventListener('change', function () {
+        applyKnownTokenMetadata(els.baseAssetInput.value, els.quoteAssetInput.value);
+      });
     });
     window.addEventListener('resize', function () {
       drawChart(state.result);
     });
+    updateWalletUi();
+    loadSupportedTokens();
     setTimeout(runBacktest, 250);
   }
 

--- a/crates/ironclaw_gateway/static/js/surfaces/projects.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/projects.js
@@ -439,6 +439,28 @@ function crOpenEngineThread(threadId) {
 
 var _projectWidgets = []; // { id, destroy }
 
+function projectWidgetScriptSource(manifest, js) {
+  return [
+    '(function() {',
+    '  var __script = document.currentScript;',
+    '  var __mountId = __script && __script.getAttribute("data-mount-id");',
+    '  var __registry = window.__IRONCLAW_PROJECT_WIDGET_MOUNTS || {};',
+    '  var __mount = __registry[__mountId];',
+    '  if (!__mount) throw new Error("Missing project widget mount: " + __mountId);',
+    '  try {',
+    '    var __destroy = (function(container, api, projectId) {',
+    js,
+    '    })(__mount.container, __mount.api, __mount.projectId);',
+    '    if (typeof __destroy === "function") __mount.destroy = __destroy;',
+    '    if (typeof __mount.onLoad === "function") __mount.onLoad();',
+    '  } catch (__err) {',
+    '    if (typeof __mount.onError === "function") { __mount.onError(__err); } else { throw __err; }',
+    '  }',
+    '})();',
+    '//# sourceURL=ironclaw-project-widget-' + manifest.id + '.js'
+  ].join('\n');
+}
+
 function loadProjectWidgets(projectId) {
   destroyProjectWidgets();
   apiFetch('/api/engine/projects/' + encodeURIComponent(projectId) + '/widgets')
@@ -466,24 +488,58 @@ function loadProjectWidgets(projectId) {
           document.head.appendChild(style);
         }
 
-        // Eval the JS module to register the widget.
+        // Run the widget as a blob-backed script. Project widget code is
+        // fetched through the authenticated API above, then executed as a
+        // same-page plugin without `unsafe-eval`.
+        var mountId = manifest.id + '-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+        var registry = window.__IRONCLAW_PROJECT_WIDGET_MOUNTS = window.__IRONCLAW_PROJECT_WIDGET_MOUNTS || {};
+        var objectUrl = null;
+        var script = null;
+        var mount = {
+          container: container,
+          api: typeof IronClaw !== 'undefined' ? IronClaw.api : null,
+          projectId: projectId,
+          destroy: null,
+          onError: function(err) {
+            console.error('[projects] Failed to mount widget ' + manifest.id + ':', err);
+            container.innerHTML = '<div class="cr-empty">Widget error: ' + manifest.id + '</div>';
+          }
+        };
+        registry[mountId] = mount;
+
         try {
-          var api = typeof IronClaw !== 'undefined' ? IronClaw.api : null;
-          var fn = new Function('container', 'api', 'projectId', w.js);
-          fn(container, api, projectId);
+          objectUrl = URL.createObjectURL(new Blob([
+            projectWidgetScriptSource(manifest, w.js)
+          ], { type: 'application/javascript' }));
+          script = document.createElement('script');
+          script.src = objectUrl;
+          script.async = false;
+          script.setAttribute('data-project-widget-script', manifest.id);
+          script.setAttribute('data-mount-id', mountId);
+          script.onerror = function() {
+            mount.onError(new Error('Failed to load widget script'));
+          };
+          document.head.appendChild(script);
 
           _projectWidgets.push({
             id: manifest.id,
             container: container,
             style: style || null,
             destroy: function() {
+              if (typeof mount.destroy === 'function') {
+                try { mount.destroy(); } catch (e) { /* ignore widget cleanup errors */ }
+              }
+              delete registry[mountId];
               container.remove();
               if (style) style.remove();
+              if (script) script.remove();
+              if (objectUrl) URL.revokeObjectURL(objectUrl);
             }
           });
         } catch (err) {
-          console.error('[projects] Failed to mount widget ' + manifest.id + ':', err);
-          container.innerHTML = '<div class="cr-empty">Widget error: ' + manifest.id + '</div>';
+          delete registry[mountId];
+          if (objectUrl) URL.revokeObjectURL(objectUrl);
+          mount.onError(err);
         }
       });
     })
@@ -1412,4 +1468,3 @@ function formatRelativeTime(isoString) {
 }
 
 // --- Users (admin) ---
-

--- a/docs/plans/2026-05-02-intents-trading-research.md
+++ b/docs/plans/2026-05-02-intents-trading-research.md
@@ -138,6 +138,13 @@ Minimum framework requirements before a strategy can build an intent:
 - Added `portfolio.plan_dripstack_browse` to model topic →
   publication → article → purchase-confirmation guided browse before a
   selected article becomes a paid-source candidate.
+- Added `portfolio.prepare_dripstack_paid_fetch` to make the one-article
+  DripStack confirmation, 402 challenge, and receipt-backed retry
+  boundary explicit without signing or reading paid text inside the
+  portfolio tool.
+- Added `portfolio.plan_near_intents_trial` so a user can rehearse the
+  workflow with a nominal NEAR wallet, strategy gates, setup steps, and
+  a generated unsigned `build_intent` request.
 - Added replay scenarios for individual strategies, suite ranking, and
   a swap-shaped unsigned intent bundle.
 - Added the first bundled strategy corpus:
@@ -150,6 +157,9 @@ Minimum framework requirements before a strategy can build an intent:
 - Added paid research attribution to the widget so selected sources,
   MPP/x402 rails, and NEAR funding-route hints are visible before any
   unsigned intent is built.
+- Added nominal NEAR trial status to the widget so the operator can see
+  wallet budget, quote readiness, setup steps, and trial gates without
+  reading JSON.
 
 ## Multi-Day Roadmap
 
@@ -157,6 +167,6 @@ Minimum framework requirements before a strategy can build an intent:
 |---|---|---|
 | M1 data ingestion | CoinGecko/CCXT CSV import, Hyperliquid candle snapshot recorder, Dune/NEAR portfolio context. | Backtests can run from saved market-data episodes, not hand-written candles. |
 | M2 strategy lab | Parameter grids, walk-forward splits, regime splits, benchmark comparisons, strategy doc thresholds. | A strategy report shows train/test windows, drawdown, turnover, and rejection reasons. |
-| M3 risk/intent bridge | Map approved suite results to `MovementPlan`, quote replay, solver refusal tests, route expiry tests, widget state updates. | A paper-intent can be rebuilt deterministically from research + backtest + quote fixture and inspected in the Projects UI. |
+| M3 risk/intent bridge | Map approved suite results to `MovementPlan`, quote replay, solver refusal tests, route expiry tests, nominal trial state, widget state updates. | A paper-intent can be rebuilt deterministically from research + backtest + quote fixture and inspected in the Projects UI. |
 | M4 portals and HL signals | Hyperliquid funding/book/candle adapters, DefiLlama risk context, optional CoinGecko fallback. | HL data is used as signal/risk context without pretending to execute perps. |
 | M5 UI/mission | Widget for watchlist, ranked strategies, risk gates, pending intents, and paper PnL journal. | User can inspect the autonomous run without reading JSON. |

--- a/docs/plans/2026-05-02-near-intents-trial-runbook.md
+++ b/docs/plans/2026-05-02-near-intents-trial-runbook.md
@@ -68,6 +68,11 @@ Useful docs:
    `solver="near-intents"` and remains unsigned.
 7. Write widget state with `format_intents_widget`, including
    `trial_plan`.
+8. In the Projects view, use the NEAR Intents Console ticket controls to
+   adjust nominal budget, trade cap, funding path, and selected
+   strategy. Its action buttons write the exact next IronClaw prompt for
+   trial planning, backtesting, fixture intent construction, paid
+   research, or unsigned live quote requests.
 
 ## What To Watch
 

--- a/docs/plans/2026-05-02-near-intents-trial-runbook.md
+++ b/docs/plans/2026-05-02-near-intents-trial-runbook.md
@@ -18,11 +18,17 @@ wallet while keeping every agent-produced artifact unsigned.
 
 ## NEAR Intents Funding Notes
 
-Current NEAR Intents docs say the verifier accepts wrapped/tokenized
-assets, not raw native NEAR transfers. For a native NEAR trial, wrap NEAR
-to wNEAR first, then use the verifier deposit flow. The bridge/deposit
-service is available at `https://bridge.chaindefuser.com/rpc`, and the
-solver relay is at `https://solver-relay-v2.chaindefuser.com/rpc`.
+NEAR Intents supports deposits across supported assets through higher
+level routes such as the 1Click Swap API and the Deposit/Withdrawal
+Service. If you use those routes, native NEAR wrapping can be handled for
+you. The manual warning in this runbook is narrower: when integrating
+directly with the Verifier contract, it accepts NEP-141 token balances,
+so native NEAR is represented as wNEAR (`nep141:wrap.near`) and raw
+native NEAR should not be sent directly to `intents.near`.
+
+The bridge/deposit service is available at
+`https://bridge.chaindefuser.com/rpc`, and the solver relay is at
+`https://solver-relay-v2.chaindefuser.com/rpc`.
 
 Useful docs:
 

--- a/docs/plans/2026-05-02-near-intents-trial-runbook.md
+++ b/docs/plans/2026-05-02-near-intents-trial-runbook.md
@@ -1,0 +1,73 @@
+# Nominal NEAR Intents Trial Runbook
+
+**Date**: 2026-05-02
+
+This runbook is for testing the Intents Trading Agent with a small NEAR
+wallet while keeping every agent-produced artifact unsigned.
+
+## Safety Model
+
+- Use a separate NEAR account funded only with the amount you are
+  willing to test.
+- Start with `mode="paper"` and `solver="fixture"`.
+- Move to `mode="quote"` only after backtest and risk gates pass.
+- The agent never sees private keys, seed phrases, wallet exports, or
+  signing material.
+- A live quote is not an executed trade. Wallet signing remains outside
+  IronClaw.
+
+## NEAR Intents Funding Notes
+
+Current NEAR Intents docs say the verifier accepts wrapped/tokenized
+assets, not raw native NEAR transfers. For a native NEAR trial, wrap NEAR
+to wNEAR first, then use the verifier deposit flow. The bridge/deposit
+service is available at `https://bridge.chaindefuser.com/rpc`, and the
+solver relay is at `https://solver-relay-v2.chaindefuser.com/rpc`.
+
+Useful docs:
+
+- [Deposit/Withdrawal Service](https://docs.near-intents.org/integration/market-makers/deposit-withdrawal-service)
+- [Verifier deposits](https://docs.near-intents.org/near-intents/market-makers/verifier/deposits-and-withdrawals/deposits)
+- [Solver relay API](https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay)
+- [Intent types and execution](https://docs.near-intents.org/integration/verifier-contract/intent-types-and-execution)
+
+## IronClaw Flow
+
+1. Run `portfolio.backtest_suite` with fresh OHLCV candles and the
+   bundled strategy menu.
+2. Run `portfolio.plan_near_intents_trial`:
+
+```json
+{
+  "action": "plan_near_intents_trial",
+  "near_account_id": "your-small-test-account.near",
+  "mode": "paper",
+  "pair": "NEAR/USDC",
+  "nominal_near": 0.25,
+  "max_trade_near": 0.05,
+  "assumed_near_usd": 3.0,
+  "max_slippage_bps": 50,
+  "backtest_suite": {}
+}
+```
+
+3. Persist the returned `near-intents-trial-plan/1` under
+   `projects/intents-trading-agent/trials/`.
+4. If `safe_to_quote=false`, stop.
+5. In paper mode, run the returned `build_intent_request`; it uses
+   `solver="fixture"`.
+6. If the user explicitly requests a live quote later, rerun
+   `plan_near_intents_trial` with `mode="quote"` and fresh prices, then
+   run the returned `build_intent_request`; it uses
+   `solver="near-intents"` and remains unsigned.
+7. Write widget state with `format_intents_widget`, including
+   `trial_plan`.
+
+## What To Watch
+
+- Very small routes may fail solver minimums. Do not auto-increase size.
+- Recompute NEAR/USD before quote mode; the default price is only a
+  sizing placeholder.
+- Do not use paid research text unless a receipt-backed fetch succeeded.
+- Record every quote/intent artifact in the project journal before
+  asking the user whether to sign.

--- a/docs/plans/2026-05-02-paid-research-intents.md
+++ b/docs/plans/2026-05-02-paid-research-intents.md
@@ -83,6 +83,20 @@ flowchart LR
     without fetching the article body,
   - includes both MPP and x402 payment options for the selected article.
 
+- `portfolio.fetch_dripstack_catalog`
+  - fetches DripStack's free publication catalog,
+  - fetches free post-title metadata for a chosen publication,
+  - keeps the paid article body route out of automatic discovery.
+
+- `portfolio.prepare_dripstack_paid_fetch`
+  - prepares the one-article paid fetch boundary after a user selects a
+    DripStack post,
+  - separates confirmation, HTTP 402 challenge collection, and
+    receipt-backed retry headers,
+  - supports MPP `Authorization: Payment ...` and x402
+    `PAYMENT-SIGNATURE` handoff metadata,
+  - does not sign payments, mint receipts, or read paid article bodies.
+
 - `portfolio.format_intents_widget`
   - accepts `paid_research_plan`,
   - exposes `paid_research` in the widget state,
@@ -100,8 +114,8 @@ flowchart LR
 
 | Next PR | What to build | Done when |
 |---|---|---|
-| Source discovery adapters | Parse MPP/OpenAPI `x-payment-info`, x402 discovery, DripStack catalogs, and local `sources/paid-research.json`. | Agent can populate candidate sources without manual JSON. |
-| Payment client boundary | Add a wallet/payment-client abstraction for MPP/x402 challenge handling with receipts, never private keys. | Paid content fetch returns receipt metadata and content only after approval. |
+| Source discovery adapters | Extend beyond the DripStack free catalog adapter into generic MPP/OpenAPI `x-payment-info`, x402 discovery, and local `sources/paid-research.json`. | Agent can populate candidate sources without manual JSON. |
+| Payment client boundary | Connect `prepare_dripstack_paid_fetch` to a wallet/payment-client abstraction for live MPP/x402 challenge handling with receipts, never private keys. | Paid content fetch returns receipt metadata and content only after approval. |
 | NEAR funding route builder | Convert `near_funding_routes` into unsigned NEAR Intent funding bundles for rail wallets. | User can inspect/sign a funding intent before MPP/x402 fetch. |
 | Evidence ledger | Persist paid source receipts, content hashes, quote snippets, and answer attribution. | A journal entry can prove which writer/source contributed to which answer. |
 | Research-to-backtest loop | Track whether paid evidence changed candidate strategies and compare outcomes. | Strategy reports show paid-source deltas vs free-source baseline. |

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -4,7 +4,7 @@
   "kind": "tool",
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, nominal NEAR trial planning, and NEAR Intents trading widget state.",
   "keywords": [
     "defi",
     "portfolio",
@@ -19,7 +19,9 @@
     "x402",
     "mpp",
     "dripstack",
-    "agent-wallet"
+    "agent-wallet",
+    "near-trial",
+    "paper-trading"
   ],
   "source": {
     "dir": "tools-src/portfolio",

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -42,9 +42,12 @@ bundles** that the user can inspect and sign in their own wallet.
 
 This skill is a research and orchestration layer. It does not replace
 the `portfolio` WASM tool. Use `portfolio.scan`, `portfolio.propose`,
-`portfolio.plan_paid_research`, and `portfolio.build_intent` for
-positions, deterministic DeFi proposals, paid-source budgeting, and
-intent bundle construction.
+`portfolio.plan_near_intents_trial`, `portfolio.plan_paid_research`,
+`portfolio.fetch_dripstack_catalog`,
+`portfolio.prepare_dripstack_paid_fetch`, and `portfolio.build_intent`
+for positions, deterministic DeFi proposals, nominal-wallet rehearsals,
+free DripStack catalog access, paid-source budgeting/fetch boundaries,
+and intent bundle construction.
 
 ## Non-negotiables
 
@@ -97,6 +100,9 @@ using workspace writes. Initialize:
   "paid_research_per_article_cap_usd": 0.05,
   "paid_research_daily_cap_usd": 1.0,
   "paid_research_max_wallet_balance_usd": 5.0,
+  "trial_nominal_near": 0.25,
+  "trial_max_trade_near": 0.05,
+  "trial_pair": "NEAR/USDC",
   "require_user_approval": true
 }
 ```
@@ -108,7 +114,7 @@ using workspace writes. Initialize:
   payment metadata discovered from MPP, x402, NEAR-native, newsletter, or
   API catalogs.
 - `research/`, `debates/`, `decisions/`, `risk/`, `intents/`,
-  `journal/`, `paid-research/`, and `widgets/`.
+  `journal/`, `paid-research/`, `trials/`, and `widgets/`.
 - `strategies/` - copy or reference the baseline strategy docs bundled
   with this skill (`sma-cross-spot`, `breakout-spot`,
   `momentum-spot`, `mean-reversion-spot`,
@@ -197,12 +203,29 @@ the guided flow:
 6. Convert that article into a paid-source candidate.
 7. Only then pass the candidate to `plan_paid_research`.
 
-The deterministic helper for this is `portfolio.plan_dripstack_browse`.
-It accepts free publication/post metadata and returns one of these
-checkpoints: `topic`, `publication`, `article`, or
+Use `portfolio.fetch_dripstack_catalog` to fetch only DripStack's free
+publication catalog and free post-title metadata. Then pass that free
+metadata to `portfolio.plan_dripstack_browse`. The planner returns one
+of these checkpoints: `topic`, `publication`, `article`, or
 `purchase-confirmation`. A `purchase-confirmation` output includes a
 `paid_source_candidate` with both MPP and x402 payment options when the
 article came from DripStack.
+
+When the user confirms a specific paid DripStack article, first call
+`portfolio.prepare_dripstack_paid_fetch`. It creates the explicit
+confirmation/challenge/receipt boundary for one article:
+
+- `needs-user-confirmation`: ask the user before touching the paid route.
+- `needs-402-challenge`: probe the paid endpoint only to collect the
+  HTTP 402 payment challenge; do not summarize substitute content.
+- `ready-to-retry-with-receipt`: a payment-aware client supplied an MPP
+  or x402 receipt header and the next GET can unlock that one article.
+
+The live 402 challenge is authoritative for price and payment details.
+Current DripStack OpenAPI describes paid article routes as returning
+MPP `WWW-Authenticate` and x402 `PAYMENT-REQUIRED` challenges, with a
+fallback paid-route minimum around `$0.05` when no per-post price is
+available. Do not assume the old one-cent estimate is final.
 
 Call `portfolio` with:
 
@@ -307,6 +330,48 @@ Reject or downgrade to `watch` if:
 Always run `buy-hold` as a benchmark when enough candles are available.
 Always present the top ranked suite candidates and rejected candidates
 separately so the user can see what was considered.
+
+### 4.5 Nominal NEAR trial mode
+
+If the user wants to try the system with a small amount of NEAR, keep
+the first pass in paper mode and call `portfolio.plan_near_intents_trial`.
+
+Example:
+
+```json
+{
+  "action": "plan_near_intents_trial",
+  "near_account_id": "<optional-user-account.near>",
+  "mode": "paper",
+  "pair": "NEAR/USDC",
+  "nominal_near": 0.25,
+  "max_trade_near": 0.05,
+  "assumed_near_usd": 3.0,
+  "max_slippage_bps": 50,
+  "backtest_suite": {}
+}
+```
+
+Persist the returned `near-intents-trial-plan/1` to
+`projects/intents-trading-agent/trials/<YYYY-MM-DDTHH-MM>-near-trial.json`.
+
+Use the trial plan as the operator runbook:
+
+- The wallet should be a separate small NEAR account, not the user's
+  main wallet.
+- Native NEAR must be wrapped to wNEAR before verifier funding; do not
+  transfer raw native NEAR directly to the verifier.
+- The verifier deposit step is manual/user-wallet controlled.
+- `mode="paper"` means run the returned `build_intent_request` with
+  `solver="fixture"`.
+- `mode="quote"` means all paper gates passed and the user explicitly
+  asked for a live NEAR Intents quote; the output is still unsigned.
+- `mode="execution"` is informational only here. This skill still does
+  not sign or submit trades.
+- If the trial plan has `safe_to_quote=false`, do not request a live
+  quote.
+- Very small route sizes may be refused or dominated by minimums. Warn
+  the user rather than increasing size automatically.
 
 ### 5. Bull/bear debate
 
@@ -424,17 +489,17 @@ Persist returned bundles to
 
 After every run, call `portfolio` with `action="format_intents_widget"`
 and pass the latest pair, stance, confidence, `backtest_suite`, risk
-gates, research sources, optional `paid_research_plan`, and optional
-unsigned `IntentBundle`.
+gates, research sources, optional `trial_plan`, optional
+`paid_research_plan`, and optional unsigned `IntentBundle`.
 
 Persist the returned JSON exactly as:
 
 `projects/intents-trading-agent/widgets/state.json`
 
 The bundled project widget reads this file and renders ranked strategy
-candidates, paid source attribution, risk gates, and unsigned NEAR
-Intents status inside the IronClaw Projects view. If the widget files are
-not installed yet, copy:
+candidates, nominal NEAR trial status, paid source attribution, risk
+gates, and unsigned NEAR Intents status inside the IronClaw Projects
+view. If the widget files are not installed yet, copy:
 
 - `skills/intents-trading-agent/widgets/near-intents-console/manifest.json`
 - `skills/intents-trading-agent/widgets/near-intents-console/index.js`
@@ -452,6 +517,8 @@ Respond with specifics:
 - top supporting and opposing evidence,
 - paid source budget, selected sources, and receipt status if premium
   research was planned or used,
+- nominal NEAR trial budget, setup step status, and whether it is safe
+  to request a live quote,
 - backtest summary versus buy-and-hold when available,
 - top strategy-suite candidates when available,
 - risk gate table,

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -359,8 +359,11 @@ Use the trial plan as the operator runbook:
 
 - The wallet should be a separate small NEAR account, not the user's
   main wallet.
-- Native NEAR must be wrapped to wNEAR before verifier funding; do not
-  transfer raw native NEAR directly to the verifier.
+- If the user funds through 1Click Swap or the Deposit/Withdrawal
+  Service, native NEAR wrapping/routing may be handled by that service.
+  If funding the Verifier contract directly, use wNEAR
+  (`nep141:wrap.near`) rather than transferring raw native NEAR to
+  `intents.near`.
 - The verifier deposit step is manual/user-wallet controlled.
 - `mode="paper"` means run the returned `build_intent_request` with
   `solver="fixture"`.

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -499,10 +499,13 @@ Persist the returned JSON exactly as:
 
 `projects/intents-trading-agent/widgets/state.json`
 
-The bundled project widget reads this file and renders ranked strategy
-candidates, nominal NEAR trial status, paid source attribution, risk
-gates, and unsigned NEAR Intents status inside the IronClaw Projects
-view. If the widget files are not installed yet, copy:
+The bundled project widget reads this file and renders an interactive
+IronClaw Projects workflow: trial ticket inputs, funding-path selection,
+ranked/selectable strategies, paper intent status, guarded live-quote
+handoff, paid source attribution, risk gates, and unsigned NEAR Intents
+status. The widget writes precise prompts back into chat; it does not
+hold wallet keys, sign payloads, or submit trades. If the widget files
+are not installed yet, copy:
 
 - `skills/intents-trading-agent/widgets/near-intents-console/manifest.json`
 - `skills/intents-trading-agent/widgets/near-intents-console/index.js`

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -2,6 +2,8 @@ var root = document.createElement('section');
 root.className = 'ita-console';
 container.appendChild(root);
 
+var itaLastState = null;
+
 function itaEscape(value) {
   var div = document.createElement('div');
   div.textContent = value == null ? '' : String(value);
@@ -27,12 +29,63 @@ function itaScore(value) {
   return n.toFixed(2);
 }
 
+function itaMoney(value) {
+  var n = Number(value || 0);
+  return '$' + n.toFixed(n < 1 ? 4 : 2);
+}
+
+function itaNumber(value, fallback) {
+  if (value === '') return fallback;
+  var n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 function itaStatusClass(status) {
   var s = String(status || 'unknown').toLowerCase();
-  if (s === 'pass' || s === 'paper-built' || s === 'live-quote-built') return 'is-pass';
-  if (s === 'warn' || s === 'awaiting-signature' || s === 'watch') return 'is-warn';
+  if (s === 'pass' || s === 'paper-built' || s === 'live-quote-built' || s === 'ready') return 'is-pass';
+  if (s === 'warn' || s === 'awaiting-signature' || s === 'watch' || s === 'manual') return 'is-warn';
   if (s === 'fail' || s === 'failed' || s === 'blocked') return 'is-fail';
   return 'is-neutral';
+}
+
+function itaStoreKey() {
+  return 'ironclaw.intentsTradingAgent.ticket';
+}
+
+function itaReadPrefs() {
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    return JSON.parse(localStorage.getItem(itaStoreKey()) || '{}') || {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function itaSavePrefs(prefs) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(itaStoreKey(), JSON.stringify(prefs || {}));
+}
+
+function itaTrialDefaults(state) {
+  var plan = state && state.trial_plan ? state.trial_plan : {};
+  var prefs = itaReadPrefs();
+  return {
+    pair: prefs.pair || plan.pair || (state && state.pair) || 'NEAR/USDC',
+    mode: prefs.mode || plan.mode || (state && state.mode) || 'paper',
+    nearAccount: prefs.nearAccount || '',
+    nominalNear: itaNumber(prefs.nominalNear, itaNumber(plan.nominal_near, 0.25)),
+    maxTradeNear: itaNumber(prefs.maxTradeNear, itaNumber(plan.max_trade_near, 0.05)),
+    assumedNearUsd: itaNumber(prefs.assumedNearUsd, itaNumber(plan.assumed_near_usd, 3.0)),
+    maxSlippageBps: itaNumber(prefs.maxSlippageBps, 50),
+    selectedStrategyId: prefs.selectedStrategyId || plan.selected_strategy_id || plan.recommended_strategy_id || itaFirstStrategyId(state),
+    fundingPath: prefs.fundingPath || 'managed'
+  };
+}
+
+function itaPersistPref(name, value) {
+  var prefs = itaReadPrefs();
+  prefs[name] = value;
+  itaSavePrefs(prefs);
 }
 
 function itaReadState(slug) {
@@ -61,28 +114,162 @@ function itaLoadProjectSlug() {
     });
 }
 
-function itaCandidateRows(candidates) {
-  if (!Array.isArray(candidates) || candidates.length === 0) {
-    return '<div class="ita-empty-line">No ranked strategies yet.</div>';
-  }
-  return '<div class="ita-table" role="table" aria-label="Ranked strategy candidates">'
-    + candidates.map(function(c) {
-      return '<div class="ita-row" role="row">'
-        + '<div class="ita-rank">#' + itaEscape(c.rank || '-') + '</div>'
-        + '<div class="ita-strategy">'
-        + '<strong>' + itaEscape(c.id || 'candidate') + '</strong>'
-        + '<span>' + itaEscape(c.strategy_kind || 'strategy') + '</span>'
-        + '</div>'
-        + '<div class="ita-metric"><span>Score</span><strong>' + itaScore(c.selection_score) + '</strong></div>'
-        + '<div class="ita-metric"><span>Return</span><strong>' + itaPct(c.total_return_pct) + '</strong></div>'
-        + '<div class="ita-metric"><span>Alpha</span><strong>' + itaPct(c.alpha_vs_buy_hold_pct) + '</strong></div>'
-        + '<div class="ita-metric"><span>DD</span><strong>' + itaPct(-Math.abs(Number(c.max_drawdown_pct || 0))) + '</strong></div>'
-        + '<div class="ita-gate ' + (c.passes_basic_gate ? 'is-pass' : 'is-fail') + '">'
-        + (c.passes_basic_gate ? 'Gate pass' : 'Gate fail')
-        + '</div>'
+function itaAllStrategies(state) {
+  var seen = {};
+  var out = [];
+  var top = Array.isArray(state && state.top_candidates) ? state.top_candidates : [];
+  var menu = state && state.trial_plan && Array.isArray(state.trial_plan.strategy_menu)
+    ? state.trial_plan.strategy_menu
+    : [];
+
+  top.forEach(function(candidate) {
+    if (!candidate || seen[candidate.id]) return;
+    seen[candidate.id] = true;
+    out.push({
+      id: candidate.id,
+      kind: candidate.strategy_kind || 'strategy',
+      rank: candidate.rank,
+      score: candidate.selection_score,
+      returnPct: candidate.total_return_pct,
+      alphaPct: candidate.alpha_vs_buy_hold_pct,
+      drawdownPct: candidate.max_drawdown_pct,
+      trades: candidate.trades,
+      passes: !!candidate.passes_basic_gate,
+      note: 'Backtested candidate'
+    });
+  });
+
+  menu.forEach(function(strategy) {
+    if (!strategy || seen[strategy.id]) return;
+    seen[strategy.id] = true;
+    out.push({
+      id: strategy.id,
+      kind: strategy.kind || 'strategy',
+      rank: null,
+      score: null,
+      returnPct: null,
+      alphaPct: null,
+      drawdownPct: null,
+      trades: null,
+      passes: null,
+      note: strategy.note || '',
+      sizePct: strategy.position_size_pct,
+      stopLossBps: strategy.stop_loss_bps
+    });
+  });
+
+  return out;
+}
+
+function itaFirstStrategyId(state) {
+  var strategies = itaAllStrategies(state || {});
+  return strategies.length ? strategies[0].id : 'sma_cross_fast';
+}
+
+function itaWorkflow(state) {
+  var plan = state && state.trial_plan;
+  var candidates = Array.isArray(state && state.top_candidates) ? state.top_candidates : [];
+  var passing = candidates.some(function(candidate) { return candidate.passes_basic_gate; });
+  var intent = state && state.intent;
+  var paperBuilt = !!intent && (intent.status === 'paper-built' || intent.status === 'live-quote-built');
+  var quoteBuilt = !!intent && intent.status === 'live-quote-built';
+  return [
+    { label: 'Ticket', status: plan ? 'pass' : 'warn', detail: plan ? 'Trial plan ready' : 'Needs plan' },
+    { label: 'Backtest', status: passing ? 'pass' : candidates.length ? 'fail' : 'warn', detail: passing ? 'Passing strategy' : 'Run suite' },
+    { label: 'Paper', status: paperBuilt ? 'pass' : 'warn', detail: paperBuilt ? 'Fixture built' : 'Build fixture' },
+    { label: 'Quote', status: quoteBuilt ? 'pass' : plan && plan.safe_to_quote ? 'ready' : 'blocked', detail: quoteBuilt ? 'Live quote built' : plan && plan.safe_to_quote ? 'Ready' : 'Blocked' }
+  ];
+}
+
+function itaPhaseRail(state) {
+  return '<div class="ita-phases" aria-label="Trial workflow">'
+    + itaWorkflow(state).map(function(phase, index) {
+      return '<div class="ita-phase ' + itaStatusClass(phase.status) + '">'
+        + '<span>' + (index + 1) + '</span>'
+        + '<strong>' + itaEscape(phase.label) + '</strong>'
+        + '<small>' + itaEscape(phase.detail) + '</small>'
         + '</div>';
     }).join('')
     + '</div>';
+}
+
+function itaTicket(state, prefs) {
+  var modeOptions = ['paper', 'quote', 'execution'];
+  var fundingOptions = [
+    { id: 'managed', label: '1Click / Deposit API' },
+    { id: 'direct', label: 'Direct Verifier' }
+  ];
+
+  return '<section class="ita-ticket">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Trial Ticket</div><p>Nominal NEAR sizing, route mode, and funding path.</p></div></div>'
+    + '<div class="ita-ticket-grid">'
+    + itaField('Pair', 'pair', prefs.pair, 'text', 'NEAR/USDC')
+    + itaField('NEAR account', 'nearAccount', prefs.nearAccount, 'text', 'small-test.near')
+    + itaField('Budget NEAR', 'nominalNear', prefs.nominalNear, 'number', '0.25', '0.01', '0.01')
+    + itaField('Trade cap NEAR', 'maxTradeNear', prefs.maxTradeNear, 'number', '0.05', '0.01', '0.01')
+    + itaField('NEAR USD', 'assumedNearUsd', prefs.assumedNearUsd, 'number', '3.00', '0.01', '0.01')
+    + itaField('Slippage bps', 'maxSlippageBps', prefs.maxSlippageBps, 'number', '50', '1', '1')
+    + '</div>'
+    + '<div class="ita-segments" role="group" aria-label="Mode">'
+    + modeOptions.map(function(mode) {
+      return '<button type="button" class="' + (prefs.mode === mode ? 'is-selected' : '') + '" data-pref-button="mode" data-value="' + itaEscape(mode) + '">' + itaEscape(mode) + '</button>';
+    }).join('')
+    + '</div>'
+    + '<div class="ita-segments" role="group" aria-label="Funding path">'
+    + fundingOptions.map(function(option) {
+      return '<button type="button" class="' + (prefs.fundingPath === option.id ? 'is-selected' : '') + '" data-pref-button="fundingPath" data-value="' + itaEscape(option.id) + '">' + itaEscape(option.label) + '</button>';
+    }).join('')
+    + '</div>'
+    + '</section>';
+}
+
+function itaField(label, name, value, type, placeholder, step, min) {
+  return '<label class="ita-field">'
+    + '<span>' + itaEscape(label) + '</span>'
+    + '<input data-pref="' + itaEscape(name) + '" type="' + itaEscape(type) + '" value="' + itaEscape(value == null ? '' : value) + '" placeholder="' + itaEscape(placeholder || '') + '"'
+    + (step ? ' step="' + itaEscape(step) + '"' : '')
+    + (min ? ' min="' + itaEscape(min) + '"' : '')
+    + '>'
+    + '</label>';
+}
+
+function itaStrategyLab(state, prefs) {
+  var strategies = itaAllStrategies(state);
+  if (!strategies.length) {
+    strategies = [{
+      id: prefs.selectedStrategyId || 'sma_cross_fast',
+      kind: 'sma-cross',
+      rank: null,
+      score: null,
+      returnPct: null,
+      alphaPct: null,
+      drawdownPct: null,
+      trades: null,
+      passes: null,
+      note: 'Default strategy menu loads after plan_near_intents_trial.'
+    }];
+  }
+
+  return '<section class="ita-strategy-lab">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Strategy Lab</div><p>Select a strategy before paper or quote mode.</p></div>'
+    + '<button type="button" data-run="backtest">Run Backtest Suite</button></div>'
+    + '<div class="ita-strategy-list">'
+    + strategies.map(function(strategy) {
+      var selected = prefs.selectedStrategyId === strategy.id;
+      var gate = strategy.passes == null ? 'manual' : strategy.passes ? 'pass' : 'fail';
+      return '<button type="button" class="ita-strategy-row ' + (selected ? 'is-selected ' : '') + itaStatusClass(gate) + '" data-strategy="' + itaEscape(strategy.id) + '">'
+        + '<span class="ita-rank">' + (strategy.rank ? '#' + itaEscape(strategy.rank) : '-') + '</span>'
+        + '<span class="ita-strategy-name"><strong>' + itaEscape(strategy.id) + '</strong><small>' + itaEscape(strategy.kind) + '</small></span>'
+        + '<span><small>Score</small><strong>' + (strategy.score == null ? '-' : itaScore(strategy.score)) + '</strong></span>'
+        + '<span><small>Return</small><strong>' + (strategy.returnPct == null ? '-' : itaPct(strategy.returnPct)) + '</strong></span>'
+        + '<span><small>Alpha</small><strong>' + (strategy.alphaPct == null ? '-' : itaPct(strategy.alphaPct)) + '</strong></span>'
+        + '<span><small>DD</small><strong>' + (strategy.drawdownPct == null ? '-' : itaPct(-Math.abs(Number(strategy.drawdownPct || 0)))) + '</strong></span>'
+        + '<span class="ita-pill ' + itaStatusClass(gate) + '">' + itaEscape(gate) + '</span>'
+        + (strategy.note ? '<em>' + itaEscape(strategy.note) + '</em>' : '')
+        + '</button>';
+    }).join('')
+    + '</div>'
+    + '</section>';
 }
 
 function itaRiskGates(gates) {
@@ -125,9 +312,68 @@ function itaIntent(intent) {
     + '</div>';
 }
 
-function itaMoney(value) {
-  var n = Number(value || 0);
-  return '$' + n.toFixed(n < 1 ? 4 : 2);
+function itaTrialPlan(plan) {
+  if (!plan) {
+    return '<div class="ita-empty-line">No nominal NEAR trial plan recorded.</div>';
+  }
+  return '<div class="ita-trial">'
+    + '<div class="ita-trial-bar">'
+    + '<div><span>Budget</span><strong>' + itaEscape(plan.nominal_near || 0) + ' NEAR</strong></div>'
+    + '<div><span>Trade cap</span><strong>' + itaEscape(plan.max_trade_near || 0) + ' NEAR</strong></div>'
+    + '<div><span>USD est.</span><strong>' + itaMoney(plan.max_trade_usd) + '</strong></div>'
+    + '<div><span>Quote</span><strong>' + (plan.safe_to_quote ? 'Ready' : 'Blocked') + '</strong></div>'
+    + '</div>'
+    + (plan.next_action ? '<div class="ita-trial-next">' + itaEscape(plan.next_action) + '</div>' : '')
+    + '</div>';
+}
+
+function itaSetupPanel(state) {
+  var plan = state && state.trial_plan;
+  var steps = plan && Array.isArray(plan.setup_steps) ? plan.setup_steps : [];
+  var gates = []
+    .concat(Array.isArray(state && state.risk_gates) ? state.risk_gates : [])
+    .concat(plan && Array.isArray(plan.risk_gates) ? plan.risk_gates : []);
+  var warnings = plan && Array.isArray(plan.warnings) ? plan.warnings : [];
+
+  return '<section class="ita-setup">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Funding And Gates</div><p>Wallet setup, quote blockers, and signing boundary.</p></div></div>'
+    + (steps.length ? '<div class="ita-steps">'
+      + steps.map(function(step) {
+        return '<div><span>' + itaEscape(step.order || '') + '</span><strong>' + itaEscape(step.name || 'Step') + '</strong><small>' + itaEscape(step.status || 'manual') + '</small><p>' + itaEscape(step.detail || '') + '</p></div>';
+      }).join('')
+      + '</div>' : '<div class="ita-empty-line">No setup steps recorded.</div>')
+    + '<div class="ita-section-title ita-tight-title">Risk Gates</div>'
+    + itaRiskGates(gates)
+    + (warnings.length ? '<div class="ita-warnings">'
+      + warnings.map(function(warning) { return '<span>' + itaEscape(warning) + '</span>'; }).join('')
+      + '</div>' : '')
+    + '</section>';
+}
+
+function itaRunPanel(state, prefs) {
+  var plan = state && state.trial_plan;
+  var quoteReady = !!(plan && plan.safe_to_quote);
+  var hasPlan = !!plan;
+  var intent = state && state.intent;
+  var hasPaperIntent = !!intent && (intent.status === 'paper-built' || intent.status === 'live-quote-built');
+
+  return '<section class="ita-run-panel">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Paper And Quote</div><p>Build fixture first, then request an unsigned live quote.</p></div></div>'
+    + '<div class="ita-run-grid">'
+    + '<div><span>Selected</span><strong>' + itaEscape(prefs.selectedStrategyId || '-') + '</strong></div>'
+    + '<div><span>Mode</span><strong>' + itaEscape(prefs.mode) + '</strong></div>'
+    + '<div><span>Funding</span><strong>' + itaEscape(prefs.fundingPath === 'direct' ? 'Direct Verifier' : '1Click / Deposit API') + '</strong></div>'
+    + '<div><span>Live quote</span><strong>' + (quoteReady ? 'Ready' : 'Blocked') + '</strong></div>'
+    + '</div>'
+    + itaTrialPlan(plan)
+    + itaIntent(intent)
+    + '<div class="ita-run-actions">'
+    + '<button type="button" data-run="plan">Plan Trial</button>'
+    + '<button type="button" data-run="paper" ' + (hasPlan ? '' : 'disabled') + '>Build Paper Intent</button>'
+    + '<button type="button" data-run="quote" ' + (quoteReady && hasPaperIntent ? '' : 'disabled') + '>Request Live Quote</button>'
+    + '<button type="button" data-run="paid">Paid Research</button>'
+    + '</div>'
+    + '</section>';
 }
 
 function itaPaidResearch(plan) {
@@ -136,8 +382,6 @@ function itaPaidResearch(plan) {
   }
   var sources = Array.isArray(plan.payable_sources) ? plan.payable_sources : [];
   var rails = Array.isArray(plan.payment_rails) ? plan.payment_rails : [];
-  var routes = Array.isArray(plan.near_funding_routes) ? plan.near_funding_routes : [];
-  var gates = Array.isArray(plan.policy_gates) ? plan.policy_gates : [];
   var wallet = plan.wallet_policy || null;
   return '<div class="ita-paid">'
     + '<div class="ita-paid-bar">'
@@ -153,7 +397,7 @@ function itaPaidResearch(plan) {
     + (sources.length ? sources.map(function(source) {
       return '<div class="ita-source-line">'
         + '<div><strong>' + itaEscape(source.title || source.id) + '</strong>'
-        + '<span>' + itaEscape(source.author || 'Unknown author') + ' · ' + itaEscape(source.protocol || 'manual') + ' / ' + itaEscape(source.network || 'manual') + '</span></div>'
+        + '<span>' + itaEscape(source.author || 'Unknown author') + ' / ' + itaEscape(source.protocol || 'manual') + ' / ' + itaEscape(source.network || 'manual') + '</span></div>'
         + '<div class="ita-source-price">' + itaMoney(source.amount_usd) + '</div>'
         + (source.receipt_required ? '<span class="ita-pill is-warn">Receipt</span>' : '<span class="ita-pill is-pass">Free</span>')
         + '</div>';
@@ -164,127 +408,171 @@ function itaPaidResearch(plan) {
     + (rails.length ? rails.map(function(rail) {
       return '<div class="ita-rail-line"><span>' + itaEscape(rail.protocol || 'manual') + '</span><strong>' + itaMoney(rail.allocated_usd) + '</strong></div>';
     }).join('') : '<div class="ita-empty-line">No payment rails.</div>')
-    + (routes.length ? '<div class="ita-route-note">' + routes.map(function(route) {
-      return itaEscape(route.via || 'near-intents') + ' -> ' + itaEscape(route.target_protocol || 'rail') + ' ' + itaMoney(route.amount_usd);
-    }).join('<br>') + '</div>' : '')
-    + '</div>'
-    + '</div>'
     + (wallet ? '<div class="ita-wallet-line">'
-      + '<div><span>Agent Wallet</span><strong>' + itaEscape(wallet.provider || 'Agent wallet') + ' · ' + itaEscape(wallet.network || 'base') + '</strong></div>'
+      + '<div><span>Agent Wallet</span><strong>' + itaEscape(wallet.provider || 'Agent wallet') + ' / ' + itaEscape(wallet.network || 'base') + '</strong></div>'
       + '<div><span>Balance</span><strong>' + itaMoney(wallet.balance_usd) + '</strong></div>'
-      + '<div><span>Articles</span><strong>' + itaEscape(wallet.max_articles_at_default_price || 0) + '</strong></div>'
       + '<span class="ita-pill ' + (wallet.safe_to_autopay ? 'is-pass' : 'is-warn') + '">' + (wallet.safe_to_autopay ? 'Policy OK' : 'Approval') + '</span>'
-      + '</div>'
-      + (Array.isArray(wallet.audit_urls) && wallet.audit_urls.length ? '<div class="ita-audit-links">'
-        + wallet.audit_urls.map(function(url) {
-          return '<a href="' + itaEscape(url) + '" target="_blank" rel="noreferrer">' + itaEscape(String(url).replace(/^https?:\/\//, '').replace(/\/$/, '')) + '</a>';
-        }).join('')
-        + '</div>' : '') : '')
-    + (gates.length ? '<div class="ita-paid-gates">' + itaRiskGates(gates) + '</div>' : '')
+      + '</div>' : '')
+    + '</div>'
+    + '</div>'
     + '</div>';
 }
 
-function itaTrialPlan(plan) {
-  if (!plan) {
-    return '<div class="ita-empty-line">No nominal NEAR trial plan recorded.</div>';
-  }
-  var steps = Array.isArray(plan.setup_steps) ? plan.setup_steps : [];
-  var gates = Array.isArray(plan.risk_gates) ? plan.risk_gates : [];
-  return '<div class="ita-trial">'
-    + '<div class="ita-trial-bar">'
-    + '<div><span>Budget</span><strong>' + itaEscape(plan.nominal_near || 0) + ' NEAR</strong></div>'
-    + '<div><span>Trade cap</span><strong>' + itaEscape(plan.max_trade_near || 0) + ' NEAR</strong></div>'
-    + '<div><span>USD est.</span><strong>' + itaMoney(plan.max_trade_usd) + '</strong></div>'
-    + '<div><span>Quote</span><strong>' + (plan.safe_to_quote ? 'Ready' : 'Blocked') + '</strong></div>'
-    + '</div>'
-    + '<div class="ita-trial-meta">'
-    + '<span class="ita-pill ' + itaStatusClass(plan.safe_to_quote ? 'pass' : 'blocked') + '">' + itaEscape(plan.mode || 'paper') + '</span>'
-    + (plan.recommended_strategy_id ? '<strong>' + itaEscape(plan.recommended_strategy_id) + '</strong>' : '<strong>No strategy selected</strong>')
-    + '<span>' + itaEscape(plan.pair || 'NEAR/USDC') + '</span>'
-    + '</div>'
-    + (steps.length ? '<div class="ita-trial-steps">'
-      + steps.slice(0, 5).map(function(step) {
-        return '<div><span>' + itaEscape(step.order || '') + '</span><strong>' + itaEscape(step.name || 'Step') + '</strong><small>' + itaEscape(step.status || 'manual') + '</small></div>';
-      }).join('')
-      + '</div>' : '')
-    + (gates.length ? '<div class="ita-trial-gates">' + itaRiskGates(gates.slice(0, 5)) + '</div>' : '')
-    + (plan.next_action ? '<div class="ita-trial-next">' + itaEscape(plan.next_action) + '</div>' : '')
-    + '</div>';
+function itaPaidPanel(state) {
+  return '<section class="ita-paid-panel">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Research Budget</div><p>Paid-source spend and receipt readiness.</p></div>'
+    + '<button type="button" data-run="paid">Prepare Paid Research</button></div>'
+    + itaPaidResearch(state && state.paid_research)
+    + '</section>';
+}
+
+function itaCleanPayload(payload) {
+  var out = {};
+  Object.keys(payload).forEach(function(key) {
+    var value = payload[key];
+    if (value === undefined || value === null || value === '') return;
+    out[key] = value;
+  });
+  return out;
+}
+
+function itaTrialPayload(state, prefs, mode) {
+  return itaCleanPayload({
+    action: 'plan_near_intents_trial',
+    near_account_id: prefs.nearAccount,
+    mode: mode || prefs.mode || 'paper',
+    pair: prefs.pair || 'NEAR/USDC',
+    nominal_near: itaNumber(prefs.nominalNear, 0.25),
+    max_trade_near: itaNumber(prefs.maxTradeNear, 0.05),
+    assumed_near_usd: itaNumber(prefs.assumedNearUsd, 3.0),
+    max_slippage_bps: Math.round(itaNumber(prefs.maxSlippageBps, 50)),
+    selected_strategy_id: prefs.selectedStrategyId
+  });
 }
 
 function itaWritePrompt(kind, state) {
   if (api && api.navigate) api.navigate('chat');
   var input = document.getElementById('chat-input');
   if (!input) return;
-  var pair = state && state.pair ? state.pair : 'the watched pair';
-  input.value = kind === 'trial'
-    ? 'For the Intents Trading Agent, prepare a nominal NEAR trial for ' + pair + ': use paper mode first, cap the trial wallet, show the strategy menu, run backtest_suite before any live quote, and keep all NEAR Intents payloads unsigned.'
-    : kind === 'paid'
-    ? 'For the Intents Trading Agent, build a paid research plan for ' + pair + ' first: discover MPP/x402/NEAR payable sources, enforce the source budget, require receipts before use, then run backtest_suite and risk gates before any unsigned NEAR intent.'
-    : kind === 'quote'
-    ? 'For the Intents Trading Agent, request a live NEAR Intents quote for ' + pair + ' only if all current risk gates still pass. Keep it unsigned.'
-    : 'For the Intents Trading Agent, run the paper NEAR Intents workflow for ' + pair + ': research, backtest_suite, risk gates, and unsigned intent preview.';
+
+  var prefs = itaTrialDefaults(state || {});
+  var pair = prefs.pair || 'NEAR/USDC';
+  var payloadMode = kind === 'quote' ? 'quote' : kind === 'paper' ? 'paper' : prefs.mode || 'paper';
+  var funding = prefs.fundingPath === 'direct'
+    ? 'direct Verifier funding: use wNEAR/nep141:wrap.near for direct deposits and keep signing in the wallet'
+    : 'managed 1Click or Deposit/Withdrawal Service funding: let the service route/wrap supported assets where applicable';
+  var trialPayload = itaTrialPayload(state, prefs, payloadMode);
+  var text;
+
+  if (kind === 'plan') {
+    text = 'Build and persist the nominal NEAR Intents trial frontend state.\n\nRun portfolio.plan_near_intents_trial with:\n```json\n'
+      + JSON.stringify(trialPayload, null, 2)
+      + '\n```\nFunding path selected in the UI: ' + funding
+      + '\n\nThen run portfolio.format_intents_widget with the trial_plan, latest backtest_suite if available, and write the result to projects/intents-trading-agent/widgets/state.json.';
+  } else if (kind === 'backtest') {
+    text = 'Run a fresh backtest suite for the Intents Trading Agent on ' + pair + '. Include the default strategy menu plus the selected strategy `'
+      + (prefs.selectedStrategyId || 'sma_cross_fast')
+      + '`, rank by risk-adjusted return, reject lookahead bias, then refresh projects/intents-trading-agent/widgets/state.json with portfolio.format_intents_widget.';
+  } else if (kind === 'paper') {
+    text = 'Build the paper NEAR Intents run for ' + pair + '. Use the latest near-intents-trial-plan/1, selected strategy `'
+      + (prefs.selectedStrategyId || 'sma_cross_fast')
+      + '`, and solver=fixture. Keep the output unsigned, persist the intent preview, and refresh the widget state.';
+  } else if (kind === 'quote') {
+    text = 'Request an unsigned live NEAR Intents quote for ' + pair + ' only if all current trial and strategy gates still pass.\n\nFirst rerun portfolio.plan_near_intents_trial in quote mode with:\n```json\n'
+      + JSON.stringify(trialPayload, null, 2)
+      + '\n```\nThen build_intent with solver=near-intents. Do not sign, submit, or increase the trade size automatically. Funding path: ' + funding + '. Refresh the widget state with the unsigned quote preview.';
+  } else {
+    text = 'Prepare paid research for ' + pair + ' before any live quote. Use free DripStack catalog/title routes first, require explicit user confirmation before paid bodies, require payment receipts, enforce a small spend cap, then refresh the Intents Trading Agent widget.';
+  }
+
+  input.value = text;
   input.focus();
+  input.dispatchEvent(new Event('input', { bubbles: true }));
   if (typeof autoGrow === 'function') autoGrow(input);
 }
 
+function itaWire(state) {
+  root.querySelectorAll('[data-pref]').forEach(function(input) {
+    input.addEventListener('input', function() {
+      var name = input.getAttribute('data-pref');
+      var value = input.type === 'number' && input.value !== '' ? Number(input.value) : input.value;
+      itaPersistPref(name, value);
+    });
+  });
+
+  root.querySelectorAll('[data-pref-button]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      itaPersistPref(button.getAttribute('data-pref-button'), button.getAttribute('data-value'));
+      itaRender(state);
+    });
+  });
+
+  root.querySelectorAll('[data-strategy]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      itaPersistPref('selectedStrategyId', button.getAttribute('data-strategy'));
+      itaRender(state);
+    });
+  });
+
+  root.querySelectorAll('[data-run]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      if (button.disabled) return;
+      itaWritePrompt(button.getAttribute('data-run'), state);
+    });
+  });
+}
+
 function itaRender(state) {
-  var statusClass = itaStatusClass(state.stance);
+  itaLastState = state;
+  var prefs = itaTrialDefaults(state || {});
+  var statusClass = itaStatusClass(state && state.stance);
+  var generatedAt = state && state.generated_at ? state.generated_at : '-';
+  var sourceCount = state && state.paid_research ? state.paid_research.selected_count : state && state.source_count || 0;
+
   root.innerHTML = '<div class="ita-head">'
     + '<div>'
     + '<div class="ita-kicker">NEAR Intents Trading Agent</div>'
-    + '<h3>' + itaEscape(state.pair || 'Watchlist') + '</h3>'
+    + '<h3>' + itaEscape(prefs.pair || state.pair || 'Watchlist') + '</h3>'
     + '</div>'
     + '<div class="ita-head-actions">'
-    + '<span class="ita-pill ' + statusClass + '">' + itaEscape(state.stance || 'watch') + '</span>'
-    + '<button type="button" data-action="ita-refresh">Refresh</button>'
+    + '<span class="ita-pill ' + statusClass + '">' + itaEscape(state && state.stance || 'watch') + '</span>'
+    + '<button type="button" data-action="refresh">Refresh</button>'
     + '</div>'
     + '</div>'
     + '<div class="ita-summary">'
-    + '<div><span>Mode</span><strong>' + itaEscape(state.mode || 'paper') + '</strong></div>'
-    + '<div><span>Confidence</span><strong>' + (state.confidence == null ? '-' : Math.round(Number(state.confidence) * 100) + '%') + '</strong></div>'
-    + '<div><span>Sources</span><strong>' + itaEscape(state.paid_research ? state.paid_research.selected_count : state.source_count || 0) + '</strong></div>'
-    + '<div><span>Updated</span><strong>' + itaEscape(state.generated_at || '-') + '</strong></div>'
+    + '<div><span>Mode</span><strong>' + itaEscape(prefs.mode) + '</strong></div>'
+    + '<div><span>Confidence</span><strong>' + (state && state.confidence == null ? '-' : Math.round(Number(state && state.confidence || 0) * 100) + '%') + '</strong></div>'
+    + '<div><span>Sources</span><strong>' + itaEscape(sourceCount) + '</strong></div>'
+    + '<div><span>Updated</span><strong>' + itaEscape(generatedAt) + '</strong></div>'
     + '</div>'
-    + '<div class="ita-body">'
-    + '<section><div class="ita-section-title">Nominal NEAR Trial</div>' + itaTrialPlan(state.trial_plan) + '</section>'
-    + '<section><div class="ita-section-title">Paid Research</div>' + itaPaidResearch(state.paid_research) + '</section>'
-    + '<section><div class="ita-section-title">Strategy Suite</div>' + itaCandidateRows(state.top_candidates) + '</section>'
-    + '<section><div class="ita-section-title">Risk Gates</div>' + itaRiskGates(state.risk_gates) + '</section>'
-    + '<section><div class="ita-section-title">Unsigned Intent</div>' + itaIntent(state.intent) + '</section>'
+    + itaPhaseRail(state || {})
+    + '<div class="ita-workspace">'
+    + '<div class="ita-primary">'
+    + itaTicket(state || {}, prefs)
+    + itaStrategyLab(state || {}, prefs)
+    + itaRunPanel(state || {}, prefs)
     + '</div>'
-    + (state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '')
-    + '<div class="ita-actions">'
-    + '<button type="button" data-action="ita-trial">Prepare NEAR Trial</button>'
-    + '<button type="button" data-action="ita-paid">Prepare Paid Research</button>'
-    + '<button type="button" data-action="ita-paper">Prepare Paper Run</button>'
-    + '<button type="button" data-action="ita-quote">Prepare Live Quote Request</button>'
-    + '</div>';
+    + '<div class="ita-secondary">'
+    + itaSetupPanel(state || {})
+    + itaPaidPanel(state || {})
+    + '</div>'
+    + '</div>'
+    + (state && state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '');
 
-  root.querySelector('[data-action="ita-refresh"]').addEventListener('click', itaLoad);
-  root.querySelector('[data-action="ita-trial"]').addEventListener('click', function() {
-    itaWritePrompt('trial', state);
-  });
-  root.querySelector('[data-action="ita-paid"]').addEventListener('click', function() {
-    itaWritePrompt('paid', state);
-  });
-  root.querySelector('[data-action="ita-paper"]').addEventListener('click', function() {
-    itaWritePrompt('paper', state);
-  });
-  root.querySelector('[data-action="ita-quote"]').addEventListener('click', function() {
-    itaWritePrompt('quote', state);
-  });
+  var refresh = root.querySelector('[data-action="refresh"]');
+  if (refresh) refresh.addEventListener('click', itaLoad);
+  itaWire(state || {});
 }
 
 function itaRenderEmpty() {
   root.innerHTML = '<div class="ita-empty">'
     + '<div class="ita-kicker">NEAR Intents Trading Agent</div>'
     + '<h3>No console state yet</h3>'
-    + '<p>Run the paper workflow to produce ranked strategies, risk gates, and an unsigned intent preview.</p>'
-    + '<button type="button" data-action="ita-paper-empty">Prepare Paper Run</button>'
+    + '<p>Start with a nominal NEAR trial ticket and fixture-only paper run.</p>'
+    + '<button type="button" data-run="plan">Plan Trial</button>'
     + '</div>';
-  root.querySelector('[data-action="ita-paper-empty"]').addEventListener('click', function() {
-    itaWritePrompt('paper', { pair: 'the configured watchlist' });
+  root.querySelector('[data-run="plan"]').addEventListener('click', function() {
+    itaWritePrompt('plan', { pair: 'NEAR/USDC', mode: 'paper' });
   });
 }
 

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -184,12 +184,42 @@ function itaPaidResearch(plan) {
     + '</div>';
 }
 
+function itaTrialPlan(plan) {
+  if (!plan) {
+    return '<div class="ita-empty-line">No nominal NEAR trial plan recorded.</div>';
+  }
+  var steps = Array.isArray(plan.setup_steps) ? plan.setup_steps : [];
+  var gates = Array.isArray(plan.risk_gates) ? plan.risk_gates : [];
+  return '<div class="ita-trial">'
+    + '<div class="ita-trial-bar">'
+    + '<div><span>Budget</span><strong>' + itaEscape(plan.nominal_near || 0) + ' NEAR</strong></div>'
+    + '<div><span>Trade cap</span><strong>' + itaEscape(plan.max_trade_near || 0) + ' NEAR</strong></div>'
+    + '<div><span>USD est.</span><strong>' + itaMoney(plan.max_trade_usd) + '</strong></div>'
+    + '<div><span>Quote</span><strong>' + (plan.safe_to_quote ? 'Ready' : 'Blocked') + '</strong></div>'
+    + '</div>'
+    + '<div class="ita-trial-meta">'
+    + '<span class="ita-pill ' + itaStatusClass(plan.safe_to_quote ? 'pass' : 'blocked') + '">' + itaEscape(plan.mode || 'paper') + '</span>'
+    + (plan.recommended_strategy_id ? '<strong>' + itaEscape(plan.recommended_strategy_id) + '</strong>' : '<strong>No strategy selected</strong>')
+    + '<span>' + itaEscape(plan.pair || 'NEAR/USDC') + '</span>'
+    + '</div>'
+    + (steps.length ? '<div class="ita-trial-steps">'
+      + steps.slice(0, 5).map(function(step) {
+        return '<div><span>' + itaEscape(step.order || '') + '</span><strong>' + itaEscape(step.name || 'Step') + '</strong><small>' + itaEscape(step.status || 'manual') + '</small></div>';
+      }).join('')
+      + '</div>' : '')
+    + (gates.length ? '<div class="ita-trial-gates">' + itaRiskGates(gates.slice(0, 5)) + '</div>' : '')
+    + (plan.next_action ? '<div class="ita-trial-next">' + itaEscape(plan.next_action) + '</div>' : '')
+    + '</div>';
+}
+
 function itaWritePrompt(kind, state) {
   if (api && api.navigate) api.navigate('chat');
   var input = document.getElementById('chat-input');
   if (!input) return;
   var pair = state && state.pair ? state.pair : 'the watched pair';
-  input.value = kind === 'paid'
+  input.value = kind === 'trial'
+    ? 'For the Intents Trading Agent, prepare a nominal NEAR trial for ' + pair + ': use paper mode first, cap the trial wallet, show the strategy menu, run backtest_suite before any live quote, and keep all NEAR Intents payloads unsigned.'
+    : kind === 'paid'
     ? 'For the Intents Trading Agent, build a paid research plan for ' + pair + ' first: discover MPP/x402/NEAR payable sources, enforce the source budget, require receipts before use, then run backtest_suite and risk gates before any unsigned NEAR intent.'
     : kind === 'quote'
     ? 'For the Intents Trading Agent, request a live NEAR Intents quote for ' + pair + ' only if all current risk gates still pass. Keep it unsigned.'
@@ -217,6 +247,7 @@ function itaRender(state) {
     + '<div><span>Updated</span><strong>' + itaEscape(state.generated_at || '-') + '</strong></div>'
     + '</div>'
     + '<div class="ita-body">'
+    + '<section><div class="ita-section-title">Nominal NEAR Trial</div>' + itaTrialPlan(state.trial_plan) + '</section>'
     + '<section><div class="ita-section-title">Paid Research</div>' + itaPaidResearch(state.paid_research) + '</section>'
     + '<section><div class="ita-section-title">Strategy Suite</div>' + itaCandidateRows(state.top_candidates) + '</section>'
     + '<section><div class="ita-section-title">Risk Gates</div>' + itaRiskGates(state.risk_gates) + '</section>'
@@ -224,12 +255,16 @@ function itaRender(state) {
     + '</div>'
     + (state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '')
     + '<div class="ita-actions">'
+    + '<button type="button" data-action="ita-trial">Prepare NEAR Trial</button>'
     + '<button type="button" data-action="ita-paid">Prepare Paid Research</button>'
     + '<button type="button" data-action="ita-paper">Prepare Paper Run</button>'
     + '<button type="button" data-action="ita-quote">Prepare Live Quote Request</button>'
     + '</div>';
 
   root.querySelector('[data-action="ita-refresh"]').addEventListener('click', itaLoad);
+  root.querySelector('[data-action="ita-trial"]').addEventListener('click', function() {
+    itaWritePrompt('trial', state);
+  });
   root.querySelector('[data-action="ita-paid"]').addEventListener('click', function() {
     itaWritePrompt('paid', state);
   });

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -3,7 +3,7 @@
   padding: 16px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--panel) 92%, var(--accent-subtle) 8%);
+  background: color-mix(in srgb, var(--panel) 94%, var(--surface) 6%);
   color: var(--text);
 }
 
@@ -30,11 +30,26 @@
 }
 
 .ita-head-actions,
-.ita-actions {
+.ita-section-head,
+.ita-run-actions,
+.ita-segments {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.ita-section-head {
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.ita-section-head p,
+.ita-empty p {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  margin: 2px 0 0;
 }
 
 .ita-console button {
@@ -54,8 +69,18 @@
   background: var(--accent-subtle);
 }
 
-.ita-pill,
-.ita-gate {
+.ita-console button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.ita-console button.is-selected,
+.ita-strategy-row.is-selected {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent-subtle) 72%, var(--surface) 28%);
+}
+
+.ita-pill {
   align-items: center;
   border: 1px solid var(--border);
   border-radius: 999px;
@@ -69,18 +94,20 @@
 }
 
 .ita-pill.is-pass,
-.ita-gate.is-pass {
+.ita-phase.is-pass span,
+.ita-strategy-row.is-pass .ita-pill {
   border-color: color-mix(in srgb, var(--success) 45%, var(--border) 55%);
   color: var(--success);
 }
 
-.ita-pill.is-warn {
+.ita-pill.is-warn,
+.ita-phase.is-warn span {
   border-color: color-mix(in srgb, var(--warning) 45%, var(--border) 55%);
   color: var(--warning);
 }
 
 .ita-pill.is-fail,
-.ita-gate.is-fail {
+.ita-phase.is-fail span {
   border-color: color-mix(in srgb, var(--error) 45%, var(--border) 55%);
   color: var(--error);
 }
@@ -89,30 +116,52 @@
   color: var(--text-secondary);
 }
 
-.ita-summary {
+.ita-summary,
+.ita-phases,
+.ita-ticket-grid,
+.ita-run-grid,
+.ita-trial-bar,
+.ita-intent-grid,
+.ita-paid-bar {
   display: grid;
   gap: 8px;
+}
+
+.ita-summary {
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
 .ita-summary > div,
-.ita-intent-grid > div {
+.ita-run-grid > div,
+.ita-trial-bar > div,
+.ita-intent-grid > div,
+.ita-paid-bar > div {
   border-top: 1px solid var(--border);
   padding-top: 8px;
 }
 
 .ita-summary span,
+.ita-run-grid span,
+.ita-trial-bar span,
 .ita-intent-grid span,
-.ita-metric span {
+.ita-paid-bar span,
+.ita-source-line span,
+.ita-wallet-line span,
+.ita-subtitle {
   color: var(--text-muted);
   display: block;
   font-size: var(--text-xs);
 }
 
 .ita-summary strong,
+.ita-run-grid strong,
+.ita-trial-bar strong,
 .ita-intent-grid strong,
-.ita-metric strong {
+.ita-paid-bar strong,
+.ita-source-line strong,
+.ita-rail-line strong,
+.ita-wallet-line strong {
   color: var(--text);
   display: block;
   font-size: var(--text-sm);
@@ -122,39 +171,134 @@
   white-space: nowrap;
 }
 
-.ita-body {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.9fr);
+.ita-phases {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-bottom: 16px;
 }
 
-.ita-body section:first-child,
-.ita-body section:nth-child(2),
-.ita-body section:nth-child(5) {
-  grid-column: 1 / -1;
+.ita-phase {
+  border-top: 1px solid var(--border);
+  min-height: 62px;
+  padding-top: 8px;
+}
+
+.ita-phase span {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: var(--text-xs);
+  font-weight: 800;
+  height: 22px;
+  justify-content: center;
+  width: 22px;
+}
+
+.ita-phase strong,
+.ita-phase small {
+  display: block;
+}
+
+.ita-phase strong {
+  font-size: var(--text-sm);
+  margin-top: 6px;
+}
+
+.ita-phase small {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  margin-top: 2px;
+}
+
+.ita-workspace {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.8fr);
+}
+
+.ita-primary,
+.ita-secondary {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+
+.ita-ticket,
+.ita-strategy-lab,
+.ita-run-panel,
+.ita-setup,
+.ita-paid-panel {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
 }
 
 .ita-section-title {
   color: var(--text-secondary);
   font-size: var(--text-sm);
   font-weight: 700;
-  margin-bottom: 8px;
 }
 
-.ita-table,
-.ita-gates {
+.ita-tight-title {
+  margin-top: 14px;
+}
+
+.ita-ticket-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 10px;
+}
+
+.ita-field span {
+  color: var(--text-muted);
+  display: block;
+  font-size: var(--text-xs);
+  margin-bottom: 4px;
+}
+
+.ita-field input {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font: inherit;
+  min-height: 34px;
+  padding: 6px 8px;
+  width: 100%;
+}
+
+.ita-field input:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.ita-segments {
+  margin-top: 8px;
+}
+
+.ita-segments button {
+  min-width: 96px;
+}
+
+.ita-strategy-list {
   display: grid;
   gap: 6px;
 }
 
-.ita-row {
+.ita-strategy-row {
   align-items: center;
   display: grid;
   gap: 8px;
-  grid-template-columns: 42px minmax(120px, 1.3fr) repeat(4, minmax(66px, 0.55fr)) 86px;
-  min-height: 54px;
-  padding: 8px 0;
-  border-top: 1px solid var(--border);
+  grid-template-columns: 42px minmax(150px, 1.35fr) repeat(4, minmax(62px, 0.5fr)) 82px;
+  min-height: 58px;
+  padding: 8px;
+  text-align: left;
+}
+
+.ita-strategy-row em {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-style: normal;
+  grid-column: 2 / -1;
+  line-height: 1.35;
 }
 
 .ita-rank {
@@ -162,18 +306,131 @@
   font-weight: 800;
 }
 
-.ita-strategy strong,
-.ita-strategy span {
+.ita-strategy-name strong,
+.ita-strategy-name small,
+.ita-strategy-row span small,
+.ita-strategy-row span strong {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.ita-strategy span {
+.ita-strategy-name small,
+.ita-strategy-row span small {
   color: var(--text-muted);
   font-size: var(--text-xs);
   margin-top: 2px;
+}
+
+.ita-run-grid,
+.ita-trial-bar,
+.ita-intent-grid,
+.ita-paid-bar {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ita-trial,
+.ita-intent,
+.ita-paid {
+  border-top: 1px solid var(--border);
+  margin-top: 12px;
+  padding-top: 10px;
+}
+
+.ita-trial-next,
+.ita-next,
+.ita-intent-empty,
+.ita-empty-line,
+.ita-loading {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.ita-trial-next,
+.ita-next {
+  border-top: 1px solid var(--border);
+  line-height: 1.5;
+  margin-top: 10px;
+  padding-top: 8px;
+}
+
+.ita-intent-main {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.ita-intent-main > span:last-child {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.ita-minout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.ita-minout span,
+.ita-warnings span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  padding: 4px 8px;
+}
+
+.ita-run-actions {
+  margin-top: 12px;
+}
+
+.ita-steps {
+  display: grid;
+  gap: 8px;
+}
+
+.ita-steps > div {
+  border-top: 1px solid var(--border);
+  min-height: 64px;
+  padding-top: 8px;
+}
+
+.ita-steps span {
+  color: var(--accent);
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.ita-steps strong,
+.ita-steps small {
+  display: inline-block;
+}
+
+.ita-steps strong {
+  font-size: var(--text-sm);
+  margin: 2px 8px 0 0;
+}
+
+.ita-steps small {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.ita-steps p {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.45;
+  margin: 4px 0 0;
+}
+
+.ita-gates {
+  display: grid;
+  gap: 6px;
 }
 
 .ita-gate-row {
@@ -192,84 +449,14 @@
   color: var(--text-muted);
   font-size: var(--text-xs);
   grid-column: 1 / -1;
+  line-height: 1.4;
 }
 
-.ita-intent {
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
-}
-
-.ita-intent-main {
-  align-items: center;
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
-}
-
-.ita-intent-main > span:last-child,
-.ita-next,
-.ita-intent-empty,
-.ita-empty-line,
-.ita-loading {
-  color: var(--text-muted);
-  font-size: var(--text-sm);
-}
-
-.ita-intent-grid {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.ita-minout {
+.ita-warnings {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 10px;
-}
-
-.ita-minout span {
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
-  padding: 4px 8px;
-}
-
-.ita-paid {
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
-}
-
-.ita-paid-bar {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.ita-paid-bar > div {
-  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  padding-top: 8px;
-}
-
-.ita-paid-bar span,
-.ita-source-line span,
-.ita-subtitle {
-  color: var(--text-muted);
-  display: block;
-  font-size: var(--text-xs);
-}
-
-.ita-paid-bar strong,
-.ita-source-line strong,
-.ita-rail-line strong {
-  display: block;
-  font-size: var(--text-sm);
-  margin-top: 2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .ita-paid-query {
@@ -281,7 +468,7 @@
 .ita-paid-lanes {
   display: grid;
   gap: 16px;
-  grid-template-columns: minmax(0, 1.25fr) minmax(220px, 0.75fr);
+  grid-template-columns: minmax(0, 1.2fr) minmax(180px, 0.8fr);
   margin-top: 12px;
 }
 
@@ -323,220 +510,72 @@
   text-transform: uppercase;
 }
 
-.ita-route-note {
-  border-top: 1px solid var(--border);
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  line-height: 1.5;
-  margin-top: 8px;
-  padding-top: 8px;
-}
-
-.ita-paid-gates {
-  margin-top: 12px;
-}
-
 .ita-wallet-line {
-  align-items: center;
   border-top: 1px solid var(--border);
   display: grid;
   gap: 8px;
-  grid-template-columns: minmax(0, 1fr) 84px 76px auto;
+  grid-template-columns: minmax(0, 1fr) 84px;
   margin-top: 12px;
   min-height: 48px;
   padding-top: 8px;
-}
-
-.ita-wallet-line span,
-.ita-audit-links a {
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-}
-
-.ita-wallet-line strong {
-  display: block;
-  font-size: var(--text-sm);
-  margin-top: 2px;
-}
-
-.ita-trial {
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
-}
-
-.ita-trial-bar {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.ita-trial-bar > div {
-  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  padding-top: 8px;
-}
-
-.ita-trial-bar span,
-.ita-trial-meta span,
-.ita-trial-steps small,
-.ita-trial-next {
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-}
-
-.ita-trial-bar strong {
-  display: block;
-  font-size: var(--text-sm);
-  margin-top: 2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ita-trial-meta {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 10px;
-}
-
-.ita-trial-meta strong {
-  font-size: var(--text-sm);
-}
-
-.ita-trial-steps {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  margin-top: 12px;
-}
-
-.ita-trial-steps > div {
-  border-top: 1px solid var(--border);
-  min-height: 58px;
-  padding-top: 8px;
-}
-
-.ita-trial-steps span {
-  color: var(--accent);
-  display: block;
-  font-size: var(--text-xs);
-  font-weight: 800;
-}
-
-.ita-trial-steps strong,
-.ita-trial-steps small {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ita-trial-steps strong {
-  font-size: var(--text-sm);
-  margin-top: 2px;
-}
-
-.ita-trial-gates {
-  margin-top: 12px;
-}
-
-.ita-trial-next {
-  border-top: 1px solid var(--border);
-  line-height: 1.5;
-  margin-top: 10px;
-  padding-top: 8px;
-}
-
-.ita-audit-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 8px;
-}
-
-.ita-audit-links a {
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
-.ita-next {
-  border-top: 1px solid var(--border);
-  margin-top: 14px;
-  padding-top: 10px;
-}
-
-.ita-actions {
-  margin-top: 12px;
 }
 
 .ita-empty {
   padding: 8px 0;
 }
 
-.ita-empty p {
-  color: var(--text-secondary);
-  margin: 6px 0 12px;
-  max-width: 720px;
-}
-
-@media (max-width: 980px) {
-  .ita-summary,
-  .ita-body,
-  .ita-paid-bar,
-  .ita-paid-lanes,
-  .ita-intent-grid,
-  .ita-trial-bar,
-  .ita-trial-steps {
-    grid-template-columns: 1fr 1fr;
+@media (max-width: 1080px) {
+  .ita-workspace,
+  .ita-paid-lanes {
+    grid-template-columns: 1fr;
   }
 
-  .ita-row {
-    grid-template-columns: 36px minmax(120px, 1fr) 76px;
+  .ita-ticket-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .ita-row .ita-metric:nth-of-type(n + 3) {
+  .ita-strategy-row {
+    grid-template-columns: 38px minmax(140px, 1fr) repeat(3, minmax(62px, 0.5fr)) 82px;
+  }
+
+  .ita-strategy-row > span:nth-of-type(6) {
     display: none;
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
   .ita-console {
     padding: 12px;
   }
 
   .ita-head,
+  .ita-section-head,
   .ita-intent-main {
     align-items: flex-start;
     flex-direction: column;
   }
 
   .ita-summary,
-  .ita-body,
-  .ita-paid-bar,
-  .ita-paid-lanes,
-  .ita-intent-grid,
+  .ita-phases,
+  .ita-ticket-grid,
+  .ita-run-grid,
   .ita-trial-bar,
-  .ita-trial-steps {
+  .ita-intent-grid,
+  .ita-paid-bar,
+  .ita-source-line,
+  .ita-wallet-line {
     grid-template-columns: 1fr;
   }
 
-  .ita-row {
+  .ita-strategy-row {
     grid-template-columns: 32px minmax(0, 1fr);
   }
 
-  .ita-row .ita-metric,
-  .ita-row .ita-gate {
+  .ita-strategy-row > span:not(.ita-rank):not(.ita-strategy-name),
+  .ita-strategy-row .ita-pill,
+  .ita-strategy-row em {
     grid-column: 2;
     justify-self: start;
-  }
-
-  .ita-source-line {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .ita-wallet-line {
-    grid-template-columns: minmax(0, 1fr);
   }
 
   .ita-source-price {

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -129,7 +129,8 @@
 }
 
 .ita-body section:first-child,
-.ita-body section:nth-child(4) {
+.ita-body section:nth-child(2),
+.ita-body section:nth-child(5) {
   grid-column: 1 / -1;
 }
 
@@ -358,6 +359,95 @@
   margin-top: 2px;
 }
 
+.ita-trial {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.ita-trial-bar {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ita-trial-bar > div {
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  padding-top: 8px;
+}
+
+.ita-trial-bar span,
+.ita-trial-meta span,
+.ita-trial-steps small,
+.ita-trial-next {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.ita-trial-bar strong {
+  display: block;
+  font-size: var(--text-sm);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-trial-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.ita-trial-meta strong {
+  font-size: var(--text-sm);
+}
+
+.ita-trial-steps {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin-top: 12px;
+}
+
+.ita-trial-steps > div {
+  border-top: 1px solid var(--border);
+  min-height: 58px;
+  padding-top: 8px;
+}
+
+.ita-trial-steps span {
+  color: var(--accent);
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.ita-trial-steps strong,
+.ita-trial-steps small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-trial-steps strong {
+  font-size: var(--text-sm);
+  margin-top: 2px;
+}
+
+.ita-trial-gates {
+  margin-top: 12px;
+}
+
+.ita-trial-next {
+  border-top: 1px solid var(--border);
+  line-height: 1.5;
+  margin-top: 10px;
+  padding-top: 8px;
+}
+
 .ita-audit-links {
   display: flex;
   flex-wrap: wrap;
@@ -395,7 +485,9 @@
   .ita-body,
   .ita-paid-bar,
   .ita-paid-lanes,
-  .ita-intent-grid {
+  .ita-intent-grid,
+  .ita-trial-bar,
+  .ita-trial-steps {
     grid-template-columns: 1fr 1fr;
   }
 
@@ -423,7 +515,9 @@
   .ita-body,
   .ita-paid-bar,
   .ita-paid-lanes,
-  .ita-intent-grid {
+  .ita-intent-grid,
+  .ita-trial-bar,
+  .ita-trial-steps {
     grid-template-columns: 1fr;
   }
 

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -55,6 +55,50 @@
     "https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay",
     "https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint"
   ],
+  "trial_plan": {
+    "schema_version": "near-intents-trial-plan/1",
+    "mode": "paper",
+    "pair": "NEAR/USDC",
+    "nominal_near": 0.25,
+    "max_trade_near": 0.05,
+    "max_trade_usd": 0.15,
+    "safe_to_quote": true,
+    "safe_to_execute": false,
+    "recommended_strategy_id": "sma_cross_fast",
+    "setup_steps": [
+      {
+        "order": 1,
+        "name": "Use a small wallet",
+        "status": "manual",
+        "detail": "Fund a separate NEAR account with only the amount you are willing to test."
+      },
+      {
+        "order": 2,
+        "name": "Wrap NEAR",
+        "status": "manual",
+        "detail": "Convert native NEAR into wNEAR before verifier funding."
+      },
+      {
+        "order": 3,
+        "name": "Deposit to verifier",
+        "status": "manual",
+        "detail": "Deposit wNEAR into intents.near; do not transfer raw NEAR directly."
+      }
+    ],
+    "risk_gates": [
+      {
+        "name": "trade-cap",
+        "status": "pass",
+        "detail": "Single trial trade is capped at 0.05 NEAR."
+      },
+      {
+        "name": "signing-boundary",
+        "status": "pass",
+        "detail": "IronClaw returns unsigned payloads only."
+      }
+    ],
+    "next_action": "Run backtest_suite with fresh candles before any live quote."
+  },
   "paid_research": {
     "schema_version": "paid-research-plan/1",
     "query": "Should the NEAR/BTC paper intent use premium route and liquidity research before quoting?",

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -61,10 +61,33 @@
     "pair": "NEAR/USDC",
     "nominal_near": 0.25,
     "max_trade_near": 0.05,
+    "assumed_near_usd": 3.0,
     "max_trade_usd": 0.15,
     "safe_to_quote": true,
     "safe_to_execute": false,
     "recommended_strategy_id": "sma_cross_fast",
+    "strategy_menu": [
+      {
+        "id": "buy_hold_baseline",
+        "kind": "buy-hold",
+        "position_size_pct": 1.0,
+        "note": "Baseline for comparing active signals."
+      },
+      {
+        "id": "sma_cross_fast",
+        "kind": "sma-cross",
+        "position_size_pct": 0.8,
+        "stop_loss_bps": 1200.0,
+        "note": "Trend-following candidate for clean spot rotations."
+      },
+      {
+        "id": "mean_reversion_range",
+        "kind": "mean-reversion",
+        "position_size_pct": 0.5,
+        "stop_loss_bps": 700.0,
+        "note": "Range strategy for pullback entries."
+      }
+    ],
     "setup_steps": [
       {
         "order": 1,
@@ -96,6 +119,9 @@
         "status": "pass",
         "detail": "IronClaw returns unsigned payloads only."
       }
+    ],
+    "warnings": [
+      "This is not financial advice and it is not an execution bot. Treat every quote as experimental."
     ],
     "next_action": "Run backtest_suite with fresh candles before any live quote."
   },

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -74,15 +74,15 @@
       },
       {
         "order": 2,
-        "name": "Wrap NEAR",
+        "name": "Choose funding path",
         "status": "manual",
-        "detail": "Convert native NEAR into wNEAR before verifier funding."
+        "detail": "Use 1Click or the Deposit/Withdrawal Service for managed routing, or wrap native NEAR into wNEAR before a direct verifier deposit."
       },
       {
         "order": 3,
         "name": "Deposit to verifier",
         "status": "manual",
-        "detail": "Deposit wNEAR into intents.near; do not transfer raw NEAR directly."
+        "detail": "For a direct Verifier-contract deposit, deposit wNEAR into intents.near with ft_transfer_call; do not send raw native NEAR directly."
       }
     ],
     "risk_gates": [

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -68,6 +68,7 @@ pub use router::{
     list_engine_thread_steps,
     list_engine_threads,
     pause_engine_mission,
+    register_engine_project_for_workspace_path,
     resolve_engine_auth_callback,
     resolve_gate,
     resume_engine_mission,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -5378,6 +5378,29 @@ pub async fn list_engine_thread_events(
 }
 
 /// List all projects.
+fn engine_project_info(project: ironclaw_engine::Project) -> EngineProjectInfo {
+    EngineProjectInfo {
+        id: project.id.to_string(),
+        name: project.name,
+        description: project.description,
+        goals: project.goals,
+        metrics: project.metrics,
+        created_at: project.created_at.to_rfc3339(),
+    }
+}
+
+fn extract_project_slug_from_workspace_path(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("projects/")?;
+    let (slug, remainder) = rest.split_once('/')?;
+    if slug.is_empty() || slug == "." || slug == ".." || slug.starts_with('.') {
+        return None;
+    }
+    if remainder.is_empty() {
+        return None;
+    }
+    Some(slug)
+}
+
 pub async fn list_engine_projects(user_id: &str) -> Result<Vec<EngineProjectInfo>, Error> {
     let Some(lock) = ENGINE_STATE.get() else {
         return Ok(Vec::new());
@@ -5393,17 +5416,60 @@ pub async fn list_engine_projects(user_id: &str) -> Result<Vec<EngineProjectInfo
         .await
         .map_err(|e| engine_err("list projects", e))?;
 
-    Ok(projects
-        .iter()
-        .map(|p| EngineProjectInfo {
-            id: p.id.to_string(),
-            name: p.name.clone(),
-            description: p.description.clone(),
-            goals: p.goals.clone(),
-            metrics: p.metrics.clone(),
-            created_at: p.created_at.to_rfc3339(),
-        })
-        .collect())
+    Ok(projects.into_iter().map(engine_project_info).collect())
+}
+
+/// Register a project implied by a workspace path such as
+/// `projects/<slug>/AGENTS.md`.
+///
+/// LLM-facing `memory_write` calls go through `EffectBridgeAdapter`, which
+/// already performs this auto-registration. The authenticated HTTP memory API
+/// writes directly to the workspace, so it needs the same bridge hook or
+/// project widgets installed via `/api/memory/write` stay invisible until a
+/// separate agent tool call happens to create the project.
+pub async fn register_engine_project_for_workspace_path(
+    path: &str,
+    user_id: &str,
+) -> Result<Option<EngineProjectInfo>, Error> {
+    let Some(slug) = extract_project_slug_from_workspace_path(path) else {
+        return Ok(None);
+    };
+
+    let Some(lock) = ENGINE_STATE.get() else {
+        return Ok(None);
+    };
+    let guard = lock.read().await;
+    let Some(state) = guard.as_ref() else {
+        return Ok(None);
+    };
+
+    let slug_lower = ironclaw_engine::types::slugify_simple(slug);
+    if slug_lower.is_empty() {
+        return Ok(None);
+    }
+
+    let existing = state
+        .store
+        .list_projects(user_id)
+        .await
+        .map_err(|e| engine_err("list projects", e))?;
+
+    if let Some(project) = existing.iter().find(|p| {
+        p.user_id == user_id
+            && (ironclaw_engine::types::slugify_simple(&p.name) == slug_lower
+                || p.name.eq_ignore_ascii_case(&slug_lower))
+    }) {
+        return Ok(Some(engine_project_info(project.clone())));
+    }
+
+    let project = ironclaw_engine::Project::new(user_id, slug, "");
+    state
+        .store
+        .save_project(&project)
+        .await
+        .map_err(|e| engine_err("register project", e))?;
+
+    Ok(Some(engine_project_info(project)))
 }
 
 /// Get a single project by ID.
@@ -5428,14 +5494,7 @@ pub async fn get_engine_project(
 
     Ok(project
         .filter(|p| p.is_owned_by(user_id))
-        .map(|p| EngineProjectInfo {
-            id: p.id.to_string(),
-            name: p.name,
-            description: p.description,
-            goals: p.goals,
-            metrics: p.metrics,
-            created_at: p.created_at.to_rfc3339(),
-        }))
+        .map(engine_project_info))
 }
 
 /// Projects overview — health, stats, attention items for all projects.
@@ -6319,6 +6378,72 @@ mod tests {
     // letting concurrent tests overwrite the shared `ENGINE_STATE` `OnceLock`.
     use super::test_support::ENGINE_STATE_TEST_LOCK;
     static CWD_TEST_LOCK: LazyLock<TokioMutex<()>> = LazyLock::new(|| TokioMutex::new(()));
+
+    #[test]
+    fn workspace_project_slug_extraction_matches_memory_write_shape() {
+        assert_eq!(
+            extract_project_slug_from_workspace_path("projects/intents-trading-agent/AGENTS.md"),
+            Some("intents-trading-agent")
+        );
+        assert_eq!(
+            extract_project_slug_from_workspace_path(
+                "projects/intents-trading-agent/.system/widgets/near-intents-console/index.js"
+            ),
+            Some("intents-trading-agent")
+        );
+        assert_eq!(extract_project_slug_from_workspace_path("projects"), None);
+        assert_eq!(
+            extract_project_slug_from_workspace_path("projects/foo"),
+            None
+        );
+        assert_eq!(
+            extract_project_slug_from_workspace_path("projects/.hidden/file.md"),
+            None
+        );
+        assert_eq!(
+            extract_project_slug_from_workspace_path("notes/projects/foo.md"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn http_workspace_project_registration_is_idempotent() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let store = Arc::new(TestStore::new());
+        let state = make_expected_test_state(Arc::clone(&store));
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+        *lock.write().await = Some(state);
+
+        let first = register_engine_project_for_workspace_path(
+            "projects/intents-trading-agent/AGENTS.md",
+            "alice",
+        )
+        .await
+        .expect("register ok")
+        .expect("project path should register");
+        let second = register_engine_project_for_workspace_path(
+            "projects/intents-trading-agent/.system/widgets/near-intents-console/index.js",
+            "alice",
+        )
+        .await
+        .expect("register ok")
+        .expect("same project path should resolve");
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.name, "intents-trading-agent");
+        let projects = store.list_projects("alice").await.expect("list projects");
+        assert_eq!(projects.len(), 1);
+
+        let ignored =
+            register_engine_project_for_workspace_path("scratch/not-a-project.md", "alice")
+                .await
+                .expect("non-project write ok");
+        assert!(ignored.is_none());
+        assert_eq!(store.list_projects("alice").await.unwrap().len(), 1);
+
+        *lock.write().await = None;
+    }
 
     // ──────────────────────────────────────────────────────────────────
     // `bridge_outcome_for_failed_thread` — caller-level coverage.

--- a/src/channels/web/handlers/memory.rs
+++ b/src/channels/web/handlers/memory.rs
@@ -171,6 +171,7 @@ pub async fn memory_write_handler(
             };
             (status, e.to_string())
         })?;
+        register_project_write(&req.path, &user.user_id).await;
         return Ok(Json(MemoryWriteResponse {
             path: req.path,
             status: "written",
@@ -192,12 +193,24 @@ pub async fn memory_write_handler(
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
 
+    register_project_write(&req.path, &user.user_id).await;
+
     Ok(Json(MemoryWriteResponse {
         path: req.path,
         status: "written",
         redirected: None,
         actual_layer: None,
     }))
+}
+
+async fn register_project_write(path: &str, user_id: &str) {
+    if let Err(e) = crate::bridge::register_engine_project_for_workspace_path(path, user_id).await {
+        tracing::debug!(
+            path,
+            user_id,
+            "memory write succeeded but project auto-registration failed: {e}"
+        );
+    }
 }
 
 pub async fn memory_search_handler(

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -61,8 +61,9 @@ use crate::channels::web::platform::static_files::{
     BASE_CSP_HEADER, admin_css_handler, admin_html_handler, admin_js_handler, css_handler,
     debug_init_handler, debug_panel_css_handler, debug_panel_js_handler, favicon_handler,
     health_handler, i18n_app_handler, i18n_en_handler, i18n_index_handler, i18n_ko_handler,
-    i18n_zh_handler, index_handler, js_handler, project_file_handler, project_index_handler,
-    project_redirect_handler, theme_css_handler, theme_init_handler,
+    i18n_zh_handler, index_handler, js_handler, near_intents_experiment_css_handler,
+    near_intents_experiment_html_handler, near_intents_experiment_js_handler, project_file_handler,
+    project_index_handler, project_redirect_handler, theme_css_handler, theme_init_handler,
 };
 
 // Feature slices under `features/<slice>/`. As of ironclaw#2599 stage 4d,
@@ -472,7 +473,23 @@ pub async fn start_server(
         .route("/admin/", get(admin_html_handler))
         .route("/admin/{*path}", get(admin_html_handler))
         .route("/admin.css", get(admin_css_handler))
-        .route("/admin.js", get(admin_js_handler));
+        .route("/admin.js", get(admin_js_handler))
+        .route(
+            "/experiments/near-intents",
+            get(near_intents_experiment_html_handler),
+        )
+        .route(
+            "/experiments/near-intents/",
+            get(near_intents_experiment_html_handler),
+        )
+        .route(
+            "/experiments/near-intents.css",
+            get(near_intents_experiment_css_handler),
+        )
+        .route(
+            "/experiments/near-intents.js",
+            get(near_intents_experiment_js_handler),
+        );
 
     // Project file serving (behind auth to prevent unauthorized file access).
     let projects = Router::new()

--- a/src/channels/web/platform/static_files.rs
+++ b/src/channels/web/platform/static_files.rs
@@ -62,7 +62,7 @@ const STYLE_SRC: &str = "'self' 'unsafe-inline' https://fonts.googleapis.com";
 const FONT_SRC: &str = "https://fonts.gstatic.com data:";
 const CONNECT_SRC: &str = "'self' https://esm.sh https://rpc.mainnet.near.org https://rpc.testnet.near.org \
      https://api.exchange.coinbase.com https://api.coingecko.com https://api.hyperliquid.xyz \
-     https://solver-relay-v2.chaindefuser.com";
+     https://solver-relay-v2.chaindefuser.com https://1click.chaindefuser.com";
 const IMG_SRC: &str =
     "'self' data: blob: https://*.googleusercontent.com https://avatars.githubusercontent.com";
 const FRAME_SRC: &str = "https://accounts.google.com https://appleid.apple.com";

--- a/src/channels/web/platform/static_files.rs
+++ b/src/channels/web/platform/static_files.rs
@@ -57,7 +57,7 @@ use crate::workspace::Workspace;
 
 /// `script-src` sources other than `'self'` and the per-response nonce.
 const SCRIPT_SRC_EXTRAS: &str =
-    "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh";
+    "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh blob:";
 const STYLE_SRC: &str = "'self' 'unsafe-inline' https://fonts.googleapis.com";
 const FONT_SRC: &str = "https://fonts.gstatic.com data:";
 const CONNECT_SRC: &str =
@@ -1080,6 +1080,10 @@ mod tests {
         assert!(
             csp.contains("script-src 'self' 'nonce-deadbeefcafebabe' https://cdn.jsdelivr.net"),
             "nonce source must appear immediately after 'self' in script-src; got: {csp}"
+        );
+        assert!(
+            csp.contains(" blob:"),
+            "project widget blob scripts must stay allowed by script-src; got: {csp}"
         );
         // The other directives must match the static BASE_CSP so the
         // per-response value never accidentally relaxes anything else.

--- a/src/channels/web/platform/static_files.rs
+++ b/src/channels/web/platform/static_files.rs
@@ -60,8 +60,9 @@ const SCRIPT_SRC_EXTRAS: &str =
     "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh blob:";
 const STYLE_SRC: &str = "'self' 'unsafe-inline' https://fonts.googleapis.com";
 const FONT_SRC: &str = "https://fonts.gstatic.com data:";
-const CONNECT_SRC: &str =
-    "'self' https://esm.sh https://rpc.mainnet.near.org https://rpc.testnet.near.org";
+const CONNECT_SRC: &str = "'self' https://esm.sh https://rpc.mainnet.near.org https://rpc.testnet.near.org \
+     https://api.exchange.coinbase.com https://api.coingecko.com https://api.hyperliquid.xyz \
+     https://solver-relay-v2.chaindefuser.com";
 const IMG_SRC: &str =
     "'self' data: blob: https://*.googleusercontent.com https://avatars.githubusercontent.com";
 const FRAME_SRC: &str = "https://accounts.google.com https://appleid.apple.com";
@@ -847,6 +848,36 @@ pub(crate) async fn admin_js_handler() -> impl IntoResponse {
             (header::CACHE_CONTROL, "no-cache"),
         ],
         assets::ADMIN_JS,
+    )
+}
+
+pub(crate) async fn near_intents_experiment_html_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        assets::NEAR_INTENTS_EXPERIMENT_HTML,
+    )
+}
+
+pub(crate) async fn near_intents_experiment_css_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "text/css"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        assets::NEAR_INTENTS_EXPERIMENT_CSS,
+    )
+}
+
+pub(crate) async fn near_intents_experiment_js_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "application/javascript"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        assets::NEAR_INTENTS_EXPERIMENT_JS,
     )
 }
 

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, nominal NEAR trial planning, and NEAR Intents trading widget state.",
   "discovery_summary": {
     "always_required": [
       "action"
@@ -14,12 +14,15 @@
       "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
       "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, autonomous-wallet policy gates, agentic-SEO trust gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
       "`plan_dripstack_browse` models DripStack's guided topic → publication → article flow from free catalog/post metadata. A selected article becomes a paid-source candidate for `plan_paid_research`; the tool never buys or fetches article bodies.",
-      "`format_intents_widget` requires a `pair` and optional backtest-suite output, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
+      "`fetch_dripstack_catalog` fetches DripStack's free publication catalog or free post-title metadata for one publication. It never calls paid article-body routes.",
+      "`prepare_dripstack_paid_fetch` requires one publication slug and post slug. It prepares the explicit confirmation, HTTP 402 challenge, and receipt-backed retry boundary for one paid article; it never signs or reads paid content by itself.",
+      "`plan_near_intents_trial` prepares a nominal-NEAR paper/quote rehearsal with wallet/funding setup steps, strategy-menu defaults, risk gates, and an unsigned build_intent request.",
+      "`format_intents_widget` requires a `pair` and optional backtest-suite output, trial plan, paid research plan, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; free DripStack catalog fetch returns `dripstack-catalog/1`; paid fetch preparation returns `dripstack-paid-fetch-plan/1`; nominal NEAR trial planning returns `near-intents-trial-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -45,6 +48,14 @@
         ],
         "fee_bps": 10,
         "slippage_bps": 5
+      },
+      {
+        "action": "plan_near_intents_trial",
+        "mode": "paper",
+        "pair": "NEAR/USDC",
+        "nominal_near": 0.25,
+        "max_trade_near": 0.05,
+        "assumed_near_usd": 3.0
       },
       {
         "action": "format_intents_widget",
@@ -83,6 +94,17 @@
             "description": "Crypto market structure, liquidity, and onchain trading research."
           }
         ]
+      },
+      {
+        "action": "fetch_dripstack_catalog",
+        "publication_slug": "premiumcrypto.substack.com"
+      },
+      {
+        "action": "prepare_dripstack_paid_fetch",
+        "publication_slug": "premiumcrypto.substack.com",
+        "post_slug": "near-intents-liquidity",
+        "payment_protocol": "mpp",
+        "user_confirmed_purchase": false
       }
     ]
   },
@@ -105,9 +127,14 @@
           "methods": ["GET"]
         },
         {
-          "host": "solver-relay.chaindefuser.com",
+          "host": "solver-relay-v2.chaindefuser.com",
           "path_prefix": "/rpc",
           "methods": ["POST"]
+        },
+        {
+          "host": "dripstack.xyz",
+          "path_prefix": "/api/v1/publications",
+          "methods": ["GET"]
         }
       ],
       "credentials": {

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, nominal NEAR trial planning, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, nominal NEAR trial planning, and interactive NEAR Intents trading widget state.",
   "discovery_summary": {
     "always_required": [
       "action"
@@ -17,7 +17,7 @@
       "`fetch_dripstack_catalog` fetches DripStack's free publication catalog or free post-title metadata for one publication. It never calls paid article-body routes.",
       "`prepare_dripstack_paid_fetch` requires one publication slug and post slug. It prepares the explicit confirmation, HTTP 402 challenge, and receipt-backed retry boundary for one paid article; it never signs or reads paid content by itself.",
       "`plan_near_intents_trial` prepares a nominal-NEAR paper/quote rehearsal with wallet/funding setup steps, strategy-menu defaults, risk gates, and an unsigned build_intent request.",
-      "`format_intents_widget` requires a `pair` and optional backtest-suite output, trial plan, paid research plan, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
+      "`format_intents_widget` requires a `pair` and optional backtest-suite output, trial plan, paid research plan, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the interactive project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",

--- a/tools-src/portfolio/scenarios/intents-trading-agent-near-trial.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-near-trial.yaml
@@ -1,0 +1,115 @@
+id: intents-trading-agent-near-trial
+description: |
+  Plans a nominal-NEAR rehearsal: rank strategies, prepare a small
+  paper/quote budget, keep the generated build_intent request unsigned,
+  and surface the trial state in the console widget.
+steps:
+  - name: rank_trial_strategies
+    action: backtest_suite
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      candidates:
+        - id: buy_hold_baseline
+          strategy:
+            kind: buy-hold
+        - id: sma_cross_fast
+          max_position_pct: 0.8
+          stop_loss_bps: 1200
+          strategy:
+            kind: sma-cross
+            fast_window: 2
+            slow_window: 4
+        - id: momentum_rotation
+          max_position_pct: 0.8
+          stop_loss_bps: 1000
+          strategy:
+            kind: momentum
+            lookback_window: 3
+            threshold_bps: 500
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 10.2, high: 10.7, low: 10.0, close: 10.5, volume: 1200}
+        - {ts: "2026-01-06T00:00:00Z", open: 10.6, high: 11.2, low: 10.5, close: 11.0, volume: 1300}
+        - {ts: "2026-01-07T00:00:00Z", open: 11.1, high: 12.1, low: 11.0, close: 12.0, volume: 1400}
+        - {ts: "2026-01-08T00:00:00Z", open: 12.1, high: 13.1, low: 12.0, close: 13.0, volume: 1500}
+        - {ts: "2026-01-09T00:00:00Z", open: 13.1, high: 14.1, low: 13.0, close: 14.0, volume: 1600}
+        - {ts: "2026-01-10T00:00:00Z", open: 13.8, high: 14.0, low: 12.8, close: 13.0, volume: 1500}
+        - {ts: "2026-01-11T00:00:00Z", open: 12.8, high: 13.0, low: 11.8, close: 12.0, volume: 1400}
+        - {ts: "2026-01-12T00:00:00Z", open: 11.8, high: 12.0, low: 10.8, close: 11.0, volume: 1300}
+        - {ts: "2026-01-13T00:00:00Z", open: 10.8, high: 11.0, low: 9.8, close: 10.0, volume: 1200}
+        - {ts: "2026-01-14T00:00:00Z", open: 9.8, high: 10.0, low: 8.8, close: 9.0, volume: 1100}
+    capture:
+      backtest_suite_var: suite
+    expect:
+      backtest_suite_schema_version: intents-backtest-suite/1
+      backtest_suite_any_passes_basic_gate: true
+
+  - name: plan_nominal_near_trial
+    action: plan_near_intents_trial
+    params:
+      near_account_id: tester.near
+      mode: paper
+      pair: NEAR/USDC
+      nominal_near: 0.25
+      max_trade_near: 0.05
+      assumed_near_usd: 3.0
+      max_slippage_bps: 50
+      backtest_suite: "$suite"
+    capture:
+      trial_plan_var: trial
+    expect:
+      near_trial_schema_version: near-intents-trial-plan/1
+      near_trial_safe_to_quote: true
+      near_trial_build_solver: fixture
+
+  - name: widget_with_trial_plan
+    action: format_intents_widget
+    params:
+      generated_at: "2026-05-02T17:30:00Z"
+      project_id: intents-trading-agent
+      mode: paper
+      pair: NEAR/USDC
+      stance: paper-intent
+      confidence: 0.7
+      backtest_suite: "$suite"
+      trial_plan: "$trial"
+      risk_gates:
+        - name: unsigned-only
+          status: pass
+          detail: Wallet signature required outside the agent.
+      next_action: Run paper mode before requesting a live quote.
+    expect:
+      intents_widget_schema_version: intents-trading-widget/1
+      intents_widget_top_candidates_min: 1
+      intents_widget_trial_safe_to_quote: true
+
+  - name: paid_fetch_requires_confirmation
+    action: prepare_dripstack_paid_fetch
+    params:
+      publication_slug: premiumcrypto.substack.com
+      post_slug: near-intents-liquidity
+      title: NEAR Intents liquidity and solver-routing risk
+      price_usd: 0.01
+      payment_protocol: mpp
+      user_confirmed_purchase: false
+    expect:
+      dripstack_paid_fetch_status: needs-user-confirmation
+
+  - name: paid_fetch_with_receipt_header
+    action: prepare_dripstack_paid_fetch
+    params:
+      publication_slug: premiumcrypto.substack.com
+      post_slug: near-intents-liquidity
+      title: NEAR Intents liquidity and solver-routing risk
+      price_usd: 0.05
+      payment_protocol: mpp
+      user_confirmed_purchase: true
+      mpp_authorization: "signed-payment-credential-placeholder"
+    expect:
+      dripstack_paid_fetch_status: ready-to-retry-with-receipt
+      dripstack_paid_fetch_headers_min: 1

--- a/tools-src/portfolio/src/intents/solver.rs
+++ b/tools-src/portfolio/src/intents/solver.rs
@@ -5,7 +5,7 @@
 //! 1. **Production** (`fetch_quote`) — POSTs a quote request to the
 //!    NEAR Intents solver relay via `host::http_request`. Only runs
 //!    in the WASM sandbox. The endpoint is pinned at
-//!    `solver-relay.chaindefuser.com/rpc` by M4. Bumping it is a
+//!    `solver-relay-v2.chaindefuser.com/rpc` by M4. Bumping it is a
 //!    coordinated change: update here, update the capabilities
 //!    allowlist, re-record fixtures.
 //!
@@ -197,7 +197,7 @@ pub fn fetch_quote(plan: &MovementPlan, slippage_bps: u16) -> Result<SolverQuote
 
     let response = crate::near::agent::host::http_request(
         "POST",
-        "https://solver-relay.chaindefuser.com/rpc",
+        "https://solver-relay-v2.chaindefuser.com/rpc",
         &headers.to_string(),
         Some(&body),
         None,
@@ -309,7 +309,7 @@ mod tests {
     /// ```
     ///
     /// Requires:
-    ///   - Network access to `solver-relay.chaindefuser.com`
+    ///   - Network access to `solver-relay-v2.chaindefuser.com`
     ///   - Full WASM toolchain (cargo-component, wasm32-wasip2)
     ///
     /// Any panic here is a signal that the real solver's shape has

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -22,6 +22,12 @@
 //!   premium-source query, and prepare attribution/payment gates.
 //! - `plan_dripstack_browse` — model DripStack's guided topic →
 //!   publication → article purchase flow without fetching paid content.
+//! - `fetch_dripstack_catalog` — fetch DripStack's free publication or
+//!   publication-post metadata routes for guided browse.
+//! - `prepare_dripstack_paid_fetch` — prepare the explicit
+//!   confirmation/receipt boundary for a single paid DripStack article.
+//! - `plan_near_intents_trial` — prepare a nominal-NEAR paper/quote
+//!   rehearsal with strategy gates and unsigned intent build requests.
 //! - `format_intents_widget` — build the NEAR Intents trading console
 //!   view model consumed by the project widget.
 //!
@@ -40,6 +46,7 @@
 //! ├── intents/            // build_intent: solver call + bounded checks
 //! ├── backtest.rs         // paper strategy replay/ranking over OHLCV candles
 //! ├── research.rs         // paid research source budgeting/attribution
+//! ├── trial.rs            // nominal NEAR rehearsal planning
 //! └── widget.rs           // web widget state formatters
 //! ```
 
@@ -57,6 +64,7 @@ mod indexer;
 mod intents;
 mod research;
 mod strategy;
+mod trial;
 mod types;
 mod widget;
 
@@ -150,6 +158,25 @@ enum PortfolioAction {
     #[serde(rename = "plan_dripstack_browse")]
     PlanDripstackBrowse(research::DripstackBrowseInput),
 
+    /// Fetch DripStack's free catalog routes. This may return
+    /// publication metadata or post-title metadata; it does not fetch
+    /// paid article bodies.
+    #[serde(rename = "fetch_dripstack_catalog")]
+    FetchDripstackCatalog(research::DripstackCatalogInput),
+
+    /// Prepare the paid article fetch boundary for one DripStack post:
+    /// confirmation, 402 challenge probe, and receipt-backed retry
+    /// headers. It never creates a payment receipt or reads article
+    /// content by itself.
+    #[serde(rename = "prepare_dripstack_paid_fetch")]
+    PrepareDripstackPaidFetch(research::DripstackPaidFetchInput),
+
+    /// Plan a nominal-NEAR trial run. This returns setup guardrails,
+    /// strategy menu defaults, and a paper/live-quote `build_intent`
+    /// request without signing or moving funds.
+    #[serde(rename = "plan_near_intents_trial")]
+    PlanNearIntentsTrial(trial::NearTrialPlanInput),
+
     /// Build the render-ready view model the web widget consumes.
     /// Writes to `projects/<id>/widgets/state.json`.
     #[serde(rename = "format_widget")]
@@ -233,6 +260,7 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
          backtest, backtest_suite, plan_paid_research, plan_dripstack_browse, \
+         fetch_dripstack_catalog, prepare_dripstack_paid_fetch, plan_near_intents_trial, \
          format_suggestion, format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
@@ -339,6 +367,21 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = research::plan_dripstack_browse(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize plan_dripstack_browse response: {e}"))
+        }
+        PortfolioAction::FetchDripstackCatalog(input) => {
+            let output = research::fetch_dripstack_catalog(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize fetch_dripstack_catalog response: {e}"))
+        }
+        PortfolioAction::PrepareDripstackPaidFetch(input) => {
+            let output = research::prepare_dripstack_paid_fetch(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize prepare_dripstack_paid_fetch response: {e}"))
+        }
+        PortfolioAction::PlanNearIntentsTrial(input) => {
+            let output = trial::plan(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize plan_near_intents_trial response: {e}"))
         }
         PortfolioAction::FormatWidget(input) => {
             let output = widget::format_widget(input);

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -880,6 +880,95 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "dripstack_paid_fetch_status" => {
+                let got = response
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| panic!("[{path}] step '{}': missing status", step.name));
+                let want = expected
+                    .as_str()
+                    .expect("dripstack_paid_fetch_status: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': paid fetch status mismatch",
+                    step.name
+                );
+            }
+            "dripstack_paid_fetch_headers_min" => {
+                let len = response
+                    .get("request_headers")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("dripstack_paid_fetch_headers_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': paid fetch headers {len} < min {want}",
+                    step.name
+                );
+            }
+            "near_trial_schema_version" => {
+                let got = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("near_trial_schema_version: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': near trial schema mismatch",
+                    step.name
+                );
+            }
+            "near_trial_safe_to_quote" => {
+                let got = response
+                    .get("safe_to_quote")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let want = expected.as_bool().expect("near_trial_safe_to_quote: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': near trial quote readiness mismatch",
+                    step.name
+                );
+            }
+            "near_trial_build_solver" => {
+                let got = response
+                    .pointer("/build_intent_request/solver")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /build_intent_request/solver",
+                            step.name
+                        )
+                    });
+                let want = expected.as_str().expect("near_trial_build_solver: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': near trial build solver mismatch",
+                    step.name
+                );
+            }
+            "intents_widget_trial_safe_to_quote" => {
+                let got = response
+                    .pointer("/trial_plan/safe_to_quote")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let want = expected
+                    .as_bool()
+                    .expect("intents_widget_trial_safe_to_quote: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': widget trial quote readiness mismatch",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name
@@ -899,7 +988,9 @@ fn capture_vars(path: &str, step: &Step, response: &Value, vars: &mut BTreeMap<S
                 .get("proposals")
                 .cloned()
                 .unwrap_or(Value::Array(Vec::new())),
+            "backtest_suite_var" => response.clone(),
             "paid_research_plan_var" => response.clone(),
+            "trial_plan_var" => response.clone(),
             "dripstack_paid_source_var" => response
                 .get("paid_source_candidate")
                 .cloned()

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 // non-settlement ranking, budgeting, and policy hints. Settlement remains with
 // the payment rails; this tolerance avoids machine-epsilon threshold mistakes.
 const USD_TOLERANCE: f64 = 1e-6;
+const DRIPSTACK_FALLBACK_PRICE_USD: f64 = 0.05;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct PaidResearchPlanInput {
@@ -134,6 +135,32 @@ pub struct DripstackBrowseInput {
     pub publications: Vec<DripstackPublicationInput>,
     #[serde(default)]
     pub posts: Vec<DripstackPostInput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DripstackCatalogInput {
+    #[serde(default)]
+    pub publication_slug: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DripstackPaidFetchInput {
+    pub publication_slug: String,
+    pub post_slug: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub price_usd: Option<f64>,
+    #[serde(default)]
+    pub payment_protocol: Option<String>,
+    #[serde(default)]
+    pub user_confirmed_purchase: bool,
+    #[serde(default)]
+    pub mpp_authorization: Option<String>,
+    #[serde(default)]
+    pub x402_payment_signature: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -310,6 +337,15 @@ pub struct DripstackBrowsePlan {
 }
 
 #[derive(Debug, Serialize)]
+pub struct DripstackCatalogResult {
+    pub schema_version: &'static str,
+    pub endpoint: String,
+    pub publications: Vec<DripstackPublicationInput>,
+    pub posts: Vec<DripstackPostInput>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
 pub struct DripstackPublicationMatch {
     pub rank: usize,
     pub slug: String,
@@ -334,6 +370,28 @@ pub struct DripstackPostCandidate {
     pub published_at: Option<String>,
     pub price_usd: f64,
     pub endpoint: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DripstackPaidFetchPlan {
+    pub schema_version: &'static str,
+    pub endpoint: String,
+    pub method: String,
+    pub status: String,
+    pub payment_protocol: String,
+    pub estimated_price_usd: f64,
+    pub expected_unpaid_status: u16,
+    pub request_headers: Vec<DripstackFetchHeader>,
+    pub supported_protocols: Vec<String>,
+    pub guardrails: Vec<String>,
+    pub warnings: Vec<String>,
+    pub next_action: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DripstackFetchHeader {
+    pub name: String,
+    pub value_preview: String,
 }
 
 pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
@@ -792,6 +850,216 @@ pub fn plan_dripstack_browse(input: DripstackBrowseInput) -> Result<DripstackBro
         guardrails,
         warnings,
     })
+}
+
+pub fn fetch_dripstack_catalog(
+    input: DripstackCatalogInput,
+) -> Result<DripstackCatalogResult, String> {
+    let publication_slug = input
+        .publication_slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|slug| !slug.is_empty());
+    let endpoint = if let Some(slug) = publication_slug {
+        format!("https://dripstack.xyz/api/v1/publications/{slug}")
+    } else {
+        "https://dripstack.xyz/api/v1/publications".to_string()
+    };
+    let raw = http_get_text(&endpoint)?;
+    if publication_slug.is_some() {
+        parse_dripstack_publication_detail(&endpoint, &raw)
+    } else {
+        parse_dripstack_publications(&endpoint, &raw)
+    }
+}
+
+fn parse_dripstack_publications(
+    endpoint: &str,
+    json: &str,
+) -> Result<DripstackCatalogResult, String> {
+    #[derive(Deserialize)]
+    struct ListResponse {
+        #[serde(default)]
+        publications: Vec<DripstackPublicationInput>,
+    }
+
+    let response: ListResponse = serde_json::from_str(json)
+        .map_err(|e| format!("DripStack publications JSON parse: {e}"))?;
+    Ok(DripstackCatalogResult {
+        schema_version: "dripstack-catalog/1",
+        endpoint: endpoint.to_string(),
+        publications: response.publications,
+        posts: Vec::new(),
+        warnings: Vec::new(),
+    })
+}
+
+fn parse_dripstack_publication_detail(
+    endpoint: &str,
+    json: &str,
+) -> Result<DripstackCatalogResult, String> {
+    #[derive(Deserialize)]
+    struct DetailResponse {
+        slug: String,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default, alias = "siteUrl")]
+        site_url: Option<String>,
+        #[serde(default, alias = "lastSyncedAt")]
+        last_synced_at: Option<String>,
+        #[serde(default)]
+        posts: Vec<DripstackPostInput>,
+    }
+
+    let response: DetailResponse = serde_json::from_str(json)
+        .map_err(|e| format!("DripStack publication detail JSON parse: {e}"))?;
+    Ok(DripstackCatalogResult {
+        schema_version: "dripstack-catalog/1",
+        endpoint: endpoint.to_string(),
+        publications: vec![DripstackPublicationInput {
+            slug: response.slug,
+            title: response.title,
+            description: response.description,
+            site_url: response.site_url,
+            last_synced_at: response.last_synced_at,
+        }],
+        posts: response.posts,
+        warnings: Vec::new(),
+    })
+}
+
+pub fn prepare_dripstack_paid_fetch(
+    input: DripstackPaidFetchInput,
+) -> Result<DripstackPaidFetchPlan, String> {
+    let publication_slug = input.publication_slug.trim();
+    let post_slug = input.post_slug.trim();
+    if publication_slug.is_empty() {
+        return Err("publication_slug is required for prepare_dripstack_paid_fetch".to_string());
+    }
+    if post_slug.is_empty() {
+        return Err("post_slug is required for prepare_dripstack_paid_fetch".to_string());
+    }
+
+    let endpoint = input.endpoint.unwrap_or_else(|| {
+        format!("https://dripstack.xyz/api/v1/publications/{publication_slug}/{post_slug}")
+    });
+    let payment_protocol = normalize_protocol(
+        input.payment_protocol.as_deref().unwrap_or("mpp"),
+        input.price_usd.unwrap_or(DRIPSTACK_FALLBACK_PRICE_USD),
+    );
+    if !matches!(payment_protocol.as_str(), "mpp" | "x402") {
+        return Err(
+            "prepare_dripstack_paid_fetch payment_protocol must be mpp or x402".to_string(),
+        );
+    }
+
+    let estimated_price_usd =
+        clean_nonnegative(input.price_usd.unwrap_or(DRIPSTACK_FALLBACK_PRICE_USD))
+            .max(DRIPSTACK_FALLBACK_PRICE_USD);
+    let guardrails = vec![
+        "Paid article body fetch is one article at a time.".to_string(),
+        "The live HTTP 402 challenge is authoritative for amount, network, and receipt format."
+            .to_string(),
+        "The agent may prepare headers from a receipt but must not create the receipt with hidden keys."
+            .to_string(),
+        "Fetched article text can be summarized only after the receipt-backed retry succeeds."
+            .to_string(),
+    ];
+    let mut warnings = Vec::new();
+    if input.price_usd.unwrap_or(0.0) < DRIPSTACK_FALLBACK_PRICE_USD {
+        warnings.push(
+            "Static catalog price is below the current DripStack fallback; live 402 may require at least $0.05."
+                .to_string(),
+        );
+    }
+
+    let mut request_headers = Vec::new();
+    let status;
+    let next_action;
+    if !input.user_confirmed_purchase {
+        status = "needs-user-confirmation".to_string();
+        next_action = format!(
+            "Ask the user to confirm buying '{}' before probing the paid endpoint.",
+            input.title.unwrap_or_else(|| post_slug.to_string())
+        );
+    } else if payment_protocol == "mpp" {
+        if let Some(auth) = input
+            .mpp_authorization
+            .filter(|value| !value.trim().is_empty())
+        {
+            request_headers.push(DripstackFetchHeader {
+                name: "Authorization".to_string(),
+                value_preview: preview_secret_header("Payment", &auth),
+            });
+            status = "ready-to-retry-with-receipt".to_string();
+            next_action =
+                "Retry the paid GET with the MPP Authorization header, then summarize only the returned article."
+                    .to_string();
+        } else {
+            status = "needs-402-challenge".to_string();
+            next_action =
+                "GET the paid endpoint without content synthesis, collect the HTTP 402 WWW-Authenticate challenge, then pass it to the payment client."
+                    .to_string();
+        }
+    } else if let Some(sig) = input
+        .x402_payment_signature
+        .filter(|value| !value.trim().is_empty())
+    {
+        request_headers.push(DripstackFetchHeader {
+            name: "PAYMENT-SIGNATURE".to_string(),
+            value_preview: preview_secret_header("x402", &sig),
+        });
+        status = "ready-to-retry-with-receipt".to_string();
+        next_action =
+            "Retry the paid GET with PAYMENT-SIGNATURE, then summarize only the returned article."
+                .to_string();
+    } else {
+        status = "needs-402-challenge".to_string();
+        next_action =
+            "GET the paid endpoint without content synthesis, collect the HTTP 402 PAYMENT-REQUIRED challenge, then pass it to the x402 payment client."
+                .to_string();
+    }
+
+    Ok(DripstackPaidFetchPlan {
+        schema_version: "dripstack-paid-fetch-plan/1",
+        endpoint,
+        method: "GET".to_string(),
+        status,
+        payment_protocol,
+        estimated_price_usd: round4(estimated_price_usd),
+        expected_unpaid_status: 402,
+        request_headers,
+        supported_protocols: vec!["mpp".to_string(), "x402".to_string()],
+        guardrails,
+        warnings,
+        next_action,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn http_get_text(endpoint: &str) -> Result<String, String> {
+    let headers = serde_json::json!({
+        "Accept": "application/json",
+        "User-Agent": "IronClaw-Portfolio-Tool/0.1"
+    });
+    let response =
+        crate::near::agent::host::http_request("GET", endpoint, &headers.to_string(), None, None)
+            .map_err(|e| format!("DripStack HTTP error: {e}"))?;
+    if response.status < 200 || response.status >= 300 {
+        let body = String::from_utf8_lossy(&response.body);
+        return Err(format!("DripStack {}: {body}", response.status));
+    }
+    String::from_utf8(response.body).map_err(|e| format!("DripStack response not UTF-8: {e}"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn http_get_text(_endpoint: &str) -> Result<String, String> {
+    Err(
+        "DripStack live catalog fetch only works inside the WASM sandbox; use plan_dripstack_browse with supplied free metadata in replay tests."
+            .to_string(),
+    )
 }
 
 fn score_source(
@@ -1303,6 +1571,16 @@ fn round4(value: f64) -> f64 {
     (value * 10_000.0).round() / 10_000.0
 }
 
+fn preview_secret_header(prefix: &str, value: &str) -> String {
+    let trimmed = value.trim();
+    let visible: String = trimmed.chars().take(10).collect();
+    if trimmed.len() <= visible.len() {
+        format!("{prefix} {visible}")
+    } else {
+        format!("{prefix} {visible}...")
+    }
+}
+
 fn default_budget_usd() -> f64 {
     5.0
 }
@@ -1474,5 +1752,47 @@ mod tests {
         assert!(tokens.contains("trading"));
         assert!(!tokens.contains("a"));
         assert!(!tokens.contains("for"));
+    }
+
+    #[test]
+    fn parses_dripstack_publication_catalog() {
+        let parsed = parse_dripstack_publications(
+            "https://dripstack.xyz/api/v1/publications",
+            r#"{
+              "publications": [{
+                "slug": "premiumcrypto.substack.com",
+                "title": "Premium Crypto Notes",
+                "description": "Crypto and market structure.",
+                "siteUrl": "https://premiumcrypto.substack.com",
+                "lastSyncedAt": "2026-05-02T00:00:00Z"
+              }]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.schema_version, "dripstack-catalog/1");
+        assert_eq!(parsed.publications.len(), 1);
+        assert_eq!(parsed.publications[0].slug, "premiumcrypto.substack.com");
+        assert!(parsed.posts.is_empty());
+    }
+
+    #[test]
+    fn prepares_mpp_paid_fetch_receipt_boundary() {
+        let plan = prepare_dripstack_paid_fetch(DripstackPaidFetchInput {
+            publication_slug: "premiumcrypto.substack.com".to_string(),
+            post_slug: "near-intents-liquidity".to_string(),
+            title: Some("NEAR Intents liquidity".to_string()),
+            endpoint: None,
+            price_usd: Some(0.05),
+            payment_protocol: Some("mpp".to_string()),
+            user_confirmed_purchase: true,
+            mpp_authorization: Some("signed-payment-credential-placeholder".to_string()),
+            x402_payment_signature: None,
+        })
+        .unwrap();
+
+        assert_eq!(plan.schema_version, "dripstack-paid-fetch-plan/1");
+        assert_eq!(plan.status, "ready-to-retry-with-receipt");
+        assert_eq!(plan.request_headers[0].name, "Authorization");
     }
 }

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -185,6 +185,10 @@
           "type": "object",
           "description": "Optional output from plan_paid_research. The widget extracts budget, payable sources, rails, policy gates, and NEAR funding routes."
         },
+        "trial_plan": {
+          "type": "object",
+          "description": "Optional output from plan_near_intents_trial. The widget extracts nominal budget, setup steps, trial risk gates, and quote readiness."
+        },
         "next_action": {
           "type": "string",
           "description": "Operator-facing next step shown in the widget."
@@ -484,6 +488,16 @@
     },
     {
       "properties": {
+        "action": { "const": "fetch_dripstack_catalog" },
+        "publication_slug": {
+          "type": "string",
+          "description": "Optional publication slug. Omit to fetch the free publication catalog; provide it to fetch free post-title metadata for one publication."
+        }
+      },
+      "required": ["action"]
+    },
+    {
+      "properties": {
         "action": { "const": "plan_dripstack_browse" },
         "topic": {
           "type": "string",
@@ -536,6 +550,105 @@
             "required": ["slug", "title"]
           },
           "default": []
+        }
+      },
+      "required": ["action"]
+    },
+    {
+      "properties": {
+        "action": { "const": "prepare_dripstack_paid_fetch" },
+        "publication_slug": {
+          "type": "string",
+          "minLength": 1,
+          "description": "DripStack publication slug exactly as returned by the free catalog."
+        },
+        "post_slug": {
+          "type": "string",
+          "minLength": 1,
+          "description": "DripStack post slug exactly as returned by the free publication detail route."
+        },
+        "title": {
+          "type": "string",
+          "description": "Optional display title for confirmation prompts."
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Optional paid article endpoint. Defaults to https://dripstack.xyz/api/v1/publications/{publication_slug}/{post_slug}."
+        },
+        "price_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Static estimated price. The live HTTP 402 challenge remains authoritative."
+        },
+        "payment_protocol": {
+          "type": "string",
+          "enum": ["mpp", "x402"],
+          "default": "mpp"
+        },
+        "user_confirmed_purchase": {
+          "type": "boolean",
+          "default": false,
+          "description": "Must be true before the agent probes the paid endpoint or prepares receipt-backed retry headers."
+        },
+        "mpp_authorization": {
+          "type": "string",
+          "description": "MPP Authorization credential returned by a payment-aware client. The tool only previews the header; it never signs."
+        },
+        "x402_payment_signature": {
+          "type": "string",
+          "description": "x402 PAYMENT-SIGNATURE returned by a payment-aware client. The tool only previews the header; it never signs."
+        }
+      },
+      "required": ["action", "publication_slug", "post_slug"]
+    },
+    {
+      "properties": {
+        "action": { "const": "plan_near_intents_trial" },
+        "near_account_id": {
+          "type": "string",
+          "description": "Optional NEAR signer account id for the trial wallet."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["paper", "quote", "execution"],
+          "default": "paper",
+          "description": "Paper builds fixture intents; quote prepares a live NEAR Intents quote request; execution remains manual-wallet only."
+        },
+        "pair": {
+          "type": "string",
+          "default": "NEAR/USDC",
+          "description": "Trial pair. Single-token values are normalized as NEAR/<token>."
+        },
+        "nominal_near": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "default": 0.25,
+          "description": "Total NEAR budget the user intends to keep in the isolated trial wallet."
+        },
+        "max_trade_near": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Maximum NEAR-equivalent size for one trial quote/trade."
+        },
+        "assumed_near_usd": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "default": 3.0,
+          "description": "Fresh NEAR/USD estimate used only for sizing. Recompute before any live quote."
+        },
+        "max_slippage_bps": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000,
+          "default": 50
+        },
+        "selected_strategy_id": {
+          "type": "string",
+          "description": "Optional strategy id selected from backtest_suite ranked results."
+        },
+        "backtest_suite": {
+          "type": "object",
+          "description": "Optional output from backtest_suite, used to gate/recommend the trial strategy."
         }
       },
       "required": ["action"]

--- a/tools-src/portfolio/src/trial.rs
+++ b/tools-src/portfolio/src/trial.rs
@@ -161,10 +161,10 @@ pub fn plan(input: NearTrialPlanInput) -> Result<NearTrialPlan, String> {
                 }),
         },
         TrialRiskGate {
-            name: "native-near-wrap".to_string(),
+            name: "near-funding-path".to_string(),
             status: "warn".to_string(),
             detail:
-                "The verifier does not accept raw native NEAR deposits; wrap NEAR to wNEAR before verifier funding."
+                "1Click or Deposit/Withdrawal Service flows may handle native NEAR wrapping. Direct verifier funding expects wNEAR (nep141:wrap.near), not a raw native NEAR transfer."
                     .to_string(),
         },
         strategy_gate,
@@ -400,10 +400,10 @@ fn setup_steps() -> Vec<TrialSetupStep> {
         },
         TrialSetupStep {
             order: 2,
-            name: "Wrap NEAR".to_string(),
+            name: "Choose funding path".to_string(),
             status: "manual".to_string(),
             detail:
-                "Convert the trial amount from native NEAR into wNEAR before depositing to the verifier."
+                "Use 1Click or the Deposit/Withdrawal Service for managed routing, or wrap native NEAR into wNEAR before a direct verifier deposit."
                     .to_string(),
         },
         TrialSetupStep {
@@ -411,7 +411,7 @@ fn setup_steps() -> Vec<TrialSetupStep> {
             name: "Deposit to verifier".to_string(),
             status: "manual".to_string(),
             detail:
-                "Deposit wNEAR into intents.near using the official verifier deposit flow; do not transfer raw NEAR directly."
+                "For a direct Verifier-contract deposit, deposit wNEAR into intents.near with ft_transfer_call; do not send raw native NEAR directly."
                     .to_string(),
         },
         TrialSetupStep {

--- a/tools-src/portfolio/src/trial.rs
+++ b/tools-src/portfolio/src/trial.rs
@@ -1,0 +1,638 @@
+//! Trial-mode planning for users who want to rehearse NEAR Intents
+//! trading with a nominal amount of NEAR.
+//!
+//! This module does not sign, wrap, deposit, quote, or execute. It turns
+//! a small user budget into a concrete paper/quote workflow: strategy
+//! candidates to backtest, funding caveats, risk gates, and a
+//! `build_intent` request the skill can run in fixture or live-quote
+//! mode after explicit user approval.
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::types::{MovementLeg, MovementPlan, ProjectConfig, TokenAmount};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NearTrialPlanInput {
+    #[serde(default)]
+    pub near_account_id: Option<String>,
+    #[serde(default = "default_trial_mode")]
+    pub mode: String,
+    #[serde(default = "default_pair")]
+    pub pair: String,
+    #[serde(default = "default_nominal_near")]
+    pub nominal_near: f64,
+    #[serde(default)]
+    pub max_trade_near: Option<f64>,
+    #[serde(default = "default_assumed_near_usd")]
+    pub assumed_near_usd: f64,
+    #[serde(default = "default_max_slippage_bps")]
+    pub max_slippage_bps: u16,
+    #[serde(default)]
+    pub selected_strategy_id: Option<String>,
+    #[serde(default)]
+    pub backtest_suite: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NearTrialPlan {
+    pub schema_version: &'static str,
+    pub mode: String,
+    pub pair: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub near_account_id: Option<String>,
+    pub nominal_near: f64,
+    pub max_trade_near: f64,
+    pub assumed_near_usd: f64,
+    pub max_trade_usd: f64,
+    pub safe_to_quote: bool,
+    pub safe_to_execute: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended_strategy_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_strategy_id: Option<String>,
+    pub strategy_menu: Vec<TrialStrategyCandidate>,
+    pub setup_steps: Vec<TrialSetupStep>,
+    pub risk_gates: Vec<TrialRiskGate>,
+    pub movement_plan: MovementPlan,
+    pub build_intent_request: serde_json::Value,
+    pub docs: Vec<TrialDocRef>,
+    pub warnings: Vec<String>,
+    pub next_action: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrialStrategyCandidate {
+    pub id: String,
+    pub kind: String,
+    pub position_size_pct: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub take_profit_bps: Option<f64>,
+    pub note: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrialSetupStep {
+    pub order: usize,
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrialRiskGate {
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrialDocRef {
+    pub label: String,
+    pub url: String,
+}
+
+pub fn plan(input: NearTrialPlanInput) -> Result<NearTrialPlan, String> {
+    let mode = normalize_mode(&input.mode)?;
+    let pair = normalize_pair(&input.pair);
+    let nominal_near = clean_positive(input.nominal_near, "nominal_near")?;
+    let assumed_near_usd = clean_positive(input.assumed_near_usd, "assumed_near_usd")?;
+    let max_trade_near = input
+        .max_trade_near
+        .unwrap_or_else(|| default_max_trade_near(nominal_near));
+    let max_trade_near = clean_positive(max_trade_near, "max_trade_near")?;
+    let max_slippage_bps = input.max_slippage_bps.min(1_000);
+    let max_trade_usd = round4(max_trade_near * assumed_near_usd);
+    let min_out_usd = round4(max_trade_usd * (1.0 - max_slippage_bps as f64 / 10_000.0));
+
+    let strategy_menu = default_strategy_menu();
+    let (recommended_strategy_id, strategy_gate) = strategy_gate(
+        input.selected_strategy_id.as_deref(),
+        input.backtest_suite.as_ref(),
+        &strategy_menu,
+    );
+
+    let mut risk_gates = vec![
+        TrialRiskGate {
+            name: "nominal-budget".to_string(),
+            status: if nominal_near <= 1.0 { "pass" } else { "warn" }.to_string(),
+            detail: format!(
+                "Trial wallet budget is {:.4} NEAR. Keep this wallet small and separate from long-term holdings.",
+                nominal_near
+            ),
+        },
+        TrialRiskGate {
+            name: "trade-cap".to_string(),
+            status: if max_trade_near <= nominal_near {
+                "pass"
+            } else {
+                "fail"
+            }
+            .to_string(),
+            detail: format!(
+                "Single trial trade is capped at {:.4} NEAR, estimated at ${:.4}.",
+                max_trade_near, max_trade_usd
+            ),
+        },
+        TrialRiskGate {
+            name: "small-route-liquidity".to_string(),
+            status: if max_trade_usd >= 1.0 { "pass" } else { "warn" }.to_string(),
+            detail:
+                "Very small quote sizes may be refused or dominated by route/bridge minimums; paper mode still works."
+                    .to_string(),
+        },
+        TrialRiskGate {
+            name: "wallet-account".to_string(),
+            status: if input.near_account_id.is_some() {
+                "pass"
+            } else {
+                "warn"
+            }
+            .to_string(),
+            detail: input
+                .near_account_id
+                .as_ref()
+                .map(|account| format!("Use {account} only after you have reviewed the unsigned payload."))
+                .unwrap_or_else(|| {
+                    "No NEAR account id supplied; paper mode can run, live quote setup should record the signer account."
+                        .to_string()
+                }),
+        },
+        TrialRiskGate {
+            name: "native-near-wrap".to_string(),
+            status: "warn".to_string(),
+            detail:
+                "The verifier does not accept raw native NEAR deposits; wrap NEAR to wNEAR before verifier funding."
+                    .to_string(),
+        },
+        strategy_gate,
+        TrialRiskGate {
+            name: "signing-boundary".to_string(),
+            status: if mode == "execution" { "blocked" } else { "pass" }.to_string(),
+            detail: if mode == "execution" {
+                "Execution cannot be autonomous here: IronClaw builds unsigned payloads, then your wallet must sign outside the agent."
+                    .to_string()
+            } else {
+                "This action returns only plans and unsigned build requests; it cannot spend funds."
+                    .to_string()
+            },
+        },
+    ];
+
+    if max_slippage_bps > 100 {
+        risk_gates.push(TrialRiskGate {
+            name: "slippage-cap".to_string(),
+            status: "warn".to_string(),
+            detail: format!(
+                "Max slippage is {} bps. For a nominal trial, prefer <= 100 bps unless route depth is poor.",
+                max_slippage_bps
+            ),
+        });
+    }
+
+    let movement_plan = movement_plan(&pair, max_trade_near, max_trade_usd, min_out_usd);
+    let solver = if mode == "paper" {
+        "fixture"
+    } else {
+        "near-intents"
+    };
+    let build_intent_request = json!({
+        "action": "build_intent",
+        "solver": solver,
+        "plan": movement_plan,
+        "config": {
+            "max_slippage_bps": max_slippage_bps,
+            "auto_intent_ceiling_usd": max_trade_usd + 1.0,
+            "allowed_chains": ["near"]
+        }
+    });
+
+    let safe_to_quote = mode != "execution"
+        && risk_gates
+            .iter()
+            .all(|gate| gate.status != "fail" && gate.status != "blocked");
+    let safe_to_execute = false;
+    let next_action = match mode.as_str() {
+        "paper" => "Run backtest_suite with fresh candles, select a passing strategy, then run build_intent with solver=fixture.".to_string(),
+        "quote" => "After paper gates pass, run build_intent with solver=near-intents to request an unsigned live quote; do not sign yet.".to_string(),
+        _ => "Execution remains manual-wallet only: inspect the signed payload request, then decide in your wallet outside IronClaw.".to_string(),
+    };
+
+    let warnings = vec![
+        "This is not financial advice and it is not an execution bot. Treat every quote as experimental."
+            .to_string(),
+        "Prices are estimates unless supplied from a fresh market data source; re-run before any live quote."
+            .to_string(),
+    ];
+
+    Ok(NearTrialPlan {
+        schema_version: "near-intents-trial-plan/1",
+        mode,
+        pair,
+        near_account_id: input.near_account_id,
+        nominal_near: round4(nominal_near),
+        max_trade_near: round4(max_trade_near),
+        assumed_near_usd: round4(assumed_near_usd),
+        max_trade_usd,
+        safe_to_quote,
+        safe_to_execute,
+        recommended_strategy_id,
+        selected_strategy_id: input.selected_strategy_id,
+        strategy_menu,
+        setup_steps: setup_steps(),
+        risk_gates,
+        movement_plan,
+        build_intent_request,
+        docs: doc_refs(),
+        warnings,
+        next_action,
+    })
+}
+
+fn movement_plan(
+    pair: &str,
+    max_trade_near: f64,
+    max_trade_usd: f64,
+    min_out_usd: f64,
+) -> MovementPlan {
+    let target_symbol = pair
+        .split('/')
+        .nth(1)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("USDC")
+        .to_uppercase();
+    let target_address = if target_symbol == "USDC" {
+        Some("usdc.near".to_string())
+    } else {
+        None
+    };
+    MovementPlan {
+        legs: vec![MovementLeg {
+            kind: "swap".to_string(),
+            chain: "near".to_string(),
+            from_token: Some(TokenAmount {
+                symbol: "wNEAR".to_string(),
+                address: Some("wrap.near".to_string()),
+                chain: "near".to_string(),
+                amount: format!("{max_trade_near:.6}"),
+                value_usd: format!("{max_trade_usd:.4}"),
+            }),
+            to_token: Some(TokenAmount {
+                symbol: target_symbol.clone(),
+                address: target_address.clone(),
+                chain: "near".to_string(),
+                amount: format!("{min_out_usd:.6}"),
+                value_usd: format!("{min_out_usd:.4}"),
+            }),
+            description: format!(
+                "Nominal NEAR Intents trial swap from wNEAR into {target_symbol}; user wallet signs only after reviewing the quote."
+            ),
+        }],
+        expected_out: TokenAmount {
+            symbol: target_symbol.clone(),
+            address: target_address,
+            chain: "near".to_string(),
+            amount: format!("{min_out_usd:.6}"),
+            value_usd: format!("{min_out_usd:.4}"),
+        },
+        expected_cost_usd: "0.00".to_string(),
+        proposal_id: format!("trial-near-{}", target_symbol.to_lowercase()),
+    }
+}
+
+fn strategy_gate(
+    selected_strategy_id: Option<&str>,
+    suite: Option<&serde_json::Value>,
+    menu: &[TrialStrategyCandidate],
+) -> (Option<String>, TrialRiskGate) {
+    let fallback = menu.first().map(|candidate| candidate.id.clone());
+    let Some(suite) = suite else {
+        return (
+            fallback,
+            TrialRiskGate {
+                name: "strategy-backtest".to_string(),
+                status: "warn".to_string(),
+                detail: "No backtest_suite output supplied; run the menu before a live quote."
+                    .to_string(),
+            },
+        );
+    };
+    let ranked = suite
+        .get("ranked")
+        .and_then(|value| value.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let recommended = ranked
+        .iter()
+        .find(|candidate| {
+            candidate
+                .get("passes_basic_gate")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false)
+        })
+        .or_else(|| ranked.first())
+        .and_then(|candidate| candidate.get("id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .or(fallback);
+
+    if let Some(selected) = selected_strategy_id {
+        let maybe_selected = ranked.iter().find(|candidate| {
+            candidate.get("id").and_then(|value| value.as_str()) == Some(selected)
+        });
+        let Some(candidate) = maybe_selected else {
+            return (
+                recommended,
+                TrialRiskGate {
+                    name: "strategy-backtest".to_string(),
+                    status: "fail".to_string(),
+                    detail: format!(
+                        "Selected strategy '{selected}' was not present in the backtest suite."
+                    ),
+                },
+            );
+        };
+        let passes = candidate
+            .get("passes_basic_gate")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        return (
+            recommended,
+            TrialRiskGate {
+                name: "strategy-backtest".to_string(),
+                status: if passes { "pass" } else { "fail" }.to_string(),
+                detail: format!(
+                    "Selected strategy '{selected}' {} the basic paper gate.",
+                    if passes { "passed" } else { "failed" }
+                ),
+            },
+        );
+    }
+
+    (
+        recommended.clone(),
+        TrialRiskGate {
+            name: "strategy-backtest".to_string(),
+            status: if recommended.is_some() {
+                "pass"
+            } else {
+                "warn"
+            }
+            .to_string(),
+            detail: recommended
+                .map(|id| format!("Recommended paper strategy: {id}."))
+                .unwrap_or_else(|| "Backtest suite had no ranked candidates.".to_string()),
+        },
+    )
+}
+
+fn setup_steps() -> Vec<TrialSetupStep> {
+    vec![
+        TrialSetupStep {
+            order: 1,
+            name: "Use a small wallet".to_string(),
+            status: "manual".to_string(),
+            detail: "Fund a separate NEAR account with only the amount you are willing to test."
+                .to_string(),
+        },
+        TrialSetupStep {
+            order: 2,
+            name: "Wrap NEAR".to_string(),
+            status: "manual".to_string(),
+            detail:
+                "Convert the trial amount from native NEAR into wNEAR before depositing to the verifier."
+                    .to_string(),
+        },
+        TrialSetupStep {
+            order: 3,
+            name: "Deposit to verifier".to_string(),
+            status: "manual".to_string(),
+            detail:
+                "Deposit wNEAR into intents.near using the official verifier deposit flow; do not transfer raw NEAR directly."
+                    .to_string(),
+        },
+        TrialSetupStep {
+            order: 4,
+            name: "Paper first".to_string(),
+            status: "required".to_string(),
+            detail:
+                "Run strategy backtests and fixture intent construction before requesting a live quote."
+                    .to_string(),
+        },
+        TrialSetupStep {
+            order: 5,
+            name: "Wallet review".to_string(),
+            status: "required".to_string(),
+            detail: "Any live quote still needs your wallet signature outside the agent.".to_string(),
+        },
+    ]
+}
+
+fn default_strategy_menu() -> Vec<TrialStrategyCandidate> {
+    vec![
+        TrialStrategyCandidate {
+            id: "buy_hold_baseline".to_string(),
+            kind: "buy-hold".to_string(),
+            position_size_pct: 1.0,
+            stop_loss_bps: None,
+            take_profit_bps: None,
+            note: "Baseline for comparing active signals.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "sma_cross_fast".to_string(),
+            kind: "sma-cross".to_string(),
+            position_size_pct: 0.8,
+            stop_loss_bps: Some(1_200.0),
+            take_profit_bps: None,
+            note: "Trend-following candidate for clean spot rotations.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "breakout_short".to_string(),
+            kind: "breakout".to_string(),
+            position_size_pct: 0.8,
+            stop_loss_bps: Some(1_000.0),
+            take_profit_bps: None,
+            note: "Looks for range breaks; sensitive to false moves.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "momentum_rotation".to_string(),
+            kind: "momentum".to_string(),
+            position_size_pct: 0.8,
+            stop_loss_bps: Some(1_000.0),
+            take_profit_bps: None,
+            note: "Simple lookback momentum for token rotation tests.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "mean_reversion_range".to_string(),
+            kind: "mean-reversion".to_string(),
+            position_size_pct: 0.5,
+            stop_loss_bps: Some(700.0),
+            take_profit_bps: None,
+            note: "Range strategy for pullback entries.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "rsi_reversion".to_string(),
+            kind: "rsi-mean-reversion".to_string(),
+            position_size_pct: 0.5,
+            stop_loss_bps: Some(700.0),
+            take_profit_bps: None,
+            note: "Oversold/exit threshold candidate.".to_string(),
+        },
+    ]
+}
+
+fn doc_refs() -> Vec<TrialDocRef> {
+    vec![
+        TrialDocRef {
+            label: "NEAR Intents deposit/withdrawal service".to_string(),
+            url: "https://docs.near-intents.org/integration/market-makers/deposit-withdrawal-service"
+                .to_string(),
+        },
+        TrialDocRef {
+            label: "NEAR Intents verifier deposits".to_string(),
+            url: "https://docs.near-intents.org/near-intents/market-makers/verifier/deposits-and-withdrawals/deposits"
+                .to_string(),
+        },
+        TrialDocRef {
+            label: "NEAR Intents solver relay API".to_string(),
+            url: "https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay"
+                .to_string(),
+        },
+    ]
+}
+
+fn normalize_mode(mode: &str) -> Result<String, String> {
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "" | "paper" => Ok("paper".to_string()),
+        "quote" | "live-quote" => Ok("quote".to_string()),
+        "execution" | "execute" => Ok("execution".to_string()),
+        other => Err(format!(
+            "unknown near trial mode '{other}'; expected paper, quote, or execution"
+        )),
+    }
+}
+
+fn normalize_pair(pair: &str) -> String {
+    let trimmed = pair.trim();
+    if trimmed.is_empty() {
+        default_pair()
+    } else if trimmed.contains('/') {
+        trimmed.to_uppercase()
+    } else {
+        format!("NEAR/{}", trimmed.to_uppercase())
+    }
+}
+
+fn clean_positive(value: f64, name: &str) -> Result<f64, String> {
+    if value.is_finite() && value > 0.0 {
+        Ok(value)
+    } else {
+        Err(format!("{name} must be a positive finite number"))
+    }
+}
+
+fn round4(value: f64) -> f64 {
+    (value * 10_000.0).round() / 10_000.0
+}
+
+fn default_trial_mode() -> String {
+    "paper".to_string()
+}
+
+fn default_pair() -> String {
+    "NEAR/USDC".to_string()
+}
+
+fn default_nominal_near() -> f64 {
+    0.25
+}
+
+fn default_max_trade_near(nominal_near: f64) -> f64 {
+    if nominal_near <= 0.01 {
+        nominal_near
+    } else {
+        (nominal_near * 0.2).max(0.01).min(nominal_near)
+    }
+}
+
+fn default_assumed_near_usd() -> f64 {
+    3.0
+}
+
+fn default_max_slippage_bps() -> u16 {
+    ProjectConfig::default().max_slippage_bps
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trial_plan_defaults_to_paper_fixture_request() {
+        let plan = plan(NearTrialPlanInput {
+            near_account_id: Some("alice.near".to_string()),
+            mode: "paper".to_string(),
+            pair: "NEAR/USDC".to_string(),
+            nominal_near: 0.25,
+            max_trade_near: Some(0.05),
+            assumed_near_usd: 3.0,
+            max_slippage_bps: 50,
+            selected_strategy_id: None,
+            backtest_suite: None,
+        })
+        .unwrap();
+        assert_eq!(plan.schema_version, "near-intents-trial-plan/1");
+        assert_eq!(plan.build_intent_request["solver"], "fixture");
+        assert!(!plan.safe_to_execute);
+        assert_eq!(plan.movement_plan.expected_out.symbol, "USDC");
+    }
+
+    #[test]
+    fn quote_mode_uses_near_intents_solver() {
+        let plan = plan(NearTrialPlanInput {
+            mode: "quote".to_string(),
+            ..NearTrialPlanInput {
+                near_account_id: None,
+                mode: "paper".to_string(),
+                pair: "USDC".to_string(),
+                nominal_near: 1.0,
+                max_trade_near: Some(0.1),
+                assumed_near_usd: 3.0,
+                max_slippage_bps: 50,
+                selected_strategy_id: None,
+                backtest_suite: None,
+            }
+        })
+        .unwrap();
+        assert_eq!(plan.mode, "quote");
+        assert_eq!(plan.build_intent_request["solver"], "near-intents");
+    }
+
+    #[test]
+    fn over_budget_trade_fails_gate() {
+        let plan = plan(NearTrialPlanInput {
+            nominal_near: 0.1,
+            max_trade_near: Some(0.2),
+            ..NearTrialPlanInput {
+                near_account_id: None,
+                mode: "paper".to_string(),
+                pair: "NEAR/USDC".to_string(),
+                nominal_near: 0.25,
+                max_trade_near: None,
+                assumed_near_usd: 3.0,
+                max_slippage_bps: 50,
+                selected_strategy_id: None,
+                backtest_suite: None,
+            }
+        })
+        .unwrap();
+        assert!(plan
+            .risk_gates
+            .iter()
+            .any(|gate| { gate.name == "trade-cap" && gate.status == "fail" }));
+        assert!(!plan.safe_to_quote);
+    }
+}

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -297,6 +297,7 @@ pub struct IntentsTrialSummary {
     pub pair: String,
     pub nominal_near: f64,
     pub max_trade_near: f64,
+    pub assumed_near_usd: f64,
     pub max_trade_usd: f64,
     pub safe_to_quote: bool,
     pub safe_to_execute: bool,
@@ -304,10 +305,24 @@ pub struct IntentsTrialSummary {
     pub recommended_strategy_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selected_strategy_id: Option<String>,
+    pub strategy_menu: Vec<IntentsTrialStrategy>,
     pub setup_steps: Vec<IntentsTrialStep>,
     pub risk_gates: Vec<IntentsRiskGate>,
+    pub warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsTrialStrategy {
+    pub id: String,
+    pub kind: String,
+    pub position_size_pct: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub take_profit_bps: Option<f64>,
+    pub note: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -642,6 +657,21 @@ fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidRes
 }
 
 fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
+    let strategy_menu = value
+        .get("strategy_menu")
+        .and_then(|strategies| strategies.as_array())
+        .into_iter()
+        .flatten()
+        .take(8)
+        .map(|strategy| IntentsTrialStrategy {
+            id: string_field(strategy, "id", "strategy"),
+            kind: string_field(strategy, "kind", "unknown"),
+            position_size_pct: number_field(strategy, "position_size_pct"),
+            stop_loss_bps: strategy.get("stop_loss_bps").and_then(|v| v.as_f64()),
+            take_profit_bps: strategy.get("take_profit_bps").and_then(|v| v.as_f64()),
+            note: string_field(strategy, "note", ""),
+        })
+        .collect();
     let setup_steps = value
         .get("setup_steps")
         .and_then(|steps| steps.as_array())
@@ -667,6 +697,13 @@ fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
             detail: Some(string_field(gate, "detail", "")),
         })
         .collect();
+    let warnings = value
+        .get("warnings")
+        .and_then(|warnings| warnings.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|warning| warning.as_str().map(str::to_string))
+        .collect();
 
     IntentsTrialSummary {
         schema_version: string_field(value, "schema_version", "near-intents-trial-plan/1"),
@@ -674,6 +711,7 @@ fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
         pair: string_field(value, "pair", "NEAR/USDC"),
         nominal_near: number_field(value, "nominal_near"),
         max_trade_near: number_field(value, "max_trade_near"),
+        assumed_near_usd: number_field(value, "assumed_near_usd"),
         max_trade_usd: number_field(value, "max_trade_usd"),
         safe_to_quote: value
             .get("safe_to_quote")
@@ -691,8 +729,10 @@ fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
             .get("selected_strategy_id")
             .and_then(|v| v.as_str())
             .map(str::to_string),
+        strategy_menu,
         setup_steps,
         risk_gates,
+        warnings,
         next_action: value
             .get("next_action")
             .and_then(|v| v.as_str())
@@ -1129,7 +1169,37 @@ mod tests {
                 }],
                 "warnings": []
             })),
-            trial_plan: None,
+            trial_plan: Some(serde_json::json!({
+                "schema_version": "near-intents-trial-plan/1",
+                "mode": "paper",
+                "pair": "NEAR/USDC",
+                "nominal_near": 0.25,
+                "max_trade_near": 0.05,
+                "assumed_near_usd": 3.0,
+                "max_trade_usd": 0.15,
+                "safe_to_quote": true,
+                "safe_to_execute": false,
+                "recommended_strategy_id": "sma_cross_fast",
+                "strategy_menu": [{
+                    "id": "sma_cross_fast",
+                    "kind": "sma-cross",
+                    "position_size_pct": 0.8,
+                    "stop_loss_bps": 1200.0,
+                    "note": "Trend-following candidate for clean spot rotations."
+                }],
+                "setup_steps": [{
+                    "order": 1,
+                    "name": "Use a small wallet",
+                    "status": "manual",
+                    "detail": "Fund a separate NEAR account."
+                }],
+                "risk_gates": [{
+                    "name": "trade-cap",
+                    "status": "pass",
+                    "detail": "Single trade cap passed."
+                }],
+                "warnings": ["Paper only."]
+            })),
             next_action: Some("Request live quote only after user approval.".to_string()),
         });
 
@@ -1142,6 +1212,10 @@ mod tests {
         assert_eq!(paid_research.selected_count, 1);
         assert_eq!(paid_research.payable_sources[0].protocol, "x402");
         assert_eq!(paid_research.near_funding_routes[0].via, "near-intents");
+        let trial_plan = w.trial_plan.unwrap();
+        assert!(trial_plan.safe_to_quote);
+        assert_eq!(trial_plan.assumed_near_usd, 3.0);
+        assert_eq!(trial_plan.strategy_menu[0].id, "sma_cross_fast");
     }
 
     // ---- only ready proposals in suggestions ----

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -57,6 +57,8 @@ pub struct FormatIntentsTradingWidgetInput {
     #[serde(default)]
     pub paid_research_plan: Option<serde_json::Value>,
     #[serde(default)]
+    pub trial_plan: Option<serde_json::Value>,
+    #[serde(default)]
     pub next_action: Option<String>,
 }
 
@@ -180,6 +182,8 @@ pub struct IntentsTradingWidgetState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paid_research: Option<IntentsPaidResearchSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub trial_plan: Option<IntentsTrialSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
 }
 
@@ -284,6 +288,34 @@ pub struct IntentsPaidResearchWalletPolicy {
     pub daily_cap_usd: f64,
     pub safe_to_autopay: bool,
     pub audit_urls: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsTrialSummary {
+    pub schema_version: String,
+    pub mode: String,
+    pub pair: String,
+    pub nominal_near: f64,
+    pub max_trade_near: f64,
+    pub max_trade_usd: f64,
+    pub safe_to_quote: bool,
+    pub safe_to_execute: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended_strategy_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_strategy_id: Option<String>,
+    pub setup_steps: Vec<IntentsTrialStep>,
+    pub risk_gates: Vec<IntentsRiskGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsTrialStep {
+    pub order: usize,
+    pub name: String,
+    pub status: String,
+    pub detail: String,
 }
 
 fn default_mode() -> String {
@@ -419,6 +451,7 @@ pub fn format_intents_trading_widget(
         .paid_research_plan
         .as_ref()
         .map(paid_research_summary_from_value);
+    let trial_plan = input.trial_plan.as_ref().map(trial_summary_from_value);
 
     IntentsTradingWidgetState {
         schema_version: "intents-trading-widget/1",
@@ -434,6 +467,7 @@ pub fn format_intents_trading_widget(
         source_count: input.research_sources.len(),
         research_sources: input.research_sources,
         paid_research,
+        trial_plan,
         next_action: input.next_action,
     }
 }
@@ -604,6 +638,65 @@ fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidRes
         policy_gates,
         wallet_policy,
         warnings,
+    }
+}
+
+fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
+    let setup_steps = value
+        .get("setup_steps")
+        .and_then(|steps| steps.as_array())
+        .into_iter()
+        .flatten()
+        .take(6)
+        .map(|step| IntentsTrialStep {
+            order: step.get("order").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
+            name: string_field(step, "name", "Step"),
+            status: string_field(step, "status", "manual"),
+            detail: string_field(step, "detail", ""),
+        })
+        .collect();
+    let risk_gates = value
+        .get("risk_gates")
+        .and_then(|gates| gates.as_array())
+        .into_iter()
+        .flatten()
+        .take(8)
+        .map(|gate| IntentsRiskGate {
+            name: string_field(gate, "name", "gate"),
+            status: string_field(gate, "status", "unknown"),
+            detail: Some(string_field(gate, "detail", "")),
+        })
+        .collect();
+
+    IntentsTrialSummary {
+        schema_version: string_field(value, "schema_version", "near-intents-trial-plan/1"),
+        mode: string_field(value, "mode", "paper"),
+        pair: string_field(value, "pair", "NEAR/USDC"),
+        nominal_near: number_field(value, "nominal_near"),
+        max_trade_near: number_field(value, "max_trade_near"),
+        max_trade_usd: number_field(value, "max_trade_usd"),
+        safe_to_quote: value
+            .get("safe_to_quote")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        safe_to_execute: value
+            .get("safe_to_execute")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        recommended_strategy_id: value
+            .get("recommended_strategy_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        selected_strategy_id: value
+            .get("selected_strategy_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        setup_steps,
+        risk_gates,
+        next_action: value
+            .get("next_action")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
     }
 }
 
@@ -1036,6 +1129,7 @@ mod tests {
                 }],
                 "warnings": []
             })),
+            trial_plan: None,
             next_action: Some("Request live quote only after user approval.".to_string()),
         });
 


### PR DESCRIPTION
## Summary

- adds `plan_near_intents_trial` for small-NEAR paper/quote rehearsals with strategy gates, wallet setup steps, and unsigned `build_intent` requests
- adds DripStack free-catalog fetching plus a one-article paid-fetch boundary for confirmation, HTTP 402 challenge collection, and receipt-backed retry headers
- updates the Intents Trading Agent skill, widget state/UI, replay scenario, and runbook so users can try the workflow with nominal NEAR without hidden signing or paid-content fetching
- updates the live NEAR Intents solver relay host to the current `solver-relay-v2.chaindefuser.com` endpoint

## Validation

- `cargo test` in `tools-src/portfolio` -- 214 passed, 10 ignored
- `cargo test -p ironclaw_gateway` -- 60 unit tests + 1 doctest passed
- `cargo clippy --all --tests --examples --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `node --check skills/intents-trading-agent/widgets/near-intents-console/index.js`
- JSON validation for portfolio schema/capabilities/registry/sample widget state
- `git diff --check`

## Notes

This is stacked on #3211. It still does not sign NEAR Intents, MPP, or x402 payments. Live paid article content remains behind a receipt handoff, and live quote mode remains unsigned/user-wallet controlled.
