### PR TITLE
fix(ci): unblock main after reborn merge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,6 +73,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Free runner disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
@@ -125,7 +132,7 @@ jobs:
   e2e-coverage:
     name: E2E Coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read
@@ -133,6 +140,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      - name: Free runner disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:

--- a/crates/ironclaw_scripts/src/lib.rs
+++ b/crates/ironclaw_scripts/src/lib.rs
@@ -610,17 +610,22 @@ fn bounded_lossy(bytes: &[u8], limit: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::OsString, fs, io::Cursor, sync::Mutex};
+    use std::io::Cursor;
 
+    #[cfg(unix)]
+    use std::{ffi::OsString, fs, sync::Mutex};
+
+    #[cfg(unix)]
+    use super::{DockerScriptBackend, ScriptBackend};
     use super::{
-        DockerScriptBackend, ScriptBackend, ScriptBackendRequest, docker_run_args, read_bounded,
-        validate_docker_image_reference,
+        ScriptBackendRequest, docker_run_args, read_bounded, validate_docker_image_reference,
     };
     use ironclaw_host_api::{CapabilityId, InvocationId, ResourceScope, TenantId, UserId};
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
+    #[cfg(unix)]
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
@@ -773,8 +778,10 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     struct EnvRestore(Vec<(&'static str, Option<OsString>)>);
 
+    #[cfg(unix)]
     impl Drop for EnvRestore {
         fn drop(&mut self) {
             for (key, value) in &self.0 {


### PR DESCRIPTION
## Summary
- fix Windows clippy by gating unix-only script test imports/helpers behind `#[cfg(unix)]`
- free hosted-runner disk before coverage builds to avoid `No space left on device` from `cargo llvm-cov`
- raise E2E coverage timeout from 30 to 60 minutes; post-merge run was cancelled at the old 30-minute cap

## Evidence
Post-merge main failures inspected:
- Code Style: Windows clippy failed on unused unix-only test imports/dead code in `ironclaw_scripts`
- Code Coverage: unit coverage jobs ran out of disk; E2E coverage hit timeout while tests were still running

Local verification:
- `cargo fmt --check`
- `cargo clippy -p ironclaw_scripts --tests -- -D warnings`
- `cargo clippy -p ironclaw_scripts --tests --all-features -- -D warnings`
- `cargo clippy --all --tests --examples --no-default-features --features libsql -- -D warnings`
- `cargo test -p ironclaw_scripts`
- `git diff --check`