### PR TITLE
Make Skills E2E lifecycle deterministic

### DIFF
--- a/tests/e2e/E2E_DEBT.md
+++ b/tests/e2e/E2E_DEBT.md
@@ -1,0 +1,27 @@
+# E2E skip/xfail debt inventory
+
+This inventory tracks skip/xfail debt found in `tests/e2e/scenarios/` while auditing from `origin/main` for the first E2E debt campaign.
+
+## Summary
+
+| Cluster | Files | Debt type | Determinism | Recommended action |
+| --- | --- | --- | --- | --- |
+| ClawHub skills search/install | `test_skills.py` | Runtime `pytest.skip` when registry/search/install is unavailable or slow | Deterministic with Playwright route mocks | Fix in this campaign: mock the skills API for frontend lifecycle tests so CI never depends on ClawHub availability. |
+| Gmail extension OAuth legacy flow | `test_extension_oauth.py`, `test_routine_oauth_credential_injection.py` | Runtime skips when Gmail install/auth prerequisites are absent | Mostly deterministic if migrated to existing isolated OAuth fixtures | Follow-up: consolidate with hosted OAuth fixtures used by newer v2 OAuth tests; avoid module-order globals. |
+| MCP auth flow legacy flow | `test_mcp_auth_flow.py` | Runtime skips when mock MCP install/auth URL prerequisites are absent | Mostly deterministic with fixture refactor | Follow-up: convert install/auth state to fixtures instead of module-order state and make failure explicit. |
+| Telegram OAuth URL placeholders | `test_oauth_url_parameters.py` | Static skip placeholders with `pass` bodies | Blocked on Telegram channel E2E fixture/product setup | Follow-up: either implement a fake Telegram channel fixture or move placeholders to issue/docs and remove dead skipped tests. |
+| Portfolio widget availability | `test_portfolio.py` | Runtime skip when portfolio widget is not registered in this build | Product/build dependent | Follow-up: decide whether portfolio is a required test fixture or optional extension; if optional, keep documented skip. |
+| v2 auth/OAuth matrix xfails | `test_v2_auth_oauth_matrix.py` | Static xfails for known engine-v2 contract/product gaps | Requires product behavior changes or deeper engine debug | Follow-up: split into product issues; do not silently un-xfail without matching contract changes. |
+| v2 auth approval/cancel fallback | `test_v2_engine_auth_cancel.py`, `test_v2_engine_auth_flow.py` | Runtime skips when dedicated fixtures remain in approval gating rather than auth gating | Requires fixture/model prompt control | Follow-up: pin mock LLM/tool prompt path so tests reach intended auth state deterministically. |
+| v2 Google OAuth binary/refresh prerequisites | `test_v2_engine_oauth_google.py` | Runtime skips when google-drive WASM binary or refresh-token prerequisite is missing | Deterministic if fixture builds/provides WASM and OAuth callback state | Follow-up: prebuild or fixture-install the WASM artifact, then make refresh tests independent. |
+| Skill OAuth guided auth fallback | `test_skill_oauth_flow.py` | Runtime skip if auth flow does not trigger under current engine mode | Requires fixture/model control | Follow-up: pin engine mode and mock LLM response to force the guided auth branch. |
+
+## Selected cluster for this campaign
+
+**ClawHub skills search/install** is selected because it is the smallest high-value deterministic cluster: the tests are intended to validate the browser skills UI lifecycle, but currently depend on live ClawHub search results and network timing. The E2E README already recommends `page.route()` for tabs that depend on external data. Mocking `/api/skills`, `/api/skills/search`, `/api/skills/install`, and `DELETE /api/skills/{name}` keeps the test end-to-end at the browser/API contract layer without requiring live external services.
+
+## Remaining debt policy
+
+- Runtime skips are acceptable only when the prerequisite is genuinely outside the deterministic E2E harness and the reason names that prerequisite.
+- UI lifecycle tests should prefer local route mocks when they are not validating the backend integration itself.
+- Placeholder skipped tests with `pass` bodies should either become real tests or move to tracked follow-up documentation/issues.

--- a/tests/e2e/E2E_DEBT.md
+++ b/tests/e2e/E2E_DEBT.md
@@ -20,6 +20,8 @@ This inventory tracks skip/xfail debt found in `tests/e2e/scenarios/` while audi
 
 **ClawHub skills search/install** is selected because it is the smallest high-value deterministic cluster: the tests are intended to validate the browser skills UI lifecycle, but currently depend on live ClawHub search results and network timing. The E2E README already recommends `page.route()` for tabs that depend on external data. Mocking `/api/skills`, `/api/skills/search`, `/api/skills/install`, and `DELETE /api/skills/{name}` keeps the test end-to-end at the browser/API contract layer without requiring live external services.
 
+Live ClawHub contract coverage belongs below the browser E2E tier: gateway/API integration tests should validate request/response shape, authentication, error handling, and registry availability separately from deterministic UI lifecycle tests.
+
 ## Remaining debt policy
 
 - Runtime skips are acceptable only when the prerequisite is genuinely outside the deterministic E2E harness and the reason names that prerequisite.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -69,6 +69,11 @@ Then Playwright drives a headless Chromium browser against the gateway, making D
 For the live 20+ turn persona workflows and recurring tool-misuse patterns seen
 there, see [`LIVE_TOOL_FAILURES.md`](./LIVE_TOOL_FAILURES.md).
 
+## Skip/xfail debt
+
+For the current inventory of E2E skips/xfails and the policy for keeping browser
+lifecycle tests deterministic, see [`E2E_DEBT.md`](./E2E_DEBT.md).
+
 ## Mocking API responses with `page.route()`
 
 For tabs that depend on external data (extensions, jobs, memory, routines), use

--- a/tests/e2e/scenarios/test_skills.py
+++ b/tests/e2e/scenarios/test_skills.py
@@ -1,6 +1,6 @@
 """Scenario 3: Skills search, install, and remove lifecycle."""
 
-import asyncio
+import json
 from urllib.parse import unquote, urlparse
 
 from helpers import SEL
@@ -49,6 +49,7 @@ async def mock_skills_api(page):
     still exercising the real browser code paths.
     """
     installed = []
+    install_requests = []
 
     async def fulfill_json(route, payload):
         await route.fulfill(
@@ -81,6 +82,7 @@ async def mock_skills_api(page):
             return
 
         if path == "/api/skills/install" and request.method == "POST":
+            install_requests.append(json.loads(request.post_data or "{}"))
             if not any(skill["name"] == MOCK_INSTALLED_SKILL["name"] for skill in installed):
                 installed = [dict(MOCK_INSTALLED_SKILL)]
             await fulfill_json(
@@ -104,6 +106,7 @@ async def mock_skills_api(page):
         await route.continue_()
 
     await page.route("**/api/skills**", handle)
+    return {"install_requests": install_requests}
 
 
 async def test_skills_tab_visible(page):
@@ -133,7 +136,7 @@ async def test_skills_search(page):
 
 async def test_skills_install_and_remove(page):
     """Install a mocked catalog skill from search results, then remove it."""
-    await mock_skills_api(page)
+    mock_api = await mock_skills_api(page)
     await go_to_skills(page)
 
     search_input = page.locator(SEL["skill_search_input"])
@@ -143,18 +146,18 @@ async def test_skills_install_and_remove(page):
     results = page.locator(SEL["skill_search_result"])
     await results.first.wait_for(state="visible", timeout=5000)
 
-    page.once("dialog", lambda dialog: asyncio.create_task(dialog.accept()))
-
     install_btn = results.first.locator("button", has_text="Install")
     assert await install_btn.count() == 1, "Expected mocked catalog skill to be installable"
     async with page.expect_response(lambda r: "/api/skills/install" in r.url) as install_response:
         await install_btn.click()
     response = await install_response.value
     assert response.ok
+    assert mock_api["install_requests"] == [
+        {"name": MOCK_CATALOG_SKILL["name"], "slug": MOCK_CATALOG_SKILL["slug"]}
+    ], "Install request should use the catalog skill name and slug"
 
-    # The install action updates the search card immediately; refresh the
-    # installed-skills list so the remove path starts from that UI surface.
-    await page.evaluate("loadSkills()")
+    # The app refreshes the installed-skills list after a successful install;
+    # waiting on the DOM keeps this as a black-box UI contract.
     installed = page.locator(SEL["skill_installed"])
     await installed.first.wait_for(state="visible", timeout=5000)
 

--- a/tests/e2e/scenarios/test_skills.py
+++ b/tests/e2e/scenarios/test_skills.py
@@ -1,7 +1,35 @@
 """Scenario 3: Skills search, install, and remove lifecycle."""
 
-import pytest
+import asyncio
+from urllib.parse import unquote, urlparse
+
 from helpers import SEL
+
+
+MOCK_CATALOG_SKILL = {
+    "slug": "e2e/markdown-helper",
+    "name": "Markdown Helper",
+    "description": "Deterministic E2E skill for markdown workflows.",
+    "version": "1.0.0",
+    "score": 1.0,
+    "updatedAt": 1778000000000,
+    "stars": 12,
+    "downloads": 3456,
+    "owner": "e2e",
+    "installed": False,
+}
+
+MOCK_INSTALLED_SKILL = {
+    "name": "markdown-helper",
+    "description": "Deterministic E2E skill for markdown workflows.",
+    "version": "1.0.0",
+    "trust": "Installed",
+    "source": "Installed",
+    "keywords": ["markdown", "e2e"],
+    "usage_hint": "Type `/markdown-helper` in chat to force-activate this skill.",
+    "has_requirements": False,
+    "has_scripts": False,
+}
 
 
 async def go_to_skills(page):
@@ -13,6 +41,71 @@ async def go_to_skills(page):
     )
 
 
+async def mock_skills_api(page):
+    """Mock skills API endpoints used by the browser lifecycle tests.
+
+    These tests validate the Settings > Skills UI contract, not live ClawHub
+    availability. Keeping the API local avoids skip-on-network behavior while
+    still exercising the real browser code paths.
+    """
+    installed = []
+
+    async def fulfill_json(route, payload):
+        await route.fulfill(
+            json=payload,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    async def handle(route):
+        nonlocal installed
+        request = route.request
+        path = urlparse(request.url).path
+
+        if path == "/api/skills" and request.method == "GET":
+            await fulfill_json(route, {"skills": installed, "count": len(installed)})
+            return
+
+        if path == "/api/skills/search" and request.method == "POST":
+            catalog_skill = dict(MOCK_CATALOG_SKILL)
+            catalog_skill["installed"] = any(
+                skill["name"] == MOCK_INSTALLED_SKILL["name"] for skill in installed
+            )
+            await fulfill_json(
+                route,
+                {
+                    "catalog": [catalog_skill],
+                    "installed": installed,
+                    "registry_url": "https://clawhub.example.test",
+                },
+            )
+            return
+
+        if path == "/api/skills/install" and request.method == "POST":
+            if not any(skill["name"] == MOCK_INSTALLED_SKILL["name"] for skill in installed):
+                installed = [dict(MOCK_INSTALLED_SKILL)]
+            await fulfill_json(
+                route,
+                {
+                    "success": True,
+                    "message": "Skill 'markdown-helper' installed",
+                },
+            )
+            return
+
+        if path.startswith("/api/skills/") and request.method == "DELETE":
+            name = unquote(path.removeprefix("/api/skills/"))
+            installed = [skill for skill in installed if skill["name"] != name]
+            await fulfill_json(
+                route,
+                {"success": True, "message": f"Skill '{name}' removed"},
+            )
+            return
+
+        await route.continue_()
+
+    await page.route("**/api/skills**", handle)
+
+
 async def test_skills_tab_visible(page):
     """Skills subtab shows the search interface."""
     await go_to_skills(page)
@@ -22,68 +115,63 @@ async def test_skills_tab_visible(page):
 
 
 async def test_skills_search(page):
-    """Search ClawHub for skills and verify results appear."""
+    """Search renders deterministic catalog results without live ClawHub."""
+    await mock_skills_api(page)
     await go_to_skills(page)
 
     search_input = page.locator(SEL["skill_search_input"])
     await search_input.fill("markdown")
     await search_input.press("Enter")
 
-    # Wait for results (ClawHub may be slow)
-    try:
-        results = page.locator(SEL["skill_search_result"])
-        await results.first.wait_for(state="visible", timeout=20000)
-    except Exception:
-        pytest.skip("ClawHub registry unreachable or returned no results")
+    results = page.locator(SEL["skill_search_result"])
+    await results.first.wait_for(state="visible", timeout=5000)
 
     count = await results.count()
     assert count >= 1, "Expected at least 1 search result"
+    assert "Markdown Helper" in await results.first.inner_text()
 
 
 async def test_skills_install_and_remove(page):
-    """Install a skill from search results, then remove it."""
+    """Install a mocked catalog skill from search results, then remove it."""
+    await mock_skills_api(page)
     await go_to_skills(page)
 
-    # Search
     search_input = page.locator(SEL["skill_search_input"])
     await search_input.fill("markdown")
     await search_input.press("Enter")
 
-    try:
-        results = page.locator(SEL["skill_search_result"])
-        await results.first.wait_for(state="visible", timeout=20000)
-    except Exception:
-        pytest.skip("ClawHub registry unreachable or returned no results")
+    results = page.locator(SEL["skill_search_result"])
+    await results.first.wait_for(state="visible", timeout=5000)
 
-    # Auto-accept confirm dialogs
-    await page.evaluate("window.confirm = () => true")
+    page.once("dialog", lambda dialog: asyncio.create_task(dialog.accept()))
 
-    # Install first result
     install_btn = results.first.locator("button", has_text="Install")
-    if await install_btn.count() == 0:
-        pytest.skip("No installable skills found in results")
-    await install_btn.click()
+    assert await install_btn.count() == 1, "Expected mocked catalog skill to be installable"
+    async with page.expect_response(lambda r: "/api/skills/install" in r.url) as install_response:
+        await install_btn.click()
+    response = await install_response.value
+    assert response.ok
 
-    # Wait for install to complete -- the UI calls loadSkills() after install,
-    # which populates #skills-list with .ext-card elements
+    # The install action updates the search card immediately; refresh the
+    # installed-skills list so the remove path starts from that UI surface.
+    await page.evaluate("loadSkills()")
     installed = page.locator(SEL["skill_installed"])
-    try:
-        await installed.first.wait_for(state="visible", timeout=15000)
-    except Exception:
-        pytest.skip("Skill install did not update the installed list in time")
+    await installed.first.wait_for(state="visible", timeout=5000)
 
     installed_count = await installed.count()
     assert installed_count >= 1, "Skill should appear in installed list after install"
+    assert "markdown-helper" in await installed.first.inner_text()
 
-    # Remove the skill via confirm modal
     remove_btn = installed.first.locator("button", has_text="Remove")
-    if await remove_btn.count() > 0:
-        await remove_btn.click()
-        # Confirm in the modal
-        confirm_btn = page.locator(SEL["confirm_modal_btn"])
-        await confirm_btn.wait_for(state="visible", timeout=5000)
-        await confirm_btn.click()
-        # Wait for the card to disappear or list to shrink
-        await page.wait_for_timeout(3000)
-        new_count = await page.locator(SEL["skill_installed"]).count()
-        assert new_count < installed_count, "Skill should be removed from installed list"
+    assert await remove_btn.count() == 1, "Installed mocked skill should be removable"
+    await remove_btn.click()
+
+    confirm_btn = page.locator(SEL["confirm_modal_btn"])
+    await confirm_btn.wait_for(state="visible", timeout=5000)
+    await confirm_btn.click()
+
+    await page.wait_for_function(
+        """(selector) => document.querySelectorAll(selector).length === 0""",
+        arg=SEL["skill_installed"],
+        timeout=5000,
+    )


### PR DESCRIPTION
## Summary
- Add an E2E skip/xfail debt inventory with follow-up recommendations
- Link the inventory from the E2E README
- Replace live ClawHub-dependent Skills UI lifecycle checks with deterministic Playwright API mocks
- Remove skip fallbacks from `test_skills.py` search/install/remove paths

## Verification
- `cd tests/e2e && python -m pytest scenarios/test_skills.py -q` → 3 passed
- `cd tests/e2e && python -m pytest scenarios/test_extensions.py::test_activate_mcp_server_success -q` → 1 passed (reran setup-time timeout from first full attempt)
- `cd tests/e2e && python -m pytest scenarios/ -q` → 439 passed, 14 skipped, 3 xfailed in 1613.24s

## Notes
The first full-suite run had one transient Playwright `Page.goto` setup timeout in `test_extensions.py::test_activate_mcp_server_success`; that test passed in isolation and the subsequent full-suite rerun passed cleanly. The remaining skips/xfails are inventoried in `tests/e2e/E2E_DEBT.md`.