### PR TITLE
feat(reborn): define turn coordinator public API

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -93,6 +93,20 @@ fn reborn_turns_public_surface_keeps_runner_api_explicit() {
 }
 
 #[test]
+fn reborn_turns_public_surface_uses_turn_ids_not_runtime_or_process_ids() {
+    let root = workspace_root();
+    let turns_src = root.join("crates/ironclaw_turns/src");
+    let mut violations = Vec::new();
+    collect_forbidden_turns_identifier_uses(&turns_src, &root, &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "ironclaw_turns public API must use TurnId/TurnRunId instead of lower runtime/process identifiers:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn reborn_runtime_http_egress_has_single_network_boundary() {
     let forbidden = [
         ForbiddenRuntimeNetworkUse {
@@ -160,6 +174,36 @@ fn reborn_runtime_http_egress_has_single_network_boundary() {
 struct ForbiddenRuntimeNetworkUse {
     pattern: &'static str,
     reason: &'static str,
+}
+
+fn collect_forbidden_turns_identifier_uses(
+    dir: &std::path::Path,
+    root: &std::path::Path,
+    violations: &mut Vec<String>,
+) {
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", dir.display()));
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|err| panic!("failed to read dir entry: {err}"));
+        let path = entry.path();
+        if path.is_dir() {
+            collect_forbidden_turns_identifier_uses(&path, root, violations);
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let contents = std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        for pattern in ["InvocationId", "ProcessId"] {
+            if contents.contains(pattern) {
+                violations.push(format!(
+                    "{} contains forbidden lower identifier `{pattern}`",
+                    path.strip_prefix(root).unwrap_or(&path).display()
+                ));
+            }
+        }
+    }
 }
 
 struct BoundaryRule {

--- a/crates/ironclaw_turns/CLAUDE.md
+++ b/crates/ironclaw_turns/CLAUDE.md
@@ -3,6 +3,7 @@
 - Own host-layer turn coordination contracts only: canonical turn scope, turn/run IDs, adapter-safe coordinator APIs, runner transition ports, store traits, and redacted lifecycle events.
 - Stay above the Reborn kernel facade. Do not depend on or re-export raw `CapabilityHost`, dispatcher, process host, runtime-lane adapters, raw filesystem, network, secrets, MCP, script, or WASM handles.
 - Product adapters use `TurnCoordinator` methods only. Trusted workers may import `ironclaw_turns::runner` explicitly; do not add runner transition APIs to the public prelude.
+- Mutating adapter-facing APIs must take scoped idempotency keys. `submit_turn` accepts requested run-profile hints and `received_at`; responses/state expose resolved profile id+version, not lower runtime handles.
 - Consume canonical binding/session refs from upstream services. Do not parse Slack/Telegram/Web/CLI identity, channel conversation IDs, or raw transcript content in this crate.
 - Active-run exclusivity is keyed by canonical scoped thread `(tenant_id, agent_id, project_id?, thread_id)` and must not include channel IDs or user IDs.
 - Blocked/resumable runs keep the same-thread active lock until resume, cancel, fail, or complete. Terminal transitions release the lock exactly once.

--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -68,10 +68,9 @@ where
         &self,
         request: SubmitTurnRequest,
     ) -> Result<SubmitTurnResponse, TurnError> {
-        self.admission_policy
-            .check_submit(&request)
-            .map_err(TurnError::AdmissionRejected)?;
-        self.store.submit_turn(request).await
+        self.store
+            .submit_turn(request, self.admission_policy.as_ref())
+            .await
     }
 
     async fn resume_turn(

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -55,7 +55,7 @@ impl InMemoryTurnEventSink {
 #[async_trait]
 impl TurnEventSink for InMemoryTurnEventSink {
     async fn publish(&self, event: TurnLifecycleEvent) -> Result<(), TurnError> {
-        let mut events = self.events.lock().map_err(|_| TurnError::Backend {
+        let mut events = self.events.lock().map_err(|_| TurnError::Unavailable {
             reason: "turn event sink mutex poisoned".to_string(),
         })?;
         events.push(event);

--- a/crates/ironclaw_turns/src/ids.rs
+++ b/crates/ironclaw_turns/src/ids.rs
@@ -156,6 +156,32 @@ bounded_ref!(SourceBindingRef, "source_binding_ref");
 bounded_ref!(ReplyTargetBindingRef, "reply_target_binding_ref");
 bounded_ref!(GateRef, "gate_ref");
 bounded_ref!(IdempotencyKey, "idempotency_key");
+bounded_ref!(RunProfileRequest, "run_profile_request");
+bounded_ref!(RunProfileId, "run_profile_id");
+
+impl RunProfileId {
+    pub fn default_profile() -> Self {
+        Self("default".to_string())
+    }
+
+    pub fn from_request(request: &RunProfileRequest) -> Self {
+        Self(request.as_str().to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RunProfileVersion(u64);
+
+impl RunProfileVersion {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
 
 fn validate_ref(kind: &'static str, value: &str) -> Result<(), String> {
     if value.is_empty() {

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -21,15 +21,18 @@ pub use coordinator::{
 };
 pub use events::{InMemoryTurnEventSink, TurnEventKind, TurnEventSink, TurnLifecycleEvent};
 pub use ids::{
-    AcceptedMessageRef, GateRef, IdempotencyKey, ReplyTargetBindingRef, SourceBindingRef,
-    TurnCheckpointId, TurnId, TurnLeaseToken, TurnRunId, TurnRunnerId,
+    AcceptedMessageRef, GateRef, IdempotencyKey, ReplyTargetBindingRef, RunProfileId,
+    RunProfileRequest, RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId,
+    TurnLeaseToken, TurnRunId, TurnRunnerId,
 };
 pub use memory::InMemoryTurnStateStore;
-pub use request::{CancelRunRequest, GetRunStateRequest, ResumeTurnRequest, SubmitTurnRequest};
+pub use request::{
+    CancelRunRequest, GetRunStateRequest, ResumeTurnRequest, SubmitTurnRequest, TurnTimestamp,
+};
 pub use response::{CancelRunResponse, ResumeTurnResponse, SubmitTurnResponse, ThreadBusy};
 pub use scope::{TurnActor, TurnScope};
 pub use status::{
-    AdmissionRejection, BlockedReason, SanitizedCancelReason, SanitizedFailure, TurnError,
-    TurnRunProfile, TurnRunState, TurnStatus,
+    AdmissionRejection, AdmissionRejectionReason, BlockedReason, SanitizedCancelReason,
+    SanitizedFailure, TurnError, TurnErrorCategory, TurnRunProfile, TurnRunState, TurnStatus,
 };
 pub use store::TurnStateStore;

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -143,16 +143,25 @@ impl TurnStateStore for InMemoryTurnStateStore {
         request: SubmitTurnRequest,
         admission_policy: &dyn TurnAdmissionPolicy,
     ) -> Result<SubmitTurnResponse, TurnError> {
-        let mut inner = self.lock_inner()?;
         let idempotency_key = SubmitIdempotencyKey {
             scope: request.scope.clone(),
             key: request.idempotency_key.clone(),
         };
+        {
+            let inner = self.lock_inner()?;
+            if let Some(result) = inner.submit_idempotency.get(&idempotency_key) {
+                return result.clone();
+            }
+        }
+
+        let admission_result = admission_policy.check_submit(&request);
+
+        let mut inner = self.lock_inner()?;
         if let Some(result) = inner.submit_idempotency.get(&idempotency_key) {
             return result.clone();
         }
 
-        if let Err(rejection) = admission_policy.check_submit(&request) {
+        if let Err(rejection) = admission_result {
             let response = Err(TurnError::AdmissionRejected(rejection));
             inner.remember_submit_idempotency(idempotency_key, response.clone());
             return response;

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -483,7 +483,9 @@ impl Inner {
                 });
             }
             if record.gate_ref.as_ref() != Some(&request.gate_resolution_ref) {
-                return Err(TurnError::ScopeNotFound);
+                return Err(TurnError::InvalidRequest {
+                    reason: "gate resolution reference mismatch".to_string(),
+                });
             }
             record.status = TurnStatus::Queued;
             record.gate_ref = None;

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -6,11 +6,11 @@ use std::{
 };
 
 use crate::{
-    CancelRunRequest, CancelRunResponse, GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef,
-    ResumeTurnRequest, ResumeTurnResponse, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
-    SubmitTurnResponse, ThreadBusy, TurnActor, TurnCheckpointId, TurnError, TurnEventKind,
-    TurnLifecycleEvent, TurnRunId, TurnRunProfile, TurnRunState, TurnScope, TurnStateStore,
-    TurnStatus,
+    AcceptedMessageRef, CancelRunRequest, CancelRunResponse, GetRunStateRequest, IdempotencyKey,
+    ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse, SanitizedFailure,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
+    TurnAdmissionPolicy, TurnCheckpointId, TurnError, TurnEventKind, TurnLifecycleEvent, TurnRunId,
+    TurnRunProfile, TurnRunState, TurnScope, TurnStateStore, TurnStatus,
     events::EventCursor,
     runner::{
         BlockRunRequest, ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest,
@@ -48,6 +48,7 @@ struct RunRecord {
     run_id: TurnRunId,
     status: TurnStatus,
     profile: TurnRunProfile,
+    accepted_message_ref: AcceptedMessageRef,
     source_binding_ref: SourceBindingRef,
     reply_target_binding_ref: ReplyTargetBindingRef,
     checkpoint_id: Option<TurnCheckpointId>,
@@ -56,6 +57,7 @@ struct RunRecord {
     event_cursor: EventCursor,
     runner_id: Option<crate::TurnRunnerId>,
     lease_token: Option<crate::TurnLeaseToken>,
+    received_at: crate::TurnTimestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -93,7 +95,7 @@ impl InMemoryTurnStateStore {
     }
 
     fn lock_inner(&self) -> Result<MutexGuard<'_, Inner>, TurnError> {
-        self.inner.lock().map_err(|_| TurnError::Backend {
+        self.inner.lock().map_err(|_| TurnError::Unavailable {
             reason: "turn state store mutex poisoned".to_string(),
         })
     }
@@ -104,6 +106,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
     async fn submit_turn(
         &self,
         request: SubmitTurnRequest,
+        admission_policy: &dyn TurnAdmissionPolicy,
     ) -> Result<SubmitTurnResponse, TurnError> {
         let mut inner = self.lock_inner()?;
         let idempotency_key = SubmitIdempotencyKey {
@@ -112,6 +115,15 @@ impl TurnStateStore for InMemoryTurnStateStore {
         };
         if let Some(result) = inner.submit_idempotency.get(&idempotency_key) {
             return result.clone();
+        }
+
+        if let Err(rejection) = admission_policy.check_submit(&request) {
+            let response = Err(TurnError::AdmissionRejected(rejection));
+            inner
+                .submit_idempotency
+                .insert(idempotency_key, response.clone());
+            inner.prune_idempotency_records();
+            return response;
         }
 
         let lock_key = TurnLockKey::from(&request.scope);
@@ -129,13 +141,15 @@ impl TurnStateStore for InMemoryTurnStateStore {
         let turn_id = crate::TurnId::new();
         let run_id = TurnRunId::new();
         let cursor = inner.next_cursor();
+        let profile = TurnRunProfile::resolve(request.requested_run_profile.as_ref());
         let record = RunRecord {
             scope: request.scope.clone(),
             actor: request.actor,
             turn_id,
             run_id,
             status: TurnStatus::Queued,
-            profile: request.profile.clone(),
+            profile: profile.clone(),
+            accepted_message_ref: request.accepted_message_ref.clone(),
             source_binding_ref: request.source_binding_ref,
             reply_target_binding_ref: request.reply_target_binding_ref.clone(),
             checkpoint_id: None,
@@ -144,6 +158,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             event_cursor: cursor,
             runner_id: None,
             lease_token: None,
+            received_at: request.received_at,
         };
         inner.active_locks.insert(lock_key, run_id);
         inner.queued_runs.push_back(run_id);
@@ -154,8 +169,10 @@ impl TurnStateStore for InMemoryTurnStateStore {
             turn_id,
             run_id,
             status: TurnStatus::Queued,
-            profile: request.profile,
+            resolved_run_profile_id: profile.id,
+            resolved_run_profile_version: profile.version,
             event_cursor: cursor,
+            accepted_message_ref: request.accepted_message_ref,
             reply_target_binding_ref: request.reply_target_binding_ref,
         });
         inner
@@ -214,7 +231,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             .get(&request.run_id)
             .filter(|record| record.scope == request.scope)
             .map(RunRecord::state)
-            .ok_or(TurnError::NotFound)
+            .ok_or(TurnError::ScopeNotFound)
     }
 }
 
@@ -333,7 +350,7 @@ impl Inner {
     }
 
     fn take_record(&mut self, run_id: TurnRunId) -> Result<RunRecord, TurnError> {
-        self.records.remove(&run_id).ok_or(TurnError::NotFound)
+        self.records.remove(&run_id).ok_or(TurnError::ScopeNotFound)
     }
 
     fn pop_matching_queued_run(&mut self, scope_filter: Option<&TurnScope>) -> Option<TurnRunId> {
@@ -366,7 +383,7 @@ impl Inner {
         let mut record = self.take_record(request.run_id)?;
         let result = (|| {
             if record.scope != request.scope {
-                return Err(TurnError::NotFound);
+                return Err(TurnError::ScopeNotFound);
             }
             if !matches!(
                 record.status,
@@ -378,10 +395,12 @@ impl Inner {
                 });
             }
             if record.gate_ref.as_ref() != Some(&request.gate_resolution_ref) {
-                return Err(TurnError::NotFound);
+                return Err(TurnError::ScopeNotFound);
             }
             record.status = TurnStatus::Queued;
             record.gate_ref = None;
+            record.source_binding_ref = request.source_binding_ref.clone();
+            record.reply_target_binding_ref = request.reply_target_binding_ref.clone();
             record.event_cursor = self.next_cursor();
             self.queued_runs.push_back(record.run_id);
             let response = ResumeTurnResponse {
@@ -403,7 +422,7 @@ impl Inner {
         let mut record = self.take_record(request.run_id)?;
         let result = (|| {
             if record.scope != request.scope {
-                return Err(TurnError::NotFound);
+                return Err(TurnError::ScopeNotFound);
             }
             if record.status.is_terminal() {
                 return Ok(CancelRunResponse {
@@ -535,9 +554,12 @@ impl RunRecord {
             turn_id: self.turn_id,
             run_id: self.run_id,
             status: self.status,
-            profile: self.profile.clone(),
+            accepted_message_ref: self.accepted_message_ref.clone(),
             source_binding_ref: self.source_binding_ref.clone(),
             reply_target_binding_ref: self.reply_target_binding_ref.clone(),
+            resolved_run_profile_id: self.profile.id.clone(),
+            resolved_run_profile_version: self.profile.version,
+            received_at: self.received_at,
             checkpoint_id: self.checkpoint_id,
             gate_ref: self.gate_ref.clone(),
             failure: self.failure.clone(),

--- a/crates/ironclaw_turns/src/request.rs
+++ b/crates/ironclaw_turns/src/request.rs
@@ -1,9 +1,12 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AcceptedMessageRef, GateRef, IdempotencyKey, ReplyTargetBindingRef, SanitizedCancelReason,
-    SourceBindingRef, TurnActor, TurnRunId, TurnRunProfile, TurnScope,
+    AcceptedMessageRef, GateRef, IdempotencyKey, ReplyTargetBindingRef, RunProfileRequest,
+    SanitizedCancelReason, SourceBindingRef, TurnActor, TurnRunId, TurnScope,
 };
+
+pub type TurnTimestamp = DateTime<Utc>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SubmitTurnRequest {
@@ -12,8 +15,9 @@ pub struct SubmitTurnRequest {
     pub accepted_message_ref: AcceptedMessageRef,
     pub source_binding_ref: SourceBindingRef,
     pub reply_target_binding_ref: ReplyTargetBindingRef,
-    pub profile: TurnRunProfile,
+    pub requested_run_profile: Option<RunProfileRequest>,
     pub idempotency_key: IdempotencyKey,
+    pub received_at: TurnTimestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,6 +26,8 @@ pub struct ResumeTurnRequest {
     pub actor: TurnActor,
     pub run_id: TurnRunId,
     pub gate_resolution_ref: GateRef,
+    pub source_binding_ref: SourceBindingRef,
+    pub reply_target_binding_ref: ReplyTargetBindingRef,
     pub idempotency_key: IdempotencyKey,
 }
 

--- a/crates/ironclaw_turns/src/response.rs
+++ b/crates/ironclaw_turns/src/response.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{ReplyTargetBindingRef, TurnRunId, TurnRunProfile, TurnStatus, events::EventCursor};
+use crate::{
+    AcceptedMessageRef, ReplyTargetBindingRef, RunProfileId, RunProfileVersion, TurnRunId,
+    TurnStatus, events::EventCursor,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SubmitTurnResponse {
@@ -8,8 +11,10 @@ pub enum SubmitTurnResponse {
         turn_id: crate::TurnId,
         run_id: TurnRunId,
         status: TurnStatus,
-        profile: TurnRunProfile,
+        resolved_run_profile_id: RunProfileId,
+        resolved_run_profile_version: RunProfileVersion,
         event_cursor: EventCursor,
+        accepted_message_ref: AcceptedMessageRef,
         reply_target_binding_ref: ReplyTargetBindingRef,
     },
 }

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -244,12 +244,12 @@ impl TurnError {
         match self {
             Self::ThreadBusy(_) => TurnErrorCategory::ThreadBusy,
             Self::AdmissionRejected(rejection) => match rejection.reason {
-                AdmissionRejectionReason::Unauthorized => TurnErrorCategory::Unauthorized,
-                AdmissionRejectionReason::Unavailable => TurnErrorCategory::Unavailable,
+                AdmissionRejectionReason::TenantLimit => TurnErrorCategory::AdmissionRejected,
                 AdmissionRejectionReason::ProfileRejected => TurnErrorCategory::InvalidRequest,
-                AdmissionRejectionReason::TenantLimit | AdmissionRejectionReason::Policy => {
-                    TurnErrorCategory::AdmissionRejected
+                AdmissionRejectionReason::Policy | AdmissionRejectionReason::Unauthorized => {
+                    TurnErrorCategory::Unauthorized
                 }
+                AdmissionRejectionReason::Unavailable => TurnErrorCategory::Unavailable,
             },
             Self::ScopeNotFound => TurnErrorCategory::ScopeNotFound,
             Self::Unauthorized => TurnErrorCategory::Unauthorized,

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -246,9 +246,10 @@ impl TurnError {
             Self::AdmissionRejected(rejection) => match rejection.reason {
                 AdmissionRejectionReason::Unauthorized => TurnErrorCategory::Unauthorized,
                 AdmissionRejectionReason::Unavailable => TurnErrorCategory::Unavailable,
-                AdmissionRejectionReason::TenantLimit
-                | AdmissionRejectionReason::ProfileRejected
-                | AdmissionRejectionReason::Policy => TurnErrorCategory::AdmissionRejected,
+                AdmissionRejectionReason::ProfileRejected => TurnErrorCategory::InvalidRequest,
+                AdmissionRejectionReason::TenantLimit | AdmissionRejectionReason::Policy => {
+                    TurnErrorCategory::AdmissionRejected
+                }
             },
             Self::ScopeNotFound => TurnErrorCategory::ScopeNotFound,
             Self::Unauthorized => TurnErrorCategory::Unauthorized,

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    GateRef, ReplyTargetBindingRef, SourceBindingRef, TurnCheckpointId, TurnId, TurnRunId,
-    TurnScope, events::EventCursor,
+    AcceptedMessageRef, GateRef, ReplyTargetBindingRef, RunProfileId, RunProfileRequest,
+    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId, TurnRunId, TurnScope,
+    events::EventCursor, request::TurnTimestamp,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -32,15 +33,17 @@ impl TurnStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TurnRunProfile {
-    pub profile_name: String,
+    pub id: RunProfileId,
+    pub version: RunProfileVersion,
     pub allow_steering: bool,
     pub auto_queue_followups: bool,
 }
 
 impl TurnRunProfile {
-    pub fn new(profile_name: impl Into<String>) -> Self {
+    pub fn resolve(_request: Option<&RunProfileRequest>) -> Self {
         Self {
-            profile_name: profile_name.into(),
+            id: RunProfileId::default_profile(),
+            version: RunProfileVersion::new(1),
             allow_steering: false,
             auto_queue_followups: false,
         }
@@ -142,18 +145,45 @@ impl SanitizedCancelReason {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdmissionRejectionReason {
+    TenantLimit,
+    ProfileRejected,
+    Policy,
+    Unauthorized,
+    Unavailable,
+}
+
+impl AdmissionRejectionReason {
+    pub fn category(self) -> &'static str {
+        match self {
+            Self::TenantLimit => "tenant_limit",
+            Self::ProfileRejected => "profile_rejected",
+            Self::Policy => "policy",
+            Self::Unauthorized => "unauthorized",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AdmissionRejection {
-    pub reason: String,
+    pub reason: AdmissionRejectionReason,
     pub retry_after_ms: Option<u64>,
 }
 
 impl AdmissionRejection {
-    pub fn new(reason: impl Into<String>) -> Self {
+    pub fn new(reason: AdmissionRejectionReason) -> Self {
         Self {
-            reason: reason.into(),
+            reason,
             retry_after_ms: None,
         }
+    }
+
+    pub fn with_retry_after_ms(mut self, retry_after_ms: u64) -> Self {
+        self.retry_after_ms = Some(retry_after_ms);
+        self
     }
 }
 
@@ -163,13 +193,28 @@ pub struct TurnRunState {
     pub turn_id: TurnId,
     pub run_id: TurnRunId,
     pub status: TurnStatus,
-    pub profile: TurnRunProfile,
+    pub accepted_message_ref: AcceptedMessageRef,
     pub source_binding_ref: SourceBindingRef,
     pub reply_target_binding_ref: ReplyTargetBindingRef,
+    pub resolved_run_profile_id: RunProfileId,
+    pub resolved_run_profile_version: RunProfileVersion,
+    pub received_at: TurnTimestamp,
     pub checkpoint_id: Option<TurnCheckpointId>,
     pub gate_ref: Option<GateRef>,
     pub failure: Option<SanitizedFailure>,
     pub event_cursor: EventCursor,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnErrorCategory {
+    ThreadBusy,
+    AdmissionRejected,
+    ScopeNotFound,
+    Unauthorized,
+    InvalidRequest,
+    Unavailable,
+    Conflict,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -179,11 +224,54 @@ pub enum TurnError {
     #[error("turn admission rejected: {0:?}")]
     AdmissionRejected(AdmissionRejection),
     #[error("turn run not found")]
-    NotFound,
+    ScopeNotFound,
+    #[error("turn request is unauthorized")]
+    Unauthorized,
+    #[error("invalid turn request: {reason}")]
+    InvalidRequest { reason: String },
+    #[error("turn service unavailable: {reason}")]
+    Unavailable { reason: String },
+    #[error("turn conflict: {reason}")]
+    Conflict { reason: String },
     #[error("invalid turn transition from {from:?} to {to:?}")]
     InvalidTransition { from: TurnStatus, to: TurnStatus },
     #[error("turn run lease mismatch")]
     LeaseMismatch,
-    #[error("turn backend error: {reason}")]
-    Backend { reason: String },
+}
+
+impl TurnError {
+    pub fn category(&self) -> TurnErrorCategory {
+        match self {
+            Self::ThreadBusy(_) => TurnErrorCategory::ThreadBusy,
+            Self::AdmissionRejected(rejection) => match rejection.reason {
+                AdmissionRejectionReason::Unauthorized => TurnErrorCategory::Unauthorized,
+                AdmissionRejectionReason::Unavailable => TurnErrorCategory::Unavailable,
+                AdmissionRejectionReason::TenantLimit
+                | AdmissionRejectionReason::ProfileRejected
+                | AdmissionRejectionReason::Policy => TurnErrorCategory::AdmissionRejected,
+            },
+            Self::ScopeNotFound => TurnErrorCategory::ScopeNotFound,
+            Self::Unauthorized => TurnErrorCategory::Unauthorized,
+            Self::InvalidRequest { .. } => TurnErrorCategory::InvalidRequest,
+            Self::Unavailable { .. } => TurnErrorCategory::Unavailable,
+            Self::Conflict { .. } | Self::InvalidTransition { .. } | Self::LeaseMismatch => {
+                TurnErrorCategory::Conflict
+            }
+        }
+    }
+
+    pub fn is_expected_admission_outcome(&self) -> bool {
+        matches!(self, Self::ThreadBusy(_) | Self::AdmissionRejected(_))
+    }
+
+    pub fn adapter_status_code(&self) -> u16 {
+        match self.category() {
+            TurnErrorCategory::ThreadBusy | TurnErrorCategory::Conflict => 409,
+            TurnErrorCategory::AdmissionRejected => 429,
+            TurnErrorCategory::ScopeNotFound => 404,
+            TurnErrorCategory::Unauthorized => 403,
+            TurnErrorCategory::InvalidRequest => 400,
+            TurnErrorCategory::Unavailable => 503,
+        }
+    }
 }

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     CancelRunRequest, CancelRunResponse, GetRunStateRequest, ResumeTurnRequest, ResumeTurnResponse,
-    SubmitTurnRequest, SubmitTurnResponse, TurnError, TurnRunState,
+    SubmitTurnRequest, SubmitTurnResponse, TurnAdmissionPolicy, TurnError, TurnRunState,
 };
 
 #[async_trait]
@@ -10,6 +10,7 @@ pub trait TurnStateStore: Send + Sync {
     async fn submit_turn(
         &self,
         request: SubmitTurnRequest,
+        admission_policy: &dyn TurnAdmissionPolicy,
     ) -> Result<SubmitTurnResponse, TurnError>;
 
     async fn resume_turn(

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -336,7 +336,7 @@ fn admission_rejection_reason_status_mapping_is_user_actionable() {
     assert_eq!(
         TurnError::AdmissionRejected(AdmissionRejection::new(AdmissionRejectionReason::Policy))
             .adapter_status_code(),
-        429
+        403
     );
     assert_eq!(
         TurnError::AdmissionRejected(AdmissionRejection::new(
@@ -379,6 +379,18 @@ async fn admission_policy_rejection_is_typed_and_does_not_create_run() {
         ))
         .adapter_status_code(),
         403
+    );
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(AdmissionRejectionReason::Policy))
+            .adapter_status_code(),
+        403
+    );
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::ProfileRejected
+        ))
+        .adapter_status_code(),
+        400
     );
     assert_eq!(
         TurnError::AdmissionRejected(AdmissionRejection::new(
@@ -507,6 +519,61 @@ async fn blocked_run_persists_checkpoint_and_keeps_same_thread_lock_until_resume
     assert_eq!(duplicate, resumed);
     assert_eq!(store.events().len(), event_count_after_resume);
     assert_eq!(resumed.status, TurnStatus::Queued);
+}
+
+#[tokio::test]
+async fn resume_turn_with_wrong_gate_resolution_ref_is_invalid_request() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            reason: BlockedReason::Approval {
+                gate_ref: GateRef::new("approval-gate").unwrap(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let err = coordinator
+        .resume_turn(ResumeTurnRequest {
+            scope: scope("thread-a"),
+            actor: actor(),
+            run_id,
+            gate_resolution_ref: GateRef::new("wrong-gate").unwrap(),
+            source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-resume-wrong-gate").unwrap(),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        TurnError::InvalidRequest {
+            reason: "gate resolution reference mismatch".to_string(),
+        }
+    );
+    assert_eq!(err.adapter_status_code(), 400);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -1,13 +1,18 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
+use chrono::{DateTime, TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
-    AcceptedMessageRef, AdmissionRejection, BlockedReason, CancelRunRequest,
-    DefaultTurnCoordinator, GateRef, GetRunStateRequest, IdempotencyKey, InMemoryTurnEventSink,
-    InMemoryTurnStateStore, ReplyTargetBindingRef, ResumeTurnRequest, SanitizedCancelReason,
-    SanitizedFailure, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
-    TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnCoordinator, TurnError, TurnEventKind,
-    TurnEventSink, TurnLeaseToken, TurnLifecycleEvent, TurnRunId, TurnRunProfile, TurnRunnerId,
+    AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, BlockedReason,
+    CancelRunRequest, DefaultTurnCoordinator, GateRef, GetRunStateRequest, IdempotencyKey,
+    InMemoryTurnEventSink, InMemoryTurnStateStore, ReplyTargetBindingRef, ResumeTurnRequest,
+    RunProfileRequest, RunProfileVersion, SanitizedCancelReason, SanitizedFailure,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
+    TurnAdmissionPolicy, TurnCheckpointId, TurnCoordinator, TurnError, TurnErrorCategory,
+    TurnEventKind, TurnEventSink, TurnLeaseToken, TurnLifecycleEvent, TurnRunId, TurnRunnerId,
     TurnScope, TurnStatus,
     events::EventCursor,
     runner::{
@@ -27,12 +32,16 @@ async fn submit_turn_accepts_only_canonical_refs_and_returns_redacted_metadata()
         turn_id: _,
         run_id,
         status,
-        profile,
+        resolved_run_profile_id,
+        resolved_run_profile_version,
         event_cursor,
+        accepted_message_ref,
         reply_target_binding_ref,
     } = response;
     assert_eq!(status, TurnStatus::Queued);
-    assert_eq!(profile.profile_name, "default");
+    assert_eq!(resolved_run_profile_id.as_str(), "default");
+    assert_eq!(resolved_run_profile_version, RunProfileVersion::new(1));
+    assert_eq!(accepted_message_ref, request.accepted_message_ref);
     assert_eq!(reply_target_binding_ref, request.reply_target_binding_ref);
     assert_eq!(event_cursor.0, 1);
 
@@ -44,9 +53,47 @@ async fn submit_turn_accepts_only_canonical_refs_and_returns_redacted_metadata()
         .await
         .unwrap();
     assert_eq!(state.status, TurnStatus::Queued);
+    assert_eq!(state.accepted_message_ref.as_str(), "message-thread-a");
     assert_eq!(state.source_binding_ref.as_str(), "source-web");
     assert_eq!(state.reply_target_binding_ref.as_str(), "reply-web");
+    assert_eq!(state.resolved_run_profile_id.as_str(), "default");
+    assert_eq!(
+        state.resolved_run_profile_version,
+        RunProfileVersion::new(1)
+    );
+    assert_eq!(state.received_at, received_at());
     assert_eq!(state.failure, None);
+}
+
+#[tokio::test]
+async fn requested_run_profile_is_a_hint_not_resolved_authority() {
+    let (coordinator, _store) = coordinator();
+    let mut request = submit_request("thread-a", "idem-profile-hint");
+    request.requested_run_profile = Some(RunProfileRequest::new("experimental-fast-lane").unwrap());
+
+    let response = coordinator.submit_turn(request.clone()).await.unwrap();
+
+    let SubmitTurnResponse::Accepted {
+        run_id,
+        resolved_run_profile_id,
+        resolved_run_profile_version,
+        ..
+    } = response;
+    assert_eq!(resolved_run_profile_id.as_str(), "default");
+    assert_eq!(resolved_run_profile_version, RunProfileVersion::new(1));
+
+    let state = coordinator
+        .get_run_state(GetRunStateRequest {
+            scope: request.scope,
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(state.resolved_run_profile_id.as_str(), "default");
+    assert_eq!(
+        state.resolved_run_profile_version,
+        RunProfileVersion::new(1)
+    );
 }
 
 #[tokio::test]
@@ -67,7 +114,7 @@ async fn same_thread_active_run_returns_busy_but_different_threads_run_independe
         TurnError::ThreadBusy(ThreadBusy {
             active_run_id,
             status: TurnStatus::Queued,
-            ..
+            event_cursor: EventCursor(1),
         }) if active_run_id == first_run_id
     ));
 
@@ -135,6 +182,39 @@ async fn transient_busy_submit_is_not_cached_after_thread_unlocks() {
 }
 
 #[tokio::test]
+async fn submit_turn_idempotency_replays_before_policy_is_rechecked() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let coordinator = DefaultTurnCoordinator::new(store)
+        .with_admission_policy(Arc::new(AllowFirstThenDeny::default()));
+    let request = submit_request("thread-a", "idem-submit-a");
+
+    let first = coordinator.submit_turn(request.clone()).await.unwrap();
+    let duplicate = coordinator.submit_turn(request).await.unwrap();
+
+    assert_eq!(duplicate, first);
+}
+
+#[tokio::test]
+async fn submit_turn_idempotency_replays_same_admission_rejection() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let coordinator = DefaultTurnCoordinator::new(store.clone())
+        .with_admission_policy(Arc::new(DenyFirstThenAllow::default()));
+    let request = submit_request("thread-a", "idem-submit-rejected");
+
+    let first = coordinator.submit_turn(request.clone()).await.unwrap_err();
+    let duplicate = coordinator.submit_turn(request).await.unwrap_err();
+
+    assert_eq!(duplicate, first);
+    assert_eq!(
+        duplicate,
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::TenantLimit
+        ))
+    );
+    assert!(store.events().is_empty());
+}
+
+#[tokio::test]
 async fn submit_turn_idempotency_is_scoped_to_canonical_thread() {
     let (coordinator, _store) = coordinator();
     let first = coordinator
@@ -167,7 +247,9 @@ async fn get_run_state_wrong_scope_returns_not_found_without_leaking_existence()
         .await
         .unwrap_err();
 
-    assert_eq!(err, TurnError::NotFound);
+    assert_eq!(err, TurnError::ScopeNotFound);
+    assert_eq!(err.category(), TurnErrorCategory::ScopeNotFound);
+    assert_eq!(err.adapter_status_code(), 404);
 }
 
 #[tokio::test]
@@ -181,9 +263,28 @@ async fn admission_policy_rejection_is_typed_and_does_not_create_run() {
 
     assert_eq!(
         err,
-        TurnError::AdmissionRejected(AdmissionRejection::new("tenant_limit"))
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::TenantLimit
+        ))
     );
+    assert!(err.is_expected_admission_outcome());
+    assert_eq!(err.category(), TurnErrorCategory::AdmissionRejected);
+    assert_eq!(err.adapter_status_code(), 429);
     assert!(store.events().is_empty());
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::Unauthorized
+        ))
+        .adapter_status_code(),
+        403
+    );
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::Unavailable
+        ))
+        .adapter_status_code(),
+        503
+    );
     assert_eq!(
         coordinator
             .get_run_state(GetRunStateRequest {
@@ -192,7 +293,7 @@ async fn admission_policy_rejection_is_typed_and_does_not_create_run() {
             })
             .await
             .unwrap_err(),
-        TurnError::NotFound
+        TurnError::ScopeNotFound
     );
 }
 
@@ -286,16 +387,23 @@ async fn blocked_run_persists_checkpoint_and_keeps_same_thread_lock_until_resume
         .unwrap_err();
     assert!(matches!(busy, TurnError::ThreadBusy(_)));
 
+    let resume_request = ResumeTurnRequest {
+        scope: scope("thread-a"),
+        actor: actor(),
+        run_id,
+        gate_resolution_ref: gate_ref,
+        source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
+        idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
+    };
     let resumed = coordinator
-        .resume_turn(ResumeTurnRequest {
-            scope: scope("thread-a"),
-            actor: actor(),
-            run_id,
-            gate_resolution_ref: gate_ref,
-            idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
-        })
+        .resume_turn(resume_request.clone())
         .await
         .unwrap();
+    let event_count_after_resume = store.events().len();
+    let duplicate = coordinator.resume_turn(resume_request).await.unwrap();
+    assert_eq!(duplicate, resumed);
+    assert_eq!(store.events().len(), event_count_after_resume);
     assert_eq!(resumed.status, TurnStatus::Queued);
 }
 
@@ -426,6 +534,8 @@ fn bounded_refs_validate_during_deserialization() {
     assert!(serde_json::from_str::<AcceptedMessageRef>("\"message-ok\"").is_ok());
     assert!(serde_json::from_str::<AcceptedMessageRef>("\"\"").is_err());
     assert!(serde_json::from_str::<SourceBindingRef>("\"source\\nsecret\"").is_err());
+    assert!(serde_json::from_str::<RunProfileRequest>("\"default\"").is_ok());
+    assert!(serde_json::from_str::<RunProfileRequest>("\"profile\\nsecret\"").is_err());
     let oversized = format!("\"{}\"", "x".repeat(257));
     assert!(serde_json::from_str::<GateRef>(&oversized).is_err());
 }
@@ -526,9 +636,14 @@ fn submit_request(thread: &str, idempotency_key: &str) -> SubmitTurnRequest {
         accepted_message_ref: AcceptedMessageRef::new(format!("message-{thread}")).unwrap(),
         source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
         reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
-        profile: TurnRunProfile::new("default"),
+        requested_run_profile: Some(RunProfileRequest::new("default").unwrap()),
         idempotency_key: IdempotencyKey::new(idempotency_key).unwrap(),
+        received_at: received_at(),
     }
+}
+
+fn received_at() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 5, 12, 0, 0).unwrap()
 }
 
 fn cancel_request(thread: &str, run_id: TurnRunId, idempotency_key: &str) -> CancelRunRequest {
@@ -559,10 +674,46 @@ fn actor() -> TurnActor {
     TurnActor::new(UserId::new("user1").unwrap())
 }
 
+#[derive(Default)]
+struct AllowFirstThenDeny {
+    calls: AtomicUsize,
+}
+
+impl TurnAdmissionPolicy for AllowFirstThenDeny {
+    fn check_submit(&self, _request: &SubmitTurnRequest) -> Result<(), AdmissionRejection> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            Ok(())
+        } else {
+            Err(AdmissionRejection::new(
+                AdmissionRejectionReason::TenantLimit,
+            ))
+        }
+    }
+}
+
+#[derive(Default)]
+struct DenyFirstThenAllow {
+    calls: AtomicUsize,
+}
+
+impl TurnAdmissionPolicy for DenyFirstThenAllow {
+    fn check_submit(&self, _request: &SubmitTurnRequest) -> Result<(), AdmissionRejection> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            Err(AdmissionRejection::new(
+                AdmissionRejectionReason::TenantLimit,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
 struct DenyAll;
 
 impl TurnAdmissionPolicy for DenyAll {
     fn check_submit(&self, _request: &SubmitTurnRequest) -> Result<(), AdmissionRejection> {
-        Err(AdmissionRejection::new("tenant_limit"))
+        Err(AdmissionRejection::new(
+            AdmissionRejectionReason::TenantLimit,
+        ))
     }
 }

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -1,6 +1,10 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+        mpsc,
+    },
+    time::Duration,
 };
 
 use chrono::{DateTime, TimeZone, Utc};
@@ -194,6 +198,29 @@ async fn submit_turn_idempotency_replays_before_policy_is_rechecked() {
     assert_eq!(duplicate, first);
 }
 
+#[test]
+fn submit_turn_admission_policy_can_reenter_store_without_deadlock() {
+    let (sender, receiver) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let store = Arc::new(InMemoryTurnStateStore::default());
+        let coordinator = DefaultTurnCoordinator::new(store.clone())
+            .with_admission_policy(Arc::new(ReentrantStorePolicy { store }));
+        let result = runtime
+            .block_on(coordinator.submit_turn(submit_request("thread-a", "idem-reentrant-policy")));
+        let _ = sender.send(result);
+    });
+
+    let result = receiver
+        .recv_timeout(Duration::from_secs(1))
+        .expect("submit_turn should not deadlock when admission policy reads store state");
+    assert!(matches!(result, Ok(SubmitTurnResponse::Accepted { .. })));
+}
+
 #[tokio::test]
 async fn submit_turn_idempotency_replays_same_admission_rejection() {
     let store = Arc::new(InMemoryTurnStateStore::default());
@@ -281,6 +308,50 @@ async fn get_run_state_wrong_scope_returns_not_found_without_leaking_existence()
     assert_eq!(err, TurnError::ScopeNotFound);
     assert_eq!(err.category(), TurnErrorCategory::ScopeNotFound);
     assert_eq!(err.adapter_status_code(), 404);
+}
+
+#[test]
+fn admission_rejection_reason_status_mapping_is_user_actionable() {
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::TenantLimit
+        ))
+        .adapter_status_code(),
+        429
+    );
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::ProfileRejected
+        ))
+        .category(),
+        TurnErrorCategory::InvalidRequest
+    );
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::ProfileRejected
+        ))
+        .adapter_status_code(),
+        400
+    );
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(AdmissionRejectionReason::Policy))
+            .adapter_status_code(),
+        429
+    );
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::Unauthorized
+        ))
+        .adapter_status_code(),
+        403
+    );
+    assert_eq!(
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::Unavailable
+        ))
+        .adapter_status_code(),
+        503
+    );
 }
 
 #[tokio::test]
@@ -779,6 +850,17 @@ fn scope(thread: &str) -> TurnScope {
 
 fn actor() -> TurnActor {
     TurnActor::new(UserId::new("user1").unwrap())
+}
+
+struct ReentrantStorePolicy {
+    store: Arc<InMemoryTurnStateStore>,
+}
+
+impl TurnAdmissionPolicy for ReentrantStorePolicy {
+    fn check_submit(&self, _request: &SubmitTurnRequest) -> Result<(), AdmissionRejection> {
+        let _ = self.store.events();
+        Ok(())
+    }
 }
 
 #[derive(Default)]

--- a/docs/reborn/contracts/turns-agent-loop.md
+++ b/docs/reborn/contracts/turns-agent-loop.md
@@ -91,6 +91,8 @@ Rules:
 - memory prompt context uses the same tenant/user/project/agent scope;
 - channel metadata does not grant authority by itself.
 
+Adapter-facing `TurnCoordinator` requests carry canonical scope plus durable references only: accepted-message ref, source/reply binding refs, actor metadata, requested run-profile hint, scoped idempotency key, and `received_at`. Submit responses expose redacted metadata including run status, event cursor, accepted-message ref, reply-target binding ref, and resolved run-profile id+version; scoped run-state reads additionally expose the source binding ref. Trusted runner transition APIs stay behind the explicit `ironclaw_turns::runner` surface rather than the adapter prelude.
+
 ---
 
 ## 4. Turn lifecycle


### PR DESCRIPTION
## Summary

Closes #3198. Refs #3013.

- Defines adapter-safe `TurnCoordinator` request/response/error shapes for submit/resume/cancel/state reads.
- Adds requested run-profile hints, resolved profile id/version, accepted message refs, reply/source binding refs, `received_at`, and stable error categories/status mapping without raw content or lower runtime handles.
- Makes submit idempotency authoritative before admission re-checks and keeps runner transition APIs behind explicit `ironclaw_turns::runner` imports.
- Updates the Reborn turns contract and crate guardrails for the public API boundary.

## Verification

- `cargo fmt --check`
- `cargo test -p ironclaw_turns`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries`
- `cargo clippy -p ironclaw_turns -p ironclaw_architecture --tests -- -D warnings`
- `git diff --check`
- `rg -n "\\b(unwrap|expect|panic!)\\s*\\(" crates/ironclaw_turns/src` (no matches)
- `cargo check --workspace`

## Review

- Read-only reviewer subagent re-review: clean.
