### PR TITLE
feat(turns): add db-backed turn state stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4425,6 +4425,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4416,11 +4416,15 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "deadpool-postgres",
  "ironclaw_host_api",
+ "libsql",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
  "uuid",
 ]
 

--- a/crates/ironclaw_turns/Cargo.toml
+++ b/crates/ironclaw_turns/Cargo.toml
@@ -25,6 +25,7 @@ libsql = { version = "0.6", optional = true, default-features = false, features 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tracing = "0.1"
 tokio-postgres = { version = "0.7", optional = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/crates/ironclaw_turns/Cargo.toml
+++ b/crates/ironclaw_turns/Cargo.toml
@@ -11,14 +11,23 @@ homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
 publish = false
 
+[features]
+default = []
+postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
+libsql = ["dep:libsql"]
+
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+deadpool-postgres = { version = "0.14", optional = true }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
+tokio-postgres = { version = "0.7", optional = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
-serde_json = "1"
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_turns/src/db.rs
+++ b/crates/ironclaw_turns/src/db.rs
@@ -1,0 +1,901 @@
+use async_trait::async_trait;
+#[cfg(feature = "libsql")]
+use std::sync::Arc;
+
+use crate::{
+    CancelRunRequest, CancelRunResponse, GetRunStateRequest, InMemoryTurnStateStore,
+    InMemoryTurnStateStoreLimits, ResumeTurnRequest, ResumeTurnResponse, SubmitTurnRequest,
+    SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionPolicy, TurnCheckpointRecord, TurnError,
+    TurnIdempotencyRecord, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord, TurnRunState,
+    TurnStateStore,
+    runner::{
+        BlockRunRequest, CancelRunCompletionRequest, ClaimRunRequest, ClaimedTurnRun,
+        CompleteRunRequest, FailRunRequest, HeartbeatRequest, RecoverExpiredLeasesRequest,
+        RecoverExpiredLeasesResponse, TurnRunTransitionPort,
+    },
+};
+
+#[cfg(feature = "libsql")]
+const LIBSQL_TURN_STATE_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS turn_records (
+    turn_id TEXT PRIMARY KEY,
+    scope_key TEXT NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_records_scope ON turn_records(scope_key);
+
+CREATE TABLE IF NOT EXISTS turn_run_records (
+    run_id TEXT PRIMARY KEY,
+    turn_id TEXT NOT NULL,
+    scope_key TEXT NOT NULL,
+    status TEXT NOT NULL,
+    event_cursor INTEGER NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_run_records_scope ON turn_run_records(scope_key);
+CREATE INDEX IF NOT EXISTS idx_turn_run_records_status ON turn_run_records(status);
+
+CREATE TABLE IF NOT EXISTS turn_active_locks (
+    scope_key TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    lock_version INTEGER NOT NULL,
+    payload TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS turn_checkpoints (
+    checkpoint_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_checkpoints_run ON turn_checkpoints(run_id, sequence);
+
+CREATE TABLE IF NOT EXISTS turn_idempotency_records (
+    record_key TEXT PRIMARY KEY,
+    scope_key TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    run_id TEXT,
+    idempotency_key TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_idempotency_scope ON turn_idempotency_records(scope_key, operation);
+"#;
+
+#[cfg(feature = "postgres")]
+const POSTGRES_TURN_STATE_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS turn_records (
+    turn_id TEXT PRIMARY KEY,
+    scope_key TEXT NOT NULL,
+    payload JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_records_scope ON turn_records(scope_key);
+
+CREATE TABLE IF NOT EXISTS turn_run_records (
+    run_id TEXT PRIMARY KEY,
+    turn_id TEXT NOT NULL,
+    scope_key TEXT NOT NULL,
+    status TEXT NOT NULL,
+    event_cursor BIGINT NOT NULL,
+    payload JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_run_records_scope ON turn_run_records(scope_key);
+CREATE INDEX IF NOT EXISTS idx_turn_run_records_status ON turn_run_records(status);
+
+CREATE TABLE IF NOT EXISTS turn_active_locks (
+    scope_key TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    lock_version BIGINT NOT NULL,
+    payload JSONB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS turn_checkpoints (
+    checkpoint_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    sequence BIGINT NOT NULL,
+    payload JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_checkpoints_run ON turn_checkpoints(run_id, sequence);
+
+CREATE TABLE IF NOT EXISTS turn_idempotency_records (
+    record_key TEXT PRIMARY KEY,
+    scope_key TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    run_id TEXT,
+    idempotency_key TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    payload JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_idempotency_scope ON turn_idempotency_records(scope_key, operation);
+"#;
+
+#[cfg(feature = "libsql")]
+pub struct LibSqlTurnStateStore {
+    db: Arc<libsql::Database>,
+    limits: InMemoryTurnStateStoreLimits,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlTurnStateStore {
+    pub fn new(db: Arc<libsql::Database>) -> Self {
+        Self {
+            db,
+            limits: InMemoryTurnStateStoreLimits::default(),
+        }
+    }
+
+    pub fn with_limits(mut self, limits: InMemoryTurnStateStoreLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), TurnError> {
+        let conn = self.connect().await?;
+        conn.execute_batch(LIBSQL_TURN_STATE_SCHEMA)
+            .await
+            .map_err(db_error)?;
+        Ok(())
+    }
+
+    pub async fn persistence_snapshot(&self) -> Result<TurnPersistenceSnapshot, TurnError> {
+        self.load_snapshot().await
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, TurnError> {
+        let conn = self.db.connect().map_err(db_error)?;
+        conn.query("PRAGMA busy_timeout = 5000", ())
+            .await
+            .map_err(db_error)?;
+        Ok(conn)
+    }
+
+    async fn begin_immediate(&self) -> Result<libsql::Connection, TurnError> {
+        let conn = self.connect().await?;
+        conn.execute("BEGIN IMMEDIATE", ())
+            .await
+            .map_err(db_error)?;
+        Ok(conn)
+    }
+
+    async fn load_store_from_conn(
+        &self,
+        conn: &libsql::Connection,
+    ) -> Result<InMemoryTurnStateStore, TurnError> {
+        InMemoryTurnStateStore::from_persistence_snapshot(
+            libsql_load_snapshot(conn).await?,
+            self.limits,
+        )
+    }
+
+    async fn load_snapshot(&self) -> Result<TurnPersistenceSnapshot, TurnError> {
+        let conn = self.connect().await?;
+        conn.execute("BEGIN", ()).await.map_err(db_error)?;
+        let result = libsql_load_snapshot(&conn).await;
+        finish_libsql_transaction(&conn, result).await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl TurnStateStore for LibSqlTurnStateStore {
+    async fn submit_turn(
+        &self,
+        request: SubmitTurnRequest,
+        admission_policy: &dyn TurnAdmissionPolicy,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.submit_turn(request, admission_policy).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn resume_turn(
+        &self,
+        request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.resume_turn(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn request_cancel(
+        &self,
+        request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.request_cancel(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        self.load_snapshot()
+            .await
+            .and_then(|snapshot| {
+                InMemoryTurnStateStore::from_persistence_snapshot(snapshot, self.limits)
+            })?
+            .get_run_state(request)
+            .await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl TurnRunTransitionPort for LibSqlTurnStateStore {
+    async fn claim_next_run(
+        &self,
+        request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.claim_next_run(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<crate::events::EventCursor, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.heartbeat(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.recover_expired_leases(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.block_run(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.complete_run(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.cancel_run(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.fail_run(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub struct PostgresTurnStateStore {
+    pool: deadpool_postgres::Pool,
+    limits: InMemoryTurnStateStoreLimits,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresTurnStateStore {
+    pub fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self {
+            pool,
+            limits: InMemoryTurnStateStoreLimits::default(),
+        }
+    }
+
+    pub fn with_limits(mut self, limits: InMemoryTurnStateStoreLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), TurnError> {
+        let client = self.client().await?;
+        client
+            .batch_execute(POSTGRES_TURN_STATE_SCHEMA)
+            .await
+            .map_err(db_error)?;
+        Ok(())
+    }
+
+    pub async fn persistence_snapshot(&self) -> Result<TurnPersistenceSnapshot, TurnError> {
+        self.load_snapshot().await
+    }
+
+    async fn client(&self) -> Result<deadpool_postgres::Object, TurnError> {
+        self.pool.get().await.map_err(db_error)
+    }
+
+    async fn load_store_from_txn(
+        &self,
+        txn: &impl deadpool_postgres::GenericClient,
+    ) -> Result<InMemoryTurnStateStore, TurnError> {
+        InMemoryTurnStateStore::from_persistence_snapshot(
+            postgres_load_snapshot(txn).await?,
+            self.limits,
+        )
+    }
+
+    async fn load_snapshot(&self) -> Result<TurnPersistenceSnapshot, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE MODE").await?;
+        let snapshot = postgres_load_snapshot(&txn).await?;
+        txn.commit().await.map_err(db_error)?;
+        Ok(snapshot)
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait]
+impl TurnStateStore for PostgresTurnStateStore {
+    async fn submit_turn(
+        &self,
+        request: SubmitTurnRequest,
+        admission_policy: &dyn TurnAdmissionPolicy,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.submit_turn(request, admission_policy).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn resume_turn(
+        &self,
+        request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.resume_turn(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn request_cancel(
+        &self,
+        request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.request_cancel(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        self.load_snapshot()
+            .await
+            .and_then(|snapshot| {
+                InMemoryTurnStateStore::from_persistence_snapshot(snapshot, self.limits)
+            })?
+            .get_run_state(request)
+            .await
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait]
+impl TurnRunTransitionPort for PostgresTurnStateStore {
+    async fn claim_next_run(
+        &self,
+        request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.claim_next_run(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<crate::events::EventCursor, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.heartbeat(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.recover_expired_leases(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.block_run(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.complete_run(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.cancel_run(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.fail_run(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_load_payloads<T>(conn: &libsql::Connection, sql: &str) -> Result<Vec<T>, TurnError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let mut rows = conn.query(sql, ()).await.map_err(db_error)?;
+    let mut payloads = Vec::new();
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let payload: String = row.get(0).map_err(db_error)?;
+        payloads.push(serde_json::from_str(&payload).map_err(db_error)?);
+    }
+    Ok(payloads)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_load_snapshot(
+    conn: &libsql::Connection,
+) -> Result<TurnPersistenceSnapshot, TurnError> {
+    let turns = libsql_load_payloads::<TurnRecord>(
+        conn,
+        "SELECT payload FROM turn_records ORDER BY turn_id",
+    )
+    .await?;
+    let runs = libsql_load_payloads::<TurnRunRecord>(
+        conn,
+        "SELECT payload FROM turn_run_records ORDER BY event_cursor, run_id",
+    )
+    .await?;
+    let active_locks = libsql_load_payloads::<TurnActiveLockRecord>(
+        conn,
+        "SELECT payload FROM turn_active_locks ORDER BY scope_key",
+    )
+    .await?;
+    let checkpoints = libsql_load_payloads::<TurnCheckpointRecord>(
+        conn,
+        "SELECT payload FROM turn_checkpoints ORDER BY run_id, sequence",
+    )
+    .await?;
+    let idempotency_records = libsql_load_payloads::<TurnIdempotencyRecord>(
+        conn,
+        "SELECT payload FROM turn_idempotency_records ORDER BY created_at, record_key",
+    )
+    .await?;
+    Ok(TurnPersistenceSnapshot {
+        turns,
+        runs,
+        active_locks,
+        checkpoints,
+        idempotency_records,
+    })
+}
+
+#[cfg(feature = "libsql")]
+async fn finish_libsql_transaction<T>(
+    conn: &libsql::Connection,
+    result: Result<T, TurnError>,
+) -> Result<T, TurnError> {
+    match result {
+        Ok(value) => {
+            conn.execute("COMMIT", ()).await.map_err(db_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(error)
+        }
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_replace_snapshot(
+    conn: &libsql::Connection,
+    snapshot: &TurnPersistenceSnapshot,
+) -> Result<(), TurnError> {
+    for table in [
+        "turn_idempotency_records",
+        "turn_checkpoints",
+        "turn_active_locks",
+        "turn_run_records",
+        "turn_records",
+    ] {
+        let sql = format!("DELETE FROM {table}");
+        conn.execute(sql.as_str(), ()).await.map_err(db_error)?;
+    }
+
+    for record in &snapshot.turns {
+        conn.execute(
+            "INSERT INTO turn_records (turn_id, scope_key, payload) VALUES (?1, ?2, ?3)",
+            libsql::params![
+                record.turn_id.to_string(),
+                scope_key(&record.scope)?,
+                to_json(record)?
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.runs {
+        conn.execute(
+            "INSERT INTO turn_run_records (run_id, turn_id, scope_key, status, event_cursor, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            libsql::params![
+                record.run_id.to_string(),
+                record.turn_id.to_string(),
+                scope_key(&record.scope)?,
+                status_key(record.status)?,
+                record.event_cursor.0 as i64,
+                to_json(record)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.active_locks {
+        conn.execute(
+            "INSERT INTO turn_active_locks (scope_key, run_id, status, lock_version, payload) VALUES (?1, ?2, ?3, ?4, ?5)",
+            libsql::params![
+                scope_key(&record.key.scope)?,
+                record.run_id.to_string(),
+                status_key(record.status)?,
+                record.lock_version.as_u64() as i64,
+                to_json(record)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.checkpoints {
+        conn.execute(
+            "INSERT INTO turn_checkpoints (checkpoint_id, run_id, sequence, payload) VALUES (?1, ?2, ?3, ?4)",
+            libsql::params![
+                record.checkpoint_id.as_uuid().to_string(),
+                record.run_id.to_string(),
+                record.sequence as i64,
+                to_json(record)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.idempotency_records {
+        conn.execute(
+            "INSERT INTO turn_idempotency_records (record_key, scope_key, operation, run_id, idempotency_key, created_at, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            libsql::params![
+                idempotency_record_key(record)?,
+                scope_key(&record.scope)?,
+                operation_key(record)?,
+                record.run_id.map(|run_id| run_id.to_string()),
+                record.key.as_str(),
+                record.created_at.to_rfc3339(),
+                to_json(record)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+async fn lock_postgres_turn_tables(
+    client: &impl deadpool_postgres::GenericClient,
+    mode: &str,
+) -> Result<(), TurnError> {
+    let statement = format!(
+        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_idempotency_records IN {mode}"
+    );
+    client.batch_execute(&statement).await.map_err(db_error)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_load_payloads<T>(
+    client: &impl deadpool_postgres::GenericClient,
+    sql: &str,
+) -> Result<Vec<T>, TurnError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let rows = client.query(sql, &[]).await.map_err(db_error)?;
+    rows.into_iter()
+        .map(|row| {
+            let payload: String = row.get(0);
+            serde_json::from_str(&payload).map_err(db_error)
+        })
+        .collect()
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_load_snapshot(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<TurnPersistenceSnapshot, TurnError> {
+    let turns = postgres_load_payloads::<TurnRecord>(
+        client,
+        "SELECT payload::text FROM turn_records ORDER BY turn_id",
+    )
+    .await?;
+    let runs = postgres_load_payloads::<TurnRunRecord>(
+        client,
+        "SELECT payload::text FROM turn_run_records ORDER BY event_cursor, run_id",
+    )
+    .await?;
+    let active_locks = postgres_load_payloads::<TurnActiveLockRecord>(
+        client,
+        "SELECT payload::text FROM turn_active_locks ORDER BY scope_key",
+    )
+    .await?;
+    let checkpoints = postgres_load_payloads::<TurnCheckpointRecord>(
+        client,
+        "SELECT payload::text FROM turn_checkpoints ORDER BY run_id, sequence",
+    )
+    .await?;
+    let idempotency_records = postgres_load_payloads::<TurnIdempotencyRecord>(
+        client,
+        "SELECT payload::text FROM turn_idempotency_records ORDER BY created_at, record_key",
+    )
+    .await?;
+    Ok(TurnPersistenceSnapshot {
+        turns,
+        runs,
+        active_locks,
+        checkpoints,
+        idempotency_records,
+    })
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_replace_snapshot(
+    txn: &impl deadpool_postgres::GenericClient,
+    snapshot: &TurnPersistenceSnapshot,
+) -> Result<(), TurnError> {
+    for table in [
+        "turn_idempotency_records",
+        "turn_checkpoints",
+        "turn_active_locks",
+        "turn_run_records",
+        "turn_records",
+    ] {
+        let sql = format!("DELETE FROM {table}");
+        txn.execute(sql.as_str(), &[]).await.map_err(db_error)?;
+    }
+
+    for record in &snapshot.turns {
+        let payload = to_json(record)?;
+        txn.execute(
+            "INSERT INTO turn_records (turn_id, scope_key, payload) VALUES ($1, $2, $3::jsonb)",
+            &[
+                &record.turn_id.to_string(),
+                &scope_key(&record.scope)?,
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.runs {
+        let payload = to_json(record)?;
+        txn.execute(
+            "INSERT INTO turn_run_records (run_id, turn_id, scope_key, status, event_cursor, payload) VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+            &[
+                &record.run_id.to_string(),
+                &record.turn_id.to_string(),
+                &scope_key(&record.scope)?,
+                &status_key(record.status)?,
+                &(record.event_cursor.0 as i64),
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.active_locks {
+        let payload = to_json(record)?;
+        txn.execute(
+            "INSERT INTO turn_active_locks (scope_key, run_id, status, lock_version, payload) VALUES ($1, $2, $3, $4, $5::jsonb)",
+            &[
+                &scope_key(&record.key.scope)?,
+                &record.run_id.to_string(),
+                &status_key(record.status)?,
+                &(record.lock_version.as_u64() as i64),
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.checkpoints {
+        let payload = to_json(record)?;
+        txn.execute(
+            "INSERT INTO turn_checkpoints (checkpoint_id, run_id, sequence, payload) VALUES ($1, $2, $3, $4::jsonb)",
+            &[
+                &record.checkpoint_id.as_uuid().to_string(),
+                &record.run_id.to_string(),
+                &(record.sequence as i64),
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.idempotency_records {
+        let payload = to_json(record)?;
+        txn.execute(
+            "INSERT INTO turn_idempotency_records (record_key, scope_key, operation, run_id, idempotency_key, created_at, payload) VALUES ($1, $2, $3, $4, $5, $6::timestamptz, $7::jsonb)",
+            &[
+                &idempotency_record_key(record)?,
+                &scope_key(&record.scope)?,
+                &operation_key(record)?,
+                &record.run_id.map(|run_id| run_id.to_string()),
+                &record.key.as_str(),
+                &record.created_at.to_rfc3339(),
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    Ok(())
+}
+
+fn to_json<T>(value: &T) -> Result<String, TurnError>
+where
+    T: serde::Serialize,
+{
+    serde_json::to_string(value).map_err(db_error)
+}
+
+fn scope_key(scope: &crate::TurnScope) -> Result<String, TurnError> {
+    to_json(scope)
+}
+
+fn status_key(status: crate::TurnStatus) -> Result<String, TurnError> {
+    to_json(&status)
+}
+
+fn operation_key(record: &TurnIdempotencyRecord) -> Result<String, TurnError> {
+    to_json(&record.operation)
+}
+
+fn idempotency_record_key(record: &TurnIdempotencyRecord) -> Result<String, TurnError> {
+    Ok(format!(
+        "{}|{}|{}|{}",
+        scope_key(&record.scope)?,
+        operation_key(record)?,
+        record
+            .run_id
+            .map(|run_id| run_id.to_string())
+            .unwrap_or_default(),
+        record.key.as_str()
+    ))
+}
+
+fn db_error(_error: impl std::fmt::Display) -> TurnError {
+    TurnError::Unavailable {
+        reason: "turn state persistence unavailable".to_string(),
+    }
+}

--- a/crates/ironclaw_turns/src/db.rs
+++ b/crates/ironclaw_turns/src/db.rs
@@ -882,20 +882,25 @@ fn operation_key(record: &TurnIdempotencyRecord) -> Result<String, TurnError> {
 }
 
 fn idempotency_record_key(record: &TurnIdempotencyRecord) -> Result<String, TurnError> {
-    Ok(format!(
-        "{}|{}|{}|{}",
-        scope_key(&record.scope)?,
-        operation_key(record)?,
-        record
-            .run_id
-            .map(|run_id| run_id.to_string())
-            .unwrap_or_default(),
-        record.key.as_str()
-    ))
+    #[derive(serde::Serialize)]
+    struct IdempotencyRecordKey<'a> {
+        scope: &'a crate::TurnScope,
+        operation: crate::TurnIdempotencyOperationKind,
+        run_id: Option<String>,
+        key: &'a str,
+    }
+
+    to_json(&IdempotencyRecordKey {
+        scope: &record.scope,
+        operation: record.operation,
+        run_id: record.run_id.map(|run_id| run_id.to_string()),
+        key: record.key.as_str(),
+    })
 }
 
-fn db_error(_error: impl std::fmt::Display) -> TurnError {
+fn db_error(error: impl std::fmt::Display) -> TurnError {
+    tracing::debug!(%error, "turn state persistence operation failed");
     TurnError::Unavailable {
-        reason: "turn state persistence unavailable".to_string(),
+        reason: "turn state persistence temporarily unavailable".to_string(),
     }
 }

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -6,6 +6,8 @@
 //! transition APIs are intentionally not re-exported from this crate prelude.
 
 pub mod coordinator;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+pub mod db;
 pub mod events;
 pub mod ids;
 pub mod memory;
@@ -19,6 +21,10 @@ pub mod store;
 pub use coordinator::{
     AllowAllTurnAdmissionPolicy, DefaultTurnCoordinator, TurnAdmissionPolicy, TurnCoordinator,
 };
+#[cfg(feature = "libsql")]
+pub use db::LibSqlTurnStateStore;
+#[cfg(feature = "postgres")]
+pub use db::PostgresTurnStateStore;
 pub use events::{InMemoryTurnEventSink, TurnEventKind, TurnEventSink, TurnLifecycleEvent};
 pub use ids::{
     AcceptedMessageRef, GateRef, IdempotencyKey, ReplyTargetBindingRef, RunProfileId,

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -143,6 +143,16 @@ impl InMemoryTurnStateStore {
         }
     }
 
+    pub fn from_persistence_snapshot(
+        snapshot: TurnPersistenceSnapshot,
+        limits: InMemoryTurnStateStoreLimits,
+    ) -> Result<Self, TurnError> {
+        Ok(Self {
+            inner: Mutex::new(Inner::from_persistence_snapshot(snapshot, limits)?),
+            submit_idempotency_ready: Condvar::new(),
+        })
+    }
+
     pub fn persistence_snapshot(&self) -> TurnPersistenceSnapshot {
         match self.inner.lock() {
             Ok(inner) => inner.persistence_snapshot(),
@@ -475,6 +485,136 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
 }
 
 impl Inner {
+    fn from_persistence_snapshot(
+        snapshot: TurnPersistenceSnapshot,
+        limits: InMemoryTurnStateStoreLimits,
+    ) -> Result<Self, TurnError> {
+        let mut cursor = 0;
+        let turns = snapshot
+            .turns
+            .into_iter()
+            .map(|record| (record.turn_id, record))
+            .collect::<HashMap<_, _>>();
+        let mut records = HashMap::new();
+        let mut queued_runs = VecDeque::new();
+        let mut terminal_runs = VecDeque::new();
+        for run in snapshot.runs {
+            cursor = cursor.max(run.event_cursor.0);
+            let actor = turns
+                .get(&run.turn_id)
+                .map(|turn| turn.actor.clone())
+                .ok_or_else(|| TurnError::Unavailable {
+                    reason: "turn run references missing turn record".to_string(),
+                })?;
+            if run.status == TurnStatus::Queued {
+                queued_runs.push_back(run.run_id);
+            }
+            if run.status.is_terminal() {
+                terminal_runs.push_back(run.run_id);
+            }
+            records.insert(
+                run.run_id,
+                RunRecord {
+                    scope: run.scope,
+                    actor,
+                    turn_id: run.turn_id,
+                    run_id: run.run_id,
+                    status: run.status,
+                    profile: run.profile,
+                    accepted_message_ref: run.accepted_message_ref,
+                    source_binding_ref: run.source_binding_ref,
+                    reply_target_binding_ref: run.reply_target_binding_ref,
+                    checkpoint_id: run.checkpoint_id,
+                    gate_ref: run.gate_ref,
+                    failure: run.failure,
+                    event_cursor: run.event_cursor,
+                    runner_id: run.runner_id,
+                    lease_token: run.lease_token,
+                    lease_expires_at: run.lease_expires_at,
+                    last_heartbeat_at: run.last_heartbeat_at,
+                    claim_count: run.claim_count,
+                    received_at: run.received_at,
+                },
+            );
+        }
+
+        let mut active_locks = HashMap::new();
+        for lock in snapshot.active_locks {
+            active_locks.insert(lock.key.clone(), lock);
+        }
+
+        let mut submit_idempotency = HashMap::new();
+        let mut resume_idempotency = HashMap::new();
+        let mut cancel_idempotency = HashMap::new();
+        let mut idempotency_records = HashMap::new();
+        let mut submit_idempotency_order = VecDeque::new();
+        let mut resume_idempotency_order = VecDeque::new();
+        let mut cancel_idempotency_order = VecDeque::new();
+        let mut idempotency_record_order = VecDeque::new();
+        let mut ordered_idempotency_records = snapshot.idempotency_records;
+        ordered_idempotency_records.sort_by_key(|record| record.created_at);
+        for record in ordered_idempotency_records {
+            let persisted_key = persisted_key_for_record(&record);
+            idempotency_record_order.push_back(persisted_key.clone());
+            idempotency_records.insert(persisted_key, record.clone());
+            match record.operation {
+                TurnIdempotencyOperationKind::Submit => {
+                    if let Some(replay) = record.replay_submit() {
+                        let key = SubmitIdempotencyKey {
+                            scope: record.scope.clone(),
+                            key: record.key.clone(),
+                        };
+                        submit_idempotency_order.push_back(key.clone());
+                        submit_idempotency.insert(key, replay);
+                    }
+                }
+                TurnIdempotencyOperationKind::Resume => {
+                    if let (Some(run_id), Some(replay)) = (record.run_id, record.replay_resume()) {
+                        let key = RunIdempotencyKey {
+                            scope: record.scope.clone(),
+                            run_id,
+                            key: record.key.clone(),
+                        };
+                        resume_idempotency_order.push_back(key.clone());
+                        resume_idempotency.insert(key, replay);
+                    }
+                }
+                TurnIdempotencyOperationKind::Cancel => {
+                    if let (Some(run_id), Some(replay)) = (record.run_id, record.replay_cancel()) {
+                        let key = RunIdempotencyKey {
+                            scope: record.scope.clone(),
+                            run_id,
+                            key: record.key.clone(),
+                        };
+                        cancel_idempotency_order.push_back(key.clone());
+                        cancel_idempotency.insert(key, replay);
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            cursor,
+            turns,
+            records,
+            queued_runs,
+            terminal_runs,
+            active_locks,
+            checkpoints: snapshot.checkpoints,
+            submit_idempotency,
+            submit_idempotency_in_flight: HashSet::new(),
+            resume_idempotency,
+            cancel_idempotency,
+            idempotency_records,
+            submit_idempotency_order,
+            resume_idempotency_order,
+            cancel_idempotency_order,
+            idempotency_record_order,
+            events: Vec::new(),
+            limits,
+        })
+    }
+
     fn next_cursor(&mut self) -> EventCursor {
         self.cursor = self.cursor.saturating_add(1);
         EventCursor(self.cursor)

--- a/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
@@ -275,7 +275,7 @@ fn received_at() -> DateTime<Utc> {
 fn scope(thread: &str) -> TurnScope {
     TurnScope::new(
         TenantId::new("tenant1").unwrap(),
-        AgentId::new("agent1").unwrap(),
+        Some(AgentId::new("agent1").unwrap()),
         Some(ProjectId::new("project1").unwrap()),
         ThreadId::new(thread).unwrap(),
     )

--- a/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
@@ -1,0 +1,286 @@
+#![cfg(any(feature = "libsql", feature = "postgres"))]
+#![cfg_attr(
+    all(feature = "postgres", not(feature = "libsql")),
+    allow(dead_code, unused_imports)
+)]
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_turns::{
+    AcceptedMessageRef, CancelRunRequest, DefaultTurnCoordinator, IdempotencyKey,
+    ReplyTargetBindingRef, RunProfileRequest, SanitizedCancelReason, SourceBindingRef,
+    SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor, TurnCoordinator, TurnError,
+    TurnRunId, TurnScope, TurnStatus,
+    runner::{ClaimRunRequest, RecoverExpiredLeasesRequest, TurnRunTransitionPort},
+};
+
+#[cfg(feature = "libsql")]
+use ironclaw_turns::LibSqlTurnStateStore;
+#[cfg(feature = "postgres")]
+use ironclaw_turns::PostgresTurnStateStore;
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_turn_state_store_persists_submit_and_busy_across_instances() {
+    let (db, _dir) = libsql_db().await;
+    let store = Arc::new(LibSqlTurnStateStore::new(db.clone()));
+    store.run_migrations().await.unwrap();
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+
+    let accepted = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&accepted);
+
+    let reopened = Arc::new(LibSqlTurnStateStore::new(db));
+    let reopened_coordinator = DefaultTurnCoordinator::new(reopened);
+    let busy = reopened_coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-b"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        busy,
+        TurnError::ThreadBusy(ThreadBusy {
+            active_run_id,
+            status: TurnStatus::Queued,
+            ..
+        }) if active_run_id == run_id
+    ));
+
+    let duplicate = reopened_coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    assert_eq!(duplicate, accepted);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_turn_state_store_serializes_concurrent_submits_for_same_thread() {
+    let (db, _dir) = libsql_db().await;
+    let store_a = Arc::new(LibSqlTurnStateStore::new(db.clone()));
+    store_a.run_migrations().await.unwrap();
+    let store_b = Arc::new(LibSqlTurnStateStore::new(db));
+    let coordinator_a = DefaultTurnCoordinator::new(store_a.clone());
+    let coordinator_b = DefaultTurnCoordinator::new(store_b);
+
+    let (first, second) = tokio::join!(
+        coordinator_a.submit_turn(submit_request("thread-a", "idem-submit-a")),
+        coordinator_b.submit_turn(submit_request("thread-a", "idem-submit-b")),
+    );
+
+    let accepted = [first.as_ref(), second.as_ref()]
+        .into_iter()
+        .filter(|result| matches!(result, Ok(SubmitTurnResponse::Accepted { .. })))
+        .count();
+    let busy = [first.as_ref(), second.as_ref()]
+        .into_iter()
+        .filter(|result| matches!(result, Err(TurnError::ThreadBusy(_))))
+        .count();
+    assert_eq!(accepted, 1);
+    assert_eq!(busy, 1);
+
+    let snapshot = store_a.persistence_snapshot().await.unwrap();
+    assert_eq!(snapshot.turns.len(), 1);
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.active_locks.len(), 1);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_turn_state_store_persists_runner_recovery_and_cancel_flow() {
+    let (db, _dir) = libsql_db().await;
+    let store = Arc::new(LibSqlTurnStateStore::new(db.clone()));
+    store.run_migrations().await.unwrap();
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = ironclaw_turns::TurnRunnerId::new();
+    let lease_token = ironclaw_turns::TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let snapshot = store.persistence_snapshot().await.unwrap();
+    let lease_expires_at = snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap()
+        .lease_expires_at
+        .unwrap();
+
+    let reopened = Arc::new(LibSqlTurnStateStore::new(db));
+    let recovered = reopened
+        .recover_expired_leases(RecoverExpiredLeasesRequest {
+            now: lease_expires_at + ChronoDuration::milliseconds(1),
+            scope_filter: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(recovered.recovered.len(), 1);
+    assert_eq!(recovered.recovered[0].status, TurnStatus::RecoveryRequired);
+
+    let reopened_coordinator = DefaultTurnCoordinator::new(reopened.clone());
+    let busy = reopened_coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-after-recovery"))
+        .await
+        .unwrap_err();
+    assert!(matches!(busy, TurnError::ThreadBusy(_)));
+
+    let cancelled = reopened_coordinator
+        .cancel_run(cancel_request("thread-a", run_id, "idem-cancel-recovered"))
+        .await
+        .unwrap();
+    assert_eq!(cancelled.status, TurnStatus::Cancelled);
+
+    let replacement = reopened_coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-replacement"))
+        .await
+        .unwrap();
+    assert!(matches!(replacement, SubmitTurnResponse::Accepted { .. }));
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_turn_state_store_persists_submit_and_busy_across_instances_when_configured() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let thread = format!("pg-thread-{suffix}");
+    let store = Arc::new(PostgresTurnStateStore::new(pool.clone()));
+    store.run_migrations().await.unwrap();
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+
+    let accepted = coordinator
+        .submit_turn(submit_request(&thread, &format!("idem-submit-a-{suffix}")))
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&accepted);
+
+    let reopened = Arc::new(PostgresTurnStateStore::new(pool));
+    let reopened_coordinator = DefaultTurnCoordinator::new(reopened);
+    let busy = reopened_coordinator
+        .submit_turn(submit_request(&thread, &format!("idem-submit-b-{suffix}")))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        busy,
+        TurnError::ThreadBusy(ThreadBusy {
+            active_run_id,
+            status: TurnStatus::Queued,
+            ..
+        }) if active_run_id == run_id
+    ));
+}
+
+#[cfg(feature = "postgres")]
+#[test]
+fn postgres_turn_state_store_implements_turn_contract_traits() {
+    fn assert_state_store<T: ironclaw_turns::TurnStateStore>() {}
+    fn assert_runner_port<T: TurnRunTransitionPort>() {}
+    assert_state_store::<PostgresTurnStateStore>();
+    assert_runner_port::<PostgresTurnStateStore>();
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_db() -> (Arc<libsql::Database>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("turns.db");
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    (db, dir)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_pool() -> Option<deadpool_postgres::Pool> {
+    let Ok(url) = std::env::var("IRONCLAW_TURNS_POSTGRES_URL") else {
+        eprintln!("skipping postgres turn-state contract: IRONCLAW_TURNS_POSTGRES_URL not set");
+        return None;
+    };
+    let config: tokio_postgres::Config = match url.parse() {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("skipping postgres turn-state contract: invalid url ({error})");
+            return None;
+        }
+    };
+    let manager = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
+    let pool = deadpool_postgres::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .unwrap();
+    if let Err(error) = pool.get().await {
+        eprintln!("skipping postgres turn-state contract: database unavailable ({error})");
+        return None;
+    }
+    Some(pool)
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos()
+}
+
+fn submit_request(thread: &str, idempotency_key: &str) -> SubmitTurnRequest {
+    SubmitTurnRequest {
+        scope: scope(thread),
+        actor: actor(),
+        accepted_message_ref: AcceptedMessageRef::new(format!(
+            "message-{thread}-{idempotency_key}"
+        ))
+        .unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
+        requested_run_profile: Some(RunProfileRequest::new("default").unwrap()),
+        idempotency_key: IdempotencyKey::new(idempotency_key).unwrap(),
+        received_at: received_at(),
+    }
+}
+
+fn cancel_request(thread: &str, run_id: TurnRunId, idempotency_key: &str) -> CancelRunRequest {
+    CancelRunRequest {
+        scope: scope(thread),
+        actor: actor(),
+        run_id,
+        reason: SanitizedCancelReason::UserRequested,
+        idempotency_key: IdempotencyKey::new(idempotency_key).unwrap(),
+    }
+}
+
+fn accepted_run_id(response: &SubmitTurnResponse) -> TurnRunId {
+    let SubmitTurnResponse::Accepted { run_id, .. } = response;
+    *run_id
+}
+
+fn received_at() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 6, 12, 0, 0).unwrap()
+}
+
+fn scope(thread: &str) -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant1").unwrap(),
+        AgentId::new("agent1").unwrap(),
+        Some(ProjectId::new("project1").unwrap()),
+        ThreadId::new(thread).unwrap(),
+    )
+}
+
+fn actor() -> TurnActor {
+    TurnActor::new(UserId::new("user1").unwrap())
+}

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -33,7 +33,7 @@ The `ironclaw_turns` contract models persistence with these record families:
 | `turn_checkpoints` | Dedicated checkpoint/gate records written when a running run blocks. |
 | `turn_idempotency_keys` | Prior sanitized outcomes for scoped submit/resume/cancel idempotency keys. |
 
-The initial PostgreSQL/libSQL adapter slice stores each logical record family in its own table with indexed metadata columns plus a serialized contract payload. Backends must preserve the same semantics as the in-memory contract tests while later slices harden service-graph wiring.
+The initial PostgreSQL/libSQL adapter slice stores each logical record family in its own table with indexed metadata columns plus a serialized contract payload. Mutations hold a backend transaction/write lock across snapshot load, in-memory contract mutation, and snapshot replacement so active-lock and idempotency semantics remain atomic. Backends must preserve the same semantics as the in-memory contract tests while later slices add incremental row-level updates, targeted read paths, and service-graph wiring.
 
 ---
 

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -33,7 +33,7 @@ The `ironclaw_turns` contract models persistence with these record families:
 | `turn_checkpoints` | Dedicated checkpoint/gate records written when a running run blocks. |
 | `turn_idempotency_keys` | Prior sanitized outcomes for scoped submit/resume/cancel idempotency keys. |
 
-Concrete PostgreSQL/libSQL tables are intentionally deferred until the DB adapter slice. Backends must preserve the same semantics when those adapters are added.
+The initial PostgreSQL/libSQL adapter slice stores each logical record family in its own table with indexed metadata columns plus a serialized contract payload. Backends must preserve the same semantics as the in-memory contract tests while later slices harden service-graph wiring.
 
 ---
 

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -44,4 +44,4 @@ Product adapters must continue to use `TurnCoordinator`. Runner transition APIs 
 
 ## 5. Deferred work
 
-This slice defines the core lease/recovery state machine in `ironclaw_turns`. Concrete PostgreSQL/libSQL adapters, AgentLoopHost/AgentLoopDriver integration, side-effect boundary checkpoint cadence inside the loop, and safe explicit retry/fork UX remain follow-up slices.
+The current `ironclaw_turns` slices define the core lease/recovery state machine and initial PostgreSQL/libSQL persistence adapters. AgentLoopHost/AgentLoopDriver integration, side-effect boundary checkpoint cadence inside the loop, production service-graph wiring, and safe explicit retry/fork UX remain follow-up slices.


### PR DESCRIPTION
## Summary
- add libSQL and PostgreSQL feature-gated TurnStateStore adapters for ironclaw_turns
- persist logical turn record families with transaction-held load/mutate/save semantics
- add DB contract tests for libSQL persistence, concurrent submit serialization, PostgreSQL env-backed caller path, and adapter trait availability
- update Reborn turn persistence/runner docs for the initial DB adapter slice

## Verification
- CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --all-features --test db_turn_state_store_contract
- CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --test turn_coordinator_contract
- CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --lib
- CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo clippy -p ironclaw_turns --all-targets --all-features
- bash scripts/pre-commit-safety.sh
- git diff --check