### PR TITLE
fix(e2e): stabilize coverage suite failures

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -47,6 +47,19 @@ fn resolve_settings_temperature(
         .map(|t| (t as f32).clamp(0.0, 2.0))
 }
 
+fn chat_job_context(
+    message: &IncomingMessage,
+    thread_id: Uuid,
+    user_tz: chrono_tz::Tz,
+) -> JobContext {
+    let mut job_ctx = JobContext::with_user(&message.user_id, "chat", "Interactive chat session")
+        .with_requester_id(&message.sender_id);
+    job_ctx.conversation_id = Some(thread_id);
+    job_ctx.user_timezone = user_tz.name().to_string();
+    job_ctx.metadata = crate::agent::agent_loop::chat_tool_execution_metadata(message);
+    job_ctx
+}
+
 /// Result of the agentic loop execution.
 pub(super) enum AgenticLoopResult {
     /// Completed with a response.
@@ -247,12 +260,8 @@ impl Agent {
         }
 
         // Create a JobContext for tool execution (chat doesn't have a real job)
-        let mut job_ctx =
-            JobContext::with_user(&message.user_id, "chat", "Interactive chat session")
-                .with_requester_id(&message.sender_id);
+        let mut job_ctx = chat_job_context(message, thread_id, user_tz);
         job_ctx.http_interceptor = self.deps.http_interceptor.clone();
-        job_ctx.user_timezone = user_tz.name().to_string();
-        job_ctx.metadata = crate::agent::agent_loop::chat_tool_execution_metadata(message);
 
         // Build system prompts once for this turn. Two variants: with tools
         // (normal iterations) and without (force_text final iteration).
@@ -1818,7 +1827,7 @@ mod tests {
     use crate::agent::agent_loop::{Agent, AgentDeps};
     use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
     use crate::agent::session::Session;
-    use crate::channels::ChannelManager;
+    use crate::channels::{ChannelManager, IncomingMessage};
     use crate::config::{AgentConfig, SafetyConfig, SkillsConfig};
     use crate::context::{ContextManager, JobContext};
     use crate::error::Error;
@@ -1829,6 +1838,7 @@ mod tests {
     };
     use crate::tools::{ApprovalRequirement, Tool, ToolError, ToolOutput, ToolRegistry};
     use ironclaw_safety::SafetyLayer;
+    use uuid::Uuid;
 
     use super::{
         capture_auth_prompt, check_auth_required, extract_auth_prompt, parse_auth_result,
@@ -2741,6 +2751,17 @@ mod tests {
         .to_string());
 
         assert!(check_auth_required("tool_activate", &result).is_none());
+    }
+
+    #[test]
+    fn test_chat_job_context_includes_thread_id_for_sse_scoped_tools() {
+        let thread_id = Uuid::new_v4();
+        let message = IncomingMessage::new("web", "test-user", "/plan Ship it");
+
+        let job_ctx = super::chat_job_context(&message, thread_id, chrono_tz::UTC);
+
+        assert_eq!(job_ctx.conversation_id, Some(thread_id));
+        assert_eq!(job_ctx.user_timezone, "UTC");
     }
 
     #[tokio::test]

--- a/tests/e2e/scenarios/test_settings_search.py
+++ b/tests/e2e/scenarios/test_settings_search.py
@@ -8,9 +8,11 @@ Covers:
   - Clearing search restores all items
 """
 
+import asyncio
 import json
+import uuid
 
-from helpers import SEL, api_post
+from helpers import SEL, api_get, api_post
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -180,21 +182,35 @@ async def test_search_filters_extension_cards(page):
 async def test_search_filters_user_rows(page, ironclaw_server):
     """Search filters user table rows in the Users subtab."""
     # Seed two users via the admin API
-    await api_post(ironclaw_server, "/api/admin/users", json={
-        "display_name": "Alice Searchtest",
-        "email": "alice-searchtest@example.test",
+    suffix = uuid.uuid4().hex[:8]
+    alice = await api_post(ironclaw_server, "/api/admin/users", json={
+        "display_name": f"Alice Searchtest {suffix}",
+        "email": f"alice-searchtest-{suffix}@example.test",
         "role": "member",
     })
-    await api_post(ironclaw_server, "/api/admin/users", json={
-        "display_name": "Bob Searchtest",
-        "email": "bob-searchtest@example.test",
+    assert alice.status_code == 200, alice.text
+    bob = await api_post(ironclaw_server, "/api/admin/users", json={
+        "display_name": f"Bob Searchtest {suffix}",
+        "email": f"bob-searchtest-{suffix}@example.test",
         "role": "member",
     })
+    assert bob.status_code == 200, bob.text
+
+    expected_ids = {alice.json()["id"], bob.json()["id"]}
+    for _ in range(20):
+        listed = await api_get(ironclaw_server, "/api/admin/users")
+        assert listed.status_code == 200, listed.text
+        listed_ids = {u["id"] for u in listed.json().get("users", [])}
+        if expected_ids <= listed_ids:
+            break
+        await asyncio.sleep(0.25)
+    else:
+        raise AssertionError("Seeded users did not appear in admin API list")
 
     await _open_settings_subtab(page, "users")
 
     rows = page.locator(SEL["users_tbody_row"])
-    await rows.first.wait_for(state="visible", timeout=5000)
+    await rows.first.wait_for(state="visible", timeout=15000)
     total = await rows.count()
     assert total >= 2, f"Need at least 2 user rows, got {total}"
 

--- a/tests/e2e/scenarios/test_skill_oauth_flow.py
+++ b/tests/e2e/scenarios/test_skill_oauth_flow.py
@@ -28,6 +28,7 @@ import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from helpers import api_get, api_post, auth_headers, AUTH_TOKEN
+from scenarios.test_auth_no_duplicate_response import auth_sse_server
 
 
 # ---------------------------------------------------------------------------
@@ -362,11 +363,16 @@ class TestSSEAuthEvents:
     """Test that auth events are emitted via SSE for web gateway."""
 
     @pytest.mark.asyncio
-    async def test_auth_required_sse_event(self, ironclaw_server):
+    async def test_auth_required_sse_event(self, auth_sse_server):
         """Auth onboarding SSE event should be emitted when credential is missing."""
+        # Use the isolated auth SSE fixture: it starts ironclaw with a mock
+        # GitHub skill whose credential mapping points at the loopback mock API.
+        # The shared ironclaw_server cannot add that host mapping after startup.
+        base_url = auth_sse_server
+
         # Connect to SSE stream
         thread_r = await api_post(
-            ironclaw_server, "/api/chat/thread/new", timeout=15
+            base_url, "/api/chat/thread/new", timeout=15
         )
         thread_id = thread_r.json()["id"]
 
@@ -374,19 +380,22 @@ class TestSSEAuthEvents:
 
         async def collect_sse_events():
             """Collect SSE events in the background."""
-            url = f"{ironclaw_server}/api/chat/events?token={AUTH_TOKEN}"
-            async with httpx.AsyncClient() as client:
-                async with client.stream("GET", url, timeout=30) as resp:
-                    async for line in resp.aiter_lines():
-                        if line.startswith("data:"):
-                            try:
-                                data = json.loads(line[5:].strip())
-                                events_received.append(data)
-                            except json.JSONDecodeError:
-                                pass
-                        # Stop after getting enough events
-                        if len(events_received) > 20:
-                            break
+            url = f"{base_url}/api/chat/events?token={AUTH_TOKEN}"
+            try:
+                async with httpx.AsyncClient() as client:
+                    async with client.stream("GET", url, timeout=30) as resp:
+                        async for line in resp.aiter_lines():
+                            if line.startswith("data:"):
+                                try:
+                                    data = json.loads(line[5:].strip())
+                                    events_received.append(data)
+                                except json.JSONDecodeError:
+                                    pass
+                            # Stop after getting enough events
+                            if len(events_received) > 20:
+                                break
+            except (asyncio.CancelledError, httpx.TimeoutException):
+                pass
 
         # Start collecting events
         sse_task = asyncio.create_task(collect_sse_events())
@@ -396,7 +405,7 @@ class TestSSEAuthEvents:
 
         # Send a message that triggers auth
         await api_post(
-            ironclaw_server,
+            base_url,
             "/api/chat/send",
             json={
                 "content": "show github issues for nearai/ironclaw",
@@ -405,8 +414,16 @@ class TestSSEAuthEvents:
             timeout=30,
         )
 
-        # Wait for events to arrive
-        await asyncio.sleep(10)
+        # Wait for auth events to arrive. Coverage-instrumented CI can be
+        # slow, so poll the collected stream instead of sleeping a fixed 10s.
+        deadline = asyncio.get_running_loop().time() + 45
+        while asyncio.get_running_loop().time() < deadline:
+            if any(
+                e.get("type") == "onboarding_state" and e.get("state") == "auth_required"
+                for e in events_received
+            ) or "approval_needed" in [e.get("type", "") for e in events_received]:
+                break
+            await asyncio.sleep(0.5)
         sse_task.cancel()
         try:
             await sse_task

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -292,33 +292,38 @@ async def test_refresh_skips_readonly_external_active_thread(page):
 
     await page.route("**/api/chat/threads", patch_threads_response)
 
-    # 4. Reload — loadThreads() should skip the "http" active thread
-    await page.reload()
-    await page.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
-    await _wait_for_connected(page, timeout=15000)
+    try:
+        # 4. Reload — loadThreads() should skip the "http" active thread
+        await page.reload()
+        await page.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+        await _wait_for_connected(page, timeout=15000)
 
-    # 5. Assert we landed on the writable gateway conversation, not the
-    # patched read-only external thread, and that the legacy pinned assistant
-    # chrome is gone from the DOM.
-    assert fallback_gateway_thread_id, "expected a gateway fallback thread id"
-    await page.wait_for_function(
-        "(expected) => currentThreadId === expected",
-        arg=fallback_gateway_thread_id,
-        timeout=15000,
-    )
-    assert await page.locator("#assistant-thread").count() == 0
+        # 5. Assert we landed on a writable gateway conversation, not the
+        # patched read-only external thread. In a full-suite run there may be
+        # an existing gateway conversation newer than the assistant fallback,
+        # so the invariant is "not the read-only active thread" rather than a
+        # specific fallback id.
+        assert fallback_gateway_thread_id, "expected a gateway fallback thread id"
+        await page.wait_for_function(
+            "(external) => !!currentThreadId && currentThreadId !== external",
+            arg=ext_thread_id,
+            timeout=15000,
+        )
+        current_thread = await page.evaluate("() => currentThreadId")
+        assert current_thread != ext_thread_id
+        assert await page.locator("#assistant-thread").count() == 0
 
-    # 6. Chat input should be enabled (not disabled by read-only state)
-    chat_input = page.locator(SEL["chat_input"])
-    await chat_input.wait_for(state="visible", timeout=5000)
-    is_disabled = await chat_input.is_disabled()
-    assert not is_disabled, "Chat input should be enabled on the fallback gateway thread"
-
-    # Drain in-flight route callbacks before the `page` fixture closes the
-    # context (see the setup comment at step 3 for the root cause). The
-    # `ignoreErrors` behavior swallows the cancellation of any mid-flight
-    # `route.fetch()` so it cannot surface on an unrelated later test.
-    await page.unroute_all(behavior="ignoreErrors")
+        # 6. Chat input should be enabled (not disabled by read-only state)
+        chat_input = page.locator(SEL["chat_input"])
+        await chat_input.wait_for(state="visible", timeout=5000)
+        is_disabled = await chat_input.is_disabled()
+        assert not is_disabled, "Chat input should be enabled on the fallback gateway thread"
+    finally:
+        # Drain in-flight route callbacks before the `page` fixture closes the
+        # context (see the setup comment at step 3 for the root cause). The
+        # `ignoreErrors` behavior swallows the cancellation of any mid-flight
+        # `route.fetch()` so it cannot surface on an unrelated later test.
+        await page.unroute_all(behavior="ignoreErrors")
 
 
 async def test_sse_keepalive_comments_arrive(managed_gateway_server):


### PR DESCRIPTION
## Summary
- Thread-scope chat `JobContext` so `plan_update` emits current-thread SSE events and plan-mode checklists render in the web UI.
- Stabilize the users settings-search E2E by using unique seeded users and waiting for API visibility before asserting UI rows.
- Make the OAuth SSE auth-event scenario use the isolated auth fixture with deterministic credential host mapping and poll for SSE auth events.
- Relax the read-only active-thread refresh E2E to assert the user-visible invariant: reload must not land on the patched read-only external thread and chat input remains enabled.

## Verification
- `CARGO_TARGET_DIR=/tmp/ironclaw-fix-target CARGO_INCREMENTAL=0 cargo test --lib --no-default-features --features libsql agent::dispatcher::tests::test_chat_job_context_includes_thread_id_for_sse_scoped_tools -- --exact`
- `CARGO_TARGET_DIR=/tmp/ironclaw-fix-target CARGO_INCREMENTAL=0 pytest scenarios/test_plan_mode.py scenarios/test_settings_search.py::test_search_filters_user_rows scenarios/test_skill_oauth_flow.py::TestSSEAuthEvents::test_auth_required_sse_event scenarios/test_sse_reconnect.py::test_refresh_skips_readonly_external_active_thread -v --timeout=120`
