### PR TITLE
fix(routines): normalize notification summaries with truncation and metadata (#1321)

### DIFF
--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -742,6 +742,7 @@ impl RoutineEngine {
             status,
             Some(summary),
             thread_id.as_deref(),
+            run.job_id,
         )
         .await;
 
@@ -1110,7 +1111,7 @@ struct EngineContext {
 }
 
 /// Execute a routine run. Handles both lightweight and full_job modes.
-async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineRun) {
+async fn execute_routine(ctx: EngineContext, mut routine: Routine, mut run: RoutineRun) {
     // Increment running count (atomic: survives panics in the execution below)
     ctx.running_count.fetch_add(1, Ordering::Relaxed);
 
@@ -1199,7 +1200,7 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
                         description,
                         max_iterations: *max_iterations,
                     };
-                    execute_full_job(&ctx, &routine, &run, &execution).await
+                    execute_full_job(&ctx, &routine, &mut run, &execution).await
                 }
             };
 
@@ -1358,6 +1359,7 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         status,
         summary.as_deref(),
         thread_id.as_deref(),
+        run.job_id,
     )
     .await;
 }
@@ -1414,7 +1416,7 @@ struct FullJobExecutionConfig<'a> {
 async fn execute_full_job(
     ctx: &EngineContext,
     routine: &Routine,
-    run: &RoutineRun,
+    run: &mut RoutineRun,
     execution: &FullJobExecutionConfig<'_>,
 ) -> Result<(RunStatus, Option<String>, Option<i32>), RoutineError> {
     // Full-job routines dispatch through the scheduler (same as /job
@@ -1481,6 +1483,9 @@ async fn execute_full_job(
         .map_err(|e| RoutineError::Database {
             reason: format!("failed to link run to job: {e}"),
         })?;
+
+    // Keep the in-memory struct in sync so send_notification can read run.job_id.
+    run.job_id = Some(job_id);
 
     tracing::info!(
         routine = %routine.name,
@@ -2063,6 +2068,16 @@ async fn execute_routine_tool(
     Ok(result_str)
 }
 
+/// Human-readable label for a run status, suitable for user-facing notifications.
+fn status_display_label(status: RunStatus) -> &'static str {
+    match status {
+        RunStatus::Ok => "Completed",
+        RunStatus::Attention => "Needs attention",
+        RunStatus::Failed => "Failed",
+        RunStatus::Running => "Running",
+    }
+}
+
 /// Send a notification based on the routine's notify config and run status.
 #[allow(clippy::too_many_arguments)]
 async fn send_notification(
@@ -2073,6 +2088,7 @@ async fn send_notification(
     status: RunStatus,
     summary: Option<&str>,
     thread_id: Option<&str>,
+    job_id: Option<Uuid>,
 ) {
     let should_notify = match status {
         RunStatus::Ok => notify.on_success,
@@ -2092,23 +2108,37 @@ async fn send_notification(
         RunStatus::Running => "⏳",
     };
 
+    let label = status_display_label(status);
+
     let message = match summary {
-        Some(s) => format!("{} *Routine '{}'*: {}\n\n{}", icon, routine_name, status, s),
-        None => format!("{} *Routine '{}'*: {}", icon, routine_name, status),
+        Some(s) => {
+            let sanitized = sanitize_summary(s);
+            format!(
+                "{} *Routine '{}'*: {}\n\n{}",
+                icon, routine_name, label, sanitized
+            )
+        }
+        None => format!("{} *Routine '{}'*: {}", icon, routine_name, label),
     };
+
+    let mut metadata = serde_json::json!({
+        "source": "routine",
+        "routine_name": routine_name,
+        "status": status.to_string(),
+        "owner_id": owner_id,
+        "notify_user": notify.user,
+        "notify_channel": notify.channel,
+    });
+
+    if let Some(jid) = job_id {
+        metadata["job_id"] = serde_json::json!(jid.to_string());
+    }
 
     let response = OutgoingResponse {
         content: message,
         thread_id: thread_id.map(String::from),
         attachments: Vec::new(),
-        metadata: serde_json::json!({
-            "source": "routine",
-            "routine_name": routine_name,
-            "status": status.to_string(),
-            "owner_id": owner_id,
-            "notify_user": notify.user,
-            "notify_channel": notify.channel,
-        }),
+        metadata,
     };
 
     if let Err(e) = tx.send(response).await {
@@ -2171,7 +2201,6 @@ fn truncate(s: &str, max: usize) -> String {
 /// 2. Strip HTML tags to prevent injection in web-rendered notifications
 /// 3. Collapse multiple whitespace/newlines to single spaces for cleaner output
 /// 4. Truncate to 500 chars to prevent oversized notifications
-#[cfg(test)]
 fn sanitize_summary(s: &str) -> String {
     // Strip control characters (keep newline for now, collapse later)
     let no_control: String = s
@@ -2198,19 +2227,107 @@ fn sanitize_summary(s: &str) -> String {
     }
 }
 
-/// Remove HTML/XML tags from a string.
-#[cfg(test)]
+/// Remove actual HTML tags from a string while preserving non-HTML angle brackets.
+///
+/// Only strips patterns that look like real HTML/XML tags (e.g. `<div>`, `</p>`,
+/// `<img src=...>`), not generic angle-bracket content like `Vec<String>`,
+/// `cat < input.txt`, or comparison operators.
+///
+/// Also strips HTML comments (`<!--...-->`), SVG/MathML tags, and custom elements
+/// (tags containing hyphens like `<custom-element>`).
 fn strip_html_tags(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut in_tag = false;
-    for c in s.chars() {
-        match c {
-            '<' => in_tag = true,
-            '>' if in_tag => in_tag = false,
-            _ if !in_tag => result.push(c),
-            _ => {}
+    use regex::Regex;
+    use std::sync::LazyLock;
+
+    // HTML comment pattern: <!--...-->
+    static COMMENT_RE: LazyLock<Option<Regex>> =
+        LazyLock::new(|| Regex::new(r"<!--[\s\S]*?-->").ok());
+
+    // Known HTML/SVG/MathML tag names.
+    static HTML_TAG_RE: LazyLock<Option<Regex>> = LazyLock::new(|| {
+        let tags = "a|abbr|address|area|article|aside|audio|b|base|bdi|bdo|blockquote|\
+            body|br|button|canvas|caption|cite|code|col|colgroup|data|datalist|dd|del|\
+            details|dfn|dialog|div|dl|dt|em|embed|fieldset|figcaption|figure|footer|\
+            form|h[1-6]|head|header|hgroup|hr|html|i|iframe|img|input|ins|kbd|label|\
+            legend|li|link|main|map|mark|meta|meter|nav|noscript|object|ol|optgroup|\
+            option|output|p|param|picture|pre|progress|q|rp|rt|ruby|s|samp|script|\
+            section|select|slot|small|source|span|strong|style|sub|summary|sup|table|\
+            tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|u|ul|var|\
+            video|wbr|\
+            svg|g|path|circle|ellipse|line|polyline|polygon|rect|text|tspan|defs|\
+            clippath|mask|pattern|image|use|symbol|marker|lineargradient|\
+            radialgradient|stop|filter|foreignobject|animate|animatetransform|\
+            math|mrow|mi|mo|mn|ms|mtext|mfrac|msqrt|mroot|msub|msup|msubsup|\
+            munder|mover|munderover|mtable|mtr|mtd|mspace|mpadded|mfenced|menclose";
+        Regex::new(&format!(r"(?i)</?(?:{})(?:\s[^>]*)?\s*/?>", tags)).ok()
+    });
+
+    // Preserve Rust/Java/C++ generics: Identifier<Type>, HashMap<K, V>, Vec<u8>, etc.
+    static GENERIC_PRESERVE_RE: LazyLock<Option<Regex>> =
+        LazyLock::new(|| Regex::new(r"[A-Z]\w*<[^>]+>").ok());
+
+    // Catch-all for unknown/future tags and custom elements.
+    static CATCHALL_TAG_RE: LazyLock<Option<Regex>> =
+        LazyLock::new(|| Regex::new(r"</?[a-zA-Z][\w-]*(?:\s[^>]*)?\s*/?>").ok());
+
+    let mut result = s.to_string();
+
+    let mut failed = false;
+
+    // Step 1: Strip HTML comments first (they can contain anything).
+    if let Some(re) = COMMENT_RE.as_ref() {
+        result = re.replace_all(&result, "").into_owned();
+    } else {
+        tracing::debug!(
+            "HTML comment regex failed to compile; falling back to angle-bracket strip"
+        );
+        failed = true;
+    }
+
+    // Step 2: Strip known HTML/SVG/MathML tags by allowlist.
+    if let Some(re) = HTML_TAG_RE.as_ref() {
+        result = re.replace_all(&result, "").into_owned();
+    } else {
+        tracing::debug!("HTML tag regex failed to compile; falling back to angle-bracket strip");
+        failed = true;
+    }
+
+    // Fail-closed: if any regex failed to compile, strip all angle brackets.
+    if failed {
+        result = result.chars().filter(|c| *c != '<' && *c != '>').collect();
+        return result;
+    }
+
+    // Step 3: Two-pass catch-all for unknown/future tags and custom elements.
+    match (GENERIC_PRESERVE_RE.as_ref(), CATCHALL_TAG_RE.as_ref()) {
+        (Some(generic_re), Some(catchall_re)) => {
+            // Collect generics and replace with placeholders
+            let mut generics: Vec<String> = Vec::new();
+            let preserved = generic_re
+                .replace_all(&result, |caps: &regex::Captures| {
+                    let idx = generics.len();
+                    generics.push(caps[0].to_string());
+                    format!("\x00GEN{idx}\x00")
+                })
+                .into_owned();
+
+            // Strip all remaining HTML-like tags
+            let stripped = catchall_re.replace_all(&preserved, "").into_owned();
+
+            // Restore generics from placeholders
+            result = stripped;
+            for (idx, generic) in generics.iter().enumerate() {
+                result = result.replace(&format!("\x00GEN{idx}\x00"), generic);
+            }
+        }
+        _ => {
+            tracing::debug!(
+                "Catch-all or generic-preserve regex failed to compile; stripping all angle brackets"
+            );
+            result = result.chars().filter(|c| *c != '<' && *c != '>').collect();
         }
     }
+
     result
 }
 
@@ -2933,6 +3050,234 @@ mod tests {
     /// so the message tool can route to the correct channel. Previously,
     /// `..Default::default()` left metadata as null, causing messages to land
     /// in the user's DM instead of the originating Slack channel.
+    #[test]
+    fn test_sanitize_summary_preserves_non_html_angle_brackets() {
+        use super::sanitize_summary;
+
+        // Rust/Java generics must pass through unchanged
+        assert_eq!(
+            sanitize_summary("expected Vec<String>"),
+            "expected Vec<String>"
+        );
+        assert_eq!(
+            sanitize_summary("HashMap<String, Vec<u8>>"),
+            "HashMap<String, Vec<u8>>"
+        );
+
+        // Shell redirects must pass through unchanged
+        assert_eq!(sanitize_summary("cat < input.txt"), "cat < input.txt");
+
+        // Comparison operators must pass through unchanged
+        assert_eq!(sanitize_summary("x < 10 && y > 20"), "x < 10 && y > 20");
+
+        // Mixed: real HTML stripped but generics preserved
+        assert_eq!(
+            sanitize_summary("Error in Vec<String>: <b>failed</b>"),
+            "Error in Vec<String>: failed"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_summary_truncates_long_text() {
+        use super::sanitize_summary;
+
+        let short = "This is a short summary.";
+        assert_eq!(sanitize_summary(short), short);
+
+        let long = "x".repeat(600);
+        let result = sanitize_summary(&long);
+        assert!(
+            result.len() <= 503,
+            "Truncated summary should be at most 503 bytes (500 + '...')"
+        );
+        assert!(
+            result.ends_with("..."),
+            "Truncated summary should end with ellipsis"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_summary_strips_all_html_forms() {
+        use super::sanitize_summary;
+
+        // Self-closing tags without whitespace: <br/>, <img/>
+        assert_eq!(sanitize_summary("line1<br/>line2"), "line1line2");
+        assert_eq!(sanitize_summary("text<img/>more"), "textmore");
+        assert_eq!(sanitize_summary("text<br />more"), "textmore");
+
+        // HTML comments
+        assert_eq!(sanitize_summary("before<!--x-->after"), "beforeafter");
+        assert_eq!(sanitize_summary("a<!-- multi\nline -->b"), "ab");
+
+        // SVG tags (can carry event handlers)
+        assert_eq!(
+            sanitize_summary("<svg onload=alert(1)>payload</svg>"),
+            "payload"
+        );
+        assert_eq!(sanitize_summary("<svg><circle r=10/></svg>"), "");
+
+        // MathML tags
+        assert_eq!(sanitize_summary("<math><mrow>x</mrow></math>"), "x");
+
+        // Custom elements (web components with hyphens)
+        assert_eq!(
+            sanitize_summary("before<custom-element>inner</custom-element>after"),
+            "beforeinnerafter"
+        );
+        assert_eq!(
+            sanitize_summary("<my-widget foo=\"bar\">content</my-widget>"),
+            "content"
+        );
+
+        // Generics must still be preserved
+        assert_eq!(
+            sanitize_summary("expected Vec<String>"),
+            "expected Vec<String>"
+        );
+    }
+
+    #[test]
+    fn test_status_display_label_readable() {
+        use super::status_display_label;
+
+        assert_eq!(status_display_label(RunStatus::Ok), "Completed");
+        assert_eq!(status_display_label(RunStatus::Failed), "Failed");
+        assert_eq!(
+            status_display_label(RunStatus::Attention),
+            "Needs attention"
+        );
+        assert_eq!(status_display_label(RunStatus::Running), "Running");
+    }
+
+    #[tokio::test]
+    async fn test_notification_message_uses_readable_status() {
+        use tokio::sync::mpsc;
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let notify = NotifyConfig {
+            on_success: true,
+            on_failure: true,
+            on_attention: true,
+            ..Default::default()
+        };
+
+        super::send_notification(
+            &tx,
+            &notify,
+            "user-1",
+            "my-routine",
+            RunStatus::Ok,
+            Some("All good"),
+            None,
+            None,
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("should receive notification");
+        assert!(
+            msg.content.contains("Completed"),
+            "Notification should use readable label 'Completed', got: {}",
+            msg.content
+        );
+        assert!(
+            !msg.content.contains(": ok"),
+            "Notification should not contain raw lowercase status"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_notification_includes_job_id_in_metadata() {
+        use tokio::sync::mpsc;
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let notify = NotifyConfig {
+            on_failure: true,
+            ..Default::default()
+        };
+        let job_id = uuid::Uuid::new_v4();
+
+        super::send_notification(
+            &tx,
+            &notify,
+            "user-1",
+            "my-routine",
+            RunStatus::Failed,
+            Some("something broke"),
+            None,
+            Some(job_id),
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("should receive notification");
+        let meta_job_id = msg.metadata["job_id"]
+            .as_str()
+            .expect("metadata should contain job_id");
+        assert_eq!(meta_job_id, job_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_notification_omits_job_id_when_none() {
+        use tokio::sync::mpsc;
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let notify = NotifyConfig {
+            on_success: true,
+            ..Default::default()
+        };
+
+        super::send_notification(
+            &tx,
+            &notify,
+            "user-1",
+            "my-routine",
+            RunStatus::Ok,
+            Some("done"),
+            None,
+            None,
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("should receive notification");
+        assert!(
+            msg.metadata.get("job_id").is_none(),
+            "metadata should not contain job_id when None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_notification_truncates_long_summary() {
+        use tokio::sync::mpsc;
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let notify = NotifyConfig {
+            on_failure: true,
+            ..Default::default()
+        };
+
+        let long_summary = "z".repeat(1000);
+        super::send_notification(
+            &tx,
+            &notify,
+            "user-1",
+            "my-routine",
+            RunStatus::Failed,
+            Some(&long_summary),
+            None,
+            None,
+        )
+        .await;
+
+        let msg = rx.recv().await.expect("should receive notification");
+        assert!(
+            !msg.content.contains(&long_summary),
+            "Notification should truncate long summaries"
+        );
+        assert!(
+            msg.content.contains("..."),
+            "Truncated notification should contain ellipsis"
+        );
+    }
+
     #[test]
     fn test_build_lightweight_prompt_preserves_notify_config() {
         let notify = NotifyConfig {


### PR DESCRIPTION
## Summary

Recreates #1470 on a clean branch from current staging. The original branch had accumulated 951 commits of merge-history divergence, making rebase impractical (per #1470 final comments).

- Capitalizes status labels in notifications: "ok" → "Completed", "attention" → "Needs attention", "failed" → "Failed"
- Truncates long summaries to 500 chars with UTF-8-safe ellipsis
- Adds `job_id` to notification metadata for full-job routines (enables tracing failures)
- Strips HTML/control chars, collapses whitespace, preserves non-HTML angle brackets (`Vec<u8>`, shell redirects, comparisons) via allowlist + generic-preserve regex
- Fail-closed sanitization: any regex compile failure falls back to stripping all angle brackets

## Test plan

- [x] `cargo test -p ironclaw routine_engine::sanitize_summary` covers HTML stripping, control chars, multibyte truncation, and non-HTML angle-bracket preservation
- [x] Status label assertions for ok/attention/failed → "Completed"/"Needs attention"/"Failed"
- [x] `job_id` propagation test for full-job routines

## Outstanding

- **MEDIUM** (carryover from #1470): `GENERIC_PRESERVE_RE` (`[A-Z]\w*<[^>]+>`) anchor can preserve uppercase-prefixed pseudo-generics like `Foo<script>...`, leaving the inner content as text. Notifications are rendered as text in current channels (Telegram/email), so this is not exploitable today, but if any consumer ever HTML-renders these strings the inner content would survive. Tracking as a follow-up — happy to tighten the regex on this PR if reviewers prefer.

Replaces #1470. Closes #1321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)