### PR TITLE
feat(portfolio): natural-language → portfolio action compiler

### DIFF
--- a/crates/ironclaw_gateway/src/assets.rs
+++ b/crates/ironclaw_gateway/src/assets.rs
@@ -172,3 +172,16 @@ pub const ADMIN_CSS: &str = include_str!("../static/admin/admin.css");
 
 /// Admin panel JavaScript.
 pub const ADMIN_JS: &str = include_str!("../static/admin/admin.js");
+
+// ==================== Public Experiments ====================
+
+/// Standalone NEAR Intents public experiment.
+pub const NEAR_INTENTS_EXPERIMENT_HTML: &str =
+    include_str!("../static/experiments/near-intents.html");
+
+/// Styles for the standalone NEAR Intents public experiment.
+pub const NEAR_INTENTS_EXPERIMENT_CSS: &str =
+    include_str!("../static/experiments/near-intents.css");
+
+/// JavaScript for the standalone NEAR Intents public experiment.
+pub const NEAR_INTENTS_EXPERIMENT_JS: &str = include_str!("../static/experiments/near-intents.js");

--- a/crates/ironclaw_gateway/static/experiments/near-intents.css
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.css
@@ -1,0 +1,500 @@
+:root {
+  color-scheme: dark;
+  --bg: #080a0c;
+  --ink: #f3f6f0;
+  --muted: #9aa69c;
+  --line: rgba(243, 246, 240, 0.14);
+  --line-strong: rgba(243, 246, 240, 0.24);
+  --panel: rgba(19, 24, 24, 0.82);
+  --panel-strong: rgba(27, 34, 33, 0.96);
+  --accent: #6ef0b0;
+  --accent-2: #f4c46b;
+  --danger: #ff7a7a;
+  --shadow: rgba(0, 0, 0, 0.34);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(110, 240, 176, 0.12), transparent 26rem),
+    linear-gradient(140deg, #080a0c 0%, #0e1412 42%, #171314 100%);
+  color: var(--ink);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+select,
+input,
+a {
+  outline-color: var(--accent);
+}
+
+.lab-shell {
+  min-height: 100svh;
+}
+
+.hero {
+  min-height: 84svh;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: end;
+  padding: clamp(28px, 5vw, 72px);
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid var(--line);
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(8, 10, 12, 0.98), rgba(8, 10, 12, 0.58) 52%, rgba(8, 10, 12, 0.94)),
+    url("data:image/svg+xml,%3Csvg width='1400' height='900' viewBox='0 0 1400 900' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='1400' height='900' fill='%230b1110'/%3E%3Cg fill='none' stroke='%236ef0b0' stroke-opacity='.20'%3E%3Cpath d='M0 610 C190 550 250 450 410 484 C560 516 620 698 780 650 C930 604 960 360 1120 332 C1240 312 1300 400 1400 382' stroke-width='3'/%3E%3Cpath d='M0 690 C210 632 280 596 436 610 C590 625 668 760 820 736 C1000 708 1036 470 1190 448 C1274 436 1330 472 1400 458' stroke-width='2'/%3E%3Cpath d='M0 524 C160 490 250 330 390 360 C560 396 604 552 760 506 C930 456 984 250 1140 228 C1250 212 1308 276 1400 250' stroke-width='2'/%3E%3C/g%3E%3Cg fill='%236ef0b0' fill-opacity='.35'%3E%3Ccircle cx='410' cy='484' r='5'/%3E%3Ccircle cx='780' cy='650' r='5'/%3E%3Ccircle cx='1120' cy='332' r='5'/%3E%3Ccircle cx='820' cy='736' r='4'/%3E%3Ccircle cx='760' cy='506' r='4'/%3E%3C/g%3E%3Cg fill='%23f4c46b' fill-opacity='.28'%3E%3Crect x='1020' y='140' width='230' height='34' rx='4'/%3E%3Crect x='1060' y='190' width='180' height='18' rx='3'/%3E%3Crect x='940' y='740' width='290' height='26' rx='3'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: cover;
+  background-position: center;
+  transform: scale(1.02);
+  animation: heroDrift 900ms ease-out both;
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+  width: min(760px, 100%);
+  padding-bottom: clamp(58px, 8vh, 100px);
+  animation: riseIn 520ms ease-out both;
+}
+
+.eyebrow,
+.section-kicker {
+  margin: 0 0 12px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 760;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 18px;
+  max-width: 720px;
+  font-size: clamp(48px, 10vw, 118px);
+  line-height: 0.9;
+  letter-spacing: 0;
+}
+
+.lede {
+  max-width: 610px;
+  color: rgba(243, 246, 240, 0.82);
+  font-size: clamp(18px, 2vw, 24px);
+  line-height: 1.38;
+}
+
+.hero-actions,
+.console-toolbar {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.primary-action,
+.secondary-action,
+.console-toolbar button,
+.strategy-list button {
+  min-height: 44px;
+  border: 1px solid var(--line-strong);
+  color: var(--ink);
+  background: rgba(243, 246, 240, 0.08);
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease;
+}
+
+.primary-action,
+.secondary-action,
+.console-toolbar button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 18px;
+  border-radius: 6px;
+}
+
+.primary-action {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #06100b;
+  font-weight: 780;
+}
+
+.primary-action:hover,
+.secondary-action:hover,
+.console-toolbar button:hover,
+.strategy-list button:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent);
+}
+
+.market-strip {
+  position: absolute;
+  z-index: 1;
+  right: clamp(22px, 5vw, 72px);
+  bottom: clamp(22px, 5vw, 72px);
+  width: min(580px, calc(100% - 44px));
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--line);
+  background: rgba(8, 10, 12, 0.62);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 20px 70px var(--shadow);
+}
+
+.market-strip div,
+.metrics-row div {
+  padding: 16px;
+  border-right: 1px solid var(--line);
+}
+
+.market-strip div:last-child,
+.metrics-row div:last-child {
+  border-right: 0;
+}
+
+.market-strip span,
+.metrics-row span {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.market-strip strong,
+.metrics-row strong {
+  font-size: clamp(18px, 2vw, 24px);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 340px minmax(0, 1fr);
+  min-height: 820px;
+  border-bottom: 1px solid var(--line);
+}
+
+.controls {
+  padding: 26px;
+  border-right: 1px solid var(--line);
+  background: rgba(8, 10, 12, 0.44);
+}
+
+.control-block {
+  padding: 22px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.control-block:first-child {
+  padding-top: 0;
+}
+
+.control-block:last-child {
+  border-bottom: 0;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 14px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  padding: 0 12px;
+  background: rgba(243, 246, 240, 0.06);
+  color: var(--ink);
+}
+
+select option {
+  color: #07110d;
+}
+
+.strategy-list {
+  display: grid;
+  gap: 10px;
+}
+
+.strategy-list button {
+  border-radius: 6px;
+  padding: 13px 14px;
+  text-align: left;
+}
+
+.strategy-list button[aria-checked="true"] {
+  border-color: var(--accent);
+  background: rgba(110, 240, 176, 0.12);
+}
+
+.strategy-list strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.strategy-list span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.live-panel {
+  padding: clamp(24px, 4vw, 44px);
+  background: linear-gradient(180deg, rgba(243, 246, 240, 0.03), rgba(243, 246, 240, 0.01));
+}
+
+.panel-header,
+.console-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.panel-header h2,
+.paper-copy h2 {
+  margin-bottom: 0;
+  font-size: clamp(30px, 5vw, 58px);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.status-pill {
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  padding: 9px 14px;
+  color: var(--accent);
+  background: rgba(110, 240, 176, 0.08);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.status-pill.warn {
+  color: var(--accent-2);
+  background: rgba(244, 196, 107, 0.08);
+}
+
+.status-pill.danger {
+  color: var(--danger);
+  background: rgba(255, 122, 122, 0.08);
+}
+
+.chart-wrap {
+  margin-top: 28px;
+  border: 1px solid var(--line);
+  background: rgba(8, 10, 12, 0.52);
+  min-height: 330px;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: min(48vh, 520px);
+}
+
+.metrics-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 16px;
+  border: 1px solid var(--line);
+  background: rgba(8, 10, 12, 0.36);
+}
+
+.decision-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 28px;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+
+.decision-grid > div {
+  padding: 22px;
+  background: rgba(8, 10, 12, 0.58);
+}
+
+.decision-copy {
+  margin: 0;
+  color: rgba(243, 246, 240, 0.76);
+  line-height: 1.55;
+}
+
+.paper-band {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.28fr);
+  gap: clamp(24px, 4vw, 54px);
+  padding: clamp(30px, 5vw, 76px);
+  background: #0b0e10;
+}
+
+.paper-copy p:last-child {
+  max-width: 560px;
+  color: rgba(243, 246, 240, 0.75);
+  line-height: 1.55;
+}
+
+.intent-console {
+  min-width: 0;
+  border: 1px solid var(--line);
+  background: #080a0c;
+  box-shadow: 0 20px 70px var(--shadow);
+}
+
+.console-toolbar {
+  padding: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.console-toolbar button {
+  min-width: 136px;
+}
+
+pre {
+  margin: 0;
+  min-height: 360px;
+  max-height: 560px;
+  overflow: auto;
+  padding: 18px;
+  color: #dce7df;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@keyframes riseIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes heroDrift {
+  from {
+    opacity: 0.7;
+    transform: scale(1.06);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1.02);
+  }
+}
+
+@media (max-width: 960px) {
+  .hero {
+    min-height: 760px;
+  }
+
+  .market-strip,
+  .workspace,
+  .paper-band,
+  .decision-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .market-strip {
+    left: 22px;
+    right: 22px;
+  }
+
+  .workspace {
+    min-height: auto;
+  }
+
+  .controls {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .metrics-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metrics-row div:nth-child(2) {
+    border-right: 0;
+  }
+
+  .metrics-row div:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 620px) {
+  .hero {
+    padding: 22px;
+    min-height: 720px;
+  }
+
+  .hero-copy {
+    padding-bottom: 230px;
+  }
+
+  .market-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .market-strip div {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .market-strip div:last-child {
+    border-bottom: 0;
+  }
+
+  .metrics-row {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics-row div {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .metrics-row div:last-child {
+    border-bottom: 0;
+  }
+
+  .panel-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/crates/ironclaw_gateway/static/experiments/near-intents.html
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>NEAR Intents Strategy Lab</title>
+  <link rel="stylesheet" href="/experiments/near-intents.css">
+</head>
+<body>
+  <main class="lab-shell">
+    <section class="hero">
+      <div class="hero-copy">
+        <p class="eyebrow">Public experiment</p>
+        <h1>NEAR Intents Strategy Lab</h1>
+        <p class="lede">Run live-data paper strategies, inspect the signal, and produce an unsigned direct NEAR Intents trial payload.</p>
+        <div class="hero-actions">
+          <button id="runLiveBtn" class="primary-action" type="button">Run live strategy</button>
+          <a class="secondary-action" href="#paper">View paper intent</a>
+        </div>
+      </div>
+      <div class="market-strip" aria-label="Market snapshot">
+        <div>
+          <span>Source</span>
+          <strong id="sourceLabel">Waiting</strong>
+        </div>
+        <div>
+          <span id="priceCaption">Last price</span>
+          <strong id="priceLabel">-</strong>
+        </div>
+        <div>
+          <span>Signal</span>
+          <strong id="signalLabel">Idle</strong>
+        </div>
+      </div>
+    </section>
+
+    <section class="workspace" aria-label="Strategy workspace">
+      <aside class="controls" aria-label="Experiment controls">
+        <div class="control-block">
+          <p class="section-kicker">Market</p>
+          <label>
+            Pair
+            <select id="pairSelect">
+              <option value="NEAR-USD" selected>NEAR / USD</option>
+              <option value="BTC-USD">BTC / USD</option>
+              <option value="ETH-USD">ETH / USD</option>
+              <option value="SOL-USD">SOL / USD</option>
+            </select>
+          </label>
+          <label>
+            Lookback
+            <select id="lookbackSelect">
+              <option value="30" selected>30 days</option>
+              <option value="14">14 days</option>
+              <option value="7">7 days</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="control-block">
+          <p class="section-kicker">Strategy</p>
+          <div id="strategyList" class="strategy-list" role="radiogroup" aria-label="Strategy"></div>
+        </div>
+
+        <div class="control-block">
+          <p class="section-kicker">Trial ticket</p>
+          <label>
+            NEAR account
+            <input id="accountInput" type="text" placeholder="small-test.near" autocomplete="off">
+          </label>
+          <label>
+            Paper budget, USD
+            <input id="budgetInput" type="number" min="0.01" step="0.01" value="0.25">
+          </label>
+          <label>
+            Max trade, USD
+            <input id="tradeCapInput" type="number" min="0.01" step="0.01" value="0.05">
+          </label>
+          <label>
+            Slippage, bps
+            <input id="slippageInput" type="number" min="1" max="500" step="1" value="50">
+          </label>
+        </div>
+      </aside>
+
+      <section class="live-panel" aria-label="Live strategy output">
+        <div class="panel-header">
+          <div>
+            <p class="section-kicker">Live paper run</p>
+            <h2 id="strategyTitle">SMA Cross</h2>
+          </div>
+          <div id="statusPill" class="status-pill">Idle</div>
+        </div>
+
+        <div class="chart-wrap">
+          <canvas id="priceCanvas" width="1200" height="520" aria-label="Price chart"></canvas>
+        </div>
+
+        <div class="metrics-row" aria-label="Backtest metrics">
+          <div>
+            <span>Return</span>
+            <strong id="returnMetric">-</strong>
+          </div>
+          <div>
+            <span>Max drawdown</span>
+            <strong id="drawdownMetric">-</strong>
+          </div>
+          <div>
+            <span>Trades</span>
+            <strong id="tradesMetric">-</strong>
+          </div>
+          <div>
+            <span>Confidence</span>
+            <strong id="confidenceMetric">-</strong>
+          </div>
+        </div>
+
+        <div class="decision-grid">
+          <div>
+            <p class="section-kicker">Signal note</p>
+            <p id="signalNote" class="decision-copy">Run the strategy to load recent candles and generate a paper decision.</p>
+          </div>
+          <div>
+            <p class="section-kicker">Risk boundary</p>
+            <p class="decision-copy">This page never signs or broadcasts. It only creates an unsigned trial payload for review.</p>
+          </div>
+        </div>
+      </section>
+    </section>
+
+    <section id="paper" class="paper-band" aria-label="Paper intent">
+      <div class="paper-copy">
+        <p class="section-kicker">Unsigned NEAR Intents draft</p>
+        <h2>Show the strategy, not a custody flow.</h2>
+        <p>External viewers can see live data, the strategy decision, sizing, and the exact unsigned direct-intent payload. A wallet signature remains a separate explicit step.</p>
+      </div>
+      <div class="intent-console">
+        <div class="console-toolbar">
+          <button id="buildIntentBtn" type="button">Build paper intent</button>
+          <button id="copyIntentBtn" type="button">Copy JSON</button>
+        </div>
+        <pre id="intentOutput">Run a strategy to prepare an unsigned payload.</pre>
+      </div>
+    </section>
+  </main>
+  <script src="/experiments/near-intents.js"></script>
+</body>
+</html>

--- a/crates/ironclaw_gateway/static/experiments/near-intents.js
+++ b/crates/ironclaw_gateway/static/experiments/near-intents.js
@@ -1,0 +1,528 @@
+(function () {
+  'use strict';
+
+  var strategies = [
+    {
+      id: 'sma_cross',
+      name: 'SMA Cross',
+      copy: 'Trend-following spot strategy using 12h and 48h moving averages.'
+    },
+    {
+      id: 'mean_reversion',
+      name: 'Mean Reversion',
+      copy: 'Range strategy using a 20h z-score and volatility-aware exits.'
+    },
+    {
+      id: 'breakout',
+      name: 'Breakout',
+      copy: 'Momentum strategy that reacts to 24h channel breaks.'
+    },
+    {
+      id: 'hl_momentum_watch',
+      name: 'HL Momentum Watch',
+      copy: 'Hyperliquid-style momentum watcher with spot-only NEAR Intents output.'
+    }
+  ];
+
+  var state = {
+    candles: [],
+    pair: 'NEAR-USD',
+    source: 'Waiting',
+    selectedStrategy: 'sma_cross',
+    result: null,
+    lastIntent: null
+  };
+
+  var els = {
+    runLiveBtn: document.getElementById('runLiveBtn'),
+    pairSelect: document.getElementById('pairSelect'),
+    lookbackSelect: document.getElementById('lookbackSelect'),
+    strategyList: document.getElementById('strategyList'),
+    accountInput: document.getElementById('accountInput'),
+    budgetInput: document.getElementById('budgetInput'),
+    tradeCapInput: document.getElementById('tradeCapInput'),
+    slippageInput: document.getElementById('slippageInput'),
+    sourceLabel: document.getElementById('sourceLabel'),
+    priceCaption: document.getElementById('priceCaption'),
+    priceLabel: document.getElementById('priceLabel'),
+    signalLabel: document.getElementById('signalLabel'),
+    strategyTitle: document.getElementById('strategyTitle'),
+    statusPill: document.getElementById('statusPill'),
+    priceCanvas: document.getElementById('priceCanvas'),
+    returnMetric: document.getElementById('returnMetric'),
+    drawdownMetric: document.getElementById('drawdownMetric'),
+    tradesMetric: document.getElementById('tradesMetric'),
+    confidenceMetric: document.getElementById('confidenceMetric'),
+    signalNote: document.getElementById('signalNote'),
+    buildIntentBtn: document.getElementById('buildIntentBtn'),
+    copyIntentBtn: document.getElementById('copyIntentBtn'),
+    intentOutput: document.getElementById('intentOutput')
+  };
+
+  function fmtUsd(n) {
+    if (!Number.isFinite(n)) return '-';
+    return '$' + n.toLocaleString(undefined, {
+      minimumFractionDigits: n < 10 ? 4 : 2,
+      maximumFractionDigits: n < 10 ? 4 : 2
+    });
+  }
+
+  function fmtPct(n) {
+    if (!Number.isFinite(n)) return '-';
+    var sign = n > 0 ? '+' : '';
+    return sign + (n * 100).toFixed(2) + '%';
+  }
+
+  function clamp(n, min, max) {
+    return Math.max(min, Math.min(max, n));
+  }
+
+  function average(values) {
+    if (!values.length) return 0;
+    return values.reduce(function (sum, value) { return sum + value; }, 0) / values.length;
+  }
+
+  function stdev(values) {
+    if (values.length < 2) return 0;
+    var mean = average(values);
+    var variance = average(values.map(function (value) {
+      return Math.pow(value - mean, 2);
+    }));
+    return Math.sqrt(variance);
+  }
+
+  function movingAverage(candles, end, period) {
+    if (end + 1 < period) return null;
+    var slice = candles.slice(end + 1 - period, end + 1).map(function (c) { return c.close; });
+    return average(slice);
+  }
+
+  function setStatus(text, tone) {
+    els.statusPill.textContent = text;
+    els.statusPill.className = 'status-pill' + (tone ? ' ' + tone : '');
+  }
+
+  function selectedStrategy() {
+    return strategies.find(function (strategy) {
+      return strategy.id === state.selectedStrategy;
+    }) || strategies[0];
+  }
+
+  function renderStrategies() {
+    els.strategyList.innerHTML = '';
+    strategies.forEach(function (strategy) {
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.setAttribute('role', 'radio');
+      button.setAttribute('aria-checked', strategy.id === state.selectedStrategy ? 'true' : 'false');
+      button.innerHTML = '<strong>' + strategy.name + '</strong><span>' + strategy.copy + '</span>';
+      button.addEventListener('click', function () {
+        state.selectedStrategy = strategy.id;
+        renderStrategies();
+        els.strategyTitle.textContent = strategy.name;
+        if (state.candles.length) runStrategy();
+      });
+      els.strategyList.appendChild(button);
+    });
+  }
+
+  async function fetchCoinbaseCandles(pair, days) {
+    var end = Math.floor(Date.now() / 1000);
+    var start = end - Number(days) * 24 * 60 * 60;
+    var url = 'https://api.exchange.coinbase.com/products/' + encodeURIComponent(pair) +
+      '/candles?granularity=3600&start=' + new Date(start * 1000).toISOString() +
+      '&end=' + new Date(end * 1000).toISOString();
+    var res = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!res.ok) throw new Error('Coinbase candles failed: ' + res.status);
+    var rows = await res.json();
+    if (!Array.isArray(rows) || rows.length < 24) throw new Error('Coinbase returned too few candles');
+    return rows.map(function (row) {
+      return {
+        time: row[0] * 1000,
+        low: Number(row[1]),
+        high: Number(row[2]),
+        open: Number(row[3]),
+        close: Number(row[4]),
+        volume: Number(row[5])
+      };
+    }).sort(function (a, b) { return a.time - b.time; });
+  }
+
+  async function fetchCoingeckoNear(days) {
+    var url = 'https://api.coingecko.com/api/v3/coins/near/market_chart?vs_currency=usd&days=' +
+      encodeURIComponent(days) + '&interval=hourly';
+    var res = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!res.ok) throw new Error('CoinGecko failed: ' + res.status);
+    var body = await res.json();
+    if (!body.prices || body.prices.length < 24) throw new Error('CoinGecko returned too few prices');
+    return body.prices.map(function (row) {
+      var price = Number(row[1]);
+      return {
+        time: Number(row[0]),
+        low: price,
+        high: price,
+        open: price,
+        close: price,
+        volume: 0
+      };
+    });
+  }
+
+  async function fetchCandles() {
+    var pair = els.pairSelect.value;
+    var days = els.lookbackSelect.value;
+    state.pair = pair;
+    try {
+      state.source = 'Coinbase hourly';
+      return await fetchCoinbaseCandles(pair, days);
+    } catch (err) {
+      if (pair !== 'NEAR-USD') throw err;
+      state.source = 'CoinGecko hourly';
+      return fetchCoingeckoNear(days);
+    }
+  }
+
+  function syntheticFallbackCandles(pair, days) {
+    var count = Number(days) * 24;
+    var baseByPair = {
+      'NEAR-USD': 1.28,
+      'BTC-USD': 94500,
+      'ETH-USD': 1820,
+      'SOL-USD': 126
+    };
+    var base = baseByPair[pair] || 1;
+    var candles = [];
+    var now = Date.now();
+    var drift = pair === 'BTC-USD' ? 0.00008 : 0.00018;
+
+    for (var i = 0; i < count; i += 1) {
+      var wave = Math.sin(i / 9) * 0.016 + Math.cos(i / 31) * 0.026;
+      var shock = Math.sin(i / 3.7) * 0.005;
+      var trend = (i - count / 2) * drift;
+      var close = base * (1 + trend + wave + shock);
+      candles.push({
+        time: now - (count - i) * 60 * 60 * 1000,
+        low: close * 0.994,
+        high: close * 1.006,
+        open: close * (1 - shock / 2),
+        close: close,
+        volume: 0
+      });
+    }
+
+    state.source = 'Sample fallback';
+    return candles;
+  }
+
+  function signalAt(candles, index, strategyId) {
+    var candle = candles[index];
+    if (!candle) return { side: 'hold', score: 0, reason: 'No candle' };
+
+    if (strategyId === 'sma_cross') {
+      var fast = movingAverage(candles, index, 12);
+      var slow = movingAverage(candles, index, 48);
+      if (!fast || !slow) return { side: 'hold', score: 0, reason: 'Waiting for SMA warmup' };
+      var spread = (fast - slow) / slow;
+      if (spread > 0.006) return { side: 'buy', score: clamp(spread * 900, 0.15, 0.92), reason: 'Fast average is above slow average.' };
+      if (spread < -0.006) return { side: 'sell', score: clamp(Math.abs(spread) * 900, 0.15, 0.92), reason: 'Fast average is below slow average.' };
+      return { side: 'hold', score: 0.34, reason: 'Averages are compressed.' };
+    }
+
+    if (strategyId === 'mean_reversion') {
+      if (index < 20) return { side: 'hold', score: 0, reason: 'Waiting for range warmup' };
+      var window = candles.slice(index - 19, index + 1).map(function (c) { return c.close; });
+      var mean = average(window);
+      var sigma = stdev(window);
+      var z = sigma > 0 ? (candle.close - mean) / sigma : 0;
+      if (z < -1.15) return { side: 'buy', score: clamp(Math.abs(z) / 2.8, 0.22, 0.88), reason: 'Price is below its local range.' };
+      if (z > 1.15) return { side: 'sell', score: clamp(Math.abs(z) / 2.8, 0.22, 0.88), reason: 'Price is above its local range.' };
+      return { side: 'hold', score: 0.36, reason: 'Price is near fair range.' };
+    }
+
+    if (strategyId === 'breakout') {
+      if (index < 24) return { side: 'hold', score: 0, reason: 'Waiting for channel warmup' };
+      var channel = candles.slice(index - 24, index);
+      var high = Math.max.apply(null, channel.map(function (c) { return c.high; }));
+      var low = Math.min.apply(null, channel.map(function (c) { return c.low; }));
+      if (candle.close > high) return { side: 'buy', score: 0.78, reason: 'Price cleared the 24h channel high.' };
+      if (candle.close < low) return { side: 'sell', score: 0.78, reason: 'Price lost the 24h channel low.' };
+      return { side: 'hold', score: 0.31, reason: 'Price remains inside the channel.' };
+    }
+
+    if (index < 12) return { side: 'hold', score: 0, reason: 'Waiting for momentum warmup' };
+    var prior = candles[index - 12].close;
+    var momentum = prior > 0 ? (candle.close - prior) / prior : 0;
+    if (momentum > 0.025) return { side: 'buy', score: clamp(momentum * 10, 0.24, 0.86), reason: '12h momentum is positive; paper-only spot route.' };
+    if (momentum < -0.025) return { side: 'sell', score: clamp(Math.abs(momentum) * 10, 0.24, 0.86), reason: '12h momentum is negative; paper-only de-risk route.' };
+    return { side: 'hold', score: 0.35, reason: 'Momentum is not decisive.' };
+  }
+
+  function backtest(candles, strategyId) {
+    var equity = 1;
+    var peak = 1;
+    var maxDrawdown = 0;
+    var position = 0;
+    var trades = 0;
+    var curve = [];
+
+    for (var i = 1; i < candles.length; i += 1) {
+      var signal = signalAt(candles, i - 1, strategyId);
+      var nextPosition = signal.side === 'buy' ? 1 : signal.side === 'sell' ? 0 : position;
+      if (nextPosition !== position) trades += 1;
+      position = nextPosition;
+      var ret = candles[i - 1].close > 0 ? (candles[i].close - candles[i - 1].close) / candles[i - 1].close : 0;
+      equity *= 1 + position * ret;
+      peak = Math.max(peak, equity);
+      maxDrawdown = Math.max(maxDrawdown, peak > 0 ? (peak - equity) / peak : 0);
+      curve.push(equity);
+    }
+
+    var latest = signalAt(candles, candles.length - 1, strategyId);
+    var totalReturn = equity - 1;
+    var confidence = clamp(0.45 + latest.score * 0.42 + Math.min(Math.max(totalReturn, -0.15), 0.25), 0.05, 0.93);
+    return {
+      latest: latest,
+      totalReturn: totalReturn,
+      maxDrawdown: maxDrawdown,
+      trades: trades,
+      confidence: confidence,
+      curve: curve
+    };
+  }
+
+  function drawChart() {
+    var canvas = els.priceCanvas;
+    var ctx = canvas.getContext('2d');
+    var width = canvas.width;
+    var height = canvas.height;
+    var candles = state.candles;
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = '#080a0c';
+    ctx.fillRect(0, 0, width, height);
+
+    if (!candles.length) {
+      ctx.fillStyle = '#9aa69c';
+      ctx.font = '28px system-ui';
+      ctx.fillText('Run live strategy to draw recent candles', 44, height / 2);
+      return;
+    }
+
+    var closes = candles.map(function (c) { return c.close; });
+    var min = Math.min.apply(null, closes);
+    var max = Math.max.apply(null, closes);
+    var pad = Math.max((max - min) * 0.12, max * 0.01);
+    var lo = min - pad;
+    var hi = max + pad;
+
+    function x(i) {
+      return candles.length <= 1 ? 0 : (i / (candles.length - 1)) * width;
+    }
+
+    function y(price) {
+      return height - ((price - lo) / (hi - lo)) * height;
+    }
+
+    ctx.strokeStyle = 'rgba(243, 246, 240, 0.08)';
+    ctx.lineWidth = 1;
+    for (var g = 1; g < 5; g += 1) {
+      ctx.beginPath();
+      ctx.moveTo(0, (height / 5) * g);
+      ctx.lineTo(width, (height / 5) * g);
+      ctx.stroke();
+    }
+
+    var gradient = ctx.createLinearGradient(0, 0, 0, height);
+    gradient.addColorStop(0, 'rgba(110, 240, 176, 0.32)');
+    gradient.addColorStop(1, 'rgba(110, 240, 176, 0)');
+    ctx.beginPath();
+    closes.forEach(function (close, i) {
+      if (i === 0) ctx.moveTo(x(i), y(close));
+      else ctx.lineTo(x(i), y(close));
+    });
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height);
+    ctx.closePath();
+    ctx.fillStyle = gradient;
+    ctx.fill();
+
+    ctx.beginPath();
+    closes.forEach(function (close, i) {
+      if (i === 0) ctx.moveTo(x(i), y(close));
+      else ctx.lineTo(x(i), y(close));
+    });
+    ctx.strokeStyle = '#6ef0b0';
+    ctx.lineWidth = 3;
+    ctx.stroke();
+
+    if (state.result && state.result.curve.length > 2) {
+      var curve = state.result.curve;
+      var cMin = Math.min.apply(null, curve);
+      var cMax = Math.max.apply(null, curve);
+      ctx.beginPath();
+      curve.forEach(function (point, i) {
+        var px = (i / (curve.length - 1)) * width;
+        var py = height - ((point - cMin) / Math.max(cMax - cMin, 0.0001)) * height;
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      });
+      ctx.strokeStyle = 'rgba(244, 196, 107, 0.72)';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+  }
+
+  function updateMetrics() {
+    var last = state.candles[state.candles.length - 1];
+    els.sourceLabel.textContent = state.source;
+    els.priceCaption.textContent = 'Last ' + state.pair.replace('-USD', '');
+    els.priceLabel.textContent = last ? fmtUsd(last.close) : '-';
+
+    if (!state.result) {
+      els.signalLabel.textContent = 'Idle';
+      els.returnMetric.textContent = '-';
+      els.drawdownMetric.textContent = '-';
+      els.tradesMetric.textContent = '-';
+      els.confidenceMetric.textContent = '-';
+      return;
+    }
+
+    var latest = state.result.latest;
+    els.signalLabel.textContent = latest.side.toUpperCase();
+    els.returnMetric.textContent = fmtPct(state.result.totalReturn);
+    els.drawdownMetric.textContent = fmtPct(-state.result.maxDrawdown);
+    els.tradesMetric.textContent = String(state.result.trades);
+    els.confidenceMetric.textContent = Math.round(state.result.confidence * 100) + '%';
+    els.signalNote.textContent = latest.reason + ' Latest paper decision: ' + latest.side.toUpperCase() + ' with ' + Math.round(state.result.confidence * 100) + '% confidence.';
+
+    if (latest.side === 'buy') setStatus('Paper buy', '');
+    else if (latest.side === 'sell') setStatus('Paper sell', 'warn');
+    else setStatus('Hold', 'warn');
+  }
+
+  async function runLive() {
+    setStatus('Loading candles', 'warn');
+    els.runLiveBtn.disabled = true;
+    try {
+      state.candles = await fetchCandles();
+      runStrategy();
+    } catch (err) {
+      state.candles = syntheticFallbackCandles(els.pairSelect.value, els.lookbackSelect.value);
+      runStrategy();
+      setStatus('Sample data', 'warn');
+      els.signalNote.textContent = 'Live data failed, so this run is using deterministic sample candles. The page is still safe; no funds or signatures are touched.';
+    } finally {
+      els.runLiveBtn.disabled = false;
+    }
+  }
+
+  function runStrategy() {
+    var strategy = selectedStrategy();
+    els.strategyTitle.textContent = strategy.name;
+    state.result = backtest(state.candles, strategy.id);
+    updateMetrics();
+    drawChart();
+    buildIntent();
+  }
+
+  function tokenForPair(pair) {
+    if (pair.indexOf('NEAR') === 0) return 'wrap.near';
+    if (pair.indexOf('BTC') === 0) return 'btc.omft.near';
+    if (pair.indexOf('ETH') === 0) return 'eth.omft.near';
+    if (pair.indexOf('SOL') === 0) return 'sol.omft.near';
+    return 'wrap.near';
+  }
+
+  function buildIntent() {
+    var last = state.candles[state.candles.length - 1];
+    var strategy = selectedStrategy();
+    var latest = state.result ? state.result.latest : { side: 'hold', reason: 'No signal yet' };
+    var budgetUsd = Number(els.budgetInput.value || 0);
+    var tradeCapUsd = Number(els.tradeCapInput.value || 0);
+    var slippageBps = Number(els.slippageInput.value || 0);
+    var safeTradeUsd = Math.max(0, Math.min(budgetUsd, tradeCapUsd));
+    var side = latest.side;
+    var account = els.accountInput.value.trim() || '<viewer-provided-account.near>';
+    var minOutUsd = safeTradeUsd * (1 - slippageBps / 10000);
+    var quoteRequest = side === 'hold' ? null : {
+      sell: side === 'buy'
+        ? { token: 'usdc.near', amount_usd_estimate: Number(safeTradeUsd.toFixed(6)) }
+        : { token: tokenForPair(state.pair), amount_usd_estimate: Number(safeTradeUsd.toFixed(6)) },
+      buy: side === 'buy'
+        ? { token: tokenForPair(state.pair), min_amount_usd: Number(minOutUsd.toFixed(6)) }
+        : { token: 'usdc.near', min_amount_usd: Number(minOutUsd.toFixed(6)) },
+      slippage_bps: slippageBps
+    };
+
+    state.lastIntent = {
+      schema: 'near-intents-public-experiment/1',
+      mode: 'paper',
+      public_demo: true,
+      execution_boundary: 'unsigned-only',
+      created_at: new Date().toISOString(),
+      account_id: account,
+      market: {
+        pair: state.pair.replace('-', '/'),
+        source: state.source,
+        last_price_usd: last ? Number(last.close.toFixed(8)) : null
+      },
+      strategy: {
+        id: strategy.id,
+        name: strategy.name,
+        decision: side,
+        confidence: state.result ? Number(state.result.confidence.toFixed(4)) : null,
+        note: latest.reason
+      },
+      risk: {
+        nominal_budget_usd: budgetUsd,
+        max_trade_usd: safeTradeUsd,
+        slippage_bps: slippageBps,
+        funding_asset_hint: 'any_near_intents_supported_deposit_asset',
+        no_auto_signing: true,
+        no_broadcast: true
+      },
+      draft_intent: {
+        venue: 'near_intents',
+        deposit_model: 'direct_near_intents_balance_or_any_supported_asset',
+        solver_quote_required: true,
+        decision: side,
+        quote_request: quoteRequest,
+        hold_reason: side === 'hold' ? latest.reason : null,
+        expires_in_seconds: 120
+      }
+    };
+    els.intentOutput.textContent = JSON.stringify(state.lastIntent, null, 2);
+  }
+
+  function copyIntent() {
+    var text = els.intentOutput.textContent || '';
+    if (!text || text.indexOf('{') !== 0) return;
+    navigator.clipboard.writeText(text).then(function () {
+      els.copyIntentBtn.textContent = 'Copied';
+      setTimeout(function () {
+        els.copyIntentBtn.textContent = 'Copy JSON';
+      }, 1200);
+    }).catch(function () {
+      els.copyIntentBtn.textContent = 'Copy failed';
+      setTimeout(function () {
+        els.copyIntentBtn.textContent = 'Copy JSON';
+      }, 1200);
+    });
+  }
+
+  function bind() {
+    renderStrategies();
+    drawChart();
+    els.runLiveBtn.addEventListener('click', runLive);
+    els.pairSelect.addEventListener('change', runLive);
+    els.lookbackSelect.addEventListener('change', runLive);
+    els.buildIntentBtn.addEventListener('click', buildIntent);
+    els.copyIntentBtn.addEventListener('click', copyIntent);
+    [els.accountInput, els.budgetInput, els.tradeCapInput, els.slippageInput].forEach(function (input) {
+      input.addEventListener('input', buildIntent);
+    });
+    window.addEventListener('resize', drawChart);
+    setTimeout(runLive, 250);
+  }
+
+  bind();
+}());

--- a/crates/ironclaw_gateway/static/js/surfaces/projects.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/projects.js
@@ -439,6 +439,28 @@ function crOpenEngineThread(threadId) {
 
 var _projectWidgets = []; // { id, destroy }
 
+function projectWidgetScriptSource(manifest, js) {
+  return [
+    '(function() {',
+    '  var __script = document.currentScript;',
+    '  var __mountId = __script && __script.getAttribute("data-mount-id");',
+    '  var __registry = window.__IRONCLAW_PROJECT_WIDGET_MOUNTS || {};',
+    '  var __mount = __registry[__mountId];',
+    '  if (!__mount) throw new Error("Missing project widget mount: " + __mountId);',
+    '  try {',
+    '    var __destroy = (function(container, api, projectId) {',
+    js,
+    '    })(__mount.container, __mount.api, __mount.projectId);',
+    '    if (typeof __destroy === "function") __mount.destroy = __destroy;',
+    '    if (typeof __mount.onLoad === "function") __mount.onLoad();',
+    '  } catch (__err) {',
+    '    if (typeof __mount.onError === "function") { __mount.onError(__err); } else { throw __err; }',
+    '  }',
+    '})();',
+    '//# sourceURL=ironclaw-project-widget-' + manifest.id + '.js'
+  ].join('\n');
+}
+
 function loadProjectWidgets(projectId) {
   destroyProjectWidgets();
   apiFetch('/api/engine/projects/' + encodeURIComponent(projectId) + '/widgets')
@@ -466,24 +488,58 @@ function loadProjectWidgets(projectId) {
           document.head.appendChild(style);
         }
 
-        // Eval the JS module to register the widget.
+        // Run the widget as a blob-backed script. Project widget code is
+        // fetched through the authenticated API above, then executed as a
+        // same-page plugin without `unsafe-eval`.
+        var mountId = manifest.id + '-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+        var registry = window.__IRONCLAW_PROJECT_WIDGET_MOUNTS = window.__IRONCLAW_PROJECT_WIDGET_MOUNTS || {};
+        var objectUrl = null;
+        var script = null;
+        var mount = {
+          container: container,
+          api: typeof IronClaw !== 'undefined' ? IronClaw.api : null,
+          projectId: projectId,
+          destroy: null,
+          onError: function(err) {
+            console.error('[projects] Failed to mount widget ' + manifest.id + ':', err);
+            container.innerHTML = '<div class="cr-empty">Widget error: ' + manifest.id + '</div>';
+          }
+        };
+        registry[mountId] = mount;
+
         try {
-          var api = typeof IronClaw !== 'undefined' ? IronClaw.api : null;
-          var fn = new Function('container', 'api', 'projectId', w.js);
-          fn(container, api, projectId);
+          objectUrl = URL.createObjectURL(new Blob([
+            projectWidgetScriptSource(manifest, w.js)
+          ], { type: 'application/javascript' }));
+          script = document.createElement('script');
+          script.src = objectUrl;
+          script.async = false;
+          script.setAttribute('data-project-widget-script', manifest.id);
+          script.setAttribute('data-mount-id', mountId);
+          script.onerror = function() {
+            mount.onError(new Error('Failed to load widget script'));
+          };
+          document.head.appendChild(script);
 
           _projectWidgets.push({
             id: manifest.id,
             container: container,
             style: style || null,
             destroy: function() {
+              if (typeof mount.destroy === 'function') {
+                try { mount.destroy(); } catch (e) { /* ignore widget cleanup errors */ }
+              }
+              delete registry[mountId];
               container.remove();
               if (style) style.remove();
+              if (script) script.remove();
+              if (objectUrl) URL.revokeObjectURL(objectUrl);
             }
           });
         } catch (err) {
-          console.error('[projects] Failed to mount widget ' + manifest.id + ':', err);
-          container.innerHTML = '<div class="cr-empty">Widget error: ' + manifest.id + '</div>';
+          delete registry[mountId];
+          if (objectUrl) URL.revokeObjectURL(objectUrl);
+          mount.onError(err);
         }
       });
     })
@@ -1412,4 +1468,3 @@ function formatRelativeTime(isoString) {
 }
 
 // --- Users (admin) ---
-

--- a/docs/plans/2026-05-02-intents-trading-agent.md
+++ b/docs/plans/2026-05-02-intents-trading-agent.md
@@ -1,0 +1,183 @@
+# Intents Trading Agent on IronClaw
+
+**Status**: prototype scaffold
+**Date**: 2026-05-02
+**Owner**: tbd
+
+## Goal
+
+Build a TradingAgents-style crypto trading workflow on top of IronClaw
+that can research multichain spot opportunities, debate bull and bear
+cases, apply deterministic risk gates, and produce unsigned NEAR Intent
+bundles for user review.
+
+The first version is intentionally conservative: paper mode by default,
+quote-only when explicitly requested, no private keys, no signing, and
+no raw chain transaction builders.
+
+## Existing IronClaw foundation
+
+IronClaw already has the right execution primitive in
+`tools-src/portfolio`:
+
+- `scan` discovers EVM and NEAR portfolio positions.
+- `propose` emits deterministic DeFi movement proposals from strategy
+  docs.
+- `build_intent` turns a `MovementPlan` into a `portfolio-intent/1`
+  unsigned intent bundle through fixture, replay, or live NEAR Intents
+  solver paths.
+- `backtest` runs deterministic long-only spot strategy tests over
+  caller-provided OHLCV candles before a trade idea is eligible for
+  intent construction.
+- `backtest_suite` ranks a menu of strategy candidates over the same
+  OHLCV episode so users can choose from tested alternatives.
+
+The new `skills/intents-trading-agent` skill is the orchestration layer
+above that tool.
+
+## TradingAgents role mapping
+
+| TradingAgents role | IronClaw prototype role | Output |
+|---|---|---|
+| Fundamentals analyst | Market data analyst | Trend, volume, volatility, liquidity context |
+| News analyst | News/sentiment analyst | Catalyst and risk event memo |
+| Technical analyst | Market data analyst | Setup, invalidation, regime notes |
+| Research bull | Bull memo | Best case for the trade |
+| Research bear | Bear memo | Best case against the trade |
+| Trader | Trader proposal | Direction, notional, route, expected output |
+| Risk manager | Risk analyst | Gate pass/fail table |
+| Portfolio manager | Manager synthesis | Final stance: skip, watch, paper-intent, quote-intent |
+
+## Open-source references
+
+The local implementation borrows design patterns from mature
+open-source trading frameworks without copying code:
+
+- [Freqtrade](https://github.com/freqtrade/freqtrade): dry-run first,
+  explicit backtesting, fee/slippage-aware reporting, strategy
+  discovery, hyperopt, and lookahead/recursive-analysis commands.
+- [Backtrader](https://www.backtrader.com/): strategy/analyzer split
+  and reusable metrics.
+- [Jesse](https://github.com/jesse-ai/jesse): crypto-native strategy
+  research, multi-symbol/timeframe discipline, risk helpers, metrics,
+  optimization, Monte Carlo analysis, and debug workflow.
+- [TradingAgents](https://github.com/TauricResearch/TradingAgents):
+  analyst, bull/bear debate, trader, risk, and portfolio manager role
+  decomposition.
+
+The code remains an IronClaw-native Rust/WASM tool path so licensing,
+audit boundaries, and unsigned-intent constraints stay simple.
+
+## Project layout
+
+The skill writes state under `projects/intents-trading-agent/`:
+
+```text
+projects/intents-trading-agent/
+|-- AGENTS.md
+|-- config.json
+|-- watchlist.md
+|-- addresses.md
+|-- .system/
+|   `-- widgets/
+|       `-- near-intents-console/
+|           |-- manifest.json
+|           |-- index.js
+|           `-- style.css
+|-- state/
+|   |-- latest.json
+|   `-- history/
+|-- research/
+|-- debates/
+|-- decisions/
+|-- risk/
+|-- backtests/
+|-- intents/
+|-- journal/
+`-- widgets/
+    `-- state.json
+```
+
+This is separate from the existing `portfolio` project so market
+research, trading theses, and intent artifacts are not mixed with the
+general DeFi portfolio keeper.
+
+## Execution model
+
+1. Load project config, watchlist, wallet addresses, recent decisions,
+   and pending intents.
+2. Scan wallet addresses through `portfolio.scan` when available.
+3. Run analyst memos for market data, onchain exposure, news/sentiment,
+   intents/liquidity, and risk.
+4. Run and rank a backtest suite when OHLCV candles are available.
+5. Write bull and bear cases, then a manager synthesis.
+6. If the stance is `paper-intent` or `quote-intent`, build a
+   `MovementPlan`.
+7. Apply risk gates.
+8. Call `portfolio.build_intent`.
+9. Call `portfolio.format_intents_widget`.
+10. Persist the unsigned bundle, widget state, and summarize what was built.
+
+## Modes
+
+| Mode | Solver | Intended use |
+|---|---|---|
+| `paper` | `fixture` | Local experiments, replayable tests, no live quote claims |
+| `quote` | `near-intents` | Live quote only, still unsigned |
+| `execution` | future wallet flow | Requires explicit user signing outside the agent |
+
+The default config sets `mode` to `paper`.
+
+## Risk gates
+
+A proposal cannot become an intent unless all configured gates pass:
+
+- notional <= `max_notional_usd`,
+- daily turnover <= `max_daily_turnover_usd`,
+- confidence >= `min_confidence`,
+- expected edge >= `min_expected_edge_bps`,
+- asset and chain allowlists,
+- slippage <= `max_slippage_bps`,
+- backtest return, drawdown, trade count, and alpha gates pass when
+  candles are available,
+- no stale data,
+- no unresolved security or exploit concern,
+- no conflicting pending intent.
+
+## M0 deliverables
+
+- `skills/intents-trading-agent/SKILL.md` defines the workflow.
+- `skills/intents-trading-agent/strategies/*.md` defines the first
+  spot strategy test corpus plus Hyperliquid signal/risk-gate notes.
+- `portfolio.backtest` evaluates `buy-hold`, `sma-cross`, `breakout`,
+  `momentum`, `mean-reversion`, and `rsi-mean-reversion` strategies
+  with fee/slippage, stop/take-profit, and lookahead-safe next-open
+  execution.
+- `portfolio.backtest_suite` evaluates a menu of candidates with common
+  assumptions, ranks them by a transparent selection score, and returns
+  basic gate pass/fail flags.
+- `tools-src/portfolio/scenarios/intents-trading-agent-backtest-*.yaml`
+  covers the strategy baselines and suite ranking in the replay suite.
+- `tools-src/portfolio/scenarios/intents-trading-agent-swap.yaml`
+  proves a swap-shaped trading plan can be converted into an unsigned
+  intent bundle in replay tests.
+- `portfolio.format_intents_widget` emits `intents-trading-widget/1`
+  state for the IronClaw Projects widget.
+- `skills/intents-trading-agent/widgets/near-intents-console/` provides
+  the project widget that renders ranked strategies, risk gates, and
+  unsigned NEAR Intents status.
+- `tools-src/portfolio/fixtures/solver/ita-swap-near-usdc-btc-near.json`
+  records the deterministic solver response for the scenario.
+
+## Next milestones
+
+1. Add a project widget that shows stance, backtest metrics, risk gates,
+   pending intents,
+   and recent paper PnL.
+2. Add a data-source adapter for token prices and volatility, keeping
+   it read-only.
+3. Add replay scenarios for cross-chain spot rotation and route refusal.
+4. Add walk-forward validation, parameter grids, and regime-split reports over
+   `state/history`, `journal`, and external candle files.
+5. Integrate a wallet-signing handoff only after the unsigned-artifact
+   flow is stable and auditable.

--- a/docs/plans/2026-05-02-intents-trading-research.md
+++ b/docs/plans/2026-05-02-intents-trading-research.md
@@ -35,6 +35,17 @@ initial scaffold.
 | [DefiLlama API](https://defillama.com/docs/api) | Protocol TVL, yields, unlocks, stablecoins, broader DeFi context. | Risk/catalyst context and yield comparison. | Great for gating and context, not execution. |
 | [CCXT](https://github.com/ccxt/ccxt) | Exchange OHLCV/order books/trades from many CEX venues. | Optional external research adapter. | Use public market data only unless user explicitly designs a separate API-key execution mode. |
 
+## Paid Research / Agent Payment Inventory
+
+| Source | Useful data | Fit for IronClaw | Notes |
+|---|---|---|---|
+| [DripStack](https://dripstack.xyz) | Premium financial newsletter discovery and paid full-post access. | Pattern for a paid research layer before trading decisions. | Paid routes are MPP/x402 gated; use only through receipt-backed paid-source flows. |
+| [DripStack OpenAPI](https://dripstack.xyz/openapi.json) | Free catalog endpoints and paid post endpoint metadata with HTTP 402 challenges. | Candidate source discovery adapter. | Runtime 402 challenges are authoritative over static pricing. |
+| [MPP](https://mpp.dev/) | HTTP-native machine payments for API requests, tool calls, and content. | Payment rail for paid research, not a trading execution rail. | Treat as external until IronClaw has a payment-client boundary. |
+| [Payment Authentication specs](https://paymentauth.org/) | Payment HTTP auth scheme, charge intent, discovery, and JSON-RPC/MCP transport. | Shape for paid MCP/tool calls and source fetches. | Useful for future MCP paid-source implementation. |
+| [x402 docs](https://docs.x402.org/) | HTTP 402 payment standard for APIs/content without accounts or sessions. | Base-compatible paid-source rail. | Do not mix x402 payment with NEAR intent signing; keep each receipt explicit. |
+| [Cloudflare x402 docs](https://developers.cloudflare.com/agents/agentic-payments/x402/) | Concrete 402 challenge/retry flow for agents. | Reference for the payment-client boundary. | Portfolio tool should plan and attribute; a wallet/payment client handles signatures. |
+
 ## Hyperliquid / "HL" Strategy Notes
 
 Assumption: "HL" means Hyperliquid. If the user meant another portal,
@@ -120,6 +131,9 @@ Minimum framework requirements before a strategy can build an intent:
 - Added `portfolio.backtest` for long-only spot strategy replay.
 - Added `portfolio.backtest_suite` to rank a strategy menu over a common
   candle episode.
+- Added `portfolio.plan_paid_research` to budget and attribute premium
+  research sources before using paid newsletter/API content in a trading
+  decision.
 - Added replay scenarios for individual strategies, suite ranking, and
   a swap-shaped unsigned intent bundle.
 - Added the first bundled strategy corpus:
@@ -129,6 +143,9 @@ Minimum framework requirements before a strategy can build an intent:
   funding carry watch, book imbalance gate, and perp momentum signal.
 - Added `portfolio.format_intents_widget` and a NEAR Intents project
   widget template so the workflow has an operator-facing IronClaw UI.
+- Added paid research attribution to the widget so selected sources,
+  MPP/x402 rails, and NEAR funding-route hints are visible before any
+  unsigned intent is built.
 
 ## Multi-Day Roadmap
 

--- a/docs/plans/2026-05-02-intents-trading-research.md
+++ b/docs/plans/2026-05-02-intents-trading-research.md
@@ -133,7 +133,11 @@ Minimum framework requirements before a strategy can build an intent:
   candle episode.
 - Added `portfolio.plan_paid_research` to budget and attribute premium
   research sources before using paid newsletter/API content in a trading
-  decision.
+  decision, including source-trust gates, agent-wallet caps, and
+  MPP/x402 payment alternatives.
+- Added `portfolio.plan_dripstack_browse` to model topic →
+  publication → article → purchase-confirmation guided browse before a
+  selected article becomes a paid-source candidate.
 - Added replay scenarios for individual strategies, suite ranking, and
   a swap-shaped unsigned intent bundle.
 - Added the first bundled strategy corpus:

--- a/docs/plans/2026-05-02-intents-trading-research.md
+++ b/docs/plans/2026-05-02-intents-trading-research.md
@@ -1,0 +1,141 @@
+# Intents Trading Agent Research Notes
+
+**Date**: 2026-05-02
+**Purpose**: evaluate open-source trading/backtesting systems and
+IronClaw skills before expanding the intents trading agent beyond the
+initial scaffold.
+
+## Source Review
+
+| Project | What it contributes | What to avoid |
+|---|---|---|
+| [Freqtrade](https://github.com/freqtrade/freqtrade) | Mature crypto-bot lifecycle: data download, backtesting, backtest analysis, hyperopt, plotting, dry-run/live split, strategy listing, lookahead analysis, recursive analysis. | Do not import strategy code or live exchange execution. IronClaw should keep execution unsigned and wallet-mediated. |
+| [Freqtrade hyperopt docs](https://www.freqtrade.io/en/stable/hyperopt/) | Hyperparameter search is just repeated backtesting over historical data with explicit loss functions, min-trades, fee, timerange, pair, timeframe, and data-format controls. | Do not add heavy optimization dependencies into the WASM tool yet. Start with deterministic grid/replay hooks. |
+| [Freqtrade lookahead analysis](https://docs.freqtrade.io/en/latest/lookahead-analysis/) | Bias detection is a first-class command, not a footnote. Backtests must prove they do not use future candles. | Do not accept indicator code that only works because it saw the whole dataframe. |
+| [Jesse](https://github.com/jesse-ai/jesse) | Crypto-native research framework: simple strategy syntax, indicator library, multiple symbols/timeframes, risk helpers, metrics, debug mode, optimization, Monte Carlo, ML pipeline. | No leverage/shorts in v0. No partial-fill simulation until solver route and wallet handoff exist. |
+| [Backtrader](https://www.backtrader.com/) | Clear separation between strategy, data feeds, broker/store, observers, and analyzers. Reusable analyzers are the right mental model for metrics. | Backtrader is Python/process heavy; do not embed it in the sandbox path. Use its architecture pattern. |
+| [Backtrader analyzers](https://www.backtrader.com/docu/analyzers/analyzers/) | Analyzers evaluate one strategy's performance and return compact results after a run. This maps well to `portfolio.backtest` returning `metrics`, `trades`, and `equity_curve`. | Avoid opaque metrics without trade logs; every metric should be traceable to candles and fills. |
+| [Hummingbot](https://github.com/hummingbot/hummingbot) | Connector/strategy split, market-making posture, CEX+DEX venue abstraction, and bot config discipline. | Market making needs live order management, inventory controls, and cancel/replace mechanics; do not pretend NEAR Intent swaps are an order book maker. |
+| [Hummingbot perpetual market making](https://hummingbot.org/strategies/v1-strategies/perpetual-market-making/) | Funding-aware perp strategies, mid-price references, spreads, and position management are useful design references for future Hyperliquid research. | Perps/leverage stay out of v0; use HL only as a signal source until execution semantics are explicit. |
+| [CCXT](https://github.com/ccxt/ccxt) | Unified exchange market-data API across many venues; public endpoints include tickers, order books, trades, and OHLCV. | Private exchange trading APIs conflict with the unsigned-wallet constraint; do not route execution through API keys. |
+| [vectorbt](https://vectorbt.dev/) | Fast vectorized parameter sweeps and heatmaps; good mental model for running many strategy variants over the same series. | Python/numpy research can live outside the WASM boundary; production gates should remain deterministic and replayable. |
+| [TradingAgents](https://github.com/TauricResearch/TradingAgents) | Analyst team, bull/bear research debate, trader, risk management, and portfolio-management decomposition. | Do not let the debate layer bypass deterministic gates. LLM confidence is advisory, not execution authority. |
+
+## Crypto Portal / Data Source Inventory
+
+| Source | Useful data | Fit for IronClaw | Notes |
+|---|---|---|---|
+| [NEAR Intents solver relay](https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay) | Quote requests, signed-intent publishing, status checks. | Execution/quote path, but unsigned until user wallet signs. | `portfolio.build_intent` already models fixture/replay/live solver modes. |
+| [NEAR Intents chain/address support](https://docs.near-intents.org/near-intents/chain-address-support) | Supported signing standards, token support, chain support. | Capability discovery and route gating. | Use this before promising a multichain route. |
+| [Hyperliquid info endpoint](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint) | All mids, user fills, L2 book snapshots, candle snapshots. | Strong read-only signal source for Hyperliquid spot/perp market context. | Candle snapshots are capped; long history needs recording or external archives. |
+| [Hyperliquid funding docs](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/funding) | Hourly funding mechanics and premium/oracle relationship. | Signal source for perp/spot divergence and risk-on/risk-off regimes. | Funding/carry execution is not v0 because v0 stays spot-only. |
+| [Hyperliquid historical data](https://hyperliquid.gitbook.io/hyperliquid-docs/historical-data) | S3 archives for L2 books, asset contexts, fills, explorer blocks. | Backfill source for serious HL strategy research. | The docs warn archive timeliness/completeness is not guaranteed. |
+| [Dune Sim API](https://docs.sim.dune.com/) | Wallet balances, token metadata, activity, transactions across many chains. | Existing `portfolio.scan` EVM source. | Requires API key; read-only. |
+| [CoinGecko trading guide](https://docs.coingecko.com/trading) | Spot prices, OHLC candles, market chart ranges, onchain OHLCV. | Candidate market-data adapter for backtests. | Good enough for daily/hourly research; verify plan/rate limits before automation. |
+| [DefiLlama API](https://defillama.com/docs/api) | Protocol TVL, yields, unlocks, stablecoins, broader DeFi context. | Risk/catalyst context and yield comparison. | Great for gating and context, not execution. |
+| [CCXT](https://github.com/ccxt/ccxt) | Exchange OHLCV/order books/trades from many CEX venues. | Optional external research adapter. | Use public market data only unless user explicitly designs a separate API-key execution mode. |
+
+## Hyperliquid / "HL" Strategy Notes
+
+Assumption: "HL" means Hyperliquid. If the user meant another portal,
+rename this section and keep the same gate structure.
+
+| Strategy family | Signal inputs | Can intents execute it now? | Research decision |
+|---|---|---|---|
+| Perp funding/carry | Funding rate, oracle/perp premium, spot hedge availability. | No, because v0 is spot-only and NEAR Intents are swap/bridge oriented here. | Track as signal and future module; no autonomous perp execution. |
+| Perp momentum / breakout | HL candle snapshots, all mids, L2 liquidity, open interest context from external sources. | Partially: signal can map to spot token rotation through intents. | Candidate v1 signal source after candle ingestion exists. |
+| Order-book imbalance | HL L2 book snapshots, spread, depth, impact price. | No as a maker; maybe as a slippage/liquidity gate for taker intents. | Use for risk gates before trade selection, not as standalone execution. |
+| Liquidation / squeeze context | Funding, premium, order-book thinning, liquidation feeds from third-party portals. | Signal only. | Needs robust data provenance and false-positive controls. |
+| Vault/copy-trading | Public vault/user portfolio and fills data. | No direct copy execution. | Could become an analyst input after privacy and survivorship-bias review. |
+
+## Strategy Selection Model
+
+The local tool should expose two levels:
+
+1. `portfolio.backtest`: one strategy config over one OHLCV episode.
+2. `portfolio.backtest_suite`: many candidate configs over the same
+   episode, ranked by a transparent deterministic score.
+
+The suite is not optimizer magic. It is the minimum "people can choose
+from strategies" primitive:
+
+- all candidates share the same candles, fee, slippage, and starting cash,
+- each candidate may override size, stop-loss, and take-profit,
+- output includes metrics, warnings, `selection_score`, and
+  `passes_basic_gate`,
+- no intent can be built from the suite result unless the risk manager
+  still approves it.
+
+## IronClaw Skill Evaluation
+
+| Skill/tool | Use in framework | Decision |
+|---|---|---|
+| `portfolio` tool | Position scans, DeFi proposals, intent construction, now backtesting. | Core execution and research substrate. |
+| `portfolio` skill | Project bootstrap and portfolio keeper conventions. | Reuse file layout ideas; keep trading-agent state separate. |
+| `llm-council` | Optional multi-model bull/bear/manager review. | Advisory only; never a substitute for risk gates. |
+| `decision-capture` | Durable records for accepted/rejected trade decisions. | Companion skill, useful for trade journal and later outcome review. |
+| `trader-setup` | Existing equities/options commitment workflow. | Pattern reference only; crypto intents gets its own project and config. |
+| `commitment-*` skills | Missions, digests, follow-up reminders. | Useful after strategy/backtest corpus stabilizes; not required for M0. |
+
+## Strategy Families To Offer
+
+| Strategy | Kind | Best market | Primary gate |
+|---|---|---|---|
+| Buy and hold benchmark | `buy-hold` | Any candidate pair | Benchmark only |
+| SMA cross | `sma-cross` | Trending, liquid markets | Positive alpha vs buy-hold after costs |
+| Breakout | `breakout` | Strong trend continuation | Drawdown and false-breakout controls |
+| Momentum | `momentum` | Rotation/risk-on markets | Regime split and turnover cost |
+| Mean reversion | `mean-reversion` | Rangebound, deep-liquidity assets | Win rate and stop discipline |
+| RSI mean reversion | `rsi-mean-reversion` | Oversold but unimpaired large caps | Catalyst/security veto |
+
+## Backtest Requirements
+
+Minimum framework requirements before a strategy can build an intent:
+
+1. Historical candles are oldest-to-newest and pass OHLC consistency.
+2. Signals are computed on closed candles and executed at next open.
+3. Fees and slippage are explicit.
+4. Result includes trade log, equity curve, drawdown, win rate, profit
+   factor, exposure, average trade return, and buy-hold alpha.
+5. Strategy-specific minimums are enforced from the strategy doc.
+6. Any exploit/depeg/unlock/regulatory risk can veto an otherwise good
+   backtest.
+7. Strategy menus are evaluated via suite ranking before choosing a
+   paper-intent candidate.
+8. Walk-forward and out-of-sample splits are required before claiming a
+   strategy is robust rather than merely fit to one episode.
+
+## Near-Term Gaps
+
+- Live OHLCV ingestion is still missing.
+- Walk-forward and out-of-sample splits are still missing.
+- Hyperparameter search is not implemented yet.
+- Monte Carlo / trade-order shuffling is not implemented yet.
+- Solver-route replay and market-data replay are separate; they need a
+  shared episode format.
+- No widget yet for backtest/risk/intent status.
+
+## Implementation Slice From This Sprint
+
+- Added `portfolio.backtest` for long-only spot strategy replay.
+- Added `portfolio.backtest_suite` to rank a strategy menu over a common
+  candle episode.
+- Added replay scenarios for individual strategies, suite ranking, and
+  a swap-shaped unsigned intent bundle.
+- Added the first bundled strategy corpus:
+  `buy-hold`, `sma-cross`, `breakout`, `momentum`, `mean-reversion`,
+  and `rsi-mean-reversion`.
+- Added first Hyperliquid-specific docs as signal/risk inputs:
+  funding carry watch, book imbalance gate, and perp momentum signal.
+- Added `portfolio.format_intents_widget` and a NEAR Intents project
+  widget template so the workflow has an operator-facing IronClaw UI.
+
+## Multi-Day Roadmap
+
+| Phase | Work | Exit criteria |
+|---|---|---|
+| M1 data ingestion | CoinGecko/CCXT CSV import, Hyperliquid candle snapshot recorder, Dune/NEAR portfolio context. | Backtests can run from saved market-data episodes, not hand-written candles. |
+| M2 strategy lab | Parameter grids, walk-forward splits, regime splits, benchmark comparisons, strategy doc thresholds. | A strategy report shows train/test windows, drawdown, turnover, and rejection reasons. |
+| M3 risk/intent bridge | Map approved suite results to `MovementPlan`, quote replay, solver refusal tests, route expiry tests, widget state updates. | A paper-intent can be rebuilt deterministically from research + backtest + quote fixture and inspected in the Projects UI. |
+| M4 portals and HL signals | Hyperliquid funding/book/candle adapters, DefiLlama risk context, optional CoinGecko fallback. | HL data is used as signal/risk context without pretending to execute perps. |
+| M5 UI/mission | Widget for watchlist, ranked strategies, risk gates, pending intents, and paper PnL journal. | User can inspect the autonomous run without reading JSON. |

--- a/docs/plans/2026-05-02-intents-trading-research.md
+++ b/docs/plans/2026-05-02-intents-trading-research.md
@@ -138,6 +138,13 @@ Minimum framework requirements before a strategy can build an intent:
 - Added `portfolio.plan_dripstack_browse` to model topic →
   publication → article → purchase-confirmation guided browse before a
   selected article becomes a paid-source candidate.
+- Added `portfolio.prepare_dripstack_paid_fetch` to make the one-article
+  DripStack confirmation, 402 challenge, and receipt-backed retry
+  boundary explicit without signing or reading paid text inside the
+  portfolio tool.
+- Added `portfolio.plan_near_intents_trial` so a user can rehearse the
+  workflow with a nominal NEAR wallet, strategy gates, setup steps, and
+  a generated unsigned `build_intent` request.
 - Added replay scenarios for individual strategies, suite ranking, and
   a swap-shaped unsigned intent bundle.
 - Added the first bundled strategy corpus:
@@ -150,6 +157,9 @@ Minimum framework requirements before a strategy can build an intent:
 - Added paid research attribution to the widget so selected sources,
   MPP/x402 rails, and NEAR funding-route hints are visible before any
   unsigned intent is built.
+- Added nominal NEAR trial status to the widget so the operator can see
+  wallet budget, quote readiness, setup steps, and trial gates without
+  reading JSON.
 
 ## Multi-Day Roadmap
 
@@ -157,6 +167,6 @@ Minimum framework requirements before a strategy can build an intent:
 |---|---|---|
 | M1 data ingestion | CoinGecko/CCXT CSV import, Hyperliquid candle snapshot recorder, Dune/NEAR portfolio context. | Backtests can run from saved market-data episodes, not hand-written candles. |
 | M2 strategy lab | Parameter grids, walk-forward splits, regime splits, benchmark comparisons, strategy doc thresholds. | A strategy report shows train/test windows, drawdown, turnover, and rejection reasons. |
-| M3 risk/intent bridge | Map approved suite results to `MovementPlan`, quote replay, solver refusal tests, route expiry tests, widget state updates. | A paper-intent can be rebuilt deterministically from research + backtest + quote fixture and inspected in the Projects UI. |
+| M3 risk/intent bridge | Map approved suite results to `MovementPlan`, quote replay, solver refusal tests, route expiry tests, nominal trial state, widget state updates. | A paper-intent can be rebuilt deterministically from research + backtest + quote fixture and inspected in the Projects UI. |
 | M4 portals and HL signals | Hyperliquid funding/book/candle adapters, DefiLlama risk context, optional CoinGecko fallback. | HL data is used as signal/risk context without pretending to execute perps. |
 | M5 UI/mission | Widget for watchlist, ranked strategies, risk gates, pending intents, and paper PnL journal. | User can inspect the autonomous run without reading JSON. |

--- a/docs/plans/2026-05-02-near-intents-trial-runbook.md
+++ b/docs/plans/2026-05-02-near-intents-trial-runbook.md
@@ -68,6 +68,11 @@ Useful docs:
    `solver="near-intents"` and remains unsigned.
 7. Write widget state with `format_intents_widget`, including
    `trial_plan`.
+8. In the Projects view, use the NEAR Intents Console ticket controls to
+   adjust nominal budget, trade cap, funding path, and selected
+   strategy. Its action buttons write the exact next IronClaw prompt for
+   trial planning, backtesting, fixture intent construction, paid
+   research, or unsigned live quote requests.
 
 ## What To Watch
 

--- a/docs/plans/2026-05-02-near-intents-trial-runbook.md
+++ b/docs/plans/2026-05-02-near-intents-trial-runbook.md
@@ -18,11 +18,17 @@ wallet while keeping every agent-produced artifact unsigned.
 
 ## NEAR Intents Funding Notes
 
-Current NEAR Intents docs say the verifier accepts wrapped/tokenized
-assets, not raw native NEAR transfers. For a native NEAR trial, wrap NEAR
-to wNEAR first, then use the verifier deposit flow. The bridge/deposit
-service is available at `https://bridge.chaindefuser.com/rpc`, and the
-solver relay is at `https://solver-relay-v2.chaindefuser.com/rpc`.
+NEAR Intents supports deposits across supported assets through higher
+level routes such as the 1Click Swap API and the Deposit/Withdrawal
+Service. If you use those routes, native NEAR wrapping can be handled for
+you. The manual warning in this runbook is narrower: when integrating
+directly with the Verifier contract, it accepts NEP-141 token balances,
+so native NEAR is represented as wNEAR (`nep141:wrap.near`) and raw
+native NEAR should not be sent directly to `intents.near`.
+
+The bridge/deposit service is available at
+`https://bridge.chaindefuser.com/rpc`, and the solver relay is at
+`https://solver-relay-v2.chaindefuser.com/rpc`.
 
 Useful docs:
 

--- a/docs/plans/2026-05-02-near-intents-trial-runbook.md
+++ b/docs/plans/2026-05-02-near-intents-trial-runbook.md
@@ -1,0 +1,73 @@
+# Nominal NEAR Intents Trial Runbook
+
+**Date**: 2026-05-02
+
+This runbook is for testing the Intents Trading Agent with a small NEAR
+wallet while keeping every agent-produced artifact unsigned.
+
+## Safety Model
+
+- Use a separate NEAR account funded only with the amount you are
+  willing to test.
+- Start with `mode="paper"` and `solver="fixture"`.
+- Move to `mode="quote"` only after backtest and risk gates pass.
+- The agent never sees private keys, seed phrases, wallet exports, or
+  signing material.
+- A live quote is not an executed trade. Wallet signing remains outside
+  IronClaw.
+
+## NEAR Intents Funding Notes
+
+Current NEAR Intents docs say the verifier accepts wrapped/tokenized
+assets, not raw native NEAR transfers. For a native NEAR trial, wrap NEAR
+to wNEAR first, then use the verifier deposit flow. The bridge/deposit
+service is available at `https://bridge.chaindefuser.com/rpc`, and the
+solver relay is at `https://solver-relay-v2.chaindefuser.com/rpc`.
+
+Useful docs:
+
+- [Deposit/Withdrawal Service](https://docs.near-intents.org/integration/market-makers/deposit-withdrawal-service)
+- [Verifier deposits](https://docs.near-intents.org/near-intents/market-makers/verifier/deposits-and-withdrawals/deposits)
+- [Solver relay API](https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay)
+- [Intent types and execution](https://docs.near-intents.org/integration/verifier-contract/intent-types-and-execution)
+
+## IronClaw Flow
+
+1. Run `portfolio.backtest_suite` with fresh OHLCV candles and the
+   bundled strategy menu.
+2. Run `portfolio.plan_near_intents_trial`:
+
+```json
+{
+  "action": "plan_near_intents_trial",
+  "near_account_id": "your-small-test-account.near",
+  "mode": "paper",
+  "pair": "NEAR/USDC",
+  "nominal_near": 0.25,
+  "max_trade_near": 0.05,
+  "assumed_near_usd": 3.0,
+  "max_slippage_bps": 50,
+  "backtest_suite": {}
+}
+```
+
+3. Persist the returned `near-intents-trial-plan/1` under
+   `projects/intents-trading-agent/trials/`.
+4. If `safe_to_quote=false`, stop.
+5. In paper mode, run the returned `build_intent_request`; it uses
+   `solver="fixture"`.
+6. If the user explicitly requests a live quote later, rerun
+   `plan_near_intents_trial` with `mode="quote"` and fresh prices, then
+   run the returned `build_intent_request`; it uses
+   `solver="near-intents"` and remains unsigned.
+7. Write widget state with `format_intents_widget`, including
+   `trial_plan`.
+
+## What To Watch
+
+- Very small routes may fail solver minimums. Do not auto-increase size.
+- Recompute NEAR/USD before quote mode; the default price is only a
+  sizing placeholder.
+- Do not use paid research text unless a receipt-backed fetch succeeded.
+- Record every quote/intent artifact in the project journal before
+  asking the user whether to sign.

--- a/docs/plans/2026-05-02-paid-research-intents.md
+++ b/docs/plans/2026-05-02-paid-research-intents.md
@@ -1,0 +1,101 @@
+# Paid Research Layer For NEAR Intents Trading
+
+**Date**: 2026-05-02
+**Trigger**: Michael Blau's X post about DripStack described a chat UI
+over paid financial newsletters where writers are paid when their posts
+are used in answers, using MPP on Tempo and x402 on Base.
+
+## What The Post Changes
+
+This is not a trading strategy by itself. It is a missing research
+market layer for the trading agent:
+
+1. discover premium financial/crypto writers and paid research APIs,
+2. price which sources are worth buying for a specific trade question,
+3. pay or prepare payment through agent-native rails,
+4. attribute source usage in the answer,
+5. keep the NEAR Intents trade path gated by backtests and risk checks.
+
+DripStack's public site exposes the same shape: free publication and post
+discovery, plus paid full-post access. Its OpenAPI says paid post routes
+return HTTP 402 and can present both MPP and x402 payment challenges. Its
+agent skill says paid posts are gated by x402/MPP micropayments and that
+agents should fetch publication/post metadata before attempting a paid
+post.
+
+## Source Notes
+
+| Source | Relevant detail | Implementation decision |
+|---|---|---|
+| [DripStack](https://dripstack.xyz) | Landing page frames the product as premium financial-writer Q&A with source payment. | Use it as the target product pattern, not as a dependency. |
+| [DripStack SKILL.md](https://dripstack.xyz/SKILL.md) | Free catalog first, paid full post route later, payment-aware client required. | IronClaw should separate source discovery from paid content fetch. |
+| [DripStack OpenAPI](https://dripstack.xyz/openapi.json) | Paid full-post endpoint declares 402 responses with MPP `WWW-Authenticate` and x402 `PAYMENT-REQUIRED`. | Store payment rail metadata on candidate sources and require receipts before using paid text. |
+| [MPP](https://mpp.dev/) | Described as an open machine-to-machine payment protocol for API requests, tool calls, or content in the same HTTP call. | Model MPP as one paid-source rail. |
+| [MPP payment specs](https://paymentauth.org/) | Defines a Payment HTTP Authentication scheme, charge intent, service discovery, and JSON-RPC/MCP transport. | Treat paid tool/resource calls as a protocol-level challenge, not an ad hoc checkout. |
+| [Stripe MPP announcement](https://stripe.com/blog/machine-payments-protocol) | Agents request resources, services return payment requests, agents authorize payment, then resources are delivered. | Keep IronClaw's output as a payment plan until a wallet/payment client authorizes. |
+| [x402 docs](https://docs.x402.org/) | x402 uses HTTP 402 so clients can pay for APIs/content without accounts or sessions. | Model x402 as the Base-compatible paid-source rail. |
+| [Cloudflare x402 docs](https://developers.cloudflare.com/agents/agentic-payments/x402/) | Resource server replies with 402 and payment details, client retries with a payment payload. | Do not fetch paywalled content with plain HTTP; surface a payable plan first. |
+
+## Architecture
+
+```mermaid
+flowchart LR
+  A["Trade question"] --> B["Free source discovery"]
+  B --> C["portfolio.plan_paid_research"]
+  C --> D["Paid source plan"]
+  D --> E{"User/payment policy approves?"}
+  E -- no --> F["Free-source research only"]
+  E -- yes --> G["Payment-aware client handles MPP/x402/NEAR rail"]
+  G --> H["Receipt + paid evidence"]
+  H --> I["Analyst synthesis with source credits"]
+  I --> J["portfolio.backtest_suite"]
+  J --> K["Risk gates"]
+  K --> L["portfolio.build_intent unsigned NEAR Intent"]
+```
+
+## What Was Implemented In This Slice
+
+- `portfolio.plan_paid_research`
+  - ranks source candidates by relevance, trust, freshness, tag match,
+    and budget cost,
+  - selects sources under a dollar cap,
+  - emits source attribution IDs,
+  - summarizes MPP, x402, NEAR-native, subscription, manual, or free
+    rails,
+  - emits `near_funding_routes` so a NEAR treasury can prepare rail
+    funding through NEAR Intents before external MPP/x402 payment,
+  - emits policy gates for budget, receipts, attribution, payment
+    authorization, and the trading risk gate.
+
+- `portfolio.format_intents_widget`
+  - accepts `paid_research_plan`,
+  - exposes `paid_research` in the widget state,
+  - shows payable sources, allocated budget, rails, and NEAR funding
+    routes in the project widget.
+
+- `intents-trading-agent` skill
+  - adds paid research as a formal step before backtesting,
+  - stores plans under `projects/intents-trading-agent/paid-research/`,
+  - forbids paid text use without receipts,
+  - requires paid source credit IDs when paid evidence is used,
+  - keeps backtest/risk gates mandatory before any unsigned NEAR Intent.
+
+## Open Implementation Work
+
+| Next PR | What to build | Done when |
+|---|---|---|
+| Source discovery adapters | Parse MPP/OpenAPI `x-payment-info`, x402 discovery, DripStack catalogs, and local `sources/paid-research.json`. | Agent can populate candidate sources without manual JSON. |
+| Payment client boundary | Add a wallet/payment-client abstraction for MPP/x402 challenge handling with receipts, never private keys. | Paid content fetch returns receipt metadata and content only after approval. |
+| NEAR funding route builder | Convert `near_funding_routes` into unsigned NEAR Intent funding bundles for rail wallets. | User can inspect/sign a funding intent before MPP/x402 fetch. |
+| Evidence ledger | Persist paid source receipts, content hashes, quote snippets, and answer attribution. | A journal entry can prove which writer/source contributed to which answer. |
+| Research-to-backtest loop | Track whether paid evidence changed candidate strategies and compare outcomes. | Strategy reports show paid-source deltas vs free-source baseline. |
+
+## Hard Boundaries
+
+- Premium research is evidence, not execution authority.
+- Paid content must not be summarized, quoted, or used as a factual basis
+  before a receipt exists.
+- The agent does not sign MPP, x402, or NEAR payments.
+- NEAR Intents remain the preferred asset/treasury routing surface for
+  this project, but MPP/x402 paid content rails are external services
+  unless/until a NEAR-native paid-content rail exists.

--- a/docs/plans/2026-05-02-paid-research-intents.md
+++ b/docs/plans/2026-05-02-paid-research-intents.md
@@ -83,6 +83,20 @@ flowchart LR
     without fetching the article body,
   - includes both MPP and x402 payment options for the selected article.
 
+- `portfolio.fetch_dripstack_catalog`
+  - fetches DripStack's free publication catalog,
+  - fetches free post-title metadata for a chosen publication,
+  - keeps the paid article body route out of automatic discovery.
+
+- `portfolio.prepare_dripstack_paid_fetch`
+  - prepares the one-article paid fetch boundary after a user selects a
+    DripStack post,
+  - separates confirmation, HTTP 402 challenge collection, and
+    receipt-backed retry headers,
+  - supports MPP `Authorization: Payment ...` and x402
+    `PAYMENT-SIGNATURE` handoff metadata,
+  - does not sign payments, mint receipts, or read paid article bodies.
+
 - `portfolio.format_intents_widget`
   - accepts `paid_research_plan`,
   - exposes `paid_research` in the widget state,
@@ -100,8 +114,8 @@ flowchart LR
 
 | Next PR | What to build | Done when |
 |---|---|---|
-| Source discovery adapters | Parse MPP/OpenAPI `x-payment-info`, x402 discovery, DripStack catalogs, and local `sources/paid-research.json`. | Agent can populate candidate sources without manual JSON. |
-| Payment client boundary | Add a wallet/payment-client abstraction for MPP/x402 challenge handling with receipts, never private keys. | Paid content fetch returns receipt metadata and content only after approval. |
+| Source discovery adapters | Extend beyond the DripStack free catalog adapter into generic MPP/OpenAPI `x-payment-info`, x402 discovery, and local `sources/paid-research.json`. | Agent can populate candidate sources without manual JSON. |
+| Payment client boundary | Connect `prepare_dripstack_paid_fetch` to a wallet/payment-client abstraction for live MPP/x402 challenge handling with receipts, never private keys. | Paid content fetch returns receipt metadata and content only after approval. |
 | NEAR funding route builder | Convert `near_funding_routes` into unsigned NEAR Intent funding bundles for rail wallets. | User can inspect/sign a funding intent before MPP/x402 fetch. |
 | Evidence ledger | Persist paid source receipts, content hashes, quote snippets, and answer attribution. | A journal entry can prove which writer/source contributed to which answer. |
 | Research-to-backtest loop | Track whether paid evidence changed candidate strategies and compare outcomes. | Strategy reports show paid-source deltas vs free-source baseline. |

--- a/docs/plans/2026-05-02-paid-research-intents.md
+++ b/docs/plans/2026-05-02-paid-research-intents.md
@@ -60,18 +60,34 @@ flowchart LR
     and budget cost,
   - selects sources under a dollar cap,
   - emits source attribution IDs,
+  - supports multiple payment options per source, so a DripStack article
+    can advertise both MPP on Tempo and x402 on Base,
   - summarizes MPP, x402, NEAR-native, subscription, manual, or free
     rails,
+  - applies basic agentic-SEO defenses through trust and source-risk
+    gates,
+  - models a small autonomous wallet policy, including per-article caps,
+    daily caps, default one-cent article math, and audit links,
   - emits `near_funding_routes` so a NEAR treasury can prepare rail
     funding through NEAR Intents before external MPP/x402 payment,
   - emits policy gates for budget, receipts, attribution, payment
     authorization, and the trading risk gate.
 
+- `portfolio.plan_dripstack_browse`
+  - models DripStack's guided browse flow from free metadata,
+  - returns `topic`, `publication`, `article`, or
+    `purchase-confirmation` checkpoints,
+  - shortlists publications from the user topic,
+  - shortlists post summaries for a chosen publication,
+  - converts one user-selected article into a paid-source candidate
+    without fetching the article body,
+  - includes both MPP and x402 payment options for the selected article.
+
 - `portfolio.format_intents_widget`
   - accepts `paid_research_plan`,
   - exposes `paid_research` in the widget state,
-  - shows payable sources, allocated budget, rails, and NEAR funding
-    routes in the project widget.
+  - shows payable sources, allocated budget, rails, NEAR funding routes,
+    autonomous-wallet caps, and audit links in the project widget.
 
 - `intents-trading-agent` skill
   - adds paid research as a formal step before backtesting,

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -4,7 +4,7 @@
   "kind": "tool",
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, nominal NEAR trial planning, and NEAR Intents trading widget state.",
   "keywords": [
     "defi",
     "portfolio",
@@ -19,7 +19,9 @@
     "x402",
     "mpp",
     "dripstack",
-    "agent-wallet"
+    "agent-wallet",
+    "near-trial",
+    "paper-trading"
   ],
   "source": {
     "dir": "tools-src/portfolio",

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -4,7 +4,7 @@
   "kind": "tool",
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, and unsigned NEAR Intent construction. Single tool with three operations: scan, propose, build_intent.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
   "keywords": [
     "defi",
     "portfolio",
@@ -12,7 +12,9 @@
     "wallet",
     "rebalance",
     "near-intents",
-    "crypto"
+    "crypto",
+    "backtesting",
+    "trading"
   ],
   "source": {
     "dir": "tools-src/portfolio",

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -17,7 +17,9 @@
     "trading",
     "paid-research",
     "x402",
-    "mpp"
+    "mpp",
+    "dripstack",
+    "agent-wallet"
   ],
   "source": {
     "dir": "tools-src/portfolio",

--- a/registry/tools/portfolio.json
+++ b/registry/tools/portfolio.json
@@ -4,7 +4,7 @@
   "kind": "tool",
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, and NEAR Intents trading widget state.",
   "keywords": [
     "defi",
     "portfolio",
@@ -14,7 +14,10 @@
     "near-intents",
     "crypto",
     "backtesting",
-    "trading"
+    "trading",
+    "paid-research",
+    "x402",
+    "mpp"
   ],
   "source": {
     "dir": "tools-src/portfolio",

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -42,8 +42,9 @@ bundles** that the user can inspect and sign in their own wallet.
 
 This skill is a research and orchestration layer. It does not replace
 the `portfolio` WASM tool. Use `portfolio.scan`, `portfolio.propose`,
-and `portfolio.build_intent` for positions, deterministic DeFi
-proposals, and intent bundle construction.
+`portfolio.plan_paid_research`, and `portfolio.build_intent` for
+positions, deterministic DeFi proposals, paid-source budgeting, and
+intent bundle construction.
 
 ## Non-negotiables
 
@@ -62,6 +63,11 @@ proposals, and intent bundle construction.
    after the risk manager approves it against project config.
 6. **Audit trail first.** Persist research, debate notes, risk checks,
    decisions, and built intents under `projects/intents-trading-agent/`.
+7. **Paid content requires receipts.** Paywalled newsletters, APIs, or
+   premium posts can be planned and attributed before use, but their
+   actual text must not be quoted or relied on until a payment receipt
+   exists. Writers/source owners must be credited when their paid work
+   contributes to an answer.
 
 ## Project bootstrap
 
@@ -83,6 +89,9 @@ using workspace writes. Initialize:
   "allowed_chains": [],
   "allowed_assets": ["NEAR", "USDC", "USDT", "BTC", "ETH"],
   "disallowed_assets": [],
+  "paid_research_budget_usd": 0.25,
+  "paid_research_max_sources": 4,
+  "paid_research_mode": "plan-only",
   "require_user_approval": true
 }
 ```
@@ -90,8 +99,11 @@ using workspace writes. Initialize:
 - `watchlist.md` - token pairs, chains, and theses the user cares about.
 - `addresses.md` - optional wallet addresses to scan.
 - `state/latest.json` and `state/history/`.
+- `sources/paid-research.json` - optional candidate premium sources and
+  payment metadata discovered from MPP, x402, NEAR-native, newsletter, or
+  API catalogs.
 - `research/`, `debates/`, `decisions/`, `risk/`, `intents/`,
-  `journal/`, and `widgets/`.
+  `journal/`, `paid-research/`, and `widgets/`.
 - `strategies/` - copy or reference the baseline strategy docs bundled
   with this skill (`sma-cross-spot`, `breakout-spot`,
   `momentum-spot`, `mean-reversion-spot`,
@@ -154,7 +166,56 @@ grounded.
 Write role outputs to
 `projects/intents-trading-agent/research/<YYYY-MM-DD>/<role>.md`.
 
-### 3. Strategy lab and backtest
+### 3. Paid research planning
+
+When the run would benefit from premium newsletters, research APIs, or
+paid posts, create a source plan before reading paywalled content. This
+is the DripStack-style pattern: the agent can decide which sources are
+worth paying for, but payment and attribution are explicit.
+
+Candidate sources may come from:
+
+- `projects/intents-trading-agent/sources/paid-research.json`,
+- public MPP or x402 service discovery,
+- a user-provided source list,
+- free/public research already collected by the analyst team.
+
+Call `portfolio` with:
+
+```json
+{
+  "action": "plan_paid_research",
+  "query": "<specific question the trade needs answered>",
+  "pair": "<pair>",
+  "budget_usd": 0.25,
+  "max_sources": 4,
+  "spending_mode": "plan-only",
+  "near_funding_asset": "USDC.near",
+  "sources": []
+}
+```
+
+The returned `paid-research-plan/1` is a budget and attribution plan,
+not a content fetch. Persist it to:
+
+`projects/intents-trading-agent/paid-research/<YYYY-MM-DDTHH-MM>-<pair>.json`
+
+Use the plan as follows:
+
+- If `ready_for_paid_fetch` is false, continue with free sources only.
+- If selected sources require MPP on Tempo or x402 on Base, treat
+  `near_funding_routes` as hints for how a NEAR Intents-funded treasury
+  could fund the rail wallet. This does not authorize the actual paid
+  fetch.
+- Never include paid source text in the answer or research memo until
+  the payment client returns a receipt.
+- When paid source text is used, include source IDs from
+  `selected_sources[].attribution.credit_id` in the answer and journal.
+- Paid research can change the thesis or confidence, but it cannot
+  bypass the strategy suite, backtest gates, risk gates, or unsigned-only
+  NEAR Intent boundary.
+
+### 4. Strategy lab and backtest
 
 Before a strategy can become a trade proposal, run a deterministic
 backtest when historical OHLCV candles are available. Prefer
@@ -204,7 +265,7 @@ Always run `buy-hold` as a benchmark when enough candles are available.
 Always present the top ranked suite candidates and rejected candidates
 separately so the user can see what was considered.
 
-### 4. Bull/bear debate
+### 5. Bull/bear debate
 
 Create two concise debate memos:
 
@@ -221,7 +282,7 @@ Then write a manager synthesis with:
 
 Persist to `projects/intents-trading-agent/debates/<YYYY-MM-DDTHH-MM>-<pair>.md`.
 
-### 5. Trader proposal
+### 6. Trader proposal
 
 Only create a trade proposal when the manager stance is
 `paper-intent` or `quote-intent`.
@@ -236,12 +297,13 @@ A proposal must include:
 - invalidation condition,
 - expiry or review time,
 - confidence,
-- risk gates and their pass/fail result.
+- risk gates and their pass/fail result,
+- paid research source IDs used, if any.
 
 The trade proposal is not executable by itself. It is a request for an
 unsigned intent bundle.
 
-### 6. Risk gates
+### 7. Risk gates
 
 Reject or downgrade to `watch` if any gate fails:
 
@@ -255,11 +317,13 @@ Reject or downgrade to `watch` if any gate fails:
 - no unresolved security/exploit concern
 - no existing conflicting pending intent
 - backtest gates pass when candles are available
+- paid source text is not used without receipts
+- paid research spend is within `paid_research_budget_usd`
 
 If `require_user_approval` is true, do not ask the user to sign; ask
 whether they want a live quote or want to keep it as paper.
 
-### 7. Build unsigned intent
+### 8. Build unsigned intent
 
 For an approved `paper-intent`, call `portfolio.build_intent` with
 `solver: "fixture"` so the output is clearly a deterministic test
@@ -313,19 +377,21 @@ For cross-chain moves, use ordered `withdraw`, `bridge`, `swap`, and
 Persist returned bundles to
 `projects/intents-trading-agent/intents/<YYYY-MM-DDTHH-MM>-<proposal_id>.json`.
 
-### 8. Format the project widget
+### 9. Format the project widget
 
 After every run, call `portfolio` with `action="format_intents_widget"`
 and pass the latest pair, stance, confidence, `backtest_suite`, risk
-gates, research sources, and optional unsigned `IntentBundle`.
+gates, research sources, optional `paid_research_plan`, and optional
+unsigned `IntentBundle`.
 
 Persist the returned JSON exactly as:
 
 `projects/intents-trading-agent/widgets/state.json`
 
 The bundled project widget reads this file and renders ranked strategy
-candidates, risk gates, and unsigned NEAR Intents status inside the
-IronClaw Projects view. If the widget files are not installed yet, copy:
+candidates, paid source attribution, risk gates, and unsigned NEAR
+Intents status inside the IronClaw Projects view. If the widget files are
+not installed yet, copy:
 
 - `skills/intents-trading-agent/widgets/near-intents-console/manifest.json`
 - `skills/intents-trading-agent/widgets/near-intents-console/index.js`
@@ -335,12 +401,14 @@ to:
 
 `projects/intents-trading-agent/.system/widgets/near-intents-console/`
 
-### 9. Response
+### 10. Response
 
 Respond with specifics:
 
 - stance and confidence,
 - top supporting and opposing evidence,
+- paid source budget, selected sources, and receipt status if premium
+  research was planned or used,
 - backtest summary versus buy-and-hold when available,
 - top strategy-suite candidates when available,
 - risk gate table,

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -92,6 +92,11 @@ using workspace writes. Initialize:
   "paid_research_budget_usd": 0.25,
   "paid_research_max_sources": 4,
   "paid_research_mode": "plan-only",
+  "paid_research_agent_wallet_provider": "AgentCash",
+  "paid_research_default_article_price_usd": 0.01,
+  "paid_research_per_article_cap_usd": 0.05,
+  "paid_research_daily_cap_usd": 1.0,
+  "paid_research_max_wallet_balance_usd": 5.0,
   "require_user_approval": true
 }
 ```
@@ -177,8 +182,27 @@ Candidate sources may come from:
 
 - `projects/intents-trading-agent/sources/paid-research.json`,
 - public MPP or x402 service discovery,
+- DripStack guided browse results,
 - a user-provided source list,
 - free/public research already collected by the analyst team.
+
+For DripStack-style newsletter access, do not scrape or bulk-buy. Use
+the guided flow:
+
+1. Ask for a topic if none was provided.
+2. Use free catalog metadata to shortlist publications.
+3. Let the user choose one publication.
+4. Use free post summaries to shortlist articles.
+5. Let the user choose one article.
+6. Convert that article into a paid-source candidate.
+7. Only then pass the candidate to `plan_paid_research`.
+
+The deterministic helper for this is `portfolio.plan_dripstack_browse`.
+It accepts free publication/post metadata and returns one of these
+checkpoints: `topic`, `publication`, `article`, or
+`purchase-confirmation`. A `purchase-confirmation` output includes a
+`paid_source_candidate` with both MPP and x402 payment options when the
+article came from DripStack.
 
 Call `portfolio` with:
 
@@ -191,6 +215,16 @@ Call `portfolio` with:
   "max_sources": 4,
   "spending_mode": "plan-only",
   "near_funding_asset": "USDC.near",
+  "preferred_payment_protocols": ["mpp", "x402"],
+  "agent_wallet": {
+    "provider": "AgentCash",
+    "network": "base",
+    "balance_usd": 5.0,
+    "default_article_price_usd": 0.01,
+    "per_article_cap_usd": 0.05,
+    "daily_cap_usd": 1.0,
+    "max_wallet_balance_usd": 5.0
+  },
   "sources": []
 }
 ```
@@ -207,6 +241,15 @@ Use the plan as follows:
   `near_funding_routes` as hints for how a NEAR Intents-funded treasury
   could fund the rail wallet. This does not authorize the actual paid
   fetch.
+- For autonomous wallets, keep balances small. The default policy is
+  `$5` maximum wallet balance, `$0.05` per article, and `$1` daily
+  research spend. This mirrors the "small USDC balance" operating model:
+  enough for many one-cent articles, not enough to create a large blast
+  radius.
+- Record audit links such as `mppscan.com` and `x402scan.com` in the
+  paid-research plan or journal so spend can be reviewed after a run.
+- Treat highly optimized source metadata as an adversarial surface.
+  Reject or downgrade sources with low trust or high `seo_risk_score`.
 - Never include paid source text in the answer or research memo until
   the payment client returns a receipt.
 - When paid source text is used, include source IDs from

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: intents-trading-agent
+version: 0.1.0
+description: TradingAgents-style crypto trading workflow for IronClaw that researches multichain spot opportunities, debates bull/bear cases, applies risk gates, and builds unsigned NEAR Intent bundles through the portfolio tool.
+activation:
+  keywords:
+    - intents trading
+    - trading agent
+    - crypto trading agent
+    - autonomous crypto trading
+    - multichain trading
+    - near intents trading
+    - intent based trading
+    - rebalance into
+    - swap thesis
+    - token rotation
+  patterns:
+    - "(?i)(trade|swap|rotate|rebalance).*(NEAR Intents|intents|multichain|cross-chain)"
+    - "(?i)(autonomous|agentic).*(crypto|token|trading|portfolio)"
+    - "(?i)(build|try|prototype).*(TradingAgents|trading agents).*(IronClaw|intents)"
+  exclude_keywords:
+    - nft
+    - mint
+  tags:
+    - crypto
+    - trading
+    - finance
+    - intents
+  max_context_tokens: 5000
+requires:
+  skills:
+    - portfolio
+    - llm-council
+    - decision-capture
+---
+
+# Intents Trading Agent
+
+You run a TradingAgents-style crypto workflow on top of IronClaw.
+The goal is to turn market research into **unsigned NEAR Intent
+bundles** that the user can inspect and sign in their own wallet.
+
+This skill is a research and orchestration layer. It does not replace
+the `portfolio` WASM tool. Use `portfolio.scan`, `portfolio.propose`,
+and `portfolio.build_intent` for positions, deterministic DeFi
+proposals, and intent bundle construction.
+
+## Non-negotiables
+
+1. **No private keys.** Never ask for seed phrases, private keys, or
+   signing material. Never claim to have signed or submitted a trade.
+2. **Unsigned only.** The agent may autonomously research, rank, and
+   build unsigned intent artifacts. Signing is always a user-wallet
+   action outside this skill.
+3. **Paper mode by default.** Unless the user explicitly opts into live
+   quoting, use fixture/replay paths and mark all output as test or
+   paper. Do not present fixture bundles as executable quotes.
+4. **Spot only in v0.** Do not propose leverage, perps, borrowing, or
+   recursive collateral loops. Defensive deleveraging proposals from
+   `portfolio.propose` are allowed.
+5. **Risk gates before intents.** A trade idea becomes an intent only
+   after the risk manager approves it against project config.
+6. **Audit trail first.** Persist research, debate notes, risk checks,
+   decisions, and built intents under `projects/intents-trading-agent/`.
+
+## Project bootstrap
+
+If the project does not exist, create `projects/intents-trading-agent/`
+using workspace writes. Initialize:
+
+- `AGENTS.md` - operating principles and tool boundaries.
+- `config.json`:
+
+```json
+{
+  "mode": "paper",
+  "max_notional_usd": 100,
+  "max_daily_turnover_usd": 250,
+  "max_slippage_bps": 50,
+  "min_confidence": 0.72,
+  "min_expected_edge_bps": 75,
+  "cooldown_minutes": 240,
+  "allowed_chains": [],
+  "allowed_assets": ["NEAR", "USDC", "USDT", "BTC", "ETH"],
+  "disallowed_assets": [],
+  "require_user_approval": true
+}
+```
+
+- `watchlist.md` - token pairs, chains, and theses the user cares about.
+- `addresses.md` - optional wallet addresses to scan.
+- `state/latest.json` and `state/history/`.
+- `research/`, `debates/`, `decisions/`, `risk/`, `intents/`,
+  `journal/`, and `widgets/`.
+- `strategies/` - copy or reference the baseline strategy docs bundled
+  with this skill (`sma-cross-spot`, `breakout-spot`,
+  `momentum-spot`, `mean-reversion-spot`,
+  `rsi-mean-reversion-spot`, `buy-hold-benchmark`) plus signal/gate
+  docs such as `hyperliquid-funding-carry-watch`,
+  `hyperliquid-book-imbalance-gate`, and
+  `hyperliquid-perp-momentum-signal`.
+- `.system/widgets/near-intents-console/` - copy the bundled widget
+  files from `skills/intents-trading-agent/widgets/near-intents-console/`
+  so IronClaw Projects can render the NEAR Intents trading console.
+
+If a `portfolio` project already exists, read it for wallet/address
+context, but keep trading-agent research and decisions in
+`projects/intents-trading-agent/`.
+
+## Run procedure
+
+### 1. Load state
+
+Read config, watchlist, addresses, latest state, recent decisions, and
+open unsigned intents. If the user provides a wallet address, append it
+to `addresses.md` and scan it.
+
+If addresses are present, call:
+
+```json
+{
+  "action": "scan",
+  "addresses": ["<address>"],
+  "chains": "*",
+  "source": "auto"
+}
+```
+
+Save the returned positions exactly as `state/latest.json` and append a
+dated copy under `state/history/`.
+
+### 2. Analyst team
+
+Run the analysis as distinct roles. Keep each role short and evidence
+grounded.
+
+- **Market Data Analyst**: price trend, volume, volatility, liquidity,
+  and drawdown context for the watched pair. For Hyperliquid/HL ideas,
+  include funding, candle snapshot, all-mids, and L2 book context when
+  available, but treat those as signal/risk inputs unless execution
+  support is explicitly implemented.
+- **Onchain/Portfolio Analyst**: wallet exposure, idle balances,
+  concentration, chain exposure, and any deterministic proposals from
+  `portfolio.propose`.
+- **News/Sentiment Analyst**: recent catalysts, governance, listings,
+  exploits, unlocks, regulatory events, and social sentiment. Use web
+  search for current facts when available.
+- **Intents/Liquidity Analyst**: whether the move is suitable for
+  intent execution, likely source/destination chains, route complexity,
+  solver quote risk, slippage budget, and expiry risk.
+- **Risk Analyst**: position sizing, downside scenario, correlation,
+  liquidity, stale data, and whether the idea passes config gates.
+
+Write role outputs to
+`projects/intents-trading-agent/research/<YYYY-MM-DD>/<role>.md`.
+
+### 3. Strategy lab and backtest
+
+Before a strategy can become a trade proposal, run a deterministic
+backtest when historical OHLCV candles are available. Prefer
+`action="backtest_suite"` when evaluating a menu of strategies, and use
+`action="backtest"` only for a single focused strategy check.
+
+For a strategy menu, call `portfolio` with:
+
+- `candles`: oldest-to-newest OHLCV candles,
+- `candidates`: strategy configs with stable IDs,
+- common fees, slippage, and starting cash.
+
+Each candidate may include `max_position_pct`, `stop_loss_bps`, and
+`take_profit_bps`. Persist the returned ranked suite exactly as
+`projects/intents-trading-agent/backtests/<YYYY-MM-DDTHH-MM>-suite-<pair>.json`.
+
+For a single strategy, call `portfolio` with `action="backtest"` and
+pass:
+
+- `candles`: oldest-to-newest OHLCV candles,
+- `strategy`: one of `buy-hold`, `sma-cross`, `breakout`,
+  `momentum`, `mean-reversion`, `rsi-mean-reversion`,
+- fees, slippage, max position size, and optional stop/take-profit.
+
+The backtester is inspired by common open-source trading frameworks:
+dry-run/backtest-first workflow, explicit fee/slippage assumptions,
+lookahead-safe next-open execution, analyzers/metrics, and a
+buy-and-hold benchmark. Do not copy external strategy code into the
+workspace; use these as design patterns and keep the local implementation
+auditable.
+
+Persist reports to
+`projects/intents-trading-agent/backtests/<YYYY-MM-DDTHH-MM>-<strategy>-<pair>.json`.
+
+Reject or downgrade to `watch` if:
+
+- `lookahead_safe` is false,
+- no suite candidate passes `passes_basic_gate`,
+- completed trades are below the strategy doc minimum,
+- max drawdown exceeds project risk budget,
+- total return is negative after fees and slippage,
+- alpha versus buy-and-hold is negative for a trend-following strategy,
+- win rate or profit factor fails the strategy doc minimum,
+- the test sample is too small or excludes a relevant stress regime.
+
+Always run `buy-hold` as a benchmark when enough candles are available.
+Always present the top ranked suite candidates and rejected candidates
+separately so the user can see what was considered.
+
+### 4. Bull/bear debate
+
+Create two concise debate memos:
+
+- Bull case: why the trade should be considered now.
+- Bear case: why it should be skipped, sized down, or delayed.
+
+Then write a manager synthesis with:
+
+- consensus points,
+- unresolved disagreements,
+- key missing data,
+- confidence score from 0 to 1,
+- final stance: `skip`, `watch`, `paper-intent`, or `quote-intent`.
+
+Persist to `projects/intents-trading-agent/debates/<YYYY-MM-DDTHH-MM>-<pair>.md`.
+
+### 5. Trader proposal
+
+Only create a trade proposal when the manager stance is
+`paper-intent` or `quote-intent`.
+
+A proposal must include:
+
+- pair and direction,
+- source asset, destination asset, source chain, destination chain,
+- notional USD and token amount,
+- expected output and expected cost,
+- thesis,
+- invalidation condition,
+- expiry or review time,
+- confidence,
+- risk gates and their pass/fail result.
+
+The trade proposal is not executable by itself. It is a request for an
+unsigned intent bundle.
+
+### 6. Risk gates
+
+Reject or downgrade to `watch` if any gate fails:
+
+- `notional_usd <= max_notional_usd`
+- daily turnover including pending intents <= `max_daily_turnover_usd`
+- confidence >= `min_confidence`
+- expected edge >= `min_expected_edge_bps`
+- source and destination assets are allowed and not disallowed
+- slippage <= `max_slippage_bps`
+- data freshness is acceptable
+- no unresolved security/exploit concern
+- no existing conflicting pending intent
+- backtest gates pass when candles are available
+
+If `require_user_approval` is true, do not ask the user to sign; ask
+whether they want a live quote or want to keep it as paper.
+
+### 7. Build unsigned intent
+
+For an approved `paper-intent`, call `portfolio.build_intent` with
+`solver: "fixture"` so the output is clearly a deterministic test
+bundle.
+
+For an approved `quote-intent`, call `portfolio.build_intent` with
+`solver: "near-intents"` only if the user explicitly requested live
+quoting and the environment supports it. The returned bundle is still
+unsigned.
+
+Use a `MovementPlan` shaped like:
+
+```json
+{
+  "proposal_id": "ita-<YYYYMMDD>-<pair>-<slug>",
+  "legs": [
+    {
+      "kind": "swap",
+      "chain": "<source-chain>",
+      "from_token": {
+        "symbol": "<source-symbol>",
+        "address": null,
+        "chain": "<source-chain>",
+        "amount": "<amount>",
+        "value_usd": "<notional-usd>"
+      },
+      "to_token": {
+        "symbol": "<destination-symbol>",
+        "address": null,
+        "chain": "<destination-chain>",
+        "amount": "<expected-amount>",
+        "value_usd": "<expected-usd>"
+      },
+      "description": "Swap <source> to <destination> via NEAR Intents"
+    }
+  ],
+  "expected_out": {
+    "symbol": "<destination-symbol>",
+    "address": null,
+    "chain": "<destination-chain>",
+    "amount": "<expected-amount>",
+    "value_usd": "<expected-usd>"
+  },
+  "expected_cost_usd": "<max-cost-usd>"
+}
+```
+
+For cross-chain moves, use ordered `withdraw`, `bridge`, `swap`, and
+`deposit` legs as needed. Never hand-build a raw EVM transaction.
+
+Persist returned bundles to
+`projects/intents-trading-agent/intents/<YYYY-MM-DDTHH-MM>-<proposal_id>.json`.
+
+### 8. Format the project widget
+
+After every run, call `portfolio` with `action="format_intents_widget"`
+and pass the latest pair, stance, confidence, `backtest_suite`, risk
+gates, research sources, and optional unsigned `IntentBundle`.
+
+Persist the returned JSON exactly as:
+
+`projects/intents-trading-agent/widgets/state.json`
+
+The bundled project widget reads this file and renders ranked strategy
+candidates, risk gates, and unsigned NEAR Intents status inside the
+IronClaw Projects view. If the widget files are not installed yet, copy:
+
+- `skills/intents-trading-agent/widgets/near-intents-console/manifest.json`
+- `skills/intents-trading-agent/widgets/near-intents-console/index.js`
+- `skills/intents-trading-agent/widgets/near-intents-console/style.css`
+
+to:
+
+`projects/intents-trading-agent/.system/widgets/near-intents-console/`
+
+### 9. Response
+
+Respond with specifics:
+
+- stance and confidence,
+- top supporting and opposing evidence,
+- backtest summary versus buy-and-hold when available,
+- top strategy-suite candidates when available,
+- risk gate table,
+- proposed notional and route,
+- intent status: `none`, `paper-built`, `live-quote-built`, or
+  `blocked`,
+- widget status and state path,
+- exact project paths written.
+
+Make clear that this is research and unsigned intent construction, not
+financial advice or executed trading.
+
+## Recurring mission
+
+Offer, but do not auto-create, a mission:
+
+- `name`: `intents-trading-agent`
+- `project_id`: `intents-trading-agent`
+- `cadence`: `0 */4 * * *`
+- `goal`: "Run the intents trading workflow in paper mode for the
+  configured watchlist. Research current market/onchain/news context,
+  run and rank a strategy suite when candles are available, debate bull
+  and bear cases, apply risk gates, and build unsigned paper intent
+  bundles only when every gate passes. Never sign or submit trades."
+
+If the user later opts into live quotes, update the mission goal to say
+`live quote bundles are allowed, signing remains user-only`.

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -42,9 +42,12 @@ bundles** that the user can inspect and sign in their own wallet.
 
 This skill is a research and orchestration layer. It does not replace
 the `portfolio` WASM tool. Use `portfolio.scan`, `portfolio.propose`,
-`portfolio.plan_paid_research`, and `portfolio.build_intent` for
-positions, deterministic DeFi proposals, paid-source budgeting, and
-intent bundle construction.
+`portfolio.plan_near_intents_trial`, `portfolio.plan_paid_research`,
+`portfolio.fetch_dripstack_catalog`,
+`portfolio.prepare_dripstack_paid_fetch`, and `portfolio.build_intent`
+for positions, deterministic DeFi proposals, nominal-wallet rehearsals,
+free DripStack catalog access, paid-source budgeting/fetch boundaries,
+and intent bundle construction.
 
 ## Non-negotiables
 
@@ -97,6 +100,9 @@ using workspace writes. Initialize:
   "paid_research_per_article_cap_usd": 0.05,
   "paid_research_daily_cap_usd": 1.0,
   "paid_research_max_wallet_balance_usd": 5.0,
+  "trial_nominal_near": 0.25,
+  "trial_max_trade_near": 0.05,
+  "trial_pair": "NEAR/USDC",
   "require_user_approval": true
 }
 ```
@@ -108,7 +114,7 @@ using workspace writes. Initialize:
   payment metadata discovered from MPP, x402, NEAR-native, newsletter, or
   API catalogs.
 - `research/`, `debates/`, `decisions/`, `risk/`, `intents/`,
-  `journal/`, `paid-research/`, and `widgets/`.
+  `journal/`, `paid-research/`, `trials/`, and `widgets/`.
 - `strategies/` - copy or reference the baseline strategy docs bundled
   with this skill (`sma-cross-spot`, `breakout-spot`,
   `momentum-spot`, `mean-reversion-spot`,
@@ -197,12 +203,29 @@ the guided flow:
 6. Convert that article into a paid-source candidate.
 7. Only then pass the candidate to `plan_paid_research`.
 
-The deterministic helper for this is `portfolio.plan_dripstack_browse`.
-It accepts free publication/post metadata and returns one of these
-checkpoints: `topic`, `publication`, `article`, or
+Use `portfolio.fetch_dripstack_catalog` to fetch only DripStack's free
+publication catalog and free post-title metadata. Then pass that free
+metadata to `portfolio.plan_dripstack_browse`. The planner returns one
+of these checkpoints: `topic`, `publication`, `article`, or
 `purchase-confirmation`. A `purchase-confirmation` output includes a
 `paid_source_candidate` with both MPP and x402 payment options when the
 article came from DripStack.
+
+When the user confirms a specific paid DripStack article, first call
+`portfolio.prepare_dripstack_paid_fetch`. It creates the explicit
+confirmation/challenge/receipt boundary for one article:
+
+- `needs-user-confirmation`: ask the user before touching the paid route.
+- `needs-402-challenge`: probe the paid endpoint only to collect the
+  HTTP 402 payment challenge; do not summarize substitute content.
+- `ready-to-retry-with-receipt`: a payment-aware client supplied an MPP
+  or x402 receipt header and the next GET can unlock that one article.
+
+The live 402 challenge is authoritative for price and payment details.
+Current DripStack OpenAPI describes paid article routes as returning
+MPP `WWW-Authenticate` and x402 `PAYMENT-REQUIRED` challenges, with a
+fallback paid-route minimum around `$0.05` when no per-post price is
+available. Do not assume the old one-cent estimate is final.
 
 Call `portfolio` with:
 
@@ -307,6 +330,48 @@ Reject or downgrade to `watch` if:
 Always run `buy-hold` as a benchmark when enough candles are available.
 Always present the top ranked suite candidates and rejected candidates
 separately so the user can see what was considered.
+
+### 4.5 Nominal NEAR trial mode
+
+If the user wants to try the system with a small amount of NEAR, keep
+the first pass in paper mode and call `portfolio.plan_near_intents_trial`.
+
+Example:
+
+```json
+{
+  "action": "plan_near_intents_trial",
+  "near_account_id": "<optional-user-account.near>",
+  "mode": "paper",
+  "pair": "NEAR/USDC",
+  "nominal_near": 0.25,
+  "max_trade_near": 0.05,
+  "assumed_near_usd": 3.0,
+  "max_slippage_bps": 50,
+  "backtest_suite": {}
+}
+```
+
+Persist the returned `near-intents-trial-plan/1` to
+`projects/intents-trading-agent/trials/<YYYY-MM-DDTHH-MM>-near-trial.json`.
+
+Use the trial plan as the operator runbook:
+
+- The wallet should be a separate small NEAR account, not the user's
+  main wallet.
+- Native NEAR must be wrapped to wNEAR before verifier funding; do not
+  transfer raw native NEAR directly to the verifier.
+- The verifier deposit step is manual/user-wallet controlled.
+- `mode="paper"` means run the returned `build_intent_request` with
+  `solver="fixture"`.
+- `mode="quote"` means all paper gates passed and the user explicitly
+  asked for a live NEAR Intents quote; the output is still unsigned.
+- `mode="execution"` is informational only here. This skill still does
+  not sign or submit trades.
+- If the trial plan has `safe_to_quote=false`, do not request a live
+  quote.
+- Very small route sizes may be refused or dominated by minimums. Warn
+  the user rather than increasing size automatically.
 
 ### 5. Bull/bear debate
 
@@ -424,17 +489,17 @@ Persist returned bundles to
 
 After every run, call `portfolio` with `action="format_intents_widget"`
 and pass the latest pair, stance, confidence, `backtest_suite`, risk
-gates, research sources, optional `paid_research_plan`, and optional
-unsigned `IntentBundle`.
+gates, research sources, optional `trial_plan`, optional
+`paid_research_plan`, and optional unsigned `IntentBundle`.
 
 Persist the returned JSON exactly as:
 
 `projects/intents-trading-agent/widgets/state.json`
 
 The bundled project widget reads this file and renders ranked strategy
-candidates, paid source attribution, risk gates, and unsigned NEAR
-Intents status inside the IronClaw Projects view. If the widget files are
-not installed yet, copy:
+candidates, nominal NEAR trial status, paid source attribution, risk
+gates, and unsigned NEAR Intents status inside the IronClaw Projects
+view. If the widget files are not installed yet, copy:
 
 - `skills/intents-trading-agent/widgets/near-intents-console/manifest.json`
 - `skills/intents-trading-agent/widgets/near-intents-console/index.js`
@@ -452,6 +517,8 @@ Respond with specifics:
 - top supporting and opposing evidence,
 - paid source budget, selected sources, and receipt status if premium
   research was planned or used,
+- nominal NEAR trial budget, setup step status, and whether it is safe
+  to request a live quote,
 - backtest summary versus buy-and-hold when available,
 - top strategy-suite candidates when available,
 - risk gate table,

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -359,8 +359,11 @@ Use the trial plan as the operator runbook:
 
 - The wallet should be a separate small NEAR account, not the user's
   main wallet.
-- Native NEAR must be wrapped to wNEAR before verifier funding; do not
-  transfer raw native NEAR directly to the verifier.
+- If the user funds through 1Click Swap or the Deposit/Withdrawal
+  Service, native NEAR wrapping/routing may be handled by that service.
+  If funding the Verifier contract directly, use wNEAR
+  (`nep141:wrap.near`) rather than transferring raw native NEAR to
+  `intents.near`.
 - The verifier deposit step is manual/user-wallet controlled.
 - `mode="paper"` means run the returned `build_intent_request` with
   `solver="fixture"`.

--- a/skills/intents-trading-agent/SKILL.md
+++ b/skills/intents-trading-agent/SKILL.md
@@ -499,10 +499,13 @@ Persist the returned JSON exactly as:
 
 `projects/intents-trading-agent/widgets/state.json`
 
-The bundled project widget reads this file and renders ranked strategy
-candidates, nominal NEAR trial status, paid source attribution, risk
-gates, and unsigned NEAR Intents status inside the IronClaw Projects
-view. If the widget files are not installed yet, copy:
+The bundled project widget reads this file and renders an interactive
+IronClaw Projects workflow: trial ticket inputs, funding-path selection,
+ranked/selectable strategies, paper intent status, guarded live-quote
+handoff, paid source attribution, risk gates, and unsigned NEAR Intents
+status. The widget writes precise prompts back into chat; it does not
+hold wallet keys, sign payloads, or submit trades. If the widget files
+are not installed yet, copy:
 
 - `skills/intents-trading-agent/widgets/near-intents-console/manifest.json`
 - `skills/intents-trading-agent/widgets/near-intents-console/index.js`

--- a/skills/intents-trading-agent/strategies/breakout-spot.md
+++ b/skills/intents-trading-agent/strategies/breakout-spot.md
@@ -1,0 +1,26 @@
+---
+id: breakout-spot
+version: 1
+kind: breakout
+timeframes: ["1h", "4h", "1d"]
+parameters:
+  lookback_window: 20
+  threshold_bps: 25
+  max_position_pct: 0.5
+risk:
+  stop_loss_bps: 1000
+  take_profit_bps: 1800
+  min_backtest_trades: 5
+  min_alpha_vs_buy_hold_pct: 0
+---
+
+# Breakout Spot Baseline
+
+Trend-continuation baseline for high-liquidity pairs. Enter when a
+closed candle breaks above the prior lookback high by the threshold;
+exit on a downside break, stop-loss, or take-profit.
+
+This is meant to catch strong directional moves while still being
+compatible with intent-based spot execution. Reject it when volume is
+thin, spreads are wide, or the projected route needs fragile
+cross-chain hops.

--- a/skills/intents-trading-agent/strategies/buy-hold-benchmark.md
+++ b/skills/intents-trading-agent/strategies/buy-hold-benchmark.md
@@ -1,0 +1,17 @@
+---
+id: buy-hold-benchmark
+version: 1
+kind: buy-hold
+timeframes: ["1h", "4h", "1d"]
+parameters:
+  max_position_pct: 1.0
+risk:
+  benchmark_only: true
+---
+
+# Buy and Hold Benchmark
+
+Baseline benchmark for alpha checks. The trading agent should compare
+active strategies against buy-and-hold after fees and slippage. A
+strategy that adds complexity but underperforms buy-and-hold should be
+rejected or downgraded to watch mode.

--- a/skills/intents-trading-agent/strategies/dca-spot.md
+++ b/skills/intents-trading-agent/strategies/dca-spot.md
@@ -1,0 +1,102 @@
+---
+id: dca-spot
+version: 1
+kind: dca
+timeframes: ["1h", "4h", "1d", "1w"]
+parameters:
+  notional_per_period_usd: 100
+  period_candles: 7
+  offset: 0
+  skip_above_premium_bps: null
+  opportunistic_below_discount_bps: null
+  fee_bps: 10
+  slippage_bps: 5
+risk:
+  min_total_periods: 6
+  max_per_period_notional_usd: 1000
+  max_total_notional_usd: 25000
+  max_underlying_drawdown_pct: 70
+gates:
+  unsigned_only: true
+  intents_supported_destination: true
+---
+
+# Dollar-Cost Averaging (Spot)
+
+Recurring fixed-notional buys into a NEAR-Intents-supported destination
+asset (NEAR, USDC, USDT, BTC, ETH, WETH, WBTC). The strategy doc bounds
+two surfaces:
+
+1. **`portfolio.backtest_dca`** — replays the schedule over candles and
+   reports lots, average cost basis, breakeven price, mark-to-market,
+   alpha vs lump-sum buy-and-hold, and the underlying drawdown the
+   schedule had to survive.
+2. **`portfolio.plan_dca_schedule`** — emits a cron expression, per-period
+   plan list, deterministic risk gates, and a `build_intent` template
+   the agent uses to produce one unsigned intent per period. The agent
+   never signs.
+
+## When to use
+
+- The user has a multi-week / multi-month accumulation thesis and
+  wants exposure averaged across regimes, not timed to one entry.
+- The asset is illiquid enough that splitting size reduces solver
+  refusal risk and per-period slippage.
+- The user does not have a high-confidence directional view and wants
+  drawdown-tolerance over peak return.
+
+## When not to use
+
+- Total notional fits comfortably in one solver quote with low slippage
+  — lump-sum buy-and-hold has lower fee drag.
+- The thesis is event-driven (governance vote, listing, unlock) and
+  expected to resolve inside one cadence period.
+- The destination asset is not in the NEAR Intents allowlist; the
+  schedule planner will warn but the route may still fail.
+
+## Optional symmetric price band
+
+The backtest accepts two band parameters that turn vanilla DCA into a
+mild "skip when stretched, double-up when discounted" variant without
+breaking determinism:
+
+- `skip_above_premium_bps`: skip a buy when the candle close is more
+  than this many bps above the running average cost basis. Reduces
+  buying into late-stage rallies.
+- `opportunistic_below_discount_bps`: double the buy when the candle
+  close is more than this many bps below the running average cost
+  basis. Front-loads accumulation during selloffs.
+
+Both are off by default. Setting either preserves the deterministic
+replay contract — the band is evaluated on candle close, after the
+running average is updated, with no lookahead.
+
+## Backtest gates before live quoting
+
+A DCA schedule is eligible for live (`mode="quote"`) intent
+construction only if all of the following hold over the candle replay:
+
+- the schedule completed at least `min_total_periods` lots,
+- mark-to-market vs lump-sum buy-and-hold is within an explicit
+  tolerance the operator set in project config,
+- max underlying drawdown is within `max_underlying_drawdown_pct`,
+- the destination asset is in the NEAR Intents allowlist, or the
+  operator has explicitly approved an off-allowlist route,
+- per-period notional does not exceed `max_per_period_notional_usd`,
+- total schedule notional does not exceed `max_total_notional_usd`.
+
+Failing any of these downgrades the proposal to `watch` and refuses to
+emit a quote-mode build_intent template.
+
+## Cron cadence
+
+The schedule planner accepts:
+
+- `daily` → `0 12 * * *`
+- `weekly` → `0 12 * * 1` (Monday noon UTC)
+- `biweekly` → `0 12 1,15 * *`
+- `monthly` → `0 12 1 * *`
+- a raw 5-or-6-field cron string for custom cadences.
+
+Cron is advisory metadata. IronClaw schedules each period independently
+through its mission/cron layer; the DCA planner does not run a daemon.

--- a/skills/intents-trading-agent/strategies/hyperliquid-book-imbalance-gate.md
+++ b/skills/intents-trading-agent/strategies/hyperliquid-book-imbalance-gate.md
@@ -1,0 +1,33 @@
+---
+id: hyperliquid-book-imbalance-gate
+version: 1
+kind: gate-hyperliquid-orderbook
+venue: hyperliquid
+status: risk-gate
+timeframes: ["1m", "5m", "15m"]
+data_sources:
+  - hyperliquid_l2_book
+  - hyperliquid_all_mids
+parameters:
+  depth_bps: 50
+  max_spread_bps: 20
+  min_bid_ask_depth_ratio: 0.65
+  max_bid_ask_depth_ratio: 1.55
+risk:
+  blocks_intent_when_book_thin: true
+  blocks_intent_when_spread_wide: true
+---
+
+# Hyperliquid Book Imbalance Gate
+
+Risk gate for checking whether a Hyperliquid market is too thin,
+one-sided, or wide-spread to support a spot intent thesis. This is not a
+market-making strategy. It should block or downsize trades when book
+conditions imply poor execution or fragile momentum.
+
+Pass only when the top-of-book spread is inside budget, depth near the
+intended route size is adequate, and bid/ask depth is not badly skewed.
+
+Fail the gate when a trade would be forced through a thin book, when
+spread exceeds the configured threshold, or when imbalance suggests the
+signal is already crowded.

--- a/skills/intents-trading-agent/strategies/hyperliquid-funding-carry-watch.md
+++ b/skills/intents-trading-agent/strategies/hyperliquid-funding-carry-watch.md
@@ -1,0 +1,35 @@
+---
+id: hyperliquid-funding-carry-watch
+version: 1
+kind: signal-hyperliquid-funding
+venue: hyperliquid
+status: signal-only
+timeframes: ["1h", "8h", "1d"]
+data_sources:
+  - hyperliquid_funding
+  - hyperliquid_all_mids
+  - spot_reference_price
+parameters:
+  min_abs_funding_apr_pct: 12
+  min_observation_hours: 24
+  max_premium_bps: 75
+risk:
+  no_perp_execution_in_v0: true
+  require_spot_liquidity_check: true
+  require_funding_reversal_check: true
+---
+
+# Hyperliquid Funding Carry Watch
+
+Signal-only strategy for identifying when perp funding is extreme
+enough to matter for spot positioning. The agent may use this as
+context for a spot rotation thesis, but v0 must not open perp positions
+or claim carry execution through NEAR Intents.
+
+Use the signal when funding is persistent across multiple observations,
+the perp premium is not already mean-reverting violently, and spot
+liquidity is deep enough for the candidate intent route.
+
+Reject the signal if funding flipped recently, market depth is thin,
+oracle/mark divergence is unstable, or the proposed trade only works
+because of leverage.

--- a/skills/intents-trading-agent/strategies/hyperliquid-perp-momentum-signal.md
+++ b/skills/intents-trading-agent/strategies/hyperliquid-perp-momentum-signal.md
@@ -1,0 +1,34 @@
+---
+id: hyperliquid-perp-momentum-signal
+version: 1
+kind: signal-hyperliquid-momentum
+venue: hyperliquid
+status: signal-only
+timeframes: ["15m", "1h", "4h"]
+data_sources:
+  - hyperliquid_candle_snapshot
+  - hyperliquid_l2_book
+  - hyperliquid_all_mids
+parameters:
+  lookback_window: 20
+  min_momentum_bps: 250
+  max_chase_distance_bps: 150
+risk:
+  require_spot_backtest_confirmation: true
+  require_book_gate: true
+  require_news_veto_check: true
+---
+
+# Hyperliquid Perp Momentum Signal
+
+Signal-only strategy for using Hyperliquid perp market structure as an
+early warning that a liquid asset may be entering a momentum regime. In
+v0, this can only support a spot intent candidate; it cannot authorize
+perp orders, leverage, or API-key execution.
+
+Promote the signal only when momentum persists beyond the lookback
+window, the current price is not too far from the breakout level, and a
+matching spot strategy also passes `portfolio.backtest_suite`.
+
+Reject or downgrade when the move is already extended, book depth is
+weak, funding is crowded, or the catalyst is unverifiable.

--- a/skills/intents-trading-agent/strategies/mean-reversion-spot.md
+++ b/skills/intents-trading-agent/strategies/mean-reversion-spot.md
@@ -1,0 +1,25 @@
+---
+id: mean-reversion-spot
+version: 1
+kind: mean-reversion
+timeframes: ["1h", "4h"]
+parameters:
+  lookback_window: 20
+  threshold_bps: 300
+  max_position_pct: 0.35
+risk:
+  stop_loss_bps: 800
+  min_backtest_trades: 8
+  min_win_rate_pct: 45
+---
+
+# Mean Reversion Spot Baseline
+
+Liquidity-reversion baseline for large-cap pairs. Enter when price
+closes materially below a moving average and exit when price reverts to
+the average.
+
+Use only on assets with deep liquidity and no obvious impairment
+catalyst. Do not use this to catch falling knives after hacks, token
+unlock shocks, depegs, regulatory events, or protocol insolvency
+rumors.

--- a/skills/intents-trading-agent/strategies/momentum-spot.md
+++ b/skills/intents-trading-agent/strategies/momentum-spot.md
@@ -1,0 +1,25 @@
+---
+id: momentum-spot
+version: 1
+kind: momentum
+timeframes: ["4h", "1d"]
+parameters:
+  lookback_window: 20
+  threshold_bps: 500
+  max_position_pct: 0.4
+risk:
+  stop_loss_bps: 1000
+  min_backtest_trades: 5
+  min_alpha_vs_buy_hold_pct: 0
+---
+
+# Momentum Spot Baseline
+
+Relative momentum baseline for liquid assets. Enter when trailing
+lookback return clears the threshold; exit when trailing momentum
+fades to zero or lower.
+
+Use this for rotation candidates where the thesis is continued strength
+rather than a single breakout candle. Reject when the asset is already
+extended into a known unlock, exploit, delisting, depeg, or governance
+risk window.

--- a/skills/intents-trading-agent/strategies/rsi-mean-reversion-spot.md
+++ b/skills/intents-trading-agent/strategies/rsi-mean-reversion-spot.md
@@ -1,0 +1,26 @@
+---
+id: rsi-mean-reversion-spot
+version: 1
+kind: rsi-mean-reversion
+timeframes: ["1h", "4h"]
+parameters:
+  lookback_window: 14
+  entry_threshold: 30
+  exit_threshold: 55
+  max_position_pct: 0.3
+risk:
+  stop_loss_bps: 700
+  min_backtest_trades: 8
+  min_win_rate_pct: 45
+---
+
+# RSI Mean Reversion Spot Baseline
+
+Oscillator-driven reversion baseline. Enter when RSI is oversold and
+exit when RSI normalizes. This is only appropriate for deep-liquidity
+assets where the move looks like flow exhaustion, not fundamental
+impairment.
+
+Reject the strategy during protocol exploit news, stablecoin depegs,
+forced unlocks, liquidation cascades, chain halts, or any case where
+the "oversold" move may be information rather than noise.

--- a/skills/intents-trading-agent/strategies/sma-cross-spot.md
+++ b/skills/intents-trading-agent/strategies/sma-cross-spot.md
@@ -1,0 +1,25 @@
+---
+id: sma-cross-spot
+version: 1
+kind: sma-cross
+timeframes: ["1h", "4h", "1d"]
+parameters:
+  fast_window: 8
+  slow_window: 21
+  max_position_pct: 0.5
+risk:
+  stop_loss_bps: 800
+  min_backtest_trades: 5
+  min_alpha_vs_buy_hold_pct: 0
+---
+
+# SMA Cross Spot Baseline
+
+Trend-following baseline for liquid spot pairs. Enter when the fast
+moving average crosses above the slow moving average; exit on the
+reverse cross or a stop-loss.
+
+Use this as a sanity benchmark, not a production strategy. It should
+only graduate to an intent candidate when the backtest shows enough
+trades, positive alpha after fees and slippage, and drawdown inside the
+project risk budget.

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -125,12 +125,61 @@ function itaIntent(intent) {
     + '</div>';
 }
 
+function itaMoney(value) {
+  var n = Number(value || 0);
+  return '$' + n.toFixed(n < 1 ? 4 : 2);
+}
+
+function itaPaidResearch(plan) {
+  if (!plan) {
+    return '<div class="ita-empty-line">No paid research plan recorded.</div>';
+  }
+  var sources = Array.isArray(plan.payable_sources) ? plan.payable_sources : [];
+  var rails = Array.isArray(plan.payment_rails) ? plan.payment_rails : [];
+  var routes = Array.isArray(plan.near_funding_routes) ? plan.near_funding_routes : [];
+  var gates = Array.isArray(plan.policy_gates) ? plan.policy_gates : [];
+  return '<div class="ita-paid">'
+    + '<div class="ita-paid-bar">'
+    + '<div><span>Budget</span><strong>' + itaMoney(plan.budget_usd) + '</strong></div>'
+    + '<div><span>Allocated</span><strong>' + itaMoney(plan.allocated_usd) + '</strong></div>'
+    + '<div><span>Unspent</span><strong>' + itaMoney(plan.unspent_usd) + '</strong></div>'
+    + '<div><span>Fetch</span><strong>' + (plan.ready_for_paid_fetch ? 'Ready' : 'Blocked') + '</strong></div>'
+    + '</div>'
+    + (plan.query ? '<div class="ita-paid-query">' + itaEscape(plan.query) + '</div>' : '')
+    + '<div class="ita-paid-lanes">'
+    + '<div>'
+    + '<div class="ita-subtitle">Payable Sources</div>'
+    + (sources.length ? sources.map(function(source) {
+      return '<div class="ita-source-line">'
+        + '<div><strong>' + itaEscape(source.title || source.id) + '</strong>'
+        + '<span>' + itaEscape(source.author || 'Unknown author') + ' · ' + itaEscape(source.protocol || 'manual') + ' / ' + itaEscape(source.network || 'manual') + '</span></div>'
+        + '<div class="ita-source-price">' + itaMoney(source.amount_usd) + '</div>'
+        + (source.receipt_required ? '<span class="ita-pill is-warn">Receipt</span>' : '<span class="ita-pill is-pass">Free</span>')
+        + '</div>';
+    }).join('') : '<div class="ita-empty-line">No payable sources selected.</div>')
+    + '</div>'
+    + '<div>'
+    + '<div class="ita-subtitle">Rails</div>'
+    + (rails.length ? rails.map(function(rail) {
+      return '<div class="ita-rail-line"><span>' + itaEscape(rail.protocol || 'manual') + '</span><strong>' + itaMoney(rail.allocated_usd) + '</strong></div>';
+    }).join('') : '<div class="ita-empty-line">No payment rails.</div>')
+    + (routes.length ? '<div class="ita-route-note">' + routes.map(function(route) {
+      return itaEscape(route.via || 'near-intents') + ' -> ' + itaEscape(route.target_protocol || 'rail') + ' ' + itaMoney(route.amount_usd);
+    }).join('<br>') + '</div>' : '')
+    + '</div>'
+    + '</div>'
+    + (gates.length ? '<div class="ita-paid-gates">' + itaRiskGates(gates) + '</div>' : '')
+    + '</div>';
+}
+
 function itaWritePrompt(kind, state) {
   if (api && api.navigate) api.navigate('chat');
   var input = document.getElementById('chat-input');
   if (!input) return;
   var pair = state && state.pair ? state.pair : 'the watched pair';
-  input.value = kind === 'quote'
+  input.value = kind === 'paid'
+    ? 'For the Intents Trading Agent, build a paid research plan for ' + pair + ' first: discover MPP/x402/NEAR payable sources, enforce the source budget, require receipts before use, then run backtest_suite and risk gates before any unsigned NEAR intent.'
+    : kind === 'quote'
     ? 'For the Intents Trading Agent, request a live NEAR Intents quote for ' + pair + ' only if all current risk gates still pass. Keep it unsigned.'
     : 'For the Intents Trading Agent, run the paper NEAR Intents workflow for ' + pair + ': research, backtest_suite, risk gates, and unsigned intent preview.';
   input.focus();
@@ -152,21 +201,26 @@ function itaRender(state) {
     + '<div class="ita-summary">'
     + '<div><span>Mode</span><strong>' + itaEscape(state.mode || 'paper') + '</strong></div>'
     + '<div><span>Confidence</span><strong>' + (state.confidence == null ? '-' : Math.round(Number(state.confidence) * 100) + '%') + '</strong></div>'
-    + '<div><span>Sources</span><strong>' + itaEscape(state.source_count || 0) + '</strong></div>'
+    + '<div><span>Sources</span><strong>' + itaEscape(state.paid_research ? state.paid_research.selected_count : state.source_count || 0) + '</strong></div>'
     + '<div><span>Updated</span><strong>' + itaEscape(state.generated_at || '-') + '</strong></div>'
     + '</div>'
     + '<div class="ita-body">'
+    + '<section><div class="ita-section-title">Paid Research</div>' + itaPaidResearch(state.paid_research) + '</section>'
     + '<section><div class="ita-section-title">Strategy Suite</div>' + itaCandidateRows(state.top_candidates) + '</section>'
     + '<section><div class="ita-section-title">Risk Gates</div>' + itaRiskGates(state.risk_gates) + '</section>'
     + '<section><div class="ita-section-title">Unsigned Intent</div>' + itaIntent(state.intent) + '</section>'
     + '</div>'
     + (state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '')
     + '<div class="ita-actions">'
+    + '<button type="button" data-action="ita-paid">Prepare Paid Research</button>'
     + '<button type="button" data-action="ita-paper">Prepare Paper Run</button>'
     + '<button type="button" data-action="ita-quote">Prepare Live Quote Request</button>'
     + '</div>';
 
   root.querySelector('[data-action="ita-refresh"]').addEventListener('click', itaLoad);
+  root.querySelector('[data-action="ita-paid"]').addEventListener('click', function() {
+    itaWritePrompt('paid', state);
+  });
   root.querySelector('[data-action="ita-paper"]').addEventListener('click', function() {
     itaWritePrompt('paper', state);
   });

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -2,6 +2,8 @@ var root = document.createElement('section');
 root.className = 'ita-console';
 container.appendChild(root);
 
+var itaLastState = null;
+
 function itaEscape(value) {
   var div = document.createElement('div');
   div.textContent = value == null ? '' : String(value);
@@ -27,12 +29,63 @@ function itaScore(value) {
   return n.toFixed(2);
 }
 
+function itaMoney(value) {
+  var n = Number(value || 0);
+  return '$' + n.toFixed(n < 1 ? 4 : 2);
+}
+
+function itaNumber(value, fallback) {
+  if (value === '') return fallback;
+  var n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 function itaStatusClass(status) {
   var s = String(status || 'unknown').toLowerCase();
-  if (s === 'pass' || s === 'paper-built' || s === 'live-quote-built') return 'is-pass';
-  if (s === 'warn' || s === 'awaiting-signature' || s === 'watch') return 'is-warn';
+  if (s === 'pass' || s === 'paper-built' || s === 'live-quote-built' || s === 'ready') return 'is-pass';
+  if (s === 'warn' || s === 'awaiting-signature' || s === 'watch' || s === 'manual') return 'is-warn';
   if (s === 'fail' || s === 'failed' || s === 'blocked') return 'is-fail';
   return 'is-neutral';
+}
+
+function itaStoreKey() {
+  return 'ironclaw.intentsTradingAgent.ticket';
+}
+
+function itaReadPrefs() {
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    return JSON.parse(localStorage.getItem(itaStoreKey()) || '{}') || {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function itaSavePrefs(prefs) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(itaStoreKey(), JSON.stringify(prefs || {}));
+}
+
+function itaTrialDefaults(state) {
+  var plan = state && state.trial_plan ? state.trial_plan : {};
+  var prefs = itaReadPrefs();
+  return {
+    pair: prefs.pair || plan.pair || (state && state.pair) || 'NEAR/USDC',
+    mode: prefs.mode || plan.mode || (state && state.mode) || 'paper',
+    nearAccount: prefs.nearAccount || '',
+    nominalNear: itaNumber(prefs.nominalNear, itaNumber(plan.nominal_near, 0.25)),
+    maxTradeNear: itaNumber(prefs.maxTradeNear, itaNumber(plan.max_trade_near, 0.05)),
+    assumedNearUsd: itaNumber(prefs.assumedNearUsd, itaNumber(plan.assumed_near_usd, 3.0)),
+    maxSlippageBps: itaNumber(prefs.maxSlippageBps, 50),
+    selectedStrategyId: prefs.selectedStrategyId || plan.selected_strategy_id || plan.recommended_strategy_id || itaFirstStrategyId(state),
+    fundingPath: prefs.fundingPath || 'managed'
+  };
+}
+
+function itaPersistPref(name, value) {
+  var prefs = itaReadPrefs();
+  prefs[name] = value;
+  itaSavePrefs(prefs);
 }
 
 function itaReadState(slug) {
@@ -61,28 +114,162 @@ function itaLoadProjectSlug() {
     });
 }
 
-function itaCandidateRows(candidates) {
-  if (!Array.isArray(candidates) || candidates.length === 0) {
-    return '<div class="ita-empty-line">No ranked strategies yet.</div>';
-  }
-  return '<div class="ita-table" role="table" aria-label="Ranked strategy candidates">'
-    + candidates.map(function(c) {
-      return '<div class="ita-row" role="row">'
-        + '<div class="ita-rank">#' + itaEscape(c.rank || '-') + '</div>'
-        + '<div class="ita-strategy">'
-        + '<strong>' + itaEscape(c.id || 'candidate') + '</strong>'
-        + '<span>' + itaEscape(c.strategy_kind || 'strategy') + '</span>'
-        + '</div>'
-        + '<div class="ita-metric"><span>Score</span><strong>' + itaScore(c.selection_score) + '</strong></div>'
-        + '<div class="ita-metric"><span>Return</span><strong>' + itaPct(c.total_return_pct) + '</strong></div>'
-        + '<div class="ita-metric"><span>Alpha</span><strong>' + itaPct(c.alpha_vs_buy_hold_pct) + '</strong></div>'
-        + '<div class="ita-metric"><span>DD</span><strong>' + itaPct(-Math.abs(Number(c.max_drawdown_pct || 0))) + '</strong></div>'
-        + '<div class="ita-gate ' + (c.passes_basic_gate ? 'is-pass' : 'is-fail') + '">'
-        + (c.passes_basic_gate ? 'Gate pass' : 'Gate fail')
-        + '</div>'
+function itaAllStrategies(state) {
+  var seen = {};
+  var out = [];
+  var top = Array.isArray(state && state.top_candidates) ? state.top_candidates : [];
+  var menu = state && state.trial_plan && Array.isArray(state.trial_plan.strategy_menu)
+    ? state.trial_plan.strategy_menu
+    : [];
+
+  top.forEach(function(candidate) {
+    if (!candidate || seen[candidate.id]) return;
+    seen[candidate.id] = true;
+    out.push({
+      id: candidate.id,
+      kind: candidate.strategy_kind || 'strategy',
+      rank: candidate.rank,
+      score: candidate.selection_score,
+      returnPct: candidate.total_return_pct,
+      alphaPct: candidate.alpha_vs_buy_hold_pct,
+      drawdownPct: candidate.max_drawdown_pct,
+      trades: candidate.trades,
+      passes: !!candidate.passes_basic_gate,
+      note: 'Backtested candidate'
+    });
+  });
+
+  menu.forEach(function(strategy) {
+    if (!strategy || seen[strategy.id]) return;
+    seen[strategy.id] = true;
+    out.push({
+      id: strategy.id,
+      kind: strategy.kind || 'strategy',
+      rank: null,
+      score: null,
+      returnPct: null,
+      alphaPct: null,
+      drawdownPct: null,
+      trades: null,
+      passes: null,
+      note: strategy.note || '',
+      sizePct: strategy.position_size_pct,
+      stopLossBps: strategy.stop_loss_bps
+    });
+  });
+
+  return out;
+}
+
+function itaFirstStrategyId(state) {
+  var strategies = itaAllStrategies(state || {});
+  return strategies.length ? strategies[0].id : 'sma_cross_fast';
+}
+
+function itaWorkflow(state) {
+  var plan = state && state.trial_plan;
+  var candidates = Array.isArray(state && state.top_candidates) ? state.top_candidates : [];
+  var passing = candidates.some(function(candidate) { return candidate.passes_basic_gate; });
+  var intent = state && state.intent;
+  var paperBuilt = !!intent && (intent.status === 'paper-built' || intent.status === 'live-quote-built');
+  var quoteBuilt = !!intent && intent.status === 'live-quote-built';
+  return [
+    { label: 'Ticket', status: plan ? 'pass' : 'warn', detail: plan ? 'Trial plan ready' : 'Needs plan' },
+    { label: 'Backtest', status: passing ? 'pass' : candidates.length ? 'fail' : 'warn', detail: passing ? 'Passing strategy' : 'Run suite' },
+    { label: 'Paper', status: paperBuilt ? 'pass' : 'warn', detail: paperBuilt ? 'Fixture built' : 'Build fixture' },
+    { label: 'Quote', status: quoteBuilt ? 'pass' : plan && plan.safe_to_quote ? 'ready' : 'blocked', detail: quoteBuilt ? 'Live quote built' : plan && plan.safe_to_quote ? 'Ready' : 'Blocked' }
+  ];
+}
+
+function itaPhaseRail(state) {
+  return '<div class="ita-phases" aria-label="Trial workflow">'
+    + itaWorkflow(state).map(function(phase, index) {
+      return '<div class="ita-phase ' + itaStatusClass(phase.status) + '">'
+        + '<span>' + (index + 1) + '</span>'
+        + '<strong>' + itaEscape(phase.label) + '</strong>'
+        + '<small>' + itaEscape(phase.detail) + '</small>'
         + '</div>';
     }).join('')
     + '</div>';
+}
+
+function itaTicket(state, prefs) {
+  var modeOptions = ['paper', 'quote', 'execution'];
+  var fundingOptions = [
+    { id: 'managed', label: '1Click / Deposit API' },
+    { id: 'direct', label: 'Direct Verifier' }
+  ];
+
+  return '<section class="ita-ticket">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Trial Ticket</div><p>Nominal NEAR sizing, route mode, and funding path.</p></div></div>'
+    + '<div class="ita-ticket-grid">'
+    + itaField('Pair', 'pair', prefs.pair, 'text', 'NEAR/USDC')
+    + itaField('NEAR account', 'nearAccount', prefs.nearAccount, 'text', 'small-test.near')
+    + itaField('Budget NEAR', 'nominalNear', prefs.nominalNear, 'number', '0.25', '0.01', '0.01')
+    + itaField('Trade cap NEAR', 'maxTradeNear', prefs.maxTradeNear, 'number', '0.05', '0.01', '0.01')
+    + itaField('NEAR USD', 'assumedNearUsd', prefs.assumedNearUsd, 'number', '3.00', '0.01', '0.01')
+    + itaField('Slippage bps', 'maxSlippageBps', prefs.maxSlippageBps, 'number', '50', '1', '1')
+    + '</div>'
+    + '<div class="ita-segments" role="group" aria-label="Mode">'
+    + modeOptions.map(function(mode) {
+      return '<button type="button" class="' + (prefs.mode === mode ? 'is-selected' : '') + '" data-pref-button="mode" data-value="' + itaEscape(mode) + '">' + itaEscape(mode) + '</button>';
+    }).join('')
+    + '</div>'
+    + '<div class="ita-segments" role="group" aria-label="Funding path">'
+    + fundingOptions.map(function(option) {
+      return '<button type="button" class="' + (prefs.fundingPath === option.id ? 'is-selected' : '') + '" data-pref-button="fundingPath" data-value="' + itaEscape(option.id) + '">' + itaEscape(option.label) + '</button>';
+    }).join('')
+    + '</div>'
+    + '</section>';
+}
+
+function itaField(label, name, value, type, placeholder, step, min) {
+  return '<label class="ita-field">'
+    + '<span>' + itaEscape(label) + '</span>'
+    + '<input data-pref="' + itaEscape(name) + '" type="' + itaEscape(type) + '" value="' + itaEscape(value == null ? '' : value) + '" placeholder="' + itaEscape(placeholder || '') + '"'
+    + (step ? ' step="' + itaEscape(step) + '"' : '')
+    + (min ? ' min="' + itaEscape(min) + '"' : '')
+    + '>'
+    + '</label>';
+}
+
+function itaStrategyLab(state, prefs) {
+  var strategies = itaAllStrategies(state);
+  if (!strategies.length) {
+    strategies = [{
+      id: prefs.selectedStrategyId || 'sma_cross_fast',
+      kind: 'sma-cross',
+      rank: null,
+      score: null,
+      returnPct: null,
+      alphaPct: null,
+      drawdownPct: null,
+      trades: null,
+      passes: null,
+      note: 'Default strategy menu loads after plan_near_intents_trial.'
+    }];
+  }
+
+  return '<section class="ita-strategy-lab">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Strategy Lab</div><p>Select a strategy before paper or quote mode.</p></div>'
+    + '<button type="button" data-run="backtest">Run Backtest Suite</button></div>'
+    + '<div class="ita-strategy-list">'
+    + strategies.map(function(strategy) {
+      var selected = prefs.selectedStrategyId === strategy.id;
+      var gate = strategy.passes == null ? 'manual' : strategy.passes ? 'pass' : 'fail';
+      return '<button type="button" class="ita-strategy-row ' + (selected ? 'is-selected ' : '') + itaStatusClass(gate) + '" data-strategy="' + itaEscape(strategy.id) + '">'
+        + '<span class="ita-rank">' + (strategy.rank ? '#' + itaEscape(strategy.rank) : '-') + '</span>'
+        + '<span class="ita-strategy-name"><strong>' + itaEscape(strategy.id) + '</strong><small>' + itaEscape(strategy.kind) + '</small></span>'
+        + '<span><small>Score</small><strong>' + (strategy.score == null ? '-' : itaScore(strategy.score)) + '</strong></span>'
+        + '<span><small>Return</small><strong>' + (strategy.returnPct == null ? '-' : itaPct(strategy.returnPct)) + '</strong></span>'
+        + '<span><small>Alpha</small><strong>' + (strategy.alphaPct == null ? '-' : itaPct(strategy.alphaPct)) + '</strong></span>'
+        + '<span><small>DD</small><strong>' + (strategy.drawdownPct == null ? '-' : itaPct(-Math.abs(Number(strategy.drawdownPct || 0)))) + '</strong></span>'
+        + '<span class="ita-pill ' + itaStatusClass(gate) + '">' + itaEscape(gate) + '</span>'
+        + (strategy.note ? '<em>' + itaEscape(strategy.note) + '</em>' : '')
+        + '</button>';
+    }).join('')
+    + '</div>'
+    + '</section>';
 }
 
 function itaRiskGates(gates) {
@@ -125,9 +312,68 @@ function itaIntent(intent) {
     + '</div>';
 }
 
-function itaMoney(value) {
-  var n = Number(value || 0);
-  return '$' + n.toFixed(n < 1 ? 4 : 2);
+function itaTrialPlan(plan) {
+  if (!plan) {
+    return '<div class="ita-empty-line">No nominal NEAR trial plan recorded.</div>';
+  }
+  return '<div class="ita-trial">'
+    + '<div class="ita-trial-bar">'
+    + '<div><span>Budget</span><strong>' + itaEscape(plan.nominal_near || 0) + ' NEAR</strong></div>'
+    + '<div><span>Trade cap</span><strong>' + itaEscape(plan.max_trade_near || 0) + ' NEAR</strong></div>'
+    + '<div><span>USD est.</span><strong>' + itaMoney(plan.max_trade_usd) + '</strong></div>'
+    + '<div><span>Quote</span><strong>' + (plan.safe_to_quote ? 'Ready' : 'Blocked') + '</strong></div>'
+    + '</div>'
+    + (plan.next_action ? '<div class="ita-trial-next">' + itaEscape(plan.next_action) + '</div>' : '')
+    + '</div>';
+}
+
+function itaSetupPanel(state) {
+  var plan = state && state.trial_plan;
+  var steps = plan && Array.isArray(plan.setup_steps) ? plan.setup_steps : [];
+  var gates = []
+    .concat(Array.isArray(state && state.risk_gates) ? state.risk_gates : [])
+    .concat(plan && Array.isArray(plan.risk_gates) ? plan.risk_gates : []);
+  var warnings = plan && Array.isArray(plan.warnings) ? plan.warnings : [];
+
+  return '<section class="ita-setup">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Funding And Gates</div><p>Wallet setup, quote blockers, and signing boundary.</p></div></div>'
+    + (steps.length ? '<div class="ita-steps">'
+      + steps.map(function(step) {
+        return '<div><span>' + itaEscape(step.order || '') + '</span><strong>' + itaEscape(step.name || 'Step') + '</strong><small>' + itaEscape(step.status || 'manual') + '</small><p>' + itaEscape(step.detail || '') + '</p></div>';
+      }).join('')
+      + '</div>' : '<div class="ita-empty-line">No setup steps recorded.</div>')
+    + '<div class="ita-section-title ita-tight-title">Risk Gates</div>'
+    + itaRiskGates(gates)
+    + (warnings.length ? '<div class="ita-warnings">'
+      + warnings.map(function(warning) { return '<span>' + itaEscape(warning) + '</span>'; }).join('')
+      + '</div>' : '')
+    + '</section>';
+}
+
+function itaRunPanel(state, prefs) {
+  var plan = state && state.trial_plan;
+  var quoteReady = !!(plan && plan.safe_to_quote);
+  var hasPlan = !!plan;
+  var intent = state && state.intent;
+  var hasPaperIntent = !!intent && (intent.status === 'paper-built' || intent.status === 'live-quote-built');
+
+  return '<section class="ita-run-panel">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Paper And Quote</div><p>Build fixture first, then request an unsigned live quote.</p></div></div>'
+    + '<div class="ita-run-grid">'
+    + '<div><span>Selected</span><strong>' + itaEscape(prefs.selectedStrategyId || '-') + '</strong></div>'
+    + '<div><span>Mode</span><strong>' + itaEscape(prefs.mode) + '</strong></div>'
+    + '<div><span>Funding</span><strong>' + itaEscape(prefs.fundingPath === 'direct' ? 'Direct Verifier' : '1Click / Deposit API') + '</strong></div>'
+    + '<div><span>Live quote</span><strong>' + (quoteReady ? 'Ready' : 'Blocked') + '</strong></div>'
+    + '</div>'
+    + itaTrialPlan(plan)
+    + itaIntent(intent)
+    + '<div class="ita-run-actions">'
+    + '<button type="button" data-run="plan">Plan Trial</button>'
+    + '<button type="button" data-run="paper" ' + (hasPlan ? '' : 'disabled') + '>Build Paper Intent</button>'
+    + '<button type="button" data-run="quote" ' + (quoteReady && hasPaperIntent ? '' : 'disabled') + '>Request Live Quote</button>'
+    + '<button type="button" data-run="paid">Paid Research</button>'
+    + '</div>'
+    + '</section>';
 }
 
 function itaPaidResearch(plan) {
@@ -136,8 +382,6 @@ function itaPaidResearch(plan) {
   }
   var sources = Array.isArray(plan.payable_sources) ? plan.payable_sources : [];
   var rails = Array.isArray(plan.payment_rails) ? plan.payment_rails : [];
-  var routes = Array.isArray(plan.near_funding_routes) ? plan.near_funding_routes : [];
-  var gates = Array.isArray(plan.policy_gates) ? plan.policy_gates : [];
   var wallet = plan.wallet_policy || null;
   return '<div class="ita-paid">'
     + '<div class="ita-paid-bar">'
@@ -153,7 +397,7 @@ function itaPaidResearch(plan) {
     + (sources.length ? sources.map(function(source) {
       return '<div class="ita-source-line">'
         + '<div><strong>' + itaEscape(source.title || source.id) + '</strong>'
-        + '<span>' + itaEscape(source.author || 'Unknown author') + ' · ' + itaEscape(source.protocol || 'manual') + ' / ' + itaEscape(source.network || 'manual') + '</span></div>'
+        + '<span>' + itaEscape(source.author || 'Unknown author') + ' / ' + itaEscape(source.protocol || 'manual') + ' / ' + itaEscape(source.network || 'manual') + '</span></div>'
         + '<div class="ita-source-price">' + itaMoney(source.amount_usd) + '</div>'
         + (source.receipt_required ? '<span class="ita-pill is-warn">Receipt</span>' : '<span class="ita-pill is-pass">Free</span>')
         + '</div>';
@@ -164,127 +408,171 @@ function itaPaidResearch(plan) {
     + (rails.length ? rails.map(function(rail) {
       return '<div class="ita-rail-line"><span>' + itaEscape(rail.protocol || 'manual') + '</span><strong>' + itaMoney(rail.allocated_usd) + '</strong></div>';
     }).join('') : '<div class="ita-empty-line">No payment rails.</div>')
-    + (routes.length ? '<div class="ita-route-note">' + routes.map(function(route) {
-      return itaEscape(route.via || 'near-intents') + ' -> ' + itaEscape(route.target_protocol || 'rail') + ' ' + itaMoney(route.amount_usd);
-    }).join('<br>') + '</div>' : '')
-    + '</div>'
-    + '</div>'
     + (wallet ? '<div class="ita-wallet-line">'
-      + '<div><span>Agent Wallet</span><strong>' + itaEscape(wallet.provider || 'Agent wallet') + ' · ' + itaEscape(wallet.network || 'base') + '</strong></div>'
+      + '<div><span>Agent Wallet</span><strong>' + itaEscape(wallet.provider || 'Agent wallet') + ' / ' + itaEscape(wallet.network || 'base') + '</strong></div>'
       + '<div><span>Balance</span><strong>' + itaMoney(wallet.balance_usd) + '</strong></div>'
-      + '<div><span>Articles</span><strong>' + itaEscape(wallet.max_articles_at_default_price || 0) + '</strong></div>'
       + '<span class="ita-pill ' + (wallet.safe_to_autopay ? 'is-pass' : 'is-warn') + '">' + (wallet.safe_to_autopay ? 'Policy OK' : 'Approval') + '</span>'
-      + '</div>'
-      + (Array.isArray(wallet.audit_urls) && wallet.audit_urls.length ? '<div class="ita-audit-links">'
-        + wallet.audit_urls.map(function(url) {
-          return '<a href="' + itaEscape(url) + '" target="_blank" rel="noreferrer">' + itaEscape(String(url).replace(/^https?:\/\//, '').replace(/\/$/, '')) + '</a>';
-        }).join('')
-        + '</div>' : '') : '')
-    + (gates.length ? '<div class="ita-paid-gates">' + itaRiskGates(gates) + '</div>' : '')
+      + '</div>' : '')
+    + '</div>'
+    + '</div>'
     + '</div>';
 }
 
-function itaTrialPlan(plan) {
-  if (!plan) {
-    return '<div class="ita-empty-line">No nominal NEAR trial plan recorded.</div>';
-  }
-  var steps = Array.isArray(plan.setup_steps) ? plan.setup_steps : [];
-  var gates = Array.isArray(plan.risk_gates) ? plan.risk_gates : [];
-  return '<div class="ita-trial">'
-    + '<div class="ita-trial-bar">'
-    + '<div><span>Budget</span><strong>' + itaEscape(plan.nominal_near || 0) + ' NEAR</strong></div>'
-    + '<div><span>Trade cap</span><strong>' + itaEscape(plan.max_trade_near || 0) + ' NEAR</strong></div>'
-    + '<div><span>USD est.</span><strong>' + itaMoney(plan.max_trade_usd) + '</strong></div>'
-    + '<div><span>Quote</span><strong>' + (plan.safe_to_quote ? 'Ready' : 'Blocked') + '</strong></div>'
-    + '</div>'
-    + '<div class="ita-trial-meta">'
-    + '<span class="ita-pill ' + itaStatusClass(plan.safe_to_quote ? 'pass' : 'blocked') + '">' + itaEscape(plan.mode || 'paper') + '</span>'
-    + (plan.recommended_strategy_id ? '<strong>' + itaEscape(plan.recommended_strategy_id) + '</strong>' : '<strong>No strategy selected</strong>')
-    + '<span>' + itaEscape(plan.pair || 'NEAR/USDC') + '</span>'
-    + '</div>'
-    + (steps.length ? '<div class="ita-trial-steps">'
-      + steps.slice(0, 5).map(function(step) {
-        return '<div><span>' + itaEscape(step.order || '') + '</span><strong>' + itaEscape(step.name || 'Step') + '</strong><small>' + itaEscape(step.status || 'manual') + '</small></div>';
-      }).join('')
-      + '</div>' : '')
-    + (gates.length ? '<div class="ita-trial-gates">' + itaRiskGates(gates.slice(0, 5)) + '</div>' : '')
-    + (plan.next_action ? '<div class="ita-trial-next">' + itaEscape(plan.next_action) + '</div>' : '')
-    + '</div>';
+function itaPaidPanel(state) {
+  return '<section class="ita-paid-panel">'
+    + '<div class="ita-section-head"><div><div class="ita-section-title">Research Budget</div><p>Paid-source spend and receipt readiness.</p></div>'
+    + '<button type="button" data-run="paid">Prepare Paid Research</button></div>'
+    + itaPaidResearch(state && state.paid_research)
+    + '</section>';
+}
+
+function itaCleanPayload(payload) {
+  var out = {};
+  Object.keys(payload).forEach(function(key) {
+    var value = payload[key];
+    if (value === undefined || value === null || value === '') return;
+    out[key] = value;
+  });
+  return out;
+}
+
+function itaTrialPayload(state, prefs, mode) {
+  return itaCleanPayload({
+    action: 'plan_near_intents_trial',
+    near_account_id: prefs.nearAccount,
+    mode: mode || prefs.mode || 'paper',
+    pair: prefs.pair || 'NEAR/USDC',
+    nominal_near: itaNumber(prefs.nominalNear, 0.25),
+    max_trade_near: itaNumber(prefs.maxTradeNear, 0.05),
+    assumed_near_usd: itaNumber(prefs.assumedNearUsd, 3.0),
+    max_slippage_bps: Math.round(itaNumber(prefs.maxSlippageBps, 50)),
+    selected_strategy_id: prefs.selectedStrategyId
+  });
 }
 
 function itaWritePrompt(kind, state) {
   if (api && api.navigate) api.navigate('chat');
   var input = document.getElementById('chat-input');
   if (!input) return;
-  var pair = state && state.pair ? state.pair : 'the watched pair';
-  input.value = kind === 'trial'
-    ? 'For the Intents Trading Agent, prepare a nominal NEAR trial for ' + pair + ': use paper mode first, cap the trial wallet, show the strategy menu, run backtest_suite before any live quote, and keep all NEAR Intents payloads unsigned.'
-    : kind === 'paid'
-    ? 'For the Intents Trading Agent, build a paid research plan for ' + pair + ' first: discover MPP/x402/NEAR payable sources, enforce the source budget, require receipts before use, then run backtest_suite and risk gates before any unsigned NEAR intent.'
-    : kind === 'quote'
-    ? 'For the Intents Trading Agent, request a live NEAR Intents quote for ' + pair + ' only if all current risk gates still pass. Keep it unsigned.'
-    : 'For the Intents Trading Agent, run the paper NEAR Intents workflow for ' + pair + ': research, backtest_suite, risk gates, and unsigned intent preview.';
+
+  var prefs = itaTrialDefaults(state || {});
+  var pair = prefs.pair || 'NEAR/USDC';
+  var payloadMode = kind === 'quote' ? 'quote' : kind === 'paper' ? 'paper' : prefs.mode || 'paper';
+  var funding = prefs.fundingPath === 'direct'
+    ? 'direct Verifier funding: use wNEAR/nep141:wrap.near for direct deposits and keep signing in the wallet'
+    : 'managed 1Click or Deposit/Withdrawal Service funding: let the service route/wrap supported assets where applicable';
+  var trialPayload = itaTrialPayload(state, prefs, payloadMode);
+  var text;
+
+  if (kind === 'plan') {
+    text = 'Build and persist the nominal NEAR Intents trial frontend state.\n\nRun portfolio.plan_near_intents_trial with:\n```json\n'
+      + JSON.stringify(trialPayload, null, 2)
+      + '\n```\nFunding path selected in the UI: ' + funding
+      + '\n\nThen run portfolio.format_intents_widget with the trial_plan, latest backtest_suite if available, and write the result to projects/intents-trading-agent/widgets/state.json.';
+  } else if (kind === 'backtest') {
+    text = 'Run a fresh backtest suite for the Intents Trading Agent on ' + pair + '. Include the default strategy menu plus the selected strategy `'
+      + (prefs.selectedStrategyId || 'sma_cross_fast')
+      + '`, rank by risk-adjusted return, reject lookahead bias, then refresh projects/intents-trading-agent/widgets/state.json with portfolio.format_intents_widget.';
+  } else if (kind === 'paper') {
+    text = 'Build the paper NEAR Intents run for ' + pair + '. Use the latest near-intents-trial-plan/1, selected strategy `'
+      + (prefs.selectedStrategyId || 'sma_cross_fast')
+      + '`, and solver=fixture. Keep the output unsigned, persist the intent preview, and refresh the widget state.';
+  } else if (kind === 'quote') {
+    text = 'Request an unsigned live NEAR Intents quote for ' + pair + ' only if all current trial and strategy gates still pass.\n\nFirst rerun portfolio.plan_near_intents_trial in quote mode with:\n```json\n'
+      + JSON.stringify(trialPayload, null, 2)
+      + '\n```\nThen build_intent with solver=near-intents. Do not sign, submit, or increase the trade size automatically. Funding path: ' + funding + '. Refresh the widget state with the unsigned quote preview.';
+  } else {
+    text = 'Prepare paid research for ' + pair + ' before any live quote. Use free DripStack catalog/title routes first, require explicit user confirmation before paid bodies, require payment receipts, enforce a small spend cap, then refresh the Intents Trading Agent widget.';
+  }
+
+  input.value = text;
   input.focus();
+  input.dispatchEvent(new Event('input', { bubbles: true }));
   if (typeof autoGrow === 'function') autoGrow(input);
 }
 
+function itaWire(state) {
+  root.querySelectorAll('[data-pref]').forEach(function(input) {
+    input.addEventListener('input', function() {
+      var name = input.getAttribute('data-pref');
+      var value = input.type === 'number' && input.value !== '' ? Number(input.value) : input.value;
+      itaPersistPref(name, value);
+    });
+  });
+
+  root.querySelectorAll('[data-pref-button]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      itaPersistPref(button.getAttribute('data-pref-button'), button.getAttribute('data-value'));
+      itaRender(state);
+    });
+  });
+
+  root.querySelectorAll('[data-strategy]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      itaPersistPref('selectedStrategyId', button.getAttribute('data-strategy'));
+      itaRender(state);
+    });
+  });
+
+  root.querySelectorAll('[data-run]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      if (button.disabled) return;
+      itaWritePrompt(button.getAttribute('data-run'), state);
+    });
+  });
+}
+
 function itaRender(state) {
-  var statusClass = itaStatusClass(state.stance);
+  itaLastState = state;
+  var prefs = itaTrialDefaults(state || {});
+  var statusClass = itaStatusClass(state && state.stance);
+  var generatedAt = state && state.generated_at ? state.generated_at : '-';
+  var sourceCount = state && state.paid_research ? state.paid_research.selected_count : state && state.source_count || 0;
+
   root.innerHTML = '<div class="ita-head">'
     + '<div>'
     + '<div class="ita-kicker">NEAR Intents Trading Agent</div>'
-    + '<h3>' + itaEscape(state.pair || 'Watchlist') + '</h3>'
+    + '<h3>' + itaEscape(prefs.pair || state.pair || 'Watchlist') + '</h3>'
     + '</div>'
     + '<div class="ita-head-actions">'
-    + '<span class="ita-pill ' + statusClass + '">' + itaEscape(state.stance || 'watch') + '</span>'
-    + '<button type="button" data-action="ita-refresh">Refresh</button>'
+    + '<span class="ita-pill ' + statusClass + '">' + itaEscape(state && state.stance || 'watch') + '</span>'
+    + '<button type="button" data-action="refresh">Refresh</button>'
     + '</div>'
     + '</div>'
     + '<div class="ita-summary">'
-    + '<div><span>Mode</span><strong>' + itaEscape(state.mode || 'paper') + '</strong></div>'
-    + '<div><span>Confidence</span><strong>' + (state.confidence == null ? '-' : Math.round(Number(state.confidence) * 100) + '%') + '</strong></div>'
-    + '<div><span>Sources</span><strong>' + itaEscape(state.paid_research ? state.paid_research.selected_count : state.source_count || 0) + '</strong></div>'
-    + '<div><span>Updated</span><strong>' + itaEscape(state.generated_at || '-') + '</strong></div>'
+    + '<div><span>Mode</span><strong>' + itaEscape(prefs.mode) + '</strong></div>'
+    + '<div><span>Confidence</span><strong>' + (state && state.confidence == null ? '-' : Math.round(Number(state && state.confidence || 0) * 100) + '%') + '</strong></div>'
+    + '<div><span>Sources</span><strong>' + itaEscape(sourceCount) + '</strong></div>'
+    + '<div><span>Updated</span><strong>' + itaEscape(generatedAt) + '</strong></div>'
     + '</div>'
-    + '<div class="ita-body">'
-    + '<section><div class="ita-section-title">Nominal NEAR Trial</div>' + itaTrialPlan(state.trial_plan) + '</section>'
-    + '<section><div class="ita-section-title">Paid Research</div>' + itaPaidResearch(state.paid_research) + '</section>'
-    + '<section><div class="ita-section-title">Strategy Suite</div>' + itaCandidateRows(state.top_candidates) + '</section>'
-    + '<section><div class="ita-section-title">Risk Gates</div>' + itaRiskGates(state.risk_gates) + '</section>'
-    + '<section><div class="ita-section-title">Unsigned Intent</div>' + itaIntent(state.intent) + '</section>'
+    + itaPhaseRail(state || {})
+    + '<div class="ita-workspace">'
+    + '<div class="ita-primary">'
+    + itaTicket(state || {}, prefs)
+    + itaStrategyLab(state || {}, prefs)
+    + itaRunPanel(state || {}, prefs)
     + '</div>'
-    + (state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '')
-    + '<div class="ita-actions">'
-    + '<button type="button" data-action="ita-trial">Prepare NEAR Trial</button>'
-    + '<button type="button" data-action="ita-paid">Prepare Paid Research</button>'
-    + '<button type="button" data-action="ita-paper">Prepare Paper Run</button>'
-    + '<button type="button" data-action="ita-quote">Prepare Live Quote Request</button>'
-    + '</div>';
+    + '<div class="ita-secondary">'
+    + itaSetupPanel(state || {})
+    + itaPaidPanel(state || {})
+    + '</div>'
+    + '</div>'
+    + (state && state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '');
 
-  root.querySelector('[data-action="ita-refresh"]').addEventListener('click', itaLoad);
-  root.querySelector('[data-action="ita-trial"]').addEventListener('click', function() {
-    itaWritePrompt('trial', state);
-  });
-  root.querySelector('[data-action="ita-paid"]').addEventListener('click', function() {
-    itaWritePrompt('paid', state);
-  });
-  root.querySelector('[data-action="ita-paper"]').addEventListener('click', function() {
-    itaWritePrompt('paper', state);
-  });
-  root.querySelector('[data-action="ita-quote"]').addEventListener('click', function() {
-    itaWritePrompt('quote', state);
-  });
+  var refresh = root.querySelector('[data-action="refresh"]');
+  if (refresh) refresh.addEventListener('click', itaLoad);
+  itaWire(state || {});
 }
 
 function itaRenderEmpty() {
   root.innerHTML = '<div class="ita-empty">'
     + '<div class="ita-kicker">NEAR Intents Trading Agent</div>'
     + '<h3>No console state yet</h3>'
-    + '<p>Run the paper workflow to produce ranked strategies, risk gates, and an unsigned intent preview.</p>'
-    + '<button type="button" data-action="ita-paper-empty">Prepare Paper Run</button>'
+    + '<p>Start with a nominal NEAR trial ticket and fixture-only paper run.</p>'
+    + '<button type="button" data-run="plan">Plan Trial</button>'
     + '</div>';
-  root.querySelector('[data-action="ita-paper-empty"]').addEventListener('click', function() {
-    itaWritePrompt('paper', { pair: 'the configured watchlist' });
+  root.querySelector('[data-run="plan"]').addEventListener('click', function() {
+    itaWritePrompt('plan', { pair: 'NEAR/USDC', mode: 'paper' });
   });
 }
 

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -184,12 +184,42 @@ function itaPaidResearch(plan) {
     + '</div>';
 }
 
+function itaTrialPlan(plan) {
+  if (!plan) {
+    return '<div class="ita-empty-line">No nominal NEAR trial plan recorded.</div>';
+  }
+  var steps = Array.isArray(plan.setup_steps) ? plan.setup_steps : [];
+  var gates = Array.isArray(plan.risk_gates) ? plan.risk_gates : [];
+  return '<div class="ita-trial">'
+    + '<div class="ita-trial-bar">'
+    + '<div><span>Budget</span><strong>' + itaEscape(plan.nominal_near || 0) + ' NEAR</strong></div>'
+    + '<div><span>Trade cap</span><strong>' + itaEscape(plan.max_trade_near || 0) + ' NEAR</strong></div>'
+    + '<div><span>USD est.</span><strong>' + itaMoney(plan.max_trade_usd) + '</strong></div>'
+    + '<div><span>Quote</span><strong>' + (plan.safe_to_quote ? 'Ready' : 'Blocked') + '</strong></div>'
+    + '</div>'
+    + '<div class="ita-trial-meta">'
+    + '<span class="ita-pill ' + itaStatusClass(plan.safe_to_quote ? 'pass' : 'blocked') + '">' + itaEscape(plan.mode || 'paper') + '</span>'
+    + (plan.recommended_strategy_id ? '<strong>' + itaEscape(plan.recommended_strategy_id) + '</strong>' : '<strong>No strategy selected</strong>')
+    + '<span>' + itaEscape(plan.pair || 'NEAR/USDC') + '</span>'
+    + '</div>'
+    + (steps.length ? '<div class="ita-trial-steps">'
+      + steps.slice(0, 5).map(function(step) {
+        return '<div><span>' + itaEscape(step.order || '') + '</span><strong>' + itaEscape(step.name || 'Step') + '</strong><small>' + itaEscape(step.status || 'manual') + '</small></div>';
+      }).join('')
+      + '</div>' : '')
+    + (gates.length ? '<div class="ita-trial-gates">' + itaRiskGates(gates.slice(0, 5)) + '</div>' : '')
+    + (plan.next_action ? '<div class="ita-trial-next">' + itaEscape(plan.next_action) + '</div>' : '')
+    + '</div>';
+}
+
 function itaWritePrompt(kind, state) {
   if (api && api.navigate) api.navigate('chat');
   var input = document.getElementById('chat-input');
   if (!input) return;
   var pair = state && state.pair ? state.pair : 'the watched pair';
-  input.value = kind === 'paid'
+  input.value = kind === 'trial'
+    ? 'For the Intents Trading Agent, prepare a nominal NEAR trial for ' + pair + ': use paper mode first, cap the trial wallet, show the strategy menu, run backtest_suite before any live quote, and keep all NEAR Intents payloads unsigned.'
+    : kind === 'paid'
     ? 'For the Intents Trading Agent, build a paid research plan for ' + pair + ' first: discover MPP/x402/NEAR payable sources, enforce the source budget, require receipts before use, then run backtest_suite and risk gates before any unsigned NEAR intent.'
     : kind === 'quote'
     ? 'For the Intents Trading Agent, request a live NEAR Intents quote for ' + pair + ' only if all current risk gates still pass. Keep it unsigned.'
@@ -217,6 +247,7 @@ function itaRender(state) {
     + '<div><span>Updated</span><strong>' + itaEscape(state.generated_at || '-') + '</strong></div>'
     + '</div>'
     + '<div class="ita-body">'
+    + '<section><div class="ita-section-title">Nominal NEAR Trial</div>' + itaTrialPlan(state.trial_plan) + '</section>'
     + '<section><div class="ita-section-title">Paid Research</div>' + itaPaidResearch(state.paid_research) + '</section>'
     + '<section><div class="ita-section-title">Strategy Suite</div>' + itaCandidateRows(state.top_candidates) + '</section>'
     + '<section><div class="ita-section-title">Risk Gates</div>' + itaRiskGates(state.risk_gates) + '</section>'
@@ -224,12 +255,16 @@ function itaRender(state) {
     + '</div>'
     + (state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '')
     + '<div class="ita-actions">'
+    + '<button type="button" data-action="ita-trial">Prepare NEAR Trial</button>'
     + '<button type="button" data-action="ita-paid">Prepare Paid Research</button>'
     + '<button type="button" data-action="ita-paper">Prepare Paper Run</button>'
     + '<button type="button" data-action="ita-quote">Prepare Live Quote Request</button>'
     + '</div>';
 
   root.querySelector('[data-action="ita-refresh"]').addEventListener('click', itaLoad);
+  root.querySelector('[data-action="ita-trial"]').addEventListener('click', function() {
+    itaWritePrompt('trial', state);
+  });
   root.querySelector('[data-action="ita-paid"]').addEventListener('click', function() {
     itaWritePrompt('paid', state);
   });

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -1,0 +1,202 @@
+var root = document.createElement('section');
+root.className = 'ita-console';
+container.appendChild(root);
+
+function itaEscape(value) {
+  var div = document.createElement('div');
+  div.textContent = value == null ? '' : String(value);
+  return div.innerHTML;
+}
+
+function itaSlugify(value) {
+  return String(value || 'intents-trading-agent')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || 'intents-trading-agent';
+}
+
+function itaPct(value) {
+  var n = Number(value || 0);
+  var sign = n > 0 ? '+' : '';
+  return sign + n.toFixed(2) + '%';
+}
+
+function itaScore(value) {
+  var n = Number(value || 0);
+  return n.toFixed(2);
+}
+
+function itaStatusClass(status) {
+  var s = String(status || 'unknown').toLowerCase();
+  if (s === 'pass' || s === 'paper-built' || s === 'live-quote-built') return 'is-pass';
+  if (s === 'warn' || s === 'awaiting-signature' || s === 'watch') return 'is-warn';
+  if (s === 'fail' || s === 'failed' || s === 'blocked') return 'is-fail';
+  return 'is-neutral';
+}
+
+function itaReadState(slug) {
+  var path = 'projects/' + slug + '/widgets/state.json';
+  return api.fetch('/api/memory/read?path=' + encodeURIComponent(path))
+    .then(function(res) {
+      if (!res.ok) throw new Error('state not found');
+      return res.json();
+    })
+    .then(function(doc) {
+      return JSON.parse(doc.content || '{}');
+    });
+}
+
+function itaLoadProjectSlug() {
+  return api.fetch('/api/engine/projects/' + encodeURIComponent(projectId))
+    .then(function(res) {
+      if (!res.ok) throw new Error('project not found');
+      return res.json();
+    })
+    .then(function(data) {
+      return itaSlugify(data && data.project && data.project.name);
+    })
+    .catch(function() {
+      return 'intents-trading-agent';
+    });
+}
+
+function itaCandidateRows(candidates) {
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    return '<div class="ita-empty-line">No ranked strategies yet.</div>';
+  }
+  return '<div class="ita-table" role="table" aria-label="Ranked strategy candidates">'
+    + candidates.map(function(c) {
+      return '<div class="ita-row" role="row">'
+        + '<div class="ita-rank">#' + itaEscape(c.rank || '-') + '</div>'
+        + '<div class="ita-strategy">'
+        + '<strong>' + itaEscape(c.id || 'candidate') + '</strong>'
+        + '<span>' + itaEscape(c.strategy_kind || 'strategy') + '</span>'
+        + '</div>'
+        + '<div class="ita-metric"><span>Score</span><strong>' + itaScore(c.selection_score) + '</strong></div>'
+        + '<div class="ita-metric"><span>Return</span><strong>' + itaPct(c.total_return_pct) + '</strong></div>'
+        + '<div class="ita-metric"><span>Alpha</span><strong>' + itaPct(c.alpha_vs_buy_hold_pct) + '</strong></div>'
+        + '<div class="ita-metric"><span>DD</span><strong>' + itaPct(-Math.abs(Number(c.max_drawdown_pct || 0))) + '</strong></div>'
+        + '<div class="ita-gate ' + (c.passes_basic_gate ? 'is-pass' : 'is-fail') + '">'
+        + (c.passes_basic_gate ? 'Gate pass' : 'Gate fail')
+        + '</div>'
+        + '</div>';
+    }).join('')
+    + '</div>';
+}
+
+function itaRiskGates(gates) {
+  if (!Array.isArray(gates) || gates.length === 0) {
+    return '<div class="ita-empty-line">No risk gates recorded.</div>';
+  }
+  return '<div class="ita-gates">'
+    + gates.map(function(gate) {
+      return '<div class="ita-gate-row">'
+        + '<span class="ita-gate-name">' + itaEscape(gate.name || 'gate') + '</span>'
+        + '<span class="ita-pill ' + itaStatusClass(gate.status) + '">' + itaEscape(gate.status || 'unknown') + '</span>'
+        + (gate.detail ? '<span class="ita-gate-detail">' + itaEscape(gate.detail) + '</span>' : '')
+        + '</div>';
+    }).join('')
+    + '</div>';
+}
+
+function itaIntent(intent) {
+  if (!intent) {
+    return '<div class="ita-intent-empty">No unsigned intent built for this run.</div>';
+  }
+  var minOut = Array.isArray(intent.min_out) ? intent.min_out : [];
+  return '<div class="ita-intent">'
+    + '<div class="ita-intent-main">'
+    + '<span class="ita-pill ' + itaStatusClass(intent.status) + '">' + itaEscape(intent.status || 'none') + '</span>'
+    + '<strong>' + itaEscape(intent.route_label || 'NEAR Intents route') + '</strong>'
+    + '<span>' + itaEscape(intent.quote_source || 'fixture') + ' quote source</span>'
+    + '</div>'
+    + '<div class="ita-intent-grid">'
+    + '<div><span>Bundle</span><strong>' + itaEscape(intent.id || '-') + '</strong></div>'
+    + '<div><span>Legs</span><strong>' + itaEscape(intent.legs || 0) + '</strong></div>'
+    + '<div><span>Cost</span><strong>$' + itaEscape(intent.total_cost_usd || '0.00') + '</strong></div>'
+    + '<div><span>Signer</span><strong>' + itaEscape(intent.signer_placeholder || '<signed-by-user>') + '</strong></div>'
+    + '</div>'
+    + (minOut.length ? '<div class="ita-minout">'
+      + minOut.map(function(token) {
+        return '<span>' + itaEscape(token.amount) + ' ' + itaEscape(token.symbol) + ' on ' + itaEscape(token.chain) + '</span>';
+      }).join('')
+      + '</div>' : '')
+    + '</div>';
+}
+
+function itaWritePrompt(kind, state) {
+  if (api && api.navigate) api.navigate('chat');
+  var input = document.getElementById('chat-input');
+  if (!input) return;
+  var pair = state && state.pair ? state.pair : 'the watched pair';
+  input.value = kind === 'quote'
+    ? 'For the Intents Trading Agent, request a live NEAR Intents quote for ' + pair + ' only if all current risk gates still pass. Keep it unsigned.'
+    : 'For the Intents Trading Agent, run the paper NEAR Intents workflow for ' + pair + ': research, backtest_suite, risk gates, and unsigned intent preview.';
+  input.focus();
+  if (typeof autoGrow === 'function') autoGrow(input);
+}
+
+function itaRender(state) {
+  var statusClass = itaStatusClass(state.stance);
+  root.innerHTML = '<div class="ita-head">'
+    + '<div>'
+    + '<div class="ita-kicker">NEAR Intents Trading Agent</div>'
+    + '<h3>' + itaEscape(state.pair || 'Watchlist') + '</h3>'
+    + '</div>'
+    + '<div class="ita-head-actions">'
+    + '<span class="ita-pill ' + statusClass + '">' + itaEscape(state.stance || 'watch') + '</span>'
+    + '<button type="button" data-action="ita-refresh">Refresh</button>'
+    + '</div>'
+    + '</div>'
+    + '<div class="ita-summary">'
+    + '<div><span>Mode</span><strong>' + itaEscape(state.mode || 'paper') + '</strong></div>'
+    + '<div><span>Confidence</span><strong>' + (state.confidence == null ? '-' : Math.round(Number(state.confidence) * 100) + '%') + '</strong></div>'
+    + '<div><span>Sources</span><strong>' + itaEscape(state.source_count || 0) + '</strong></div>'
+    + '<div><span>Updated</span><strong>' + itaEscape(state.generated_at || '-') + '</strong></div>'
+    + '</div>'
+    + '<div class="ita-body">'
+    + '<section><div class="ita-section-title">Strategy Suite</div>' + itaCandidateRows(state.top_candidates) + '</section>'
+    + '<section><div class="ita-section-title">Risk Gates</div>' + itaRiskGates(state.risk_gates) + '</section>'
+    + '<section><div class="ita-section-title">Unsigned Intent</div>' + itaIntent(state.intent) + '</section>'
+    + '</div>'
+    + (state.next_action ? '<div class="ita-next">' + itaEscape(state.next_action) + '</div>' : '')
+    + '<div class="ita-actions">'
+    + '<button type="button" data-action="ita-paper">Prepare Paper Run</button>'
+    + '<button type="button" data-action="ita-quote">Prepare Live Quote Request</button>'
+    + '</div>';
+
+  root.querySelector('[data-action="ita-refresh"]').addEventListener('click', itaLoad);
+  root.querySelector('[data-action="ita-paper"]').addEventListener('click', function() {
+    itaWritePrompt('paper', state);
+  });
+  root.querySelector('[data-action="ita-quote"]').addEventListener('click', function() {
+    itaWritePrompt('quote', state);
+  });
+}
+
+function itaRenderEmpty() {
+  root.innerHTML = '<div class="ita-empty">'
+    + '<div class="ita-kicker">NEAR Intents Trading Agent</div>'
+    + '<h3>No console state yet</h3>'
+    + '<p>Run the paper workflow to produce ranked strategies, risk gates, and an unsigned intent preview.</p>'
+    + '<button type="button" data-action="ita-paper-empty">Prepare Paper Run</button>'
+    + '</div>';
+  root.querySelector('[data-action="ita-paper-empty"]').addEventListener('click', function() {
+    itaWritePrompt('paper', { pair: 'the configured watchlist' });
+  });
+}
+
+function itaRenderLoading() {
+  root.innerHTML = '<div class="ita-loading">Loading NEAR Intents console...</div>';
+}
+
+function itaLoad() {
+  itaRenderLoading();
+  itaLoadProjectSlug()
+    .then(itaReadState)
+    .then(itaRender)
+    .catch(itaRenderEmpty);
+}
+
+itaLoad();

--- a/skills/intents-trading-agent/widgets/near-intents-console/index.js
+++ b/skills/intents-trading-agent/widgets/near-intents-console/index.js
@@ -138,6 +138,7 @@ function itaPaidResearch(plan) {
   var rails = Array.isArray(plan.payment_rails) ? plan.payment_rails : [];
   var routes = Array.isArray(plan.near_funding_routes) ? plan.near_funding_routes : [];
   var gates = Array.isArray(plan.policy_gates) ? plan.policy_gates : [];
+  var wallet = plan.wallet_policy || null;
   return '<div class="ita-paid">'
     + '<div class="ita-paid-bar">'
     + '<div><span>Budget</span><strong>' + itaMoney(plan.budget_usd) + '</strong></div>'
@@ -168,6 +169,17 @@ function itaPaidResearch(plan) {
     }).join('<br>') + '</div>' : '')
     + '</div>'
     + '</div>'
+    + (wallet ? '<div class="ita-wallet-line">'
+      + '<div><span>Agent Wallet</span><strong>' + itaEscape(wallet.provider || 'Agent wallet') + ' · ' + itaEscape(wallet.network || 'base') + '</strong></div>'
+      + '<div><span>Balance</span><strong>' + itaMoney(wallet.balance_usd) + '</strong></div>'
+      + '<div><span>Articles</span><strong>' + itaEscape(wallet.max_articles_at_default_price || 0) + '</strong></div>'
+      + '<span class="ita-pill ' + (wallet.safe_to_autopay ? 'is-pass' : 'is-warn') + '">' + (wallet.safe_to_autopay ? 'Policy OK' : 'Approval') + '</span>'
+      + '</div>'
+      + (Array.isArray(wallet.audit_urls) && wallet.audit_urls.length ? '<div class="ita-audit-links">'
+        + wallet.audit_urls.map(function(url) {
+          return '<a href="' + itaEscape(url) + '" target="_blank" rel="noreferrer">' + itaEscape(String(url).replace(/^https?:\/\//, '').replace(/\/$/, '')) + '</a>';
+        }).join('')
+        + '</div>' : '') : '')
     + (gates.length ? '<div class="ita-paid-gates">' + itaRiskGates(gates) + '</div>' : '')
     + '</div>';
 }

--- a/skills/intents-trading-agent/widgets/near-intents-console/manifest.json
+++ b/skills/intents-trading-agent/widgets/near-intents-console/manifest.json
@@ -1,0 +1,6 @@
+{
+  "id": "near-intents-console",
+  "name": "NEAR Intents Console",
+  "slot": "project_header",
+  "position": "before:missions"
+}

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -335,6 +335,41 @@
   margin-top: 12px;
 }
 
+.ita-wallet-line {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 84px 76px auto;
+  margin-top: 12px;
+  min-height: 48px;
+  padding-top: 8px;
+}
+
+.ita-wallet-line span,
+.ita-audit-links a {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.ita-wallet-line strong {
+  display: block;
+  font-size: var(--text-sm);
+  margin-top: 2px;
+}
+
+.ita-audit-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.ita-audit-links a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .ita-next {
   border-top: 1px solid var(--border);
   margin-top: 14px;
@@ -403,6 +438,10 @@
   }
 
   .ita-source-line {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ita-wallet-line {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -128,7 +128,8 @@
   grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.9fr);
 }
 
-.ita-body section:nth-child(3) {
+.ita-body section:first-child,
+.ita-body section:nth-child(4) {
   grid-column: 1 / -1;
 }
 
@@ -235,6 +236,105 @@
   padding: 4px 8px;
 }
 
+.ita-paid {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.ita-paid-bar {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ita-paid-bar > div {
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  padding-top: 8px;
+}
+
+.ita-paid-bar span,
+.ita-source-line span,
+.ita-subtitle {
+  color: var(--text-muted);
+  display: block;
+  font-size: var(--text-xs);
+}
+
+.ita-paid-bar strong,
+.ita-source-line strong,
+.ita-rail-line strong {
+  display: block;
+  font-size: var(--text-sm);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-paid-query {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  margin-top: 10px;
+}
+
+.ita-paid-lanes {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.25fr) minmax(220px, 0.75fr);
+  margin-top: 12px;
+}
+
+.ita-subtitle {
+  font-weight: 700;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+.ita-source-line {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 76px auto;
+  min-height: 48px;
+  padding: 8px 0;
+}
+
+.ita-source-price {
+  color: var(--accent);
+  font-size: var(--text-sm);
+  font-weight: 800;
+  text-align: right;
+}
+
+.ita-rail-line {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  min-height: 36px;
+}
+
+.ita-rail-line span {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.ita-route-note {
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  margin-top: 8px;
+  padding-top: 8px;
+}
+
+.ita-paid-gates {
+  margin-top: 12px;
+}
+
 .ita-next {
   border-top: 1px solid var(--border);
   margin-top: 14px;
@@ -258,6 +358,8 @@
 @media (max-width: 980px) {
   .ita-summary,
   .ita-body,
+  .ita-paid-bar,
+  .ita-paid-lanes,
   .ita-intent-grid {
     grid-template-columns: 1fr 1fr;
   }
@@ -284,6 +386,8 @@
 
   .ita-summary,
   .ita-body,
+  .ita-paid-bar,
+  .ita-paid-lanes,
   .ita-intent-grid {
     grid-template-columns: 1fr;
   }
@@ -296,5 +400,13 @@
   .ita-row .ita-gate {
     grid-column: 2;
     justify-self: start;
+  }
+
+  .ita-source-line {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ita-source-price {
+    text-align: left;
   }
 }

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -1,0 +1,300 @@
+.ita-console {
+  margin: 14px 0 18px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 92%, var(--accent-subtle) 8%);
+  color: var(--text);
+}
+
+.ita-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.ita-kicker {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.ita-head h3,
+.ita-empty h3 {
+  margin: 2px 0 0;
+  font-size: 22px;
+  line-height: 1.15;
+}
+
+.ita-head-actions,
+.ita-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.ita-console button {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-sm);
+  min-height: 32px;
+  padding: 6px 10px;
+}
+
+.ita-console button:hover {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.ita-pill,
+.ita-gate {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  justify-content: center;
+  min-height: 24px;
+  padding: 3px 9px;
+  text-transform: uppercase;
+}
+
+.ita-pill.is-pass,
+.ita-gate.is-pass {
+  border-color: color-mix(in srgb, var(--success) 45%, var(--border) 55%);
+  color: var(--success);
+}
+
+.ita-pill.is-warn {
+  border-color: color-mix(in srgb, var(--warning) 45%, var(--border) 55%);
+  color: var(--warning);
+}
+
+.ita-pill.is-fail,
+.ita-gate.is-fail {
+  border-color: color-mix(in srgb, var(--error) 45%, var(--border) 55%);
+  color: var(--error);
+}
+
+.ita-pill.is-neutral {
+  color: var(--text-secondary);
+}
+
+.ita-summary {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-bottom: 16px;
+}
+
+.ita-summary > div,
+.ita-intent-grid > div {
+  border-top: 1px solid var(--border);
+  padding-top: 8px;
+}
+
+.ita-summary span,
+.ita-intent-grid span,
+.ita-metric span {
+  color: var(--text-muted);
+  display: block;
+  font-size: var(--text-xs);
+}
+
+.ita-summary strong,
+.ita-intent-grid strong,
+.ita-metric strong {
+  color: var(--text);
+  display: block;
+  font-size: var(--text-sm);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-body {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.9fr);
+}
+
+.ita-body section:nth-child(3) {
+  grid-column: 1 / -1;
+}
+
+.ita-section-title {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.ita-table,
+.ita-gates {
+  display: grid;
+  gap: 6px;
+}
+
+.ita-row {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 42px minmax(120px, 1.3fr) repeat(4, minmax(66px, 0.55fr)) 86px;
+  min-height: 54px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.ita-rank {
+  color: var(--accent);
+  font-weight: 800;
+}
+
+.ita-strategy strong,
+.ita-strategy span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-strategy span {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  margin-top: 2px;
+}
+
+.ita-gate-row {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(120px, 1fr) auto;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.ita-gate-name {
+  font-weight: 700;
+}
+
+.ita-gate-detail {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  grid-column: 1 / -1;
+}
+
+.ita-intent {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.ita-intent-main {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.ita-intent-main > span:last-child,
+.ita-next,
+.ita-intent-empty,
+.ita-empty-line,
+.ita-loading {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.ita-intent-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ita-minout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.ita-minout span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  padding: 4px 8px;
+}
+
+.ita-next {
+  border-top: 1px solid var(--border);
+  margin-top: 14px;
+  padding-top: 10px;
+}
+
+.ita-actions {
+  margin-top: 12px;
+}
+
+.ita-empty {
+  padding: 8px 0;
+}
+
+.ita-empty p {
+  color: var(--text-secondary);
+  margin: 6px 0 12px;
+  max-width: 720px;
+}
+
+@media (max-width: 980px) {
+  .ita-summary,
+  .ita-body,
+  .ita-intent-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .ita-row {
+    grid-template-columns: 36px minmax(120px, 1fr) 76px;
+  }
+
+  .ita-row .ita-metric:nth-of-type(n + 3) {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .ita-console {
+    padding: 12px;
+  }
+
+  .ita-head,
+  .ita-intent-main {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .ita-summary,
+  .ita-body,
+  .ita-intent-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ita-row {
+    grid-template-columns: 32px minmax(0, 1fr);
+  }
+
+  .ita-row .ita-metric,
+  .ita-row .ita-gate {
+    grid-column: 2;
+    justify-self: start;
+  }
+}

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -3,7 +3,7 @@
   padding: 16px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--panel) 92%, var(--accent-subtle) 8%);
+  background: color-mix(in srgb, var(--panel) 94%, var(--surface) 6%);
   color: var(--text);
 }
 
@@ -30,11 +30,26 @@
 }
 
 .ita-head-actions,
-.ita-actions {
+.ita-section-head,
+.ita-run-actions,
+.ita-segments {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.ita-section-head {
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.ita-section-head p,
+.ita-empty p {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  margin: 2px 0 0;
 }
 
 .ita-console button {
@@ -54,8 +69,18 @@
   background: var(--accent-subtle);
 }
 
-.ita-pill,
-.ita-gate {
+.ita-console button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.ita-console button.is-selected,
+.ita-strategy-row.is-selected {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent-subtle) 72%, var(--surface) 28%);
+}
+
+.ita-pill {
   align-items: center;
   border: 1px solid var(--border);
   border-radius: 999px;
@@ -69,18 +94,20 @@
 }
 
 .ita-pill.is-pass,
-.ita-gate.is-pass {
+.ita-phase.is-pass span,
+.ita-strategy-row.is-pass .ita-pill {
   border-color: color-mix(in srgb, var(--success) 45%, var(--border) 55%);
   color: var(--success);
 }
 
-.ita-pill.is-warn {
+.ita-pill.is-warn,
+.ita-phase.is-warn span {
   border-color: color-mix(in srgb, var(--warning) 45%, var(--border) 55%);
   color: var(--warning);
 }
 
 .ita-pill.is-fail,
-.ita-gate.is-fail {
+.ita-phase.is-fail span {
   border-color: color-mix(in srgb, var(--error) 45%, var(--border) 55%);
   color: var(--error);
 }
@@ -89,30 +116,52 @@
   color: var(--text-secondary);
 }
 
-.ita-summary {
+.ita-summary,
+.ita-phases,
+.ita-ticket-grid,
+.ita-run-grid,
+.ita-trial-bar,
+.ita-intent-grid,
+.ita-paid-bar {
   display: grid;
   gap: 8px;
+}
+
+.ita-summary {
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  margin-bottom: 16px;
+  margin-bottom: 14px;
 }
 
 .ita-summary > div,
-.ita-intent-grid > div {
+.ita-run-grid > div,
+.ita-trial-bar > div,
+.ita-intent-grid > div,
+.ita-paid-bar > div {
   border-top: 1px solid var(--border);
   padding-top: 8px;
 }
 
 .ita-summary span,
+.ita-run-grid span,
+.ita-trial-bar span,
 .ita-intent-grid span,
-.ita-metric span {
+.ita-paid-bar span,
+.ita-source-line span,
+.ita-wallet-line span,
+.ita-subtitle {
   color: var(--text-muted);
   display: block;
   font-size: var(--text-xs);
 }
 
 .ita-summary strong,
+.ita-run-grid strong,
+.ita-trial-bar strong,
 .ita-intent-grid strong,
-.ita-metric strong {
+.ita-paid-bar strong,
+.ita-source-line strong,
+.ita-rail-line strong,
+.ita-wallet-line strong {
   color: var(--text);
   display: block;
   font-size: var(--text-sm);
@@ -122,39 +171,134 @@
   white-space: nowrap;
 }
 
-.ita-body {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.9fr);
+.ita-phases {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-bottom: 16px;
 }
 
-.ita-body section:first-child,
-.ita-body section:nth-child(2),
-.ita-body section:nth-child(5) {
-  grid-column: 1 / -1;
+.ita-phase {
+  border-top: 1px solid var(--border);
+  min-height: 62px;
+  padding-top: 8px;
+}
+
+.ita-phase span {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: var(--text-xs);
+  font-weight: 800;
+  height: 22px;
+  justify-content: center;
+  width: 22px;
+}
+
+.ita-phase strong,
+.ita-phase small {
+  display: block;
+}
+
+.ita-phase strong {
+  font-size: var(--text-sm);
+  margin-top: 6px;
+}
+
+.ita-phase small {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  margin-top: 2px;
+}
+
+.ita-workspace {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.8fr);
+}
+
+.ita-primary,
+.ita-secondary {
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+
+.ita-ticket,
+.ita-strategy-lab,
+.ita-run-panel,
+.ita-setup,
+.ita-paid-panel {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
 }
 
 .ita-section-title {
   color: var(--text-secondary);
   font-size: var(--text-sm);
   font-weight: 700;
-  margin-bottom: 8px;
 }
 
-.ita-table,
-.ita-gates {
+.ita-tight-title {
+  margin-top: 14px;
+}
+
+.ita-ticket-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 10px;
+}
+
+.ita-field span {
+  color: var(--text-muted);
+  display: block;
+  font-size: var(--text-xs);
+  margin-bottom: 4px;
+}
+
+.ita-field input {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font: inherit;
+  min-height: 34px;
+  padding: 6px 8px;
+  width: 100%;
+}
+
+.ita-field input:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.ita-segments {
+  margin-top: 8px;
+}
+
+.ita-segments button {
+  min-width: 96px;
+}
+
+.ita-strategy-list {
   display: grid;
   gap: 6px;
 }
 
-.ita-row {
+.ita-strategy-row {
   align-items: center;
   display: grid;
   gap: 8px;
-  grid-template-columns: 42px minmax(120px, 1.3fr) repeat(4, minmax(66px, 0.55fr)) 86px;
-  min-height: 54px;
-  padding: 8px 0;
-  border-top: 1px solid var(--border);
+  grid-template-columns: 42px minmax(150px, 1.35fr) repeat(4, minmax(62px, 0.5fr)) 82px;
+  min-height: 58px;
+  padding: 8px;
+  text-align: left;
+}
+
+.ita-strategy-row em {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-style: normal;
+  grid-column: 2 / -1;
+  line-height: 1.35;
 }
 
 .ita-rank {
@@ -162,18 +306,131 @@
   font-weight: 800;
 }
 
-.ita-strategy strong,
-.ita-strategy span {
+.ita-strategy-name strong,
+.ita-strategy-name small,
+.ita-strategy-row span small,
+.ita-strategy-row span strong {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.ita-strategy span {
+.ita-strategy-name small,
+.ita-strategy-row span small {
   color: var(--text-muted);
   font-size: var(--text-xs);
   margin-top: 2px;
+}
+
+.ita-run-grid,
+.ita-trial-bar,
+.ita-intent-grid,
+.ita-paid-bar {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ita-trial,
+.ita-intent,
+.ita-paid {
+  border-top: 1px solid var(--border);
+  margin-top: 12px;
+  padding-top: 10px;
+}
+
+.ita-trial-next,
+.ita-next,
+.ita-intent-empty,
+.ita-empty-line,
+.ita-loading {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.ita-trial-next,
+.ita-next {
+  border-top: 1px solid var(--border);
+  line-height: 1.5;
+  margin-top: 10px;
+  padding-top: 8px;
+}
+
+.ita-intent-main {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.ita-intent-main > span:last-child {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.ita-minout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.ita-minout span,
+.ita-warnings span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  padding: 4px 8px;
+}
+
+.ita-run-actions {
+  margin-top: 12px;
+}
+
+.ita-steps {
+  display: grid;
+  gap: 8px;
+}
+
+.ita-steps > div {
+  border-top: 1px solid var(--border);
+  min-height: 64px;
+  padding-top: 8px;
+}
+
+.ita-steps span {
+  color: var(--accent);
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.ita-steps strong,
+.ita-steps small {
+  display: inline-block;
+}
+
+.ita-steps strong {
+  font-size: var(--text-sm);
+  margin: 2px 8px 0 0;
+}
+
+.ita-steps small {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.ita-steps p {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.45;
+  margin: 4px 0 0;
+}
+
+.ita-gates {
+  display: grid;
+  gap: 6px;
 }
 
 .ita-gate-row {
@@ -192,84 +449,14 @@
   color: var(--text-muted);
   font-size: var(--text-xs);
   grid-column: 1 / -1;
+  line-height: 1.4;
 }
 
-.ita-intent {
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
-}
-
-.ita-intent-main {
-  align-items: center;
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
-}
-
-.ita-intent-main > span:last-child,
-.ita-next,
-.ita-intent-empty,
-.ita-empty-line,
-.ita-loading {
-  color: var(--text-muted);
-  font-size: var(--text-sm);
-}
-
-.ita-intent-grid {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.ita-minout {
+.ita-warnings {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 10px;
-}
-
-.ita-minout span {
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
-  padding: 4px 8px;
-}
-
-.ita-paid {
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
-}
-
-.ita-paid-bar {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.ita-paid-bar > div {
-  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  padding-top: 8px;
-}
-
-.ita-paid-bar span,
-.ita-source-line span,
-.ita-subtitle {
-  color: var(--text-muted);
-  display: block;
-  font-size: var(--text-xs);
-}
-
-.ita-paid-bar strong,
-.ita-source-line strong,
-.ita-rail-line strong {
-  display: block;
-  font-size: var(--text-sm);
-  margin-top: 2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .ita-paid-query {
@@ -281,7 +468,7 @@
 .ita-paid-lanes {
   display: grid;
   gap: 16px;
-  grid-template-columns: minmax(0, 1.25fr) minmax(220px, 0.75fr);
+  grid-template-columns: minmax(0, 1.2fr) minmax(180px, 0.8fr);
   margin-top: 12px;
 }
 
@@ -323,220 +510,72 @@
   text-transform: uppercase;
 }
 
-.ita-route-note {
-  border-top: 1px solid var(--border);
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  line-height: 1.5;
-  margin-top: 8px;
-  padding-top: 8px;
-}
-
-.ita-paid-gates {
-  margin-top: 12px;
-}
-
 .ita-wallet-line {
-  align-items: center;
   border-top: 1px solid var(--border);
   display: grid;
   gap: 8px;
-  grid-template-columns: minmax(0, 1fr) 84px 76px auto;
+  grid-template-columns: minmax(0, 1fr) 84px;
   margin-top: 12px;
   min-height: 48px;
   padding-top: 8px;
-}
-
-.ita-wallet-line span,
-.ita-audit-links a {
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-}
-
-.ita-wallet-line strong {
-  display: block;
-  font-size: var(--text-sm);
-  margin-top: 2px;
-}
-
-.ita-trial {
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
-}
-
-.ita-trial-bar {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.ita-trial-bar > div {
-  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  padding-top: 8px;
-}
-
-.ita-trial-bar span,
-.ita-trial-meta span,
-.ita-trial-steps small,
-.ita-trial-next {
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-}
-
-.ita-trial-bar strong {
-  display: block;
-  font-size: var(--text-sm);
-  margin-top: 2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ita-trial-meta {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 10px;
-}
-
-.ita-trial-meta strong {
-  font-size: var(--text-sm);
-}
-
-.ita-trial-steps {
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  margin-top: 12px;
-}
-
-.ita-trial-steps > div {
-  border-top: 1px solid var(--border);
-  min-height: 58px;
-  padding-top: 8px;
-}
-
-.ita-trial-steps span {
-  color: var(--accent);
-  display: block;
-  font-size: var(--text-xs);
-  font-weight: 800;
-}
-
-.ita-trial-steps strong,
-.ita-trial-steps small {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ita-trial-steps strong {
-  font-size: var(--text-sm);
-  margin-top: 2px;
-}
-
-.ita-trial-gates {
-  margin-top: 12px;
-}
-
-.ita-trial-next {
-  border-top: 1px solid var(--border);
-  line-height: 1.5;
-  margin-top: 10px;
-  padding-top: 8px;
-}
-
-.ita-audit-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 8px;
-}
-
-.ita-audit-links a {
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
-.ita-next {
-  border-top: 1px solid var(--border);
-  margin-top: 14px;
-  padding-top: 10px;
-}
-
-.ita-actions {
-  margin-top: 12px;
 }
 
 .ita-empty {
   padding: 8px 0;
 }
 
-.ita-empty p {
-  color: var(--text-secondary);
-  margin: 6px 0 12px;
-  max-width: 720px;
-}
-
-@media (max-width: 980px) {
-  .ita-summary,
-  .ita-body,
-  .ita-paid-bar,
-  .ita-paid-lanes,
-  .ita-intent-grid,
-  .ita-trial-bar,
-  .ita-trial-steps {
-    grid-template-columns: 1fr 1fr;
+@media (max-width: 1080px) {
+  .ita-workspace,
+  .ita-paid-lanes {
+    grid-template-columns: 1fr;
   }
 
-  .ita-row {
-    grid-template-columns: 36px minmax(120px, 1fr) 76px;
+  .ita-ticket-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .ita-row .ita-metric:nth-of-type(n + 3) {
+  .ita-strategy-row {
+    grid-template-columns: 38px minmax(140px, 1fr) repeat(3, minmax(62px, 0.5fr)) 82px;
+  }
+
+  .ita-strategy-row > span:nth-of-type(6) {
     display: none;
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
   .ita-console {
     padding: 12px;
   }
 
   .ita-head,
+  .ita-section-head,
   .ita-intent-main {
     align-items: flex-start;
     flex-direction: column;
   }
 
   .ita-summary,
-  .ita-body,
-  .ita-paid-bar,
-  .ita-paid-lanes,
-  .ita-intent-grid,
+  .ita-phases,
+  .ita-ticket-grid,
+  .ita-run-grid,
   .ita-trial-bar,
-  .ita-trial-steps {
+  .ita-intent-grid,
+  .ita-paid-bar,
+  .ita-source-line,
+  .ita-wallet-line {
     grid-template-columns: 1fr;
   }
 
-  .ita-row {
+  .ita-strategy-row {
     grid-template-columns: 32px minmax(0, 1fr);
   }
 
-  .ita-row .ita-metric,
-  .ita-row .ita-gate {
+  .ita-strategy-row > span:not(.ita-rank):not(.ita-strategy-name),
+  .ita-strategy-row .ita-pill,
+  .ita-strategy-row em {
     grid-column: 2;
     justify-self: start;
-  }
-
-  .ita-source-line {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .ita-wallet-line {
-    grid-template-columns: minmax(0, 1fr);
   }
 
   .ita-source-price {

--- a/skills/intents-trading-agent/widgets/near-intents-console/style.css
+++ b/skills/intents-trading-agent/widgets/near-intents-console/style.css
@@ -129,7 +129,8 @@
 }
 
 .ita-body section:first-child,
-.ita-body section:nth-child(4) {
+.ita-body section:nth-child(2),
+.ita-body section:nth-child(5) {
   grid-column: 1 / -1;
 }
 
@@ -358,6 +359,95 @@
   margin-top: 2px;
 }
 
+.ita-trial {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.ita-trial-bar {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ita-trial-bar > div {
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  padding-top: 8px;
+}
+
+.ita-trial-bar span,
+.ita-trial-meta span,
+.ita-trial-steps small,
+.ita-trial-next {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.ita-trial-bar strong {
+  display: block;
+  font-size: var(--text-sm);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-trial-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.ita-trial-meta strong {
+  font-size: var(--text-sm);
+}
+
+.ita-trial-steps {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin-top: 12px;
+}
+
+.ita-trial-steps > div {
+  border-top: 1px solid var(--border);
+  min-height: 58px;
+  padding-top: 8px;
+}
+
+.ita-trial-steps span {
+  color: var(--accent);
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.ita-trial-steps strong,
+.ita-trial-steps small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ita-trial-steps strong {
+  font-size: var(--text-sm);
+  margin-top: 2px;
+}
+
+.ita-trial-gates {
+  margin-top: 12px;
+}
+
+.ita-trial-next {
+  border-top: 1px solid var(--border);
+  line-height: 1.5;
+  margin-top: 10px;
+  padding-top: 8px;
+}
+
 .ita-audit-links {
   display: flex;
   flex-wrap: wrap;
@@ -395,7 +485,9 @@
   .ita-body,
   .ita-paid-bar,
   .ita-paid-lanes,
-  .ita-intent-grid {
+  .ita-intent-grid,
+  .ita-trial-bar,
+  .ita-trial-steps {
     grid-template-columns: 1fr 1fr;
   }
 
@@ -423,7 +515,9 @@
   .ita-body,
   .ita-paid-bar,
   .ita-paid-lanes,
-  .ita-intent-grid {
+  .ita-intent-grid,
+  .ita-trial-bar,
+  .ita-trial-steps {
     grid-template-columns: 1fr;
   }
 

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -55,5 +55,76 @@
     "https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay",
     "https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint"
   ],
+  "paid_research": {
+    "schema_version": "paid-research-plan/1",
+    "query": "Should the NEAR/BTC paper intent use premium route and liquidity research before quoting?",
+    "budget_usd": 0.05,
+    "allocated_usd": 0.04,
+    "unspent_usd": 0.01,
+    "selected_count": 2,
+    "ready_for_paid_fetch": true,
+    "ready_for_trade_research": true,
+    "payment_rails": [
+      {
+        "protocol": "mpp",
+        "count": 1,
+        "allocated_usd": 0.02
+      },
+      {
+        "protocol": "x402",
+        "count": 1,
+        "allocated_usd": 0.02
+      }
+    ],
+    "payable_sources": [
+      {
+        "id": "premium-near-liquidity",
+        "title": "NEAR/BTC solver liquidity note",
+        "author": "Premium Macro Writer",
+        "protocol": "mpp",
+        "network": "tempo",
+        "amount_usd": 0.02,
+        "evidence_weight": 0.52,
+        "receipt_required": true
+      },
+      {
+        "id": "base-x402-route-risk",
+        "title": "Intent route risk memo",
+        "author": "Onchain Researcher",
+        "protocol": "x402",
+        "network": "base",
+        "amount_usd": 0.02,
+        "evidence_weight": 0.48,
+        "receipt_required": true
+      }
+    ],
+    "near_funding_routes": [
+      {
+        "target_protocol": "mpp",
+        "target_network": "tempo",
+        "amount_usd": 0.02,
+        "via": "near-intents"
+      },
+      {
+        "target_protocol": "x402",
+        "target_network": "base",
+        "amount_usd": 0.02,
+        "via": "near-intents"
+      }
+    ],
+    "policy_gates": [
+      {
+        "name": "receipt-before-use",
+        "status": "pass",
+        "detail": "Paywalled source text is used only after a payment receipt."
+      },
+      {
+        "name": "trade-gate",
+        "status": "pass",
+        "detail": "Premium research does not bypass backtest or risk gates."
+      }
+    ],
+    "warnings": []
+  },
   "next_action": "Ask the user before requesting a live NEAR Intents quote."
 }

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -55,6 +55,50 @@
     "https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay",
     "https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint"
   ],
+  "trial_plan": {
+    "schema_version": "near-intents-trial-plan/1",
+    "mode": "paper",
+    "pair": "NEAR/USDC",
+    "nominal_near": 0.25,
+    "max_trade_near": 0.05,
+    "max_trade_usd": 0.15,
+    "safe_to_quote": true,
+    "safe_to_execute": false,
+    "recommended_strategy_id": "sma_cross_fast",
+    "setup_steps": [
+      {
+        "order": 1,
+        "name": "Use a small wallet",
+        "status": "manual",
+        "detail": "Fund a separate NEAR account with only the amount you are willing to test."
+      },
+      {
+        "order": 2,
+        "name": "Wrap NEAR",
+        "status": "manual",
+        "detail": "Convert native NEAR into wNEAR before verifier funding."
+      },
+      {
+        "order": 3,
+        "name": "Deposit to verifier",
+        "status": "manual",
+        "detail": "Deposit wNEAR into intents.near; do not transfer raw NEAR directly."
+      }
+    ],
+    "risk_gates": [
+      {
+        "name": "trade-cap",
+        "status": "pass",
+        "detail": "Single trial trade is capped at 0.05 NEAR."
+      },
+      {
+        "name": "signing-boundary",
+        "status": "pass",
+        "detail": "IronClaw returns unsigned payloads only."
+      }
+    ],
+    "next_action": "Run backtest_suite with fresh candles before any live quote."
+  },
   "paid_research": {
     "schema_version": "paid-research-plan/1",
     "query": "Should the NEAR/BTC paper intent use premium route and liquidity research before quoting?",

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -124,6 +124,23 @@
         "detail": "Premium research does not bypass backtest or risk gates."
       }
     ],
+    "wallet_policy": {
+      "provider": "AgentCash",
+      "address": "0x3333333333333333333333333333333333333333",
+      "network": "base",
+      "balance_usd": 5.0,
+      "default_article_price_usd": 0.01,
+      "max_articles_at_default_price": 500,
+      "per_article_cap_usd": 0.05,
+      "daily_cap_usd": 1.0,
+      "max_wallet_balance_usd": 5.0,
+      "safe_to_autopay": true,
+      "audit_urls": [
+        "https://mppscan.com/",
+        "https://www.x402scan.com/"
+      ],
+      "warnings": []
+    },
     "warnings": []
   },
   "next_action": "Ask the user before requesting a live NEAR Intents quote."

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -61,10 +61,33 @@
     "pair": "NEAR/USDC",
     "nominal_near": 0.25,
     "max_trade_near": 0.05,
+    "assumed_near_usd": 3.0,
     "max_trade_usd": 0.15,
     "safe_to_quote": true,
     "safe_to_execute": false,
     "recommended_strategy_id": "sma_cross_fast",
+    "strategy_menu": [
+      {
+        "id": "buy_hold_baseline",
+        "kind": "buy-hold",
+        "position_size_pct": 1.0,
+        "note": "Baseline for comparing active signals."
+      },
+      {
+        "id": "sma_cross_fast",
+        "kind": "sma-cross",
+        "position_size_pct": 0.8,
+        "stop_loss_bps": 1200.0,
+        "note": "Trend-following candidate for clean spot rotations."
+      },
+      {
+        "id": "mean_reversion_range",
+        "kind": "mean-reversion",
+        "position_size_pct": 0.5,
+        "stop_loss_bps": 700.0,
+        "note": "Range strategy for pullback entries."
+      }
+    ],
     "setup_steps": [
       {
         "order": 1,
@@ -96,6 +119,9 @@
         "status": "pass",
         "detail": "IronClaw returns unsigned payloads only."
       }
+    ],
+    "warnings": [
+      "This is not financial advice and it is not an execution bot. Treat every quote as experimental."
     ],
     "next_action": "Run backtest_suite with fresh candles before any live quote."
   },

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -74,15 +74,15 @@
       },
       {
         "order": 2,
-        "name": "Wrap NEAR",
+        "name": "Choose funding path",
         "status": "manual",
-        "detail": "Convert native NEAR into wNEAR before verifier funding."
+        "detail": "Use 1Click or the Deposit/Withdrawal Service for managed routing, or wrap native NEAR into wNEAR before a direct verifier deposit."
       },
       {
         "order": 3,
         "name": "Deposit to verifier",
         "status": "manual",
-        "detail": "Deposit wNEAR into intents.near; do not transfer raw NEAR directly."
+        "detail": "For a direct Verifier-contract deposit, deposit wNEAR into intents.near with ft_transfer_call; do not send raw native NEAR directly."
       }
     ],
     "risk_gates": [

--- a/skills/intents-trading-agent/widgets/sample-state.json
+++ b/skills/intents-trading-agent/widgets/sample-state.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "intents-trading-widget/1",
+  "generated_at": "2026-05-02T16:30:00Z",
+  "project_id": "intents-trading-agent",
+  "mode": "paper",
+  "pair": "NEAR/BTC",
+  "stance": "paper-intent",
+  "confidence": 0.74,
+  "top_candidates": [
+    {
+      "rank": 1,
+      "id": "sma_cross_fast",
+      "strategy_kind": "sma-cross",
+      "selection_score": 18.5,
+      "passes_basic_gate": true,
+      "total_return_pct": 12.0,
+      "alpha_vs_buy_hold_pct": 3.0,
+      "max_drawdown_pct": 8.0,
+      "trades": 6
+    }
+  ],
+  "risk_gates": [
+    {
+      "name": "unsigned-only",
+      "status": "pass",
+      "detail": "Wallet signature required outside the agent."
+    },
+    {
+      "name": "live-quote",
+      "status": "warn",
+      "detail": "Live NEAR Intents quote requires explicit user approval."
+    }
+  ],
+  "intent": {
+    "id": "intent-widget-fixture",
+    "status": "paper-built",
+    "route_label": "NEAR -> BTC via NEAR Intents",
+    "quote_source": "fixture",
+    "schema_version": "portfolio-intent/1",
+    "legs": 1,
+    "total_cost_usd": "0.42",
+    "expires_at": 1775000000,
+    "signer_placeholder": "<signed-by-user>",
+    "min_out": [
+      {
+        "symbol": "BTC",
+        "chain": "near",
+        "amount": "0.001",
+        "value_usd": "70.00"
+      }
+    ]
+  },
+  "source_count": 2,
+  "research_sources": [
+    "https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay",
+    "https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint"
+  ],
+  "next_action": "Ask the user before requesting a live NEAR Intents quote."
+}

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -68,6 +68,7 @@ pub use router::{
     list_engine_thread_steps,
     list_engine_threads,
     pause_engine_mission,
+    register_engine_project_for_workspace_path,
     resolve_engine_auth_callback,
     resolve_gate,
     resume_engine_mission,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -5378,6 +5378,29 @@ pub async fn list_engine_thread_events(
 }
 
 /// List all projects.
+fn engine_project_info(project: ironclaw_engine::Project) -> EngineProjectInfo {
+    EngineProjectInfo {
+        id: project.id.to_string(),
+        name: project.name,
+        description: project.description,
+        goals: project.goals,
+        metrics: project.metrics,
+        created_at: project.created_at.to_rfc3339(),
+    }
+}
+
+fn extract_project_slug_from_workspace_path(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("projects/")?;
+    let (slug, remainder) = rest.split_once('/')?;
+    if slug.is_empty() || slug == "." || slug == ".." || slug.starts_with('.') {
+        return None;
+    }
+    if remainder.is_empty() {
+        return None;
+    }
+    Some(slug)
+}
+
 pub async fn list_engine_projects(user_id: &str) -> Result<Vec<EngineProjectInfo>, Error> {
     let Some(lock) = ENGINE_STATE.get() else {
         return Ok(Vec::new());
@@ -5393,17 +5416,60 @@ pub async fn list_engine_projects(user_id: &str) -> Result<Vec<EngineProjectInfo
         .await
         .map_err(|e| engine_err("list projects", e))?;
 
-    Ok(projects
-        .iter()
-        .map(|p| EngineProjectInfo {
-            id: p.id.to_string(),
-            name: p.name.clone(),
-            description: p.description.clone(),
-            goals: p.goals.clone(),
-            metrics: p.metrics.clone(),
-            created_at: p.created_at.to_rfc3339(),
-        })
-        .collect())
+    Ok(projects.into_iter().map(engine_project_info).collect())
+}
+
+/// Register a project implied by a workspace path such as
+/// `projects/<slug>/AGENTS.md`.
+///
+/// LLM-facing `memory_write` calls go through `EffectBridgeAdapter`, which
+/// already performs this auto-registration. The authenticated HTTP memory API
+/// writes directly to the workspace, so it needs the same bridge hook or
+/// project widgets installed via `/api/memory/write` stay invisible until a
+/// separate agent tool call happens to create the project.
+pub async fn register_engine_project_for_workspace_path(
+    path: &str,
+    user_id: &str,
+) -> Result<Option<EngineProjectInfo>, Error> {
+    let Some(slug) = extract_project_slug_from_workspace_path(path) else {
+        return Ok(None);
+    };
+
+    let Some(lock) = ENGINE_STATE.get() else {
+        return Ok(None);
+    };
+    let guard = lock.read().await;
+    let Some(state) = guard.as_ref() else {
+        return Ok(None);
+    };
+
+    let slug_lower = ironclaw_engine::types::slugify_simple(slug);
+    if slug_lower.is_empty() {
+        return Ok(None);
+    }
+
+    let existing = state
+        .store
+        .list_projects(user_id)
+        .await
+        .map_err(|e| engine_err("list projects", e))?;
+
+    if let Some(project) = existing.iter().find(|p| {
+        p.user_id == user_id
+            && (ironclaw_engine::types::slugify_simple(&p.name) == slug_lower
+                || p.name.eq_ignore_ascii_case(&slug_lower))
+    }) {
+        return Ok(Some(engine_project_info(project.clone())));
+    }
+
+    let project = ironclaw_engine::Project::new(user_id, slug, "");
+    state
+        .store
+        .save_project(&project)
+        .await
+        .map_err(|e| engine_err("register project", e))?;
+
+    Ok(Some(engine_project_info(project)))
 }
 
 /// Get a single project by ID.
@@ -5428,14 +5494,7 @@ pub async fn get_engine_project(
 
     Ok(project
         .filter(|p| p.is_owned_by(user_id))
-        .map(|p| EngineProjectInfo {
-            id: p.id.to_string(),
-            name: p.name,
-            description: p.description,
-            goals: p.goals,
-            metrics: p.metrics,
-            created_at: p.created_at.to_rfc3339(),
-        }))
+        .map(engine_project_info))
 }
 
 /// Projects overview — health, stats, attention items for all projects.
@@ -6319,6 +6378,72 @@ mod tests {
     // letting concurrent tests overwrite the shared `ENGINE_STATE` `OnceLock`.
     use super::test_support::ENGINE_STATE_TEST_LOCK;
     static CWD_TEST_LOCK: LazyLock<TokioMutex<()>> = LazyLock::new(|| TokioMutex::new(()));
+
+    #[test]
+    fn workspace_project_slug_extraction_matches_memory_write_shape() {
+        assert_eq!(
+            extract_project_slug_from_workspace_path("projects/intents-trading-agent/AGENTS.md"),
+            Some("intents-trading-agent")
+        );
+        assert_eq!(
+            extract_project_slug_from_workspace_path(
+                "projects/intents-trading-agent/.system/widgets/near-intents-console/index.js"
+            ),
+            Some("intents-trading-agent")
+        );
+        assert_eq!(extract_project_slug_from_workspace_path("projects"), None);
+        assert_eq!(
+            extract_project_slug_from_workspace_path("projects/foo"),
+            None
+        );
+        assert_eq!(
+            extract_project_slug_from_workspace_path("projects/.hidden/file.md"),
+            None
+        );
+        assert_eq!(
+            extract_project_slug_from_workspace_path("notes/projects/foo.md"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn http_workspace_project_registration_is_idempotent() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let store = Arc::new(TestStore::new());
+        let state = make_expected_test_state(Arc::clone(&store));
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+        *lock.write().await = Some(state);
+
+        let first = register_engine_project_for_workspace_path(
+            "projects/intents-trading-agent/AGENTS.md",
+            "alice",
+        )
+        .await
+        .expect("register ok")
+        .expect("project path should register");
+        let second = register_engine_project_for_workspace_path(
+            "projects/intents-trading-agent/.system/widgets/near-intents-console/index.js",
+            "alice",
+        )
+        .await
+        .expect("register ok")
+        .expect("same project path should resolve");
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.name, "intents-trading-agent");
+        let projects = store.list_projects("alice").await.expect("list projects");
+        assert_eq!(projects.len(), 1);
+
+        let ignored =
+            register_engine_project_for_workspace_path("scratch/not-a-project.md", "alice")
+                .await
+                .expect("non-project write ok");
+        assert!(ignored.is_none());
+        assert_eq!(store.list_projects("alice").await.unwrap().len(), 1);
+
+        *lock.write().await = None;
+    }
 
     // ──────────────────────────────────────────────────────────────────
     // `bridge_outcome_for_failed_thread` — caller-level coverage.

--- a/src/channels/web/handlers/memory.rs
+++ b/src/channels/web/handlers/memory.rs
@@ -171,6 +171,7 @@ pub async fn memory_write_handler(
             };
             (status, e.to_string())
         })?;
+        register_project_write(&req.path, &user.user_id).await;
         return Ok(Json(MemoryWriteResponse {
             path: req.path,
             status: "written",
@@ -192,12 +193,24 @@ pub async fn memory_write_handler(
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
 
+    register_project_write(&req.path, &user.user_id).await;
+
     Ok(Json(MemoryWriteResponse {
         path: req.path,
         status: "written",
         redirected: None,
         actual_layer: None,
     }))
+}
+
+async fn register_project_write(path: &str, user_id: &str) {
+    if let Err(e) = crate::bridge::register_engine_project_for_workspace_path(path, user_id).await {
+        tracing::debug!(
+            path,
+            user_id,
+            "memory write succeeded but project auto-registration failed: {e}"
+        );
+    }
 }
 
 pub async fn memory_search_handler(

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -61,8 +61,9 @@ use crate::channels::web::platform::static_files::{
     BASE_CSP_HEADER, admin_css_handler, admin_html_handler, admin_js_handler, css_handler,
     debug_init_handler, debug_panel_css_handler, debug_panel_js_handler, favicon_handler,
     health_handler, i18n_app_handler, i18n_en_handler, i18n_index_handler, i18n_ko_handler,
-    i18n_zh_handler, index_handler, js_handler, project_file_handler, project_index_handler,
-    project_redirect_handler, theme_css_handler, theme_init_handler,
+    i18n_zh_handler, index_handler, js_handler, near_intents_experiment_css_handler,
+    near_intents_experiment_html_handler, near_intents_experiment_js_handler, project_file_handler,
+    project_index_handler, project_redirect_handler, theme_css_handler, theme_init_handler,
 };
 
 // Feature slices under `features/<slice>/`. As of ironclaw#2599 stage 4d,
@@ -472,7 +473,23 @@ pub async fn start_server(
         .route("/admin/", get(admin_html_handler))
         .route("/admin/{*path}", get(admin_html_handler))
         .route("/admin.css", get(admin_css_handler))
-        .route("/admin.js", get(admin_js_handler));
+        .route("/admin.js", get(admin_js_handler))
+        .route(
+            "/experiments/near-intents",
+            get(near_intents_experiment_html_handler),
+        )
+        .route(
+            "/experiments/near-intents/",
+            get(near_intents_experiment_html_handler),
+        )
+        .route(
+            "/experiments/near-intents.css",
+            get(near_intents_experiment_css_handler),
+        )
+        .route(
+            "/experiments/near-intents.js",
+            get(near_intents_experiment_js_handler),
+        );
 
     // Project file serving (behind auth to prevent unauthorized file access).
     let projects = Router::new()

--- a/src/channels/web/platform/static_files.rs
+++ b/src/channels/web/platform/static_files.rs
@@ -57,7 +57,7 @@ use crate::workspace::Workspace;
 
 /// `script-src` sources other than `'self'` and the per-response nonce.
 const SCRIPT_SRC_EXTRAS: &str =
-    "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh";
+    "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh blob:";
 const STYLE_SRC: &str = "'self' 'unsafe-inline' https://fonts.googleapis.com";
 const FONT_SRC: &str = "https://fonts.gstatic.com data:";
 const CONNECT_SRC: &str =
@@ -1080,6 +1080,10 @@ mod tests {
         assert!(
             csp.contains("script-src 'self' 'nonce-deadbeefcafebabe' https://cdn.jsdelivr.net"),
             "nonce source must appear immediately after 'self' in script-src; got: {csp}"
+        );
+        assert!(
+            csp.contains(" blob:"),
+            "project widget blob scripts must stay allowed by script-src; got: {csp}"
         );
         // The other directives must match the static BASE_CSP so the
         // per-response value never accidentally relaxes anything else.

--- a/src/channels/web/platform/static_files.rs
+++ b/src/channels/web/platform/static_files.rs
@@ -60,8 +60,9 @@ const SCRIPT_SRC_EXTRAS: &str =
     "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh blob:";
 const STYLE_SRC: &str = "'self' 'unsafe-inline' https://fonts.googleapis.com";
 const FONT_SRC: &str = "https://fonts.gstatic.com data:";
-const CONNECT_SRC: &str =
-    "'self' https://esm.sh https://rpc.mainnet.near.org https://rpc.testnet.near.org";
+const CONNECT_SRC: &str = "'self' https://esm.sh https://rpc.mainnet.near.org https://rpc.testnet.near.org \
+     https://api.exchange.coinbase.com https://api.coingecko.com https://api.hyperliquid.xyz \
+     https://solver-relay-v2.chaindefuser.com";
 const IMG_SRC: &str =
     "'self' data: blob: https://*.googleusercontent.com https://avatars.githubusercontent.com";
 const FRAME_SRC: &str = "https://accounts.google.com https://appleid.apple.com";
@@ -847,6 +848,36 @@ pub(crate) async fn admin_js_handler() -> impl IntoResponse {
             (header::CACHE_CONTROL, "no-cache"),
         ],
         assets::ADMIN_JS,
+    )
+}
+
+pub(crate) async fn near_intents_experiment_html_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        assets::NEAR_INTENTS_EXPERIMENT_HTML,
+    )
+}
+
+pub(crate) async fn near_intents_experiment_css_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "text/css"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        assets::NEAR_INTENTS_EXPERIMENT_CSS,
+    )
+}
+
+pub(crate) async fn near_intents_experiment_js_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "application/javascript"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        assets::NEAR_INTENTS_EXPERIMENT_JS,
     )
 }
 

--- a/tests/support/live_mission_helpers.rs
+++ b/tests/support/live_mission_helpers.rs
@@ -4,7 +4,6 @@
 //! (`tests/e2e_live_mission_gmail.rs`, etc.) can reuse the same approval
 //! responder and notification heuristics without copy-paste drift.
 
-#![cfg(feature = "libsql")]
 #![allow(dead_code)] // shared API; not every test uses every helper
 
 use std::collections::HashSet;

--- a/tools-src/portfolio/fixtures/solver/ita-swap-near-usdc-btc-near.json
+++ b/tools-src/portfolio/fixtures/solver/ita-swap-near-usdc-btc-near.json
@@ -1,0 +1,31 @@
+{
+  "quote_id": "q-ita-swap-near-usdc-btc-2026-05-02",
+  "quote_version": "near-intents/1",
+  "legs": [
+    {
+      "id": "swap-near-usdc-btc",
+      "kind": "swap",
+      "chain": "near",
+      "near_intent_payload": {
+        "op": "swap",
+        "from_chain": "near",
+        "to_chain": "near",
+        "from_asset": "USDC",
+        "to_asset": "BTC",
+        "amount_in": "100.00",
+        "min_amount_out": "0.00099500",
+        "paper_mode": true,
+        "source": "intents-trading-agent-smoke"
+      },
+      "min_out": {
+        "symbol": "BTC",
+        "chain": "near",
+        "amount": "0.00099500",
+        "value_usd": "98.01"
+      },
+      "quoted_by": "relay-solver/replay"
+    }
+  ],
+  "total_cost_usd": "1.50",
+  "expires_at_unix": 1800000000
+}

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, nominal NEAR trial planning, and NEAR Intents trading widget state.",
   "discovery_summary": {
     "always_required": [
       "action"
@@ -14,12 +14,15 @@
       "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
       "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, autonomous-wallet policy gates, agentic-SEO trust gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
       "`plan_dripstack_browse` models DripStack's guided topic → publication → article flow from free catalog/post metadata. A selected article becomes a paid-source candidate for `plan_paid_research`; the tool never buys or fetches article bodies.",
-      "`format_intents_widget` requires a `pair` and optional backtest-suite output, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
+      "`fetch_dripstack_catalog` fetches DripStack's free publication catalog or free post-title metadata for one publication. It never calls paid article-body routes.",
+      "`prepare_dripstack_paid_fetch` requires one publication slug and post slug. It prepares the explicit confirmation, HTTP 402 challenge, and receipt-backed retry boundary for one paid article; it never signs or reads paid content by itself.",
+      "`plan_near_intents_trial` prepares a nominal-NEAR paper/quote rehearsal with wallet/funding setup steps, strategy-menu defaults, risk gates, and an unsigned build_intent request.",
+      "`format_intents_widget` requires a `pair` and optional backtest-suite output, trial plan, paid research plan, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; free DripStack catalog fetch returns `dripstack-catalog/1`; paid fetch preparation returns `dripstack-paid-fetch-plan/1`; nominal NEAR trial planning returns `near-intents-trial-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -45,6 +48,14 @@
         ],
         "fee_bps": 10,
         "slippage_bps": 5
+      },
+      {
+        "action": "plan_near_intents_trial",
+        "mode": "paper",
+        "pair": "NEAR/USDC",
+        "nominal_near": 0.25,
+        "max_trade_near": 0.05,
+        "assumed_near_usd": 3.0
       },
       {
         "action": "format_intents_widget",
@@ -83,6 +94,17 @@
             "description": "Crypto market structure, liquidity, and onchain trading research."
           }
         ]
+      },
+      {
+        "action": "fetch_dripstack_catalog",
+        "publication_slug": "premiumcrypto.substack.com"
+      },
+      {
+        "action": "prepare_dripstack_paid_fetch",
+        "publication_slug": "premiumcrypto.substack.com",
+        "post_slug": "near-intents-liquidity",
+        "payment_protocol": "mpp",
+        "user_confirmed_purchase": false
       }
     ]
   },
@@ -105,9 +127,14 @@
           "methods": ["GET"]
         },
         {
-          "host": "solver-relay.chaindefuser.com",
+          "host": "solver-relay-v2.chaindefuser.com",
           "path_prefix": "/rpc",
           "methods": ["POST"]
+        },
+        {
+          "host": "dripstack.xyz",
+          "path_prefix": "/api/v1/publications",
+          "methods": ["GET"]
         }
       ],
       "credentials": {

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, and NEAR Intents trading widget state.",
   "discovery_summary": {
     "always_required": [
       "action"
@@ -12,12 +12,13 @@
       "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`.",
       "`backtest` requires oldest-to-newest OHLCV `candles` plus a long-only spot `strategy` (`buy-hold`, `sma-cross`, `breakout`, `mean-reversion`, `momentum`, or `rsi-mean-reversion`). Fees, slippage, position size, stop-loss, and take-profit are optional.",
       "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
+      "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, policy gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
       "`format_intents_widget` requires a `pair` and optional backtest-suite output, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -51,6 +52,24 @@
         "stance": "watch",
         "risk_gates": [
           { "name": "unsigned-only", "status": "pass", "detail": "Wallet signature required outside the agent." }
+        ]
+      },
+      {
+        "action": "plan_paid_research",
+        "query": "Should the NEAR/BTC paper intent pay for premium source research before quoting?",
+        "pair": "NEAR/BTC",
+        "budget_usd": 0.05,
+        "spending_mode": "quote",
+        "sources": [
+          {
+            "id": "premium-route-risk",
+            "title": "Intent route risk memo",
+            "author": "Researcher",
+            "url": "https://example.com/route-risk",
+            "tags": ["near-intents", "btc"],
+            "price_usd": 0.02,
+            "payment": { "protocol": "x402", "network": "base", "asset": "USDC" }
+          }
         ]
       }
     ]

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -12,6 +12,11 @@
       "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`.",
       "`backtest` requires oldest-to-newest OHLCV `candles` plus a long-only spot `strategy` (`buy-hold`, `sma-cross`, `breakout`, `mean-reversion`, `momentum`, or `rsi-mean-reversion`). Fees, slippage, position size, stop-loss, and take-profit are optional.",
       "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
+      "`backtest_walkforward` requires `candles`, a `strategy`, and `n_folds` >= 2. It splits the series into contiguous, non-overlapping fold windows, runs the same strategy on each fold's in-sample and out-of-sample ranges, and returns per-fold metrics plus an aggregate robustness verdict (`robust`, `fragile`, or `overfit`). Parameters are not refit.",
+      "`backtest_montecarlo` requires `trade_returns_pct` (per-trade percent returns from a prior backtest). It uses a seeded xorshift64* PRNG to resample (`shuffle`) or rearrange (`permute`) the trade order across `iterations` paths and returns return / drawdown / terminal-equity distributions plus loss probabilities.",
+      "`backtest_grid` requires `candles`, a `base` strategy, and at least one `axes` entry or sizing/stop/take-profit options. It enumerates the cartesian product, hands the resulting candidates to `backtest_suite`, and returns a ranked grid plus a flat cell table. The `max_cells` cap defaults to 1024.",
+      "`validate_episode` requires an `episode` (id, pair, candles; optional solver_fixture, news_context, timeframe, generated_at, source). It returns a deterministic summary; no backtest runs.",
+      "`replay_episode` requires an `episode` and `candidates` menu. It validates the episode, runs `backtest_suite` against the embedded candles, and surfaces the solver fixture and news context for the caller to route into `build_intent` and analyst memos.",
       "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, autonomous-wallet policy gates, agentic-SEO trust gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
       "`plan_dripstack_browse` models DripStack's guided topic → publication → article flow from free catalog/post metadata. A selected article becomes a paid-source candidate for `plan_paid_research`; the tool never buys or fetches article bodies.",
       "`fetch_dripstack_catalog` fetches DripStack's free publication catalog or free post-title metadata for one publication. It never calls paid article-body routes.",
@@ -22,7 +27,7 @@
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; free DripStack catalog fetch returns `dripstack-catalog/1`; paid fetch preparation returns `dripstack-paid-fetch-plan/1`; nominal NEAR trial planning returns `near-intents-trial-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; walk-forward returns `intents-walkforward/1`; Monte Carlo returns `intents-montecarlo/1`; grid sweeps return `intents-grid/1`; episode validation returns `intents-episode/1`; episode replay returns `intents-episode-replay/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; free DripStack catalog fetch returns `dripstack-catalog/1`; paid fetch preparation returns `dripstack-paid-fetch-plan/1`; nominal NEAR trial planning returns `near-intents-trial-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -105,6 +110,46 @@
         "post_slug": "near-intents-liquidity",
         "payment_protocol": "mpp",
         "user_confirmed_purchase": false
+      },
+      {
+        "action": "backtest_walkforward",
+        "candles": [],
+        "strategy": { "kind": "sma-cross", "fast_window": 5, "slow_window": 20 },
+        "n_folds": 4,
+        "train_pct": 0.7,
+        "embargo": 1
+      },
+      {
+        "action": "backtest_montecarlo",
+        "trade_returns_pct": [1.5, -0.5, 2.0, -1.0, 0.8],
+        "initial_cash_usd": 1000,
+        "iterations": 1000,
+        "seed": 42,
+        "method": "shuffle"
+      },
+      {
+        "action": "backtest_grid",
+        "candles": [],
+        "base": { "kind": "sma-cross", "fast_window": 5, "slow_window": 20 },
+        "axes": [
+          { "param": "fast_window", "values": [3, 5, 8] },
+          { "param": "slow_window", "values": [15, 20, 30] }
+        ],
+        "max_cells": 32
+      },
+      {
+        "action": "replay_episode",
+        "episode": {
+          "id": "near-usdc-q1",
+          "pair": "NEAR/USDC",
+          "timeframe": "1d",
+          "candles": [],
+          "solver_fixture": null,
+          "news_context": []
+        },
+        "candidates": [
+          { "id": "buy_hold", "strategy": { "kind": "buy-hold" } }
+        ]
       }
     ]
   },

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -17,6 +17,8 @@
       "`backtest_grid` requires `candles`, a `base` strategy, and at least one `axes` entry or sizing/stop/take-profit options. It enumerates the cartesian product, hands the resulting candidates to `backtest_suite`, and returns a ranked grid plus a flat cell table. The `max_cells` cap defaults to 1024.",
       "`validate_episode` requires an `episode` (id, pair, candles; optional solver_fixture, news_context, timeframe, generated_at, source). It returns a deterministic summary; no backtest runs.",
       "`replay_episode` requires an `episode` and `candidates` menu. It validates the episode, runs `backtest_suite` against the embedded candles, and surfaces the solver fixture and news context for the caller to route into `build_intent` and analyst memos.",
+      "`backtest_dca` requires `candles` and `notional_per_period_usd`. It replays a fixed-cadence buy schedule, optionally with a symmetric price band (`skip_above_premium_bps` / `opportunistic_below_discount_bps`). Reports lots, breakeven, mark-to-market, max underlying drawdown, and alpha vs lump-sum buy-and-hold.",
+      "`plan_dca_schedule` requires a `pair`, source/destination asset+chain, `notional_per_period_usd`, `cadence`, and `total_periods`. It emits a cron expression, per-period plans, deterministic risk gates, and a `build_intent` template the caller uses per period. All output is unsigned.",
       "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, autonomous-wallet policy gates, agentic-SEO trust gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
       "`plan_dripstack_browse` models DripStack's guided topic → publication → article flow from free catalog/post metadata. A selected article becomes a paid-source candidate for `plan_paid_research`; the tool never buys or fetches article bodies.",
       "`fetch_dripstack_catalog` fetches DripStack's free publication catalog or free post-title metadata for one publication. It never calls paid article-body routes.",
@@ -27,7 +29,7 @@
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; walk-forward returns `intents-walkforward/1`; Monte Carlo returns `intents-montecarlo/1`; grid sweeps return `intents-grid/1`; episode validation returns `intents-episode/1`; episode replay returns `intents-episode-replay/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; free DripStack catalog fetch returns `dripstack-catalog/1`; paid fetch preparation returns `dripstack-paid-fetch-plan/1`; nominal NEAR trial planning returns `near-intents-trial-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; walk-forward returns `intents-walkforward/1`; Monte Carlo returns `intents-montecarlo/1`; grid sweeps return `intents-grid/1`; episode validation returns `intents-episode/1`; episode replay returns `intents-episode-replay/1`; DCA backtest returns `intents-dca-backtest/1`; DCA schedule planning returns `intents-dca-schedule/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; free DripStack catalog fetch returns `dripstack-catalog/1`; paid fetch preparation returns `dripstack-paid-fetch-plan/1`; nominal NEAR trial planning returns `near-intents-trial-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -150,6 +152,31 @@
         "candidates": [
           { "id": "buy_hold", "strategy": { "kind": "buy-hold" } }
         ]
+      },
+      {
+        "action": "backtest_dca",
+        "candles": [],
+        "notional_per_period_usd": 100,
+        "period_candles": 7,
+        "skip_above_premium_bps": 1500,
+        "opportunistic_below_discount_bps": 1500,
+        "fee_bps": 10,
+        "slippage_bps": 5,
+        "initial_cash_usd": 5000
+      },
+      {
+        "action": "plan_dca_schedule",
+        "pair": "NEAR/USDC",
+        "source_asset": "USDC",
+        "destination_asset": "NEAR",
+        "source_chain": "near",
+        "destination_chain": "near",
+        "notional_per_period_usd": 100,
+        "cadence": "weekly",
+        "total_periods": 26,
+        "max_slippage_bps": 50,
+        "assumed_price_usd": 3.0,
+        "mode": "paper"
       }
     ]
   },

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, and unsigned NEAR Intent construction. Single tool with three operations: scan, propose, build_intent.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, and NEAR Intents trading widget state.",
   "discovery_summary": {
     "always_required": [
       "action"
@@ -9,11 +9,15 @@
     "conditional_requirements": [
       "`scan` requires `addresses` (list of wallet addresses).",
       "`propose` requires `positions` (output of `scan`). `strategies` is optional — defaults to the bundled strategies (stablecoin-yield-floor, lending-health-guard, lp-impermanent-loss-watch, near-staking-yield, near-lending-yield, near-lp-yield) when omitted or empty. `config` is optional.",
-      "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`."
+      "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`.",
+      "`backtest` requires oldest-to-newest OHLCV `candles` plus a long-only spot `strategy` (`buy-hold`, `sma-cross`, `breakout`, `mean-reversion`, `momentum`, or `rsi-mean-reversion`). Fees, slippage, position size, stop-loss, and take-profit are optional.",
+      "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
+      "`format_intents_widget` requires a `pair` and optional backtest-suite output, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -29,6 +33,25 @@
         "positions": [],
         "strategies": [],
         "config": { "floor_apy": 0.04, "max_risk_score": 3 }
+      },
+      {
+        "action": "backtest_suite",
+        "candles": [],
+        "candidates": [
+          { "id": "sma_5_20", "strategy": { "kind": "sma-cross", "fast_window": 5, "slow_window": 20 } },
+          { "id": "buy_hold", "strategy": { "kind": "buy-hold" } }
+        ],
+        "fee_bps": 10,
+        "slippage_bps": 5
+      },
+      {
+        "action": "format_intents_widget",
+        "pair": "NEAR/BTC",
+        "mode": "paper",
+        "stance": "watch",
+        "risk_gates": [
+          { "name": "unsigned-only", "status": "pass", "detail": "Wallet signature required outside the agent." }
+        ]
       }
     ]
   },

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -12,13 +12,14 @@
       "`build_intent` requires `plan` (a MovementPlan from a Proposal). `config` and `solver` are optional; `solver` defaults to `fixture`.",
       "`backtest` requires oldest-to-newest OHLCV `candles` plus a long-only spot `strategy` (`buy-hold`, `sma-cross`, `breakout`, `mean-reversion`, `momentum`, or `rsi-mean-reversion`). Fees, slippage, position size, stop-loss, and take-profit are optional.",
       "`backtest_suite` requires oldest-to-newest OHLCV `candles` plus a `candidates` menu. It returns ranked strategy results and a basic intent-eligibility gate.",
-      "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, policy gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
+      "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, autonomous-wallet policy gates, agentic-SEO trust gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
+      "`plan_dripstack_browse` models DripStack's guided topic → publication → article flow from free catalog/post metadata. A selected article becomes a paid-source candidate for `plan_paid_research`; the tool never buys or fetches article bodies.",
       "`format_intents_widget` requires a `pair` and optional backtest-suite output, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -69,6 +70,17 @@
             "tags": ["near-intents", "btc"],
             "price_usd": 0.02,
             "payment": { "protocol": "x402", "network": "base", "asset": "USDC" }
+          }
+        ]
+      },
+      {
+        "action": "plan_dripstack_browse",
+        "topic": "crypto market structure",
+        "publications": [
+          {
+            "slug": "premiumcrypto.substack.com",
+            "title": "Premium Crypto Notes",
+            "description": "Crypto market structure, liquidity, and onchain trading research."
           }
         ]
       }

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "wit_version": "0.3.0",
-  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, nominal NEAR trial planning, and NEAR Intents trading widget state.",
+  "description": "Cross-chain DeFi portfolio discovery, ranked rebalancing proposals, unsigned NEAR Intent construction, deterministic spot strategy backtesting/suite ranking, paid research budgeting/attribution, nominal NEAR trial planning, and interactive NEAR Intents trading widget state.",
   "discovery_summary": {
     "always_required": [
       "action"
@@ -17,7 +17,7 @@
       "`fetch_dripstack_catalog` fetches DripStack's free publication catalog or free post-title metadata for one publication. It never calls paid article-body routes.",
       "`prepare_dripstack_paid_fetch` requires one publication slug and post slug. It prepares the explicit confirmation, HTTP 402 challenge, and receipt-backed retry boundary for one paid article; it never signs or reads paid content by itself.",
       "`plan_near_intents_trial` prepares a nominal-NEAR paper/quote rehearsal with wallet/funding setup steps, strategy-menu defaults, risk gates, and an unsigned build_intent request.",
-      "`format_intents_widget` requires a `pair` and optional backtest-suite output, trial plan, paid research plan, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the project widget."
+      "`format_intents_widget` requires a `pair` and optional backtest-suite output, trial plan, paid research plan, risk gates, and unsigned IntentBundle. It returns `intents-trading-widget/1` state for the interactive project widget."
     ],
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",

--- a/tools-src/portfolio/portfolio-tool.capabilities.json
+++ b/tools-src/portfolio/portfolio-tool.capabilities.json
@@ -19,6 +19,7 @@
       "`replay_episode` requires an `episode` and `candidates` menu. It validates the episode, runs `backtest_suite` against the embedded candles, and surfaces the solver fixture and news context for the caller to route into `build_intent` and analyst memos.",
       "`backtest_dca` requires `candles` and `notional_per_period_usd`. It replays a fixed-cadence buy schedule, optionally with a symmetric price band (`skip_above_premium_bps` / `opportunistic_below_discount_bps`). Reports lots, breakeven, mark-to-market, max underlying drawdown, and alpha vs lump-sum buy-and-hold.",
       "`plan_dca_schedule` requires a `pair`, source/destination asset+chain, `notional_per_period_usd`, `cadence`, and `total_periods`. It emits a cron expression, per-period plans, deterministic risk gates, and a `build_intent` template the caller uses per period. All output is unsigned.",
+      "`compile_intent_prompt` requires a natural-language `prompt` and returns the recommended next portfolio action (`plan_dca_schedule`, `build_intent`, `backtest_suite`, `plan_paid_research`, `format_intents_widget`, or `noop`) plus its params, extracted fields, assumptions, clarifications, and gates. Deterministic pattern matching, no LLM call. The caller invokes the recommended action separately after risk gating.",
       "`plan_paid_research` requires a `query` and optional candidate `sources`. It returns a budgeted paid-source plan with MPP/x402/NEAR rail attribution, autonomous-wallet policy gates, agentic-SEO trust gates, and NEAR funding-route hints; it does not fetch paywalled content or sign payments.",
       "`plan_dripstack_browse` models DripStack's guided topic → publication → article flow from free catalog/post metadata. A selected article becomes a paid-source candidate for `plan_paid_research`; the tool never buys or fetches article bodies.",
       "`fetch_dripstack_catalog` fetches DripStack's free publication catalog or free post-title metadata for one publication. It never calls paid article-body routes.",
@@ -29,7 +30,7 @@
     "notes": [
       "All operations are read-only and produce no signed payloads. The agent never holds private keys.",
       "Scan supports historical queries via the optional `at` field (block per chain or timestamp).",
-      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; walk-forward returns `intents-walkforward/1`; Monte Carlo returns `intents-montecarlo/1`; grid sweeps return `intents-grid/1`; episode validation returns `intents-episode/1`; episode replay returns `intents-episode-replay/1`; DCA backtest returns `intents-dca-backtest/1`; DCA schedule planning returns `intents-dca-schedule/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; free DripStack catalog fetch returns `dripstack-catalog/1`; paid fetch preparation returns `dripstack-paid-fetch-plan/1`; nominal NEAR trial planning returns `near-intents-trial-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
+      "Backtest uses closed-candle signals with next-open execution to avoid lookahead and returns metrics under `intents-backtest/1`; suite ranking returns `intents-backtest-suite/1`; walk-forward returns `intents-walkforward/1`; Monte Carlo returns `intents-montecarlo/1`; grid sweeps return `intents-grid/1`; episode validation returns `intents-episode/1`; episode replay returns `intents-episode-replay/1`; DCA backtest returns `intents-dca-backtest/1`; DCA schedule planning returns `intents-dca-schedule/1`; natural-language compile returns `intents-nl-compile/1`; paid research planning returns `paid-research-plan/1`; DripStack guided browse planning returns `dripstack-browse-plan/1`; free DripStack catalog fetch returns `dripstack-catalog/1`; paid fetch preparation returns `dripstack-paid-fetch-plan/1`; nominal NEAR trial planning returns `near-intents-trial-plan/1`; NEAR Intents trading console state returns `intents-trading-widget/1`.",
       "Sources: `fixture` (embedded test data), `dune` (EVM via Dune Sim), `near` (NEAR via FastNEAR+Intear), `auto` (detect per address).",
       "Use `tool_info(name: \"portfolio\", detail: \"schema\")` for the full schema before guessing fields."
     ],
@@ -177,6 +178,12 @@
         "max_slippage_bps": 50,
         "assumed_price_usd": 3.0,
         "mode": "paper"
+      },
+      {
+        "action": "compile_intent_prompt",
+        "prompt": "DCA $100 weekly into NEAR for 6 months",
+        "default_chain": "near",
+        "default_funding_asset": "USDC"
       }
     ]
   },

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-breakout.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-breakout.yaml
@@ -1,0 +1,33 @@
+id: intents-trading-agent-backtest-breakout
+description: |
+  Backtests a long-only breakout strategy with explicit fee/slippage
+  assumptions. This is the trend-following baseline in the strategy
+  test corpus.
+steps:
+  - name: backtest_breakout
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 0.75
+      take_profit_bps: 1800
+      strategy:
+        kind: breakout
+        lookback_window: 3
+        threshold_bps: 25
+      candles:
+        - {ts: "2026-02-01T00:00:00Z", open: 20.0, high: 20.3, low: 19.8, close: 20.0, volume: 900}
+        - {ts: "2026-02-02T00:00:00Z", open: 20.1, high: 20.4, low: 19.9, close: 20.1, volume: 900}
+        - {ts: "2026-02-03T00:00:00Z", open: 20.0, high: 20.3, low: 19.7, close: 20.0, volume: 900}
+        - {ts: "2026-02-04T00:00:00Z", open: 20.2, high: 20.5, low: 20.0, close: 20.2, volume: 950}
+        - {ts: "2026-02-05T00:00:00Z", open: 20.3, high: 21.2, low: 20.2, close: 21.1, volume: 1300}
+        - {ts: "2026-02-06T00:00:00Z", open: 21.2, high: 22.4, low: 21.0, close: 22.1, volume: 1500}
+        - {ts: "2026-02-07T00:00:00Z", open: 22.2, high: 23.5, low: 22.0, close: 23.2, volume: 1600}
+        - {ts: "2026-02-08T00:00:00Z", open: 23.3, high: 24.6, low: 23.0, close: 24.0, volume: 1700}
+        - {ts: "2026-02-09T00:00:00Z", open: 24.0, high: 24.4, low: 23.3, close: 23.8, volume: 1200}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 5
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-mean-reversion.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-mean-reversion.yaml
@@ -1,0 +1,34 @@
+id: intents-trading-agent-backtest-mean-reversion
+description: |
+  Backtests a liquidity-aware mean-reversion baseline. The strategy
+  buys a sharp discount to a short moving average and exits when
+  price normalizes.
+steps:
+  - name: backtest_mean_reversion
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 0.5
+      stop_loss_bps: 800
+      strategy:
+        kind: mean-reversion
+        lookback_window: 3
+        threshold_bps: 300
+      candles:
+        - {ts: "2026-03-01T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 2000}
+        - {ts: "2026-03-02T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 2000}
+        - {ts: "2026-03-03T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 2000}
+        - {ts: "2026-03-04T00:00:00Z", open: 98.0, high: 99.0, low: 93.0, close: 94.0, volume: 2600}
+        - {ts: "2026-03-05T00:00:00Z", open: 94.5, high: 96.0, low: 92.5, close: 93.0, volume: 2500}
+        - {ts: "2026-03-06T00:00:00Z", open: 93.5, high: 96.5, low: 93.0, close: 95.0, volume: 2300}
+        - {ts: "2026-03-07T00:00:00Z", open: 95.5, high: 99.0, low: 95.0, close: 98.0, volume: 2200}
+        - {ts: "2026-03-08T00:00:00Z", open: 98.5, high: 102.0, low: 98.0, close: 101.0, volume: 2200}
+        - {ts: "2026-03-09T00:00:00Z", open: 101.0, high: 102.0, low: 99.0, close: 100.0, volume: 1900}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 0
+      backtest_max_drawdown_le: 10
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-momentum.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-momentum.yaml
@@ -1,0 +1,33 @@
+id: intents-trading-agent-backtest-momentum
+description: |
+  Backtests a trailing-return momentum strategy. This expands the
+  strategy corpus beyond moving-average and breakout signals for
+  users who want rotation-style choices.
+steps:
+  - name: backtest_momentum
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 0.6
+      stop_loss_bps: 1000
+      strategy:
+        kind: momentum
+        lookback_window: 3
+        threshold_bps: 500
+      candles:
+        - {ts: "2026-04-01T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-04-02T00:00:00Z", open: 10.2, high: 10.4, low: 10.0, close: 10.2, volume: 1100}
+        - {ts: "2026-04-03T00:00:00Z", open: 10.4, high: 10.6, low: 10.2, close: 10.4, volume: 1200}
+        - {ts: "2026-04-04T00:00:00Z", open: 10.6, high: 10.8, low: 10.4, close: 10.6, volume: 1300}
+        - {ts: "2026-04-05T00:00:00Z", open: 11.2, high: 11.4, low: 11.0, close: 11.2, volume: 1600}
+        - {ts: "2026-04-06T00:00:00Z", open: 11.8, high: 12.0, low: 11.6, close: 11.8, volume: 1800}
+        - {ts: "2026-04-07T00:00:00Z", open: 12.4, high: 12.6, low: 12.1, close: 12.4, volume: 1900}
+        - {ts: "2026-04-08T00:00:00Z", open: 12.0, high: 12.2, low: 11.7, close: 12.0, volume: 1500}
+        - {ts: "2026-04-09T00:00:00Z", open: 11.5, high: 11.7, low: 11.2, close: 11.5, volume: 1300}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 0
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-rsi.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-rsi.yaml
@@ -1,0 +1,36 @@
+id: intents-trading-agent-backtest-rsi
+description: |
+  Backtests an RSI mean-reversion strategy. This gives users an
+  oscillator-style choice distinct from SMA, breakout, and momentum
+  strategies.
+steps:
+  - name: backtest_rsi_mean_reversion
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 0.4
+      stop_loss_bps: 700
+      strategy:
+        kind: rsi-mean-reversion
+        lookback_window: 5
+        entry_threshold: 25
+        exit_threshold: 55
+      candles:
+        - {ts: "2026-05-01T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 2000}
+        - {ts: "2026-05-02T00:00:00Z", open: 98.0, high: 99.0, low: 97.0, close: 98.0, volume: 2200}
+        - {ts: "2026-05-03T00:00:00Z", open: 96.0, high: 97.0, low: 95.0, close: 96.0, volume: 2400}
+        - {ts: "2026-05-04T00:00:00Z", open: 94.0, high: 95.0, low: 93.0, close: 94.0, volume: 2500}
+        - {ts: "2026-05-05T00:00:00Z", open: 92.0, high: 93.0, low: 91.0, close: 92.0, volume: 2600}
+        - {ts: "2026-05-06T00:00:00Z", open: 90.0, high: 91.0, low: 89.0, close: 90.0, volume: 2700}
+        - {ts: "2026-05-07T00:00:00Z", open: 91.0, high: 92.0, low: 90.0, close: 91.0, volume: 2500}
+        - {ts: "2026-05-08T00:00:00Z", open: 93.0, high: 94.0, low: 92.0, close: 93.0, volume: 2300}
+        - {ts: "2026-05-09T00:00:00Z", open: 95.0, high: 96.0, low: 94.0, close: 95.0, volume: 2200}
+        - {ts: "2026-05-10T00:00:00Z", open: 98.0, high: 99.0, low: 97.0, close: 98.0, volume: 2100}
+        - {ts: "2026-05-11T00:00:00Z", open: 101.0, high: 102.0, low: 100.0, close: 101.0, volume: 2000}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 0
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-sma.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-sma.yaml
@@ -1,0 +1,40 @@
+id: intents-trading-agent-backtest-sma
+description: |
+  Backtests an SMA crossover strategy before it is eligible for
+  intent construction. This mirrors the TradingAgents flow where
+  the trader must clear a historical sanity check before the risk
+  manager allows a paper intent.
+steps:
+  - name: backtest_sma_cross
+    action: backtest
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      max_position_pct: 1
+      stop_loss_bps: 1200
+      strategy:
+        kind: sma-cross
+        fast_window: 2
+        slow_window: 4
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 10.2, high: 10.7, low: 10.0, close: 10.5, volume: 1200}
+        - {ts: "2026-01-06T00:00:00Z", open: 10.6, high: 11.2, low: 10.5, close: 11.0, volume: 1300}
+        - {ts: "2026-01-07T00:00:00Z", open: 11.1, high: 12.1, low: 11.0, close: 12.0, volume: 1400}
+        - {ts: "2026-01-08T00:00:00Z", open: 12.1, high: 13.1, low: 12.0, close: 13.0, volume: 1500}
+        - {ts: "2026-01-09T00:00:00Z", open: 13.1, high: 14.1, low: 13.0, close: 14.0, volume: 1600}
+        - {ts: "2026-01-10T00:00:00Z", open: 13.8, high: 14.0, low: 12.8, close: 13.0, volume: 1500}
+        - {ts: "2026-01-11T00:00:00Z", open: 12.8, high: 13.0, low: 11.8, close: 12.0, volume: 1400}
+        - {ts: "2026-01-12T00:00:00Z", open: 11.8, high: 12.0, low: 10.8, close: 11.0, volume: 1300}
+        - {ts: "2026-01-13T00:00:00Z", open: 10.8, high: 11.0, low: 9.8, close: 10.0, volume: 1200}
+        - {ts: "2026-01-14T00:00:00Z", open: 9.8, high: 10.0, low: 8.8, close: 9.0, volume: 1100}
+    expect:
+      backtest_schema_version: intents-backtest/1
+      backtest_trades_min: 1
+      backtest_total_return_gt: 10
+      backtest_max_drawdown_le: 20
+      backtest_lookahead_safe: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-backtest-suite.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-backtest-suite.yaml
@@ -1,0 +1,72 @@
+id: intents-trading-agent-backtest-suite
+description: |
+  Ranks a menu of deterministic spot strategies over the same candle
+  episode. This is the strategy-selection gate an autonomous intents
+  trading agent should clear before asking for any wallet-signed action.
+steps:
+  - name: rank_strategy_menu
+    action: backtest_suite
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      candidates:
+        - id: buy_hold_baseline
+          strategy:
+            kind: buy-hold
+        - id: sma_cross_fast
+          max_position_pct: 1
+          stop_loss_bps: 1200
+          strategy:
+            kind: sma-cross
+            fast_window: 2
+            slow_window: 4
+        - id: breakout_short
+          max_position_pct: 0.8
+          stop_loss_bps: 1000
+          strategy:
+            kind: breakout
+            lookback_window: 3
+            threshold_bps: 25
+        - id: momentum_rotation
+          max_position_pct: 0.8
+          stop_loss_bps: 1000
+          strategy:
+            kind: momentum
+            lookback_window: 3
+            threshold_bps: 500
+        - id: mean_reversion_range
+          max_position_pct: 0.5
+          stop_loss_bps: 700
+          strategy:
+            kind: mean-reversion
+            lookback_window: 3
+            threshold_bps: 300
+        - id: rsi_reversion
+          max_position_pct: 0.5
+          stop_loss_bps: 700
+          strategy:
+            kind: rsi-mean-reversion
+            lookback_window: 5
+            entry_threshold: 25
+            exit_threshold: 55
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 10.2, high: 10.7, low: 10.0, close: 10.5, volume: 1200}
+        - {ts: "2026-01-06T00:00:00Z", open: 10.6, high: 11.2, low: 10.5, close: 11.0, volume: 1300}
+        - {ts: "2026-01-07T00:00:00Z", open: 11.1, high: 12.1, low: 11.0, close: 12.0, volume: 1400}
+        - {ts: "2026-01-08T00:00:00Z", open: 12.1, high: 13.1, low: 12.0, close: 13.0, volume: 1500}
+        - {ts: "2026-01-09T00:00:00Z", open: 13.1, high: 14.1, low: 13.0, close: 14.0, volume: 1600}
+        - {ts: "2026-01-10T00:00:00Z", open: 13.8, high: 14.0, low: 12.8, close: 13.0, volume: 1500}
+        - {ts: "2026-01-11T00:00:00Z", open: 12.8, high: 13.0, low: 11.8, close: 12.0, volume: 1400}
+        - {ts: "2026-01-12T00:00:00Z", open: 11.8, high: 12.0, low: 10.8, close: 11.0, volume: 1300}
+        - {ts: "2026-01-13T00:00:00Z", open: 10.8, high: 11.0, low: 9.8, close: 10.0, volume: 1200}
+        - {ts: "2026-01-14T00:00:00Z", open: 9.8, high: 10.0, low: 8.8, close: 9.0, volume: 1100}
+    expect:
+      backtest_suite_schema_version: intents-backtest-suite/1
+      backtest_suite_ranked_min: 6
+      backtest_suite_top_trades_min: 1
+      backtest_suite_any_passes_basic_gate: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-dca-backtest.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-dca-backtest.yaml
@@ -1,0 +1,49 @@
+id: intents-trading-agent-dca-backtest
+description: |
+  Replays a weekly DCA buy schedule into a NEAR-priced asset over a 14-week
+  candle series with a symmetric price band. Verifies lot count, executed
+  vs skipped-band ratio, and breakeven price.
+steps:
+  - name: dca_weekly_with_band
+    action: backtest_dca
+    params:
+      notional_per_period_usd: 100
+      period_candles: 7
+      offset: 0
+      skip_above_premium_bps: 1500
+      opportunistic_below_discount_bps: 2000
+      fee_bps: 0
+      slippage_bps: 0
+      initial_cash_usd: 5000
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 3.00, high: 3.05, low: 2.95, close: 3.00, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 3.00, high: 3.05, low: 2.95, close: 3.00, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 3.00, high: 3.05, low: 2.95, close: 3.00, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 3.00, high: 3.05, low: 2.95, close: 3.00, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 3.00, high: 3.05, low: 2.95, close: 3.00, volume: 1000}
+        - {ts: "2026-01-06T00:00:00Z", open: 3.00, high: 3.05, low: 2.95, close: 3.00, volume: 1000}
+        - {ts: "2026-01-07T00:00:00Z", open: 3.00, high: 3.05, low: 2.95, close: 3.00, volume: 1000}
+        - {ts: "2026-01-08T00:00:00Z", open: 3.20, high: 3.30, low: 3.15, close: 3.25, volume: 1000}
+        - {ts: "2026-01-09T00:00:00Z", open: 3.30, high: 3.40, low: 3.25, close: 3.35, volume: 1000}
+        - {ts: "2026-01-10T00:00:00Z", open: 3.40, high: 3.50, low: 3.35, close: 3.45, volume: 1000}
+        - {ts: "2026-01-11T00:00:00Z", open: 3.50, high: 3.60, low: 3.45, close: 3.55, volume: 1000}
+        - {ts: "2026-01-12T00:00:00Z", open: 3.60, high: 3.70, low: 3.55, close: 3.65, volume: 1000}
+        - {ts: "2026-01-13T00:00:00Z", open: 3.70, high: 3.80, low: 3.65, close: 3.75, volume: 1000}
+        - {ts: "2026-01-14T00:00:00Z", open: 4.50, high: 4.60, low: 4.45, close: 4.55, volume: 1000}
+        - {ts: "2026-01-15T00:00:00Z", open: 4.50, high: 4.60, low: 4.45, close: 4.50, volume: 1000}
+        - {ts: "2026-01-16T00:00:00Z", open: 4.40, high: 4.50, low: 4.35, close: 4.40, volume: 1000}
+        - {ts: "2026-01-17T00:00:00Z", open: 4.30, high: 4.40, low: 4.25, close: 4.30, volume: 1000}
+        - {ts: "2026-01-18T00:00:00Z", open: 4.20, high: 4.30, low: 4.15, close: 4.20, volume: 1000}
+        - {ts: "2026-01-19T00:00:00Z", open: 4.10, high: 4.20, low: 4.05, close: 4.10, volume: 1000}
+        - {ts: "2026-01-20T00:00:00Z", open: 4.00, high: 4.10, low: 3.95, close: 4.00, volume: 1000}
+        - {ts: "2026-01-21T00:00:00Z", open: 1.50, high: 1.60, low: 1.45, close: 1.50, volume: 1000}
+        - {ts: "2026-01-22T00:00:00Z", open: 1.60, high: 1.70, low: 1.55, close: 1.65, volume: 1000}
+        - {ts: "2026-01-23T00:00:00Z", open: 1.70, high: 1.80, low: 1.65, close: 1.75, volume: 1000}
+        - {ts: "2026-01-24T00:00:00Z", open: 1.80, high: 1.90, low: 1.75, close: 1.85, volume: 1000}
+        - {ts: "2026-01-25T00:00:00Z", open: 1.90, high: 2.00, low: 1.85, close: 1.95, volume: 1000}
+        - {ts: "2026-01-26T00:00:00Z", open: 2.00, high: 2.10, low: 1.95, close: 2.00, volume: 1000}
+        - {ts: "2026-01-27T00:00:00Z", open: 2.10, high: 2.20, low: 2.05, close: 2.10, volume: 1000}
+        - {ts: "2026-01-28T00:00:00Z", open: 2.20, high: 2.30, low: 2.15, close: 2.25, volume: 1000}
+    expect:
+      backtest_schema_version: intents-dca-backtest/1
+      dca_breakeven_within: [1.5, 4.0]

--- a/tools-src/portfolio/scenarios/intents-trading-agent-dca-schedule.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-dca-schedule.yaml
@@ -1,0 +1,47 @@
+id: intents-trading-agent-dca-schedule
+description: |
+  Plans a 26-week DCA accumulation into NEAR funded by USDC at $100 per
+  period. Verifies the cron expression, schedule length, the embedded
+  build_intent template, and that all gates allow paper-mode quoting.
+steps:
+  - name: weekly_near_dca
+    action: plan_dca_schedule
+    params:
+      pair: NEAR/USDC
+      source_asset: USDC
+      destination_asset: NEAR
+      source_chain: near
+      destination_chain: near
+      notional_per_period_usd: 100
+      cadence: weekly
+      total_periods: 26
+      max_slippage_bps: 50
+      assumed_price_usd: 3.0
+      mode: paper
+      notional_currency: USDC
+    expect:
+      backtest_schema_version: intents-dca-schedule/1
+      dca_schedule_cron: "0 12 * * 1"
+      dca_schedule_periods_len: 26
+      dca_schedule_safe_to_quote: true
+      dca_schedule_template_action: build_intent
+  - name: monthly_btc_dca
+    action: plan_dca_schedule
+    params:
+      pair: BTC/USDC
+      source_asset: USDC
+      destination_asset: BTC
+      source_chain: near
+      destination_chain: bitcoin
+      notional_per_period_usd: 250
+      cadence: monthly
+      total_periods: 12
+      max_slippage_bps: 75
+      assumed_price_usd: 110000
+      mode: paper
+      notional_currency: USDC
+    expect:
+      backtest_schema_version: intents-dca-schedule/1
+      dca_schedule_cron: "0 12 1 * *"
+      dca_schedule_periods_len: 12
+      dca_schedule_template_action: build_intent

--- a/tools-src/portfolio/scenarios/intents-trading-agent-dripstack-browse.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-dripstack-browse.yaml
@@ -1,0 +1,100 @@
+id: intents-trading-agent-dripstack-browse
+description: |
+  Models DripStack as a guided browse flow: topic shortlist, publication
+  choice, article choice, then a paid-source candidate with both MPP and
+  x402 options. The paid article body is never fetched by this tool.
+steps:
+  - name: ask_topic
+    action: plan_dripstack_browse
+    params: {}
+    expect:
+      dripstack_checkpoint: topic
+  - name: shortlist_publications
+    action: plan_dripstack_browse
+    params:
+      topic: "crypto market structure"
+      publications:
+        - slug: premiumcrypto.substack.com
+          title: "Premium Crypto Notes"
+          description: "Crypto market structure, liquidity, exchanges, stablecoins, and onchain trading research."
+          site_url: "https://premiumcrypto.substack.com"
+        - slug: culturesignals.substack.com
+          title: "Culture Signals"
+          description: "Culture, media, and technology essays."
+          site_url: "https://culturesignals.substack.com"
+    expect:
+      dripstack_checkpoint: publication
+      dripstack_publications_min: 1
+  - name: list_articles
+    action: plan_dripstack_browse
+    params:
+      topic: "crypto market structure"
+      selected_publication_slug: premiumcrypto.substack.com
+      publications:
+        - slug: premiumcrypto.substack.com
+          title: "Premium Crypto Notes"
+          description: "Crypto market structure, liquidity, exchanges, stablecoins, and onchain trading research."
+          site_url: "https://premiumcrypto.substack.com"
+      posts:
+        - slug: near-intents-liquidity
+          title: "NEAR Intents liquidity and solver-routing risk"
+          subtitle: "A short premium note on route expiry, taker depth, and BTC leg risk."
+          author: "Premium Crypto Writer"
+          price_usd: 0.01
+        - slug: exchange-fragmentation
+          title: "Exchange fragmentation and agent order flow"
+          subtitle: "How agent traffic changes exchange liquidity."
+          author: "Premium Crypto Writer"
+          price_usd: 0.02
+    expect:
+      dripstack_checkpoint: article
+      dripstack_posts_min: 2
+  - name: selected_article_candidate
+    action: plan_dripstack_browse
+    params:
+      topic: "crypto market structure"
+      selected_publication_slug: premiumcrypto.substack.com
+      selected_post_slug: near-intents-liquidity
+      publications:
+        - slug: premiumcrypto.substack.com
+          title: "Premium Crypto Notes"
+          description: "Crypto market structure, liquidity, exchanges, stablecoins, and onchain trading research."
+          site_url: "https://premiumcrypto.substack.com"
+      posts:
+        - slug: near-intents-liquidity
+          title: "NEAR Intents liquidity and solver-routing risk"
+          subtitle: "A short premium note on route expiry, taker depth, and BTC leg risk."
+          author: "Premium Crypto Writer"
+          price_usd: 0.01
+    capture:
+      dripstack_paid_source_var: drip_source
+    expect:
+      dripstack_checkpoint: purchase-confirmation
+      dripstack_has_paid_source_candidate: true
+  - name: plan_payment_for_selected_article
+    action: plan_paid_research
+    params:
+      query: "Use the selected DripStack article only if it clears wallet and receipt gates."
+      pair: NEAR/BTC
+      budget_usd: 0.05
+      max_sources: 1
+      min_relevance: 0.2
+      min_trust_score: 0.4
+      spending_mode: quote
+      preferred_payment_protocols: [mpp, x402]
+      agent_wallet:
+        provider: AgentCash
+        network: base
+        address: "0x3333333333333333333333333333333333333333"
+        balance_usd: 5.0
+        per_article_cap_usd: 0.05
+        daily_cap_usd: 1.0
+        max_wallet_balance_usd: 5.0
+      sources:
+        - "$drip_source"
+    expect:
+      paid_research_schema_version: paid-research-plan/1
+      paid_research_selected_min: 1
+      paid_research_allocated_le: 0.05
+      paid_research_has_rail: mpp
+      paid_research_near_funding_routes_min: 1

--- a/tools-src/portfolio/scenarios/intents-trading-agent-episode.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-episode.yaml
@@ -1,0 +1,74 @@
+id: intents-trading-agent-episode
+description: |
+  Validates an episode (candles + solver fixture + news context), then
+  replays it through backtest_suite. Verifies the shared episode shape
+  routes candles into the suite and surfaces the solver fixture intact.
+steps:
+  - name: validate
+    action: validate_episode
+    params:
+      episode:
+        id: near-usdc-2026-q1-mini
+        pair: NEAR/USDC
+        timeframe: "1d"
+        source: manual
+        generated_at: "2026-05-02T22:00:00Z"
+        notes: "Mini fixture for replay-suite coverage; not a real market window."
+        solver_fixture:
+          kind: swap
+          chain: near
+          from: NEAR
+          to: USDC
+          quote_amount: "0.05"
+        news_context:
+          - ts: "2026-04-30"
+            headline: "Hypothetical NEAR governance proposal opens"
+            url: "https://example.test/n1"
+            source: example
+            kind: governance
+        candles:
+          - {ts: "2026-04-01T00:00:00Z", open: 3.00, high: 3.05, low: 2.98, close: 3.02, volume: 1000}
+          - {ts: "2026-04-02T00:00:00Z", open: 3.02, high: 3.10, low: 3.00, close: 3.08, volume: 1100}
+          - {ts: "2026-04-03T00:00:00Z", open: 3.08, high: 3.15, low: 3.05, close: 3.12, volume: 1200}
+          - {ts: "2026-04-04T00:00:00Z", open: 3.12, high: 3.20, low: 3.10, close: 3.18, volume: 1300}
+          - {ts: "2026-04-05T00:00:00Z", open: 3.18, high: 3.25, low: 3.15, close: 3.22, volume: 1400}
+          - {ts: "2026-04-06T00:00:00Z", open: 3.22, high: 3.30, low: 3.20, close: 3.28, volume: 1500}
+          - {ts: "2026-04-07T00:00:00Z", open: 3.28, high: 3.35, low: 3.25, close: 3.32, volume: 1600}
+          - {ts: "2026-04-08T00:00:00Z", open: 3.32, high: 3.40, low: 3.30, close: 3.38, volume: 1700}
+    expect:
+      backtest_schema_version: intents-episode/1
+      episode_summary_candles: 8
+  - name: replay
+    action: replay_episode
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 0
+      slippage_bps: 0
+      episode:
+        id: near-usdc-2026-q1-mini
+        pair: NEAR/USDC
+        timeframe: "1d"
+        source: manual
+        solver_fixture:
+          kind: swap
+          chain: near
+          from: NEAR
+          to: USDC
+        news_context: []
+        candles:
+          - {ts: "2026-04-01T00:00:00Z", open: 3.00, high: 3.05, low: 2.98, close: 3.02, volume: 1000}
+          - {ts: "2026-04-02T00:00:00Z", open: 3.02, high: 3.10, low: 3.00, close: 3.08, volume: 1100}
+          - {ts: "2026-04-03T00:00:00Z", open: 3.08, high: 3.15, low: 3.05, close: 3.12, volume: 1200}
+          - {ts: "2026-04-04T00:00:00Z", open: 3.12, high: 3.20, low: 3.10, close: 3.18, volume: 1300}
+          - {ts: "2026-04-05T00:00:00Z", open: 3.18, high: 3.25, low: 3.15, close: 3.22, volume: 1400}
+          - {ts: "2026-04-06T00:00:00Z", open: 3.22, high: 3.30, low: 3.20, close: 3.28, volume: 1500}
+          - {ts: "2026-04-07T00:00:00Z", open: 3.28, high: 3.35, low: 3.25, close: 3.32, volume: 1600}
+          - {ts: "2026-04-08T00:00:00Z", open: 3.32, high: 3.40, low: 3.30, close: 3.38, volume: 1700}
+      candidates:
+        - id: buy_hold
+          strategy:
+            kind: buy-hold
+    expect:
+      backtest_schema_version: intents-episode-replay/1
+      episode_replay_top_trades_min: 1
+      episode_replay_solver_kind: swap

--- a/tools-src/portfolio/scenarios/intents-trading-agent-grid.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-grid.yaml
@@ -1,0 +1,57 @@
+id: intents-trading-agent-grid
+description: |
+  Cartesian sweep over fast_window x slow_window for an SMA-cross strategy
+  on a steady uptrend candle series. Verifies enumeration count, suite
+  ranking integration, and that at least one cell clears the basic gate.
+steps:
+  - name: sma_grid
+    action: backtest_grid
+    params:
+      base:
+        kind: sma-cross
+        fast_window: 5
+        slow_window: 20
+      axes:
+        - param: fast_window
+          values: [3, 5, 8]
+        - param: slow_window
+          values: [12, 20]
+      max_cells: 32
+      initial_cash_usd: 1000
+      fee_bps: 0
+      slippage_bps: 0
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-06T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-07T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-08T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-09T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-10T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-11T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-12T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-13T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-14T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-15T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-16T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-17T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-18T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-19T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-20T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-21T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-22T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-23T00:00:00Z", open: 102.0, high: 103.0, low: 101.0, close: 103.0, volume: 1000}
+        - {ts: "2026-01-24T00:00:00Z", open: 104.0, high: 105.0, low: 103.0, close: 105.0, volume: 1000}
+        - {ts: "2026-01-25T00:00:00Z", open: 106.0, high: 107.0, low: 105.0, close: 107.0, volume: 1000}
+        - {ts: "2026-01-26T00:00:00Z", open: 108.0, high: 109.0, low: 107.0, close: 109.0, volume: 1000}
+        - {ts: "2026-01-27T00:00:00Z", open: 110.0, high: 111.0, low: 109.0, close: 111.0, volume: 1000}
+        - {ts: "2026-01-28T00:00:00Z", open: 112.0, high: 113.0, low: 111.0, close: 113.0, volume: 1000}
+        - {ts: "2026-01-29T00:00:00Z", open: 114.0, high: 115.0, low: 113.0, close: 115.0, volume: 1000}
+        - {ts: "2026-01-30T00:00:00Z", open: 116.0, high: 117.0, low: 115.0, close: 117.0, volume: 1000}
+    expect:
+      backtest_schema_version: intents-grid/1
+      grid_cells_len: 6
+      grid_top_passes_basic_gate: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-montecarlo.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-montecarlo.yaml
@@ -1,0 +1,31 @@
+id: intents-trading-agent-montecarlo
+description: |
+  Trade-order Monte Carlo with a fixed seed. Bounds the median return so a
+  regression in the xorshift64* PRNG, the resampling logic, or the equity
+  compounding is detected. Loss probability is bounded loosely because the
+  trade sample is intentionally small.
+steps:
+  - name: shuffle_resample
+    action: backtest_montecarlo
+    params:
+      trade_returns_pct: [1.5, -0.5, 2.0, -1.0, 0.8, 0.3, -0.2, 1.1, 0.6, -0.4]
+      initial_cash_usd: 1000
+      iterations: 500
+      seed: 42
+      method: shuffle
+    expect:
+      backtest_schema_version: intents-montecarlo/1
+      montecarlo_iterations: 500
+      montecarlo_p50_within: [-5, 15]
+  - name: permute_preserves_mean
+    action: backtest_montecarlo
+    params:
+      trade_returns_pct: [1.0, -0.5, 1.5, -0.2, 0.7]
+      initial_cash_usd: 1000
+      iterations: 250
+      seed: 7
+      method: permute
+    expect:
+      backtest_schema_version: intents-montecarlo/1
+      montecarlo_iterations: 250
+      montecarlo_p50_within: [2.4, 2.6]

--- a/tools-src/portfolio/scenarios/intents-trading-agent-near-trial.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-near-trial.yaml
@@ -1,0 +1,115 @@
+id: intents-trading-agent-near-trial
+description: |
+  Plans a nominal-NEAR rehearsal: rank strategies, prepare a small
+  paper/quote budget, keep the generated build_intent request unsigned,
+  and surface the trial state in the console widget.
+steps:
+  - name: rank_trial_strategies
+    action: backtest_suite
+    params:
+      initial_cash_usd: 1000
+      fee_bps: 10
+      slippage_bps: 5
+      candidates:
+        - id: buy_hold_baseline
+          strategy:
+            kind: buy-hold
+        - id: sma_cross_fast
+          max_position_pct: 0.8
+          stop_loss_bps: 1200
+          strategy:
+            kind: sma-cross
+            fast_window: 2
+            slow_window: 4
+        - id: momentum_rotation
+          max_position_pct: 0.8
+          stop_loss_bps: 1000
+          strategy:
+            kind: momentum
+            lookback_window: 3
+            threshold_bps: 500
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 10.0, high: 10.2, low: 9.8, close: 10.0, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 10.2, high: 10.7, low: 10.0, close: 10.5, volume: 1200}
+        - {ts: "2026-01-06T00:00:00Z", open: 10.6, high: 11.2, low: 10.5, close: 11.0, volume: 1300}
+        - {ts: "2026-01-07T00:00:00Z", open: 11.1, high: 12.1, low: 11.0, close: 12.0, volume: 1400}
+        - {ts: "2026-01-08T00:00:00Z", open: 12.1, high: 13.1, low: 12.0, close: 13.0, volume: 1500}
+        - {ts: "2026-01-09T00:00:00Z", open: 13.1, high: 14.1, low: 13.0, close: 14.0, volume: 1600}
+        - {ts: "2026-01-10T00:00:00Z", open: 13.8, high: 14.0, low: 12.8, close: 13.0, volume: 1500}
+        - {ts: "2026-01-11T00:00:00Z", open: 12.8, high: 13.0, low: 11.8, close: 12.0, volume: 1400}
+        - {ts: "2026-01-12T00:00:00Z", open: 11.8, high: 12.0, low: 10.8, close: 11.0, volume: 1300}
+        - {ts: "2026-01-13T00:00:00Z", open: 10.8, high: 11.0, low: 9.8, close: 10.0, volume: 1200}
+        - {ts: "2026-01-14T00:00:00Z", open: 9.8, high: 10.0, low: 8.8, close: 9.0, volume: 1100}
+    capture:
+      backtest_suite_var: suite
+    expect:
+      backtest_suite_schema_version: intents-backtest-suite/1
+      backtest_suite_any_passes_basic_gate: true
+
+  - name: plan_nominal_near_trial
+    action: plan_near_intents_trial
+    params:
+      near_account_id: tester.near
+      mode: paper
+      pair: NEAR/USDC
+      nominal_near: 0.25
+      max_trade_near: 0.05
+      assumed_near_usd: 3.0
+      max_slippage_bps: 50
+      backtest_suite: "$suite"
+    capture:
+      trial_plan_var: trial
+    expect:
+      near_trial_schema_version: near-intents-trial-plan/1
+      near_trial_safe_to_quote: true
+      near_trial_build_solver: fixture
+
+  - name: widget_with_trial_plan
+    action: format_intents_widget
+    params:
+      generated_at: "2026-05-02T17:30:00Z"
+      project_id: intents-trading-agent
+      mode: paper
+      pair: NEAR/USDC
+      stance: paper-intent
+      confidence: 0.7
+      backtest_suite: "$suite"
+      trial_plan: "$trial"
+      risk_gates:
+        - name: unsigned-only
+          status: pass
+          detail: Wallet signature required outside the agent.
+      next_action: Run paper mode before requesting a live quote.
+    expect:
+      intents_widget_schema_version: intents-trading-widget/1
+      intents_widget_top_candidates_min: 1
+      intents_widget_trial_safe_to_quote: true
+
+  - name: paid_fetch_requires_confirmation
+    action: prepare_dripstack_paid_fetch
+    params:
+      publication_slug: premiumcrypto.substack.com
+      post_slug: near-intents-liquidity
+      title: NEAR Intents liquidity and solver-routing risk
+      price_usd: 0.01
+      payment_protocol: mpp
+      user_confirmed_purchase: false
+    expect:
+      dripstack_paid_fetch_status: needs-user-confirmation
+
+  - name: paid_fetch_with_receipt_header
+    action: prepare_dripstack_paid_fetch
+    params:
+      publication_slug: premiumcrypto.substack.com
+      post_slug: near-intents-liquidity
+      title: NEAR Intents liquidity and solver-routing risk
+      price_usd: 0.05
+      payment_protocol: mpp
+      user_confirmed_purchase: true
+      mpp_authorization: "signed-payment-credential-placeholder"
+    expect:
+      dripstack_paid_fetch_status: ready-to-retry-with-receipt
+      dripstack_paid_fetch_headers_min: 1

--- a/tools-src/portfolio/scenarios/intents-trading-agent-nl-compile.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-nl-compile.yaml
@@ -1,0 +1,58 @@
+id: intents-trading-agent-nl-compile
+description: |
+  Natural-language compile pass over the four supported intent kinds
+  plus a no-op. Verifies recommended action, structured params, and
+  confidence floor.
+steps:
+  - name: dca_six_months_into_near
+    action: compile_intent_prompt
+    params:
+      prompt: "DCA $100 weekly into NEAR for 6 months"
+    expect:
+      backtest_schema_version: intents-nl-compile/1
+      nl_intent_kind: dca-schedule
+      nl_recommended_action: plan_dca_schedule
+      nl_param_eq:
+        pair: "NEAR/USDC"
+        cadence: "weekly"
+        total_periods: 25
+        notional_per_period_usd: 100.0
+      nl_confidence_min: 0.7
+  - name: swap_btc_to_usdc
+    action: compile_intent_prompt
+    params:
+      prompt: "swap 0.5 BTC to USDC on near"
+    expect:
+      nl_intent_kind: swap
+      nl_recommended_action: build_intent
+  - name: backtest_sma_pair
+    action: compile_intent_prompt
+    params:
+      prompt: "backtest sma 5/20 on NEAR/USDC"
+    expect:
+      nl_intent_kind: backtest
+      nl_recommended_action: backtest_suite
+  - name: research_pair
+    action: compile_intent_prompt
+    params:
+      prompt: "research catalyst risk on NEAR/USDC this week"
+    expect:
+      nl_intent_kind: research
+      nl_recommended_action: plan_paid_research
+      nl_param_eq:
+        pair: "NEAR/USDC"
+        budget_usd: 0.0
+  - name: watch_btc_breakout
+    action: compile_intent_prompt
+    params:
+      prompt: "watch BTC for breakout above 70000"
+    expect:
+      nl_intent_kind: watch
+      nl_recommended_action: format_intents_widget
+  - name: unsupported_prompt
+    action: compile_intent_prompt
+    params:
+      prompt: "hello there"
+    expect:
+      nl_intent_kind: unsupported
+      nl_recommended_action: noop

--- a/tools-src/portfolio/scenarios/intents-trading-agent-paid-research.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-paid-research.yaml
@@ -1,0 +1,132 @@
+id: intents-trading-agent-paid-research
+description: |
+  Plans a DripStack-style premium research query before using paid
+  source text in a NEAR Intents trading decision. The plan selects
+  payable MPP/x402 sources under budget, creates NEAR funding-route
+  hints, and feeds attribution into the project widget state.
+steps:
+  - name: paid_research_plan
+    action: plan_paid_research
+    params:
+      query: "Should the NEAR/BTC paper intent pay for premium solver liquidity and route risk research before requesting a quote?"
+      pair: NEAR/BTC
+      budget_usd: 0.05
+      max_sources: 3
+      min_relevance: 0.35
+      max_source_age_days: 14
+      spending_mode: quote
+      near_funding_asset: USDC.near
+      required_tags: [near-intents]
+      sources:
+        - id: premium-near-liquidity
+          title: "NEAR/BTC solver liquidity note"
+          author: "Premium Macro Writer"
+          publisher: "DripStack Research"
+          url: "https://example.com/near-btc-liquidity"
+          summary: "Premium note on NEAR Intents solver depth, BTC routing, slippage, and quote risk."
+          tags: [near-intents, btc, liquidity]
+          price_usd: 0.02
+          relevance: 0.92
+          trust_score: 0.82
+          freshness_score: 0.95
+          age_days: 1
+          payment:
+            protocol: mpp
+            network: tempo
+            asset: USDC
+            recipient: "0x1111111111111111111111111111111111111111"
+            endpoint: "https://example.com/near-btc-liquidity/pay"
+        - id: base-x402-route-risk
+          title: "Intent route risk memo"
+          author: "Onchain Researcher"
+          publisher: "Route Desk"
+          url: "https://example.com/intent-route-risk"
+          summary: "x402 paid memo covering Base, NEAR Intents, solver route expiry, and BTC destination risk."
+          tags: [near-intents, route-risk, btc]
+          price_usd: 0.02
+          relevance: 0.89
+          trust_score: 0.78
+          freshness_score: 0.9
+          age_days: 2
+          payment:
+            protocol: x402
+            network: base
+            asset: USDC
+            recipient: "0x2222222222222222222222222222222222222222"
+            endpoint: "https://example.com/intent-route-risk/pay"
+        - id: stale-alpha
+          title: "Old NEAR/BTC alpha note"
+          author: "Archive Writer"
+          publisher: "Old Desk"
+          url: "https://example.com/stale-alpha"
+          summary: "Old note on NEAR/BTC market structure."
+          tags: [near-intents, btc]
+          price_usd: 0.01
+          relevance: 0.7
+          trust_score: 0.5
+          freshness_score: 0.2
+          age_days: 60
+          payment:
+            protocol: x402
+            network: base
+            asset: USDC
+        - id: expensive-premium-pack
+          title: "Premium intent execution pack"
+          author: "Institutional Desk"
+          publisher: "Expensive Research"
+          url: "https://example.com/expensive-pack"
+          summary: "Broad premium pack on NEAR Intents and cross-chain execution."
+          tags: [near-intents, btc]
+          price_usd: 0.20
+          relevance: 0.95
+          trust_score: 0.9
+          freshness_score: 0.9
+          age_days: 1
+          payment:
+            protocol: mpp
+            network: tempo
+            asset: USDC
+    capture:
+      paid_research_plan_var: paid_plan
+    expect:
+      paid_research_schema_version: paid-research-plan/1
+      paid_research_selected_min: 2
+      paid_research_allocated_le: 0.05
+      paid_research_has_rail: x402
+      paid_research_near_funding_routes_min: 2
+  - name: format_console_state
+    action: format_intents_widget
+    params:
+      generated_at: "2026-05-02T19:15:00Z"
+      project_id: intents-trading-agent
+      mode: paper
+      pair: NEAR/BTC
+      stance: watch
+      confidence: 0.68
+      paid_research_plan: "$paid_plan"
+      backtest_suite:
+        schema_version: intents-backtest-suite/1
+        ranked:
+          - rank: 1
+            id: sma_cross_fast
+            strategy: {kind: sma-cross}
+            selection_score: 18.5
+            passes_basic_gate: true
+            metrics:
+              total_return_pct: 12.0
+              alpha_vs_buy_hold_pct: 3.0
+              max_drawdown_pct: 8.0
+              trades: 6
+      risk_gates:
+        - {name: receipt-before-use, status: pass, detail: "Paid source text is blocked until receipts exist."}
+        - {name: backtest-required, status: pass, detail: "Premium research cannot bypass the strategy suite."}
+      research_sources:
+        - https://dripstack.xyz
+        - https://mpp.dev
+        - https://docs.x402.org/
+      next_action: "Pay for selected sources only after user approval, then re-run research before building any unsigned intent."
+    expect:
+      intents_widget_schema_version: intents-trading-widget/1
+      intents_widget_top_candidates_min: 1
+      intents_widget_paid_sources_min: 2
+      intents_widget_paid_ready: true

--- a/tools-src/portfolio/scenarios/intents-trading-agent-swap.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-swap.yaml
@@ -1,0 +1,46 @@
+id: intents-trading-agent-swap
+description: |
+  Smoke test for the Intents Trading Agent skill. A paper-mode
+  TradingAgents-style workflow drafts a spot swap MovementPlan
+  (USDC -> BTC on NEAR) and asks portfolio.build_intent to turn it
+  into an unsigned portfolio-intent/1 bundle. The replay solver fixture
+  keeps the test deterministic while exercising the same parser and
+  bounded checks used by live solver responses.
+steps:
+  - name: build_paper_swap_intent
+    action: build_intent
+    params:
+      plan:
+        proposal_id: ita-swap-near-usdc-btc
+        legs:
+          - kind: swap
+            chain: near
+            from_token:
+              symbol: USDC
+              chain: near
+              amount: "100.00"
+              value_usd: "100.00"
+            to_token:
+              symbol: BTC
+              chain: near
+              amount: "0.00100000"
+              value_usd: "98.50"
+            description: Swap 100 USDC to BTC through a NEAR Intents route
+        expected_out:
+          symbol: BTC
+          chain: near
+          amount: "0.00100000"
+          value_usd: "98.50"
+        expected_cost_usd: "1.50"
+      config:
+        floor_apy: 0.04
+        max_risk_score: 3
+        notify_threshold_usd: 25
+        auto_intent_ceiling_usd: 100
+        max_slippage_bps: 50
+        allowed_chains: ["near"]
+      solver: replay
+    expect:
+      bundle_legs_min: 1
+      bundle_first_leg_kind: swap
+      bundle_schema_version: portfolio-intent/1

--- a/tools-src/portfolio/scenarios/intents-trading-agent-walkforward.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-walkforward.yaml
@@ -1,0 +1,65 @@
+id: intents-trading-agent-walkforward
+description: |
+  Runs a fixed-strategy walk-forward across four contiguous folds on a
+  long-uptrend candle series. Buy-and-hold is the baseline because its
+  out-of-sample return is bounded by the fold window's drift, which keeps
+  the test deterministic. The aggregate robustness verdict is asserted to
+  fall in {robust, fragile} (overfit would indicate a regression).
+steps:
+  - name: walkforward_buy_hold
+    action: backtest_walkforward
+    params:
+      n_folds: 4
+      train_pct: 0.7
+      embargo: 1
+      initial_cash_usd: 1000
+      fee_bps: 0
+      slippage_bps: 0
+      max_position_pct: 1
+      strategy:
+        kind: buy-hold
+      candles:
+        - {ts: "2026-01-01T00:00:00Z", open: 100.0, high: 101.0, low: 99.0, close: 100.0, volume: 1000}
+        - {ts: "2026-01-02T00:00:00Z", open: 100.5, high: 101.5, low: 99.5, close: 101.0, volume: 1000}
+        - {ts: "2026-01-03T00:00:00Z", open: 101.5, high: 102.5, low: 100.5, close: 102.0, volume: 1000}
+        - {ts: "2026-01-04T00:00:00Z", open: 102.5, high: 103.5, low: 101.5, close: 103.0, volume: 1000}
+        - {ts: "2026-01-05T00:00:00Z", open: 103.5, high: 104.5, low: 102.5, close: 104.0, volume: 1000}
+        - {ts: "2026-01-06T00:00:00Z", open: 104.5, high: 105.5, low: 103.5, close: 105.0, volume: 1000}
+        - {ts: "2026-01-07T00:00:00Z", open: 105.5, high: 106.5, low: 104.5, close: 106.0, volume: 1000}
+        - {ts: "2026-01-08T00:00:00Z", open: 106.5, high: 107.5, low: 105.5, close: 107.0, volume: 1000}
+        - {ts: "2026-01-09T00:00:00Z", open: 107.5, high: 108.5, low: 106.5, close: 108.0, volume: 1000}
+        - {ts: "2026-01-10T00:00:00Z", open: 108.5, high: 109.5, low: 107.5, close: 109.0, volume: 1000}
+        - {ts: "2026-01-11T00:00:00Z", open: 109.5, high: 110.5, low: 108.5, close: 110.0, volume: 1000}
+        - {ts: "2026-01-12T00:00:00Z", open: 110.5, high: 111.5, low: 109.5, close: 111.0, volume: 1000}
+        - {ts: "2026-01-13T00:00:00Z", open: 111.5, high: 112.5, low: 110.5, close: 112.0, volume: 1000}
+        - {ts: "2026-01-14T00:00:00Z", open: 112.5, high: 113.5, low: 111.5, close: 113.0, volume: 1000}
+        - {ts: "2026-01-15T00:00:00Z", open: 113.5, high: 114.5, low: 112.5, close: 114.0, volume: 1000}
+        - {ts: "2026-01-16T00:00:00Z", open: 114.5, high: 115.5, low: 113.5, close: 115.0, volume: 1000}
+        - {ts: "2026-01-17T00:00:00Z", open: 115.5, high: 116.5, low: 114.5, close: 116.0, volume: 1000}
+        - {ts: "2026-01-18T00:00:00Z", open: 116.5, high: 117.5, low: 115.5, close: 117.0, volume: 1000}
+        - {ts: "2026-01-19T00:00:00Z", open: 117.5, high: 118.5, low: 116.5, close: 118.0, volume: 1000}
+        - {ts: "2026-01-20T00:00:00Z", open: 118.5, high: 119.5, low: 117.5, close: 119.0, volume: 1000}
+        - {ts: "2026-01-21T00:00:00Z", open: 119.5, high: 120.5, low: 118.5, close: 120.0, volume: 1000}
+        - {ts: "2026-01-22T00:00:00Z", open: 120.5, high: 121.5, low: 119.5, close: 121.0, volume: 1000}
+        - {ts: "2026-01-23T00:00:00Z", open: 121.5, high: 122.5, low: 120.5, close: 122.0, volume: 1000}
+        - {ts: "2026-01-24T00:00:00Z", open: 122.5, high: 123.5, low: 121.5, close: 123.0, volume: 1000}
+        - {ts: "2026-01-25T00:00:00Z", open: 123.5, high: 124.5, low: 122.5, close: 124.0, volume: 1000}
+        - {ts: "2026-01-26T00:00:00Z", open: 124.5, high: 125.5, low: 123.5, close: 125.0, volume: 1000}
+        - {ts: "2026-01-27T00:00:00Z", open: 125.5, high: 126.5, low: 124.5, close: 126.0, volume: 1000}
+        - {ts: "2026-01-28T00:00:00Z", open: 126.5, high: 127.5, low: 125.5, close: 127.0, volume: 1000}
+        - {ts: "2026-01-29T00:00:00Z", open: 127.5, high: 128.5, low: 126.5, close: 128.0, volume: 1000}
+        - {ts: "2026-01-30T00:00:00Z", open: 128.5, high: 129.5, low: 127.5, close: 129.0, volume: 1000}
+        - {ts: "2026-01-31T00:00:00Z", open: 129.5, high: 130.5, low: 128.5, close: 130.0, volume: 1000}
+        - {ts: "2026-02-01T00:00:00Z", open: 130.5, high: 131.5, low: 129.5, close: 131.0, volume: 1000}
+        - {ts: "2026-02-02T00:00:00Z", open: 131.5, high: 132.5, low: 130.5, close: 132.0, volume: 1000}
+        - {ts: "2026-02-03T00:00:00Z", open: 132.5, high: 133.5, low: 131.5, close: 133.0, volume: 1000}
+        - {ts: "2026-02-04T00:00:00Z", open: 133.5, high: 134.5, low: 132.5, close: 134.0, volume: 1000}
+        - {ts: "2026-02-05T00:00:00Z", open: 134.5, high: 135.5, low: 133.5, close: 135.0, volume: 1000}
+        - {ts: "2026-02-06T00:00:00Z", open: 135.5, high: 136.5, low: 134.5, close: 136.0, volume: 1000}
+        - {ts: "2026-02-07T00:00:00Z", open: 136.5, high: 137.5, low: 135.5, close: 137.0, volume: 1000}
+        - {ts: "2026-02-08T00:00:00Z", open: 137.5, high: 138.5, low: 136.5, close: 138.0, volume: 1000}
+        - {ts: "2026-02-09T00:00:00Z", open: 138.5, high: 139.5, low: 137.5, close: 139.0, volume: 1000}
+    expect:
+      backtest_schema_version: intents-walkforward/1
+      walkforward_folds_len: 4
+      walkforward_robustness_in: ["robust", "fragile"]

--- a/tools-src/portfolio/scenarios/intents-trading-agent-widget.yaml
+++ b/tools-src/portfolio/scenarios/intents-trading-agent-widget.yaml
@@ -1,0 +1,74 @@
+id: intents-trading-agent-widget
+description: |
+  Formats the NEAR Intents trading console state consumed by the
+  project widget. The state is render-ready: ranked strategy choices,
+  risk gates, and unsigned intent preview in one payload.
+steps:
+  - name: format_console_state
+    action: format_intents_widget
+    params:
+      generated_at: "2026-05-02T16:30:00Z"
+      project_id: intents-trading-agent
+      mode: paper
+      pair: NEAR/BTC
+      stance: paper-intent
+      confidence: 0.74
+      backtest_suite:
+        schema_version: intents-backtest-suite/1
+        ranked:
+          - rank: 1
+            id: sma_cross_fast
+            strategy: {kind: sma-cross}
+            selection_score: 18.5
+            passes_basic_gate: true
+            metrics:
+              total_return_pct: 12.0
+              alpha_vs_buy_hold_pct: 3.0
+              max_drawdown_pct: 8.0
+              trades: 6
+          - rank: 2
+            id: buy_hold_baseline
+            strategy: {kind: buy-hold}
+            selection_score: 9.0
+            passes_basic_gate: true
+            metrics:
+              total_return_pct: 9.0
+              alpha_vs_buy_hold_pct: 0.0
+              max_drawdown_pct: 10.0
+              trades: 1
+      risk_gates:
+        - {name: unsigned-only, status: pass, detail: "Wallet signature required outside the agent."}
+        - {name: max-notional, status: pass, detail: "Paper notional is below config ceiling."}
+        - {name: live-quote, status: warn, detail: "Live NEAR Intents quote requires explicit user approval."}
+      intent:
+        status: paper-built
+        route_label: "NEAR -> BTC via NEAR Intents"
+        quote_source: fixture
+        bundle:
+          id: intent-widget-fixture
+          schema_version: portfolio-intent/1
+          total_cost_usd: "0.42"
+          expires_at: 1775000000
+          signer_placeholder: "<signed-by-user>"
+          bounded_checks:
+            max_slippage_bps: 50
+            solver_quote_version: fixture
+            min_out_per_leg:
+              - {symbol: BTC, address: null, chain: near, amount: "0.001", value_usd: "70.00"}
+          legs:
+            - id: leg-1
+              kind: swap
+              chain: near
+              depends_on: null
+              quoted_by: fixture
+              min_out: {symbol: BTC, address: null, chain: near, amount: "0.001", value_usd: "70.00"}
+              near_intent_payload:
+                intent: token_diff
+      research_sources:
+        - https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay
+        - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint
+      next_action: "Ask the user before requesting a live NEAR Intents quote."
+    expect:
+      intents_widget_schema_version: intents-trading-widget/1
+      intents_widget_top_candidates_min: 2
+      intents_widget_intent_status: paper-built

--- a/tools-src/portfolio/src/backtest.rs
+++ b/tools-src/portfolio/src/backtest.rs
@@ -597,6 +597,7 @@ fn enter_trade(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn exit_trade(
     idx: usize,
     candle: &Candle,
@@ -816,6 +817,7 @@ fn rsi(candles: &[Candle], end_idx: usize, window: usize) -> Option<f64> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn compute_metrics(
     initial_cash: f64,
     end_cash: f64,

--- a/tools-src/portfolio/src/backtest.rs
+++ b/tools-src/portfolio/src/backtest.rs
@@ -1,0 +1,1179 @@
+//! Deterministic spot backtesting for the Intents Trading Agent.
+//!
+//! This is intentionally small and pure: no exchange adapters, no
+//! external market data fetches, and no live orders. The skill passes
+//! candle data in, this module evaluates long-only strategy rules, and
+//! returns metrics plus a trade log. Execution uses the next candle's
+//! open after a signal is formed on a closed candle, which keeps replay
+//! tests honest and avoids lookahead by construction.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BacktestInput {
+    pub candles: Vec<Candle>,
+    pub strategy: StrategyConfig,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+    #[serde(default = "default_fee_bps")]
+    pub fee_bps: f64,
+    #[serde(default = "default_slippage_bps")]
+    pub slippage_bps: f64,
+    #[serde(default = "default_max_position_pct")]
+    pub max_position_pct: f64,
+    #[serde(default)]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(default)]
+    pub take_profit_bps: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BacktestSuiteInput {
+    pub candles: Vec<Candle>,
+    pub candidates: Vec<BacktestCandidate>,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+    #[serde(default = "default_fee_bps")]
+    pub fee_bps: f64,
+    #[serde(default = "default_slippage_bps")]
+    pub slippage_bps: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BacktestCandidate {
+    pub id: String,
+    pub strategy: StrategyConfig,
+    #[serde(default)]
+    pub max_position_pct: Option<f64>,
+    #[serde(default)]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(default)]
+    pub take_profit_bps: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Candle {
+    pub ts: String,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    #[serde(default)]
+    pub volume: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StrategyConfig {
+    /// Supported values: "buy-hold", "sma-cross", "breakout",
+    /// "mean-reversion", "momentum", "rsi-mean-reversion".
+    pub kind: String,
+    #[serde(default)]
+    pub fast_window: Option<usize>,
+    #[serde(default)]
+    pub slow_window: Option<usize>,
+    #[serde(default)]
+    pub lookback_window: Option<usize>,
+    #[serde(default)]
+    pub threshold_bps: Option<f64>,
+    #[serde(default)]
+    pub entry_threshold: Option<f64>,
+    #[serde(default)]
+    pub exit_threshold: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BacktestOutput {
+    pub schema_version: &'static str,
+    pub strategy: StrategySummary,
+    pub metrics: BacktestMetrics,
+    pub trades: Vec<BacktestTrade>,
+    pub equity_curve: Vec<EquityPoint>,
+    pub warnings: Vec<String>,
+    pub lookahead_safe: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BacktestSuiteOutput {
+    pub schema_version: &'static str,
+    pub ranked: Vec<BacktestSuiteResult>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BacktestSuiteResult {
+    pub rank: usize,
+    pub id: String,
+    pub strategy: StrategySummary,
+    pub selection_score: f64,
+    pub passes_basic_gate: bool,
+    pub metrics: BacktestMetrics,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StrategySummary {
+    pub kind: String,
+    pub fast_window: Option<usize>,
+    pub slow_window: Option<usize>,
+    pub lookback_window: Option<usize>,
+    pub threshold_bps: Option<f64>,
+    pub entry_threshold: Option<f64>,
+    pub exit_threshold: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BacktestMetrics {
+    pub candles: usize,
+    pub trades: usize,
+    pub start_equity_usd: String,
+    pub end_equity_usd: String,
+    pub total_return_pct: f64,
+    pub buy_hold_return_pct: f64,
+    pub alpha_vs_buy_hold_pct: f64,
+    pub max_drawdown_pct: f64,
+    pub win_rate_pct: f64,
+    pub exposure_pct: f64,
+    pub profit_factor: f64,
+    pub average_trade_return_pct: f64,
+    pub return_stability: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BacktestTrade {
+    pub entry_index: usize,
+    pub exit_index: usize,
+    pub entry_ts: String,
+    pub exit_ts: String,
+    pub entry_price: String,
+    pub exit_price: String,
+    pub units: String,
+    pub gross_pnl_usd: String,
+    pub net_pnl_usd: String,
+    pub return_pct: f64,
+    pub exit_reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EquityPoint {
+    pub index: usize,
+    pub ts: String,
+    pub equity_usd: String,
+    pub in_position: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Signal {
+    Enter,
+    Exit,
+    Hold,
+}
+
+#[derive(Debug, Clone)]
+struct OpenTrade {
+    entry_index: usize,
+    entry_ts: String,
+    entry_price: f64,
+    units: f64,
+    entry_notional: f64,
+    entry_fee: f64,
+}
+
+fn default_initial_cash_usd() -> f64 {
+    10_000.0
+}
+
+fn default_fee_bps() -> f64 {
+    10.0
+}
+
+fn default_slippage_bps() -> f64 {
+    5.0
+}
+
+fn default_max_position_pct() -> f64 {
+    1.0
+}
+
+pub fn run(input: BacktestInput) -> Result<BacktestOutput, String> {
+    validate_input(&input)?;
+
+    let mut warnings = vec![
+        "Backtest is long-only spot and does not model funding, borrow, MEV, partial fills, solver expiry, or route refusal.".to_string(),
+        "Signals are generated on closed candles and executed at the next candle open to avoid lookahead.".to_string(),
+    ];
+
+    if input.candles.len() < 30 {
+        warnings.push("Small sample: fewer than 30 candles; metrics are fragile.".to_string());
+    }
+
+    let fee_rate = input.fee_bps / 10_000.0;
+    let slip_rate = input.slippage_bps / 10_000.0;
+    let max_position_pct = input.max_position_pct.clamp(0.0, 1.0);
+
+    let mut cash = input.initial_cash_usd;
+    let mut open: Option<OpenTrade> = None;
+    let mut trades = Vec::new();
+    let mut equity_curve = Vec::with_capacity(input.candles.len());
+    let mut periodic_returns = Vec::new();
+    let mut prior_equity: Option<f64> = None;
+    let mut exposure_count = 0usize;
+    let mut pending = if input.strategy.kind == "buy-hold" {
+        Signal::Enter
+    } else {
+        Signal::Hold
+    };
+
+    for idx in 0..input.candles.len() {
+        let candle = &input.candles[idx];
+
+        match pending {
+            Signal::Enter if open.is_none() => {
+                open = enter_trade(
+                    idx,
+                    candle,
+                    &mut cash,
+                    max_position_pct,
+                    fee_rate,
+                    slip_rate,
+                );
+            }
+            Signal::Exit if open.is_some() => {
+                exit_trade(
+                    idx,
+                    candle,
+                    candle.open * (1.0 - slip_rate),
+                    "signal",
+                    fee_rate,
+                    &mut cash,
+                    &mut open,
+                    &mut trades,
+                );
+            }
+            _ => {}
+        }
+        pending = Signal::Hold;
+
+        if let Some(active) = &open {
+            if let Some(stop_bps) = input.stop_loss_bps {
+                let stop_price = active.entry_price * (1.0 - stop_bps / 10_000.0);
+                if candle.low <= stop_price {
+                    exit_trade(
+                        idx,
+                        candle,
+                        stop_price * (1.0 - slip_rate),
+                        "stop-loss",
+                        fee_rate,
+                        &mut cash,
+                        &mut open,
+                        &mut trades,
+                    );
+                }
+            }
+        }
+
+        if let Some(active) = &open {
+            if let Some(tp_bps) = input.take_profit_bps {
+                let take_profit_price = active.entry_price * (1.0 + tp_bps / 10_000.0);
+                if candle.high >= take_profit_price {
+                    exit_trade(
+                        idx,
+                        candle,
+                        take_profit_price * (1.0 - slip_rate),
+                        "take-profit",
+                        fee_rate,
+                        &mut cash,
+                        &mut open,
+                        &mut trades,
+                    );
+                }
+            }
+        }
+
+        let equity = mark_equity(cash, open.as_ref(), candle.close);
+        if let Some(prev) = prior_equity {
+            if prev > 0.0 {
+                periodic_returns.push((equity / prev) - 1.0);
+            }
+        }
+        prior_equity = Some(equity);
+        if open.is_some() {
+            exposure_count += 1;
+        }
+        equity_curve.push(EquityPoint {
+            index: idx,
+            ts: candle.ts.clone(),
+            equity_usd: format!("{equity:.2}"),
+            in_position: open.is_some(),
+        });
+
+        if idx + 1 < input.candles.len() {
+            pending = signal_at(&input.candles, idx, &input.strategy, open.is_some())?;
+        }
+    }
+
+    if let Some(last) = input.candles.last() {
+        if open.is_some() {
+            let idx = input.candles.len() - 1;
+            exit_trade(
+                idx,
+                last,
+                last.close * (1.0 - slip_rate),
+                "end-of-test",
+                fee_rate,
+                &mut cash,
+                &mut open,
+                &mut trades,
+            );
+            if let Some(point) = equity_curve.last_mut() {
+                point.equity_usd = format!("{cash:.2}");
+                point.in_position = false;
+            }
+        }
+    }
+
+    if trades.is_empty() {
+        warnings.push("No completed trades; inspect strategy windows and thresholds.".to_string());
+    }
+
+    let metrics = compute_metrics(
+        input.initial_cash_usd,
+        cash,
+        &input.candles,
+        &trades,
+        &equity_curve,
+        &periodic_returns,
+        exposure_count,
+        slip_rate,
+    );
+
+    Ok(BacktestOutput {
+        schema_version: "intents-backtest/1",
+        strategy: StrategySummary {
+            kind: input.strategy.kind,
+            fast_window: input.strategy.fast_window,
+            slow_window: input.strategy.slow_window,
+            lookback_window: input.strategy.lookback_window,
+            threshold_bps: input.strategy.threshold_bps,
+            entry_threshold: input.strategy.entry_threshold,
+            exit_threshold: input.strategy.exit_threshold,
+        },
+        metrics,
+        trades,
+        equity_curve,
+        warnings,
+        lookahead_safe: true,
+    })
+}
+
+pub fn run_suite(input: BacktestSuiteInput) -> Result<BacktestSuiteOutput, String> {
+    validate_suite_input(&input)?;
+
+    let mut ranked = Vec::with_capacity(input.candidates.len());
+    for candidate in input.candidates {
+        let output = run(BacktestInput {
+            candles: input.candles.clone(),
+            strategy: candidate.strategy,
+            initial_cash_usd: input.initial_cash_usd,
+            fee_bps: input.fee_bps,
+            slippage_bps: input.slippage_bps,
+            max_position_pct: candidate
+                .max_position_pct
+                .unwrap_or_else(default_max_position_pct),
+            stop_loss_bps: candidate.stop_loss_bps,
+            take_profit_bps: candidate.take_profit_bps,
+        })?;
+
+        let selection_score = selection_score(&output.metrics);
+        let passes_basic_gate = passes_basic_gate(&output.metrics);
+
+        ranked.push(BacktestSuiteResult {
+            rank: 0,
+            id: candidate.id,
+            strategy: output.strategy,
+            selection_score,
+            passes_basic_gate,
+            metrics: output.metrics,
+            warnings: output.warnings,
+        });
+    }
+
+    ranked.sort_by(|a, b| {
+        b.selection_score
+            .partial_cmp(&a.selection_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    for (idx, result) in ranked.iter_mut().enumerate() {
+        result.rank = idx + 1;
+    }
+
+    Ok(BacktestSuiteOutput {
+        schema_version: "intents-backtest-suite/1",
+        ranked,
+        warnings: vec![
+            "Selection score is a deterministic paper-trading heuristic, not expected return."
+                .to_string(),
+            "Use out-of-sample, walk-forward, market-data replay, and solver-route replay before live wallet signing."
+                .to_string(),
+        ],
+    })
+}
+
+fn validate_suite_input(input: &BacktestSuiteInput) -> Result<(), String> {
+    if input.candidates.is_empty() {
+        return Err("backtest_suite requires at least one candidate".to_string());
+    }
+    if !input.initial_cash_usd.is_finite() || input.initial_cash_usd <= 0.0 {
+        return Err("initial_cash_usd must be > 0".to_string());
+    }
+    if !input.fee_bps.is_finite() || input.fee_bps < 0.0 {
+        return Err("fee_bps must be >= 0".to_string());
+    }
+    if !input.slippage_bps.is_finite() || input.slippage_bps < 0.0 {
+        return Err("slippage_bps must be >= 0".to_string());
+    }
+
+    let mut ids = std::collections::BTreeSet::new();
+    for candidate in &input.candidates {
+        if candidate.id.trim().is_empty() {
+            return Err("backtest_suite candidate id must be non-empty".to_string());
+        }
+        if !ids.insert(candidate.id.clone()) {
+            return Err(format!(
+                "backtest_suite candidate id '{}' is duplicated",
+                candidate.id
+            ));
+        }
+        let max_position_pct = candidate
+            .max_position_pct
+            .unwrap_or_else(default_max_position_pct);
+        validate_input(&BacktestInput {
+            candles: input.candles.clone(),
+            strategy: candidate.strategy.clone(),
+            initial_cash_usd: input.initial_cash_usd,
+            fee_bps: input.fee_bps,
+            slippage_bps: input.slippage_bps,
+            max_position_pct,
+            stop_loss_bps: candidate.stop_loss_bps,
+            take_profit_bps: candidate.take_profit_bps,
+        })?;
+    }
+
+    Ok(())
+}
+
+fn selection_score(metrics: &BacktestMetrics) -> f64 {
+    let trade_penalty = if metrics.trades == 0 { 25.0 } else { 0.0 };
+    let drawdown_penalty = metrics.max_drawdown_pct * 0.75;
+    let exposure_penalty = (metrics.exposure_pct - 85.0).max(0.0) * 0.05;
+    let profit_factor_bonus = metrics.profit_factor.clamp(0.0, 5.0) * 2.0;
+    let stability_bonus = metrics.return_stability.clamp(-5.0, 5.0) * 2.0;
+    let score = metrics.total_return_pct + metrics.alpha_vs_buy_hold_pct
+        - drawdown_penalty
+        - exposure_penalty
+        - trade_penalty
+        + (metrics.win_rate_pct * 0.05)
+        + profit_factor_bonus
+        + stability_bonus;
+
+    if score.is_finite() {
+        score
+    } else {
+        -1_000_000.0
+    }
+}
+
+fn passes_basic_gate(metrics: &BacktestMetrics) -> bool {
+    metrics.trades > 0
+        && metrics.total_return_pct > 0.0
+        && metrics.alpha_vs_buy_hold_pct >= -5.0
+        && metrics.max_drawdown_pct <= 35.0
+        && metrics.profit_factor >= 1.0
+}
+
+fn validate_input(input: &BacktestInput) -> Result<(), String> {
+    if input.candles.len() < 2 {
+        return Err("backtest requires at least 2 candles".to_string());
+    }
+    if !input.initial_cash_usd.is_finite() || input.initial_cash_usd <= 0.0 {
+        return Err("initial_cash_usd must be > 0".to_string());
+    }
+    if !input.fee_bps.is_finite() || input.fee_bps < 0.0 {
+        return Err("fee_bps must be >= 0".to_string());
+    }
+    if !input.slippage_bps.is_finite() || input.slippage_bps < 0.0 {
+        return Err("slippage_bps must be >= 0".to_string());
+    }
+    if !input.max_position_pct.is_finite()
+        || input.max_position_pct <= 0.0
+        || input.max_position_pct > 1.0
+    {
+        return Err("max_position_pct must be in (0, 1]".to_string());
+    }
+    for (idx, c) in input.candles.iter().enumerate() {
+        for (name, value) in [
+            ("open", c.open),
+            ("high", c.high),
+            ("low", c.low),
+            ("close", c.close),
+        ] {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(format!("candle {idx} {name} must be > 0"));
+            }
+        }
+        if c.high < c.low || c.high < c.open || c.high < c.close {
+            return Err(format!("candle {idx} high is inconsistent"));
+        }
+        if c.low > c.open || c.low > c.close {
+            return Err(format!("candle {idx} low is inconsistent"));
+        }
+    }
+
+    match input.strategy.kind.as_str() {
+        "buy-hold" => {}
+        "sma-cross" => {
+            let fast = input.strategy.fast_window.unwrap_or(5);
+            let slow = input.strategy.slow_window.unwrap_or(20);
+            if fast == 0 || slow == 0 || fast >= slow {
+                return Err("sma-cross requires 0 < fast_window < slow_window".to_string());
+            }
+        }
+        "breakout" => {
+            let lookback = input.strategy.lookback_window.unwrap_or(20);
+            if lookback == 0 {
+                return Err("breakout requires lookback_window > 0".to_string());
+            }
+        }
+        "mean-reversion" => {
+            let lookback = input.strategy.lookback_window.unwrap_or(20);
+            if lookback == 0 {
+                return Err("mean-reversion requires lookback_window > 0".to_string());
+            }
+        }
+        "momentum" => {
+            let lookback = input.strategy.lookback_window.unwrap_or(20);
+            if lookback == 0 {
+                return Err("momentum requires lookback_window > 0".to_string());
+            }
+        }
+        "rsi-mean-reversion" => {
+            let lookback = input.strategy.lookback_window.unwrap_or(14);
+            if lookback == 0 {
+                return Err("rsi-mean-reversion requires lookback_window > 0".to_string());
+            }
+        }
+        other => return Err(format!("unknown backtest strategy kind: {other}")),
+    }
+
+    Ok(())
+}
+
+fn enter_trade(
+    idx: usize,
+    candle: &Candle,
+    cash: &mut f64,
+    max_position_pct: f64,
+    fee_rate: f64,
+    slip_rate: f64,
+) -> Option<OpenTrade> {
+    if *cash <= 0.0 {
+        return None;
+    }
+    let execution_price = candle.open * (1.0 + slip_rate);
+    let notional = (*cash * max_position_pct) / (1.0 + fee_rate);
+    if notional <= 0.0 {
+        return None;
+    }
+    let fee = notional * fee_rate;
+    let units = notional / execution_price;
+    *cash -= notional + fee;
+    Some(OpenTrade {
+        entry_index: idx,
+        entry_ts: candle.ts.clone(),
+        entry_price: execution_price,
+        units,
+        entry_notional: notional,
+        entry_fee: fee,
+    })
+}
+
+fn exit_trade(
+    idx: usize,
+    candle: &Candle,
+    execution_price: f64,
+    reason: &str,
+    fee_rate: f64,
+    cash: &mut f64,
+    open: &mut Option<OpenTrade>,
+    trades: &mut Vec<BacktestTrade>,
+) {
+    let Some(active) = open.take() else {
+        return;
+    };
+    let exit_notional = active.units * execution_price;
+    let exit_fee = exit_notional * fee_rate;
+    *cash += exit_notional - exit_fee;
+
+    let gross_pnl = exit_notional - active.entry_notional;
+    let net_pnl = gross_pnl - active.entry_fee - exit_fee;
+    let denom = active.entry_notional + active.entry_fee;
+    let return_pct = if denom > 0.0 {
+        (net_pnl / denom) * 100.0
+    } else {
+        0.0
+    };
+
+    trades.push(BacktestTrade {
+        entry_index: active.entry_index,
+        exit_index: idx,
+        entry_ts: active.entry_ts,
+        exit_ts: candle.ts.clone(),
+        entry_price: format!("{:.8}", active.entry_price),
+        exit_price: format!("{execution_price:.8}"),
+        units: format!("{:.8}", active.units),
+        gross_pnl_usd: format!("{gross_pnl:.2}"),
+        net_pnl_usd: format!("{net_pnl:.2}"),
+        return_pct,
+        exit_reason: reason.to_string(),
+    });
+}
+
+fn mark_equity(cash: f64, open: Option<&OpenTrade>, close: f64) -> f64 {
+    cash + open.map(|t| t.units * close).unwrap_or(0.0)
+}
+
+fn signal_at(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    match strategy.kind.as_str() {
+        "buy-hold" => Ok(Signal::Hold),
+        "sma-cross" => sma_cross_signal(candles, idx, strategy, in_position),
+        "breakout" => breakout_signal(candles, idx, strategy, in_position),
+        "mean-reversion" => mean_reversion_signal(candles, idx, strategy, in_position),
+        "momentum" => momentum_signal(candles, idx, strategy, in_position),
+        "rsi-mean-reversion" => rsi_signal(candles, idx, strategy, in_position),
+        other => Err(format!("unknown backtest strategy kind: {other}")),
+    }
+}
+
+fn sma_cross_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let fast = strategy.fast_window.unwrap_or(5);
+    let slow = strategy.slow_window.unwrap_or(20);
+    if idx < slow {
+        return Ok(Signal::Hold);
+    }
+    let Some(fast_prev) = sma(candles, idx - 1, fast) else {
+        return Ok(Signal::Hold);
+    };
+    let Some(slow_prev) = sma(candles, idx - 1, slow) else {
+        return Ok(Signal::Hold);
+    };
+    let Some(fast_now) = sma(candles, idx, fast) else {
+        return Ok(Signal::Hold);
+    };
+    let Some(slow_now) = sma(candles, idx, slow) else {
+        return Ok(Signal::Hold);
+    };
+
+    if !in_position && fast_prev <= slow_prev && fast_now > slow_now {
+        Ok(Signal::Enter)
+    } else if in_position && fast_prev >= slow_prev && fast_now < slow_now {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn breakout_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let lookback = strategy.lookback_window.unwrap_or(20);
+    if idx < lookback {
+        return Ok(Signal::Hold);
+    }
+    let threshold = strategy.threshold_bps.unwrap_or(0.0) / 10_000.0;
+    let window = &candles[idx - lookback..idx];
+    let prior_high = window
+        .iter()
+        .map(|c| c.high)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let prior_low = window.iter().map(|c| c.low).fold(f64::INFINITY, f64::min);
+    let close = candles[idx].close;
+
+    if !in_position && close > prior_high * (1.0 + threshold) {
+        Ok(Signal::Enter)
+    } else if in_position && close < prior_low * (1.0 - threshold) {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn mean_reversion_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let lookback = strategy.lookback_window.unwrap_or(20);
+    let threshold = strategy.threshold_bps.unwrap_or(200.0) / 10_000.0;
+    let Some(avg) = sma(candles, idx, lookback) else {
+        return Ok(Signal::Hold);
+    };
+    let close = candles[idx].close;
+    if !in_position && close <= avg * (1.0 - threshold) {
+        Ok(Signal::Enter)
+    } else if in_position && close >= avg {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn momentum_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let lookback = strategy.lookback_window.unwrap_or(20);
+    if idx < lookback {
+        return Ok(Signal::Hold);
+    }
+    let threshold = strategy.threshold_bps.unwrap_or(200.0) / 10_000.0;
+    let prior = candles[idx - lookback].close;
+    let momentum = (candles[idx].close / prior) - 1.0;
+    if !in_position && momentum >= threshold {
+        Ok(Signal::Enter)
+    } else if in_position && momentum <= 0.0 {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn rsi_signal(
+    candles: &[Candle],
+    idx: usize,
+    strategy: &StrategyConfig,
+    in_position: bool,
+) -> Result<Signal, String> {
+    let lookback = strategy.lookback_window.unwrap_or(14);
+    let Some(rsi) = rsi(candles, idx, lookback) else {
+        return Ok(Signal::Hold);
+    };
+    let entry = strategy.entry_threshold.unwrap_or(30.0);
+    let exit = strategy.exit_threshold.unwrap_or(50.0);
+    if !in_position && rsi <= entry {
+        Ok(Signal::Enter)
+    } else if in_position && rsi >= exit {
+        Ok(Signal::Exit)
+    } else {
+        Ok(Signal::Hold)
+    }
+}
+
+fn sma(candles: &[Candle], end_idx: usize, window: usize) -> Option<f64> {
+    if window == 0 || end_idx + 1 < window {
+        return None;
+    }
+    let start = end_idx + 1 - window;
+    let sum: f64 = candles[start..=end_idx].iter().map(|c| c.close).sum();
+    Some(sum / window as f64)
+}
+
+fn rsi(candles: &[Candle], end_idx: usize, window: usize) -> Option<f64> {
+    if window == 0 || end_idx < window {
+        return None;
+    }
+    let start = end_idx + 1 - window;
+    let mut gains = 0.0;
+    let mut losses = 0.0;
+    for i in start..=end_idx {
+        let delta = candles[i].close - candles[i - 1].close;
+        if delta >= 0.0 {
+            gains += delta;
+        } else {
+            losses += delta.abs();
+        }
+    }
+    if losses == 0.0 {
+        Some(100.0)
+    } else {
+        let rs = gains / losses;
+        Some(100.0 - (100.0 / (1.0 + rs)))
+    }
+}
+
+fn compute_metrics(
+    initial_cash: f64,
+    end_cash: f64,
+    candles: &[Candle],
+    trades: &[BacktestTrade],
+    equity_curve: &[EquityPoint],
+    periodic_returns: &[f64],
+    exposure_count: usize,
+    slip_rate: f64,
+) -> BacktestMetrics {
+    let total_return_pct = pct_return(initial_cash, end_cash);
+    let first_buy = candles
+        .first()
+        .map(|c| c.open * (1.0 + slip_rate))
+        .unwrap_or(0.0);
+    let last_sell = candles
+        .last()
+        .map(|c| c.close * (1.0 - slip_rate))
+        .unwrap_or(0.0);
+    let buy_hold_return_pct = pct_return(first_buy, last_sell);
+
+    let wins = trades.iter().filter(|t| t.return_pct > 0.0).count();
+    let win_rate_pct = if trades.is_empty() {
+        0.0
+    } else {
+        wins as f64 / trades.len() as f64 * 100.0
+    };
+    let average_trade_return_pct = if trades.is_empty() {
+        0.0
+    } else {
+        trades.iter().map(|t| t.return_pct).sum::<f64>() / trades.len() as f64
+    };
+
+    let mut gross_wins = 0.0;
+    let mut gross_losses = 0.0;
+    for t in trades {
+        let pnl = parse_money(&t.net_pnl_usd);
+        if pnl >= 0.0 {
+            gross_wins += pnl;
+        } else {
+            gross_losses += pnl.abs();
+        }
+    }
+    let profit_factor = if gross_losses > 0.0 {
+        gross_wins / gross_losses
+    } else if gross_wins > 0.0 {
+        gross_wins
+    } else {
+        0.0
+    };
+
+    BacktestMetrics {
+        candles: candles.len(),
+        trades: trades.len(),
+        start_equity_usd: format!("{initial_cash:.2}"),
+        end_equity_usd: format!("{end_cash:.2}"),
+        total_return_pct,
+        buy_hold_return_pct,
+        alpha_vs_buy_hold_pct: total_return_pct - buy_hold_return_pct,
+        max_drawdown_pct: max_drawdown_pct(equity_curve),
+        win_rate_pct,
+        exposure_pct: exposure_count as f64 / candles.len() as f64 * 100.0,
+        profit_factor,
+        average_trade_return_pct,
+        return_stability: return_stability(periodic_returns),
+    }
+}
+
+fn pct_return(start: f64, end: f64) -> f64 {
+    if start > 0.0 {
+        ((end / start) - 1.0) * 100.0
+    } else {
+        0.0
+    }
+}
+
+fn max_drawdown_pct(equity_curve: &[EquityPoint]) -> f64 {
+    let mut peak = 0.0;
+    let mut max_dd = 0.0;
+    for point in equity_curve {
+        let equity = parse_money(&point.equity_usd);
+        if equity > peak {
+            peak = equity;
+        }
+        if peak > 0.0 {
+            let dd = (peak - equity) / peak * 100.0;
+            if dd > max_dd {
+                max_dd = dd;
+            }
+        }
+    }
+    max_dd
+}
+
+fn return_stability(returns: &[f64]) -> f64 {
+    if returns.len() < 2 {
+        return 0.0;
+    }
+    let mean = returns.iter().sum::<f64>() / returns.len() as f64;
+    let variance =
+        returns.iter().map(|r| (r - mean).powi(2)).sum::<f64>() / (returns.len() - 1) as f64;
+    let stddev = variance.sqrt();
+    if stddev > 0.0 {
+        mean / stddev
+    } else {
+        0.0
+    }
+}
+
+fn parse_money(s: &str) -> f64 {
+    s.parse::<f64>().unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candle(idx: usize, close: f64) -> Candle {
+        Candle {
+            ts: format!("2026-05-{idx:02}T00:00:00Z"),
+            open: close,
+            high: close * 1.01,
+            low: close * 0.99,
+            close,
+            volume: 1_000.0,
+        }
+    }
+
+    fn run_with(kind: &str, closes: &[f64], strategy: StrategyConfig) -> BacktestOutput {
+        let candles = closes
+            .iter()
+            .enumerate()
+            .map(|(idx, close)| candle(idx + 1, *close))
+            .collect();
+        run(BacktestInput {
+            candles,
+            strategy: StrategyConfig {
+                kind: kind.to_string(),
+                ..strategy
+            },
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            max_position_pct: 1.0,
+            stop_loss_bps: None,
+            take_profit_bps: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn buy_hold_enters_and_exits() {
+        let out = run_with(
+            "buy-hold",
+            &[100.0, 110.0, 120.0],
+            StrategyConfig {
+                kind: "buy-hold".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert_eq!(out.schema_version, "intents-backtest/1");
+        assert_eq!(out.metrics.trades, 1);
+        assert!(out.metrics.total_return_pct > 19.0);
+        assert!(out.lookahead_safe);
+    }
+
+    #[test]
+    fn suite_ranks_candidate_menu() {
+        let closes = [
+            10.0, 10.0, 10.0, 10.0, 10.5, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 16.0, 15.0,
+            14.0, 13.0, 12.0,
+        ];
+        let candles = closes
+            .iter()
+            .enumerate()
+            .map(|(idx, close)| candle(idx + 1, *close))
+            .collect();
+
+        let out = run_suite(BacktestSuiteInput {
+            candles,
+            candidates: vec![
+                BacktestCandidate {
+                    id: "buy_hold".to_string(),
+                    strategy: StrategyConfig {
+                        kind: "buy-hold".to_string(),
+                        fast_window: None,
+                        slow_window: None,
+                        lookback_window: None,
+                        threshold_bps: None,
+                        entry_threshold: None,
+                        exit_threshold: None,
+                    },
+                    max_position_pct: None,
+                    stop_loss_bps: None,
+                    take_profit_bps: None,
+                },
+                BacktestCandidate {
+                    id: "sma".to_string(),
+                    strategy: StrategyConfig {
+                        kind: "sma-cross".to_string(),
+                        fast_window: Some(2),
+                        slow_window: Some(4),
+                        lookback_window: None,
+                        threshold_bps: None,
+                        entry_threshold: None,
+                        exit_threshold: None,
+                    },
+                    max_position_pct: Some(1.0),
+                    stop_loss_bps: Some(1200.0),
+                    take_profit_bps: None,
+                },
+            ],
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+        })
+        .unwrap();
+
+        assert_eq!(out.schema_version, "intents-backtest-suite/1");
+        assert_eq!(out.ranked.len(), 2);
+        assert_eq!(out.ranked[0].rank, 1);
+        assert!(out.ranked.iter().any(|result| result.passes_basic_gate));
+    }
+
+    #[test]
+    fn sma_cross_produces_a_trade() {
+        let closes = [
+            10.0, 10.0, 10.0, 10.0, 10.0, 10.5, 11.0, 12.0, 13.0, 14.0, 13.0, 12.0, 11.0, 10.0, 9.0,
+        ];
+        let out = run_with(
+            "sma-cross",
+            &closes,
+            StrategyConfig {
+                kind: "sma-cross".to_string(),
+                fast_window: Some(2),
+                slow_window: Some(4),
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn breakout_produces_a_trade() {
+        let closes = [10.0, 10.1, 10.0, 10.2, 10.1, 11.0, 11.5, 12.0, 12.5, 13.0];
+        let out = run_with(
+            "breakout",
+            &closes,
+            StrategyConfig {
+                kind: "breakout".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: Some(3),
+                threshold_bps: Some(25.0),
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn mean_reversion_produces_a_trade() {
+        let closes = [100.0, 100.0, 100.0, 94.0, 93.0, 95.0, 98.0, 101.0, 100.0];
+        let out = run_with(
+            "mean-reversion",
+            &closes,
+            StrategyConfig {
+                kind: "mean-reversion".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: Some(3),
+                threshold_bps: Some(300.0),
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn momentum_produces_a_trade() {
+        let closes = [10.0, 10.2, 10.4, 10.6, 11.2, 11.8, 12.4, 12.0, 11.5];
+        let out = run_with(
+            "momentum",
+            &closes,
+            StrategyConfig {
+                kind: "momentum".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: Some(3),
+                threshold_bps: Some(500.0),
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn rsi_mean_reversion_produces_a_trade() {
+        let closes = [
+            100.0, 98.0, 96.0, 94.0, 92.0, 90.0, 91.0, 93.0, 95.0, 98.0, 101.0,
+        ];
+        let out = run_with(
+            "rsi-mean-reversion",
+            &closes,
+            StrategyConfig {
+                kind: "rsi-mean-reversion".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: Some(5),
+                threshold_bps: None,
+                entry_threshold: Some(25.0),
+                exit_threshold: Some(55.0),
+            },
+        );
+        assert!(out.metrics.trades >= 1);
+    }
+
+    #[test]
+    fn invalid_ohlc_errors() {
+        let result = run(BacktestInput {
+            candles: vec![
+                Candle {
+                    ts: "a".to_string(),
+                    open: 10.0,
+                    high: 9.0,
+                    low: 8.0,
+                    close: 10.0,
+                    volume: 0.0,
+                },
+                candle(2, 10.0),
+            ],
+            strategy: StrategyConfig {
+                kind: "buy-hold".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            max_position_pct: 1.0,
+            stop_loss_bps: None,
+            take_profit_bps: None,
+        });
+        assert!(result.unwrap_err().contains("high"));
+    }
+}

--- a/tools-src/portfolio/src/dca.rs
+++ b/tools-src/portfolio/src/dca.rs
@@ -1,0 +1,875 @@
+//! Dollar-cost averaging (DCA) for the Intents Trading Agent.
+//!
+//! Two surfaces:
+//!
+//! - `backtest_dca`: deterministic replay of a fixed-cadence,
+//!   fixed-notional buy schedule over a candle series. Reports lots,
+//!   average cost basis, breakeven price, mark-to-market, alpha vs
+//!   lump-sum buy-and-hold, and the underlying drawdown the schedule
+//!   had to survive. Optional symmetric price band turns the schedule
+//!   into a "skip when stretched, double-up when discounted" variant
+//!   without breaking determinism.
+//!
+//! - `plan_dca_schedule`: turn a user-friendly description (pair,
+//!   chains, per-period USD, cadence, total periods) into a recurring
+//!   intent schedule. Emits a `build_intent` template the caller uses
+//!   per period plus deterministic risk gates and a cron expression.
+//!   Quotes are unsigned; signing remains a wallet action outside the
+//!   agent.
+//!
+//! Both are pure functions — no live HTTP, no signing, no key access.
+
+use serde::{Deserialize, Serialize};
+
+use crate::backtest::{Candle, EquityPoint};
+
+// -------------------- shared defaults --------------------
+
+fn default_initial_cash_usd() -> f64 {
+    10_000.0
+}
+
+fn default_fee_bps() -> f64 {
+    10.0
+}
+
+fn default_slippage_bps() -> f64 {
+    5.0
+}
+
+fn default_max_slippage_bps() -> f64 {
+    50.0
+}
+
+fn default_period_candles() -> usize {
+    1
+}
+
+fn default_mode() -> String {
+    "paper".to_string()
+}
+
+fn default_assumed_price_usd() -> Option<f64> {
+    None
+}
+
+fn default_currency() -> String {
+    "USDC".to_string()
+}
+
+// -------------------- backtest_dca --------------------
+
+#[derive(Debug, Deserialize)]
+pub struct DcaBacktestInput {
+    pub candles: Vec<Candle>,
+    /// Notional USD committed per buy.
+    pub notional_per_period_usd: f64,
+    /// Buy every N candles. 1 = every candle.
+    #[serde(default = "default_period_candles")]
+    pub period_candles: usize,
+    /// Skip the first `offset` candles before the first buy.
+    #[serde(default)]
+    pub offset: usize,
+    /// If set, skip a buy when the candidate close is more than
+    /// `skip_above_premium_bps` above the running average cost basis.
+    #[serde(default)]
+    pub skip_above_premium_bps: Option<f64>,
+    /// If set, double the buy when the candidate close is more than
+    /// `opportunistic_below_discount_bps` below the running average
+    /// cost basis.
+    #[serde(default)]
+    pub opportunistic_below_discount_bps: Option<f64>,
+    #[serde(default = "default_fee_bps")]
+    pub fee_bps: f64,
+    #[serde(default = "default_slippage_bps")]
+    pub slippage_bps: f64,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DcaBacktestOutput {
+    pub schema_version: &'static str,
+    pub periods_planned: usize,
+    pub periods_executed: usize,
+    pub periods_skipped_band: usize,
+    pub periods_skipped_cash: usize,
+    pub periods_doubled: usize,
+    pub initial_cash_usd: String,
+    pub total_invested_usd: String,
+    pub fees_paid_usd: String,
+    pub units_acquired: String,
+    pub average_cost_basis_usd: String,
+    pub breakeven_price_usd: String,
+    pub final_close_usd: String,
+    pub mark_to_market_usd: String,
+    pub total_return_pct: f64,
+    pub vs_lumpsum_buy_hold_pct: f64,
+    pub max_underlying_drawdown_pct: f64,
+    pub lots: Vec<DcaLot>,
+    pub equity_curve: Vec<EquityPoint>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DcaLot {
+    pub index: usize,
+    pub ts: String,
+    pub price_usd: String,
+    pub notional_usd: String,
+    pub units: String,
+    pub fee_usd: String,
+    /// "regular" | "doubled" | "skipped-band" | "skipped-cash"
+    pub kind: String,
+}
+
+pub fn run_backtest(input: DcaBacktestInput) -> Result<DcaBacktestOutput, String> {
+    if input.candles.len() < 2 {
+        return Err("dca backtest requires at least 2 candles".to_string());
+    }
+    if !input.notional_per_period_usd.is_finite() || input.notional_per_period_usd <= 0.0 {
+        return Err("notional_per_period_usd must be > 0".to_string());
+    }
+    if input.period_candles == 0 {
+        return Err("period_candles must be >= 1".to_string());
+    }
+    if input.offset >= input.candles.len() {
+        return Err("offset must be less than the number of candles".to_string());
+    }
+    if !input.fee_bps.is_finite() || input.fee_bps < 0.0 {
+        return Err("fee_bps must be >= 0".to_string());
+    }
+    if !input.slippage_bps.is_finite() || input.slippage_bps < 0.0 {
+        return Err("slippage_bps must be >= 0".to_string());
+    }
+    for (idx, c) in input.candles.iter().enumerate() {
+        for (name, value) in [
+            ("open", c.open),
+            ("high", c.high),
+            ("low", c.low),
+            ("close", c.close),
+        ] {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(format!("candle {idx} {name} invalid"));
+            }
+        }
+        if c.high < c.low || c.high < c.open || c.high < c.close {
+            return Err(format!("candle {idx} high inconsistent"));
+        }
+        if c.low > c.open || c.low > c.close {
+            return Err(format!("candle {idx} low inconsistent"));
+        }
+    }
+
+    let fee_rate = input.fee_bps / 10_000.0;
+    let slip_rate = input.slippage_bps / 10_000.0;
+    let mut cash = input.initial_cash_usd;
+    let mut units = 0.0_f64;
+    let mut invested = 0.0_f64;
+    let mut fees = 0.0_f64;
+    let mut planned = 0usize;
+    let mut executed = 0usize;
+    let mut skipped_band = 0usize;
+    let mut skipped_cash = 0usize;
+    let mut doubled = 0usize;
+    let mut lots = Vec::new();
+    let mut equity_curve = Vec::with_capacity(input.candles.len());
+    let mut peak_close = 0.0_f64;
+    let mut max_dd = 0.0_f64;
+
+    let skip_premium = input
+        .skip_above_premium_bps
+        .map(|bps| bps.max(0.0) / 10_000.0);
+    let double_discount = input
+        .opportunistic_below_discount_bps
+        .map(|bps| bps.max(0.0) / 10_000.0);
+
+    for (idx, candle) in input.candles.iter().enumerate() {
+        if candle.close > peak_close {
+            peak_close = candle.close;
+        }
+        if peak_close > 0.0 {
+            let dd = (peak_close - candle.close) / peak_close * 100.0;
+            if dd > max_dd {
+                max_dd = dd;
+            }
+        }
+
+        let fires =
+            idx >= input.offset && (idx - input.offset).is_multiple_of(input.period_candles);
+        if fires {
+            planned += 1;
+            let avg_basis = if units > 0.0 { invested / units } else { 0.0 };
+            let mut commit_usd = input.notional_per_period_usd;
+            let mut kind = "regular";
+
+            if let (Some(bps), true) = (skip_premium, units > 0.0) {
+                let limit = avg_basis * (1.0 + bps);
+                if candle.close > limit {
+                    skipped_band += 1;
+                    lots.push(DcaLot {
+                        index: idx,
+                        ts: candle.ts.clone(),
+                        price_usd: format!("{:.8}", candle.close),
+                        notional_usd: "0.00".to_string(),
+                        units: "0".to_string(),
+                        fee_usd: "0.00".to_string(),
+                        kind: "skipped-band".to_string(),
+                    });
+                    push_curve(&mut equity_curve, idx, candle, cash, units);
+                    continue;
+                }
+            }
+
+            if let (Some(bps), true) = (double_discount, units > 0.0) {
+                let limit = avg_basis * (1.0 - bps);
+                if candle.close < limit {
+                    commit_usd *= 2.0;
+                    kind = "doubled";
+                    doubled += 1;
+                }
+            }
+
+            if cash <= 0.0 {
+                skipped_cash += 1;
+                lots.push(DcaLot {
+                    index: idx,
+                    ts: candle.ts.clone(),
+                    price_usd: format!("{:.8}", candle.close),
+                    notional_usd: "0.00".to_string(),
+                    units: "0".to_string(),
+                    fee_usd: "0.00".to_string(),
+                    kind: "skipped-cash".to_string(),
+                });
+                push_curve(&mut equity_curve, idx, candle, cash, units);
+                continue;
+            }
+
+            let buy_usd = commit_usd.min(cash);
+            let execution_price = candle.close * (1.0 + slip_rate);
+            let principal = buy_usd / (1.0 + fee_rate);
+            let fee = principal * fee_rate;
+            let unit_buy = principal / execution_price;
+            cash -= principal + fee;
+            units += unit_buy;
+            invested += principal;
+            fees += fee;
+            executed += 1;
+            lots.push(DcaLot {
+                index: idx,
+                ts: candle.ts.clone(),
+                price_usd: format!("{execution_price:.8}"),
+                notional_usd: format!("{principal:.2}"),
+                units: format!("{unit_buy:.8}"),
+                fee_usd: format!("{fee:.2}"),
+                kind: kind.to_string(),
+            });
+        }
+
+        push_curve(&mut equity_curve, idx, candle, cash, units);
+    }
+
+    let final_close = input.candles.last().map(|c| c.close).unwrap_or(0.0);
+    let mtm = cash + units * final_close;
+    let total_return_pct = if input.initial_cash_usd > 0.0 {
+        (mtm / input.initial_cash_usd - 1.0) * 100.0
+    } else {
+        0.0
+    };
+    let lumpsum_pct =
+        if let (Some(first), Some(last)) = (input.candles.first(), input.candles.last()) {
+            let buy = first.open * (1.0 + slip_rate);
+            let sell = last.close * (1.0 - slip_rate);
+            if buy > 0.0 {
+                (sell / buy - 1.0) * 100.0
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+    let avg_basis = if units > 0.0 { invested / units } else { 0.0 };
+    let breakeven = if units > 0.0 {
+        (invested + fees) / units
+    } else {
+        0.0
+    };
+
+    let mut warnings = vec![
+        "DCA backtest commits at candle close with explicit slippage; signals are not lookahead."
+            .to_string(),
+    ];
+    if executed == 0 {
+        warnings.push(
+            "no buys executed; check offset, period_candles, and notional vs initial cash"
+                .to_string(),
+        );
+    }
+    if input.candles.len() < 30 {
+        warnings.push("small sample: fewer than 30 candles".to_string());
+    }
+    if cash < 0.0 {
+        warnings.push(
+            "cash went negative; treat the over-commit as a financing assumption, not a real fill"
+                .to_string(),
+        );
+    }
+
+    Ok(DcaBacktestOutput {
+        schema_version: "intents-dca-backtest/1",
+        periods_planned: planned,
+        periods_executed: executed,
+        periods_skipped_band: skipped_band,
+        periods_skipped_cash: skipped_cash,
+        periods_doubled: doubled,
+        initial_cash_usd: format!("{:.2}", input.initial_cash_usd),
+        total_invested_usd: format!("{invested:.2}"),
+        fees_paid_usd: format!("{fees:.2}"),
+        units_acquired: format!("{units:.8}"),
+        average_cost_basis_usd: format!("{avg_basis:.8}"),
+        breakeven_price_usd: format!("{breakeven:.8}"),
+        final_close_usd: format!("{final_close:.8}"),
+        mark_to_market_usd: format!("{mtm:.2}"),
+        total_return_pct,
+        vs_lumpsum_buy_hold_pct: total_return_pct - lumpsum_pct,
+        max_underlying_drawdown_pct: max_dd,
+        lots,
+        equity_curve,
+        warnings,
+    })
+}
+
+fn push_curve(curve: &mut Vec<EquityPoint>, idx: usize, candle: &Candle, cash: f64, units: f64) {
+    let equity = cash + units * candle.close;
+    curve.push(EquityPoint {
+        index: idx,
+        ts: candle.ts.clone(),
+        equity_usd: format!("{equity:.2}"),
+        in_position: units > 0.0,
+    });
+}
+
+// -------------------- plan_dca_schedule --------------------
+
+#[derive(Debug, Deserialize)]
+pub struct DcaScheduleInput {
+    pub pair: String,
+    pub source_asset: String,
+    pub destination_asset: String,
+    pub source_chain: String,
+    pub destination_chain: String,
+    pub notional_per_period_usd: f64,
+    /// One of: "daily", "weekly", "biweekly", "monthly", or a raw cron
+    /// string (5 or 6 fields).
+    pub cadence: String,
+    pub total_periods: usize,
+    #[serde(default = "default_max_slippage_bps")]
+    pub max_slippage_bps: f64,
+    #[serde(default)]
+    pub start_at: Option<String>,
+    #[serde(default = "default_assumed_price_usd")]
+    pub assumed_price_usd: Option<f64>,
+    /// "paper" (fixture solver, default) or "quote" (live solver).
+    /// Always unsigned regardless.
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    /// Defaults to USDC. The notional currency the user denominates the
+    /// schedule in.
+    #[serde(default = "default_currency")]
+    pub notional_currency: String,
+    /// Optional solver override (e.g. `near-intents`). Defaults to
+    /// `fixture` in paper mode and `near-intents` in quote mode.
+    #[serde(default)]
+    pub solver: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DcaScheduleOutput {
+    pub schema_version: &'static str,
+    pub pair: String,
+    pub mode: String,
+    pub cadence: String,
+    pub cron: String,
+    pub total_periods: usize,
+    pub source_asset: String,
+    pub destination_asset: String,
+    pub source_chain: String,
+    pub destination_chain: String,
+    pub notional_per_period_usd: String,
+    pub total_notional_usd: String,
+    pub assumed_price_usd: Option<f64>,
+    pub estimated_total_units: Option<String>,
+    pub max_slippage_bps: f64,
+    pub solver: String,
+    pub safe_to_quote: bool,
+    pub risk_gates: Vec<DcaGate>,
+    pub schedule: Vec<DcaPeriodPlan>,
+    pub build_intent_request_template: serde_json::Value,
+    pub schedule_summary: String,
+    pub guardrails: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DcaGate {
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DcaPeriodPlan {
+    pub index: usize,
+    pub fires_at: String,
+    pub notional_usd: String,
+    pub estimated_units: Option<String>,
+    pub note: String,
+}
+
+pub fn plan_schedule(input: DcaScheduleInput) -> Result<DcaScheduleOutput, String> {
+    if input.pair.trim().is_empty() {
+        return Err("pair must be non-empty".to_string());
+    }
+    if input.source_asset.trim().is_empty() || input.destination_asset.trim().is_empty() {
+        return Err("source_asset and destination_asset must be non-empty".to_string());
+    }
+    if input.source_chain.trim().is_empty() || input.destination_chain.trim().is_empty() {
+        return Err("source_chain and destination_chain must be non-empty".to_string());
+    }
+    if !input.notional_per_period_usd.is_finite() || input.notional_per_period_usd <= 0.0 {
+        return Err("notional_per_period_usd must be > 0".to_string());
+    }
+    if input.total_periods == 0 {
+        return Err("total_periods must be >= 1".to_string());
+    }
+    if !input.max_slippage_bps.is_finite() || input.max_slippage_bps < 0.0 {
+        return Err("max_slippage_bps must be >= 0".to_string());
+    }
+    let mode = match input.mode.as_str() {
+        "paper" | "quote" => input.mode.clone(),
+        other => return Err(format!("mode must be paper or quote (got {other})")),
+    };
+    let solver = input.solver.clone().unwrap_or_else(|| match mode.as_str() {
+        "paper" => "fixture".to_string(),
+        _ => "near-intents".to_string(),
+    });
+
+    let (cron, fires_at) = cadence_to_cron(&input.cadence)?;
+
+    let total_notional = input.notional_per_period_usd * input.total_periods as f64;
+    let estimated_total_units = input
+        .assumed_price_usd
+        .filter(|p| *p > 0.0)
+        .map(|p| total_notional / p);
+    let est_units_per_period = input
+        .assumed_price_usd
+        .filter(|p| *p > 0.0)
+        .map(|p| input.notional_per_period_usd / p);
+
+    let schedule: Vec<DcaPeriodPlan> = (0..input.total_periods)
+        .map(|i| {
+            let note = if i == 0 {
+                "First lot. Re-quote price before signing; the agent never signs.".to_string()
+            } else {
+                format!(
+                    "Lot {} of {}. Verify slippage and price drift before signing.",
+                    i + 1,
+                    input.total_periods
+                )
+            };
+            DcaPeriodPlan {
+                index: i,
+                fires_at: relative_fire_time(&fires_at, i),
+                notional_usd: format!("{:.2}", input.notional_per_period_usd),
+                estimated_units: est_units_per_period.map(|u| format!("{u:.8}")),
+                note,
+            }
+        })
+        .collect();
+
+    let mut gates: Vec<DcaGate> = Vec::new();
+    let big_total = total_notional > 10_000.0;
+    gates.push(DcaGate {
+        name: "max_slippage".to_string(),
+        status: if input.max_slippage_bps <= 100.0 {
+            "pass".to_string()
+        } else {
+            "warn".to_string()
+        },
+        detail: format!(
+            "max_slippage_bps={} (recommend <= 100 for spot DCA)",
+            input.max_slippage_bps
+        ),
+    });
+    gates.push(DcaGate {
+        name: "total_notional".to_string(),
+        status: if big_total {
+            "warn".to_string()
+        } else {
+            "pass".to_string()
+        },
+        detail: format!(
+            "Total commit ${total_notional:.2} across {} periods",
+            input.total_periods
+        ),
+    });
+    let supported_assets = ["NEAR", "USDC", "USDT", "BTC", "ETH", "WETH", "WBTC"];
+    let src_supported = supported_assets
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case(&input.source_asset));
+    let dst_supported = supported_assets
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case(&input.destination_asset));
+    gates.push(DcaGate {
+        name: "asset_allowlist".to_string(),
+        status: if src_supported && dst_supported {
+            "pass".to_string()
+        } else {
+            "warn".to_string()
+        },
+        detail: format!(
+            "{} → {} (intents-supported: {} → {})",
+            input.source_asset, input.destination_asset, src_supported, dst_supported
+        ),
+    });
+    gates.push(DcaGate {
+        name: "unsigned_only".to_string(),
+        status: "pass".to_string(),
+        detail: "Wallet signature is required outside the agent.".to_string(),
+    });
+
+    let safe_to_quote = gates
+        .iter()
+        .all(|g| g.status == "pass" || g.status == "warn")
+        && mode == "paper"
+        || (mode == "quote"
+            && gates
+                .iter()
+                .all(|g| g.status == "pass" || g.status == "warn")
+            && src_supported
+            && dst_supported);
+
+    let template = serde_json::json!({
+        "action": "build_intent",
+        "solver": solver,
+        "plan": {
+            "proposal_id": format!("dca-{}-{}", slug(&input.pair), input.cadence),
+            "legs": [
+                {
+                    "kind": "swap",
+                    "chain": input.source_chain,
+                    "from_token": {
+                        "symbol": input.source_asset,
+                        "address": null,
+                        "chain": input.source_chain,
+                        "amount": format!("{:.6}", input.notional_per_period_usd),
+                        "value_usd": format!("{:.2}", input.notional_per_period_usd)
+                    },
+                    "to_token": {
+                        "symbol": input.destination_asset,
+                        "address": null,
+                        "chain": input.destination_chain,
+                        "amount": est_units_per_period
+                            .map(|u| format!("{u:.6}"))
+                            .unwrap_or_else(|| "TBD".to_string()),
+                        "value_usd": format!("{:.2}", input.notional_per_period_usd)
+                    },
+                    "description": format!(
+                        "DCA lot for {}: swap {} {} -> {} via NEAR Intents",
+                        input.pair, input.notional_per_period_usd, input.source_asset, input.destination_asset
+                    )
+                }
+            ],
+            "expected_out": {
+                "symbol": input.destination_asset,
+                "address": null,
+                "chain": input.destination_chain,
+                "amount": est_units_per_period
+                    .map(|u| format!("{u:.6}"))
+                    .unwrap_or_else(|| "TBD".to_string()),
+                "value_usd": format!("{:.2}", input.notional_per_period_usd)
+            },
+            "expected_cost_usd": format!("{:.2}", input.notional_per_period_usd)
+        }
+    });
+
+    let summary = format!(
+        "DCA ${:.2} {} -> {} every {} for {} periods (~${:.2}); cron `{}`",
+        input.notional_per_period_usd,
+        input.source_asset,
+        input.destination_asset,
+        input.cadence,
+        input.total_periods,
+        total_notional,
+        cron
+    );
+
+    let guardrails = vec![
+        "Per-period intent must be re-quoted before user signs; agent never signs.".to_string(),
+        "If solver returns empty quote, skip the period and journal the miss.".to_string(),
+        "If the live close drifts more than max_slippage_bps from the assumed price, pause and re-plan.".to_string(),
+        "Honor `cooldown_minutes` from project config; do not chain quotes back-to-back without operator confirmation.".to_string(),
+        "Cron is advisory metadata, not a daemon — IronClaw schedules each tick separately.".to_string(),
+    ];
+
+    let mut warnings: Vec<String> = Vec::new();
+    if !src_supported {
+        warnings.push(format!(
+            "source asset '{}' is not in the default NEAR Intents allowlist; verify route support",
+            input.source_asset
+        ));
+    }
+    if !dst_supported {
+        warnings.push(format!(
+            "destination asset '{}' is not in the default NEAR Intents allowlist; verify route support",
+            input.destination_asset
+        ));
+    }
+    if input.assumed_price_usd.is_none() && mode == "quote" {
+        warnings.push(
+            "live quote mode without assumed_price_usd; estimated_units will be empty until the solver replies"
+                .to_string(),
+        );
+    }
+
+    Ok(DcaScheduleOutput {
+        schema_version: "intents-dca-schedule/1",
+        pair: input.pair,
+        mode,
+        cadence: input.cadence.clone(),
+        cron: cron.clone(),
+        total_periods: input.total_periods,
+        source_asset: input.source_asset,
+        destination_asset: input.destination_asset,
+        source_chain: input.source_chain,
+        destination_chain: input.destination_chain,
+        notional_per_period_usd: format!("{:.2}", input.notional_per_period_usd),
+        total_notional_usd: format!("{total_notional:.2}"),
+        assumed_price_usd: input.assumed_price_usd,
+        estimated_total_units: estimated_total_units.map(|u| format!("{u:.8}")),
+        max_slippage_bps: input.max_slippage_bps,
+        solver,
+        safe_to_quote,
+        risk_gates: gates,
+        schedule,
+        build_intent_request_template: template,
+        schedule_summary: summary,
+        guardrails,
+        warnings,
+    })
+}
+
+fn cadence_to_cron(cadence: &str) -> Result<(String, String), String> {
+    match cadence {
+        "daily" => Ok(("0 12 * * *".to_string(), "+1 day".to_string())),
+        "weekly" => Ok(("0 12 * * 1".to_string(), "+1 week".to_string())),
+        "biweekly" => Ok(("0 12 1,15 * *".to_string(), "+2 weeks".to_string())),
+        "monthly" => Ok(("0 12 1 * *".to_string(), "+1 month".to_string())),
+        other => {
+            let fields: Vec<&str> = other.split_whitespace().collect();
+            if fields.len() == 5 || fields.len() == 6 {
+                Ok((other.to_string(), "per-cron".to_string()))
+            } else {
+                Err(format!(
+                    "cadence must be one of daily/weekly/biweekly/monthly or a 5-or-6-field cron (got '{other}')"
+                ))
+            }
+        }
+    }
+}
+
+fn relative_fire_time(unit: &str, idx: usize) -> String {
+    if idx == 0 {
+        return "first cron tick after start".to_string();
+    }
+    format!("{idx} ticks after start ({unit} cadence)")
+}
+
+fn slug(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cs(closes: &[f64]) -> Vec<Candle> {
+        closes
+            .iter()
+            .enumerate()
+            .map(|(i, c)| Candle {
+                ts: format!("2026-01-{:02}T00:00:00Z", i + 1),
+                open: *c,
+                high: c * 1.01,
+                low: c * 0.99,
+                close: *c,
+                volume: 1_000.0,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn dca_buys_at_each_period() {
+        let out = run_backtest(DcaBacktestInput {
+            candles: cs(&[10.0, 11.0, 9.0, 12.0, 10.5, 11.5, 13.0, 14.0, 12.5, 11.0]),
+            notional_per_period_usd: 100.0,
+            period_candles: 1,
+            offset: 0,
+            skip_above_premium_bps: None,
+            opportunistic_below_discount_bps: None,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            initial_cash_usd: 2_000.0,
+        })
+        .unwrap();
+        assert_eq!(out.periods_planned, 10);
+        assert_eq!(out.periods_executed, 10);
+        assert_eq!(out.lots.len(), 10);
+        assert_eq!(out.schema_version, "intents-dca-backtest/1");
+        let total_invested: f64 = out.total_invested_usd.parse().unwrap();
+        assert!((total_invested - 1_000.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn dca_band_skips_above_premium() {
+        let out = run_backtest(DcaBacktestInput {
+            candles: cs(&[10.0, 10.0, 10.0, 50.0, 10.0, 10.0, 10.0, 50.0, 10.0, 10.0]),
+            notional_per_period_usd: 100.0,
+            period_candles: 1,
+            offset: 0,
+            // 100% above avg = skip
+            skip_above_premium_bps: Some(10_000.0),
+            opportunistic_below_discount_bps: None,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            initial_cash_usd: 2_000.0,
+        })
+        .unwrap();
+        assert!(out.periods_skipped_band >= 1);
+        assert!(out.periods_executed < 10);
+    }
+
+    #[test]
+    fn dca_doubles_at_discount() {
+        let out = run_backtest(DcaBacktestInput {
+            candles: cs(&[10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 5.0, 5.0, 5.0]),
+            notional_per_period_usd: 100.0,
+            period_candles: 1,
+            offset: 0,
+            skip_above_premium_bps: None,
+            // 30% below avg triggers double-up
+            opportunistic_below_discount_bps: Some(3_000.0),
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            initial_cash_usd: 2_000.0,
+        })
+        .unwrap();
+        assert!(out.periods_doubled >= 1);
+    }
+
+    #[test]
+    fn dca_period_skips_until_offset() {
+        let out = run_backtest(DcaBacktestInput {
+            candles: cs(&[10.0; 12]),
+            notional_per_period_usd: 100.0,
+            period_candles: 3,
+            offset: 1,
+            skip_above_premium_bps: None,
+            opportunistic_below_discount_bps: None,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            initial_cash_usd: 2_000.0,
+        })
+        .unwrap();
+        // candles fired at idx 1, 4, 7, 10 → 4 lots
+        assert_eq!(out.periods_executed, 4);
+    }
+
+    #[test]
+    fn schedule_weekly_emits_cron_and_template() {
+        let out = plan_schedule(DcaScheduleInput {
+            pair: "NEAR/USDC".to_string(),
+            source_asset: "USDC".to_string(),
+            destination_asset: "NEAR".to_string(),
+            source_chain: "near".to_string(),
+            destination_chain: "near".to_string(),
+            notional_per_period_usd: 100.0,
+            cadence: "weekly".to_string(),
+            total_periods: 26,
+            max_slippage_bps: 50.0,
+            start_at: None,
+            assumed_price_usd: Some(3.0),
+            mode: "paper".to_string(),
+            notional_currency: "USDC".to_string(),
+            solver: None,
+        })
+        .unwrap();
+        assert_eq!(out.schema_version, "intents-dca-schedule/1");
+        assert_eq!(out.cron, "0 12 * * 1");
+        assert_eq!(out.solver, "fixture");
+        assert_eq!(out.schedule.len(), 26);
+        assert!(out.safe_to_quote);
+        assert!(out.estimated_total_units.is_some());
+        assert!(
+            out.build_intent_request_template
+                .pointer("/plan/legs/0/kind")
+                .and_then(|v| v.as_str())
+                == Some("swap")
+        );
+    }
+
+    #[test]
+    fn schedule_rejects_bad_cadence() {
+        let err = plan_schedule(DcaScheduleInput {
+            pair: "NEAR/USDC".to_string(),
+            source_asset: "USDC".to_string(),
+            destination_asset: "NEAR".to_string(),
+            source_chain: "near".to_string(),
+            destination_chain: "near".to_string(),
+            notional_per_period_usd: 100.0,
+            cadence: "fortnightly".to_string(),
+            total_periods: 12,
+            max_slippage_bps: 50.0,
+            start_at: None,
+            assumed_price_usd: Some(3.0),
+            mode: "paper".to_string(),
+            notional_currency: "USDC".to_string(),
+            solver: None,
+        })
+        .unwrap_err();
+        assert!(err.contains("cadence"));
+    }
+
+    #[test]
+    fn schedule_quote_mode_picks_near_intents() {
+        let out = plan_schedule(DcaScheduleInput {
+            pair: "NEAR/USDC".to_string(),
+            source_asset: "USDC".to_string(),
+            destination_asset: "NEAR".to_string(),
+            source_chain: "near".to_string(),
+            destination_chain: "near".to_string(),
+            notional_per_period_usd: 50.0,
+            cadence: "daily".to_string(),
+            total_periods: 7,
+            max_slippage_bps: 50.0,
+            start_at: None,
+            assumed_price_usd: Some(3.0),
+            mode: "quote".to_string(),
+            notional_currency: "USDC".to_string(),
+            solver: None,
+        })
+        .unwrap();
+        assert_eq!(out.solver, "near-intents");
+        assert_eq!(out.cron, "0 12 * * *");
+    }
+}

--- a/tools-src/portfolio/src/episode.rs
+++ b/tools-src/portfolio/src/episode.rs
@@ -1,0 +1,347 @@
+//! Shared episode format for the Intents Trading Agent.
+//!
+//! An episode bundles the three replay surfaces the agent currently
+//! treats as separate inputs:
+//!
+//! - candle series for `backtest` / `backtest_suite`,
+//! - solver fixture for `build_intent` (`solver: "fixture"`),
+//! - news/catalyst snippets for the news/sentiment analyst.
+//!
+//! It is the substrate the research notes call out as missing
+//! ("solver-route replay and market-data replay are separate; they
+//! need a shared episode format"). Two actions are exposed:
+//!
+//! - `validate_episode`: structural checks plus a deterministic
+//!   summary, no side effects.
+//! - `replay_episode`: validate, then run a `backtest_suite` against
+//!   the embedded candles. The solver fixture and news context are
+//!   surfaced verbatim so the caller can route them into
+//!   `build_intent` and the analyst memos.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::backtest::{self, BacktestCandidate, BacktestSuiteInput, BacktestSuiteOutput, Candle};
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Episode {
+    pub id: String,
+    pub pair: String,
+    #[serde(default)]
+    pub timeframe: Option<String>,
+    pub candles: Vec<Candle>,
+    #[serde(default)]
+    pub solver_fixture: Option<Value>,
+    #[serde(default)]
+    pub news_context: Vec<NewsItem>,
+    #[serde(default)]
+    pub generated_at: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+pub struct NewsItem {
+    pub ts: String,
+    pub headline: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub kind: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ValidateEpisodeInput {
+    pub episode: Episode,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EpisodeSummary {
+    pub schema_version: &'static str,
+    pub id: String,
+    pub pair: String,
+    pub timeframe: Option<String>,
+    pub generated_at: Option<String>,
+    pub source: Option<String>,
+    pub candles: usize,
+    pub first_ts: Option<String>,
+    pub last_ts: Option<String>,
+    pub min_close: f64,
+    pub max_close: f64,
+    pub buy_hold_return_pct: f64,
+    pub has_solver_fixture: bool,
+    pub solver_fixture_kind: Option<String>,
+    pub news_items: usize,
+    pub warnings: Vec<String>,
+}
+
+pub fn validate(input: ValidateEpisodeInput) -> Result<EpisodeSummary, String> {
+    summarize(&input.episode)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReplayEpisodeInput {
+    pub episode: Episode,
+    pub candidates: Vec<BacktestCandidate>,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+    #[serde(default = "default_fee_bps")]
+    pub fee_bps: f64,
+    #[serde(default = "default_slippage_bps")]
+    pub slippage_bps: f64,
+}
+
+fn default_initial_cash_usd() -> f64 {
+    10_000.0
+}
+
+fn default_fee_bps() -> f64 {
+    10.0
+}
+
+fn default_slippage_bps() -> f64 {
+    5.0
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReplayEpisodeOutput {
+    pub schema_version: &'static str,
+    pub episode: EpisodeSummary,
+    pub backtest_suite: BacktestSuiteOutput,
+    pub solver_fixture: Option<Value>,
+    pub news_context: Vec<NewsItem>,
+}
+
+pub fn replay(input: ReplayEpisodeInput) -> Result<ReplayEpisodeOutput, String> {
+    let summary = summarize(&input.episode)?;
+    if input.candidates.is_empty() {
+        return Err("replay_episode requires at least one candidate".to_string());
+    }
+    let suite = backtest::run_suite(BacktestSuiteInput {
+        candles: input.episode.candles.clone(),
+        candidates: input.candidates,
+        initial_cash_usd: input.initial_cash_usd,
+        fee_bps: input.fee_bps,
+        slippage_bps: input.slippage_bps,
+    })?;
+
+    Ok(ReplayEpisodeOutput {
+        schema_version: "intents-episode-replay/1",
+        episode: summary,
+        backtest_suite: suite,
+        solver_fixture: input.episode.solver_fixture,
+        news_context: input.episode.news_context,
+    })
+}
+
+fn summarize(episode: &Episode) -> Result<EpisodeSummary, String> {
+    if episode.id.trim().is_empty() {
+        return Err("episode id must be non-empty".to_string());
+    }
+    if episode.pair.trim().is_empty() {
+        return Err("episode pair must be non-empty".to_string());
+    }
+    if episode.candles.len() < 2 {
+        return Err("episode requires at least 2 candles".to_string());
+    }
+    let mut warnings = Vec::new();
+    let mut prior_ts: Option<&str> = None;
+    let mut min_close = f64::INFINITY;
+    let mut max_close = f64::NEG_INFINITY;
+    for (idx, c) in episode.candles.iter().enumerate() {
+        if !c.open.is_finite() || c.open <= 0.0 {
+            return Err(format!("candle {idx} open invalid"));
+        }
+        if !c.high.is_finite() || c.high <= 0.0 {
+            return Err(format!("candle {idx} high invalid"));
+        }
+        if !c.low.is_finite() || c.low <= 0.0 {
+            return Err(format!("candle {idx} low invalid"));
+        }
+        if !c.close.is_finite() || c.close <= 0.0 {
+            return Err(format!("candle {idx} close invalid"));
+        }
+        if c.high < c.low || c.high < c.open || c.high < c.close {
+            return Err(format!("candle {idx} high inconsistent"));
+        }
+        if c.low > c.open || c.low > c.close {
+            return Err(format!("candle {idx} low inconsistent"));
+        }
+        if let Some(prev) = prior_ts {
+            if c.ts.as_str() < prev {
+                return Err(format!(
+                    "candles must be oldest-to-newest; candle {idx} ts '{}' precedes prior '{prev}'",
+                    c.ts
+                ));
+            }
+            if c.ts.as_str() == prev {
+                warnings.push(format!("candle {idx} ts equals prior candle"));
+            }
+        }
+        prior_ts = Some(&c.ts);
+        if c.close < min_close {
+            min_close = c.close;
+        }
+        if c.close > max_close {
+            max_close = c.close;
+        }
+    }
+    let first_ts = episode.candles.first().map(|c| c.ts.clone());
+    let last_ts = episode.candles.last().map(|c| c.ts.clone());
+    let bh_return =
+        if let (Some(first), Some(last)) = (episode.candles.first(), episode.candles.last()) {
+            (last.close / first.open - 1.0) * 100.0
+        } else {
+            0.0
+        };
+
+    let solver_fixture_kind = episode
+        .solver_fixture
+        .as_ref()
+        .and_then(|v| v.get("kind"))
+        .and_then(|k| k.as_str())
+        .map(|s| s.to_string());
+
+    if episode.candles.len() < 30 {
+        warnings.push("small episode: fewer than 30 candles".to_string());
+    }
+    if episode.solver_fixture.is_none() {
+        warnings
+            .push("episode has no solver_fixture; intent build replay not available".to_string());
+    }
+    if episode.news_context.is_empty() {
+        warnings.push("episode has no news_context; analyst memo replay not available".to_string());
+    }
+
+    Ok(EpisodeSummary {
+        schema_version: "intents-episode/1",
+        id: episode.id.clone(),
+        pair: episode.pair.clone(),
+        timeframe: episode.timeframe.clone(),
+        generated_at: episode.generated_at.clone(),
+        source: episode.source.clone(),
+        candles: episode.candles.len(),
+        first_ts,
+        last_ts,
+        min_close,
+        max_close,
+        buy_hold_return_pct: bh_return,
+        has_solver_fixture: episode.solver_fixture.is_some(),
+        solver_fixture_kind,
+        news_items: episode.news_context.len(),
+        warnings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backtest::StrategyConfig;
+
+    fn cs(closes: &[f64]) -> Vec<Candle> {
+        closes
+            .iter()
+            .enumerate()
+            .map(|(i, c)| Candle {
+                ts: format!("2026-04-{:02}T00:00:00Z", i + 1),
+                open: *c,
+                high: c * 1.01,
+                low: c * 0.99,
+                close: *c,
+                volume: 1_000.0,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn validate_episode_returns_summary() {
+        let ep = Episode {
+            id: "near-usdc-2026q1".to_string(),
+            pair: "NEAR/USDC".to_string(),
+            timeframe: Some("1d".to_string()),
+            candles: cs(&[3.0, 3.1, 3.2, 3.4]),
+            solver_fixture: None,
+            news_context: vec![],
+            generated_at: Some("2026-05-02".to_string()),
+            source: Some("manual".to_string()),
+            notes: None,
+        };
+        let summary = validate(ValidateEpisodeInput { episode: ep }).unwrap();
+        assert_eq!(summary.candles, 4);
+        assert_eq!(summary.pair, "NEAR/USDC");
+        assert!(summary.buy_hold_return_pct > 12.0);
+    }
+
+    #[test]
+    fn replay_runs_suite_over_episode() {
+        let ep = Episode {
+            id: "ep-1".to_string(),
+            pair: "BTC/USDC".to_string(),
+            timeframe: Some("1d".to_string()),
+            candles: cs(&[
+                100.0, 100.5, 101.0, 102.5, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0,
+            ]),
+            solver_fixture: Some(serde_json::json!({"kind": "swap"})),
+            news_context: vec![NewsItem {
+                ts: "2026-04-02".to_string(),
+                headline: "Test".to_string(),
+                url: None,
+                source: None,
+                kind: None,
+            }],
+            generated_at: None,
+            source: None,
+            notes: None,
+        };
+        let out = replay(ReplayEpisodeInput {
+            episode: ep,
+            candidates: vec![BacktestCandidate {
+                id: "buy_hold".to_string(),
+                strategy: StrategyConfig {
+                    kind: "buy-hold".to_string(),
+                    fast_window: None,
+                    slow_window: None,
+                    lookback_window: None,
+                    threshold_bps: None,
+                    entry_threshold: None,
+                    exit_threshold: None,
+                },
+                max_position_pct: None,
+                stop_loss_bps: None,
+                take_profit_bps: None,
+            }],
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+        })
+        .unwrap();
+        assert_eq!(out.episode.solver_fixture_kind.as_deref(), Some("swap"));
+        assert_eq!(out.backtest_suite.ranked.len(), 1);
+    }
+
+    #[test]
+    fn rejects_descending_timestamps() {
+        let mut candles = cs(&[100.0, 101.0, 102.0]);
+        candles[0].ts = "2026-05-10T00:00:00Z".to_string();
+        candles[1].ts = "2026-05-01T00:00:00Z".to_string();
+        let err = validate(ValidateEpisodeInput {
+            episode: Episode {
+                id: "x".to_string(),
+                pair: "x/y".to_string(),
+                timeframe: None,
+                candles,
+                solver_fixture: None,
+                news_context: vec![],
+                generated_at: None,
+                source: None,
+                notes: None,
+            },
+        })
+        .unwrap_err();
+        assert!(err.contains("oldest-to-newest"));
+    }
+}

--- a/tools-src/portfolio/src/intents/solver.rs
+++ b/tools-src/portfolio/src/intents/solver.rs
@@ -5,7 +5,7 @@
 //! 1. **Production** (`fetch_quote`) — POSTs a quote request to the
 //!    NEAR Intents solver relay via `host::http_request`. Only runs
 //!    in the WASM sandbox. The endpoint is pinned at
-//!    `solver-relay.chaindefuser.com/rpc` by M4. Bumping it is a
+//!    `solver-relay-v2.chaindefuser.com/rpc` by M4. Bumping it is a
 //!    coordinated change: update here, update the capabilities
 //!    allowlist, re-record fixtures.
 //!
@@ -197,7 +197,7 @@ pub fn fetch_quote(plan: &MovementPlan, slippage_bps: u16) -> Result<SolverQuote
 
     let response = crate::near::agent::host::http_request(
         "POST",
-        "https://solver-relay.chaindefuser.com/rpc",
+        "https://solver-relay-v2.chaindefuser.com/rpc",
         &headers.to_string(),
         Some(&body),
         None,
@@ -309,7 +309,7 @@ mod tests {
     /// ```
     ///
     /// Requires:
-    ///   - Network access to `solver-relay.chaindefuser.com`
+    ///   - Network access to `solver-relay-v2.chaindefuser.com`
     ///   - Full WASM toolchain (cargo-component, wasm32-wasip2)
     ///
     /// Any panic here is a signal that the real solver's shape has

--- a/tools-src/portfolio/src/lab.rs
+++ b/tools-src/portfolio/src/lab.rs
@@ -1,0 +1,1000 @@
+//! Strategy lab primitives for the Intents Trading Agent.
+//!
+//! Wraps `backtest::run` and `backtest::run_suite` with three
+//! deterministic research workflows:
+//!
+//! - `backtest_walkforward`: contiguous, non-overlapping fold windows;
+//!   each fold splits its window into in-sample and out-of-sample
+//!   ranges, runs the same strategy on both, and reports the IS/OOS
+//!   gap. The strategy parameters are not refit — this is a regime
+//!   robustness check, not a hyperparameter search.
+//! - `backtest_montecarlo`: trade-order resampling on a caller-provided
+//!   per-trade return series, producing return / drawdown / terminal
+//!   equity distributions. Uses an xorshift64* PRNG seeded from the
+//!   request so runs are reproducible.
+//! - `backtest_grid`: cartesian sweep over strategy parameter axes
+//!   plus optional sizing/stop/take-profit options. Materializes
+//!   candidates, hands them to `backtest::run_suite`, and returns the
+//!   ranked grid plus a flat cell table for heatmaps.
+//!
+//! All inputs are pure functions of caller-provided candles or trade
+//! logs. No network, no exchange adapters, no signing, no randomness
+//! that isn't seeded.
+
+use serde::{Deserialize, Serialize};
+
+use crate::backtest::{
+    self, BacktestCandidate, BacktestInput, BacktestMetrics, BacktestSuiteInput,
+    BacktestSuiteResult, Candle, StrategyConfig, StrategySummary,
+};
+
+// -------------------- shared defaults --------------------
+
+fn default_initial_cash_usd() -> f64 {
+    10_000.0
+}
+
+fn default_fee_bps() -> f64 {
+    10.0
+}
+
+fn default_slippage_bps() -> f64 {
+    5.0
+}
+
+fn default_max_position_pct() -> f64 {
+    1.0
+}
+
+// -------------------- walk-forward --------------------
+
+#[derive(Debug, Deserialize)]
+pub struct WalkForwardInput {
+    pub candles: Vec<Candle>,
+    pub strategy: StrategyConfig,
+    /// Number of non-overlapping fold windows to split the candle
+    /// series into.
+    pub n_folds: usize,
+    /// Fraction of each fold window used for the in-sample (training)
+    /// run. The remaining tail (minus the embargo) is the
+    /// out-of-sample (test) run.
+    #[serde(default = "default_train_pct")]
+    pub train_pct: f64,
+    /// Number of candles to drop between train and test windows. Used
+    /// to prevent leakage from indicator state.
+    #[serde(default)]
+    pub embargo: usize,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+    #[serde(default = "default_fee_bps")]
+    pub fee_bps: f64,
+    #[serde(default = "default_slippage_bps")]
+    pub slippage_bps: f64,
+    #[serde(default = "default_max_position_pct")]
+    pub max_position_pct: f64,
+    #[serde(default)]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(default)]
+    pub take_profit_bps: Option<f64>,
+}
+
+fn default_train_pct() -> f64 {
+    0.7
+}
+
+#[derive(Debug, Serialize)]
+pub struct WalkForwardOutput {
+    pub schema_version: &'static str,
+    pub strategy: StrategySummary,
+    pub n_folds: usize,
+    pub train_pct: f64,
+    pub embargo: usize,
+    pub folds: Vec<WalkForwardFold>,
+    pub aggregate: WalkForwardAggregate,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WalkForwardFold {
+    pub index: usize,
+    pub train_start_index: usize,
+    pub train_end_index: usize,
+    pub test_start_index: usize,
+    pub test_end_index: usize,
+    pub train_metrics: BacktestMetrics,
+    pub test_metrics: BacktestMetrics,
+    pub is_oos_gap_pct: f64,
+    pub passes_test_gate: bool,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WalkForwardAggregate {
+    pub mean_train_return_pct: f64,
+    pub mean_test_return_pct: f64,
+    pub mean_is_oos_gap_pct: f64,
+    pub worst_test_drawdown_pct: f64,
+    pub fold_pass_rate: f64,
+    pub robustness: String,
+}
+
+pub fn run_walkforward(input: WalkForwardInput) -> Result<WalkForwardOutput, String> {
+    if input.n_folds < 2 {
+        return Err("walkforward requires n_folds >= 2".to_string());
+    }
+    if !input.train_pct.is_finite() || input.train_pct <= 0.0 || input.train_pct >= 1.0 {
+        return Err("walkforward train_pct must be in (0, 1)".to_string());
+    }
+    if input.candles.len() < input.n_folds * 4 {
+        return Err(format!(
+            "walkforward requires at least {} candles (n_folds * 4)",
+            input.n_folds * 4
+        ));
+    }
+
+    let total = input.candles.len();
+    let window = total / input.n_folds;
+    let mut folds = Vec::with_capacity(input.n_folds);
+    let mut warnings = Vec::new();
+
+    let mut sum_train = 0.0;
+    let mut sum_test = 0.0;
+    let mut sum_gap = 0.0;
+    let mut worst_dd = 0.0_f64;
+    let mut passes = 0usize;
+
+    for k in 0..input.n_folds {
+        let win_start = k * window;
+        let win_end = if k + 1 == input.n_folds {
+            total
+        } else {
+            (k + 1) * window
+        };
+        let win_len = win_end - win_start;
+        let train_len = ((win_len as f64) * input.train_pct).floor() as usize;
+        if train_len < 2 {
+            return Err(format!(
+                "walkforward fold {k}: train window has fewer than 2 candles; reduce n_folds or train_pct"
+            ));
+        }
+        let train_start = win_start;
+        let train_end = win_start + train_len;
+        let test_start = train_end + input.embargo;
+        if test_start + 2 > win_end {
+            return Err(format!(
+                "walkforward fold {k}: test window has fewer than 2 candles after embargo"
+            ));
+        }
+        let test_end = win_end;
+
+        let train_candles = input.candles[train_start..train_end].to_vec();
+        let test_candles = input.candles[test_start..test_end].to_vec();
+
+        let train_out = backtest::run(BacktestInput {
+            candles: train_candles,
+            strategy: input.strategy.clone(),
+            initial_cash_usd: input.initial_cash_usd,
+            fee_bps: input.fee_bps,
+            slippage_bps: input.slippage_bps,
+            max_position_pct: input.max_position_pct,
+            stop_loss_bps: input.stop_loss_bps,
+            take_profit_bps: input.take_profit_bps,
+        })?;
+
+        let test_out = backtest::run(BacktestInput {
+            candles: test_candles,
+            strategy: input.strategy.clone(),
+            initial_cash_usd: input.initial_cash_usd,
+            fee_bps: input.fee_bps,
+            slippage_bps: input.slippage_bps,
+            max_position_pct: input.max_position_pct,
+            stop_loss_bps: input.stop_loss_bps,
+            take_profit_bps: input.take_profit_bps,
+        })?;
+
+        let train_ret = train_out.metrics.total_return_pct;
+        let test_ret = test_out.metrics.total_return_pct;
+        let gap = train_ret - test_ret;
+        sum_train += train_ret;
+        sum_test += test_ret;
+        sum_gap += gap;
+        if test_out.metrics.max_drawdown_pct > worst_dd {
+            worst_dd = test_out.metrics.max_drawdown_pct;
+        }
+        let passes_test_gate = test_ret > 0.0
+            && test_out.metrics.max_drawdown_pct <= 35.0
+            && test_out.metrics.profit_factor >= 1.0
+            && test_out.metrics.trades > 0;
+        if passes_test_gate {
+            passes += 1;
+        }
+
+        let mut fold_warnings = Vec::new();
+        if test_out.metrics.trades == 0 {
+            fold_warnings.push(format!(
+                "fold {k}: zero out-of-sample trades; strategy did not signal in test window"
+            ));
+        }
+        if gap > 25.0 {
+            fold_warnings.push(format!(
+                "fold {k}: IS/OOS gap > 25pp; possible regime overfit"
+            ));
+        }
+
+        folds.push(WalkForwardFold {
+            index: k,
+            train_start_index: train_start,
+            train_end_index: train_end,
+            test_start_index: test_start,
+            test_end_index: test_end,
+            train_metrics: train_out.metrics,
+            test_metrics: test_out.metrics,
+            is_oos_gap_pct: gap,
+            passes_test_gate,
+            warnings: fold_warnings,
+        });
+    }
+
+    let n = input.n_folds as f64;
+    let mean_train = sum_train / n;
+    let mean_test = sum_test / n;
+    let mean_gap = sum_gap / n;
+    let pass_rate = passes as f64 / n;
+
+    let robustness = if mean_test <= 0.0 {
+        "overfit".to_string()
+    } else if mean_gap.abs() > 25.0 || pass_rate < 0.5 {
+        "fragile".to_string()
+    } else {
+        "robust".to_string()
+    };
+
+    if mean_test <= 0.0 {
+        warnings.push(
+            "mean out-of-sample return is non-positive; do not use this strategy for live quotes"
+                .to_string(),
+        );
+    }
+    if mean_gap > 25.0 {
+        warnings.push("mean IS/OOS gap > 25pp; strategy likely fits training regimes".to_string());
+    }
+    if pass_rate < 0.5 {
+        warnings.push(format!(
+            "only {} of {} folds passed the basic test gate; widen the data window or simplify the strategy",
+            passes, input.n_folds
+        ));
+    }
+
+    let strategy_summary = StrategySummary {
+        kind: input.strategy.kind.clone(),
+        fast_window: input.strategy.fast_window,
+        slow_window: input.strategy.slow_window,
+        lookback_window: input.strategy.lookback_window,
+        threshold_bps: input.strategy.threshold_bps,
+        entry_threshold: input.strategy.entry_threshold,
+        exit_threshold: input.strategy.exit_threshold,
+    };
+
+    Ok(WalkForwardOutput {
+        schema_version: "intents-walkforward/1",
+        strategy: strategy_summary,
+        n_folds: input.n_folds,
+        train_pct: input.train_pct,
+        embargo: input.embargo,
+        folds,
+        aggregate: WalkForwardAggregate {
+            mean_train_return_pct: mean_train,
+            mean_test_return_pct: mean_test,
+            mean_is_oos_gap_pct: mean_gap,
+            worst_test_drawdown_pct: worst_dd,
+            fold_pass_rate: pass_rate,
+            robustness,
+        },
+        warnings,
+    })
+}
+
+// -------------------- monte carlo --------------------
+
+#[derive(Debug, Deserialize)]
+pub struct MonteCarloInput {
+    /// Per-trade percentage returns (e.g. 1.5 = +1.5%). Typically the
+    /// `trades[].return_pct` array from a prior `backtest` response.
+    pub trade_returns_pct: Vec<f64>,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+    #[serde(default = "default_iterations")]
+    pub iterations: usize,
+    /// Seed for the deterministic xorshift64* PRNG. Fixed default so
+    /// scenarios are reproducible without an explicit seed.
+    #[serde(default = "default_mc_seed")]
+    pub seed: u64,
+    /// "shuffle" (sample with replacement) or "permute" (rearrange the
+    /// existing trade order without replacement). Permutation
+    /// preserves the empirical mean; shuffling exposes tail risk.
+    #[serde(default = "default_mc_method")]
+    pub method: String,
+}
+
+fn default_iterations() -> usize {
+    1_000
+}
+
+fn default_mc_seed() -> u64 {
+    0xC0FFEE_DEADBEEF
+}
+
+fn default_mc_method() -> String {
+    "shuffle".to_string()
+}
+
+#[derive(Debug, Serialize)]
+pub struct MonteCarloOutput {
+    pub schema_version: &'static str,
+    pub iterations: usize,
+    pub seed: u64,
+    pub method: String,
+    pub sample_size: usize,
+    pub initial_cash_usd: f64,
+    pub return_distribution: Distribution,
+    pub drawdown_distribution: Distribution,
+    pub terminal_equity_distribution: Distribution,
+    pub probability_of_loss: f64,
+    pub probability_of_drawdown_above_25pct: f64,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct Distribution {
+    pub mean: f64,
+    pub stddev: f64,
+    pub min: f64,
+    pub p05: f64,
+    pub p25: f64,
+    pub p50: f64,
+    pub p75: f64,
+    pub p95: f64,
+    pub max: f64,
+}
+
+pub fn run_montecarlo(input: MonteCarloInput) -> Result<MonteCarloOutput, String> {
+    if input.trade_returns_pct.is_empty() {
+        return Err("montecarlo requires at least 1 trade return".to_string());
+    }
+    if input.iterations == 0 {
+        return Err("montecarlo requires iterations >= 1".to_string());
+    }
+    if !input.initial_cash_usd.is_finite() || input.initial_cash_usd <= 0.0 {
+        return Err("initial_cash_usd must be > 0".to_string());
+    }
+    let method = match input.method.as_str() {
+        "shuffle" => Method::Shuffle,
+        "permute" => Method::Permute,
+        other => return Err(format!("unknown montecarlo method: {other}")),
+    };
+    for (idx, r) in input.trade_returns_pct.iter().enumerate() {
+        if !r.is_finite() {
+            return Err(format!("trade_returns_pct[{idx}] is not finite"));
+        }
+    }
+
+    let mut warnings = Vec::new();
+    if input.trade_returns_pct.len() < 5 {
+        warnings.push(format!(
+            "small sample: {} trades; resampled distributions are fragile",
+            input.trade_returns_pct.len()
+        ));
+    }
+
+    let mut rng = XorShift64Star::new(input.seed);
+    let n = input.trade_returns_pct.len();
+    let iterations = input.iterations;
+
+    let mut total_returns = Vec::with_capacity(iterations);
+    let mut drawdowns = Vec::with_capacity(iterations);
+    let mut terminals = Vec::with_capacity(iterations);
+    let mut loss_count = 0usize;
+    let mut dd_above_25_count = 0usize;
+
+    let mut perm_buffer: Vec<f64> = input.trade_returns_pct.clone();
+
+    for _ in 0..iterations {
+        let path: Vec<f64> = match method {
+            Method::Shuffle => (0..n)
+                .map(|_| {
+                    let idx = (rng.next() as usize) % n;
+                    input.trade_returns_pct[idx]
+                })
+                .collect(),
+            Method::Permute => {
+                fisher_yates(&mut perm_buffer, &mut rng);
+                perm_buffer.clone()
+            }
+        };
+
+        let mut equity = input.initial_cash_usd;
+        let mut peak = equity;
+        let mut max_dd = 0.0_f64;
+        for r in &path {
+            equity *= 1.0 + r / 100.0;
+            if equity > peak {
+                peak = equity;
+            }
+            if peak > 0.0 {
+                let dd = (peak - equity) / peak * 100.0;
+                if dd > max_dd {
+                    max_dd = dd;
+                }
+            }
+        }
+        let total_return_pct = (equity / input.initial_cash_usd - 1.0) * 100.0;
+        total_returns.push(total_return_pct);
+        drawdowns.push(max_dd);
+        terminals.push(equity);
+        if total_return_pct <= 0.0 {
+            loss_count += 1;
+        }
+        if max_dd >= 25.0 {
+            dd_above_25_count += 1;
+        }
+    }
+
+    let return_distribution = describe(&mut total_returns);
+    let drawdown_distribution = describe(&mut drawdowns);
+    let terminal_equity_distribution = describe(&mut terminals);
+
+    Ok(MonteCarloOutput {
+        schema_version: "intents-montecarlo/1",
+        iterations,
+        seed: input.seed,
+        method: input.method,
+        sample_size: n,
+        initial_cash_usd: input.initial_cash_usd,
+        return_distribution,
+        drawdown_distribution,
+        terminal_equity_distribution,
+        probability_of_loss: loss_count as f64 / iterations as f64,
+        probability_of_drawdown_above_25pct: dd_above_25_count as f64 / iterations as f64,
+        warnings,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Method {
+    Shuffle,
+    Permute,
+}
+
+struct XorShift64Star {
+    state: u64,
+}
+
+impl XorShift64Star {
+    fn new(seed: u64) -> Self {
+        // Avoid the all-zero degenerate state by mixing a constant.
+        let s = if seed == 0 {
+            0x9E37_79B9_7F4A_7C15
+        } else {
+            seed
+        };
+        Self { state: s }
+    }
+
+    fn next(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.state = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+}
+
+fn fisher_yates(buf: &mut [f64], rng: &mut XorShift64Star) {
+    if buf.len() < 2 {
+        return;
+    }
+    for i in (1..buf.len()).rev() {
+        let j = (rng.next() as usize) % (i + 1);
+        buf.swap(i, j);
+    }
+}
+
+fn describe(values: &mut [f64]) -> Distribution {
+    if values.is_empty() {
+        return Distribution::default();
+    }
+    let n = values.len() as f64;
+    let mean = values.iter().sum::<f64>() / n;
+    let variance = if values.len() > 1 {
+        values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / (n - 1.0)
+    } else {
+        0.0
+    };
+    let stddev = variance.sqrt();
+
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let min = *values.first().unwrap_or(&0.0);
+    let max = *values.last().unwrap_or(&0.0);
+    let pct = |q: f64| -> f64 {
+        let pos = (q * (values.len().saturating_sub(1)) as f64).round() as usize;
+        values[pos.min(values.len() - 1)]
+    };
+
+    Distribution {
+        mean,
+        stddev,
+        min,
+        p05: pct(0.05),
+        p25: pct(0.25),
+        p50: pct(0.50),
+        p75: pct(0.75),
+        p95: pct(0.95),
+        max,
+    }
+}
+
+// -------------------- grid sweep --------------------
+
+#[derive(Debug, Deserialize)]
+pub struct GridInput {
+    pub candles: Vec<Candle>,
+    pub base: StrategyConfig,
+    /// Strategy-parameter axes. The cartesian product of these axes
+    /// (combined with the optional sizing/stop/take-profit options
+    /// below) defines the grid.
+    #[serde(default)]
+    pub axes: Vec<GridAxis>,
+    #[serde(default)]
+    pub max_position_pct_options: Vec<f64>,
+    #[serde(default)]
+    pub stop_loss_bps_options: Vec<f64>,
+    #[serde(default)]
+    pub take_profit_bps_options: Vec<f64>,
+    #[serde(default = "default_initial_cash_usd")]
+    pub initial_cash_usd: f64,
+    #[serde(default = "default_fee_bps")]
+    pub fee_bps: f64,
+    #[serde(default = "default_slippage_bps")]
+    pub slippage_bps: f64,
+    /// Hard cap on materialized cells. Default is enough for a 6-axis
+    /// 4-value-each sweep without DOSing the WASM sandbox.
+    #[serde(default = "default_max_cells")]
+    pub max_cells: usize,
+}
+
+fn default_max_cells() -> usize {
+    1024
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+pub struct GridAxis {
+    /// One of: "fast_window", "slow_window", "lookback_window",
+    /// "threshold_bps", "entry_threshold", "exit_threshold".
+    pub param: String,
+    pub values: Vec<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GridOutput {
+    pub schema_version: &'static str,
+    pub base: StrategySummary,
+    pub axes: Vec<GridAxis>,
+    pub cells: Vec<GridCell>,
+    pub ranked: Vec<BacktestSuiteResult>,
+    pub warnings: Vec<String>,
+    pub total_cells: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GridCell {
+    pub id: String,
+    pub params: serde_json::Value,
+    pub max_position_pct: f64,
+    pub stop_loss_bps: Option<f64>,
+    pub take_profit_bps: Option<f64>,
+}
+
+pub fn run_grid(input: GridInput) -> Result<GridOutput, String> {
+    if !input.initial_cash_usd.is_finite() || input.initial_cash_usd <= 0.0 {
+        return Err("initial_cash_usd must be > 0".to_string());
+    }
+    for axis in &input.axes {
+        if axis.values.is_empty() {
+            return Err(format!("grid axis '{}' has no values", axis.param));
+        }
+        match axis.param.as_str() {
+            "fast_window" | "slow_window" | "lookback_window" | "threshold_bps"
+            | "entry_threshold" | "exit_threshold" => {}
+            other => return Err(format!("unknown grid axis param: {other}")),
+        }
+    }
+
+    let position_options = if input.max_position_pct_options.is_empty() {
+        vec![1.0]
+    } else {
+        input.max_position_pct_options.clone()
+    };
+    let stop_options: Vec<Option<f64>> = if input.stop_loss_bps_options.is_empty() {
+        vec![None]
+    } else {
+        input
+            .stop_loss_bps_options
+            .iter()
+            .map(|v| Some(*v))
+            .collect()
+    };
+    let tp_options: Vec<Option<f64>> = if input.take_profit_bps_options.is_empty() {
+        vec![None]
+    } else {
+        input
+            .take_profit_bps_options
+            .iter()
+            .map(|v| Some(*v))
+            .collect()
+    };
+
+    let mut total: usize = 1;
+    for axis in &input.axes {
+        total = total
+            .checked_mul(axis.values.len())
+            .ok_or_else(|| "grid cell count overflow".to_string())?;
+    }
+    total = total
+        .checked_mul(position_options.len())
+        .and_then(|t| t.checked_mul(stop_options.len()))
+        .and_then(|t| t.checked_mul(tp_options.len()))
+        .ok_or_else(|| "grid cell count overflow".to_string())?;
+
+    if total > input.max_cells {
+        return Err(format!(
+            "grid would generate {total} cells (>{max}); narrow the axes or raise max_cells",
+            max = input.max_cells
+        ));
+    }
+
+    let mut cells: Vec<GridCell> = Vec::with_capacity(total);
+    let mut candidates: Vec<BacktestCandidate> = Vec::with_capacity(total);
+
+    enumerate_axes(
+        &input.axes,
+        0,
+        &mut Vec::new(),
+        &position_options,
+        &stop_options,
+        &tp_options,
+        &input.base,
+        &mut cells,
+        &mut candidates,
+    )?;
+
+    let suite = backtest::run_suite(BacktestSuiteInput {
+        candles: input.candles,
+        candidates,
+        initial_cash_usd: input.initial_cash_usd,
+        fee_bps: input.fee_bps,
+        slippage_bps: input.slippage_bps,
+    })?;
+
+    let mut warnings = suite.warnings;
+    if suite.ranked.iter().all(|r| !r.passes_basic_gate) {
+        warnings
+            .push("no grid cell passed the basic gate; widen axes or change strategy".to_string());
+    }
+
+    let base = StrategySummary {
+        kind: input.base.kind.clone(),
+        fast_window: input.base.fast_window,
+        slow_window: input.base.slow_window,
+        lookback_window: input.base.lookback_window,
+        threshold_bps: input.base.threshold_bps,
+        entry_threshold: input.base.entry_threshold,
+        exit_threshold: input.base.exit_threshold,
+    };
+
+    Ok(GridOutput {
+        schema_version: "intents-grid/1",
+        base,
+        axes: input.axes,
+        total_cells: cells.len(),
+        cells,
+        ranked: suite.ranked,
+        warnings,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn enumerate_axes(
+    axes: &[GridAxis],
+    depth: usize,
+    selected: &mut Vec<(String, f64)>,
+    position_options: &[f64],
+    stop_options: &[Option<f64>],
+    tp_options: &[Option<f64>],
+    base: &StrategyConfig,
+    cells: &mut Vec<GridCell>,
+    candidates: &mut Vec<BacktestCandidate>,
+) -> Result<(), String> {
+    if depth == axes.len() {
+        for &pos in position_options {
+            for &stop in stop_options {
+                for &tp in tp_options {
+                    let mut strategy = base.clone();
+                    let mut params = serde_json::Map::new();
+                    for (name, value) in selected.iter() {
+                        apply_param(&mut strategy, name, *value)?;
+                        params.insert(name.clone(), serde_json::json!(*value));
+                    }
+                    let id = make_cell_id(selected, pos, stop, tp);
+                    cells.push(GridCell {
+                        id: id.clone(),
+                        params: serde_json::Value::Object(params),
+                        max_position_pct: pos,
+                        stop_loss_bps: stop,
+                        take_profit_bps: tp,
+                    });
+                    candidates.push(BacktestCandidate {
+                        id,
+                        strategy,
+                        max_position_pct: Some(pos),
+                        stop_loss_bps: stop,
+                        take_profit_bps: tp,
+                    });
+                }
+            }
+        }
+        return Ok(());
+    }
+    let axis = &axes[depth];
+    for value in &axis.values {
+        selected.push((axis.param.clone(), *value));
+        enumerate_axes(
+            axes,
+            depth + 1,
+            selected,
+            position_options,
+            stop_options,
+            tp_options,
+            base,
+            cells,
+            candidates,
+        )?;
+        selected.pop();
+    }
+    Ok(())
+}
+
+fn apply_param(strategy: &mut StrategyConfig, name: &str, value: f64) -> Result<(), String> {
+    match name {
+        "fast_window" => strategy.fast_window = Some(value as usize),
+        "slow_window" => strategy.slow_window = Some(value as usize),
+        "lookback_window" => strategy.lookback_window = Some(value as usize),
+        "threshold_bps" => strategy.threshold_bps = Some(value),
+        "entry_threshold" => strategy.entry_threshold = Some(value),
+        "exit_threshold" => strategy.exit_threshold = Some(value),
+        other => return Err(format!("unknown grid param: {other}")),
+    }
+    Ok(())
+}
+
+fn make_cell_id(
+    selected: &[(String, f64)],
+    pos: f64,
+    stop: Option<f64>,
+    tp: Option<f64>,
+) -> String {
+    let mut parts: Vec<String> = selected
+        .iter()
+        .map(|(name, value)| format!("{name}={value}"))
+        .collect();
+    parts.push(format!("pos={pos}"));
+    if let Some(s) = stop {
+        parts.push(format!("stop={s}"));
+    }
+    if let Some(t) = tp {
+        parts.push(format!("tp={t}"));
+    }
+    parts.join("|")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candle(idx: usize, close: f64) -> Candle {
+        Candle {
+            ts: format!("2026-01-{idx:02}T00:00:00Z"),
+            open: close,
+            high: close * 1.01,
+            low: close * 0.99,
+            close,
+            volume: 1_000.0,
+        }
+    }
+
+    fn series(closes: &[f64]) -> Vec<Candle> {
+        closes
+            .iter()
+            .enumerate()
+            .map(|(idx, c)| candle(idx + 1, *c))
+            .collect()
+    }
+
+    #[test]
+    fn walkforward_computes_per_fold_and_aggregate() {
+        // 40 candles, gentle uptrend so buy-hold has a non-trivial return
+        let mut closes = Vec::new();
+        for i in 0..40 {
+            closes.push(100.0 + i as f64);
+        }
+        let out = run_walkforward(WalkForwardInput {
+            candles: series(&closes),
+            strategy: StrategyConfig {
+                kind: "buy-hold".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+            n_folds: 4,
+            train_pct: 0.7,
+            embargo: 1,
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            max_position_pct: 1.0,
+            stop_loss_bps: None,
+            take_profit_bps: None,
+        })
+        .unwrap();
+        assert_eq!(out.schema_version, "intents-walkforward/1");
+        assert_eq!(out.folds.len(), 4);
+        assert!(out.aggregate.mean_test_return_pct > 0.0);
+    }
+
+    #[test]
+    fn walkforward_rejects_too_few_candles() {
+        let closes = [100.0, 101.0, 102.0, 103.0];
+        let err = run_walkforward(WalkForwardInput {
+            candles: series(&closes),
+            strategy: StrategyConfig {
+                kind: "buy-hold".to_string(),
+                fast_window: None,
+                slow_window: None,
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+            n_folds: 5,
+            train_pct: 0.7,
+            embargo: 0,
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            max_position_pct: 1.0,
+            stop_loss_bps: None,
+            take_profit_bps: None,
+        })
+        .unwrap_err();
+        assert!(err.contains("at least"));
+    }
+
+    #[test]
+    fn montecarlo_reproduces_with_same_seed() {
+        let returns = vec![1.5, -0.5, 2.0, -1.0, 0.8, 0.3, -0.2, 1.1];
+        let a = run_montecarlo(MonteCarloInput {
+            trade_returns_pct: returns.clone(),
+            initial_cash_usd: 1_000.0,
+            iterations: 200,
+            seed: 42,
+            method: "shuffle".to_string(),
+        })
+        .unwrap();
+        let b = run_montecarlo(MonteCarloInput {
+            trade_returns_pct: returns,
+            initial_cash_usd: 1_000.0,
+            iterations: 200,
+            seed: 42,
+            method: "shuffle".to_string(),
+        })
+        .unwrap();
+        assert_eq!(a.return_distribution.p50, b.return_distribution.p50);
+        assert_eq!(a.drawdown_distribution.p95, b.drawdown_distribution.p95);
+    }
+
+    #[test]
+    fn montecarlo_permute_preserves_mean() {
+        let returns = vec![1.0, -0.5, 1.5, -0.2, 0.7];
+        let out = run_montecarlo(MonteCarloInput {
+            trade_returns_pct: returns.clone(),
+            initial_cash_usd: 1_000.0,
+            iterations: 500,
+            seed: 1,
+            method: "permute".to_string(),
+        })
+        .unwrap();
+        // Permutation re-orders the empirical sequence, so each path's
+        // compounded return is a permutation invariant of returns.
+        let mut equity = 1_000.0;
+        for r in &returns {
+            equity *= 1.0 + r / 100.0;
+        }
+        let observed = (equity / 1_000.0 - 1.0) * 100.0;
+        assert!((out.return_distribution.mean - observed).abs() < 1e-6);
+        assert!((out.return_distribution.p50 - observed).abs() < 1e-6);
+    }
+
+    #[test]
+    fn grid_enumerates_cartesian_product() {
+        let mut closes = Vec::new();
+        for i in 0..30 {
+            closes.push(100.0 + i as f64);
+        }
+        let out = run_grid(GridInput {
+            candles: series(&closes),
+            base: StrategyConfig {
+                kind: "sma-cross".to_string(),
+                fast_window: Some(5),
+                slow_window: Some(20),
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+            axes: vec![
+                GridAxis {
+                    param: "fast_window".to_string(),
+                    values: vec![3.0, 5.0],
+                },
+                GridAxis {
+                    param: "slow_window".to_string(),
+                    values: vec![10.0, 20.0],
+                },
+            ],
+            max_position_pct_options: vec![1.0],
+            stop_loss_bps_options: vec![],
+            take_profit_bps_options: vec![],
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            max_cells: 64,
+        })
+        .unwrap();
+        assert_eq!(out.cells.len(), 4);
+        assert_eq!(out.ranked.len(), 4);
+        assert_eq!(out.schema_version, "intents-grid/1");
+    }
+
+    #[test]
+    fn grid_enforces_cell_cap() {
+        let closes = [100.0, 101.0, 102.0, 103.0, 104.0];
+        let err = run_grid(GridInput {
+            candles: series(&closes),
+            base: StrategyConfig {
+                kind: "sma-cross".to_string(),
+                fast_window: Some(2),
+                slow_window: Some(3),
+                lookback_window: None,
+                threshold_bps: None,
+                entry_threshold: None,
+                exit_threshold: None,
+            },
+            axes: vec![GridAxis {
+                param: "fast_window".to_string(),
+                values: (1..=10).map(|i| i as f64).collect(),
+            }],
+            max_position_pct_options: vec![],
+            stop_loss_bps_options: vec![],
+            take_profit_bps_options: vec![],
+            initial_cash_usd: 1_000.0,
+            fee_bps: 0.0,
+            slippage_bps: 0.0,
+            max_cells: 5,
+        })
+        .unwrap_err();
+        assert!(err.contains("max_cells"));
+    }
+}

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -18,6 +18,21 @@
 //!   caller-provided OHLCV candles before any intent is built.
 //! - `backtest_suite` — rank several strategy candidates over the same
 //!   candle episode before any strategy is selected for paper intent work.
+//! - `backtest_walkforward` — fixed-strategy walk-forward across N
+//!   contiguous, non-overlapping fold windows; reports per-fold
+//!   IS/OOS gap and an aggregate robustness verdict.
+//! - `backtest_montecarlo` — seeded resample/permute over a per-trade
+//!   return series; reports return / drawdown / terminal-equity
+//!   distributions and loss probabilities.
+//! - `backtest_grid` — cartesian sweep over strategy parameter axes
+//!   plus optional sizing/stop/take-profit options; ranked through
+//!   `backtest_suite`.
+//! - `validate_episode` — structural check for the shared episode
+//!   format (candles + optional solver fixture + optional news
+//!   context).
+//! - `replay_episode` — validate then replay an episode through
+//!   `backtest_suite`, surfacing the embedded solver fixture and
+//!   news context.
 //! - `plan_paid_research` — rank paid/free research sources, budget a
 //!   premium-source query, and prepare attribution/payment gates.
 //! - `plan_dripstack_browse` — model DripStack's guided topic →
@@ -59,9 +74,11 @@ use serde::{Deserialize, Serialize};
 
 mod analyzer;
 mod backtest;
+mod episode;
 mod format;
 mod indexer;
 mod intents;
+mod lab;
 mod research;
 mod strategy;
 mod trial;
@@ -143,6 +160,43 @@ enum PortfolioAction {
     /// menu of choices instead of blindly evaluating one strategy.
     #[serde(rename = "backtest_suite")]
     BacktestSuite(backtest::BacktestSuiteInput),
+
+    /// Run a fixed-strategy walk-forward across N contiguous,
+    /// non-overlapping fold windows, splitting each fold into
+    /// in-sample (train) and out-of-sample (test) ranges with an
+    /// optional embargo. Reports per-fold IS/OOS gap and an
+    /// aggregate robustness verdict. Does not refit parameters.
+    #[serde(rename = "backtest_walkforward")]
+    BacktestWalkForward(lab::WalkForwardInput),
+
+    /// Run a deterministic Monte Carlo on a per-trade return series
+    /// (typically `trades[].return_pct` from a prior backtest). Uses
+    /// a seeded xorshift64* PRNG to resample or permute the trade
+    /// order and reports return / drawdown / terminal-equity
+    /// distributions plus loss probabilities.
+    #[serde(rename = "backtest_montecarlo")]
+    BacktestMonteCarlo(lab::MonteCarloInput),
+
+    /// Cartesian sweep over strategy parameter axes plus optional
+    /// sizing/stop/take-profit options. Materializes candidates,
+    /// runs `backtest_suite`, and returns the ranked grid plus a
+    /// flat cell table. Enforces a `max_cells` cap so the WASM
+    /// sandbox can't be DOSed by an oversized request.
+    #[serde(rename = "backtest_grid")]
+    BacktestGrid(lab::GridInput),
+
+    /// Validate a multi-surface episode (candles + optional solver
+    /// fixture + optional news context) and return a deterministic
+    /// summary. No backtest is run.
+    #[serde(rename = "validate_episode")]
+    ValidateEpisode(episode::ValidateEpisodeInput),
+
+    /// Validate an episode and replay it through `backtest_suite`,
+    /// surfacing the embedded solver fixture and news context so the
+    /// caller can route them into `build_intent` and the analyst
+    /// memos.
+    #[serde(rename = "replay_episode")]
+    ReplayEpisode(episode::ReplayEpisodeInput),
 
     /// Plan a premium-source research query before fetching paywalled
     /// content. This ranks candidate sources, enforces a budget, and
@@ -259,9 +313,10 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          classifies them against an embedded protocol registry, generates ranked \
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
-         backtest, backtest_suite, plan_paid_research, plan_dripstack_browse, \
-         fetch_dripstack_catalog, prepare_dripstack_paid_fetch, plan_near_intents_trial, \
-         format_suggestion, format_widget, format_intents_widget. \
+         backtest, backtest_suite, backtest_walkforward, backtest_montecarlo, \
+         backtest_grid, validate_episode, replay_episode, plan_paid_research, \
+         plan_dripstack_browse, fetch_dripstack_catalog, prepare_dripstack_paid_fetch, \
+         plan_near_intents_trial, format_suggestion, format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
     }
@@ -357,6 +412,31 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = backtest::run_suite(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize backtest_suite response: {e}"))
+        }
+        PortfolioAction::BacktestWalkForward(input) => {
+            let output = lab::run_walkforward(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize backtest_walkforward response: {e}"))
+        }
+        PortfolioAction::BacktestMonteCarlo(input) => {
+            let output = lab::run_montecarlo(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize backtest_montecarlo response: {e}"))
+        }
+        PortfolioAction::BacktestGrid(input) => {
+            let output = lab::run_grid(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize backtest_grid response: {e}"))
+        }
+        PortfolioAction::ValidateEpisode(input) => {
+            let output = episode::validate(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize validate_episode response: {e}"))
+        }
+        PortfolioAction::ReplayEpisode(input) => {
+            let output = episode::replay(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize replay_episode response: {e}"))
         }
         PortfolioAction::PlanPaidResearch(input) => {
             let output = research::plan(input)?;

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -20,6 +20,8 @@
 //!   candle episode before any strategy is selected for paper intent work.
 //! - `plan_paid_research` — rank paid/free research sources, budget a
 //!   premium-source query, and prepare attribution/payment gates.
+//! - `plan_dripstack_browse` — model DripStack's guided topic →
+//!   publication → article purchase flow without fetching paid content.
 //! - `format_intents_widget` — build the NEAR Intents trading console
 //!   view model consumed by the project widget.
 //!
@@ -141,6 +143,13 @@ enum PortfolioAction {
     #[serde(rename = "plan_paid_research")]
     PlanPaidResearch(research::PaidResearchPlanInput),
 
+    /// Plan the DripStack guided-browse flow. Free catalog/post-title
+    /// metadata goes in; a selected article becomes a paid-source
+    /// candidate for `plan_paid_research`. It never buys or fetches
+    /// article bodies.
+    #[serde(rename = "plan_dripstack_browse")]
+    PlanDripstackBrowse(research::DripstackBrowseInput),
+
     /// Build the render-ready view model the web widget consumes.
     /// Writes to `projects/<id>/widgets/state.json`.
     #[serde(rename = "format_widget")]
@@ -223,8 +232,8 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          classifies them against an embedded protocol registry, generates ranked \
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
-         backtest, backtest_suite, plan_paid_research, format_suggestion, \
-         format_widget, format_intents_widget. \
+         backtest, backtest_suite, plan_paid_research, plan_dripstack_browse, \
+         format_suggestion, format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
     }
@@ -325,6 +334,11 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = research::plan(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize plan_paid_research response: {e}"))
+        }
+        PortfolioAction::PlanDripstackBrowse(input) => {
+            let output = research::plan_dripstack_browse(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize plan_dripstack_browse response: {e}"))
         }
         PortfolioAction::FormatWidget(input) => {
             let output = widget::format_widget(input);

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -22,6 +22,12 @@
 //!   premium-source query, and prepare attribution/payment gates.
 //! - `plan_dripstack_browse` — model DripStack's guided topic →
 //!   publication → article purchase flow without fetching paid content.
+//! - `fetch_dripstack_catalog` — fetch DripStack's free publication or
+//!   publication-post metadata routes for guided browse.
+//! - `prepare_dripstack_paid_fetch` — prepare the explicit
+//!   confirmation/receipt boundary for a single paid DripStack article.
+//! - `plan_near_intents_trial` — prepare a nominal-NEAR paper/quote
+//!   rehearsal with strategy gates and unsigned intent build requests.
 //! - `format_intents_widget` — build the NEAR Intents trading console
 //!   view model consumed by the project widget.
 //!
@@ -40,6 +46,7 @@
 //! ├── intents/            // build_intent: solver call + bounded checks
 //! ├── backtest.rs         // paper strategy replay/ranking over OHLCV candles
 //! ├── research.rs         // paid research source budgeting/attribution
+//! ├── trial.rs            // nominal NEAR rehearsal planning
 //! └── widget.rs           // web widget state formatters
 //! ```
 
@@ -57,6 +64,7 @@ mod indexer;
 mod intents;
 mod research;
 mod strategy;
+mod trial;
 mod types;
 mod widget;
 
@@ -150,6 +158,25 @@ enum PortfolioAction {
     #[serde(rename = "plan_dripstack_browse")]
     PlanDripstackBrowse(research::DripstackBrowseInput),
 
+    /// Fetch DripStack's free catalog routes. This may return
+    /// publication metadata or post-title metadata; it does not fetch
+    /// paid article bodies.
+    #[serde(rename = "fetch_dripstack_catalog")]
+    FetchDripstackCatalog(research::DripstackCatalogInput),
+
+    /// Prepare the paid article fetch boundary for one DripStack post:
+    /// confirmation, 402 challenge probe, and receipt-backed retry
+    /// headers. It never creates a payment receipt or reads article
+    /// content by itself.
+    #[serde(rename = "prepare_dripstack_paid_fetch")]
+    PrepareDripstackPaidFetch(research::DripstackPaidFetchInput),
+
+    /// Plan a nominal-NEAR trial run. This returns setup guardrails,
+    /// strategy menu defaults, and a paper/live-quote `build_intent`
+    /// request without signing or moving funds.
+    #[serde(rename = "plan_near_intents_trial")]
+    PlanNearIntentsTrial(trial::NearTrialPlanInput),
+
     /// Build the render-ready view model the web widget consumes.
     /// Writes to `projects/<id>/widgets/state.json`.
     #[serde(rename = "format_widget")]
@@ -233,6 +260,7 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
          backtest, backtest_suite, plan_paid_research, plan_dripstack_browse, \
+         fetch_dripstack_catalog, prepare_dripstack_paid_fetch, plan_near_intents_trial, \
          format_suggestion, format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
@@ -339,6 +367,21 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = research::plan_dripstack_browse(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize plan_dripstack_browse response: {e}"))
+        }
+        PortfolioAction::FetchDripstackCatalog(input) => {
+            let output = research::fetch_dripstack_catalog(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize fetch_dripstack_catalog response: {e}"))
+        }
+        PortfolioAction::PrepareDripstackPaidFetch(input) => {
+            let output = research::prepare_dripstack_paid_fetch(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize prepare_dripstack_paid_fetch response: {e}"))
+        }
+        PortfolioAction::PlanNearIntentsTrial(input) => {
+            let output = trial::plan(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize plan_near_intents_trial response: {e}"))
         }
         PortfolioAction::FormatWidget(input) => {
             let output = widget::format_widget(input);

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -18,6 +18,8 @@
 //!   caller-provided OHLCV candles before any intent is built.
 //! - `backtest_suite` — rank several strategy candidates over the same
 //!   candle episode before any strategy is selected for paper intent work.
+//! - `plan_paid_research` — rank paid/free research sources, budget a
+//!   premium-source query, and prepare attribution/payment gates.
 //! - `format_intents_widget` — build the NEAR Intents trading console
 //!   view model consumed by the project widget.
 //!
@@ -35,6 +37,7 @@
 //! ├── strategy/           // propose: parse strategy docs + filter
 //! ├── intents/            // build_intent: solver call + bounded checks
 //! ├── backtest.rs         // paper strategy replay/ranking over OHLCV candles
+//! ├── research.rs         // paid research source budgeting/attribution
 //! └── widget.rs           // web widget state formatters
 //! ```
 
@@ -50,6 +53,7 @@ mod backtest;
 mod format;
 mod indexer;
 mod intents;
+mod research;
 mod strategy;
 mod types;
 mod widget;
@@ -129,6 +133,13 @@ enum PortfolioAction {
     /// menu of choices instead of blindly evaluating one strategy.
     #[serde(rename = "backtest_suite")]
     BacktestSuite(backtest::BacktestSuiteInput),
+
+    /// Plan a premium-source research query before fetching paywalled
+    /// content. This ranks candidate sources, enforces a budget, and
+    /// returns attribution/payment gates for MPP, x402, and NEAR
+    /// Intents-style rails. It never fetches paid content or signs.
+    #[serde(rename = "plan_paid_research")]
+    PlanPaidResearch(research::PaidResearchPlanInput),
 
     /// Build the render-ready view model the web widget consumes.
     /// Writes to `projects/<id>/widgets/state.json`.
@@ -212,8 +223,8 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          classifies them against an embedded protocol registry, generates ranked \
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
-         backtest, backtest_suite, format_suggestion, format_widget, \
-         format_intents_widget. \
+         backtest, backtest_suite, plan_paid_research, format_suggestion, \
+         format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
     }
@@ -309,6 +320,11 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = backtest::run_suite(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize backtest_suite response: {e}"))
+        }
+        PortfolioAction::PlanPaidResearch(input) => {
+            let output = research::plan(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize plan_paid_research response: {e}"))
         }
         PortfolioAction::FormatWidget(input) => {
             let output = widget::format_widget(input);

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -38,6 +38,11 @@
 //! - `plan_dca_schedule` — emit a recurring DCA schedule (cron + per
 //!   period plan + `build_intent` template + risk gates) for a
 //!   NEAR-Intents-supported destination asset; unsigned only.
+//! - `compile_intent_prompt` — turn a natural-language trade prompt
+//!   ("DCA $100 weekly into NEAR for 6 months") into a structured
+//!   recommended action plus extracted fields, assumptions,
+//!   clarifications, and gates. Deterministic pattern matching, no
+//!   LLM call.
 //! - `plan_paid_research` — rank paid/free research sources, budget a
 //!   premium-source query, and prepare attribution/payment gates.
 //! - `plan_dripstack_browse` — model DripStack's guided topic →
@@ -85,6 +90,7 @@ mod format;
 mod indexer;
 mod intents;
 mod lab;
+mod nl;
 mod research;
 mod strategy;
 mod trial;
@@ -219,6 +225,15 @@ enum PortfolioAction {
     #[serde(rename = "plan_dca_schedule")]
     PlanDcaSchedule(dca::DcaScheduleInput),
 
+    /// Compile a natural-language trade prompt into a structured
+    /// recommended action (one of `plan_dca_schedule`, `build_intent`,
+    /// `backtest_suite`, `plan_paid_research`, `format_intents_widget`,
+    /// or `noop`). Deterministic pattern matching, no LLM call. The
+    /// caller invokes the recommended action separately after risk
+    /// gating; this compiler never executes anything.
+    #[serde(rename = "compile_intent_prompt")]
+    CompileIntentPrompt(nl::CompileInput),
+
     /// Plan a premium-source research query before fetching paywalled
     /// content. This ranks candidate sources, enforces a budget, and
     /// returns attribution/payment gates for MPP, x402, and NEAR
@@ -335,7 +350,8 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
          backtest, backtest_suite, backtest_walkforward, backtest_montecarlo, \
-         backtest_grid, backtest_dca, plan_dca_schedule, validate_episode, replay_episode, plan_paid_research, \
+         backtest_grid, backtest_dca, plan_dca_schedule, compile_intent_prompt, \
+         validate_episode, replay_episode, plan_paid_research, \
          plan_dripstack_browse, fetch_dripstack_catalog, prepare_dripstack_paid_fetch, \
          plan_near_intents_trial, format_suggestion, format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
@@ -468,6 +484,11 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = dca::plan_schedule(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize plan_dca_schedule response: {e}"))
+        }
+        PortfolioAction::CompileIntentPrompt(input) => {
+            let output = nl::compile(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize compile_intent_prompt response: {e}"))
         }
         PortfolioAction::PlanPaidResearch(input) => {
             let output = research::plan(input)?;

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -5,7 +5,7 @@
 
 //! Portfolio WASM tool for IronClaw.
 //!
-//! Single tool with three operations:
+//! Single tool with multiple operations:
 //!
 //! - `scan` — discover positions across chains for one or more addresses
 //!   and classify them against the embedded protocol registry.
@@ -14,6 +14,12 @@
 //!   filter; LLM does the final ranking via the skill playbook).
 //! - `build_intent` — translate a movement plan into an unsigned NEAR
 //!   Intent bundle, applying bounded checks before returning.
+//! - `backtest` — run deterministic long-only spot strategy tests over
+//!   caller-provided OHLCV candles before any intent is built.
+//! - `backtest_suite` — rank several strategy candidates over the same
+//!   candle episode before any strategy is selected for paper intent work.
+//! - `format_intents_widget` — build the NEAR Intents trading console
+//!   view model consumed by the project widget.
 //!
 //! The agent never holds private keys. All output is read-only or
 //! unsigned.
@@ -27,7 +33,9 @@
 //! ├── indexer/            // scan: fetch + normalize raw positions
 //! ├── analyzer/           // classify raw positions via protocols/*.json
 //! ├── strategy/           // propose: parse strategy docs + filter
-//! └── intents/            // build_intent: solver call + bounded checks
+//! ├── intents/            // build_intent: solver call + bounded checks
+//! ├── backtest.rs         // paper strategy replay/ranking over OHLCV candles
+//! └── widget.rs           // web widget state formatters
 //! ```
 
 wit_bindgen::generate!({
@@ -38,6 +46,7 @@ wit_bindgen::generate!({
 use serde::{Deserialize, Serialize};
 
 mod analyzer;
+mod backtest;
 mod format;
 mod indexer;
 mod intents;
@@ -109,10 +118,28 @@ enum PortfolioAction {
     #[serde(rename = "progress")]
     Progress(format::ProgressInput),
 
+    /// Run deterministic long-only spot backtests over caller-provided
+    /// OHLCV candles. Used by the Intents Trading Agent before a
+    /// candidate trade is eligible for intent construction.
+    #[serde(rename = "backtest")]
+    Backtest(backtest::BacktestInput),
+
+    /// Run and rank several deterministic long-only spot strategy
+    /// candidates over the same OHLCV episode. Used to build a
+    /// menu of choices instead of blindly evaluating one strategy.
+    #[serde(rename = "backtest_suite")]
+    BacktestSuite(backtest::BacktestSuiteInput),
+
     /// Build the render-ready view model the web widget consumes.
     /// Writes to `projects/<id>/widgets/state.json`.
     #[serde(rename = "format_widget")]
     FormatWidget(widget::FormatWidgetInput),
+
+    /// Build the render-ready view model the Intents Trading Agent
+    /// project widget consumes. The caller persists it under
+    /// `projects/intents-trading-agent/widgets/state.json`.
+    #[serde(rename = "format_intents_widget")]
+    FormatIntentsWidget(widget::FormatIntentsTradingWidgetInput),
 }
 
 fn default_chains() -> ChainSelector {
@@ -184,7 +211,9 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
         "Cross-chain DeFi portfolio analyzer. Discovers positions across chains, \
          classifies them against an embedded protocol registry, generates ranked \
          rebalancing proposals from declarative strategy docs, and builds unsigned \
-         NEAR Intent bundles. Three operations: scan, propose, build_intent. \
+         NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
+         backtest, backtest_suite, format_suggestion, format_widget, \
+         format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
             .to_string()
     }
@@ -272,10 +301,24 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = format::format_progress(input);
             serde_json::to_string(&output).map_err(|e| format!("Serialize progress response: {e}"))
         }
+        PortfolioAction::Backtest(input) => {
+            let output = backtest::run(input)?;
+            serde_json::to_string(&output).map_err(|e| format!("Serialize backtest response: {e}"))
+        }
+        PortfolioAction::BacktestSuite(input) => {
+            let output = backtest::run_suite(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize backtest_suite response: {e}"))
+        }
         PortfolioAction::FormatWidget(input) => {
             let output = widget::format_widget(input);
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize format_widget response: {e}"))
+        }
+        PortfolioAction::FormatIntentsWidget(input) => {
+            let output = widget::format_intents_trading_widget(input);
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize format_intents_widget response: {e}"))
         }
     }
 }

--- a/tools-src/portfolio/src/lib.rs
+++ b/tools-src/portfolio/src/lib.rs
@@ -33,6 +33,11 @@
 //! - `replay_episode` — validate then replay an episode through
 //!   `backtest_suite`, surfacing the embedded solver fixture and
 //!   news context.
+//! - `backtest_dca` — replay a fixed-cadence dollar-cost-averaging
+//!   buy schedule with optional symmetric price-band variants.
+//! - `plan_dca_schedule` — emit a recurring DCA schedule (cron + per
+//!   period plan + `build_intent` template + risk gates) for a
+//!   NEAR-Intents-supported destination asset; unsigned only.
 //! - `plan_paid_research` — rank paid/free research sources, budget a
 //!   premium-source query, and prepare attribution/payment gates.
 //! - `plan_dripstack_browse` — model DripStack's guided topic →
@@ -74,6 +79,7 @@ use serde::{Deserialize, Serialize};
 
 mod analyzer;
 mod backtest;
+mod dca;
 mod episode;
 mod format;
 mod indexer;
@@ -198,6 +204,21 @@ enum PortfolioAction {
     #[serde(rename = "replay_episode")]
     ReplayEpisode(episode::ReplayEpisodeInput),
 
+    /// Replay a fixed-cadence dollar-cost-averaging schedule over a
+    /// candle series. Reports lots, breakeven, mark-to-market, and
+    /// alpha vs lump-sum buy-and-hold. Optional symmetric price band
+    /// turns the schedule into "skip when stretched, double-up when
+    /// discounted" without breaking determinism.
+    #[serde(rename = "backtest_dca")]
+    BacktestDca(dca::DcaBacktestInput),
+
+    /// Plan a recurring DCA schedule into a NEAR-Intents-supported
+    /// destination asset. Emits a cron expression, per-period plans,
+    /// risk gates, and a `build_intent` template the caller uses per
+    /// period. All output is unsigned; signing remains user-only.
+    #[serde(rename = "plan_dca_schedule")]
+    PlanDcaSchedule(dca::DcaScheduleInput),
+
     /// Plan a premium-source research query before fetching paywalled
     /// content. This ranks candidate sources, enforces a budget, and
     /// returns attribution/payment gates for MPP, x402, and NEAR
@@ -314,7 +335,7 @@ impl exports::near::agent::tool::Guest for PortfolioTool {
          rebalancing proposals from declarative strategy docs, and builds unsigned \
          NEAR Intent bundles. Operations: scan, propose, build_intent, progress, \
          backtest, backtest_suite, backtest_walkforward, backtest_montecarlo, \
-         backtest_grid, validate_episode, replay_episode, plan_paid_research, \
+         backtest_grid, backtest_dca, plan_dca_schedule, validate_episode, replay_episode, plan_paid_research, \
          plan_dripstack_browse, fetch_dripstack_catalog, prepare_dripstack_paid_fetch, \
          plan_near_intents_trial, format_suggestion, format_widget, format_intents_widget. \
          Read-only and unsigned — the agent never holds private keys."
@@ -437,6 +458,16 @@ fn execute_inner(params: &str) -> Result<String, String> {
             let output = episode::replay(input)?;
             serde_json::to_string(&output)
                 .map_err(|e| format!("Serialize replay_episode response: {e}"))
+        }
+        PortfolioAction::BacktestDca(input) => {
+            let output = dca::run_backtest(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize backtest_dca response: {e}"))
+        }
+        PortfolioAction::PlanDcaSchedule(input) => {
+            let output = dca::plan_schedule(input)?;
+            serde_json::to_string(&output)
+                .map_err(|e| format!("Serialize plan_dca_schedule response: {e}"))
         }
         PortfolioAction::PlanPaidResearch(input) => {
             let output = research::plan(input)?;

--- a/tools-src/portfolio/src/nl.rs
+++ b/tools-src/portfolio/src/nl.rs
@@ -1,0 +1,1191 @@
+//! Natural-language → portfolio action compiler.
+//!
+//! Deterministic, pattern-based parsing of trade prompts into one of
+//! six recommended next actions:
+//!
+//! - `plan_dca_schedule` — recurring buy
+//!   ("DCA $100 weekly into NEAR for 6 months"),
+//! - `build_intent` — one-shot rotation
+//!   ("swap 0.5 BTC to USDC on near"),
+//! - `backtest_suite` — paper test request
+//!   ("backtest SMA 5/20 + buy-hold on NEAR/USDC"),
+//! - `plan_paid_research` — premium research request
+//!   ("what's catalyst risk on NEAR this week"),
+//! - `format_intents_widget` — passive surveillance
+//!   ("watch BTC for breakout above 70k"),
+//! - `noop` — no usable interpretation; the caller should ask the
+//!   user for more detail.
+//!
+//! The compiler returns a structured plan (extracted fields,
+//! assumptions, clarifications, gates) plus the params it would
+//! invoke. It never calls the action — the agent does that after
+//! risk-gating. This is a deterministic UX layer, not an LLM call:
+//! the same prompt always returns the same plan.
+//!
+//! The compiler is the "vibratrading-style" surface for intents
+//! trading: chat in, structured proposal out, all unsigned. Signing
+//! is always a wallet action outside the agent.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+#[derive(Debug, Deserialize)]
+pub struct CompileInput {
+    pub prompt: String,
+    /// Default chain when the prompt omits chain. Defaults to "near"
+    /// because NEAR Intents is the agent's primary execution surface.
+    #[serde(default = "default_chain")]
+    pub default_chain: String,
+    /// Default source asset for DCA when the prompt names a
+    /// destination but no source. Defaults to USDC.
+    #[serde(default = "default_funding_asset")]
+    pub default_funding_asset: String,
+    /// Optional pair the agent is currently focused on; used to
+    /// resolve ambiguous backtest prompts that don't name a pair.
+    #[serde(default)]
+    pub focus_pair: Option<String>,
+}
+
+fn default_chain() -> String {
+    "near".to_string()
+}
+
+fn default_funding_asset() -> String {
+    "USDC".to_string()
+}
+
+#[derive(Debug, Serialize)]
+pub struct CompileOutput {
+    pub schema_version: &'static str,
+    pub prompt: String,
+    pub intent_kind: String,
+    pub confidence: f64,
+    pub recommended_action: String,
+    pub recommended_params: Value,
+    pub extracted: Extracted,
+    pub assumptions: Vec<String>,
+    pub clarifications_needed: Vec<String>,
+    pub gates: Vec<NlGate>,
+    pub trace: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct Extracted {
+    pub source_asset: Option<String>,
+    pub destination_asset: Option<String>,
+    pub source_chain: Option<String>,
+    pub destination_chain: Option<String>,
+    pub amount: Option<String>,
+    pub amount_unit: Option<String>,
+    pub cadence: Option<String>,
+    pub total_periods: Option<usize>,
+    pub strategy_kind: Option<String>,
+    pub fast_window: Option<usize>,
+    pub slow_window: Option<usize>,
+    pub price_band_premium_bps: Option<f64>,
+    pub price_band_discount_bps: Option<f64>,
+    pub watch_threshold: Option<String>,
+    pub research_query: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NlGate {
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+const ASSETS: &[&str] = &[
+    "NEAR", "USDC", "USDT", "DAI", "BTC", "WBTC", "ETH", "WETH", "SOL", "ARB", "OP", "MATIC",
+    "AVAX", "BNB", "DOGE", "TON", "SUI", "APT", "LINK", "UNI",
+];
+const INTENTS_SUPPORTED: &[&str] = &["NEAR", "USDC", "USDT", "BTC", "WBTC", "ETH", "WETH"];
+const CHAINS: &[&str] = &[
+    "near",
+    "ethereum",
+    "arbitrum",
+    "base",
+    "optimism",
+    "polygon",
+    "bitcoin",
+    "solana",
+    "bnb",
+    "avalanche",
+    "ton",
+];
+
+pub fn compile(input: CompileInput) -> Result<CompileOutput, String> {
+    let raw = input.prompt.clone();
+    if raw.trim().is_empty() {
+        return Err("prompt must be non-empty".to_string());
+    }
+    let prompt = raw.to_lowercase();
+    let mut trace = Vec::new();
+    let mut extracted = Extracted::default();
+    let mut assumptions = Vec::new();
+    let mut clarifications = Vec::new();
+
+    let kind = classify(&prompt, &mut trace);
+    trace.push(format!("classified: {kind}"));
+
+    let (recommended_action, recommended_params, confidence, gates) = match kind.as_str() {
+        "dca-schedule" => build_dca(
+            &prompt,
+            &input,
+            &mut extracted,
+            &mut assumptions,
+            &mut clarifications,
+            &mut trace,
+        ),
+        "swap" => build_swap(
+            &prompt,
+            &raw,
+            &input,
+            &mut extracted,
+            &mut assumptions,
+            &mut clarifications,
+            &mut trace,
+        ),
+        "backtest" => build_backtest(
+            &prompt,
+            &input,
+            &mut extracted,
+            &mut assumptions,
+            &mut clarifications,
+            &mut trace,
+        ),
+        "research" => build_research(
+            &raw,
+            &input,
+            &mut extracted,
+            &mut assumptions,
+            &mut clarifications,
+            &mut trace,
+        ),
+        "watch" => build_watch(
+            &prompt,
+            &input,
+            &mut extracted,
+            &mut assumptions,
+            &mut clarifications,
+            &mut trace,
+        ),
+        _ => (
+            "noop".to_string(),
+            json!({}),
+            0.05,
+            vec![NlGate {
+                name: "intent_recognized".to_string(),
+                status: "fail".to_string(),
+                detail:
+                    "prompt did not match any supported intent kind; ask the user for cadence, asset, or strategy"
+                        .to_string(),
+            }],
+        ),
+    };
+
+    Ok(CompileOutput {
+        schema_version: "intents-nl-compile/1",
+        prompt: raw,
+        intent_kind: kind,
+        confidence,
+        recommended_action,
+        recommended_params,
+        extracted,
+        assumptions,
+        clarifications_needed: clarifications,
+        gates,
+        trace,
+    })
+}
+
+fn classify(prompt: &str, trace: &mut Vec<String>) -> String {
+    if contains_any(
+        prompt,
+        &[
+            "dca",
+            "dollar cost average",
+            "dollar-cost average",
+            "average into",
+            "stack ",
+            "accumulate",
+            "buy weekly",
+            "buy monthly",
+            "buy daily",
+        ],
+    ) {
+        trace.push("matched: dca keywords".to_string());
+        return "dca-schedule".to_string();
+    }
+    if contains_any(
+        prompt,
+        &[
+            "swap ",
+            "rotate ",
+            "convert ",
+            "move ",
+            "exchange ",
+            "trade ",
+            "rebalance",
+        ],
+    ) {
+        trace.push("matched: swap keywords".to_string());
+        return "swap".to_string();
+    }
+    if contains_any(
+        prompt,
+        &[
+            "backtest",
+            "paper test",
+            "paper-test",
+            "paper trade",
+            "historical test",
+        ],
+    ) {
+        trace.push("matched: backtest keywords".to_string());
+        return "backtest".to_string();
+    }
+    if contains_any(
+        prompt,
+        &[
+            "watch ",
+            "monitor ",
+            "alert ",
+            "notify",
+            "tell me when",
+            "let me know when",
+        ],
+    ) {
+        trace.push("matched: watch keywords".to_string());
+        return "watch".to_string();
+    }
+    if contains_any(
+        prompt,
+        &[
+            "research ",
+            "what is the catalyst",
+            "what are the catalysts",
+            "catalyst",
+            "due diligence",
+            "what's happening with",
+            "whats happening with",
+            "is there news",
+            "explain ",
+            "summarize ",
+        ],
+    ) {
+        trace.push("matched: research keywords".to_string());
+        return "research".to_string();
+    }
+    "unsupported".to_string()
+}
+
+fn build_dca(
+    prompt: &str,
+    input: &CompileInput,
+    extracted: &mut Extracted,
+    assumptions: &mut Vec<String>,
+    clarifications: &mut Vec<String>,
+    trace: &mut Vec<String>,
+) -> (String, Value, f64, Vec<NlGate>) {
+    let amount = parse_amount(prompt, trace).unwrap_or(100.0);
+    if !prompt_mentions_money(prompt) {
+        assumptions.push(format!(
+            "assumed notional ${amount} per period (no amount in prompt)"
+        ));
+    }
+    extracted.amount = Some(format!("{amount:.2}"));
+    extracted.amount_unit = Some("USD".to_string());
+
+    let dest = find_destination(prompt, trace).unwrap_or_else(|| {
+        assumptions.push(
+            "no destination asset detected; defaulted to NEAR (primary intents asset)".to_string(),
+        );
+        "NEAR".to_string()
+    });
+    extracted.destination_asset = Some(dest.clone());
+
+    let src = find_source(prompt, trace).unwrap_or_else(|| {
+        assumptions.push(format!(
+            "assumed source asset {} (typical funding stable)",
+            input.default_funding_asset
+        ));
+        input.default_funding_asset.clone()
+    });
+    extracted.source_asset = Some(src.clone());
+
+    let cadence = parse_cadence(prompt, trace).unwrap_or_else(|| {
+        assumptions.push("assumed weekly cadence (no cadence in prompt)".to_string());
+        "weekly".to_string()
+    });
+    extracted.cadence = Some(cadence.clone());
+
+    let total_periods = parse_total_periods(prompt, &cadence, trace).unwrap_or_else(|| {
+        let default = match cadence.as_str() {
+            "daily" => 30,
+            "weekly" => 26,
+            "biweekly" => 13,
+            "monthly" => 12,
+            _ => 12,
+        };
+        assumptions.push(format!(
+            "assumed {default} periods (no duration in prompt; cadence={cadence})"
+        ));
+        default
+    });
+    extracted.total_periods = Some(total_periods);
+
+    let chain = parse_chain(prompt).unwrap_or_else(|| {
+        assumptions.push(format!("assumed chain {} (default)", input.default_chain));
+        input.default_chain.clone()
+    });
+    extracted.source_chain = Some(chain.clone());
+    extracted.destination_chain = Some(chain.clone());
+
+    if let Some(bps) = parse_price_floor(prompt) {
+        extracted.price_band_discount_bps = Some(bps);
+        trace.push(format!("matched: price floor → discount {bps}bps"));
+    }
+    if let Some(bps) = parse_price_ceiling(prompt) {
+        extracted.price_band_premium_bps = Some(bps);
+        trace.push(format!("matched: price ceiling → premium {bps}bps"));
+    }
+
+    let pair = format!("{dest}/{src}");
+    let intents_supported = INTENTS_SUPPORTED
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case(&dest));
+    if !intents_supported {
+        clarifications.push(format!(
+            "destination asset '{dest}' is outside the default NEAR Intents allowlist; confirm route"
+        ));
+    }
+
+    let mut params = json!({
+        "action": "plan_dca_schedule",
+        "pair": pair,
+        "source_asset": src,
+        "destination_asset": dest,
+        "source_chain": chain,
+        "destination_chain": chain,
+        "notional_per_period_usd": amount,
+        "cadence": cadence,
+        "total_periods": total_periods,
+        "max_slippage_bps": 50.0,
+        "mode": "paper",
+        "notional_currency": input.default_funding_asset,
+    });
+    if let Some(p) = extracted.price_band_premium_bps {
+        params["skip_above_premium_bps"] = json!(p);
+    }
+    if let Some(d) = extracted.price_band_discount_bps {
+        params["opportunistic_below_discount_bps"] = json!(d);
+    }
+
+    let gates = vec![
+        NlGate {
+            name: "intents_supported_destination".to_string(),
+            status: if intents_supported { "pass" } else { "warn" }.to_string(),
+            detail: format!("destination={} (allowlist={intents_supported})", dest),
+        },
+        NlGate {
+            name: "duration_within_year".to_string(),
+            status: if total_periods <= 365 { "pass" } else { "warn" }.to_string(),
+            detail: format!("{total_periods} periods at {cadence} cadence"),
+        },
+        NlGate {
+            name: "unsigned_only".to_string(),
+            status: "pass".to_string(),
+            detail: "agent never signs; per-period intents must be re-quoted before user signs"
+                .to_string(),
+        },
+    ];
+
+    let confidence = match assumptions.len() {
+        0 => 0.95,
+        1..=2 => 0.85,
+        3..=4 => 0.7,
+        _ => 0.5,
+    };
+    ("plan_dca_schedule".to_string(), params, confidence, gates)
+}
+
+fn build_swap(
+    prompt: &str,
+    raw: &str,
+    input: &CompileInput,
+    extracted: &mut Extracted,
+    assumptions: &mut Vec<String>,
+    clarifications: &mut Vec<String>,
+    trace: &mut Vec<String>,
+) -> (String, Value, f64, Vec<NlGate>) {
+    // Look for "<num> <asset> to <asset>"
+    let tokens: Vec<&str> = prompt.split_whitespace().collect();
+    let mut amount: Option<f64> = None;
+    let mut from_asset: Option<String> = None;
+    let mut to_asset: Option<String> = None;
+
+    for (i, tok) in tokens.iter().enumerate() {
+        if let Ok(n) = tok.trim_start_matches('$').parse::<f64>() {
+            if amount.is_none() {
+                amount = Some(n);
+                if let Some(next) = tokens.get(i + 1) {
+                    if let Some(a) = match_asset(next) {
+                        from_asset = Some(a);
+                    }
+                }
+            }
+        }
+    }
+    for (i, tok) in tokens.iter().enumerate() {
+        if matches!(*tok, "to" | "into" | "for") {
+            if let Some(next) = tokens.get(i + 1) {
+                if let Some(a) = match_asset(next) {
+                    to_asset = Some(a);
+                }
+            }
+        }
+    }
+    if from_asset.is_none() {
+        for tok in &tokens {
+            if let Some(a) = match_asset(tok) {
+                if Some(&a) != to_asset.as_ref() {
+                    from_asset = Some(a);
+                    break;
+                }
+            }
+        }
+    }
+
+    extracted.amount = amount.map(|n| format!("{n}"));
+    extracted.source_asset = from_asset.clone();
+    extracted.destination_asset = to_asset.clone();
+
+    let chain = parse_chain(prompt).unwrap_or_else(|| {
+        assumptions.push(format!("assumed chain {} (default)", input.default_chain));
+        input.default_chain.clone()
+    });
+    extracted.source_chain = Some(chain.clone());
+    extracted.destination_chain = Some(chain.clone());
+
+    if amount.is_none() {
+        clarifications.push("amount not detected; specify how much to swap".to_string());
+    }
+    if from_asset.is_none() {
+        clarifications.push("source asset not detected".to_string());
+    }
+    if to_asset.is_none() {
+        clarifications.push("destination asset not detected".to_string());
+    }
+
+    let intents_supported_src = from_asset
+        .as_ref()
+        .map(|a| INTENTS_SUPPORTED.iter().any(|s| s.eq_ignore_ascii_case(a)))
+        .unwrap_or(false);
+    let intents_supported_dst = to_asset
+        .as_ref()
+        .map(|a| INTENTS_SUPPORTED.iter().any(|s| s.eq_ignore_ascii_case(a)))
+        .unwrap_or(false);
+
+    let proposal_id = format!(
+        "nl-swap-{}-{}-{}",
+        from_asset.as_deref().unwrap_or("?"),
+        to_asset.as_deref().unwrap_or("?"),
+        amount
+            .map(|n| format!("{n}"))
+            .unwrap_or_else(|| "0".to_string()),
+    );
+
+    let plan = json!({
+        "proposal_id": proposal_id.to_lowercase(),
+        "legs": [{
+            "kind": "swap",
+            "chain": chain,
+            "from_token": {
+                "symbol": from_asset.clone().unwrap_or_default(),
+                "address": null,
+                "chain": chain,
+                "amount": amount.map(|n| format!("{n}")).unwrap_or_default(),
+                "value_usd": ""
+            },
+            "to_token": {
+                "symbol": to_asset.clone().unwrap_or_default(),
+                "address": null,
+                "chain": chain,
+                "amount": "TBD",
+                "value_usd": ""
+            },
+            "description": format!(
+                "Swap {} {} -> {} via NEAR Intents (compiled from prompt)",
+                amount.map(|n| format!("{n}")).unwrap_or_else(|| "?".to_string()),
+                from_asset.as_deref().unwrap_or("?"),
+                to_asset.as_deref().unwrap_or("?")
+            )
+        }],
+        "expected_out": {
+            "symbol": to_asset.clone().unwrap_or_default(),
+            "address": null,
+            "chain": chain,
+            "amount": "TBD",
+            "value_usd": ""
+        },
+        "expected_cost_usd": ""
+    });
+
+    let params = json!({
+        "action": "build_intent",
+        "solver": "fixture",
+        "plan": plan,
+    });
+
+    let gates = vec![
+        NlGate {
+            name: "asset_pair_recognized".to_string(),
+            status: if from_asset.is_some() && to_asset.is_some() {
+                "pass"
+            } else {
+                "warn"
+            }
+            .to_string(),
+            detail: format!(
+                "from={:?} to={:?}",
+                from_asset.as_deref().unwrap_or("?"),
+                to_asset.as_deref().unwrap_or("?")
+            ),
+        },
+        NlGate {
+            name: "intents_supported".to_string(),
+            status: if intents_supported_src && intents_supported_dst {
+                "pass"
+            } else {
+                "warn"
+            }
+            .to_string(),
+            detail: format!(
+                "src_in_allowlist={intents_supported_src} dst_in_allowlist={intents_supported_dst}"
+            ),
+        },
+        NlGate {
+            name: "unsigned_only".to_string(),
+            status: "pass".to_string(),
+            detail: "agent never signs; quote must be re-fetched before user signs".to_string(),
+        },
+    ];
+
+    let confidence = if amount.is_some() && from_asset.is_some() && to_asset.is_some() {
+        0.8
+    } else {
+        0.4
+    };
+    let _ = raw;
+    let _ = trace;
+    ("build_intent".to_string(), params, confidence, gates)
+}
+
+fn build_backtest(
+    prompt: &str,
+    input: &CompileInput,
+    extracted: &mut Extracted,
+    assumptions: &mut Vec<String>,
+    clarifications: &mut Vec<String>,
+    trace: &mut Vec<String>,
+) -> (String, Value, f64, Vec<NlGate>) {
+    let pair = parse_pair(prompt)
+        .or_else(|| input.focus_pair.clone())
+        .unwrap_or_else(|| {
+            assumptions.push(
+                "no pair detected; defaulted to NEAR/USDC (primary intents pair)".to_string(),
+            );
+            "NEAR/USDC".to_string()
+        });
+    let kind = parse_strategy_kind(prompt);
+    extracted.strategy_kind = Some(kind.clone());
+
+    let (fast, slow) = match kind.as_str() {
+        "sma-cross" => parse_sma_windows(prompt, trace),
+        _ => (None, None),
+    };
+    extracted.fast_window = fast;
+    extracted.slow_window = slow;
+
+    let mut candidates = vec![json!({
+        "id": "buy_hold",
+        "strategy": { "kind": "buy-hold" }
+    })];
+    let candidate_strategy = match kind.as_str() {
+        "sma-cross" => json!({
+            "kind": "sma-cross",
+            "fast_window": fast.unwrap_or(5),
+            "slow_window": slow.unwrap_or(20),
+        }),
+        "breakout" => json!({
+            "kind": "breakout",
+            "lookback_window": 20
+        }),
+        "momentum" => json!({
+            "kind": "momentum",
+            "lookback_window": 20
+        }),
+        "mean-reversion" => json!({
+            "kind": "mean-reversion",
+            "lookback_window": 20,
+            "threshold_bps": 200
+        }),
+        "rsi-mean-reversion" => json!({
+            "kind": "rsi-mean-reversion",
+            "lookback_window": 14,
+            "entry_threshold": 30,
+            "exit_threshold": 50
+        }),
+        _ => json!({"kind": "buy-hold"}),
+    };
+    if kind != "buy-hold" {
+        candidates.push(json!({
+            "id": kind.replace('-', "_"),
+            "strategy": candidate_strategy
+        }));
+    }
+
+    clarifications
+        .push("backtest requires OHLCV candles; provide oldest-to-newest candle array".to_string());
+
+    let params = json!({
+        "action": "backtest_suite",
+        "candidates": candidates,
+        "candles": [],
+        "fee_bps": 10,
+        "slippage_bps": 5,
+        "initial_cash_usd": 1000,
+        "_pair_hint": pair,
+    });
+
+    let gates = vec![
+        NlGate {
+            name: "strategy_recognized".to_string(),
+            status: "pass".to_string(),
+            detail: format!("strategy={kind}"),
+        },
+        NlGate {
+            name: "candles_required".to_string(),
+            status: "warn".to_string(),
+            detail:
+                "candles must be supplied separately; this is a deterministic paper test, not live"
+                    .to_string(),
+        },
+    ];
+
+    ("backtest_suite".to_string(), params, 0.7, gates)
+}
+
+fn build_research(
+    raw: &str,
+    _input: &CompileInput,
+    extracted: &mut Extracted,
+    _assumptions: &mut Vec<String>,
+    clarifications: &mut Vec<String>,
+    _trace: &mut Vec<String>,
+) -> (String, Value, f64, Vec<NlGate>) {
+    extracted.research_query = Some(raw.to_string());
+    let pair = parse_pair(&raw.to_lowercase());
+    let mut params = json!({
+        "action": "plan_paid_research",
+        "query": raw,
+        "budget_usd": 0.0,
+        "max_sources": 4,
+        "spending_mode": "paper",
+    });
+    if let Some(p) = pair {
+        params["pair"] = json!(p);
+    }
+    clarifications.push(
+        "research mode defaults to free sources only; raise budget_usd to allow paid sources"
+            .to_string(),
+    );
+    let gates = vec![NlGate {
+        name: "free_sources_only".to_string(),
+        status: "pass".to_string(),
+        detail: "default budget_usd=0 — paid sources require explicit user opt-in".to_string(),
+    }];
+    ("plan_paid_research".to_string(), params, 0.6, gates)
+}
+
+fn build_watch(
+    prompt: &str,
+    _input: &CompileInput,
+    extracted: &mut Extracted,
+    _assumptions: &mut Vec<String>,
+    clarifications: &mut Vec<String>,
+    trace: &mut Vec<String>,
+) -> (String, Value, f64, Vec<NlGate>) {
+    let pair = parse_pair(prompt).unwrap_or_else(|| "NEAR/USDC".to_string());
+    let threshold = parse_threshold(prompt, trace);
+    extracted.watch_threshold = threshold.clone();
+
+    if threshold.is_none() {
+        clarifications.push(
+            "watch threshold not detected; specify a price or condition (e.g. 'breakout above 70000')"
+                .to_string(),
+        );
+    }
+
+    let params = json!({
+        "action": "format_intents_widget",
+        "pair": pair,
+        "mode": "paper",
+        "stance": "watch",
+        "risk_gates": [{
+            "name": "passive-watch",
+            "status": "pass",
+            "detail": format!(
+                "compiled from prompt; threshold={}",
+                threshold.clone().unwrap_or_else(|| "unspecified".to_string())
+            )
+        }]
+    });
+    let gates = vec![NlGate {
+        name: "passive".to_string(),
+        status: "pass".to_string(),
+        detail: "watch mode does not produce intents; only widget state".to_string(),
+    }];
+    ("format_intents_widget".to_string(), params, 0.55, gates)
+}
+
+// -------------------- helpers --------------------
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|n| haystack.contains(n))
+}
+
+fn match_asset(token: &str) -> Option<String> {
+    let cleaned: String = token
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_uppercase();
+    if cleaned.is_empty() {
+        return None;
+    }
+    ASSETS
+        .iter()
+        .find(|a| **a == cleaned)
+        .map(|a| (*a).to_string())
+}
+
+fn find_destination(prompt: &str, trace: &mut Vec<String>) -> Option<String> {
+    for keyword in &["into ", " in ", " to ", "buy ", "stack ", "accumulate "] {
+        if let Some(pos) = prompt.find(keyword) {
+            let tail = &prompt[pos + keyword.len()..];
+            if let Some(asset) = first_asset(tail) {
+                trace.push(format!("dest matched after '{}': {asset}", keyword.trim()));
+                return Some(asset);
+            }
+        }
+    }
+    first_asset(prompt)
+}
+
+fn find_source(prompt: &str, trace: &mut Vec<String>) -> Option<String> {
+    for keyword in &["from ", "with ", "using "] {
+        if let Some(pos) = prompt.find(keyword) {
+            let tail = &prompt[pos + keyword.len()..];
+            if let Some(asset) = first_asset(tail) {
+                trace.push(format!(
+                    "source matched after '{}': {asset}",
+                    keyword.trim()
+                ));
+                return Some(asset);
+            }
+        }
+    }
+    None
+}
+
+fn first_asset(text: &str) -> Option<String> {
+    text.split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .find_map(match_asset)
+}
+
+fn prompt_mentions_money(prompt: &str) -> bool {
+    prompt.contains('$')
+        || contains_any(
+            prompt,
+            &["usd", "usdc", "usdt", "dollar", "dollars", "bucks"],
+        )
+}
+
+fn parse_amount(prompt: &str, trace: &mut Vec<String>) -> Option<f64> {
+    let bytes = prompt.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if c == '$' || c.is_ascii_digit() {
+            let start = if c == '$' { i + 1 } else { i };
+            let mut end = start;
+            while end < bytes.len() {
+                let ch = bytes[end] as char;
+                if ch.is_ascii_digit() || ch == '.' || ch == ',' {
+                    end += 1;
+                } else {
+                    break;
+                }
+            }
+            if end > start {
+                let raw: String = prompt[start..end].chars().filter(|c| *c != ',').collect();
+                if let Ok(n) = raw.parse::<f64>() {
+                    let suffix = prompt[end..].trim_start();
+                    let value = if suffix.starts_with('k') || suffix.starts_with('K') {
+                        n * 1_000.0
+                    } else if suffix.starts_with('m') || suffix.starts_with('M') {
+                        n * 1_000_000.0
+                    } else {
+                        n
+                    };
+                    if value > 0.0 {
+                        trace.push(format!("amount matched: {value}"));
+                        return Some(value);
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn parse_cadence(prompt: &str, trace: &mut Vec<String>) -> Option<String> {
+    let pairs = [
+        ("daily", "daily"),
+        ("each day", "daily"),
+        ("every day", "daily"),
+        ("a day", "daily"),
+        ("per day", "daily"),
+        ("weekly", "weekly"),
+        ("each week", "weekly"),
+        ("every week", "weekly"),
+        ("a week", "weekly"),
+        ("per week", "weekly"),
+        ("biweekly", "biweekly"),
+        ("fortnightly", "biweekly"),
+        ("every two weeks", "biweekly"),
+        ("every 2 weeks", "biweekly"),
+        ("monthly", "monthly"),
+        ("each month", "monthly"),
+        ("every month", "monthly"),
+        ("a month", "monthly"),
+        ("per month", "monthly"),
+    ];
+    for (needle, normalized) in pairs {
+        if prompt.contains(needle) {
+            trace.push(format!("cadence matched: {needle} → {normalized}"));
+            return Some(normalized.to_string());
+        }
+    }
+    None
+}
+
+fn parse_total_periods(prompt: &str, cadence: &str, trace: &mut Vec<String>) -> Option<usize> {
+    // Look for "for N <unit>", "over N <unit>", or "N <unit>".
+    let units = [
+        ("day", 1usize),
+        ("days", 1),
+        ("week", 7),
+        ("weeks", 7),
+        ("month", 30),
+        ("months", 30),
+        ("year", 365),
+        ("years", 365),
+    ];
+    let bytes = prompt.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] as char == ',') {
+                i += 1;
+            }
+            let raw: String = prompt[start..i].chars().filter(|c| *c != ',').collect();
+            if let Ok(n) = raw.parse::<usize>() {
+                let tail = prompt[i..].trim_start();
+                for (unit, days) in units {
+                    if word_starts_with(tail, unit) {
+                        let total_days = n * days;
+                        let periods = match cadence {
+                            "daily" => total_days,
+                            "weekly" => total_days / 7,
+                            "biweekly" => total_days / 14,
+                            "monthly" => total_days / 30,
+                            _ => total_days,
+                        };
+                        if periods > 0 {
+                            trace.push(format!(
+                                "duration matched: {n} {unit} → {periods} {cadence} periods"
+                            ));
+                            return Some(periods);
+                        }
+                    }
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+fn word_starts_with(haystack: &str, needle: &str) -> bool {
+    if !haystack.starts_with(needle) {
+        return false;
+    }
+    match haystack.as_bytes().get(needle.len()) {
+        None => true,
+        Some(b) => !(*b as char).is_ascii_alphabetic(),
+    }
+}
+
+fn parse_chain(prompt: &str) -> Option<String> {
+    for chain in CHAINS {
+        let needle = format!(" on {chain}");
+        if prompt.contains(&needle) {
+            return Some((*chain).to_string());
+        }
+    }
+    None
+}
+
+fn parse_price_floor(prompt: &str) -> Option<f64> {
+    if contains_any(
+        prompt,
+        &[
+            "below ",
+            "under ",
+            "if it dips",
+            "if discounted",
+            "on the dip",
+        ],
+    ) {
+        Some(2_000.0)
+    } else {
+        None
+    }
+}
+
+fn parse_price_ceiling(prompt: &str) -> Option<f64> {
+    if contains_any(
+        prompt,
+        &[
+            "above ",
+            "over ",
+            "if stretched",
+            "skip when stretched",
+            "at a premium",
+        ],
+    ) {
+        Some(1_500.0)
+    } else {
+        None
+    }
+}
+
+fn parse_pair(prompt: &str) -> Option<String> {
+    let upper = prompt.to_uppercase();
+    let separators = ['/', '-'];
+    for sep in separators {
+        for window in upper.split_whitespace() {
+            if window.contains(sep) {
+                let parts: Vec<&str> = window.split(sep).collect();
+                if parts.len() == 2 {
+                    let a = match_asset(parts[0]);
+                    let b = match_asset(parts[1]);
+                    if let (Some(a), Some(b)) = (a, b) {
+                        return Some(format!("{a}/{b}"));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn parse_strategy_kind(prompt: &str) -> String {
+    if prompt.contains("rsi") {
+        "rsi-mean-reversion".to_string()
+    } else if prompt.contains("sma") || prompt.contains("moving average") || prompt.contains(" ma ")
+    {
+        "sma-cross".to_string()
+    } else if prompt.contains("breakout") {
+        "breakout".to_string()
+    } else if prompt.contains("momentum") {
+        "momentum".to_string()
+    } else if prompt.contains("mean reversion") || prompt.contains("mean-reversion") {
+        "mean-reversion".to_string()
+    } else if prompt.contains("buy and hold") || prompt.contains("buy-and-hold") {
+        "buy-hold".to_string()
+    } else if prompt.contains("dca") {
+        "dca".to_string()
+    } else {
+        "sma-cross".to_string()
+    }
+}
+
+fn parse_sma_windows(prompt: &str, trace: &mut Vec<String>) -> (Option<usize>, Option<usize>) {
+    // Look for "<n>/<n>" pattern.
+    for window in prompt.split_whitespace() {
+        if let Some((a, b)) = window.split_once('/') {
+            if let (Ok(fa), Ok(sa)) = (a.parse::<usize>(), b.parse::<usize>()) {
+                if fa < sa && fa > 0 && sa > 0 && sa < 500 {
+                    trace.push(format!("sma windows matched: {fa}/{sa}"));
+                    return (Some(fa), Some(sa));
+                }
+            }
+        }
+    }
+    (None, None)
+}
+
+fn parse_threshold(prompt: &str, trace: &mut Vec<String>) -> Option<String> {
+    let keywords = [
+        "above ",
+        "below ",
+        "breakout above ",
+        "drop below ",
+        "cross ",
+        "reaches ",
+    ];
+    for k in keywords {
+        if let Some(pos) = prompt.find(k) {
+            let tail = &prompt[pos..];
+            let snippet: String = tail.chars().take(40).collect();
+            trace.push(format!("threshold matched: '{snippet}'"));
+            return Some(snippet);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compile_str(s: &str) -> CompileOutput {
+        compile(CompileInput {
+            prompt: s.to_string(),
+            default_chain: "near".to_string(),
+            default_funding_asset: "USDC".to_string(),
+            focus_pair: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn dca_six_months_into_near() {
+        let out = compile_str("DCA $100 weekly into NEAR for 6 months");
+        assert_eq!(out.intent_kind, "dca-schedule");
+        assert_eq!(out.recommended_action, "plan_dca_schedule");
+        assert_eq!(out.recommended_params["pair"], "NEAR/USDC");
+        assert_eq!(out.recommended_params["cadence"], "weekly");
+        assert_eq!(
+            out.recommended_params["total_periods"].as_u64().unwrap(),
+            (6 * 30) / 7
+        );
+        assert_eq!(
+            out.recommended_params["notional_per_period_usd"]
+                .as_f64()
+                .unwrap(),
+            100.0
+        );
+        assert!(out.confidence >= 0.7);
+    }
+
+    #[test]
+    fn dca_with_price_floor_sets_band() {
+        let out = compile_str("dca $50 daily into NEAR if it dips below market");
+        assert_eq!(out.intent_kind, "dca-schedule");
+        assert!(out
+            .recommended_params
+            .get("opportunistic_below_discount_bps")
+            .is_some());
+    }
+
+    #[test]
+    fn swap_btc_to_usdc() {
+        let out = compile_str("swap 0.5 BTC to USDC on near");
+        assert_eq!(out.intent_kind, "swap");
+        assert_eq!(out.recommended_action, "build_intent");
+        let from = out.recommended_params["plan"]["legs"][0]["from_token"]["symbol"].clone();
+        let to = out.recommended_params["plan"]["legs"][0]["to_token"]["symbol"].clone();
+        assert_eq!(from, "BTC");
+        assert_eq!(to, "USDC");
+    }
+
+    #[test]
+    fn backtest_sma_5_20() {
+        let out = compile_str("backtest sma 5/20 on NEAR/USDC");
+        assert_eq!(out.intent_kind, "backtest");
+        assert_eq!(out.recommended_action, "backtest_suite");
+        let cands = out.recommended_params["candidates"].as_array().unwrap();
+        assert!(cands.iter().any(|c| c["id"] == "buy_hold"));
+        assert!(cands.iter().any(|c| c["strategy"]["kind"] == "sma-cross"));
+        assert_eq!(out.extracted.fast_window, Some(5));
+        assert_eq!(out.extracted.slow_window, Some(20));
+    }
+
+    #[test]
+    fn research_extracts_pair_and_query() {
+        let out = compile_str("research catalyst risk on NEAR/USDC this week");
+        assert_eq!(out.intent_kind, "research");
+        assert_eq!(out.recommended_params["pair"], "NEAR/USDC");
+        assert_eq!(out.recommended_params["budget_usd"].as_f64().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn watch_keeps_threshold() {
+        let out = compile_str("watch BTC for breakout above 70000");
+        assert_eq!(out.intent_kind, "watch");
+        assert!(out.extracted.watch_threshold.is_some());
+    }
+
+    #[test]
+    fn unsupported_prompt_returns_noop() {
+        let out = compile_str("hi how are you");
+        assert_eq!(out.intent_kind, "unsupported");
+        assert_eq!(out.recommended_action, "noop");
+    }
+
+    #[test]
+    fn empty_prompt_errors() {
+        let err = compile(CompileInput {
+            prompt: "   ".to_string(),
+            default_chain: "near".to_string(),
+            default_funding_asset: "USDC".to_string(),
+            focus_pair: None,
+        })
+        .unwrap_err();
+        assert!(err.contains("non-empty"));
+    }
+
+    #[test]
+    fn dca_default_assumptions_when_minimal() {
+        let out = compile_str("dca into ETH");
+        assert_eq!(out.intent_kind, "dca-schedule");
+        assert!(out.assumptions.len() >= 2);
+        assert_eq!(out.recommended_params["destination_asset"], "ETH");
+    }
+
+    #[test]
+    fn dca_thousand_dollar_amount() {
+        let out = compile_str("DCA $1.5k monthly into BTC for 1 year");
+        assert_eq!(out.intent_kind, "dca-schedule");
+        assert_eq!(
+            out.recommended_params["notional_per_period_usd"]
+                .as_f64()
+                .unwrap(),
+            1_500.0
+        );
+        assert_eq!(out.recommended_params["cadence"], "monthly");
+        assert_eq!(
+            out.recommended_params["total_periods"].as_u64().unwrap(),
+            12
+        );
+    }
+}

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -969,6 +969,147 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "walkforward_folds_len" => {
+                let len = response
+                    .get("folds")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected.as_u64().expect("walkforward_folds_len: number") as usize;
+                assert_eq!(
+                    len, want,
+                    "[{path}] step '{}': walkforward folds {len} != {want}",
+                    step.name
+                );
+            }
+            "walkforward_robustness_in" => {
+                let got = response
+                    .pointer("/aggregate/robustness")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /aggregate/robustness",
+                            step.name
+                        )
+                    });
+                let allowed: Vec<String> = expected
+                    .as_array()
+                    .expect("walkforward_robustness_in: array")
+                    .iter()
+                    .map(|v| v.as_str().expect("string").to_string())
+                    .collect();
+                assert!(
+                    allowed.iter().any(|v| v == got),
+                    "[{path}] step '{}': robustness '{got}' not in {:?}",
+                    step.name,
+                    allowed
+                );
+            }
+            "montecarlo_iterations" => {
+                let got = response
+                    .get("iterations")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let want = expected.as_u64().expect("montecarlo_iterations: number");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': montecarlo iterations mismatch",
+                    step.name
+                );
+            }
+            "montecarlo_p50_within" => {
+                let bounds = expected
+                    .as_array()
+                    .expect("montecarlo_p50_within: [low, high]");
+                let low = bounds[0].as_f64().expect("low number");
+                let high = bounds[1].as_f64().expect("high number");
+                let got = response
+                    .pointer("/return_distribution/p50")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /return_distribution/p50",
+                            step.name
+                        )
+                    });
+                assert!(
+                    got >= low && got <= high,
+                    "[{path}] step '{}': montecarlo p50 {got} not in [{low}, {high}]",
+                    step.name
+                );
+            }
+            "grid_cells_len" => {
+                let len = response
+                    .get("cells")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected.as_u64().expect("grid_cells_len: number") as usize;
+                assert_eq!(
+                    len, want,
+                    "[{path}] step '{}': grid cells {len} != {want}",
+                    step.name
+                );
+            }
+            "grid_top_passes_basic_gate" => {
+                let got = response
+                    .pointer("/ranked/0/passes_basic_gate")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let want = expected
+                    .as_bool()
+                    .expect("grid_top_passes_basic_gate: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': grid top passes_basic_gate mismatch",
+                    step.name
+                );
+            }
+            "episode_summary_candles" => {
+                let got = response
+                    .get("candles")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let want = expected.as_u64().expect("episode_summary_candles: number");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': episode candles count mismatch",
+                    step.name
+                );
+            }
+            "episode_replay_top_trades_min" => {
+                let trades = response
+                    .pointer("/backtest_suite/ranked/0/metrics/trades")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("episode_replay_top_trades_min: number");
+                assert!(
+                    trades >= want,
+                    "[{path}] step '{}': episode replay top trades {trades} < {want}",
+                    step.name
+                );
+            }
+            "episode_replay_solver_kind" => {
+                let got = response
+                    .pointer("/episode/solver_fixture_kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /episode/solver_fixture_kind",
+                            step.name
+                        )
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("episode_replay_solver_kind: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': episode solver kind mismatch",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -1110,6 +1110,120 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "dca_periods_executed" => {
+                let got = response
+                    .get("periods_executed")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let want = expected.as_u64().expect("dca_periods_executed: number");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': dca executed {got} != {want}",
+                    step.name
+                );
+            }
+            "dca_periods_skipped_band_min" => {
+                let got = response
+                    .get("periods_skipped_band")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("dca_periods_skipped_band_min: number");
+                assert!(
+                    got >= want,
+                    "[{path}] step '{}': dca skipped-band {got} < {want}",
+                    step.name
+                );
+            }
+            "dca_total_invested_lt" => {
+                let invested = response
+                    .get("total_invested_usd")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .unwrap_or(0.0);
+                let want = expected.as_f64().expect("dca_total_invested_lt: number");
+                assert!(
+                    invested < want,
+                    "[{path}] step '{}': dca total invested {invested} >= {want}",
+                    step.name
+                );
+            }
+            "dca_breakeven_within" => {
+                let bounds = expected
+                    .as_array()
+                    .expect("dca_breakeven_within: [low, high]");
+                let low = bounds[0].as_f64().expect("low");
+                let high = bounds[1].as_f64().expect("high");
+                let got = response
+                    .get("breakeven_price_usd")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .unwrap_or(0.0);
+                assert!(
+                    got >= low && got <= high,
+                    "[{path}] step '{}': dca breakeven {got} not in [{low}, {high}]",
+                    step.name
+                );
+            }
+            "dca_schedule_cron" => {
+                let got = response
+                    .get("cron")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| panic!("[{path}] step '{}': missing cron", step.name));
+                let want = expected.as_str().expect("dca_schedule_cron: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': dca cron mismatch",
+                    step.name
+                );
+            }
+            "dca_schedule_safe_to_quote" => {
+                let got = response
+                    .get("safe_to_quote")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let want = expected
+                    .as_bool()
+                    .expect("dca_schedule_safe_to_quote: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': dca safe_to_quote mismatch",
+                    step.name
+                );
+            }
+            "dca_schedule_periods_len" => {
+                let len = response
+                    .get("schedule")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected.as_u64().expect("dca_schedule_periods_len: number") as usize;
+                assert_eq!(
+                    len, want,
+                    "[{path}] step '{}': dca schedule periods {len} != {want}",
+                    step.name
+                );
+            }
+            "dca_schedule_template_action" => {
+                let got = response
+                    .pointer("/build_intent_request_template/action")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing build_intent_request_template/action",
+                            step.name
+                        )
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("dca_schedule_template_action: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': dca template action mismatch",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -1224,6 +1224,66 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "nl_intent_kind" => {
+                let got = response
+                    .get("intent_kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing intent_kind", step.name)
+                    });
+                let want = expected.as_str().expect("nl_intent_kind: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': nl intent_kind mismatch",
+                    step.name
+                );
+            }
+            "nl_recommended_action" => {
+                let got = response
+                    .get("recommended_action")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing recommended_action", step.name)
+                    });
+                let want = expected.as_str().expect("nl_recommended_action: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': nl recommended_action mismatch",
+                    step.name
+                );
+            }
+            "nl_param_eq" => {
+                let pairs = expected
+                    .as_object()
+                    .expect("nl_param_eq: object of {pointer: expected}");
+                for (pointer, want) in pairs {
+                    let got = response
+                        .pointer(&format!("/recommended_params/{pointer}"))
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "[{path}] step '{}': missing recommended_params/{pointer}",
+                                step.name
+                            )
+                        });
+                    assert_eq!(
+                        got, want,
+                        "[{path}] step '{}': nl_param_eq[{pointer}] mismatch",
+                        step.name
+                    );
+                }
+            }
+            "nl_confidence_min" => {
+                let got = response
+                    .get("confidence")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0);
+                let want = expected.as_f64().expect("nl_confidence_min: number");
+                assert!(
+                    got >= want,
+                    "[{path}] step '{}': nl confidence {got} < {want}",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -719,6 +719,115 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "paid_research_schema_version" => {
+                let v = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("paid_research_schema_version: string");
+                assert_eq!(
+                    v, want,
+                    "[{path}] step '{}': paid research schema mismatch",
+                    step.name
+                );
+            }
+            "paid_research_selected_min" => {
+                let len = response
+                    .get("selected_sources")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("paid_research_selected_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': paid research selected {len} < min {want}",
+                    step.name
+                );
+            }
+            "paid_research_allocated_le" => {
+                let allocated = response
+                    .get("allocated_usd")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing allocated_usd", step.name)
+                    });
+                let want = expected
+                    .as_f64()
+                    .expect("paid_research_allocated_le: number");
+                assert!(
+                    allocated <= want + f64::EPSILON,
+                    "[{path}] step '{}': paid research allocated {allocated} > {want}",
+                    step.name
+                );
+            }
+            "paid_research_has_rail" => {
+                let rail = expected.as_str().expect("paid_research_has_rail: string");
+                let rails = response
+                    .get("payment_rails")
+                    .and_then(|v| v.as_array())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing payment_rails", step.name)
+                    });
+                let found = rails
+                    .iter()
+                    .any(|item| item.get("protocol").and_then(|v| v.as_str()) == Some(rail));
+                assert!(
+                    found,
+                    "[{path}] step '{}': paid research rail '{rail}' not found",
+                    step.name
+                );
+            }
+            "paid_research_near_funding_routes_min" => {
+                let len = response
+                    .get("near_funding_routes")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("paid_research_near_funding_routes_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': NEAR funding routes {len} < min {want}",
+                    step.name
+                );
+            }
+            "intents_widget_paid_sources_min" => {
+                let len = response
+                    .pointer("/paid_research/payable_sources")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("intents_widget_paid_sources_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': intents widget paid sources {len} < min {want}",
+                    step.name
+                );
+            }
+            "intents_widget_paid_ready" => {
+                let got = response
+                    .pointer("/paid_research/ready_for_paid_fetch")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let want = expected.as_bool().expect("intents_widget_paid_ready: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': paid research ready mismatch",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name
@@ -738,6 +847,7 @@ fn capture_vars(path: &str, step: &Step, response: &Value, vars: &mut BTreeMap<S
                 .get("proposals")
                 .cloned()
                 .unwrap_or(Value::Array(Vec::new())),
+            "paid_research_plan_var" => response.clone(),
             "first_ready_plan_var" => response
                 .get("proposals")
                 .and_then(|v| v.as_array())

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -828,6 +828,58 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "dripstack_checkpoint" => {
+                let got = response
+                    .get("checkpoint")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| panic!("[{path}] step '{}': missing checkpoint", step.name));
+                let want = expected.as_str().expect("dripstack_checkpoint: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': dripstack checkpoint mismatch",
+                    step.name
+                );
+            }
+            "dripstack_publications_min" => {
+                let len = response
+                    .get("matched_publications")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("dripstack_publications_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': matched publications {len} < min {want}",
+                    step.name
+                );
+            }
+            "dripstack_posts_min" => {
+                let len = response
+                    .get("post_candidates")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected.as_u64().expect("dripstack_posts_min: number") as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': post candidates {len} < min {want}",
+                    step.name
+                );
+            }
+            "dripstack_has_paid_source_candidate" => {
+                let got = response.get("paid_source_candidate").is_some();
+                let want = expected
+                    .as_bool()
+                    .expect("dripstack_has_paid_source_candidate: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': paid source candidate presence mismatch",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name
@@ -848,6 +900,15 @@ fn capture_vars(path: &str, step: &Step, response: &Value, vars: &mut BTreeMap<S
                 .cloned()
                 .unwrap_or(Value::Array(Vec::new())),
             "paid_research_plan_var" => response.clone(),
+            "dripstack_paid_source_var" => response
+                .get("paid_source_candidate")
+                .cloned()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "[{path}] step '{}': missing paid_source_candidate to capture",
+                        step.name
+                    )
+                }),
             "first_ready_plan_var" => response
                 .get("proposals")
                 .and_then(|v| v.as_array())

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -880,6 +880,95 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "dripstack_paid_fetch_status" => {
+                let got = response
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| panic!("[{path}] step '{}': missing status", step.name));
+                let want = expected
+                    .as_str()
+                    .expect("dripstack_paid_fetch_status: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': paid fetch status mismatch",
+                    step.name
+                );
+            }
+            "dripstack_paid_fetch_headers_min" => {
+                let len = response
+                    .get("request_headers")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("dripstack_paid_fetch_headers_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': paid fetch headers {len} < min {want}",
+                    step.name
+                );
+            }
+            "near_trial_schema_version" => {
+                let got = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("near_trial_schema_version: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': near trial schema mismatch",
+                    step.name
+                );
+            }
+            "near_trial_safe_to_quote" => {
+                let got = response
+                    .get("safe_to_quote")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let want = expected.as_bool().expect("near_trial_safe_to_quote: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': near trial quote readiness mismatch",
+                    step.name
+                );
+            }
+            "near_trial_build_solver" => {
+                let got = response
+                    .pointer("/build_intent_request/solver")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /build_intent_request/solver",
+                            step.name
+                        )
+                    });
+                let want = expected.as_str().expect("near_trial_build_solver: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': near trial build solver mismatch",
+                    step.name
+                );
+            }
+            "intents_widget_trial_safe_to_quote" => {
+                let got = response
+                    .pointer("/trial_plan/safe_to_quote")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let want = expected
+                    .as_bool()
+                    .expect("intents_widget_trial_safe_to_quote: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': widget trial quote readiness mismatch",
+                    step.name
+                );
+            }
             other => panic!(
                 "[{path}] step '{}': unknown expectation key '{other}'",
                 step.name
@@ -899,7 +988,9 @@ fn capture_vars(path: &str, step: &Step, response: &Value, vars: &mut BTreeMap<S
                 .get("proposals")
                 .cloned()
                 .unwrap_or(Value::Array(Vec::new())),
+            "backtest_suite_var" => response.clone(),
             "paid_research_plan_var" => response.clone(),
+            "trial_plan_var" => response.clone(),
             "dripstack_paid_source_var" => response
                 .get("paid_source_candidate")
                 .cloned()

--- a/tools-src/portfolio/src/replay_tests.rs
+++ b/tools-src/portfolio/src/replay_tests.rs
@@ -365,6 +365,180 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                     step.name
                 );
             }
+            "bundle_first_leg_kind" => {
+                let kind = response
+                    .pointer("/bundle/legs/0/kind")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing /bundle/legs/0/kind", step.name)
+                    });
+                let want = expected.as_str().expect("bundle_first_leg_kind: string");
+                assert_eq!(
+                    kind, want,
+                    "[{path}] step '{}': first bundle leg kind mismatch",
+                    step.name
+                );
+            }
+            "backtest_schema_version" => {
+                let v = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected.as_str().expect("backtest_schema_version: string");
+                assert_eq!(
+                    v, want,
+                    "[{path}] step '{}': backtest schema mismatch",
+                    step.name
+                );
+            }
+            "backtest_trades_min" => {
+                let trades = response
+                    .pointer("/metrics/trades")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing /metrics/trades", step.name)
+                    });
+                let want = expected.as_u64().expect("backtest_trades_min: number");
+                assert!(
+                    trades >= want,
+                    "[{path}] step '{}': backtest trades {} < min {}",
+                    step.name,
+                    trades,
+                    want
+                );
+            }
+            "backtest_total_return_gt" => {
+                let value = response
+                    .pointer("/metrics/total_return_pct")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /metrics/total_return_pct",
+                            step.name
+                        )
+                    });
+                let want = expected.as_f64().expect("backtest_total_return_gt: number");
+                assert!(
+                    value > want,
+                    "[{path}] step '{}': total_return_pct {} <= {}",
+                    step.name,
+                    value,
+                    want
+                );
+            }
+            "backtest_max_drawdown_le" => {
+                let value = response
+                    .pointer("/metrics/max_drawdown_pct")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /metrics/max_drawdown_pct",
+                            step.name
+                        )
+                    });
+                let want = expected.as_f64().expect("backtest_max_drawdown_le: number");
+                assert!(
+                    value <= want,
+                    "[{path}] step '{}': max_drawdown_pct {} > {}",
+                    step.name,
+                    value,
+                    want
+                );
+            }
+            "backtest_lookahead_safe" => {
+                let value = response
+                    .get("lookahead_safe")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing lookahead_safe", step.name)
+                    });
+                let want = expected.as_bool().expect("backtest_lookahead_safe: bool");
+                assert_eq!(
+                    value, want,
+                    "[{path}] step '{}': lookahead_safe mismatch",
+                    step.name
+                );
+            }
+            "backtest_suite_schema_version" => {
+                let v = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("backtest_suite_schema_version: string");
+                assert_eq!(
+                    v, want,
+                    "[{path}] step '{}': backtest suite schema mismatch",
+                    step.name
+                );
+            }
+            "backtest_suite_ranked_min" => {
+                let ranked = response
+                    .get("ranked")
+                    .and_then(|v| v.as_array())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing ranked array", step.name)
+                    });
+                let want = expected
+                    .as_u64()
+                    .expect("backtest_suite_ranked_min: number")
+                    as usize;
+                assert!(
+                    ranked.len() >= want,
+                    "[{path}] step '{}': ranked candidates {} < min {}",
+                    step.name,
+                    ranked.len(),
+                    want
+                );
+            }
+            "backtest_suite_top_trades_min" => {
+                let trades = response
+                    .pointer("/ranked/0/metrics/trades")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "[{path}] step '{}': missing /ranked/0/metrics/trades",
+                            step.name
+                        )
+                    });
+                let want = expected
+                    .as_u64()
+                    .expect("backtest_suite_top_trades_min: number");
+                assert!(
+                    trades >= want,
+                    "[{path}] step '{}': top-ranked trades {} < min {}",
+                    step.name,
+                    trades,
+                    want
+                );
+            }
+            "backtest_suite_any_passes_basic_gate" => {
+                let ranked = response
+                    .get("ranked")
+                    .and_then(|v| v.as_array())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing ranked array", step.name)
+                    });
+                let got = ranked.iter().any(|result| {
+                    result
+                        .get("passes_basic_gate")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false)
+                });
+                let want = expected
+                    .as_bool()
+                    .expect("backtest_suite_any_passes_basic_gate: bool");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': basic-gate match mismatch",
+                    step.name
+                );
+            }
             "equal_to_step" => {
                 let other_step = expected.as_str().expect("equal_to_step: string");
                 let prior_resp = prior.get(other_step).unwrap_or_else(|| {
@@ -494,6 +668,54 @@ fn check_expectations(path: &str, step: &Step, response: &Value, prior: &BTreeMa
                 assert_eq!(
                     non_empty, want,
                     "[{path}] step '{}': widget_has_non_empty_totals mismatch",
+                    step.name
+                );
+            }
+            "intents_widget_schema_version" => {
+                let v = response
+                    .get("schema_version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing schema_version", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("intents_widget_schema_version: string");
+                assert_eq!(
+                    v, want,
+                    "[{path}] step '{}': intents widget schema mismatch",
+                    step.name
+                );
+            }
+            "intents_widget_top_candidates_min" => {
+                let len = response
+                    .get("top_candidates")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                let want = expected
+                    .as_u64()
+                    .expect("intents_widget_top_candidates_min: number")
+                    as usize;
+                assert!(
+                    len >= want,
+                    "[{path}] step '{}': intents widget top candidates {len} < min {want}",
+                    step.name
+                );
+            }
+            "intents_widget_intent_status" => {
+                let got = response
+                    .pointer("/intent/status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!("[{path}] step '{}': missing /intent/status", step.name)
+                    });
+                let want = expected
+                    .as_str()
+                    .expect("intents_widget_intent_status: string");
+                assert_eq!(
+                    got, want,
+                    "[{path}] step '{}': intents widget intent status mismatch",
                     step.name
                 );
             }

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -12,6 +12,11 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
+// Paid research plans run in the WASM tool layer and use f64 only for
+// non-settlement ranking, budgeting, and policy hints. Settlement remains with
+// the payment rails; this tolerance avoids machine-epsilon threshold mistakes.
+const USD_TOLERANCE: f64 = 1e-6;
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct PaidResearchPlanInput {
     pub query: String,
@@ -416,7 +421,7 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
             rejected_sources.push(rejected(&candidate, "max-sources-reached"));
             continue;
         }
-        if candidate.price_usd > remaining_budget + f64::EPSILON {
+        if candidate.price_usd > remaining_budget + USD_TOLERANCE {
             rejected_sources.push(rejected(&candidate, "over-budget"));
             continue;
         }
@@ -447,7 +452,7 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
             rail_entry.0 += 1;
             rail_entry.1 += payment.amount_usd;
 
-            if payment.amount_usd > 0.0 && payment.protocol != "near-intents" {
+            if payment.amount_usd > 0.0 && matches!(payment.protocol.as_str(), "mpp" | "x402") {
                 let key = (
                     payment.protocol.clone(),
                     payment.network.clone(),
@@ -549,7 +554,7 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         max_selected_price_usd,
     );
     let ready_for_paid_fetch = !selected_sources.is_empty()
-        && allocated_usd <= budget_usd + f64::EPSILON
+        && allocated_usd <= budget_usd + USD_TOLERANCE
         && policy_gates.iter().all(|gate| gate.status != "fail");
     let ready_for_trade_research = ready_for_paid_fetch
         && selected_sources
@@ -951,7 +956,7 @@ fn policy_gates(
     let mut gates = vec![
         PaidResearchPolicyGate {
             name: "budget-cap".to_string(),
-            status: if allocated_usd <= budget_usd + f64::EPSILON {
+            status: if allocated_usd <= budget_usd + USD_TOLERANCE {
                 "pass"
             } else {
                 "fail"
@@ -1020,7 +1025,7 @@ fn policy_gates(
         });
         gates.push(PaidResearchPolicyGate {
             name: "per-article-cap".to_string(),
-            status: if max_selected_price_usd <= policy.per_article_cap_usd + f64::EPSILON {
+            status: if max_selected_price_usd <= policy.per_article_cap_usd + USD_TOLERANCE {
                 "pass"
             } else {
                 "fail"
@@ -1075,7 +1080,7 @@ fn agent_wallet_policy(
     if balance_usd > max_wallet_balance_usd {
         warnings.push("Agent wallet is over the configured autonomous balance cap.".to_string());
     }
-    if max_selected_price_usd > per_article_cap_usd + f64::EPSILON {
+    if max_selected_price_usd > per_article_cap_usd + USD_TOLERANCE {
         warnings.push("At least one selected source exceeds the per-article cap.".to_string());
     }
     let audit_urls = if input.audit_urls.is_empty() {
@@ -1097,8 +1102,8 @@ fn agent_wallet_policy(
         daily_cap_usd: round4(daily_cap_usd),
         max_wallet_balance_usd: round4(max_wallet_balance_usd),
         safe_to_autopay: balance_usd > 0.0
-            && balance_usd <= max_wallet_balance_usd + f64::EPSILON
-            && max_selected_price_usd <= per_article_cap_usd + f64::EPSILON,
+            && balance_usd <= max_wallet_balance_usd + USD_TOLERANCE
+            && max_selected_price_usd <= per_article_cap_usd + USD_TOLERANCE,
         audit_urls,
         warnings,
     })
@@ -1229,7 +1234,7 @@ fn tokenize(value: &str) -> BTreeSet<String> {
     value
         .split(|ch: char| !ch.is_ascii_alphanumeric())
         .map(normalize)
-        .filter(|token| token.len() > 2 && !is_stopword(token))
+        .filter(|token| token.len() > 1 && !is_stopword(token))
         .collect()
 }
 
@@ -1275,22 +1280,7 @@ fn default_network_for_protocol(protocol: &str) -> String {
 fn is_stopword(token: &str) -> bool {
     matches!(
         token,
-        "the"
-            | "and"
-            | "for"
-            | "with"
-            | "into"
-            | "from"
-            | "that"
-            | "this"
-            | "what"
-            | "when"
-            | "near"
-            | "price"
-            | "trade"
-            | "trading"
-            | "token"
-            | "crypto"
+        "the" | "and" | "for" | "with" | "into" | "from" | "that" | "this" | "what" | "when"
     )
 }
 
@@ -1433,5 +1423,56 @@ mod tests {
             .rejected_sources
             .iter()
             .any(|source| source.reason == "over-budget"));
+    }
+
+    #[test]
+    fn funding_routes_only_include_supported_crypto_native_rails() {
+        let plan = plan(PaidResearchPlanInput {
+            query: "NEAR price crypto research".to_string(),
+            pair: Some("NEAR/USDC".to_string()),
+            budget_usd: 0.09,
+            max_sources: 4,
+            min_relevance: 0.1,
+            min_trust_score: 0.4,
+            max_seo_risk_score: 0.65,
+            max_source_age_days: Some(7),
+            spending_mode: "quote".to_string(),
+            near_funding_asset: "USDC.near".to_string(),
+            preferred_payment_protocols: vec![],
+            default_article_price_usd: 0.01,
+            agent_wallet: None,
+            required_tags: vec![],
+            blocked_publishers: vec![],
+            sources: vec![
+                source("manual-source", 0.02, "manual", 0.95),
+                source("subscription-source", 0.02, "subscription", 0.9),
+                source("mpp-source", 0.02, "mpp", 0.85),
+                source("x402-source", 0.02, "x402", 0.8),
+            ],
+        })
+        .expect("plan");
+
+        let route_protocols: Vec<&str> = plan
+            .near_funding_routes
+            .iter()
+            .map(|route| route.target_protocol.as_str())
+            .collect();
+
+        assert_eq!(route_protocols, vec!["mpp", "x402"]);
+    }
+
+    #[test]
+    fn tokenize_preserves_two_letter_tickers_and_trading_terms() {
+        let tokens = tokenize("NEAR price for OP and AR crypto token trading");
+
+        assert!(tokens.contains("near"));
+        assert!(tokens.contains("price"));
+        assert!(tokens.contains("op"));
+        assert!(tokens.contains("ar"));
+        assert!(tokens.contains("crypto"));
+        assert!(tokens.contains("token"));
+        assert!(tokens.contains("trading"));
+        assert!(!tokens.contains("a"));
+        assert!(!tokens.contains("for"));
     }
 }

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 // non-settlement ranking, budgeting, and policy hints. Settlement remains with
 // the payment rails; this tolerance avoids machine-epsilon threshold mistakes.
 const USD_TOLERANCE: f64 = 1e-6;
+const DRIPSTACK_FALLBACK_PRICE_USD: f64 = 0.05;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct PaidResearchPlanInput {
@@ -134,6 +135,32 @@ pub struct DripstackBrowseInput {
     pub publications: Vec<DripstackPublicationInput>,
     #[serde(default)]
     pub posts: Vec<DripstackPostInput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DripstackCatalogInput {
+    #[serde(default)]
+    pub publication_slug: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DripstackPaidFetchInput {
+    pub publication_slug: String,
+    pub post_slug: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub price_usd: Option<f64>,
+    #[serde(default)]
+    pub payment_protocol: Option<String>,
+    #[serde(default)]
+    pub user_confirmed_purchase: bool,
+    #[serde(default)]
+    pub mpp_authorization: Option<String>,
+    #[serde(default)]
+    pub x402_payment_signature: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -310,6 +337,15 @@ pub struct DripstackBrowsePlan {
 }
 
 #[derive(Debug, Serialize)]
+pub struct DripstackCatalogResult {
+    pub schema_version: &'static str,
+    pub endpoint: String,
+    pub publications: Vec<DripstackPublicationInput>,
+    pub posts: Vec<DripstackPostInput>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
 pub struct DripstackPublicationMatch {
     pub rank: usize,
     pub slug: String,
@@ -334,6 +370,28 @@ pub struct DripstackPostCandidate {
     pub published_at: Option<String>,
     pub price_usd: f64,
     pub endpoint: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DripstackPaidFetchPlan {
+    pub schema_version: &'static str,
+    pub endpoint: String,
+    pub method: String,
+    pub status: String,
+    pub payment_protocol: String,
+    pub estimated_price_usd: f64,
+    pub expected_unpaid_status: u16,
+    pub request_headers: Vec<DripstackFetchHeader>,
+    pub supported_protocols: Vec<String>,
+    pub guardrails: Vec<String>,
+    pub warnings: Vec<String>,
+    pub next_action: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DripstackFetchHeader {
+    pub name: String,
+    pub value_preview: String,
 }
 
 pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
@@ -792,6 +850,216 @@ pub fn plan_dripstack_browse(input: DripstackBrowseInput) -> Result<DripstackBro
         guardrails,
         warnings,
     })
+}
+
+pub fn fetch_dripstack_catalog(
+    input: DripstackCatalogInput,
+) -> Result<DripstackCatalogResult, String> {
+    let publication_slug = input
+        .publication_slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|slug| !slug.is_empty());
+    let endpoint = if let Some(slug) = publication_slug {
+        format!("https://dripstack.xyz/api/v1/publications/{slug}")
+    } else {
+        "https://dripstack.xyz/api/v1/publications".to_string()
+    };
+    let raw = http_get_text(&endpoint)?;
+    if publication_slug.is_some() {
+        parse_dripstack_publication_detail(&endpoint, &raw)
+    } else {
+        parse_dripstack_publications(&endpoint, &raw)
+    }
+}
+
+fn parse_dripstack_publications(
+    endpoint: &str,
+    json: &str,
+) -> Result<DripstackCatalogResult, String> {
+    #[derive(Deserialize)]
+    struct ListResponse {
+        #[serde(default)]
+        publications: Vec<DripstackPublicationInput>,
+    }
+
+    let response: ListResponse = serde_json::from_str(json)
+        .map_err(|e| format!("DripStack publications JSON parse: {e}"))?;
+    Ok(DripstackCatalogResult {
+        schema_version: "dripstack-catalog/1",
+        endpoint: endpoint.to_string(),
+        publications: response.publications,
+        posts: Vec::new(),
+        warnings: Vec::new(),
+    })
+}
+
+fn parse_dripstack_publication_detail(
+    endpoint: &str,
+    json: &str,
+) -> Result<DripstackCatalogResult, String> {
+    #[derive(Deserialize)]
+    struct DetailResponse {
+        slug: String,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default, alias = "siteUrl")]
+        site_url: Option<String>,
+        #[serde(default, alias = "lastSyncedAt")]
+        last_synced_at: Option<String>,
+        #[serde(default)]
+        posts: Vec<DripstackPostInput>,
+    }
+
+    let response: DetailResponse = serde_json::from_str(json)
+        .map_err(|e| format!("DripStack publication detail JSON parse: {e}"))?;
+    Ok(DripstackCatalogResult {
+        schema_version: "dripstack-catalog/1",
+        endpoint: endpoint.to_string(),
+        publications: vec![DripstackPublicationInput {
+            slug: response.slug,
+            title: response.title,
+            description: response.description,
+            site_url: response.site_url,
+            last_synced_at: response.last_synced_at,
+        }],
+        posts: response.posts,
+        warnings: Vec::new(),
+    })
+}
+
+pub fn prepare_dripstack_paid_fetch(
+    input: DripstackPaidFetchInput,
+) -> Result<DripstackPaidFetchPlan, String> {
+    let publication_slug = input.publication_slug.trim();
+    let post_slug = input.post_slug.trim();
+    if publication_slug.is_empty() {
+        return Err("publication_slug is required for prepare_dripstack_paid_fetch".to_string());
+    }
+    if post_slug.is_empty() {
+        return Err("post_slug is required for prepare_dripstack_paid_fetch".to_string());
+    }
+
+    let endpoint = input.endpoint.unwrap_or_else(|| {
+        format!("https://dripstack.xyz/api/v1/publications/{publication_slug}/{post_slug}")
+    });
+    let payment_protocol = normalize_protocol(
+        input.payment_protocol.as_deref().unwrap_or("mpp"),
+        input.price_usd.unwrap_or(DRIPSTACK_FALLBACK_PRICE_USD),
+    );
+    if !matches!(payment_protocol.as_str(), "mpp" | "x402") {
+        return Err(
+            "prepare_dripstack_paid_fetch payment_protocol must be mpp or x402".to_string(),
+        );
+    }
+
+    let estimated_price_usd =
+        clean_nonnegative(input.price_usd.unwrap_or(DRIPSTACK_FALLBACK_PRICE_USD))
+            .max(DRIPSTACK_FALLBACK_PRICE_USD);
+    let guardrails = vec![
+        "Paid article body fetch is one article at a time.".to_string(),
+        "The live HTTP 402 challenge is authoritative for amount, network, and receipt format."
+            .to_string(),
+        "The agent may prepare headers from a receipt but must not create the receipt with hidden keys."
+            .to_string(),
+        "Fetched article text can be summarized only after the receipt-backed retry succeeds."
+            .to_string(),
+    ];
+    let mut warnings = Vec::new();
+    if input.price_usd.unwrap_or(0.0) < DRIPSTACK_FALLBACK_PRICE_USD {
+        warnings.push(
+            "Static catalog price is below the current DripStack fallback; live 402 may require at least $0.05."
+                .to_string(),
+        );
+    }
+
+    let mut request_headers = Vec::new();
+    let status;
+    let next_action;
+    if !input.user_confirmed_purchase {
+        status = "needs-user-confirmation".to_string();
+        next_action = format!(
+            "Ask the user to confirm buying '{}' before probing the paid endpoint.",
+            input.title.unwrap_or_else(|| post_slug.to_string())
+        );
+    } else if payment_protocol == "mpp" {
+        if let Some(auth) = input
+            .mpp_authorization
+            .filter(|value| !value.trim().is_empty())
+        {
+            request_headers.push(DripstackFetchHeader {
+                name: "Authorization".to_string(),
+                value_preview: preview_secret_header("Payment", &auth),
+            });
+            status = "ready-to-retry-with-receipt".to_string();
+            next_action =
+                "Retry the paid GET with the MPP Authorization header, then summarize only the returned article."
+                    .to_string();
+        } else {
+            status = "needs-402-challenge".to_string();
+            next_action =
+                "GET the paid endpoint without content synthesis, collect the HTTP 402 WWW-Authenticate challenge, then pass it to the payment client."
+                    .to_string();
+        }
+    } else if let Some(sig) = input
+        .x402_payment_signature
+        .filter(|value| !value.trim().is_empty())
+    {
+        request_headers.push(DripstackFetchHeader {
+            name: "PAYMENT-SIGNATURE".to_string(),
+            value_preview: preview_secret_header("x402", &sig),
+        });
+        status = "ready-to-retry-with-receipt".to_string();
+        next_action =
+            "Retry the paid GET with PAYMENT-SIGNATURE, then summarize only the returned article."
+                .to_string();
+    } else {
+        status = "needs-402-challenge".to_string();
+        next_action =
+            "GET the paid endpoint without content synthesis, collect the HTTP 402 PAYMENT-REQUIRED challenge, then pass it to the x402 payment client."
+                .to_string();
+    }
+
+    Ok(DripstackPaidFetchPlan {
+        schema_version: "dripstack-paid-fetch-plan/1",
+        endpoint,
+        method: "GET".to_string(),
+        status,
+        payment_protocol,
+        estimated_price_usd: round4(estimated_price_usd),
+        expected_unpaid_status: 402,
+        request_headers,
+        supported_protocols: vec!["mpp".to_string(), "x402".to_string()],
+        guardrails,
+        warnings,
+        next_action,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn http_get_text(endpoint: &str) -> Result<String, String> {
+    let headers = serde_json::json!({
+        "Accept": "application/json",
+        "User-Agent": "IronClaw-Portfolio-Tool/0.1"
+    });
+    let response =
+        crate::near::agent::host::http_request("GET", endpoint, &headers.to_string(), None, None)
+            .map_err(|e| format!("DripStack HTTP error: {e}"))?;
+    if response.status < 200 || response.status >= 300 {
+        let body = String::from_utf8_lossy(&response.body);
+        return Err(format!("DripStack {}: {body}", response.status));
+    }
+    String::from_utf8(response.body).map_err(|e| format!("DripStack response not UTF-8: {e}"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn http_get_text(_endpoint: &str) -> Result<String, String> {
+    Err(
+        "DripStack live catalog fetch only works inside the WASM sandbox; use plan_dripstack_browse with supplied free metadata in replay tests."
+            .to_string(),
+    )
 }
 
 fn score_source(
@@ -1303,6 +1571,16 @@ fn round4(value: f64) -> f64 {
     (value * 10_000.0).round() / 10_000.0
 }
 
+fn preview_secret_header(prefix: &str, value: &str) -> String {
+    let trimmed = value.trim();
+    let visible: String = trimmed.chars().take(10).collect();
+    if trimmed.len() <= visible.len() {
+        format!("{prefix} {visible}")
+    } else {
+        format!("{prefix} {visible}...")
+    }
+}
+
 fn default_budget_usd() -> f64 {
     5.0
 }
@@ -1474,5 +1752,47 @@ mod tests {
         assert!(tokens.contains("trading"));
         assert!(!tokens.contains("a"));
         assert!(!tokens.contains("for"));
+    }
+
+    #[test]
+    fn parses_dripstack_publication_catalog() {
+        let parsed = parse_dripstack_publications(
+            "https://dripstack.xyz/api/v1/publications",
+            r#"{
+              "publications": [{
+                "slug": "premiumcrypto.substack.com",
+                "title": "Premium Crypto Notes",
+                "description": "Crypto and market structure.",
+                "siteUrl": "https://premiumcrypto.substack.com",
+                "lastSyncedAt": "2026-05-02T00:00:00Z"
+              }]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.schema_version, "dripstack-catalog/1");
+        assert_eq!(parsed.publications.len(), 1);
+        assert_eq!(parsed.publications[0].slug, "premiumcrypto.substack.com");
+        assert!(parsed.posts.is_empty());
+    }
+
+    #[test]
+    fn prepares_mpp_paid_fetch_receipt_boundary() {
+        let plan = prepare_dripstack_paid_fetch(DripstackPaidFetchInput {
+            publication_slug: "premiumcrypto.substack.com".to_string(),
+            post_slug: "near-intents-liquidity".to_string(),
+            title: Some("NEAR Intents liquidity".to_string()),
+            endpoint: None,
+            price_usd: Some(0.05),
+            payment_protocol: Some("mpp".to_string()),
+            user_confirmed_purchase: true,
+            mpp_authorization: Some("signed-payment-credential-placeholder".to_string()),
+            x402_payment_signature: None,
+        })
+        .unwrap();
+
+        assert_eq!(plan.schema_version, "dripstack-paid-fetch-plan/1");
+        assert_eq!(plan.status, "ready-to-retry-with-receipt");
+        assert_eq!(plan.request_headers[0].name, "Authorization");
     }
 }

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -1010,9 +1010,9 @@ fn policy_gates(
     if let Some(policy) = wallet_policy {
         gates.push(PaidResearchPolicyGate {
             name: "agent-wallet-funded".to_string(),
-            status: if policy.balance_usd <= 0.0 {
-                "warn"
-            } else if policy.balance_usd > policy.max_wallet_balance_usd {
+            status: if policy.balance_usd <= 0.0
+                || policy.balance_usd > policy.max_wallet_balance_usd
+            {
                 "warn"
             } else {
                 "pass"

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -1,0 +1,797 @@
+//! Paid research planning for the Intents Trading Agent.
+//!
+//! This module models the "DripStack" pattern for IronClaw: an agent can
+//! discover premium research sources, budget a query, attribute which sources
+//! would be used in an answer, and prepare payment rails before any trading
+//! intent is built. It intentionally does not fetch paywalled content or sign
+//! payments. The output is a deterministic plan the skill can persist, show in
+//! the widget, and hand to a wallet/payment client after user approval.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PaidResearchPlanInput {
+    pub query: String,
+    #[serde(default)]
+    pub pair: Option<String>,
+    #[serde(default = "default_budget_usd")]
+    pub budget_usd: f64,
+    #[serde(default = "default_max_sources")]
+    pub max_sources: usize,
+    #[serde(default = "default_min_relevance")]
+    pub min_relevance: f64,
+    #[serde(default)]
+    pub max_source_age_days: Option<u32>,
+    #[serde(default = "default_spending_mode")]
+    pub spending_mode: String,
+    #[serde(default = "default_near_funding_asset")]
+    pub near_funding_asset: String,
+    #[serde(default)]
+    pub required_tags: Vec<String>,
+    #[serde(default)]
+    pub blocked_publishers: Vec<String>,
+    #[serde(default)]
+    pub sources: Vec<PaidResearchSourceInput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PaidResearchSourceInput {
+    pub id: String,
+    pub title: String,
+    pub author: String,
+    #[serde(default)]
+    pub publisher: Option<String>,
+    pub url: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub price_usd: Option<f64>,
+    #[serde(default)]
+    pub relevance: Option<f64>,
+    #[serde(default)]
+    pub trust_score: Option<f64>,
+    #[serde(default)]
+    pub freshness_score: Option<f64>,
+    #[serde(default)]
+    pub age_days: Option<u32>,
+    #[serde(default)]
+    pub payment: Option<PaidResearchPaymentInput>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PaidResearchPaymentInput {
+    #[serde(default = "default_payment_protocol")]
+    pub protocol: String,
+    #[serde(default)]
+    pub network: Option<String>,
+    #[serde(default)]
+    pub asset: Option<String>,
+    #[serde(default)]
+    pub recipient: Option<String>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaidResearchPlan {
+    pub schema_version: &'static str,
+    pub query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pair: Option<String>,
+    pub spending_mode: String,
+    pub budget_usd: f64,
+    pub allocated_usd: f64,
+    pub unspent_usd: f64,
+    pub selected_sources: Vec<SelectedPaidResearchSource>,
+    pub rejected_sources: Vec<RejectedPaidResearchSource>,
+    pub payment_rails: Vec<PaidResearchRailSummary>,
+    pub near_funding_routes: Vec<NearFundingRoute>,
+    pub policy_gates: Vec<PaidResearchPolicyGate>,
+    pub ready_for_paid_fetch: bool,
+    pub ready_for_trade_research: bool,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ScoredSource {
+    source: PaidResearchSourceInput,
+    relevance: f64,
+    trust_score: f64,
+    freshness_score: f64,
+    tag_score: f64,
+    selection_score: f64,
+    price_usd: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SelectedPaidResearchSource {
+    pub id: String,
+    pub title: String,
+    pub author: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publisher: Option<String>,
+    pub url: String,
+    pub tags: Vec<String>,
+    pub price_usd: f64,
+    pub relevance: f64,
+    pub trust_score: f64,
+    pub freshness_score: f64,
+    pub selection_score: f64,
+    pub evidence_weight: f64,
+    pub payment: PlannedResearchPayment,
+    pub attribution: ResearchAttribution,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PlannedResearchPayment {
+    pub protocol: String,
+    pub network: String,
+    pub asset: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recipient: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    pub amount_usd: f64,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResearchAttribution {
+    pub credit_id: String,
+    pub payable: bool,
+    pub receipt_required: bool,
+    pub answer_usage: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RejectedPaidResearchSource {
+    pub id: String,
+    pub title: String,
+    pub reason: String,
+    pub price_usd: f64,
+    pub relevance: f64,
+    pub selection_score: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaidResearchRailSummary {
+    pub protocol: String,
+    pub count: usize,
+    pub allocated_usd: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NearFundingRoute {
+    pub target_protocol: String,
+    pub target_network: String,
+    pub target_asset: String,
+    pub amount_usd: f64,
+    pub via: String,
+    pub note: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaidResearchPolicyGate {
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
+    if input.query.trim().is_empty() {
+        return Err("query is required for plan_paid_research".to_string());
+    }
+
+    let budget_usd = clean_nonnegative(input.budget_usd);
+    let max_sources = input.max_sources.max(1);
+    let min_relevance = clamp01(input.min_relevance);
+    let blocked = normalized_set(&input.blocked_publishers);
+    let required_tags = normalized_set(&input.required_tags);
+
+    let mut warnings = Vec::new();
+    if input.sources.is_empty() {
+        warnings.push("No candidate research sources were provided.".to_string());
+    }
+    if budget_usd == 0.0 {
+        warnings.push("Budget is zero; only free sources can be selected.".to_string());
+    }
+
+    let mut rejected_sources = Vec::new();
+    let mut candidates = Vec::new();
+    for source in input.sources {
+        let scored = score_source(source, &input.query, &required_tags, budget_usd);
+        if blocked.contains(&normalize(&scored.source.author))
+            || scored
+                .source
+                .publisher
+                .as_ref()
+                .map(|publisher| blocked.contains(&normalize(publisher)))
+                .unwrap_or(false)
+        {
+            rejected_sources.push(rejected(&scored, "blocked-publisher"));
+            continue;
+        }
+        if !required_tags.is_empty() && !source_has_required_tags(&scored.source, &required_tags) {
+            rejected_sources.push(rejected(&scored, "missing-required-tags"));
+            continue;
+        }
+        if let (Some(max_age), Some(age)) = (input.max_source_age_days, scored.source.age_days) {
+            if age > max_age {
+                rejected_sources.push(rejected(&scored, "stale-source"));
+                continue;
+            }
+        }
+        if scored.relevance < min_relevance {
+            rejected_sources.push(rejected(&scored, "below-min-relevance"));
+            continue;
+        }
+        candidates.push(scored);
+    }
+
+    candidates.sort_by(|a, b| {
+        b.selection_score
+            .partial_cmp(&a.selection_score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| {
+                a.price_usd
+                    .partial_cmp(&b.price_usd)
+                    .unwrap_or(Ordering::Equal)
+            })
+            .then_with(|| a.source.id.cmp(&b.source.id))
+    });
+
+    let mut selected_scored = Vec::new();
+    let mut remaining_budget = budget_usd;
+    for candidate in candidates {
+        if selected_scored.len() >= max_sources {
+            rejected_sources.push(rejected(&candidate, "max-sources-reached"));
+            continue;
+        }
+        if candidate.price_usd > remaining_budget + f64::EPSILON {
+            rejected_sources.push(rejected(&candidate, "over-budget"));
+            continue;
+        }
+        remaining_budget = (remaining_budget - candidate.price_usd).max(0.0);
+        selected_scored.push(candidate);
+    }
+
+    let allocated_usd: f64 = selected_scored.iter().map(|s| s.price_usd).sum();
+    let score_sum: f64 = selected_scored
+        .iter()
+        .map(|s| s.selection_score.max(0.0))
+        .sum();
+    let mut rail_totals: BTreeMap<String, (usize, f64)> = BTreeMap::new();
+    let mut funding_totals: BTreeMap<(String, String, String), f64> = BTreeMap::new();
+
+    let selected_sources: Vec<SelectedPaidResearchSource> = selected_scored
+        .into_iter()
+        .map(|scored| {
+            let payment = planned_payment(&scored, &input.spending_mode);
+            let rail_entry = rail_totals
+                .entry(payment.protocol.clone())
+                .or_insert((0, 0.0));
+            rail_entry.0 += 1;
+            rail_entry.1 += payment.amount_usd;
+
+            if payment.amount_usd > 0.0 && payment.protocol != "near-intents" {
+                let key = (
+                    payment.protocol.clone(),
+                    payment.network.clone(),
+                    payment.asset.clone(),
+                );
+                *funding_totals.entry(key).or_insert(0.0) += payment.amount_usd;
+            }
+
+            let evidence_weight = if score_sum > 0.0 {
+                round4(scored.selection_score.max(0.0) / score_sum)
+            } else {
+                0.0
+            };
+            let payable = payment.amount_usd > 0.0;
+            SelectedPaidResearchSource {
+                id: scored.source.id.clone(),
+                title: scored.source.title.clone(),
+                author: scored.source.author.clone(),
+                publisher: scored.source.publisher.clone(),
+                url: scored.source.url.clone(),
+                tags: scored.source.tags.clone(),
+                price_usd: round4(scored.price_usd),
+                relevance: round4(scored.relevance),
+                trust_score: round4(scored.trust_score),
+                freshness_score: round4(scored.freshness_score),
+                selection_score: round4(scored.selection_score),
+                evidence_weight,
+                payment,
+                attribution: ResearchAttribution {
+                    credit_id: format!("research-credit/{}", scored.source.id),
+                    payable,
+                    receipt_required: payable,
+                    answer_usage: if payable {
+                        "cite only after payment receipt, then credit this source in the answer"
+                            .to_string()
+                    } else {
+                        "free/public source can be cited with URL attribution".to_string()
+                    },
+                },
+            }
+        })
+        .collect();
+
+    let payment_rails = rail_totals
+        .into_iter()
+        .map(
+            |(protocol, (count, allocated_usd))| PaidResearchRailSummary {
+                protocol,
+                count,
+                allocated_usd: round4(allocated_usd),
+            },
+        )
+        .collect();
+
+    let near_funding_routes = funding_totals
+        .into_iter()
+        .map(
+            |((target_protocol, target_network, target_asset), amount_usd)| NearFundingRoute {
+                target_protocol: target_protocol.clone(),
+                target_network,
+                target_asset,
+                amount_usd: round4(amount_usd),
+                via: "near-intents".to_string(),
+                note: format!(
+                    "Use a NEAR Intents funding route from {} into the {} rail wallet before the paid fetch; this does not itself authorize the content payment.",
+                    input.near_funding_asset, target_protocol
+                ),
+            },
+        )
+        .collect();
+
+    if selected_sources.is_empty() && !rejected_sources.is_empty() {
+        warnings.push(
+            "All candidate paid research sources were rejected by budget or gates.".to_string(),
+        );
+    }
+
+    let paid_selected = selected_sources
+        .iter()
+        .filter(|source| source.payment.amount_usd > 0.0)
+        .count();
+    let policy_gates = policy_gates(
+        &input.spending_mode,
+        budget_usd,
+        allocated_usd,
+        paid_selected,
+    );
+    let ready_for_paid_fetch = !selected_sources.is_empty()
+        && allocated_usd <= budget_usd + f64::EPSILON
+        && policy_gates.iter().all(|gate| gate.status != "fail");
+    let ready_for_trade_research = ready_for_paid_fetch
+        && selected_sources
+            .iter()
+            .map(|source| source.evidence_weight)
+            .sum::<f64>()
+            > 0.0;
+
+    Ok(PaidResearchPlan {
+        schema_version: "paid-research-plan/1",
+        query: input.query,
+        pair: input.pair,
+        spending_mode: input.spending_mode,
+        budget_usd: round4(budget_usd),
+        allocated_usd: round4(allocated_usd),
+        unspent_usd: round4((budget_usd - allocated_usd).max(0.0)),
+        selected_sources,
+        rejected_sources,
+        payment_rails,
+        near_funding_routes,
+        policy_gates,
+        ready_for_paid_fetch,
+        ready_for_trade_research,
+        warnings,
+    })
+}
+
+fn score_source(
+    source: PaidResearchSourceInput,
+    query: &str,
+    required_tags: &BTreeSet<String>,
+    budget_usd: f64,
+) -> ScoredSource {
+    let text = format!(
+        "{} {} {} {}",
+        source.title,
+        source.author,
+        source.summary.as_deref().unwrap_or_default(),
+        source.tags.join(" ")
+    );
+    let lexical = lexical_relevance(query, &text);
+    let relevance = source
+        .relevance
+        .map(clamp01)
+        .unwrap_or(lexical)
+        .max(lexical * 0.9);
+    let trust_score = source.trust_score.map(clamp01).unwrap_or(0.6);
+    let freshness_score = source
+        .freshness_score
+        .map(clamp01)
+        .unwrap_or_else(|| age_freshness(source.age_days));
+    let tag_score = tag_score(&source, query, required_tags);
+    let price_usd = clean_nonnegative(source.price_usd.unwrap_or(0.0));
+    let cost_penalty = if budget_usd > 0.0 {
+        (price_usd / budget_usd).min(1.0) * 0.08
+    } else if price_usd > 0.0 {
+        0.25
+    } else {
+        0.0
+    };
+    let selection_score =
+        (relevance * 0.50) + (trust_score * 0.22) + (freshness_score * 0.18) + (tag_score * 0.10)
+            - cost_penalty;
+
+    ScoredSource {
+        source,
+        relevance,
+        trust_score,
+        freshness_score,
+        tag_score,
+        selection_score: selection_score.max(0.0),
+        price_usd,
+    }
+}
+
+fn planned_payment(scored: &ScoredSource, spending_mode: &str) -> PlannedResearchPayment {
+    let raw = scored
+        .source
+        .payment
+        .clone()
+        .unwrap_or(PaidResearchPaymentInput {
+            protocol: if scored.price_usd > 0.0 {
+                "manual".to_string()
+            } else {
+                "free".to_string()
+            },
+            network: None,
+            asset: None,
+            recipient: None,
+            endpoint: None,
+        });
+    let protocol = normalize_protocol(&raw.protocol, scored.price_usd);
+    let is_free = scored.price_usd == 0.0 || protocol == "free";
+    let network = raw
+        .network
+        .unwrap_or_else(|| default_network_for_protocol(&protocol));
+    let asset = raw.asset.unwrap_or_else(|| {
+        if is_free {
+            "none".to_string()
+        } else {
+            "USDC".to_string()
+        }
+    });
+    let status = if is_free {
+        "free".to_string()
+    } else if spending_mode == "autopay" {
+        "requires-policy-wallet".to_string()
+    } else {
+        "requires-user-approval".to_string()
+    };
+
+    PlannedResearchPayment {
+        protocol,
+        network,
+        asset,
+        recipient: raw.recipient,
+        endpoint: raw.endpoint,
+        amount_usd: round4(scored.price_usd),
+        status,
+    }
+}
+
+fn policy_gates(
+    spending_mode: &str,
+    budget_usd: f64,
+    allocated_usd: f64,
+    paid_selected: usize,
+) -> Vec<PaidResearchPolicyGate> {
+    let mut gates = vec![
+        PaidResearchPolicyGate {
+            name: "budget-cap".to_string(),
+            status: if allocated_usd <= budget_usd + f64::EPSILON {
+                "pass"
+            } else {
+                "fail"
+            }
+            .to_string(),
+            detail: format!(
+                "Allocated ${:.4} of the ${:.4} paid research budget.",
+                allocated_usd, budget_usd
+            ),
+        },
+        PaidResearchPolicyGate {
+            name: "receipt-before-use".to_string(),
+            status: "pass".to_string(),
+            detail:
+                "Paywalled source text must not be used in an answer until a payment receipt exists."
+                    .to_string(),
+        },
+        PaidResearchPolicyGate {
+            name: "citation-attribution".to_string(),
+            status: "pass".to_string(),
+            detail:
+                "Every answer using paid research must include source IDs so writers can be credited."
+                    .to_string(),
+        },
+        PaidResearchPolicyGate {
+            name: "trade-gate".to_string(),
+            status: "pass".to_string(),
+            detail:
+                "Paid research can influence the thesis, but backtest and risk gates still control NEAR intent construction."
+                    .to_string(),
+        },
+    ];
+
+    let approval_status = match spending_mode {
+        "plan-only" | "quote" => "pass",
+        "autopay" if paid_selected == 0 => "pass",
+        "autopay" => "warn",
+        _ => "warn",
+    };
+    gates.push(PaidResearchPolicyGate {
+        name: "payment-authorization".to_string(),
+        status: approval_status.to_string(),
+        detail: if spending_mode == "autopay" {
+            "Autopay requires a policy wallet with explicit source, amount, and cadence caps."
+                .to_string()
+        } else {
+            "Live source payments remain user-approved; this plan only prepares payable attribution."
+                .to_string()
+        },
+    });
+
+    gates
+}
+
+fn rejected(scored: &ScoredSource, reason: &str) -> RejectedPaidResearchSource {
+    RejectedPaidResearchSource {
+        id: scored.source.id.clone(),
+        title: scored.source.title.clone(),
+        reason: reason.to_string(),
+        price_usd: round4(scored.price_usd),
+        relevance: round4(scored.relevance),
+        selection_score: round4(scored.selection_score),
+    }
+}
+
+fn lexical_relevance(query: &str, text: &str) -> f64 {
+    let query_tokens = tokenize(query);
+    if query_tokens.is_empty() {
+        return 0.0;
+    }
+    let text_tokens = tokenize(text);
+    if text_tokens.is_empty() {
+        return 0.0;
+    }
+    let matches = query_tokens
+        .iter()
+        .filter(|token| text_tokens.contains(*token))
+        .count();
+    (matches as f64 / query_tokens.len() as f64).min(1.0)
+}
+
+fn tag_score(
+    source: &PaidResearchSourceInput,
+    query: &str,
+    required_tags: &BTreeSet<String>,
+) -> f64 {
+    let source_tags = normalized_set(&source.tags);
+    if source_tags.is_empty() {
+        return 0.0;
+    }
+    if !required_tags.is_empty() {
+        let hits = required_tags
+            .iter()
+            .filter(|tag| source_tags.contains(*tag))
+            .count();
+        return hits as f64 / required_tags.len() as f64;
+    }
+    let query_tokens = tokenize(query);
+    let hits = query_tokens
+        .iter()
+        .filter(|token| source_tags.contains(*token))
+        .count();
+    (hits as f64 / query_tokens.len().max(1) as f64).min(1.0)
+}
+
+fn source_has_required_tags(
+    source: &PaidResearchSourceInput,
+    required_tags: &BTreeSet<String>,
+) -> bool {
+    let source_tags = normalized_set(&source.tags);
+    required_tags.iter().all(|tag| source_tags.contains(tag))
+}
+
+fn age_freshness(age_days: Option<u32>) -> f64 {
+    match age_days {
+        Some(0..=1) => 1.0,
+        Some(2..=7) => 0.85,
+        Some(8..=30) => 0.65,
+        Some(31..=90) => 0.45,
+        Some(_) => 0.25,
+        None => 0.55,
+    }
+}
+
+fn tokenize(value: &str) -> BTreeSet<String> {
+    value
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .map(normalize)
+        .filter(|token| token.len() > 2 && !is_stopword(token))
+        .collect()
+}
+
+fn normalized_set(values: &[String]) -> BTreeSet<String> {
+    values
+        .iter()
+        .map(|value| normalize(value))
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn normalize_protocol(protocol: &str, price_usd: f64) -> String {
+    let protocol = normalize(protocol);
+    if price_usd == 0.0 {
+        return "free".to_string();
+    }
+    match protocol.as_str() {
+        "near" | "near_intents" | "near-intents" => "near-intents".to_string(),
+        "mpp" | "tempo" => "mpp".to_string(),
+        "x402" | "base-x402" => "x402".to_string(),
+        "subscription" => "subscription".to_string(),
+        "manual" => "manual".to_string(),
+        "free" => "free".to_string(),
+        _ => "manual".to_string(),
+    }
+}
+
+fn default_network_for_protocol(protocol: &str) -> String {
+    match protocol {
+        "near-intents" => "near".to_string(),
+        "mpp" => "tempo".to_string(),
+        "x402" => "base".to_string(),
+        "subscription" => "offchain".to_string(),
+        "free" => "none".to_string(),
+        _ => "manual".to_string(),
+    }
+}
+
+fn is_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "the"
+            | "and"
+            | "for"
+            | "with"
+            | "into"
+            | "from"
+            | "that"
+            | "this"
+            | "what"
+            | "when"
+            | "near"
+            | "price"
+            | "trade"
+            | "trading"
+            | "token"
+            | "crypto"
+    )
+}
+
+fn clean_nonnegative(value: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        0.0
+    }
+}
+
+fn clamp01(value: f64) -> f64 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    value.clamp(0.0, 1.0)
+}
+
+fn round4(value: f64) -> f64 {
+    (value * 10_000.0).round() / 10_000.0
+}
+
+fn default_budget_usd() -> f64 {
+    5.0
+}
+
+fn default_max_sources() -> usize {
+    4
+}
+
+fn default_min_relevance() -> f64 {
+    0.35
+}
+
+fn default_spending_mode() -> String {
+    "plan-only".to_string()
+}
+
+fn default_near_funding_asset() -> String {
+    "USDC.near".to_string()
+}
+
+fn default_payment_protocol() -> String {
+    "manual".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(id: &str, price_usd: f64, protocol: &str, relevance: f64) -> PaidResearchSourceInput {
+        PaidResearchSourceInput {
+            id: id.to_string(),
+            title: format!("{id} NEAR Intents research"),
+            author: "Writer".to_string(),
+            publisher: Some("Research Desk".to_string()),
+            url: format!("https://example.com/{id}"),
+            summary: Some("NEAR BTC liquidity, solver quality, and intent route risk.".to_string()),
+            tags: vec!["near-intents".to_string(), "btc".to_string()],
+            price_usd: Some(price_usd),
+            relevance: Some(relevance),
+            trust_score: Some(0.8),
+            freshness_score: Some(0.9),
+            age_days: Some(1),
+            payment: Some(PaidResearchPaymentInput {
+                protocol: protocol.to_string(),
+                network: None,
+                asset: Some("USDC".to_string()),
+                recipient: Some("0xmerchant".to_string()),
+                endpoint: Some(format!("https://example.com/{id}/paid")),
+            }),
+        }
+    }
+
+    #[test]
+    fn paid_research_plan_respects_budget_and_routes_external_rails() {
+        let plan = plan(PaidResearchPlanInput {
+            query: "NEAR BTC solver route risk".to_string(),
+            pair: Some("NEAR/BTC".to_string()),
+            budget_usd: 0.05,
+            max_sources: 3,
+            min_relevance: 0.2,
+            max_source_age_days: Some(7),
+            spending_mode: "quote".to_string(),
+            near_funding_asset: "USDC.near".to_string(),
+            required_tags: vec!["near-intents".to_string()],
+            blocked_publishers: vec![],
+            sources: vec![
+                source("mpp-source", 0.02, "mpp", 0.9),
+                source("x402-source", 0.02, "x402", 0.85),
+                source("too-expensive", 0.10, "x402", 0.95),
+            ],
+        })
+        .expect("plan");
+
+        assert_eq!(plan.schema_version, "paid-research-plan/1");
+        assert_eq!(plan.selected_sources.len(), 2);
+        assert!(plan.allocated_usd <= 0.05);
+        assert_eq!(plan.near_funding_routes.len(), 2);
+        assert!(plan
+            .rejected_sources
+            .iter()
+            .any(|source| source.reason == "over-budget"));
+    }
+}

--- a/tools-src/portfolio/src/research.rs
+++ b/tools-src/portfolio/src/research.rs
@@ -23,12 +23,22 @@ pub struct PaidResearchPlanInput {
     pub max_sources: usize,
     #[serde(default = "default_min_relevance")]
     pub min_relevance: f64,
+    #[serde(default = "default_min_trust_score")]
+    pub min_trust_score: f64,
+    #[serde(default = "default_max_seo_risk_score")]
+    pub max_seo_risk_score: f64,
     #[serde(default)]
     pub max_source_age_days: Option<u32>,
     #[serde(default = "default_spending_mode")]
     pub spending_mode: String,
     #[serde(default = "default_near_funding_asset")]
     pub near_funding_asset: String,
+    #[serde(default)]
+    pub preferred_payment_protocols: Vec<String>,
+    #[serde(default = "default_article_price_usd")]
+    pub default_article_price_usd: f64,
+    #[serde(default)]
+    pub agent_wallet: Option<AgentWalletPolicyInput>,
     #[serde(default)]
     pub required_tags: Vec<String>,
     #[serde(default)]
@@ -37,7 +47,7 @@ pub struct PaidResearchPlanInput {
     pub sources: Vec<PaidResearchSourceInput>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PaidResearchSourceInput {
     pub id: String,
     pub title: String,
@@ -58,9 +68,13 @@ pub struct PaidResearchSourceInput {
     #[serde(default)]
     pub freshness_score: Option<f64>,
     #[serde(default)]
+    pub seo_risk_score: Option<f64>,
+    #[serde(default)]
     pub age_days: Option<u32>,
     #[serde(default)]
     pub payment: Option<PaidResearchPaymentInput>,
+    #[serde(default)]
+    pub payment_options: Vec<PaidResearchPaymentInput>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -75,6 +89,76 @@ pub struct PaidResearchPaymentInput {
     pub recipient: Option<String>,
     #[serde(default)]
     pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentWalletPolicyInput {
+    #[serde(default = "default_agent_wallet_provider")]
+    pub provider: String,
+    #[serde(default)]
+    pub address: Option<String>,
+    #[serde(default = "default_agent_wallet_network")]
+    pub network: String,
+    #[serde(default)]
+    pub balance_usd: Option<f64>,
+    #[serde(default = "default_article_price_usd")]
+    pub default_article_price_usd: f64,
+    #[serde(default = "default_per_article_cap_usd")]
+    pub per_article_cap_usd: f64,
+    #[serde(default = "default_daily_wallet_cap_usd")]
+    pub daily_cap_usd: f64,
+    #[serde(default = "default_max_wallet_balance_usd")]
+    pub max_wallet_balance_usd: f64,
+    #[serde(default)]
+    pub audit_urls: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DripstackBrowseInput {
+    #[serde(default)]
+    pub topic: Option<String>,
+    #[serde(default)]
+    pub selected_publication_slug: Option<String>,
+    #[serde(default)]
+    pub selected_post_slug: Option<String>,
+    #[serde(default)]
+    pub max_results: Option<usize>,
+    #[serde(default = "default_article_price_usd")]
+    pub default_price_usd: f64,
+    #[serde(default)]
+    pub publications: Vec<DripstackPublicationInput>,
+    #[serde(default)]
+    pub posts: Vec<DripstackPostInput>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DripstackPublicationInput {
+    pub slug: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "siteUrl")]
+    pub site_url: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "lastSyncedAt")]
+    pub last_synced_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DripstackPostInput {
+    pub slug: String,
+    pub title: String,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub author: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "publishedAt")]
+    pub published_at: Option<String>,
+    #[serde(default)]
+    pub price_usd: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -92,6 +176,8 @@ pub struct PaidResearchPlan {
     pub payment_rails: Vec<PaidResearchRailSummary>,
     pub near_funding_routes: Vec<NearFundingRoute>,
     pub policy_gates: Vec<PaidResearchPolicyGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wallet_policy: Option<AgentWalletPolicy>,
     pub ready_for_paid_fetch: bool,
     pub ready_for_trade_research: bool,
     pub warnings: Vec<String>,
@@ -106,6 +192,7 @@ struct ScoredSource {
     tag_score: f64,
     selection_score: f64,
     price_usd: f64,
+    seo_risk_score: f64,
 }
 
 #[derive(Debug, Serialize)]
@@ -121,13 +208,16 @@ pub struct SelectedPaidResearchSource {
     pub relevance: f64,
     pub trust_score: f64,
     pub freshness_score: f64,
+    pub seo_risk_score: f64,
     pub selection_score: f64,
     pub evidence_weight: f64,
     pub payment: PlannedResearchPayment,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub payment_options: Vec<PlannedResearchPayment>,
     pub attribution: ResearchAttribution,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PlannedResearchPayment {
     pub protocol: String,
     pub network: String,
@@ -182,6 +272,65 @@ pub struct PaidResearchPolicyGate {
     pub detail: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct AgentWalletPolicy {
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    pub network: String,
+    pub balance_usd: f64,
+    pub default_article_price_usd: f64,
+    pub max_articles_at_default_price: usize,
+    pub per_article_cap_usd: f64,
+    pub daily_cap_usd: f64,
+    pub max_wallet_balance_usd: f64,
+    pub safe_to_autopay: bool,
+    pub audit_urls: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DripstackBrowsePlan {
+    pub schema_version: &'static str,
+    pub checkpoint: String,
+    pub prompt: String,
+    pub matched_publications: Vec<DripstackPublicationMatch>,
+    pub post_candidates: Vec<DripstackPostCandidate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_article: Option<DripstackPostCandidate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paid_source_candidate: Option<PaidResearchSourceInput>,
+    pub guardrails: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DripstackPublicationMatch {
+    pub rank: usize,
+    pub slug: String,
+    pub title: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub site_url: Option<String>,
+    pub relevance: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DripstackPostCandidate {
+    pub rank: usize,
+    pub publication_slug: String,
+    pub slug: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subtitle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
+    pub price_usd: f64,
+    pub endpoint: String,
+}
+
 pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
     if input.query.trim().is_empty() {
         return Err("query is required for plan_paid_research".to_string());
@@ -190,8 +339,15 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
     let budget_usd = clean_nonnegative(input.budget_usd);
     let max_sources = input.max_sources.max(1);
     let min_relevance = clamp01(input.min_relevance);
+    let min_trust_score = clamp01(input.min_trust_score);
+    let max_seo_risk_score = clamp01(input.max_seo_risk_score);
     let blocked = normalized_set(&input.blocked_publishers);
     let required_tags = normalized_set(&input.required_tags);
+    let preferred_payment_protocols =
+        preferred_payment_protocols(&input.preferred_payment_protocols);
+    let spending_mode = input.spending_mode.clone();
+    let default_article_price_usd = clean_nonnegative(input.default_article_price_usd);
+    let agent_wallet = input.agent_wallet.clone();
 
     let mut warnings = Vec::new();
     if input.sources.is_empty() {
@@ -228,6 +384,14 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         }
         if scored.relevance < min_relevance {
             rejected_sources.push(rejected(&scored, "below-min-relevance"));
+            continue;
+        }
+        if scored.trust_score < min_trust_score {
+            rejected_sources.push(rejected(&scored, "below-min-trust"));
+            continue;
+        }
+        if scored.seo_risk_score > max_seo_risk_score {
+            rejected_sources.push(rejected(&scored, "seo-risk-too-high"));
             continue;
         }
         candidates.push(scored);
@@ -271,7 +435,12 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
     let selected_sources: Vec<SelectedPaidResearchSource> = selected_scored
         .into_iter()
         .map(|scored| {
-            let payment = planned_payment(&scored, &input.spending_mode);
+            let payment_options =
+                planned_payment_options(&scored, &spending_mode, &preferred_payment_protocols);
+            let payment = payment_options
+                .first()
+                .cloned()
+                .unwrap_or_else(|| planned_payment_default(&scored, &spending_mode));
             let rail_entry = rail_totals
                 .entry(payment.protocol.clone())
                 .or_insert((0, 0.0));
@@ -304,9 +473,11 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
                 relevance: round4(scored.relevance),
                 trust_score: round4(scored.trust_score),
                 freshness_score: round4(scored.freshness_score),
+                seo_risk_score: round4(scored.seo_risk_score),
                 selection_score: round4(scored.selection_score),
                 evidence_weight,
                 payment,
+                payment_options,
                 attribution: ResearchAttribution {
                     credit_id: format!("research-credit/{}", scored.source.id),
                     payable,
@@ -360,11 +531,22 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         .iter()
         .filter(|source| source.payment.amount_usd > 0.0)
         .count();
+    let max_selected_price_usd = selected_sources
+        .iter()
+        .map(|source| source.price_usd)
+        .fold(0.0, f64::max);
+    let wallet_policy = agent_wallet_policy(
+        agent_wallet.as_ref(),
+        max_selected_price_usd,
+        default_article_price_usd,
+    );
     let policy_gates = policy_gates(
-        &input.spending_mode,
+        &spending_mode,
         budget_usd,
         allocated_usd,
         paid_selected,
+        wallet_policy.as_ref(),
+        max_selected_price_usd,
     );
     let ready_for_paid_fetch = !selected_sources.is_empty()
         && allocated_usd <= budget_usd + f64::EPSILON
@@ -380,7 +562,7 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         schema_version: "paid-research-plan/1",
         query: input.query,
         pair: input.pair,
-        spending_mode: input.spending_mode,
+        spending_mode,
         budget_usd: round4(budget_usd),
         allocated_usd: round4(allocated_usd),
         unspent_usd: round4((budget_usd - allocated_usd).max(0.0)),
@@ -389,8 +571,220 @@ pub fn plan(input: PaidResearchPlanInput) -> Result<PaidResearchPlan, String> {
         payment_rails,
         near_funding_routes,
         policy_gates,
+        wallet_policy,
         ready_for_paid_fetch,
         ready_for_trade_research,
+        warnings,
+    })
+}
+
+pub fn plan_dripstack_browse(input: DripstackBrowseInput) -> Result<DripstackBrowsePlan, String> {
+    let guardrails = vec![
+        "Guided browse only: topic, publication, article, then explicit purchase approval."
+            .to_string(),
+        "Catalog and post-title routes are free; article body remains gated until 402 payment succeeds."
+            .to_string(),
+        "Never auto-buy: a selected article becomes a paid-source candidate, not fetched content."
+            .to_string(),
+        "Paid article text requires a receipt before it can be summarized, quoted, or used in a trade thesis."
+            .to_string(),
+    ];
+    let mut warnings = Vec::new();
+    let max_results = input.max_results.unwrap_or(5).clamp(1, 10);
+    let default_price_usd = clean_nonnegative(input.default_price_usd).max(0.01);
+
+    let topic = input
+        .topic
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let selected_publication_slug = input
+        .selected_publication_slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let selected_post_slug = input
+        .selected_post_slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    if topic.is_none() && selected_publication_slug.is_none() {
+        return Ok(DripstackBrowsePlan {
+            schema_version: "dripstack-browse-plan/1",
+            checkpoint: "topic".to_string(),
+            prompt: "Choose a topic first: finance, crypto, AI, tech, business, geopolitics, or culture.".to_string(),
+            matched_publications: Vec::new(),
+            post_candidates: Vec::new(),
+            selected_article: None,
+            paid_source_candidate: None,
+            guardrails,
+            warnings,
+        });
+    }
+
+    let matched_publications = if let Some(topic) = topic {
+        let mut scored: Vec<(f64, &DripstackPublicationInput)> = input
+            .publications
+            .iter()
+            .map(|publication| (publication_relevance(topic, publication), publication))
+            .filter(|(score, _)| *score > 0.0)
+            .collect();
+        scored.sort_by(|a, b| {
+            b.0.partial_cmp(&a.0)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.1.slug.cmp(&b.1.slug))
+        });
+        scored
+            .into_iter()
+            .take(max_results)
+            .enumerate()
+            .map(
+                |(idx, (relevance, publication))| DripstackPublicationMatch {
+                    rank: idx + 1,
+                    slug: publication.slug.clone(),
+                    title: publication
+                        .title
+                        .clone()
+                        .unwrap_or_else(|| publication.slug.clone()),
+                    description: publication.description.clone().unwrap_or_default(),
+                    site_url: publication.site_url.clone(),
+                    relevance: round4(relevance),
+                },
+            )
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    if selected_publication_slug.is_none() {
+        if input.publications.is_empty() {
+            warnings.push(
+                "No publication catalog was supplied. Fetch DripStack GET /api/v1/publications before this step."
+                    .to_string(),
+            );
+        }
+        return Ok(DripstackBrowsePlan {
+            schema_version: "dripstack-browse-plan/1",
+            checkpoint: "publication".to_string(),
+            prompt: "Pick one matched publication before listing articles.".to_string(),
+            matched_publications,
+            post_candidates: Vec::new(),
+            selected_article: None,
+            paid_source_candidate: None,
+            guardrails,
+            warnings,
+        });
+    }
+
+    let publication_slug = selected_publication_slug.unwrap();
+    let publication = input
+        .publications
+        .iter()
+        .find(|publication| publication.slug == publication_slug);
+    if publication.is_none() && !input.publications.is_empty() {
+        warnings.push(format!(
+            "Selected publication '{publication_slug}' was not found in the supplied catalog."
+        ));
+    }
+    let publication_title = publication
+        .and_then(|publication| publication.title.clone())
+        .unwrap_or_else(|| publication_slug.to_string());
+
+    let post_candidates: Vec<DripstackPostCandidate> = input
+        .posts
+        .iter()
+        .take(max_results)
+        .enumerate()
+        .map(|(idx, post)| post_candidate(idx + 1, publication_slug, post, default_price_usd))
+        .collect();
+
+    if selected_post_slug.is_none() {
+        if input.posts.is_empty() {
+            warnings.push(format!(
+                "No post summaries were supplied. Fetch DripStack GET /api/v1/publications/{publication_slug} before choosing an article."
+            ));
+        }
+        return Ok(DripstackBrowsePlan {
+            schema_version: "dripstack-browse-plan/1",
+            checkpoint: "article".to_string(),
+            prompt: format!(
+                "Pick one article from {publication_title}; no article body is fetched yet."
+            ),
+            matched_publications,
+            post_candidates,
+            selected_article: None,
+            paid_source_candidate: None,
+            guardrails,
+            warnings,
+        });
+    }
+
+    let selected_post_slug = selected_post_slug.unwrap();
+    let selected_post = input
+        .posts
+        .iter()
+        .find(|post| post.slug == selected_post_slug)
+        .ok_or_else(|| {
+            format!(
+                "Selected post '{selected_post_slug}' was not found in the supplied post summaries."
+            )
+        })?;
+    let selected_article = post_candidate(1, publication_slug, selected_post, default_price_usd);
+    let title = selected_article.title.clone();
+    let author = selected_article
+        .author
+        .clone()
+        .unwrap_or_else(|| publication_title.clone());
+    let paid_source_candidate = PaidResearchSourceInput {
+        id: format!("dripstack:{publication_slug}:{selected_post_slug}"),
+        title,
+        author,
+        publisher: Some(publication_title),
+        url: selected_article.endpoint.clone(),
+        summary: selected_article.subtitle.clone(),
+        tags: vec![
+            "dripstack".to_string(),
+            "paid-content".to_string(),
+            "financial-research".to_string(),
+        ],
+        price_usd: Some(selected_article.price_usd),
+        relevance: Some(0.75),
+        trust_score: Some(0.65),
+        freshness_score: selected_article.published_at.as_ref().map(|_| 0.75),
+        seo_risk_score: Some(0.35),
+        age_days: None,
+        payment: None,
+        payment_options: vec![
+            PaidResearchPaymentInput {
+                protocol: "mpp".to_string(),
+                network: Some("tempo".to_string()),
+                asset: Some("USDC".to_string()),
+                recipient: None,
+                endpoint: Some(selected_article.endpoint.clone()),
+            },
+            PaidResearchPaymentInput {
+                protocol: "x402".to_string(),
+                network: Some("base".to_string()),
+                asset: Some("USDC".to_string()),
+                recipient: None,
+                endpoint: Some(selected_article.endpoint.clone()),
+            },
+        ],
+    };
+
+    Ok(DripstackBrowsePlan {
+        schema_version: "dripstack-browse-plan/1",
+        checkpoint: "purchase-confirmation".to_string(),
+        prompt: format!(
+            "Confirm before paying for this article. The planned price is ${:.4}; article body remains locked until the payment-aware client returns a receipt.",
+            selected_article.price_usd
+        ),
+        matched_publications,
+        post_candidates,
+        selected_article: Some(selected_article),
+        paid_source_candidate: Some(paid_source_candidate),
+        guardrails,
         warnings,
     })
 }
@@ -419,6 +813,13 @@ fn score_source(
         .freshness_score
         .map(clamp01)
         .unwrap_or_else(|| age_freshness(source.age_days));
+    let seo_risk_score = source.seo_risk_score.map(clamp01).unwrap_or_else(|| {
+        if trust_score < 0.45 && relevance > 0.8 {
+            0.75
+        } else {
+            0.25
+        }
+    });
     let tag_score = tag_score(&source, query, required_tags);
     let price_usd = clean_nonnegative(source.price_usd.unwrap_or(0.0));
     let cost_penalty = if budget_usd > 0.0 {
@@ -440,15 +841,27 @@ fn score_source(
         tag_score,
         selection_score: selection_score.max(0.0),
         price_usd,
+        seo_risk_score,
     }
 }
 
-fn planned_payment(scored: &ScoredSource, spending_mode: &str) -> PlannedResearchPayment {
-    let raw = scored
-        .source
-        .payment
-        .clone()
-        .unwrap_or(PaidResearchPaymentInput {
+fn planned_payment_options(
+    scored: &ScoredSource,
+    spending_mode: &str,
+    preferred_protocols: &[String],
+) -> Vec<PlannedResearchPayment> {
+    let mut raw_options = if scored.source.payment_options.is_empty() {
+        scored
+            .source
+            .payment
+            .clone()
+            .into_iter()
+            .collect::<Vec<_>>()
+    } else {
+        scored.source.payment_options.clone()
+    };
+    if raw_options.is_empty() {
+        raw_options.push(PaidResearchPaymentInput {
             protocol: if scored.price_usd > 0.0 {
                 "manual".to_string()
             } else {
@@ -459,6 +872,43 @@ fn planned_payment(scored: &ScoredSource, spending_mode: &str) -> PlannedResearc
             recipient: None,
             endpoint: None,
         });
+    }
+
+    let mut options: Vec<PlannedResearchPayment> = raw_options
+        .into_iter()
+        .map(|raw| planned_payment_from_raw(scored, raw, spending_mode))
+        .collect();
+    options.sort_by(|a, b| {
+        payment_rank(&a.protocol, preferred_protocols)
+            .cmp(&payment_rank(&b.protocol, preferred_protocols))
+            .then_with(|| a.network.cmp(&b.network))
+    });
+    options
+}
+
+fn planned_payment_default(scored: &ScoredSource, spending_mode: &str) -> PlannedResearchPayment {
+    planned_payment_from_raw(
+        scored,
+        PaidResearchPaymentInput {
+            protocol: if scored.price_usd > 0.0 {
+                "manual".to_string()
+            } else {
+                "free".to_string()
+            },
+            network: None,
+            asset: None,
+            recipient: None,
+            endpoint: None,
+        },
+        spending_mode,
+    )
+}
+
+fn planned_payment_from_raw(
+    scored: &ScoredSource,
+    raw: PaidResearchPaymentInput,
+    spending_mode: &str,
+) -> PlannedResearchPayment {
     let protocol = normalize_protocol(&raw.protocol, scored.price_usd);
     let is_free = scored.price_usd == 0.0 || protocol == "free";
     let network = raw
@@ -495,6 +945,8 @@ fn policy_gates(
     budget_usd: f64,
     allocated_usd: f64,
     paid_selected: usize,
+    wallet_policy: Option<&AgentWalletPolicy>,
+    max_selected_price_usd: f64,
 ) -> Vec<PaidResearchPolicyGate> {
     let mut gates = vec![
         PaidResearchPolicyGate {
@@ -550,6 +1002,44 @@ fn policy_gates(
                 .to_string()
         },
     });
+    if let Some(policy) = wallet_policy {
+        gates.push(PaidResearchPolicyGate {
+            name: "agent-wallet-funded".to_string(),
+            status: if policy.balance_usd <= 0.0 {
+                "warn"
+            } else if policy.balance_usd > policy.max_wallet_balance_usd {
+                "warn"
+            } else {
+                "pass"
+            }
+            .to_string(),
+            detail: format!(
+                "{} wallet balance is ${:.2}; cap is ${:.2}.",
+                policy.provider, policy.balance_usd, policy.max_wallet_balance_usd
+            ),
+        });
+        gates.push(PaidResearchPolicyGate {
+            name: "per-article-cap".to_string(),
+            status: if max_selected_price_usd <= policy.per_article_cap_usd + f64::EPSILON {
+                "pass"
+            } else {
+                "fail"
+            }
+            .to_string(),
+            detail: format!(
+                "Highest selected source is ${:.4}; wallet per-article cap is ${:.4}.",
+                max_selected_price_usd, policy.per_article_cap_usd
+            ),
+        });
+    } else if paid_selected > 0 {
+        gates.push(PaidResearchPolicyGate {
+            name: "agent-wallet-configured".to_string(),
+            status: "warn".to_string(),
+            detail:
+                "No agent wallet policy was supplied; paid fetches must stay in explicit approval mode."
+                    .to_string(),
+        });
+    }
 
     gates
 }
@@ -563,6 +1053,81 @@ fn rejected(scored: &ScoredSource, reason: &str) -> RejectedPaidResearchSource {
         relevance: round4(scored.relevance),
         selection_score: round4(scored.selection_score),
     }
+}
+
+fn agent_wallet_policy(
+    input: Option<&AgentWalletPolicyInput>,
+    max_selected_price_usd: f64,
+    fallback_article_price_usd: f64,
+) -> Option<AgentWalletPolicy> {
+    let input = input?;
+    let balance_usd = clean_nonnegative(input.balance_usd.unwrap_or(0.0));
+    let default_article_price_usd = clean_nonnegative(input.default_article_price_usd)
+        .max(clean_nonnegative(fallback_article_price_usd))
+        .max(0.0001);
+    let per_article_cap_usd = clean_nonnegative(input.per_article_cap_usd);
+    let daily_cap_usd = clean_nonnegative(input.daily_cap_usd);
+    let max_wallet_balance_usd = clean_nonnegative(input.max_wallet_balance_usd);
+    let mut warnings = Vec::new();
+    if balance_usd == 0.0 {
+        warnings.push("Agent wallet has no declared USDC balance.".to_string());
+    }
+    if balance_usd > max_wallet_balance_usd {
+        warnings.push("Agent wallet is over the configured autonomous balance cap.".to_string());
+    }
+    if max_selected_price_usd > per_article_cap_usd + f64::EPSILON {
+        warnings.push("At least one selected source exceeds the per-article cap.".to_string());
+    }
+    let audit_urls = if input.audit_urls.is_empty() {
+        vec![
+            "https://mppscan.com/".to_string(),
+            "https://www.x402scan.com/".to_string(),
+        ]
+    } else {
+        input.audit_urls.clone()
+    };
+    Some(AgentWalletPolicy {
+        provider: input.provider.clone(),
+        address: input.address.clone(),
+        network: input.network.clone(),
+        balance_usd: round4(balance_usd),
+        default_article_price_usd: round4(default_article_price_usd),
+        max_articles_at_default_price: (balance_usd / default_article_price_usd).floor() as usize,
+        per_article_cap_usd: round4(per_article_cap_usd),
+        daily_cap_usd: round4(daily_cap_usd),
+        max_wallet_balance_usd: round4(max_wallet_balance_usd),
+        safe_to_autopay: balance_usd > 0.0
+            && balance_usd <= max_wallet_balance_usd + f64::EPSILON
+            && max_selected_price_usd <= per_article_cap_usd + f64::EPSILON,
+        audit_urls,
+        warnings,
+    })
+}
+
+fn preferred_payment_protocols(raw: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = raw
+        .iter()
+        .map(|protocol| normalize_protocol(protocol, 1.0))
+        .filter(|protocol| !protocol.is_empty())
+        .collect();
+    if out.is_empty() {
+        out = vec![
+            "near-intents".to_string(),
+            "mpp".to_string(),
+            "x402".to_string(),
+            "subscription".to_string(),
+            "manual".to_string(),
+            "free".to_string(),
+        ];
+    }
+    out
+}
+
+fn payment_rank(protocol: &str, preferred_protocols: &[String]) -> usize {
+    preferred_protocols
+        .iter()
+        .position(|candidate| candidate == protocol)
+        .unwrap_or(usize::MAX)
 }
 
 fn lexical_relevance(query: &str, text: &str) -> f64 {
@@ -579,6 +1144,42 @@ fn lexical_relevance(query: &str, text: &str) -> f64 {
         .filter(|token| text_tokens.contains(*token))
         .count();
     (matches as f64 / query_tokens.len() as f64).min(1.0)
+}
+
+fn publication_relevance(topic: &str, publication: &DripstackPublicationInput) -> f64 {
+    lexical_relevance(
+        topic,
+        &format!(
+            "{} {} {}",
+            publication.title.as_deref().unwrap_or_default(),
+            publication.description.as_deref().unwrap_or_default(),
+            publication.site_url.as_deref().unwrap_or_default()
+        ),
+    )
+}
+
+fn post_candidate(
+    rank: usize,
+    publication_slug: &str,
+    post: &DripstackPostInput,
+    default_price_usd: f64,
+) -> DripstackPostCandidate {
+    DripstackPostCandidate {
+        rank,
+        publication_slug: publication_slug.to_string(),
+        slug: post.slug.clone(),
+        title: post.title.clone(),
+        subtitle: post.subtitle.clone(),
+        author: post.author.clone(),
+        published_at: post.published_at.clone(),
+        price_usd: round4(clean_nonnegative(
+            post.price_usd.unwrap_or(default_price_usd),
+        )),
+        endpoint: format!(
+            "https://dripstack.xyz/api/v1/publications/{}/{}",
+            publication_slug, post.slug
+        ),
+    }
 }
 
 fn tag_score(
@@ -724,6 +1325,14 @@ fn default_min_relevance() -> f64 {
     0.35
 }
 
+fn default_min_trust_score() -> f64 {
+    0.45
+}
+
+fn default_max_seo_risk_score() -> f64 {
+    0.65
+}
+
 fn default_spending_mode() -> String {
     "plan-only".to_string()
 }
@@ -734,6 +1343,30 @@ fn default_near_funding_asset() -> String {
 
 fn default_payment_protocol() -> String {
     "manual".to_string()
+}
+
+fn default_agent_wallet_provider() -> String {
+    "AgentCash".to_string()
+}
+
+fn default_agent_wallet_network() -> String {
+    "base".to_string()
+}
+
+fn default_article_price_usd() -> f64 {
+    0.01
+}
+
+fn default_per_article_cap_usd() -> f64 {
+    0.05
+}
+
+fn default_daily_wallet_cap_usd() -> f64 {
+    1.0
+}
+
+fn default_max_wallet_balance_usd() -> f64 {
+    5.0
 }
 
 #[cfg(test)]
@@ -753,6 +1386,7 @@ mod tests {
             relevance: Some(relevance),
             trust_score: Some(0.8),
             freshness_score: Some(0.9),
+            seo_risk_score: Some(0.2),
             age_days: Some(1),
             payment: Some(PaidResearchPaymentInput {
                 protocol: protocol.to_string(),
@@ -761,6 +1395,7 @@ mod tests {
                 recipient: Some("0xmerchant".to_string()),
                 endpoint: Some(format!("https://example.com/{id}/paid")),
             }),
+            payment_options: Vec::new(),
         }
     }
 
@@ -772,9 +1407,14 @@ mod tests {
             budget_usd: 0.05,
             max_sources: 3,
             min_relevance: 0.2,
+            min_trust_score: 0.4,
+            max_seo_risk_score: 0.65,
             max_source_age_days: Some(7),
             spending_mode: "quote".to_string(),
             near_funding_asset: "USDC.near".to_string(),
+            preferred_payment_protocols: vec!["mpp".to_string(), "x402".to_string()],
+            default_article_price_usd: 0.01,
+            agent_wallet: None,
             required_tags: vec!["near-intents".to_string()],
             blocked_publishers: vec![],
             sources: vec![

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -324,6 +324,214 @@
     },
     {
       "properties": {
+        "action": { "const": "backtest_walkforward" },
+        "candles": {
+          "type": "array",
+          "description": "OHLCV candles sorted oldest to newest. Split into N contiguous, non-overlapping fold windows.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ts": { "type": "string" },
+              "open": { "type": "number", "exclusiveMinimum": 0 },
+              "high": { "type": "number", "exclusiveMinimum": 0 },
+              "low": { "type": "number", "exclusiveMinimum": 0 },
+              "close": { "type": "number", "exclusiveMinimum": 0 },
+              "volume": { "type": "number" }
+            },
+            "required": ["ts", "open", "high", "low", "close"]
+          },
+          "minItems": 8
+        },
+        "strategy": {
+          "type": "object",
+          "description": "Long-only spot strategy config. Same kinds as 'backtest'.",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["buy-hold", "sma-cross", "breakout", "mean-reversion", "momentum", "rsi-mean-reversion"]
+            },
+            "fast_window": { "type": "integer", "minimum": 1 },
+            "slow_window": { "type": "integer", "minimum": 1 },
+            "lookback_window": { "type": "integer", "minimum": 1 },
+            "threshold_bps": { "type": "number", "minimum": 0 },
+            "entry_threshold": { "type": "number", "minimum": 0 },
+            "exit_threshold": { "type": "number", "minimum": 0 }
+          },
+          "required": ["kind"]
+        },
+        "n_folds": { "type": "integer", "minimum": 2 },
+        "train_pct": { "type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1, "default": 0.7 },
+        "embargo": { "type": "integer", "minimum": 0, "default": 0 },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 },
+        "fee_bps": { "type": "number", "minimum": 0, "default": 10 },
+        "slippage_bps": { "type": "number", "minimum": 0, "default": 5 },
+        "max_position_pct": { "type": "number", "exclusiveMinimum": 0, "maximum": 1, "default": 1 },
+        "stop_loss_bps": { "type": "number", "minimum": 0 },
+        "take_profit_bps": { "type": "number", "minimum": 0 }
+      },
+      "required": ["action", "candles", "strategy", "n_folds"]
+    },
+    {
+      "properties": {
+        "action": { "const": "backtest_montecarlo" },
+        "trade_returns_pct": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 1,
+          "description": "Per-trade percent returns. Typically the trades[].return_pct array from a prior backtest."
+        },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 },
+        "iterations": { "type": "integer", "minimum": 1, "default": 1000 },
+        "seed": { "type": "integer", "default": 13888280946577510895 },
+        "method": { "type": "string", "enum": ["shuffle", "permute"], "default": "shuffle" }
+      },
+      "required": ["action", "trade_returns_pct"]
+    },
+    {
+      "properties": {
+        "action": { "const": "backtest_grid" },
+        "candles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ts": { "type": "string" },
+              "open": { "type": "number", "exclusiveMinimum": 0 },
+              "high": { "type": "number", "exclusiveMinimum": 0 },
+              "low": { "type": "number", "exclusiveMinimum": 0 },
+              "close": { "type": "number", "exclusiveMinimum": 0 },
+              "volume": { "type": "number" }
+            },
+            "required": ["ts", "open", "high", "low", "close"]
+          },
+          "minItems": 2
+        },
+        "base": {
+          "type": "object",
+          "description": "Base strategy config; axes override these fields per cell.",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["buy-hold", "sma-cross", "breakout", "mean-reversion", "momentum", "rsi-mean-reversion"]
+            },
+            "fast_window": { "type": "integer", "minimum": 1 },
+            "slow_window": { "type": "integer", "minimum": 1 },
+            "lookback_window": { "type": "integer", "minimum": 1 },
+            "threshold_bps": { "type": "number", "minimum": 0 },
+            "entry_threshold": { "type": "number", "minimum": 0 },
+            "exit_threshold": { "type": "number", "minimum": 0 }
+          },
+          "required": ["kind"]
+        },
+        "axes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "param": {
+                "type": "string",
+                "enum": ["fast_window", "slow_window", "lookback_window", "threshold_bps", "entry_threshold", "exit_threshold"]
+              },
+              "values": {
+                "type": "array",
+                "items": { "type": "number" },
+                "minItems": 1
+              }
+            },
+            "required": ["param", "values"]
+          }
+        },
+        "max_position_pct_options": { "type": "array", "items": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 } },
+        "stop_loss_bps_options": { "type": "array", "items": { "type": "number", "minimum": 0 } },
+        "take_profit_bps_options": { "type": "array", "items": { "type": "number", "minimum": 0 } },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 },
+        "fee_bps": { "type": "number", "minimum": 0, "default": 10 },
+        "slippage_bps": { "type": "number", "minimum": 0, "default": 5 },
+        "max_cells": { "type": "integer", "minimum": 1, "default": 1024 }
+      },
+      "required": ["action", "candles", "base"]
+    },
+    {
+      "properties": {
+        "action": { "const": "validate_episode" },
+        "episode": {
+          "type": "object",
+          "description": "Multi-surface episode bundling candles, optional solver fixture, and optional news context.",
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "pair": { "type": "string", "minLength": 1 },
+            "timeframe": { "type": "string" },
+            "candles": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ts": { "type": "string" },
+                  "open": { "type": "number", "exclusiveMinimum": 0 },
+                  "high": { "type": "number", "exclusiveMinimum": 0 },
+                  "low": { "type": "number", "exclusiveMinimum": 0 },
+                  "close": { "type": "number", "exclusiveMinimum": 0 },
+                  "volume": { "type": "number" }
+                },
+                "required": ["ts", "open", "high", "low", "close"]
+              },
+              "minItems": 2
+            },
+            "solver_fixture": {},
+            "news_context": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ts": { "type": "string" },
+                  "headline": { "type": "string" },
+                  "url": { "type": "string" },
+                  "source": { "type": "string" },
+                  "kind": { "type": "string" }
+                },
+                "required": ["ts", "headline"]
+              }
+            },
+            "generated_at": { "type": "string" },
+            "source": { "type": "string" },
+            "notes": { "type": "string" }
+          },
+          "required": ["id", "pair", "candles"]
+        }
+      },
+      "required": ["action", "episode"]
+    },
+    {
+      "properties": {
+        "action": { "const": "replay_episode" },
+        "episode": {
+          "type": "object",
+          "description": "Same shape as validate_episode.",
+          "required": ["id", "pair", "candles"]
+        },
+        "candidates": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "strategy": { "type": "object", "required": ["kind"] },
+              "max_position_pct": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+              "stop_loss_bps": { "type": "number", "minimum": 0 },
+              "take_profit_bps": { "type": "number", "minimum": 0 }
+            },
+            "required": ["id", "strategy"]
+          }
+        },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 },
+        "fee_bps": { "type": "number", "minimum": 0, "default": 10 },
+        "slippage_bps": { "type": "number", "minimum": 0, "default": 5 }
+      },
+      "required": ["action", "episode", "candidates"]
+    },
+    {
+      "properties": {
         "action": { "const": "plan_paid_research" },
         "query": {
           "type": "string",

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -349,6 +349,20 @@
           "default": 0.35,
           "description": "Minimum relevance gate after explicit and lexical scoring."
         },
+        "min_trust_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.45,
+          "description": "Minimum trust gate to reduce agentic-SEO manipulation."
+        },
+        "max_seo_risk_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.65,
+          "description": "Maximum accepted source-manipulation risk score."
+        },
         "max_source_age_days": {
           "type": "integer",
           "minimum": 0,
@@ -364,6 +378,36 @@
           "type": "string",
           "default": "USDC.near",
           "description": "NEAR-side asset to route from when funding external MPP/x402 rails through NEAR Intents."
+        },
+        "preferred_payment_protocols": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["near-intents", "mpp", "x402", "subscription", "manual", "free"]
+          },
+          "default": ["near-intents", "mpp", "x402", "subscription", "manual", "free"],
+          "description": "Payment rail preference order when a source supports more than one rail."
+        },
+        "default_article_price_usd": {
+          "type": "number",
+          "minimum": 0,
+          "default": 0.01,
+          "description": "Default article price used for wallet-cap math."
+        },
+        "agent_wallet": {
+          "type": "object",
+          "description": "Optional autonomous wallet policy. This is policy metadata only, not signing material.",
+          "properties": {
+            "provider": { "type": "string", "default": "AgentCash" },
+            "address": { "type": "string" },
+            "network": { "type": "string", "default": "base" },
+            "balance_usd": { "type": "number", "minimum": 0 },
+            "default_article_price_usd": { "type": "number", "minimum": 0, "default": 0.01 },
+            "per_article_cap_usd": { "type": "number", "minimum": 0, "default": 0.05 },
+            "daily_cap_usd": { "type": "number", "minimum": 0, "default": 1.0 },
+            "max_wallet_balance_usd": { "type": "number", "minimum": 0, "default": 5.0 },
+            "audit_urls": { "type": "array", "items": { "type": "string" }, "default": [] }
+          }
         },
         "required_tags": {
           "type": "array",
@@ -394,6 +438,7 @@
               "relevance": { "type": "number", "minimum": 0, "maximum": 1 },
               "trust_score": { "type": "number", "minimum": 0, "maximum": 1 },
               "freshness_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "seo_risk_score": { "type": "number", "minimum": 0, "maximum": 1 },
               "age_days": { "type": "integer", "minimum": 0 },
               "payment": {
                 "type": "object",
@@ -409,6 +454,25 @@
                   "recipient": { "type": "string" },
                   "endpoint": { "type": "string" }
                 }
+              },
+              "payment_options": {
+                "type": "array",
+                "description": "Alternative rails accepted by the same source, for example DripStack supporting both MPP and x402.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "protocol": {
+                      "type": "string",
+                      "enum": ["near-intents", "mpp", "x402", "subscription", "manual", "free"],
+                      "default": "manual"
+                    },
+                    "network": { "type": "string" },
+                    "asset": { "type": "string" },
+                    "recipient": { "type": "string" },
+                    "endpoint": { "type": "string" }
+                  }
+                },
+                "default": []
               }
             },
             "required": ["id", "title", "author", "url"]
@@ -417,6 +481,64 @@
         }
       },
       "required": ["action", "query"]
+    },
+    {
+      "properties": {
+        "action": { "const": "plan_dripstack_browse" },
+        "topic": {
+          "type": "string",
+          "description": "User topic. If absent, the output checkpoint asks for a topic before any catalog work."
+        },
+        "selected_publication_slug": {
+          "type": "string",
+          "description": "Publication slug selected by the user from a matched shortlist."
+        },
+        "selected_post_slug": {
+          "type": "string",
+          "description": "Post slug selected by the user from post summaries."
+        },
+        "max_results": { "type": "integer", "minimum": 1, "maximum": 10, "default": 5 },
+        "default_price_usd": {
+          "type": "number",
+          "minimum": 0,
+          "default": 0.01,
+          "description": "Default planned article price when a post-specific price is unavailable."
+        },
+        "publications": {
+          "type": "array",
+          "description": "Free DripStack publication catalog rows from GET /api/v1/publications.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": { "type": "string" },
+              "title": { "type": "string" },
+              "description": { "type": "string" },
+              "site_url": { "type": "string" },
+              "last_synced_at": { "type": "string" }
+            },
+            "required": ["slug"]
+          },
+          "default": []
+        },
+        "posts": {
+          "type": "array",
+          "description": "Free post summaries from GET /api/v1/publications/{publicationSlug}.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": { "type": "string" },
+              "title": { "type": "string" },
+              "subtitle": { "type": "string" },
+              "author": { "type": "string" },
+              "published_at": { "type": "string" },
+              "price_usd": { "type": "number", "minimum": 0 }
+            },
+            "required": ["slug", "title"]
+          },
+          "default": []
+        }
+      },
+      "required": ["action"]
     },
     {
       "properties": {

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -181,6 +181,10 @@
           "items": { "type": "string" },
           "default": []
         },
+        "paid_research_plan": {
+          "type": "object",
+          "description": "Optional output from plan_paid_research. The widget extracts budget, payable sources, rails, policy gates, and NEAR funding routes."
+        },
         "next_action": {
           "type": "string",
           "description": "Operator-facing next step shown in the widget."
@@ -313,6 +317,106 @@
         "slippage_bps": { "type": "number", "minimum": 0, "default": 5 }
       },
       "required": ["action", "candles", "candidates"]
+    },
+    {
+      "properties": {
+        "action": { "const": "plan_paid_research" },
+        "query": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Question or research task to answer before a trading decision."
+        },
+        "pair": {
+          "type": "string",
+          "description": "Optional watched pair, for example NEAR/BTC."
+        },
+        "budget_usd": {
+          "type": "number",
+          "minimum": 0,
+          "default": 5,
+          "description": "Maximum total spend across selected paid sources. Zero allows only free sources."
+        },
+        "max_sources": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 4,
+          "description": "Maximum number of sources to select."
+        },
+        "min_relevance": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.35,
+          "description": "Minimum relevance gate after explicit and lexical scoring."
+        },
+        "max_source_age_days": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional freshness gate for sources that include age_days."
+        },
+        "spending_mode": {
+          "type": "string",
+          "enum": ["plan-only", "quote", "autopay"],
+          "default": "plan-only",
+          "description": "plan-only and quote never authorize payment; autopay still requires a policy wallet outside this tool."
+        },
+        "near_funding_asset": {
+          "type": "string",
+          "default": "USDC.near",
+          "description": "NEAR-side asset to route from when funding external MPP/x402 rails through NEAR Intents."
+        },
+        "required_tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "All selected sources must include these tags when provided."
+        },
+        "blocked_publishers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Authors or publishers to exclude from selection."
+        },
+        "sources": {
+          "type": "array",
+          "description": "Candidate free or paid sources discovered from newsletters, APIs, x402/MPP discovery, or project config.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "title": { "type": "string" },
+              "author": { "type": "string" },
+              "publisher": { "type": "string" },
+              "url": { "type": "string" },
+              "summary": { "type": "string" },
+              "tags": { "type": "array", "items": { "type": "string" }, "default": [] },
+              "price_usd": { "type": "number", "minimum": 0 },
+              "relevance": { "type": "number", "minimum": 0, "maximum": 1 },
+              "trust_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "freshness_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "age_days": { "type": "integer", "minimum": 0 },
+              "payment": {
+                "type": "object",
+                "description": "Payment rail metadata. This is planning data only; no payment is signed.",
+                "properties": {
+                  "protocol": {
+                    "type": "string",
+                    "enum": ["near-intents", "mpp", "x402", "subscription", "manual", "free"],
+                    "default": "manual"
+                  },
+                  "network": { "type": "string" },
+                  "asset": { "type": "string" },
+                  "recipient": { "type": "string" },
+                  "endpoint": { "type": "string" }
+                }
+              }
+            },
+            "required": ["id", "title", "author", "url"]
+          },
+          "default": []
+        }
+      },
+      "required": ["action", "query"]
     },
     {
       "properties": {

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -185,6 +185,10 @@
           "type": "object",
           "description": "Optional output from plan_paid_research. The widget extracts budget, payable sources, rails, policy gates, and NEAR funding routes."
         },
+        "trial_plan": {
+          "type": "object",
+          "description": "Optional output from plan_near_intents_trial. The widget extracts nominal budget, setup steps, trial risk gates, and quote readiness."
+        },
         "next_action": {
           "type": "string",
           "description": "Operator-facing next step shown in the widget."
@@ -484,6 +488,16 @@
     },
     {
       "properties": {
+        "action": { "const": "fetch_dripstack_catalog" },
+        "publication_slug": {
+          "type": "string",
+          "description": "Optional publication slug. Omit to fetch the free publication catalog; provide it to fetch free post-title metadata for one publication."
+        }
+      },
+      "required": ["action"]
+    },
+    {
+      "properties": {
         "action": { "const": "plan_dripstack_browse" },
         "topic": {
           "type": "string",
@@ -536,6 +550,105 @@
             "required": ["slug", "title"]
           },
           "default": []
+        }
+      },
+      "required": ["action"]
+    },
+    {
+      "properties": {
+        "action": { "const": "prepare_dripstack_paid_fetch" },
+        "publication_slug": {
+          "type": "string",
+          "minLength": 1,
+          "description": "DripStack publication slug exactly as returned by the free catalog."
+        },
+        "post_slug": {
+          "type": "string",
+          "minLength": 1,
+          "description": "DripStack post slug exactly as returned by the free publication detail route."
+        },
+        "title": {
+          "type": "string",
+          "description": "Optional display title for confirmation prompts."
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Optional paid article endpoint. Defaults to https://dripstack.xyz/api/v1/publications/{publication_slug}/{post_slug}."
+        },
+        "price_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Static estimated price. The live HTTP 402 challenge remains authoritative."
+        },
+        "payment_protocol": {
+          "type": "string",
+          "enum": ["mpp", "x402"],
+          "default": "mpp"
+        },
+        "user_confirmed_purchase": {
+          "type": "boolean",
+          "default": false,
+          "description": "Must be true before the agent probes the paid endpoint or prepares receipt-backed retry headers."
+        },
+        "mpp_authorization": {
+          "type": "string",
+          "description": "MPP Authorization credential returned by a payment-aware client. The tool only previews the header; it never signs."
+        },
+        "x402_payment_signature": {
+          "type": "string",
+          "description": "x402 PAYMENT-SIGNATURE returned by a payment-aware client. The tool only previews the header; it never signs."
+        }
+      },
+      "required": ["action", "publication_slug", "post_slug"]
+    },
+    {
+      "properties": {
+        "action": { "const": "plan_near_intents_trial" },
+        "near_account_id": {
+          "type": "string",
+          "description": "Optional NEAR signer account id for the trial wallet."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["paper", "quote", "execution"],
+          "default": "paper",
+          "description": "Paper builds fixture intents; quote prepares a live NEAR Intents quote request; execution remains manual-wallet only."
+        },
+        "pair": {
+          "type": "string",
+          "default": "NEAR/USDC",
+          "description": "Trial pair. Single-token values are normalized as NEAR/<token>."
+        },
+        "nominal_near": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "default": 0.25,
+          "description": "Total NEAR budget the user intends to keep in the isolated trial wallet."
+        },
+        "max_trade_near": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Maximum NEAR-equivalent size for one trial quote/trade."
+        },
+        "assumed_near_usd": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "default": 3.0,
+          "description": "Fresh NEAR/USD estimate used only for sizing. Recompute before any live quote."
+        },
+        "max_slippage_bps": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000,
+          "default": 50
+        },
+        "selected_strategy_id": {
+          "type": "string",
+          "description": "Optional strategy id selected from backtest_suite ranked results."
+        },
+        "backtest_suite": {
+          "type": "object",
+          "description": "Optional output from backtest_suite, used to gate/recommend the trial strategy."
         }
       },
       "required": ["action"]

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -582,6 +582,20 @@
     },
     {
       "properties": {
+        "action": { "const": "compile_intent_prompt" },
+        "prompt": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Natural-language trade prompt. Examples: 'DCA $100 weekly into NEAR for 6 months', 'swap 0.5 BTC to USDC on near', 'backtest sma 5/20 on NEAR/USDC', 'watch BTC for breakout above 70000'."
+        },
+        "default_chain": { "type": "string", "default": "near" },
+        "default_funding_asset": { "type": "string", "default": "USDC" },
+        "focus_pair": { "type": "string" }
+      },
+      "required": ["action", "prompt"]
+    },
+    {
+      "properties": {
         "action": { "const": "plan_paid_research" },
         "query": {
           "type": "string",

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -109,6 +109,87 @@
     },
     {
       "properties": {
+        "action": { "const": "format_intents_widget" },
+        "generated_at": {
+          "type": "string",
+          "description": "ISO 8601 timestamp for the current strategy/intent report."
+        },
+        "project_id": {
+          "type": "string",
+          "description": "Project slug or id, usually intents-trading-agent."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["paper", "quote", "execution"],
+          "default": "paper",
+          "description": "Trading workflow mode. Execution remains future wallet-only plumbing."
+        },
+        "pair": {
+          "type": "string",
+          "description": "Watched pair, for example NEAR/BTC."
+        },
+        "stance": {
+          "type": "string",
+          "enum": ["skip", "watch", "paper-intent", "quote-intent", "blocked"],
+          "default": "watch"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "backtest_suite": {
+          "type": "object",
+          "description": "Output from backtest_suite. Top five ranked candidates are extracted for the widget."
+        },
+        "risk_gates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "status": {
+                "type": "string",
+                "enum": ["pass", "warn", "fail", "blocked", "unknown"]
+              },
+              "detail": { "type": "string" }
+            },
+            "required": ["name", "status"]
+          },
+          "default": []
+        },
+        "intent": {
+          "type": "object",
+          "description": "Optional unsigned NEAR Intent bundle preview.",
+          "properties": {
+            "bundle": {
+              "type": "object",
+              "description": "IntentBundle returned from build_intent."
+            },
+            "status": {
+              "type": "string",
+              "enum": ["none", "paper-built", "live-quote-built", "awaiting-signature", "submitted", "failed", "blocked"],
+              "default": "none"
+            },
+            "route_label": { "type": "string" },
+            "quote_source": { "type": "string" }
+          },
+          "required": ["bundle"]
+        },
+        "research_sources": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "next_action": {
+          "type": "string",
+          "description": "Operator-facing next step shown in the widget."
+        }
+      },
+      "required": ["action", "pair"]
+    },
+    {
+      "properties": {
         "action": { "const": "progress" },
         "history": {
           "type": "array",
@@ -128,6 +209,110 @@
         }
       },
       "required": ["action", "history", "config"]
+    },
+    {
+      "properties": {
+        "action": { "const": "backtest" },
+        "candles": {
+          "type": "array",
+          "description": "OHLCV candles sorted oldest to newest. Signals are formed on candle close and executed at the next candle open.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ts": { "type": "string" },
+              "open": { "type": "number", "exclusiveMinimum": 0 },
+              "high": { "type": "number", "exclusiveMinimum": 0 },
+              "low": { "type": "number", "exclusiveMinimum": 0 },
+              "close": { "type": "number", "exclusiveMinimum": 0 },
+              "volume": { "type": "number" }
+            },
+            "required": ["ts", "open", "high", "low", "close"]
+          },
+          "minItems": 2
+        },
+        "strategy": {
+          "type": "object",
+          "description": "Long-only spot strategy config. Supported kinds: buy-hold, sma-cross, breakout, mean-reversion, momentum, rsi-mean-reversion.",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["buy-hold", "sma-cross", "breakout", "mean-reversion", "momentum", "rsi-mean-reversion"]
+            },
+            "fast_window": { "type": "integer", "minimum": 1 },
+            "slow_window": { "type": "integer", "minimum": 1 },
+            "lookback_window": { "type": "integer", "minimum": 1 },
+            "threshold_bps": { "type": "number", "minimum": 0 },
+            "entry_threshold": { "type": "number", "minimum": 0 },
+            "exit_threshold": { "type": "number", "minimum": 0 }
+          },
+          "required": ["kind"]
+        },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 },
+        "fee_bps": { "type": "number", "minimum": 0, "default": 10 },
+        "slippage_bps": { "type": "number", "minimum": 0, "default": 5 },
+        "max_position_pct": { "type": "number", "exclusiveMinimum": 0, "maximum": 1, "default": 1 },
+        "stop_loss_bps": { "type": "number", "minimum": 0 },
+        "take_profit_bps": { "type": "number", "minimum": 0 }
+      },
+      "required": ["action", "candles", "strategy"]
+    },
+    {
+      "properties": {
+        "action": { "const": "backtest_suite" },
+        "candles": {
+          "type": "array",
+          "description": "OHLCV candles sorted oldest to newest. Every candidate is evaluated against this same market episode.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ts": { "type": "string" },
+              "open": { "type": "number", "exclusiveMinimum": 0 },
+              "high": { "type": "number", "exclusiveMinimum": 0 },
+              "low": { "type": "number", "exclusiveMinimum": 0 },
+              "close": { "type": "number", "exclusiveMinimum": 0 },
+              "volume": { "type": "number" }
+            },
+            "required": ["ts", "open", "high", "low", "close"]
+          },
+          "minItems": 2
+        },
+        "candidates": {
+          "type": "array",
+          "description": "Strategy menu to rank. Each candidate may override position size, stop-loss, and take-profit.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "strategy": {
+                "type": "object",
+                "description": "Long-only spot strategy config. Supported kinds: buy-hold, sma-cross, breakout, mean-reversion, momentum, rsi-mean-reversion.",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": ["buy-hold", "sma-cross", "breakout", "mean-reversion", "momentum", "rsi-mean-reversion"]
+                  },
+                  "fast_window": { "type": "integer", "minimum": 1 },
+                  "slow_window": { "type": "integer", "minimum": 1 },
+                  "lookback_window": { "type": "integer", "minimum": 1 },
+                  "threshold_bps": { "type": "number", "minimum": 0 },
+                  "entry_threshold": { "type": "number", "minimum": 0 },
+                  "exit_threshold": { "type": "number", "minimum": 0 }
+                },
+                "required": ["kind"]
+              },
+              "max_position_pct": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+              "stop_loss_bps": { "type": "number", "minimum": 0 },
+              "take_profit_bps": { "type": "number", "minimum": 0 }
+            },
+            "required": ["id", "strategy"]
+          },
+          "minItems": 1
+        },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 },
+        "fee_bps": { "type": "number", "minimum": 0, "default": 10 },
+        "slippage_bps": { "type": "number", "minimum": 0, "default": 5 }
+      },
+      "required": ["action", "candles", "candidates"]
     },
     {
       "properties": {

--- a/tools-src/portfolio/src/schema.json
+++ b/tools-src/portfolio/src/schema.json
@@ -532,6 +532,56 @@
     },
     {
       "properties": {
+        "action": { "const": "backtest_dca" },
+        "candles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ts": { "type": "string" },
+              "open": { "type": "number", "exclusiveMinimum": 0 },
+              "high": { "type": "number", "exclusiveMinimum": 0 },
+              "low": { "type": "number", "exclusiveMinimum": 0 },
+              "close": { "type": "number", "exclusiveMinimum": 0 },
+              "volume": { "type": "number" }
+            },
+            "required": ["ts", "open", "high", "low", "close"]
+          },
+          "minItems": 2
+        },
+        "notional_per_period_usd": { "type": "number", "exclusiveMinimum": 0 },
+        "period_candles": { "type": "integer", "minimum": 1, "default": 1 },
+        "offset": { "type": "integer", "minimum": 0, "default": 0 },
+        "skip_above_premium_bps": { "type": "number", "minimum": 0 },
+        "opportunistic_below_discount_bps": { "type": "number", "minimum": 0 },
+        "fee_bps": { "type": "number", "minimum": 0, "default": 10 },
+        "slippage_bps": { "type": "number", "minimum": 0, "default": 5 },
+        "initial_cash_usd": { "type": "number", "exclusiveMinimum": 0, "default": 10000 }
+      },
+      "required": ["action", "candles", "notional_per_period_usd"]
+    },
+    {
+      "properties": {
+        "action": { "const": "plan_dca_schedule" },
+        "pair": { "type": "string", "minLength": 1 },
+        "source_asset": { "type": "string", "minLength": 1 },
+        "destination_asset": { "type": "string", "minLength": 1 },
+        "source_chain": { "type": "string", "minLength": 1 },
+        "destination_chain": { "type": "string", "minLength": 1 },
+        "notional_per_period_usd": { "type": "number", "exclusiveMinimum": 0 },
+        "cadence": { "type": "string", "description": "daily | weekly | biweekly | monthly | raw 5-or-6-field cron" },
+        "total_periods": { "type": "integer", "minimum": 1 },
+        "max_slippage_bps": { "type": "number", "minimum": 0, "default": 50 },
+        "start_at": { "type": "string" },
+        "assumed_price_usd": { "type": "number", "exclusiveMinimum": 0 },
+        "mode": { "type": "string", "enum": ["paper", "quote"], "default": "paper" },
+        "notional_currency": { "type": "string", "default": "USDC" },
+        "solver": { "type": "string" }
+      },
+      "required": ["action", "pair", "source_asset", "destination_asset", "source_chain", "destination_chain", "notional_per_period_usd", "cadence", "total_periods"]
+    },
+    {
+      "properties": {
         "action": { "const": "plan_paid_research" },
         "query": {
           "type": "string",

--- a/tools-src/portfolio/src/trial.rs
+++ b/tools-src/portfolio/src/trial.rs
@@ -161,10 +161,10 @@ pub fn plan(input: NearTrialPlanInput) -> Result<NearTrialPlan, String> {
                 }),
         },
         TrialRiskGate {
-            name: "native-near-wrap".to_string(),
+            name: "near-funding-path".to_string(),
             status: "warn".to_string(),
             detail:
-                "The verifier does not accept raw native NEAR deposits; wrap NEAR to wNEAR before verifier funding."
+                "1Click or Deposit/Withdrawal Service flows may handle native NEAR wrapping. Direct verifier funding expects wNEAR (nep141:wrap.near), not a raw native NEAR transfer."
                     .to_string(),
         },
         strategy_gate,
@@ -400,10 +400,10 @@ fn setup_steps() -> Vec<TrialSetupStep> {
         },
         TrialSetupStep {
             order: 2,
-            name: "Wrap NEAR".to_string(),
+            name: "Choose funding path".to_string(),
             status: "manual".to_string(),
             detail:
-                "Convert the trial amount from native NEAR into wNEAR before depositing to the verifier."
+                "Use 1Click or the Deposit/Withdrawal Service for managed routing, or wrap native NEAR into wNEAR before a direct verifier deposit."
                     .to_string(),
         },
         TrialSetupStep {
@@ -411,7 +411,7 @@ fn setup_steps() -> Vec<TrialSetupStep> {
             name: "Deposit to verifier".to_string(),
             status: "manual".to_string(),
             detail:
-                "Deposit wNEAR into intents.near using the official verifier deposit flow; do not transfer raw NEAR directly."
+                "For a direct Verifier-contract deposit, deposit wNEAR into intents.near with ft_transfer_call; do not send raw native NEAR directly."
                     .to_string(),
         },
         TrialSetupStep {

--- a/tools-src/portfolio/src/trial.rs
+++ b/tools-src/portfolio/src/trial.rs
@@ -1,0 +1,638 @@
+//! Trial-mode planning for users who want to rehearse NEAR Intents
+//! trading with a nominal amount of NEAR.
+//!
+//! This module does not sign, wrap, deposit, quote, or execute. It turns
+//! a small user budget into a concrete paper/quote workflow: strategy
+//! candidates to backtest, funding caveats, risk gates, and a
+//! `build_intent` request the skill can run in fixture or live-quote
+//! mode after explicit user approval.
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::types::{MovementLeg, MovementPlan, ProjectConfig, TokenAmount};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NearTrialPlanInput {
+    #[serde(default)]
+    pub near_account_id: Option<String>,
+    #[serde(default = "default_trial_mode")]
+    pub mode: String,
+    #[serde(default = "default_pair")]
+    pub pair: String,
+    #[serde(default = "default_nominal_near")]
+    pub nominal_near: f64,
+    #[serde(default)]
+    pub max_trade_near: Option<f64>,
+    #[serde(default = "default_assumed_near_usd")]
+    pub assumed_near_usd: f64,
+    #[serde(default = "default_max_slippage_bps")]
+    pub max_slippage_bps: u16,
+    #[serde(default)]
+    pub selected_strategy_id: Option<String>,
+    #[serde(default)]
+    pub backtest_suite: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NearTrialPlan {
+    pub schema_version: &'static str,
+    pub mode: String,
+    pub pair: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub near_account_id: Option<String>,
+    pub nominal_near: f64,
+    pub max_trade_near: f64,
+    pub assumed_near_usd: f64,
+    pub max_trade_usd: f64,
+    pub safe_to_quote: bool,
+    pub safe_to_execute: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended_strategy_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_strategy_id: Option<String>,
+    pub strategy_menu: Vec<TrialStrategyCandidate>,
+    pub setup_steps: Vec<TrialSetupStep>,
+    pub risk_gates: Vec<TrialRiskGate>,
+    pub movement_plan: MovementPlan,
+    pub build_intent_request: serde_json::Value,
+    pub docs: Vec<TrialDocRef>,
+    pub warnings: Vec<String>,
+    pub next_action: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrialStrategyCandidate {
+    pub id: String,
+    pub kind: String,
+    pub position_size_pct: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub take_profit_bps: Option<f64>,
+    pub note: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrialSetupStep {
+    pub order: usize,
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrialRiskGate {
+    pub name: String,
+    pub status: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrialDocRef {
+    pub label: String,
+    pub url: String,
+}
+
+pub fn plan(input: NearTrialPlanInput) -> Result<NearTrialPlan, String> {
+    let mode = normalize_mode(&input.mode)?;
+    let pair = normalize_pair(&input.pair);
+    let nominal_near = clean_positive(input.nominal_near, "nominal_near")?;
+    let assumed_near_usd = clean_positive(input.assumed_near_usd, "assumed_near_usd")?;
+    let max_trade_near = input
+        .max_trade_near
+        .unwrap_or_else(|| default_max_trade_near(nominal_near));
+    let max_trade_near = clean_positive(max_trade_near, "max_trade_near")?;
+    let max_slippage_bps = input.max_slippage_bps.min(1_000);
+    let max_trade_usd = round4(max_trade_near * assumed_near_usd);
+    let min_out_usd = round4(max_trade_usd * (1.0 - max_slippage_bps as f64 / 10_000.0));
+
+    let strategy_menu = default_strategy_menu();
+    let (recommended_strategy_id, strategy_gate) = strategy_gate(
+        input.selected_strategy_id.as_deref(),
+        input.backtest_suite.as_ref(),
+        &strategy_menu,
+    );
+
+    let mut risk_gates = vec![
+        TrialRiskGate {
+            name: "nominal-budget".to_string(),
+            status: if nominal_near <= 1.0 { "pass" } else { "warn" }.to_string(),
+            detail: format!(
+                "Trial wallet budget is {:.4} NEAR. Keep this wallet small and separate from long-term holdings.",
+                nominal_near
+            ),
+        },
+        TrialRiskGate {
+            name: "trade-cap".to_string(),
+            status: if max_trade_near <= nominal_near {
+                "pass"
+            } else {
+                "fail"
+            }
+            .to_string(),
+            detail: format!(
+                "Single trial trade is capped at {:.4} NEAR, estimated at ${:.4}.",
+                max_trade_near, max_trade_usd
+            ),
+        },
+        TrialRiskGate {
+            name: "small-route-liquidity".to_string(),
+            status: if max_trade_usd >= 1.0 { "pass" } else { "warn" }.to_string(),
+            detail:
+                "Very small quote sizes may be refused or dominated by route/bridge minimums; paper mode still works."
+                    .to_string(),
+        },
+        TrialRiskGate {
+            name: "wallet-account".to_string(),
+            status: if input.near_account_id.is_some() {
+                "pass"
+            } else {
+                "warn"
+            }
+            .to_string(),
+            detail: input
+                .near_account_id
+                .as_ref()
+                .map(|account| format!("Use {account} only after you have reviewed the unsigned payload."))
+                .unwrap_or_else(|| {
+                    "No NEAR account id supplied; paper mode can run, live quote setup should record the signer account."
+                        .to_string()
+                }),
+        },
+        TrialRiskGate {
+            name: "native-near-wrap".to_string(),
+            status: "warn".to_string(),
+            detail:
+                "The verifier does not accept raw native NEAR deposits; wrap NEAR to wNEAR before verifier funding."
+                    .to_string(),
+        },
+        strategy_gate,
+        TrialRiskGate {
+            name: "signing-boundary".to_string(),
+            status: if mode == "execution" { "blocked" } else { "pass" }.to_string(),
+            detail: if mode == "execution" {
+                "Execution cannot be autonomous here: IronClaw builds unsigned payloads, then your wallet must sign outside the agent."
+                    .to_string()
+            } else {
+                "This action returns only plans and unsigned build requests; it cannot spend funds."
+                    .to_string()
+            },
+        },
+    ];
+
+    if max_slippage_bps > 100 {
+        risk_gates.push(TrialRiskGate {
+            name: "slippage-cap".to_string(),
+            status: "warn".to_string(),
+            detail: format!(
+                "Max slippage is {} bps. For a nominal trial, prefer <= 100 bps unless route depth is poor.",
+                max_slippage_bps
+            ),
+        });
+    }
+
+    let movement_plan = movement_plan(&pair, max_trade_near, max_trade_usd, min_out_usd);
+    let solver = if mode == "paper" {
+        "fixture"
+    } else {
+        "near-intents"
+    };
+    let build_intent_request = json!({
+        "action": "build_intent",
+        "solver": solver,
+        "plan": movement_plan,
+        "config": {
+            "max_slippage_bps": max_slippage_bps,
+            "auto_intent_ceiling_usd": max_trade_usd + 1.0,
+            "allowed_chains": ["near"]
+        }
+    });
+
+    let safe_to_quote = mode != "execution"
+        && risk_gates
+            .iter()
+            .all(|gate| gate.status != "fail" && gate.status != "blocked");
+    let safe_to_execute = false;
+    let next_action = match mode.as_str() {
+        "paper" => "Run backtest_suite with fresh candles, select a passing strategy, then run build_intent with solver=fixture.".to_string(),
+        "quote" => "After paper gates pass, run build_intent with solver=near-intents to request an unsigned live quote; do not sign yet.".to_string(),
+        _ => "Execution remains manual-wallet only: inspect the signed payload request, then decide in your wallet outside IronClaw.".to_string(),
+    };
+
+    let warnings = vec![
+        "This is not financial advice and it is not an execution bot. Treat every quote as experimental."
+            .to_string(),
+        "Prices are estimates unless supplied from a fresh market data source; re-run before any live quote."
+            .to_string(),
+    ];
+
+    Ok(NearTrialPlan {
+        schema_version: "near-intents-trial-plan/1",
+        mode,
+        pair,
+        near_account_id: input.near_account_id,
+        nominal_near: round4(nominal_near),
+        max_trade_near: round4(max_trade_near),
+        assumed_near_usd: round4(assumed_near_usd),
+        max_trade_usd,
+        safe_to_quote,
+        safe_to_execute,
+        recommended_strategy_id,
+        selected_strategy_id: input.selected_strategy_id,
+        strategy_menu,
+        setup_steps: setup_steps(),
+        risk_gates,
+        movement_plan,
+        build_intent_request,
+        docs: doc_refs(),
+        warnings,
+        next_action,
+    })
+}
+
+fn movement_plan(
+    pair: &str,
+    max_trade_near: f64,
+    max_trade_usd: f64,
+    min_out_usd: f64,
+) -> MovementPlan {
+    let target_symbol = pair
+        .split('/')
+        .nth(1)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("USDC")
+        .to_uppercase();
+    let target_address = if target_symbol == "USDC" {
+        Some("usdc.near".to_string())
+    } else {
+        None
+    };
+    MovementPlan {
+        legs: vec![MovementLeg {
+            kind: "swap".to_string(),
+            chain: "near".to_string(),
+            from_token: Some(TokenAmount {
+                symbol: "wNEAR".to_string(),
+                address: Some("wrap.near".to_string()),
+                chain: "near".to_string(),
+                amount: format!("{max_trade_near:.6}"),
+                value_usd: format!("{max_trade_usd:.4}"),
+            }),
+            to_token: Some(TokenAmount {
+                symbol: target_symbol.clone(),
+                address: target_address.clone(),
+                chain: "near".to_string(),
+                amount: format!("{min_out_usd:.6}"),
+                value_usd: format!("{min_out_usd:.4}"),
+            }),
+            description: format!(
+                "Nominal NEAR Intents trial swap from wNEAR into {target_symbol}; user wallet signs only after reviewing the quote."
+            ),
+        }],
+        expected_out: TokenAmount {
+            symbol: target_symbol.clone(),
+            address: target_address,
+            chain: "near".to_string(),
+            amount: format!("{min_out_usd:.6}"),
+            value_usd: format!("{min_out_usd:.4}"),
+        },
+        expected_cost_usd: "0.00".to_string(),
+        proposal_id: format!("trial-near-{}", target_symbol.to_lowercase()),
+    }
+}
+
+fn strategy_gate(
+    selected_strategy_id: Option<&str>,
+    suite: Option<&serde_json::Value>,
+    menu: &[TrialStrategyCandidate],
+) -> (Option<String>, TrialRiskGate) {
+    let fallback = menu.first().map(|candidate| candidate.id.clone());
+    let Some(suite) = suite else {
+        return (
+            fallback,
+            TrialRiskGate {
+                name: "strategy-backtest".to_string(),
+                status: "warn".to_string(),
+                detail: "No backtest_suite output supplied; run the menu before a live quote."
+                    .to_string(),
+            },
+        );
+    };
+    let ranked = suite
+        .get("ranked")
+        .and_then(|value| value.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let recommended = ranked
+        .iter()
+        .find(|candidate| {
+            candidate
+                .get("passes_basic_gate")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false)
+        })
+        .or_else(|| ranked.first())
+        .and_then(|candidate| candidate.get("id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .or(fallback);
+
+    if let Some(selected) = selected_strategy_id {
+        let maybe_selected = ranked.iter().find(|candidate| {
+            candidate.get("id").and_then(|value| value.as_str()) == Some(selected)
+        });
+        let Some(candidate) = maybe_selected else {
+            return (
+                recommended,
+                TrialRiskGate {
+                    name: "strategy-backtest".to_string(),
+                    status: "fail".to_string(),
+                    detail: format!(
+                        "Selected strategy '{selected}' was not present in the backtest suite."
+                    ),
+                },
+            );
+        };
+        let passes = candidate
+            .get("passes_basic_gate")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        return (
+            recommended,
+            TrialRiskGate {
+                name: "strategy-backtest".to_string(),
+                status: if passes { "pass" } else { "fail" }.to_string(),
+                detail: format!(
+                    "Selected strategy '{selected}' {} the basic paper gate.",
+                    if passes { "passed" } else { "failed" }
+                ),
+            },
+        );
+    }
+
+    (
+        recommended.clone(),
+        TrialRiskGate {
+            name: "strategy-backtest".to_string(),
+            status: if recommended.is_some() {
+                "pass"
+            } else {
+                "warn"
+            }
+            .to_string(),
+            detail: recommended
+                .map(|id| format!("Recommended paper strategy: {id}."))
+                .unwrap_or_else(|| "Backtest suite had no ranked candidates.".to_string()),
+        },
+    )
+}
+
+fn setup_steps() -> Vec<TrialSetupStep> {
+    vec![
+        TrialSetupStep {
+            order: 1,
+            name: "Use a small wallet".to_string(),
+            status: "manual".to_string(),
+            detail: "Fund a separate NEAR account with only the amount you are willing to test."
+                .to_string(),
+        },
+        TrialSetupStep {
+            order: 2,
+            name: "Wrap NEAR".to_string(),
+            status: "manual".to_string(),
+            detail:
+                "Convert the trial amount from native NEAR into wNEAR before depositing to the verifier."
+                    .to_string(),
+        },
+        TrialSetupStep {
+            order: 3,
+            name: "Deposit to verifier".to_string(),
+            status: "manual".to_string(),
+            detail:
+                "Deposit wNEAR into intents.near using the official verifier deposit flow; do not transfer raw NEAR directly."
+                    .to_string(),
+        },
+        TrialSetupStep {
+            order: 4,
+            name: "Paper first".to_string(),
+            status: "required".to_string(),
+            detail:
+                "Run strategy backtests and fixture intent construction before requesting a live quote."
+                    .to_string(),
+        },
+        TrialSetupStep {
+            order: 5,
+            name: "Wallet review".to_string(),
+            status: "required".to_string(),
+            detail: "Any live quote still needs your wallet signature outside the agent.".to_string(),
+        },
+    ]
+}
+
+fn default_strategy_menu() -> Vec<TrialStrategyCandidate> {
+    vec![
+        TrialStrategyCandidate {
+            id: "buy_hold_baseline".to_string(),
+            kind: "buy-hold".to_string(),
+            position_size_pct: 1.0,
+            stop_loss_bps: None,
+            take_profit_bps: None,
+            note: "Baseline for comparing active signals.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "sma_cross_fast".to_string(),
+            kind: "sma-cross".to_string(),
+            position_size_pct: 0.8,
+            stop_loss_bps: Some(1_200.0),
+            take_profit_bps: None,
+            note: "Trend-following candidate for clean spot rotations.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "breakout_short".to_string(),
+            kind: "breakout".to_string(),
+            position_size_pct: 0.8,
+            stop_loss_bps: Some(1_000.0),
+            take_profit_bps: None,
+            note: "Looks for range breaks; sensitive to false moves.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "momentum_rotation".to_string(),
+            kind: "momentum".to_string(),
+            position_size_pct: 0.8,
+            stop_loss_bps: Some(1_000.0),
+            take_profit_bps: None,
+            note: "Simple lookback momentum for token rotation tests.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "mean_reversion_range".to_string(),
+            kind: "mean-reversion".to_string(),
+            position_size_pct: 0.5,
+            stop_loss_bps: Some(700.0),
+            take_profit_bps: None,
+            note: "Range strategy for pullback entries.".to_string(),
+        },
+        TrialStrategyCandidate {
+            id: "rsi_reversion".to_string(),
+            kind: "rsi-mean-reversion".to_string(),
+            position_size_pct: 0.5,
+            stop_loss_bps: Some(700.0),
+            take_profit_bps: None,
+            note: "Oversold/exit threshold candidate.".to_string(),
+        },
+    ]
+}
+
+fn doc_refs() -> Vec<TrialDocRef> {
+    vec![
+        TrialDocRef {
+            label: "NEAR Intents deposit/withdrawal service".to_string(),
+            url: "https://docs.near-intents.org/integration/market-makers/deposit-withdrawal-service"
+                .to_string(),
+        },
+        TrialDocRef {
+            label: "NEAR Intents verifier deposits".to_string(),
+            url: "https://docs.near-intents.org/near-intents/market-makers/verifier/deposits-and-withdrawals/deposits"
+                .to_string(),
+        },
+        TrialDocRef {
+            label: "NEAR Intents solver relay API".to_string(),
+            url: "https://docs.near-intents.org/near-intents/market-makers/bus/solver-relay"
+                .to_string(),
+        },
+    ]
+}
+
+fn normalize_mode(mode: &str) -> Result<String, String> {
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "" | "paper" => Ok("paper".to_string()),
+        "quote" | "live-quote" => Ok("quote".to_string()),
+        "execution" | "execute" => Ok("execution".to_string()),
+        other => Err(format!(
+            "unknown near trial mode '{other}'; expected paper, quote, or execution"
+        )),
+    }
+}
+
+fn normalize_pair(pair: &str) -> String {
+    let trimmed = pair.trim();
+    if trimmed.is_empty() {
+        default_pair()
+    } else if trimmed.contains('/') {
+        trimmed.to_uppercase()
+    } else {
+        format!("NEAR/{}", trimmed.to_uppercase())
+    }
+}
+
+fn clean_positive(value: f64, name: &str) -> Result<f64, String> {
+    if value.is_finite() && value > 0.0 {
+        Ok(value)
+    } else {
+        Err(format!("{name} must be a positive finite number"))
+    }
+}
+
+fn round4(value: f64) -> f64 {
+    (value * 10_000.0).round() / 10_000.0
+}
+
+fn default_trial_mode() -> String {
+    "paper".to_string()
+}
+
+fn default_pair() -> String {
+    "NEAR/USDC".to_string()
+}
+
+fn default_nominal_near() -> f64 {
+    0.25
+}
+
+fn default_max_trade_near(nominal_near: f64) -> f64 {
+    if nominal_near <= 0.01 {
+        nominal_near
+    } else {
+        (nominal_near * 0.2).max(0.01).min(nominal_near)
+    }
+}
+
+fn default_assumed_near_usd() -> f64 {
+    3.0
+}
+
+fn default_max_slippage_bps() -> u16 {
+    ProjectConfig::default().max_slippage_bps
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trial_plan_defaults_to_paper_fixture_request() {
+        let plan = plan(NearTrialPlanInput {
+            near_account_id: Some("alice.near".to_string()),
+            mode: "paper".to_string(),
+            pair: "NEAR/USDC".to_string(),
+            nominal_near: 0.25,
+            max_trade_near: Some(0.05),
+            assumed_near_usd: 3.0,
+            max_slippage_bps: 50,
+            selected_strategy_id: None,
+            backtest_suite: None,
+        })
+        .unwrap();
+        assert_eq!(plan.schema_version, "near-intents-trial-plan/1");
+        assert_eq!(plan.build_intent_request["solver"], "fixture");
+        assert!(!plan.safe_to_execute);
+        assert_eq!(plan.movement_plan.expected_out.symbol, "USDC");
+    }
+
+    #[test]
+    fn quote_mode_uses_near_intents_solver() {
+        let plan = plan(NearTrialPlanInput {
+            mode: "quote".to_string(),
+            ..NearTrialPlanInput {
+                near_account_id: None,
+                mode: "paper".to_string(),
+                pair: "USDC".to_string(),
+                nominal_near: 1.0,
+                max_trade_near: Some(0.1),
+                assumed_near_usd: 3.0,
+                max_slippage_bps: 50,
+                selected_strategy_id: None,
+                backtest_suite: None,
+            }
+        })
+        .unwrap();
+        assert_eq!(plan.mode, "quote");
+        assert_eq!(plan.build_intent_request["solver"], "near-intents");
+    }
+
+    #[test]
+    fn over_budget_trade_fails_gate() {
+        let plan = plan(NearTrialPlanInput {
+            nominal_near: 0.1,
+            max_trade_near: Some(0.2),
+            ..NearTrialPlanInput {
+                near_account_id: None,
+                mode: "paper".to_string(),
+                pair: "NEAR/USDC".to_string(),
+                nominal_near: 0.25,
+                max_trade_near: None,
+                assumed_near_usd: 3.0,
+                max_slippage_bps: 50,
+                selected_strategy_id: None,
+                backtest_suite: None,
+            }
+        })
+        .unwrap();
+        assert!(plan
+            .risk_gates
+            .iter()
+            .any(|gate| { gate.name == "trade-cap" && gate.status == "fail" }));
+        assert!(!plan.safe_to_quote);
+    }
+}

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -34,9 +34,53 @@ pub struct FormatWidgetInput {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct FormatIntentsTradingWidgetInput {
+    #[serde(default)]
+    pub generated_at: Option<String>,
+    #[serde(default)]
+    pub project_id: Option<String>,
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    pub pair: String,
+    #[serde(default = "default_stance")]
+    pub stance: String,
+    #[serde(default)]
+    pub confidence: Option<f64>,
+    #[serde(default)]
+    pub backtest_suite: Option<serde_json::Value>,
+    #[serde(default)]
+    pub risk_gates: Vec<IntentsRiskGateInput>,
+    #[serde(default)]
+    pub intent: Option<IntentsIntentInput>,
+    #[serde(default)]
+    pub research_sources: Vec<String>,
+    #[serde(default)]
+    pub next_action: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct PendingIntentInput {
     pub bundle: IntentBundle,
     pub status: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IntentsRiskGateInput {
+    pub name: String,
+    pub status: String,
+    #[serde(default)]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IntentsIntentInput {
+    pub bundle: IntentBundle,
+    #[serde(default = "default_intent_status")]
+    pub status: String,
+    #[serde(default)]
+    pub route_label: Option<String>,
+    #[serde(default)]
+    pub quote_source: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -113,6 +157,83 @@ pub struct WidgetPendingIntent {
     pub expires_at: i64,
 }
 
+#[derive(Debug, Serialize)]
+pub struct IntentsTradingWidgetState {
+    pub schema_version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generated_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    pub mode: String,
+    pub pair: String,
+    pub stance: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+    pub top_candidates: Vec<IntentsStrategyCandidate>,
+    pub risk_gates: Vec<IntentsRiskGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intent: Option<IntentsIntentPreview>,
+    pub source_count: usize,
+    pub research_sources: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsStrategyCandidate {
+    pub rank: usize,
+    pub id: String,
+    pub strategy_kind: String,
+    pub selection_score: f64,
+    pub passes_basic_gate: bool,
+    pub total_return_pct: f64,
+    pub alpha_vs_buy_hold_pct: f64,
+    pub max_drawdown_pct: f64,
+    pub trades: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsRiskGate {
+    pub name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsIntentPreview {
+    pub id: String,
+    pub status: String,
+    pub route_label: String,
+    pub quote_source: String,
+    pub schema_version: String,
+    pub legs: usize,
+    pub total_cost_usd: String,
+    pub expires_at: i64,
+    pub signer_placeholder: String,
+    pub min_out: Vec<IntentMinOutPreview>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentMinOutPreview {
+    pub symbol: String,
+    pub chain: String,
+    pub amount: String,
+    pub value_usd: String,
+}
+
+fn default_mode() -> String {
+    "paper".to_string()
+}
+
+fn default_stance() -> String {
+    "watch".to_string()
+}
+
+fn default_intent_status() -> String {
+    "none".to_string()
+}
+
 pub fn format_widget(input: FormatWidgetInput) -> WidgetState {
     let totals = compute_totals(&input);
 
@@ -175,6 +296,115 @@ pub fn format_widget(input: FormatWidgetInput) -> WidgetState {
         pending_intents,
         next_mission_run: input.next_mission_run.clone(),
         progress_metric: input.progress.clone(),
+    }
+}
+
+pub fn format_intents_trading_widget(
+    input: FormatIntentsTradingWidgetInput,
+) -> IntentsTradingWidgetState {
+    let top_candidates = input
+        .backtest_suite
+        .as_ref()
+        .and_then(|suite| suite.get("ranked"))
+        .and_then(|ranked| ranked.as_array())
+        .into_iter()
+        .flatten()
+        .take(5)
+        .map(strategy_candidate_from_value)
+        .collect();
+
+    let risk_gates = input
+        .risk_gates
+        .into_iter()
+        .map(|gate| IntentsRiskGate {
+            name: gate.name,
+            status: gate.status,
+            detail: gate.detail,
+        })
+        .collect();
+
+    let intent = input.intent.map(|intent| {
+        let min_out = intent
+            .bundle
+            .bounded_checks
+            .min_out_per_leg
+            .iter()
+            .map(|token| IntentMinOutPreview {
+                symbol: token.symbol.clone(),
+                chain: token.chain.clone(),
+                amount: token.amount.clone(),
+                value_usd: token.value_usd.clone(),
+            })
+            .collect();
+        IntentsIntentPreview {
+            id: intent.bundle.id,
+            status: intent.status,
+            route_label: intent
+                .route_label
+                .unwrap_or_else(|| "NEAR Intents route".to_string()),
+            quote_source: intent.quote_source.unwrap_or_else(|| "fixture".to_string()),
+            schema_version: intent.bundle.schema_version,
+            legs: intent.bundle.legs.len(),
+            total_cost_usd: intent.bundle.total_cost_usd,
+            expires_at: intent.bundle.expires_at,
+            signer_placeholder: intent.bundle.signer_placeholder,
+            min_out,
+        }
+    });
+
+    IntentsTradingWidgetState {
+        schema_version: "intents-trading-widget/1",
+        generated_at: input.generated_at,
+        project_id: input.project_id,
+        mode: input.mode,
+        pair: input.pair,
+        stance: input.stance,
+        confidence: input.confidence,
+        top_candidates,
+        risk_gates,
+        intent,
+        source_count: input.research_sources.len(),
+        research_sources: input.research_sources,
+        next_action: input.next_action,
+    }
+}
+
+fn strategy_candidate_from_value(value: &serde_json::Value) -> IntentsStrategyCandidate {
+    let default_metrics = serde_json::Value::Null;
+    let metrics = value.get("metrics").unwrap_or(&default_metrics);
+    IntentsStrategyCandidate {
+        rank: value.get("rank").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
+        id: value
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("candidate")
+            .to_string(),
+        strategy_kind: value
+            .pointer("/strategy/kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string(),
+        selection_score: value
+            .get("selection_score")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        passes_basic_gate: value
+            .get("passes_basic_gate")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        total_return_pct: metrics
+            .get("total_return_pct")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        alpha_vs_buy_hold_pct: metrics
+            .get("alpha_vs_buy_hold_pct")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        max_drawdown_pct: metrics
+            .get("max_drawdown_pct")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        trades: metrics.get("trades").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
     }
 }
 
@@ -486,6 +716,83 @@ mod tests {
         assert_eq!(w.pending_intents[0].legs, 2);
         assert_eq!(w.pending_intents[0].total_cost_usd, "0.50");
         assert_eq!(w.pending_intents[0].expires_at, 1712345678);
+    }
+
+    #[test]
+    fn intents_trading_widget_summarizes_suite_and_intent() {
+        use crate::types::{BoundedChecks, IntentBundle, IntentLeg, TokenAmount};
+
+        let token = TokenAmount {
+            symbol: "BTC".into(),
+            address: None,
+            chain: "near".into(),
+            amount: "0.001".into(),
+            value_usd: "70.00".into(),
+        };
+
+        let w = format_intents_trading_widget(FormatIntentsTradingWidgetInput {
+            generated_at: Some("2026-05-02T16:00:00Z".to_string()),
+            project_id: Some("intents-trading-agent".to_string()),
+            mode: "paper".to_string(),
+            pair: "NEAR/BTC".to_string(),
+            stance: "paper-intent".to_string(),
+            confidence: Some(0.74),
+            backtest_suite: Some(serde_json::json!({
+                "schema_version": "intents-backtest-suite/1",
+                "ranked": [{
+                    "rank": 1,
+                    "id": "sma_cross_fast",
+                    "strategy": { "kind": "sma-cross" },
+                    "selection_score": 18.5,
+                    "passes_basic_gate": true,
+                    "metrics": {
+                        "total_return_pct": 12.0,
+                        "alpha_vs_buy_hold_pct": 3.0,
+                        "max_drawdown_pct": 8.0,
+                        "trades": 6
+                    }
+                }]
+            })),
+            risk_gates: vec![IntentsRiskGateInput {
+                name: "unsigned-only".to_string(),
+                status: "pass".to_string(),
+                detail: Some("Wallet signature required outside the agent.".to_string()),
+            }],
+            intent: Some(IntentsIntentInput {
+                bundle: IntentBundle {
+                    id: "intent-1".to_string(),
+                    legs: vec![IntentLeg {
+                        id: "leg-1".to_string(),
+                        kind: "swap".to_string(),
+                        chain: "near".to_string(),
+                        near_intent_payload: serde_json::json!({ "intent": "token_diff" }),
+                        depends_on: None,
+                        min_out: token.clone(),
+                        quoted_by: "fixture".to_string(),
+                    }],
+                    total_cost_usd: "0.42".to_string(),
+                    bounded_checks: BoundedChecks {
+                        min_out_per_leg: vec![token],
+                        max_slippage_bps: 50,
+                        solver_quote_version: "fixture".to_string(),
+                    },
+                    expires_at: 1_775_000_000,
+                    signer_placeholder: "<signed-by-user>".to_string(),
+                    schema_version: "portfolio-intent/1".to_string(),
+                },
+                status: "paper-built".to_string(),
+                route_label: Some("NEAR -> BTC via NEAR Intents".to_string()),
+                quote_source: Some("fixture".to_string()),
+            }),
+            research_sources: vec!["https://docs.near-intents.org/".to_string()],
+            next_action: Some("Request live quote only after user approval.".to_string()),
+        });
+
+        assert_eq!(w.schema_version, "intents-trading-widget/1");
+        assert_eq!(w.top_candidates.len(), 1);
+        assert!(w.top_candidates[0].passes_basic_gate);
+        assert_eq!(w.intent.unwrap().status, "paper-built");
+        assert_eq!(w.source_count, 1);
     }
 
     // ---- only ready proposals in suggestions ----

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -297,6 +297,7 @@ pub struct IntentsTrialSummary {
     pub pair: String,
     pub nominal_near: f64,
     pub max_trade_near: f64,
+    pub assumed_near_usd: f64,
     pub max_trade_usd: f64,
     pub safe_to_quote: bool,
     pub safe_to_execute: bool,
@@ -304,10 +305,24 @@ pub struct IntentsTrialSummary {
     pub recommended_strategy_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selected_strategy_id: Option<String>,
+    pub strategy_menu: Vec<IntentsTrialStrategy>,
     pub setup_steps: Vec<IntentsTrialStep>,
     pub risk_gates: Vec<IntentsRiskGate>,
+    pub warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsTrialStrategy {
+    pub id: String,
+    pub kind: String,
+    pub position_size_pct: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_loss_bps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub take_profit_bps: Option<f64>,
+    pub note: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -642,6 +657,21 @@ fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidRes
 }
 
 fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
+    let strategy_menu = value
+        .get("strategy_menu")
+        .and_then(|strategies| strategies.as_array())
+        .into_iter()
+        .flatten()
+        .take(8)
+        .map(|strategy| IntentsTrialStrategy {
+            id: string_field(strategy, "id", "strategy"),
+            kind: string_field(strategy, "kind", "unknown"),
+            position_size_pct: number_field(strategy, "position_size_pct"),
+            stop_loss_bps: strategy.get("stop_loss_bps").and_then(|v| v.as_f64()),
+            take_profit_bps: strategy.get("take_profit_bps").and_then(|v| v.as_f64()),
+            note: string_field(strategy, "note", ""),
+        })
+        .collect();
     let setup_steps = value
         .get("setup_steps")
         .and_then(|steps| steps.as_array())
@@ -667,6 +697,13 @@ fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
             detail: Some(string_field(gate, "detail", "")),
         })
         .collect();
+    let warnings = value
+        .get("warnings")
+        .and_then(|warnings| warnings.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|warning| warning.as_str().map(str::to_string))
+        .collect();
 
     IntentsTrialSummary {
         schema_version: string_field(value, "schema_version", "near-intents-trial-plan/1"),
@@ -674,6 +711,7 @@ fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
         pair: string_field(value, "pair", "NEAR/USDC"),
         nominal_near: number_field(value, "nominal_near"),
         max_trade_near: number_field(value, "max_trade_near"),
+        assumed_near_usd: number_field(value, "assumed_near_usd"),
         max_trade_usd: number_field(value, "max_trade_usd"),
         safe_to_quote: value
             .get("safe_to_quote")
@@ -691,8 +729,10 @@ fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
             .get("selected_strategy_id")
             .and_then(|v| v.as_str())
             .map(str::to_string),
+        strategy_menu,
         setup_steps,
         risk_gates,
+        warnings,
         next_action: value
             .get("next_action")
             .and_then(|v| v.as_str())
@@ -1129,7 +1169,37 @@ mod tests {
                 }],
                 "warnings": []
             })),
-            trial_plan: None,
+            trial_plan: Some(serde_json::json!({
+                "schema_version": "near-intents-trial-plan/1",
+                "mode": "paper",
+                "pair": "NEAR/USDC",
+                "nominal_near": 0.25,
+                "max_trade_near": 0.05,
+                "assumed_near_usd": 3.0,
+                "max_trade_usd": 0.15,
+                "safe_to_quote": true,
+                "safe_to_execute": false,
+                "recommended_strategy_id": "sma_cross_fast",
+                "strategy_menu": [{
+                    "id": "sma_cross_fast",
+                    "kind": "sma-cross",
+                    "position_size_pct": 0.8,
+                    "stop_loss_bps": 1200.0,
+                    "note": "Trend-following candidate for clean spot rotations."
+                }],
+                "setup_steps": [{
+                    "order": 1,
+                    "name": "Use a small wallet",
+                    "status": "manual",
+                    "detail": "Fund a separate NEAR account."
+                }],
+                "risk_gates": [{
+                    "name": "trade-cap",
+                    "status": "pass",
+                    "detail": "Single trade cap passed."
+                }],
+                "warnings": ["Paper only."]
+            })),
             next_action: Some("Request live quote only after user approval.".to_string()),
         });
 
@@ -1142,6 +1212,10 @@ mod tests {
         assert_eq!(paid_research.selected_count, 1);
         assert_eq!(paid_research.payable_sources[0].protocol, "x402");
         assert_eq!(paid_research.near_funding_routes[0].via, "near-intents");
+        let trial_plan = w.trial_plan.unwrap();
+        assert!(trial_plan.safe_to_quote);
+        assert_eq!(trial_plan.assumed_near_usd, 3.0);
+        assert_eq!(trial_plan.strategy_menu[0].id, "sma_cross_fast");
     }
 
     // ---- only ready proposals in suggestions ----

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -240,6 +240,8 @@ pub struct IntentsPaidResearchSummary {
     pub payable_sources: Vec<IntentsPayableResearchSource>,
     pub near_funding_routes: Vec<IntentsPaidResearchFundingRoute>,
     pub policy_gates: Vec<IntentsRiskGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wallet_policy: Option<IntentsPaidResearchWalletPolicy>,
     pub warnings: Vec<String>,
 }
 
@@ -268,6 +270,20 @@ pub struct IntentsPaidResearchFundingRoute {
     pub target_network: String,
     pub amount_usd: f64,
     pub via: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPaidResearchWalletPolicy {
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    pub network: String,
+    pub balance_usd: f64,
+    pub max_articles_at_default_price: usize,
+    pub per_article_cap_usd: f64,
+    pub daily_cap_usd: f64,
+    pub safe_to_autopay: bool,
+    pub audit_urls: Vec<String>,
 }
 
 fn default_mode() -> String {
@@ -530,6 +546,34 @@ fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidRes
                 .map(|detail| detail.to_string()),
         })
         .collect();
+    let wallet_policy = value
+        .get("wallet_policy")
+        .map(|wallet| IntentsPaidResearchWalletPolicy {
+            provider: string_field(wallet, "provider", "AgentCash"),
+            address: wallet
+                .get("address")
+                .and_then(|address| address.as_str())
+                .map(|address| address.to_string()),
+            network: string_field(wallet, "network", "base"),
+            balance_usd: number_field(wallet, "balance_usd"),
+            max_articles_at_default_price: wallet
+                .get("max_articles_at_default_price")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as usize,
+            per_article_cap_usd: number_field(wallet, "per_article_cap_usd"),
+            daily_cap_usd: number_field(wallet, "daily_cap_usd"),
+            safe_to_autopay: wallet
+                .get("safe_to_autopay")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            audit_urls: wallet
+                .get("audit_urls")
+                .and_then(|urls| urls.as_array())
+                .into_iter()
+                .flatten()
+                .filter_map(|url| url.as_str().map(|url| url.to_string()))
+                .collect(),
+        });
 
     let warnings = value
         .get("warnings")
@@ -558,6 +602,7 @@ fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidRes
         payable_sources,
         near_funding_routes,
         policy_gates,
+        wallet_policy,
         warnings,
     }
 }

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -57,6 +57,8 @@ pub struct FormatIntentsTradingWidgetInput {
     #[serde(default)]
     pub paid_research_plan: Option<serde_json::Value>,
     #[serde(default)]
+    pub trial_plan: Option<serde_json::Value>,
+    #[serde(default)]
     pub next_action: Option<String>,
 }
 
@@ -180,6 +182,8 @@ pub struct IntentsTradingWidgetState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paid_research: Option<IntentsPaidResearchSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub trial_plan: Option<IntentsTrialSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
 }
 
@@ -284,6 +288,34 @@ pub struct IntentsPaidResearchWalletPolicy {
     pub daily_cap_usd: f64,
     pub safe_to_autopay: bool,
     pub audit_urls: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsTrialSummary {
+    pub schema_version: String,
+    pub mode: String,
+    pub pair: String,
+    pub nominal_near: f64,
+    pub max_trade_near: f64,
+    pub max_trade_usd: f64,
+    pub safe_to_quote: bool,
+    pub safe_to_execute: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended_strategy_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_strategy_id: Option<String>,
+    pub setup_steps: Vec<IntentsTrialStep>,
+    pub risk_gates: Vec<IntentsRiskGate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsTrialStep {
+    pub order: usize,
+    pub name: String,
+    pub status: String,
+    pub detail: String,
 }
 
 fn default_mode() -> String {
@@ -419,6 +451,7 @@ pub fn format_intents_trading_widget(
         .paid_research_plan
         .as_ref()
         .map(paid_research_summary_from_value);
+    let trial_plan = input.trial_plan.as_ref().map(trial_summary_from_value);
 
     IntentsTradingWidgetState {
         schema_version: "intents-trading-widget/1",
@@ -434,6 +467,7 @@ pub fn format_intents_trading_widget(
         source_count: input.research_sources.len(),
         research_sources: input.research_sources,
         paid_research,
+        trial_plan,
         next_action: input.next_action,
     }
 }
@@ -604,6 +638,65 @@ fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidRes
         policy_gates,
         wallet_policy,
         warnings,
+    }
+}
+
+fn trial_summary_from_value(value: &serde_json::Value) -> IntentsTrialSummary {
+    let setup_steps = value
+        .get("setup_steps")
+        .and_then(|steps| steps.as_array())
+        .into_iter()
+        .flatten()
+        .take(6)
+        .map(|step| IntentsTrialStep {
+            order: step.get("order").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
+            name: string_field(step, "name", "Step"),
+            status: string_field(step, "status", "manual"),
+            detail: string_field(step, "detail", ""),
+        })
+        .collect();
+    let risk_gates = value
+        .get("risk_gates")
+        .and_then(|gates| gates.as_array())
+        .into_iter()
+        .flatten()
+        .take(8)
+        .map(|gate| IntentsRiskGate {
+            name: string_field(gate, "name", "gate"),
+            status: string_field(gate, "status", "unknown"),
+            detail: Some(string_field(gate, "detail", "")),
+        })
+        .collect();
+
+    IntentsTrialSummary {
+        schema_version: string_field(value, "schema_version", "near-intents-trial-plan/1"),
+        mode: string_field(value, "mode", "paper"),
+        pair: string_field(value, "pair", "NEAR/USDC"),
+        nominal_near: number_field(value, "nominal_near"),
+        max_trade_near: number_field(value, "max_trade_near"),
+        max_trade_usd: number_field(value, "max_trade_usd"),
+        safe_to_quote: value
+            .get("safe_to_quote")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        safe_to_execute: value
+            .get("safe_to_execute")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        recommended_strategy_id: value
+            .get("recommended_strategy_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        selected_strategy_id: value
+            .get("selected_strategy_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        setup_steps,
+        risk_gates,
+        next_action: value
+            .get("next_action")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
     }
 }
 
@@ -1036,6 +1129,7 @@ mod tests {
                 }],
                 "warnings": []
             })),
+            trial_plan: None,
             next_action: Some("Request live quote only after user approval.".to_string()),
         });
 

--- a/tools-src/portfolio/src/widget.rs
+++ b/tools-src/portfolio/src/widget.rs
@@ -55,6 +55,8 @@ pub struct FormatIntentsTradingWidgetInput {
     #[serde(default)]
     pub research_sources: Vec<String>,
     #[serde(default)]
+    pub paid_research_plan: Option<serde_json::Value>,
+    #[serde(default)]
     pub next_action: Option<String>,
 }
 
@@ -176,6 +178,8 @@ pub struct IntentsTradingWidgetState {
     pub source_count: usize,
     pub research_sources: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub paid_research: Option<IntentsPaidResearchSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_action: Option<String>,
 }
 
@@ -220,6 +224,50 @@ pub struct IntentMinOutPreview {
     pub chain: String,
     pub amount: String,
     pub value_usd: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPaidResearchSummary {
+    pub schema_version: String,
+    pub query: String,
+    pub budget_usd: f64,
+    pub allocated_usd: f64,
+    pub unspent_usd: f64,
+    pub selected_count: usize,
+    pub ready_for_paid_fetch: bool,
+    pub ready_for_trade_research: bool,
+    pub payment_rails: Vec<IntentsPaidResearchRail>,
+    pub payable_sources: Vec<IntentsPayableResearchSource>,
+    pub near_funding_routes: Vec<IntentsPaidResearchFundingRoute>,
+    pub policy_gates: Vec<IntentsRiskGate>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPaidResearchRail {
+    pub protocol: String,
+    pub count: usize,
+    pub allocated_usd: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPayableResearchSource {
+    pub id: String,
+    pub title: String,
+    pub author: String,
+    pub protocol: String,
+    pub network: String,
+    pub amount_usd: f64,
+    pub evidence_weight: f64,
+    pub receipt_required: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IntentsPaidResearchFundingRoute {
+    pub target_protocol: String,
+    pub target_network: String,
+    pub amount_usd: f64,
+    pub via: String,
 }
 
 fn default_mode() -> String {
@@ -351,6 +399,10 @@ pub fn format_intents_trading_widget(
             min_out,
         }
     });
+    let paid_research = input
+        .paid_research_plan
+        .as_ref()
+        .map(paid_research_summary_from_value);
 
     IntentsTradingWidgetState {
         schema_version: "intents-trading-widget/1",
@@ -365,6 +417,7 @@ pub fn format_intents_trading_widget(
         intent,
         source_count: input.research_sources.len(),
         research_sources: input.research_sources,
+        paid_research,
         next_action: input.next_action,
     }
 }
@@ -406,6 +459,119 @@ fn strategy_candidate_from_value(value: &serde_json::Value) -> IntentsStrategyCa
             .unwrap_or(0.0),
         trades: metrics.get("trades").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
     }
+}
+
+fn paid_research_summary_from_value(value: &serde_json::Value) -> IntentsPaidResearchSummary {
+    let selected_sources = value
+        .get("selected_sources")
+        .and_then(|sources| sources.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let payable_sources = selected_sources
+        .iter()
+        .take(6)
+        .map(|source| {
+            let payment = source.get("payment").unwrap_or(&serde_json::Value::Null);
+            let attribution = source
+                .get("attribution")
+                .unwrap_or(&serde_json::Value::Null);
+            IntentsPayableResearchSource {
+                id: string_field(source, "id", "source"),
+                title: string_field(source, "title", "Untitled source"),
+                author: string_field(source, "author", "Unknown author"),
+                protocol: string_field(payment, "protocol", "manual"),
+                network: string_field(payment, "network", "manual"),
+                amount_usd: number_field(payment, "amount_usd"),
+                evidence_weight: number_field(source, "evidence_weight"),
+                receipt_required: attribution
+                    .get("receipt_required")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            }
+        })
+        .collect();
+
+    let payment_rails = value
+        .get("payment_rails")
+        .and_then(|rails| rails.as_array())
+        .into_iter()
+        .flatten()
+        .map(|rail| IntentsPaidResearchRail {
+            protocol: string_field(rail, "protocol", "manual"),
+            count: rail.get("count").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
+            allocated_usd: number_field(rail, "allocated_usd"),
+        })
+        .collect();
+
+    let near_funding_routes = value
+        .get("near_funding_routes")
+        .and_then(|routes| routes.as_array())
+        .into_iter()
+        .flatten()
+        .map(|route| IntentsPaidResearchFundingRoute {
+            target_protocol: string_field(route, "target_protocol", "manual"),
+            target_network: string_field(route, "target_network", "manual"),
+            amount_usd: number_field(route, "amount_usd"),
+            via: string_field(route, "via", "near-intents"),
+        })
+        .collect();
+
+    let policy_gates = value
+        .get("policy_gates")
+        .and_then(|gates| gates.as_array())
+        .into_iter()
+        .flatten()
+        .map(|gate| IntentsRiskGate {
+            name: string_field(gate, "name", "paid-research-gate"),
+            status: string_field(gate, "status", "unknown"),
+            detail: gate
+                .get("detail")
+                .and_then(|detail| detail.as_str())
+                .map(|detail| detail.to_string()),
+        })
+        .collect();
+
+    let warnings = value
+        .get("warnings")
+        .and_then(|warnings| warnings.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|warning| warning.as_str().map(|warning| warning.to_string()))
+        .collect();
+
+    IntentsPaidResearchSummary {
+        schema_version: string_field(value, "schema_version", "paid-research-plan/1"),
+        query: string_field(value, "query", ""),
+        budget_usd: number_field(value, "budget_usd"),
+        allocated_usd: number_field(value, "allocated_usd"),
+        unspent_usd: number_field(value, "unspent_usd"),
+        selected_count: selected_sources.len(),
+        ready_for_paid_fetch: value
+            .get("ready_for_paid_fetch")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        ready_for_trade_research: value
+            .get("ready_for_trade_research")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        payment_rails,
+        payable_sources,
+        near_funding_routes,
+        policy_gates,
+        warnings,
+    }
+}
+
+fn string_field(value: &serde_json::Value, field: &str, default: &str) -> String {
+    value
+        .get(field)
+        .and_then(|v| v.as_str())
+        .unwrap_or(default)
+        .to_string()
+}
+
+fn number_field(value: &serde_json::Value, field: &str) -> f64 {
+    value.get(field).and_then(|v| v.as_f64()).unwrap_or(0.0)
 }
 
 fn compute_totals(input: &FormatWidgetInput) -> WidgetTotals {
@@ -785,6 +951,46 @@ mod tests {
                 quote_source: Some("fixture".to_string()),
             }),
             research_sources: vec!["https://docs.near-intents.org/".to_string()],
+            paid_research_plan: Some(serde_json::json!({
+                "schema_version": "paid-research-plan/1",
+                "query": "NEAR/BTC route risk",
+                "budget_usd": 0.05,
+                "allocated_usd": 0.02,
+                "unspent_usd": 0.03,
+                "ready_for_paid_fetch": true,
+                "ready_for_trade_research": true,
+                "payment_rails": [{
+                    "protocol": "x402",
+                    "count": 1,
+                    "allocated_usd": 0.02
+                }],
+                "selected_sources": [{
+                    "id": "paid-alpha-1",
+                    "title": "NEAR/BTC route risk",
+                    "author": "Researcher",
+                    "evidence_weight": 1.0,
+                    "payment": {
+                        "protocol": "x402",
+                        "network": "base",
+                        "amount_usd": 0.02
+                    },
+                    "attribution": {
+                        "receipt_required": true
+                    }
+                }],
+                "near_funding_routes": [{
+                    "target_protocol": "x402",
+                    "target_network": "base",
+                    "amount_usd": 0.02,
+                    "via": "near-intents"
+                }],
+                "policy_gates": [{
+                    "name": "receipt-before-use",
+                    "status": "pass",
+                    "detail": "Receipt required."
+                }],
+                "warnings": []
+            })),
             next_action: Some("Request live quote only after user approval.".to_string()),
         });
 
@@ -793,6 +999,10 @@ mod tests {
         assert!(w.top_candidates[0].passes_basic_gate);
         assert_eq!(w.intent.unwrap().status, "paper-built");
         assert_eq!(w.source_count, 1);
+        let paid_research = w.paid_research.unwrap();
+        assert_eq!(paid_research.selected_count, 1);
+        assert_eq!(paid_research.payable_sources[0].protocol, "x402");
+        assert_eq!(paid_research.near_funding_routes[0].via, "near-intents");
     }
 
     // ---- only ready proposals in suggestions ----


### PR DESCRIPTION
## Summary

Adds \`compile_intent_prompt\`, a deterministic pattern-based parser that turns natural-language trade prompts into a structured next action. Same prompt → same plan, no LLM call. Schema \`intents-nl-compile/1\`.

This is the \"vibratrading-style\" UX layer for the intents trading agent: chat in, structured proposal out, all unsigned. The compiler never executes — the agent invokes the recommended action separately after risk-gating.

## Recognized intent kinds

| Prompt | Recommended action |
|---|---|
| \"DCA \$100 weekly into NEAR for 6 months\" | \`plan_dca_schedule\` |
| \"swap 0.5 BTC to USDC on near\" | \`build_intent\` |
| \"backtest sma 5/20 on NEAR/USDC\" | \`backtest_suite\` |
| \"research catalyst risk on NEAR\" | \`plan_paid_research\` |
| \"watch BTC for breakout above 70000\" | \`format_intents_widget\` |
| anything unrecognized | \`noop\` |

Output includes \`recommended_action\`, ready-to-invoke \`recommended_params\`, \`extracted\` fields, \`assumptions\`, \`clarifications_needed\`, deterministic \`gates\`, \`confidence\` 0..1, and a \`trace\` of which patterns matched.

## Stack

Stacks under \`feat/portfolio-dca-strategy\` → \`feat/portfolio-strategy-lab\` → \`codex/near-intents-trial-mode\`. Will conflict with main until those branches merge.

## Test plan

- [x] \`cargo test --lib -p portfolio-tool\` — 240 pass / 0 fail / 10 ignored
- [x] \`cargo clippy --tests --all-features -- -D warnings\` — clean
- [x] 10 new unit tests in \`nl::tests\`
- [x] 1 new replay scenario covering all six intent kinds end-to-end
- [x] No new dependencies
- [x] No private keys, signing material, or live HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)