### PR TITLE
skills: salvage Linear credential and identity bootstrap fix from #2901

### DIFF
--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -61,10 +61,10 @@ refreshed_at: 2026-04-21
 stale_after: 2026-05-21
 ---
 # Linear identity
-- user_id: 8a7f...-uuid
-- display_name: Tobias Holenstein
-- email: tobias@...
-- timezone: Europe/Zurich
+user_id: 8a7f...-uuid
+display_name: Tobias Holenstein
+email: tobias@...
+timezone: Europe/Zurich
 
 ## Teams
 - id: team-uuid-a, key: ENG, name: Engineering

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -108,7 +108,7 @@ http(method="POST", url="https://api.linear.app/graphql", body={"query": "{ issu
 ### List Issues Assigned to the User (uses identity cache)
 
 ```
-http(method="POST", url="https://api.linear.app/graphql", body={"query": "query($uid: ID!) { issues(filter: { assignee: { id: { eq: $uid } }, state: { type: { nin: [\"completed\", \"canceled\"] } } }, first: 50, orderBy: updatedAt) { nodes { id identifier title state { name type } priority priorityLabel url updatedAt } } }", "variables": {"uid": "<cached user_id>"}})
+http(method="POST", url="https://api.linear.app/graphql", body={"query": "query($uid: ID!) { issues(filter: { assignee: { id: { eq: $uid } }, state: { type: { nin: [completed, canceled] } } }, first: 50, orderBy: updatedAt) { nodes { id identifier title state { name type } priority priorityLabel url updatedAt } } }", "variables": {"uid": "<cached user_id>"}})
 ```
 
 Never pass `viewer.id` inline from a fresh round-trip when the cache is valid — consult `context/intel/linear-identity.md`.

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -1,29 +1,39 @@
 ---
 name: linear
-version: "1.0.0"
-description: Linear issue tracker API integration
+version: "1.2.0"
+description: Linear issue tracker API integration. Covers first-use identity bootstrap (viewer + teams cached), raw GraphQL for list/search/create/update, and the rules for handling "my issues" / "assigned to me" requests.
 activation:
   keywords:
     - "linear"
-    - "ticket"
-    - "sprint"
-    - "backlog"
-    - "roadmap"
+    - "my linear"
+    - "linear issue"
+    - "linear issues"
+    - "linear ticket"
+    - "linear tickets"
+    - "linear backlog"
+    - "linear assignments"
+    - "my linear issues"
+    - "my linear tickets"
+    - "assigned in linear"
+    - "linear.app"
   exclude_keywords:
     - "jira"
     - "asana"
+    - "github issue"
   patterns:
-    - "(?i)(create|list|show|assign|close|update)\\s.*(issue|ticket|task|bug)"
-    - "(?i)linear\\.app"
+    - "(?i)linear\\.(?:app|com)"
+    - "(?i)\\blinear\\b.+(issue|ticket|task|backlog|board)"
+    - "(?i)(create|show|list|close|update).+linear\\s+(issue|ticket)"
   tags:
     - "project-management"
     - "issue-tracking"
-  max_context_tokens: 2000
+  max_context_tokens: 1600
 credentials:
   - name: linear_api_key
     provider: linear
     location:
-      type: bearer
+      type: header
+      name: Authorization
     hosts:
       - "api.linear.app"
     setup_instructions: "Create an API key at https://linear.app/settings/api"
@@ -31,7 +41,57 @@ credentials:
 
 # Linear API Skill
 
-You have access to the Linear GraphQL API via the `http` tool. Credentials are automatically injected — **never construct Authorization headers manually**. When the URL host is `api.linear.app`, the system injects `Authorization: Bearer {linear_api_key}` transparently.
+You have access to the Linear GraphQL API via the `http` tool. Credentials are automatically injected — **never construct Authorization headers manually**. When the URL host is `api.linear.app`, the system injects `Authorization: {linear_api_key}` transparently (no Bearer prefix — Linear API keys are sent raw).
+
+## Identity bootstrap (first use)
+
+Linear's API key does not tell you who the user IS inside Linear. Before running any "my issues" / "assigned to me" / "my tickets" request, make sure the user's Linear identity is cached. This avoids re-fetching `viewer` on every request and makes filter-by-assignee queries deterministic.
+
+### Cache file
+
+Path: `context/intel/linear-identity.md`
+
+Shape:
+
+```yaml
+---
+type: linear-identity
+bootstrapped_at: 2026-04-21
+refreshed_at: 2026-04-21
+stale_after: 2026-05-21
+---
+# Linear identity
+- user_id: 8a7f...-uuid
+- display_name: Tobias Holenstein
+- email: tobias@...
+- timezone: Europe/Zurich
+
+## Teams
+- id: team-uuid-a, key: ENG, name: Engineering
+- id: team-uuid-b, key: PROD, name: Product
+
+## Default team
+ENG
+```
+
+### Bootstrap flow
+
+1. `memory_read("context/intel/linear-identity.md")`. If the file exists and `stale_after` is in the future, use it and stop.
+2. If missing or stale, run one GraphQL call:
+   ```
+   query { viewer { id name displayName email } teams(first: 50) { nodes { id key name } } }
+   ```
+3. Write the cache via `memory_write` with `stale_after` = today + 30 days.
+4. If the returned team list has exactly one team, record it as `Default team`. If more than one, ask the user once: *"I see teams ENG, PROD, OPS. Which one do you default to for new issues?"* and store the answer.
+5. On HTTP 401 or an `AuthenticationError` GraphQL error, invalidate the cache and re-prompt the user to check their API key — do not silently retry.
+
+### Using the cached identity
+
+- "list my issues" / "what's assigned to me" → filter by `assignee: { id: { eq: "<cached user_id>" } }`, **not** by `assignee: { isMe: true }` (the `isMe` filter is not universally available and `viewer` round-trips are wasteful).
+- "create an issue in my team" → use cached `Default team` id without asking.
+- "create an issue in <team name>" → match against cached team names; ask only if no match.
+- Skills that import external work (`commitment-link`) must consume this cache rather than re-resolving identity per run.
+
 
 ## API Patterns
 
@@ -44,6 +104,14 @@ All requests are `POST` with a JSON body containing `query` and optional `variab
 ```
 http(method="POST", url="https://api.linear.app/graphql", body={"query": "{ issues(first: 20, orderBy: updatedAt) { nodes { id identifier title state { name } assignee { name } priority priorityLabel createdAt } } }"})
 ```
+
+### List Issues Assigned to the User (uses identity cache)
+
+```
+http(method="POST", url="https://api.linear.app/graphql", body={"query": "query($uid: ID!) { issues(filter: { assignee: { id: { eq: $uid } }, state: { type: { nin: [\"completed\", \"canceled\"] } } }, first: 50, orderBy: updatedAt) { nodes { id identifier title state { name type } priority priorityLabel url updatedAt } } }", "variables": {"uid": "<cached user_id>"}})
+```
+
+Never pass `viewer.id` inline from a fresh round-trip when the cache is valid — consult `context/intel/linear-identity.md`.
 
 ### Get Issue by Identifier
 

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -90,7 +90,7 @@ ENG
 - "list my issues" / "what's assigned to me" → filter by `assignee: { id: { eq: "<cached user_id>" } }`, **not** by `assignee: { isMe: true }` (the `isMe` filter is not universally available and `viewer` round-trips are wasteful).
 - "create an issue in my team" → use cached `Default team` id without asking.
 - "create an issue in <team name>" → match against cached team names; ask only if no match.
-- Skills that import external work (`commitment-link`) must consume this cache rather than re-resolving identity per run.
+- Skills that import external work into Linear must consume this cache rather than re-resolving identity per run.
 
 
 ## API Patterns


### PR DESCRIPTION
Salvage of #2901 onto current main.

## Summary

Cherry-picked the Linear skill documentation/configuration fix from #2901 onto current `origin/main`.

This updates `skills/linear/SKILL.md` so Linear API keys are injected as a raw `Authorization` header instead of `Authorization: Bearer ...`, adds first-use identity bootstrap guidance for deterministic "my issues" / "assigned to me" flows, and tightens activation patterns.

A maintainer follow-up commit removes a stale named cross-skill reference (`commitment-link`) that does not exist in the current skills directory, while preserving the general guidance that other Linear-importing skills should consume the cached identity.

## Original PR

- Original PR: #2901
- Original PR author: @tobias-nf
- Original head branch: `feat/linear-skill-identity-bootstrap`
- Original commit(s):
  - 1046f81f9cdbd4acdea8fd9e3348e7313ae8f2e9
  - c1be93eddc08efe1ca1de657cfab38fdcfb4b484
  - bf88156cfe4c01e124a524bb3a797034b02fac0a
- Original branch also contained merge commit `412ea5c81db24e7340cb9587b02b57111bdbf487` from `staging`; it was intentionally not cherry-picked because it introduced unrelated `src/bridge/*` changes and the PR's changed-file set is only `skills/linear/SKILL.md`.
- Original commit authors:
  - Tobias Holenstein <tobias.holenstein@near.foundation>
  - tobias-nf <tobias.holenstein@near.foundation>
- Original co-author trailers:
  - `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
  - `Co-authored-by: gemini-code-assist[bot] <176961590+gemini-code-assist[bot]@users.noreply.github.com>`
- Attribution: original author and commit SHAs recorded; squash merge planned by default.
- Authorship preservation mode: squash-attributed. This branch also includes one maintainer-authored follow-up commit: `skills(linear): remove stale cross-skill reference`.

## Salvage review

- Relevance: still relevant because current `origin/main` has `skills/linear/SKILL.md` using `type: bearer` and describing `Authorization: Bearer {linear_api_key}`, while the PR documents Linear's raw `Authorization: <key>` behavior.
- Supersession check: current `origin/main` does not already include the Linear identity bootstrap or raw-header credential fix.
- Source-of-truth check: checked current `skills/linear/SKILL.md`, skill credential injection tests, and the current skills directory; `type: header` with `name: Authorization` is supported by existing credential injection parsing, and the stale `commitment-link` reference was removed.
- Review check: upstream bot review comments were already addressed by original commits `c1be93e` and `bf88156` (flat YAML identity cache shape and unquoted GraphQL enum values).
- Risk track: Track A, skill file only. No runtime source-code changes.

## Validation

- `git diff --check origin/main...HEAD` -> passed
- Skill content sanity check for frontmatter, `type: header`, `name: Authorization`, absence of stale `Authorization: Bearer {linear_api_key}`, and absence of `commitment-link` -> passed
- `cargo test --manifest-path .worktrees/salvage-pr-2901-linear-skill/Cargo.toml --test skill_credential_injection test_parse_all_credential_location_types --features libsql --quiet` -> passed

## Notes

- No runtime source-code changes.
- Recommended merge method: squash merge by default, preserving attribution in the PR/squash text.
