### PR TITLE
test(db): serialize postgres migration fixup tests

### DIFF
--- a/src/db/migration_fixup.rs
+++ b/src/db/migration_fixup.rs
@@ -301,6 +301,10 @@ mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
+    #[cfg(feature = "integration")]
+    static POSTGRES_MIGRATION_FIXUP_TEST_LOCK: tokio::sync::Mutex<()> =
+        tokio::sync::Mutex::const_new(());
+
     fn migrations_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations")
     }
@@ -647,6 +651,7 @@ mod tests {
                 return;
             }
         };
+        let _guard = POSTGRES_MIGRATION_FIXUP_TEST_LOCK.lock().await;
 
         // Make sure refinery_schema_history exists. We can't rely on
         // the test DB having had migrations run, so create it on
@@ -795,6 +800,7 @@ mod tests {
                 return;
             }
         };
+        let _guard = POSTGRES_MIGRATION_FIXUP_TEST_LOCK.lock().await;
 
         // Make sure refinery_schema_history exists so we exercise the
         // post-history-check branch (the early-return on missing table


### PR DESCRIPTION
## Summary
- serialize the two PostgreSQL migration-fixup integration tests that both create/use the shared `refinery_schema_history` table
- avoids a CI race where concurrent `CREATE TABLE IF NOT EXISTS refinery_schema_history` can fail with a duplicate `pg_type_typname_nsp_index` error

## Why
Main's Coverage (all-features) job failed on commit `576eb3bb7d6f01db6a92371243f838f059db11f1` in `db::migration_fixup::tests::rejects_canonical_in_known_bad_checksums`, not in the libSQL decimal parser test. The panic was:

`duplicate key value violates unique constraint "pg_type_typname_nsp_index" ... refinery_schema_history`

That points to an existing parallel Postgres DDL race, not a product-code regression.

## Verification
- `cargo fmt --check`
- `cargo test --lib --all-features db::migration_fixup::tests::rejects_canonical_in_known_bad_checksums -- --nocapture`
- `cargo check --all-features -q`
- `git diff --check`