### PR TITLE
fix(reborn): harden turn coordinator contracts

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -405,6 +405,7 @@ fn boundary_rules() -> Vec<BoundaryRule> {
                 "ironclaw_dispatcher",
                 "ironclaw_extensions",
                 "ironclaw_filesystem",
+                "ironclaw_host_runtime",
                 "ironclaw_mcp",
                 "ironclaw_memory",
                 "ironclaw_network",

--- a/crates/ironclaw_turns/CLAUDE.md
+++ b/crates/ironclaw_turns/CLAUDE.md
@@ -5,6 +5,6 @@
 - Product adapters use `TurnCoordinator` methods only. Trusted workers may import `ironclaw_turns::runner` explicitly; do not add runner transition APIs to the public prelude.
 - Consume canonical binding/session refs from upstream services. Do not parse Slack/Telegram/Web/CLI identity, channel conversation IDs, or raw transcript content in this crate.
 - Active-run exclusivity is keyed by canonical scoped thread `(tenant_id, agent_id, project_id?, thread_id)` and must not include channel IDs or user IDs.
-- Blocked/resumable runs keep the same-thread active lock until resume, cancel, fail, or complete. Terminal transitions release the lock exactly once.
+- Blocked/resumable runs keep the same-thread active lock until resume, cancel, fail, or complete. Running cancellation is two-phase: public cancel requests move to `CancelRequested`, and a trusted runner cancellation completion moves to terminal `Cancelled` and releases the lock exactly once.
 - Store lifecycle metadata and references only. Do not persist raw prompts, assistant content, tool input, secrets, host paths, or backend error details in turn state or events.
 - Keep concrete PostgreSQL/libSQL adapters and product projection/egress wiring out of the core contract unless a scoped follow-up explicitly adds them with parity tests.

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -24,7 +24,7 @@ pub use ids::{
     AcceptedMessageRef, GateRef, IdempotencyKey, ReplyTargetBindingRef, SourceBindingRef,
     TurnCheckpointId, TurnId, TurnLeaseToken, TurnRunId, TurnRunnerId,
 };
-pub use memory::InMemoryTurnStateStore;
+pub use memory::{InMemoryTurnStateStore, InMemoryTurnStateStoreLimits};
 pub use request::{CancelRunRequest, GetRunStateRequest, ResumeTurnRequest, SubmitTurnRequest};
 pub use response::{CancelRunResponse, ResumeTurnResponse, SubmitTurnResponse, ThreadBusy};
 pub use scope::{TurnActor, TurnScope};

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -13,8 +13,8 @@ use crate::{
     TurnStatus,
     events::EventCursor,
     runner::{
-        BlockRunRequest, ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest,
-        HeartbeatRequest, TurnRunTransitionPort,
+        BlockRunRequest, CancelRunCompletionRequest, ClaimRunRequest, ClaimedTurnRun,
+        CompleteRunRequest, FailRunRequest, HeartbeatRequest, TurnRunTransitionPort,
     },
 };
 
@@ -22,9 +22,31 @@ const MAX_EVENTS: usize = 10_000;
 const MAX_TERMINAL_RECORDS: usize = 10_000;
 const MAX_IDEMPOTENCY_RECORDS: usize = 10_000;
 
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InMemoryTurnStateStoreLimits {
+    pub max_events: usize,
+    pub max_terminal_records: usize,
+    pub max_idempotency_records: usize,
+}
+
+impl Default for InMemoryTurnStateStoreLimits {
+    fn default() -> Self {
+        Self {
+            max_events: MAX_EVENTS,
+            max_terminal_records: MAX_TERMINAL_RECORDS,
+            max_idempotency_records: MAX_IDEMPOTENCY_RECORDS,
+        }
+    }
+}
+
 pub struct InMemoryTurnStateStore {
     inner: Mutex<Inner>,
+}
+
+impl Default for InMemoryTurnStateStore {
+    fn default() -> Self {
+        Self::with_limits(InMemoryTurnStateStoreLimits::default())
+    }
 }
 
 #[derive(Default)]
@@ -37,7 +59,11 @@ struct Inner {
     submit_idempotency: HashMap<SubmitIdempotencyKey, Result<SubmitTurnResponse, TurnError>>,
     resume_idempotency: HashMap<RunIdempotencyKey, Result<ResumeTurnResponse, TurnError>>,
     cancel_idempotency: HashMap<RunIdempotencyKey, Result<CancelRunResponse, TurnError>>,
+    submit_idempotency_order: VecDeque<SubmitIdempotencyKey>,
+    resume_idempotency_order: VecDeque<RunIdempotencyKey>,
+    cancel_idempotency_order: VecDeque<RunIdempotencyKey>,
     events: Vec<TurnLifecycleEvent>,
+    limits: InMemoryTurnStateStoreLimits,
 }
 
 #[derive(Debug, Clone)]
@@ -85,6 +111,15 @@ struct RunIdempotencyKey {
 }
 
 impl InMemoryTurnStateStore {
+    pub fn with_limits(limits: InMemoryTurnStateStoreLimits) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                limits,
+                ..Inner::default()
+            }),
+        }
+    }
+
     pub fn events(&self) -> Vec<TurnLifecycleEvent> {
         match self.inner.lock() {
             Ok(inner) => inner.events.clone(),
@@ -158,10 +193,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             event_cursor: cursor,
             reply_target_binding_ref: request.reply_target_binding_ref,
         });
-        inner
-            .submit_idempotency
-            .insert(idempotency_key, response.clone());
-        inner.prune_idempotency_records();
+        inner.remember_submit_idempotency(idempotency_key, response.clone());
         response
     }
 
@@ -179,10 +211,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             return result.clone();
         }
         let result = inner.resume_turn_once(&request);
-        inner
-            .resume_idempotency
-            .insert(idempotency_key, result.clone());
-        inner.prune_idempotency_records();
+        inner.remember_resume_idempotency(idempotency_key, result.clone());
         result
     }
 
@@ -200,10 +229,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             return result.clone();
         }
         let result = inner.request_cancel_once(&request);
-        inner
-            .cancel_idempotency
-            .insert(idempotency_key, result.clone());
-        inner.prune_idempotency_records();
+        inner.remember_cancel_idempotency(idempotency_key, result.clone());
         result
     }
 
@@ -293,6 +319,14 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
         )
     }
 
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        let mut inner = self.lock_inner()?;
+        inner.cancel_completion_transition(request.run_id, request.runner_id, request.lease_token)
+    }
+
     async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
         let mut inner = self.lock_inner()?;
         inner.terminal_transition(
@@ -326,10 +360,58 @@ impl Inner {
             kind,
             sanitized_reason,
         });
-        if self.events.len() > MAX_EVENTS {
-            let excess = self.events.len() - MAX_EVENTS;
+        if self.events.len() > self.limits.max_events {
+            let excess = self.events.len() - self.limits.max_events;
             self.events.drain(0..excess);
         }
+    }
+
+    fn remember_submit_idempotency(
+        &mut self,
+        key: SubmitIdempotencyKey,
+        result: Result<SubmitTurnResponse, TurnError>,
+    ) {
+        if !self.submit_idempotency.contains_key(&key) {
+            self.submit_idempotency_order.push_back(key.clone());
+        }
+        self.submit_idempotency.insert(key, result);
+        prune_ordered_map(
+            &mut self.submit_idempotency,
+            &mut self.submit_idempotency_order,
+            self.limits.max_idempotency_records,
+        );
+    }
+
+    fn remember_resume_idempotency(
+        &mut self,
+        key: RunIdempotencyKey,
+        result: Result<ResumeTurnResponse, TurnError>,
+    ) {
+        if !self.resume_idempotency.contains_key(&key) {
+            self.resume_idempotency_order.push_back(key.clone());
+        }
+        self.resume_idempotency.insert(key, result);
+        prune_ordered_map(
+            &mut self.resume_idempotency,
+            &mut self.resume_idempotency_order,
+            self.limits.max_idempotency_records,
+        );
+    }
+
+    fn remember_cancel_idempotency(
+        &mut self,
+        key: RunIdempotencyKey,
+        result: Result<CancelRunResponse, TurnError>,
+    ) {
+        if !self.cancel_idempotency.contains_key(&key) {
+            self.cancel_idempotency_order.push_back(key.clone());
+        }
+        self.cancel_idempotency.insert(key, result);
+        prune_ordered_map(
+            &mut self.cancel_idempotency,
+            &mut self.cancel_idempotency_order,
+            self.limits.max_idempotency_records,
+        );
     }
 
     fn take_record(&mut self, run_id: TurnRunId) -> Result<RunRecord, TurnError> {
@@ -459,6 +541,38 @@ impl Inner {
         result
     }
 
+    fn cancel_completion_transition(
+        &mut self,
+        run_id: TurnRunId,
+        runner_id: crate::TurnRunnerId,
+        lease_token: crate::TurnLeaseToken,
+    ) -> Result<TurnRunState, TurnError> {
+        let mut record = self.take_record(run_id)?;
+        let result = (|| {
+            ensure_lease(&record, runner_id, lease_token)?;
+            if record.status != TurnStatus::CancelRequested {
+                return Err(TurnError::InvalidTransition {
+                    from: record.status,
+                    to: TurnStatus::Cancelled,
+                });
+            }
+            record.status = TurnStatus::Cancelled;
+            record.failure = None;
+            record.runner_id = None;
+            record.lease_token = None;
+            record.event_cursor = self.next_cursor();
+            self.release_active_lock(&record);
+            self.remove_queued_run(record.run_id);
+            let state = record.state();
+            self.push_event(&record, TurnEventKind::Cancelled, None);
+            self.mark_terminal(record.run_id);
+            Ok(state)
+        })();
+        self.records.insert(record.run_id, record);
+        self.prune_terminal_records();
+        result
+    }
+
     fn terminal_transition(
         &mut self,
         run_id: TurnRunId,
@@ -471,7 +585,7 @@ impl Inner {
         let mut record = self.take_record(run_id)?;
         let result = (|| {
             ensure_lease(&record, runner_id, lease_token)?;
-            if record.status.is_terminal() {
+            if record.status == TurnStatus::CancelRequested || record.status.is_terminal() {
                 return Err(TurnError::InvalidTransition {
                     from: record.status,
                     to: status,
@@ -506,7 +620,7 @@ impl Inner {
     }
 
     fn prune_terminal_records(&mut self) {
-        while self.terminal_runs.len() > MAX_TERMINAL_RECORDS {
+        while self.terminal_runs.len() > self.limits.max_terminal_records {
             let Some(run_id) = self.terminal_runs.pop_front() else {
                 break;
             };
@@ -518,12 +632,6 @@ impl Inner {
                 self.records.remove(&run_id);
             }
         }
-    }
-
-    fn prune_idempotency_records(&mut self) {
-        prune_map(&mut self.submit_idempotency, MAX_IDEMPOTENCY_RECORDS);
-        prune_map(&mut self.resume_idempotency, MAX_IDEMPOTENCY_RECORDS);
-        prune_map(&mut self.cancel_idempotency, MAX_IDEMPOTENCY_RECORDS);
     }
 }
 
@@ -557,14 +665,18 @@ fn ensure_lease(
     Ok(())
 }
 
-fn prune_map<K, V>(map: &mut HashMap<K, V>, max_len: usize)
+fn prune_ordered_map<K, V>(map: &mut HashMap<K, V>, order: &mut VecDeque<K>, max_len: usize)
 where
-    K: Clone + Eq + Hash,
+    K: Eq + Hash,
 {
     while map.len() > max_len {
-        let Some(key) = map.keys().next().cloned() else {
+        let Some(key) = order.pop_front() else {
             break;
         };
         map.remove(&key);
+    }
+
+    while order.front().is_some_and(|key| !map.contains_key(key)) {
+        order.pop_front();
     }
 }

--- a/crates/ironclaw_turns/src/runner.rs
+++ b/crates/ironclaw_turns/src/runner.rs
@@ -52,8 +52,16 @@ pub struct FailRunRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CancelRunCompletionRequest {
+    pub run_id: TurnRunId,
+    pub runner_id: TurnRunnerId,
+    pub lease_token: TurnLeaseToken,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TurnRunnerOutcome {
     Completed,
+    Cancelled,
     Blocked {
         checkpoint_id: TurnCheckpointId,
         reason: BlockedReason,
@@ -75,6 +83,11 @@ pub trait TurnRunTransitionPort: Send + Sync {
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError>;
 
     async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError>;
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError>;
 
     async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError>;
 }

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -4,15 +4,15 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
     AcceptedMessageRef, AdmissionRejection, BlockedReason, CancelRunRequest,
     DefaultTurnCoordinator, GateRef, GetRunStateRequest, IdempotencyKey, InMemoryTurnEventSink,
-    InMemoryTurnStateStore, ReplyTargetBindingRef, ResumeTurnRequest, SanitizedCancelReason,
-    SanitizedFailure, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
-    TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnCoordinator, TurnError, TurnEventKind,
-    TurnEventSink, TurnLeaseToken, TurnLifecycleEvent, TurnRunId, TurnRunProfile, TurnRunnerId,
-    TurnScope, TurnStatus,
+    InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, ReplyTargetBindingRef, ResumeTurnRequest,
+    SanitizedCancelReason, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
+    SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnCheckpointId,
+    TurnCoordinator, TurnError, TurnEventKind, TurnEventSink, TurnLeaseToken, TurnLifecycleEvent,
+    TurnRunId, TurnRunProfile, TurnRunnerId, TurnScope, TurnStatus,
     events::EventCursor,
     runner::{
-        BlockRunRequest, ClaimRunRequest, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
-        TurnRunTransitionPort,
+        BlockRunRequest, CancelRunCompletionRequest, ClaimRunRequest, CompleteRunRequest,
+        FailRunRequest, HeartbeatRequest, TurnRunTransitionPort,
     },
 };
 
@@ -132,6 +132,37 @@ async fn transient_busy_submit_is_not_cached_after_thread_unlocks() {
 
     let accepted_after_unlock = coordinator.submit_turn(busy_request).await.unwrap();
     assert_ne!(accepted_run_id(&accepted_after_unlock), first_run_id);
+}
+
+#[tokio::test]
+async fn idempotency_retention_keeps_the_newest_result_when_pruned() {
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            max_idempotency_records: 2,
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store);
+
+    coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap();
+    let newest = coordinator
+        .submit_turn(submit_request("thread-c", "idem-submit-c"))
+        .await
+        .unwrap();
+
+    let duplicate_newest = coordinator
+        .submit_turn(submit_request("thread-c", "idem-submit-c"))
+        .await
+        .unwrap();
+
+    assert_eq!(duplicate_newest, newest);
 }
 
 #[tokio::test]
@@ -332,6 +363,49 @@ async fn cancel_run_is_idempotent_and_marks_running_run_cancel_requested_without
 }
 
 #[tokio::test]
+async fn runner_can_terminally_cancel_running_run_and_release_lock() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    coordinator
+        .cancel_run(cancel_request("thread-a", run_id, "idem-cancel-a"))
+        .await
+        .unwrap();
+
+    let cancelled = store
+        .cancel_run(CancelRunCompletionRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(cancelled.status, TurnStatus::Cancelled);
+    assert!(cancelled.failure.is_none());
+    let next = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-b"))
+        .await
+        .unwrap();
+    assert_ne!(accepted_run_id(&next), run_id);
+}
+
+#[tokio::test]
 async fn cancel_run_for_queued_run_terminally_cancels_and_releases_lock() {
     let (coordinator, store) = coordinator();
     let run_id = accepted_run_id(
@@ -382,6 +456,39 @@ async fn cancelled_running_run_cannot_be_reopened_as_blocked() {
         .cancel_run(cancel_request("thread-a", run_id, "idem-cancel-a"))
         .await
         .unwrap();
+
+    let completed_after_cancel = store
+        .complete_run(CompleteRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        completed_after_cancel,
+        TurnError::InvalidTransition {
+            from: TurnStatus::CancelRequested,
+            to: TurnStatus::Completed,
+        }
+    );
+
+    let failed_after_cancel = store
+        .fail_run(FailRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            failure: SanitizedFailure::new("late_failure").unwrap(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        failed_after_cancel,
+        TurnError::InvalidTransition {
+            from: TurnStatus::CancelRequested,
+            to: TurnStatus::Failed,
+        }
+    );
 
     let blocked_after_cancel = store
         .block_run(BlockRunRequest {


### PR DESCRIPTION
## Summary

Follow-up to #3250 read-only review findings. Refs #3013 and #3195.

- Adds explicit trusted runner cancellation completion so `CancelRequested` running runs can terminally become `Cancelled` and release the active lock.
- Prevents `CancelRequested` runs from being completed or failed through the normal terminal runner paths.
- Replaces arbitrary idempotency retention pruning with deterministic insertion-order retention and coverage that the newest result remains replayable at capacity.
- Extends the `ironclaw_turns` architecture boundary guard to forbid direct `ironclaw_host_runtime` dependencies.

## Verification

- `cargo fmt --check`
- `cargo test -p ironclaw_turns`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries`
- `cargo clippy -p ironclaw_turns -p ironclaw_architecture --tests -- -D warnings`
- `git diff --check`
- `rg -n "\\b(unwrap|expect|panic!)\\s*\\(" crates/ironclaw_turns/src` (no matches)
- `cargo check --workspace`

## Review

- Reviewer subagent re-review: clean.
