### PR TITLE
fix(config): keep startup LLM fallback in-memory only (#3229)

### DIFF
--- a/.github/workflows/regression-test-check.yml
+++ b/.github/workflows/regression-test-check.yml
@@ -21,25 +21,29 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Fetch PR head and base
+      - name: Fetch PR base
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git fetch origin -- "$BASE_REF"
-          git fetch origin -- "pull/${PR_NUMBER}/head:pr-head"
 
       - name: Check for regression tests
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
           BASE_REF="origin/${PR_BASE_REF}"
-          # Use the actual PR head, not the merge commit that actions/checkout checks out
-          HEAD_REF="pr-head"
+          # Use the PR head SHA from the event payload directly. The previous
+          # approach fetched `refs/pull/N/head`, which GitHub occasionally
+          # fails to publish for in-repo PRs (hit on #3324, blocking this
+          # workflow before any of its actual checks could run). The SHA is
+          # reachable locally because actions/checkout (fetch-depth: 0)
+          # already pulled the merge commit, whose second parent is this SHA.
+          HEAD_REF="$PR_HEAD_SHA"
 
           # --- 1. Is this a fix PR? Check title first, then commit messages ---
           IS_FIX=false

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -181,9 +181,10 @@ impl LlmConfig {
         // The previously-selected model was tied to the unusable backend
         // (e.g. "openai/gpt-4o" for OpenRouter, "kimi-k2-turbo-preview" for
         // a custom kimi provider). Sending it to NearAI would 404. Clear it
-        // so resolve_model falls through to NearAI's default. The DB sync in
-        // Config::re_resolve_llm_with_secrets deletes the row persistently;
-        // this keeps the in-memory config consistent for the current process.
+        // so resolve_model falls through to NearAI's default. This is
+        // in-memory only — the user's DB-persisted selected_model is
+        // deliberately preserved so a transient hydration failure does not
+        // destroy their configured selection on next restart (#3229).
         fallback.selected_model = None;
         let cfg = Self::resolve(&fallback).map_err(|e| {
             tracing::error!(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -481,6 +481,13 @@ impl Config {
         // backend is unusable. This prevents the #2514 crash-loop and keeps the
         // instance runnable while the user fixes their provider configuration.
         //
+        // The fallback is in-memory only — the user's DB-persisted
+        // `llm_backend` and `selected_model` are deliberately left untouched
+        // so a transient hydration failure (DB read race, secrets decryption
+        // hiccup) does not destroy their configured provider on next restart
+        // (#3229). The previous behavior of syncing the fallback into the DB
+        // turned a one-off fallback into a permanent reversion.
+        //
         // Hot-reload path (strict): use pure `resolve` so a bad save fails the
         // whole call and lets the caller roll back the triggering settings
         // write. Silently falling back here would be worse UX — the user
@@ -490,50 +497,7 @@ impl Config {
             return LlmConfig::resolve(&settings);
         }
 
-        let configured_backend = settings.llm_backend.clone();
-        let cfg = LlmConfig::resolve_with_fallback(&settings)?;
-
-        // If fallback demoted the backend, persist the effective backend to
-        // the DB so the UI, status endpoint, and any other consumers stay
-        // consistent with what is actually running. Without this, the user
-        // would see "Active: openrouter" in Settings while the runtime is
-        // quietly using NearAI.
-        if let Some(store) = store
-            && fallback_fired(configured_backend.as_deref(), &cfg.backend)
-        {
-            tracing::warn!(
-                configured = ?configured_backend,
-                active = %cfg.backend,
-                "Syncing llm_backend in DB to reflect post-fallback runtime state"
-            );
-            if let Err(e) = store
-                .set_setting(
-                    user_id,
-                    "llm_backend",
-                    &serde_json::Value::String(cfg.backend.clone()),
-                )
-                .await
-            {
-                tracing::warn!(
-                    error = %e,
-                    "Failed to persist post-fallback llm_backend to DB — UI may \
-                     display the previously-selected backend until next save"
-                );
-            }
-            // The previously-selected model is almost certainly wrong for
-            // the NearAI fallback (e.g. an OpenRouter model name). Clear
-            // it so resolve_model() picks NearAI's default on next load.
-            if settings.selected_model.is_some()
-                && let Err(e) = store.delete_setting(user_id, "selected_model").await
-            {
-                tracing::warn!(
-                    error = %e,
-                    "Failed to clear selected_model after fallback"
-                );
-            }
-        }
-
-        Ok(cfg)
+        LlmConfig::resolve_with_fallback(&settings)
     }
 
     /// Resolve only the LLM configuration from the current source stack.
@@ -613,63 +577,6 @@ impl Config {
             relay: RelayConfig::from_env(),
         })
     }
-}
-
-/// Detect whether `resolve_with_fallback` demoted the user-configured backend
-/// to NearAI. Returns true when the user explicitly asked for something
-/// non-trivial (non-empty, not already nearai) and the resolver landed on a
-/// different backend. Aliases like `open_ai` → `openai` are not counted as a
-/// fallback — only cross-backend demotion is.
-fn fallback_fired(configured: Option<&str>, active: &str) -> bool {
-    let configured = match configured.map(str::trim).filter(|s| !s.is_empty()) {
-        Some(c) => c,
-        None => return false,
-    };
-    // Normalize both sides so alias-only drift (e.g. open_ai → openai,
-    // near / near_ai → nearai) doesn't spuriously look like a fallback.
-    normalize_backend(configured) != normalize_backend(active)
-}
-
-/// Normalize a backend id to the canonical form that `LlmConfig::resolve`
-/// lands on after alias resolution. Must produce the same canonical id the
-/// resolver uses — otherwise `fallback_fired` will mis-fire on every restart
-/// for any DB value that's a known alias (e.g. `claude` → `anthropic`,
-/// `bigmodel` → `zai`, `github-copilot` → `github_copilot`) and trigger a
-/// spurious DB rewrite.
-///
-/// Two sources of aliases:
-/// 1. Registry-defined aliases — delegated to `ProviderRegistry::find`, which
-///    is the same lookup `resolve_registry_provider` uses.
-/// 2. Hardcoded aliases for the four "virtual" backends that are not in the
-///    registry (nearai / bedrock / gemini_oauth / openai_codex). These must
-///    stay in sync with the matching branches in `LlmConfig::resolve`.
-fn normalize_backend(raw: &str) -> String {
-    let lower = raw.to_lowercase();
-
-    // (1) Virtual backends (not in the registry) — hardcoded alias list
-    // mirroring LlmConfig::resolve.
-    match lower.as_str() {
-        "nearai" | "near" | "near_ai" => return "nearai".to_string(),
-        "bedrock" | "aws" | "aws_bedrock" => return "bedrock".to_string(),
-        "gemini_oauth" | "gemini-oauth" => return "gemini_oauth".to_string(),
-        "openai_codex" | "openai-codex" | "codex" => return "openai_codex".to_string(),
-        _ => {}
-    }
-
-    // (2) Registry providers — any alias declared in `providers.json` is
-    // resolved by `ProviderRegistry::find` to its canonical `id`. This is the
-    // SAME canonicalization `LlmConfig::resolve_registry_provider` does, so
-    // DB values like `claude` / `bigmodel` / `github-copilot` / `open_ai`
-    // won't look like a fallback.
-    if let Some(def) = crate::llm::ProviderRegistry::load().find(&lower) {
-        return def.id.clone();
-    }
-
-    // Unknown backend — resolve() treats it as openai_compatible at runtime,
-    // but here we conservatively return the input as-is. A truly unknown id
-    // won't match the canonical `active` either way; the comparison in
-    // `fallback_fired` just has to be consistent between both sides.
-    lower
 }
 
 pub(crate) fn load_bootstrap_settings(
@@ -1493,85 +1400,89 @@ mod tests {
         );
     }
 
-    // ── fallback_fired / normalize_backend tests ─────────────────────────
-    //
-    // These gate the post-fallback DB sync in re_resolve_llm_with_secrets,
-    // so wrong answers either (a) let stale user intent linger in the DB
-    // (UI shows openrouter, runtime uses NearAI) or (b) clobber the user's
-    // selection every startup even though nothing meaningfully changed.
+    // Regression for #3229: a startup-path fallback to NearAI must NOT
+    // overwrite the user's DB-persisted llm_backend / selected_model.
+    // Before the fix, a transient hydration failure (DB read race, secrets
+    // decryption hiccup) would cause the fallback to be persisted, turning
+    // a one-off into a permanent reversion of the user's configured provider.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn startup_fallback_must_not_overwrite_persisted_user_backend() {
+        use crate::db::SettingsStore;
 
-    #[test]
-    fn fallback_fired_detects_cross_backend_demotion() {
-        // The #2514 scenario: user picked openrouter, config was unusable,
-        // resolver demoted to NearAI. DB must be synced.
-        assert!(fallback_fired(Some("openrouter"), "nearai"));
-        assert!(fallback_fired(Some("anthropic"), "nearai"));
-        assert!(fallback_fired(Some("openai_compatible"), "nearai"));
-    }
+        let _env_guard = crate::config::helpers::lock_env();
+        // SAFETY: Under ENV_MUTEX. Strip env-var inputs so we are testing the
+        // DB-driven path, not values that happen to be set in the test runner.
+        unsafe {
+            std::env::remove_var("LLM_BACKEND");
+            std::env::remove_var("LLM_API_KEY");
+            std::env::remove_var("LLM_BASE_URL");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("OPENROUTER_API_KEY");
+            std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("ANTHROPIC_OAUTH_TOKEN");
+        }
 
-    #[test]
-    fn fallback_fired_ignores_alias_normalization() {
-        // `resolve` canonicalises backend aliases (near → nearai, open_ai →
-        // openai) but that is not a fallback and must not trigger a DB
-        // rewrite — doing so would churn the row on every startup.
-        //
-        // Virtual backends (not in the registry — alias set hardcoded in
-        // normalize_backend):
-        assert!(!fallback_fired(Some("near"), "nearai"));
-        assert!(!fallback_fired(Some("near_ai"), "nearai"));
-        assert!(!fallback_fired(Some("aws"), "bedrock"));
-        assert!(!fallback_fired(Some("aws_bedrock"), "bedrock"));
-        assert!(!fallback_fired(Some("codex"), "openai_codex"));
-        assert!(!fallback_fired(Some("openai-codex"), "openai_codex"));
-        assert!(!fallback_fired(Some("gemini-oauth"), "gemini_oauth"));
-    }
+        // Seed the user's DB row with a properly-configured registry backend
+        // selection but without a hydratable API key, mirroring the #3229
+        // reproduction (Gemini configured in onboarding, key not yet
+        // injected from the encrypted secrets store).
+        let store = FakeSettingsStore::new();
+        store
+            .seed(
+                "owner-user",
+                "llm_backend",
+                serde_json::Value::String("openrouter".to_string()),
+            )
+            .await;
+        store
+            .seed(
+                "owner-user",
+                "selected_model",
+                serde_json::Value::String("openai/gpt-4o-mini".to_string()),
+            )
+            .await;
 
-    #[test]
-    fn fallback_fired_ignores_registry_aliases() {
-        // Regression: `providers.json` declares aliases for many registry
-        // providers (e.g. `claude` → `anthropic`, `bigmodel` → `zai`,
-        // `github-copilot` → `github_copilot`, `open_ai` → `openai`).
-        // `resolve_registry_provider` canonicalises these to the registry's
-        // `id` field, so a DB value of `claude` produces `cfg.backend ==
-        // "anthropic"`. normalize_backend must delegate to the registry so
-        // this is recognised as alias drift, not a fallback. Otherwise the
-        // DB gets rewritten on every startup for users who happen to have
-        // the alias form saved.
-        assert!(!fallback_fired(Some("claude"), "anthropic"));
-        assert!(!fallback_fired(Some("bigmodel"), "zai"));
-        assert!(!fallback_fired(Some("github-copilot"), "github_copilot"));
-        assert!(!fallback_fired(Some("githubcopilot"), "github_copilot"));
-        assert!(!fallback_fired(Some("open_ai"), "openai"));
-        assert!(!fallback_fired(
-            Some("openai-compatible"),
-            "openai_compatible"
-        ));
-        assert!(!fallback_fired(Some("compatible"), "openai_compatible"));
-        assert!(!fallback_fired(Some("open_router"), "openrouter"));
-    }
+        let toml = empty_toml_path();
+        let cfg = Config::resolve_llm_with_secrets(
+            Some(&store as &(dyn crate::db::SettingsStore + Sync)),
+            "owner-user",
+            Some(toml.path()),
+            None, // no secrets store: forces the unusable-config fallback path
+            true,
+        )
+        .await
+        .expect("startup-path resolve should succeed via in-memory NearAI fallback");
 
-    #[test]
-    fn fallback_fired_ignores_empty_or_unset_configured() {
-        // When the DB never had llm_backend set, the default of "nearai"
-        // resolves naturally — there is nothing to sync back.
-        assert!(!fallback_fired(None, "nearai"));
-        assert!(!fallback_fired(Some(""), "nearai"));
-        assert!(!fallback_fired(Some("   "), "nearai"));
-    }
+        // In-memory: the runtime is NearAI so the instance is usable
+        // (#2514 crash-loop prevention still works).
+        assert_eq!(
+            cfg.backend, "nearai",
+            "missing API key must trigger the in-memory NearAI fallback"
+        );
 
-    #[test]
-    fn fallback_fired_treats_case_insensitively() {
-        // DB values can be lowercase or mixed-case; don't treat case-only
-        // drift as a meaningful change.
-        assert!(!fallback_fired(Some("NearAI"), "nearai"));
-        assert!(!fallback_fired(Some("OPENAI"), "openai"));
-    }
-
-    #[test]
-    fn fallback_fired_same_backend_no_sync() {
-        // A properly-configured backend must not trigger a DB rewrite.
-        assert!(!fallback_fired(Some("nearai"), "nearai"));
-        assert!(!fallback_fired(Some("anthropic"), "anthropic"));
-        assert!(!fallback_fired(Some("openrouter"), "openrouter"));
+        // Critical invariant: the user's DB row is untouched. On the next
+        // restart, with secrets hydration succeeding, the user's original
+        // openrouter+model selection takes effect again. The pre-fix code
+        // overwrote llm_backend to "nearai" and deleted selected_model,
+        // permanently destroying the user's intent.
+        let backend = store
+            .get_setting("owner-user", "llm_backend")
+            .await
+            .expect("DB read");
+        assert_eq!(
+            backend,
+            Some(serde_json::Value::String("openrouter".to_string())),
+            "startup fallback must preserve the user's persisted llm_backend (#3229)"
+        );
+        let model = store
+            .get_setting("owner-user", "selected_model")
+            .await
+            .expect("DB read");
+        assert_eq!(
+            model,
+            Some(serde_json::Value::String("openai/gpt-4o-mini".to_string())),
+            "startup fallback must preserve the user's persisted selected_model (#3229)"
+        );
     }
 }


### PR DESCRIPTION
Closes #3229.

## Summary

- A transient hydration failure on startup (DB read race, secrets decryption hiccup) used to overwrite the user's persisted `llm_backend` with `nearai` and delete `selected_model` from the DB, turning a one-off fallback into a permanent reversion of the configured provider. After the fix, the fallback stays in-memory: the runtime still demotes to NearAI to keep the instance usable (#2514 crash-loop prevention is preserved), but the user's DB row is left untouched, so the next restart with credentials available picks up their original config.
- Removed the post-fallback DB write block in `Config::resolve_llm_with_secrets_inner`, plus the now-unused `fallback_fired` / `normalize_backend` helpers and their five unit tests (those existed solely to gate the deleted write). Net `-88` lines on the bug fix.
- Updated the stale comment in `LlmConfig::resolve_nearai_fallback` that referenced the removed DB sync.

## Scope expansion: workflow brittleness fix

While debugging this PR's CI, GitHub failed to publish `refs/pull/3324/head` (confirmed by `git ls-remote` against origin — only `pull/3324/merge` exists; comparable open PRs have both refs). The `regression-test-check.yml` workflow was hard-failing on `git fetch origin pull/N/head:pr-head` before any of its actual checks could run. This was a pre-existing brittleness — the workflow assumes `refs/pull/N/head` is always published, which GitHub does not guarantee.

Bundled fix: derive the head SHA from `github.event.pull_request.head.sha` (always present in the event payload) instead of fetching `refs/pull/N/head`. The merge commit `actions/checkout` already produces with `fetch-depth: 0` has the head SHA as its second parent, so it's locally reachable. Future PRs hit by the same GitHub ref-publishing bug will not need this manual unsticking.

The empty `ci: re-trigger workflows` commit in the history is residue from earlier debugging — it pushed a refreshed SHA to nudge GitHub into publishing the missing ref (didn't work, hence the workflow change).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib` — 5614 passed
- [x] New regression test `config::tests::startup_fallback_must_not_overwrite_persisted_user_backend` — seeds `llm_backend = "openrouter"` + `selected_model = "openai/gpt-4o-mini"`, calls the startup path with no secrets store (forces the unusable-config fallback), asserts the runtime falls back to NearAI **and** the DB row is unchanged. Would have failed on `main` (the row got rewritten to `nearai` and `selected_model` deleted).
- [x] `scripts/pre-commit-safety.sh` passes
- [ ] Workflow change verified in CI on this PR (the very thing it's trying to fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)