### PR TITLE
Build worker runtime into IronClaw Docker image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,7 +209,7 @@ HEARTBEAT_NOTIFY_USER=default
 #                                        # commands directly on the host. Without this
 #                                        # set to "true", full_access is downgraded to
 #                                        # workspace_write.
-# SANDBOX_IMAGE=ironclaw-worker:latest
+# SANDBOX_IMAGE=ironclaw-worker:latest     # Docker image. Use "self" inside the published IronClaw Docker image.
 # SANDBOX_TIMEOUT_SECS=120
 # SANDBOX_MEMORY_LIMIT_MB=2048
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,18 +121,56 @@ RUN set -eux; \
 # Stage 5a: Shared runtime base
 FROM debian:bookworm-slim AS runtime-base
 
+# Install the worker toolchain in the main runtime image too. Docker-packaged
+# deployments set SANDBOX_IMAGE=self below, so worker jobs can spawn from the
+# already-present IronClaw image instead of pulling ironclaw-worker on startup.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+        nodejs \
+        npm \
+        python3 \
+        python3-pip \
+        python3-venv \
+        gh \
     && rm -rf /var/lib/apt/lists/*
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh \
+    && sh /tmp/rustup-init.sh -y --default-toolchain 1.92.0 \
+    && rm /tmp/rustup-init.sh \
+    && chmod -R a+rX /usr/local/rustup /usr/local/cargo
+
+RUN npm install -g @anthropic-ai/claude-code@latest
 
 COPY --from=builder /app/target/dist/ironclaw /usr/local/bin/ironclaw
 COPY --from=builder /app/migrations /app/migrations
 
 # Non-root user
-ENV HOME=/home/ironclaw
+ENV HOME=/home/ironclaw \
+    SANDBOX_IMAGE=self
 RUN useradd -m -d /home/ironclaw -u 1000 ironclaw \
     && mkdir -p /home/ironclaw/.ironclaw \
-    && chown -R ironclaw:ironclaw /home/ironclaw
+    && mkdir -p \
+        /home/ironclaw/.claude \
+        /home/sandbox/.ironclaw \
+        /home/sandbox/.claude \
+        /workspace \
+    && chown -R ironclaw:ironclaw /home/ironclaw /home/sandbox /workspace
 WORKDIR /home/ironclaw
 
 EXPOSE 3000

--- a/docs/capabilities/configuration.mdx
+++ b/docs/capabilities/configuration.mdx
@@ -247,7 +247,7 @@ The HTTP webhook binds to `127.0.0.1:8080` by default. To receive webhooks from 
 | `SANDBOX_TIMEOUT_SECS` | int | `120` | Command timeout |
 | `SANDBOX_MEMORY_LIMIT_MB` | int | `2048` | Memory limit per container |
 | `SANDBOX_CPU_SHARES` | int | `1024` | CPU shares (relative weight) |
-| `SANDBOX_IMAGE` | string | `ironclaw-worker:latest` | Docker image |
+| `SANDBOX_IMAGE` | string | `ironclaw-worker:latest` | Docker image. Published IronClaw Docker images set this to `self`, which reuses the running IronClaw image for worker containers. |
 | `SANDBOX_AUTO_PULL` | bool | `true` | Auto-pull missing images |
 | `SANDBOX_EXTRA_DOMAINS` | list | — | Additional allowed domains |
 

--- a/docs/drafts/install/docker.mdx
+++ b/docs/drafts/install/docker.mdx
@@ -133,6 +133,10 @@ IronClaw can launch sandbox containers. In Docker, this requires:
 1. **Docker socket mount** (shown above): Allows IronClaw to launch sibling containers
 2. **Privileged mode** (optional): Only if sandbox jobs need elevated permissions
 
+The published Docker image includes the worker runtime and defaults `SANDBOX_IMAGE=self`.
+With the Docker socket mounted, IronClaw resolves `self` to the currently running image ID,
+so sandbox jobs do not need to pull `nearaidev/ironclaw-worker` before starting.
+
 ```bash
 # With privileged mode (not recommended unless needed)
 docker run -d \

--- a/docs/drafts/setup/configuration.mdx
+++ b/docs/drafts/setup/configuration.mdx
@@ -247,7 +247,7 @@ The HTTP webhook binds to `0.0.0.0:8080` by default. If you don't need external 
 | `SANDBOX_TIMEOUT_SECS` | int | `120` | Command timeout |
 | `SANDBOX_MEMORY_LIMIT_MB` | int | `2048` | Memory limit per container |
 | `SANDBOX_CPU_SHARES` | int | `1024` | CPU shares (relative weight) |
-| `SANDBOX_IMAGE` | string | `ironclaw-worker:latest` | Docker image |
+| `SANDBOX_IMAGE` | string | `ironclaw-worker:latest` | Docker image. Published IronClaw Docker images set this to `self`, which reuses the running IronClaw image for worker containers. |
 | `SANDBOX_AUTO_PULL` | bool | `true` | Auto-pull missing images |
 | `SANDBOX_EXTRA_DOMAINS` | list | — | Additional allowed domains |
 

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::bootstrap::ironclaw_base_dir;
 use crate::error::OrchestratorError;
 use crate::orchestrator::auth::{CredentialGrant, TokenStore};
-use crate::sandbox::connect_docker;
+use crate::sandbox::{connect_docker, resolve_image_reference};
 
 use ironclaw_common::MAX_WORKER_ITERATIONS;
 
@@ -419,6 +419,12 @@ impl ContainerJobManager {
     ) -> Result<(), OrchestratorError> {
         // Connect to Docker (reuses cached connection)
         let docker = self.docker().await?;
+        let image = resolve_image_reference(&docker, &self.config.image)
+            .await
+            .map_err(|e| OrchestratorError::ContainerCreationFailed {
+                job_id,
+                reason: e.to_string(),
+            })?;
 
         // Build container configuration
         // Use host.docker.internal on all platforms — the extra_hosts mapping
@@ -431,6 +437,7 @@ impl ContainerJobManager {
         );
 
         let mut env_vec = vec![
+            "HOME=/home/sandbox".to_string(),
             format!("IRONCLAW_WORKER_TOKEN={}", token),
             format!("IRONCLAW_JOB_ID={}", job_id),
             format!("IRONCLAW_ORCHESTRATOR_URL={}", orchestrator_url),
@@ -578,7 +585,7 @@ impl ContainerJobManager {
         );
 
         let container_config = Config {
-            image: Some(self.config.image.clone()),
+            image: Some(image),
             cmd: Some(cmd),
             env: Some(env_vec),
             host_config: Some(host_config),

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::bootstrap::ironclaw_base_dir;
 use crate::error::OrchestratorError;
 use crate::orchestrator::auth::{CredentialGrant, TokenStore};
-use crate::sandbox::{connect_docker, resolve_image_reference};
+use crate::sandbox::{SANDBOX_HOME, connect_docker, resolve_image_reference};
 
 use ironclaw_common::MAX_WORKER_ITERATIONS;
 
@@ -437,7 +437,7 @@ impl ContainerJobManager {
         );
 
         let mut env_vec = vec![
-            "HOME=/home/sandbox".to_string(),
+            format!("HOME={SANDBOX_HOME}"),
             format!("IRONCLAW_WORKER_TOKEN={}", token),
             format!("IRONCLAW_JOB_ID={}", job_id),
             format!("IRONCLAW_ORCHESTRATOR_URL={}", orchestrator_url),
@@ -476,7 +476,7 @@ impl ContainerJobManager {
             {
                 Some(config_path) => {
                     binds.push(format!(
-                        "{}:/home/sandbox/.ironclaw/mcp-servers.json:ro",
+                        "{}:{SANDBOX_HOME}/.ironclaw/mcp-servers.json:ro",
                         config_path.display()
                     ));
                     tracing::debug!(

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -43,6 +43,13 @@ use futures::StreamExt;
 use crate::sandbox::config::{ResourceLimits, SandboxPolicy};
 use crate::sandbox::error::{Result, SandboxError};
 
+/// Home directory used by sandbox/worker containers.
+///
+/// This intentionally differs from the IronClaw service user's home in the
+/// combined Docker image; spawned job containers should keep their tool state
+/// under the sandbox home.
+pub const SANDBOX_HOME: &str = "/home/sandbox";
+
 /// Output from container execution.
 #[derive(Debug, Clone)]
 pub struct ContainerOutput {
@@ -511,7 +518,7 @@ impl ContainerRunner {
             .map(|(k, v)| format!("{}={}", k, v))
             .collect();
         if !env_vec.iter().any(|value| value.starts_with("HOME=")) {
-            env_vec.push("HOME=/home/sandbox".to_string());
+            env_vec.push(format!("HOME={SANDBOX_HOME}"));
         }
 
         // Add proxy environment (uses host.docker.internal for Mac/Windows, 172.17.0.1 for Linux)
@@ -575,7 +582,7 @@ impl ContainerRunner {
                 [
                     ("/tmp".to_string(), "size=512M".to_string()),
                     (
-                        "/home/sandbox/.cargo/registry".to_string(),
+                        format!("{SANDBOX_HOME}/.cargo/registry"),
                         "size=1G".to_string(),
                     ),
                 ]

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -33,8 +33,8 @@ use std::time::Duration;
 
 use bollard::Docker;
 use bollard::container::{
-    Config, CreateContainerOptions, LogOutput, LogsOptions, RemoveContainerOptions,
-    StartContainerOptions, WaitContainerOptions,
+    Config, CreateContainerOptions, InspectContainerOptions, LogOutput, LogsOptions,
+    RemoveContainerOptions, StartContainerOptions, WaitContainerOptions,
 };
 use bollard::exec::{CreateExecOptions, StartExecResults};
 use bollard::models::HostConfig;
@@ -86,6 +86,117 @@ fn append_with_limit(buffer: &mut String, text: &str, limit: usize) -> bool {
     let end = crate::util::floor_char_boundary(text, remaining);
     buffer.push_str(&text[..end]);
     true
+}
+
+/// Returns true when `image` asks IronClaw to reuse the image that is running
+/// the current container. Intended for Docker-packaged deployments where the
+/// main IronClaw image contains the worker runtime.
+pub fn is_self_image_alias(image: &str) -> bool {
+    let normalized = image.trim().to_ascii_lowercase();
+    normalized == "self" || normalized == "ironclaw:self"
+}
+
+/// Resolve a Docker image reference before creating sandbox containers.
+///
+/// The special `self` / `ironclaw:self` alias resolves to the image ID of the
+/// current IronClaw container via the Docker API. This lets published Docker
+/// images spawn worker containers from the already-present image instead of
+/// pulling a separate `ironclaw-worker` image on startup or first use.
+pub async fn resolve_image_reference(docker: &Docker, image: &str) -> Result<String> {
+    if !is_self_image_alias(image) {
+        return Ok(image.to_string());
+    }
+
+    let candidates = current_container_id_candidates();
+    if candidates.is_empty() {
+        return Err(SandboxError::ContainerCreationFailed {
+            reason: self_image_resolution_error("no current container id candidates found"),
+        });
+    }
+
+    let mut last_error = None;
+    for candidate in candidates {
+        match docker
+            .inspect_container(&candidate, None::<InspectContainerOptions>)
+            .await
+        {
+            Ok(details) => {
+                if let Some(image_id) = details.image.filter(|value| !value.trim().is_empty()) {
+                    tracing::info!(
+                        container = %candidate,
+                        image = %image_id,
+                        "Resolved sandbox image alias to current container image"
+                    );
+                    return Ok(image_id);
+                }
+                last_error = Some(format!("container {candidate} has no image id"));
+            }
+            Err(e) => {
+                tracing::debug!(
+                    container = %candidate,
+                    error = %e,
+                    "Failed to inspect current container candidate"
+                );
+                last_error = Some(e.to_string());
+            }
+        }
+    }
+
+    Err(SandboxError::ContainerCreationFailed {
+        reason: self_image_resolution_error(
+            last_error
+                .as_deref()
+                .unwrap_or("Docker did not return an image id for any candidate"),
+        ),
+    })
+}
+
+fn self_image_resolution_error(detail: &str) -> String {
+    format!(
+        "SANDBOX_IMAGE=self requires running inside a Docker container with access to the Docker API; {detail}. Set SANDBOX_IMAGE to an explicit image reference to override."
+    )
+}
+
+fn current_container_id_candidates() -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Ok(hostname) = std::env::var("HOSTNAME")
+        && is_safe_container_lookup(&hostname)
+    {
+        push_unique(&mut candidates, hostname.trim().to_string());
+    }
+
+    if let Ok(cgroup) = std::fs::read_to_string("/proc/self/cgroup") {
+        for candidate in container_id_candidates_from_cgroup(&cgroup) {
+            push_unique(&mut candidates, candidate);
+        }
+    }
+
+    candidates
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn is_safe_container_lookup(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+}
+
+fn container_id_candidates_from_cgroup(cgroup: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    for token in cgroup.split(|c: char| !c.is_ascii_hexdigit()) {
+        if (12..=64).contains(&token.len()) && token.bytes().all(|b| b.is_ascii_hexdigit()) {
+            push_unique(&mut candidates, token.to_string());
+        }
+    }
+    candidates
 }
 
 impl ContainerRunner {
@@ -399,6 +510,9 @@ impl ContainerRunner {
             .into_iter()
             .map(|(k, v)| format!("{}={}", k, v))
             .collect();
+        if !env_vec.iter().any(|value| value.starts_with("HOME=")) {
+            env_vec.push("HOME=/home/sandbox".to_string());
+        }
 
         // Add proxy environment (uses host.docker.internal for Mac/Windows, 172.17.0.1 for Linux)
         let proxy_host = if cfg!(target_os = "linux") {
@@ -747,6 +861,30 @@ mod tests {
         let truncated = append_with_limit(&mut out, "hello", 10);
         assert!(!truncated);
         assert_eq!(out, "hello");
+    }
+
+    #[test]
+    fn self_image_alias_accepts_documented_values() {
+        assert!(is_self_image_alias("self"));
+        assert!(is_self_image_alias(" ironclaw:self "));
+        assert!(!is_self_image_alias("ironclaw-worker:latest"));
+    }
+
+    #[test]
+    fn cgroup_candidate_parser_finds_docker_and_systemd_ids() {
+        let id = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let candidates = container_id_candidates_from_cgroup(&format!(
+            "0::/docker/{id}\n1:name=systemd:/docker-{id}.scope\n"
+        ));
+
+        assert_eq!(candidates, vec![id.to_string()]);
+    }
+
+    #[test]
+    fn hostname_candidate_validation_rejects_unsafe_values() {
+        assert!(is_safe_container_lookup("ironclaw-worker-123"));
+        assert!(!is_safe_container_lookup("../docker.sock"));
+        assert!(!is_safe_container_lookup(""));
     }
 
     #[cfg(unix)]

--- a/src/sandbox/manager.rs
+++ b/src/sandbox/manager.rs
@@ -38,7 +38,9 @@ use tokio::sync::RwLock;
 use bollard::Docker;
 
 use crate::sandbox::config::{ResourceLimits, SandboxConfig, SandboxPolicy};
-use crate::sandbox::container::{ContainerOutput, ContainerRunner, connect_docker};
+use crate::sandbox::container::{
+    ContainerOutput, ContainerRunner, connect_docker, resolve_image_reference,
+};
 use crate::sandbox::error::{Result, SandboxError};
 use crate::sandbox::proxy::{HttpProxy, NetworkProxyBuilder};
 
@@ -85,6 +87,7 @@ pub struct SandboxManager {
     config: SandboxConfig,
     proxy: Arc<RwLock<Option<HttpProxy>>>,
     docker: Arc<RwLock<Option<Docker>>>,
+    resolved_image: Arc<RwLock<Option<String>>>,
     initialized: std::sync::atomic::AtomicBool,
 }
 
@@ -95,6 +98,7 @@ impl SandboxManager {
             config,
             proxy: Arc::new(RwLock::new(None)),
             docker: Arc::new(RwLock::new(None)),
+            resolved_image: Arc::new(RwLock::new(None)),
             initialized: std::sync::atomic::AtomicBool::new(false),
         }
     }
@@ -139,10 +143,11 @@ impl SandboxManager {
                 reason: e.to_string(),
             })?;
 
-        // Check for / pull image using a temporary runner
+        // Check for / pull image using a temporary runner.
+        let resolved_image = resolve_image_reference(&docker, &self.config.image).await?;
         let checker = ContainerRunner::new(
             docker.clone(),
-            self.config.image.clone(),
+            resolved_image.clone(),
             self.config.proxy_port,
         );
         if !checker.image_exists().await {
@@ -152,13 +157,14 @@ impl SandboxManager {
                 return Err(SandboxError::ContainerCreationFailed {
                     reason: format!(
                         "image {} not found and auto_pull is disabled",
-                        self.config.image
+                        resolved_image
                     ),
                 });
             }
         }
 
         *self.docker.write().await = Some(docker);
+        *self.resolved_image.write().await = Some(resolved_image);
 
         // Start the network proxy if we're using a sandboxed policy
         if self.config.policy.is_sandboxed() {
@@ -181,6 +187,8 @@ impl SandboxManager {
         if let Some(proxy) = self.proxy.write().await.take() {
             proxy.stop().await;
         }
+
+        *self.resolved_image.write().await = None;
 
         self.initialized
             .store(false, std::sync::atomic::Ordering::SeqCst);
@@ -297,7 +305,13 @@ impl SandboxManager {
                 .ok_or_else(|| SandboxError::DockerNotAvailable {
                     reason: "Docker connection not initialized".to_string(),
                 })?;
-        let runner = ContainerRunner::new(docker, self.config.image.clone(), proxy_port);
+        let image = self
+            .resolved_image
+            .read()
+            .await
+            .clone()
+            .unwrap_or_else(|| self.config.image.clone());
+        let runner = ContainerRunner::new(docker, image, proxy_port);
 
         let limits = ResourceLimits {
             memory_bytes: self.config.memory_limit_mb * 1024 * 1024,

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -94,7 +94,8 @@ pub mod proxy;
 
 pub use config::{ResourceLimits, SandboxConfig, SandboxPolicy};
 pub use container::{
-    ContainerOutput, ContainerRunner, connect_docker, is_self_image_alias, resolve_image_reference,
+    ContainerOutput, ContainerRunner, SANDBOX_HOME, connect_docker, is_self_image_alias,
+    resolve_image_reference,
 };
 pub use detect::{DockerDetection, DockerStatus, Platform, check_docker};
 pub use error::{Result, SandboxError};

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -93,7 +93,9 @@ pub mod manager;
 pub mod proxy;
 
 pub use config::{ResourceLimits, SandboxConfig, SandboxPolicy};
-pub use container::{ContainerOutput, ContainerRunner, connect_docker};
+pub use container::{
+    ContainerOutput, ContainerRunner, connect_docker, is_self_image_alias, resolve_image_reference,
+};
 pub use detect::{DockerDetection, DockerStatus, Platform, check_docker};
 pub use error::{Result, SandboxError};
 pub use manager::{ExecOutput, SandboxManager, SandboxManagerBuilder};


### PR DESCRIPTION
## Summary

- Build the IronClaw runtime image with the worker runtime toolchain so the same image can run sandbox workers.
- Default Docker runtime config to `SANDBOX_IMAGE=self` and resolve that alias to the current container image ID before spawning sandbox/job containers, avoiding startup pulls of `nearaidev/ironclaw-worker`.
- Document the new Docker behavior and `SANDBOX_IMAGE=self` configuration.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [x] Dependencies

## Linked Issue

None.

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test --lib sandbox::container`, `cargo test --test dockerfile_runtime_home`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: attempted `docker build --target runtime -t ironclaw:self-test .`; local Docker build was blocked by transient Debian apt mirror `500/503` package download failures before image completion.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

Touches sandbox container image selection and worker container startup. Adds a `self` image alias that resolves to the current IronClaw container image ID through Docker inspect; does not weaken auth, secret handling, approval policy, or sandbox isolation.

## Database Impact

None.

## Blast Radius

Docker runtime image packaging, sandbox container creation, and orchestrator job worker container creation. Main risk is environments where `SANDBOX_IMAGE=self` cannot resolve the current container through Docker metadata; operators can fall back to an explicit `SANDBOX_IMAGE`.

## Rollback Plan

Revert this change or set `SANDBOX_IMAGE` back to an explicit worker image such as `nearaidev/ironclaw-worker:latest`.

## Review Follow-Through

Reviewer attention requested on the `SANDBOX_IMAGE=self` resolution behavior and Docker runtime dependency set. Local Docker smoke should be rerun on a stable apt mirror/network because the attempted build failed before image completion due Debian package download errors.

---

**Review track**: C
