### PR TITLE
ci: build ironclaw docker image with staging tag from main branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,9 @@ on:
         required: false
         type: string
         default: ""
+  # Rolling :staging image tags from main branch (hourly)
+  schedule:
+    - cron: '0 * * * *'
 
 env:
   IMAGE_NAME: nearaidev/ironclaw
@@ -44,6 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ github.event_name == 'schedule' && 'main' || '' }}
           persist-credentials: false
 
       - name: Resolve source git commit
@@ -64,28 +68,20 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Detected version: ${VERSION}"
 
-      - name: Validate tag override
-        if: inputs.tag != ''
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          if [[ ! "${INPUT_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
-            echo "::error::Input tag '${INPUT_TAG}' does not match Docker tag grammar"
-            exit 1
-          fi
-          if [[ "${INPUT_TAG}" == "staging" ]]; then
-            echo "::error::The staging tag has been retired. Use a different tag or rely on release tags."
-            exit 1
-          fi
-
       - name: Determine tags
         id: tags
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
           IS_RELEASE_BUILD: ${{ inputs.release && 'true' || 'false' }}
           INPUT_TAG: ${{ inputs.tag }}
           SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
         run: |
+          if [[ -n "${INPUT_TAG}" && ! "${INPUT_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
+            echo "::error::Input tag '${INPUT_TAG}' does not match Docker tag grammar"
+            exit 1
+          fi
+
           SHA="sha-${SOURCE_SHA::7}"
           echo "sha_tag=${SHA}" >> "$GITHUB_OUTPUT"
 
@@ -97,20 +93,32 @@ jobs:
             WORKER_TAGS="${WORKER_IMAGE_NAME}:${VERSION}"
             WORKER_TAGS="${WORKER_TAGS},${WORKER_IMAGE_NAME}:latest"
             WORKER_TAGS="${WORKER_TAGS},${WORKER_IMAGE_NAME}:${SHA}"
+          elif [[ "${EVENT_NAME}" == "schedule" ]]; then
+            # Daily staging: :staging + :sha-xxx
+            TAGS="${IMAGE_NAME}:staging"
+            TAGS="${TAGS},${IMAGE_NAME}:${SHA}"
+            WORKER_TAGS="${WORKER_IMAGE_NAME}:staging"
+            WORKER_TAGS="${WORKER_TAGS},${WORKER_IMAGE_NAME}:${SHA}"
           else
             # Manual dispatch: :sha-xxx only
             TAGS="${IMAGE_NAME}:${SHA}"
             WORKER_TAGS="${WORKER_IMAGE_NAME}:${SHA}"
           fi
 
+          # Manual override adds an extra tag (e.g. "staging")
           if [[ -n "${INPUT_TAG}" ]]; then
             TAGS="${TAGS},${IMAGE_NAME}:${INPUT_TAG}"
             WORKER_TAGS="${WORKER_TAGS},${WORKER_IMAGE_NAME}:${INPUT_TAG}"
           fi
-
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "worker_tags=${WORKER_TAGS}" >> "$GITHUB_OUTPUT"
-          echo "target=runtime" >> "$GITHUB_OUTPUT"
+
+          # Staging builds get pre-bundled WASM extensions
+          if [[ "${EVENT_NAME}" == "schedule" || "${INPUT_TAG}" == "staging" ]]; then
+            echo "target=runtime-staging" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=runtime" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Log in to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -118,10 +126,40 @@ jobs:
           username: ${{ vars.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
+      - name: Check if current staging commit is already built
+        id: check
+        if: steps.tags.outputs.target == 'runtime-staging'
+        env:
+          SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
+        run: |
+          CURRENT_BUILT_SHA=""
+          WORKER_BUILT_SHA=""
+
+          if docker pull "${IMAGE_NAME}:staging" > /dev/null 2>&1; then
+            CURRENT_BUILT_SHA=$(docker inspect --format='{{index .Config.Labels "ironclaw.git.sha"}}' "${IMAGE_NAME}:staging" 2>/dev/null || echo "")
+          fi
+          if docker pull "${WORKER_IMAGE_NAME}:staging" > /dev/null 2>&1; then
+            WORKER_BUILT_SHA=$(docker inspect --format='{{index .Config.Labels "ironclaw.git.sha"}}' "${WORKER_IMAGE_NAME}:staging" 2>/dev/null || echo "")
+          fi
+
+          echo "Current built commit (ironclaw): ${CURRENT_BUILT_SHA:-<none>}"
+          echo "Current built commit (ironclaw-worker): ${WORKER_BUILT_SHA:-<none>}"
+          echo "Current source commit: ${SOURCE_SHA}"
+
+          if [[ -n "${CURRENT_BUILT_SHA}" && "${CURRENT_BUILT_SHA}" == "${SOURCE_SHA}" && -n "${WORKER_BUILT_SHA}" && "${WORKER_BUILT_SHA}" == "${SOURCE_SHA}" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Current commit already built for both images — skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "At least one image is missing or out of date — proceeding."
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check.outputs.skip != 'true'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push (ironclaw)
+        if: steps.check.outputs.skip != 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -135,6 +173,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push (ironclaw-worker)
+        if: steps.check.outputs.skip != 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -149,6 +188,7 @@ jobs:
 
       - name: Create releases-manager app token
         id: app-token
+        if: steps.check.outputs.skip != 'true'
         continue-on-error: true
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
@@ -158,14 +198,13 @@ jobs:
           repositories: ironclaw-dind
 
       - name: Trigger ironclaw-dind Build & Push
-        if: >
-          steps.app-token.outcome == 'success' &&
-          github.event_name == 'workflow_call' &&
-          steps.version.outputs.version != ''
+        if: steps.app-token.outcome == 'success' && steps.check.outputs.skip != 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          EVENT_NAME: ${{ github.event_name }}
           IS_RELEASE_BUILD: ${{ inputs.release && 'true' || 'false' }}
+          INPUT_TAG: ${{ inputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           if [[ "${IS_RELEASE_BUILD}" == "true" && -n "${VERSION}" ]]; then
@@ -173,23 +212,45 @@ jobs:
               --method POST \
               -f event_type="ironclaw_image_published" \
               -f client_payload[version]="${VERSION}"
+          elif [[ "${EVENT_NAME}" == "schedule" ]] || [[ "${INPUT_TAG}" == "staging" ]]; then
+            gh api repos/nearai/ironclaw-dind/dispatches \
+              --method POST \
+              -f event_type="ironclaw_image_published"
           fi
 
       - name: Summary
+        if: steps.check.outputs.skip != 'true'
+        env:
+          TAGS: ${{ steps.tags.outputs.tags }}
+          WORKER_TAGS: ${{ steps.tags.outputs.worker_tags }}
+          VERSION: ${{ steps.version.outputs.version }}
+          SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
         run: |
           {
             echo "## Docker Images"
             echo ""
             echo "**ironclaw:**"
             echo '```'
-            echo "${{ steps.tags.outputs.tags }}" | tr ',' '\n'
+            echo "${TAGS}" | tr ',' '\n'
             echo '```'
             echo ""
             echo "**ironclaw-worker:**"
             echo '```'
-            echo "${{ steps.tags.outputs.worker_tags }}" | tr ',' '\n'
+            echo "${WORKER_TAGS}" | tr ',' '\n'
             echo '```'
             echo ""
-            echo "- version: \`${{ steps.version.outputs.version }}\`"
-            echo "- sha: \`${{ steps.source_sha.outputs.sha }}\`"
+            echo "- version: \`${VERSION}\`"
+            echo "- sha: \`${SOURCE_SHA}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summary (skipped)
+        if: steps.check.outputs.skip == 'true'
+        env:
+          SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
+        run: |
+          {
+            echo "## Docker Images — skipped"
+            echo ""
+            echo "Current commit already built for \`${IMAGE_NAME}:staging\`."
+            echo "- sha: \`${SOURCE_SHA}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,7 +94,7 @@ jobs:
             WORKER_TAGS="${WORKER_TAGS},${WORKER_IMAGE_NAME}:latest"
             WORKER_TAGS="${WORKER_TAGS},${WORKER_IMAGE_NAME}:${SHA}"
           elif [[ "${EVENT_NAME}" == "schedule" ]]; then
-            # Daily staging: :staging + :sha-xxx
+            # Hourly staging: :staging + :sha-xxx
             TAGS="${IMAGE_NAME}:staging"
             TAGS="${TAGS},${IMAGE_NAME}:${SHA}"
             WORKER_TAGS="${WORKER_IMAGE_NAME}:staging"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -126,7 +126,7 @@ jobs:
           username: ${{ vars.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
-      - name: Check if current staging commit is already built
+      - name: Check if current git commit is already built
         id: check
         if: steps.tags.outputs.target == 'runtime-staging'
         env:


### PR DESCRIPTION
## Summary

- Restores the full **Docker Image** workflow behavior from before the merge-queue cutover (#3104): hourly schedule, `:staging` and `:sha-*` tags, `runtime-staging` vs `runtime`, skip-when-already-built using the `ironclaw.git.sha` label, and **`ironclaw-dind`** repository dispatches for release vs rolling staging.
- Schedules a **checkout of `main`** (instead of the `staging` git branch) for the hourly job so rolling **`:staging`** Docker tags track **`main`** while keeping the same image tag names for deploys.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- N/A — workflow YAML only -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: Reviewed `.github/workflows/docker.yml` for branch ref (`main`), schedule cron, tag/target logic, skip gate, and `ironclaw-dind` dispatch branches; YAML parses cleanly.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None — CI-only change. Docker Hub publish and GitHub App token usage for `ironclaw-dind` dispatch match the prior intended behavior.

## Database Impact

None

## Blast Radius

**CI / release plumbing only.** Touches Docker Hub tags (`:staging`, `:sha-*`, and release tags when invoked from `release.yml`), hourly scheduled runs, and optional **`ironclaw-dind`** downstream builds. A mistake here