### PR TITLE
fix(ci): unblock coverage on main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,6 +38,9 @@ jobs:
   coverage:
     name: Coverage (${{ matrix.name }})
     runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
     permissions:
       id-token: write
       contents: read

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -738,7 +738,8 @@ mod tests {
             "test-user",
             ThreadConfig::default(),
         );
-        let effects: Arc<dyn EffectExecutor> = Arc::new(MockEffects::new(vec![], vec![]));
+        let effects: Arc<dyn EffectExecutor> =
+            Arc::new(MockEffects::new(vec![test_action("web_search")], vec![]));
         let leases = Arc::new(LeaseManager::new());
         let policy = Arc::new(PolicyEngine::new());
         let ctx = make_exec_context(&thread);

--- a/crates/ironclaw_engine/src/runtime/manager.rs
+++ b/crates/ironclaw_engine/src/runtime/manager.rs
@@ -782,7 +782,15 @@ mod tests {
             _: &[CapabilityLease],
             _: &crate::traits::effect::ThreadExecutionContext,
         ) -> Result<Vec<ActionDef>, EngineError> {
-            Ok(vec![])
+            Ok(vec![ActionDef {
+                name: "test_tool".into(),
+                description: "Test".into(),
+                parameters_schema: serde_json::json!({}),
+                effects: vec![EffectType::ReadLocal],
+                requires_approval: false,
+                model_tool_surface: ModelToolSurface::FullSchema,
+                discovery: None,
+            }])
         }
 
         async fn available_capabilities(
@@ -1428,9 +1436,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Give it a moment to start, then stop
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        let _ = mgr.stop_thread(tid, "test-user").await;
+        mgr.stop_thread(tid, "user").await.unwrap();
 
         let outcome = mgr.join_thread(tid).await.unwrap();
         assert!(matches!(


### PR DESCRIPTION
## Summary
- Update stale engine-v2 unit-test fixtures so callable-inventory preflight reaches the intended no-lease/stop paths.
- Assert `stop_thread` uses the owning user instead of ignoring an ownership failure.
- Strip dev/test debug info in the coverage matrix to reduce all-features runner disk pressure.

## Test Plan
- [x] cargo fmt --check
- [x] cargo test -p ironclaw_engine --lib