### PR TITLE
feat(turns): add loop exit handshake contract

### DIFF
--- a/crates/ironclaw_turns/src/ids.rs
+++ b/crates/ironclaw_turns/src/ids.rs
@@ -158,6 +158,11 @@ bounded_ref!(GateRef, "gate_ref");
 bounded_ref!(IdempotencyKey, "idempotency_key");
 bounded_ref!(RunProfileRequest, "run_profile_request");
 bounded_ref!(RunProfileId, "run_profile_id");
+bounded_ref!(LoopExitId, "loop_exit_id");
+bounded_ref!(LoopMessageRef, "loop_message_ref");
+bounded_ref!(LoopResultRef, "loop_result_ref");
+bounded_ref!(LoopUsageSummaryRef, "loop_usage_summary_ref");
+bounded_ref!(LoopDiagnosticRef, "loop_diagnostic_ref");
 
 impl RunProfileId {
     pub fn default_profile() -> Self {

--- a/crates/ironclaw_turns/src/ids.rs
+++ b/crates/ironclaw_turns/src/ids.rs
@@ -151,6 +151,44 @@ macro_rules! bounded_ref {
     };
 }
 
+macro_rules! loop_ref {
+    ($name:ident, $kind:literal, $prefix:literal) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, String> {
+                let value = value.into();
+                validate_loop_ref($kind, $prefix, &value)?;
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
 bounded_ref!(AcceptedMessageRef, "accepted_message_ref");
 bounded_ref!(SourceBindingRef, "source_binding_ref");
 bounded_ref!(ReplyTargetBindingRef, "reply_target_binding_ref");
@@ -158,11 +196,12 @@ bounded_ref!(GateRef, "gate_ref");
 bounded_ref!(IdempotencyKey, "idempotency_key");
 bounded_ref!(RunProfileRequest, "run_profile_request");
 bounded_ref!(RunProfileId, "run_profile_id");
-bounded_ref!(LoopExitId, "loop_exit_id");
-bounded_ref!(LoopMessageRef, "loop_message_ref");
-bounded_ref!(LoopResultRef, "loop_result_ref");
-bounded_ref!(LoopUsageSummaryRef, "loop_usage_summary_ref");
-bounded_ref!(LoopDiagnosticRef, "loop_diagnostic_ref");
+loop_ref!(LoopExitId, "loop_exit_id", "exit:");
+loop_ref!(LoopMessageRef, "loop_message_ref", "msg:");
+loop_ref!(LoopResultRef, "loop_result_ref", "result:");
+loop_ref!(LoopGateRef, "loop_gate_ref", "gate:");
+loop_ref!(LoopUsageSummaryRef, "loop_usage_summary_ref", "usage:");
+loop_ref!(LoopDiagnosticRef, "loop_diagnostic_ref", "diag:");
 
 impl RunProfileId {
     pub fn default_profile() -> Self {
@@ -197,6 +236,25 @@ fn validate_ref(kind: &'static str, value: &str) -> Result<(), String> {
     }
     if value.chars().any(|c| c == '\0' || c.is_control()) {
         return Err(format!("{kind} must not contain control characters"));
+    }
+    Ok(())
+}
+
+fn validate_loop_ref(kind: &'static str, prefix: &'static str, value: &str) -> Result<(), String> {
+    validate_ref(kind, value)?;
+    let Some(suffix) = value.strip_prefix(prefix) else {
+        return Err(format!("{kind} must start with {prefix}"));
+    };
+    if suffix.is_empty() {
+        return Err(format!("{kind} must include an opaque id after {prefix}"));
+    }
+    if !suffix
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+    {
+        return Err(format!(
+            "{kind} opaque id must contain only ASCII letters, digits, _, -, or ."
+        ));
     }
     Ok(())
 }

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -28,10 +28,10 @@ pub use db::LibSqlTurnStateStore;
 pub use db::PostgresTurnStateStore;
 pub use events::{InMemoryTurnEventSink, TurnEventKind, TurnEventSink, TurnLifecycleEvent};
 pub use ids::{
-    AcceptedMessageRef, GateRef, IdempotencyKey, LoopDiagnosticRef, LoopExitId, LoopMessageRef,
-    LoopResultRef, LoopUsageSummaryRef, ReplyTargetBindingRef, RunProfileId, RunProfileRequest,
-    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId, TurnLeaseToken, TurnRunId,
-    TurnRunnerId,
+    AcceptedMessageRef, GateRef, IdempotencyKey, LoopDiagnosticRef, LoopExitId, LoopGateRef,
+    LoopMessageRef, LoopResultRef, LoopUsageSummaryRef, ReplyTargetBindingRef, RunProfileId,
+    RunProfileRequest, RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId,
+    TurnLeaseToken, TurnRunId, TurnRunnerId,
 };
 pub use loop_exit::{
     LoopBlocked, LoopBlockedKind, LoopCancelled, LoopCancelledReasonKind, LoopCompleted,

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -10,6 +10,7 @@ pub mod coordinator;
 pub mod db;
 pub mod events;
 pub mod ids;
+pub mod loop_exit;
 pub mod memory;
 pub mod request;
 pub mod response;
@@ -27,9 +28,16 @@ pub use db::LibSqlTurnStateStore;
 pub use db::PostgresTurnStateStore;
 pub use events::{InMemoryTurnEventSink, TurnEventKind, TurnEventSink, TurnLifecycleEvent};
 pub use ids::{
-    AcceptedMessageRef, GateRef, IdempotencyKey, ReplyTargetBindingRef, RunProfileId,
-    RunProfileRequest, RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId,
-    TurnLeaseToken, TurnRunId, TurnRunnerId,
+    AcceptedMessageRef, GateRef, IdempotencyKey, LoopDiagnosticRef, LoopExitId, LoopMessageRef,
+    LoopResultRef, LoopUsageSummaryRef, ReplyTargetBindingRef, RunProfileId, RunProfileRequest,
+    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId, TurnLeaseToken, TurnRunId,
+    TurnRunnerId,
+};
+pub use loop_exit::{
+    LoopBlocked, LoopBlockedKind, LoopCancelled, LoopCancelledReasonKind, LoopCompleted,
+    LoopCompletionKind, LoopExit, LoopExitInvalidHandling, LoopExitMapping,
+    LoopExitValidationDecision, LoopExitValidationPolicy, LoopExitViolation, LoopExitViolationKind,
+    LoopFailed, LoopFailureKind,
 };
 pub use memory::{InMemoryTurnStateStore, InMemoryTurnStateStoreLimits};
 pub use request::{

--- a/crates/ironclaw_turns/src/loop_exit.rs
+++ b/crates/ironclaw_turns/src/loop_exit.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    BlockedReason, GateRef, LoopDiagnosticRef, LoopExitId, LoopMessageRef, LoopResultRef,
-    LoopUsageSummaryRef, SanitizedFailure, TurnCheckpointId, runner::TurnRunnerOutcome,
+    BlockedReason, GateRef, LoopDiagnosticRef, LoopExitId, LoopGateRef, LoopMessageRef,
+    LoopResultRef, LoopUsageSummaryRef, SanitizedFailure, TurnCheckpointId,
+    runner::TurnRunnerOutcome,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -28,12 +29,26 @@ impl LoopExit {
         let exit_id = self.exit_id().clone();
         match self {
             Self::Completed(exit) => validate_completed_exit(exit_id, exit, policy),
-            Self::Blocked(exit) => LoopExitValidationDecision::trusted(
+            Self::Blocked(exit) if policy.blocked_evidence_verified => {
+                match exit.kind.to_blocked_reason(exit.gate_ref) {
+                    Ok(reason) => LoopExitValidationDecision::trusted(
+                        exit_id,
+                        TurnRunnerOutcome::Blocked {
+                            checkpoint_id: exit.checkpoint_id,
+                            reason,
+                        },
+                    ),
+                    Err(()) => invalid_exit_decision(
+                        exit_id,
+                        LoopExitViolationKind::UnverifiedBlockedEvidence,
+                        policy.invalid_handling,
+                    ),
+                }
+            }
+            Self::Blocked(_exit) => invalid_exit_decision(
                 exit_id,
-                TurnRunnerOutcome::Blocked {
-                    checkpoint_id: exit.checkpoint_id,
-                    reason: exit.kind.to_blocked_reason(exit.gate_ref),
-                },
+                LoopExitViolationKind::UnverifiedBlockedEvidence,
+                policy.invalid_handling,
             ),
             Self::Cancelled(_exit) if policy.host_cancellation_observed => {
                 LoopExitValidationDecision::trusted(exit_id, TurnRunnerOutcome::Cancelled)
@@ -102,7 +117,7 @@ pub enum LoopCompletionKind {
 #[serde(deny_unknown_fields)]
 pub struct LoopBlocked {
     pub kind: LoopBlockedKind,
-    pub gate_ref: GateRef,
+    pub gate_ref: LoopGateRef,
     pub checkpoint_id: TurnCheckpointId,
     pub exit_id: LoopExitId,
 }
@@ -116,12 +131,13 @@ pub enum LoopBlockedKind {
 }
 
 impl LoopBlockedKind {
-    fn to_blocked_reason(self, gate_ref: GateRef) -> BlockedReason {
-        match self {
+    fn to_blocked_reason(self, gate_ref: LoopGateRef) -> Result<BlockedReason, ()> {
+        let gate_ref = GateRef::new(gate_ref.as_str()).map_err(|_| ())?;
+        Ok(match self {
             Self::Approval => BlockedReason::Approval { gate_ref },
             Self::Auth => BlockedReason::Auth { gate_ref },
             Self::Resource => BlockedReason::Resource { gate_ref },
-        }
+        })
     }
 }
 
@@ -194,6 +210,8 @@ pub struct LoopExitValidationPolicy {
     pub require_final_checkpoint: bool,
     pub host_cancellation_observed: bool,
     pub invalid_handling: LoopExitInvalidHandling,
+    pub completion_refs_verified: bool,
+    pub blocked_evidence_verified: bool,
 }
 
 impl Default for LoopExitValidationPolicy {
@@ -202,6 +220,8 @@ impl Default for LoopExitValidationPolicy {
             require_final_checkpoint: false,
             host_cancellation_observed: false,
             invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+            completion_refs_verified: false,
+            blocked_evidence_verified: false,
         }
     }
 }
@@ -257,7 +277,9 @@ impl LoopExitViolation {
 #[serde(rename_all = "snake_case")]
 pub enum LoopExitViolationKind {
     MissingCompletionReference,
+    UnverifiedCompletionReference,
     MissingFinalCheckpoint,
+    UnverifiedBlockedEvidence,
     CancellationNotObserved,
 }
 
@@ -265,7 +287,9 @@ impl LoopExitViolationKind {
     fn category(self) -> &'static str {
         match self {
             Self::MissingCompletionReference => "missing_completion_reference",
+            Self::UnverifiedCompletionReference => "unverified_completion_reference",
             Self::MissingFinalCheckpoint => "missing_final_checkpoint",
+            Self::UnverifiedBlockedEvidence => "unverified_blocked_evidence",
             Self::CancellationNotObserved => "cancellation_not_observed",
         }
     }
@@ -273,9 +297,10 @@ impl LoopExitViolationKind {
     fn failure_category(self) -> &'static str {
         match self {
             Self::CancellationNotObserved => "interrupted_unexpectedly",
-            Self::MissingCompletionReference | Self::MissingFinalCheckpoint => {
-                "driver_protocol_violation"
-            }
+            Self::MissingCompletionReference
+            | Self::UnverifiedCompletionReference
+            | Self::MissingFinalCheckpoint
+            | Self::UnverifiedBlockedEvidence => "driver_protocol_violation",
         }
     }
 }
@@ -289,6 +314,14 @@ fn validate_completed_exit(
         return invalid_exit_decision(
             exit_id,
             LoopExitViolationKind::MissingCompletionReference,
+            policy.invalid_handling,
+        );
+    }
+
+    if !policy.completion_refs_verified {
+        return invalid_exit_decision(
+            exit_id,
+            LoopExitViolationKind::UnverifiedCompletionReference,
             policy.invalid_handling,
         );
     }

--- a/crates/ironclaw_turns/src/loop_exit.rs
+++ b/crates/ironclaw_turns/src/loop_exit.rs
@@ -1,4 +1,6 @@
-use serde::{Deserialize, Serialize};
+use std::{collections::HashSet, hash::Hash};
+
+use serde::{Deserialize, Serialize, de};
 
 use crate::{
     BlockedReason, GateRef, LoopDiagnosticRef, LoopExitId, LoopGateRef, LoopMessageRef,
@@ -58,11 +60,18 @@ impl LoopExit {
                 LoopExitViolationKind::CancellationNotObserved,
                 policy.invalid_handling,
             ),
-            Self::Failed(exit) => LoopExitValidationDecision::trusted(
+            Self::Failed(exit) if policy.failure_evidence_verified => {
+                LoopExitValidationDecision::trusted(
+                    exit_id,
+                    TurnRunnerOutcome::Failed {
+                        failure: exit.reason_kind.to_sanitized_failure(),
+                    },
+                )
+            }
+            Self::Failed(_exit) => invalid_exit_decision(
                 exit_id,
-                TurnRunnerOutcome::Failed {
-                    failure: exit.reason_kind.to_sanitized_failure(),
-                },
+                LoopExitViolationKind::UnverifiedFailureEvidence,
+                policy.invalid_handling,
             ),
         }
     }
@@ -91,7 +100,9 @@ impl LoopExit {
 #[serde(deny_unknown_fields)]
 pub struct LoopCompleted {
     pub completion_kind: LoopCompletionKind,
+    #[serde(deserialize_with = "deserialize_bounded_unique_refs")]
     pub reply_message_refs: Vec<LoopMessageRef>,
+    #[serde(deserialize_with = "deserialize_bounded_unique_refs")]
     pub result_refs: Vec<LoopResultRef>,
     pub final_checkpoint_id: Option<TurnCheckpointId>,
     pub usage_summary_ref: Option<LoopUsageSummaryRef>,
@@ -146,6 +157,7 @@ impl LoopBlockedKind {
 pub struct LoopCancelled {
     pub reason_kind: LoopCancelledReasonKind,
     pub checkpoint_id: Option<TurnCheckpointId>,
+    #[serde(deserialize_with = "deserialize_bounded_unique_refs")]
     pub interrupted_message_refs: Vec<LoopMessageRef>,
     pub exit_id: LoopExitId,
 }
@@ -212,6 +224,7 @@ pub struct LoopExitValidationPolicy {
     pub invalid_handling: LoopExitInvalidHandling,
     pub completion_refs_verified: bool,
     pub blocked_evidence_verified: bool,
+    pub failure_evidence_verified: bool,
 }
 
 impl Default for LoopExitValidationPolicy {
@@ -222,6 +235,7 @@ impl Default for LoopExitValidationPolicy {
             invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
             completion_refs_verified: false,
             blocked_evidence_verified: false,
+            failure_evidence_verified: false,
         }
     }
 }
@@ -280,6 +294,7 @@ pub enum LoopExitViolationKind {
     UnverifiedCompletionReference,
     MissingFinalCheckpoint,
     UnverifiedBlockedEvidence,
+    UnverifiedFailureEvidence,
     CancellationNotObserved,
 }
 
@@ -290,6 +305,7 @@ impl LoopExitViolationKind {
             Self::UnverifiedCompletionReference => "unverified_completion_reference",
             Self::MissingFinalCheckpoint => "missing_final_checkpoint",
             Self::UnverifiedBlockedEvidence => "unverified_blocked_evidence",
+            Self::UnverifiedFailureEvidence => "unverified_failure_evidence",
             Self::CancellationNotObserved => "cancellation_not_observed",
         }
     }
@@ -300,9 +316,35 @@ impl LoopExitViolationKind {
             Self::MissingCompletionReference
             | Self::UnverifiedCompletionReference
             | Self::MissingFinalCheckpoint
-            | Self::UnverifiedBlockedEvidence => "driver_protocol_violation",
+            | Self::UnverifiedBlockedEvidence
+            | Self::UnverifiedFailureEvidence => "driver_protocol_violation",
         }
     }
+}
+
+const MAX_LOOP_EXIT_REF_COUNT: usize = 64;
+
+fn deserialize_bounded_unique_refs<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de> + Eq + Hash,
+{
+    let values = Vec::<T>::deserialize(deserializer)?;
+    if values.len() > MAX_LOOP_EXIT_REF_COUNT {
+        return Err(de::Error::custom(format!(
+            "loop exit ref list must contain at most {MAX_LOOP_EXIT_REF_COUNT} entries"
+        )));
+    }
+
+    let mut seen = HashSet::with_capacity(values.len());
+    for value in &values {
+        if !seen.insert(value) {
+            return Err(de::Error::custom(
+                "loop exit ref list must not contain duplicates",
+            ));
+        }
+    }
+    Ok(values)
 }
 
 fn validate_completed_exit(

--- a/crates/ironclaw_turns/src/loop_exit.rs
+++ b/crates/ironclaw_turns/src/loop_exit.rs
@@ -1,0 +1,323 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BlockedReason, GateRef, LoopDiagnosticRef, LoopExitId, LoopMessageRef, LoopResultRef,
+    LoopUsageSummaryRef, SanitizedFailure, TurnCheckpointId, runner::TurnRunnerOutcome,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopExit {
+    Completed(LoopCompleted),
+    Blocked(LoopBlocked),
+    Cancelled(LoopCancelled),
+    Failed(LoopFailed),
+}
+
+impl LoopExit {
+    pub fn exit_id(&self) -> &LoopExitId {
+        match self {
+            Self::Completed(exit) => &exit.exit_id,
+            Self::Blocked(exit) => &exit.exit_id,
+            Self::Cancelled(exit) => &exit.exit_id,
+            Self::Failed(exit) => &exit.exit_id,
+        }
+    }
+
+    pub fn validate(self, policy: LoopExitValidationPolicy) -> LoopExitValidationDecision {
+        let exit_id = self.exit_id().clone();
+        match self {
+            Self::Completed(exit) => validate_completed_exit(exit_id, exit, policy),
+            Self::Blocked(exit) => LoopExitValidationDecision::trusted(
+                exit_id,
+                TurnRunnerOutcome::Blocked {
+                    checkpoint_id: exit.checkpoint_id,
+                    reason: exit.kind.to_blocked_reason(exit.gate_ref),
+                },
+            ),
+            Self::Cancelled(_exit) if policy.host_cancellation_observed => {
+                LoopExitValidationDecision::trusted(exit_id, TurnRunnerOutcome::Cancelled)
+            }
+            Self::Cancelled(_exit) => invalid_exit_decision(
+                exit_id,
+                LoopExitViolationKind::CancellationNotObserved,
+                policy.invalid_handling,
+            ),
+            Self::Failed(exit) => LoopExitValidationDecision::trusted(
+                exit_id,
+                TurnRunnerOutcome::Failed {
+                    failure: exit.reason_kind.to_sanitized_failure(),
+                },
+            ),
+        }
+    }
+
+    pub fn cancelled_for_observed_interrupt(exit_id: LoopExitId) -> Self {
+        Self::Cancelled(LoopCancelled {
+            reason_kind: LoopCancelledReasonKind::HostInterrupt,
+            checkpoint_id: None,
+            interrupted_message_refs: Vec::new(),
+            exit_id,
+        })
+    }
+
+    pub fn failed(reason_kind: LoopFailureKind, exit_id: LoopExitId) -> Self {
+        Self::Failed(LoopFailed {
+            reason_kind,
+            checkpoint_id: None,
+            usage_summary_ref: None,
+            diagnostic_ref: None,
+            exit_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoopCompleted {
+    pub completion_kind: LoopCompletionKind,
+    pub reply_message_refs: Vec<LoopMessageRef>,
+    pub result_refs: Vec<LoopResultRef>,
+    pub final_checkpoint_id: Option<TurnCheckpointId>,
+    pub usage_summary_ref: Option<LoopUsageSummaryRef>,
+    pub exit_id: LoopExitId,
+}
+
+impl LoopCompleted {
+    fn has_durable_completion_ref(&self) -> bool {
+        !self.reply_message_refs.is_empty() || !self.result_refs.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopCompletionKind {
+    FinalReply,
+    AskUserReply,
+    NoReply,
+    DelegatedResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoopBlocked {
+    pub kind: LoopBlockedKind,
+    pub gate_ref: GateRef,
+    pub checkpoint_id: TurnCheckpointId,
+    pub exit_id: LoopExitId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopBlockedKind {
+    Approval,
+    Auth,
+    Resource,
+}
+
+impl LoopBlockedKind {
+    fn to_blocked_reason(self, gate_ref: GateRef) -> BlockedReason {
+        match self {
+            Self::Approval => BlockedReason::Approval { gate_ref },
+            Self::Auth => BlockedReason::Auth { gate_ref },
+            Self::Resource => BlockedReason::Resource { gate_ref },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoopCancelled {
+    pub reason_kind: LoopCancelledReasonKind,
+    pub checkpoint_id: Option<TurnCheckpointId>,
+    pub interrupted_message_refs: Vec<LoopMessageRef>,
+    pub exit_id: LoopExitId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopCancelledReasonKind {
+    HostCancellation,
+    HostInterrupt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoopFailed {
+    pub reason_kind: LoopFailureKind,
+    pub checkpoint_id: Option<TurnCheckpointId>,
+    pub usage_summary_ref: Option<LoopUsageSummaryRef>,
+    pub diagnostic_ref: Option<LoopDiagnosticRef>,
+    pub exit_id: LoopExitId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopFailureKind {
+    ModelError,
+    ContextBuildFailed,
+    CapabilityProtocolError,
+    IterationLimit,
+    InvalidModelOutput,
+    CheckpointRejected,
+    TranscriptWriteFailed,
+    DriverBug,
+    InterruptedUnexpectedly,
+}
+
+impl LoopFailureKind {
+    fn to_sanitized_failure(self) -> SanitizedFailure {
+        SanitizedFailure::from_trusted_static(match self {
+            Self::ModelError => "model_error",
+            Self::ContextBuildFailed => "context_build_failed",
+            Self::CapabilityProtocolError => "capability_protocol_error",
+            Self::IterationLimit => "iteration_limit",
+            Self::InvalidModelOutput => "invalid_model_output",
+            Self::CheckpointRejected => "checkpoint_rejected",
+            Self::TranscriptWriteFailed => "transcript_write_failed",
+            Self::DriverBug => "driver_bug",
+            Self::InterruptedUnexpectedly => "interrupted_unexpectedly",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopExitInvalidHandling {
+    FailTerminal,
+    RecoveryRequired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoopExitValidationPolicy {
+    pub require_final_checkpoint: bool,
+    pub host_cancellation_observed: bool,
+    pub invalid_handling: LoopExitInvalidHandling,
+}
+
+impl Default for LoopExitValidationPolicy {
+    fn default() -> Self {
+        Self {
+            require_final_checkpoint: false,
+            host_cancellation_observed: false,
+            invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoopExitValidationDecision {
+    pub exit_id: LoopExitId,
+    pub mapping: LoopExitMapping,
+    pub violation: Option<LoopExitViolation>,
+}
+
+impl LoopExitValidationDecision {
+    fn trusted(exit_id: LoopExitId, outcome: TurnRunnerOutcome) -> Self {
+        Self {
+            exit_id,
+            mapping: outcome.into(),
+            violation: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopExitMapping {
+    RunnerOutcome(TurnRunnerOutcome),
+    RecoveryRequired { failure: SanitizedFailure },
+}
+
+impl From<TurnRunnerOutcome> for LoopExitMapping {
+    fn from(outcome: TurnRunnerOutcome) -> Self {
+        Self::RunnerOutcome(outcome)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LoopExitViolation {
+    kind: LoopExitViolationKind,
+}
+
+impl LoopExitViolation {
+    pub fn kind(&self) -> LoopExitViolationKind {
+        self.kind
+    }
+
+    pub fn category(&self) -> &'static str {
+        self.kind.category()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopExitViolationKind {
+    MissingCompletionReference,
+    MissingFinalCheckpoint,
+    CancellationNotObserved,
+}
+
+impl LoopExitViolationKind {
+    fn category(self) -> &'static str {
+        match self {
+            Self::MissingCompletionReference => "missing_completion_reference",
+            Self::MissingFinalCheckpoint => "missing_final_checkpoint",
+            Self::CancellationNotObserved => "cancellation_not_observed",
+        }
+    }
+
+    fn failure_category(self) -> &'static str {
+        match self {
+            Self::CancellationNotObserved => "interrupted_unexpectedly",
+            Self::MissingCompletionReference | Self::MissingFinalCheckpoint => {
+                "driver_protocol_violation"
+            }
+        }
+    }
+}
+
+fn validate_completed_exit(
+    exit_id: LoopExitId,
+    exit: LoopCompleted,
+    policy: LoopExitValidationPolicy,
+) -> LoopExitValidationDecision {
+    if !exit.has_durable_completion_ref() {
+        return invalid_exit_decision(
+            exit_id,
+            LoopExitViolationKind::MissingCompletionReference,
+            policy.invalid_handling,
+        );
+    }
+
+    if policy.require_final_checkpoint && exit.final_checkpoint_id.is_none() {
+        return invalid_exit_decision(
+            exit_id,
+            LoopExitViolationKind::MissingFinalCheckpoint,
+            policy.invalid_handling,
+        );
+    }
+
+    LoopExitValidationDecision::trusted(exit_id, TurnRunnerOutcome::Completed)
+}
+
+fn invalid_exit_decision(
+    exit_id: LoopExitId,
+    kind: LoopExitViolationKind,
+    handling: LoopExitInvalidHandling,
+) -> LoopExitValidationDecision {
+    let failure = SanitizedFailure::from_trusted_static(kind.failure_category());
+    let mapping = match handling {
+        LoopExitInvalidHandling::FailTerminal => TurnRunnerOutcome::Failed { failure }.into(),
+        LoopExitInvalidHandling::RecoveryRequired => LoopExitMapping::RecoveryRequired { failure },
+    };
+
+    LoopExitValidationDecision {
+        exit_id,
+        mapping,
+        violation: Some(LoopExitViolation { kind }),
+    }
+}

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -87,6 +87,13 @@ impl SanitizedFailure {
         Ok(Self { category })
     }
 
+    pub(crate) fn from_trusted_static(category: &'static str) -> Self {
+        debug_assert!(validate_sanitized_category("failure_category", category).is_ok());
+        Self {
+            category: category.to_string(),
+        }
+    }
+
     pub fn category(&self) -> &str {
         &self.category
     }

--- a/crates/ironclaw_turns/tests/loop_exit_contract.rs
+++ b/crates/ironclaw_turns/tests/loop_exit_contract.rs
@@ -1,17 +1,17 @@
 use ironclaw_turns::{
     BlockedReason, GateRef, LoopBlocked, LoopBlockedKind, LoopCompleted, LoopCompletionKind,
     LoopExit, LoopExitId, LoopExitInvalidHandling, LoopExitValidationDecision,
-    LoopExitValidationPolicy, LoopFailureKind, LoopMessageRef, LoopResultRef, SanitizedFailure,
-    TurnCheckpointId, runner::TurnRunnerOutcome,
+    LoopExitValidationPolicy, LoopFailureKind, LoopGateRef, LoopMessageRef, LoopResultRef,
+    SanitizedFailure, TurnCheckpointId, runner::TurnRunnerOutcome,
 };
 use serde_json::json;
 
 #[test]
 fn completed_ask_user_exit_maps_to_trusted_completed_outcome_without_final_checkpoint() {
-    let exit_id = exit_id("exit-completed");
+    let exit_id = exit_id("exit:completed");
     let decision = LoopExit::Completed(LoopCompleted {
         completion_kind: LoopCompletionKind::AskUserReply,
-        reply_message_refs: vec![message_ref("assistant-question")],
+        reply_message_refs: vec![message_ref("msg:assistant-question")],
         result_refs: vec![],
         final_checkpoint_id: None,
         usage_summary_ref: None,
@@ -21,6 +21,8 @@ fn completed_ask_user_exit_maps_to_trusted_completed_outcome_without_final_check
         require_final_checkpoint: false,
         host_cancellation_observed: false,
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
+        completion_refs_verified: true,
+        blocked_evidence_verified: false,
     });
 
     assert_eq!(decision.exit_id, exit_id);
@@ -36,13 +38,15 @@ fn completed_exit_without_durable_refs_maps_to_protocol_failure_or_recovery() {
         result_refs: vec![],
         final_checkpoint_id: None,
         usage_summary_ref: None,
-        exit_id: exit_id("exit-missing-refs"),
+        exit_id: exit_id("exit:missing-refs"),
     });
 
     let safe_decision = exit.clone().validate(LoopExitValidationPolicy {
         require_final_checkpoint: false,
         host_cancellation_observed: false,
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
+        completion_refs_verified: true,
+        blocked_evidence_verified: false,
     });
     assert_eq!(
         safe_decision.mapping,
@@ -60,6 +64,8 @@ fn completed_exit_without_durable_refs_maps_to_protocol_failure_or_recovery() {
         require_final_checkpoint: false,
         host_cancellation_observed: false,
         invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+        completion_refs_verified: true,
+        blocked_evidence_verified: false,
     });
     assert!(matches!(
         uncertain_decision,
@@ -71,19 +77,50 @@ fn completed_exit_without_durable_refs_maps_to_protocol_failure_or_recovery() {
 }
 
 #[test]
-fn final_checkpoint_policy_rejects_terminal_exit_without_checkpoint() {
-    let decision = LoopExit::Completed(LoopCompleted {
+fn completed_exit_requires_host_verified_completion_refs_before_trusted_mapping() {
+    let exit = LoopExit::Completed(LoopCompleted {
         completion_kind: LoopCompletionKind::FinalReply,
-        reply_message_refs: vec![message_ref("assistant-final")],
+        reply_message_refs: vec![message_ref("msg:assistant-final")],
         result_refs: vec![],
         final_checkpoint_id: None,
         usage_summary_ref: None,
-        exit_id: exit_id("exit-no-final-checkpoint"),
+        exit_id: exit_id("exit:unverified-completion"),
+    });
+
+    let decision = exit.validate(LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+        completion_refs_verified: false,
+        blocked_evidence_verified: false,
+    });
+
+    assert_eq!(
+        decision.violation.unwrap().category(),
+        "unverified_completion_reference"
+    );
+    assert!(matches!(
+        decision.mapping,
+        ironclaw_turns::LoopExitMapping::RecoveryRequired { .. }
+    ));
+}
+
+#[test]
+fn final_checkpoint_policy_rejects_terminal_exit_without_checkpoint() {
+    let decision = LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::FinalReply,
+        reply_message_refs: vec![message_ref("msg:assistant-final")],
+        result_refs: vec![],
+        final_checkpoint_id: None,
+        usage_summary_ref: None,
+        exit_id: exit_id("exit:no-final-checkpoint"),
     })
     .validate(LoopExitValidationPolicy {
         require_final_checkpoint: true,
         host_cancellation_observed: false,
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
+        completion_refs_verified: true,
+        blocked_evidence_verified: false,
     });
 
     assert_eq!(
@@ -100,16 +137,23 @@ fn final_checkpoint_policy_rejects_terminal_exit_without_checkpoint() {
 }
 
 #[test]
-fn blocked_exit_maps_to_block_run_outcome_with_checkpoint_and_gate_ref() {
+fn blocked_exit_maps_to_block_run_outcome_with_verified_checkpoint_and_gate_ref() {
     let checkpoint_id = TurnCheckpointId::new();
-    let gate_ref = GateRef::new("approval-gate").unwrap();
+    let loop_gate_ref = loop_gate_ref("gate:approval-gate");
+    let gate_ref = GateRef::new(loop_gate_ref.as_str()).unwrap();
     let decision = LoopExit::Blocked(LoopBlocked {
         kind: LoopBlockedKind::Approval,
-        gate_ref: gate_ref.clone(),
+        gate_ref: loop_gate_ref,
         checkpoint_id,
-        exit_id: exit_id("exit-blocked"),
+        exit_id: exit_id("exit:blocked"),
     })
-    .validate(LoopExitValidationPolicy::default());
+    .validate(LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+        completion_refs_verified: false,
+        blocked_evidence_verified: true,
+    });
 
     assert_eq!(decision.violation, None);
     assert_eq!(
@@ -123,13 +167,41 @@ fn blocked_exit_maps_to_block_run_outcome_with_checkpoint_and_gate_ref() {
 }
 
 #[test]
+fn blocked_exit_requires_host_verified_gate_and_checkpoint_before_trusted_mapping() {
+    let decision = LoopExit::Blocked(LoopBlocked {
+        kind: LoopBlockedKind::Approval,
+        gate_ref: loop_gate_ref("gate:approval-gate"),
+        checkpoint_id: TurnCheckpointId::new(),
+        exit_id: exit_id("exit:unverified-blocked"),
+    })
+    .validate(LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+        completion_refs_verified: false,
+        blocked_evidence_verified: false,
+    });
+
+    assert_eq!(
+        decision.violation.unwrap().category(),
+        "unverified_blocked_evidence"
+    );
+    assert!(matches!(
+        decision.mapping,
+        ironclaw_turns::LoopExitMapping::RecoveryRequired { .. }
+    ));
+}
+
+#[test]
 fn cancelled_exit_requires_observed_host_cancellation() {
-    let exit = LoopExit::cancelled_for_observed_interrupt(exit_id("exit-cancelled"));
+    let exit = LoopExit::cancelled_for_observed_interrupt(exit_id("exit:cancelled"));
 
     let rejected = exit.clone().validate(LoopExitValidationPolicy {
         require_final_checkpoint: false,
         host_cancellation_observed: false,
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
+        completion_refs_verified: false,
+        blocked_evidence_verified: false,
     });
     assert_eq!(
         rejected.mapping,
@@ -147,6 +219,8 @@ fn cancelled_exit_requires_observed_host_cancellation() {
         require_final_checkpoint: false,
         host_cancellation_observed: true,
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
+        completion_refs_verified: false,
+        blocked_evidence_verified: false,
     });
     assert_eq!(accepted.mapping, TurnRunnerOutcome::Cancelled.into());
     assert_eq!(accepted.violation, None);
@@ -156,7 +230,7 @@ fn cancelled_exit_requires_observed_host_cancellation() {
 fn iteration_limit_failure_maps_to_stable_sanitized_runner_failure() {
     let decision = LoopExit::failed(
         LoopFailureKind::IterationLimit,
-        exit_id("exit-max-iterations"),
+        exit_id("exit:max-iterations"),
     )
     .validate(LoopExitValidationPolicy::default());
 
@@ -174,11 +248,11 @@ fn loop_exit_wire_shape_rejects_raw_payload_fields_and_recovery_required_variant
     let raw_completed = json!({
         "completed": {
             "completion_kind": "final_reply",
-            "reply_message_refs": ["assistant-final"],
+            "reply_message_refs": ["msg:assistant-final"],
             "result_refs": [],
             "final_checkpoint_id": null,
             "usage_summary_ref": null,
-            "exit_id": "exit-raw",
+            "exit_id": "exit:raw",
             "raw_reply_text": "secret prompt-adjacent content"
         }
     });
@@ -187,9 +261,9 @@ fn loop_exit_wire_shape_rejects_raw_payload_fields_and_recovery_required_variant
     let raw_blocked = json!({
         "blocked": {
             "kind": "approval",
-            "gate_ref": "approval-gate",
+            "gate_ref": "gate:approval-gate",
             "checkpoint_id": TurnCheckpointId::new(),
-            "exit_id": "exit-raw-blocked",
+            "exit_id": "exit:raw-blocked",
             "raw_approval_payload": {"tool_input": "secret"}
         }
     });
@@ -198,12 +272,41 @@ fn loop_exit_wire_shape_rejects_raw_payload_fields_and_recovery_required_variant
     assert!(serde_json::from_value::<LoopExit>(json!({"recovery_required": {}})).is_err());
 }
 
+#[test]
+fn loop_refs_reject_raw_payload_like_values_inside_ref_strings() {
+    for raw in [
+        "plain assistant text",
+        "secret prompt-adjacent content",
+        "/tmp/host/path",
+        "Error: provider leaked stack",
+        "tool_input={\"secret\":true}",
+    ] {
+        assert!(
+            LoopMessageRef::new(raw).is_err(),
+            "message ref accepted {raw:?}"
+        );
+        assert!(
+            LoopResultRef::new(raw).is_err(),
+            "result ref accepted {raw:?}"
+        );
+        assert!(LoopGateRef::new(raw).is_err(), "gate ref accepted {raw:?}");
+    }
+
+    assert!(LoopMessageRef::new("msg:assistant-final").is_ok());
+    assert!(LoopResultRef::new("result:delegated-job-1").is_ok());
+    assert!(LoopGateRef::new("gate:approval-gate").is_ok());
+}
+
 fn exit_id(value: &str) -> LoopExitId {
     LoopExitId::new(value).unwrap()
 }
 
 fn message_ref(value: &str) -> LoopMessageRef {
     LoopMessageRef::new(value).unwrap()
+}
+
+fn loop_gate_ref(value: &str) -> LoopGateRef {
+    LoopGateRef::new(value).unwrap()
 }
 
 #[allow(dead_code)]

--- a/crates/ironclaw_turns/tests/loop_exit_contract.rs
+++ b/crates/ironclaw_turns/tests/loop_exit_contract.rs
@@ -1,0 +1,212 @@
+use ironclaw_turns::{
+    BlockedReason, GateRef, LoopBlocked, LoopBlockedKind, LoopCompleted, LoopCompletionKind,
+    LoopExit, LoopExitId, LoopExitInvalidHandling, LoopExitValidationDecision,
+    LoopExitValidationPolicy, LoopFailureKind, LoopMessageRef, LoopResultRef, SanitizedFailure,
+    TurnCheckpointId, runner::TurnRunnerOutcome,
+};
+use serde_json::json;
+
+#[test]
+fn completed_ask_user_exit_maps_to_trusted_completed_outcome_without_final_checkpoint() {
+    let exit_id = exit_id("exit-completed");
+    let decision = LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::AskUserReply,
+        reply_message_refs: vec![message_ref("assistant-question")],
+        result_refs: vec![],
+        final_checkpoint_id: None,
+        usage_summary_ref: None,
+        exit_id: exit_id.clone(),
+    })
+    .validate(LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::FailTerminal,
+    });
+
+    assert_eq!(decision.exit_id, exit_id);
+    assert_eq!(decision.violation, None);
+    assert_eq!(decision.mapping, TurnRunnerOutcome::Completed.into());
+}
+
+#[test]
+fn completed_exit_without_durable_refs_maps_to_protocol_failure_or_recovery() {
+    let exit = LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::FinalReply,
+        reply_message_refs: vec![],
+        result_refs: vec![],
+        final_checkpoint_id: None,
+        usage_summary_ref: None,
+        exit_id: exit_id("exit-missing-refs"),
+    });
+
+    let safe_decision = exit.clone().validate(LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::FailTerminal,
+    });
+    assert_eq!(
+        safe_decision.mapping,
+        TurnRunnerOutcome::Failed {
+            failure: SanitizedFailure::new("driver_protocol_violation").unwrap(),
+        }
+        .into()
+    );
+    assert_eq!(
+        safe_decision.violation.unwrap().category(),
+        "missing_completion_reference"
+    );
+
+    let uncertain_decision = exit.validate(LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+    });
+    assert!(matches!(
+        uncertain_decision,
+        LoopExitValidationDecision {
+            mapping: ironclaw_turns::LoopExitMapping::RecoveryRequired { .. },
+            ..
+        }
+    ));
+}
+
+#[test]
+fn final_checkpoint_policy_rejects_terminal_exit_without_checkpoint() {
+    let decision = LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::FinalReply,
+        reply_message_refs: vec![message_ref("assistant-final")],
+        result_refs: vec![],
+        final_checkpoint_id: None,
+        usage_summary_ref: None,
+        exit_id: exit_id("exit-no-final-checkpoint"),
+    })
+    .validate(LoopExitValidationPolicy {
+        require_final_checkpoint: true,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::FailTerminal,
+    });
+
+    assert_eq!(
+        decision.violation.unwrap().category(),
+        "missing_final_checkpoint"
+    );
+    assert_eq!(
+        decision.mapping,
+        TurnRunnerOutcome::Failed {
+            failure: SanitizedFailure::new("driver_protocol_violation").unwrap(),
+        }
+        .into()
+    );
+}
+
+#[test]
+fn blocked_exit_maps_to_block_run_outcome_with_checkpoint_and_gate_ref() {
+    let checkpoint_id = TurnCheckpointId::new();
+    let gate_ref = GateRef::new("approval-gate").unwrap();
+    let decision = LoopExit::Blocked(LoopBlocked {
+        kind: LoopBlockedKind::Approval,
+        gate_ref: gate_ref.clone(),
+        checkpoint_id,
+        exit_id: exit_id("exit-blocked"),
+    })
+    .validate(LoopExitValidationPolicy::default());
+
+    assert_eq!(decision.violation, None);
+    assert_eq!(
+        decision.mapping,
+        TurnRunnerOutcome::Blocked {
+            checkpoint_id,
+            reason: BlockedReason::Approval { gate_ref },
+        }
+        .into()
+    );
+}
+
+#[test]
+fn cancelled_exit_requires_observed_host_cancellation() {
+    let exit = LoopExit::cancelled_for_observed_interrupt(exit_id("exit-cancelled"));
+
+    let rejected = exit.clone().validate(LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::FailTerminal,
+    });
+    assert_eq!(
+        rejected.mapping,
+        TurnRunnerOutcome::Failed {
+            failure: SanitizedFailure::new("interrupted_unexpectedly").unwrap(),
+        }
+        .into()
+    );
+    assert_eq!(
+        rejected.violation.unwrap().category(),
+        "cancellation_not_observed"
+    );
+
+    let accepted = exit.validate(LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: true,
+        invalid_handling: LoopExitInvalidHandling::FailTerminal,
+    });
+    assert_eq!(accepted.mapping, TurnRunnerOutcome::Cancelled.into());
+    assert_eq!(accepted.violation, None);
+}
+
+#[test]
+fn iteration_limit_failure_maps_to_stable_sanitized_runner_failure() {
+    let decision = LoopExit::failed(
+        LoopFailureKind::IterationLimit,
+        exit_id("exit-max-iterations"),
+    )
+    .validate(LoopExitValidationPolicy::default());
+
+    assert_eq!(
+        decision.mapping,
+        TurnRunnerOutcome::Failed {
+            failure: SanitizedFailure::new("iteration_limit").unwrap(),
+        }
+        .into()
+    );
+}
+
+#[test]
+fn loop_exit_wire_shape_rejects_raw_payload_fields_and_recovery_required_variant() {
+    let raw_completed = json!({
+        "completed": {
+            "completion_kind": "final_reply",
+            "reply_message_refs": ["assistant-final"],
+            "result_refs": [],
+            "final_checkpoint_id": null,
+            "usage_summary_ref": null,
+            "exit_id": "exit-raw",
+            "raw_reply_text": "secret prompt-adjacent content"
+        }
+    });
+    assert!(serde_json::from_value::<LoopExit>(raw_completed).is_err());
+
+    let raw_blocked = json!({
+        "blocked": {
+            "kind": "approval",
+            "gate_ref": "approval-gate",
+            "checkpoint_id": TurnCheckpointId::new(),
+            "exit_id": "exit-raw-blocked",
+            "raw_approval_payload": {"tool_input": "secret"}
+        }
+    });
+    assert!(serde_json::from_value::<LoopExit>(raw_blocked).is_err());
+
+    assert!(serde_json::from_value::<LoopExit>(json!({"recovery_required": {}})).is_err());
+}
+
+fn exit_id(value: &str) -> LoopExitId {
+    LoopExitId::new(value).unwrap()
+}
+
+fn message_ref(value: &str) -> LoopMessageRef {
+    LoopMessageRef::new(value).unwrap()
+}
+
+#[allow(dead_code)]
+fn result_ref(value: &str) -> LoopResultRef {
+    LoopResultRef::new(value).unwrap()
+}

--- a/crates/ironclaw_turns/tests/loop_exit_contract.rs
+++ b/crates/ironclaw_turns/tests/loop_exit_contract.rs
@@ -23,6 +23,7 @@ fn completed_ask_user_exit_maps_to_trusted_completed_outcome_without_final_check
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
         completion_refs_verified: true,
         blocked_evidence_verified: false,
+        failure_evidence_verified: false,
     });
 
     assert_eq!(decision.exit_id, exit_id);
@@ -47,6 +48,7 @@ fn completed_exit_without_durable_refs_maps_to_protocol_failure_or_recovery() {
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
         completion_refs_verified: true,
         blocked_evidence_verified: false,
+        failure_evidence_verified: false,
     });
     assert_eq!(
         safe_decision.mapping,
@@ -66,6 +68,7 @@ fn completed_exit_without_durable_refs_maps_to_protocol_failure_or_recovery() {
         invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
         completion_refs_verified: true,
         blocked_evidence_verified: false,
+        failure_evidence_verified: false,
     });
     assert!(matches!(
         uncertain_decision,
@@ -93,6 +96,7 @@ fn completed_exit_requires_host_verified_completion_refs_before_trusted_mapping(
         invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
         completion_refs_verified: false,
         blocked_evidence_verified: false,
+        failure_evidence_verified: false,
     });
 
     assert_eq!(
@@ -121,6 +125,7 @@ fn final_checkpoint_policy_rejects_terminal_exit_without_checkpoint() {
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
         completion_refs_verified: true,
         blocked_evidence_verified: false,
+        failure_evidence_verified: false,
     });
 
     assert_eq!(
@@ -153,6 +158,7 @@ fn blocked_exit_maps_to_block_run_outcome_with_verified_checkpoint_and_gate_ref(
         invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
         completion_refs_verified: false,
         blocked_evidence_verified: true,
+        failure_evidence_verified: false,
     });
 
     assert_eq!(decision.violation, None);
@@ -180,6 +186,7 @@ fn blocked_exit_requires_host_verified_gate_and_checkpoint_before_trusted_mappin
         invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
         completion_refs_verified: false,
         blocked_evidence_verified: false,
+        failure_evidence_verified: false,
     });
 
     assert_eq!(
@@ -202,6 +209,7 @@ fn cancelled_exit_requires_observed_host_cancellation() {
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
         completion_refs_verified: false,
         blocked_evidence_verified: false,
+        failure_evidence_verified: false,
     });
     assert_eq!(
         rejected.mapping,
@@ -221,18 +229,22 @@ fn cancelled_exit_requires_observed_host_cancellation() {
         invalid_handling: LoopExitInvalidHandling::FailTerminal,
         completion_refs_verified: false,
         blocked_evidence_verified: false,
+        failure_evidence_verified: false,
     });
     assert_eq!(accepted.mapping, TurnRunnerOutcome::Cancelled.into());
     assert_eq!(accepted.violation, None);
 }
 
 #[test]
-fn iteration_limit_failure_maps_to_stable_sanitized_runner_failure() {
+fn iteration_limit_failure_maps_to_stable_sanitized_runner_failure_after_host_verification() {
     let decision = LoopExit::failed(
         LoopFailureKind::IterationLimit,
         exit_id("exit:max-iterations"),
     )
-    .validate(LoopExitValidationPolicy::default());
+    .validate(LoopExitValidationPolicy {
+        failure_evidence_verified: true,
+        ..LoopExitValidationPolicy::default()
+    });
 
     assert_eq!(
         decision.mapping,
@@ -241,6 +253,21 @@ fn iteration_limit_failure_maps_to_stable_sanitized_runner_failure() {
         }
         .into()
     );
+}
+
+#[test]
+fn failed_exit_requires_host_verified_failure_evidence_before_trusted_mapping() {
+    let decision = LoopExit::failed(LoopFailureKind::DriverBug, exit_id("exit:driver-bug"))
+        .validate(LoopExitValidationPolicy::default());
+
+    assert_eq!(
+        decision.violation.unwrap().category(),
+        "unverified_failure_evidence"
+    );
+    assert!(matches!(
+        decision.mapping,
+        ironclaw_turns::LoopExitMapping::RecoveryRequired { .. }
+    ));
 }
 
 #[test]
@@ -270,6 +297,36 @@ fn loop_exit_wire_shape_rejects_raw_payload_fields_and_recovery_required_variant
     assert!(serde_json::from_value::<LoopExit>(raw_blocked).is_err());
 
     assert!(serde_json::from_value::<LoopExit>(json!({"recovery_required": {}})).is_err());
+}
+
+#[test]
+fn loop_exit_rejects_oversized_or_duplicate_ref_vectors() {
+    let oversized_messages = (0..65)
+        .map(|index| format!("msg:item-{index}"))
+        .collect::<Vec<_>>();
+    let raw_completed = json!({
+        "completed": {
+            "completion_kind": "final_reply",
+            "reply_message_refs": oversized_messages,
+            "result_refs": [],
+            "final_checkpoint_id": null,
+            "usage_summary_ref": null,
+            "exit_id": "exit:oversized"
+        }
+    });
+    assert!(serde_json::from_value::<LoopExit>(raw_completed).is_err());
+
+    let duplicate_refs = json!({
+        "completed": {
+            "completion_kind": "final_reply",
+            "reply_message_refs": ["msg:dup", "msg:dup"],
+            "result_refs": [],
+            "final_checkpoint_id": null,
+            "usage_summary_ref": null,
+            "exit_id": "exit:duplicates"
+        }
+    });
+    assert!(serde_json::from_value::<LoopExit>(duplicate_refs).is_err());
 }
 
 #[test]

--- a/docs/reborn/contracts/_contract-freeze-index.md
+++ b/docs/reborn/contracts/_contract-freeze-index.md
@@ -84,6 +84,7 @@ If a task needs to change one of those answers, it is not implementation work; i
 - [`memory.md`](memory.md)
 - [`settings-config.md`](settings-config.md)
 - [`turns-agent-loop.md`](turns-agent-loop.md)
+- [`loop-exit.md`](loop-exit.md)
 - [`turn-persistence.md`](turn-persistence.md)
 - [`turn-runner.md`](turn-runner.md)
 - [`migration-compatibility.md`](migration-compatibility.md)

--- a/docs/reborn/contracts/loop-exit.md
+++ b/docs/reborn/contracts/loop-exit.md
@@ -10,7 +10,7 @@
 
 `LoopExit` is the driver-facing claim returned by an agent-loop attempt after a runner has already claimed a turn run. It is not durable run state and it is not trusted by itself.
 
-`TurnRunner` validates `LoopExit` evidence before translating it to a trusted `TurnRunnerOutcome` or to `RecoveryRequired` when safety cannot be proven.
+`TurnRunner` validates `LoopExit` evidence before translating it to a trusted `TurnRunnerOutcome` or to `RecoveryRequired` when safety cannot be proven. Syntactically valid refs are not evidence by themselves; the host/runner must verify referenced transcript, result, checkpoint, and gate records before trusting an exit.
 
 This prevents unsafe state changes such as releasing the active-thread lock after a driver says `Completed` without durable transcript/result refs, or blocking a run without a durable checkpoint and gate reference.
 
@@ -26,7 +26,7 @@ AgentLoopDriver
   -> TurnStateStore transition
 ```
 
-`LoopExit` contains references only. It must not carry raw prompts, assistant text, tool inputs, approval payloads, secrets, host paths, provider errors, stack traces, or raw runtime output.
+`LoopExit` contains references only. It must not carry raw prompts, assistant text, tool inputs, approval payloads, secrets, host paths, provider errors, stack traces, or raw runtime output. Loop-owned refs use tight host-minted opaque prefixes (`exit:`, `msg:`, `result:`, `gate:`, `usage:`, `diag:`) to avoid accepting free-form payload text as evidence.
 
 ---
 
@@ -47,9 +47,9 @@ The driver-facing variants are fixed for the MVP:
 
 ## 4. Evidence requirements
 
-- `Completed` requires at least one durable reply-message ref or result ref. Raw reply text is rejected by the wire shape.
+- `Completed` requires at least one durable reply-message ref or result ref, and the host/runner must verify those refs exist before mapping to a trusted completed outcome. Raw reply text is rejected by the wire shape and by strict loop-ref grammar.
 - `Completed` requires `final_checkpoint_id` only when the resolved run profile/checkpoint policy requires a terminal checkpoint.
-- `Blocked` requires all of: blocked kind, durable `gate_ref`, and `checkpoint_id`. The blocked kind is limited to approval, auth, and resource for MVP.
+- `Blocked` requires all of: blocked kind, durable `gate_ref`, and `checkpoint_id`, and the host/runner must verify the gate/checkpoint evidence before mapping to a trusted blocked outcome. The blocked kind is limited to approval, auth, and resource for MVP.
 - `Cancelled` is accepted only when the host cancellation/interrupt input was observed by the runner/host policy.
 - `Failed` uses stable sanitized failure kinds such as `iteration_limit`, `model_error`, `context_build_failed`, or `driver_bug`.
 - Usage/cost truth remains in host accounting/projection stores; `LoopExit` may carry only usage-summary refs.
@@ -66,7 +66,9 @@ Validation always produces a redacted decision:
 Initial validation covers:
 
 - completed exits missing durable completion refs;
+- completed exits whose refs have not been verified by host evidence;
 - terminal exits missing a required final checkpoint;
+- blocked exits whose checkpoint/gate evidence has not been verified by host evidence;
 - cancelled exits without observed host cancellation/interrupt.
 
 Later slices may add validation against transcript draft state, checkpoint freshness, event evidence, usage-summary refs, and idempotent exit replay storage.

--- a/docs/reborn/contracts/loop-exit.md
+++ b/docs/reborn/contracts/loop-exit.md
@@ -51,7 +51,8 @@ The driver-facing variants are fixed for the MVP:
 - `Completed` requires `final_checkpoint_id` only when the resolved run profile/checkpoint policy requires a terminal checkpoint.
 - `Blocked` requires all of: blocked kind, durable `gate_ref`, and `checkpoint_id`, and the host/runner must verify the gate/checkpoint evidence before mapping to a trusted blocked outcome. The blocked kind is limited to approval, auth, and resource for MVP.
 - `Cancelled` is accepted only when the host cancellation/interrupt input was observed by the runner/host policy.
-- `Failed` uses stable sanitized failure kinds such as `iteration_limit`, `model_error`, `context_build_failed`, or `driver_bug`.
+- `Failed` uses stable sanitized failure kinds such as `iteration_limit`, `model_error`, `context_build_failed`, or `driver_bug`, and the host/runner must verify the failure evidence is safe to terminalize before mapping to a trusted failed outcome.
+- Ref lists are bounded and duplicate-free so a driver cannot force unbounded evidence verification work.
 - Usage/cost truth remains in host accounting/projection stores; `LoopExit` may carry only usage-summary refs.
 
 ---
@@ -69,6 +70,7 @@ Initial validation covers:
 - completed exits whose refs have not been verified by host evidence;
 - terminal exits missing a required final checkpoint;
 - blocked exits whose checkpoint/gate evidence has not been verified by host evidence;
+- failed exits whose failure evidence has not been verified safe to terminalize by host evidence;
 - cancelled exits without observed host cancellation/interrupt.
 
 Later slices may add validation against transcript draft state, checkpoint freshness, event evidence, usage-summary refs, and idempotent exit replay storage.

--- a/docs/reborn/contracts/loop-exit.md
+++ b/docs/reborn/contracts/loop-exit.md
@@ -1,0 +1,85 @@
+# Reborn Contract — Loop Exit Handshake
+
+**Status:** Contract-freeze draft  
+**Date:** 2026-05-06  
+**Depends on:** [`turn-runner.md`](turn-runner.md), [`turn-persistence.md`](turn-persistence.md), [`turns-agent-loop.md`](turns-agent-loop.md)
+
+---
+
+## 1. Purpose
+
+`LoopExit` is the driver-facing claim returned by an agent-loop attempt after a runner has already claimed a turn run. It is not durable run state and it is not trusted by itself.
+
+`TurnRunner` validates `LoopExit` evidence before translating it to a trusted `TurnRunnerOutcome` or to `RecoveryRequired` when safety cannot be proven.
+
+This prevents unsafe state changes such as releasing the active-thread lock after a driver says `Completed` without durable transcript/result refs, or blocking a run without a durable checkpoint and gate reference.
+
+---
+
+## 2. Boundary
+
+```text
+AgentLoopDriver
+  -> LoopExit claim
+  -> TurnRunner validates evidence/policy
+  -> TurnRunnerOutcome or RecoveryRequired
+  -> TurnStateStore transition
+```
+
+`LoopExit` contains references only. It must not carry raw prompts, assistant text, tool inputs, approval payloads, secrets, host paths, provider errors, stack traces, or raw runtime output.
+
+---
+
+## 3. Exit variants
+
+The driver-facing variants are fixed for the MVP:
+
+| Variant | Meaning | Trusted mapping after validation |
+| --- | --- | --- |
+| `Completed` | Loop reached a terminal user-visible or result-producing boundary. | `TurnRunnerOutcome::Completed` |
+| `Blocked` | Loop stopped at an approval/auth/resource gate with a safe resume checkpoint. | `TurnRunnerOutcome::Blocked` |
+| `Cancelled` | Loop observed a host cancellation/interrupt and stopped safely. | `TurnRunnerOutcome::Cancelled` |
+| `Failed` | Loop stopped because of a stable sanitized failure category. | `TurnRunnerOutcome::Failed` |
+
+`RecoveryRequired` is intentionally not a normal driver return. It is runner/system-derived when validation cannot prove side-effect safety.
+
+---
+
+## 4. Evidence requirements
+
+- `Completed` requires at least one durable reply-message ref or result ref. Raw reply text is rejected by the wire shape.
+- `Completed` requires `final_checkpoint_id` only when the resolved run profile/checkpoint policy requires a terminal checkpoint.
+- `Blocked` requires all of: blocked kind, durable `gate_ref`, and `checkpoint_id`. The blocked kind is limited to approval, auth, and resource for MVP.
+- `Cancelled` is accepted only when the host cancellation/interrupt input was observed by the runner/host policy.
+- `Failed` uses stable sanitized failure kinds such as `iteration_limit`, `model_error`, `context_build_failed`, or `driver_bug`.
+- Usage/cost truth remains in host accounting/projection stores; `LoopExit` may carry only usage-summary refs.
+
+---
+
+## 5. Invalid exit handling
+
+Validation always produces a redacted decision:
+
+- If the invalid exit is safe to terminalize, it maps to `TurnRunnerOutcome::Failed` with a stable sanitized category such as `driver_protocol_violation` or `interrupted_unexpectedly`.
+- If side-effect safety cannot be proven, it maps to `RecoveryRequired`; the active-thread lock must remain held until explicit operator/user resolution.
+
+Initial validation covers:
+
+- completed exits missing durable completion refs;
+- terminal exits missing a required final checkpoint;
+- cancelled exits without observed host cancellation/interrupt.
+
+Later slices may add validation against transcript draft state, checkpoint freshness, event evidence, usage-summary refs, and idempotent exit replay storage.
+
+---
+
+## 6. Implemented slice
+
+`ironclaw_turns` currently provides pure contract types and a deterministic validator:
+
+- `LoopExit`, `LoopCompleted`, `LoopBlocked`, `LoopCancelled`, `LoopFailed`;
+- bounded durable reference types for loop exit/message/result/usage/diagnostic refs;
+- `LoopExitValidationPolicy` and `LoopExitValidationDecision`;
+- one-way mapping to `TurnRunnerOutcome` or `LoopExitMapping::RecoveryRequired`.
+
+This slice deliberately does not wire a production `AgentLoopDriver`, durable exit-id idempotency storage, transcript draft validation, or product service-graph integration.

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -46,8 +46,8 @@ Product adapters must continue to use `TurnCoordinator`. Runner transition APIs 
 
 Agent-loop drivers return `LoopExit` claims. `TurnRunner` validates those claims before applying a trusted outcome:
 
-- valid completed exits map to `TurnRunnerOutcome::Completed`;
-- valid blocked exits require checkpoint + gate refs and map to `TurnRunnerOutcome::Blocked`;
+- valid completed exits require host-verified durable reply/result refs and map to `TurnRunnerOutcome::Completed`;
+- valid blocked exits require host-verified checkpoint + gate refs and map to `TurnRunnerOutcome::Blocked`;
 - valid cancelled exits require observed host cancellation/interrupt and map to `TurnRunnerOutcome::Cancelled`;
 - valid failed exits map stable sanitized failure kinds to `TurnRunnerOutcome::Failed`;
 - invalid exits map either to sanitized terminal failure or runner/system-derived `RecoveryRequired` depending on side-effect safety evidence.

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -2,7 +2,7 @@
 
 **Status:** Contract-freeze draft  
 **Date:** 2026-05-06  
-**Depends on:** [`turn-persistence.md`](turn-persistence.md), [`turns-agent-loop.md`](turns-agent-loop.md), [`runtime-profiles.md`](runtime-profiles.md)
+**Depends on:** [`turn-persistence.md`](turn-persistence.md), [`turns-agent-loop.md`](turns-agent-loop.md), [`loop-exit.md`](loop-exit.md), [`runtime-profiles.md`](runtime-profiles.md)
 
 ---
 
@@ -10,7 +10,7 @@
 
 `TurnRunner` is the trusted worker-side control plane for executable turn runs. It claims queued runs, maintains leases while model/tool work is active, records safe checkpoint/block/terminal transitions, and moves abandoned work to explicit recovery instead of blindly retrying side effects.
 
-Product adapters must continue to use `TurnCoordinator`. Runner transition APIs are trusted-worker APIs and remain under `ironclaw_turns::runner`.
+Product adapters must continue to use `TurnCoordinator`. Runner transition APIs are trusted-worker APIs and remain under `ironclaw_turns::runner`. Driver-facing loop exits remain distinct from trusted runner outcomes; see [`loop-exit.md`](loop-exit.md).
 
 ---
 
@@ -42,6 +42,16 @@ Product adapters must continue to use `TurnCoordinator`. Runner transition APIs 
 
 ---
 
-## 5. Deferred work
+## 5. Loop exit validation
 
-The current `ironclaw_turns` slices define the core lease/recovery state machine and initial PostgreSQL/libSQL persistence adapters. AgentLoopHost/AgentLoopDriver integration, side-effect boundary checkpoint cadence inside the loop, production service-graph wiring, and safe explicit retry/fork UX remain follow-up slices.
+Agent-loop drivers return `LoopExit` claims. `TurnRunner` validates those claims before applying a trusted outcome:
+
+- valid completed exits map to `TurnRunnerOutcome::Completed`;
+- valid blocked exits require checkpoint + gate refs and map to `TurnRunnerOutcome::Blocked`;
+- valid cancelled exits require observed host cancellation/interrupt and map to `TurnRunnerOutcome::Cancelled`;
+- valid failed exits map stable sanitized failure kinds to `TurnRunnerOutcome::Failed`;
+- invalid exits map either to sanitized terminal failure or runner/system-derived `RecoveryRequired` depending on side-effect safety evidence.
+
+## 6. Deferred work
+
+The current `ironclaw_turns` slices define the core lease/recovery state machine, initial PostgreSQL/libSQL persistence adapters, and pure `LoopExit` validation/mapping types. AgentLoopHost/AgentLoopDriver integration, durable exit-id replay storage, transcript draft validation, side-effect boundary checkpoint cadence inside the loop, production service-graph wiring, and safe explicit retry/fork UX remain follow-up slices.

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -49,7 +49,7 @@ Agent-loop drivers return `LoopExit` claims. `TurnRunner` validates those claims
 - valid completed exits require host-verified durable reply/result refs and map to `TurnRunnerOutcome::Completed`;
 - valid blocked exits require host-verified checkpoint + gate refs and map to `TurnRunnerOutcome::Blocked`;
 - valid cancelled exits require observed host cancellation/interrupt and map to `TurnRunnerOutcome::Cancelled`;
-- valid failed exits map stable sanitized failure kinds to `TurnRunnerOutcome::Failed`;
+- valid failed exits require host-verified evidence that the failure is safe to terminalize, then map stable sanitized failure kinds to `TurnRunnerOutcome::Failed`;
 - invalid exits map either to sanitized terminal failure or runner/system-derived `RecoveryRequired` depending on side-effect safety evidence.
 
 ## 6. Deferred work

--- a/docs/reborn/contracts/turns-agent-loop.md
+++ b/docs/reborn/contracts/turns-agent-loop.md
@@ -2,7 +2,7 @@
 
 **Status:** Contract-freeze draft
 **Date:** 2026-04-25
-**Depends on:** [`host-api.md`](host-api.md), [`capabilities.md`](capabilities.md), [`memory.md`](memory.md), [`events-projections.md`](events-projections.md), [`processes.md`](processes.md), [`turn-persistence.md`](turn-persistence.md)
+**Depends on:** [`host-api.md`](host-api.md), [`capabilities.md`](capabilities.md), [`memory.md`](memory.md), [`events-projections.md`](events-projections.md), [`processes.md`](processes.md), [`turn-persistence.md`](turn-persistence.md), [`loop-exit.md`](loop-exit.md)
 
 ---
 
@@ -127,6 +127,7 @@ running -> completed|failed|cancelled
 
 Rules:
 
+- agent-loop drivers report how an attempt stopped with `LoopExit`; validation and trusted outcome mapping follow [`loop-exit.md`](loop-exit.md);
 - runner claim, lease, heartbeat, and expired-lease recovery rules follow [`turn-runner.md`](turn-runner.md);
 - persistence records, active-lock ownership, runner lease fields, checkpoints, and idempotency outcomes follow [`turn-persistence.md`](turn-persistence.md);
 - state transitions are persisted before externally visible side effects where needed for recovery;


### PR DESCRIPTION
## Summary
- Add distinct driver-facing LoopExit contract types and bounded refs in ironclaw_turns.
- Add pure validation/mapping from LoopExit to trusted TurnRunnerOutcome or RecoveryRequired.
- Document the LoopExit handshake and link it from Reborn turn runner/agent-loop contracts.

## Test Plan
- [x] CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --test loop_exit_contract
- [x] CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --all-features --test loop_exit_contract
- [x] CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --test turn_coordinator_contract
- [x] CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --lib
- [x] CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --all-features --test db_turn_state_store_contract
- [x] CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo clippy -p ironclaw_turns --all-targets --all-features
- [x] bash scripts/pre-commit-safety.sh
- [x] cargo fmt --check --package ironclaw_turns
- [x] git diff --check

Closes #3232