### PR TITLE
feat(turns): add turn run wake notifier seam

### DIFF
--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -3,12 +3,31 @@ use std::sync::Arc;
 
 use crate::{
     AdmissionRejection, CancelRunRequest, CancelRunResponse, GetRunStateRequest, ResumeTurnRequest,
-    ResumeTurnResponse, SubmitTurnRequest, SubmitTurnResponse, TurnError, TurnRunState,
-    TurnStateStore,
+    ResumeTurnResponse, SubmitTurnRequest, SubmitTurnResponse, TurnError, TurnRunId, TurnRunState,
+    TurnScope, TurnStateStore, TurnStatus, events::EventCursor,
 };
 
 pub trait TurnAdmissionPolicy: Send + Sync {
     fn check_submit(&self, request: &SubmitTurnRequest) -> Result<(), AdmissionRejection>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnRunWake {
+    pub scope: TurnScope,
+    pub run_id: TurnRunId,
+    pub status: TurnStatus,
+    pub event_cursor: EventCursor,
+}
+
+pub trait TurnRunWakeNotifier: Send + Sync {
+    fn notify_queued_run(&self, wake: TurnRunWake);
+}
+
+#[derive(Debug, Default)]
+pub struct NoopTurnRunWakeNotifier;
+
+impl TurnRunWakeNotifier for NoopTurnRunWakeNotifier {
+    fn notify_queued_run(&self, _wake: TurnRunWake) {}
 }
 
 #[derive(Debug, Default)]
@@ -40,6 +59,7 @@ pub trait TurnCoordinator: Send + Sync {
 pub struct DefaultTurnCoordinator<S> {
     store: Arc<S>,
     admission_policy: Arc<dyn TurnAdmissionPolicy>,
+    wake_notifier: Arc<dyn TurnRunWakeNotifier>,
 }
 
 impl<S> DefaultTurnCoordinator<S>
@@ -50,12 +70,42 @@ where
         Self {
             store,
             admission_policy: Arc::new(AllowAllTurnAdmissionPolicy),
+            wake_notifier: Arc::new(NoopTurnRunWakeNotifier),
         }
     }
 
     pub fn with_admission_policy(mut self, policy: Arc<dyn TurnAdmissionPolicy>) -> Self {
         self.admission_policy = policy;
         self
+    }
+
+    pub fn with_wake_notifier(mut self, notifier: Arc<dyn TurnRunWakeNotifier>) -> Self {
+        self.wake_notifier = notifier;
+        self
+    }
+}
+
+fn submit_wake(scope: TurnScope, response: &SubmitTurnResponse) -> TurnRunWake {
+    let SubmitTurnResponse::Accepted {
+        run_id,
+        status,
+        event_cursor,
+        ..
+    } = response;
+    TurnRunWake {
+        scope,
+        run_id: *run_id,
+        status: *status,
+        event_cursor: *event_cursor,
+    }
+}
+
+fn resume_wake(scope: TurnScope, response: &ResumeTurnResponse) -> TurnRunWake {
+    TurnRunWake {
+        scope,
+        run_id: response.run_id,
+        status: response.status,
+        event_cursor: response.event_cursor,
     }
 }
 
@@ -68,16 +118,25 @@ where
         &self,
         request: SubmitTurnRequest,
     ) -> Result<SubmitTurnResponse, TurnError> {
-        self.store
+        let scope = request.scope.clone();
+        let response = self
+            .store
             .submit_turn(request, self.admission_policy.as_ref())
-            .await
+            .await?;
+        self.wake_notifier
+            .notify_queued_run(submit_wake(scope, &response));
+        Ok(response)
     }
 
     async fn resume_turn(
         &self,
         request: ResumeTurnRequest,
     ) -> Result<ResumeTurnResponse, TurnError> {
-        self.store.resume_turn(request).await
+        let scope = request.scope.clone();
+        let response = self.store.resume_turn(request).await?;
+        self.wake_notifier
+            .notify_queued_run(resume_wake(scope, &response));
+        Ok(response)
     }
 
     async fn cancel_run(&self, request: CancelRunRequest) -> Result<CancelRunResponse, TurnError> {

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -20,7 +20,8 @@ pub mod status;
 pub mod store;
 
 pub use coordinator::{
-    AllowAllTurnAdmissionPolicy, DefaultTurnCoordinator, TurnAdmissionPolicy, TurnCoordinator,
+    AllowAllTurnAdmissionPolicy, DefaultTurnCoordinator, NoopTurnRunWakeNotifier,
+    TurnAdmissionPolicy, TurnCoordinator, TurnRunWake, TurnRunWakeNotifier,
 };
 #[cfg(feature = "libsql")]
 pub use db::LibSqlTurnStateStore;

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -19,7 +19,8 @@ use ironclaw_turns::{
     SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy,
     TurnCheckpointId, TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventSink,
     TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnLeaseToken, TurnLifecycleEvent,
-    TurnLockVersion, TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
+    TurnLockVersion, TurnRunId, TurnRunState, TurnRunWake, TurnRunWakeNotifier, TurnRunnerId,
+    TurnScope, TurnStatus,
     events::EventCursor,
     runner::{
         ApplyLoopExitRequest, ApplyValidatedLoopExitRequest, BlockRunRequest,
@@ -143,6 +144,105 @@ async fn same_thread_active_run_returns_busy_but_different_threads_run_independe
         .await
         .unwrap();
     assert_ne!(accepted_run_id(&independent), first_run_id);
+}
+
+#[tokio::test]
+async fn submit_turn_wakes_runner_only_after_accepting_queued_run() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let notifier = Arc::new(RecordingWakeNotifier::default());
+    let coordinator = DefaultTurnCoordinator::new(store)
+        .with_wake_notifier(notifier.clone())
+        .with_admission_policy(Arc::new(DenyFirstThenAllow::default()));
+    let rejected_request = submit_request("thread-a", "idem-rejected");
+
+    let rejected = coordinator.submit_turn(rejected_request).await.unwrap_err();
+    assert!(matches!(rejected, TurnError::AdmissionRejected(_)));
+    assert!(notifier.wakes().is_empty());
+
+    let accepted_request = submit_request("thread-a", "idem-accepted");
+    let accepted = coordinator
+        .submit_turn(accepted_request.clone())
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&accepted);
+    assert_eq!(
+        notifier.wakes(),
+        vec![TurnRunWake {
+            scope: accepted_request.scope,
+            run_id,
+            status: TurnStatus::Queued,
+            event_cursor: EventCursor(1),
+        }]
+    );
+
+    let busy = coordinator
+        .submit_turn(submit_request("thread-a", "idem-busy"))
+        .await
+        .unwrap_err();
+    assert!(matches!(busy, TurnError::ThreadBusy(_)));
+    assert_eq!(notifier.wakes().len(), 1);
+}
+
+#[tokio::test]
+async fn resume_turn_wakes_runner_for_same_run_after_requeue() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let notifier = Arc::new(RecordingWakeNotifier::default());
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(notifier.clone());
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    notifier.clear();
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let gate_ref = GateRef::new("approval-gate").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let resumed = coordinator
+        .resume_turn(ResumeTurnRequest {
+            scope: scope("thread-a"),
+            actor: actor(),
+            run_id,
+            gate_resolution_ref: gate_ref,
+            source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        notifier.wakes(),
+        vec![TurnRunWake {
+            scope: scope("thread-a"),
+            run_id,
+            status: TurnStatus::Queued,
+            event_cursor: resumed.event_cursor,
+        }]
+    );
 }
 
 #[tokio::test]
@@ -1946,6 +2046,27 @@ fn scope(thread: &str) -> TurnScope {
 
 fn actor() -> TurnActor {
     TurnActor::new(UserId::new("user1").unwrap())
+}
+
+#[derive(Default)]
+struct RecordingWakeNotifier {
+    wakes: Mutex<Vec<TurnRunWake>>,
+}
+
+impl RecordingWakeNotifier {
+    fn wakes(&self) -> Vec<TurnRunWake> {
+        self.wakes.lock().unwrap().clone()
+    }
+
+    fn clear(&self) {
+        self.wakes.lock().unwrap().clear();
+    }
+}
+
+impl TurnRunWakeNotifier for RecordingWakeNotifier {
+    fn notify_queued_run(&self, wake: TurnRunWake) {
+        self.wakes.lock().unwrap().push(wake);
+    }
 }
 
 struct AtomicLoopExitPort {

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -21,6 +21,7 @@ Product adapters must continue to use `TurnCoordinator`. Runner transition APIs 
 - A successful claim stores `runner_id`, `lease_token`, `last_heartbeat_at`, `lease_expires_at`, increments `claim_count`, updates the active lock, and emits `RunnerClaimed`.
 - `heartbeat` requires the matching `runner_id` and `lease_token` and rejects leases whose `lease_expires_at` has already passed; on success it refreshes `last_heartbeat_at`, extends `lease_expires_at`, touches the active lock, and emits `RunnerHeartbeat`.
 - Pull-based claims are authoritative. Wake notifications are optimization hints only.
+- After `TurnCoordinator` durably accepts a submitted run or requeues a resumed run, it may emit a redacted queued-run wake hint containing only the canonical scope, `TurnRunId`, queued status, and event cursor. Wake delivery is not a source of truth and duplicate hints must be harmless.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a redacted `TurnRunWake` / `TurnRunWakeNotifier` seam on `DefaultTurnCoordinator`
- emit queued-run wake hints only after durable submit/resume store success
- document wake hints as optimization-only and duplicate-safe

## Tests
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --test turn_coordinator_contract`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --all-features`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo clippy -p ironclaw_turns --all-targets --all-features -- -D warnings`
- `bash scripts/pre-commit-safety.sh`
- `cargo fmt --check --package ironclaw_turns`
- `git diff --check`

## Review
- paranoid review run `ca02b9df`: 3 independent reviewers, no Critical/High/Medium findings
