### PR TITLE
fix(ci): keep nightly e2e alert outside reusable workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,8 +11,6 @@ on:
         required: false
         type: string
         default: full
-  schedule:
-    - cron: "0 3 * * *"  # Nightly full E2E at 03:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -127,24 +125,3 @@ jobs:
             exit 1
           fi
 
-  nightly-alert:
-    name: Nightly E2E Alert
-    runs-on: ubuntu-latest
-    if: always() && github.event_name == 'schedule'
-    permissions:
-      actions: read
-      contents: read
-      issues: write
-    needs: [e2e]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Report nightly E2E result
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          ALERT_WORKFLOW_NAME: Nightly E2E
-          ALERT_ISSUE_TITLE: Nightly E2E failed
-          ALERT_RESULT: ${{ needs.e2e.result }}
-        run: .github/scripts/nightly-alert-issue.sh

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,46 @@
+name: Nightly E2E
+
+# Scheduled wrapper around the reusable E2E workflow. Keep alerting here rather
+# than inside e2e.yml so callers like Run Tests can reference e2e.yml without
+# inheriting schedule-only issue-writing permissions.
+on:
+  schedule:
+    - cron: "0 3 * * *" # Nightly full E2E at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: Full E2E
+    uses: ./.github/workflows/e2e.yml
+    with:
+      ref: ${{ github.sha }}
+      mode: full
+
+  nightly-alert:
+    name: Nightly E2E Alert
+    runs-on: ubuntu-latest
+    if: always() && github.event_name == 'schedule'
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    needs: [e2e]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Report nightly E2E result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ALERT_WORKFLOW_NAME: Nightly E2E
+          ALERT_ISSUE_TITLE: Nightly E2E failed
+          ALERT_RESULT: ${{ needs.e2e.result }}
+        run: .github/scripts/nightly-alert-issue.sh


### PR DESCRIPTION
## Summary
- remove the scheduled alert job from reusable `.github/workflows/e2e.yml`
- add a dedicated `Nightly E2E` wrapper workflow that schedules full E2E and reports issues on scheduled failures

## Why
`Run Tests` on main has been failing at workflow startup since #3293. The reusable `e2e.yml` gained a schedule-only alert job requesting `issues: write`. Even though the e2e jobs in `test.yml` are conditional, GitHub validates the referenced reusable workflow and fails startup before creating jobs.

## Verification
- Parsed `.github/workflows/e2e.yml`, `.github/workflows/nightly-e2e.yml`, and `.github/workflows/test.yml` with Ruby YAML parser.

Expected effect: the next main push should start `Run Tests` normally instead of `startup_failure`.