### PR TITLE
docs: salvage Docker Hub image name fix from #3217

### DIFF
--- a/docs/drafts/install/docker.mdx
+++ b/docs/drafts/install/docker.mdx
@@ -31,8 +31,8 @@ docker run -d \
   # -v /var/run/docker.sock:/var/run/docker.sock \
   -p 3000:3000 \
   -p 8080:8080 \
-  # Pin to a specific IronClaw version for reproducible, rollback-friendly deployments.
-  nearaidev/ironclaw:latest 
+  # Replace :latest with a specific version tag for reproducible, rollback-friendly deployments.
+  nearaidev/ironclaw:latest
 ```
 
 ## Docker Compose
@@ -44,7 +44,7 @@ version: '3.8'
 
 services:
   ironclaw:
-    # Pin to a specific IronClaw version for reproducible, rollback-friendly deployments.
+    # Replace :latest with a specific version tag for reproducible, rollback-friendly deployments.
     image: nearaidev/ironclaw:latest
     container_name: ironclaw
     restart: unless-stopped

--- a/docs/drafts/install/docker.mdx
+++ b/docs/drafts/install/docker.mdx
@@ -32,7 +32,7 @@ docker run -d \
   -p 3000:3000 \
   -p 8080:8080 \
   # Pin to a specific IronClaw version for reproducible, rollback-friendly deployments.
-  nearai/ironclaw:latest 
+  nearaidev/ironclaw:latest 
 ```
 
 ## Docker Compose
@@ -45,7 +45,7 @@ version: '3.8'
 services:
   ironclaw:
     # Pin to a specific IronClaw version for reproducible, rollback-friendly deployments.
-    image: nearai/ironclaw:latest
+    image: nearaidev/ironclaw:latest
     container_name: ironclaw
     restart: unless-stopped
 
@@ -121,7 +121,7 @@ docker run -d \
   -v ~/.ironclaw:/home/ironclaw/.ironclaw \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 3000:3000 \
-  nearai/ironclaw:latest
+  nearaidev/ironclaw:latest
 ```
 
 See [Configuration Reference](/setup/configuration) for all options.
@@ -195,7 +195,7 @@ server {
 
 ```bash
 # Pull latest image
-docker pull nearai/ironclaw:latest
+docker pull nearaidev/ironclaw:latest
 
 # Recreate container
 docker stop ironclaw
@@ -205,7 +205,7 @@ docker run -d \
   -v ~/.ironclaw:/home/ironclaw/.ironclaw \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 3000:3000 \
-  nearai/ironclaw:latest
+  nearaidev/ironclaw:latest
 
 # Or with docker compose
 docker compose pull

--- a/docs/drafts/install/uninstalling.mdx
+++ b/docs/drafts/install/uninstalling.mdx
@@ -51,7 +51,7 @@ brew services stop ironclaw    # Homebrew
     docker rm ironclaw
 
     # Remove image
-    docker rmi nearai/ironclaw:latest
+    docker rmi nearaidev/ironclaw:latest
     ```
   </Tab>
 </Tabs>

--- a/docs/drafts/install/updating.mdx
+++ b/docs/drafts/install/updating.mdx
@@ -43,7 +43,7 @@ ironclaw --version
   <Tab title="Docker">
     ```bash
     # Pull latest image
-    docker pull nearai/ironclaw:latest
+    docker pull nearaidev/ironclaw:latest
 
     # Recreate container
     docker stop ironclaw
@@ -115,7 +115,7 @@ If you need to rollback:
 curl -fsSL https://install.ironclaw.ai | bash -s -- --version 0.12.0
 
 # Docker
-docker pull nearai/ironclaw:v0.12.0
+docker pull nearaidev/ironclaw:v0.12.0
 ```
 
 <Warning>

--- a/docs/drafts/platforms/docker-compose.mdx
+++ b/docs/drafts/platforms/docker-compose.mdx
@@ -21,7 +21,7 @@ version: "3.9"
 
 services:
   ironclaw:
-    image: nearai/ironclaw:latest
+    image: nearaidev/ironclaw:latest
     container_name: ironclaw
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
Salvage of #3217 onto current main.

## Summary

Cherry-picked the Docker documentation fix from #3217 onto current `origin/main`.

This updates Docker Hub image references from `nearai/ironclaw` to the published `nearaidev/ironclaw` image in the Docker install/update/uninstall/compose docs. The change remains relevant because the current publish workflows use `nearaidev/ironclaw`, and issue #2963 reports that `nearai/ironclaw:latest` does not exist.

A maintainer follow-up commit addresses the review comment on #3217 by changing the misleading “Pin to a specific IronClaw version” comments next to `:latest` examples to “Replace :latest with a specific version tag...” guidance.

## Original PR

- Original PR: #3217
- Original PR author: @abbyshekit
- Original head branch: `docs/correct-dockerhub-image-name`
- Original commit(s):
  - 738c4eca7c1a90a2e092242e098ecb2883e0a47f
- Original commit author: Abhishek Vaidyanathan <abhishekvaidyanathan@0a:c3:a6:ef:bb:28.home>
- Original co-author trailer: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
- Attribution: original author, original commit SHA, and co-author trailer recorded; squash merge planned by default.
- Authorship preservation mode: squash-attributed. This branch also includes one maintainer-authored follow-up commit: `docs(docker): clarify latest tag guidance`.

## Salvage review

- Relevance: still relevant because current `origin/main` docs contain Docker image references to `nearai/ironclaw:<tag>`, while `.github/workflows/docker.yml` publishes `nearaidev/ironclaw`.
- Supersession check: current `origin/main` does not already contain this Docker docs fix; no stale `nearai/ironclaw:<tag>` refs remain in docs after the salvage branch.
- Source-of-truth check: compared against `.github/workflows/docker.yml` and `.github/workflows/rebuild-release-image.yml`, both of which use `nearaidev/ironclaw`.
- Review check: addressed the bot review comment about `:latest` examples being adjacent to “Pin to a specific version” comments.
- Risk track: Track A, docs-only.

## Validation

- `git grep -n "nearai/ironclaw:" -- docs` -> passed; no stale Docker image refs with a tag remain in docs
- `git diff --check origin/main...HEAD` -> passed
- Changed-doc patch check for newly introduced markdown links -> passed; no new markdown links introduced
- Review-comment check for old “Pin to a specific IronClaw version” wording in `docs/drafts/install/docker.mdx` -> passed; old wording removed

## Notes

- No source-code changes.
- Recommended merge method: squash merge by default, preserving attribution in the PR/squash text.
