### PR TITLE
test(libsql): cover decimal parser error branch

### DIFF
--- a/src/db/libsql/users.rs
+++ b/src/db/libsql/users.rs
@@ -1239,6 +1239,22 @@ mod tests {
         .unwrap();
     }
 
+    #[test]
+    fn test_parse_libsql_decimal_text_accepts_scientific_and_reports_invalid() {
+        let scientific = parse_libsql_decimal_text("7.5e-05", "cost").unwrap();
+        assert_eq!(
+            scientific,
+            rust_decimal::Decimal::from_str_exact("0.000075").unwrap()
+        );
+
+        let err = parse_libsql_decimal_text("not-a-decimal", "cost").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("invalid cost value 'not-a-decimal'"),
+            "unexpected error: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn test_user_summary_stats_empty() {
         let (db, _dir) = setup().await;


### PR DESCRIPTION
## Summary
- add a focused unit test for the libSQL decimal aggregate parser
- covers scientific notation parsing and the invalid-value error mapping branch that Codecov marked uncovered on main

## Why
Main is red only on `codecov/patch` for commit `dd77b31653b217affb7b427c70b059ed54270fe3`: 80% patch coverage vs 90% target. The missed lines are from the newly added parser branch.

## Verification
- `cargo fmt --check`
- `cargo test --lib --no-default-features --features libsql test_parse_libsql_decimal_text_accepts_scientific_and_reports_invalid -- --nocapture`
- `cargo check --no-default-features --features libsql -q`
- `git diff --check`