### PR TITLE
feat(reborn): add turn persistence contracts

### DIFF
--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -35,4 +35,9 @@ pub use status::{
     AdmissionRejection, AdmissionRejectionReason, BlockedReason, SanitizedCancelReason,
     SanitizedFailure, TurnError, TurnErrorCategory, TurnRunProfile, TurnRunState, TurnStatus,
 };
-pub use store::TurnStateStore;
+pub use store::{
+    TurnActiveLockKey, TurnActiveLockRecord, TurnCheckpointRecord, TurnIdempotencyErrorReplay,
+    TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnIdempotencyRecord,
+    TurnIdempotencyReplay, TurnLockVersion, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord,
+    TurnStateStore,
+};

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -1,16 +1,21 @@
 use async_trait::async_trait;
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     hash::Hash,
-    sync::{Mutex, MutexGuard},
+    sync::{Condvar, Mutex, MutexGuard},
 };
+
+use chrono::Utc;
 
 use crate::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, GetRunStateRequest, IdempotencyKey,
     ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse, SanitizedFailure,
-    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
-    TurnAdmissionPolicy, TurnCheckpointId, TurnError, TurnEventKind, TurnLifecycleEvent, TurnRunId,
-    TurnRunProfile, TurnRunState, TurnScope, TurnStateStore, TurnStatus,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActiveLockKey,
+    TurnActiveLockRecord, TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnCheckpointRecord,
+    TurnError, TurnEventKind, TurnIdempotencyErrorReplay, TurnIdempotencyOperationKind,
+    TurnIdempotencyOutcomeKind, TurnIdempotencyRecord, TurnIdempotencyReplay, TurnLifecycleEvent,
+    TurnLockVersion, TurnPersistenceSnapshot, TurnRecord, TurnRunId, TurnRunProfile, TurnRunRecord,
+    TurnRunState, TurnScope, TurnStateStore, TurnStatus,
     events::EventCursor,
     runner::{
         BlockRunRequest, CancelRunCompletionRequest, ClaimRunRequest, ClaimedTurnRun,
@@ -41,6 +46,7 @@ impl Default for InMemoryTurnStateStoreLimits {
 
 pub struct InMemoryTurnStateStore {
     inner: Mutex<Inner>,
+    submit_idempotency_ready: Condvar,
 }
 
 impl Default for InMemoryTurnStateStore {
@@ -52,16 +58,21 @@ impl Default for InMemoryTurnStateStore {
 #[derive(Default)]
 struct Inner {
     cursor: u64,
+    turns: HashMap<crate::TurnId, TurnRecord>,
     records: HashMap<TurnRunId, RunRecord>,
     queued_runs: VecDeque<TurnRunId>,
     terminal_runs: VecDeque<TurnRunId>,
-    active_locks: HashMap<TurnLockKey, TurnRunId>,
+    active_locks: HashMap<TurnActiveLockKey, TurnActiveLockRecord>,
+    checkpoints: Vec<TurnCheckpointRecord>,
     submit_idempotency: HashMap<SubmitIdempotencyKey, Result<SubmitTurnResponse, TurnError>>,
+    submit_idempotency_in_flight: HashSet<SubmitIdempotencyKey>,
     resume_idempotency: HashMap<RunIdempotencyKey, Result<ResumeTurnResponse, TurnError>>,
     cancel_idempotency: HashMap<RunIdempotencyKey, Result<CancelRunResponse, TurnError>>,
+    idempotency_records: HashMap<PersistedIdempotencyKey, TurnIdempotencyRecord>,
     submit_idempotency_order: VecDeque<SubmitIdempotencyKey>,
     resume_idempotency_order: VecDeque<RunIdempotencyKey>,
     cancel_idempotency_order: VecDeque<RunIdempotencyKey>,
+    idempotency_record_order: VecDeque<PersistedIdempotencyKey>,
     events: Vec<TurnLifecycleEvent>,
     limits: InMemoryTurnStateStoreLimits,
 }
@@ -83,20 +94,10 @@ struct RunRecord {
     event_cursor: EventCursor,
     runner_id: Option<crate::TurnRunnerId>,
     lease_token: Option<crate::TurnLeaseToken>,
+    lease_expires_at: Option<crate::TurnTimestamp>,
+    last_heartbeat_at: Option<crate::TurnTimestamp>,
+    claim_count: u64,
     received_at: crate::TurnTimestamp,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct TurnLockKey {
-    scope: TurnScope,
-}
-
-impl From<&TurnScope> for TurnLockKey {
-    fn from(scope: &TurnScope) -> Self {
-        Self {
-            scope: scope.clone(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -112,6 +113,14 @@ struct RunIdempotencyKey {
     key: IdempotencyKey,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PersistedIdempotencyKey {
+    scope: TurnScope,
+    operation: TurnIdempotencyOperationKind,
+    run_id: Option<TurnRunId>,
+    key: IdempotencyKey,
+}
+
 impl InMemoryTurnStateStore {
     pub fn with_limits(limits: InMemoryTurnStateStoreLimits) -> Self {
         Self {
@@ -119,6 +128,7 @@ impl InMemoryTurnStateStore {
                 limits,
                 ..Inner::default()
             }),
+            submit_idempotency_ready: Condvar::new(),
         }
     }
 
@@ -129,10 +139,28 @@ impl InMemoryTurnStateStore {
         }
     }
 
+    pub fn persistence_snapshot(&self) -> TurnPersistenceSnapshot {
+        match self.inner.lock() {
+            Ok(inner) => inner.persistence_snapshot(),
+            Err(poisoned) => poisoned.into_inner().persistence_snapshot(),
+        }
+    }
+
     fn lock_inner(&self) -> Result<MutexGuard<'_, Inner>, TurnError> {
         self.inner.lock().map_err(|_| TurnError::Unavailable {
             reason: "turn state store mutex poisoned".to_string(),
         })
+    }
+
+    fn wait_for_submit_idempotency<'a>(
+        &self,
+        inner: MutexGuard<'a, Inner>,
+    ) -> Result<MutexGuard<'a, Inner>, TurnError> {
+        self.submit_idempotency_ready
+            .wait(inner)
+            .map_err(|_| TurnError::Unavailable {
+                reason: "turn state store mutex poisoned".to_string(),
+            })
     }
 }
 
@@ -147,42 +175,75 @@ impl TurnStateStore for InMemoryTurnStateStore {
             scope: request.scope.clone(),
             key: request.idempotency_key.clone(),
         };
-        {
-            let inner = self.lock_inner()?;
+        let mut inner = self.lock_inner()?;
+        loop {
             if let Some(result) = inner.submit_idempotency.get(&idempotency_key) {
                 return result.clone();
             }
+            if inner
+                .submit_idempotency_in_flight
+                .insert(idempotency_key.clone())
+            {
+                break;
+            }
+            inner = self.wait_for_submit_idempotency(inner)?;
         }
+        drop(inner);
 
         let admission_result = admission_policy.check_submit(&request);
 
         let mut inner = self.lock_inner()?;
-        if let Some(result) = inner.submit_idempotency.get(&idempotency_key) {
-            return result.clone();
+        if let Some(result) = inner.submit_idempotency.get(&idempotency_key).cloned() {
+            inner.submit_idempotency_in_flight.remove(&idempotency_key);
+            self.submit_idempotency_ready.notify_all();
+            return result;
         }
 
         if let Err(rejection) = admission_result {
             let response = Err(TurnError::AdmissionRejected(rejection));
-            inner.remember_submit_idempotency(idempotency_key, response.clone());
+            inner.remember_submit_idempotency(
+                idempotency_key.clone(),
+                response.clone(),
+                request.received_at,
+            );
+            inner.submit_idempotency_in_flight.remove(&idempotency_key);
+            self.submit_idempotency_ready.notify_all();
             return response;
         }
 
-        let lock_key = TurnLockKey::from(&request.scope);
-        if let Some(active_run_id) = inner.active_locks.get(&lock_key)
-            && let Some(record) = inner.records.get(active_run_id)
+        let lock_key = TurnActiveLockKey::from(&request.scope);
+        if let Some(active_lock) = inner.active_locks.get(&lock_key)
+            && let Some(record) = inner.records.get(&active_lock.run_id)
             && record.status.keeps_active_lock()
         {
-            return Err(TurnError::ThreadBusy(ThreadBusy {
-                active_run_id: *active_run_id,
+            let response = Err(TurnError::ThreadBusy(ThreadBusy {
+                active_run_id: active_lock.run_id,
                 status: record.status,
                 event_cursor: record.event_cursor,
             }));
+            inner.remember_submit_idempotency(
+                idempotency_key.clone(),
+                response.clone(),
+                request.received_at,
+            );
+            inner.submit_idempotency_in_flight.remove(&idempotency_key);
+            self.submit_idempotency_ready.notify_all();
+            return response;
         }
 
         let turn_id = crate::TurnId::new();
         let run_id = TurnRunId::new();
         let cursor = inner.next_cursor();
         let profile = TurnRunProfile::resolve(request.requested_run_profile.as_ref());
+        let turn_record = TurnRecord {
+            turn_id,
+            scope: request.scope.clone(),
+            actor: request.actor.clone(),
+            accepted_message_ref: request.accepted_message_ref.clone(),
+            source_binding_ref: request.source_binding_ref.clone(),
+            reply_target_binding_ref: request.reply_target_binding_ref.clone(),
+            created_at: request.received_at,
+        };
         let record = RunRecord {
             scope: request.scope.clone(),
             actor: request.actor,
@@ -191,7 +252,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             status: TurnStatus::Queued,
             profile: profile.clone(),
             accepted_message_ref: request.accepted_message_ref.clone(),
-            source_binding_ref: request.source_binding_ref,
+            source_binding_ref: request.source_binding_ref.clone(),
             reply_target_binding_ref: request.reply_target_binding_ref.clone(),
             checkpoint_id: None,
             gate_ref: None,
@@ -199,9 +260,23 @@ impl TurnStateStore for InMemoryTurnStateStore {
             event_cursor: cursor,
             runner_id: None,
             lease_token: None,
+            lease_expires_at: None,
+            last_heartbeat_at: None,
+            claim_count: 0,
             received_at: request.received_at,
         };
-        inner.active_locks.insert(lock_key, run_id);
+        inner.turns.insert(turn_id, turn_record);
+        inner.active_locks.insert(
+            lock_key.clone(),
+            TurnActiveLockRecord {
+                key: lock_key,
+                run_id,
+                status: TurnStatus::Queued,
+                lock_version: TurnLockVersion::new(1),
+                acquired_at: request.received_at,
+                updated_at: request.received_at,
+            },
+        );
         inner.queued_runs.push_back(run_id);
         inner.records.insert(run_id, record.clone());
         inner.push_event(&record, TurnEventKind::Submitted, None);
@@ -216,7 +291,13 @@ impl TurnStateStore for InMemoryTurnStateStore {
             accepted_message_ref: request.accepted_message_ref,
             reply_target_binding_ref: request.reply_target_binding_ref,
         });
-        inner.remember_submit_idempotency(idempotency_key, response.clone());
+        inner.remember_submit_idempotency(
+            idempotency_key.clone(),
+            response.clone(),
+            record.received_at,
+        );
+        inner.submit_idempotency_in_flight.remove(&idempotency_key);
+        self.submit_idempotency_ready.notify_all();
         response
     }
 
@@ -234,7 +315,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             return result.clone();
         }
         let result = inner.resume_turn_once(&request);
-        inner.remember_resume_idempotency(idempotency_key, result.clone());
+        inner.remember_resume_idempotency(idempotency_key, result.clone(), Utc::now());
         result
     }
 
@@ -252,7 +333,7 @@ impl TurnStateStore for InMemoryTurnStateStore {
             return result.clone();
         }
         let result = inner.request_cancel_once(&request);
-        inner.remember_cancel_idempotency(idempotency_key, result.clone());
+        inner.remember_cancel_idempotency(idempotency_key, result.clone(), Utc::now());
         result
     }
 
@@ -278,10 +359,14 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
             return Ok(None);
         };
         let mut record = inner.take_record(run_id)?;
+        let now = Utc::now();
         record.status = TurnStatus::Running;
         record.runner_id = Some(request.runner_id);
         record.lease_token = Some(request.lease_token);
+        record.last_heartbeat_at = Some(now);
+        record.claim_count = record.claim_count.saturating_add(1);
         record.event_cursor = inner.next_cursor();
+        inner.update_active_lock(&record, now);
         let claimed = ClaimedTurnRun {
             state: record.state(),
             runner_id: request.runner_id,
@@ -297,7 +382,10 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
         let mut record = inner.take_record(request.run_id)?;
         let result = (|| {
             ensure_lease(&record, request.runner_id, request.lease_token)?;
+            let now = Utc::now();
+            record.last_heartbeat_at = Some(now);
             record.event_cursor = inner.next_cursor();
+            inner.touch_active_lock(&record, now);
             inner.push_event(&record, TurnEventKind::RunnerHeartbeat, None);
             Ok(record.event_cursor)
         })();
@@ -316,12 +404,21 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
                     to: request.reason.status(),
                 });
             }
+            let now = Utc::now();
             record.status = request.reason.status();
             record.checkpoint_id = Some(request.checkpoint_id);
             record.gate_ref = Some(request.reason.gate_ref().clone());
             record.runner_id = None;
             record.lease_token = None;
+            record.lease_expires_at = None;
             record.event_cursor = inner.next_cursor();
+            inner.record_checkpoint(
+                &record,
+                request.checkpoint_id,
+                request.reason.gate_ref().clone(),
+                now,
+            );
+            inner.update_active_lock(&record, now);
             let state = record.state();
             inner.push_event(&record, TurnEventKind::Blocked, None);
             Ok(state)
@@ -389,51 +486,133 @@ impl Inner {
         }
     }
 
+    fn persistence_snapshot(&self) -> TurnPersistenceSnapshot {
+        let mut turns = self.turns.values().cloned().collect::<Vec<_>>();
+        turns.sort_by_key(|record| record.created_at);
+        let mut runs = self
+            .records
+            .values()
+            .map(RunRecord::persistence_record)
+            .collect::<Vec<_>>();
+        runs.sort_by_key(|record| record.event_cursor);
+        let mut active_locks = self.active_locks.values().cloned().collect::<Vec<_>>();
+        active_locks.sort_by_key(|record| record.acquired_at);
+        let mut checkpoints = self.checkpoints.clone();
+        checkpoints.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.sequence.cmp(&b.sequence))
+        });
+        let mut idempotency_records = self
+            .idempotency_records
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        idempotency_records.sort_by_key(|record| record.created_at);
+        TurnPersistenceSnapshot {
+            turns,
+            runs,
+            active_locks,
+            checkpoints,
+            idempotency_records,
+        }
+    }
+
     fn remember_submit_idempotency(
         &mut self,
         key: SubmitIdempotencyKey,
         result: Result<SubmitTurnResponse, TurnError>,
+        created_at: crate::TurnTimestamp,
     ) {
         if !self.submit_idempotency.contains_key(&key) {
             self.submit_idempotency_order.push_back(key.clone());
         }
+        let record = submit_idempotency_record(&key, &result, created_at);
+        self.remember_persisted_idempotency(record);
         self.submit_idempotency.insert(key, result);
-        prune_ordered_map(
+        let removed = prune_ordered_map(
             &mut self.submit_idempotency,
             &mut self.submit_idempotency_order,
             self.limits.max_idempotency_records,
         );
+        for key in removed {
+            self.remove_persisted_submit_idempotency(&key);
+        }
+        self.prune_idempotency_records();
     }
 
     fn remember_resume_idempotency(
         &mut self,
         key: RunIdempotencyKey,
         result: Result<ResumeTurnResponse, TurnError>,
+        created_at: crate::TurnTimestamp,
     ) {
         if !self.resume_idempotency.contains_key(&key) {
             self.resume_idempotency_order.push_back(key.clone());
         }
+        let record = resume_idempotency_record(&key, &result, created_at);
+        self.remember_persisted_idempotency(record);
         self.resume_idempotency.insert(key, result);
-        prune_ordered_map(
+        let removed = prune_ordered_map(
             &mut self.resume_idempotency,
             &mut self.resume_idempotency_order,
             self.limits.max_idempotency_records,
         );
+        for key in removed {
+            self.remove_persisted_run_idempotency(TurnIdempotencyOperationKind::Resume, &key);
+        }
+        self.prune_idempotency_records();
     }
 
     fn remember_cancel_idempotency(
         &mut self,
         key: RunIdempotencyKey,
         result: Result<CancelRunResponse, TurnError>,
+        created_at: crate::TurnTimestamp,
     ) {
         if !self.cancel_idempotency.contains_key(&key) {
             self.cancel_idempotency_order.push_back(key.clone());
         }
+        let record = cancel_idempotency_record(&key, &result, created_at);
+        self.remember_persisted_idempotency(record);
         self.cancel_idempotency.insert(key, result);
-        prune_ordered_map(
+        let removed = prune_ordered_map(
             &mut self.cancel_idempotency,
             &mut self.cancel_idempotency_order,
             self.limits.max_idempotency_records,
+        );
+        for key in removed {
+            self.remove_persisted_run_idempotency(TurnIdempotencyOperationKind::Cancel, &key);
+        }
+        self.prune_idempotency_records();
+    }
+
+    fn remember_persisted_idempotency(&mut self, record: TurnIdempotencyRecord) {
+        let key = persisted_key_for_record(&record);
+        if !self.idempotency_records.contains_key(&key) {
+            self.idempotency_record_order.push_back(key.clone());
+        }
+        self.idempotency_records.insert(key, record);
+    }
+
+    fn remove_persisted_submit_idempotency(&mut self, key: &SubmitIdempotencyKey) {
+        self.idempotency_records.remove(&persisted_submit_key(key));
+    }
+
+    fn remove_persisted_run_idempotency(
+        &mut self,
+        operation: TurnIdempotencyOperationKind,
+        key: &RunIdempotencyKey,
+    ) {
+        self.idempotency_records
+            .remove(&persisted_run_key(operation, key));
+    }
+
+    fn prune_idempotency_records(&mut self) {
+        let _removed = prune_ordered_map(
+            &mut self.idempotency_records,
+            &mut self.idempotency_record_order,
+            self.limits.max_idempotency_records.saturating_mul(3),
         );
     }
 
@@ -487,11 +666,13 @@ impl Inner {
                     reason: "gate resolution reference mismatch".to_string(),
                 });
             }
+            let now = Utc::now();
             record.status = TurnStatus::Queued;
             record.gate_ref = None;
             record.source_binding_ref = request.source_binding_ref.clone();
             record.reply_target_binding_ref = request.reply_target_binding_ref.clone();
             record.event_cursor = self.next_cursor();
+            self.update_active_lock(&record, now);
             self.queued_runs.push_back(record.run_id);
             let response = ResumeTurnResponse {
                 run_id: record.run_id,
@@ -541,10 +722,13 @@ impl Inner {
                     });
                 }
             };
+            let now = Utc::now();
             record.status = next_status;
             if record.status.is_terminal() {
                 self.release_active_lock(&record);
                 self.remove_queued_run(record.run_id);
+            } else {
+                self.update_active_lock(&record, now);
             }
             record.event_cursor = self.next_cursor();
             let response = CancelRunResponse {
@@ -587,6 +771,7 @@ impl Inner {
             record.failure = None;
             record.runner_id = None;
             record.lease_token = None;
+            record.lease_expires_at = None;
             record.event_cursor = self.next_cursor();
             self.release_active_lock(&record);
             self.remove_queued_run(record.run_id);
@@ -622,6 +807,7 @@ impl Inner {
             record.failure = failure.clone();
             record.runner_id = None;
             record.lease_token = None;
+            record.lease_expires_at = None;
             record.event_cursor = self.next_cursor();
             self.release_active_lock(&record);
             self.remove_queued_run(record.run_id);
@@ -635,9 +821,56 @@ impl Inner {
         result
     }
 
+    fn update_active_lock(&mut self, record: &RunRecord, updated_at: crate::TurnTimestamp) {
+        let lock_key = TurnActiveLockKey::from(&record.scope);
+        if let Some(lock) = self.active_locks.get_mut(&lock_key)
+            && lock.run_id == record.run_id
+        {
+            lock.status = record.status;
+            lock.lock_version = lock.lock_version.incremented();
+            lock.updated_at = updated_at;
+        }
+    }
+
+    fn touch_active_lock(&mut self, record: &RunRecord, updated_at: crate::TurnTimestamp) {
+        let lock_key = TurnActiveLockKey::from(&record.scope);
+        if let Some(lock) = self.active_locks.get_mut(&lock_key)
+            && lock.run_id == record.run_id
+        {
+            lock.updated_at = updated_at;
+        }
+    }
+
+    fn record_checkpoint(
+        &mut self,
+        record: &RunRecord,
+        checkpoint_id: TurnCheckpointId,
+        gate_ref: crate::GateRef,
+        created_at: crate::TurnTimestamp,
+    ) {
+        let sequence = self
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.run_id == record.run_id)
+            .count()
+            .saturating_add(1) as u64;
+        self.checkpoints.push(TurnCheckpointRecord {
+            checkpoint_id,
+            run_id: record.run_id,
+            sequence,
+            status: record.status,
+            gate_ref,
+            created_at,
+        });
+    }
+
     fn release_active_lock(&mut self, record: &RunRecord) {
-        let lock_key = TurnLockKey::from(&record.scope);
-        if self.active_locks.get(&lock_key) == Some(&record.run_id) {
+        let lock_key = TurnActiveLockKey::from(&record.scope);
+        if self
+            .active_locks
+            .get(&lock_key)
+            .is_some_and(|lock| lock.run_id == record.run_id)
+        {
             self.active_locks.remove(&lock_key);
         }
     }
@@ -663,6 +896,29 @@ impl Inner {
 }
 
 impl RunRecord {
+    fn persistence_record(&self) -> TurnRunRecord {
+        TurnRunRecord {
+            run_id: self.run_id,
+            turn_id: self.turn_id,
+            scope: self.scope.clone(),
+            accepted_message_ref: self.accepted_message_ref.clone(),
+            source_binding_ref: self.source_binding_ref.clone(),
+            reply_target_binding_ref: self.reply_target_binding_ref.clone(),
+            status: self.status,
+            profile: self.profile.clone(),
+            checkpoint_id: self.checkpoint_id,
+            gate_ref: self.gate_ref.clone(),
+            failure: self.failure.clone(),
+            event_cursor: self.event_cursor,
+            runner_id: self.runner_id,
+            lease_token: self.lease_token,
+            lease_expires_at: self.lease_expires_at,
+            last_heartbeat_at: self.last_heartbeat_at,
+            claim_count: self.claim_count,
+            received_at: self.received_at,
+        }
+    }
+
     fn state(&self) -> TurnRunState {
         let _ = &self.actor;
         TurnRunState {
@@ -684,6 +940,145 @@ impl RunRecord {
     }
 }
 
+fn persisted_key_for_record(record: &TurnIdempotencyRecord) -> PersistedIdempotencyKey {
+    PersistedIdempotencyKey {
+        scope: record.scope.clone(),
+        operation: record.operation,
+        run_id: match record.operation {
+            TurnIdempotencyOperationKind::Submit => None,
+            TurnIdempotencyOperationKind::Resume | TurnIdempotencyOperationKind::Cancel => {
+                record.run_id
+            }
+        },
+        key: record.key.clone(),
+    }
+}
+
+fn persisted_submit_key(key: &SubmitIdempotencyKey) -> PersistedIdempotencyKey {
+    PersistedIdempotencyKey {
+        scope: key.scope.clone(),
+        operation: TurnIdempotencyOperationKind::Submit,
+        run_id: None,
+        key: key.key.clone(),
+    }
+}
+
+fn persisted_run_key(
+    operation: TurnIdempotencyOperationKind,
+    key: &RunIdempotencyKey,
+) -> PersistedIdempotencyKey {
+    PersistedIdempotencyKey {
+        scope: key.scope.clone(),
+        operation,
+        run_id: Some(key.run_id),
+        key: key.key.clone(),
+    }
+}
+
+fn submit_idempotency_record(
+    key: &SubmitIdempotencyKey,
+    result: &Result<SubmitTurnResponse, TurnError>,
+    created_at: crate::TurnTimestamp,
+) -> TurnIdempotencyRecord {
+    let (turn_id, run_id, outcome, replay) = match result {
+        Ok(
+            response @ SubmitTurnResponse::Accepted {
+                turn_id, run_id, ..
+            },
+        ) => (
+            Some(*turn_id),
+            Some(*run_id),
+            TurnIdempotencyOutcomeKind::Accepted,
+            TurnIdempotencyReplay::SubmitAccepted(response.clone()),
+        ),
+        Err(TurnError::ThreadBusy(busy)) => (
+            None,
+            Some(busy.active_run_id),
+            TurnIdempotencyOutcomeKind::ThreadBusy,
+            TurnIdempotencyReplay::SubmitThreadBusy(busy.clone()),
+        ),
+        Err(TurnError::AdmissionRejected(rejection)) => (
+            None,
+            None,
+            TurnIdempotencyOutcomeKind::AdmissionRejected,
+            TurnIdempotencyReplay::SubmitAdmissionRejected(rejection.clone()),
+        ),
+        Err(error) => (
+            None,
+            None,
+            TurnIdempotencyOutcomeKind::from_error(error),
+            TurnIdempotencyReplay::Error(TurnIdempotencyErrorReplay::from_error(error)),
+        ),
+    };
+    TurnIdempotencyRecord {
+        scope: key.scope.clone(),
+        operation: TurnIdempotencyOperationKind::Submit,
+        key: key.key.clone(),
+        turn_id,
+        run_id,
+        outcome,
+        replay,
+        created_at,
+        expires_at: None,
+    }
+}
+
+fn resume_idempotency_record(
+    key: &RunIdempotencyKey,
+    result: &Result<ResumeTurnResponse, TurnError>,
+    created_at: crate::TurnTimestamp,
+) -> TurnIdempotencyRecord {
+    let (outcome, replay) = match result {
+        Ok(response) => (
+            TurnIdempotencyOutcomeKind::Resumed,
+            TurnIdempotencyReplay::ResumeSucceeded(response.clone()),
+        ),
+        Err(error) => (
+            TurnIdempotencyOutcomeKind::from_error(error),
+            TurnIdempotencyReplay::Error(TurnIdempotencyErrorReplay::from_error(error)),
+        ),
+    };
+    TurnIdempotencyRecord {
+        scope: key.scope.clone(),
+        operation: TurnIdempotencyOperationKind::Resume,
+        key: key.key.clone(),
+        turn_id: None,
+        run_id: Some(key.run_id),
+        outcome,
+        replay,
+        created_at,
+        expires_at: None,
+    }
+}
+
+fn cancel_idempotency_record(
+    key: &RunIdempotencyKey,
+    result: &Result<CancelRunResponse, TurnError>,
+    created_at: crate::TurnTimestamp,
+) -> TurnIdempotencyRecord {
+    let (outcome, replay) = match result {
+        Ok(response) => (
+            TurnIdempotencyOutcomeKind::CancelRecorded,
+            TurnIdempotencyReplay::CancelRecorded(response.clone()),
+        ),
+        Err(error) => (
+            TurnIdempotencyOutcomeKind::from_error(error),
+            TurnIdempotencyReplay::Error(TurnIdempotencyErrorReplay::from_error(error)),
+        ),
+    };
+    TurnIdempotencyRecord {
+        scope: key.scope.clone(),
+        operation: TurnIdempotencyOperationKind::Cancel,
+        key: key.key.clone(),
+        turn_id: None,
+        run_id: Some(key.run_id),
+        outcome,
+        replay,
+        created_at,
+        expires_at: None,
+    }
+}
+
 fn ensure_lease(
     record: &RunRecord,
     runner_id: crate::TurnRunnerId,
@@ -695,18 +1090,26 @@ fn ensure_lease(
     Ok(())
 }
 
-fn prune_ordered_map<K, V>(map: &mut HashMap<K, V>, order: &mut VecDeque<K>, max_len: usize)
+fn prune_ordered_map<K, V>(
+    map: &mut HashMap<K, V>,
+    order: &mut VecDeque<K>,
+    max_len: usize,
+) -> Vec<K>
 where
     K: Eq + Hash,
 {
+    let mut removed = Vec::new();
     while map.len() > max_len {
         let Some(key) = order.pop_front() else {
             break;
         };
-        map.remove(&key);
+        if map.remove(&key).is_some() {
+            removed.push(key);
+        }
     }
 
     while order.front().is_some_and(|key| !map.contains_key(key)) {
         order.pop_front();
     }
+    removed
 }

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -121,6 +121,14 @@ fn validate_sanitized_category(kind: &'static str, value: &str) -> Result<(), St
     if value.chars().any(|c| c == '\0' || c.is_control()) {
         return Err(format!("{kind} must not contain control characters"));
     }
+    if !value
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(format!(
+            "{kind} must contain only lowercase ASCII letters, digits, or underscores"
+        ));
+    }
     Ok(())
 }
 

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -1,8 +1,13 @@
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    CancelRunRequest, CancelRunResponse, GetRunStateRequest, ResumeTurnRequest, ResumeTurnResponse,
-    SubmitTurnRequest, SubmitTurnResponse, TurnAdmissionPolicy, TurnError, TurnRunState,
+    AcceptedMessageRef, AdmissionRejection, CancelRunRequest, CancelRunResponse, GateRef,
+    GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef, ResumeTurnRequest,
+    ResumeTurnResponse, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
+    TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnError, TurnErrorCategory, TurnId,
+    TurnLeaseToken, TurnRunId, TurnRunProfile, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
+    TurnTimestamp, events::EventCursor,
 };
 
 #[async_trait]
@@ -24,4 +29,249 @@ pub trait TurnStateStore: Send + Sync {
     ) -> Result<CancelRunResponse, TurnError>;
 
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TurnLockVersion(u64);
+
+impl TurnLockVersion {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    pub fn incremented(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TurnActiveLockKey {
+    pub scope: TurnScope,
+}
+
+impl From<&TurnScope> for TurnActiveLockKey {
+    fn from(scope: &TurnScope) -> Self {
+        Self {
+            scope: scope.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnRecord {
+    pub turn_id: TurnId,
+    pub scope: TurnScope,
+    pub actor: TurnActor,
+    pub accepted_message_ref: AcceptedMessageRef,
+    pub source_binding_ref: SourceBindingRef,
+    pub reply_target_binding_ref: ReplyTargetBindingRef,
+    pub created_at: TurnTimestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnRunRecord {
+    pub run_id: TurnRunId,
+    pub turn_id: TurnId,
+    pub scope: TurnScope,
+    pub accepted_message_ref: AcceptedMessageRef,
+    pub source_binding_ref: SourceBindingRef,
+    pub reply_target_binding_ref: ReplyTargetBindingRef,
+    pub status: TurnStatus,
+    pub profile: TurnRunProfile,
+    pub checkpoint_id: Option<TurnCheckpointId>,
+    pub gate_ref: Option<GateRef>,
+    pub failure: Option<crate::SanitizedFailure>,
+    pub event_cursor: EventCursor,
+    pub runner_id: Option<TurnRunnerId>,
+    pub lease_token: Option<TurnLeaseToken>,
+    pub lease_expires_at: Option<TurnTimestamp>,
+    pub last_heartbeat_at: Option<TurnTimestamp>,
+    pub claim_count: u64,
+    pub received_at: TurnTimestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnActiveLockRecord {
+    pub key: TurnActiveLockKey,
+    pub run_id: TurnRunId,
+    pub status: TurnStatus,
+    pub lock_version: TurnLockVersion,
+    pub acquired_at: TurnTimestamp,
+    pub updated_at: TurnTimestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnCheckpointRecord {
+    pub checkpoint_id: TurnCheckpointId,
+    pub run_id: TurnRunId,
+    pub sequence: u64,
+    pub status: TurnStatus,
+    pub gate_ref: GateRef,
+    pub created_at: TurnTimestamp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnIdempotencyOperationKind {
+    Submit,
+    Resume,
+    Cancel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnIdempotencyOutcomeKind {
+    Accepted,
+    ThreadBusy,
+    AdmissionRejected,
+    Resumed,
+    CancelRecorded,
+    ScopeNotFound,
+    Unauthorized,
+    InvalidRequest,
+    Unavailable,
+    Conflict,
+}
+
+impl TurnIdempotencyOutcomeKind {
+    pub fn from_error(error: &TurnError) -> Self {
+        match error {
+            TurnError::ThreadBusy(_) => Self::ThreadBusy,
+            TurnError::AdmissionRejected(_) => Self::AdmissionRejected,
+            TurnError::ScopeNotFound => Self::ScopeNotFound,
+            TurnError::Unauthorized => Self::Unauthorized,
+            TurnError::InvalidRequest { .. } => Self::InvalidRequest,
+            TurnError::Unavailable { .. } => Self::Unavailable,
+            TurnError::Conflict { .. }
+            | TurnError::InvalidTransition { .. }
+            | TurnError::LeaseMismatch => Self::Conflict,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TurnIdempotencyReplay {
+    SubmitAccepted(SubmitTurnResponse),
+    SubmitThreadBusy(ThreadBusy),
+    SubmitAdmissionRejected(AdmissionRejection),
+    ResumeSucceeded(ResumeTurnResponse),
+    CancelRecorded(CancelRunResponse),
+    Error(TurnIdempotencyErrorReplay),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnIdempotencyErrorReplay {
+    pub category: TurnErrorCategory,
+    pub adapter_status_code: u16,
+}
+
+impl TurnIdempotencyErrorReplay {
+    pub fn from_error(error: &TurnError) -> Self {
+        Self {
+            category: error.category(),
+            adapter_status_code: error.adapter_status_code(),
+        }
+    }
+
+    fn to_error(&self) -> TurnError {
+        match self.category {
+            TurnErrorCategory::ScopeNotFound => TurnError::ScopeNotFound,
+            TurnErrorCategory::Unauthorized => TurnError::Unauthorized,
+            TurnErrorCategory::InvalidRequest => TurnError::InvalidRequest {
+                reason: "replayed invalid request".to_string(),
+            },
+            TurnErrorCategory::Unavailable => TurnError::Unavailable {
+                reason: "replayed unavailable".to_string(),
+            },
+            TurnErrorCategory::Conflict => TurnError::Conflict {
+                reason: "replayed conflict".to_string(),
+            },
+            TurnErrorCategory::ThreadBusy => TurnError::Conflict {
+                reason: "replayed malformed thread-busy idempotency record".to_string(),
+            },
+            TurnErrorCategory::AdmissionRejected => TurnError::Conflict {
+                reason: "replayed malformed admission idempotency record".to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnIdempotencyRecord {
+    pub scope: TurnScope,
+    pub operation: TurnIdempotencyOperationKind,
+    pub key: IdempotencyKey,
+    pub turn_id: Option<TurnId>,
+    pub run_id: Option<TurnRunId>,
+    pub outcome: TurnIdempotencyOutcomeKind,
+    pub replay: TurnIdempotencyReplay,
+    pub created_at: TurnTimestamp,
+    pub expires_at: Option<TurnTimestamp>,
+}
+
+impl TurnIdempotencyRecord {
+    pub fn replay_submit(&self) -> Option<Result<SubmitTurnResponse, TurnError>> {
+        if self.operation != TurnIdempotencyOperationKind::Submit {
+            return None;
+        }
+        match &self.replay {
+            TurnIdempotencyReplay::SubmitAccepted(response) => Some(Ok(response.clone())),
+            TurnIdempotencyReplay::SubmitThreadBusy(busy) => {
+                Some(Err(TurnError::ThreadBusy(busy.clone())))
+            }
+            TurnIdempotencyReplay::SubmitAdmissionRejected(rejection) => {
+                Some(Err(TurnError::AdmissionRejected(rejection.clone())))
+            }
+            TurnIdempotencyReplay::Error(error)
+                if self.operation == TurnIdempotencyOperationKind::Submit =>
+            {
+                Some(Err(error.to_error()))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn replay_resume(&self) -> Option<Result<ResumeTurnResponse, TurnError>> {
+        if self.operation != TurnIdempotencyOperationKind::Resume {
+            return None;
+        }
+        match &self.replay {
+            TurnIdempotencyReplay::ResumeSucceeded(response) => Some(Ok(response.clone())),
+            TurnIdempotencyReplay::Error(error)
+                if self.operation == TurnIdempotencyOperationKind::Resume =>
+            {
+                Some(Err(error.to_error()))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn replay_cancel(&self) -> Option<Result<CancelRunResponse, TurnError>> {
+        if self.operation != TurnIdempotencyOperationKind::Cancel {
+            return None;
+        }
+        match &self.replay {
+            TurnIdempotencyReplay::CancelRecorded(response) => Some(Ok(response.clone())),
+            TurnIdempotencyReplay::Error(error)
+                if self.operation == TurnIdempotencyOperationKind::Cancel =>
+            {
+                Some(Err(error.to_error()))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TurnPersistenceSnapshot {
+    pub turns: Vec<TurnRecord>,
+    pub runs: Vec<TurnRunRecord>,
+    pub active_locks: Vec<TurnActiveLockRecord>,
+    pub checkpoints: Vec<TurnCheckpointRecord>,
+    pub idempotency_records: Vec<TurnIdempotencyRecord>,
 }

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
         mpsc,
     },
@@ -16,8 +16,9 @@ use ironclaw_turns::{
     ReplyTargetBindingRef, ResumeTurnRequest, RunProfileRequest, RunProfileVersion,
     SanitizedCancelReason, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
     SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnCheckpointId,
-    TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventSink, TurnLeaseToken,
-    TurnLifecycleEvent, TurnRunId, TurnRunnerId, TurnScope, TurnStatus,
+    TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventSink,
+    TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnLeaseToken, TurnLifecycleEvent,
+    TurnLockVersion, TurnRunId, TurnRunnerId, TurnScope, TurnStatus,
     events::EventCursor,
     runner::{
         BlockRunRequest, CancelRunCompletionRequest, ClaimRunRequest, CompleteRunRequest,
@@ -130,21 +131,86 @@ async fn same_thread_active_run_returns_busy_but_different_threads_run_independe
 }
 
 #[tokio::test]
-async fn submit_turn_idempotency_replays_same_success_result() {
+async fn submit_turn_persistence_snapshot_has_atomic_success_artifacts() {
+    let (coordinator, store) = coordinator();
+    let request = submit_request("thread-a", "idem-submit-a");
+
+    let response = coordinator.submit_turn(request.clone()).await.unwrap();
+    let SubmitTurnResponse::Accepted {
+        turn_id,
+        run_id,
+        status,
+        event_cursor,
+        ..
+    } = response;
+
+    let snapshot = store.persistence_snapshot();
+    assert_eq!(snapshot.turns.len(), 1);
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.active_locks.len(), 1);
+    assert_eq!(snapshot.checkpoints.len(), 0);
+    assert_eq!(snapshot.idempotency_records.len(), 1);
+
+    let turn = &snapshot.turns[0];
+    assert_eq!(turn.turn_id, turn_id);
+    assert_eq!(turn.scope, request.scope);
+    assert_eq!(turn.actor, request.actor);
+    assert_eq!(turn.accepted_message_ref, request.accepted_message_ref);
+    assert_eq!(turn.source_binding_ref, request.source_binding_ref);
+    assert_eq!(
+        turn.reply_target_binding_ref,
+        request.reply_target_binding_ref
+    );
+    assert_eq!(turn.created_at, request.received_at);
+
+    let run = &snapshot.runs[0];
+    assert_eq!(run.run_id, run_id);
+    assert_eq!(run.turn_id, turn_id);
+    assert_eq!(run.status, status);
+    assert_eq!(run.event_cursor, event_cursor);
+    assert_eq!(run.claim_count, 0);
+    assert_eq!(run.runner_id, None);
+    assert_eq!(run.lease_token, None);
+
+    let lock = &snapshot.active_locks[0];
+    assert_eq!(lock.key.scope, request.scope);
+    assert_eq!(lock.run_id, run_id);
+    assert_eq!(lock.status, TurnStatus::Queued);
+    assert_eq!(lock.lock_version, TurnLockVersion::new(1));
+    assert_eq!(lock.acquired_at, request.received_at);
+    assert_eq!(lock.updated_at, request.received_at);
+
+    let idempotency = &snapshot.idempotency_records[0];
+    assert_eq!(idempotency.scope, request.scope);
+    assert_eq!(idempotency.operation, TurnIdempotencyOperationKind::Submit);
+    assert_eq!(idempotency.key, request.idempotency_key);
+    assert_eq!(idempotency.turn_id, Some(turn_id));
+    assert_eq!(idempotency.run_id, Some(run_id));
+    assert_eq!(idempotency.outcome, TurnIdempotencyOutcomeKind::Accepted);
+    assert_eq!(idempotency.created_at, request.received_at);
+}
+
+#[tokio::test]
+async fn same_thread_lock_excludes_actor_identity() {
     let (coordinator, _store) = coordinator();
     let first = coordinator
         .submit_turn(submit_request("thread-a", "idem-submit-a"))
         .await
         .unwrap();
-    let duplicate = coordinator
-        .submit_turn(submit_request("thread-a", "idem-submit-a"))
-        .await
-        .unwrap();
-    assert_eq!(duplicate, first);
+    let first_run_id = accepted_run_id(&first);
+    let mut second_actor = submit_request("thread-a", "idem-submit-b");
+    second_actor.actor = TurnActor::new(UserId::new("user2").unwrap());
+
+    let busy = coordinator.submit_turn(second_actor).await.unwrap_err();
+
+    assert!(matches!(
+        busy,
+        TurnError::ThreadBusy(ThreadBusy { active_run_id, .. }) if active_run_id == first_run_id
+    ));
 }
 
 #[tokio::test]
-async fn transient_busy_submit_is_not_cached_after_thread_unlocks() {
+async fn submit_turn_busy_path_records_idempotent_thread_busy_without_new_run() {
     let (coordinator, store) = coordinator();
     let first_run_id = accepted_run_id(
         &coordinator
@@ -153,13 +219,31 @@ async fn transient_busy_submit_is_not_cached_after_thread_unlocks() {
             .unwrap(),
     );
     let busy_request = submit_request("thread-a", "idem-submit-b");
-    assert!(matches!(
-        coordinator
-            .submit_turn(busy_request.clone())
-            .await
-            .unwrap_err(),
-        TurnError::ThreadBusy(_)
-    ));
+
+    let busy = coordinator
+        .submit_turn(busy_request.clone())
+        .await
+        .unwrap_err();
+
+    let snapshot = store.persistence_snapshot();
+    assert_eq!(snapshot.turns.len(), 1);
+    assert_eq!(snapshot.runs.len(), 1);
+    let busy_idempotency = snapshot
+        .idempotency_records
+        .iter()
+        .find(|record| record.key == busy_request.idempotency_key)
+        .expect("busy submit idempotency result must be recorded");
+    assert_eq!(
+        busy_idempotency.operation,
+        TurnIdempotencyOperationKind::Submit
+    );
+    assert_eq!(busy_idempotency.turn_id, None);
+    assert_eq!(busy_idempotency.run_id, Some(first_run_id));
+    assert_eq!(
+        busy_idempotency.outcome,
+        TurnIdempotencyOutcomeKind::ThreadBusy
+    );
+    assert_eq!(busy_idempotency.created_at, busy_request.received_at);
 
     let runner_id = TurnRunnerId::new();
     let lease_token = TurnLeaseToken::new();
@@ -181,8 +265,300 @@ async fn transient_busy_submit_is_not_cached_after_thread_unlocks() {
         .await
         .unwrap();
 
-    let accepted_after_unlock = coordinator.submit_turn(busy_request).await.unwrap();
-    assert_ne!(accepted_run_id(&accepted_after_unlock), first_run_id);
+    let duplicate = coordinator.submit_turn(busy_request).await.unwrap_err();
+    assert_eq!(duplicate, busy);
+    assert_eq!(store.persistence_snapshot().turns.len(), 1);
+}
+
+#[tokio::test]
+async fn runner_claim_and_block_update_persistent_run_lock_and_checkpoint_records() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let claimed = store.persistence_snapshot();
+    let run = claimed
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap();
+    assert_eq!(run.status, TurnStatus::Running);
+    assert_eq!(run.runner_id, Some(runner_id));
+    assert_eq!(run.lease_token, Some(lease_token));
+    assert_eq!(run.claim_count, 1);
+    let lock = claimed
+        .active_locks
+        .iter()
+        .find(|lock| lock.run_id == run_id)
+        .unwrap();
+    assert_eq!(lock.status, TurnStatus::Running);
+    assert_eq!(lock.lock_version, TurnLockVersion::new(2));
+
+    let checkpoint_id = TurnCheckpointId::new();
+    let gate_ref = GateRef::new("approval-gate").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id,
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let blocked = store.persistence_snapshot();
+    let run = blocked
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap();
+    assert_eq!(run.status, TurnStatus::BlockedApproval);
+    assert_eq!(run.checkpoint_id, Some(checkpoint_id));
+    assert_eq!(run.gate_ref, Some(gate_ref.clone()));
+    assert_eq!(run.runner_id, None);
+    assert_eq!(run.lease_token, None);
+    let lock = blocked
+        .active_locks
+        .iter()
+        .find(|lock| lock.run_id == run_id)
+        .unwrap();
+    assert_eq!(lock.status, TurnStatus::BlockedApproval);
+    assert_eq!(lock.lock_version, TurnLockVersion::new(3));
+    assert_eq!(blocked.checkpoints.len(), 1);
+    let checkpoint = &blocked.checkpoints[0];
+    assert_eq!(checkpoint.checkpoint_id, checkpoint_id);
+    assert_eq!(checkpoint.run_id, run_id);
+    assert_eq!(checkpoint.sequence, 1);
+    assert_eq!(checkpoint.gate_ref, gate_ref);
+}
+
+#[tokio::test]
+async fn resume_updates_persisted_run_binding_refs_and_replay_envelope() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let gate_ref = GateRef::new("approval-gate").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+    let resume_request = ResumeTurnRequest {
+        scope: scope("thread-a"),
+        actor: actor(),
+        run_id,
+        gate_resolution_ref: gate_ref,
+        source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
+        idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
+    };
+
+    let resumed = coordinator
+        .resume_turn(resume_request.clone())
+        .await
+        .unwrap();
+
+    let snapshot = store.persistence_snapshot();
+    let run = snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap();
+    assert_eq!(run.source_binding_ref, resume_request.source_binding_ref);
+    assert_eq!(
+        run.reply_target_binding_ref,
+        resume_request.reply_target_binding_ref
+    );
+    let replay_record = snapshot
+        .idempotency_records
+        .iter()
+        .find(|record| record.key == resume_request.idempotency_key)
+        .expect("resume idempotency record must be persisted");
+    assert_eq!(replay_record.replay_resume().unwrap(), Ok(resumed));
+}
+
+#[tokio::test]
+async fn persisted_submit_busy_and_cancel_replay_envelopes_are_reconstructable() {
+    let (coordinator, store) = coordinator();
+    let first_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let busy_request = submit_request("thread-a", "idem-submit-b");
+    let busy = coordinator
+        .submit_turn(busy_request.clone())
+        .await
+        .unwrap_err();
+    let cancel = coordinator
+        .cancel_run(cancel_request(
+            "thread-a",
+            first_run_id,
+            "idem-cancel-running-a",
+        ))
+        .await
+        .unwrap();
+
+    let snapshot = store.persistence_snapshot();
+    let busy_record = snapshot
+        .idempotency_records
+        .iter()
+        .find(|record| record.key == busy_request.idempotency_key)
+        .expect("busy submit idempotency record must be persisted");
+    assert_eq!(busy_record.replay_submit().unwrap(), Err(busy));
+    let cancel_record = snapshot
+        .idempotency_records
+        .iter()
+        .find(|record| record.key == IdempotencyKey::new("idem-cancel-running-a").unwrap())
+        .expect("cancel idempotency record must be persisted");
+    assert_eq!(cancel_record.replay_cancel().unwrap(), Ok(cancel));
+}
+
+#[tokio::test]
+async fn submit_turn_idempotency_replays_same_success_result() {
+    let (coordinator, _store) = coordinator();
+    let first = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    let duplicate = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    assert_eq!(duplicate, first);
+}
+
+#[tokio::test]
+async fn submit_turn_busy_idempotency_replays_after_thread_unlocks() {
+    let (coordinator, store) = coordinator();
+    let first_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let busy_request = submit_request("thread-a", "idem-submit-b");
+    let busy = coordinator
+        .submit_turn(busy_request.clone())
+        .await
+        .unwrap_err();
+    assert!(matches!(busy, TurnError::ThreadBusy(_)));
+
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let duplicate_after_unlock = coordinator.submit_turn(busy_request).await.unwrap_err();
+    assert_eq!(duplicate_after_unlock, busy);
+}
+
+#[test]
+fn concurrent_duplicate_submit_waits_for_in_flight_admission_result() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let policy = Arc::new(BlockingAdmissionPolicy {
+        calls: AtomicUsize::new(0),
+        entered: entered_tx,
+        release: Mutex::new(release_rx),
+    });
+
+    let first_store = store.clone();
+    let first_policy = policy.clone();
+    let first = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let coordinator =
+            DefaultTurnCoordinator::new(first_store).with_admission_policy(first_policy);
+        runtime
+            .block_on(coordinator.submit_turn(submit_request("thread-a", "idem-submit-concurrent")))
+    });
+    entered_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("first submit should enter admission policy");
+
+    let second_store = store.clone();
+    let second_policy = policy.clone();
+    let second = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let coordinator =
+            DefaultTurnCoordinator::new(second_store).with_admission_policy(second_policy);
+        runtime
+            .block_on(coordinator.submit_turn(submit_request("thread-a", "idem-submit-concurrent")))
+    });
+
+    std::thread::sleep(Duration::from_millis(50));
+    release_tx
+        .send(())
+        .expect("first submit should still be waiting for admission release");
+
+    let first = first.join().unwrap().unwrap();
+    let second = second.join().unwrap().unwrap();
+    assert_eq!(second, first);
+    assert_eq!(policy.calls.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
@@ -239,6 +615,190 @@ async fn submit_turn_idempotency_replays_same_admission_rejection() {
         ))
     );
     assert!(store.events().is_empty());
+}
+
+#[tokio::test]
+async fn idempotency_persistence_snapshot_retains_each_operation_kind_capacity() {
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            max_idempotency_records: 1,
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let gate_ref = GateRef::new("approval-gate").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+    coordinator
+        .resume_turn(ResumeTurnRequest {
+            scope: scope("thread-a"),
+            actor: actor(),
+            run_id,
+            gate_resolution_ref: gate_ref,
+            source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
+        })
+        .await
+        .unwrap();
+    coordinator
+        .cancel_run(cancel_request("thread-a", run_id, "idem-cancel-a"))
+        .await
+        .unwrap();
+
+    let snapshot = store.persistence_snapshot();
+    assert_eq!(snapshot.idempotency_records.len(), 3);
+    assert!(snapshot.idempotency_records.iter().any(|record| {
+        record.operation == TurnIdempotencyOperationKind::Submit
+            && record.key == IdempotencyKey::new("idem-submit-a").unwrap()
+    }));
+    assert!(snapshot.idempotency_records.iter().any(|record| {
+        record.operation == TurnIdempotencyOperationKind::Resume
+            && record.key == IdempotencyKey::new("idem-resume-a").unwrap()
+    }));
+    assert!(snapshot.idempotency_records.iter().any(|record| {
+        record.operation == TurnIdempotencyOperationKind::Cancel
+            && record.key == IdempotencyKey::new("idem-cancel-a").unwrap()
+    }));
+}
+
+#[tokio::test]
+async fn idempotency_persistence_snapshot_drops_records_when_replay_cache_prunes_them() {
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            max_idempotency_records: 1,
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+
+    coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap();
+
+    let snapshot = store.persistence_snapshot();
+    assert!(!snapshot.idempotency_records.iter().any(|record| {
+        record.operation == TurnIdempotencyOperationKind::Submit
+            && record.key == IdempotencyKey::new("idem-submit-a").unwrap()
+    }));
+    assert!(snapshot.idempotency_records.iter().any(|record| {
+        record.operation == TurnIdempotencyOperationKind::Submit
+            && record.key == IdempotencyKey::new("idem-submit-b").unwrap()
+    }));
+}
+
+#[tokio::test]
+async fn idempotency_replay_helpers_require_matching_operation_kind() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let gate_ref = GateRef::new("approval-gate").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+    coordinator
+        .resume_turn(ResumeTurnRequest {
+            scope: scope("thread-a"),
+            actor: actor(),
+            run_id,
+            gate_resolution_ref: gate_ref,
+            source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
+        })
+        .await
+        .unwrap();
+    coordinator
+        .cancel_run(cancel_request("thread-a", run_id, "idem-cancel-a"))
+        .await
+        .unwrap();
+
+    let snapshot = store.persistence_snapshot();
+    let submit = snapshot
+        .idempotency_records
+        .iter()
+        .find(|record| record.operation == TurnIdempotencyOperationKind::Submit)
+        .unwrap();
+    assert!(submit.replay_submit().is_some());
+    let mut mislabeled_submit = submit.clone();
+    mislabeled_submit.operation = TurnIdempotencyOperationKind::Cancel;
+    assert!(mislabeled_submit.replay_submit().is_none());
+
+    let resume = snapshot
+        .idempotency_records
+        .iter()
+        .find(|record| record.operation == TurnIdempotencyOperationKind::Resume)
+        .unwrap();
+    assert!(resume.replay_resume().is_some());
+    let mut mislabeled_resume = resume.clone();
+    mislabeled_resume.operation = TurnIdempotencyOperationKind::Submit;
+    assert!(mislabeled_resume.replay_resume().is_none());
+
+    let cancel = snapshot
+        .idempotency_records
+        .iter()
+        .find(|record| record.operation == TurnIdempotencyOperationKind::Cancel)
+        .unwrap();
+    assert!(cancel.replay_cancel().is_some());
+    let mut mislabeled_cancel = cancel.clone();
+    mislabeled_cancel.operation = TurnIdempotencyOperationKind::Resume;
+    assert!(mislabeled_cancel.replay_cancel().is_none());
 }
 
 #[tokio::test]
@@ -767,11 +1327,16 @@ async fn cancelled_running_run_cannot_be_reopened_as_blocked() {
 }
 
 #[tokio::test]
-async fn sanitized_failure_rejects_empty_controlled_or_oversized_categories() {
+async fn sanitized_failure_rejects_empty_controlled_oversized_or_unsanitized_categories() {
     assert!(SanitizedFailure::new("policy").is_ok());
+    assert!(SanitizedFailure::new("policy_timeout").is_ok());
     assert!(SanitizedFailure::new("").is_err());
     assert!(SanitizedFailure::new("backend\nsecret=leaked").is_err());
     assert!(SanitizedFailure::new("x".repeat(257)).is_err());
+    assert!(SanitizedFailure::new("/Users/alice/.ssh/config").is_err());
+    assert!(SanitizedFailure::new("https://internal.example/error").is_err());
+    assert!(SanitizedFailure::new("openai api key sk-test failed").is_err());
+    assert!(SanitizedFailure::new("policy-timeout").is_err());
 }
 
 #[test]
@@ -917,6 +1482,26 @@ fn scope(thread: &str) -> TurnScope {
 
 fn actor() -> TurnActor {
     TurnActor::new(UserId::new("user1").unwrap())
+}
+
+struct BlockingAdmissionPolicy {
+    calls: AtomicUsize,
+    entered: mpsc::Sender<()>,
+    release: Mutex<mpsc::Receiver<()>>,
+}
+
+impl TurnAdmissionPolicy for BlockingAdmissionPolicy {
+    fn check_submit(&self, _request: &SubmitTurnRequest) -> Result<(), AdmissionRejection> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            let _ = self.entered.send(());
+            self.release
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_secs(1))
+                .expect("test should release first admission check");
+        }
+        Ok(())
+    }
 }
 
 struct ReentrantStorePolicy {

--- a/docs/reborn/contracts/_contract-freeze-index.md
+++ b/docs/reborn/contracts/_contract-freeze-index.md
@@ -84,6 +84,7 @@ If a task needs to change one of those answers, it is not implementation work; i
 - [`memory.md`](memory.md)
 - [`settings-config.md`](settings-config.md)
 - [`turns-agent-loop.md`](turns-agent-loop.md)
+- [`turn-persistence.md`](turn-persistence.md)
 - [`migration-compatibility.md`](migration-compatibility.md)
 
 ---

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -1,0 +1,76 @@
+# Reborn Contract — Turn Persistence and Active Locks
+
+**Status:** Contract-freeze draft  
+**Date:** 2026-05-05  
+**Depends on:** [`turns-agent-loop.md`](turns-agent-loop.md), [`host-api.md`](host-api.md), [`events-projections.md`](events-projections.md), [`runtime-profiles.md`](runtime-profiles.md)
+
+---
+
+## 1. Purpose
+
+Turn persistence owns durable control-plane state for host-layer turn coordination:
+
+- accepted turn metadata and canonical binding references;
+- executable turn-run lifecycle state;
+- one-active-run-per-canonical-thread locks;
+- runner lease/checkpoint metadata;
+- idempotency outcomes for adapter-facing mutations;
+- redacted lifecycle cursors needed for replay/recovery.
+
+It does **not** own canonical transcript/message storage. Transcript and thread-message history remain in the transcript/thread storage boundary.
+
+---
+
+## 2. Logical records
+
+The `ironclaw_turns` contract models persistence with these record families:
+
+| Record | Ownership |
+| --- | --- |
+| `turns` | One accepted inbound message: scope, actor, accepted-message ref, source/reply binding refs, created timestamp. |
+| `turn_runs` | Executable state for one run: current source/reply binding refs, status, resolved run-profile snapshot, latest checkpoint/gate refs, runner lease fields, event cursor. |
+| `turn_active_locks` | One lock per canonical scoped thread while a run is active or resumable. |
+| `turn_checkpoints` | Dedicated checkpoint/gate records written when a running run blocks. |
+| `turn_idempotency_keys` | Prior sanitized outcomes for scoped submit/resume/cancel idempotency keys. |
+
+Concrete PostgreSQL/libSQL tables are intentionally deferred until the DB adapter slice. Backends must preserve the same semantics when those adapters are added.
+
+---
+
+## 3. Active-lock rules
+
+- Active-lock key is the canonical `TurnScope`: tenant, agent, optional project, and thread.
+- The key excludes `TurnActor.user_id`, channel IDs, source binding refs, and reply binding refs.
+- A lock stores the current owning `TurnRunId`, explicit `TurnStatus`, monotonically increasing `TurnLockVersion`, `acquired_at`, and `updated_at`.
+- Queued, running, cancel-requested, blocked, and recovery-required runs keep the lock.
+- Terminal runs release the lock exactly once.
+- Runner claim/resume/block/cancel-request transitions update the lock status/version while keeping ownership with the same run.
+
+---
+
+## 4. Idempotency rules
+
+Adapter-facing mutations persist sanitized idempotency outcomes:
+
+- `submit_turn` success records the accepted turn/run IDs and accepted response kind.
+- `submit_turn` busy path records a `ThreadBusy` outcome without creating a new turn/run.
+- Admission rejections are replayable and do not create turn/run records.
+- `resume_turn` and `cancel_run` record scoped run-operation outcomes.
+- Idempotency records include a redacted replay envelope with response-critical fields such as status, event cursor, active run ID, admission reason/retry metadata, and cancellation `already_terminal` state.
+
+A duplicate idempotency key must replay the prior sanitized success/error outcome instead of re-running admission, lock acquisition, or state transitions.
+
+---
+
+## 5. Runner lease and checkpoint rules
+
+- Claiming a queued run atomically moves it to `Running`, stores runner ID/lease token, increments `claim_count`, and updates heartbeat metadata.
+- Heartbeats only renew metadata for matching runner ID/lease token.
+- Blocking a running run writes a checkpoint record, stores the latest checkpoint/gate refs on the run, clears current lease ownership, and keeps the active lock.
+- Terminal runner outcomes require the matching runner ID/lease token and release the active lock only if the run still owns it.
+
+---
+
+## 6. Redaction boundary
+
+Turn persistence stores metadata and references only. It must not persist raw prompts, assistant content, tool input, secrets, host paths, or backend error details in turn/run/checkpoint/idempotency records.

--- a/docs/reborn/contracts/turns-agent-loop.md
+++ b/docs/reborn/contracts/turns-agent-loop.md
@@ -2,7 +2,7 @@
 
 **Status:** Contract-freeze draft
 **Date:** 2026-04-25
-**Depends on:** [`host-api.md`](host-api.md), [`capabilities.md`](capabilities.md), [`memory.md`](memory.md), [`events-projections.md`](events-projections.md), [`processes.md`](processes.md)
+**Depends on:** [`host-api.md`](host-api.md), [`capabilities.md`](capabilities.md), [`memory.md`](memory.md), [`events-projections.md`](events-projections.md), [`processes.md`](processes.md), [`turn-persistence.md`](turn-persistence.md)
 
 ---
 
@@ -124,6 +124,7 @@ running -> completed|failed|cancelled
 
 Rules:
 
+- persistence records, active-lock ownership, runner lease fields, checkpoints, and idempotency outcomes follow [`turn-persistence.md`](turn-persistence.md);
 - state transitions are persisted before externally visible side effects where needed for recovery;
 - approval-blocked turns persist enough fingerprint metadata to resume without raw input leakage;
 - cancellation requests propagate to running process/capability work when possible;

--- a/tests/support/live_mission_helpers.rs
+++ b/tests/support/live_mission_helpers.rs
@@ -4,7 +4,6 @@
 //! (`tests/e2e_live_mission_gmail.rs`, etc.) can reuse the same approval
 //! responder and notification heuristics without copy-paste drift.
 
-#![cfg(feature = "libsql")]
 #![allow(dead_code)] // shared API; not every test uses every helper
 
 use std::collections::HashSet;


### PR DESCRIPTION
## Summary

- adds contract-level turn persistence records for turns, runs, active locks, checkpoints, and idempotency outcomes
- makes the in-memory turn store maintain explicit active-lock, checkpoint, current binding-ref, and idempotency replay metadata
- coordinates same-key submit idempotency while admission is in flight so duplicates replay without re-running admission
- documents the Reborn turn persistence/active-lock contract and links it from the turn loop contract index
- removes a redundant test-support `cfg` attribute so workspace all-features clippy stays clean

## Scope notes

This is the first #3202 contract slice. Concrete PostgreSQL/libSQL adapters remain out of scope here per the issue non-goals and the existing `ironclaw_turns` dependency guardrails.

Refs #3202.

## Verification

- `cargo fmt --check`
- RED before fix, then green:
  - `cargo test -p ironclaw_turns --test turn_coordinator_contract idempotency_persistence_snapshot_retains_each_operation_kind_capacity`
  - `cargo test -p ironclaw_turns --test turn_coordinator_contract idempotency_persistence_snapshot_drops_records_when_replay_cache_prunes_them`
  - `cargo test -p ironclaw_turns --test turn_coordinator_contract idempotency_replay_helpers_require_matching_operation_kind`
  - `cargo test -p ironclaw_turns --test turn_coordinator_contract sanitized_failure_rejects_empty_controlled_oversized_or_unsanitized_categories`
  - `cargo test -p ironclaw_turns --test turn_coordinator_contract concurrent_duplicate_submit_waits_for_in_flight_admission_result`
- `cargo test -p ironclaw_turns`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries`
- `cargo clippy --all --tests --examples --all-features -- -D warnings`
- `git diff --check`
- `rg -n "\\b(unwrap|expect|panic!)\\s*\\(" crates/ironclaw_turns/src` (no production matches)
- `cargo check --workspace`

## Review

- Reviewer subagent pass after fixes: no actionable findings.
- Addressed Gemini comment about aggregate idempotency snapshot pruning with a failing regression test first.
- Paranoid loop passes found Medium idempotency liveness/operation-discriminator issues, Medium sanitized-failure category issue, and Medium concurrent same-key submit admission issue; fixed all with failing tests first.
