### PR TITLE
chore(ci): add hermetic local gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,15 +23,5 @@ if $NEEDS_CHECK; then
     fi
 fi
 
-# i18n parity: when any language pack changes, all languages must stay in sync.
-if echo "$STAGED" | grep -qE '^crates/ironclaw_gateway/static/i18n/.*\.js$'; then
-    echo "pre-commit: checking i18n parity..."
-    if ! ./scripts/check-i18n-parity.sh; then
-        echo ""
-        echo "Commit blocked: i18n parity check failed."
-        echo "Every key added to en.js must also be added to all other language files (zh-CN.js, ko.js, ...)."
-        echo "Placeholder tokens like {name} must match across all languages."
-        echo "To bypass: git commit --no-verify"
-        exit 1
-    fi
-fi
+echo "pre-commit: running staged safety checks..."
+./scripts/pre-commit-safety.sh

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Pre-push hook: runs quality gate before pushing
+# Pre-push hook: runs the hermetic local quality gate before pushing.
 # Skip with: git push --no-verify
+# Skip only the test portions with: IRONCLAW_PREPUSH_TEST=0 git push
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 SCRIPT_DIR="$REPO_ROOT/scripts/ci"
+REMOTE_NAME="${1:-}"
 
-# Default: baseline quality gate
-"$SCRIPT_DIR/quality_gate.sh"
+# Default: Hermes-style hermetic local gate.
+"$SCRIPT_DIR/hermetic_gate.sh"
 
 # Optional strict delta lint (env-gated)
 if [ "${IRONCLAW_STRICT_DELTA_LINT:-0}" = "1" ]; then
-    "$SCRIPT_DIR/delta_lint.sh" "$1"
+    "$SCRIPT_DIR/delta_lint.sh" "$REMOTE_NAME"
 elif [ "${IRONCLAW_STRICT_LINT:-0}" = "1" ]; then
     echo "==> clippy (strict: all warnings)"
     cargo clippy --locked --all-targets -- -D warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,14 +72,14 @@ cargo fmt --all -- --check
 bash scripts/pre-commit-safety.sh
 cargo clippy --locked --all-targets -- -D clippy::correctness
 cargo test --locked --lib
-cargo test --locked --no-default-features --features libsql
 ```
 
 Optional deterministic tiers are available when you want broader local coverage:
 
 ```bash
-IRONCLAW_HERMETIC_REPLAY=1 scripts/ci/hermetic_gate.sh  # replay snapshot tests
-IRONCLAW_HERMETIC_E2E=1 scripts/ci/hermetic_gate.sh     # browser smoke E2E slice
+IRONCLAW_HERMETIC_DUAL_BACKEND=1 scripts/ci/hermetic_gate.sh  # libsql feature matrix
+IRONCLAW_HERMETIC_REPLAY=1 scripts/ci/hermetic_gate.sh        # replay snapshot tests
+IRONCLAW_HERMETIC_E2E=1 scripts/ci/hermetic_gate.sh           # browser smoke E2E slice
 ```
 
 The pre-push hook runs this wrapper by default. You can bypass the whole hook with `git push --no-verify`, or skip only the test portions with `IRONCLAW_PREPUSH_TEST=0 git push` while still keeping fmt, safety checks, and clippy correctness.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,33 @@ cargo test --features integration                            # + PostgreSQL test
 
 These commands are for day-to-day iteration while you are developing locally. The pre-submission checks below are intentionally stricter and use CI-style flags so you can catch formatting drift and clippy warnings before requesting review.
 
+### Hermetic Local Gate
+
+For a Hermes-style local confidence check, use the hermetic wrapper:
+
+```bash
+scripts/ci/hermetic_gate.sh
+```
+
+The wrapper scrubs provider credentials and real database URLs from the environment, uses an isolated temporary `IRONCLAW_BASE_DIR`, forces a temp libSQL database, pins deterministic locale/time settings, and runs the fast local gate:
+
+```bash
+cargo fmt --all -- --check
+bash scripts/pre-commit-safety.sh
+cargo clippy --locked --all-targets -- -D clippy::correctness
+cargo test --locked --lib
+cargo test --locked --no-default-features --features libsql
+```
+
+Optional deterministic tiers are available when you want broader local coverage:
+
+```bash
+IRONCLAW_HERMETIC_REPLAY=1 scripts/ci/hermetic_gate.sh  # replay snapshot tests
+IRONCLAW_HERMETIC_E2E=1 scripts/ci/hermetic_gate.sh     # browser smoke E2E slice
+```
+
+The pre-push hook runs this wrapper by default. You can bypass the whole hook with `git push --no-verify`, or skip only the test portions with `IRONCLAW_PREPUSH_TEST=0 git push` while still keeping fmt, safety checks, and clippy correctness.
+
 ## Before You Open a PR
 
 Run the local validation checks required before requesting a review. These are stricter than the commands for iterative development:

--- a/scripts/ci/hermetic_gate.sh
+++ b/scripts/ci/hermetic_gate.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Hermes-style hermetic local quality gate for IronClaw.
+#
+# Defaults to fast, local-only checks that should not read real provider keys,
+# user profiles, or the developer's ~/.ironclaw state. Expensive deterministic
+# tiers are opt-in via IRONCLAW_HERMETIC_REPLAY=1 and IRONCLAW_HERMETIC_E2E=1.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+DRY_RUN="${IRONCLAW_HERMETIC_DRY_RUN:-0}"
+KEEP_TMP="${IRONCLAW_HERMETIC_KEEP_TMP:-0}"
+TMP_ROOT="${IRONCLAW_HERMETIC_TMPDIR:-}"
+
+if [ -z "$TMP_ROOT" ]; then
+    TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/ironclaw-hermetic.XXXXXX")"
+    CREATED_TMP=1
+else
+    mkdir -p "$TMP_ROOT"
+    CREATED_TMP=0
+fi
+
+cleanup() {
+    if [ "$KEEP_TMP" != "1" ] && [ "${CREATED_TMP:-0}" = "1" ]; then
+        rm -rf "$TMP_ROOT"
+    fi
+}
+trap cleanup EXIT
+
+# Credential-bearing environment. The list is intentionally explicit and
+# conservative: tests that need fake credentials should set test constants in
+# code/fixtures, not inherit developer secrets from the shell.
+CREDENTIAL_VARS=(
+    OPENAI_API_KEY
+    ANTHROPIC_API_KEY
+    ANTHROPIC_OAUTH_TOKEN
+    GEMINI_API_KEY
+    GOOGLE_API_KEY
+    GOOGLE_OAUTH_CLIENT_ID
+    GOOGLE_OAUTH_CLIENT_SECRET
+    GOOGLE_OAUTH_TOKEN
+    GITHUB_TOKEN
+    GH_TOKEN
+    SLACK_BOT_TOKEN
+    SLACK_APP_TOKEN
+    TELEGRAM_BOT_TOKEN
+    DISCORD_TOKEN
+    NOTION_TOKEN
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_SESSION_TOKEN
+    AWS_PROFILE
+    DATABASE_URL
+    LIBSQL_URL
+    LIBSQL_AUTH_TOKEN
+    SECRETS_MASTER_KEY
+)
+
+# Behavior/configuration variables that can make tests read real local state or
+# select non-hermetic backends/providers. Controlled replacements are exported
+# below after the unset loop.
+BEHAVIOR_VARS=(
+    IRONCLAW_BASE_DIR
+    IRONCLAW_PROFILE
+    DATABASE_BACKEND
+    LIBSQL_PATH
+    LLM_BACKEND
+    LLM_BASE_URL
+    LLM_MODEL
+)
+
+for var in "${CREDENTIAL_VARS[@]}" "${BEHAVIOR_VARS[@]}"; do
+    unset "$var" || true
+done
+
+# Keep credential keys present-but-empty so dotenv loaders inside Rust and
+# Python children cannot repopulate them from the repository's ignored `.env`
+# or the isolated IronClaw `.env`. `dotenvy` does not overwrite existing env
+# vars, and IronClaw's config helpers treat empty strings as absent.
+for var in "${CREDENTIAL_VARS[@]}"; do
+    export "$var="
+done
+
+export IRONCLAW_BASE_DIR="$TMP_ROOT/ironclaw"
+export DATABASE_BACKEND="libsql"
+export LIBSQL_PATH="$IRONCLAW_BASE_DIR/ironclaw.db"
+HERMETIC_LOCALE="C"
+if command -v locale >/dev/null 2>&1 && locale -a 2>/dev/null | grep -qi '^C\.UTF-8$'; then
+    HERMETIC_LOCALE="C.UTF-8"
+fi
+export TZ="UTC"
+export LANG="$HERMETIC_LOCALE"
+export LC_ALL="$HERMETIC_LOCALE"
+export PYTHONHASHSEED="0"
+export AWS_EC2_METADATA_DISABLED="true"
+export ONBOARD_COMPLETED="true"
+
+mkdir -p "$IRONCLAW_BASE_DIR"
+
+mask_var() {
+    local name="$1"
+    if [ -n "${!name+x}" ]; then
+        printf '%s=%s\n' "$name" "${!name}"
+    else
+        printf '%s=<unset>\n' "$name"
+    fi
+}
+
+print_environment_summary() {
+    echo "==> hermetic environment"
+    mask_var OPENAI_API_KEY
+    mask_var ANTHROPIC_API_KEY
+    mask_var DATABASE_URL
+    mask_var DATABASE_BACKEND
+    mask_var LIBSQL_PATH
+    mask_var IRONCLAW_BASE_DIR
+    mask_var TZ
+    mask_var LANG
+    mask_var LC_ALL
+    mask_var PYTHONHASHSEED
+    mask_var AWS_EC2_METADATA_DISABLED
+}
+
+run_cmd() {
+    echo "+ $*"
+    if [ "$DRY_RUN" = "1" ]; then
+        return 0
+    fi
+    "$@"
+}
+
+print_environment_summary
+
+echo "==> fmt check"
+run_cmd cargo fmt --all -- --check
+
+echo "==> pre-commit safety checks"
+run_cmd bash scripts/pre-commit-safety.sh
+
+echo "==> clippy (correctness)"
+run_cmd cargo clippy --locked --all-targets -- -D clippy::correctness
+
+if [ "${IRONCLAW_PREPUSH_TEST:-1}" = "1" ]; then
+    echo "==> tests (lib only)"
+    run_cmd cargo test --locked --lib
+
+    echo "==> tests (libsql hermetic configuration)"
+    run_cmd cargo test --locked --no-default-features --features libsql
+
+    if [ "${IRONCLAW_HERMETIC_REPLAY:-0}" = "1" ]; then
+        echo "==> replay snapshot tests"
+        run_cmd cargo insta test \
+            --check \
+            --no-default-features \
+            --features "libsql,replay" \
+            --test e2e_engine_v2 \
+            --test e2e_recorded_trace \
+            --test e2e_live
+    fi
+
+    if [ "${IRONCLAW_HERMETIC_E2E:-0}" = "1" ]; then
+        echo "==> browser e2e smoke build"
+        run_cmd cargo build --locked --no-default-features --features libsql
+
+        echo "==> browser e2e smoke"
+        run_cmd pytest tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py -v --timeout=120
+    fi
+else
+    echo "==> tests skipped (IRONCLAW_PREPUSH_TEST=0)"
+fi

--- a/scripts/ci/hermetic_gate.sh
+++ b/scripts/ci/hermetic_gate.sh
@@ -3,7 +3,8 @@
 #
 # Defaults to fast, local-only checks that should not read real provider keys,
 # user profiles, or the developer's ~/.ironclaw state. Expensive deterministic
-# tiers are opt-in via IRONCLAW_HERMETIC_REPLAY=1 and IRONCLAW_HERMETIC_E2E=1.
+# tiers are opt-in via IRONCLAW_HERMETIC_DUAL_BACKEND=1,
+# IRONCLAW_HERMETIC_REPLAY=1, and IRONCLAW_HERMETIC_E2E=1.
 
 set -euo pipefail
 
@@ -37,6 +38,11 @@ CREDENTIAL_VARS=(
     ANTHROPIC_OAUTH_TOKEN
     GEMINI_API_KEY
     GOOGLE_API_KEY
+    LLM_API_KEY
+    NEARAI_API_KEY
+    NEARAI_SESSION_TOKEN
+    TINFOIL_API_KEY
+    TRANSCRIPTION_API_KEY
     GOOGLE_OAUTH_CLIENT_ID
     GOOGLE_OAUTH_CLIENT_SECRET
     GOOGLE_OAUTH_TOKEN
@@ -51,6 +57,7 @@ CREDENTIAL_VARS=(
     AWS_SECRET_ACCESS_KEY
     AWS_SESSION_TOKEN
     AWS_PROFILE
+    CHANNEL_RELAY_API_KEY
     DATABASE_URL
     LIBSQL_URL
     LIBSQL_AUTH_TOKEN
@@ -111,6 +118,10 @@ print_environment_summary() {
     echo "==> hermetic environment"
     mask_var OPENAI_API_KEY
     mask_var ANTHROPIC_API_KEY
+    mask_var NEARAI_API_KEY
+    mask_var NEARAI_SESSION_TOKEN
+    mask_var TINFOIL_API_KEY
+    mask_var LLM_API_KEY
     mask_var DATABASE_URL
     mask_var DATABASE_BACKEND
     mask_var LIBSQL_PATH
@@ -145,8 +156,12 @@ if [ "${IRONCLAW_PREPUSH_TEST:-1}" = "1" ]; then
     echo "==> tests (lib only)"
     run_cmd cargo test --locked --lib
 
-    echo "==> tests (libsql hermetic configuration)"
-    run_cmd cargo test --locked --no-default-features --features libsql
+    if [ "${IRONCLAW_HERMETIC_DUAL_BACKEND:-0}" = "1" ]; then
+        echo "==> tests (libsql hermetic configuration)"
+        run_cmd cargo test --locked --no-default-features --features libsql
+    else
+        echo "==> libsql hermetic tests skipped (IRONCLAW_HERMETIC_DUAL_BACKEND=1 to enable)"
+    fi
 
     if [ "${IRONCLAW_HERMETIC_REPLAY:-0}" = "1" ]; then
         echo "==> replay snapshot tests"
@@ -164,8 +179,12 @@ if [ "${IRONCLAW_PREPUSH_TEST:-1}" = "1" ]; then
         run_cmd cargo build --locked --no-default-features --features libsql
 
         echo "==> browser e2e smoke"
-        run_cmd pytest tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py -v --timeout=120
+        run_cmd python3 -m pytest tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py -v --timeout=120
     fi
 else
     echo "==> tests skipped (IRONCLAW_PREPUSH_TEST=0)"
+fi
+
+if [ "$KEEP_TMP" = "1" ]; then
+    echo "tmpdir kept: $TMP_ROOT"
 fi

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -2,15 +2,17 @@
 # Developer setup script for IronClaw.
 #
 # Gets a fresh checkout ready for development without requiring
-# Docker, PostgreSQL, or any external services.
+# Docker, PostgreSQL, or any external services. Installs repo-local git
+# hooks via core.hooksPath so pre-push uses the hermetic local gate.
 #
 # Usage:
 #   ./scripts/dev-setup.sh
 #
 # After running, you can:
-#   cargo check           # default features (postgres + libsql)
-#   cargo test            # default test suite (uses libsql temp DB)
-#   cargo test --all-features         # full test suite
+#   cargo check                         # default features (postgres + libsql)
+#   cargo test                          # default test suite (uses libsql temp DB)
+#   scripts/ci/hermetic_gate.sh         # hermetic local gate used by pre-push
+#   cargo test --all-features           # full test suite
 
 set -euo pipefail
 
@@ -48,17 +50,12 @@ cargo test
 
 # 6. Install git hooks
 echo "[6/6] Installing git hooks..."
-HOOKS_DIR=$(git rev-parse --git-path hooks 2>/dev/null) || true
-if [ -n "$HOOKS_DIR" ]; then
-    mkdir -p "$HOOKS_DIR"
-    SCRIPTS_ABS="$(cd "$(dirname "$0")" && pwd)"
-    ln -sf "$SCRIPTS_ABS/commit-msg-regression.sh" "$HOOKS_DIR/commit-msg"
-    echo "  commit-msg hook installed (regression test enforcement)"
-    ln -sf "$SCRIPTS_ABS/pre-commit-safety.sh" "$HOOKS_DIR/pre-commit"
-    echo "  pre-commit hook installed (UTF-8, case-sensitivity, /tmp, redaction checks)"
-    REPO_ROOT="$(git rev-parse --show-toplevel)"
-    ln -sf "$REPO_ROOT/.githooks/pre-push" "$HOOKS_DIR/pre-push"
-    echo "  pre-push hook installed (quality gate + optional delta lint)"
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    git config core.hooksPath .githooks
+    echo "  core.hooksPath .githooks configured"
+    echo "  pre-commit hook enabled (version bumps + safety checks)"
+    echo "  commit-msg hook enabled (regression test enforcement)"
+    echo "  pre-push hook enabled (hermetic gate + optional strict lint)"
 else
     echo "  Skipped: not a git repository"
 fi
@@ -69,5 +66,6 @@ echo ""
 echo "Quick start:"
 echo "  cargo run                            # Run with default features"
 echo "  cargo test                           # Test suite (libsql temp DB)"
+echo "  scripts/ci/hermetic_gate.sh          # Hermetic local gate used by pre-push"
 echo "  cargo test --all-features            # Full test suite"
 echo "  cargo clippy --all-features          # Lint all code"

--- a/scripts/test-hermetic-gate.sh
+++ b/scripts/test-hermetic-gate.sh
@@ -67,21 +67,29 @@ assert_not_contains "real home does not leak" "$run_default" "/real/home/that/mu
 assert_not_contains "secrets do not leak" "$run_default" "secret-openai"
 
 ENV_BACKUP=""
+ENV_SYMLINK_TARGET=""
 ENV_EXISTED=0
-if [ -e .env ]; then
+ENV_WAS_SYMLINK=0
+if [ -L .env ]; then
+    ENV_SYMLINK_TARGET=$(readlink .env)
+    ENV_EXISTED=1
+    ENV_WAS_SYMLINK=1
+elif [ -e .env ]; then
     ENV_BACKUP=$(mktemp "${TMPDIR:-/tmp}/ironclaw-env-backup.XXXXXX")
     cp .env "$ENV_BACKUP"
     ENV_EXISTED=1
 fi
 cleanup_env_fixture() {
-    if [ "$ENV_EXISTED" -eq 1 ]; then
+    rm -f .env
+    if [ "$ENV_WAS_SYMLINK" -eq 1 ]; then
+        ln -s "$ENV_SYMLINK_TARGET" .env
+    elif [ "$ENV_EXISTED" -eq 1 ]; then
         cp "$ENV_BACKUP" .env
-        rm -f "$ENV_BACKUP"
-    else
-        rm -f .env
     fi
+    rm -f "${ENV_BACKUP:-}"
 }
 trap cleanup_env_fixture EXIT
+rm -f .env
 cat > .env <<'EOF_ENV'
 OPENAI_API_KEY=dotenv-openai-secret
 ANTHROPIC_API_KEY=dotenv-anthropic-secret
@@ -102,25 +110,43 @@ assert_contains "runs fmt" "$run_default" "cargo fmt --all -- --check"
 assert_contains "runs pre-commit safety" "$run_default" "bash scripts/pre-commit-safety.sh"
 assert_contains "runs correctness clippy" "$run_default" "cargo clippy --locked --all-targets -- -D clippy::correctness"
 assert_contains "runs lib tests" "$run_default" "cargo test --locked --lib"
-assert_contains "runs libsql hermetic tests" "$run_default" "cargo test --locked --no-default-features --features libsql"
+assert_contains "libsql hermetic tests are opt-in" "$run_default" "IRONCLAW_HERMETIC_DUAL_BACKEND=1 to enable"
+assert_not_contains "dual backend tier is opt-in" "$run_default" "cargo test --locked --no-default-features --features libsql"
 assert_not_contains "replay tier is opt-in" "$run_default" "cargo insta test"
 assert_not_contains "browser e2e tier is opt-in" "$run_default" "pytest tests/e2e"
 
 run_optional=$(
     IRONCLAW_HERMETIC_DRY_RUN=1 \
+    IRONCLAW_HERMETIC_DUAL_BACKEND=1 \
     IRONCLAW_HERMETIC_REPLAY=1 \
     IRONCLAW_HERMETIC_E2E=1 \
     scripts/ci/hermetic_gate.sh
 )
+assert_contains "dual backend tier can be enabled" "$run_optional" "cargo test --locked --no-default-features --features libsql"
 assert_contains "replay tier can be enabled" "$run_optional" "cargo insta test"
 assert_contains "e2e tier builds libsql binary" "$run_optional" "cargo build --locked --no-default-features --features libsql"
-assert_contains "e2e tier runs browser smoke slice" "$run_optional" "pytest tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py -v --timeout=120"
+assert_contains "e2e tier runs browser smoke slice" "$run_optional" "python3 -m pytest tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py -v --timeout=120"
+
+run_keep_tmp=$(
+    IRONCLAW_HERMETIC_DRY_RUN=1 \
+    IRONCLAW_HERMETIC_KEEP_TMP=1 \
+    scripts/ci/hermetic_gate.sh
+)
+assert_contains "keep tmp prints retained path" "$run_keep_tmp" "tmpdir kept:"
 
 if grep -Fq 'hermetic_gate.sh' .githooks/pre-push; then
     echo "OK: pre-push invokes hermetic gate"
     PASS=$((PASS + 1))
 else
     echo "FAIL: pre-push invokes hermetic gate"
+    FAIL=$((FAIL + 1))
+fi
+
+if [ "$(readlink .githooks/commit-msg 2>/dev/null || true)" = "../scripts/commit-msg-regression.sh" ]; then
+    echo "OK: commit-msg hook delegates regression enforcement"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: commit-msg hook delegates regression enforcement"
     FAIL=$((FAIL + 1))
 fi
 

--- a/scripts/test-hermetic-gate.sh
+++ b/scripts/test-hermetic-gate.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Regression tests for the Hermes-style hermetic local gate.
+#
+# These tests intentionally exercise the gate in dry-run mode so they verify
+# command wiring and environment isolation without compiling the workspace.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if grep -Fq -- "$needle" <<<"$haystack"; then
+        echo "OK: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — missing: $needle"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if grep -Fq -- "$needle" <<<"$haystack"; then
+        echo "FAIL: $label — unexpectedly found: $needle"
+        FAIL=$((FAIL + 1))
+    else
+        echo "OK: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_line() {
+    local label="$1" haystack="$2" expected="$3"
+    if grep -Fxq -- "$expected" <<<"$haystack"; then
+        echo "OK: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — missing exact line: $expected"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+if [ ! -x scripts/ci/hermetic_gate.sh ]; then
+    echo "FAIL: scripts/ci/hermetic_gate.sh exists and is executable"
+    exit 1
+fi
+
+run_default=$(
+    OPENAI_API_KEY="secret-openai" \
+    ANTHROPIC_API_KEY="secret-anthropic" \
+    DATABASE_URL="postgres://user:password@example.invalid/db" \
+    IRONCLAW_BASE_DIR="/real/home/that/must/not/leak" \
+    IRONCLAW_HERMETIC_DRY_RUN=1 \
+    scripts/ci/hermetic_gate.sh
+)
+
+assert_contains "dry-run announces hermetic environment" "$run_default" "==> hermetic environment"
+assert_line "provider keys are scrubbed and dotenv-blocked" "$run_default" "OPENAI_API_KEY="
+assert_line "anthropic key is scrubbed and dotenv-blocked" "$run_default" "ANTHROPIC_API_KEY="
+assert_line "database url is scrubbed and dotenv-blocked" "$run_default" "DATABASE_URL="
+assert_contains "uses libsql backend" "$run_default" "DATABASE_BACKEND=libsql"
+assert_contains "uses isolated ironclaw base dir" "$run_default" "IRONCLAW_BASE_DIR="
+assert_not_contains "real home does not leak" "$run_default" "/real/home/that/must/not/leak"
+assert_not_contains "secrets do not leak" "$run_default" "secret-openai"
+
+ENV_BACKUP=""
+ENV_EXISTED=0
+if [ -e .env ]; then
+    ENV_BACKUP=$(mktemp "${TMPDIR:-/tmp}/ironclaw-env-backup.XXXXXX")
+    cp .env "$ENV_BACKUP"
+    ENV_EXISTED=1
+fi
+cleanup_env_fixture() {
+    if [ "$ENV_EXISTED" -eq 1 ]; then
+        cp "$ENV_BACKUP" .env
+        rm -f "$ENV_BACKUP"
+    else
+        rm -f .env
+    fi
+}
+trap cleanup_env_fixture EXIT
+cat > .env <<'EOF_ENV'
+OPENAI_API_KEY=dotenv-openai-secret
+ANTHROPIC_API_KEY=dotenv-anthropic-secret
+DATABASE_URL=postgres://dotenv:secret@example.invalid/db
+EOF_ENV
+run_dotenv=$(
+    IRONCLAW_HERMETIC_DRY_RUN=1 \
+    scripts/ci/hermetic_gate.sh
+)
+assert_line "dotenv openai is masked empty" "$run_dotenv" "OPENAI_API_KEY="
+assert_line "dotenv anthropic is masked empty" "$run_dotenv" "ANTHROPIC_API_KEY="
+assert_line "dotenv database url is masked empty" "$run_dotenv" "DATABASE_URL="
+assert_not_contains "dotenv openai secret does not leak" "$run_dotenv" "dotenv-openai-secret"
+assert_not_contains "dotenv anthropic secret does not leak" "$run_dotenv" "dotenv-anthropic-secret"
+assert_not_contains "dotenv database secret does not leak" "$run_dotenv" "postgres://dotenv:secret"
+
+assert_contains "runs fmt" "$run_default" "cargo fmt --all -- --check"
+assert_contains "runs pre-commit safety" "$run_default" "bash scripts/pre-commit-safety.sh"
+assert_contains "runs correctness clippy" "$run_default" "cargo clippy --locked --all-targets -- -D clippy::correctness"
+assert_contains "runs lib tests" "$run_default" "cargo test --locked --lib"
+assert_contains "runs libsql hermetic tests" "$run_default" "cargo test --locked --no-default-features --features libsql"
+assert_not_contains "replay tier is opt-in" "$run_default" "cargo insta test"
+assert_not_contains "browser e2e tier is opt-in" "$run_default" "pytest tests/e2e"
+
+run_optional=$(
+    IRONCLAW_HERMETIC_DRY_RUN=1 \
+    IRONCLAW_HERMETIC_REPLAY=1 \
+    IRONCLAW_HERMETIC_E2E=1 \
+    scripts/ci/hermetic_gate.sh
+)
+assert_contains "replay tier can be enabled" "$run_optional" "cargo insta test"
+assert_contains "e2e tier builds libsql binary" "$run_optional" "cargo build --locked --no-default-features --features libsql"
+assert_contains "e2e tier runs browser smoke slice" "$run_optional" "pytest tests/e2e/scenarios/test_connection.py tests/e2e/scenarios/test_chat.py -v --timeout=120"
+
+if grep -Fq 'hermetic_gate.sh' .githooks/pre-push; then
+    echo "OK: pre-push invokes hermetic gate"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: pre-push invokes hermetic gate"
+    FAIL=$((FAIL + 1))
+fi
+
+if grep -Fq 'core.hooksPath .githooks' scripts/dev-setup.sh; then
+    echo "OK: dev setup uses core.hooksPath"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: dev setup uses core.hooksPath"
+    FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- add a Hermes-style hermetic local gate wrapper for fmt, safety checks, clippy correctness, and hermetic Rust test tiers
- wire pre-push to the hermetic gate and dev setup to repo-local `.githooks` via `core.hooksPath`
- document the workflow and add a shell regression test for env scrubbing and optional tiers

## Validation
- `scripts/test-hermetic-gate.sh`
- `scripts/test-pre-commit-safety.sh`
- `bash -n scripts/ci/hermetic_gate.sh scripts/test-hermetic-gate.sh .githooks/pre-push .githooks/pre-commit scripts/dev-setup.sh`
- `IRONCLAW_HERMETIC_DRY_RUN=1 scripts/ci/hermetic_gate.sh`
- `git diff --check`
- `cargo test --locked --lib --no-run -q`

## Risk / rollback
- Local workflow change only; CI gates remain authoritative.
- Roll back by reverting this PR or setting `git config --unset core.hooksPath` locally.
- Pre-push can still be bypassed with `git push --no-verify`; test portions can be skipped with `IRONCLAW_PREPUSH_TEST=0`.
