### PR TITLE
ci: slim main merge queue checks

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -70,7 +70,7 @@ jobs:
           FULL='[{"name":"all-features","flags":"--all-features"},{"name":"default","flags":""},{"name":"libsql-only","flags":"--no-default-features --features libsql"}]'
           SLIM='[{"name":"all-features","flags":"--all-features"}]'
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "matrix=${SLIM}" >> "$GITHUB_OUTPUT"
           else
             echo "matrix=${FULL}" >> "$GITHUB_OUTPUT"
@@ -153,7 +153,7 @@ jobs:
   clippy-windows:
     name: Clippy Windows (${{ matrix.name }})
     needs: [changes, clippy-matrix]
-    if: needs.changes.outputs.has_code == 'true' && github.event_name != 'pull_request'
+    if: needs.changes.outputs.has_code == 'true' && github.event_name == 'push'
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-deep-ci.yml
+++ b/.github/workflows/nightly-deep-ci.yml
@@ -1,0 +1,37 @@
+name: Nightly Deep CI
+
+# This workflow intentionally reuses the canonical Run Tests workflow instead
+# of duplicating job definitions here. With event_name == workflow_call,
+# .github/workflows/test.yml runs the deterministic deep suite:
+# - full Rust test matrix: all-features, default, libsql-only
+# - heavy runtime integration tests
+# - Telegram integration partitions
+# - replay snapshot gate
+# - Telegram and Slack channel tests
+# - WASM/WIT compatibility checks
+# - Windows compile matrix
+# - benchmark compilation
+#
+# Docker is intentionally excluded here because QA/release Docker images are
+# owned by the separate Docker pipeline and need release-team alignment.
+# Full browser E2E is scheduled separately by .github/workflows/e2e.yml.
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # Daily deterministic deep CI at 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-deep-ci-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deterministic-deep-tests:
+    name: Deterministic Deep Tests
+    uses: ./.github/workflows/test.yml
+    with:
+      ref: main
+      include_docker: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,9 @@ jobs:
             echo "has_engine_replay_risk=false" >> "$GITHUB_OUTPUT"
           fi
           echo "has_runtime_heavy_risk=true" >> "$GITHUB_OUTPUT"
-          # Keep full browser E2E outside the workflow-call / push path for now;
-          # merge_group runs cover the full browser suite before queued merges land.
+          # Keep deterministic full browser E2E in its own scheduled/manual
+          # workflow. The merge queue runs only smoke coverage for web-risk
+          # changes so queued merges remain fast.
           echo "has_web_risk=false" >> "$GITHUB_OUTPUT"
           echo "has_wasm_abi_risk=true" >> "$GITHUB_OUTPUT"
           echo "has_telegram_risk=true" >> "$GITHUB_OUTPUT"
@@ -144,7 +145,7 @@ jobs:
           FULL='[{"name":"all-features","flags":"--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"},{"name":"default","flags":""},{"name":"libsql-only","flags":"--no-default-features --features libsql"}]'
           SLIM='[{"name":"all-features","flags":"--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"}]'
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "test_matrix=${SLIM}" >> "$GITHUB_OUTPUT"
             echo "windows_matrix=${SLIM}" >> "$GITHUB_OUTPUT"
           else
@@ -196,7 +197,9 @@ jobs:
   heavy-integration-tests:
     name: Heavy Integration Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.has_runtime_heavy_risk == 'true')
+    if: >
+      needs.changes.outputs.docs_only != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_runtime_heavy_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -223,7 +226,9 @@ jobs:
   telegram-integration-tests:
     name: Telegram Integration Tests (${{ matrix.partition }})
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.has_runtime_heavy_risk == 'true')
+    if: >
+      needs.changes.outputs.docs_only != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_runtime_heavy_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -281,18 +286,20 @@ jobs:
       mode: smoke
 
   web-e2e-full:
-    name: Web E2E Full
+    name: Web E2E Smoke (merge queue)
     needs: changes
     if: needs.changes.outputs.docs_only != 'true' && github.event_name == 'merge_group' && needs.changes.outputs.has_web_risk == 'true'
     uses: ./.github/workflows/e2e.yml
     with:
       ref: ${{ inputs.ref || github.sha }}
-      mode: full
+      mode: smoke
 
   telegram-tests:
     name: Telegram Channel Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.has_telegram_risk == 'true')
+    if: >
+      needs.changes.outputs.docs_only != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_telegram_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -314,7 +321,9 @@ jobs:
   slack-tests:
     name: Slack Channel Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.has_slack_risk == 'true')
+    if: >
+      needs.changes.outputs.docs_only != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_slack_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -341,7 +350,7 @@ jobs:
   windows-build:
     name: Windows Build (${{ matrix.name }})
     needs: [changes, matrix-config]
-    if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'pull_request'
+    if: needs.changes.outputs.docs_only != 'true' && (github.event_name == 'push' || github.event_name == 'workflow_call')
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -365,7 +374,9 @@ jobs:
   wasm-wit-compat:
     name: WASM WIT Compatibility
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.has_wasm_abi_risk == 'true')
+    if: >
+      needs.changes.outputs.docs_only != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_call' || needs.changes.outputs.has_wasm_abi_risk == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -402,7 +413,10 @@ jobs:
   bench-compile:
     name: Benchmark Compilation
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'pull_request' && needs.changes.outputs.has_core_code == 'true'
+    if: >
+      needs.changes.outputs.docs_only != 'true' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_call') &&
+      needs.changes.outputs.has_core_code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -424,8 +438,7 @@ jobs:
     needs: changes
     if: >
       needs.changes.outputs.docs_only != 'true' &&
-      github.event_name != 'pull_request' &&
-      (github.event_name != 'workflow_call' || inputs.include_docker)
+      (github.event_name == 'push' || (github.event_name == 'workflow_call' && inputs.include_docker))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -557,7 +570,7 @@ jobs:
             require_success "tests" "${{ needs.tests.result }}"
           fi
 
-          if [[ "$event" != "pull_request" || "${{ needs.changes.outputs.has_runtime_heavy_risk }}" == "true" ]]; then
+          if [[ "$event" == "push" || "$event" == "workflow_call" || "${{ needs.changes.outputs.has_runtime_heavy_risk }}" == "true" ]]; then
             require_success "heavy-integration-tests" "${{ needs.heavy-integration-tests.result }}"
             require_success "telegram-integration-tests" "${{ needs.telegram-integration-tests.result }}"
           fi
@@ -574,27 +587,27 @@ jobs:
             require_success "web-e2e-full" "${{ needs.web-e2e-full.result }}"
           fi
 
-          if [[ "$event" != "pull_request" || "${{ needs.changes.outputs.has_telegram_risk }}" == "true" ]]; then
+          if [[ "$event" == "push" || "$event" == "workflow_call" || "${{ needs.changes.outputs.has_telegram_risk }}" == "true" ]]; then
             require_success "telegram-tests" "${{ needs.telegram-tests.result }}"
           fi
 
-          if [[ "$event" != "pull_request" || "${{ needs.changes.outputs.has_slack_risk }}" == "true" ]]; then
+          if [[ "$event" == "push" || "$event" == "workflow_call" || "${{ needs.changes.outputs.has_slack_risk }}" == "true" ]]; then
             require_success "slack-tests" "${{ needs.slack-tests.result }}"
           fi
 
-          if [[ "$event" != "pull_request" || "${{ needs.changes.outputs.has_wasm_abi_risk }}" == "true" ]]; then
+          if [[ "$event" == "push" || "$event" == "workflow_call" || "${{ needs.changes.outputs.has_wasm_abi_risk }}" == "true" ]]; then
             require_success "wasm-wit-compat" "${{ needs.wasm-wit-compat.result }}"
           fi
 
-          if [[ "$event" != "pull_request" && "${{ inputs.include_docker != false }}" == "true" ]]; then
+          if [[ "$event" == "push" || ( "$event" == "workflow_call" && "${{ inputs.include_docker != false }}" == "true" ) ]]; then
             require_success "docker-build" "${{ needs.docker-build.result }}"
           fi
 
-          if [[ "$event" != "pull_request" ]]; then
+          if [[ "$event" == "push" || "$event" == "workflow_call" ]]; then
             require_success "windows-build" "${{ needs.windows-build.result }}"
           fi
 
-          if [[ "$event" != "pull_request" && "${{ needs.changes.outputs.has_core_code }}" == "true" ]]; then
+          if [[ ( "$event" == "push" || "$event" == "workflow_call" ) && "${{ needs.changes.outputs.has_core_code }}" == "true" ]]; then
             require_success "bench-compile" "${{ needs.bench-compile.result }}"
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
         description: Commit SHA or ref to test
         required: false
         type: string
+      include_docker:
+        description: Include Docker image build in this reusable test run
+        required: false
+        type: boolean
+        default: true
   pull_request:
     branches:
       - main
@@ -417,7 +422,10 @@ jobs:
   docker-build:
     name: Docker Build
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true' && github.event_name != 'pull_request'
+    if: >
+      needs.changes.outputs.docs_only != 'true' &&
+      github.event_name != 'pull_request' &&
+      (github.event_name != 'workflow_call' || inputs.include_docker)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -578,7 +586,7 @@ jobs:
             require_success "wasm-wit-compat" "${{ needs.wasm-wit-compat.result }}"
           fi
 
-          if [[ "$event" != "pull_request" ]]; then
+          if [[ "$event" != "pull_request" && "${{ inputs.include_docker != false }}" == "true" ]]; then
             require_success "docker-build" "${{ needs.docker-build.result }}"
           fi
 


### PR DESCRIPTION
## Summary
- use slim Rust/clippy matrices for merge_group runs
- run smoke E2E instead of full E2E in merge queue for web-risk changes
- keep Docker, Windows, benchmarks, and broad channel/WASM/heavy checks out of merge_group by default; they still run on push/workflow_call and path-risk PRs

## Stack
- Stacked on #3262 because both touch test.yml. After #3262 lands, retarget this PR to main.

## Why
Main merge queue should be a fast compatibility gate. Deterministic deep coverage moves to nightly (#3261/#3262), while Docker remains owned by the QA/release pipeline.

## Validation
- git diff --check
- parsed .github/workflows/test.yml and .github/workflows/code_style.yml with Ruby YAML parser