### PR TITLE
ci: attribute nightly failures to PRs merged since last green

### DIFF
--- a/.github/scripts/nightly-alert-issue.sh
+++ b/.github/scripts/nightly-alert-issue.sh
@@ -103,11 +103,98 @@ find_open_issue() {
     --jq 'map(select(.title == env.ALERT_ISSUE_TITLE))[0].number // empty'
 }
 
+# Collect PRs merged into the alert branch since the previous successful run of
+# this workflow, so the failure issue can @-mention authors who landed in the
+# blame window. All API calls are best-effort: if any step fails (no prior
+# green run, missing GroOT pulls endpoint, transient API error) the function
+# writes a one-line note to its output file and returns 0 so the rest of the
+# alert body renders normally.
+collect_merged_prs() {
+  local output_file="$1"
+  local branch="${ALERT_BRANCH:-${GITHUB_REF_NAME:-main}}"
+  local current_sha="${ALERT_SHA}"
+  local max_prs="${ALERT_MAX_MERGED_PRS:-30}"
+
+  : > "$output_file"
+
+  local last_good_sha
+  last_good_sha="$(
+    gh run list \
+      --repo "$REPO" \
+      --workflow "$ALERT_WORKFLOW_NAME" \
+      --branch "$branch" \
+      --status success \
+      --limit 1 \
+      --json headSha \
+      --jq '.[0].headSha // empty' \
+      2>/dev/null
+  )" || true
+
+  if [[ -z "$last_good_sha" || "$last_good_sha" == "$current_sha" ]]; then
+    echo "_No prior successful \`${ALERT_WORKFLOW_NAME}\` run on \`${branch}\` to attribute against._" > "$output_file"
+    return 0
+  fi
+
+  local commits
+  commits="$(
+    gh api "repos/${REPO}/compare/${last_good_sha}...${current_sha}" \
+      --jq '.commits[].sha' \
+      2>/dev/null
+  )" || true
+
+  if [[ -z "$commits" ]]; then
+    echo "_No new commits between \`${last_good_sha:0:7}\` (last green) and \`${current_sha:0:7}\` (this run)._" > "$output_file"
+    return 0
+  fi
+
+  local pr_rows
+  pr_rows="$(mktemp)"
+  while IFS= read -r sha; do
+    [[ -z "$sha" ]] && continue
+    gh api "repos/${REPO}/commits/${sha}/pulls" \
+      --jq '.[] | select(.merged_at != null) | "\(.number)\t\(.user.login)\t\(.title)"' \
+      2>/dev/null \
+      >> "$pr_rows" || true
+  done <<< "$commits"
+
+  if [[ ! -s "$pr_rows" ]]; then
+    {
+      echo "Commits since last green at \`${last_good_sha:0:7}\` (no associated merged PRs found):"
+      echo
+      while IFS= read -r sha; do
+        [[ -z "$sha" ]] && continue
+        echo "- \`${sha:0:7}\`"
+      done <<< "$commits"
+    } > "$output_file"
+    rm -f "$pr_rows"
+    return 0
+  fi
+
+  local total_prs
+  total_prs="$(sort -k1,1n "$pr_rows" | awk -F'\t' '!seen[$1]++' | wc -l | tr -d ' ')"
+  {
+    echo "PRs merged into \`${branch}\` between \`${last_good_sha:0:7}\` (last green) and \`${current_sha:0:7}\` (this run):"
+    echo
+    sort -k1,1n "$pr_rows" \
+      | awk -F'\t' '!seen[$1]++' \
+      | head -n "$max_prs" \
+      | while IFS=$'\t' read -r number author title; do
+          echo "- #${number} ${title} — @${author}"
+        done
+    if [[ "$total_prs" -gt "$max_prs" ]]; then
+      echo
+      echo "_Showing first ${max_prs} of ${total_prs} PRs in the window._"
+    fi
+  } > "$output_file"
+  rm -f "$pr_rows"
+}
+
 write_failure_body() {
   local body_file="$1"
   local jobs_file="$2"
   local excerpt_file="$3"
   local log_error_file="$4"
+  local merged_prs_file="${5:-}"
 
   {
     echo "❌ ${ALERT_WORKFLOW_NAME} scheduled run failed."
@@ -142,6 +229,12 @@ write_failure_body() {
     sed 's/```/` ` `/g' "$excerpt_file"
     echo '```'
     echo
+    if [[ -n "$merged_prs_file" && -s "$merged_prs_file" ]]; then
+      echo "## Merged since last green"
+      echo
+      cat "$merged_prs_file"
+      echo
+    fi
     echo "This issue is updated in place on repeated failures to avoid notification spam. If the next scheduled run passes, the nightly alert job will close this issue automatically."
   } > "$body_file"
 }
@@ -191,12 +284,13 @@ main() {
     exit 0
   fi
 
-  local tmp_dir log_file log_error failed_jobs excerpt body
+  local tmp_dir log_file log_error failed_jobs excerpt body merged_prs
   tmp_dir="$(mktemp -d)"
   log_file="${tmp_dir}/failed.log"
   log_error="${tmp_dir}/failed-log-error.txt"
   failed_jobs="${tmp_dir}/failed-jobs.md"
   excerpt="${tmp_dir}/excerpt.txt"
+  merged_prs="${tmp_dir}/merged-prs.md"
   body="${tmp_dir}/issue.md"
 
   if ! gh run view "$ALERT_RUN_ID" --repo "$REPO" --log-failed > "$log_file" 2> "$log_error"; then
@@ -207,8 +301,10 @@ main() {
     --jq '.jobs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped") | "- \(.name) (`\(.conclusion // "unknown")`): \(.html_url)"' \
     > "$failed_jobs" || true
 
+  collect_merged_prs "$merged_prs"
+
   extract_failure_excerpt "$log_file" "$excerpt" "${MAX_EXCERPT_LINES:-220}"
-  write_failure_body "$body" "$failed_jobs" "$excerpt" "$log_error"
+  write_failure_body "$body" "$failed_jobs" "$excerpt" "$log_error" "$merged_prs"
   truncate_file_chars "$body" "${body}.bounded" "${MAX_ISSUE_BODY_CHARS:-60000}" "issue body"
   mv "${body}.bounded" "$body"
 

--- a/.github/scripts/nightly-alert-issue.test.sh
+++ b/.github/scripts/nightly-alert-issue.test.sh
@@ -90,6 +90,26 @@ assert_contains "${workdir}/body.md" "updated in place on repeated failures"
 truncate_file_chars "${workdir}/body.md" "${workdir}/body-bounded.md" 240 "issue body"
 assert_contains "${workdir}/body-bounded.md" "[issue body truncated to 240 characters]"
 
+# write_failure_body renders the "Merged since last green" section when given
+# a non-empty merged-PRs file, and omits it cleanly when not.
+cat > "${workdir}/merged-prs.md" <<'PRS'
+- #4242 fix(engine): tighten thread shutdown — @alice
+- #4243 chore(deps): bump tokio — @bob
+PRS
+ALERT_WORKFLOW_NAME="Nightly E2E" \
+ALERT_RESULT="failure" \
+ALERT_RUN_URL="https://github.example/runs/1" \
+ALERT_SHA="abc123" \
+write_failure_body "${workdir}/body-with-prs.md" "${workdir}/jobs.md" "${workdir}/excerpt.txt" "${workdir}/log-error.txt" "${workdir}/merged-prs.md"
+assert_contains "${workdir}/body-with-prs.md" "## Merged since last green"
+assert_contains "${workdir}/body-with-prs.md" "@alice"
+assert_contains "${workdir}/body-with-prs.md" "#4243"
+if grep -Fq "## Merged since last green" "${workdir}/body.md"; then
+  echo "Body without merged-prs file must not render the merged-PRs section" >&2
+  cat "${workdir}/body.md" >&2
+  exit 1
+fi
+
 mkdir -p "${workdir}/bin"
 cat > "${workdir}/bin/gh" <<'GH'
 #!/usr/bin/env bash
@@ -104,8 +124,25 @@ case "${1:-} ${2:-}" in
   "run view")
     echo "FAILED tests/e2e/scenarios/test_chat.py::test_chat - AssertionError"
     ;;
+  "run list")
+    if [[ "${FAKE_LAST_GREEN_SHA:-}" != "" ]]; then
+      echo "${FAKE_LAST_GREEN_SHA}"
+    fi
+    ;;
   "api repos/example/repo/actions/runs/99/jobs?per_page=100")
     echo "- E2E (core) (\`failure\`): https://github.example/jobs/1"
+    ;;
+  "api repos/example/repo/compare/deadbee...abc123")
+    echo "sha111"
+    echo "sha222"
+    ;;
+  "api repos/example/repo/commits/sha111/pulls")
+    printf '%s\t%s\t%s\n' "4242" "alice" "fix(engine): tighten thread shutdown"
+    ;;
+  "api repos/example/repo/commits/sha222/pulls")
+    printf '%s\t%s\t%s\n' "4243" "bob" "chore(deps): bump tokio"
+    # Same PR appearing on multiple commits must dedupe.
+    printf '%s\t%s\t%s\n' "4242" "alice" "fix(engine): tighten thread shutdown"
     ;;
   "issue edit"|"issue create"|"issue close")
     ;;
@@ -122,6 +159,7 @@ run_alert_script() {
   PATH="${workdir}/bin:${PATH}" \
   FAKE_GH_CALLS="${workdir}/gh-calls.txt" \
   FAKE_EXISTING_ISSUE="${FAKE_EXISTING_ISSUE:-}" \
+  FAKE_LAST_GREEN_SHA="${FAKE_LAST_GREEN_SHA:-}" \
   GH_TOKEN="token" \
   REPO="example/repo" \
   GITHUB_RUN_ID="99" \
@@ -129,6 +167,7 @@ run_alert_script() {
   GITHUB_SERVER_URL="https://github.example" \
   GITHUB_REPOSITORY="example/repo" \
   GITHUB_SHA="abc123" \
+  ALERT_BRANCH="main" \
   ALERT_WORKFLOW_NAME="Nightly E2E" \
   ALERT_ISSUE_TITLE="Nightly E2E failed" \
   ALERT_RESULT="$result" \
@@ -136,13 +175,59 @@ run_alert_script() {
 }
 
 : > "${workdir}/gh-calls.txt"
-FAKE_EXISTING_ISSUE="1" run_alert_script "failure"
+FAKE_EXISTING_ISSUE="1" FAKE_LAST_GREEN_SHA="deadbee" run_alert_script "failure"
 assert_contains "${workdir}/gh-calls.txt" "issue edit 42"
+assert_contains "${workdir}/gh-calls.txt" "compare/deadbee...abc123"
+assert_contains "${workdir}/gh-calls.txt" "commits/sha111/pulls"
 if grep -Fq "issue comment" "${workdir}/gh-calls.txt"; then
   echo "Repeated failures must update the issue body, not add comment spam" >&2
   cat "${workdir}/gh-calls.txt" >&2
   exit 1
 fi
+
+# When no prior green run is recorded the script must still post the alert,
+# but with the no-baseline note instead of crashing.
+: > "${workdir}/gh-calls.txt"
+FAKE_EXISTING_ISSUE="1" FAKE_LAST_GREEN_SHA="" run_alert_script "failure"
+assert_contains "${workdir}/gh-calls.txt" "issue edit 42"
+if grep -Fq "compare/" "${workdir}/gh-calls.txt"; then
+  echo "Compare API must not be called when no prior green run is found" >&2
+  cat "${workdir}/gh-calls.txt" >&2
+  exit 1
+fi
+
+# Direct unit test for collect_merged_prs: happy path with two commits and a
+# duplicate PR row across commits — output must dedupe and tag both authors.
+ALERT_WORKFLOW_NAME="Nightly E2E" \
+REPO="example/repo" \
+ALERT_BRANCH="main" \
+ALERT_SHA="abc123" \
+PATH="${workdir}/bin:${PATH}" \
+FAKE_GH_CALLS="${workdir}/collect-calls.txt" \
+FAKE_LAST_GREEN_SHA="deadbee" \
+collect_merged_prs "${workdir}/merged-prs-collected.md"
+assert_contains "${workdir}/merged-prs-collected.md" "between \`deadbee\` (last green) and \`abc123\` (this run)"
+assert_contains "${workdir}/merged-prs-collected.md" "#4242"
+assert_contains "${workdir}/merged-prs-collected.md" "@alice"
+assert_contains "${workdir}/merged-prs-collected.md" "#4243"
+assert_contains "${workdir}/merged-prs-collected.md" "@bob"
+duplicate_alice_count="$(grep -Fc "@alice" "${workdir}/merged-prs-collected.md")"
+if [[ "${duplicate_alice_count}" -ne 1 ]]; then
+  echo "Expected @alice to appear exactly once after dedupe, got ${duplicate_alice_count}" >&2
+  cat "${workdir}/merged-prs-collected.md" >&2
+  exit 1
+fi
+
+# collect_merged_prs with no prior green run produces a graceful note.
+ALERT_WORKFLOW_NAME="Nightly E2E" \
+REPO="example/repo" \
+ALERT_BRANCH="main" \
+ALERT_SHA="abc123" \
+PATH="${workdir}/bin:${PATH}" \
+FAKE_GH_CALLS="${workdir}/collect-calls-empty.txt" \
+FAKE_LAST_GREEN_SHA="" \
+collect_merged_prs "${workdir}/merged-prs-empty.md"
+assert_contains "${workdir}/merged-prs-empty.md" "No prior successful"
 
 : > "${workdir}/gh-calls.txt"
 FAKE_EXISTING_ISSUE="1" run_alert_script "success"


### PR DESCRIPTION
## Summary

Extends the nightly alert script (#3293) to attribute failures to the human(s) responsible. When `nightly-alert-issue.sh` opens or updates a failure issue it now adds a "Merged since last green" section that @-mentions every PR author who landed between the previous successful run of the same workflow and the current failed one.

## Approach

- Find the previous successful run of `ALERT_WORKFLOW_NAME` on the same branch via `gh run list --workflow ... --status success --limit 1` — that's the baseline. Zero persistent state.
- `gh api repos/{repo}/compare/{last_green}...{current}` → list of commits in the window.
- For each commit, `gh api repos/{repo}/commits/{sha}/pulls` → associated merged PRs. Dedupe across commits.
- Render `- #1234 PR title — @author` lines in the failure body.

All three API stages are best-effort: a missing baseline (first run, log retention cliff, missing scopes), an empty compare window, or no associated PRs each render an inline explanatory note instead of crashing the alert. PR list is capped via `ALERT_MAX_MERGED_PRS` (default 30) to keep issue bodies bounded.

## Why now

Followed up on a discussion about #3293 — the existing alert tells you something broke but not who to ping. Author tagging is the deterministic, zero-false-positive half of the answer. (LLM-based "which PR caused the failure" attribution is a separate concern; better as a follow-up once this baseline is shipping useful context.)

## What's not in this PR

- No workflow YAML changes — `ALERT_BRANCH` falls back to `GITHUB_REF_NAME` which GitHub Actions sets automatically on `schedule` triggers, so existing callers (`nightly-deep-ci.yml`) work unchanged.
- LLM-based per-PR culprit attribution — punted to a follow-up.

## Verification

- `bash -n .github/scripts/nightly-alert-issue.sh .github/scripts/nightly-alert-issue.test.sh`
- `bash .github/scripts/nightly-alert-issue.test.sh` → all assertions pass

Three new test cases:
1. `collect_merged_prs` happy path with two commits, one duplicate PR row across commits — output dedupes and tags both authors exactly once each.
2. `collect_merged_prs` with no prior green run renders the "no baseline" note, does not call the compare API.
3. `write_failure_body` renders the "Merged since last green" section when given a non-empty merged-PRs file, omits the section cleanly when not.

## Notes

- The fake `gh` stub in the test now handles `run list`, `api .../compare/...`, and `api .../commits/{sha}/pulls`. Existing test cases continue to pass unchanged.
- `gh run list --workflow "$ALERT_WORKFLOW_NAME"` resolves the human-readable workflow name to its ID for us, so we don't need a second API call to look up the workflow.