### PR TITLE
feat(reborn): add runner lease recovery contracts

### DIFF
--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -16,6 +16,7 @@ pub enum TurnEventKind {
     Resumed,
     RunnerClaimed,
     RunnerHeartbeat,
+    RecoveryRequired,
     Blocked,
     CancelRequested,
     Cancelled,

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Condvar, Mutex, MutexGuard},
 };
 
-use chrono::Utc;
+use chrono::{Duration as ChronoDuration, Utc};
 
 use crate::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, GetRunStateRequest, IdempotencyKey,
@@ -19,19 +19,22 @@ use crate::{
     events::EventCursor,
     runner::{
         BlockRunRequest, CancelRunCompletionRequest, ClaimRunRequest, ClaimedTurnRun,
-        CompleteRunRequest, FailRunRequest, HeartbeatRequest, TurnRunTransitionPort,
+        CompleteRunRequest, FailRunRequest, HeartbeatRequest, RecoverExpiredLeasesRequest,
+        RecoverExpiredLeasesResponse, TurnRunTransitionPort,
     },
 };
 
 const MAX_EVENTS: usize = 10_000;
 const MAX_TERMINAL_RECORDS: usize = 10_000;
 const MAX_IDEMPOTENCY_RECORDS: usize = 10_000;
+const DEFAULT_RUNNER_LEASE_TTL_SECONDS: i64 = 90;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InMemoryTurnStateStoreLimits {
     pub max_events: usize,
     pub max_terminal_records: usize,
     pub max_idempotency_records: usize,
+    pub runner_lease_ttl: ChronoDuration,
 }
 
 impl Default for InMemoryTurnStateStoreLimits {
@@ -40,6 +43,7 @@ impl Default for InMemoryTurnStateStoreLimits {
             max_events: MAX_EVENTS,
             max_terminal_records: MAX_TERMINAL_RECORDS,
             max_idempotency_records: MAX_IDEMPOTENCY_RECORDS,
+            runner_lease_ttl: ChronoDuration::seconds(DEFAULT_RUNNER_LEASE_TTL_SECONDS),
         }
     }
 }
@@ -363,6 +367,7 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
         record.status = TurnStatus::Running;
         record.runner_id = Some(request.runner_id);
         record.lease_token = Some(request.lease_token);
+        record.lease_expires_at = Some(inner.next_lease_expiry(now));
         record.last_heartbeat_at = Some(now);
         record.claim_count = record.claim_count.saturating_add(1);
         record.event_cursor = inner.next_cursor();
@@ -384,6 +389,7 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
             ensure_lease(&record, request.runner_id, request.lease_token)?;
             let now = Utc::now();
             record.last_heartbeat_at = Some(now);
+            record.lease_expires_at = Some(inner.next_lease_expiry(now));
             record.event_cursor = inner.next_cursor();
             inner.touch_active_lock(&record, now);
             inner.push_event(&record, TurnEventKind::RunnerHeartbeat, None);
@@ -391,6 +397,14 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
         })();
         inner.records.insert(record.run_id, record);
         result
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        let mut inner = self.lock_inner()?;
+        Ok(inner.recover_expired_leases(request))
     }
 
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
@@ -466,6 +480,11 @@ impl Inner {
         EventCursor(self.cursor)
     }
 
+    fn next_lease_expiry(&self, now: crate::TurnTimestamp) -> crate::TurnTimestamp {
+        now.checked_add_signed(self.limits.runner_lease_ttl)
+            .unwrap_or(now)
+    }
+
     fn push_event(
         &mut self,
         record: &RunRecord,
@@ -516,6 +535,63 @@ impl Inner {
             checkpoints,
             idempotency_records,
         }
+    }
+
+    fn recover_expired_leases(
+        &mut self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> RecoverExpiredLeasesResponse {
+        let expired_run_ids = self
+            .records
+            .iter()
+            .filter_map(|(run_id, record)| {
+                if record.status != TurnStatus::Running {
+                    return None;
+                }
+                if request
+                    .scope_filter
+                    .as_ref()
+                    .is_some_and(|scope| scope != &record.scope)
+                {
+                    return None;
+                }
+                if record
+                    .lease_expires_at
+                    .is_some_and(|expires_at| expires_at <= request.now)
+                {
+                    Some(*run_id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut recovered = Vec::with_capacity(expired_run_ids.len());
+        for run_id in expired_run_ids {
+            let Some(mut record) = self.records.remove(&run_id) else {
+                continue;
+            };
+            if record.status == TurnStatus::Running
+                && record
+                    .lease_expires_at
+                    .is_some_and(|expires_at| expires_at <= request.now)
+            {
+                record.status = TurnStatus::RecoveryRequired;
+                record.runner_id = None;
+                record.lease_token = None;
+                record.lease_expires_at = None;
+                record.event_cursor = self.next_cursor();
+                self.update_active_lock(&record, request.now);
+                let state = record.state();
+                self.push_event(
+                    &record,
+                    TurnEventKind::RecoveryRequired,
+                    Some("lease_expired".to_string()),
+                );
+                recovered.push(state);
+            }
+            self.records.insert(run_id, record);
+        }
+        RecoverExpiredLeasesResponse { recovered }
     }
 
     fn remember_submit_idempotency(
@@ -707,10 +783,9 @@ impl Inner {
                 TurnStatus::Queued
                 | TurnStatus::BlockedApproval
                 | TurnStatus::BlockedAuth
-                | TurnStatus::BlockedResource => (TurnStatus::Cancelled, TurnEventKind::Cancelled),
-                TurnStatus::Running
-                | TurnStatus::CancelRequested
-                | TurnStatus::RecoveryRequired => {
+                | TurnStatus::BlockedResource
+                | TurnStatus::RecoveryRequired => (TurnStatus::Cancelled, TurnEventKind::Cancelled),
+                TurnStatus::Running | TurnStatus::CancelRequested => {
                     (TurnStatus::CancelRequested, TurnEventKind::CancelRequested)
                 }
                 status => {

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -386,8 +386,8 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
         let mut inner = self.lock_inner()?;
         let mut record = inner.take_record(request.run_id)?;
         let result = (|| {
-            ensure_lease(&record, request.runner_id, request.lease_token)?;
             let now = Utc::now();
+            ensure_active_lease(&record, request.runner_id, request.lease_token, now)?;
             record.last_heartbeat_at = Some(now);
             record.lease_expires_at = Some(inner.next_lease_expiry(now));
             record.event_cursor = inner.next_cursor();
@@ -411,14 +411,14 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
         let mut inner = self.lock_inner()?;
         let mut record = inner.take_record(request.run_id)?;
         let result = (|| {
-            ensure_lease(&record, request.runner_id, request.lease_token)?;
+            let now = Utc::now();
+            ensure_active_lease(&record, request.runner_id, request.lease_token, now)?;
             if !matches!(record.status, TurnStatus::Running) {
                 return Err(TurnError::InvalidTransition {
                     from: record.status,
                     to: request.reason.status(),
                 });
             }
-            let now = Utc::now();
             record.status = request.reason.status();
             record.checkpoint_id = Some(request.checkpoint_id);
             record.gate_ref = Some(request.reason.gate_ref().clone());
@@ -545,7 +545,10 @@ impl Inner {
             .records
             .iter()
             .filter_map(|(run_id, record)| {
-                if record.status != TurnStatus::Running {
+                if !matches!(
+                    record.status,
+                    TurnStatus::Running | TurnStatus::CancelRequested
+                ) {
                     return None;
                 }
                 if request
@@ -570,25 +573,19 @@ impl Inner {
             let Some(mut record) = self.records.remove(&run_id) else {
                 continue;
             };
-            if record.status == TurnStatus::Running
-                && record
-                    .lease_expires_at
-                    .is_some_and(|expires_at| expires_at <= request.now)
-            {
-                record.status = TurnStatus::RecoveryRequired;
-                record.runner_id = None;
-                record.lease_token = None;
-                record.lease_expires_at = None;
-                record.event_cursor = self.next_cursor();
-                self.update_active_lock(&record, request.now);
-                let state = record.state();
-                self.push_event(
-                    &record,
-                    TurnEventKind::RecoveryRequired,
-                    Some("lease_expired".to_string()),
-                );
-                recovered.push(state);
-            }
+            record.status = TurnStatus::RecoveryRequired;
+            record.runner_id = None;
+            record.lease_token = None;
+            record.lease_expires_at = None;
+            record.event_cursor = self.next_cursor();
+            self.update_active_lock(&record, request.now);
+            let state = record.state();
+            self.push_event(
+                &record,
+                TurnEventKind::RecoveryRequired,
+                Some("lease_expired".to_string()),
+            );
+            recovered.push(state);
             self.records.insert(run_id, record);
         }
         RecoverExpiredLeasesResponse { recovered }
@@ -835,7 +832,7 @@ impl Inner {
     ) -> Result<TurnRunState, TurnError> {
         let mut record = self.take_record(run_id)?;
         let result = (|| {
-            ensure_lease(&record, runner_id, lease_token)?;
+            ensure_active_lease(&record, runner_id, lease_token, Utc::now())?;
             if record.status != TurnStatus::CancelRequested {
                 return Err(TurnError::InvalidTransition {
                     from: record.status,
@@ -871,7 +868,7 @@ impl Inner {
     ) -> Result<TurnRunState, TurnError> {
         let mut record = self.take_record(run_id)?;
         let result = (|| {
-            ensure_lease(&record, runner_id, lease_token)?;
+            ensure_active_lease(&record, runner_id, lease_token, Utc::now())?;
             if record.status == TurnStatus::CancelRequested || record.status.is_terminal() {
                 return Err(TurnError::InvalidTransition {
                     from: record.status,
@@ -1154,13 +1151,22 @@ fn cancel_idempotency_record(
     }
 }
 
-fn ensure_lease(
+fn ensure_active_lease(
     record: &RunRecord,
     runner_id: crate::TurnRunnerId,
     lease_token: crate::TurnLeaseToken,
+    now: crate::TurnTimestamp,
 ) -> Result<(), TurnError> {
     if record.runner_id != Some(runner_id) || record.lease_token != Some(lease_token) {
         return Err(TurnError::LeaseMismatch);
+    }
+    if record
+        .lease_expires_at
+        .is_some_and(|expires_at| expires_at <= now)
+    {
+        return Err(TurnError::Conflict {
+            reason: "turn run lease expired".to_string(),
+        });
     }
     Ok(())
 }

--- a/crates/ironclaw_turns/src/runner.rs
+++ b/crates/ironclaw_turns/src/runner.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     BlockedReason, SanitizedFailure, TurnCheckpointId, TurnError, TurnLeaseToken, TurnRunId,
-    TurnRunState, TurnRunnerId, TurnScope, events::EventCursor,
+    TurnRunState, TurnRunnerId, TurnScope, TurnTimestamp, events::EventCursor,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,6 +25,17 @@ pub struct HeartbeatRequest {
     pub run_id: TurnRunId,
     pub runner_id: TurnRunnerId,
     pub lease_token: TurnLeaseToken,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoverExpiredLeasesRequest {
+    pub now: TurnTimestamp,
+    pub scope_filter: Option<TurnScope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecoverExpiredLeasesResponse {
+    pub recovered: Vec<TurnRunState>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,6 +90,11 @@ pub trait TurnRunTransitionPort: Send + Sync {
     ) -> Result<Option<ClaimedTurnRun>, TurnError>;
 
     async fn heartbeat(&self, request: HeartbeatRequest) -> Result<EventCursor, TurnError>;
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError>;
 
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError>;
 

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
     AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, BlockedReason,
@@ -22,7 +22,7 @@ use ironclaw_turns::{
     events::EventCursor,
     runner::{
         BlockRunRequest, CancelRunCompletionRequest, ClaimRunRequest, CompleteRunRequest,
-        FailRunRequest, HeartbeatRequest, TurnRunTransitionPort,
+        FailRunRequest, HeartbeatRequest, RecoverExpiredLeasesRequest, TurnRunTransitionPort,
     },
 };
 
@@ -1014,6 +1014,215 @@ async fn runner_claims_queued_run_with_lease_and_heartbeat_requires_matching_lea
         .await
         .unwrap();
     assert!(cursor.0 >= 3);
+}
+
+#[tokio::test]
+async fn runner_claim_and_heartbeat_persist_lease_expiry() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let claimed = store.persistence_snapshot();
+    let run = claimed
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap();
+    let first_heartbeat_at = run
+        .last_heartbeat_at
+        .expect("claim should record heartbeat timestamp");
+    let first_expiry = run
+        .lease_expires_at
+        .expect("claim should record lease expiry");
+    assert!(first_expiry > first_heartbeat_at);
+
+    std::thread::sleep(Duration::from_millis(2));
+    store
+        .heartbeat(HeartbeatRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let heartbeat = store.persistence_snapshot();
+    let run = heartbeat
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap();
+    assert!(run.last_heartbeat_at.unwrap() > first_heartbeat_at);
+    assert!(run.lease_expires_at.unwrap() > first_expiry);
+}
+
+#[tokio::test]
+async fn expired_running_lease_enters_recovery_required_and_keeps_thread_locked() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let lease_expires_at = store
+        .persistence_snapshot()
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap()
+        .lease_expires_at
+        .unwrap();
+
+    let not_yet_expired = store
+        .recover_expired_leases(RecoverExpiredLeasesRequest {
+            now: lease_expires_at - ChronoDuration::milliseconds(1),
+            scope_filter: None,
+        })
+        .await
+        .unwrap();
+    assert!(not_yet_expired.recovered.is_empty());
+
+    let recovered = store
+        .recover_expired_leases(RecoverExpiredLeasesRequest {
+            now: lease_expires_at + ChronoDuration::milliseconds(1),
+            scope_filter: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(recovered.recovered.len(), 1);
+    assert_eq!(recovered.recovered[0].run_id, run_id);
+    assert_eq!(recovered.recovered[0].status, TurnStatus::RecoveryRequired);
+
+    let snapshot = store.persistence_snapshot();
+    let run = snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap();
+    assert_eq!(run.status, TurnStatus::RecoveryRequired);
+    assert_eq!(run.runner_id, None);
+    assert_eq!(run.lease_token, None);
+    assert_eq!(run.lease_expires_at, None);
+    let lock = snapshot
+        .active_locks
+        .iter()
+        .find(|lock| lock.run_id == run_id)
+        .unwrap();
+    assert_eq!(lock.status, TurnStatus::RecoveryRequired);
+
+    let busy = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-after-recovery"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        busy,
+        TurnError::ThreadBusy(ThreadBusy {
+            status: TurnStatus::RecoveryRequired,
+            ..
+        })
+    ));
+    assert!(
+        store
+            .claim_next_run(ClaimRunRequest {
+                runner_id: TurnRunnerId::new(),
+                lease_token: TurnLeaseToken::new(),
+                scope_filter: None,
+            })
+            .await
+            .unwrap()
+            .is_none(),
+        "recovery-required work must not be auto-retried by the normal claim path"
+    );
+    assert!(store.events().iter().any(|event| {
+        event.run_id == run_id
+            && event.kind == TurnEventKind::RecoveryRequired
+            && event.sanitized_reason.as_deref() == Some("lease_expired")
+    }));
+}
+
+#[tokio::test]
+async fn cancel_recovery_required_run_releases_lock_and_allows_new_submit() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let lease_expires_at = store
+        .persistence_snapshot()
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap()
+        .lease_expires_at
+        .unwrap();
+    store
+        .recover_expired_leases(RecoverExpiredLeasesRequest {
+            now: lease_expires_at + ChronoDuration::milliseconds(1),
+            scope_filter: None,
+        })
+        .await
+        .unwrap();
+
+    let cancelled = coordinator
+        .cancel_run(CancelRunRequest {
+            scope: scope("thread-a"),
+            actor: actor(),
+            run_id,
+            reason: SanitizedCancelReason::OperatorRequested,
+            idempotency_key: IdempotencyKey::new("idem-cancel-recovered").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(cancelled.status, TurnStatus::Cancelled);
+    assert!(!cancelled.already_terminal);
+    assert!(store.persistence_snapshot().active_locks.is_empty());
+
+    let replacement = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-replacement"))
+        .await
+        .unwrap();
+    assert!(matches!(replacement, SubmitTurnResponse::Accepted { .. }));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -1017,6 +1017,157 @@ async fn runner_claims_queued_run_with_lease_and_heartbeat_requires_matching_lea
 }
 
 #[tokio::test]
+async fn expired_runner_lease_rejects_heartbeat_and_terminal_completion_before_recovery_sweep() {
+    let limits = InMemoryTurnStateStoreLimits {
+        runner_lease_ttl: ChronoDuration::milliseconds(-1),
+        ..InMemoryTurnStateStoreLimits::default()
+    };
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(limits));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let heartbeat = store
+        .heartbeat(HeartbeatRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        heartbeat,
+        TurnError::Conflict {
+            reason: "turn run lease expired".to_string(),
+        }
+    );
+
+    let completed = store
+        .complete_run(CompleteRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        completed,
+        TurnError::Conflict {
+            reason: "turn run lease expired".to_string(),
+        }
+    );
+
+    let state = coordinator
+        .get_run_state(GetRunStateRequest {
+            scope: scope("thread-a"),
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(state.status, TurnStatus::Running);
+}
+
+#[tokio::test]
+async fn expired_runner_lease_rejects_fail_and_runner_side_cancel_before_recovery_sweep() {
+    let limits = InMemoryTurnStateStoreLimits {
+        runner_lease_ttl: ChronoDuration::milliseconds(-1),
+        ..InMemoryTurnStateStoreLimits::default()
+    };
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(limits));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+
+    let failed_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let fail_runner_id = TurnRunnerId::new();
+    let fail_lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: fail_runner_id,
+            lease_token: fail_lease_token,
+            scope_filter: Some(scope("thread-a")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let failed = store
+        .fail_run(FailRunRequest {
+            run_id: failed_run_id,
+            runner_id: fail_runner_id,
+            lease_token: fail_lease_token,
+            failure: SanitizedFailure::new("late_failure").unwrap(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        failed,
+        TurnError::Conflict {
+            reason: "turn run lease expired".to_string(),
+        }
+    );
+
+    let cancelled_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-b", "idem-submit-b"))
+            .await
+            .unwrap(),
+    );
+    let cancel_runner_id = TurnRunnerId::new();
+    let cancel_lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: cancel_runner_id,
+            lease_token: cancel_lease_token,
+            scope_filter: Some(scope("thread-b")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    coordinator
+        .cancel_run(cancel_request(
+            "thread-b",
+            cancelled_run_id,
+            "idem-cancel-b",
+        ))
+        .await
+        .unwrap();
+
+    let cancelled = store
+        .cancel_run(CancelRunCompletionRequest {
+            run_id: cancelled_run_id,
+            runner_id: cancel_runner_id,
+            lease_token: cancel_lease_token,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        cancelled,
+        TurnError::Conflict {
+            reason: "turn run lease expired".to_string(),
+        }
+    );
+}
+
+#[tokio::test]
 async fn runner_claim_and_heartbeat_persist_lease_expiry() {
     let (coordinator, store) = coordinator();
     let run_id = accepted_run_id(
@@ -1166,6 +1317,88 @@ async fn expired_running_lease_enters_recovery_required_and_keeps_thread_locked(
             && event.kind == TurnEventKind::RecoveryRequired
             && event.sanitized_reason.as_deref() == Some("lease_expired")
     }));
+}
+
+#[tokio::test]
+async fn expired_cancel_requested_lease_enters_recovery_required_and_can_be_cancelled() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let lease_expires_at = store
+        .persistence_snapshot()
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap()
+        .lease_expires_at
+        .unwrap();
+
+    let cancel = coordinator
+        .cancel_run(cancel_request("thread-a", run_id, "idem-cancel-a"))
+        .await
+        .unwrap();
+    assert_eq!(cancel.status, TurnStatus::CancelRequested);
+
+    let recovered = store
+        .recover_expired_leases(RecoverExpiredLeasesRequest {
+            now: lease_expires_at + ChronoDuration::milliseconds(1),
+            scope_filter: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(recovered.recovered.len(), 1);
+    assert_eq!(recovered.recovered[0].run_id, run_id);
+    assert_eq!(recovered.recovered[0].status, TurnStatus::RecoveryRequired);
+
+    let snapshot = store.persistence_snapshot();
+    let run = snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap();
+    assert_eq!(run.status, TurnStatus::RecoveryRequired);
+    assert_eq!(run.runner_id, None);
+    assert_eq!(run.lease_token, None);
+    assert_eq!(run.lease_expires_at, None);
+    let busy = coordinator
+        .submit_turn(submit_request(
+            "thread-a",
+            "idem-submit-after-cancel-recovery",
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(busy, TurnError::ThreadBusy(_)));
+
+    let cancelled = coordinator
+        .cancel_run(cancel_request("thread-a", run_id, "idem-cancel-recovered"))
+        .await
+        .unwrap();
+    assert_eq!(cancelled.status, TurnStatus::Cancelled);
+    assert!(store.persistence_snapshot().active_locks.is_empty());
+
+    let replacement = coordinator
+        .submit_turn(submit_request(
+            "thread-a",
+            "idem-submit-after-recovered-cancel",
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(replacement, SubmitTurnResponse::Accepted { .. }));
 }
 
 #[tokio::test]

--- a/docs/reborn/contracts/_contract-freeze-index.md
+++ b/docs/reborn/contracts/_contract-freeze-index.md
@@ -85,6 +85,7 @@ If a task needs to change one of those answers, it is not implementation work; i
 - [`settings-config.md`](settings-config.md)
 - [`turns-agent-loop.md`](turns-agent-loop.md)
 - [`turn-persistence.md`](turn-persistence.md)
+- [`turn-runner.md`](turn-runner.md)
 - [`migration-compatibility.md`](migration-compatibility.md)
 
 ---

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -64,8 +64,9 @@ A duplicate idempotency key must replay the prior sanitized success/error outcom
 
 ## 5. Runner lease and checkpoint rules
 
-- Claiming a queued run atomically moves it to `Running`, stores runner ID/lease token, increments `claim_count`, and updates heartbeat metadata.
-- Heartbeats only renew metadata for matching runner ID/lease token.
+- Claiming a queued run atomically moves it to `Running`, stores runner ID/lease token, increments `claim_count`, records `last_heartbeat_at`, records `lease_expires_at`, and updates active-lock metadata.
+- Heartbeats only renew metadata for matching runner ID/lease token; successful heartbeats refresh `last_heartbeat_at` and extend `lease_expires_at`.
+- Expired `Running` leases transition to `RecoveryRequired`, clear current runner ownership, emit a redacted recovery event, and keep the active lock so uncertain side-effecting work is not auto-retried.
 - Blocking a running run writes a checkpoint record, stores the latest checkpoint/gate refs on the run, clears current lease ownership, and keeps the active lock.
 - Terminal runner outcomes require the matching runner ID/lease token and release the active lock only if the run still owns it.
 

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -65,10 +65,10 @@ A duplicate idempotency key must replay the prior sanitized success/error outcom
 ## 5. Runner lease and checkpoint rules
 
 - Claiming a queued run atomically moves it to `Running`, stores runner ID/lease token, increments `claim_count`, records `last_heartbeat_at`, records `lease_expires_at`, and updates active-lock metadata.
-- Heartbeats only renew metadata for matching runner ID/lease token; successful heartbeats refresh `last_heartbeat_at` and extend `lease_expires_at`.
-- Expired `Running` leases transition to `RecoveryRequired`, clear current runner ownership, emit a redacted recovery event, and keep the active lock so uncertain side-effecting work is not auto-retried.
-- Blocking a running run writes a checkpoint record, stores the latest checkpoint/gate refs on the run, clears current lease ownership, and keeps the active lock.
-- Terminal runner outcomes require the matching runner ID/lease token and release the active lock only if the run still owns it.
+- Heartbeats only renew metadata for matching, unexpired runner ID/lease token; successful heartbeats refresh `last_heartbeat_at` and extend `lease_expires_at`.
+- Expired `Running` and `CancelRequested` leases transition to `RecoveryRequired`, clear current runner ownership, emit a redacted recovery event, and keep the active lock so uncertain side-effecting work is not auto-retried.
+- Blocking a running run requires a matching, unexpired lease, writes a checkpoint record, stores the latest checkpoint/gate refs on the run, clears current lease ownership, and keeps the active lock.
+- Terminal runner outcomes require the matching, unexpired runner ID/lease token and release the active lock only if the run still owns it.
 
 ---
 

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -1,0 +1,47 @@
+# Reborn Contract — TurnRunner Execution Model
+
+**Status:** Contract-freeze draft  
+**Date:** 2026-05-06  
+**Depends on:** [`turn-persistence.md`](turn-persistence.md), [`turns-agent-loop.md`](turns-agent-loop.md), [`runtime-profiles.md`](runtime-profiles.md)
+
+---
+
+## 1. Purpose
+
+`TurnRunner` is the trusted worker-side control plane for executable turn runs. It claims queued runs, maintains leases while model/tool work is active, records safe checkpoint/block/terminal transitions, and moves abandoned work to explicit recovery instead of blindly retrying side effects.
+
+Product adapters must continue to use `TurnCoordinator`. Runner transition APIs are trusted-worker APIs and remain under `ironclaw_turns::runner`.
+
+---
+
+## 2. Claim and lease rules
+
+- `submit_turn` creates a queued `TurnRunId` and active-thread lock, but no model/tool side effects may run before a runner claim succeeds.
+- `claim_next_run` atomically moves one matching `Queued` run to `Running`.
+- A successful claim stores `runner_id`, `lease_token`, `last_heartbeat_at`, `lease_expires_at`, increments `claim_count`, updates the active lock, and emits `RunnerClaimed`.
+- `heartbeat` requires the matching `runner_id` and `lease_token`; on success it refreshes `last_heartbeat_at`, extends `lease_expires_at`, touches the active lock, and emits `RunnerHeartbeat`.
+- Pull-based claims are authoritative. Wake notifications are optimization hints only.
+
+---
+
+## 3. Expired lease recovery
+
+- A reconciler scans running leases using durable `lease_expires_at` metadata.
+- Expired `Running` leases transition to `RecoveryRequired`, clear current runner ownership, emit a redacted `RecoveryRequired` event with reason `lease_expired`, and keep the same canonical-thread active lock.
+- `RecoveryRequired` runs are not returned by the normal `claim_next_run` path. The system must not auto-retry uncertain side-effecting work.
+- A duplicate/new submit for the same canonical thread remains `ThreadBusy` while recovery is required.
+- Explicit cancellation of `RecoveryRequired` is terminal `Cancelled` and releases the active lock so a new turn can be submitted.
+
+---
+
+## 4. Existing checkpoint and terminal rules
+
+- `block_run` requires the current lease, persists a checkpoint/gate ref, clears runner ownership, keeps the active lock, and emits `Blocked`.
+- `complete_run`, runner-side `cancel_run`, and `fail_run` require the matching lease and release the active lock exactly once at terminal state.
+- Failure and recovery/cancel reasons are stable sanitized categories only; raw prompts, tool input, host paths, backend errors, and secrets stay out of turn state and lifecycle events.
+
+---
+
+## 5. Deferred work
+
+This slice defines the core lease/recovery state machine in `ironclaw_turns`. Concrete PostgreSQL/libSQL adapters, AgentLoopHost/AgentLoopDriver integration, side-effect boundary checkpoint cadence inside the loop, and safe explicit retry/fork UX remain follow-up slices.

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -19,15 +19,15 @@ Product adapters must continue to use `TurnCoordinator`. Runner transition APIs 
 - `submit_turn` creates a queued `TurnRunId` and active-thread lock, but no model/tool side effects may run before a runner claim succeeds.
 - `claim_next_run` atomically moves one matching `Queued` run to `Running`.
 - A successful claim stores `runner_id`, `lease_token`, `last_heartbeat_at`, `lease_expires_at`, increments `claim_count`, updates the active lock, and emits `RunnerClaimed`.
-- `heartbeat` requires the matching `runner_id` and `lease_token`; on success it refreshes `last_heartbeat_at`, extends `lease_expires_at`, touches the active lock, and emits `RunnerHeartbeat`.
+- `heartbeat` requires the matching `runner_id` and `lease_token` and rejects leases whose `lease_expires_at` has already passed; on success it refreshes `last_heartbeat_at`, extends `lease_expires_at`, touches the active lock, and emits `RunnerHeartbeat`.
 - Pull-based claims are authoritative. Wake notifications are optimization hints only.
 
 ---
 
 ## 3. Expired lease recovery
 
-- A reconciler scans running leases using durable `lease_expires_at` metadata.
-- Expired `Running` leases transition to `RecoveryRequired`, clear current runner ownership, emit a redacted `RecoveryRequired` event with reason `lease_expired`, and keep the same canonical-thread active lock.
+- A reconciler scans runner-owned `Running` and `CancelRequested` leases using durable `lease_expires_at` metadata.
+- Expired `Running` or `CancelRequested` leases transition to `RecoveryRequired`, clear current runner ownership, emit a redacted `RecoveryRequired` event with reason `lease_expired`, and keep the same canonical-thread active lock.
 - `RecoveryRequired` runs are not returned by the normal `claim_next_run` path. The system must not auto-retry uncertain side-effecting work.
 - A duplicate/new submit for the same canonical thread remains `ThreadBusy` while recovery is required.
 - Explicit cancellation of `RecoveryRequired` is terminal `Cancelled` and releases the active lock so a new turn can be submitted.
@@ -36,8 +36,8 @@ Product adapters must continue to use `TurnCoordinator`. Runner transition APIs 
 
 ## 4. Existing checkpoint and terminal rules
 
-- `block_run` requires the current lease, persists a checkpoint/gate ref, clears runner ownership, keeps the active lock, and emits `Blocked`.
-- `complete_run`, runner-side `cancel_run`, and `fail_run` require the matching lease and release the active lock exactly once at terminal state.
+- `block_run` requires the current, unexpired lease, persists a checkpoint/gate ref, clears runner ownership, keeps the active lock, and emits `Blocked`.
+- `complete_run`, runner-side `cancel_run`, and `fail_run` require the matching, unexpired lease and release the active lock exactly once at terminal state.
 - Failure and recovery/cancel reasons are stable sanitized categories only; raw prompts, tool input, host paths, backend errors, and secrets stay out of turn state and lifecycle events.
 
 ---

--- a/docs/reborn/contracts/turns-agent-loop.md
+++ b/docs/reborn/contracts/turns-agent-loop.md
@@ -119,11 +119,14 @@ accepted -> queued -> running
 running -> blocked_approval -> running
 running -> waiting_tool -> running
 running -> waiting_process -> running
+running -> recovery_required
+recovery_required -> cancelled
 running -> completed|failed|cancelled
 ```
 
 Rules:
 
+- runner claim, lease, heartbeat, and expired-lease recovery rules follow [`turn-runner.md`](turn-runner.md);
 - persistence records, active-lock ownership, runner lease fields, checkpoints, and idempotency outcomes follow [`turn-persistence.md`](turn-persistence.md);
 - state transitions are persisted before externally visible side effects where needed for recovery;
 - approval-blocked turns persist enough fingerprint metadata to resume without raw input leakage;

--- a/docs/reborn/contracts/turns-agent-loop.md
+++ b/docs/reborn/contracts/turns-agent-loop.md
@@ -107,6 +107,7 @@ blocked_approval
 blocked_auth
 waiting_tool
 waiting_process
+recovery_required
 completed
 failed
 cancelled


### PR DESCRIPTION
## Summary

- adds runner lease expiry metadata to `ironclaw_turns` claims and heartbeat renewal
- adds explicit expired-lease reconciliation via trusted `ironclaw_turns::runner::RecoverExpiredLeasesRequest`
- transitions expired running leases to `RecoveryRequired`, emits a redacted recovery event, and keeps the canonical thread lock so uncertain work is not auto-retried
- allows explicit cancellation from `RecoveryRequired` to terminally release the lock
- documents the TurnRunner execution model slice and links it from Reborn contract docs

## Scope notes

This is the first #3199 runner execution-model slice over the existing in-memory `ironclaw_turns` contract. It intentionally does not add concrete PostgreSQL/libSQL adapters, AgentLoopHost/AgentLoopDriver integration, safe retry/fork UX, or loop-side checkpoint cadence.

Refs #3199.

## Verification

- RED before fix: targeted runner recovery tests failed on missing `RecoverExpiredLeasesRequest`, `recover_expired_leases`, and `RecoveryRequired` event support.
- `cargo test -p ironclaw_turns --test turn_coordinator_contract runner_claim_and_heartbeat_persist_lease_expiry`
- `cargo test -p ironclaw_turns --test turn_coordinator_contract expired_running_lease_enters_recovery_required_and_keeps_thread_locked`
- `cargo test -p ironclaw_turns --test turn_coordinator_contract cancel_recovery_required_run_releases_lock_and_allows_new_submit`
- `cargo fmt --check`
- `cargo test -p ironclaw_turns`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries`
- `cargo clippy --all --tests --examples --all-features -- -D warnings`
- `git diff --check`
- `rg -n "\\b(unwrap|expect|panic!)\\s*\\(" crates/ironclaw_turns/src` (no production matches)
- `cargo check --workspace`
