### PR TITLE
feat(wasm): credential signers for HMAC, EIP-712, NEP-413, Solana

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2138,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2497,6 +2516,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +2564,25 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "email_address"
@@ -2748,6 +2800,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3015,6 +3077,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3127,6 +3190,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -3881,6 +3955,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bollard",
+ "borsh",
  "bs58",
  "bytes",
  "chrono",
@@ -3917,6 +3992,7 @@ dependencies = [
  "json5",
  "jsonschema",
  "jsonwebtoken",
+ "k256",
  "libsql",
  "lru 0.16.3",
  "mime_guess",
@@ -3932,6 +4008,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rig-core",
+ "rmp-serde",
  "rust_decimal",
  "rust_decimal_macros",
  "rustls 0.23.37",
@@ -3945,6 +4022,7 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "sha2",
+ "sha3",
  "subtle",
  "tar",
  "tempfile",
@@ -4267,6 +4345,29 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -6373,6 +6474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rig-core"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6445,6 +6556,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -6870,6 +7000,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7185,6 +7329,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7236,6 +7390,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest",
  "rand_core 0.6.4",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,9 +160,13 @@ aes-gcm = "0.10"
 hkdf = "0.12"
 hmac = "0.12"
 sha2 = "0.10"
+sha3 = "0.10"
 blake3 = "1"
 rand = "0.8"
 subtle = "2"  # Constant-time comparisons for token validation
+k256 = { version = "0.13", features = ["ecdsa"] }
+borsh = { version = "1.5", features = ["derive"] }
+rmp-serde = "1.3"
 
 # Multi-provider LLM support
 rig-core = { version = "0.30", default-features = false, features = ["reqwest-rustls"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -534,6 +534,9 @@ impl AppBuilder {
         if let Some(ref interceptor) = http_interceptor {
             registry = registry.with_http_interceptor(Arc::clone(interceptor));
         }
+        let signer_gate: Arc<dyn crate::secrets::SignerApprovalGate> =
+            Arc::new(crate::tools::wasm::signer_gate::TerminalSignerGate::new());
+        registry = registry.with_signer_gate(signer_gate);
         let tools = Arc::new(registry);
         tools.register_builtin_tools();
         tools.register_tool_info();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,6 +33,7 @@ mod profile;
 mod registry;
 mod routines;
 mod service;
+mod signer_render;
 mod skills;
 pub mod status;
 mod tool;

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -41,6 +41,10 @@ pub enum RegistryCommand {
         /// Build from source instead of downloading pre-built artifact
         #[arg(long)]
         build: bool,
+
+        /// Grant signing-scheme consent without an interactive prompt
+        #[arg(long)]
+        yes: bool,
     },
 
     /// Install the default bundle of recommended extensions
@@ -52,6 +56,10 @@ pub enum RegistryCommand {
         /// Build from source instead of downloading pre-built artifact
         #[arg(long)]
         build: bool,
+
+        /// Grant signing-scheme consent without an interactive prompt
+        #[arg(long)]
+        yes: bool,
     },
 }
 
@@ -77,11 +85,14 @@ pub async fn run_registry_command(cmd: RegistryCommand) -> anyhow::Result<()> {
             cmd_list(&catalog, kind.as_deref(), tag.as_deref(), verbose)
         }
         RegistryCommand::Info { name } => cmd_info(&catalog, &name),
-        RegistryCommand::Install { name, force, build } => {
-            cmd_install(&catalog, &repo_root, &name, force, build).await
-        }
-        RegistryCommand::InstallDefaults { force, build } => {
-            cmd_install(&catalog, &repo_root, "default", force, build).await
+        RegistryCommand::Install {
+            name,
+            force,
+            build,
+            yes,
+        } => cmd_install(&catalog, &repo_root, &name, force, build, yes).await,
+        RegistryCommand::InstallDefaults { force, build, yes } => {
+            cmd_install(&catalog, &repo_root, "default", force, build, yes).await
         }
     }
 }
@@ -241,6 +252,7 @@ async fn cmd_install(
     name: &str,
     force: bool,
     prefer_build: bool,
+    yes: bool,
 ) -> anyhow::Result<()> {
     let installer = RegistryInstaller::with_defaults(repo_root.to_path_buf());
 
@@ -248,6 +260,10 @@ async fn cmd_install(
 
     if manifests.is_empty() {
         anyhow::bail!("No extensions found for '{}'.", name);
+    }
+
+    for manifest in &manifests {
+        prompt_signing_consent_for_source(repo_root, manifest, yes)?;
     }
 
     if let Some(bundle_def) = bundle {
@@ -313,5 +329,35 @@ async fn cmd_install(
         }
     }
 
+    Ok(())
+}
+
+fn prompt_signing_consent_for_source(
+    repo_root: &std::path::Path,
+    manifest: &crate::registry::manifest::ExtensionManifest,
+    yes: bool,
+) -> anyhow::Result<()> {
+    let Some(source) = manifest.source.as_ref() else {
+        return Ok(());
+    };
+    let caps_path = repo_root.join(&source.dir).join(&source.capabilities);
+    if !caps_path.exists() {
+        return Ok(());
+    }
+    let content = std::fs::read_to_string(&caps_path).map_err(|e| {
+        anyhow::anyhow!(
+            "Cannot read {} for signing review: {}",
+            caps_path.display(),
+            e
+        )
+    })?;
+    let parsed = crate::tools::wasm::capabilities_schema::CapabilitiesFile::from_json(&content)
+        .map_err(|e| anyhow::anyhow!("Invalid capabilities at {}: {}", caps_path.display(), e))?;
+    if let Some(summary) =
+        crate::cli::signer_render::render_signing_summary(&parsed, &manifest.name)
+    {
+        println!("{}", summary);
+        crate::cli::signer_render::prompt_for_signing_consent(yes)?;
+    }
     Ok(())
 }

--- a/src/cli/signer_render.rs
+++ b/src/cli/signer_render.rs
@@ -1,0 +1,445 @@
+use std::fmt::Write as _;
+use std::io::{self, BufRead, IsTerminal, Write};
+
+use crate::secrets::{Eip712Domain, FieldSource};
+use crate::tools::wasm::capabilities_schema::{
+    CapabilitiesFile, CredentialLocationSchema, CredentialMappingSchema,
+};
+
+const CONSENT_PHRASE: &str = "I understand and consent to grant signing authority";
+
+struct KnownDomain {
+    name_prefix: &'static str,
+    chain_id: u64,
+    label: &'static str,
+}
+
+const KNOWN_EIP712_DOMAINS: &[KnownDomain] = &[
+    KnownDomain {
+        name_prefix: "ClobAuthDomain",
+        chain_id: 137,
+        label: "Polymarket CLOB",
+    },
+    KnownDomain {
+        name_prefix: "Polymarket CTF Exchange",
+        chain_id: 137,
+        label: "Polymarket CTF Exchange",
+    },
+    KnownDomain {
+        name_prefix: "Seaport",
+        chain_id: 1,
+        label: "OpenSea Seaport (Ethereum)",
+    },
+    KnownDomain {
+        name_prefix: "Permit2",
+        chain_id: 1,
+        label: "Uniswap Permit2 (Ethereum)",
+    },
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DomainClassification {
+    Known,
+    Unknown,
+}
+
+pub fn classify_domain(domain: &Eip712Domain) -> DomainClassification {
+    for known in KNOWN_EIP712_DOMAINS {
+        if domain.name == known.name_prefix && domain.chain_id == known.chain_id {
+            return DomainClassification::Known;
+        }
+    }
+    DomainClassification::Unknown
+}
+
+pub fn classification_label(domain: &Eip712Domain) -> String {
+    match classify_domain(domain) {
+        DomainClassification::Known => {
+            let label = KNOWN_EIP712_DOMAINS
+                .iter()
+                .find(|k| k.name_prefix == domain.name && k.chain_id == domain.chain_id)
+                .map(|k| k.label)
+                .unwrap_or("known");
+            format!("known ({})", label)
+        }
+        DomainClassification::Unknown => "unknown — review carefully".to_string(),
+    }
+}
+
+pub fn chain_name(chain_id: u64) -> Option<&'static str> {
+    match chain_id {
+        1 => Some("Ethereum Mainnet"),
+        10 => Some("Optimism"),
+        56 => Some("BNB Chain"),
+        137 => Some("Polygon Mainnet"),
+        8453 => Some("Base"),
+        42161 => Some("Arbitrum One"),
+        43114 => Some("Avalanche C-Chain"),
+        11155111 => Some("Sepolia Testnet"),
+        _ => None,
+    }
+}
+
+pub fn render_signing_summary(caps: &CapabilitiesFile, tool_name: &str) -> Option<String> {
+    let signing = caps.signing.as_ref()?;
+    if signing.schemes.is_empty() {
+        return None;
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Tool '{}' declares signing schemes:", tool_name);
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "  Signing grants the host the right to produce cryptographic signatures"
+    );
+    let _ = writeln!(
+        out,
+        "  using your private keys, over values the tool supplies at runtime."
+    );
+
+    let mut ids: Vec<&String> = signing.schemes.keys().collect();
+    ids.sort();
+    for id in ids {
+        let mapping = &signing.schemes[id];
+        let _ = writeln!(out);
+        let _ = writeln!(out, "  Scheme: {}", id);
+        let _ = writeln!(out, "    Secret: {}", mapping.secret_name);
+        render_scope(&mut out, mapping);
+        render_location(&mut out, &mapping.location);
+    }
+
+    Some(out)
+}
+
+fn render_scope(out: &mut String, mapping: &CredentialMappingSchema) {
+    if mapping.host_patterns.is_empty() && mapping.path_patterns.is_empty() {
+        let _ = writeln!(out, "    Scope:  any host, any path");
+        return;
+    }
+    let hosts = if mapping.host_patterns.is_empty() {
+        "(any host)".to_string()
+    } else {
+        mapping.host_patterns.join(", ")
+    };
+    let paths = if mapping.path_patterns.is_empty() {
+        "(any path)".to_string()
+    } else {
+        mapping.path_patterns.join(", ")
+    };
+    let _ = writeln!(out, "    Scope:  hosts={} paths={}", hosts, paths);
+}
+
+fn render_location(out: &mut String, location: &CredentialLocationSchema) {
+    match location {
+        CredentialLocationSchema::HmacSignedHeader {
+            signature_header,
+            timestamp_header,
+        } => {
+            let _ = writeln!(out, "    Type:   HMAC-SHA256 (signs every request body)");
+            let _ = writeln!(
+                out,
+                "    Output: header {}, timestamp header {}",
+                signature_header, timestamp_header
+            );
+        }
+        CredentialLocationSchema::Eip712SignedHeader {
+            domain,
+            primary_type,
+            structs,
+            ..
+        } => {
+            let _ = writeln!(out, "    Type:   EIP-712 typed message (secp256k1)");
+            render_eip712_domain(out, domain);
+            let _ = writeln!(out, "    Primary type: {}", primary_type);
+            for s in structs {
+                if &s.name != primary_type {
+                    continue;
+                }
+                let _ = writeln!(out, "    Struct {}:", s.name);
+                for field in &s.fields {
+                    let _ = writeln!(
+                        out,
+                        "      {:<16} : {:<10} <- {}",
+                        field.name,
+                        field.type_name,
+                        format_field_source(&field.source)
+                    );
+                }
+            }
+        }
+        CredentialLocationSchema::Nep413SignedHeader {
+            recipient_source,
+            message_source,
+            callback_url_source,
+            ..
+        } => {
+            let _ = writeln!(out, "    Type:   NEP-413 NEAR signed message (ed25519)");
+            let _ = writeln!(
+                out,
+                "    Recipient: <- {}",
+                format_field_source(recipient_source)
+            );
+            let _ = writeln!(
+                out,
+                "    Message:   <- {}",
+                format_field_source(message_source)
+            );
+            if let Some(cb) = callback_url_source {
+                let _ = writeln!(out, "    Callback:  <- {}", format_field_source(cb));
+            }
+        }
+        CredentialLocationSchema::SolanaSignedTransaction { message_source, .. } => {
+            let _ = writeln!(out, "    Type:   Solana ed25519 transaction signing");
+            let _ = writeln!(
+                out,
+                "    Message bytes: <- {}",
+                format_field_source(message_source)
+            );
+            let _ = writeln!(
+                out,
+                "    WARNING: Solana txs can transfer funds and SPL tokens. \
+                 Verify the host patterns name only RPC endpoints you trust."
+            );
+        }
+        _ => {
+            let _ = writeln!(out, "    Type:   (non-signing location, ignored)");
+        }
+    }
+}
+
+fn render_eip712_domain(out: &mut String, domain: &Eip712Domain) {
+    let _ = writeln!(out, "    Domain:");
+    let _ = writeln!(out, "      name:              {}", domain.name);
+    let _ = writeln!(out, "      version:           {}", domain.version);
+    let chain_label = chain_name(domain.chain_id)
+        .map(|n| format!("{} ({})", domain.chain_id, n))
+        .unwrap_or_else(|| domain.chain_id.to_string());
+    let _ = writeln!(out, "      chainId:           {}", chain_label);
+    let _ = writeln!(
+        out,
+        "      verifyingContract: {}",
+        domain
+            .verifying_contract
+            .as_deref()
+            .unwrap_or("(none specified)")
+    );
+    let _ = writeln!(
+        out,
+        "      Classification:    {}",
+        classification_label(domain)
+    );
+}
+
+fn format_field_source(src: &FieldSource) -> String {
+    match src {
+        FieldSource::Literal { value } => format!("literal \"{}\"", value),
+        FieldSource::SignerAddress => "your wallet address".to_string(),
+        FieldSource::SignerPublicKey => "your wallet public key".to_string(),
+        FieldSource::RequestTimestampSecs => "current request timestamp".to_string(),
+        FieldSource::RequestRandomNonceB64 => "fresh random nonce".to_string(),
+        FieldSource::RequestBody => "WHOLE REQUEST BODY (tool-controlled)".to_string(),
+        FieldSource::BodyFieldString { path } => {
+            format!("tool-controlled string at body.{}", path)
+        }
+        FieldSource::Bytes32Keccak256OfBytes { parts } => {
+            format!("keccak256 of {} byte parts (tool-controlled)", parts.len())
+        }
+    }
+}
+
+pub fn prompt_for_signing_consent(auto_yes: bool) -> anyhow::Result<()> {
+    if auto_yes {
+        println!("  --yes flag set: signing schemes accepted without interactive confirmation.");
+        return Ok(());
+    }
+
+    let stdin = io::stdin();
+    if !stdin.is_terminal() {
+        anyhow::bail!(
+            "Signing schemes require interactive consent. Re-run on a terminal, or pass --yes \
+             to grant explicit consent for this install."
+        );
+    }
+
+    println!();
+    println!("Type the following phrase EXACTLY to grant signing authority:");
+    println!("  \"{}\"", CONSENT_PHRASE);
+    println!("Or type anything else (e.g. \"no\") to abort.");
+    print!("> ");
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    stdin.lock().read_line(&mut input)?;
+    let trimmed = input.trim();
+
+    if trimmed == CONSENT_PHRASE {
+        Ok(())
+    } else {
+        anyhow::bail!("Signing consent declined. Installation aborted.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn eip712_domain(name: &str, chain_id: u64) -> Eip712Domain {
+        Eip712Domain {
+            name: name.to_string(),
+            version: "1".to_string(),
+            chain_id,
+            verifying_contract: None,
+        }
+    }
+
+    #[test]
+    fn classify_polymarket_clob_as_known() {
+        let domain = eip712_domain("ClobAuthDomain", 137);
+        assert_eq!(classify_domain(&domain), DomainClassification::Known);
+        assert!(classification_label(&domain).contains("Polymarket CLOB"));
+    }
+
+    #[test]
+    fn classify_unknown_domain_as_unknown() {
+        let domain = eip712_domain("ClobAuthDomain", 999);
+        assert_eq!(classify_domain(&domain), DomainClassification::Unknown);
+        assert!(classification_label(&domain).contains("review"));
+
+        let mismatched = eip712_domain("AttackerDomain", 1);
+        assert_eq!(classify_domain(&mismatched), DomainClassification::Unknown);
+    }
+
+    #[test]
+    fn chain_name_known_chains_only() {
+        assert_eq!(chain_name(1), Some("Ethereum Mainnet"));
+        assert_eq!(chain_name(137), Some("Polygon Mainnet"));
+        assert_eq!(chain_name(42161), Some("Arbitrum One"));
+        assert!(chain_name(99999).is_none());
+    }
+
+    #[test]
+    fn render_signing_summary_returns_none_without_signing_block() {
+        let json = r#"{ "http": { "allowlist": [] } }"#;
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        assert!(render_signing_summary(&caps, "no-signers").is_none());
+    }
+
+    #[test]
+    fn render_signing_summary_lists_schemes_and_classifies_domain() {
+        let json = r#"{
+            "signing": {
+                "schemes": {
+                    "polymarket_l1_clobauth": {
+                        "secret_name": "polymarket_l1_pk",
+                        "location": {
+                            "type": "eip712_signed_header",
+                            "domain": {
+                                "name": "ClobAuthDomain",
+                                "version": "1",
+                                "chain_id": 137
+                            },
+                            "primary_type": "ClobAuth",
+                            "structs": [{
+                                "name": "ClobAuth",
+                                "fields": [
+                                    { "name": "address", "type": "address", "source": { "source": "signer_address" } },
+                                    { "name": "timestamp", "type": "string", "source": { "source": "request_timestamp_secs" } },
+                                    { "name": "message", "type": "string", "source": { "source": "literal", "value": "Polymarket auth" } }
+                                ]
+                            }],
+                            "output_headers": [],
+                            "output_body_fields": []
+                        },
+                        "host_patterns": ["clob.polymarket.com"],
+                        "path_patterns": ["/auth/api-key"]
+                    }
+                }
+            }
+        }"#;
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let summary = render_signing_summary(&caps, "polymarket-clob").expect("has signing");
+        assert!(summary.contains("polymarket_l1_clobauth"));
+        assert!(summary.contains("polymarket_l1_pk"));
+        assert!(summary.contains("EIP-712"));
+        assert!(summary.contains("ClobAuth"));
+        assert!(summary.contains("address"));
+        assert!(summary.contains("your wallet address"));
+        assert!(summary.contains("literal \"Polymarket auth\""));
+        assert!(summary.contains("Polygon Mainnet"));
+        assert!(summary.contains("known (Polymarket CLOB)"));
+        assert!(summary.contains("clob.polymarket.com"));
+        assert!(summary.contains("/auth/api-key"));
+    }
+
+    #[test]
+    fn render_signing_summary_warns_on_solana() {
+        let json = r#"{
+            "signing": {
+                "schemes": {
+                    "drainer": {
+                        "secret_name": "sol_pk",
+                        "location": {
+                            "type": "solana_signed_transaction",
+                            "message_source": { "source": "request_body" },
+                            "output_body_fields": []
+                        },
+                        "host_patterns": ["solana-api.example.com"]
+                    }
+                }
+            }
+        }"#;
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let summary = render_signing_summary(&caps, "evil").expect("has signing");
+        assert!(summary.contains("Solana"));
+        assert!(summary.contains("WARNING"));
+        assert!(summary.contains("WHOLE REQUEST BODY"));
+    }
+
+    #[test]
+    fn render_signing_summary_renders_nep413_with_field_sources() {
+        let json = r#"{
+            "signing": {
+                "schemes": {
+                    "near_auth": {
+                        "secret_name": "near_pk",
+                        "location": {
+                            "type": "nep413_signed_header",
+                            "recipient_source": { "source": "literal", "value": "iron.near" },
+                            "message_source": { "source": "request_body" },
+                            "output_headers": []
+                        },
+                        "host_patterns": ["api.iron.near"]
+                    }
+                }
+            }
+        }"#;
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let summary = render_signing_summary(&caps, "iron").expect("has signing");
+        assert!(summary.contains("NEP-413"));
+        assert!(summary.contains("literal \"iron.near\""));
+        assert!(summary.contains("WHOLE REQUEST BODY"));
+    }
+
+    #[test]
+    fn format_field_source_covers_every_variant() {
+        assert!(
+            format_field_source(&FieldSource::Literal {
+                value: "v".to_string()
+            })
+            .contains("literal")
+        );
+        assert!(format_field_source(&FieldSource::SignerAddress).contains("wallet address"));
+        assert!(format_field_source(&FieldSource::SignerPublicKey).contains("public key"));
+        assert!(format_field_source(&FieldSource::RequestTimestampSecs).contains("timestamp"));
+        assert!(format_field_source(&FieldSource::RequestRandomNonceB64).contains("nonce"));
+        assert!(format_field_source(&FieldSource::RequestBody).contains("WHOLE REQUEST BODY"));
+        assert!(
+            format_field_source(&FieldSource::BodyFieldString {
+                path: "tx".to_string()
+            })
+            .contains("body.tx")
+        );
+    }
+}

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -49,6 +49,10 @@ pub enum ToolCommand {
         /// Force overwrite if tool already exists
         #[arg(short, long)]
         force: bool,
+
+        /// Grant signing-scheme consent without an interactive prompt
+        #[arg(long)]
+        yes: bool,
     },
 
     /// List installed tools
@@ -126,7 +130,20 @@ pub async fn run_tool_command(cmd: ToolCommand) -> anyhow::Result<()> {
             release,
             skip_build,
             force,
-        } => install_tool(path, name, capabilities, target, release, skip_build, force).await,
+            yes,
+        } => {
+            install_tool(
+                path,
+                name,
+                capabilities,
+                target,
+                release,
+                skip_build,
+                force,
+                yes,
+            )
+            .await
+        }
         ToolCommand::List { dir, verbose } => list_tools(dir, verbose).await,
         ToolCommand::Remove { name, dir } => remove_tool(name, dir).await,
         ToolCommand::Info {
@@ -140,6 +157,7 @@ pub async fn run_tool_command(cmd: ToolCommand) -> anyhow::Result<()> {
 }
 
 /// Install a WASM tool.
+#[allow(clippy::too_many_arguments)]
 async fn install_tool(
     path: PathBuf,
     name: Option<String>,
@@ -148,6 +166,7 @@ async fn install_tool(
     release: bool,
     skip_build: bool,
     force: bool,
+    yes: bool,
 ) -> anyhow::Result<()> {
     let target_dir = target.unwrap_or_else(default_tools_dir);
 
@@ -240,11 +259,16 @@ async fn install_tool(
         );
     }
 
-    // Validate capabilities file if provided
     if let Some(ref caps) = caps_path {
         let content = fs::read_to_string(caps).await?;
-        CapabilitiesFile::from_json(&content)
+        let parsed = CapabilitiesFile::from_json(&content)
             .map_err(|e| anyhow::anyhow!("Invalid capabilities file {}: {}", caps.display(), e))?;
+        if let Some(summary) =
+            crate::cli::signer_render::render_signing_summary(&parsed, &tool_name)
+        {
+            println!("{}", summary);
+            crate::cli::signer_render::prompt_for_signing_consent(yes)?;
+        }
     }
 
     // Copy WASM file

--- a/src/sandbox/proxy/http.rs
+++ b/src/sandbox/proxy/http.rs
@@ -376,7 +376,8 @@ async fn forward_request(
                 | CredentialLocation::UrlPath { .. }
                 | CredentialLocation::HmacSignedHeader { .. }
                 | CredentialLocation::Eip712SignedHeader { .. }
-                | CredentialLocation::Nep413SignedHeader { .. } => {
+                | CredentialLocation::Nep413SignedHeader { .. }
+                | CredentialLocation::SolanaSignedTransaction { .. } => {
                     tracing::warn!(
                         "Proxy: credential location {:?} not supported for forward proxy, skipping",
                         location

--- a/src/sandbox/proxy/http.rs
+++ b/src/sandbox/proxy/http.rs
@@ -373,7 +373,10 @@ async fn forward_request(
                 // fetch credentials via the orchestrator's GET /worker/{id}/credentials
                 // endpoint and set them directly.
                 CredentialLocation::AuthorizationBasic { .. }
-                | CredentialLocation::UrlPath { .. } => {
+                | CredentialLocation::UrlPath { .. }
+                | CredentialLocation::HmacSignedHeader { .. }
+                | CredentialLocation::Eip712SignedHeader { .. }
+                | CredentialLocation::Nep413SignedHeader { .. } => {
                     tracing::warn!(
                         "Proxy: credential location {:?} not supported for forward proxy, skipping",
                         location

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -70,8 +70,9 @@ pub use store::LibSqlSecretsStore;
 pub use store::PostgresSecretsStore;
 pub use store::{SecretConsumeResult, SecretsStore};
 pub use types::{
-    CreateSecretParams, CredentialLocation, CredentialMapping, DecryptedSecret, Secret,
-    SecretError, SecretRef,
+    BodyJsonOutput, BodyValue, BytesPart, CreateSecretParams, CredentialLocation,
+    CredentialMapping, DecryptedSecret, Eip712Domain, Eip712StructDef, Eip712TypedField,
+    FieldSource, HeaderOutput, OutputSource, Secret, SecretError, SecretRef,
 };
 pub(crate) use types::{
     extract_url_path_for_matching, host_matches_pattern, match_specificity, path_matches_prefix,

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -70,9 +70,11 @@ pub use store::LibSqlSecretsStore;
 pub use store::PostgresSecretsStore;
 pub use store::{SecretConsumeResult, SecretsStore};
 pub use types::{
-    BodyJsonOutput, BodyValue, BytesPart, CreateSecretParams, CredentialLocation,
-    CredentialMapping, DecryptedSecret, Eip712Domain, Eip712StructDef, Eip712TypedField,
-    FieldSource, HeaderOutput, OutputSource, Secret, SecretError, SecretRef,
+    AllowAllSignerGate, Approval, ApprovalRequest, BodyJsonOutput, BodyValue, BytesPart,
+    CreateSecretParams, CredentialKind, CredentialLocation, CredentialMapping, DecryptedSecret,
+    Eip712Domain, Eip712StructDef, Eip712TypedField, FieldSource, HeaderOutput, OutputSource,
+    RejectAllSignerGate, Secret, SecretError, SecretRef, SignerApprovalGate, SignerClassification,
+    classify_signing_location,
 };
 pub(crate) use types::{
     extract_url_path_for_matching, host_matches_pattern, match_specificity, path_matches_prefix,

--- a/src/secrets/types.rs
+++ b/src/secrets/types.rs
@@ -211,6 +211,155 @@ pub enum CredentialLocation {
     QueryParam { name: String },
     /// Inject by replacing a placeholder in URL or body templates
     UrlPath { placeholder: String },
+    /// HMAC-SHA256 over `${unix_seconds}${method}${path}${body}`,
+    /// emitted as URL-safe base64 in `signature_header` with the
+    /// timestamp echoed in `timestamp_header`. Secret value is the
+    /// URL-safe-base64-encoded HMAC key.
+    HmacSignedHeader {
+        signature_header: String,
+        timestamp_header: String,
+    },
+    /// EIP-712 typed structured data signing with secp256k1.
+    /// Schema declared by the tool; sources for each field come from
+    /// the closed [`FieldSource`] vocabulary so the signed payload is
+    /// bounded by the manifest review at install time.
+    Eip712SignedHeader {
+        domain: Eip712Domain,
+        primary_type: String,
+        structs: Vec<Eip712StructDef>,
+        output_headers: Vec<HeaderOutput>,
+        #[serde(default)]
+        output_body_fields: Vec<BodyJsonOutput>,
+    },
+    /// NEP-413 signed message with ed25519 (NEAR Protocol).
+    /// Nonce is always host-generated 32 random bytes per the spec.
+    Nep413SignedHeader {
+        recipient_source: FieldSource,
+        message_source: FieldSource,
+        #[serde(default)]
+        callback_url_source: Option<FieldSource>,
+        output_headers: Vec<HeaderOutput>,
+    },
+}
+
+/// EIP-712 domain separator parameters.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Eip712Domain {
+    pub name: String,
+    pub version: String,
+    pub chain_id: u64,
+    #[serde(default)]
+    pub verifying_contract: Option<String>,
+}
+
+/// EIP-712 struct definition: the primary type plus any nested types
+/// it references.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Eip712StructDef {
+    pub name: String,
+    pub fields: Vec<Eip712TypedField>,
+}
+
+/// One field of an EIP-712 struct: name, ABI type string, and the
+/// source that supplies its value at request time.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Eip712TypedField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_name: String,
+    pub source: FieldSource,
+}
+
+/// Closed vocabulary of values a signed payload field may take. The
+/// vocabulary is closed so a tool cannot declare an arbitrary signing
+/// oracle: every source is either user-reviewed at install (literal)
+/// or derived from the request the tool was already authorized to
+/// send (timestamp, body, etc.).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum FieldSource {
+    Literal {
+        value: String,
+    },
+    SignerAddress,
+    SignerPublicKey,
+    RequestTimestampSecs,
+    RequestRandomNonceB64,
+    RequestBody,
+    /// Computes `keccak256` over a byte sequence assembled from the
+    /// declared parts and emits the 32-byte digest as a 0x-prefixed
+    /// hex string suitable for an EIP-712 `bytes32` field.
+    Bytes32Keccak256OfBytes {
+        parts: Vec<BytesPart>,
+    },
+}
+
+/// Closed vocabulary of byte fragments that can be concatenated and
+/// hashed under [`FieldSource::Bytes32Keccak256OfBytes`]. Each entry
+/// is either a manifest-time literal or a deterministic transform of
+/// a request body field, so the hashed payload remains bounded by the
+/// install-time review.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BytesPart {
+    /// Raw bytes specified as a hex string in the manifest.
+    LiteralHex { hex: String },
+    /// MessagePack encoding of the JSON value at `path` in the request
+    /// body. Path uses dot notation (e.g. `action`, `signature.r`).
+    BodyFieldMsgpack { path: String },
+    /// Big-endian 8-byte encoding of the integer at `path` in the
+    /// request body.
+    BodyFieldBeU64 { path: String },
+    /// EVM address marker bytes: emits `0x00` if the field is absent
+    /// or null, otherwise `0x01` followed by the 20-byte address.
+    BodyFieldEthAddressOptionalPrefixed { path: String },
+}
+
+/// Body-mutation output. Sets the JSON value at `json_path` in the
+/// request body to a value drawn from the closed [`BodyValue`]
+/// vocabulary. Path uses dot notation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BodyJsonOutput {
+    pub json_path: String,
+    pub value: BodyValue,
+}
+
+/// Closed vocabulary of values that may be written into the request
+/// body by a signer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum BodyValue {
+    SignerAddress,
+    SignerPublicKey,
+    SignatureHex,
+    SignatureBase64,
+    SignatureRHex,
+    SignatureSHex,
+    SignatureV,
+    RequestTimestampSecs,
+    RequestRandomNonceB64,
+    LiteralString { value: String },
+    LiteralNumber { value: i64 },
+}
+
+/// Header that the signer emits, with the value source.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct HeaderOutput {
+    pub header_name: String,
+    pub value: OutputSource,
+}
+
+/// Closed vocabulary of values an output header may take.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum OutputSource {
+    Literal { value: String },
+    SignerAddress,
+    SignerPublicKey,
+    RequestTimestampSecs,
+    RequestRandomNonceB64,
+    SignatureHex,
+    SignatureBase64,
 }
 
 /// Mapping from a secret name to where it should be injected.

--- a/src/secrets/types.rs
+++ b/src/secrets/types.rs
@@ -240,6 +240,13 @@ pub enum CredentialLocation {
         callback_url_source: Option<FieldSource>,
         output_headers: Vec<HeaderOutput>,
     },
+    /// Solana transaction signing with ed25519. Tool supplies the
+    /// unsigned message bytes; runtime emits the wire-formatted
+    /// signed transaction.
+    SolanaSignedTransaction {
+        message_source: FieldSource,
+        output_body_fields: Vec<BodyJsonOutput>,
+    },
 }
 
 /// EIP-712 domain separator parameters.
@@ -292,6 +299,11 @@ pub enum FieldSource {
     Bytes32Keccak256OfBytes {
         parts: Vec<BytesPart>,
     },
+    /// Reads the JSON value at `path` in the request body and emits
+    /// it as a string. Strictly narrower than `RequestBody`.
+    BodyFieldString {
+        path: String,
+    },
 }
 
 /// Closed vocabulary of byte fragments that can be concatenated and
@@ -340,6 +352,9 @@ pub enum BodyValue {
     RequestRandomNonceB64,
     LiteralString { value: String },
     LiteralNumber { value: i64 },
+    /// Base64 of `[0x01][64-byte sig][message bytes]`. Only valid
+    /// inside `SolanaSignedTransaction` output_body_fields.
+    SolanaSignedTransactionBase64,
 }
 
 /// Header that the signer emits, with the value source.

--- a/src/secrets/types.rs
+++ b/src/secrets/types.rs
@@ -249,6 +249,142 @@ pub enum CredentialLocation {
     },
 }
 
+impl CredentialLocation {
+    pub fn is_signing(&self) -> bool {
+        matches!(
+            self,
+            Self::HmacSignedHeader { .. }
+                | Self::Eip712SignedHeader { .. }
+                | Self::Nep413SignedHeader { .. }
+                | Self::SolanaSignedTransaction { .. }
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialKind {
+    #[default]
+    NetworkAuth,
+    Signing,
+}
+
+impl CredentialKind {
+    pub fn for_location(location: &CredentialLocation) -> Self {
+        if location.is_signing() {
+            Self::Signing
+        } else {
+            Self::NetworkAuth
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignerClassification {
+    Low,
+    Medium,
+    High,
+}
+
+pub fn classify_signing_location(location: &CredentialLocation) -> SignerClassification {
+    match location {
+        CredentialLocation::SolanaSignedTransaction { .. } => SignerClassification::High,
+        CredentialLocation::Eip712SignedHeader {
+            primary_type,
+            structs,
+            ..
+        } => classify_eip712(primary_type, structs),
+        CredentialLocation::Nep413SignedHeader { .. } => SignerClassification::Low,
+        CredentialLocation::HmacSignedHeader { .. } => SignerClassification::Low,
+        _ => SignerClassification::Low,
+    }
+}
+
+fn classify_eip712(primary_type: &str, structs: &[Eip712StructDef]) -> SignerClassification {
+    let pt_lower = primary_type.to_ascii_lowercase();
+    let high_value_primary = ["permit", "approval", "transfer", "order", "withdraw"]
+        .iter()
+        .any(|kw| pt_lower.contains(kw));
+    if high_value_primary {
+        return SignerClassification::High;
+    }
+
+    let target = structs
+        .iter()
+        .find(|s| s.name == primary_type)
+        .or_else(|| structs.first());
+    let Some(target) = target else {
+        return SignerClassification::Low;
+    };
+
+    let mut has_address = false;
+    let mut has_value_or_amount = false;
+    for field in &target.fields {
+        let ty = field.type_name.to_ascii_lowercase();
+        let fname = field.name.to_ascii_lowercase();
+        if ty == "address" || ty.starts_with("address[") {
+            has_address = true;
+        }
+        if matches!(
+            fname.as_str(),
+            "value" | "amount" | "tokenid" | "token_id" | "deadline"
+        ) {
+            has_value_or_amount = true;
+        }
+        if fname == "spender" || fname == "operator" {
+            has_address = true;
+        }
+    }
+
+    if has_address && has_value_or_amount {
+        SignerClassification::High
+    } else if has_address {
+        SignerClassification::Medium
+    } else {
+        SignerClassification::Low
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ApprovalRequest {
+    pub tool_name: String,
+    pub host: String,
+    pub path: String,
+    pub secret_name: String,
+    pub classification: SignerClassification,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Approval {
+    Approved,
+    Denied,
+}
+
+#[async_trait::async_trait]
+pub trait SignerApprovalGate: Send + Sync {
+    async fn request_approval(&self, request: &ApprovalRequest) -> Approval;
+}
+
+pub struct AllowAllSignerGate;
+
+#[async_trait::async_trait]
+impl SignerApprovalGate for AllowAllSignerGate {
+    async fn request_approval(&self, _request: &ApprovalRequest) -> Approval {
+        Approval::Approved
+    }
+}
+
+pub struct RejectAllSignerGate;
+
+#[async_trait::async_trait]
+impl SignerApprovalGate for RejectAllSignerGate {
+    async fn request_approval(&self, _request: &ApprovalRequest) -> Approval {
+        Approval::Denied
+    }
+}
+
 /// EIP-712 domain separator parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Eip712Domain {
@@ -350,8 +486,12 @@ pub enum BodyValue {
     SignatureV,
     RequestTimestampSecs,
     RequestRandomNonceB64,
-    LiteralString { value: String },
-    LiteralNumber { value: i64 },
+    LiteralString {
+        value: String,
+    },
+    LiteralNumber {
+        value: i64,
+    },
     /// Base64 of `[0x01][64-byte sig][message bytes]`. Only valid
     /// inside `SolanaSignedTransaction` output_body_fields.
     SolanaSignedTransactionBase64,
@@ -398,6 +538,12 @@ pub struct CredentialMapping {
     /// silently downgraded to an unauthenticated request.
     #[serde(default)]
     pub optional: bool,
+}
+
+impl CredentialMapping {
+    pub fn kind(&self) -> CredentialKind {
+        CredentialKind::for_location(&self.location)
+    }
 }
 
 impl CredentialMapping {
@@ -605,7 +751,252 @@ pub(crate) fn host_matches_pattern(host: &str, pattern: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::secrets::types::{CreateSecretParams, DecryptedSecret, SecretRef};
+    use crate::secrets::types::{
+        CreateSecretParams, CredentialKind, CredentialLocation, DecryptedSecret, FieldSource,
+        SecretRef,
+    };
+
+    #[test]
+    fn credential_location_is_signing_classifies_variants() {
+        assert!(!CredentialLocation::AuthorizationBearer.is_signing());
+        assert!(
+            !CredentialLocation::Header {
+                name: "X-Api-Key".to_string(),
+                prefix: None,
+            }
+            .is_signing()
+        );
+        assert!(
+            CredentialLocation::HmacSignedHeader {
+                signature_header: "X-Sig".to_string(),
+                timestamp_header: "X-Ts".to_string(),
+            }
+            .is_signing()
+        );
+        assert!(
+            CredentialLocation::Nep413SignedHeader {
+                recipient_source: FieldSource::Literal {
+                    value: "iron.near".to_string()
+                },
+                message_source: FieldSource::RequestBody,
+                callback_url_source: None,
+                output_headers: vec![],
+            }
+            .is_signing()
+        );
+        assert!(
+            CredentialLocation::SolanaSignedTransaction {
+                message_source: FieldSource::RequestBody,
+                output_body_fields: vec![],
+            }
+            .is_signing()
+        );
+    }
+
+    #[test]
+    fn classify_solana_as_high() {
+        use crate::secrets::types::{SignerClassification, classify_signing_location};
+        let loc = CredentialLocation::SolanaSignedTransaction {
+            message_source: FieldSource::RequestBody,
+            output_body_fields: vec![],
+        };
+        assert_eq!(classify_signing_location(&loc), SignerClassification::High);
+    }
+
+    #[test]
+    fn classify_hmac_and_nep413_as_low() {
+        use crate::secrets::types::{SignerClassification, classify_signing_location};
+        let hmac = CredentialLocation::HmacSignedHeader {
+            signature_header: "X-Sig".to_string(),
+            timestamp_header: "X-Ts".to_string(),
+        };
+        assert_eq!(classify_signing_location(&hmac), SignerClassification::Low);
+
+        let nep413 = CredentialLocation::Nep413SignedHeader {
+            recipient_source: FieldSource::Literal {
+                value: "iron.near".to_string(),
+            },
+            message_source: FieldSource::RequestBody,
+            callback_url_source: None,
+            output_headers: vec![],
+        };
+        assert_eq!(
+            classify_signing_location(&nep413),
+            SignerClassification::Low
+        );
+    }
+
+    #[test]
+    fn classify_eip712_permit_as_high() {
+        use crate::secrets::types::{
+            Eip712Domain, Eip712StructDef, Eip712TypedField, SignerClassification,
+            classify_signing_location,
+        };
+        let loc = CredentialLocation::Eip712SignedHeader {
+            domain: Eip712Domain {
+                name: "USDC".to_string(),
+                version: "2".to_string(),
+                chain_id: 1,
+                verifying_contract: None,
+            },
+            primary_type: "Permit".to_string(),
+            structs: vec![Eip712StructDef {
+                name: "Permit".to_string(),
+                fields: vec![Eip712TypedField {
+                    name: "owner".to_string(),
+                    type_name: "address".to_string(),
+                    source: FieldSource::SignerAddress,
+                }],
+            }],
+            output_headers: vec![],
+            output_body_fields: vec![],
+        };
+        assert_eq!(classify_signing_location(&loc), SignerClassification::High);
+    }
+
+    #[test]
+    fn classify_eip712_value_and_address_as_high() {
+        use crate::secrets::types::{
+            Eip712Domain, Eip712StructDef, Eip712TypedField, SignerClassification,
+            classify_signing_location,
+        };
+        let loc = CredentialLocation::Eip712SignedHeader {
+            domain: Eip712Domain {
+                name: "X".to_string(),
+                version: "1".to_string(),
+                chain_id: 1,
+                verifying_contract: None,
+            },
+            primary_type: "Auth".to_string(),
+            structs: vec![Eip712StructDef {
+                name: "Auth".to_string(),
+                fields: vec![
+                    Eip712TypedField {
+                        name: "to".to_string(),
+                        type_name: "address".to_string(),
+                        source: FieldSource::SignerAddress,
+                    },
+                    Eip712TypedField {
+                        name: "amount".to_string(),
+                        type_name: "uint256".to_string(),
+                        source: FieldSource::RequestBody,
+                    },
+                ],
+            }],
+            output_headers: vec![],
+            output_body_fields: vec![],
+        };
+        assert_eq!(classify_signing_location(&loc), SignerClassification::High);
+    }
+
+    #[test]
+    fn classify_eip712_address_only_as_medium() {
+        use crate::secrets::types::{
+            Eip712Domain, Eip712StructDef, Eip712TypedField, SignerClassification,
+            classify_signing_location,
+        };
+        let loc = CredentialLocation::Eip712SignedHeader {
+            domain: Eip712Domain {
+                name: "ClobAuthDomain".to_string(),
+                version: "1".to_string(),
+                chain_id: 137,
+                verifying_contract: None,
+            },
+            primary_type: "ClobAuth".to_string(),
+            structs: vec![Eip712StructDef {
+                name: "ClobAuth".to_string(),
+                fields: vec![Eip712TypedField {
+                    name: "address".to_string(),
+                    type_name: "address".to_string(),
+                    source: FieldSource::SignerAddress,
+                }],
+            }],
+            output_headers: vec![],
+            output_body_fields: vec![],
+        };
+        assert_eq!(
+            classify_signing_location(&loc),
+            SignerClassification::Medium
+        );
+    }
+
+    #[test]
+    fn classify_eip712_no_value_no_address_as_low() {
+        use crate::secrets::types::{
+            Eip712Domain, Eip712StructDef, Eip712TypedField, SignerClassification,
+            classify_signing_location,
+        };
+        let loc = CredentialLocation::Eip712SignedHeader {
+            domain: Eip712Domain {
+                name: "Login".to_string(),
+                version: "1".to_string(),
+                chain_id: 1,
+                verifying_contract: None,
+            },
+            primary_type: "Auth".to_string(),
+            structs: vec![Eip712StructDef {
+                name: "Auth".to_string(),
+                fields: vec![Eip712TypedField {
+                    name: "nonce".to_string(),
+                    type_name: "string".to_string(),
+                    source: FieldSource::RequestRandomNonceB64,
+                }],
+            }],
+            output_headers: vec![],
+            output_body_fields: vec![],
+        };
+        assert_eq!(classify_signing_location(&loc), SignerClassification::Low);
+    }
+
+    #[tokio::test]
+    async fn allow_all_gate_returns_approved() {
+        use crate::secrets::types::{
+            AllowAllSignerGate, Approval, ApprovalRequest, SignerApprovalGate, SignerClassification,
+        };
+        let gate = AllowAllSignerGate;
+        let req = ApprovalRequest {
+            tool_name: "x".to_string(),
+            host: "x".to_string(),
+            path: "/".to_string(),
+            secret_name: "s".to_string(),
+            classification: SignerClassification::High,
+            summary: "test".to_string(),
+        };
+        assert_eq!(gate.request_approval(&req).await, Approval::Approved);
+    }
+
+    #[tokio::test]
+    async fn reject_all_gate_returns_denied() {
+        use crate::secrets::types::{
+            Approval, ApprovalRequest, RejectAllSignerGate, SignerApprovalGate,
+            SignerClassification,
+        };
+        let gate = RejectAllSignerGate;
+        let req = ApprovalRequest {
+            tool_name: "x".to_string(),
+            host: "x".to_string(),
+            path: "/".to_string(),
+            secret_name: "s".to_string(),
+            classification: SignerClassification::High,
+            summary: "test".to_string(),
+        };
+        assert_eq!(gate.request_approval(&req).await, Approval::Denied);
+    }
+
+    #[test]
+    fn credential_kind_for_location_picks_signing_for_signing_locations() {
+        assert_eq!(
+            CredentialKind::for_location(&CredentialLocation::AuthorizationBearer),
+            CredentialKind::NetworkAuth
+        );
+        assert_eq!(
+            CredentialKind::for_location(&CredentialLocation::HmacSignedHeader {
+                signature_header: "X-Sig".to_string(),
+                timestamp_header: "X-Ts".to_string(),
+            }),
+            CredentialKind::Signing
+        );
+    }
 
     #[test]
     fn test_secret_ref_creation() {

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -138,6 +138,9 @@ pub struct ToolRegistry {
     rate_limiter: RateLimiter,
     /// Optional HTTP interceptor propagated into registered WASM wrappers.
     http_interceptor: Option<Arc<dyn HttpInterceptor>>,
+    /// Optional approval gate for high-classification signers, propagated
+    /// into registered WASM wrappers so every signature path is gated.
+    signer_gate: Option<Arc<dyn crate::secrets::SignerApprovalGate>>,
     /// Reference to the message tool for setting context per-turn.
     message_tool: RwLock<Option<Arc<crate::tools::builtin::MessageTool>>>,
     /// Active engine version. Controls which tools are visible via
@@ -170,6 +173,7 @@ impl ToolRegistry {
             db: None,
             rate_limiter: RateLimiter::new(),
             http_interceptor: None,
+            signer_gate: None,
             message_tool: RwLock::new(None),
             engine_version: EngineVersion::V1,
         }
@@ -201,6 +205,11 @@ impl ToolRegistry {
 
     pub fn with_http_interceptor(mut self, interceptor: Arc<dyn HttpInterceptor>) -> Self {
         self.http_interceptor = Some(interceptor);
+        self
+    }
+
+    pub fn with_signer_gate(mut self, gate: Arc<dyn crate::secrets::SignerApprovalGate>) -> Self {
+        self.signer_gate = Some(gate);
         self
     }
 
@@ -986,6 +995,9 @@ impl ToolRegistry {
         }
         if let Some(interceptor) = &self.http_interceptor {
             wrapper = wrapper.with_http_interceptor(Arc::clone(interceptor));
+        }
+        if let Some(gate) = &self.signer_gate {
+            wrapper = wrapper.with_signer_gate(Arc::clone(gate));
         }
 
         // Register the tool

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -32,7 +32,10 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::secrets::{CredentialLocation, CredentialMapping};
+use crate::secrets::{
+    BodyJsonOutput, CredentialLocation, CredentialMapping, Eip712Domain, Eip712StructDef,
+    FieldSource, HeaderOutput,
+};
 use crate::tools::tool::ToolDiscoverySummary;
 use crate::tools::wasm::{
     Capabilities, EndpointPattern, HttpCapability, RateLimitConfig, SecretsCapability,
@@ -447,6 +450,31 @@ pub enum CredentialLocationSchema {
 
     /// URL/path placeholder replacement.
     UrlPath { placeholder: String },
+
+    /// HMAC-SHA256 of the request, emitted as two headers.
+    HmacSignedHeader {
+        signature_header: String,
+        timestamp_header: String,
+    },
+
+    /// EIP-712 typed structured data signing with secp256k1.
+    Eip712SignedHeader {
+        domain: Eip712Domain,
+        primary_type: String,
+        structs: Vec<Eip712StructDef>,
+        output_headers: Vec<HeaderOutput>,
+        #[serde(default)]
+        output_body_fields: Vec<BodyJsonOutput>,
+    },
+
+    /// NEP-413 NEAR signed message with ed25519.
+    Nep413SignedHeader {
+        recipient_source: FieldSource,
+        message_source: FieldSource,
+        #[serde(default)]
+        callback_url_source: Option<FieldSource>,
+        output_headers: Vec<HeaderOutput>,
+    },
 }
 
 impl CredentialLocationSchema {
@@ -467,6 +495,37 @@ impl CredentialLocationSchema {
             }
             CredentialLocationSchema::UrlPath { placeholder } => CredentialLocation::UrlPath {
                 placeholder: placeholder.clone(),
+            },
+            CredentialLocationSchema::HmacSignedHeader {
+                signature_header,
+                timestamp_header,
+            } => CredentialLocation::HmacSignedHeader {
+                signature_header: signature_header.clone(),
+                timestamp_header: timestamp_header.clone(),
+            },
+            CredentialLocationSchema::Eip712SignedHeader {
+                domain,
+                primary_type,
+                structs,
+                output_headers,
+                output_body_fields,
+            } => CredentialLocation::Eip712SignedHeader {
+                domain: domain.clone(),
+                primary_type: primary_type.clone(),
+                structs: structs.clone(),
+                output_headers: output_headers.clone(),
+                output_body_fields: output_body_fields.clone(),
+            },
+            CredentialLocationSchema::Nep413SignedHeader {
+                recipient_source,
+                message_source,
+                callback_url_source,
+                output_headers,
+            } => CredentialLocation::Nep413SignedHeader {
+                recipient_source: recipient_source.clone(),
+                message_source: message_source.clone(),
+                callback_url_source: callback_url_source.clone(),
+                output_headers: output_headers.clone(),
             },
         }
     }
@@ -914,6 +973,283 @@ mod tests {
                 assert_eq!(placeholder, "{TELEGRAM_BOT_TOKEN}");
             }
             _ => panic!("Expected UrlPath location"),
+        }
+    }
+
+    #[test]
+    fn test_parse_hmac_signed_header_credential() {
+        use crate::secrets::CredentialLocation;
+
+        let json = r#"{
+            "http": {
+                "allowlist": [{ "host": "clob.polymarket.com" }],
+                "credentials": {
+                    "polymarket_l2": {
+                        "secret_name": "polymarket_api_secret",
+                        "location": {
+                            "type": "hmac_signed_header",
+                            "signature_header": "POLY-SIGNATURE",
+                            "timestamp_header": "POLY-TIMESTAMP"
+                        },
+                        "host_patterns": ["clob.polymarket.com"]
+                    }
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let http = caps.http.unwrap();
+        let cred = http.credentials.get("polymarket_l2").unwrap();
+        match &cred.location {
+            CredentialLocationSchema::HmacSignedHeader {
+                signature_header,
+                timestamp_header,
+            } => {
+                assert_eq!(signature_header, "POLY-SIGNATURE");
+                assert_eq!(timestamp_header, "POLY-TIMESTAMP");
+            }
+            _ => panic!("Expected HmacSignedHeader location"),
+        }
+
+        let runtime = http.to_http_capability();
+        let mapping = runtime.credentials.get("polymarket_api_secret").unwrap();
+        match &mapping.location {
+            CredentialLocation::HmacSignedHeader {
+                signature_header,
+                timestamp_header,
+            } => {
+                assert_eq!(signature_header, "POLY-SIGNATURE");
+                assert_eq!(timestamp_header, "POLY-TIMESTAMP");
+            }
+            _ => panic!("Expected HmacSignedHeader after schema -> runtime conversion"),
+        }
+    }
+
+    #[test]
+    fn test_parse_eip712_signed_header_credential() {
+        use crate::secrets::{CredentialLocation, FieldSource, OutputSource};
+
+        let json = r#"{
+            "http": {
+                "allowlist": [{ "host": "clob.polymarket.com" }],
+                "credentials": {
+                    "polymarket_l1": {
+                        "secret_name": "polymarket_eth_key",
+                        "location": {
+                            "type": "eip712_signed_header",
+                            "domain": {
+                                "name": "ClobAuthDomain",
+                                "version": "1",
+                                "chain_id": 137
+                            },
+                            "primary_type": "ClobAuth",
+                            "structs": [
+                                {
+                                    "name": "ClobAuth",
+                                    "fields": [
+                                        { "name": "address", "type": "address",
+                                          "source": { "source": "signer_address" } },
+                                        { "name": "timestamp", "type": "string",
+                                          "source": { "source": "request_timestamp_secs" } },
+                                        { "name": "nonce", "type": "uint256",
+                                          "source": { "source": "literal", "value": "0" } },
+                                        { "name": "message", "type": "string",
+                                          "source": { "source": "literal",
+                                                      "value": "This message attests that I control the given wallet" } }
+                                    ]
+                                }
+                            ],
+                            "output_headers": [
+                                { "header_name": "POLY_ADDRESS",
+                                  "value": { "source": "signer_address" } },
+                                { "header_name": "POLY_SIGNATURE",
+                                  "value": { "source": "signature_hex" } },
+                                { "header_name": "POLY_TIMESTAMP",
+                                  "value": { "source": "request_timestamp_secs" } },
+                                { "header_name": "POLY_NONCE",
+                                  "value": { "source": "literal", "value": "0" } }
+                            ]
+                        },
+                        "host_patterns": ["clob.polymarket.com"]
+                    }
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let runtime = caps.http.unwrap().to_http_capability();
+        let mapping = runtime.credentials.get("polymarket_eth_key").unwrap();
+        match &mapping.location {
+            CredentialLocation::Eip712SignedHeader {
+                domain,
+                primary_type,
+                structs,
+                output_headers,
+                output_body_fields: _,
+            } => {
+                assert_eq!(domain.name, "ClobAuthDomain");
+                assert_eq!(domain.version, "1");
+                assert_eq!(domain.chain_id, 137);
+                assert_eq!(primary_type, "ClobAuth");
+                assert_eq!(structs.len(), 1);
+                assert_eq!(structs[0].fields.len(), 4);
+                assert_eq!(structs[0].fields[0].type_name, "address");
+                assert!(matches!(structs[0].fields[0].source, FieldSource::SignerAddress));
+                assert_eq!(output_headers.len(), 4);
+                assert_eq!(output_headers[1].header_name, "POLY_SIGNATURE");
+                assert!(matches!(output_headers[1].value, OutputSource::SignatureHex));
+            }
+            _ => panic!("Expected Eip712SignedHeader"),
+        }
+    }
+
+    #[test]
+    fn test_parse_eip712_signed_header_with_body_outputs() {
+        use crate::secrets::{BodyValue, BytesPart, CredentialLocation, FieldSource};
+
+        let json = r#"{
+            "http": {
+                "allowlist": [{ "host": "api.hyperliquid.xyz" }],
+                "credentials": {
+                    "hyperliquid_l1": {
+                        "secret_name": "hyperliquid_eth_key",
+                        "location": {
+                            "type": "eip712_signed_header",
+                            "domain": {
+                                "name": "Exchange",
+                                "version": "1",
+                                "chain_id": 1337,
+                                "verifying_contract": "0x0000000000000000000000000000000000000000"
+                            },
+                            "primary_type": "Agent",
+                            "structs": [
+                                {
+                                    "name": "Agent",
+                                    "fields": [
+                                        { "name": "source", "type": "string",
+                                          "source": { "source": "literal", "value": "a" } },
+                                        { "name": "connectionId", "type": "bytes32",
+                                          "source": {
+                                              "source": "bytes32_keccak256_of_bytes",
+                                              "parts": [
+                                                  { "kind": "body_field_msgpack", "path": "action" },
+                                                  { "kind": "body_field_be_u64", "path": "nonce" },
+                                                  { "kind": "body_field_eth_address_optional_prefixed",
+                                                    "path": "vaultAddress" }
+                                              ]
+                                          } }
+                                    ]
+                                }
+                            ],
+                            "output_headers": [],
+                            "output_body_fields": [
+                                { "json_path": "signature.r", "value": { "source": "signature_r_hex" } },
+                                { "json_path": "signature.s", "value": { "source": "signature_s_hex" } },
+                                { "json_path": "signature.v", "value": { "source": "signature_v" } }
+                            ]
+                        },
+                        "host_patterns": ["api.hyperliquid.xyz"]
+                    }
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let runtime = caps.http.unwrap().to_http_capability();
+        let mapping = runtime.credentials.get("hyperliquid_eth_key").unwrap();
+        match &mapping.location {
+            CredentialLocation::Eip712SignedHeader {
+                domain,
+                primary_type,
+                structs,
+                output_headers,
+                output_body_fields,
+            } => {
+                assert_eq!(domain.name, "Exchange");
+                assert_eq!(domain.chain_id, 1337);
+                assert_eq!(domain.verifying_contract.as_deref(), Some("0x0000000000000000000000000000000000000000"));
+                assert_eq!(primary_type, "Agent");
+                assert_eq!(structs.len(), 1);
+                assert_eq!(structs[0].fields.len(), 2);
+                let connection_field = &structs[0].fields[1];
+                assert_eq!(connection_field.type_name, "bytes32");
+                match &connection_field.source {
+                    FieldSource::Bytes32Keccak256OfBytes { parts } => {
+                        assert_eq!(parts.len(), 3);
+                        assert!(matches!(parts[0], BytesPart::BodyFieldMsgpack { .. }));
+                        assert!(matches!(parts[1], BytesPart::BodyFieldBeU64 { .. }));
+                        assert!(matches!(
+                            parts[2],
+                            BytesPart::BodyFieldEthAddressOptionalPrefixed { .. }
+                        ));
+                    }
+                    _ => panic!("expected Bytes32Keccak256OfBytes"),
+                }
+                assert!(output_headers.is_empty());
+                assert_eq!(output_body_fields.len(), 3);
+                assert_eq!(output_body_fields[0].json_path, "signature.r");
+                assert!(matches!(output_body_fields[0].value, BodyValue::SignatureRHex));
+                assert!(matches!(output_body_fields[1].value, BodyValue::SignatureSHex));
+                assert!(matches!(output_body_fields[2].value, BodyValue::SignatureV));
+            }
+            _ => panic!("Expected Eip712SignedHeader"),
+        }
+    }
+
+    #[test]
+    fn test_parse_nep413_signed_header_credential() {
+        use crate::secrets::{CredentialLocation, FieldSource, OutputSource};
+
+        let json = r#"{
+            "http": {
+                "allowlist": [{ "host": "api.trezu.example" }],
+                "credentials": {
+                    "trezu": {
+                        "secret_name": "near_account_key",
+                        "location": {
+                            "type": "nep413_signed_header",
+                            "recipient_source": { "source": "literal", "value": "trezu.near" },
+                            "message_source": { "source": "literal", "value": "auth-challenge" },
+                            "output_headers": [
+                                { "header_name": "X-NEAR-PUBLIC-KEY",
+                                  "value": { "source": "signer_public_key" } },
+                                { "header_name": "X-NEAR-SIGNATURE",
+                                  "value": { "source": "signature_base64" } },
+                                { "header_name": "X-NEAR-NONCE",
+                                  "value": { "source": "request_random_nonce_b64" } }
+                            ]
+                        },
+                        "host_patterns": ["api.trezu.example"]
+                    }
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let runtime = caps.http.unwrap().to_http_capability();
+        let mapping = runtime.credentials.get("near_account_key").unwrap();
+        match &mapping.location {
+            CredentialLocation::Nep413SignedHeader {
+                recipient_source,
+                message_source,
+                callback_url_source,
+                output_headers,
+            } => {
+                match recipient_source {
+                    FieldSource::Literal { value } => assert_eq!(value, "trezu.near"),
+                    _ => panic!("recipient_source must be literal"),
+                }
+                match message_source {
+                    FieldSource::Literal { value } => assert_eq!(value, "auth-challenge"),
+                    _ => panic!("message_source must be literal"),
+                }
+                assert!(callback_url_source.is_none());
+                assert_eq!(output_headers.len(), 3);
+                assert!(matches!(output_headers[0].value, OutputSource::SignerPublicKey));
+                assert!(matches!(output_headers[1].value, OutputSource::SignatureBase64));
+                assert!(matches!(output_headers[2].value, OutputSource::RequestRandomNonceB64));
+            }
+            _ => panic!("Expected Nep413SignedHeader"),
         }
     }
 

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -475,6 +475,12 @@ pub enum CredentialLocationSchema {
         callback_url_source: Option<FieldSource>,
         output_headers: Vec<HeaderOutput>,
     },
+
+    /// Solana transaction signing with ed25519.
+    SolanaSignedTransaction {
+        message_source: FieldSource,
+        output_body_fields: Vec<BodyJsonOutput>,
+    },
 }
 
 impl CredentialLocationSchema {
@@ -526,6 +532,13 @@ impl CredentialLocationSchema {
                 message_source: message_source.clone(),
                 callback_url_source: callback_url_source.clone(),
                 output_headers: output_headers.clone(),
+            },
+            CredentialLocationSchema::SolanaSignedTransaction {
+                message_source,
+                output_body_fields,
+            } => CredentialLocation::SolanaSignedTransaction {
+                message_source: message_source.clone(),
+                output_body_fields: output_body_fields.clone(),
             },
         }
     }

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -67,6 +67,13 @@ pub struct CapabilitiesFile {
     #[serde(default)]
     pub http: Option<HttpCapabilitySchema>,
 
+    /// Signing capability. Schemes here are gated by a separate user grant
+    /// from `http.credentials`; signing locations smuggled under
+    /// `http.credentials` are auto-promoted here at parse time with a
+    /// deprecation warning.
+    #[serde(default)]
+    pub signing: Option<SigningCapabilitySchema>,
+
     /// Secret existence checks.
     #[serde(default)]
     pub secrets: Option<SecretsCapabilitySchema>,
@@ -114,6 +121,7 @@ impl CapabilitiesFile {
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         let mut caps = serde_json::from_str::<Self>(json).map(Self::resolve_nested)?;
         caps.enforce_limits();
+        caps.promote_legacy_signers();
         Ok(caps)
     }
 
@@ -121,7 +129,36 @@ impl CapabilitiesFile {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
         let mut caps = serde_json::from_slice::<Self>(bytes).map(Self::resolve_nested)?;
         caps.enforce_limits();
+        caps.promote_legacy_signers();
         Ok(caps)
+    }
+
+    fn promote_legacy_signers(&mut self) {
+        let Some(http) = self.http.as_mut() else {
+            return;
+        };
+        let signing_ids: Vec<String> = http
+            .credentials
+            .iter()
+            .filter(|(_, m)| m.location.is_signing())
+            .map(|(k, _)| k.clone())
+            .collect();
+        if signing_ids.is_empty() {
+            return;
+        }
+        let signing = self
+            .signing
+            .get_or_insert_with(SigningCapabilitySchema::default);
+        for id in signing_ids {
+            if let Some(mapping) = http.credentials.remove(&id) {
+                tracing::warn!(
+                    scheme = id,
+                    "signing location under http.credentials is deprecated; \
+                     declare it under signing.schemes instead (auto-promoted)"
+                );
+                signing.schemes.entry(id).or_insert(mapping);
+            }
+        }
     }
 
     /// Truncate oversized fields to prevent unbounded memory usage.
@@ -212,6 +249,10 @@ impl CapabilitiesFile {
         // whole mapping on any invalid pattern, with a warning). Nothing to
         // re-check here.
 
+        if let Some(signing) = &self.signing {
+            signing.validate(name);
+        }
+
         // Manual auth (no OAuth) checks
         if let Some(auth) = &self.auth
             && auth.oauth.is_none()
@@ -239,6 +280,20 @@ impl CapabilitiesFile {
 
         if let Some(http) = &self.http {
             caps.http = Some(http.to_http_capability());
+        }
+
+        if let Some(signing) = &self.signing {
+            let http_cap = caps.http.get_or_insert_with(Default::default);
+            for mapping_schema in signing.schemes.values() {
+                if !mapping_schema.location.is_signing() {
+                    continue;
+                }
+                if let Some(mapping) = mapping_schema.to_credential_mapping() {
+                    http_cap
+                        .credentials
+                        .insert(mapping_schema.secret_name.clone(), mapping);
+                }
+            }
         }
 
         if let Some(secrets) = &self.secrets {
@@ -272,6 +327,26 @@ impl CapabilitiesFile {
         caps.websocket = self.websocket.clone();
 
         caps
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SigningCapabilitySchema {
+    #[serde(default)]
+    pub schemes: HashMap<String, CredentialMappingSchema>,
+}
+
+impl SigningCapabilitySchema {
+    fn validate(&self, name: &str) {
+        for (scheme_id, mapping) in &self.schemes {
+            if !mapping.location.is_signing() {
+                tracing::warn!(
+                    tool = name,
+                    scheme = scheme_id,
+                    "signing.schemes entry holds a non-signing location; ignored at runtime"
+                );
+            }
+        }
     }
 }
 
@@ -484,6 +559,16 @@ pub enum CredentialLocationSchema {
 }
 
 impl CredentialLocationSchema {
+    pub fn is_signing(&self) -> bool {
+        matches!(
+            self,
+            Self::HmacSignedHeader { .. }
+                | Self::Eip712SignedHeader { .. }
+                | Self::Nep413SignedHeader { .. }
+                | Self::SolanaSignedTransaction { .. }
+        )
+    }
+
     fn to_credential_location(&self) -> CredentialLocation {
         match self {
             CredentialLocationSchema::Bearer => CredentialLocation::AuthorizationBearer,
@@ -1011,8 +1096,11 @@ mod tests {
         }"#;
 
         let caps = CapabilitiesFile::from_json(json).unwrap();
-        let http = caps.http.unwrap();
-        let cred = http.credentials.get("polymarket_l2").unwrap();
+        let signing = caps
+            .signing
+            .as_ref()
+            .expect("hmac promoted into signing.schemes");
+        let cred = signing.schemes.get("polymarket_l2").unwrap();
         match &cred.location {
             CredentialLocationSchema::HmacSignedHeader {
                 signature_header,
@@ -1024,8 +1112,14 @@ mod tests {
             _ => panic!("Expected HmacSignedHeader location"),
         }
 
-        let runtime = http.to_http_capability();
-        let mapping = runtime.credentials.get("polymarket_api_secret").unwrap();
+        let runtime = caps.to_capabilities();
+        let mapping = runtime
+            .http
+            .as_ref()
+            .unwrap()
+            .credentials
+            .get("polymarket_api_secret")
+            .unwrap();
         match &mapping.location {
             CredentialLocation::HmacSignedHeader {
                 signature_header,
@@ -1090,8 +1184,14 @@ mod tests {
         }"#;
 
         let caps = CapabilitiesFile::from_json(json).unwrap();
-        let runtime = caps.http.unwrap().to_http_capability();
-        let mapping = runtime.credentials.get("polymarket_eth_key").unwrap();
+        let runtime = caps.to_capabilities();
+        let mapping = runtime
+            .http
+            .as_ref()
+            .unwrap()
+            .credentials
+            .get("polymarket_eth_key")
+            .unwrap();
         match &mapping.location {
             CredentialLocation::Eip712SignedHeader {
                 domain,
@@ -1107,10 +1207,16 @@ mod tests {
                 assert_eq!(structs.len(), 1);
                 assert_eq!(structs[0].fields.len(), 4);
                 assert_eq!(structs[0].fields[0].type_name, "address");
-                assert!(matches!(structs[0].fields[0].source, FieldSource::SignerAddress));
+                assert!(matches!(
+                    structs[0].fields[0].source,
+                    FieldSource::SignerAddress
+                ));
                 assert_eq!(output_headers.len(), 4);
                 assert_eq!(output_headers[1].header_name, "POLY_SIGNATURE");
-                assert!(matches!(output_headers[1].value, OutputSource::SignatureHex));
+                assert!(matches!(
+                    output_headers[1].value,
+                    OutputSource::SignatureHex
+                ));
             }
             _ => panic!("Expected Eip712SignedHeader"),
         }
@@ -1168,8 +1274,14 @@ mod tests {
         }"#;
 
         let caps = CapabilitiesFile::from_json(json).unwrap();
-        let runtime = caps.http.unwrap().to_http_capability();
-        let mapping = runtime.credentials.get("hyperliquid_eth_key").unwrap();
+        let runtime = caps.to_capabilities();
+        let mapping = runtime
+            .http
+            .as_ref()
+            .unwrap()
+            .credentials
+            .get("hyperliquid_eth_key")
+            .unwrap();
         match &mapping.location {
             CredentialLocation::Eip712SignedHeader {
                 domain,
@@ -1180,7 +1292,10 @@ mod tests {
             } => {
                 assert_eq!(domain.name, "Exchange");
                 assert_eq!(domain.chain_id, 1337);
-                assert_eq!(domain.verifying_contract.as_deref(), Some("0x0000000000000000000000000000000000000000"));
+                assert_eq!(
+                    domain.verifying_contract.as_deref(),
+                    Some("0x0000000000000000000000000000000000000000")
+                );
                 assert_eq!(primary_type, "Agent");
                 assert_eq!(structs.len(), 1);
                 assert_eq!(structs[0].fields.len(), 2);
@@ -1201,8 +1316,14 @@ mod tests {
                 assert!(output_headers.is_empty());
                 assert_eq!(output_body_fields.len(), 3);
                 assert_eq!(output_body_fields[0].json_path, "signature.r");
-                assert!(matches!(output_body_fields[0].value, BodyValue::SignatureRHex));
-                assert!(matches!(output_body_fields[1].value, BodyValue::SignatureSHex));
+                assert!(matches!(
+                    output_body_fields[0].value,
+                    BodyValue::SignatureRHex
+                ));
+                assert!(matches!(
+                    output_body_fields[1].value,
+                    BodyValue::SignatureSHex
+                ));
                 assert!(matches!(output_body_fields[2].value, BodyValue::SignatureV));
             }
             _ => panic!("Expected Eip712SignedHeader"),
@@ -1239,8 +1360,14 @@ mod tests {
         }"#;
 
         let caps = CapabilitiesFile::from_json(json).unwrap();
-        let runtime = caps.http.unwrap().to_http_capability();
-        let mapping = runtime.credentials.get("near_account_key").unwrap();
+        let runtime = caps.to_capabilities();
+        let mapping = runtime
+            .http
+            .as_ref()
+            .unwrap()
+            .credentials
+            .get("near_account_key")
+            .unwrap();
         match &mapping.location {
             CredentialLocation::Nep413SignedHeader {
                 recipient_source,
@@ -1258,9 +1385,18 @@ mod tests {
                 }
                 assert!(callback_url_source.is_none());
                 assert_eq!(output_headers.len(), 3);
-                assert!(matches!(output_headers[0].value, OutputSource::SignerPublicKey));
-                assert!(matches!(output_headers[1].value, OutputSource::SignatureBase64));
-                assert!(matches!(output_headers[2].value, OutputSource::RequestRandomNonceB64));
+                assert!(matches!(
+                    output_headers[0].value,
+                    OutputSource::SignerPublicKey
+                ));
+                assert!(matches!(
+                    output_headers[1].value,
+                    OutputSource::SignatureBase64
+                ));
+                assert!(matches!(
+                    output_headers[2].value,
+                    OutputSource::RequestRandomNonceB64
+                ));
             }
             _ => panic!("Expected Nep413SignedHeader"),
         }
@@ -2044,6 +2180,197 @@ mod tests {
             runtime.credentials["ok"].path_patterns,
             vec!["/api/v1".to_string()]
         );
+    }
+
+    #[test]
+    fn credential_location_schema_is_signing_classifies_variants() {
+        use crate::secrets::Eip712Domain;
+        assert!(!CredentialLocationSchema::Bearer.is_signing());
+        assert!(
+            !CredentialLocationSchema::Header {
+                name: "X-Api-Key".to_string(),
+                prefix: None
+            }
+            .is_signing()
+        );
+        assert!(
+            !CredentialLocationSchema::QueryParam {
+                name: "api_key".to_string()
+            }
+            .is_signing()
+        );
+        assert!(
+            CredentialLocationSchema::HmacSignedHeader {
+                signature_header: "X-Sig".to_string(),
+                timestamp_header: "X-Ts".to_string()
+            }
+            .is_signing()
+        );
+        assert!(
+            CredentialLocationSchema::Eip712SignedHeader {
+                domain: Eip712Domain {
+                    name: "Test".to_string(),
+                    version: "1".to_string(),
+                    chain_id: 1,
+                    verifying_contract: None
+                },
+                primary_type: "Auth".to_string(),
+                structs: vec![],
+                output_headers: vec![],
+                output_body_fields: vec![]
+            }
+            .is_signing()
+        );
+    }
+
+    #[test]
+    fn legacy_signing_location_under_http_credentials_promoted_to_signing_schemes() {
+        let json = r#"{
+            "http": {
+                "allowlist": [
+                    { "host": "clob.polymarket.com", "path_prefix": "/auth" }
+                ],
+                "credentials": {
+                    "polymarket_eip712": {
+                        "secret_name": "polymarket_l1_pk",
+                        "location": {
+                            "type": "eip712_signed_header",
+                            "domain": {
+                                "name": "ClobAuthDomain",
+                                "version": "1",
+                                "chain_id": 137
+                            },
+                            "primary_type": "ClobAuth",
+                            "structs": [],
+                            "output_headers": []
+                        },
+                        "host_patterns": ["clob.polymarket.com"]
+                    },
+                    "api_key": {
+                        "secret_name": "polymarket_l2_key",
+                        "location": { "type": "header", "name": "POLY-API-KEY" },
+                        "host_patterns": ["clob.polymarket.com"]
+                    }
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).expect("parse");
+
+        let http = caps.http.as_ref().expect("http present");
+        assert_eq!(
+            http.credentials.len(),
+            1,
+            "only network-auth left under http"
+        );
+        assert!(http.credentials.contains_key("api_key"));
+        assert!(!http.credentials.contains_key("polymarket_eip712"));
+
+        let signing = caps.signing.as_ref().expect("signing promoted");
+        assert_eq!(signing.schemes.len(), 1);
+        assert!(signing.schemes.contains_key("polymarket_eip712"));
+        assert!(signing.schemes["polymarket_eip712"].location.is_signing());
+    }
+
+    #[test]
+    fn new_signing_schemes_block_parses_and_keeps_http_credentials_separate() {
+        let json = r#"{
+            "http": {
+                "credentials": {
+                    "api_key": {
+                        "secret_name": "polymarket_l2_key",
+                        "location": { "type": "header", "name": "POLY-API-KEY" },
+                        "host_patterns": ["clob.polymarket.com"]
+                    }
+                }
+            },
+            "signing": {
+                "schemes": {
+                    "polymarket_eip712": {
+                        "secret_name": "polymarket_l1_pk",
+                        "location": {
+                            "type": "eip712_signed_header",
+                            "domain": {
+                                "name": "ClobAuthDomain",
+                                "version": "1",
+                                "chain_id": 137
+                            },
+                            "primary_type": "ClobAuth",
+                            "structs": [],
+                            "output_headers": []
+                        },
+                        "host_patterns": ["clob.polymarket.com"]
+                    }
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).expect("parse");
+        assert_eq!(caps.http.as_ref().unwrap().credentials.len(), 1);
+        assert_eq!(caps.signing.as_ref().unwrap().schemes.len(), 1);
+    }
+
+    #[test]
+    fn to_capabilities_merges_signing_schemes_into_runtime_credentials_map() {
+        use crate::secrets::CredentialKind;
+        let json = r#"{
+            "signing": {
+                "schemes": {
+                    "polymarket_eip712": {
+                        "secret_name": "polymarket_l1_pk",
+                        "location": {
+                            "type": "eip712_signed_header",
+                            "domain": {
+                                "name": "ClobAuthDomain",
+                                "version": "1",
+                                "chain_id": 137
+                            },
+                            "primary_type": "ClobAuth",
+                            "structs": [],
+                            "output_headers": []
+                        },
+                        "host_patterns": ["clob.polymarket.com"]
+                    }
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).expect("parse");
+        let runtime = caps.to_capabilities();
+        let http = runtime.http.expect("http present");
+        let mapping = http
+            .credentials
+            .get("polymarket_l1_pk")
+            .expect("signing mapping landed in runtime credentials");
+        assert!(mapping.location.is_signing());
+        assert_eq!(mapping.kind(), CredentialKind::Signing);
+    }
+
+    #[test]
+    fn to_capabilities_classifies_network_auth_kind() {
+        use crate::secrets::CredentialKind;
+        let json = r#"{
+            "http": {
+                "credentials": {
+                    "api_key": {
+                        "secret_name": "polymarket_l2_key",
+                        "location": { "type": "header", "name": "POLY-API-KEY" },
+                        "host_patterns": ["clob.polymarket.com"]
+                    }
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).expect("parse");
+        let runtime = caps.to_capabilities();
+        let mapping = runtime
+            .http
+            .unwrap()
+            .credentials
+            .get("polymarket_l2_key")
+            .unwrap()
+            .clone();
+        assert_eq!(mapping.kind(), CredentialKind::NetworkAuth);
     }
 
     #[test]

--- a/src/tools/wasm/credential_injector.rs
+++ b/src/tools/wasm/credential_injector.rs
@@ -429,7 +429,8 @@ pub(crate) fn inject_credential(
         }
         CredentialLocation::HmacSignedHeader { .. }
         | CredentialLocation::Eip712SignedHeader { .. }
-        | CredentialLocation::Nep413SignedHeader { .. } => {}
+        | CredentialLocation::Nep413SignedHeader { .. }
+        | CredentialLocation::SolanaSignedTransaction { .. } => {}
     }
 }
 

--- a/src/tools/wasm/credential_injector.rs
+++ b/src/tools/wasm/credential_injector.rs
@@ -427,6 +427,9 @@ pub(crate) fn inject_credential(
             // URL placeholder replacement is handled by channel/tool wrappers
             // that substitute {PLACEHOLDER} values in templated strings.
         }
+        CredentialLocation::HmacSignedHeader { .. }
+        | CredentialLocation::Eip712SignedHeader { .. }
+        | CredentialLocation::Nep413SignedHeader { .. } => {}
     }
 }
 

--- a/src/tools/wasm/credential_injector.rs
+++ b/src/tools/wasm/credential_injector.rs
@@ -522,6 +522,11 @@ pub(crate) fn inject_credential(
             // URL placeholder replacement is handled by channel/tool wrappers
             // that substitute {PLACEHOLDER} values in templated strings.
         }
+        // Signing variants are intentionally not injected here. Signatures
+        // are computed host-side in the dedicated signer path
+        // (`wrapper::inject_host_credentials`) after the request body is
+        // assembled, so the secret never enters static header/query/url
+        // placement and the WASM tool never sees key material.
         CredentialLocation::HmacSignedHeader { .. }
         | CredentialLocation::Eip712SignedHeader { .. }
         | CredentialLocation::Nep413SignedHeader { .. }

--- a/src/tools/wasm/credential_injector.rs
+++ b/src/tools/wasm/credential_injector.rs
@@ -48,6 +48,9 @@ pub enum InjectionError {
 
     #[error("No matching credential for host: {0}")]
     NoMatchingCredential(String),
+
+    #[error("Signing denied by user for secret '{0}'")]
+    SigningDenied(String),
 }
 
 impl From<SecretError> for InjectionError {
@@ -215,6 +218,18 @@ impl SharedCredentialRegistry {
         matched
     }
 
+    pub fn find_for_url_with_kind(
+        &self,
+        host: &str,
+        path: &str,
+        kind: crate::secrets::CredentialKind,
+    ) -> Vec<CredentialMapping> {
+        self.find_for_url(host, path)
+            .into_iter()
+            .filter(|m| m.kind() == kind)
+            .collect()
+    }
+
     pub fn oauth_refresh_for_secret(&self, secret_name: &str) -> Option<OAuthRefreshConfig> {
         let guard = match self.oauth_refresh.read() {
             Ok(guard) => guard,
@@ -309,6 +324,18 @@ impl CredentialInjector {
         matched
     }
 
+    pub fn find_credentials_for_url_with_kind(
+        &self,
+        host: &str,
+        path: &str,
+        kind: crate::secrets::CredentialKind,
+    ) -> Vec<&CredentialMapping> {
+        self.find_credentials_for_url(host, path)
+            .into_iter()
+            .filter(|m| m.kind() == kind)
+            .collect()
+    }
+
     /// Host-only inject. See `inject_for_url`.
     #[deprecated(note = "use inject_for_url(user_id, host, path, store) instead")]
     pub async fn inject(
@@ -334,6 +361,47 @@ impl CredentialInjector {
         let matching_mappings = self.find_credentials_for_url(host, path);
         self.inject_from_mappings(user_id, matching_mappings, store)
             .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn inject_for_url_with_approval(
+        &self,
+        user_id: &str,
+        host: &str,
+        path: &str,
+        store: &dyn SecretsStore,
+        gate: &dyn crate::secrets::SignerApprovalGate,
+        tool_name: &str,
+        min_classification: crate::secrets::SignerClassification,
+    ) -> Result<InjectedCredentials, InjectionError> {
+        let matching = self.find_credentials_for_url(host, path);
+        if matching.is_empty() {
+            return Ok(InjectedCredentials::empty());
+        }
+
+        for mapping in &matching {
+            if mapping.kind() != crate::secrets::CredentialKind::Signing {
+                continue;
+            }
+            let classification = crate::secrets::classify_signing_location(&mapping.location);
+            if !at_least(classification, min_classification) {
+                continue;
+            }
+            let summary = signer_request_summary(mapping);
+            let request = crate::secrets::ApprovalRequest {
+                tool_name: tool_name.to_string(),
+                host: host.to_string(),
+                path: path.to_string(),
+                secret_name: mapping.secret_name.clone(),
+                classification,
+                summary,
+            };
+            if gate.request_approval(&request).await == crate::secrets::Approval::Denied {
+                return Err(InjectionError::SigningDenied(mapping.secret_name.clone()));
+            }
+        }
+
+        self.inject_from_mappings(user_id, matching, store).await
     }
 
     async fn inject_from_mappings(
@@ -392,6 +460,33 @@ impl CredentialInjector {
 }
 
 /// Inject a single credential into the result.
+fn at_least(
+    actual: crate::secrets::SignerClassification,
+    floor: crate::secrets::SignerClassification,
+) -> bool {
+    use crate::secrets::SignerClassification::*;
+    let rank = |c| match c {
+        Low => 0u8,
+        Medium => 1,
+        High => 2,
+    };
+    rank(actual) >= rank(floor)
+}
+
+fn signer_request_summary(mapping: &CredentialMapping) -> String {
+    use crate::secrets::CredentialLocation;
+    let kind = match &mapping.location {
+        CredentialLocation::HmacSignedHeader { .. } => "HMAC-SHA256",
+        CredentialLocation::Eip712SignedHeader { primary_type, .. } => {
+            return format!("EIP-712 typed message: {}", primary_type);
+        }
+        CredentialLocation::Nep413SignedHeader { .. } => "NEP-413 NEAR signed message",
+        CredentialLocation::SolanaSignedTransaction { .. } => "Solana ed25519 transaction",
+        _ => "non-signing location",
+    };
+    kind.to_string()
+}
+
 pub(crate) fn inject_credential(
     result: &mut InjectedCredentials,
     location: &CredentialLocation,
@@ -477,7 +572,9 @@ mod tests {
         SecretsStore,
     };
     use crate::testing::credentials::{TEST_OPENAI_API_KEY, test_secrets_store};
-    use crate::tools::wasm::credential_injector::{CredentialInjector, base64_encode};
+    use crate::tools::wasm::credential_injector::{
+        CredentialInjector, InjectionError, base64_encode,
+    };
 
     fn test_store() -> InMemorySecretsStore {
         test_secrets_store()
@@ -810,5 +907,246 @@ mod tests {
 
         let found = registry.find_for_host("api.example.com");
         assert_eq!(found.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn inject_for_url_with_approval_calls_gate_for_high_value_signer_and_proceeds_on_approve()
+    {
+        use crate::secrets::{
+            AllowAllSignerGate, CredentialLocation, FieldSource, SignerClassification,
+        };
+
+        let store = test_store();
+        store
+            .create(
+                "user1",
+                CreateSecretParams::new("polymarket_l1_pk", "test-pk"),
+            )
+            .await
+            .unwrap();
+
+        let mut mappings = HashMap::new();
+        mappings.insert(
+            "drainer".to_string(),
+            CredentialMapping {
+                secret_name: "polymarket_l1_pk".to_string(),
+                location: CredentialLocation::SolanaSignedTransaction {
+                    message_source: FieldSource::RequestBody,
+                    output_body_fields: vec![],
+                },
+                host_patterns: vec!["solana-api.example.com".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+        let injector = CredentialInjector::new(mappings, vec!["polymarket_l1_pk".to_string()]);
+
+        let gate = AllowAllSignerGate;
+        let _result = injector
+            .inject_for_url_with_approval(
+                "user1",
+                "solana-api.example.com",
+                "/v1/tx",
+                &store,
+                &gate,
+                "evil",
+                SignerClassification::High,
+            )
+            .await
+            .expect("approved injection ok");
+    }
+
+    #[tokio::test]
+    async fn inject_for_url_with_approval_returns_signing_denied_on_reject() {
+        use crate::secrets::{
+            CredentialLocation, FieldSource, RejectAllSignerGate, SignerClassification,
+        };
+
+        let store = test_store();
+        store
+            .create("user1", CreateSecretParams::new("sol_pk", "test-pk"))
+            .await
+            .unwrap();
+
+        let mut mappings = HashMap::new();
+        mappings.insert(
+            "drainer".to_string(),
+            CredentialMapping {
+                secret_name: "sol_pk".to_string(),
+                location: CredentialLocation::SolanaSignedTransaction {
+                    message_source: FieldSource::RequestBody,
+                    output_body_fields: vec![],
+                },
+                host_patterns: vec!["solana-api.example.com".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+        let injector = CredentialInjector::new(mappings, vec!["sol_pk".to_string()]);
+
+        let gate = RejectAllSignerGate;
+        let err = injector
+            .inject_for_url_with_approval(
+                "user1",
+                "solana-api.example.com",
+                "/v1/tx",
+                &store,
+                &gate,
+                "evil",
+                SignerClassification::High,
+            )
+            .await
+            .expect_err("rejected gate must fail");
+        assert!(matches!(err, InjectionError::SigningDenied(name) if name == "sol_pk"));
+    }
+
+    #[tokio::test]
+    async fn inject_for_url_with_approval_bypasses_gate_for_network_auth() {
+        use crate::secrets::{RejectAllSignerGate, SignerClassification};
+
+        let store = test_store();
+        store
+            .create("user1", CreateSecretParams::new("api_key", "secret123"))
+            .await
+            .unwrap();
+
+        let mut mappings = HashMap::new();
+        mappings.insert(
+            "bearer".to_string(),
+            CredentialMapping {
+                secret_name: "api_key".to_string(),
+                location: CredentialLocation::AuthorizationBearer,
+                host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+        let injector = CredentialInjector::new(mappings, vec!["api_key".to_string()]);
+
+        let gate = RejectAllSignerGate;
+        let result = injector
+            .inject_for_url_with_approval(
+                "user1",
+                "api.example.com",
+                "/v1/anything",
+                &store,
+                &gate,
+                "no-signer",
+                SignerClassification::High,
+            )
+            .await
+            .expect("network auth bypasses signing gate");
+        assert!(result.headers.contains_key("Authorization"));
+    }
+
+    #[tokio::test]
+    async fn inject_for_url_with_approval_skips_gate_when_below_threshold() {
+        use crate::secrets::{
+            CredentialLocation, FieldSource, RejectAllSignerGate, SignerClassification,
+        };
+
+        let store = test_store();
+        store
+            .create("user1", CreateSecretParams::new("near_pk", "test"))
+            .await
+            .unwrap();
+
+        let mut mappings = HashMap::new();
+        mappings.insert(
+            "nep413".to_string(),
+            CredentialMapping {
+                secret_name: "near_pk".to_string(),
+                location: CredentialLocation::Nep413SignedHeader {
+                    recipient_source: FieldSource::Literal {
+                        value: "iron.near".to_string(),
+                    },
+                    message_source: FieldSource::RequestBody,
+                    callback_url_source: None,
+                    output_headers: vec![],
+                },
+                host_patterns: vec!["api.iron.near".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+        let injector = CredentialInjector::new(mappings, vec!["near_pk".to_string()]);
+
+        let gate = RejectAllSignerGate;
+        let _result = injector
+            .inject_for_url_with_approval(
+                "user1",
+                "api.iron.near",
+                "/auth",
+                &store,
+                &gate,
+                "iron",
+                SignerClassification::High,
+            )
+            .await
+            .expect("nep413 is Low classification, should not hit High gate");
+    }
+
+    #[test]
+    fn find_credentials_for_url_with_kind_separates_signing_from_network_auth() {
+        use crate::secrets::{CredentialKind, FieldSource};
+
+        let mut mappings = HashMap::new();
+        mappings.insert(
+            "api_key".to_string(),
+            CredentialMapping {
+                secret_name: "polymarket_l2_key".to_string(),
+                location: CredentialLocation::Header {
+                    name: "POLY-API-KEY".to_string(),
+                    prefix: None,
+                },
+                host_patterns: vec!["clob.polymarket.com".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+        mappings.insert(
+            "eip712".to_string(),
+            CredentialMapping {
+                secret_name: "polymarket_l1_pk".to_string(),
+                location: CredentialLocation::Nep413SignedHeader {
+                    recipient_source: FieldSource::Literal {
+                        value: "iron.near".to_string(),
+                    },
+                    message_source: FieldSource::RequestBody,
+                    callback_url_source: None,
+                    output_headers: Vec::new(),
+                },
+                host_patterns: vec!["clob.polymarket.com".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+
+        let injector = CredentialInjector::new(
+            mappings,
+            vec![
+                "polymarket_l2_key".to_string(),
+                "polymarket_l1_pk".to_string(),
+            ],
+        );
+
+        let all = injector.find_credentials_for_url("clob.polymarket.com", "/auth/api-key");
+        assert_eq!(all.len(), 2);
+
+        let net_only = injector.find_credentials_for_url_with_kind(
+            "clob.polymarket.com",
+            "/auth/api-key",
+            CredentialKind::NetworkAuth,
+        );
+        assert_eq!(net_only.len(), 1);
+        assert_eq!(net_only[0].secret_name, "polymarket_l2_key");
+
+        let signing_only = injector.find_credentials_for_url_with_kind(
+            "clob.polymarket.com",
+            "/auth/api-key",
+            CredentialKind::Signing,
+        );
+        assert_eq!(signing_only.len(), 1);
+        assert_eq!(signing_only[0].secret_name, "polymarket_l1_pk");
     }
 }

--- a/src/tools/wasm/mod.rs
+++ b/src/tools/wasm/mod.rs
@@ -84,7 +84,7 @@ pub const WIT_CHANNEL_VERSION: &str = "0.3.0";
 
 mod allowlist;
 mod capabilities;
-mod capabilities_schema;
+pub(crate) mod capabilities_schema;
 pub(crate) mod credential_injector;
 mod error;
 mod host;
@@ -93,6 +93,7 @@ mod limits;
 pub(crate) mod loader;
 mod rate_limiter;
 mod runtime;
+pub mod signer_gate;
 pub(crate) mod storage;
 mod wrapper;
 

--- a/src/tools/wasm/signer_gate.rs
+++ b/src/tools/wasm/signer_gate.rs
@@ -1,0 +1,104 @@
+use std::io::{self, BufRead, IsTerminal, Write};
+
+use async_trait::async_trait;
+
+use crate::secrets::{Approval, ApprovalRequest, SignerApprovalGate, SignerClassification};
+
+pub struct TerminalSignerGate;
+
+impl TerminalSignerGate {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TerminalSignerGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SignerApprovalGate for TerminalSignerGate {
+    async fn request_approval(&self, request: &ApprovalRequest) -> Approval {
+        let stdin = io::stdin();
+        if !stdin.is_terminal() {
+            tracing::error!(
+                tool = %request.tool_name,
+                secret = %request.secret_name,
+                "non-interactive stdin and no gate impl can reach the user; denying signing"
+            );
+            return Approval::Denied;
+        }
+
+        let mut stdout = io::stdout().lock();
+        let _ = writeln!(stdout);
+        let _ = writeln!(stdout, "[signing approval requested]");
+        let _ = writeln!(
+            stdout,
+            "  tool:           {} (secret '{}')",
+            request.tool_name, request.secret_name
+        );
+        let _ = writeln!(stdout, "  endpoint:       {}{}", request.host, request.path);
+        let _ = writeln!(
+            stdout,
+            "  classification: {}",
+            classification_label(request.classification)
+        );
+        let _ = writeln!(stdout, "  signer:         {}", request.summary);
+        let _ = writeln!(
+            stdout,
+            "Approve this signature? Type 'approve' (or 'a'/'yes'/'y') to allow,"
+        );
+        let _ = writeln!(stdout, "anything else (e.g. 'deny'/'no') to refuse.");
+        let _ = write!(stdout, "> ");
+        let _ = stdout.flush();
+        drop(stdout);
+
+        let mut input = String::new();
+        if stdin.lock().read_line(&mut input).is_err() {
+            return Approval::Denied;
+        }
+        let normalized = input.trim().to_ascii_lowercase();
+        if matches!(normalized.as_str(), "approve" | "a" | "yes" | "y") {
+            Approval::Approved
+        } else {
+            Approval::Denied
+        }
+    }
+}
+
+fn classification_label(c: SignerClassification) -> &'static str {
+    match c {
+        SignerClassification::Low => "low",
+        SignerClassification::Medium => "medium",
+        SignerClassification::High => "high",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classification_label_covers_all_levels() {
+        assert_eq!(classification_label(SignerClassification::Low), "low");
+        assert_eq!(classification_label(SignerClassification::Medium), "medium");
+        assert_eq!(classification_label(SignerClassification::High), "high");
+    }
+
+    #[tokio::test]
+    async fn terminal_gate_denies_when_stdin_not_a_tty() {
+        let gate = TerminalSignerGate::new();
+        let request = ApprovalRequest {
+            tool_name: "polymarket-clob".to_string(),
+            host: "clob.polymarket.com".to_string(),
+            path: "/auth/api-key".to_string(),
+            secret_name: "polymarket_l1_pk".to_string(),
+            classification: SignerClassification::High,
+            summary: "EIP-712 typed message: ClobAuth".to_string(),
+        };
+        let approval = gate.request_approval(&request).await;
+        assert_eq!(approval, Approval::Denied);
+    }
+}

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -498,6 +498,11 @@ fn apply_eip712_signing(
             ))
         })?;
 
+    let body_json = parse_body_json_if_needed(
+        primary.fields.iter().map(|f| &f.source),
+        body,
+    )?;
+
     let mut field_value_buf: Vec<u8> = Vec::with_capacity(32 + primary.fields.len() * 32);
     let type_string = encode_eip712_type_string(primary);
     let type_hash = keccak256(type_string.as_bytes());
@@ -508,6 +513,7 @@ fn apply_eip712_signing(
             Some(&address_hex),
             &public_key_hex,
             body,
+            body_json.as_ref(),
             timestamp_secs,
             nonce_bytes,
         )?;
@@ -585,11 +591,23 @@ fn apply_nep413_signing(
         bs58::encode(verifying_key.as_bytes()).into_string()
     );
 
+    let body_json = parse_body_json_if_needed(
+        [
+            Some(&spec.recipient_source),
+            Some(&spec.message_source),
+            spec.callback_url_source.as_ref(),
+        ]
+        .into_iter()
+        .flatten(),
+        body,
+    )?;
+
     let recipient = resolve_field_source(
         &spec.recipient_source,
         None,
         &public_key_b58,
         body,
+        body_json.as_ref(),
         timestamp_secs,
         nonce_bytes,
     )?;
@@ -598,6 +616,7 @@ fn apply_nep413_signing(
         None,
         &public_key_b58,
         body,
+        body_json.as_ref(),
         timestamp_secs,
         nonce_bytes,
     )?;
@@ -607,6 +626,7 @@ fn apply_nep413_signing(
             None,
             &public_key_b58,
             body,
+            body_json.as_ref(),
             timestamp_secs,
             nonce_bytes,
         )?),
@@ -770,14 +790,7 @@ fn encode_eip712_field_value(type_name: &str, value: &str) -> Result<[u8; 32], S
             padded[12..].copy_from_slice(&addr);
             Ok(padded)
         }
-        "uint256" => {
-            let num: u128 = value
-                .parse()
-                .map_err(|e| SignerError::InvalidField(format!("uint256 parse: {e}")))?;
-            let mut padded = [0u8; 32];
-            padded[16..].copy_from_slice(&num.to_be_bytes());
-            Ok(padded)
-        }
+        "uint256" => parse_uint256_be(value),
         "bytes32" => {
             let trimmed = value.trim_start_matches("0x");
             let bytes = hex::decode(trimmed)
@@ -796,6 +809,31 @@ fn encode_eip712_field_value(type_name: &str, value: &str) -> Result<[u8; 32], S
             "unsupported eip712 type: {other}"
         ))),
     }
+}
+
+fn parse_uint256_be(value: &str) -> Result<[u8; 32], SignerError> {
+    let s = value.trim();
+    if s.is_empty() {
+        return Err(SignerError::InvalidField("uint256 is empty".into()));
+    }
+    let mut bytes = [0u8; 32];
+    for ch in s.chars() {
+        let digit = ch.to_digit(10).ok_or_else(|| {
+            SignerError::InvalidField(format!("uint256 contains non-digit '{ch}' in '{s}'"))
+        })?;
+        let mut carry: u32 = digit;
+        for byte in bytes.iter_mut().rev() {
+            let v = u32::from(*byte) * 10 + carry;
+            *byte = (v & 0xff) as u8;
+            carry = v >> 8;
+        }
+        if carry != 0 {
+            return Err(SignerError::InvalidField(format!(
+                "uint256 overflow: '{s}' exceeds 2^256 - 1"
+            )));
+        }
+    }
+    Ok(bytes)
 }
 
 fn parse_eth_address(value: &str) -> Result<[u8; 20], SignerError> {
@@ -848,6 +886,7 @@ fn resolve_field_source(
     signer_address: Option<&str>,
     signer_public_key: &str,
     body: Option<&[u8]>,
+    body_json: Option<&serde_json::Value>,
     timestamp_secs: u64,
     nonce_bytes: &[u8; 32],
 ) -> Result<String, SignerError> {
@@ -876,7 +915,7 @@ fn resolve_field_source(
             })
         }
         FieldSource::Bytes32Keccak256OfBytes { parts } => {
-            let assembled = assemble_bytes_for_keccak(parts, body)?;
+            let assembled = assemble_bytes_for_keccak(parts, body_json)?;
             let h = keccak256(&assembled);
             Ok(format!("0x{}", hex::encode(h)))
         }
@@ -1013,31 +1052,41 @@ fn apply_body_mutations(
     Ok(())
 }
 
+fn parse_body_json_if_needed<'a, I>(
+    sources: I,
+    body: Option<&[u8]>,
+) -> Result<Option<serde_json::Value>, SignerError>
+where
+    I: IntoIterator<Item = &'a crate::secrets::FieldSource>,
+{
+    use crate::secrets::{BytesPart, FieldSource};
+    let needs = sources.into_iter().any(|s| match s {
+        FieldSource::Bytes32Keccak256OfBytes { parts } => parts
+            .iter()
+            .any(|p| !matches!(p, BytesPart::LiteralHex { .. })),
+        _ => false,
+    });
+    if !needs {
+        return Ok(None);
+    }
+    let bytes = body.ok_or_else(|| {
+        SignerError::UnsupportedSource(
+            "body-derived signer source declared but no request body provided".into(),
+        )
+    })?;
+    Ok(Some(
+        serde_json::from_slice::<serde_json::Value>(bytes)
+            .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?,
+    ))
+}
+
 fn assemble_bytes_for_keccak(
     parts: &[crate::secrets::BytesPart],
-    body: Option<&[u8]>,
+    body_json: Option<&serde_json::Value>,
 ) -> Result<Vec<u8>, SignerError> {
-    use crate::secrets::BytesPart;
-    let needs_body = parts
-        .iter()
-        .any(|p| !matches!(p, BytesPart::LiteralHex { .. }));
-    let body_json = if needs_body {
-        let bytes = body.ok_or_else(|| {
-            SignerError::UnsupportedSource(
-                "body-derived bytes_part declared but no request body provided".into(),
-            )
-        })?;
-        Some(
-            serde_json::from_slice::<serde_json::Value>(bytes)
-                .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?,
-        )
-    } else {
-        None
-    };
-
     let mut out: Vec<u8> = Vec::new();
     for part in parts {
-        let bytes = evaluate_bytes_part(part, body_json.as_ref())?;
+        let bytes = evaluate_bytes_part(part, body_json)?;
         out.extend_from_slice(&bytes);
     }
     Ok(out)
@@ -4101,6 +4150,42 @@ mod tests {
             recovered_addr, expected_address,
             "signature must recover to the signer address"
         );
+    }
+
+    #[test]
+    fn parse_uint256_handles_zero_small_max_and_overflow() {
+        let zero = super::parse_uint256_be("0").unwrap();
+        assert_eq!(zero, [0u8; 32]);
+
+        let one = super::parse_uint256_be("1").unwrap();
+        let mut expected_one = [0u8; 32];
+        expected_one[31] = 1;
+        assert_eq!(one, expected_one);
+
+        let above_u128 = "340282366920938463463374607431768211457";
+        let result = super::parse_uint256_be(above_u128).unwrap();
+        let mut expected = [0u8; 32];
+        expected[15] = 1;
+        expected[31] = 1;
+        assert_eq!(
+            result, expected,
+            "value just above 2^128 must encode without overflow"
+        );
+
+        let max = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+        let max_bytes = super::parse_uint256_be(max).unwrap();
+        assert_eq!(max_bytes, [0xffu8; 32]);
+
+        let overflow = "115792089237316195423570985008687907853269984665640564039457584007913129639936";
+        let err = super::parse_uint256_be(overflow).unwrap_err();
+        assert!(
+            matches!(err, super::SignerError::InvalidField(ref m) if m.contains("overflow")),
+            "expected overflow error, got {err:?}"
+        );
+
+        assert!(super::parse_uint256_be("").is_err());
+        assert!(super::parse_uint256_be("12a3").is_err());
+        assert!(super::parse_uint256_be("-1").is_err());
     }
 
     #[test]

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -24,6 +24,17 @@ use crate::secrets::SecretsStore;
 use crate::secrets::host_matches_pattern;
 use crate::tools::tool::{Tool, ToolDiscoverySummary, ToolError, ToolOutput};
 use crate::tools::wasm::capabilities::Capabilities;
+use base64::Engine as _;
+use borsh::BorshSerialize;
+use ed25519_dalek::Signer as _;
+use hmac::{Hmac, Mac};
+use k256::ecdsa::{Signature as K256Signature, SigningKey, signature::hazmat::PrehashSigner};
+use rand::RngCore;
+use rmp_serde::Serializer as MsgpackSerializer;
+use serde::Serialize as _;
+use sha2::{Digest, Sha256};
+use sha3::Keccak256;
+
 use crate::tools::wasm::credential_injector::{InjectedCredentials, inject_credential};
 use crate::tools::wasm::error::WasmError;
 use crate::tools::wasm::host::{HostState, LogLevel};
@@ -107,6 +118,40 @@ struct ResolvedHostCredential {
     query_params: HashMap<String, String>,
     /// Raw secret value for redaction in error messages.
     secret_value: String,
+    /// When set, the secret feeds a per-request signer (HMAC, EIP-712,
+    /// or NEP-413). The variant carries the venue-specific output
+    /// schema declared by the tool in its capabilities file.
+    signing: Option<SigningSpec>,
+}
+
+#[derive(Clone)]
+enum SigningSpec {
+    Hmac(HmacSigning),
+    Eip712(Eip712Signing),
+    Nep413(Nep413Signing),
+}
+
+#[derive(Clone)]
+struct HmacSigning {
+    signature_header: String,
+    timestamp_header: String,
+}
+
+#[derive(Clone)]
+struct Eip712Signing {
+    domain: crate::secrets::Eip712Domain,
+    primary_type: String,
+    structs: Vec<crate::secrets::Eip712StructDef>,
+    output_headers: Vec<crate::secrets::HeaderOutput>,
+    output_body_fields: Vec<crate::secrets::BodyJsonOutput>,
+}
+
+#[derive(Clone)]
+struct Nep413Signing {
+    recipient_source: crate::secrets::FieldSource,
+    message_source: crate::secrets::FieldSource,
+    callback_url_source: Option<crate::secrets::FieldSource>,
+    output_headers: Vec<crate::secrets::HeaderOutput>,
 }
 
 impl std::fmt::Debug for ResolvedHostCredential {
@@ -117,11 +162,37 @@ impl std::fmt::Debug for ResolvedHostCredential {
         // contain decrypted secret material.
         let header_keys: Vec<&String> = self.headers.keys().collect();
         let query_keys: Vec<&String> = self.query_params.keys().collect();
+        let signing_summary: Option<String> = self.signing.as_ref().map(|s| match s {
+            SigningSpec::Hmac(spec) => format!(
+                "hmac(sig={}, ts={})",
+                spec.signature_header, spec.timestamp_header
+            ),
+            SigningSpec::Eip712(spec) => {
+                let outs: Vec<&str> = spec
+                    .output_headers
+                    .iter()
+                    .map(|o| o.header_name.as_str())
+                    .collect();
+                format!(
+                    "eip712(domain={}, primary={}, outputs={:?})",
+                    spec.domain.name, spec.primary_type, outs
+                )
+            }
+            SigningSpec::Nep413(spec) => {
+                let outs: Vec<&str> = spec
+                    .output_headers
+                    .iter()
+                    .map(|o| o.header_name.as_str())
+                    .collect();
+                format!("nep413(outputs={:?})", outs)
+            }
+        });
         f.debug_struct("ResolvedHostCredential")
             .field("host_patterns", &self.host_patterns)
             .field("path_patterns", &self.path_patterns)
             .field("header_names", &header_keys)
             .field("query_param_names", &query_keys)
+            .field("signing", &signing_summary)
             .field("secret_value", &"[REDACTED]")
             .finish()
     }
@@ -226,6 +297,8 @@ impl StoreData {
     fn inject_host_credentials(
         &self,
         url_host: &str,
+        method: &str,
+        body: &mut Option<Vec<u8>>,
         headers: &mut HashMap<String, String>,
         url: &mut String,
     ) {
@@ -289,6 +362,725 @@ impl StoreData {
                     url.push_str(&frag);
                 }
             }
+
+            if let Some(signing) = &cred.signing {
+                let timestamp_secs = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let mut nonce_bytes = [0u8; 32];
+                rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+                let result = match signing {
+                    SigningSpec::Hmac(spec) => apply_hmac_signing(
+                        spec,
+                        &cred.secret_value,
+                        method,
+                        &url_path,
+                        body.as_deref(),
+                        timestamp_secs,
+                    ),
+                    SigningSpec::Eip712(spec) => apply_eip712_signing(
+                        spec,
+                        &cred.secret_value,
+                        body.as_deref(),
+                        timestamp_secs,
+                        &nonce_bytes,
+                    ),
+                    SigningSpec::Nep413(spec) => apply_nep413_signing(
+                        spec,
+                        &cred.secret_value,
+                        body.as_deref(),
+                        timestamp_secs,
+                        &nonce_bytes,
+                    ),
+                };
+
+                match result {
+                    Ok(extra) => {
+                        for (k, v) in extra.headers {
+                            headers.insert(k, v);
+                        }
+                        if let Err(error) = apply_body_mutations(body, &extra.body_mutations) {
+                            tracing::warn!(
+                                secret_name = %cred.secret_name,
+                                error = %error,
+                                "body mutation failed; signing headers applied but body left unmodified"
+                            );
+                        }
+                    }
+                    Err(error) => tracing::warn!(
+                        secret_name = %cred.secret_name,
+                        error = %error,
+                        "signer failed; skipping signing headers"
+                    ),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SignerError {
+    #[error("invalid secret material: {0}")]
+    InvalidSecret(String),
+    #[error("invalid signing schema: {0}")]
+    InvalidSchema(String),
+    #[error("invalid eip712 field: {0}")]
+    InvalidField(String),
+    #[error("source not supported in this position: {0}")]
+    UnsupportedSource(String),
+    #[error("signing failed: {0}")]
+    SignFailed(String),
+}
+
+#[derive(Debug, Default)]
+struct SignerOutput {
+    headers: Vec<(String, String)>,
+    body_mutations: Vec<(String, serde_json::Value)>,
+}
+
+fn apply_hmac_signing(
+    spec: &HmacSigning,
+    secret_value: &str,
+    method: &str,
+    path: &str,
+    body: Option<&[u8]>,
+    timestamp_secs: u64,
+) -> Result<SignerOutput, SignerError> {
+    let key_bytes = base64::engine::general_purpose::URL_SAFE
+        .decode(secret_value.as_bytes())
+        .map_err(|e| SignerError::InvalidSecret(format!("hmac key not url-safe base64: {e}")))?;
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key_bytes)
+        .map_err(|e| SignerError::SignFailed(format!("hmac key rejected: {e}")))?;
+    let timestamp = timestamp_secs.to_string();
+    mac.update(timestamp.as_bytes());
+    mac.update(method.as_bytes());
+    mac.update(path.as_bytes());
+    if let Some(body_bytes) = body {
+        mac.update(body_bytes);
+    }
+    let signature = base64::engine::general_purpose::URL_SAFE.encode(mac.finalize().into_bytes());
+    Ok(SignerOutput {
+        headers: vec![
+            (spec.signature_header.clone(), signature),
+            (spec.timestamp_header.clone(), timestamp),
+        ],
+        body_mutations: Vec::new(),
+    })
+}
+
+fn apply_eip712_signing(
+    spec: &Eip712Signing,
+    secret_value: &str,
+    body: Option<&[u8]>,
+    timestamp_secs: u64,
+    nonce_bytes: &[u8; 32],
+) -> Result<SignerOutput, SignerError> {
+    let signing_key = parse_secp256k1_secret(secret_value)?;
+    let address_bytes = derive_eth_address(&signing_key);
+    let address_hex = format!("0x{}", hex::encode(address_bytes));
+    let public_key_hex = derive_secp256k1_public_key_hex(&signing_key);
+
+    if spec.structs.len() != 1 {
+        return Err(SignerError::InvalidSchema(
+            "only single-struct eip712 schemas are supported in this build".into(),
+        ));
+    }
+    let primary = spec
+        .structs
+        .iter()
+        .find(|s| s.name == spec.primary_type)
+        .ok_or_else(|| {
+            SignerError::InvalidSchema(format!(
+                "primary type '{}' not found in declared structs",
+                spec.primary_type
+            ))
+        })?;
+
+    let mut field_value_buf: Vec<u8> = Vec::with_capacity(32 + primary.fields.len() * 32);
+    let type_string = encode_eip712_type_string(primary);
+    let type_hash = keccak256(type_string.as_bytes());
+    field_value_buf.extend_from_slice(&type_hash);
+    for field in &primary.fields {
+        let raw = resolve_field_source(
+            &field.source,
+            &address_hex,
+            &public_key_hex,
+            body,
+            timestamp_secs,
+            nonce_bytes,
+        )?;
+        let encoded = encode_eip712_field_value(&field.type_name, &raw)?;
+        field_value_buf.extend_from_slice(&encoded);
+    }
+    let struct_hash = keccak256(&field_value_buf);
+
+    let domain_separator = compute_eip712_domain_separator(&spec.domain)?;
+
+    let mut final_buf = Vec::with_capacity(2 + 32 + 32);
+    final_buf.extend_from_slice(&[0x19u8, 0x01u8]);
+    final_buf.extend_from_slice(&domain_separator);
+    final_buf.extend_from_slice(&struct_hash);
+    let final_hash = keccak256(&final_buf);
+
+    let (sig_64, recovery_id) = sign_secp256k1_recoverable(&signing_key, &final_hash)?;
+    let mut sig_with_v = Vec::with_capacity(65);
+    sig_with_v.extend_from_slice(&sig_64);
+    let v = recovery_id + 27;
+    sig_with_v.push(v);
+    let signature_hex = format!("0x{}", hex::encode(&sig_with_v));
+    let signature_b64 = base64::engine::general_purpose::URL_SAFE.encode(&sig_with_v);
+    let signature_r_hex = format!("0x{}", hex::encode(&sig_64[..32]));
+    let signature_s_hex = format!("0x{}", hex::encode(&sig_64[32..]));
+
+    let evaluated = EvaluatedSignature {
+        signer_address: address_hex.clone(),
+        signer_public_key: public_key_hex.clone(),
+        signature_hex: signature_hex.clone(),
+        signature_b64: signature_b64.clone(),
+        signature_r_hex,
+        signature_s_hex,
+        signature_v: v,
+        timestamp_secs,
+        nonce_bytes: *nonce_bytes,
+    };
+
+    let mut headers: Vec<(String, String)> = Vec::with_capacity(spec.output_headers.len());
+    for header in &spec.output_headers {
+        let value = resolve_output_source(
+            &header.value,
+            &address_hex,
+            &public_key_hex,
+            &signature_hex,
+            &signature_b64,
+            timestamp_secs,
+            nonce_bytes,
+        )?;
+        headers.push((header.header_name.clone(), value));
+    }
+
+    let mut body_mutations: Vec<(String, serde_json::Value)> =
+        Vec::with_capacity(spec.output_body_fields.len());
+    for field in &spec.output_body_fields {
+        body_mutations.push((field.json_path.clone(), evaluate_body_value(&field.value, &evaluated)));
+    }
+
+    Ok(SignerOutput {
+        headers,
+        body_mutations,
+    })
+}
+
+fn apply_nep413_signing(
+    spec: &Nep413Signing,
+    secret_value: &str,
+    body: Option<&[u8]>,
+    timestamp_secs: u64,
+    nonce_bytes: &[u8; 32],
+) -> Result<SignerOutput, SignerError> {
+    let (signing_key, verifying_key) = parse_ed25519_secret(secret_value)?;
+    let public_key_b58 = format!(
+        "ed25519:{}",
+        bs58::encode(verifying_key.as_bytes()).into_string()
+    );
+    let signer_address_placeholder = "";
+
+    let recipient = resolve_field_source(
+        &spec.recipient_source,
+        signer_address_placeholder,
+        &public_key_b58,
+        body,
+        timestamp_secs,
+        nonce_bytes,
+    )?;
+    let message = resolve_field_source(
+        &spec.message_source,
+        signer_address_placeholder,
+        &public_key_b58,
+        body,
+        timestamp_secs,
+        nonce_bytes,
+    )?;
+    let callback_url = match &spec.callback_url_source {
+        Some(src) => Some(resolve_field_source(
+            src,
+            signer_address_placeholder,
+            &public_key_b58,
+            body,
+            timestamp_secs,
+            nonce_bytes,
+        )?),
+        None => None,
+    };
+
+    let payload = Nep413Payload {
+        message,
+        nonce: *nonce_bytes,
+        recipient,
+        callback_url,
+    };
+
+    let mut serialized: Vec<u8> = Vec::new();
+    let prefix: u32 = 2_147_484_061;
+    BorshSerialize::serialize(&prefix, &mut serialized)
+        .map_err(|e| SignerError::SignFailed(format!("borsh prefix: {e}")))?;
+    BorshSerialize::serialize(&payload, &mut serialized)
+        .map_err(|e| SignerError::SignFailed(format!("borsh payload: {e}")))?;
+
+    let hash = Sha256::digest(&serialized);
+    let signature = signing_key.sign(&hash);
+    let signature_bytes = signature.to_bytes();
+    let signature_hex = format!("0x{}", hex::encode(signature_bytes));
+    let signature_b64 = base64::engine::general_purpose::URL_SAFE.encode(signature_bytes);
+
+    let mut headers: Vec<(String, String)> = Vec::with_capacity(spec.output_headers.len());
+    for header in &spec.output_headers {
+        let value = resolve_output_source(
+            &header.value,
+            signer_address_placeholder,
+            &public_key_b58,
+            &signature_hex,
+            &signature_b64,
+            timestamp_secs,
+            nonce_bytes,
+        )?;
+        headers.push((header.header_name.clone(), value));
+    }
+    Ok(SignerOutput {
+        headers,
+        body_mutations: Vec::new(),
+    })
+}
+
+#[derive(BorshSerialize)]
+struct Nep413Payload {
+    message: String,
+    nonce: [u8; 32],
+    recipient: String,
+    callback_url: Option<String>,
+}
+
+fn parse_secp256k1_secret(secret: &str) -> Result<SigningKey, SignerError> {
+    let trimmed = secret.trim().trim_start_matches("0x");
+    let bytes = hex::decode(trimmed)
+        .map_err(|e| SignerError::InvalidSecret(format!("expected hex secp256k1 key: {e}")))?;
+    if bytes.len() != 32 {
+        return Err(SignerError::InvalidSecret(format!(
+            "secp256k1 key must be 32 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    SigningKey::from_slice(&bytes)
+        .map_err(|e| SignerError::InvalidSecret(format!("invalid secp256k1 key: {e}")))
+}
+
+fn parse_ed25519_secret(
+    secret: &str,
+) -> Result<(ed25519_dalek::SigningKey, ed25519_dalek::VerifyingKey), SignerError> {
+    let trimmed = secret.trim();
+    let trimmed = trimmed.strip_prefix("ed25519:").unwrap_or(trimmed);
+    let bytes = bs58::decode(trimmed)
+        .into_vec()
+        .map_err(|e| SignerError::InvalidSecret(format!("expected base58 ed25519 key: {e}")))?;
+    let seed_bytes: [u8; 32] = match bytes.len() {
+        32 => bytes
+            .try_into()
+            .map_err(|_| SignerError::InvalidSecret("ed25519 32-byte slice".into()))?,
+        64 => bytes[..32]
+            .try_into()
+            .map_err(|_| SignerError::InvalidSecret("ed25519 64-byte slice prefix".into()))?,
+        n => {
+            return Err(SignerError::InvalidSecret(format!(
+                "ed25519 key must be 32 or 64 bytes, got {n}"
+            )));
+        }
+    };
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed_bytes);
+    let verifying_key = signing_key.verifying_key();
+    Ok((signing_key, verifying_key))
+}
+
+fn derive_eth_address(key: &SigningKey) -> [u8; 20] {
+    let pubkey_point = key.verifying_key().to_encoded_point(false);
+    let pubkey_bytes = &pubkey_point.as_bytes()[1..];
+    let hash = keccak256(pubkey_bytes);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    addr
+}
+
+fn derive_secp256k1_public_key_hex(key: &SigningKey) -> String {
+    let pubkey_point = key.verifying_key().to_encoded_point(false);
+    format!("0x{}", hex::encode(pubkey_point.as_bytes()))
+}
+
+fn keccak256(input: &[u8]) -> [u8; 32] {
+    let mut hasher = Keccak256::new();
+    hasher.update(input);
+    hasher.finalize().into()
+}
+
+fn encode_eip712_type_string(primary: &crate::secrets::Eip712StructDef) -> String {
+    let fields: Vec<String> = primary
+        .fields
+        .iter()
+        .map(|f| format!("{} {}", f.type_name, f.name))
+        .collect();
+    format!("{}({})", primary.name, fields.join(","))
+}
+
+fn compute_eip712_domain_separator(
+    domain: &crate::secrets::Eip712Domain,
+) -> Result<[u8; 32], SignerError> {
+    let mut domain_type = String::from("EIP712Domain(string name,string version,uint256 chainId");
+    if domain.verifying_contract.is_some() {
+        domain_type.push_str(",address verifyingContract");
+    }
+    domain_type.push(')');
+
+    let domain_type_hash = keccak256(domain_type.as_bytes());
+    let name_hash = keccak256(domain.name.as_bytes());
+    let version_hash = keccak256(domain.version.as_bytes());
+
+    let mut buf = Vec::with_capacity(32 * 5);
+    buf.extend_from_slice(&domain_type_hash);
+    buf.extend_from_slice(&name_hash);
+    buf.extend_from_slice(&version_hash);
+
+    let mut chain_id_be = [0u8; 32];
+    chain_id_be[24..].copy_from_slice(&domain.chain_id.to_be_bytes());
+    buf.extend_from_slice(&chain_id_be);
+
+    if let Some(addr) = &domain.verifying_contract {
+        let addr_bytes = parse_eth_address(addr)?;
+        let mut padded = [0u8; 32];
+        padded[12..].copy_from_slice(&addr_bytes);
+        buf.extend_from_slice(&padded);
+    }
+
+    Ok(keccak256(&buf))
+}
+
+fn encode_eip712_field_value(type_name: &str, value: &str) -> Result<[u8; 32], SignerError> {
+    match type_name {
+        "string" => Ok(keccak256(value.as_bytes())),
+        "address" => {
+            let addr = parse_eth_address(value)?;
+            let mut padded = [0u8; 32];
+            padded[12..].copy_from_slice(&addr);
+            Ok(padded)
+        }
+        "uint256" => {
+            let num: u128 = value
+                .parse()
+                .map_err(|e| SignerError::InvalidField(format!("uint256 parse: {e}")))?;
+            let mut padded = [0u8; 32];
+            padded[16..].copy_from_slice(&num.to_be_bytes());
+            Ok(padded)
+        }
+        "bytes32" => {
+            let trimmed = value.trim_start_matches("0x");
+            let bytes = hex::decode(trimmed)
+                .map_err(|e| SignerError::InvalidField(format!("bytes32 hex: {e}")))?;
+            if bytes.len() != 32 {
+                return Err(SignerError::InvalidField(format!(
+                    "bytes32 must be 32 bytes, got {}",
+                    bytes.len()
+                )));
+            }
+            let mut padded = [0u8; 32];
+            padded.copy_from_slice(&bytes);
+            Ok(padded)
+        }
+        other => Err(SignerError::InvalidField(format!(
+            "unsupported eip712 type: {other}"
+        ))),
+    }
+}
+
+fn parse_eth_address(value: &str) -> Result<[u8; 20], SignerError> {
+    let trimmed = value.trim().trim_start_matches("0x");
+    let bytes = hex::decode(trimmed)
+        .map_err(|e| SignerError::InvalidField(format!("address hex: {e}")))?;
+    if bytes.len() != 20 {
+        return Err(SignerError::InvalidField(format!(
+            "address must be 20 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&bytes);
+    Ok(addr)
+}
+
+fn sign_secp256k1_recoverable(
+    key: &SigningKey,
+    hash: &[u8; 32],
+) -> Result<([u8; 64], u8), SignerError> {
+    use k256::ecdsa::{RecoveryId, VerifyingKey};
+
+    let signature: K256Signature = key
+        .sign_prehash(hash)
+        .map_err(|e| SignerError::SignFailed(format!("secp256k1 sign: {e}")))?;
+    let signature = signature.normalize_s().unwrap_or(signature);
+    let verifying_key = key.verifying_key();
+
+    let mut recovery_id: Option<u8> = None;
+    for rid in 0..2u8 {
+        let id = RecoveryId::try_from(rid)
+            .map_err(|e| SignerError::SignFailed(format!("recovery id: {e}")))?;
+        if let Ok(recovered) = VerifyingKey::recover_from_prehash(hash, &signature, id)
+            && &recovered == verifying_key
+        {
+            recovery_id = Some(rid);
+            break;
+        }
+    }
+    let recovery_id = recovery_id
+        .ok_or_else(|| SignerError::SignFailed("could not derive recovery id".into()))?;
+
+    let sig_bytes: [u8; 64] = signature.to_bytes().into();
+    Ok((sig_bytes, recovery_id))
+}
+
+fn resolve_field_source(
+    source: &crate::secrets::FieldSource,
+    signer_address: &str,
+    signer_public_key: &str,
+    body: Option<&[u8]>,
+    timestamp_secs: u64,
+    nonce_bytes: &[u8; 32],
+) -> Result<String, SignerError> {
+    use crate::secrets::FieldSource;
+    match source {
+        FieldSource::Literal { value } => Ok(value.clone()),
+        FieldSource::SignerAddress => Ok(signer_address.to_string()),
+        FieldSource::SignerPublicKey => Ok(signer_public_key.to_string()),
+        FieldSource::RequestTimestampSecs => Ok(timestamp_secs.to_string()),
+        FieldSource::RequestRandomNonceB64 => {
+            Ok(base64::engine::general_purpose::URL_SAFE.encode(nonce_bytes))
+        }
+        FieldSource::RequestBody => {
+            let bytes = body.ok_or_else(|| {
+                SignerError::UnsupportedSource(
+                    "request_body source declared but no body present on this request".into(),
+                )
+            })?;
+            String::from_utf8(bytes.to_vec()).map_err(|e| {
+                SignerError::UnsupportedSource(format!("request_body is not valid utf-8: {e}"))
+            })
+        }
+        FieldSource::Bytes32Keccak256OfBytes { parts } => {
+            let assembled = assemble_bytes_for_keccak(parts, body)?;
+            let h = keccak256(&assembled);
+            Ok(format!("0x{}", hex::encode(h)))
+        }
+    }
+}
+
+fn resolve_output_source(
+    source: &crate::secrets::OutputSource,
+    signer_address: &str,
+    signer_public_key: &str,
+    signature_hex: &str,
+    signature_b64: &str,
+    timestamp_secs: u64,
+    nonce_bytes: &[u8; 32],
+) -> Result<String, SignerError> {
+    use crate::secrets::OutputSource;
+    match source {
+        OutputSource::Literal { value } => Ok(value.clone()),
+        OutputSource::SignerAddress => Ok(signer_address.to_string()),
+        OutputSource::SignerPublicKey => Ok(signer_public_key.to_string()),
+        OutputSource::RequestTimestampSecs => Ok(timestamp_secs.to_string()),
+        OutputSource::RequestRandomNonceB64 => {
+            Ok(base64::engine::general_purpose::URL_SAFE.encode(nonce_bytes))
+        }
+        OutputSource::SignatureHex => Ok(signature_hex.to_string()),
+        OutputSource::SignatureBase64 => Ok(signature_b64.to_string()),
+    }
+}
+
+struct EvaluatedSignature {
+    signer_address: String,
+    signer_public_key: String,
+    signature_hex: String,
+    signature_b64: String,
+    signature_r_hex: String,
+    signature_s_hex: String,
+    signature_v: u8,
+    timestamp_secs: u64,
+    nonce_bytes: [u8; 32],
+}
+
+fn evaluate_body_value(
+    value: &crate::secrets::BodyValue,
+    sig: &EvaluatedSignature,
+) -> serde_json::Value {
+    use crate::secrets::BodyValue;
+    use serde_json::json;
+    match value {
+        BodyValue::SignerAddress => json!(sig.signer_address),
+        BodyValue::SignerPublicKey => json!(sig.signer_public_key),
+        BodyValue::SignatureHex => json!(sig.signature_hex),
+        BodyValue::SignatureBase64 => json!(sig.signature_b64),
+        BodyValue::SignatureRHex => json!(sig.signature_r_hex),
+        BodyValue::SignatureSHex => json!(sig.signature_s_hex),
+        BodyValue::SignatureV => json!(sig.signature_v),
+        BodyValue::RequestTimestampSecs => json!(sig.timestamp_secs),
+        BodyValue::RequestRandomNonceB64 => json!(
+            base64::engine::general_purpose::URL_SAFE.encode(sig.nonce_bytes)
+        ),
+        BodyValue::LiteralString { value } => json!(value),
+        BodyValue::LiteralNumber { value } => json!(value),
+    }
+}
+
+fn json_path_get<'a>(root: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut current = root;
+    for part in path.split('.') {
+        current = current.as_object()?.get(part)?;
+    }
+    Some(current)
+}
+
+fn json_path_set(
+    root: &mut serde_json::Value,
+    path: &str,
+    value: serde_json::Value,
+) -> Result<(), SignerError> {
+    let parts: Vec<&str> = path.split('.').collect();
+    if parts.is_empty() {
+        return Err(SignerError::InvalidSchema("empty json path".into()));
+    }
+    let mut current = root;
+    for (idx, part) in parts.iter().enumerate() {
+        let is_last = idx + 1 == parts.len();
+        let map = match current {
+            serde_json::Value::Object(m) => m,
+            _ => {
+                return Err(SignerError::SignFailed(format!(
+                    "json path '{path}' descends into a non-object"
+                )));
+            }
+        };
+        if is_last {
+            map.insert((*part).to_string(), value);
+            return Ok(());
+        }
+        if !map.contains_key(*part) {
+            map.insert((*part).to_string(), serde_json::Value::Object(serde_json::Map::new()));
+        }
+        current = map
+            .get_mut(*part)
+            .ok_or_else(|| SignerError::SignFailed(format!("json path '{path}' walk failed")))?;
+    }
+    Ok(())
+}
+
+fn apply_body_mutations(
+    body: &mut Option<Vec<u8>>,
+    mutations: &[(String, serde_json::Value)],
+) -> Result<(), SignerError> {
+    if mutations.is_empty() {
+        return Ok(());
+    }
+    let bytes = body.as_deref().ok_or_else(|| {
+        SignerError::UnsupportedSource(
+            "signing declares output_body_fields but no request body provided".into(),
+        )
+    })?;
+    let mut json: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|e| SignerError::SignFailed(format!("request body is not json: {e}")))?;
+    for (path, value) in mutations {
+        json_path_set(&mut json, path, value.clone())?;
+    }
+    let new_bytes = serde_json::to_vec(&json)
+        .map_err(|e| SignerError::SignFailed(format!("re-serialize body: {e}")))?;
+    *body = Some(new_bytes);
+    Ok(())
+}
+
+fn assemble_bytes_for_keccak(
+    parts: &[crate::secrets::BytesPart],
+    body: Option<&[u8]>,
+) -> Result<Vec<u8>, SignerError> {
+    let mut out: Vec<u8> = Vec::new();
+    for part in parts {
+        let bytes = evaluate_bytes_part(part, body)?;
+        out.extend_from_slice(&bytes);
+    }
+    Ok(out)
+}
+
+fn evaluate_bytes_part(
+    part: &crate::secrets::BytesPart,
+    body: Option<&[u8]>,
+) -> Result<Vec<u8>, SignerError> {
+    use crate::secrets::BytesPart;
+    match part {
+        BytesPart::LiteralHex { hex } => {
+            let trimmed = hex.trim_start_matches("0x");
+            hex::decode(trimmed)
+                .map_err(|e| SignerError::InvalidField(format!("literal_hex: {e}")))
+        }
+        BytesPart::BodyFieldMsgpack { path } => {
+            let body_bytes = body.ok_or_else(|| {
+                SignerError::UnsupportedSource(
+                    "body_field_msgpack source needs request body".into(),
+                )
+            })?;
+            let json: serde_json::Value = serde_json::from_slice(body_bytes)
+                .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?;
+            let field = json_path_get(&json, path).ok_or_else(|| {
+                SignerError::InvalidField(format!("body field '{path}' not found"))
+            })?;
+            let mut out: Vec<u8> = Vec::new();
+            field
+                .serialize(&mut MsgpackSerializer::new(&mut out).with_struct_map())
+                .map_err(|e| SignerError::InvalidField(format!("msgpack encode: {e}")))?;
+            Ok(out)
+        }
+        BytesPart::BodyFieldBeU64 { path } => {
+            let body_bytes = body.ok_or_else(|| {
+                SignerError::UnsupportedSource(
+                    "body_field_be_u64 source needs request body".into(),
+                )
+            })?;
+            let json: serde_json::Value = serde_json::from_slice(body_bytes)
+                .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?;
+            let field = json_path_get(&json, path).ok_or_else(|| {
+                SignerError::InvalidField(format!("body field '{path}' not found"))
+            })?;
+            let n = field.as_u64().ok_or_else(|| {
+                SignerError::InvalidField(format!(
+                    "body field '{path}' must be a non-negative integer"
+                ))
+            })?;
+            Ok(n.to_be_bytes().to_vec())
+        }
+        BytesPart::BodyFieldEthAddressOptionalPrefixed { path } => {
+            let body_bytes = body.ok_or_else(|| {
+                SignerError::UnsupportedSource(
+                    "body_field_eth_address_optional_prefixed source needs request body".into(),
+                )
+            })?;
+            let json: serde_json::Value = serde_json::from_slice(body_bytes)
+                .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?;
+            match json_path_get(&json, path) {
+                None | Some(serde_json::Value::Null) => Ok(vec![0x00]),
+                Some(serde_json::Value::String(s)) => {
+                    let addr = parse_eth_address(s)?;
+                    let mut out = Vec::with_capacity(21);
+                    out.push(0x01);
+                    out.extend_from_slice(&addr);
+                    Ok(out)
+                }
+                Some(_) => Err(SignerError::InvalidField(format!(
+                    "body field '{path}' must be a string or null"
+                ))),
+            }
         }
     }
 }
@@ -333,7 +1125,7 @@ impl near::agent::host::Host for StoreData {
         method: String,
         url: String,
         headers_json: String,
-        body: Option<Vec<u8>>,
+        mut body: Option<Vec<u8>>,
         timeout_ms: Option<u32>,
     ) -> Result<near::agent::host::HttpResponse, String> {
         // Inject credentials into URL (e.g., replace {TELEGRAM_BOT_TOKEN})
@@ -389,7 +1181,7 @@ impl near::agent::host::Host for StoreData {
         // Inject pre-resolved host credentials (Bearer tokens, API keys, etc.)
         // based on the request's target host.
         if let Some(host) = extract_host_from_url(&url) {
-            self.inject_host_credentials(&host, &mut headers, &mut url);
+            self.inject_host_credentials(&host, &method, &mut body, &mut headers, &mut url);
         }
 
         // Get the max response size from capabilities (default 10MB).
@@ -1508,7 +2300,42 @@ async fn resolve_host_credentials(
         let mut injected = InjectedCredentials::empty();
         inject_credential(&mut injected, &mapping.location, &secret);
 
-        if injected.is_empty() {
+        let signing = match &mapping.location {
+            crate::secrets::CredentialLocation::HmacSignedHeader {
+                signature_header,
+                timestamp_header,
+            } => Some(SigningSpec::Hmac(HmacSigning {
+                signature_header: signature_header.clone(),
+                timestamp_header: timestamp_header.clone(),
+            })),
+            crate::secrets::CredentialLocation::Eip712SignedHeader {
+                domain,
+                primary_type,
+                structs,
+                output_headers,
+                output_body_fields,
+            } => Some(SigningSpec::Eip712(Eip712Signing {
+                domain: domain.clone(),
+                primary_type: primary_type.clone(),
+                structs: structs.clone(),
+                output_headers: output_headers.clone(),
+                output_body_fields: output_body_fields.clone(),
+            })),
+            crate::secrets::CredentialLocation::Nep413SignedHeader {
+                recipient_source,
+                message_source,
+                callback_url_source,
+                output_headers,
+            } => Some(SigningSpec::Nep413(Nep413Signing {
+                recipient_source: recipient_source.clone(),
+                message_source: message_source.clone(),
+                callback_url_source: callback_url_source.clone(),
+                output_headers: output_headers.clone(),
+            })),
+            _ => None,
+        };
+
+        if injected.is_empty() && signing.is_none() {
             continue;
         }
 
@@ -1519,6 +2346,7 @@ async fn resolve_host_credentials(
             headers: injected.headers,
             query_params: injected.query_params,
             secret_value: secret.expose().to_string(),
+            signing,
         });
     }
 
@@ -1805,6 +2633,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
+    use base64::Engine as _;
+    use hmac::Mac as _;
+    use sha2::Digest as _;
     use axum::extract::{Form, State};
     use axum::http::HeaderMap;
     use axum::routing::post;
@@ -2438,6 +3269,7 @@ mod tests {
             },
             query_params: HashMap::new(),
             secret_value: TEST_BEARER_TOKEN_123.to_string(),
+            signing: None,
         }];
 
         let store_data = StoreData::new(
@@ -2450,7 +3282,7 @@ mod tests {
         // Should inject for matching host
         let mut headers = HashMap::new();
         let mut url = "https://www.googleapis.com/calendar/v3/events".to_string();
-        store_data.inject_host_credentials("www.googleapis.com", &mut headers, &mut url);
+        store_data.inject_host_credentials("www.googleapis.com", "GET", &mut None, &mut headers, &mut url);
         assert_eq!(
             headers.get("Authorization"),
             Some(&format!("Bearer {TEST_BEARER_TOKEN_123}"))
@@ -2459,7 +3291,7 @@ mod tests {
         // Should not inject for non-matching host
         let mut headers2 = HashMap::new();
         let mut url2 = "https://other.com/api".to_string();
-        store_data.inject_host_credentials("other.com", &mut headers2, &mut url2);
+        store_data.inject_host_credentials("other.com", "GET", &mut None, &mut headers2, &mut url2);
         assert!(!headers2.contains_key("Authorization"));
     }
 
@@ -2482,6 +3314,7 @@ mod tests {
             },
             query_params: HashMap::new(),
             secret_value: "scoped-token".to_string(),
+            signing: None,
         }];
 
         let store_data = StoreData::new(
@@ -2494,7 +3327,7 @@ mod tests {
         // Should inject for matching host + matching path
         let mut headers = HashMap::new();
         let mut url = "https://api.example.com/api/v1/users".to_string();
-        store_data.inject_host_credentials("api.example.com", &mut headers, &mut url);
+        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers, &mut url);
         assert_eq!(
             headers.get("Authorization"),
             Some(&"Bearer scoped-token".to_string())
@@ -2503,13 +3336,13 @@ mod tests {
         // Should NOT inject for matching host + non-matching path
         let mut headers2 = HashMap::new();
         let mut url2 = "https://api.example.com/other/endpoint".to_string();
-        store_data.inject_host_credentials("api.example.com", &mut headers2, &mut url2);
+        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers2, &mut url2);
         assert!(!headers2.contains_key("Authorization"));
 
         // Should NOT inject for matching host + prefix-boundary attack
         let mut headers3 = HashMap::new();
         let mut url3 = "https://api.example.com/api/v1-malicious".to_string();
-        store_data.inject_host_credentials("api.example.com", &mut headers3, &mut url3);
+        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers3, &mut url3);
         assert!(!headers3.contains_key("Authorization"));
     }
 
@@ -2530,6 +3363,7 @@ mod tests {
                 },
                 query_params: HashMap::new(),
                 secret_value: "v1-token".to_string(),
+                signing: None,
             },
             ResolvedHostCredential {
                 secret_name: "v2_token".to_string(),
@@ -2542,6 +3376,7 @@ mod tests {
                 },
                 query_params: HashMap::new(),
                 secret_value: "v2-token".to_string(),
+                signing: None,
             },
         ];
 
@@ -2555,7 +3390,7 @@ mod tests {
         // /api/v1 path gets v1 token
         let mut headers = HashMap::new();
         let mut url = "https://api.example.com/api/v1/users".to_string();
-        store_data.inject_host_credentials("api.example.com", &mut headers, &mut url);
+        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers, &mut url);
         assert_eq!(
             headers.get("Authorization"),
             Some(&"Bearer v1-token".to_string())
@@ -2564,7 +3399,7 @@ mod tests {
         // /api/v2 path gets v2 token
         let mut headers2 = HashMap::new();
         let mut url2 = "https://api.example.com/api/v2/data".to_string();
-        store_data.inject_host_credentials("api.example.com", &mut headers2, &mut url2);
+        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers2, &mut url2);
         assert_eq!(
             headers2.get("Authorization"),
             Some(&"Bearer v2-token".to_string())
@@ -2573,7 +3408,7 @@ mod tests {
         // Unscoped path gets neither
         let mut headers3 = HashMap::new();
         let mut url3 = "https://api.example.com/other".to_string();
-        store_data.inject_host_credentials("api.example.com", &mut headers3, &mut url3);
+        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers3, &mut url3);
         assert!(!headers3.contains_key("Authorization"));
     }
 
@@ -2599,6 +3434,7 @@ mod tests {
                 },
                 query_params: HashMap::new(),
                 secret_value: "GLOBAL".to_string(),
+                signing: None,
             }
         }
         fn scoped() -> ResolvedHostCredential {
@@ -2613,6 +3449,7 @@ mod tests {
                 },
                 query_params: HashMap::new(),
                 secret_value: "WRITE".to_string(),
+                signing: None,
             }
         }
 
@@ -2626,7 +3463,7 @@ mod tests {
             let store = StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
             let mut headers = HashMap::new();
             let mut url = "https://api.example.com/api/v1/write/foo".to_string();
-            store.inject_host_credentials("api.example.com", &mut headers, &mut url);
+            store.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers, &mut url);
             assert_eq!(
                 headers.get("Authorization"),
                 Some(&"Bearer WRITE".to_string()),
@@ -2651,6 +3488,7 @@ mod tests {
                 q
             },
             secret_value: "secret123".to_string(),
+            signing: None,
         }];
 
         let store_data = StoreData::new(
@@ -2662,7 +3500,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://api.example.com/v1/data".to_string();
-        store_data.inject_host_credentials("api.example.com", &mut headers, &mut url);
+        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers, &mut url);
         assert!(url.contains("api_key=secret123"));
         assert!(url.contains('?'));
     }
@@ -2679,6 +3517,7 @@ mod tests {
             headers: HashMap::new(),
             query_params: HashMap::new(),
             secret_value: "super-secret-token".to_string(),
+            signing: None,
         }];
 
         let store_data = StoreData::new(
@@ -2692,6 +3531,1180 @@ mod tests {
         let redacted = store_data.redact_credentials(text);
         assert!(!redacted.contains("super-secret-token"));
         assert!(redacted.contains("[REDACTED:host_credential]"));
+    }
+
+    fn expected_hmac_signature(
+        base64_secret: &str,
+        timestamp: &str,
+        method: &str,
+        path: &str,
+        body: Option<&[u8]>,
+    ) -> String {
+        let key = base64::engine::general_purpose::URL_SAFE
+            .decode(base64_secret)
+            .expect("test secret decodes as url-safe base64");
+        let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(&key)
+            .expect("hmac accepts arbitrary key length");
+        mac.update(timestamp.as_bytes());
+        mac.update(method.as_bytes());
+        mac.update(path.as_bytes());
+        if let Some(b) = body {
+            mac.update(b);
+        }
+        base64::engine::general_purpose::URL_SAFE.encode(mac.finalize().into_bytes())
+    }
+
+    const TEST_HMAC_SECRET_B64: &str = "MDEyMzQ1Njc4OWFiY2RlZg==";
+
+    fn hmac_credential(
+        host: &str,
+        path_patterns: Vec<String>,
+        sig_header: &str,
+        ts_header: &str,
+    ) -> super::ResolvedHostCredential {
+        super::ResolvedHostCredential {
+            secret_name: "polymarket_api_secret".to_string(),
+            host_patterns: vec![host.to_string()],
+            path_patterns,
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: TEST_HMAC_SECRET_B64.to_string(),
+            signing: Some(super::SigningSpec::Hmac(super::HmacSigning {
+                signature_header: sig_header.to_string(),
+                timestamp_header: ts_header.to_string(),
+            })),
+        }
+    }
+
+    #[test]
+    fn test_inject_host_credentials_hmac_basic_get() {
+        use crate::tools::wasm::wrapper::StoreData;
+
+        let creds = vec![hmac_credential(
+            "clob.polymarket.com",
+            vec![],
+            "POLY-SIGNATURE",
+            "POLY-TIMESTAMP",
+        )];
+        let store_data =
+            StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/orders".to_string();
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        let timestamp = headers
+            .get("POLY-TIMESTAMP")
+            .expect("timestamp header was emitted")
+            .clone();
+        assert!(timestamp.parse::<u64>().is_ok(), "timestamp must be unix seconds");
+
+        let signature = headers
+            .get("POLY-SIGNATURE")
+            .expect("signature header was emitted");
+        let expected = expected_hmac_signature(
+            TEST_HMAC_SECRET_B64,
+            &timestamp,
+            "GET",
+            "/orders",
+            None,
+        );
+        assert_eq!(signature, &expected);
+    }
+
+    #[test]
+    fn test_inject_host_credentials_hmac_with_body() {
+        use crate::tools::wasm::wrapper::StoreData;
+
+        let creds = vec![hmac_credential(
+            "clob.polymarket.com",
+            vec![],
+            "POLY-SIGNATURE",
+            "POLY-TIMESTAMP",
+        )];
+        let store_data =
+            StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
+
+        let body = br#"{"price":"0.5","side":"BUY","size":"10"}"#;
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/order".to_string();
+        let mut body_slot: Option<Vec<u8>> = Some(body.to_vec());
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "POST",
+            &mut body_slot,
+            &mut headers,
+            &mut url,
+        );
+
+        let timestamp = headers.get("POLY-TIMESTAMP").unwrap().clone();
+        let signature = headers.get("POLY-SIGNATURE").unwrap();
+        let expected = expected_hmac_signature(
+            TEST_HMAC_SECRET_B64,
+            &timestamp,
+            "POST",
+            "/order",
+            Some(body),
+        );
+        assert_eq!(signature, &expected);
+
+        let signature_no_body = expected_hmac_signature(
+            TEST_HMAC_SECRET_B64,
+            &timestamp,
+            "POST",
+            "/order",
+            None,
+        );
+        assert_ne!(
+            signature, &signature_no_body,
+            "body bytes must change the resulting signature"
+        );
+    }
+
+    #[test]
+    fn test_inject_host_credentials_hmac_path_scoped_match() {
+        use crate::tools::wasm::wrapper::StoreData;
+
+        let creds = vec![hmac_credential(
+            "api.example.com",
+            vec!["/v1/private".to_string()],
+            "X-SIG",
+            "X-TS",
+        )];
+        let store_data =
+            StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
+
+        let mut headers = HashMap::new();
+        let mut url = "https://api.example.com/v1/private/orders".to_string();
+        store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert!(headers.contains_key("X-SIG"));
+        assert!(headers.contains_key("X-TS"));
+    }
+
+    #[test]
+    fn test_inject_host_credentials_hmac_path_scoped_miss() {
+        use crate::tools::wasm::wrapper::StoreData;
+
+        let creds = vec![hmac_credential(
+            "api.example.com",
+            vec!["/v1/private".to_string()],
+            "X-SIG",
+            "X-TS",
+        )];
+        let store_data =
+            StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
+
+        let mut headers = HashMap::new();
+        let mut url = "https://api.example.com/v1/public/orders".to_string();
+        store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert!(!headers.contains_key("X-SIG"));
+        assert!(!headers.contains_key("X-TS"));
+    }
+
+    #[test]
+    fn test_inject_host_credentials_hmac_host_mismatch() {
+        use crate::tools::wasm::wrapper::StoreData;
+
+        let creds = vec![hmac_credential(
+            "api.example.com",
+            vec![],
+            "X-SIG",
+            "X-TS",
+        )];
+        let store_data =
+            StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
+
+        let mut headers = HashMap::new();
+        let mut url = "https://other.com/anything".to_string();
+        store_data.inject_host_credentials(
+            "other.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn test_inject_host_credentials_hmac_invalid_secret_skips() {
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+
+        let creds = vec![ResolvedHostCredential {
+            secret_name: "polymarket_api_secret".to_string(),
+            host_patterns: vec!["clob.polymarket.com".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: "this is not valid url-safe base64!!!".to_string(),
+            signing: Some(super::SigningSpec::Hmac(super::HmacSigning {
+                signature_header: "POLY-SIGNATURE".to_string(),
+                timestamp_header: "POLY-TIMESTAMP".to_string(),
+            })),
+        }];
+        let store_data =
+            StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/orders".to_string();
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert!(!headers.contains_key("POLY-SIGNATURE"));
+        assert!(!headers.contains_key("POLY-TIMESTAMP"));
+    }
+
+    #[test]
+    fn test_inject_host_credentials_hmac_combined_with_static_bearer() {
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+
+        let api_key_cred = ResolvedHostCredential {
+            secret_name: "polymarket_api_key".to_string(),
+            host_patterns: vec!["clob.polymarket.com".to_string()],
+            path_patterns: vec![],
+            headers: {
+                let mut h = HashMap::new();
+                h.insert("POLY-API-KEY".to_string(), "the-api-key-id".to_string());
+                h
+            },
+            query_params: HashMap::new(),
+            secret_value: "the-api-key-id".to_string(),
+            signing: None,
+        };
+
+        let creds = vec![
+            api_key_cred,
+            hmac_credential(
+                "clob.polymarket.com",
+                vec![],
+                "POLY-SIGNATURE",
+                "POLY-TIMESTAMP",
+            ),
+        ];
+        let store_data =
+            StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/orders".to_string();
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert_eq!(
+            headers.get("POLY-API-KEY"),
+            Some(&"the-api-key-id".to_string())
+        );
+        assert!(headers.contains_key("POLY-SIGNATURE"));
+        assert!(headers.contains_key("POLY-TIMESTAMP"));
+    }
+
+    #[test]
+    fn test_resolved_host_credential_debug_redacts_hmac_secret() {
+        use crate::tools::wasm::wrapper::ResolvedHostCredential;
+
+        let cred = ResolvedHostCredential {
+            secret_name: "polymarket_api_secret".to_string(),
+            host_patterns: vec!["clob.polymarket.com".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: TEST_HMAC_SECRET_B64.to_string(),
+            signing: Some(super::SigningSpec::Hmac(super::HmacSigning {
+                signature_header: "POLY-SIGNATURE".to_string(),
+                timestamp_header: "POLY-TIMESTAMP".to_string(),
+            })),
+        };
+
+        let dbg = format!("{cred:?}");
+        assert!(dbg.contains("POLY-SIGNATURE"));
+        assert!(dbg.contains("POLY-TIMESTAMP"));
+        assert!(dbg.contains("[REDACTED]"));
+        assert!(!dbg.contains(TEST_HMAC_SECRET_B64));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_host_credentials_hmac_creates_signing_field() {
+        use crate::secrets::{
+            CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
+        };
+        use crate::tools::wasm::capabilities::HttpCapability;
+        use crate::tools::wasm::wrapper::resolve_host_credentials;
+
+        let store = test_secrets_store();
+        store
+            .create(
+                "user1",
+                CreateSecretParams::new("polymarket_api_secret", TEST_HMAC_SECRET_B64),
+            )
+            .await
+            .unwrap();
+
+        let mut credentials = HashMap::new();
+        credentials.insert(
+            "polymarket_api_secret".to_string(),
+            CredentialMapping {
+                secret_name: "polymarket_api_secret".to_string(),
+                location: CredentialLocation::HmacSignedHeader {
+                    signature_header: "POLY-SIGNATURE".to_string(),
+                    timestamp_header: "POLY-TIMESTAMP".to_string(),
+                },
+                host_patterns: vec!["clob.polymarket.com".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+
+        let caps = Capabilities {
+            http: Some(HttpCapability {
+                credentials,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let result = resolve_host_credentials(&caps, Some(&store), "user1", None, None).await;
+        assert_eq!(result.len(), 1);
+        assert!(result[0].headers.is_empty());
+        assert!(result[0].query_params.is_empty());
+        let signing = result[0]
+            .signing
+            .as_ref()
+            .expect("signing field populated for HmacSignedHeader location");
+        match signing {
+            super::SigningSpec::Hmac(spec) => {
+                assert_eq!(spec.signature_header, "POLY-SIGNATURE");
+                assert_eq!(spec.timestamp_header, "POLY-TIMESTAMP");
+            }
+            other => panic!("expected SigningSpec::Hmac, got {:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    const TEST_ETH_PRIVATE_KEY: &str =
+        "0x0123456789012345678901234567890123456789012345678901234567890123";
+    const TEST_NEAR_ED25519_SEED: &str =
+        "11111111111111111111111111111111";
+
+    fn polymarket_clobauth_struct() -> crate::secrets::Eip712StructDef {
+        use crate::secrets::{Eip712StructDef, Eip712TypedField, FieldSource};
+        Eip712StructDef {
+            name: "ClobAuth".to_string(),
+            fields: vec![
+                Eip712TypedField {
+                    name: "address".to_string(),
+                    type_name: "address".to_string(),
+                    source: FieldSource::SignerAddress,
+                },
+                Eip712TypedField {
+                    name: "timestamp".to_string(),
+                    type_name: "string".to_string(),
+                    source: FieldSource::RequestTimestampSecs,
+                },
+                Eip712TypedField {
+                    name: "nonce".to_string(),
+                    type_name: "uint256".to_string(),
+                    source: FieldSource::Literal {
+                        value: "0".to_string(),
+                    },
+                },
+                Eip712TypedField {
+                    name: "message".to_string(),
+                    type_name: "string".to_string(),
+                    source: FieldSource::Literal {
+                        value: "This message attests that I control the given wallet"
+                            .to_string(),
+                    },
+                },
+            ],
+        }
+    }
+
+    fn polymarket_clobauth_signing() -> super::Eip712Signing {
+        use crate::secrets::{Eip712Domain, HeaderOutput, OutputSource};
+        super::Eip712Signing {
+            domain: Eip712Domain {
+                name: "ClobAuthDomain".to_string(),
+                version: "1".to_string(),
+                chain_id: 137,
+                verifying_contract: None,
+            },
+            primary_type: "ClobAuth".to_string(),
+            structs: vec![polymarket_clobauth_struct()],
+            output_headers: vec![
+                HeaderOutput {
+                    header_name: "POLY_ADDRESS".to_string(),
+                    value: OutputSource::SignerAddress,
+                },
+                HeaderOutput {
+                    header_name: "POLY_SIGNATURE".to_string(),
+                    value: OutputSource::SignatureHex,
+                },
+                HeaderOutput {
+                    header_name: "POLY_TIMESTAMP".to_string(),
+                    value: OutputSource::RequestTimestampSecs,
+                },
+                HeaderOutput {
+                    header_name: "POLY_NONCE".to_string(),
+                    value: OutputSource::Literal {
+                        value: "0".to_string(),
+                    },
+                },
+            ],
+            output_body_fields: vec![],
+        }
+    }
+
+    #[test]
+    fn test_inject_host_credentials_eip712_polymarket_clobauth_recovers_signer() {
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+        use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+
+        let signing_key = super::parse_secp256k1_secret(TEST_ETH_PRIVATE_KEY)
+            .expect("test private key parses");
+        let expected_address = super::derive_eth_address(&signing_key);
+        let expected_address_hex = format!("0x{}", hex::encode(expected_address));
+
+        let cred = ResolvedHostCredential {
+            secret_name: "polymarket_eth_key".to_string(),
+            host_patterns: vec!["clob.polymarket.com".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: TEST_ETH_PRIVATE_KEY.to_string(),
+            signing: Some(super::SigningSpec::Eip712(polymarket_clobauth_signing())),
+        };
+
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            vec![cred],
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/auth-api-key".to_string();
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "POST",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert_eq!(headers.get("POLY_ADDRESS"), Some(&expected_address_hex));
+        assert_eq!(headers.get("POLY_NONCE"), Some(&"0".to_string()));
+
+        let timestamp_str = headers
+            .get("POLY_TIMESTAMP")
+            .expect("timestamp header emitted")
+            .clone();
+        timestamp_str
+            .parse::<u64>()
+            .expect("timestamp must be unix seconds");
+
+        let signature_hex = headers
+            .get("POLY_SIGNATURE")
+            .expect("signature header emitted")
+            .clone();
+        let sig_bytes = hex::decode(signature_hex.trim_start_matches("0x"))
+            .expect("signature is hex");
+        assert_eq!(sig_bytes.len(), 65, "signature must be 65 bytes (r||s||v)");
+        let v = sig_bytes[64];
+        assert!(v == 27 || v == 28, "v must be 27 or 28, got {v}");
+
+        let signature = Signature::from_slice(&sig_bytes[..64]).expect("valid signature");
+        let recovery_id = RecoveryId::try_from(v - 27).expect("valid recovery id");
+
+        let domain_sep =
+            super::compute_eip712_domain_separator(&polymarket_clobauth_signing().domain)
+                .expect("domain separator");
+        let primary = polymarket_clobauth_struct();
+        let type_hash =
+            super::keccak256(super::encode_eip712_type_string(&primary).as_bytes());
+        let mut struct_buf: Vec<u8> = Vec::new();
+        struct_buf.extend_from_slice(&type_hash);
+        struct_buf
+            .extend_from_slice(&super::encode_eip712_field_value("address", &expected_address_hex).unwrap());
+        struct_buf
+            .extend_from_slice(&super::encode_eip712_field_value("string", &timestamp_str).unwrap());
+        struct_buf.extend_from_slice(&super::encode_eip712_field_value("uint256", "0").unwrap());
+        struct_buf.extend_from_slice(
+            &super::encode_eip712_field_value(
+                "string",
+                "This message attests that I control the given wallet",
+            )
+            .unwrap(),
+        );
+        let struct_hash = super::keccak256(&struct_buf);
+
+        let mut final_buf: Vec<u8> = Vec::with_capacity(2 + 32 + 32);
+        final_buf.extend_from_slice(&[0x19u8, 0x01u8]);
+        final_buf.extend_from_slice(&domain_sep);
+        final_buf.extend_from_slice(&struct_hash);
+        let final_hash = super::keccak256(&final_buf);
+
+        let recovered_pk = VerifyingKey::recover_from_prehash(&final_hash, &signature, recovery_id)
+            .expect("recover from signature");
+        let recovered_point = recovered_pk.to_encoded_point(false);
+        let recovered_pk_bytes = &recovered_point.as_bytes()[1..];
+        let h = super::keccak256(recovered_pk_bytes);
+        let mut recovered_addr = [0u8; 20];
+        recovered_addr.copy_from_slice(&h[12..]);
+        assert_eq!(
+            recovered_addr, expected_address,
+            "signature must recover to the signer address"
+        );
+    }
+
+    #[test]
+    fn test_inject_host_credentials_eip712_invalid_secret_skips() {
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+
+        let cred = ResolvedHostCredential {
+            secret_name: "polymarket_eth_key".to_string(),
+            host_patterns: vec!["clob.polymarket.com".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: "not a real hex private key".to_string(),
+            signing: Some(super::SigningSpec::Eip712(polymarket_clobauth_signing())),
+        };
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            vec![cred],
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/auth-api-key".to_string();
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "POST",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert!(!headers.contains_key("POLY_ADDRESS"));
+        assert!(!headers.contains_key("POLY_SIGNATURE"));
+        assert!(!headers.contains_key("POLY_TIMESTAMP"));
+    }
+
+    #[test]
+    fn test_inject_host_credentials_eip712_multi_struct_schema_skips() {
+        use crate::secrets::{Eip712StructDef, Eip712TypedField, FieldSource};
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+
+        let mut spec = polymarket_clobauth_signing();
+        spec.structs.push(Eip712StructDef {
+            name: "Other".to_string(),
+            fields: vec![Eip712TypedField {
+                name: "x".to_string(),
+                type_name: "uint256".to_string(),
+                source: FieldSource::Literal {
+                    value: "1".to_string(),
+                },
+            }],
+        });
+
+        let cred = ResolvedHostCredential {
+            secret_name: "polymarket_eth_key".to_string(),
+            host_patterns: vec!["clob.polymarket.com".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: TEST_ETH_PRIVATE_KEY.to_string(),
+            signing: Some(super::SigningSpec::Eip712(spec)),
+        };
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            vec![cred],
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/auth-api-key".to_string();
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "POST",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn test_nep413_borsh_prefix_matches_spec() {
+        let prefix: u32 = 2_147_484_061;
+        let mut buf: Vec<u8> = Vec::new();
+        borsh::BorshSerialize::serialize(&prefix, &mut buf).unwrap();
+        assert_eq!(buf, vec![0x9D, 0x01, 0x00, 0x80]);
+    }
+
+    fn nep413_signing(recipient: &str, message: &str) -> super::Nep413Signing {
+        use crate::secrets::{FieldSource, HeaderOutput, OutputSource};
+        super::Nep413Signing {
+            recipient_source: FieldSource::Literal {
+                value: recipient.to_string(),
+            },
+            message_source: FieldSource::Literal {
+                value: message.to_string(),
+            },
+            callback_url_source: None,
+            output_headers: vec![
+                HeaderOutput {
+                    header_name: "X-NEAR-PUBLIC-KEY".to_string(),
+                    value: OutputSource::SignerPublicKey,
+                },
+                HeaderOutput {
+                    header_name: "X-NEAR-SIGNATURE".to_string(),
+                    value: OutputSource::SignatureBase64,
+                },
+                HeaderOutput {
+                    header_name: "X-NEAR-NONCE".to_string(),
+                    value: OutputSource::RequestRandomNonceB64,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn test_inject_host_credentials_nep413_signature_verifies() {
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+        use ed25519_dalek::Verifier;
+
+        let cred = ResolvedHostCredential {
+            secret_name: "near_account_key".to_string(),
+            host_patterns: vec!["api.trezu.example".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: TEST_NEAR_ED25519_SEED.to_string(),
+            signing: Some(super::SigningSpec::Nep413(nep413_signing(
+                "trezu.near",
+                "auth-challenge-2026",
+            ))),
+        };
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            vec![cred],
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://api.trezu.example/login".to_string();
+        store_data.inject_host_credentials(
+            "api.trezu.example",
+            "POST",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        let pk_str = headers
+            .get("X-NEAR-PUBLIC-KEY")
+            .expect("public key header emitted")
+            .clone();
+        assert!(pk_str.starts_with("ed25519:"));
+        let pk_b58 = pk_str.trim_start_matches("ed25519:");
+        let pk_bytes = bs58::decode(pk_b58).into_vec().unwrap();
+        let verifying_key =
+            ed25519_dalek::VerifyingKey::from_bytes(pk_bytes.as_slice().try_into().unwrap())
+                .unwrap();
+
+        let sig_b64 = headers
+            .get("X-NEAR-SIGNATURE")
+            .expect("signature header emitted")
+            .clone();
+        let sig_bytes = base64::engine::general_purpose::URL_SAFE
+            .decode(sig_b64.as_bytes())
+            .expect("signature is url-safe base64");
+        let signature =
+            ed25519_dalek::Signature::from_bytes(sig_bytes.as_slice().try_into().unwrap());
+
+        let nonce_b64 = headers
+            .get("X-NEAR-NONCE")
+            .expect("nonce header emitted")
+            .clone();
+        let nonce_bytes_vec = base64::engine::general_purpose::URL_SAFE
+            .decode(nonce_b64.as_bytes())
+            .unwrap();
+        let nonce_bytes: [u8; 32] = nonce_bytes_vec.as_slice().try_into().unwrap();
+
+        let payload = super::Nep413Payload {
+            message: "auth-challenge-2026".to_string(),
+            nonce: nonce_bytes,
+            recipient: "trezu.near".to_string(),
+            callback_url: None,
+        };
+
+        let mut serialized: Vec<u8> = Vec::new();
+        let prefix: u32 = 2_147_484_061;
+        borsh::BorshSerialize::serialize(&prefix, &mut serialized).unwrap();
+        borsh::BorshSerialize::serialize(&payload, &mut serialized).unwrap();
+        let hash = sha2::Sha256::digest(&serialized);
+
+        verifying_key
+            .verify(&hash, &signature)
+            .expect("signature must verify against the published public key");
+    }
+
+    #[test]
+    fn test_inject_host_credentials_nep413_invalid_secret_skips() {
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+
+        let cred = ResolvedHostCredential {
+            secret_name: "near_account_key".to_string(),
+            host_patterns: vec!["api.trezu.example".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: "definitely not a base58 ed25519 key !@#".to_string(),
+            signing: Some(super::SigningSpec::Nep413(nep413_signing(
+                "trezu.near",
+                "challenge",
+            ))),
+        };
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            vec![cred],
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://api.trezu.example/login".to_string();
+        store_data.inject_host_credentials(
+            "api.trezu.example",
+            "POST",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert!(!headers.contains_key("X-NEAR-PUBLIC-KEY"));
+        assert!(!headers.contains_key("X-NEAR-SIGNATURE"));
+        assert!(!headers.contains_key("X-NEAR-NONCE"));
+    }
+
+    fn hyperliquid_agent_signing() -> super::Eip712Signing {
+        use crate::secrets::{
+            BodyJsonOutput, BodyValue, BytesPart, Eip712Domain, Eip712StructDef,
+            Eip712TypedField, FieldSource, HeaderOutput, OutputSource,
+        };
+        super::Eip712Signing {
+            domain: Eip712Domain {
+                name: "Exchange".to_string(),
+                version: "1".to_string(),
+                chain_id: 1337,
+                verifying_contract: Some("0x0000000000000000000000000000000000000000".to_string()),
+            },
+            primary_type: "Agent".to_string(),
+            structs: vec![Eip712StructDef {
+                name: "Agent".to_string(),
+                fields: vec![
+                    Eip712TypedField {
+                        name: "source".to_string(),
+                        type_name: "string".to_string(),
+                        source: FieldSource::Literal {
+                            value: "a".to_string(),
+                        },
+                    },
+                    Eip712TypedField {
+                        name: "connectionId".to_string(),
+                        type_name: "bytes32".to_string(),
+                        source: FieldSource::Bytes32Keccak256OfBytes {
+                            parts: vec![
+                                BytesPart::BodyFieldMsgpack {
+                                    path: "action".to_string(),
+                                },
+                                BytesPart::BodyFieldBeU64 {
+                                    path: "nonce".to_string(),
+                                },
+                                BytesPart::BodyFieldEthAddressOptionalPrefixed {
+                                    path: "vaultAddress".to_string(),
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }],
+            output_headers: vec![HeaderOutput {
+                header_name: "X-WALLET-ADDRESS".to_string(),
+                value: OutputSource::SignerAddress,
+            }],
+            output_body_fields: vec![
+                BodyJsonOutput {
+                    json_path: "signature.r".to_string(),
+                    value: BodyValue::SignatureRHex,
+                },
+                BodyJsonOutput {
+                    json_path: "signature.s".to_string(),
+                    value: BodyValue::SignatureSHex,
+                },
+                BodyJsonOutput {
+                    json_path: "signature.v".to_string(),
+                    value: BodyValue::SignatureV,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn test_inject_host_credentials_eip712_hyperliquid_signature_in_body_recovers_signer() {
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+        use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+        use serde::Serialize as _;
+
+        let signing_key = super::parse_secp256k1_secret(TEST_ETH_PRIVATE_KEY)
+            .expect("test private key parses");
+        let expected_address = super::derive_eth_address(&signing_key);
+        let expected_address_hex = format!("0x{}", hex::encode(expected_address));
+
+        let body_json = serde_json::json!({
+            "action": { "type": "order", "grouping": "na" },
+            "nonce": 1_700_000_000_000u64,
+            "vaultAddress": serde_json::Value::Null,
+        });
+        let body_bytes = serde_json::to_vec(&body_json).unwrap();
+
+        let cred = ResolvedHostCredential {
+            secret_name: "hyperliquid_eth_key".to_string(),
+            host_patterns: vec!["api.hyperliquid.xyz".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: TEST_ETH_PRIVATE_KEY.to_string(),
+            signing: Some(super::SigningSpec::Eip712(hyperliquid_agent_signing())),
+        };
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            vec![cred],
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://api.hyperliquid.xyz/exchange".to_string();
+        let mut body_slot: Option<Vec<u8>> = Some(body_bytes.clone());
+        store_data.inject_host_credentials(
+            "api.hyperliquid.xyz",
+            "POST",
+            &mut body_slot,
+            &mut headers,
+            &mut url,
+        );
+
+        assert_eq!(headers.get("X-WALLET-ADDRESS"), Some(&expected_address_hex));
+
+        let mutated_body = body_slot.as_ref().expect("body retained after signing");
+        let mutated_json: serde_json::Value =
+            serde_json::from_slice(mutated_body).expect("body still valid json");
+
+        let r_hex = mutated_json["signature"]["r"]
+            .as_str()
+            .expect("signature.r is a string")
+            .to_string();
+        let s_hex = mutated_json["signature"]["s"]
+            .as_str()
+            .expect("signature.s is a string")
+            .to_string();
+        let v_num = mutated_json["signature"]["v"]
+            .as_u64()
+            .expect("signature.v is a number") as u8;
+        assert!(v_num == 27 || v_num == 28, "v must be 27 or 28, got {v_num}");
+
+        let r_bytes = hex::decode(r_hex.trim_start_matches("0x")).unwrap();
+        let s_bytes = hex::decode(s_hex.trim_start_matches("0x")).unwrap();
+        assert_eq!(r_bytes.len(), 32);
+        assert_eq!(s_bytes.len(), 32);
+
+        let mut sig_64 = [0u8; 64];
+        sig_64[..32].copy_from_slice(&r_bytes);
+        sig_64[32..].copy_from_slice(&s_bytes);
+        let signature = Signature::from_slice(&sig_64).unwrap();
+        let recovery_id = RecoveryId::try_from(v_num - 27).unwrap();
+
+        let mut connection_input: Vec<u8> = Vec::new();
+        let action_value = &body_json["action"];
+        action_value
+            .serialize(
+                &mut rmp_serde::Serializer::new(&mut connection_input).with_struct_map(),
+            )
+            .unwrap();
+        connection_input.extend_from_slice(&1_700_000_000_000u64.to_be_bytes());
+        connection_input.push(0x00);
+        let connection_id_bytes = super::keccak256(&connection_input);
+        let connection_id_hex = format!("0x{}", hex::encode(connection_id_bytes));
+
+        let primary = &hyperliquid_agent_signing().structs[0].clone();
+        let type_string = super::encode_eip712_type_string(primary);
+        let type_hash = super::keccak256(type_string.as_bytes());
+
+        let mut struct_buf: Vec<u8> = Vec::new();
+        struct_buf.extend_from_slice(&type_hash);
+        struct_buf.extend_from_slice(&super::encode_eip712_field_value("string", "a").unwrap());
+        struct_buf.extend_from_slice(
+            &super::encode_eip712_field_value("bytes32", &connection_id_hex).unwrap(),
+        );
+        let struct_hash = super::keccak256(&struct_buf);
+
+        let domain_separator =
+            super::compute_eip712_domain_separator(&hyperliquid_agent_signing().domain).unwrap();
+        let mut final_buf: Vec<u8> = Vec::new();
+        final_buf.extend_from_slice(&[0x19u8, 0x01u8]);
+        final_buf.extend_from_slice(&domain_separator);
+        final_buf.extend_from_slice(&struct_hash);
+        let final_hash = super::keccak256(&final_buf);
+
+        let recovered_pk =
+            VerifyingKey::recover_from_prehash(&final_hash, &signature, recovery_id)
+                .expect("recover from signature");
+        let recovered_point = recovered_pk.to_encoded_point(false);
+        let recovered_pk_bytes = &recovered_point.as_bytes()[1..];
+        let h = super::keccak256(recovered_pk_bytes);
+        let mut recovered_addr = [0u8; 20];
+        recovered_addr.copy_from_slice(&h[12..]);
+        assert_eq!(
+            recovered_addr, expected_address,
+            "Hyperliquid signature must recover to the signer address"
+        );
+
+        let original_action = body_json.get("action").unwrap();
+        assert_eq!(mutated_json.get("action"), Some(original_action),
+            "the action field must not be modified by signing");
+    }
+
+    #[test]
+    fn test_inject_host_credentials_eip712_body_field_msgpack_no_body_skips() {
+        use crate::secrets::{
+            BodyJsonOutput, BodyValue, BytesPart, Eip712Domain, Eip712StructDef,
+            Eip712TypedField, FieldSource, HeaderOutput, OutputSource,
+        };
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+
+        let cred = ResolvedHostCredential {
+            secret_name: "hyperliquid_eth_key".to_string(),
+            host_patterns: vec!["api.hyperliquid.xyz".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: TEST_ETH_PRIVATE_KEY.to_string(),
+            signing: Some(super::SigningSpec::Eip712(super::Eip712Signing {
+                domain: Eip712Domain {
+                    name: "Exchange".to_string(),
+                    version: "1".to_string(),
+                    chain_id: 1337,
+                    verifying_contract: None,
+                },
+                primary_type: "Agent".to_string(),
+                structs: vec![Eip712StructDef {
+                    name: "Agent".to_string(),
+                    fields: vec![Eip712TypedField {
+                        name: "connectionId".to_string(),
+                        type_name: "bytes32".to_string(),
+                        source: FieldSource::Bytes32Keccak256OfBytes {
+                            parts: vec![BytesPart::BodyFieldMsgpack {
+                                path: "action".to_string(),
+                            }],
+                        },
+                    }],
+                }],
+                output_headers: vec![HeaderOutput {
+                    header_name: "X-WALLET-ADDRESS".to_string(),
+                    value: OutputSource::SignerAddress,
+                }],
+                output_body_fields: vec![BodyJsonOutput {
+                    json_path: "signature".to_string(),
+                    value: BodyValue::SignatureHex,
+                }],
+            })),
+        };
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            vec![cred],
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://api.hyperliquid.xyz/exchange".to_string();
+        store_data.inject_host_credentials(
+            "api.hyperliquid.xyz",
+            "POST",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
+
+        assert!(!headers.contains_key("X-WALLET-ADDRESS"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_host_credentials_eip712_creates_signing_field() {
+        use crate::secrets::{
+            CreateSecretParams, CredentialLocation, CredentialMapping, Eip712Domain,
+            Eip712StructDef, Eip712TypedField, FieldSource, HeaderOutput, OutputSource,
+            SecretsStore,
+        };
+        use crate::tools::wasm::capabilities::HttpCapability;
+        use crate::tools::wasm::wrapper::resolve_host_credentials;
+
+        let store = test_secrets_store();
+        store
+            .create(
+                "user1",
+                CreateSecretParams::new("polymarket_eth_key", TEST_ETH_PRIVATE_KEY),
+            )
+            .await
+            .unwrap();
+
+        let mut credentials = HashMap::new();
+        credentials.insert(
+            "polymarket_eth_key".to_string(),
+            CredentialMapping {
+                secret_name: "polymarket_eth_key".to_string(),
+                location: CredentialLocation::Eip712SignedHeader {
+                    domain: Eip712Domain {
+                        name: "ClobAuthDomain".to_string(),
+                        version: "1".to_string(),
+                        chain_id: 137,
+                        verifying_contract: None,
+                    },
+                    primary_type: "ClobAuth".to_string(),
+                    structs: vec![Eip712StructDef {
+                        name: "ClobAuth".to_string(),
+                        fields: vec![Eip712TypedField {
+                            name: "address".to_string(),
+                            type_name: "address".to_string(),
+                            source: FieldSource::SignerAddress,
+                        }],
+                    }],
+                    output_headers: vec![HeaderOutput {
+                        header_name: "POLY_ADDRESS".to_string(),
+                        value: OutputSource::SignerAddress,
+                    }],
+                    output_body_fields: vec![],
+                },
+                host_patterns: vec!["clob.polymarket.com".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+
+        let caps = Capabilities {
+            http: Some(HttpCapability {
+                credentials,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let result = resolve_host_credentials(&caps, Some(&store), "user1", None, None).await;
+        assert_eq!(result.len(), 1);
+        assert!(result[0].headers.is_empty());
+        match result[0].signing.as_ref().unwrap() {
+            super::SigningSpec::Eip712(spec) => {
+                assert_eq!(spec.domain.name, "ClobAuthDomain");
+                assert_eq!(spec.primary_type, "ClobAuth");
+            }
+            _ => panic!("expected SigningSpec::Eip712"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_host_credentials_nep413_creates_signing_field() {
+        use crate::secrets::{
+            CreateSecretParams, CredentialLocation, CredentialMapping, FieldSource, HeaderOutput,
+            OutputSource, SecretsStore,
+        };
+        use crate::tools::wasm::capabilities::HttpCapability;
+        use crate::tools::wasm::wrapper::resolve_host_credentials;
+
+        let store = test_secrets_store();
+        store
+            .create(
+                "user1",
+                CreateSecretParams::new("near_account_key", TEST_NEAR_ED25519_SEED),
+            )
+            .await
+            .unwrap();
+
+        let mut credentials = HashMap::new();
+        credentials.insert(
+            "near_account_key".to_string(),
+            CredentialMapping {
+                secret_name: "near_account_key".to_string(),
+                location: CredentialLocation::Nep413SignedHeader {
+                    recipient_source: FieldSource::Literal {
+                        value: "trezu.near".to_string(),
+                    },
+                    message_source: FieldSource::Literal {
+                        value: "auth".to_string(),
+                    },
+                    callback_url_source: None,
+                    output_headers: vec![HeaderOutput {
+                        header_name: "X-NEAR-PUBLIC-KEY".to_string(),
+                        value: OutputSource::SignerPublicKey,
+                    }],
+                },
+                host_patterns: vec!["api.trezu.example".to_string()],
+                path_patterns: Vec::new(),
+                optional: false,
+            },
+        );
+
+        let caps = Capabilities {
+            http: Some(HttpCapability {
+                credentials,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let result = resolve_host_credentials(&caps, Some(&store), "user1", None, None).await;
+        assert_eq!(result.len(), 1);
+        match result[0].signing.as_ref().unwrap() {
+            super::SigningSpec::Nep413(spec) => {
+                assert_eq!(spec.output_headers.len(), 1);
+                assert_eq!(spec.output_headers[0].header_name, "X-NEAR-PUBLIC-KEY");
+            }
+            _ => panic!("expected SigningSpec::Nep413"),
+        }
     }
 
     #[tokio::test]
@@ -4084,6 +6097,7 @@ mod tests {
             headers,
             query_params,
             secret_value: "raw-secret-bytes".to_string(),
+            signing: None,
         };
 
         let debug_output = format!("{cred:?}");

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -129,6 +129,7 @@ enum SigningSpec {
     Hmac(HmacSigning),
     Eip712(Eip712Signing),
     Nep413(Nep413Signing),
+    Solana(SolanaSigning),
 }
 
 #[derive(Clone)]
@@ -152,6 +153,12 @@ struct Nep413Signing {
     message_source: crate::secrets::FieldSource,
     callback_url_source: Option<crate::secrets::FieldSource>,
     output_headers: Vec<crate::secrets::HeaderOutput>,
+}
+
+#[derive(Clone)]
+struct SolanaSigning {
+    message_source: crate::secrets::FieldSource,
+    output_body_fields: Vec<crate::secrets::BodyJsonOutput>,
 }
 
 impl std::fmt::Debug for ResolvedHostCredential {
@@ -185,6 +192,14 @@ impl std::fmt::Debug for ResolvedHostCredential {
                     .map(|o| o.header_name.as_str())
                     .collect();
                 format!("nep413(outputs={:?})", outs)
+            }
+            SigningSpec::Solana(spec) => {
+                let outs: Vec<&str> = spec
+                    .output_body_fields
+                    .iter()
+                    .map(|o| o.json_path.as_str())
+                    .collect();
+                format!("solana(body_outputs={:?})", outs)
             }
         });
         f.debug_struct("ResolvedHostCredential")
@@ -394,6 +409,13 @@ impl StoreData {
                         timestamp_secs,
                         &nonce_bytes,
                     ),
+                    SigningSpec::Solana(spec) => apply_solana_signing(
+                        spec,
+                        &cred.secret_value,
+                        body.as_deref(),
+                        timestamp_secs,
+                        &nonce_bytes,
+                    ),
                 };
 
                 match result {
@@ -569,7 +591,8 @@ fn apply_eip712_signing(
     let mut body_mutations: Vec<(String, serde_json::Value)> =
         Vec::with_capacity(spec.output_body_fields.len());
     for field in &spec.output_body_fields {
-        body_mutations.push((field.json_path.clone(), evaluate_body_value(&field.value, &evaluated)));
+        let v = evaluate_body_value(&field.value, &evaluated)?;
+        body_mutations.push((field.json_path.clone(), v));
     }
 
     Ok(SignerOutput {
@@ -678,6 +701,114 @@ struct Nep413Payload {
     nonce: [u8; 32],
     recipient: String,
     callback_url: Option<String>,
+}
+
+const SOLANA_MAX_PACKET_BYTES: usize = 1232;
+const SOLANA_SIGNATURE_BYTES: usize = 64;
+const SOLANA_SIG_COUNT_ONE_COMPACT_U16: u8 = 0x01;
+
+fn apply_solana_signing(
+    spec: &SolanaSigning,
+    secret_value: &str,
+    body: Option<&[u8]>,
+    timestamp_secs: u64,
+    nonce_bytes: &[u8; 32],
+) -> Result<SignerOutput, SignerError> {
+    use ed25519_dalek::Signer;
+
+    let (signing_key, verifying_key) = parse_ed25519_secret(secret_value)?;
+    let public_key_b58 = bs58::encode(verifying_key.as_bytes()).into_string();
+
+    let body_json =
+        parse_body_json_if_needed(std::iter::once(&spec.message_source), body)?;
+
+    let message_b64 = resolve_field_source(
+        &spec.message_source,
+        None,
+        &public_key_b58,
+        body,
+        body_json.as_ref(),
+        timestamp_secs,
+        nonce_bytes,
+    )?;
+    let message_bytes = base64::engine::general_purpose::STANDARD
+        .decode(message_b64.as_bytes())
+        .map_err(|e| {
+            SignerError::InvalidField(format!(
+                "solana message is not valid standard base64: {e}"
+            ))
+        })?;
+
+    if message_bytes.is_empty() {
+        return Err(SignerError::InvalidField(
+            "solana message must not be empty".into(),
+        ));
+    }
+    let total_tx_len = 1 + SOLANA_SIGNATURE_BYTES + message_bytes.len();
+    if total_tx_len > SOLANA_MAX_PACKET_BYTES {
+        return Err(SignerError::InvalidField(format!(
+            "solana signed transaction would be {total_tx_len} bytes, exceeds packet limit {SOLANA_MAX_PACKET_BYTES}"
+        )));
+    }
+
+    let signature_bytes = signing_key.sign(&message_bytes).to_bytes();
+
+    let mut signed_tx = Vec::with_capacity(total_tx_len);
+    signed_tx.push(SOLANA_SIG_COUNT_ONE_COMPACT_U16);
+    signed_tx.extend_from_slice(&signature_bytes);
+    signed_tx.extend_from_slice(&message_bytes);
+    let signed_tx_b64 = base64::engine::general_purpose::STANDARD.encode(&signed_tx);
+
+    let mut body_mutations: Vec<(String, serde_json::Value)> =
+        Vec::with_capacity(spec.output_body_fields.len());
+    for field in &spec.output_body_fields {
+        let v = evaluate_solana_body_value(
+            &field.value,
+            &public_key_b58,
+            &signature_bytes,
+            &signed_tx_b64,
+            timestamp_secs,
+            nonce_bytes,
+        )?;
+        body_mutations.push((field.json_path.clone(), v));
+    }
+
+    Ok(SignerOutput {
+        headers: Vec::new(),
+        body_mutations,
+    })
+}
+
+fn evaluate_solana_body_value(
+    value: &crate::secrets::BodyValue,
+    public_key_b58: &str,
+    signature_bytes: &[u8; 64],
+    signed_tx_b64: &str,
+    timestamp_secs: u64,
+    nonce_bytes: &[u8; 32],
+) -> Result<serde_json::Value, SignerError> {
+    use crate::secrets::BodyValue;
+    use serde_json::json;
+    Ok(match value {
+        BodyValue::SignerAddress | BodyValue::SignerPublicKey => json!(public_key_b58),
+        BodyValue::SignatureBase64 => {
+            json!(base64::engine::general_purpose::STANDARD.encode(signature_bytes))
+        }
+        BodyValue::SignatureHex => json!(format!("0x{}", hex::encode(signature_bytes))),
+        BodyValue::SolanaSignedTransactionBase64 => json!(signed_tx_b64),
+        BodyValue::RequestTimestampSecs => json!(timestamp_secs),
+        BodyValue::RequestRandomNonceB64 => {
+            json!(base64::engine::general_purpose::URL_SAFE.encode(nonce_bytes))
+        }
+        BodyValue::LiteralString { value } => json!(value),
+        BodyValue::LiteralNumber { value } => json!(value),
+        BodyValue::SignatureRHex | BodyValue::SignatureSHex | BodyValue::SignatureV => {
+            return Err(SignerError::InvalidSchema(
+                "ecdsa r/s/v components are not produced by the solana ed25519 signer"
+                    .into(),
+            ));
+        }
+    })
 }
 
 fn parse_secp256k1_secret(secret: &str) -> Result<SigningKey, SignerError> {
@@ -919,6 +1050,22 @@ fn resolve_field_source(
             let h = keccak256(&assembled);
             Ok(format!("0x{}", hex::encode(h)))
         }
+        FieldSource::BodyFieldString { path } => {
+            let json = body_json.ok_or_else(|| {
+                SignerError::UnsupportedSource(
+                    "body_field_string source requires the request body to be json".into(),
+                )
+            })?;
+            match json_path_get(json, path) {
+                Some(serde_json::Value::String(s)) => Ok(s.clone()),
+                Some(_) => Err(SignerError::InvalidField(format!(
+                    "body field at '{path}' is not a string"
+                ))),
+                None => Err(SignerError::InvalidField(format!(
+                    "body field at '{path}' not found"
+                ))),
+            }
+        }
     }
 }
 
@@ -965,10 +1112,10 @@ struct EvaluatedSignature {
 fn evaluate_body_value(
     value: &crate::secrets::BodyValue,
     sig: &EvaluatedSignature,
-) -> serde_json::Value {
+) -> Result<serde_json::Value, SignerError> {
     use crate::secrets::BodyValue;
     use serde_json::json;
-    match value {
+    Ok(match value {
         BodyValue::SignerAddress => json!(sig.signer_address),
         BodyValue::SignerPublicKey => json!(sig.signer_public_key),
         BodyValue::SignatureHex => json!(sig.signature_hex),
@@ -982,7 +1129,13 @@ fn evaluate_body_value(
         ),
         BodyValue::LiteralString { value } => json!(value),
         BodyValue::LiteralNumber { value } => json!(value),
-    }
+        BodyValue::SolanaSignedTransactionBase64 => {
+            return Err(SignerError::InvalidSchema(
+                "solana_signed_transaction_base64 is only valid inside solana_signed_transaction"
+                    .into(),
+            ));
+        }
+    })
 }
 
 fn json_path_get<'a>(root: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
@@ -1007,24 +1160,46 @@ fn json_path_set(
     let mut current = root;
     for (idx, part) in parts.iter().enumerate() {
         let is_last = idx + 1 == parts.len();
-        let map = match current {
-            serde_json::Value::Object(m) => m,
+        match current {
+            serde_json::Value::Object(map) => {
+                if is_last {
+                    map.insert((*part).to_string(), value);
+                    return Ok(());
+                }
+                if !map.contains_key(*part) {
+                    map.insert(
+                        (*part).to_string(),
+                        serde_json::Value::Object(serde_json::Map::new()),
+                    );
+                }
+                current = map.get_mut(*part).ok_or_else(|| {
+                    SignerError::SignFailed(format!("json path '{path}' walk failed"))
+                })?;
+            }
+            serde_json::Value::Array(arr) => {
+                let i: usize = part.parse().map_err(|_| {
+                    SignerError::SignFailed(format!(
+                        "json path '{path}' segment '{part}' is not a valid array index"
+                    ))
+                })?;
+                if i >= arr.len() {
+                    return Err(SignerError::SignFailed(format!(
+                        "json path '{path}' index {i} out of bounds (len {})",
+                        arr.len()
+                    )));
+                }
+                if is_last {
+                    arr[i] = value;
+                    return Ok(());
+                }
+                current = &mut arr[i];
+            }
             _ => {
                 return Err(SignerError::SignFailed(format!(
-                    "json path '{path}' descends into a non-object"
+                    "json path '{path}' descends into a scalar"
                 )));
             }
-        };
-        if is_last {
-            map.insert((*part).to_string(), value);
-            return Ok(());
         }
-        if !map.contains_key(*part) {
-            map.insert((*part).to_string(), serde_json::Value::Object(serde_json::Map::new()));
-        }
-        current = map
-            .get_mut(*part)
-            .ok_or_else(|| SignerError::SignFailed(format!("json path '{path}' walk failed")))?;
     }
     Ok(())
 }
@@ -1064,6 +1239,7 @@ where
         FieldSource::Bytes32Keccak256OfBytes { parts } => parts
             .iter()
             .any(|p| !matches!(p, BytesPart::LiteralHex { .. })),
+        FieldSource::BodyFieldString { .. } => true,
         _ => false,
     });
     if !needs {
@@ -2398,6 +2574,13 @@ async fn resolve_host_credentials(
                 message_source: message_source.clone(),
                 callback_url_source: callback_url_source.clone(),
                 output_headers: output_headers.clone(),
+            })),
+            crate::secrets::CredentialLocation::SolanaSignedTransaction {
+                message_source,
+                output_body_fields,
+            } => Some(SigningSpec::Solana(SolanaSigning {
+                message_source: message_source.clone(),
+                output_body_fields: output_body_fields.clone(),
             })),
             _ => None,
         };
@@ -4422,6 +4605,192 @@ mod tests {
         assert!(!headers.contains_key("X-NEAR-PUBLIC-KEY"));
         assert!(!headers.contains_key("X-NEAR-SIGNATURE"));
         assert!(!headers.contains_key("X-NEAR-NONCE"));
+    }
+
+    fn solana_signing_at(path: &str) -> super::SolanaSigning {
+        use crate::secrets::{BodyJsonOutput, BodyValue, FieldSource};
+        super::SolanaSigning {
+            message_source: FieldSource::BodyFieldString {
+                path: path.to_string(),
+            },
+            output_body_fields: vec![BodyJsonOutput {
+                json_path: "params.0".to_string(),
+                value: BodyValue::SolanaSignedTransactionBase64,
+            }],
+        }
+    }
+
+    fn solana_call(message_path: &str, body: serde_json::Value) -> Result<super::SignerOutput, super::SignerError> {
+        super::apply_solana_signing(
+            &solana_signing_at(message_path),
+            TEST_NEAR_ED25519_SEED,
+            Some(serde_json::to_vec(&body).unwrap().as_slice()),
+            0,
+            &[0u8; 32],
+        )
+    }
+
+    #[test]
+    fn test_inject_host_credentials_solana_signature_verifies() {
+        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+        use base64::engine::general_purpose::STANDARD as B64;
+        use ed25519_dalek::Verifier;
+
+        let message_bytes: Vec<u8> = (0u8..96).collect();
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "sendTransaction",
+            "params": ["", {"encoding": "base64"}],
+            "_signing": {"message_b64": B64.encode(&message_bytes)}
+        });
+        let mut body_bytes = Some(serde_json::to_vec(&body).unwrap());
+
+        let cred = ResolvedHostCredential {
+            secret_name: "solana_signer".to_string(),
+            host_patterns: vec!["api.mainnet-beta.solana.com".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: TEST_NEAR_ED25519_SEED.to_string(),
+            signing: Some(super::SigningSpec::Solana(solana_signing_at(
+                "_signing.message_b64",
+            ))),
+        };
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            vec![cred],
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://api.mainnet-beta.solana.com/".to_string();
+        store_data.inject_host_credentials(
+            "api.mainnet-beta.solana.com",
+            "POST",
+            &mut body_bytes,
+            &mut headers,
+            &mut url,
+        );
+
+        let new_body: serde_json::Value =
+            serde_json::from_slice(body_bytes.as_ref().expect("body present")).unwrap();
+        let signed_b64 = new_body["params"][0]
+            .as_str()
+            .expect("params.0 set to signed tx");
+        let signed_bytes = B64.decode(signed_b64.as_bytes()).unwrap();
+
+        assert_eq!(signed_bytes[0], super::SOLANA_SIG_COUNT_ONE_COMPACT_U16);
+        assert_eq!(
+            signed_bytes.len(),
+            1 + super::SOLANA_SIGNATURE_BYTES + message_bytes.len()
+        );
+        let sig_bytes: [u8; 64] = signed_bytes[1..1 + super::SOLANA_SIGNATURE_BYTES]
+            .try_into()
+            .unwrap();
+        assert_eq!(
+            &signed_bytes[1 + super::SOLANA_SIGNATURE_BYTES..],
+            message_bytes.as_slice()
+        );
+
+        let seed_bytes = bs58::decode(TEST_NEAR_ED25519_SEED)
+            .into_vec()
+            .unwrap();
+        let seed: [u8; 32] = seed_bytes.as_slice().try_into().unwrap();
+        let verifying_key = ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key();
+        let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+        verifying_key
+            .verify(&message_bytes, &signature)
+            .expect("ed25519 signature must verify against the message bytes");
+    }
+
+    #[test]
+    fn test_inject_host_credentials_solana_rejects_empty_message() {
+        let err = solana_call(
+            "_signing.message_b64",
+            serde_json::json!({"_signing": {"message_b64": ""}}),
+        )
+        .expect_err("empty message must be rejected");
+        assert!(err.to_string().contains("empty"), "got: {err}");
+    }
+
+    #[test]
+    fn test_inject_host_credentials_solana_rejects_oversized_message() {
+        use base64::engine::general_purpose::STANDARD as B64;
+        let oversized = vec![0u8; super::SOLANA_MAX_PACKET_BYTES];
+        let err = solana_call(
+            "_signing.message_b64",
+            serde_json::json!({"_signing": {"message_b64": B64.encode(&oversized)}}),
+        )
+        .expect_err("oversized message must be rejected");
+        assert!(err.to_string().contains("packet limit"), "got: {err}");
+    }
+
+    #[test]
+    fn test_inject_host_credentials_solana_rejects_missing_message_path() {
+        let err = solana_call(
+            "_signing.message_b64",
+            serde_json::json!({"params": []}),
+        )
+        .expect_err("missing path must be rejected");
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn test_inject_host_credentials_solana_rejects_non_string_at_path() {
+        let err = solana_call(
+            "_signing.message_b64",
+            serde_json::json!({"_signing": {"message_b64": 12345}}),
+        )
+        .expect_err("non-string at path must be rejected");
+        assert!(err.to_string().contains("not a string"), "got: {err}");
+    }
+
+    #[test]
+    fn test_solana_signed_tx_base64_rejected_in_eip712_signer() {
+        use crate::secrets::BodyValue;
+        let evaluated = super::EvaluatedSignature {
+            signer_address: String::new(),
+            signer_public_key: String::new(),
+            signature_hex: String::new(),
+            signature_b64: String::new(),
+            signature_r_hex: String::new(),
+            signature_s_hex: String::new(),
+            signature_v: 0,
+            timestamp_secs: 0,
+            nonce_bytes: [0u8; 32],
+        };
+        let err =
+            super::evaluate_body_value(&BodyValue::SolanaSignedTransactionBase64, &evaluated)
+                .expect_err("eip712 signer must reject solana-only output type");
+        assert!(err.to_string().contains("solana"), "got: {err}");
+    }
+
+    #[test]
+    fn test_solana_signer_rejects_ecdsa_rsv_outputs() {
+        use crate::secrets::{BodyJsonOutput, BodyValue};
+        use base64::engine::general_purpose::STANDARD as B64;
+
+        let bad_output = BodyJsonOutput {
+            json_path: "params.0".to_string(),
+            value: BodyValue::SignatureRHex,
+        };
+        let mut spec = solana_signing_at("_signing.message_b64");
+        spec.output_body_fields = vec![bad_output];
+
+        let body = serde_json::json!({
+            "_signing": {"message_b64": B64.encode([0u8; 32])}
+        });
+        let err = super::apply_solana_signing(
+            &spec,
+            TEST_NEAR_ED25519_SEED,
+            Some(serde_json::to_vec(&body).unwrap().as_slice()),
+            0,
+            &[0u8; 32],
+        )
+        .expect_err("solana signer must reject ecdsa r/s/v outputs");
+        assert!(err.to_string().contains("ecdsa"), "got: {err}");
     }
 
     fn hyperliquid_agent_signing() -> super::Eip712Signing {

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -331,6 +331,13 @@ impl StoreData {
                 .then_with(|| a.secret_name.cmp(&b.secret_name))
         });
 
+        let timestamp_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let mut nonce_bytes = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
         for cred in matches_for_request {
             // Merge injected headers (host credentials take precedence; the
             // most-specific match iterates last, so it wins any conflict).
@@ -364,13 +371,6 @@ impl StoreData {
             }
 
             if let Some(signing) = &cred.signing {
-                let timestamp_secs = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0);
-                let mut nonce_bytes = [0u8; 32];
-                rand::thread_rng().fill_bytes(&mut nonce_bytes);
-
                 let result = match signing {
                     SigningSpec::Hmac(spec) => apply_hmac_signing(
                         spec,
@@ -505,7 +505,7 @@ fn apply_eip712_signing(
     for field in &primary.fields {
         let raw = resolve_field_source(
             &field.source,
-            &address_hex,
+            Some(&address_hex),
             &public_key_hex,
             body,
             timestamp_secs,
@@ -550,7 +550,7 @@ fn apply_eip712_signing(
     for header in &spec.output_headers {
         let value = resolve_output_source(
             &header.value,
-            &address_hex,
+            Some(&address_hex),
             &public_key_hex,
             &signature_hex,
             &signature_b64,
@@ -584,11 +584,10 @@ fn apply_nep413_signing(
         "ed25519:{}",
         bs58::encode(verifying_key.as_bytes()).into_string()
     );
-    let signer_address_placeholder = "";
 
     let recipient = resolve_field_source(
         &spec.recipient_source,
-        signer_address_placeholder,
+        None,
         &public_key_b58,
         body,
         timestamp_secs,
@@ -596,7 +595,7 @@ fn apply_nep413_signing(
     )?;
     let message = resolve_field_source(
         &spec.message_source,
-        signer_address_placeholder,
+        None,
         &public_key_b58,
         body,
         timestamp_secs,
@@ -605,7 +604,7 @@ fn apply_nep413_signing(
     let callback_url = match &spec.callback_url_source {
         Some(src) => Some(resolve_field_source(
             src,
-            signer_address_placeholder,
+            None,
             &public_key_b58,
             body,
             timestamp_secs,
@@ -638,7 +637,7 @@ fn apply_nep413_signing(
     for header in &spec.output_headers {
         let value = resolve_output_source(
             &header.value,
-            signer_address_placeholder,
+            None,
             &public_key_b58,
             &signature_hex,
             &signature_b64,
@@ -846,7 +845,7 @@ fn sign_secp256k1_recoverable(
 
 fn resolve_field_source(
     source: &crate::secrets::FieldSource,
-    signer_address: &str,
+    signer_address: Option<&str>,
     signer_public_key: &str,
     body: Option<&[u8]>,
     timestamp_secs: u64,
@@ -855,7 +854,12 @@ fn resolve_field_source(
     use crate::secrets::FieldSource;
     match source {
         FieldSource::Literal { value } => Ok(value.clone()),
-        FieldSource::SignerAddress => Ok(signer_address.to_string()),
+        FieldSource::SignerAddress => signer_address.map(str::to_string).ok_or_else(|| {
+            SignerError::UnsupportedSource(
+                "signer_address is not produced by this signer type (use signer_public_key instead)"
+                    .into(),
+            )
+        }),
         FieldSource::SignerPublicKey => Ok(signer_public_key.to_string()),
         FieldSource::RequestTimestampSecs => Ok(timestamp_secs.to_string()),
         FieldSource::RequestRandomNonceB64 => {
@@ -881,7 +885,7 @@ fn resolve_field_source(
 
 fn resolve_output_source(
     source: &crate::secrets::OutputSource,
-    signer_address: &str,
+    signer_address: Option<&str>,
     signer_public_key: &str,
     signature_hex: &str,
     signature_b64: &str,
@@ -891,7 +895,12 @@ fn resolve_output_source(
     use crate::secrets::OutputSource;
     match source {
         OutputSource::Literal { value } => Ok(value.clone()),
-        OutputSource::SignerAddress => Ok(signer_address.to_string()),
+        OutputSource::SignerAddress => signer_address.map(str::to_string).ok_or_else(|| {
+            SignerError::UnsupportedSource(
+                "signer_address is not produced by this signer type (use signer_public_key instead)"
+                    .into(),
+            )
+        }),
         OutputSource::SignerPublicKey => Ok(signer_public_key.to_string()),
         OutputSource::RequestTimestampSecs => Ok(timestamp_secs.to_string()),
         OutputSource::RequestRandomNonceB64 => {
@@ -950,10 +959,12 @@ fn json_path_set(
     path: &str,
     value: serde_json::Value,
 ) -> Result<(), SignerError> {
-    let parts: Vec<&str> = path.split('.').collect();
-    if parts.is_empty() {
-        return Err(SignerError::InvalidSchema("empty json path".into()));
+    if path.is_empty() || path.split('.').any(str::is_empty) {
+        return Err(SignerError::InvalidSchema(format!(
+            "invalid json path '{path}'"
+        )));
     }
+    let parts: Vec<&str> = path.split('.').collect();
     let mut current = root;
     for (idx, part) in parts.iter().enumerate() {
         let is_last = idx + 1 == parts.len();
@@ -1006,9 +1017,27 @@ fn assemble_bytes_for_keccak(
     parts: &[crate::secrets::BytesPart],
     body: Option<&[u8]>,
 ) -> Result<Vec<u8>, SignerError> {
+    use crate::secrets::BytesPart;
+    let needs_body = parts
+        .iter()
+        .any(|p| !matches!(p, BytesPart::LiteralHex { .. }));
+    let body_json = if needs_body {
+        let bytes = body.ok_or_else(|| {
+            SignerError::UnsupportedSource(
+                "body-derived bytes_part declared but no request body provided".into(),
+            )
+        })?;
+        Some(
+            serde_json::from_slice::<serde_json::Value>(bytes)
+                .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?,
+        )
+    } else {
+        None
+    };
+
     let mut out: Vec<u8> = Vec::new();
     for part in parts {
-        let bytes = evaluate_bytes_part(part, body)?;
+        let bytes = evaluate_bytes_part(part, body_json.as_ref())?;
         out.extend_from_slice(&bytes);
     }
     Ok(out)
@@ -1016,7 +1045,7 @@ fn assemble_bytes_for_keccak(
 
 fn evaluate_bytes_part(
     part: &crate::secrets::BytesPart,
-    body: Option<&[u8]>,
+    body_json: Option<&serde_json::Value>,
 ) -> Result<Vec<u8>, SignerError> {
     use crate::secrets::BytesPart;
     match part {
@@ -1026,14 +1055,12 @@ fn evaluate_bytes_part(
                 .map_err(|e| SignerError::InvalidField(format!("literal_hex: {e}")))
         }
         BytesPart::BodyFieldMsgpack { path } => {
-            let body_bytes = body.ok_or_else(|| {
+            let json = body_json.ok_or_else(|| {
                 SignerError::UnsupportedSource(
                     "body_field_msgpack source needs request body".into(),
                 )
             })?;
-            let json: serde_json::Value = serde_json::from_slice(body_bytes)
-                .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?;
-            let field = json_path_get(&json, path).ok_or_else(|| {
+            let field = json_path_get(json, path).ok_or_else(|| {
                 SignerError::InvalidField(format!("body field '{path}' not found"))
             })?;
             let mut out: Vec<u8> = Vec::new();
@@ -1043,14 +1070,12 @@ fn evaluate_bytes_part(
             Ok(out)
         }
         BytesPart::BodyFieldBeU64 { path } => {
-            let body_bytes = body.ok_or_else(|| {
+            let json = body_json.ok_or_else(|| {
                 SignerError::UnsupportedSource(
                     "body_field_be_u64 source needs request body".into(),
                 )
             })?;
-            let json: serde_json::Value = serde_json::from_slice(body_bytes)
-                .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?;
-            let field = json_path_get(&json, path).ok_or_else(|| {
+            let field = json_path_get(json, path).ok_or_else(|| {
                 SignerError::InvalidField(format!("body field '{path}' not found"))
             })?;
             let n = field.as_u64().ok_or_else(|| {
@@ -1061,14 +1086,12 @@ fn evaluate_bytes_part(
             Ok(n.to_be_bytes().to_vec())
         }
         BytesPart::BodyFieldEthAddressOptionalPrefixed { path } => {
-            let body_bytes = body.ok_or_else(|| {
+            let json = body_json.ok_or_else(|| {
                 SignerError::UnsupportedSource(
                     "body_field_eth_address_optional_prefixed source needs request body".into(),
                 )
             })?;
-            let json: serde_json::Value = serde_json::from_slice(body_bytes)
-                .map_err(|e| SignerError::InvalidField(format!("body not json: {e}")))?;
-            match json_path_get(&json, path) {
+            match json_path_get(json, path) {
                 None | Some(serde_json::Value::Null) => Ok(vec![0x00]),
                 Some(serde_json::Value::String(s)) => {
                     let addr = parse_eth_address(s)?;
@@ -2169,18 +2192,13 @@ impl std::fmt::Debug for WasmToolWrapper {
     }
 }
 
-/// Pre-resolve credentials for all HTTP capability mappings.
+/// Pre-resolved credentials returned from [`resolve_host_credentials`].
 ///
-/// Called once per tool execution (in async context, before spawn_blocking)
-/// so that the synchronous WASM host function can inject credentials
-/// without needing async access to the secrets store.
-///
-/// Resolves the host credentials declared by a WASM tool for the current user.
-///
-/// Optional mappings may be skipped when unavailable. Required mappings are
-/// tracked in `missing_required` so the caller can fail closed before
-/// execution instead of letting the tool run without the credentials it
-/// declared. That prevents a malicious or misconfigured tool from issuing
+/// Resolution runs once per tool execution in an async context, before the
+/// synchronous WASM host function spawns. Optional mappings may be skipped
+/// when unavailable; required mappings that fail to resolve are tracked in
+/// `missing_required` so the caller can fail closed before execution starts.
+/// Failing closed prevents a malicious or misconfigured tool from issuing
 /// requests that silently borrow another scope's secrets or exfiltrate user
 /// context to an unauthenticated endpoint.
 struct HostCredentialsResolution {
@@ -4705,6 +4723,293 @@ mod tests {
             }
             _ => panic!("expected SigningSpec::Nep413"),
         }
+    }
+
+    const POLYMARKET_CLOB_CAPABILITIES_JSON: &str = r#"{
+      "version": "0.1.0",
+      "wit_version": "0.3.0",
+      "description": "Polymarket signed trading.",
+      "http": {
+        "allowlist": [
+          { "host": "clob.polymarket.com", "path_prefix": "/", "methods": ["GET","POST","DELETE"] }
+        ],
+        "credentials": {
+          "polymarket_l1_clobauth": {
+            "secret_name": "polymarket_l1_private_key",
+            "host_patterns": ["clob.polymarket.com"],
+            "path_patterns": ["/auth/api-key"],
+            "location": {
+              "type": "eip712_signed_header",
+              "domain": { "name": "ClobAuthDomain", "version": "1", "chain_id": 137 },
+              "primary_type": "ClobAuth",
+              "structs": [
+                {
+                  "name": "ClobAuth",
+                  "fields": [
+                    { "name": "address", "type": "address",
+                      "source": { "source": "signer_address" } },
+                    { "name": "timestamp", "type": "string",
+                      "source": { "source": "request_timestamp_secs" } },
+                    { "name": "nonce", "type": "uint256",
+                      "source": { "source": "literal", "value": "0" } },
+                    { "name": "message", "type": "string",
+                      "source": { "source": "literal", "value": "This message attests that I control the given wallet" } }
+                  ]
+                }
+              ],
+              "output_headers": [
+                { "header_name": "POLY_ADDRESS",   "value": { "source": "signer_address" } },
+                { "header_name": "POLY_SIGNATURE", "value": { "source": "signature_hex" } },
+                { "header_name": "POLY_TIMESTAMP", "value": { "source": "request_timestamp_secs" } },
+                { "header_name": "POLY_NONCE",     "value": { "source": "literal", "value": "0" } }
+              ]
+            }
+          },
+          "polymarket_l2_hmac": {
+            "secret_name": "polymarket_l2_secret",
+            "host_patterns": ["clob.polymarket.com"],
+            "location": {
+              "type": "hmac_signed_header",
+              "signature_header": "POLY_SIGNATURE",
+              "timestamp_header": "POLY_TIMESTAMP"
+            }
+          },
+          "polymarket_l2_api_key": {
+            "secret_name": "polymarket_l2_api_key",
+            "host_patterns": ["clob.polymarket.com"],
+            "location": { "type": "header", "name": "POLY_API_KEY" }
+          },
+          "polymarket_l2_passphrase": {
+            "secret_name": "polymarket_l2_passphrase",
+            "host_patterns": ["clob.polymarket.com"],
+            "location": { "type": "header", "name": "POLY_PASSPHRASE" }
+          },
+          "polymarket_l2_address": {
+            "secret_name": "polymarket_l1_address",
+            "host_patterns": ["clob.polymarket.com"],
+            "location": { "type": "header", "name": "POLY_ADDRESS" }
+          }
+        },
+        "rate_limit": { "requests_per_minute": 120, "requests_per_hour": 3600 },
+        "timeout_secs": 30
+      },
+      "secrets": {
+        "allowed_names": [
+          "polymarket_l1_private_key", "polymarket_l1_address",
+          "polymarket_l2_api_key", "polymarket_l2_secret", "polymarket_l2_passphrase"
+        ]
+      }
+    }"#;
+
+    async fn polymarket_dummy_secrets_store() -> (
+        crate::secrets::InMemorySecretsStore,
+        String,
+        String,
+    ) {
+        use crate::secrets::{CreateSecretParams, SecretsStore};
+
+        let signing_key = super::parse_secp256k1_secret(TEST_ETH_PRIVATE_KEY).unwrap();
+        let derived_address = super::derive_eth_address(&signing_key);
+        let derived_address_hex = format!("0x{}", hex::encode(derived_address));
+        let l2_secret_b64 = "dGVzdC1obWFjLXNlY3JldA==";
+
+        let store = test_secrets_store();
+        let user_id = "default";
+        for (name, value) in [
+            ("polymarket_l1_private_key", TEST_ETH_PRIVATE_KEY),
+            ("polymarket_l1_address", derived_address_hex.as_str()),
+            ("polymarket_l2_api_key", "dummy-api-key"),
+            ("polymarket_l2_secret", l2_secret_b64),
+            ("polymarket_l2_passphrase", "dummy-passphrase"),
+        ] {
+            store
+                .create(user_id, CreateSecretParams::new(name, value))
+                .await
+                .unwrap();
+        }
+
+        (store, derived_address_hex, l2_secret_b64.to_string())
+    }
+
+    #[tokio::test]
+    async fn polymarket_clob_l2_request_assembles_with_signed_headers_end_to_end() {
+        use crate::tools::wasm::capabilities_schema::CapabilitiesFile;
+        use crate::tools::wasm::wrapper::{StoreData, resolve_host_credentials};
+
+        let caps_file = CapabilitiesFile::from_json(POLYMARKET_CLOB_CAPABILITIES_JSON)
+            .expect("polymarket-clob capabilities parse");
+        let runtime_caps = caps_file.to_capabilities();
+        let (store, expected_address, l2_secret_b64) = polymarket_dummy_secrets_store().await;
+
+        let resolved =
+            resolve_host_credentials(&runtime_caps, Some(&store), "default", None, None).await;
+        assert_eq!(resolved.len(), 5, "five credential mappings should resolve");
+
+        let store_data = StoreData::new(
+            1024 * 1024,
+            runtime_caps,
+            HashMap::new(),
+            resolved.resolved,
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/data/orders".to_string();
+        let mut body: Option<Vec<u8>> = None;
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "GET",
+            &mut body,
+            &mut headers,
+            &mut url,
+        );
+
+        assert_eq!(headers.get("POLY_API_KEY").map(String::as_str), Some("dummy-api-key"));
+        assert_eq!(
+            headers.get("POLY_PASSPHRASE").map(String::as_str),
+            Some("dummy-passphrase")
+        );
+        assert_eq!(
+            headers.get("POLY_ADDRESS"),
+            Some(&expected_address),
+            "POLY_ADDRESS must match the derived wallet address"
+        );
+
+        let timestamp = headers.get("POLY_TIMESTAMP").expect("timestamp emitted").clone();
+        timestamp.parse::<u64>().expect("timestamp is unix seconds");
+
+        let signature = headers.get("POLY_SIGNATURE").expect("signature emitted");
+        let expected_sig = expected_hmac_signature(
+            &l2_secret_b64,
+            &timestamp,
+            "GET",
+            "/data/orders",
+            None,
+        );
+        assert_eq!(
+            signature, &expected_sig,
+            "L2 HMAC signature must match independent recomputation"
+        );
+
+        assert!(
+            !headers.contains_key("POLY_NONCE"),
+            "L2 path must not emit POLY_NONCE (that is L1 only)"
+        );
+    }
+
+    #[tokio::test]
+    async fn polymarket_clob_l1_register_key_request_assembles_with_eip712_headers_end_to_end() {
+        use crate::tools::wasm::capabilities_schema::CapabilitiesFile;
+        use crate::tools::wasm::wrapper::{StoreData, resolve_host_credentials};
+        use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+
+        let caps_file = CapabilitiesFile::from_json(POLYMARKET_CLOB_CAPABILITIES_JSON).unwrap();
+        let runtime_caps = caps_file.to_capabilities();
+        let (store, expected_address_hex, _) = polymarket_dummy_secrets_store().await;
+
+        let resolved =
+            resolve_host_credentials(&runtime_caps, Some(&store), "default", None, None).await;
+
+        let store_data = StoreData::new(
+            1024 * 1024,
+            runtime_caps,
+            HashMap::new(),
+            resolved.resolved,
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/auth/api-key".to_string();
+        let mut body: Option<Vec<u8>> = Some(b"{}".to_vec());
+        store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "POST",
+            &mut body,
+            &mut headers,
+            &mut url,
+        );
+
+        assert_eq!(headers.get("POLY_NONCE").map(String::as_str), Some("0"));
+        assert_eq!(
+            headers.get("POLY_ADDRESS"),
+            Some(&expected_address_hex),
+            "POLY_ADDRESS on L1 must match the EIP-712 signer-derived address"
+        );
+
+        let timestamp = headers.get("POLY_TIMESTAMP").unwrap().clone();
+        timestamp.parse::<u64>().expect("timestamp is unix seconds");
+        let signature_hex = headers.get("POLY_SIGNATURE").expect("signature emitted").clone();
+
+        let sig_bytes = hex::decode(signature_hex.trim_start_matches("0x")).unwrap();
+        assert_eq!(sig_bytes.len(), 65, "EIP-712 signature must be 65 bytes (r||s||v)");
+        let v = sig_bytes[64];
+        let signature = Signature::from_slice(&sig_bytes[..64]).unwrap();
+        let recovery_id = RecoveryId::try_from(v - 27).unwrap();
+
+        let domain = crate::secrets::Eip712Domain {
+            name: "ClobAuthDomain".to_string(),
+            version: "1".to_string(),
+            chain_id: 137,
+            verifying_contract: None,
+        };
+        let domain_sep = super::compute_eip712_domain_separator(&domain).unwrap();
+
+        let primary = crate::secrets::Eip712StructDef {
+            name: "ClobAuth".to_string(),
+            fields: vec![
+                crate::secrets::Eip712TypedField {
+                    name: "address".to_string(),
+                    type_name: "address".to_string(),
+                    source: crate::secrets::FieldSource::SignerAddress,
+                },
+                crate::secrets::Eip712TypedField {
+                    name: "timestamp".to_string(),
+                    type_name: "string".to_string(),
+                    source: crate::secrets::FieldSource::RequestTimestampSecs,
+                },
+                crate::secrets::Eip712TypedField {
+                    name: "nonce".to_string(),
+                    type_name: "uint256".to_string(),
+                    source: crate::secrets::FieldSource::Literal {
+                        value: "0".to_string(),
+                    },
+                },
+                crate::secrets::Eip712TypedField {
+                    name: "message".to_string(),
+                    type_name: "string".to_string(),
+                    source: crate::secrets::FieldSource::Literal {
+                        value: "This message attests that I control the given wallet".to_string(),
+                    },
+                },
+            ],
+        };
+        let type_hash = super::keccak256(super::encode_eip712_type_string(&primary).as_bytes());
+        let mut struct_buf: Vec<u8> = Vec::new();
+        struct_buf.extend_from_slice(&type_hash);
+        struct_buf.extend_from_slice(&super::encode_eip712_field_value("address", &expected_address_hex).unwrap());
+        struct_buf.extend_from_slice(&super::encode_eip712_field_value("string", &timestamp).unwrap());
+        struct_buf.extend_from_slice(&super::encode_eip712_field_value("uint256", "0").unwrap());
+        struct_buf.extend_from_slice(
+            &super::encode_eip712_field_value("string", "This message attests that I control the given wallet").unwrap(),
+        );
+        let struct_hash = super::keccak256(&struct_buf);
+
+        let mut final_buf: Vec<u8> = Vec::new();
+        final_buf.extend_from_slice(&[0x19u8, 0x01u8]);
+        final_buf.extend_from_slice(&domain_sep);
+        final_buf.extend_from_slice(&struct_hash);
+        let final_hash = super::keccak256(&final_buf);
+
+        let recovered_pk =
+            VerifyingKey::recover_from_prehash(&final_hash, &signature, recovery_id).unwrap();
+        let recovered_point = recovered_pk.to_encoded_point(false);
+        let recovered_pk_bytes = &recovered_point.as_bytes()[1..];
+        let h = super::keccak256(recovered_pk_bytes);
+        let mut recovered_addr = [0u8; 20];
+        recovered_addr.copy_from_slice(&h[12..]);
+        let recovered_hex = format!("0x{}", hex::encode(recovered_addr));
+        assert_eq!(
+            recovered_hex, expected_address_hex,
+            "EIP-712 signature must recover to the dummy wallet address"
+        );
     }
 
     #[tokio::test]

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -132,6 +132,55 @@ enum SigningSpec {
     Solana(SolanaSigning),
 }
 
+impl SigningSpec {
+    fn classification(&self) -> crate::secrets::SignerClassification {
+        use crate::secrets::{CredentialLocation, classify_signing_location};
+        match self {
+            SigningSpec::Hmac(s) => {
+                classify_signing_location(&CredentialLocation::HmacSignedHeader {
+                    signature_header: s.signature_header.clone(),
+                    timestamp_header: s.timestamp_header.clone(),
+                })
+            }
+            SigningSpec::Eip712(s) => {
+                classify_signing_location(&CredentialLocation::Eip712SignedHeader {
+                    domain: s.domain.clone(),
+                    primary_type: s.primary_type.clone(),
+                    structs: s.structs.clone(),
+                    output_headers: s.output_headers.clone(),
+                    output_body_fields: s.output_body_fields.clone(),
+                })
+            }
+            SigningSpec::Nep413(s) => {
+                classify_signing_location(&CredentialLocation::Nep413SignedHeader {
+                    recipient_source: s.recipient_source.clone(),
+                    message_source: s.message_source.clone(),
+                    callback_url_source: s.callback_url_source.clone(),
+                    output_headers: s.output_headers.clone(),
+                })
+            }
+            SigningSpec::Solana(s) => {
+                classify_signing_location(&CredentialLocation::SolanaSignedTransaction {
+                    message_source: s.message_source.clone(),
+                    output_body_fields: s.output_body_fields.clone(),
+                })
+            }
+        }
+    }
+
+    fn approval_summary(&self) -> String {
+        match self {
+            SigningSpec::Hmac(_) => "HMAC-SHA256 request signature".to_string(),
+            SigningSpec::Eip712(s) => format!(
+                "EIP-712 typed message: domain={} primary={} (chain {})",
+                s.domain.name, s.primary_type, s.domain.chain_id
+            ),
+            SigningSpec::Nep413(_) => "NEP-413 NEAR signed message".to_string(),
+            SigningSpec::Solana(_) => "Solana ed25519 transaction (can transfer funds)".to_string(),
+        }
+    }
+}
+
 #[derive(Clone)]
 struct HmacSigning {
     signature_header: String,
@@ -234,6 +283,9 @@ struct StoreData {
     /// Optional HTTP interceptor for testing — returns canned responses
     /// instead of making real requests when set.
     http_interceptor: Option<Arc<dyn HttpInterceptor>>,
+    signer_gate: Option<Arc<dyn crate::secrets::SignerApprovalGate>>,
+    gate_floor: crate::secrets::SignerClassification,
+    tool_label: String,
 }
 
 impl StoreData {
@@ -255,7 +307,22 @@ impl StoreData {
             host_credentials,
             http_runtime: None,
             http_interceptor: None,
+            signer_gate: None,
+            gate_floor: crate::secrets::SignerClassification::High,
+            tool_label: String::new(),
         }
+    }
+
+    fn with_signer_gate(
+        mut self,
+        gate: Arc<dyn crate::secrets::SignerApprovalGate>,
+        floor: crate::secrets::SignerClassification,
+        tool_label: String,
+    ) -> Self {
+        self.signer_gate = Some(gate);
+        self.gate_floor = floor;
+        self.tool_label = tool_label;
+        self
     }
 
     /// Inject credentials into a string by replacing placeholders.
@@ -316,7 +383,7 @@ impl StoreData {
         body: &mut Option<Vec<u8>>,
         headers: &mut HashMap<String, String>,
         url: &mut String,
-    ) {
+    ) -> Result<(), String> {
         use crate::secrets::{
             extract_url_path_for_matching, match_specificity, path_matches_prefix,
         };
@@ -339,10 +406,26 @@ impl StoreData {
             .collect();
 
         matches_for_request.sort_by(|a, b| {
-            let spec_a = match_specificity(&a.path_patterns, &url_path);
-            let spec_b = match_specificity(&b.path_patterns, &url_path);
-            spec_a
-                .cmp(&spec_b)
+            let order_key = |cred: &ResolvedHostCredential| -> (u8, u8) {
+                match &cred.signing {
+                    None => (0, 0),
+                    Some(spec) => {
+                        let class_rank = match spec.classification() {
+                            crate::secrets::SignerClassification::High => 1,
+                            crate::secrets::SignerClassification::Medium => 2,
+                            crate::secrets::SignerClassification::Low => 3,
+                        };
+                        (1, class_rank)
+                    }
+                }
+            };
+            order_key(a)
+                .cmp(&order_key(b))
+                .then_with(|| {
+                    let spec_a = match_specificity(&a.path_patterns, &url_path);
+                    let spec_b = match_specificity(&b.path_patterns, &url_path);
+                    spec_a.cmp(&spec_b)
+                })
                 .then_with(|| a.secret_name.cmp(&b.secret_name))
         });
 
@@ -354,13 +437,10 @@ impl StoreData {
         rand::thread_rng().fill_bytes(&mut nonce_bytes);
 
         for cred in matches_for_request {
-            // Merge injected headers (host credentials take precedence; the
-            // most-specific match iterates last, so it wins any conflict).
             for (key, value) in &cred.headers {
                 headers.insert(key.clone(), value.clone());
             }
 
-            // Append query parameters to URL (insert before fragment if present)
             if !cred.query_params.is_empty() {
                 let (base, fragment) = match url.find('#') {
                     Some(i) => (url[..i].to_string(), Some(url[i..].to_string())),
@@ -386,6 +466,8 @@ impl StoreData {
             }
 
             if let Some(signing) = &cred.signing {
+                self.gate_signing_if_required(signing, cred, url_host, &url_path)?;
+
                 let result = match signing {
                     SigningSpec::Hmac(spec) => apply_hmac_signing(
                         spec,
@@ -424,20 +506,69 @@ impl StoreData {
                             headers.insert(k, v);
                         }
                         if let Err(error) = apply_body_mutations(body, &extra.body_mutations) {
-                            tracing::warn!(
-                                secret_name = %cred.secret_name,
-                                error = %error,
-                                "body mutation failed; signing headers applied but body left unmodified"
-                            );
+                            return Err(format!(
+                                "body mutation failed for signer '{}': {}",
+                                cred.secret_name, error
+                            ));
                         }
                     }
-                    Err(error) => tracing::warn!(
-                        secret_name = %cred.secret_name,
-                        error = %error,
-                        "signer failed; skipping signing headers"
-                    ),
+                    Err(error) => {
+                        return Err(format!("signer '{}' failed: {}", cred.secret_name, error));
+                    }
                 }
             }
+        }
+        Ok(())
+    }
+
+    fn gate_signing_if_required(
+        &self,
+        signing: &SigningSpec,
+        cred: &ResolvedHostCredential,
+        url_host: &str,
+        url_path: &str,
+    ) -> Result<(), String> {
+        let Some(gate) = self.signer_gate.as_ref() else {
+            return Ok(());
+        };
+        let classification = signing.classification();
+        let rank = |c: crate::secrets::SignerClassification| match c {
+            crate::secrets::SignerClassification::Low => 0u8,
+            crate::secrets::SignerClassification::Medium => 1,
+            crate::secrets::SignerClassification::High => 2,
+        };
+        if rank(classification) < rank(self.gate_floor) {
+            return Ok(());
+        }
+
+        let request = crate::secrets::ApprovalRequest {
+            tool_name: self.tool_label.clone(),
+            host: url_host.to_string(),
+            path: url_path.to_string(),
+            secret_name: cred.secret_name.clone(),
+            classification,
+            summary: signing.approval_summary(),
+        };
+
+        let approval = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                tokio::task::block_in_place(|| handle.block_on(gate.request_approval(&request)))
+            }
+            Err(_) => {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| format!("approval gate runtime build failed: {}", e))?;
+                rt.block_on(gate.request_approval(&request))
+            }
+        };
+
+        match approval {
+            crate::secrets::Approval::Approved => Ok(()),
+            crate::secrets::Approval::Denied => Err(format!(
+                "signing denied by user for secret '{}'",
+                cred.secret_name
+            )),
         }
     }
 }
@@ -520,10 +651,7 @@ fn apply_eip712_signing(
             ))
         })?;
 
-    let body_json = parse_body_json_if_needed(
-        primary.fields.iter().map(|f| &f.source),
-        body,
-    )?;
+    let body_json = parse_body_json_if_needed(primary.fields.iter().map(|f| &f.source), body)?;
 
     let mut field_value_buf: Vec<u8> = Vec::with_capacity(32 + primary.fields.len() * 32);
     let type_string = encode_eip712_type_string(primary);
@@ -719,8 +847,7 @@ fn apply_solana_signing(
     let (signing_key, verifying_key) = parse_ed25519_secret(secret_value)?;
     let public_key_b58 = bs58::encode(verifying_key.as_bytes()).into_string();
 
-    let body_json =
-        parse_body_json_if_needed(std::iter::once(&spec.message_source), body)?;
+    let body_json = parse_body_json_if_needed(std::iter::once(&spec.message_source), body)?;
 
     let message_b64 = resolve_field_source(
         &spec.message_source,
@@ -734,9 +861,7 @@ fn apply_solana_signing(
     let message_bytes = base64::engine::general_purpose::STANDARD
         .decode(message_b64.as_bytes())
         .map_err(|e| {
-            SignerError::InvalidField(format!(
-                "solana message is not valid standard base64: {e}"
-            ))
+            SignerError::InvalidField(format!("solana message is not valid standard base64: {e}"))
         })?;
 
     if message_bytes.is_empty() {
@@ -804,8 +929,7 @@ fn evaluate_solana_body_value(
         BodyValue::LiteralNumber { value } => json!(value),
         BodyValue::SignatureRHex | BodyValue::SignatureSHex | BodyValue::SignatureV => {
             return Err(SignerError::InvalidSchema(
-                "ecdsa r/s/v components are not produced by the solana ed25519 signer"
-                    .into(),
+                "ecdsa r/s/v components are not produced by the solana ed25519 signer".into(),
             ));
         }
     })
@@ -969,8 +1093,8 @@ fn parse_uint256_be(value: &str) -> Result<[u8; 32], SignerError> {
 
 fn parse_eth_address(value: &str) -> Result<[u8; 20], SignerError> {
     let trimmed = value.trim().trim_start_matches("0x");
-    let bytes = hex::decode(trimmed)
-        .map_err(|e| SignerError::InvalidField(format!("address hex: {e}")))?;
+    let bytes =
+        hex::decode(trimmed).map_err(|e| SignerError::InvalidField(format!("address hex: {e}")))?;
     if bytes.len() != 20 {
         return Err(SignerError::InvalidField(format!(
             "address must be 20 bytes, got {}",
@@ -1124,9 +1248,9 @@ fn evaluate_body_value(
         BodyValue::SignatureSHex => json!(sig.signature_s_hex),
         BodyValue::SignatureV => json!(sig.signature_v),
         BodyValue::RequestTimestampSecs => json!(sig.timestamp_secs),
-        BodyValue::RequestRandomNonceB64 => json!(
-            base64::engine::general_purpose::URL_SAFE.encode(sig.nonce_bytes)
-        ),
+        BodyValue::RequestRandomNonceB64 => {
+            json!(base64::engine::general_purpose::URL_SAFE.encode(sig.nonce_bytes))
+        }
         BodyValue::LiteralString { value } => json!(value),
         BodyValue::LiteralNumber { value } => json!(value),
         BodyValue::SolanaSignedTransactionBase64 => {
@@ -1276,8 +1400,7 @@ fn evaluate_bytes_part(
     match part {
         BytesPart::LiteralHex { hex } => {
             let trimmed = hex.trim_start_matches("0x");
-            hex::decode(trimmed)
-                .map_err(|e| SignerError::InvalidField(format!("literal_hex: {e}")))
+            hex::decode(trimmed).map_err(|e| SignerError::InvalidField(format!("literal_hex: {e}")))
         }
         BytesPart::BodyFieldMsgpack { path } => {
             let json = body_json.ok_or_else(|| {
@@ -1296,9 +1419,7 @@ fn evaluate_bytes_part(
         }
         BytesPart::BodyFieldBeU64 { path } => {
             let json = body_json.ok_or_else(|| {
-                SignerError::UnsupportedSource(
-                    "body_field_be_u64 source needs request body".into(),
-                )
+                SignerError::UnsupportedSource("body_field_be_u64 source needs request body".into())
             })?;
             let field = json_path_get(json, path).ok_or_else(|| {
                 SignerError::InvalidField(format!("body field '{path}' not found"))
@@ -1429,7 +1550,7 @@ impl near::agent::host::Host for StoreData {
         // Inject pre-resolved host credentials (Bearer tokens, API keys, etc.)
         // based on the request's target host.
         if let Some(host) = extract_host_from_url(&url) {
-            self.inject_host_credentials(&host, &method, &mut body, &mut headers, &mut url);
+            self.inject_host_credentials(&host, &method, &mut body, &mut headers, &mut url)?;
         }
 
         // Get the max response size from capabilities (default 10MB).
@@ -1698,6 +1819,12 @@ pub struct WasmToolWrapper {
     /// Optional HTTP interceptor for testing — returns canned responses
     /// instead of making real requests when set.
     http_interceptor: Option<Arc<dyn HttpInterceptor>>,
+    /// Approval gate for high-classification signers. When set, the wrapper
+    /// plumbs it into per-execution `StoreData` so `inject_host_credentials`
+    /// can block on user consent before each high-value signature.
+    signer_gate: Option<Arc<dyn crate::secrets::SignerApprovalGate>>,
+    /// Classification floor at which the gate fires (default `High`).
+    signer_gate_floor: crate::secrets::SignerClassification,
 }
 
 #[derive(Debug, Clone)]
@@ -1917,7 +2044,19 @@ impl WasmToolWrapper {
             role_lookup: None,
             oauth_refresh: None,
             http_interceptor: None,
+            signer_gate: None,
+            signer_gate_floor: crate::secrets::SignerClassification::High,
         }
+    }
+
+    pub fn with_signer_gate(mut self, gate: Arc<dyn crate::secrets::SignerApprovalGate>) -> Self {
+        self.signer_gate = Some(gate);
+        self
+    }
+
+    pub fn with_signer_gate_floor(mut self, floor: crate::secrets::SignerClassification) -> Self {
+        self.signer_gate_floor = floor;
+        self
     }
 
     /// Set an HTTP interceptor for testing.
@@ -2036,6 +2175,13 @@ impl WasmToolWrapper {
             host_credentials,
         );
         store_data.http_interceptor = self.http_interceptor.clone();
+        if let Some(gate) = self.signer_gate.clone() {
+            store_data = store_data.with_signer_gate(
+                gate,
+                self.signer_gate_floor,
+                self.prepared.name.clone(),
+            );
+        }
         let mut store = Store::new(engine, store_data);
 
         // Configure fuel if enabled
@@ -2352,10 +2498,12 @@ impl Tool for WasmToolWrapper {
                 schemas,
                 discovery_summary,
                 credentials,
-                secrets_store: None, // Not needed in blocking task
+                secrets_store: None,
                 role_lookup: None,
-                oauth_refresh: None, // Already used above for pre-refresh
+                oauth_refresh: None,
                 http_interceptor: self.http_interceptor.clone(),
+                signer_gate: self.signer_gate.clone(),
+                signer_gate_floor: self.signer_gate_floor,
             };
 
             tokio::task::spawn_blocking(move || {
@@ -2883,14 +3031,14 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
-    use base64::Engine as _;
-    use hmac::Mac as _;
-    use sha2::Digest as _;
     use axum::extract::{Form, State};
     use axum::http::HeaderMap;
     use axum::routing::post;
     use axum::{Json, Router};
+    use base64::Engine as _;
+    use hmac::Mac as _;
     use serde_json::json;
+    use sha2::Digest as _;
     use tokio::net::TcpListener;
     use tokio::sync::{Mutex as AsyncMutex, oneshot};
     use uuid::Uuid;
@@ -3532,7 +3680,13 @@ mod tests {
         // Should inject for matching host
         let mut headers = HashMap::new();
         let mut url = "https://www.googleapis.com/calendar/v3/events".to_string();
-        store_data.inject_host_credentials("www.googleapis.com", "GET", &mut None, &mut headers, &mut url);
+        let _ = store_data.inject_host_credentials(
+            "www.googleapis.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
         assert_eq!(
             headers.get("Authorization"),
             Some(&format!("Bearer {TEST_BEARER_TOKEN_123}"))
@@ -3541,7 +3695,13 @@ mod tests {
         // Should not inject for non-matching host
         let mut headers2 = HashMap::new();
         let mut url2 = "https://other.com/api".to_string();
-        store_data.inject_host_credentials("other.com", "GET", &mut None, &mut headers2, &mut url2);
+        let _ = store_data.inject_host_credentials(
+            "other.com",
+            "GET",
+            &mut None,
+            &mut headers2,
+            &mut url2,
+        );
         assert!(!headers2.contains_key("Authorization"));
     }
 
@@ -3577,7 +3737,13 @@ mod tests {
         // Should inject for matching host + matching path
         let mut headers = HashMap::new();
         let mut url = "https://api.example.com/api/v1/users".to_string();
-        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers, &mut url);
+        let _ = store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
         assert_eq!(
             headers.get("Authorization"),
             Some(&"Bearer scoped-token".to_string())
@@ -3586,13 +3752,25 @@ mod tests {
         // Should NOT inject for matching host + non-matching path
         let mut headers2 = HashMap::new();
         let mut url2 = "https://api.example.com/other/endpoint".to_string();
-        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers2, &mut url2);
+        let _ = store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers2,
+            &mut url2,
+        );
         assert!(!headers2.contains_key("Authorization"));
 
         // Should NOT inject for matching host + prefix-boundary attack
         let mut headers3 = HashMap::new();
         let mut url3 = "https://api.example.com/api/v1-malicious".to_string();
-        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers3, &mut url3);
+        let _ = store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers3,
+            &mut url3,
+        );
         assert!(!headers3.contains_key("Authorization"));
     }
 
@@ -3640,7 +3818,13 @@ mod tests {
         // /api/v1 path gets v1 token
         let mut headers = HashMap::new();
         let mut url = "https://api.example.com/api/v1/users".to_string();
-        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers, &mut url);
+        let _ = store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
         assert_eq!(
             headers.get("Authorization"),
             Some(&"Bearer v1-token".to_string())
@@ -3649,7 +3833,13 @@ mod tests {
         // /api/v2 path gets v2 token
         let mut headers2 = HashMap::new();
         let mut url2 = "https://api.example.com/api/v2/data".to_string();
-        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers2, &mut url2);
+        let _ = store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers2,
+            &mut url2,
+        );
         assert_eq!(
             headers2.get("Authorization"),
             Some(&"Bearer v2-token".to_string())
@@ -3658,7 +3848,13 @@ mod tests {
         // Unscoped path gets neither
         let mut headers3 = HashMap::new();
         let mut url3 = "https://api.example.com/other".to_string();
-        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers3, &mut url3);
+        let _ = store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers3,
+            &mut url3,
+        );
         assert!(!headers3.contains_key("Authorization"));
     }
 
@@ -3713,7 +3909,13 @@ mod tests {
             let store = StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
             let mut headers = HashMap::new();
             let mut url = "https://api.example.com/api/v1/write/foo".to_string();
-            store.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers, &mut url);
+            let _ = store.inject_host_credentials(
+                "api.example.com",
+                "GET",
+                &mut None,
+                &mut headers,
+                &mut url,
+            );
             assert_eq!(
                 headers.get("Authorization"),
                 Some(&"Bearer WRITE".to_string()),
@@ -3750,7 +3952,13 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://api.example.com/v1/data".to_string();
-        store_data.inject_host_credentials("api.example.com", "GET", &mut None, &mut headers, &mut url);
+        let _ = store_data.inject_host_credentials(
+            "api.example.com",
+            "GET",
+            &mut None,
+            &mut headers,
+            &mut url,
+        );
         assert!(url.contains("api_key=secret123"));
         assert!(url.contains('?'));
     }
@@ -3841,7 +4049,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/orders".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "GET",
             &mut None,
@@ -3853,18 +4061,16 @@ mod tests {
             .get("POLY-TIMESTAMP")
             .expect("timestamp header was emitted")
             .clone();
-        assert!(timestamp.parse::<u64>().is_ok(), "timestamp must be unix seconds");
+        assert!(
+            timestamp.parse::<u64>().is_ok(),
+            "timestamp must be unix seconds"
+        );
 
         let signature = headers
             .get("POLY-SIGNATURE")
             .expect("signature header was emitted");
-        let expected = expected_hmac_signature(
-            TEST_HMAC_SECRET_B64,
-            &timestamp,
-            "GET",
-            "/orders",
-            None,
-        );
+        let expected =
+            expected_hmac_signature(TEST_HMAC_SECRET_B64, &timestamp, "GET", "/orders", None);
         assert_eq!(signature, &expected);
     }
 
@@ -3885,7 +4091,7 @@ mod tests {
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/order".to_string();
         let mut body_slot: Option<Vec<u8>> = Some(body.to_vec());
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "POST",
             &mut body_slot,
@@ -3904,13 +4110,8 @@ mod tests {
         );
         assert_eq!(signature, &expected);
 
-        let signature_no_body = expected_hmac_signature(
-            TEST_HMAC_SECRET_B64,
-            &timestamp,
-            "POST",
-            "/order",
-            None,
-        );
+        let signature_no_body =
+            expected_hmac_signature(TEST_HMAC_SECRET_B64, &timestamp, "POST", "/order", None);
         assert_ne!(
             signature, &signature_no_body,
             "body bytes must change the resulting signature"
@@ -3932,7 +4133,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://api.example.com/v1/private/orders".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "api.example.com",
             "GET",
             &mut None,
@@ -3959,7 +4160,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://api.example.com/v1/public/orders".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "api.example.com",
             "GET",
             &mut None,
@@ -3975,18 +4176,13 @@ mod tests {
     fn test_inject_host_credentials_hmac_host_mismatch() {
         use crate::tools::wasm::wrapper::StoreData;
 
-        let creds = vec![hmac_credential(
-            "api.example.com",
-            vec![],
-            "X-SIG",
-            "X-TS",
-        )];
+        let creds = vec![hmac_credential("api.example.com", vec![], "X-SIG", "X-TS")];
         let store_data =
             StoreData::new(1024 * 1024, Capabilities::default(), HashMap::new(), creds);
 
         let mut headers = HashMap::new();
         let mut url = "https://other.com/anything".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "other.com",
             "GET",
             &mut None,
@@ -4018,7 +4214,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/orders".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "GET",
             &mut None,
@@ -4062,7 +4258,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/orders".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "GET",
             &mut None,
@@ -4155,14 +4351,16 @@ mod tests {
                 assert_eq!(spec.signature_header, "POLY-SIGNATURE");
                 assert_eq!(spec.timestamp_header, "POLY-TIMESTAMP");
             }
-            other => panic!("expected SigningSpec::Hmac, got {:?}", std::mem::discriminant(other)),
+            other => panic!(
+                "expected SigningSpec::Hmac, got {:?}",
+                std::mem::discriminant(other)
+            ),
         }
     }
 
     const TEST_ETH_PRIVATE_KEY: &str =
         "0x0123456789012345678901234567890123456789012345678901234567890123";
-    const TEST_NEAR_ED25519_SEED: &str =
-        "11111111111111111111111111111111";
+    const TEST_NEAR_ED25519_SEED: &str = "11111111111111111111111111111111";
 
     fn polymarket_clobauth_struct() -> crate::secrets::Eip712StructDef {
         use crate::secrets::{Eip712StructDef, Eip712TypedField, FieldSource};
@@ -4190,8 +4388,7 @@ mod tests {
                     name: "message".to_string(),
                     type_name: "string".to_string(),
                     source: FieldSource::Literal {
-                        value: "This message attests that I control the given wallet"
-                            .to_string(),
+                        value: "This message attests that I control the given wallet".to_string(),
                     },
                 },
             ],
@@ -4238,8 +4435,8 @@ mod tests {
         use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
         use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
 
-        let signing_key = super::parse_secp256k1_secret(TEST_ETH_PRIVATE_KEY)
-            .expect("test private key parses");
+        let signing_key =
+            super::parse_secp256k1_secret(TEST_ETH_PRIVATE_KEY).expect("test private key parses");
         let expected_address = super::derive_eth_address(&signing_key);
         let expected_address_hex = format!("0x{}", hex::encode(expected_address));
 
@@ -4262,7 +4459,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/auth-api-key".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "POST",
             &mut None,
@@ -4285,8 +4482,8 @@ mod tests {
             .get("POLY_SIGNATURE")
             .expect("signature header emitted")
             .clone();
-        let sig_bytes = hex::decode(signature_hex.trim_start_matches("0x"))
-            .expect("signature is hex");
+        let sig_bytes =
+            hex::decode(signature_hex.trim_start_matches("0x")).expect("signature is hex");
         assert_eq!(sig_bytes.len(), 65, "signature must be 65 bytes (r||s||v)");
         let v = sig_bytes[64];
         assert!(v == 27 || v == 28, "v must be 27 or 28, got {v}");
@@ -4298,14 +4495,15 @@ mod tests {
             super::compute_eip712_domain_separator(&polymarket_clobauth_signing().domain)
                 .expect("domain separator");
         let primary = polymarket_clobauth_struct();
-        let type_hash =
-            super::keccak256(super::encode_eip712_type_string(&primary).as_bytes());
+        let type_hash = super::keccak256(super::encode_eip712_type_string(&primary).as_bytes());
         let mut struct_buf: Vec<u8> = Vec::new();
         struct_buf.extend_from_slice(&type_hash);
-        struct_buf
-            .extend_from_slice(&super::encode_eip712_field_value("address", &expected_address_hex).unwrap());
-        struct_buf
-            .extend_from_slice(&super::encode_eip712_field_value("string", &timestamp_str).unwrap());
+        struct_buf.extend_from_slice(
+            &super::encode_eip712_field_value("address", &expected_address_hex).unwrap(),
+        );
+        struct_buf.extend_from_slice(
+            &super::encode_eip712_field_value("string", &timestamp_str).unwrap(),
+        );
         struct_buf.extend_from_slice(&super::encode_eip712_field_value("uint256", "0").unwrap());
         struct_buf.extend_from_slice(
             &super::encode_eip712_field_value(
@@ -4359,7 +4557,8 @@ mod tests {
         let max_bytes = super::parse_uint256_be(max).unwrap();
         assert_eq!(max_bytes, [0xffu8; 32]);
 
-        let overflow = "115792089237316195423570985008687907853269984665640564039457584007913129639936";
+        let overflow =
+            "115792089237316195423570985008687907853269984665640564039457584007913129639936";
         let err = super::parse_uint256_be(overflow).unwrap_err();
         assert!(
             matches!(err, super::SignerError::InvalidField(ref m) if m.contains("overflow")),
@@ -4393,7 +4592,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/auth-api-key".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "POST",
             &mut None,
@@ -4441,7 +4640,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/auth-api-key".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "POST",
             &mut None,
@@ -4513,7 +4712,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://api.trezu.example/login".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "api.trezu.example",
             "POST",
             &mut None,
@@ -4594,7 +4793,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://api.trezu.example/login".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "api.trezu.example",
             "POST",
             &mut None,
@@ -4620,7 +4819,10 @@ mod tests {
         }
     }
 
-    fn solana_call(message_path: &str, body: serde_json::Value) -> Result<super::SignerOutput, super::SignerError> {
+    fn solana_call(
+        message_path: &str,
+        body: serde_json::Value,
+    ) -> Result<super::SignerOutput, super::SignerError> {
         super::apply_solana_signing(
             &solana_signing_at(message_path),
             TEST_NEAR_ED25519_SEED,
@@ -4666,7 +4868,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://api.mainnet-beta.solana.com/".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "api.mainnet-beta.solana.com",
             "POST",
             &mut body_bytes,
@@ -4694,9 +4896,7 @@ mod tests {
             message_bytes.as_slice()
         );
 
-        let seed_bytes = bs58::decode(TEST_NEAR_ED25519_SEED)
-            .into_vec()
-            .unwrap();
+        let seed_bytes = bs58::decode(TEST_NEAR_ED25519_SEED).into_vec().unwrap();
         let seed: [u8; 32] = seed_bytes.as_slice().try_into().unwrap();
         let verifying_key = ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key();
         let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
@@ -4729,11 +4929,8 @@ mod tests {
 
     #[test]
     fn test_inject_host_credentials_solana_rejects_missing_message_path() {
-        let err = solana_call(
-            "_signing.message_b64",
-            serde_json::json!({"params": []}),
-        )
-        .expect_err("missing path must be rejected");
+        let err = solana_call("_signing.message_b64", serde_json::json!({"params": []}))
+            .expect_err("missing path must be rejected");
         assert!(err.to_string().contains("not found"), "got: {err}");
     }
 
@@ -4761,9 +4958,8 @@ mod tests {
             timestamp_secs: 0,
             nonce_bytes: [0u8; 32],
         };
-        let err =
-            super::evaluate_body_value(&BodyValue::SolanaSignedTransactionBase64, &evaluated)
-                .expect_err("eip712 signer must reject solana-only output type");
+        let err = super::evaluate_body_value(&BodyValue::SolanaSignedTransactionBase64, &evaluated)
+            .expect_err("eip712 signer must reject solana-only output type");
         assert!(err.to_string().contains("solana"), "got: {err}");
     }
 
@@ -4795,8 +4991,8 @@ mod tests {
 
     fn hyperliquid_agent_signing() -> super::Eip712Signing {
         use crate::secrets::{
-            BodyJsonOutput, BodyValue, BytesPart, Eip712Domain, Eip712StructDef,
-            Eip712TypedField, FieldSource, HeaderOutput, OutputSource,
+            BodyJsonOutput, BodyValue, BytesPart, Eip712Domain, Eip712StructDef, Eip712TypedField,
+            FieldSource, HeaderOutput, OutputSource,
         };
         super::Eip712Signing {
             domain: Eip712Domain {
@@ -4862,8 +5058,8 @@ mod tests {
         use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
         use serde::Serialize as _;
 
-        let signing_key = super::parse_secp256k1_secret(TEST_ETH_PRIVATE_KEY)
-            .expect("test private key parses");
+        let signing_key =
+            super::parse_secp256k1_secret(TEST_ETH_PRIVATE_KEY).expect("test private key parses");
         let expected_address = super::derive_eth_address(&signing_key);
         let expected_address_hex = format!("0x{}", hex::encode(expected_address));
 
@@ -4893,7 +5089,7 @@ mod tests {
         let mut headers = HashMap::new();
         let mut url = "https://api.hyperliquid.xyz/exchange".to_string();
         let mut body_slot: Option<Vec<u8>> = Some(body_bytes.clone());
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "api.hyperliquid.xyz",
             "POST",
             &mut body_slot,
@@ -4918,7 +5114,10 @@ mod tests {
         let v_num = mutated_json["signature"]["v"]
             .as_u64()
             .expect("signature.v is a number") as u8;
-        assert!(v_num == 27 || v_num == 28, "v must be 27 or 28, got {v_num}");
+        assert!(
+            v_num == 27 || v_num == 28,
+            "v must be 27 or 28, got {v_num}"
+        );
 
         let r_bytes = hex::decode(r_hex.trim_start_matches("0x")).unwrap();
         let s_bytes = hex::decode(s_hex.trim_start_matches("0x")).unwrap();
@@ -4934,9 +5133,7 @@ mod tests {
         let mut connection_input: Vec<u8> = Vec::new();
         let action_value = &body_json["action"];
         action_value
-            .serialize(
-                &mut rmp_serde::Serializer::new(&mut connection_input).with_struct_map(),
-            )
+            .serialize(&mut rmp_serde::Serializer::new(&mut connection_input).with_struct_map())
             .unwrap();
         connection_input.extend_from_slice(&1_700_000_000_000u64.to_be_bytes());
         connection_input.push(0x00);
@@ -4963,9 +5160,8 @@ mod tests {
         final_buf.extend_from_slice(&struct_hash);
         let final_hash = super::keccak256(&final_buf);
 
-        let recovered_pk =
-            VerifyingKey::recover_from_prehash(&final_hash, &signature, recovery_id)
-                .expect("recover from signature");
+        let recovered_pk = VerifyingKey::recover_from_prehash(&final_hash, &signature, recovery_id)
+            .expect("recover from signature");
         let recovered_point = recovered_pk.to_encoded_point(false);
         let recovered_pk_bytes = &recovered_point.as_bytes()[1..];
         let h = super::keccak256(recovered_pk_bytes);
@@ -4977,15 +5173,18 @@ mod tests {
         );
 
         let original_action = body_json.get("action").unwrap();
-        assert_eq!(mutated_json.get("action"), Some(original_action),
-            "the action field must not be modified by signing");
+        assert_eq!(
+            mutated_json.get("action"),
+            Some(original_action),
+            "the action field must not be modified by signing"
+        );
     }
 
     #[test]
     fn test_inject_host_credentials_eip712_body_field_msgpack_no_body_skips() {
         use crate::secrets::{
-            BodyJsonOutput, BodyValue, BytesPart, Eip712Domain, Eip712StructDef,
-            Eip712TypedField, FieldSource, HeaderOutput, OutputSource,
+            BodyJsonOutput, BodyValue, BytesPart, Eip712Domain, Eip712StructDef, Eip712TypedField,
+            FieldSource, HeaderOutput, OutputSource,
         };
         use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
 
@@ -5035,7 +5234,7 @@ mod tests {
 
         let mut headers = HashMap::new();
         let mut url = "https://api.hyperliquid.xyz/exchange".to_string();
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "api.hyperliquid.xyz",
             "POST",
             &mut None,
@@ -5255,11 +5454,8 @@ mod tests {
       }
     }"#;
 
-    async fn polymarket_dummy_secrets_store() -> (
-        crate::secrets::InMemorySecretsStore,
-        String,
-        String,
-    ) {
+    async fn polymarket_dummy_secrets_store()
+    -> (crate::secrets::InMemorySecretsStore, String, String) {
         use crate::secrets::{CreateSecretParams, SecretsStore};
 
         let signing_key = super::parse_secp256k1_secret(TEST_ETH_PRIVATE_KEY).unwrap();
@@ -5299,17 +5495,13 @@ mod tests {
             resolve_host_credentials(&runtime_caps, Some(&store), "default", None, None).await;
         assert_eq!(resolved.len(), 5, "five credential mappings should resolve");
 
-        let store_data = StoreData::new(
-            1024 * 1024,
-            runtime_caps,
-            HashMap::new(),
-            resolved.resolved,
-        );
+        let store_data =
+            StoreData::new(1024 * 1024, runtime_caps, HashMap::new(), resolved.resolved);
 
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/data/orders".to_string();
         let mut body: Option<Vec<u8>> = None;
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "GET",
             &mut body,
@@ -5317,7 +5509,10 @@ mod tests {
             &mut url,
         );
 
-        assert_eq!(headers.get("POLY_API_KEY").map(String::as_str), Some("dummy-api-key"));
+        assert_eq!(
+            headers.get("POLY_API_KEY").map(String::as_str),
+            Some("dummy-api-key")
+        );
         assert_eq!(
             headers.get("POLY_PASSPHRASE").map(String::as_str),
             Some("dummy-passphrase")
@@ -5328,17 +5523,15 @@ mod tests {
             "POLY_ADDRESS must match the derived wallet address"
         );
 
-        let timestamp = headers.get("POLY_TIMESTAMP").expect("timestamp emitted").clone();
+        let timestamp = headers
+            .get("POLY_TIMESTAMP")
+            .expect("timestamp emitted")
+            .clone();
         timestamp.parse::<u64>().expect("timestamp is unix seconds");
 
         let signature = headers.get("POLY_SIGNATURE").expect("signature emitted");
-        let expected_sig = expected_hmac_signature(
-            &l2_secret_b64,
-            &timestamp,
-            "GET",
-            "/data/orders",
-            None,
-        );
+        let expected_sig =
+            expected_hmac_signature(&l2_secret_b64, &timestamp, "GET", "/data/orders", None);
         assert_eq!(
             signature, &expected_sig,
             "L2 HMAC signature must match independent recomputation"
@@ -5363,17 +5556,13 @@ mod tests {
         let resolved =
             resolve_host_credentials(&runtime_caps, Some(&store), "default", None, None).await;
 
-        let store_data = StoreData::new(
-            1024 * 1024,
-            runtime_caps,
-            HashMap::new(),
-            resolved.resolved,
-        );
+        let store_data =
+            StoreData::new(1024 * 1024, runtime_caps, HashMap::new(), resolved.resolved);
 
         let mut headers = HashMap::new();
         let mut url = "https://clob.polymarket.com/auth/api-key".to_string();
         let mut body: Option<Vec<u8>> = Some(b"{}".to_vec());
-        store_data.inject_host_credentials(
+        let _ = store_data.inject_host_credentials(
             "clob.polymarket.com",
             "POST",
             &mut body,
@@ -5390,10 +5579,17 @@ mod tests {
 
         let timestamp = headers.get("POLY_TIMESTAMP").unwrap().clone();
         timestamp.parse::<u64>().expect("timestamp is unix seconds");
-        let signature_hex = headers.get("POLY_SIGNATURE").expect("signature emitted").clone();
+        let signature_hex = headers
+            .get("POLY_SIGNATURE")
+            .expect("signature emitted")
+            .clone();
 
         let sig_bytes = hex::decode(signature_hex.trim_start_matches("0x")).unwrap();
-        assert_eq!(sig_bytes.len(), 65, "EIP-712 signature must be 65 bytes (r||s||v)");
+        assert_eq!(
+            sig_bytes.len(),
+            65,
+            "EIP-712 signature must be 65 bytes (r||s||v)"
+        );
         let v = sig_bytes[64];
         let signature = Signature::from_slice(&sig_bytes[..64]).unwrap();
         let recovery_id = RecoveryId::try_from(v - 27).unwrap();
@@ -5438,11 +5634,18 @@ mod tests {
         let type_hash = super::keccak256(super::encode_eip712_type_string(&primary).as_bytes());
         let mut struct_buf: Vec<u8> = Vec::new();
         struct_buf.extend_from_slice(&type_hash);
-        struct_buf.extend_from_slice(&super::encode_eip712_field_value("address", &expected_address_hex).unwrap());
-        struct_buf.extend_from_slice(&super::encode_eip712_field_value("string", &timestamp).unwrap());
+        struct_buf.extend_from_slice(
+            &super::encode_eip712_field_value("address", &expected_address_hex).unwrap(),
+        );
+        struct_buf
+            .extend_from_slice(&super::encode_eip712_field_value("string", &timestamp).unwrap());
         struct_buf.extend_from_slice(&super::encode_eip712_field_value("uint256", "0").unwrap());
         struct_buf.extend_from_slice(
-            &super::encode_eip712_field_value("string", "This message attests that I control the given wallet").unwrap(),
+            &super::encode_eip712_field_value(
+                "string",
+                "This message attests that I control the given wallet",
+            )
+            .unwrap(),
         );
         let struct_hash = super::keccak256(&struct_buf);
 
@@ -6880,6 +7083,179 @@ mod tests {
         assert!(
             !debug_output.contains("raw-secret-bytes"),
             "secret_value leaked: {debug_output}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inject_host_credentials_bails_when_signing_gate_denies() {
+        use crate::secrets::{FieldSource, RejectAllSignerGate, SignerClassification};
+        use crate::tools::wasm::wrapper::{
+            ResolvedHostCredential, SigningSpec, SolanaSigning, StoreData,
+        };
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let host_credentials = vec![ResolvedHostCredential {
+            secret_name: "sol_pk".to_string(),
+            host_patterns: vec!["solana-api.example.com".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: "fake-pk".to_string(),
+            signing: Some(SigningSpec::Solana(SolanaSigning {
+                message_source: FieldSource::RequestBody,
+                output_body_fields: vec![],
+            })),
+        }];
+
+        let gate: Arc<dyn crate::secrets::SignerApprovalGate> = Arc::new(RejectAllSignerGate);
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            host_credentials,
+        )
+        .with_signer_gate(gate, SignerClassification::High, "drainer-tool".to_string());
+
+        let mut headers = HashMap::new();
+        let mut url = "https://solana-api.example.com/v1/tx".to_string();
+        let mut body: Option<Vec<u8>> = Some(b"{}".to_vec());
+        let result = store_data.inject_host_credentials(
+            "solana-api.example.com",
+            "POST",
+            &mut body,
+            &mut headers,
+            &mut url,
+        );
+        let err = result.expect_err("denying gate must bail");
+        assert!(err.contains("denied"), "unexpected error: {err}");
+        assert!(err.contains("sol_pk"), "error should name secret: {err}");
+        assert!(headers.is_empty(), "no headers should be applied on deny");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inject_host_credentials_proceeds_when_signing_gate_approves() {
+        use crate::secrets::{AllowAllSignerGate, SignerClassification};
+        use crate::tools::wasm::wrapper::{
+            HmacSigning, ResolvedHostCredential, SigningSpec, StoreData,
+        };
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let host_credentials = vec![ResolvedHostCredential {
+            secret_name: "polymarket_l2".to_string(),
+            host_patterns: vec!["clob.polymarket.com".to_string()],
+            path_patterns: vec![],
+            headers: HashMap::new(),
+            query_params: HashMap::new(),
+            secret_value: "MDEyMzQ1Njc4OWFiY2RlZg==".to_string(),
+            signing: Some(SigningSpec::Hmac(HmacSigning {
+                signature_header: "POLY-SIGNATURE".to_string(),
+                timestamp_header: "POLY-TIMESTAMP".to_string(),
+            })),
+        }];
+
+        let gate: Arc<dyn crate::secrets::SignerApprovalGate> = Arc::new(AllowAllSignerGate);
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            host_credentials,
+        )
+        .with_signer_gate(
+            gate,
+            SignerClassification::Low,
+            "polymarket-clob".to_string(),
+        );
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.polymarket.com/order".to_string();
+        let mut body: Option<Vec<u8>> = Some(b"{}".to_vec());
+        let result = store_data.inject_host_credentials(
+            "clob.polymarket.com",
+            "POST",
+            &mut body,
+            &mut headers,
+            &mut url,
+        );
+        assert!(
+            result.is_ok(),
+            "approving gate must let signing proceed: {result:?}"
+        );
+        assert!(
+            headers.contains_key("POLY-SIGNATURE"),
+            "signing header should be written on approval: {headers:?}"
+        );
+        assert!(headers.contains_key("POLY-TIMESTAMP"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inject_host_credentials_gates_high_signer_before_low_signer_fails() {
+        use crate::secrets::{FieldSource, RejectAllSignerGate, SignerClassification};
+        use crate::tools::wasm::wrapper::{
+            HmacSigning, ResolvedHostCredential, SigningSpec, SolanaSigning, StoreData,
+        };
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let host_credentials = vec![
+            ResolvedHostCredential {
+                secret_name: "broken_hmac".to_string(),
+                host_patterns: vec!["clob.example.com".to_string()],
+                path_patterns: vec![],
+                headers: HashMap::new(),
+                query_params: HashMap::new(),
+                secret_value: "not_valid_base64!!!".to_string(),
+                signing: Some(SigningSpec::Hmac(HmacSigning {
+                    signature_header: "X-SIG".to_string(),
+                    timestamp_header: "X-TS".to_string(),
+                })),
+            },
+            ResolvedHostCredential {
+                secret_name: "high_signer".to_string(),
+                host_patterns: vec!["clob.example.com".to_string()],
+                path_patterns: vec!["/order".to_string()],
+                headers: HashMap::new(),
+                query_params: HashMap::new(),
+                secret_value: "fake-pk".to_string(),
+                signing: Some(SigningSpec::Solana(SolanaSigning {
+                    message_source: FieldSource::RequestBody,
+                    output_body_fields: vec![],
+                })),
+            },
+        ];
+
+        let gate: Arc<dyn crate::secrets::SignerApprovalGate> = Arc::new(RejectAllSignerGate);
+        let store_data = StoreData::new(
+            1024 * 1024,
+            Capabilities::default(),
+            HashMap::new(),
+            host_credentials,
+        )
+        .with_signer_gate(gate, SignerClassification::High, "smoke-tool".to_string());
+
+        let mut headers = HashMap::new();
+        let mut url = "https://clob.example.com/order".to_string();
+        let mut body: Option<Vec<u8>> = Some(b"{}".to_vec());
+        let result = store_data.inject_host_credentials(
+            "clob.example.com",
+            "POST",
+            &mut body,
+            &mut headers,
+            &mut url,
+        );
+        let err = result.expect_err("high signer gate denial must bail the request");
+        assert!(
+            err.contains("denied"),
+            "gate should have fired and denied, got: {err}"
+        );
+        assert!(
+            err.contains("high_signer"),
+            "denial should name the high signer, got: {err}"
+        );
+        assert!(
+            !err.contains("base64") && !err.contains("hmac"),
+            "low signer must not have run before the gate, got: {err}"
         );
     }
 }

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -429,12 +429,19 @@ impl StoreData {
                 .then_with(|| a.secret_name.cmp(&b.secret_name))
         });
 
+        // A fresh timestamp and 256-bit nonce are minted per request. The
+        // host does not track used nonces or enforce timestamp monotonicity:
+        // replay resistance is delegated to the destination venue's API,
+        // which is the system of record for nonce/timestamp acceptance.
         let timestamp_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
         let mut nonce_bytes = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+        let mut signed_headers: HashMap<String, (crate::secrets::SignerClassification, String)> =
+            HashMap::new();
 
         for cred in matches_for_request {
             for (key, value) in &cred.headers {
@@ -502,8 +509,32 @@ impl StoreData {
 
                 match result {
                     Ok(extra) => {
+                        let incoming = signing.classification();
                         for (k, v) in extra.headers {
-                            headers.insert(k, v);
+                            let decision = match signed_headers.get(&k) {
+                                None => HeaderPrecedence::UseIncoming,
+                                Some((existing, _)) => header_precedence(*existing, incoming),
+                            };
+                            match decision {
+                                HeaderPrecedence::UseIncoming => {
+                                    if signed_headers.contains_key(&k) {
+                                        tracing::warn!(
+                                            "signing header '{k}' collision: {incoming:?} signer supersedes a lower-classification signer"
+                                        );
+                                    }
+                                    signed_headers.insert(k, (incoming, v));
+                                }
+                                HeaderPrecedence::KeepExisting => {
+                                    tracing::warn!(
+                                        "signing header '{k}' collision: keeping higher-classification signer over {incoming:?}"
+                                    );
+                                }
+                                HeaderPrecedence::Ambiguous => {
+                                    return Err(format!(
+                                        "ambiguous signing header collision on '{k}': two {incoming:?}-classification signers target it for this request; refusing to sign"
+                                    ));
+                                }
+                            }
                         }
                         if let Err(error) = apply_body_mutations(body, &extra.body_mutations) {
                             return Err(format!(
@@ -517,6 +548,10 @@ impl StoreData {
                     }
                 }
             }
+        }
+
+        for (name, (_, value)) in signed_headers {
+            headers.insert(name, value);
         }
         Ok(())
     }
@@ -532,11 +567,7 @@ impl StoreData {
             return Ok(());
         };
         let classification = signing.classification();
-        let rank = |c: crate::secrets::SignerClassification| match c {
-            crate::secrets::SignerClassification::Low => 0u8,
-            crate::secrets::SignerClassification::Medium => 1,
-            crate::secrets::SignerClassification::High => 2,
-        };
+        let rank = classification_rank;
         if rank(classification) < rank(self.gate_floor) {
             return Ok(());
         }
@@ -570,6 +601,32 @@ impl StoreData {
                 cred.secret_name
             )),
         }
+    }
+}
+
+fn classification_rank(c: crate::secrets::SignerClassification) -> u8 {
+    match c {
+        crate::secrets::SignerClassification::Low => 0,
+        crate::secrets::SignerClassification::Medium => 1,
+        crate::secrets::SignerClassification::High => 2,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeaderPrecedence {
+    UseIncoming,
+    KeepExisting,
+    Ambiguous,
+}
+
+fn header_precedence(
+    existing: crate::secrets::SignerClassification,
+    incoming: crate::secrets::SignerClassification,
+) -> HeaderPrecedence {
+    match classification_rank(incoming).cmp(&classification_rank(existing)) {
+        std::cmp::Ordering::Greater => HeaderPrecedence::UseIncoming,
+        std::cmp::Ordering::Less => HeaderPrecedence::KeepExisting,
+        std::cmp::Ordering::Equal => HeaderPrecedence::Ambiguous,
     }
 }
 
@@ -3026,6 +3083,7 @@ fn needs_content_length_zero(method: &str, headers: &HashMap<String, String>) ->
 
 #[cfg(test)]
 mod tests {
+    use super::{HeaderPrecedence, classification_rank, header_precedence};
     use std::collections::HashMap;
     use std::net::SocketAddr;
     use std::sync::{Arc, Mutex};
@@ -4649,6 +4707,41 @@ mod tests {
         );
 
         assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn header_precedence_higher_classification_wins_both_orders() {
+        use crate::secrets::SignerClassification::{High, Low, Medium};
+        assert_eq!(
+            header_precedence(Low, Medium),
+            HeaderPrecedence::UseIncoming
+        );
+        assert_eq!(
+            header_precedence(Medium, Low),
+            HeaderPrecedence::KeepExisting
+        );
+        assert_eq!(header_precedence(Low, High), HeaderPrecedence::UseIncoming);
+        assert_eq!(
+            header_precedence(High, Medium),
+            HeaderPrecedence::KeepExisting
+        );
+        assert_eq!(header_precedence(Medium, High), HeaderPrecedence::UseIncoming);
+        assert_eq!(header_precedence(High, Low), HeaderPrecedence::KeepExisting);
+    }
+
+    #[test]
+    fn header_precedence_equal_classification_is_fail_closed_ambiguous() {
+        use crate::secrets::SignerClassification::{High, Low, Medium};
+        assert_eq!(header_precedence(Low, Low), HeaderPrecedence::Ambiguous);
+        assert_eq!(header_precedence(Medium, Medium), HeaderPrecedence::Ambiguous);
+        assert_eq!(header_precedence(High, High), HeaderPrecedence::Ambiguous);
+    }
+
+    #[test]
+    fn classification_rank_orders_low_below_medium_below_high() {
+        use crate::secrets::SignerClassification::{High, Low, Medium};
+        assert!(classification_rank(Low) < classification_rank(Medium));
+        assert!(classification_rank(Medium) < classification_rank(High));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds four new `CredentialLocation` variants (`HmacSignedHeader`, `Eip712SignedHeader`, `Nep413SignedHeader`, `SolanaSignedTransaction`) alongside the existing five static primitives. Tools declare venue-specific signing schemas in `capabilities.json` via a closed source vocabulary; the runtime stays generic. Unblocks Polymarket L1+L2, Hyperliquid, Trezu, NEAR Intents, and Solana RPC `sendTransaction` without per-venue runtime code.

## Motivation

The five existing `CredentialLocation` variants only support static placement of secrets into headers, query params, or URL placeholders. Real signing recipes need request data (method, path, body, timestamp, message bytes) that is only known at request time, plus crypto the WASM sandbox cannot safely run. This blocks every venue using HMAC, EIP-712 typed data, NEP-413, or Solana ed25519: Polymarket L1 (ClobAuth) + L2 (HMAC), Hyperliquid (EIP-712 with body-output signature), Trezu (NEP-413), NEAR Intents (NEP-413), Solana RPC (`sendTransaction` with a fully signed transaction in `params[0]`).

## Architecture

Four new variants on the existing `CredentialLocation` enum, same dispatcher loop (`inject_host_credentials`), same resolver (`resolve_host_credentials`), same schema layer. No architectural change.

Closed source vocabulary (`FieldSource`, `OutputSource`, `BodyValue`, `BytesPart`) bounds what tools can declare to be signed: every value is either user-reviewed at install time (manifest literal) or derived from the request the tool was already authorized to send (timestamp, nonce, body field, msgpack of body field, base64 message bytes). No "sign these arbitrary bytes" escape hatch exists.

Body mutation runs after the WASM tool hands over the request body but before reqwest dispatch, needed for Hyperliquid (which puts `signature.{r,s,v}` in the body) and Solana (which puts the full base64 signed transaction at `params.0` of the JSON-RPC envelope). The new `output_body_fields: Vec<BodyJsonOutput>` field declares JSON paths and value sources; the runtime parses the body once, walks the paths, sets the values, re-serializes. `json_path_set` now walks array indices so output can land at JSON-RPC params slots.

EIP-712 schemas in this PR are constrained to a single struct: only the primary type, no nested type dependencies. All four EVM target venues use single-struct schemas, so this is sufficient for the unblocking work. Multi-struct support per the full EIP-712 spec is a follow-up; the manifest format already accepts `Vec<Eip712StructDef>`, so adding nested-struct dependency resolution later is additive.

Solana signing follows the same closed-vocabulary pattern: the tool builds the unsigned wire-format message bytes itself (account ordering, recent_blockhash, instruction encoding) and places them base64-encoded in the request body via the new `FieldSource::BodyFieldString { path }` source. The runtime decodes, ed25519-signs the raw message bytes per RFC 8032, prepends the compact-u16 signature count and the 64-byte signature, base64-encodes, and writes the result via `output_body_fields` (typically into `params.0`). Total transaction size is capped at the Solana 1232-byte packet limit.

## Security

- All signing happens host-side. WASM tools never see HMAC keys, secp256k1 private keys, or ed25519 seeds.
- WIT contract unchanged: only `secret_exists(name)` is exposed to WASM, never `secret_get`.
- `LeakDetector` still scans WASM-provided URL/headers/body before any host injection.
- Sandbox proxy skip-list extended for the four signing variants alongside the existing `AuthorizationBasic`/`UrlPath` complex variants.
- `ResolvedHostCredential::Debug` redacts `secret_value` and shows only header NAMES (no values).
- Signing context (timestamp, random nonce) is generated once per request and shared across multiple matching signers.
- Solana signer rejects ECDSA r/s/v body outputs at runtime; the EIP-712 evaluator rejects `SolanaSignedTransactionBase64` outside the Solana signer. Cross-signer output type confusion fails fast.
- uint256 EIP-712 encoding uses a hand-rolled big-endian decimal parser supporting the full 2^256 - 1 range with overflow rejection.

## Tests

- 30 new tests covering all four signers, body mutation, schema deserialization, end-to-end pipeline through real capabilities manifests, uint256 encoding edge cases, and cross-signer output type confusion guards.
- Cryptographic round-trips:
  - HMAC: signature recomputed via the `hmac` crate and asserted equal.
  - EIP-712: signature recovered to the signer address via `VerifyingKey::recover_from_prehash` against the recomputed final hash (validates domain separator, type hash, struct hash).
  - NEP-413: signature verified via `ed25519_dalek::Verifier` over `sha256(prefix || borsh-payload)` (validates prefix bytes \`[0x9D, 0x01, 0x00, 0x80]\` matches \`2^31 + 413\`, borsh field order, hash).
  - Solana: signature verified via `ed25519_dalek::Verifier` directly against the raw message bytes (validates RFC 8032 application-level no-prehash, wire-format envelope assembly, base64 encoding).
- Polymarket-clob integration tests load the actual manifest content, resolve dummy secrets through `resolve_host_credentials`, and verify both L1 (\`/auth/api-key\` EIP-712) and L2 (\`/data/orders\` HMAC) paths assemble all expected headers correctly.
- Solana integration test loads a JSON-RPC sendTransaction body with the unsigned message at \`_signing.message_b64\` and verifies the assembled body has a valid signed transaction at \`params.0\` that ed25519-verifies against the signer pubkey.
- uint256 encoding regression test covers zero, value just above 2^128, the 2^256 - 1 maximum, the 2^256 overflow case, and non-numeric / negative / empty input rejection.
- Full lib suite: 5620 passed, 0 failed, 7 ignored.
- \`cargo clippy --lib --tests\`: zero warnings.

## Rollback

Additive only. New variants on existing enums, no DB migration, no schema changes, no breaking API changes. Tools that do not declare the new variants are unaffected.

## Spec references

- Polymarket: [py-clob-client signing/eip712](https://github.com/Polymarket/py-clob-client/blob/main/py_clob_client/signing/eip712.py), [py-clob-client headers](https://github.com/Polymarket/py-clob-client/blob/main/py_clob_client/headers/headers.py)
- NEP-413: [near/NEPs#413](https://github.com/near/NEPs/blob/master/neps/nep-0413.md)
- Hyperliquid: [hyperliquid-python-sdk signing.py](https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/master/hyperliquid/utils/signing.py)
- Solana: [Transaction Structure](https://solana.com/docs/core/transactions/transaction-structure), [sendTransaction RPC](https://solana.com/docs/rpc/http/sendtransaction), [solana-short-vec compact-u16 source](https://docs.rs/solana-short-vec/latest/src/solana_short_vec/lib.rs.html)