### PR TITLE
fix(turns): make run wake notifications best effort

### DIFF
--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use std::sync::Arc;
+use std::{
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::Arc,
+};
 
 use crate::{
     AdmissionRejection, CancelRunRequest, CancelRunResponse, GetRunStateRequest, ResumeTurnRequest,
@@ -19,15 +22,22 @@ pub struct TurnRunWake {
     pub event_cursor: EventCursor,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnRunWakeNotifyError {
+    DeliveryUnavailable,
+}
+
 pub trait TurnRunWakeNotifier: Send + Sync {
-    fn notify_queued_run(&self, wake: TurnRunWake);
+    fn notify_queued_run(&self, wake: TurnRunWake) -> Result<(), TurnRunWakeNotifyError>;
 }
 
 #[derive(Debug, Default)]
 pub struct NoopTurnRunWakeNotifier;
 
 impl TurnRunWakeNotifier for NoopTurnRunWakeNotifier {
-    fn notify_queued_run(&self, _wake: TurnRunWake) {}
+    fn notify_queued_run(&self, _wake: TurnRunWake) -> Result<(), TurnRunWakeNotifyError> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -109,6 +119,10 @@ fn resume_wake(scope: TurnScope, response: &ResumeTurnResponse) -> TurnRunWake {
     }
 }
 
+fn notify_queued_run_best_effort(notifier: &dyn TurnRunWakeNotifier, wake: TurnRunWake) {
+    let _ = catch_unwind(AssertUnwindSafe(|| notifier.notify_queued_run(wake)));
+}
+
 #[async_trait]
 impl<S> TurnCoordinator for DefaultTurnCoordinator<S>
 where
@@ -123,8 +137,7 @@ where
             .store
             .submit_turn(request, self.admission_policy.as_ref())
             .await?;
-        self.wake_notifier
-            .notify_queued_run(submit_wake(scope, &response));
+        notify_queued_run_best_effort(self.wake_notifier.as_ref(), submit_wake(scope, &response));
         Ok(response)
     }
 
@@ -134,8 +147,7 @@ where
     ) -> Result<ResumeTurnResponse, TurnError> {
         let scope = request.scope.clone();
         let response = self.store.resume_turn(request).await?;
-        self.wake_notifier
-            .notify_queued_run(resume_wake(scope, &response));
+        notify_queued_run_best_effort(self.wake_notifier.as_ref(), resume_wake(scope, &response));
         Ok(response)
     }
 

--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
 use std::{
+    fmt,
     panic::{AssertUnwindSafe, catch_unwind},
     sync::Arc,
 };
+use tracing::debug;
 
 use crate::{
     AdmissionRejection, CancelRunRequest, CancelRunResponse, GetRunStateRequest, ResumeTurnRequest,
@@ -23,9 +25,20 @@ pub struct TurnRunWake {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TurnRunWakeNotifyError {
     DeliveryUnavailable,
 }
+
+impl fmt::Display for TurnRunWakeNotifyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DeliveryUnavailable => formatter.write_str("delivery_unavailable"),
+        }
+    }
+}
+
+impl std::error::Error for TurnRunWakeNotifyError {}
 
 pub trait TurnRunWakeNotifier: Send + Sync {
     fn notify_queued_run(&self, wake: TurnRunWake) -> Result<(), TurnRunWakeNotifyError>;
@@ -120,7 +133,11 @@ fn resume_wake(scope: TurnScope, response: &ResumeTurnResponse) -> TurnRunWake {
 }
 
 fn notify_queued_run_best_effort(notifier: &dyn TurnRunWakeNotifier, wake: TurnRunWake) {
-    let _ = catch_unwind(AssertUnwindSafe(|| notifier.notify_queued_run(wake)));
+    match catch_unwind(AssertUnwindSafe(|| notifier.notify_queued_run(wake))) {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => debug!(error = %error, "turn run wake notification failed"),
+        Err(_) => debug!("turn run wake notifier panicked"),
+    }
 }
 
 #[async_trait]

--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -24,7 +24,7 @@ pub struct TurnRunWake {
     pub event_cursor: EventCursor,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum TurnRunWakeNotifyError {
     DeliveryUnavailable,

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -21,7 +21,7 @@ pub mod store;
 
 pub use coordinator::{
     AllowAllTurnAdmissionPolicy, DefaultTurnCoordinator, NoopTurnRunWakeNotifier,
-    TurnAdmissionPolicy, TurnCoordinator, TurnRunWake, TurnRunWakeNotifier,
+    TurnAdmissionPolicy, TurnCoordinator, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError,
 };
 #[cfg(feature = "libsql")]
 pub use db::LibSqlTurnStateStore;

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -10,17 +10,18 @@ use std::{
 use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
-    AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, BlockedReason,
-    CancelRunRequest, DefaultTurnCoordinator, GateRef, GetRunStateRequest, IdempotencyKey,
-    InMemoryTurnEventSink, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, LoopCompleted,
-    LoopCompletionKind, LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy, LoopGateRef,
-    LoopMessageRef, ReplyTargetBindingRef, ResumeTurnRequest, RunProfileId, RunProfileRequest,
-    RunProfileVersion, SanitizedCancelReason, SanitizedFailure, SourceBindingRef,
-    SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy,
-    TurnCheckpointId, TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventSink,
-    TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnLeaseToken, TurnLifecycleEvent,
-    TurnLockVersion, TurnRunId, TurnRunState, TurnRunWake, TurnRunWakeNotifier, TurnRunnerId,
-    TurnScope, TurnStatus,
+    AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, AllowAllTurnAdmissionPolicy,
+    BlockedReason, CancelRunRequest, DefaultTurnCoordinator, GateRef, GetRunStateRequest,
+    IdempotencyKey, InMemoryTurnEventSink, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits,
+    LoopCompleted, LoopCompletionKind, LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy,
+    LoopGateRef, LoopMessageRef, ReplyTargetBindingRef, ResumeTurnRequest, RunProfileId,
+    RunProfileRequest, RunProfileVersion, SanitizedCancelReason, SanitizedFailure,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
+    TurnAdmissionPolicy, TurnCheckpointId, TurnCoordinator, TurnError, TurnErrorCategory,
+    TurnEventKind, TurnEventSink, TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind,
+    TurnLeaseToken, TurnLifecycleEvent, TurnLockVersion, TurnRunId, TurnRunState, TurnRunWake,
+    TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnRunnerId, TurnScope, TurnStateStore,
+    TurnStatus,
     events::EventCursor,
     runner::{
         ApplyLoopExitRequest, ApplyValidatedLoopExitRequest, BlockRunRequest,
@@ -243,6 +244,83 @@ async fn resume_turn_wakes_runner_for_same_run_after_requeue() {
             event_cursor: resumed.event_cursor,
         }]
     );
+}
+
+#[tokio::test]
+async fn submit_turn_ignores_wake_notification_failure_after_persisting_run() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let coordinator = DefaultTurnCoordinator::new(store.clone())
+        .with_wake_notifier(Arc::new(FailingWakeNotifier));
+
+    let response = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    let run_id = accepted_run_id(&response);
+
+    let state = coordinator
+        .get_run_state(GetRunStateRequest {
+            scope: scope("thread-a"),
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(state.status, TurnStatus::Queued);
+}
+
+#[tokio::test]
+async fn resume_turn_ignores_wake_notification_panic_after_requeue() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let coordinator = DefaultTurnCoordinator::new(store.clone())
+        .with_wake_notifier(Arc::new(PanickingWakeNotifier));
+    let run_id = store
+        .submit_turn(
+            submit_request("thread-a", "idem-submit-a"),
+            &AllowAllTurnAdmissionPolicy,
+        )
+        .await
+        .map(|response| accepted_run_id(&response))
+        .unwrap();
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let gate_ref = GateRef::new("approval-gate").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let resumed = coordinator
+        .resume_turn(ResumeTurnRequest {
+            scope: scope("thread-a"),
+            actor: actor(),
+            run_id,
+            gate_resolution_ref: gate_ref,
+            source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(resumed.run_id, run_id);
+    assert_eq!(resumed.status, TurnStatus::Queued);
 }
 
 #[tokio::test]
@@ -2064,8 +2142,25 @@ impl RecordingWakeNotifier {
 }
 
 impl TurnRunWakeNotifier for RecordingWakeNotifier {
-    fn notify_queued_run(&self, wake: TurnRunWake) {
+    fn notify_queued_run(&self, wake: TurnRunWake) -> Result<(), TurnRunWakeNotifyError> {
         self.wakes.lock().unwrap().push(wake);
+        Ok(())
+    }
+}
+
+struct FailingWakeNotifier;
+
+impl TurnRunWakeNotifier for FailingWakeNotifier {
+    fn notify_queued_run(&self, _wake: TurnRunWake) -> Result<(), TurnRunWakeNotifyError> {
+        Err(TurnRunWakeNotifyError::DeliveryUnavailable)
+    }
+}
+
+struct PanickingWakeNotifier;
+
+impl TurnRunWakeNotifier for PanickingWakeNotifier {
+    fn notify_queued_run(&self, _wake: TurnRunWake) -> Result<(), TurnRunWakeNotifyError> {
+        panic!("test wake notifier panic")
     }
 }
 

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -21,7 +21,7 @@ Product adapters must continue to use `TurnCoordinator`. Runner transition APIs 
 - A successful claim stores `runner_id`, `lease_token`, `last_heartbeat_at`, `lease_expires_at`, increments `claim_count`, updates the active lock, and emits `RunnerClaimed`.
 - `heartbeat` requires the matching `runner_id` and `lease_token` and rejects leases whose `lease_expires_at` has already passed; on success it refreshes `last_heartbeat_at`, extends `lease_expires_at`, touches the active lock, and emits `RunnerHeartbeat`.
 - Pull-based claims are authoritative. Wake notifications are optimization hints only.
-- After `TurnCoordinator` durably accepts a submitted run or requeues a resumed run, it may emit a redacted queued-run wake hint containing only the canonical scope, `TurnRunId`, queued status, and event cursor. Wake delivery is not a source of truth and duplicate hints must be harmless.
+- After `TurnCoordinator` durably accepts a submitted run or requeues a resumed run, it may emit a redacted queued-run wake hint containing only the canonical scope, `TurnRunId`, queued status, and event cursor. Wake delivery is best-effort, is not a source of truth, must not fail the durable adapter call, and duplicate hints must be harmless.
 
 ---
 


### PR DESCRIPTION
## Summary
- make `TurnRunWakeNotifier` explicitly fallible with sanitized `TurnRunWakeNotifyError`
- isolate notifier `Err` and panic from the durable submit/resume response path
- add regression tests for notifier failure after submit persistence and notifier panic after resume requeue
- update turn-runner contract docs to state wake delivery is best-effort and must not fail durable adapter calls

## Reviewer finding addressed
- Medium from reviewer run `e883c4e5`: wake delivery could make a durably successful adapter call fail/panic despite being optimization-only.

## Tests
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --test turn_coordinator_contract wake_notification`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --test turn_coordinator_contract`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --all-features`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo clippy -p ironclaw_turns --all-targets --all-features -- -D warnings`
- `bash scripts/pre-commit-safety.sh`
- `cargo fmt --check --package ironclaw_turns`
- `git diff --check`

## Review
- Fix review run `c47bc44b`: 3 independent reviewers, no Critical/High/Medium findings.

## Merge policy
- Do not merge without explicit operator approval.
