### PR TITLE
docs(reborn): add crate agent maps

### DIFF
--- a/crates/ironclaw_approvals/AGENTS.md
+++ b/crates/ironclaw_approvals/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_approvals
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/approvals.md`
+- `docs/reborn/contracts/run-state.md`
+- `docs/reborn/contracts/capability-access.md`
+
+## What This Crate Owns
+
+- Exact-invocation approval requests, leases, resume coordination, and approval events.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- reusable scoped approvals or dispatch before matching fingerprinted lease validation/claim.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_approvals`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_architecture/AGENTS.md
+++ b/crates/ironclaw_architecture/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Map — ironclaw_architecture
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/_contract-freeze-index.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+
+## What This Crate Owns
+
+- Workspace architecture contract tests and Reborn dependency-boundary enforcement.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- production runtime code, production dependencies, or soft-only boundaries when a mechanical test can enforce them.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_architecture`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_authorization/AGENTS.md
+++ b/crates/ironclaw_authorization/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_authorization
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/capability-access.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+- `docs/reborn/contracts/host-api.md`
+
+## What This Crate Owns
+
+- Grant matching and trust-aware authorization decisions for capability dispatch.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- approval lease claiming, runtime dispatch, obligation execution, or stringly permission logic.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_authorization`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_capabilities/AGENTS.md
+++ b/crates/ironclaw_capabilities/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Map — ironclaw_capabilities
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/capability-access.md`
+- `docs/reborn/contracts/capabilities.md`
+- `docs/reborn/contracts/approvals.md`
+- `docs/reborn/contracts/run-state.md`
+
+## What This Crate Owns
+
+- Caller-facing CapabilityHost invoke/resume/spawn workflow and obligation seam.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- parallel dispatch paths, process lifecycle/result APIs, and dispatch before authorization/obligations/approval gates.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_capabilities`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_common/AGENTS.md
+++ b/crates/ironclaw_common/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Map — ironclaw_common
+
+## Start Here
+
+- No crate-local `CLAUDE.md` exists yet; use this map plus the repo rules below.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these sources of truth before changing shared types:
+- `.claude/rules/types.md`
+- `CLAUDE.md`
+
+## What This Crate Owns
+
+- Shared low-dependency workspace types and utilities: app events, identity newtypes, timezone validation, preview truncation, and cross-runtime constants.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- Runtime orchestration, persistence, network clients, web/TUI behavior, policy engines, or domain logic owned by more specific Reborn crates.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_common`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If a type is serialized over API or persisted data, add compatibility tests for stable names and validation behavior.
+
+## Agent Notes
+
+- Keep this crate minimal; new dependencies here affect much of the workspace.
+- Prefer validated newtypes and wire-stable enums over raw strings.
+- If a shared type only serves one subsystem, keep it in that subsystem crate until a second real caller exists.

--- a/crates/ironclaw_dispatcher/AGENTS.md
+++ b/crates/ironclaw_dispatcher/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_dispatcher
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/dispatcher.md`
+- `docs/reborn/contracts/runtime-workflows.md`
+- `docs/reborn/contracts/capability-access.md`
+
+## What This Crate Owns
+
+- Neutral runtime dispatch port that routes already-authorized capability requests to adapters.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- authorization, approval, trust, or obligation decisions; those must happen before dispatch.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_dispatcher`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_engine/AGENTS.md
+++ b/crates/ironclaw_engine/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Map — ironclaw_engine
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these design docs/contracts as the source of truth before changing behavior:
+- `docs/plans/2026-03-20-engine-v2-architecture.md`
+- `docs/reborn/contracts/agent-loop-protocol.md`
+- `docs/reborn/contracts/runtime-workflows.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+
+## What This Crate Owns
+
+- Unified thread/capability/CodeAct execution model: thread and step types, capability leases and policy, execution gates, memory docs, mission runtime, and host-facing execution traits.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- Concrete LLM providers, database backends, tool registries, channel transports, web/TUI UI, raw secrets, or host-specific filesystem/network process execution.
+- Safety scanning itself; adapters around `EffectExecutor` apply safety at the boundary.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_engine`
+- Strict check after behavior changes: `cargo clippy -p ironclaw_engine --all-targets -- -D warnings`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Keep prompt templates in files, not inline Rust strings.
+- Keep Monty/CodeAct host functions resource-bounded and panic-safe.
+- Prefer caller-level tests when a helper gates leases, dispatch, approvals, memory, events, or process side effects.

--- a/crates/ironclaw_events/AGENTS.md
+++ b/crates/ironclaw_events/AGENTS.md
@@ -16,7 +16,7 @@
 
 ## Do Not Move In Here
 
-- SSE/WebSocket product transport, raw secrets, host paths, or backend error details.
+- SSE/WebSocket product transport.
 - Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
 
 ## Validation

--- a/crates/ironclaw_events/AGENTS.md
+++ b/crates/ironclaw_events/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_events
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/events.md`
+- `docs/reborn/contracts/events-projections.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+
+## What This Crate Owns
+
+- Typed event/audit substrate contracts and redacted event envelopes.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- SSE/WebSocket product transport, raw secrets, host paths, or backend error details.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_events`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_extensions/AGENTS.md
+++ b/crates/ironclaw_extensions/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_extensions
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/extensions.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+- `docs/reborn/contracts/capability-access.md`
+
+## What This Crate Owns
+
+- Extension manifest, package identity, lifecycle, registry, and trust inputs.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- direct authority grants or runtime-specific execution logic; use capabilities/authorization/trust and lane crates.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_extensions`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_filesystem/AGENTS.md
+++ b/crates/ironclaw_filesystem/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_filesystem
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/filesystem.md`
+- `docs/reborn/contracts/storage-placement.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+
+## What This Crate Owns
+
+- Scoped filesystem substrate: root/scoped/composite filesystem surfaces and path authority.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- memory-domain path grammar, network/secrets/dispatcher behavior, and product workflow.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_filesystem`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_gateway/AGENTS.md
+++ b/crates/ironclaw_gateway/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Map — ironclaw_gateway
+
+## Start Here
+
+- No crate-local `CLAUDE.md` exists yet; use this map plus the web gateway docs below.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these sources of truth before changing behavior:
+- `src/channels/web/CLAUDE.md`
+- `.claude/rules/gateway-events.md`
+- `docs/channels/local.md`
+
+## What This Crate Owns
+
+- Browser frontend asset bundling, layout configuration, branding/tab/widget config types, widget manifests, CSS scoping, and frontend bundle assembly.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- HTTP routes, SSE/WebSocket state, auth, rate limits, CORS/origin checks, channel logic, database access, or runtime workflow behavior.
+- Direct `AppEvent` production that bypasses typed source logs and projection rules.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_gateway`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- For user-visible frontend changes, run the narrowest web/gateway test or screenshot flow that covers the changed surface.
+
+## Agent Notes
+
+- Keep this crate as static/frontend composition; server behavior stays in `src/channels/web/`.
+- Treat widget IDs, layout JSON, and public config fields as compatibility-sensitive.
+- Preserve CSP/nonce-safe asset assembly when adding scripts, styles, or widget injection points.

--- a/crates/ironclaw_host_api/AGENTS.md
+++ b/crates/ironclaw_host_api/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_host_api
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/host-api.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+- `docs/reborn/contracts/capability-access.md`
+
+## What This Crate Owns
+
+- Shared authority vocabulary and neutral host contracts: IDs, scopes, paths, actions, decisions, resources, approvals, audit, HTTP, dispatch, runtime-policy, and trust types.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- runtime execution, persistence, HTTP clients, product workflow, policy engines, and dependencies on other service/runtime crates.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_host_api`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_host_runtime/AGENTS.md
+++ b/crates/ironclaw_host_runtime/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_host_runtime
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/host-runtime.md`
+- `docs/reborn/contracts/runtime-workflows.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+
+## What This Crate Owns
+
+- Host-side composition facade for Reborn runtime lanes and shared kernel-facing services/adapters.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- product loop strategy, prompt assembly, channel UX, migrations, or duplicated low-level network/secrets/resource logic.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_host_runtime`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_mcp/AGENTS.md
+++ b/crates/ironclaw_mcp/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_mcp
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/mcp.md`
+- `docs/reborn/contracts/runtime-workflows.md`
+- `docs/reborn/contracts/processes.md`
+
+## What This Crate Owns
+
+- MCP runtime lane with fail-closed process policy and host-mediated HTTP integration.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- direct process starts, manual credentials, or direct network egress outside mediated substrates.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_mcp`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_memory/AGENTS.md
+++ b/crates/ironclaw_memory/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_memory
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/memory.md`
+- `docs/reborn/contracts/storage-placement.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+
+## What This Crate Owns
+
+- Memory document services, backend adapters, metadata/search, filesystem projection, and prompt-context safety seams.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- generic filesystem semantics, direct provider HTTP, raw secret handling, and loop prompt strategy.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_memory`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_network/AGENTS.md
+++ b/crates/ironclaw_network/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_network
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/network.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+- `docs/reborn/contracts/resources.md`
+
+## What This Crate Owns
+
+- Network policy boundary and hardened host/provider HTTP transport substrate.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- runtime-lane behavior above the boundary or manual credential injection.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_network`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_processes/AGENTS.md
+++ b/crates/ironclaw_processes/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_processes
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/processes.md`
+- `docs/reborn/contracts/resources.md`
+- `docs/reborn/contracts/events.md`
+
+## What This Crate Owns
+
+- Process lifecycle, cancellation, status, result, output-ref, and ProcessHost surfaces.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- capability authorization, approval policy, or runtime lane internals outside adapter-facing contracts.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_processes`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_reborn_event_store/AGENTS.md
+++ b/crates/ironclaw_reborn_event_store/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_reborn_event_store
+
+## Start Here
+
+- No crate-local `CLAUDE.md` exists yet; use this map plus the Reborn contracts below.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/events.md`
+- `docs/reborn/contracts/events-projections.md`
+- `docs/reborn/contracts/storage-placement.md`
+
+## What This Crate Owns
+
+- Durable event and audit store backends for Reborn events.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- product projections, transport fanout, runtime workflow policy, or backend-specific public errors.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_reborn_event_store`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_resources/AGENTS.md
+++ b/crates/ironclaw_resources/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_resources
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/resources.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+- `docs/reborn/contracts/processes.md`
+
+## What This Crate Owns
+
+- Resource reservation governor for runtime/process/network/provider/artifact budgets.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- process/runtime execution logic or best-effort accounting where contracts require fail-closed behavior.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_resources`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_run_state/AGENTS.md
+++ b/crates/ironclaw_run_state/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_run_state
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/run-state.md`
+- `docs/reborn/contracts/turn-runner.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+
+## What This Crate Owns
+
+- Run lifecycle and blocking-state contracts used by capability and approval flows.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- runtime execution, product projections, or raw prompts/assistant text/secrets/backend details in state.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_run_state`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_runtime_policy/AGENTS.md
+++ b/crates/ironclaw_runtime_policy/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_runtime_policy
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/runtime-profiles.md`
+- `docs/reborn/contracts/runtime-selection.md`
+- `docs/reborn/contracts/runtime-workflows.md`
+
+## What This Crate Owns
+
+- Runtime profile resolver and runtime selection policy.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- runtime process startup, action dispatch, or product strategy outside profile selection.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_runtime_policy`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_safety/AGENTS.md
+++ b/crates/ironclaw_safety/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Map — ironclaw_safety
+
+## Start Here
+
+- No crate-local `CLAUDE.md` exists yet; use this map plus the security rules below.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these sources of truth before changing safety behavior:
+- `.claude/rules/safety-and-sandbox.md`
+- `src/NETWORK_SECURITY.md`
+- `crates/ironclaw_safety/fuzz/README.md`
+
+## What This Crate Owns
+
+- Prompt-injection detection, input validation, sanitization, safety policy evaluation, sensitive path helpers, manual credential detection, and secret leak scanning.
+- Crate-local public API, tests, benches, fuzz targets, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- Sandbox execution, credential storage/injection, network allowlists, tool dispatch, agent loops, or UI decisions.
+- Any code path that logs or returns raw secret values while reporting a safety finding.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_safety`
+- Fuzz-target check after parser/pattern changes: follow `crates/ironclaw_safety/fuzz/README.md`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- New ingress surfaces outside this crate must scan before storage or LLM injection; keep APIs easy for callers to use correctly.
+- Prefer bounded, linear-time pattern matching; do not add backtracking regex behavior on untrusted input.
+- Add regression tests for both blocked and allowed near-miss cases when tuning detectors.

--- a/crates/ironclaw_scripts/AGENTS.md
+++ b/crates/ironclaw_scripts/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_scripts
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/scripts.md`
+- `docs/reborn/contracts/runtime-workflows.md`
+- `docs/reborn/contracts/network.md`
+
+## What This Crate Owns
+
+- Script runtime lane adapter over host-mediated filesystem, events, resources, dispatcher, and HTTP surfaces.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- manual credentials, direct provider HTTP, or duplicated dispatcher/process/resource policy.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_scripts`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_secrets/AGENTS.md
+++ b/crates/ironclaw_secrets/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_secrets
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/secrets.md`
+- `docs/reborn/contracts/storage-placement.md`
+- `docs/reborn/contracts/kernel-boundary.md`
+
+## What This Crate Owns
+
+- Secret metadata, encrypted repository contracts, leases, and one-shot consumption surfaces.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- raw secret material in errors/events/debug/snapshots/docs or provider HTTP/injection beyond mediated handoff.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_secrets`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_skills/AGENTS.md
+++ b/crates/ironclaw_skills/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Map — ironclaw_skills
+
+## Start Here
+
+- No crate-local `CLAUDE.md` exists yet; use this map plus the skills rules below.
+- Read `Cargo.toml` for actual dependencies, feature flags, and catalog/registry shape.
+- Use these sources of truth before changing behavior:
+- `.claude/rules/skills.md`
+- `CLAUDE.md`
+- `docs/reborn/contracts/extensions.md`
+
+## What This Crate Owns
+
+- Skill metadata parsing, validation, deterministic gating/scoring/selection, registry operations, catalog lookup, and trust-aware skill type definitions.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- Prompt execution, tool authorization, extension runtime dispatch, credential handling, channel UI, or ClawHub server behavior.
+- Compatibility shims for unsupported legacy skill metadata unless the parser contract explicitly changes.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_skills`
+- Feature-shape check after catalog/registry changes: `cargo test -p ironclaw_skills --all-features`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Skill selection must stay deterministic: no ambient time, network, or filesystem effects in scoring.
+- Installed skills are lower-trust than user/workspace skills; preserve tool-ceiling attenuation.
+- Add caller-level tests when parser or gating changes affect prompt assembly or tool exposure.

--- a/crates/ironclaw_trust/AGENTS.md
+++ b/crates/ironclaw_trust/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_trust
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/kernel-boundary.md`
+- `docs/reborn/contracts/extensions.md`
+- `docs/reborn/contracts/host-api.md`
+
+## What This Crate Owns
+
+- Host-controlled trust-class assignment, invalidation, and authority-ceiling policy.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- treating trust as a grant/bypass, package execution, extension storage, or capability dispatch.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_trust`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_tui/AGENTS.md
+++ b/crates/ironclaw_tui/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_tui
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these sources of truth before changing behavior:
+- `crates/ironclaw_tui/CLAUDE.md`
+- `docs/channels/local.md`
+- `src/NETWORK_SECURITY.md`
+
+## What This Crate Owns
+
+- Ratatui terminal UI primitives: `TuiApp`, event/input loop, layout/theme rendering, widgets, approval overlays, model/thread pickers, and clipboard-gated UI behavior.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- Agent loop execution, channel pairing/auth, web gateway behavior, database access, tool dispatch, or host-specific approval policy.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_tui`
+- UI/API check after public type changes: run the narrowest caller test that uses `src/channels/tui.rs` or the TUI channel bridge.
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Keep the crate independent from the main `ironclaw` crate; bridge integration belongs in `src/channels/tui.rs`.
+- Preserve keyboard shortcuts and approval affordances documented in `CLAUDE.md` unless the UX change is explicit.
+- When adding widgets, update the widget registry and rendering path together.

--- a/crates/ironclaw_turns/AGENTS.md
+++ b/crates/ironclaw_turns/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Map — ironclaw_turns
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/turns-agent-loop.md`
+- `docs/reborn/contracts/turn-persistence.md`
+- `docs/reborn/contracts/turn-runner.md`
+- `docs/reborn/contracts/loop-exit.md`
+
+## What This Crate Owns
+
+- Host-layer turn coordination contracts, canonical turn/run IDs, store traits, runner ports, and redacted lifecycle events.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- raw CapabilityHost/dispatcher/runtime handles, raw prompts/content/tool inputs/secrets/host paths, or channel identity parsing.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_turns`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.

--- a/crates/ironclaw_wasm/AGENTS.md
+++ b/crates/ironclaw_wasm/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Map — ironclaw_wasm
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts as the source of truth before changing behavior:
+- `docs/reborn/contracts/wasm.md`
+- `docs/reborn/contracts/runtime-workflows.md`
+- `docs/reborn/contracts/network.md`
+
+## What This Crate Owns
+
+- WASM runtime lane, WIT bindings, limiter, store, host adapters, and runtime config.
+- Crate-local public API, tests, and fixtures needed to prove that ownership.
+
+## Do Not Move In Here
+
+- privileged host effects outside mediated APIs or copied secrets/network/resource logic.
+- Secrets, raw host paths, backend error details, and unredacted user content in errors, events, snapshots, logs, or docs.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_wasm`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- If production persistence behavior changes, add/maintain PostgreSQL and libSQL parity tests.
+
+## Agent Notes
+
+- Keep edits inside this crate unless a contract explicitly requires a neighboring crate change.
+- Prefer caller-level tests when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, or process side effects.
+- If the contract and code disagree, stop and treat the task as a contract-change request instead of silently changing ownership.


### PR DESCRIPTION
## Summary
- add crate-local AGENTS.md maps for current Reborn crates
- point agents at the relevant Reborn contract docs and crate-local guardrails
- document ownership, forbidden responsibilities, and validation commands per crate

## Validation
- AGENTS.md path/package reference validation script
- `git diff --check`
- `cargo test -p ironclaw_architecture -q`

## Risk / rollback
- Documentation-only; no runtime behavior changes.
- Roll back by reverting this PR if the maps become stale or conflict with updated contract docs.
