### PR TITLE
ci(e2e): run full browser suite nightly

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ on:
         type: string
         default: full
   schedule:
-    - cron: "0 6 * * 1"  # Weekly Monday 6 AM UTC
+    - cron: "0 3 * * *"  # Nightly full E2E at 03:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- change the full E2E workflow schedule from weekly Monday to nightly at 03:00 UTC
- keep workflow_dispatch and workflow_call behavior unchanged

## Why
Full deterministic browser coverage needs to exist outside merge queue before we slim merge-group checks.

## Validation
- git diff --check