### PR TITLE
fix(llm): preserve thinking-mode reasoning artifacts on OpenAI-compat (#3225, #3201)

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -2223,6 +2223,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }

--- a/src/agent/agentic_loop.rs
+++ b/src/agent/agentic_loop.rs
@@ -122,10 +122,17 @@ pub trait LoopDelegate: Send + Sync {
     /// Implementations should call `reason_ctx.set_last_tool_batch_all_failed(true/false)`
     /// to report whether every tool in the batch failed. This enables the
     /// duplicate tool call detector to escalate repeated identical failures.
+    ///
+    /// `reasoning_content` is the provider-specific reasoning artifact (e.g.
+    /// DeepSeek's `reasoning_content`) that must be attached to the
+    /// `assistant_with_tool_calls` message so the next turn can echo it back —
+    /// without it, providers like DeepSeek reject the next call with HTTP 400
+    /// (#3201). `None` for providers that don't surface reasoning artifacts.
     async fn execute_tool_calls(
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        reasoning_content: Option<String>,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, Error>;
 
@@ -253,6 +260,7 @@ pub async fn run_agentic_loop(
             RespondResult::ToolCalls {
                 tool_calls,
                 content,
+                reasoning_content: _,
             } => {
                 let names: Vec<&str> = tool_calls.iter().map(|tc| tc.name.as_str()).collect();
                 tracing::debug!(
@@ -307,6 +315,7 @@ pub async fn run_agentic_loop(
             RespondResult::ToolCalls {
                 tool_calls,
                 content,
+                reasoning_content,
             } => {
                 // If the response was truncated, tool call parameters are likely
                 // incomplete. Discard them and tell the LLM to try a different
@@ -345,7 +354,7 @@ pub async fn run_agentic_loop(
                 reason_ctx.last_tool_batch_all_failed = false;
 
                 if let Some(outcome) = delegate
-                    .execute_tool_calls(tool_calls, content, reason_ctx)
+                    .execute_tool_calls(tool_calls, content, reasoning_content, reason_ctx)
                     .await?
                 {
                     return Ok(outcome);
@@ -434,6 +443,7 @@ mod tests {
             result: RespondResult::ToolCalls {
                 tool_calls: calls,
                 content: None,
+                reasoning_content: None,
             },
             usage: zero_usage(),
             finish_reason: FinishReason::ToolUse,
@@ -528,6 +538,7 @@ mod tests {
             &self,
             _tool_calls: Vec<ToolCall>,
             _content: Option<String>,
+            _reasoning_content: Option<String>,
             reason_ctx: &mut ReasoningContext,
         ) -> Result<Option<LoopOutcome>, crate::error::Error> {
             self.tool_exec_count.fetch_add(1, Ordering::SeqCst);
@@ -577,6 +588,7 @@ mod tests {
             name: "echo".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
         let delegate = MockDelegate::new(vec![
             tool_calls_output(vec![tool_call]),
@@ -687,6 +699,7 @@ mod tests {
                 &self,
                 _: Vec<ToolCall>,
                 _: Option<String>,
+                _: Option<String>,
                 _: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, crate::error::Error> {
                 Ok(None)
@@ -746,6 +759,7 @@ mod tests {
             async fn execute_tool_calls(
                 &self,
                 _: Vec<ToolCall>,
+                _: Option<String>,
                 _: Option<String>,
                 _: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, crate::error::Error> {
@@ -866,11 +880,13 @@ mod tests {
             name: "memory_write".to_string(),
             arguments: serde_json::json!({}), // empty — truncated
             reasoning: None,
+            signature: None,
         };
         let truncated_output = RespondOutput {
             result: RespondResult::ToolCalls {
                 tool_calls: vec![truncated_tool_call],
                 content: Some("I'll write the report.".to_string()),
+                reasoning_content: None,
             },
             usage: zero_usage(),
             finish_reason: FinishReason::Length, // response was truncated
@@ -918,8 +934,10 @@ mod tests {
                     name: "memory_write".to_string(),
                     arguments: serde_json::json!({}),
                     reasoning: None,
+                    signature: None,
                 }],
                 content: None,
+                reasoning_content: None,
             },
             usage: zero_usage(),
             finish_reason: FinishReason::Length,
@@ -962,6 +980,7 @@ mod tests {
             name: "echo".into(),
             arguments: serde_json::json!({"msg": "hi"}),
             reasoning: None,
+            signature: None,
         }];
         let fp = DuplicateToolCallTracker::fingerprint(&calls);
         // Tool succeeded — count stays at 0
@@ -977,6 +996,7 @@ mod tests {
             name: "http_get".into(),
             arguments: serde_json::json!({"url": "https://example.com"}),
             reasoning: None,
+            signature: None,
         }];
         let fp = DuplicateToolCallTracker::fingerprint(&calls);
         assert_eq!(tracker.record_with_fingerprint(fp, true), 1);
@@ -992,6 +1012,7 @@ mod tests {
             name: "http_get".into(),
             arguments: serde_json::json!({"url": "https://example.com"}),
             reasoning: None,
+            signature: None,
         }];
         let fp = DuplicateToolCallTracker::fingerprint(&calls);
         assert_eq!(tracker.record_with_fingerprint(fp, true), 1);
@@ -1010,12 +1031,14 @@ mod tests {
             name: "http_get".into(),
             arguments: serde_json::json!({"url": "https://a.com"}),
             reasoning: None,
+            signature: None,
         }];
         let calls_b = vec![ToolCall {
             id: "c1".into(),
             name: "http_get".into(),
             arguments: serde_json::json!({"url": "https://b.com"}),
             reasoning: None,
+            signature: None,
         }];
         let fp_a = DuplicateToolCallTracker::fingerprint(&calls_a);
         let fp_b = DuplicateToolCallTracker::fingerprint(&calls_b);
@@ -1033,12 +1056,14 @@ mod tests {
             name: "echo".into(),
             arguments: serde_json::json!({"a": 1, "b": 2}),
             reasoning: None,
+            signature: None,
         }];
         let calls_b = vec![ToolCall {
             id: "c1".into(),
             name: "echo".into(),
             arguments: serde_json::json!({"b": 2, "a": 1}),
             reasoning: None,
+            signature: None,
         }];
         assert_eq!(
             DuplicateToolCallTracker::fingerprint(&calls_a),
@@ -1055,6 +1080,7 @@ mod tests {
             name: "http_get".to_string(),
             arguments: serde_json::json!({"url": "https://broken.example.com"}),
             reasoning: None,
+            signature: None,
         };
         // 3 identical failing tool calls, then text response
         let mut delegate = MockDelegate::new(vec![
@@ -1103,6 +1129,7 @@ mod tests {
             name: "http_get".to_string(),
             arguments: serde_json::json!({"url": "https://broken.example.com"}),
             reasoning: None,
+            signature: None,
         };
         // 5 identical failing tool calls, then text response
         let mut delegate = MockDelegate::new(vec![
@@ -1140,6 +1167,7 @@ mod tests {
             name: "http_get".to_string(),
             arguments: serde_json::json!({"url": "https://broken.example.com"}),
             reasoning: None,
+            signature: None,
         };
         // 2 failing calls, then a text continuation, then 2 more of the same failing calls
         // The text response in the middle should reset the streak, so we never hit 3.
@@ -1191,6 +1219,7 @@ mod tests {
             async fn execute_tool_calls(
                 &self,
                 _: Vec<ToolCall>,
+                _: Option<String>,
                 _: Option<String>,
                 reason_ctx: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, crate::error::Error> {

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -765,6 +765,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        reasoning_content: Option<String>,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, Error> {
         // Extract and sanitize the narrative before consuming `content`.
@@ -782,12 +783,13 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 
         // Add the assistant message with tool_calls to context.
         // OpenAI protocol requires this before tool-result messages.
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        // `reasoning_content` round-trips provider-specific thinking artifacts
+        // (DeepSeek's `reasoning_content`) so the next iteration's API call
+        // includes them — required by some providers (#3201).
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone())
+                .with_reasoning_content(reasoning_content),
+        );
 
         // Execute tools and add results to context
         let _ = self
@@ -1888,6 +1890,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -1930,6 +1933,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -1973,6 +1977,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_content: None,
                 });
             }
 
@@ -1984,12 +1989,14 @@ mod tests {
                         name: "tool_activate".to_string(),
                         arguments: serde_json::json!({}),
                         reasoning: None,
+                        signature: None,
                     },
                     ToolCall {
                         id: crate::llm::generate_tool_call_id(0, 1),
                         name: "approval_tool".to_string(),
                         arguments: serde_json::json!({"target": "danger"}),
                         reasoning: None,
+                        signature: None,
                     },
                 ],
                 input_tokens: 0,
@@ -1997,6 +2004,7 @@ mod tests {
                 finish_reason: FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -2334,12 +2342,14 @@ mod tests {
                     name: "http".to_string(),
                     arguments: serde_json::json!({"url": "https://example.com"}),
                     reasoning: None,
+                    signature: None,
                 },
                 ToolCall {
                     id: "call_3".to_string(),
                     name: "echo".to_string(),
                     arguments: serde_json::json!({"message": "done"}),
                     reasoning: None,
+                    signature: None,
                 },
             ],
             selected_auth_prompt: Some(crate::agent::session::PendingAuthPrompt::new(
@@ -2843,6 +2853,7 @@ mod tests {
                     name: "echo".to_string(),
                     arguments: serde_json::json!({"message": "hi"}),
                     reasoning: None,
+                    signature: None,
                 }],
             ),
             ChatMessage::tool_result("call_1", "echo", "hi"),
@@ -2936,12 +2947,14 @@ mod tests {
                         name: "http".to_string(),
                         arguments: serde_json::json!({}),
                         reasoning: None,
+                        signature: None,
                     },
                     ToolCall {
                         id: "c2".to_string(),
                         name: "echo".to_string(),
                         arguments: serde_json::json!({}),
                         reasoning: None,
+                        signature: None,
                     },
                 ],
             ),
@@ -2976,6 +2989,7 @@ mod tests {
                     name: "echo".to_string(),
                     arguments: serde_json::json!({}),
                     reasoning: None,
+                    signature: None,
                 }],
             ),
             ChatMessage::tool_result("c1", "echo", "done"),
@@ -3097,6 +3111,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_content: None,
                 });
             }
             // Tools available: always call one.
@@ -3107,12 +3122,14 @@ mod tests {
                     name: "echo".to_string(),
                     arguments: serde_json::json!({"message": "looping"}),
                     reasoning: None,
+                    signature: None,
                 }],
                 input_tokens: 0,
                 output_tokens: 5,
                 finish_reason: FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -3306,6 +3323,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_content: None,
                 });
             }
             // Always call a tool that does not exist in the registry.
@@ -3316,12 +3334,14 @@ mod tests {
                     name: "nonexistent_tool".to_string(),
                     arguments: serde_json::json!({}),
                     reasoning: None,
+                    signature: None,
                 }],
                 input_tokens: 0,
                 output_tokens: 5,
                 finish_reason: FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -3372,6 +3392,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -553,6 +553,7 @@ impl Thread {
                         name: tc.name.clone(),
                         arguments: tc.parameters.clone(),
                         reasoning: None,
+                        signature: None,
                     })
                     .collect();
 
@@ -1525,6 +1526,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"q": "test"}),
             reasoning: None,
+            signature: None,
         };
         let messages = vec![
             ChatMessage::user("Find test"),
@@ -1556,6 +1558,7 @@ mod tests {
             name: "http".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
         let messages = vec![
             ChatMessage::user("Fetch URL"),
@@ -1622,12 +1625,14 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"q": "data"}),
             reasoning: None,
+            signature: None,
         };
         let tc2 = ToolCall {
             id: "call_b".to_string(),
             name: "write".to_string(),
             arguments: serde_json::json!({"path": "out.txt"}),
             reasoning: None,
+            signature: None,
         };
         let messages = vec![
             ChatMessage::user("Find and save"),

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -2662,6 +2662,7 @@ fn rebuild_chat_messages_from_db(
                                     .get("rationale")
                                     .and_then(|v| v.as_str())
                                     .map(String::from),
+                                signature: None,
                             })
                             .collect();
 
@@ -2804,6 +2805,7 @@ mod tests {
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_content: None,
                 })
             }
         }

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -403,6 +403,7 @@ fn thread_msg_to_chat(msg: &ThreadMessage) -> ChatMessage {
         tool_call_id: msg.action_call_id.clone(),
         name: msg.action_name.clone(),
         tool_calls: None,
+        reasoning_content: None,
     };
 
     // Convert action calls if present (assistant message with tool calls)
@@ -415,6 +416,7 @@ fn thread_msg_to_chat(msg: &ThreadMessage) -> ChatMessage {
                     name: c.action_name.clone(),
                     arguments: c.parameters.clone(),
                     reasoning: None,
+                    signature: None,
                 })
                 .collect(),
         );
@@ -685,6 +687,7 @@ mod tests {
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -851,6 +854,7 @@ mod tests {
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -1576,12 +1580,14 @@ And also check the token price:\n\
                         "project_id": "{{call-1.project_id}}"
                     }),
                     reasoning: None,
+                    signature: None,
                 }],
                 input_tokens: 10,
                 output_tokens: 10,
                 finish_reason: crate::llm::FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -1686,6 +1692,7 @@ And also check the token price:\n\
                 finish_reason: crate::llm::FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -7104,6 +7104,7 @@ mod tests {
                     finish_reason: crate::llm::FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_content: None,
                 })
             }
         }

--- a/src/channels/web/openai_compat.rs
+++ b/src/channels/web/openai_compat.rs
@@ -232,6 +232,7 @@ pub fn convert_messages(messages: &[OpenAiMessage]) -> Result<Vec<ChatMessage>, 
                                 arguments: serde_json::from_str(&tc.function.arguments)
                                     .unwrap_or(serde_json::Value::Object(Default::default())),
                                 reasoning: None,
+                                signature: None,
                             })
                             .collect();
                         Ok(ChatMessage::assistant_with_tool_calls(
@@ -249,6 +250,7 @@ pub fn convert_messages(messages: &[OpenAiMessage]) -> Result<Vec<ChatMessage>, 
                     tool_call_id: None,
                     name: m.name.clone(),
                     tool_calls: None,
+                    reasoning_content: None,
                 }),
             }
         })
@@ -956,6 +958,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"query": "rust"}),
             reasoning: None,
+            signature: None,
         }];
 
         let converted = convert_tool_calls_to_openai(&calls);

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -351,6 +351,7 @@ impl LlmProvider for AnthropicOAuthProvider {
             output_tokens: response.usage.output_tokens,
             cache_creation_input_tokens: response.usage.cache_creation_input_tokens,
             cache_read_input_tokens: response.usage.cache_read_input_tokens,
+            reasoning_content: None,
         })
     }
 
@@ -580,6 +581,7 @@ fn extract_response_content(response: &AnthropicResponse) -> (Option<String>, Ve
                     name: name.clone(),
                     arguments: input.clone(),
                     reasoning: None,
+                    signature: None,
                 });
             }
         }
@@ -629,6 +631,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"q": "test"}),
             reasoning: None,
+            signature: None,
         }];
         let messages = vec![
             ChatMessage::user("Search for test"),

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -207,6 +207,7 @@ impl LlmProvider for BedrockProvider {
             finish_reason: map_stop_reason(response.stop_reason()),
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 
@@ -578,6 +579,7 @@ fn extract_content_blocks(
                     name: tu.name().to_string(),
                     arguments: document_to_json(tu.input()),
                     reasoning: None,
+                    signature: None,
                 });
             }
             // Ignore reasoning, citations, images, etc.
@@ -816,12 +818,14 @@ mod tests {
             name: "echo".to_string(),
             arguments: serde_json::json!({"text": "hi"}),
             reasoning: None,
+            signature: None,
         };
         let tc2 = crate::llm::provider::ToolCall {
             id: "call_2".to_string(),
             name: "time".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
 
         let messages = vec![
@@ -861,6 +865,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"query": "test"}),
             reasoning: None,
+            signature: None,
         };
 
         let messages = vec![
@@ -885,6 +890,7 @@ mod tests {
             name: "echo".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
 
         let messages = vec![
@@ -978,6 +984,7 @@ mod tests {
                 name: Some("echo".to_string()),
                 tool_calls: None,
                 content_parts: Vec::new(),
+                reasoning_content: None,
             },
         ];
 
@@ -1050,12 +1057,14 @@ mod tests {
             name: "get_weather".to_string(),
             arguments: serde_json::json!({"city": "NYC"}),
             reasoning: None,
+            signature: None,
         };
         let tc2 = crate::llm::provider::ToolCall {
             id: "call_def".to_string(),
             name: "get_time".to_string(),
             arguments: serde_json::json!({"tz": "EST"}),
             reasoning: None,
+            signature: None,
         };
 
         let messages = vec![
@@ -1218,6 +1227,7 @@ mod tests {
             name: "echo".to_string(),
             arguments: serde_json::json!({"text": "hi"}),
             reasoning: None,
+            signature: None,
         };
 
         let mut messages = vec![
@@ -1262,6 +1272,7 @@ mod tests {
             name: "get_weather".to_string(),
             arguments: serde_json::json!({"city": "NYC"}),
             reasoning: None,
+            signature: None,
         };
 
         let mut messages = vec![
@@ -1299,6 +1310,7 @@ mod tests {
             name: "time".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
 
         let mut messages = vec![
@@ -1336,6 +1348,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"q": "test"}),
             reasoning: None,
+            signature: None,
         };
 
         let mut messages = vec![
@@ -1391,6 +1404,7 @@ mod tests {
             name: "echo".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
 
         let mut messages = vec![

--- a/src/llm/codex_chatgpt.rs
+++ b/src/llm/codex_chatgpt.rs
@@ -733,6 +733,7 @@ impl LlmProvider for CodexChatGptProvider {
                     name: tc.name,
                     arguments: args,
                     reasoning: None,
+                    signature: None,
                 }
             })
             .collect();
@@ -755,6 +756,7 @@ impl LlmProvider for CodexChatGptProvider {
             finish_reason,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 }
@@ -827,6 +829,7 @@ mod tests {
             name: "search".to_string(),
             arguments: json!({"query": "rust"}),
             reasoning: None,
+            signature: None,
         };
         let msg = ChatMessage::assistant_with_tool_calls(Some("thinking...".into()), vec![tc]);
         let items = CodexChatGptProvider::message_to_input_items(&msg);

--- a/src/llm/failover.rs
+++ b/src/llm/failover.rs
@@ -423,6 +423,7 @@ mod tests {
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_content: None,
                 }))),
             }
         }
@@ -833,6 +834,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
 

--- a/src/llm/gemini_oauth.rs
+++ b/src/llm/gemini_oauth.rs
@@ -1939,6 +1939,7 @@ impl GeminiOauthProvider {
                         name,
                         arguments: args,
                         reasoning: None,
+                        signature: None,
                     });
                 }
             }
@@ -2162,6 +2163,7 @@ impl LlmProvider for GeminiOauthProvider {
             tool_calls,
             cache_read_input_tokens: response.cache_read_input_tokens,
             cache_creation_input_tokens: response.cache_creation_input_tokens,
+            reasoning_content: None,
         })
     }
 }
@@ -2763,6 +2765,7 @@ mod tests {
                     name: "read_file".to_string(),
                     arguments: serde_json::json!({"path": "/tmp/x"}),
                     reasoning: None,
+                    signature: None,
                 }],
             ),
             ChatMessage::tool_result("call_1", "read_file", r#"{"output":"hello"}"#),
@@ -2802,6 +2805,7 @@ mod tests {
                     name: "echo".to_string(),
                     arguments: serde_json::json!({}),
                     reasoning: None,
+                    signature: None,
                 }],
             ),
             ChatMessage::tool_result("call_1", "echo", r#"{"output":"ok"}"#),

--- a/src/llm/github_copilot.rs
+++ b/src/llm/github_copilot.rs
@@ -348,6 +348,7 @@ impl LlmProvider for GithubCopilotProvider {
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 
@@ -604,6 +605,7 @@ fn extract_choice_content(choice: &OpenAiChoice) -> (Option<String>, Vec<ToolCal
                     arguments: serde_json::from_str(&tc.function.arguments)
                         .unwrap_or(serde_json::Value::Object(serde_json::Map::new())),
                     reasoning: None,
+                    signature: None,
                 })
                 .collect()
         })
@@ -637,6 +639,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"q": "test"}),
             reasoning: None,
+            signature: None,
         }];
         let messages = vec![
             ChatMessage::user("Search"),

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -25,6 +25,7 @@ mod nearai_chat;
 pub mod oauth_helpers;
 pub mod openai_codex_provider;
 pub mod openai_codex_session;
+mod openai_compat;
 mod provider;
 mod reasoning;
 pub mod recording;
@@ -184,7 +185,9 @@ fn create_registry_provider(
     }
 
     match config.protocol {
-        ProviderProtocol::OpenAiCompletions => create_openai_compat_from_registry(config),
+        ProviderProtocol::OpenAiCompletions => {
+            create_openai_compat_from_registry(config, request_timeout_secs)
+        }
         ProviderProtocol::Anthropic => create_anthropic_from_registry(config),
         ProviderProtocol::Ollama => create_ollama_from_registry(config),
         ProviderProtocol::GithubCopilot => {
@@ -252,27 +255,9 @@ async fn create_bedrock_provider(config: &LlmConfig) -> Result<Arc<dyn LlmProvid
 
 fn create_openai_compat_from_registry(
     config: &RegistryProviderConfig,
+    request_timeout_secs: u64,
 ) -> Result<Arc<dyn LlmProvider>, LlmError> {
-    use rig::providers::openai;
-
-    let mut extra_headers = reqwest::header::HeaderMap::new();
-    for (key, value) in &config.extra_headers {
-        let name = match reqwest::header::HeaderName::from_bytes(key.as_bytes()) {
-            Ok(n) => n,
-            Err(e) => {
-                tracing::warn!(header = %key, error = %e, "Skipping extra header: invalid name");
-                continue;
-            }
-        };
-        let val = match reqwest::header::HeaderValue::from_str(value) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(header = %key, error = %e, "Skipping extra header: invalid value");
-                continue;
-            }
-        };
-        extra_headers.insert(name, val);
-    }
+    let extra_headers = openai_compat::build_extra_headers(&config.extra_headers);
 
     let api_key = config
         .api_key
@@ -288,36 +273,33 @@ fn create_openai_compat_from_registry(
             "no-key".to_string()
         });
 
-    let mut builder = openai::Client::builder().api_key(&api_key);
-    if !config.base_url.is_empty() {
-        let base_url = normalize_openai_base_url(&config.base_url);
-        builder = builder.base_url(&base_url);
-    }
-    if !extra_headers.is_empty() {
-        builder = builder.http_headers(extra_headers);
-    }
-
-    let client: openai::Client = builder.build().map_err(|e| LlmError::RequestFailed {
-        provider: config.provider_id.clone(),
-        reason: format!("Failed to create OpenAI-compatible client: {e}"),
-    })?;
-
-    // Use CompletionsClient (Chat Completions API) instead of the default
-    // Client (Responses API). The Responses API path in rig-core handles
-    // tool results differently, which breaks IronClaw's tool call flow.
-    let client = client.completions_api();
-    let model = client.completion_model(&config.model);
+    let base_url = if config.base_url.is_empty() {
+        // Sensible default for the bare `openai` provider.
+        "https://api.openai.com/v1".to_string()
+    } else {
+        normalize_openai_base_url(&config.base_url)
+    };
 
     tracing::debug!(
         provider = %config.provider_id,
         model = %config.model,
-        base_url = %config.base_url,
+        base_url = %base_url,
         "Using OpenAI-compatible provider"
     );
 
-    let adapter = RigAdapter::new(model, &config.model)
-        .with_unsupported_params(config.unsupported_params.clone());
-    Ok(Arc::new(adapter))
+    // Use IronClaw's custom provider (not rig-core's OpenAI client) so we
+    // round-trip provider-specific extensions like DeepSeek's
+    // `reasoning_content` and Gemini's `thought_signature`. See #3201, #3225.
+    openai_compat::create_provider(
+        config.provider_id.clone(),
+        base_url,
+        api_key,
+        config.model.clone(),
+        request_timeout_secs,
+        extra_headers,
+        config.unsupported_params.clone(),
+        None,
+    )
 }
 
 fn create_anthropic_from_registry(

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -653,6 +653,7 @@ impl LlmProvider for NearAiChatProvider {
                     name: tc.function.name,
                     arguments,
                     reasoning: None,
+                    signature: None,
                 }
             })
             .collect();
@@ -693,6 +694,7 @@ impl LlmProvider for NearAiChatProvider {
             output_tokens,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 
@@ -1357,12 +1359,14 @@ mod tests {
                 name: "list_issues".to_string(),
                 arguments: serde_json::json!({"owner": "foo", "repo": "bar"}),
                 reasoning: None,
+                signature: None,
             },
             ToolCall {
                 id: "call_2".to_string(),
                 name: "search".to_string(),
                 arguments: serde_json::json!({"query": "test"}),
                 reasoning: None,
+                signature: None,
             },
         ];
 
@@ -1476,6 +1480,7 @@ mod tests {
             name: "test".to_string(),
             arguments: serde_json::json!({"key": "value"}),
             reasoning: None,
+            signature: None,
         };
         let msg = ChatMessage::assistant_with_tool_calls(None, vec![tc]);
         let chat_msg: ChatCompletionMessage = msg.into();
@@ -1727,6 +1732,7 @@ mod tests {
                     name: tc.function.name,
                     arguments,
                     reasoning: None,
+                    signature: None,
                 }
             })
             .collect();
@@ -1784,6 +1790,7 @@ mod tests {
                     name: tc.function.name,
                     arguments,
                     reasoning: None,
+                    signature: None,
                 }
             })
             .collect();
@@ -1884,6 +1891,7 @@ mod tests {
                     name: tc.function.name,
                     arguments,
                     reasoning: None,
+                    signature: None,
                 }
             })
             .collect();
@@ -2703,6 +2711,7 @@ mod tests {
                 name: "test".to_string(),
                 arguments: serde_json::json!({}),
                 reasoning: None,
+                signature: None,
             }],
         );
         let chat_msg: ChatCompletionMessage = msg.into();

--- a/src/llm/openai_codex_provider.rs
+++ b/src/llm/openai_codex_provider.rs
@@ -327,6 +327,7 @@ impl LlmProvider for OpenAiCodexProvider {
             finish_reason,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 
@@ -680,6 +681,7 @@ fn parse_sse_response(body: &str) -> Result<ParsedResponse, LlmError> {
                                 name: state.name,
                                 arguments,
                                 reasoning: None,
+                                signature: None,
                             });
                         } else {
                             // Fallback: extract directly from the item
@@ -706,6 +708,7 @@ fn parse_sse_response(body: &str) -> Result<ParsedResponse, LlmError> {
                                 name,
                                 arguments,
                                 reasoning: None,
+                                signature: None,
                             });
                         }
                     }
@@ -784,6 +787,7 @@ fn parse_sse_response(body: &str) -> Result<ParsedResponse, LlmError> {
                 name: state.name,
                 arguments,
                 reasoning: None,
+                signature: None,
             });
         }
     }
@@ -880,12 +884,14 @@ mod tests {
                 name: "search".to_string(),
                 arguments: serde_json::json!({"query": "test"}),
                 reasoning: None,
+                signature: None,
             },
             ToolCall {
                 id: "call_2".to_string(),
                 name: "read".to_string(),
                 arguments: serde_json::json!({"path": "/tmp"}),
                 reasoning: None,
+                signature: None,
             },
         ];
         let msg =
@@ -1242,6 +1248,7 @@ data: {"type":"response.completed","response":{"status":"completed","usage":{"in
             name: "mcp.server.search".to_string(),
             arguments: serde_json::json!({"q": "test"}),
             reasoning: None,
+            signature: None,
         }];
         let msg = ChatMessage::assistant_with_tool_calls(None, tool_calls);
         let items = super::convert_message(&msg, 0);
@@ -1293,6 +1300,7 @@ data: {"type":"response.completed","response":{"status":"completed","usage":{"in
             name: "mcp_server_search".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
         if let Some(original) = name_map.get(&tc.name) {
             tc.name = original.clone();

--- a/src/llm/openai_compat.rs
+++ b/src/llm/openai_compat.rs
@@ -1,0 +1,930 @@
+//! OpenAI Chat Completions provider that preserves provider-specific reasoning.
+//!
+//! This provider speaks the OpenAI Chat Completions wire format directly via
+//! `reqwest`. It exists because rig-core's OpenAI Completions provider drops
+//! two fields that several OpenAI-compatible backends require to be echoed
+//! back on subsequent turns:
+//!
+//! - **`reasoning_content`** on the assistant message — DeepSeek thinking-mode
+//!   models (`deepseek-reasoner`, `deepseek-v4-flash`) reject the next request
+//!   with `"The reasoning_content in the thinking mode must be passed back to
+//!   the API"` if it is missing. (#3201)
+//! - **`thought_signature`** on each `tool_calls[*].function` — Gemini exposed
+//!   via the OpenAI-compat endpoint (`/v1beta/openai`) returns this on tool
+//!   calls and rejects the next request with `"Function call is missing a
+//!   thought_signature in functionCall parts"` when it is absent. (#3225)
+//!
+//! Both fields are opaque to IronClaw; the provider captures them on the
+//! response and writes them back into the assistant message on the wire when
+//! the same call is referenced in a later turn. No business logic interprets
+//! the values.
+//!
+//! Other extension fields a future provider might need to round-trip can be
+//! added here following the same pattern.
+
+use async_trait::async_trait;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::llm::costs;
+use crate::llm::error::LlmError;
+use crate::llm::provider::{
+    ChatMessage, CompletionRequest, CompletionResponse, ContentPart, FinishReason, LlmProvider,
+    Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
+    sanitize_tool_messages, strip_unsupported_completion_params, strip_unsupported_tool_params,
+};
+use crate::llm::tool_schema::{ToolSchemaPolicy, shape_tool_schema};
+
+/// HTTP client timeout floor — cheap protection against the global
+/// timeout being set absurdly low. The user-supplied timeout still wins
+/// when above this value.
+const MIN_TIMEOUT_SECS: u64 = 30;
+
+/// OpenAI-compatible Chat Completions provider.
+pub struct OpenAiCompatibleProvider {
+    client: reqwest::Client,
+    base_url: String,
+    api_key: String,
+    model_name: String,
+    input_cost: Decimal,
+    output_cost: Decimal,
+    /// Provider id (e.g. "gemini", "deepseek") — used in log messages and
+    /// surfaced in `LlmError` so the failover/circuit-breaker layers can
+    /// identify the source of an error.
+    provider_id: String,
+    /// Parameter names this backend rejects (`temperature`, `max_tokens`,
+    /// `stop_sequences`). Stripped before serialization.
+    unsupported_params: HashSet<String>,
+    /// Default additional parameters merged into every request body
+    /// (e.g. provider-specific `extra_body`, `reasoning_effort`).
+    default_additional_params: Option<serde_json::Value>,
+    /// Headers attached to every request (auth, OpenRouter attribution, etc.).
+    extra_headers: HeaderMap,
+}
+
+impl OpenAiCompatibleProvider {
+    /// Build a new provider.
+    ///
+    /// `request_timeout_secs` is the upper bound for each HTTP request. The
+    /// floor is `MIN_TIMEOUT_SECS` to prevent misconfiguration from making
+    /// every call fail.
+    pub fn new(
+        provider_id: impl Into<String>,
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        request_timeout_secs: u64,
+        extra_headers: HeaderMap,
+    ) -> Result<Self, LlmError> {
+        let timeout = Duration::from_secs(request_timeout_secs.max(MIN_TIMEOUT_SECS));
+        let provider_id_str = provider_id.into();
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| LlmError::RequestFailed {
+                provider: provider_id_str.clone(),
+                reason: format!("Failed to build HTTP client: {e}"),
+            })?;
+
+        let model_str = model.into();
+        let (input_cost, output_cost) =
+            costs::model_cost(&model_str).unwrap_or_else(costs::default_cost);
+
+        Ok(Self {
+            client,
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            api_key: api_key.into(),
+            model_name: model_str,
+            input_cost,
+            output_cost,
+            provider_id: provider_id_str,
+            unsupported_params: HashSet::new(),
+            default_additional_params: None,
+            extra_headers,
+        })
+    }
+
+    pub fn with_unsupported_params(mut self, params: Vec<String>) -> Self {
+        self.unsupported_params = params.into_iter().collect();
+        self
+    }
+
+    pub fn with_additional_params(mut self, params: serde_json::Value) -> Self {
+        self.default_additional_params = Some(params);
+        self
+    }
+
+    /// Build the `/chat/completions` URL.
+    fn endpoint(&self) -> String {
+        format!("{}/chat/completions", self.base_url)
+    }
+
+    /// Wire-level POST. Returns the parsed response or a typed `LlmError`.
+    async fn post_chat_completions(
+        &self,
+        body: serde_json::Value,
+    ) -> Result<RawChatCompletionsResponse, LlmError> {
+        let mut request = self
+            .client
+            .post(self.endpoint())
+            .bearer_auth(&self.api_key)
+            .header("Content-Type", "application/json");
+        if !self.extra_headers.is_empty() {
+            request = request.headers(self.extra_headers.clone());
+        }
+
+        let response = request
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LlmError::RequestFailed {
+                provider: self.provider_id.clone(),
+                reason: format!("HTTP send failed: {e}"),
+            })?;
+
+        let status = response.status();
+        let text = response.text().await.map_err(|e| LlmError::RequestFailed {
+            provider: self.provider_id.clone(),
+            reason: format!("Failed to read response body: {e}"),
+        })?;
+
+        if !status.is_success() {
+            return Err(map_http_error(&self.provider_id, status, &text));
+        }
+
+        serde_json::from_str::<RawChatCompletionsResponse>(&text).map_err(|e| {
+            LlmError::InvalidResponse {
+                provider: self.provider_id.clone(),
+                reason: format!("Failed to parse response JSON: {e} body={text}"),
+            }
+        })
+    }
+
+    /// Convert IronClaw messages + tools + extra knobs into the OpenAI Chat
+    /// Completions request body.
+    #[allow(clippy::too_many_arguments)]
+    fn build_request_body(
+        &self,
+        mut messages: Vec<ChatMessage>,
+        tools: Vec<ToolDefinition>,
+        tool_choice: Option<String>,
+        temperature: Option<f32>,
+        max_tokens: Option<u32>,
+        stop_sequences: Option<Vec<String>>,
+        model_override: Option<&str>,
+    ) -> serde_json::Value {
+        sanitize_tool_messages(&mut messages);
+
+        let wire_messages: Vec<WireMessage> = messages.iter().map(WireMessage::from_chat).collect();
+        let wire_tools: Vec<WireTool> = tools.iter().map(WireTool::from_def).collect();
+
+        let mut body = serde_json::json!({
+            "model": model_override.unwrap_or(self.model_name.as_str()),
+            "messages": wire_messages,
+        });
+
+        let body_obj = body
+            .as_object_mut()
+            .expect("just-built JSON object is mutable");
+
+        if !wire_tools.is_empty() {
+            body_obj.insert(
+                "tools".to_string(),
+                serde_json::to_value(&wire_tools).unwrap_or(serde_json::Value::Null),
+            );
+        }
+        if let Some(choice) = tool_choice {
+            body_obj.insert("tool_choice".to_string(), serde_json::Value::String(choice));
+        }
+        if let Some(temp) = temperature {
+            body_obj.insert(
+                "temperature".to_string(),
+                serde_json::json!(round_f32_to_f64(temp)),
+            );
+        }
+        if let Some(mt) = max_tokens {
+            body_obj.insert("max_tokens".to_string(), serde_json::json!(mt));
+        }
+        if let Some(stops) = stop_sequences {
+            body_obj.insert("stop".to_string(), serde_json::json!(stops));
+        }
+
+        // Merge provider-default additional params last so explicit fields above
+        // win on conflict.
+        if let Some(defaults) = self.default_additional_params.as_ref()
+            && let Some(default_obj) = defaults.as_object()
+        {
+            for (k, v) in default_obj {
+                body_obj.entry(k).or_insert_with(|| v.clone());
+            }
+        }
+
+        body
+    }
+}
+
+/// Round f32 to f64 without binary-precision artifacts. Some servers (e.g.
+/// Zhipu/GLM) reject `0.6999...` as out of range when the user typed `0.7`.
+/// Mirrors the helper in `rig_adapter::round_f32_to_f64`.
+fn round_f32_to_f64(val: f32) -> f64 {
+    ((val as f64) * 1_000_000.0).round() / 1_000_000.0
+}
+
+/// Map an HTTP failure to the appropriate typed `LlmError`. The retry /
+/// circuit-breaker / failover layers branch on this enum, so categorising
+/// the error correctly here matters.
+fn map_http_error(provider: &str, status: reqwest::StatusCode, body: &str) -> LlmError {
+    let lower = body.to_ascii_lowercase();
+
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return LlmError::AuthFailed {
+            provider: provider.to_string(),
+        };
+    }
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return LlmError::RateLimited {
+            provider: provider.to_string(),
+            retry_after: None,
+        };
+    }
+    if status == reqwest::StatusCode::PAYLOAD_TOO_LARGE
+        || lower.contains("context_length_exceeded")
+        || lower.contains("maximum context length")
+    {
+        return LlmError::ContextLengthExceeded { used: 0, limit: 0 };
+    }
+
+    LlmError::RequestFailed {
+        provider: provider.to_string(),
+        reason: format!("HTTP {status}: {body}"),
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiCompatibleProvider {
+    fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
+    fn cost_per_token(&self) -> (Decimal, Decimal) {
+        (self.input_cost, self.output_cost)
+    }
+
+    async fn complete(
+        &self,
+        mut request: CompletionRequest,
+    ) -> Result<CompletionResponse, LlmError> {
+        let model_override = request.take_model_override();
+        strip_unsupported_completion_params(&self.unsupported_params, &mut request);
+
+        let body = self.build_request_body(
+            request.messages,
+            Vec::new(),
+            None,
+            request.temperature,
+            request.max_tokens,
+            request.stop_sequences,
+            model_override.as_deref(),
+        );
+
+        let response = self.post_chat_completions(body).await?;
+        let choice =
+            response
+                .choices
+                .into_iter()
+                .next()
+                .ok_or_else(|| LlmError::InvalidResponse {
+                    provider: self.provider_id.clone(),
+                    reason: "Response had no choices".to_string(),
+                })?;
+
+        let text = choice.message.content.unwrap_or_default();
+        let usage = response.usage.unwrap_or_default();
+
+        Ok(CompletionResponse {
+            content: text,
+            input_tokens: usage.prompt_tokens.unwrap_or(0),
+            output_tokens: usage.completion_tokens.unwrap_or(0),
+            finish_reason: parse_finish_reason(choice.finish_reason.as_deref(), false),
+            cache_read_input_tokens: usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|d| d.cached_tokens)
+                .unwrap_or(0),
+            cache_creation_input_tokens: 0,
+        })
+    }
+
+    async fn complete_with_tools(
+        &self,
+        mut request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        let model_override = request.take_model_override();
+        strip_unsupported_tool_params(&self.unsupported_params, &mut request);
+
+        let body = self.build_request_body(
+            request.messages,
+            request.tools,
+            request.tool_choice,
+            request.temperature,
+            request.max_tokens,
+            request.stop_sequences,
+            model_override.as_deref(),
+        );
+
+        let response = self.post_chat_completions(body).await?;
+        let choice =
+            response
+                .choices
+                .into_iter()
+                .next()
+                .ok_or_else(|| LlmError::InvalidResponse {
+                    provider: self.provider_id.clone(),
+                    reason: "Response had no choices".to_string(),
+                })?;
+
+        let WireAssistantMessage {
+            content,
+            tool_calls: wire_tool_calls,
+            reasoning_content,
+        } = choice.message;
+
+        let tool_calls: Vec<ToolCall> = wire_tool_calls
+            .unwrap_or_default()
+            .into_iter()
+            .map(WireToolCall::into_tool_call)
+            .collect();
+
+        let has_tool_calls = !tool_calls.is_empty();
+        let usage = response.usage.unwrap_or_default();
+
+        Ok(ToolCompletionResponse {
+            content,
+            tool_calls,
+            input_tokens: usage.prompt_tokens.unwrap_or(0),
+            output_tokens: usage.completion_tokens.unwrap_or(0),
+            finish_reason: parse_finish_reason(choice.finish_reason.as_deref(), has_tool_calls),
+            cache_read_input_tokens: usage
+                .prompt_tokens_details
+                .as_ref()
+                .and_then(|d| d.cached_tokens)
+                .unwrap_or(0),
+            cache_creation_input_tokens: 0,
+            reasoning_content,
+        })
+    }
+
+    fn active_model_name(&self) -> String {
+        self.model_name.clone()
+    }
+
+    fn effective_model_name(&self, _requested_model: Option<&str>) -> String {
+        // Like RigAdapter, the model is baked at construction time.
+        self.active_model_name()
+    }
+
+    fn set_model(&self, _model: &str) -> Result<(), LlmError> {
+        Err(LlmError::RequestFailed {
+            provider: self.provider_id.clone(),
+            reason: "Runtime model switching not supported for OpenAiCompatibleProvider; \
+                     restart with a different LLM_MODEL"
+                .to_string(),
+        })
+    }
+}
+
+fn parse_finish_reason(reason: Option<&str>, has_tool_calls: bool) -> FinishReason {
+    if has_tool_calls {
+        return FinishReason::ToolUse;
+    }
+    match reason {
+        Some("tool_calls") | Some("function_call") => FinishReason::ToolUse,
+        Some("length") | Some("max_tokens") => FinishReason::Length,
+        Some("content_filter") => FinishReason::ContentFilter,
+        Some("stop") | Some("end_turn") | None => FinishReason::Stop,
+        Some(_) => FinishReason::Unknown,
+    }
+}
+
+// ── Wire types ─────────────────────────────────────────────────────────────
+
+/// A message on the wire — what we send and what comes back. Both directions
+/// share fields, but request shape only needs `role`, `content`, optionally
+/// `tool_calls` / `tool_call_id` / `name`, and `reasoning_content` when
+/// echoing back to the upstream provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireMessage {
+    role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    content: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<WireToolCall>>,
+    /// Echoed back to providers (e.g. DeepSeek thinking mode) that require it
+    /// on the assistant message in the next turn. Captured from response,
+    /// rendered into request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reasoning_content: Option<String>,
+}
+
+impl WireMessage {
+    fn from_chat(msg: &ChatMessage) -> Self {
+        let role = match msg.role {
+            Role::System => "system",
+            Role::User => "user",
+            Role::Assistant => "assistant",
+            Role::Tool => "tool",
+        }
+        .to_string();
+
+        // Build content. For multimodal user messages, render as the OpenAI
+        // content-parts array. Otherwise, send a string.
+        let content = if matches!(msg.role, Role::User) && !msg.content_parts.is_empty() {
+            let mut parts: Vec<serde_json::Value> = Vec::new();
+            if !msg.content.is_empty() {
+                parts.push(serde_json::json!({
+                    "type": "text",
+                    "text": msg.content,
+                }));
+            }
+            for p in &msg.content_parts {
+                if let ContentPart::ImageUrl { image_url } = p {
+                    let mut image_obj = serde_json::json!({ "url": image_url.url });
+                    if let Some(detail) = image_url.detail.as_deref() {
+                        image_obj["detail"] = serde_json::Value::String(detail.to_string());
+                    }
+                    parts.push(serde_json::json!({
+                        "type": "image_url",
+                        "image_url": image_obj,
+                    }));
+                }
+            }
+            Some(serde_json::Value::Array(parts))
+        } else if msg.content.is_empty() && msg.tool_calls.as_ref().is_some_and(|c| !c.is_empty()) {
+            // Assistant messages with tool_calls and no text content: omit
+            // the content field entirely. Some providers reject `content: ""`.
+            None
+        } else {
+            Some(serde_json::Value::String(msg.content.clone()))
+        };
+
+        let tool_calls = msg
+            .tool_calls
+            .as_ref()
+            .filter(|c| !c.is_empty())
+            .map(|calls| calls.iter().map(WireToolCall::from_tool_call).collect());
+
+        Self {
+            role,
+            content,
+            tool_call_id: msg.tool_call_id.clone(),
+            name: msg.name.clone(),
+            tool_calls,
+            reasoning_content: msg.reasoning_content.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireToolCall {
+    id: String,
+    #[serde(rename = "type", default = "default_tool_type")]
+    call_type: String,
+    function: WireToolFunction,
+}
+
+fn default_tool_type() -> String {
+    "function".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireToolFunction {
+    name: String,
+    /// OpenAI Chat Completions encodes `arguments` as a JSON-encoded *string*
+    /// — not a JSON object. We serialize/deserialize accordingly.
+    arguments: String,
+    /// Gemini's `thought_signature` rides on the function payload via the
+    /// OpenAI-compat endpoint. Captured on response, sent back on next turn.
+    /// Other providers ignore unknown fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    thought_signature: Option<String>,
+}
+
+impl WireToolCall {
+    fn from_tool_call(tc: &ToolCall) -> Self {
+        Self {
+            id: tc.id.clone(),
+            call_type: "function".to_string(),
+            function: WireToolFunction {
+                name: tc.name.clone(),
+                arguments: serde_json::to_string(&tc.arguments)
+                    .unwrap_or_else(|_| "{}".to_string()),
+                thought_signature: tc.signature.clone(),
+            },
+        }
+    }
+
+    fn into_tool_call(self) -> ToolCall {
+        // Arguments come as a JSON string; parse to Value, falling back to
+        // an empty object if the model produced something unparseable.
+        let arguments: serde_json::Value = serde_json::from_str(&self.function.arguments)
+            .unwrap_or_else(|_| serde_json::json!({}));
+        ToolCall {
+            id: self.id,
+            name: self.function.name,
+            arguments,
+            reasoning: None,
+            signature: self.function.thought_signature,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct WireTool {
+    #[serde(rename = "type")]
+    tool_type: String,
+    function: WireToolDef,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct WireToolDef {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+impl WireTool {
+    fn from_def(td: &ToolDefinition) -> Self {
+        let mut description = td.description.clone();
+        let parameters = shape_tool_schema(
+            ToolSchemaPolicy::StrictOpenAi,
+            &td.parameters,
+            &mut description,
+        );
+        Self {
+            tool_type: "function".to_string(),
+            function: WireToolDef {
+                name: td.name.clone(),
+                description,
+                parameters,
+            },
+        }
+    }
+}
+
+// ── Wire response types ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawChatCompletionsResponse {
+    choices: Vec<WireChoice>,
+    #[serde(default)]
+    usage: Option<WireUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct WireChoice {
+    message: WireAssistantMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct WireAssistantMessage {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<WireToolCall>>,
+    /// DeepSeek (and other providers in thinking mode) emit this on the
+    /// assistant message. Captured here and surfaced to the caller via
+    /// `ToolCompletionResponse.reasoning_content` so the next turn can echo it.
+    #[serde(default)]
+    reasoning_content: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct WireUsage {
+    #[serde(default)]
+    prompt_tokens: Option<u32>,
+    #[serde(default)]
+    completion_tokens: Option<u32>,
+    #[serde(default)]
+    prompt_tokens_details: Option<WirePromptTokensDetails>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct WirePromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: Option<u32>,
+}
+
+/// Convenience builder used by `mod.rs` registry path.
+///
+/// Wraps `OpenAiCompatibleProvider::new` with a pre-built `HeaderMap`.
+pub fn build_extra_headers(headers: &[(String, String)]) -> HeaderMap {
+    let mut map = HeaderMap::new();
+    for (k, v) in headers {
+        let name = match HeaderName::from_bytes(k.as_bytes()) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(header = %k, error = %e, "Skipping extra header: invalid name");
+                continue;
+            }
+        };
+        let value = match HeaderValue::from_str(v) {
+            Ok(val) => val,
+            Err(e) => {
+                tracing::warn!(header = %k, error = %e, "Skipping extra header: invalid value");
+                continue;
+            }
+        };
+        map.insert(name, value);
+    }
+    map
+}
+
+/// Helper to construct an `Arc<dyn LlmProvider>` for use in the registry path.
+#[allow(clippy::too_many_arguments)]
+pub fn create_provider(
+    provider_id: impl Into<String>,
+    base_url: impl Into<String>,
+    api_key: impl Into<String>,
+    model: impl Into<String>,
+    request_timeout_secs: u64,
+    extra_headers: HeaderMap,
+    unsupported_params: Vec<String>,
+    additional_params: Option<serde_json::Value>,
+) -> Result<Arc<dyn LlmProvider>, LlmError> {
+    let mut provider = OpenAiCompatibleProvider::new(
+        provider_id,
+        base_url,
+        api_key,
+        model,
+        request_timeout_secs,
+        extra_headers,
+    )?
+    .with_unsupported_params(unsupported_params);
+    if let Some(params) = additional_params {
+        provider = provider.with_additional_params(params);
+    }
+    Ok(Arc::new(provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider() -> OpenAiCompatibleProvider {
+        OpenAiCompatibleProvider::new(
+            "test-provider",
+            "https://example.test/v1",
+            "test-key",
+            "test-model",
+            120,
+            HeaderMap::new(),
+        )
+        .expect("provider construction")
+    }
+
+    #[test]
+    fn round_f32_avoids_binary_precision_artifacts() {
+        // Direct cast produces 0.6999999... — that has shipped breakage on
+        // strict OpenAI-compat servers. Round to 6 decimals.
+        assert_eq!(round_f32_to_f64(0.7_f32), 0.7_f64);
+        assert_eq!(round_f32_to_f64(0.0_f32), 0.0_f64);
+        assert_eq!(round_f32_to_f64(1.5_f32), 1.5_f64);
+    }
+
+    #[test]
+    fn map_http_error_classifies_auth_and_rate_limit() {
+        let auth = map_http_error("p", reqwest::StatusCode::UNAUTHORIZED, "no key");
+        assert!(matches!(auth, LlmError::AuthFailed { .. }));
+        let forbidden = map_http_error("p", reqwest::StatusCode::FORBIDDEN, "no perms");
+        assert!(matches!(forbidden, LlmError::AuthFailed { .. }));
+        let rate = map_http_error("p", reqwest::StatusCode::TOO_MANY_REQUESTS, "slow down");
+        assert!(matches!(rate, LlmError::RateLimited { .. }));
+    }
+
+    #[test]
+    fn map_http_error_detects_context_overflow_in_body() {
+        let body = "{\"error\":\"context_length_exceeded\"}";
+        let err = map_http_error("p", reqwest::StatusCode::BAD_REQUEST, body);
+        assert!(matches!(err, LlmError::ContextLengthExceeded { .. }));
+    }
+
+    #[test]
+    fn parse_finish_reason_uses_tool_calls_signal() {
+        // When the provider returned tool calls but finish_reason is anything,
+        // we surface ToolUse so the agent dispatches accordingly.
+        assert_eq!(
+            parse_finish_reason(Some("stop"), true),
+            FinishReason::ToolUse
+        );
+        assert_eq!(
+            parse_finish_reason(Some("length"), false),
+            FinishReason::Length
+        );
+        assert_eq!(
+            parse_finish_reason(Some("content_filter"), false),
+            FinishReason::ContentFilter
+        );
+        assert_eq!(parse_finish_reason(None, false), FinishReason::Stop);
+    }
+
+    /// Regression for #3201 — DeepSeek requires `reasoning_content` to be
+    /// echoed back on the assistant message in the next turn. The wire
+    /// converter must serialize it when present.
+    #[test]
+    fn reasoning_content_is_serialized_on_assistant_messages() {
+        let mut msg = ChatMessage::assistant("final answer");
+        msg.reasoning_content = Some("step 1: think; step 2: respond".to_string());
+
+        let wire = WireMessage::from_chat(&msg);
+        let json = serde_json::to_value(&wire).unwrap();
+
+        assert_eq!(
+            json["reasoning_content"].as_str(),
+            Some("step 1: think; step 2: respond"),
+            "reasoning_content must round-trip onto the wire: {json}"
+        );
+    }
+
+    /// Regression for #3201 — when `reasoning_content` is None, do NOT emit
+    /// the field. (Some providers reject unknown null fields.)
+    #[test]
+    fn reasoning_content_is_omitted_when_none() {
+        let msg = ChatMessage::assistant("hello");
+        let json = serde_json::to_value(WireMessage::from_chat(&msg)).unwrap();
+        assert!(
+            json.get("reasoning_content").is_none(),
+            "reasoning_content must be omitted when None: {json}"
+        );
+    }
+
+    /// Regression for #3225 — Gemini's `thought_signature` must round-trip
+    /// on each tool call. Capture from response, echo on next request.
+    #[test]
+    fn tool_call_signature_round_trips_through_wire_format() {
+        let tc = ToolCall {
+            id: "call_1".to_string(),
+            name: "tool_search".to_string(),
+            arguments: serde_json::json!({"query": "telegram"}),
+            reasoning: None,
+            signature: Some("opaque-sig-bytes".to_string()),
+        };
+
+        let wire = WireToolCall::from_tool_call(&tc);
+        let json = serde_json::to_value(&wire).unwrap();
+        assert_eq!(
+            json["function"]["thought_signature"].as_str(),
+            Some("opaque-sig-bytes"),
+            "signature must serialize as thought_signature on the function payload: {json}"
+        );
+
+        // Now decode it back and verify the field comes through.
+        let decoded: WireToolCall = serde_json::from_value(json).unwrap();
+        let restored = decoded.into_tool_call();
+        assert_eq!(restored.signature.as_deref(), Some("opaque-sig-bytes"));
+    }
+
+    /// Capture-side regression for #3225: when a Gemini OpenAI-compat
+    /// response contains a `thought_signature` on a returned tool call,
+    /// `WireToolCall::into_tool_call` must lift it onto `ToolCall.signature`
+    /// so the agent can echo it back on the next request.
+    #[test]
+    fn tool_call_signature_captured_from_response_payload() {
+        let body = serde_json::json!({
+            "id": "tool_abc",
+            "type": "function",
+            "function": {
+                "name": "tool_search",
+                "arguments": "{\"q\":\"x\"}",
+                "thought_signature": "captured-sig"
+            }
+        });
+        let wire: WireToolCall = serde_json::from_value(body).unwrap();
+        let tc = wire.into_tool_call();
+        assert_eq!(tc.signature.as_deref(), Some("captured-sig"));
+        assert_eq!(tc.name, "tool_search");
+    }
+
+    /// Capture-side regression for #3201: when DeepSeek returns
+    /// `reasoning_content` on the assistant message, `WireAssistantMessage`
+    /// must surface the field through deserialization.
+    #[test]
+    fn assistant_reasoning_content_captured_from_response_payload() {
+        let body = serde_json::json!({
+            "content": "answer text",
+            "reasoning_content": "thought trace here"
+        });
+        let msg: WireAssistantMessage = serde_json::from_value(body).unwrap();
+        assert_eq!(msg.content.as_deref(), Some("answer text"));
+        assert_eq!(msg.reasoning_content.as_deref(), Some("thought trace here"));
+    }
+
+    /// Caller-level coverage for the request body builder. Verifies that
+    /// `tool_calls`, `reasoning_content`, and `signature` all flow into the
+    /// wire payload that `complete_with_tools` will POST. This protects the
+    /// integration between `build_request_body` and `WireMessage::from_chat`
+    /// — a unit test on either side alone would not catch a regression that
+    /// drops the round-trip data when assembling the request.
+    #[test]
+    fn build_request_body_carries_round_trip_extensions_for_assistant_turn() {
+        let p = provider();
+
+        let tc = ToolCall {
+            id: "call_x".to_string(),
+            name: "tool_search".to_string(),
+            arguments: serde_json::json!({"query": "telegram"}),
+            reasoning: None,
+            signature: Some("gemini-sig".to_string()),
+        };
+        let mut asst = ChatMessage::assistant_with_tool_calls(None, vec![tc]);
+        asst.reasoning_content = Some("deepseek-thoughts".to_string());
+
+        let messages = vec![
+            ChatMessage::user("find telegram setup steps"),
+            asst,
+            ChatMessage::tool_result("call_x", "tool_search", "no matches"),
+        ];
+
+        let body = p.build_request_body(messages, vec![], None, None, None, None, None);
+
+        let wire_msgs = body["messages"].as_array().expect("messages array");
+        // The assistant message is index 1 in our input — verify both fields
+        // are present on the wire.
+        let assistant_wire = &wire_msgs[1];
+        assert_eq!(
+            assistant_wire["reasoning_content"].as_str(),
+            Some("deepseek-thoughts"),
+            "assistant reasoning_content must carry into request body: {assistant_wire}"
+        );
+        let tool_call_wire = &assistant_wire["tool_calls"][0];
+        assert_eq!(
+            tool_call_wire["function"]["thought_signature"].as_str(),
+            Some("gemini-sig"),
+            "tool call signature must carry into request body: {tool_call_wire}"
+        );
+    }
+
+    /// `tool_choice` must be passed through verbatim when supplied. Strict
+    /// OpenAI-compat servers reject the field if it shows up as anything
+    /// other than the supported strings.
+    #[test]
+    fn build_request_body_passes_tool_choice() {
+        let p = provider();
+        let body = p.build_request_body(
+            vec![ChatMessage::user("hi")],
+            vec![],
+            Some("required".to_string()),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(body["tool_choice"].as_str(), Some("required"));
+    }
+
+    /// Provider-level default `additional_params` get merged but never
+    /// overwrite explicit fields. This protects providers like Ollama
+    /// (`think: true`) and OpenRouter from clobbering temperature/model.
+    #[test]
+    fn build_request_body_merges_default_additional_params_without_override() {
+        let p = OpenAiCompatibleProvider::new(
+            "test",
+            "https://example.test/v1",
+            "k",
+            "real-model",
+            120,
+            HeaderMap::new(),
+        )
+        .unwrap()
+        .with_additional_params(serde_json::json!({
+            "model": "should-not-clobber",
+            "reasoning_effort": "low",
+        }));
+
+        let body = p.build_request_body(
+            vec![ChatMessage::user("hi")],
+            vec![],
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(
+            body["model"].as_str(),
+            Some("real-model"),
+            "explicit model must not be overridden by default additional params"
+        );
+        assert_eq!(body["reasoning_effort"].as_str(), Some("low"));
+    }
+}

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -78,6 +78,14 @@ pub struct ChatMessage {
     /// to appear on the assistant message preceding tool result messages).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
+    /// Provider-specific reasoning content from the assistant (e.g. DeepSeek's
+    /// `reasoning_content` field on thinking-mode models). When the upstream
+    /// API requires this to be echoed back in subsequent turns (DeepSeek
+    /// rejects requests without it: "The reasoning_content in the thinking
+    /// mode must be passed back to the API"), the provider must round-trip
+    /// it verbatim. Set on assistant messages only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 impl ChatMessage {
@@ -90,6 +98,7 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            reasoning_content: None,
         }
     }
 
@@ -102,6 +111,7 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            reasoning_content: None,
         }
     }
 
@@ -116,6 +126,7 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            reasoning_content: None,
         }
     }
 
@@ -128,6 +139,7 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            reasoning_content: None,
         }
     }
 
@@ -147,6 +159,7 @@ impl ChatMessage {
             } else {
                 Some(tool_calls)
             },
+            reasoning_content: None,
         }
     }
 
@@ -163,7 +176,19 @@ impl ChatMessage {
             tool_call_id: Some(tool_call_id.into()),
             name: Some(name.into()),
             tool_calls: None,
+            reasoning_content: None,
         }
+    }
+
+    /// Attach provider-specific reasoning content to this message (builder).
+    ///
+    /// Used by providers like DeepSeek that return `reasoning_content` on
+    /// thinking-mode responses and require it to be echoed back in the next
+    /// turn. Most callers do not need this — only the LLM provider that
+    /// receives the field should set it.
+    pub fn with_reasoning_content(mut self, reasoning_content: Option<String>) -> Self {
+        self.reasoning_content = reasoning_content;
+        self
     }
 }
 
@@ -262,6 +287,15 @@ pub struct ToolCall {
     /// or derived from the shared response content as a fallback.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<String>,
+    /// Provider-specific signature attached to a tool call that must be
+    /// echoed back when this call is referenced again. Currently used for
+    /// Gemini's `thought_signature` on `functionCall` parts (the OpenAI-compat
+    /// endpoint surfaces this on each tool call); without it the API responds
+    /// HTTP 400 "Function call is missing a thought_signature in functionCall
+    /// parts". Treated as opaque bytes by IronClaw — the provider that
+    /// produces the field is the only one that interprets it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
 }
 
 /// Generate a tool-call ID that satisfies all providers.
@@ -393,6 +427,12 @@ pub struct ToolCompletionResponse {
     pub cache_read_input_tokens: u32,
     /// Tokens written to the provider's server-side prompt cache (Anthropic).
     pub cache_creation_input_tokens: u32,
+    /// Provider-specific reasoning artifact (e.g. DeepSeek's `reasoning_content`)
+    /// returned alongside an assistant message that needs to be echoed back on
+    /// the next turn. The agent layer must persist this onto the resulting
+    /// assistant `ChatMessage` so subsequent iterations include it.
+    /// `None` for providers that don't return reasoning artifacts.
+    pub reasoning_content: Option<String>,
 }
 
 /// Metadata about a model returned by the provider's API.
@@ -805,6 +845,7 @@ mod tests {
             name: "echo".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
         let mut messages = vec![
             ChatMessage::user("hello"),
@@ -849,6 +890,7 @@ mod tests {
             name: "echo".to_string(),
             arguments: serde_json::json!({}),
             reasoning: None,
+            signature: None,
         };
         let mut messages = vec![
             ChatMessage::user("test"),
@@ -875,12 +917,14 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"q": "test"}),
             reasoning: None,
+            signature: None,
         };
         let tc2 = ToolCall {
             id: "call_sel_2".to_string(),
             name: "http".to_string(),
             arguments: serde_json::json!({"url": "https://example.com"}),
             reasoning: None,
+            signature: None,
         };
         let mut messages = vec![
             ChatMessage::system("You are a helpful assistant."),

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -425,10 +425,15 @@ pub enum RespondResult {
     Text(String),
     /// The model wants to call tools. Caller should execute them and call back.
     /// Includes the optional content from the assistant message (some models
-    /// include explanatory text alongside tool calls).
+    /// include explanatory text alongside tool calls), and a provider-specific
+    /// `reasoning_content` artifact (e.g. DeepSeek thinking-mode output) that
+    /// the agent must echo back on the next request — without it DeepSeek
+    /// rejects the next call with HTTP 400 (#3201). `None` for providers that
+    /// don't surface reasoning artifacts.
     ToolCalls {
         tool_calls: Vec<ToolCall>,
         content: Option<String>,
+        reasoning_content: Option<String>,
     },
 }
 
@@ -812,6 +817,10 @@ Respond in JSON format:
                 cache_read_input_tokens: response.cache_read_input_tokens,
                 cache_creation_input_tokens: response.cache_creation_input_tokens,
             };
+            // Capture the provider-specific reasoning artifact (DeepSeek's
+            // `reasoning_content`, etc.) so it can be echoed back on the
+            // assistant message in the next turn.
+            let response_reasoning_content = response.reasoning_content.clone();
 
             // If there were tool calls, return them for execution
             if !response.tool_calls.is_empty() {
@@ -845,6 +854,7 @@ Respond in JSON format:
                     result: RespondResult::ToolCalls {
                         tool_calls,
                         content: narrative,
+                        reasoning_content: response_reasoning_content,
                     },
                     usage,
                     finish_reason: response.finish_reason,
@@ -872,6 +882,7 @@ Respond in JSON format:
                         } else {
                             Some(cleaned)
                         },
+                        reasoning_content: response_reasoning_content,
                     },
                     usage,
                     finish_reason: response.finish_reason,
@@ -1640,6 +1651,7 @@ pub(crate) fn recover_tool_calls_from_content(
                     name: name.to_string(),
                     arguments,
                     reasoning: None,
+                    signature: None,
                 });
                 continue;
             }
@@ -1655,6 +1667,7 @@ pub(crate) fn recover_tool_calls_from_content(
                     name: name.to_string(),
                     arguments: serde_json::Value::Object(Default::default()),
                     reasoning: None,
+                    signature: None,
                 });
             }
         }
@@ -1693,6 +1706,7 @@ pub(crate) fn recover_tool_calls_from_content(
                         name: name.to_string(),
                         arguments,
                         reasoning: None,
+                        signature: None,
                     });
                     remaining = &args_start[bracket_end + 1..];
                     continue;
@@ -1705,6 +1719,7 @@ pub(crate) fn recover_tool_calls_from_content(
                 name: name.to_string(),
                 arguments: serde_json::Value::Object(Default::default()),
                 reasoning: None,
+                signature: None,
             });
             remaining = after_name;
         }
@@ -3398,6 +3413,7 @@ That's my plan."#;
                     finish_reason: FinishReason::Stop,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_content: None,
                 })
             }
         }
@@ -3421,6 +3437,95 @@ That's my plan."#;
             }
             RespondResult::ToolCalls { .. } => {
                 panic!("Expected fallback text, not tool calls");
+            }
+        }
+    }
+
+    /// Regression for #3201 / #3225 (caller-level): a thinking-mode provider's
+    /// `reasoning_content` and per-tool-call `signature` must propagate through
+    /// `Reasoning::respond_with_tools` so the dispatcher can attach them to
+    /// the assistant `ChatMessage`. A unit test on `WireMessage::from_chat`
+    /// alone is not sufficient — the bug class is values getting dropped at
+    /// any layer between the provider boundary and the next-turn message
+    /// list. Per `.claude/rules/testing.md`, drive the call site that gates
+    /// the side effect (the next API call).
+    #[tokio::test]
+    async fn test_thinking_mode_reasoning_and_signature_propagate_to_respond_result() {
+        use crate::llm::provider::{
+            FinishReason, LlmProvider, ToolCompletionRequest, ToolCompletionResponse,
+        };
+        use async_trait::async_trait;
+        use rust_decimal::Decimal;
+
+        struct ThinkingModeMock;
+
+        #[async_trait]
+        impl LlmProvider for ThinkingModeMock {
+            fn model_name(&self) -> &str {
+                "thinking-mock"
+            }
+            fn cost_per_token(&self) -> (Decimal, Decimal) {
+                (Decimal::ZERO, Decimal::ZERO)
+            }
+            async fn complete(
+                &self,
+                _: crate::llm::CompletionRequest,
+            ) -> Result<crate::llm::CompletionResponse, crate::llm::LlmError> {
+                unreachable!("tool-mode test should not call complete()")
+            }
+            async fn complete_with_tools(
+                &self,
+                _: ToolCompletionRequest,
+            ) -> Result<ToolCompletionResponse, crate::llm::LlmError> {
+                Ok(ToolCompletionResponse {
+                    content: None,
+                    tool_calls: vec![ToolCall {
+                        id: "call_1".to_string(),
+                        name: "tool_search".to_string(),
+                        arguments: serde_json::json!({"q": "telegram"}),
+                        reasoning: None,
+                        signature: Some("opaque-thought-sig".to_string()),
+                    }],
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    finish_reason: FinishReason::ToolUse,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                    reasoning_content: Some("step 1: think; step 2: search".to_string()),
+                })
+            }
+        }
+
+        let reasoning = Reasoning::new(Arc::new(ThinkingModeMock));
+        let context = ReasoningContext::new()
+            .with_message(ChatMessage::user("find me telegram steps"))
+            .with_tools(vec![ToolDefinition {
+                name: "tool_search".to_string(),
+                description: "Search the registry".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            }]);
+
+        let output = reasoning.respond_with_tools(&context).await.unwrap();
+        match output.result {
+            RespondResult::ToolCalls {
+                tool_calls,
+                content: _,
+                reasoning_content,
+            } => {
+                assert_eq!(
+                    reasoning_content.as_deref(),
+                    Some("step 1: think; step 2: search"),
+                    "DeepSeek-style reasoning_content must surface on RespondResult::ToolCalls",
+                );
+                assert_eq!(tool_calls.len(), 1);
+                assert_eq!(
+                    tool_calls[0].signature.as_deref(),
+                    Some("opaque-thought-sig"),
+                    "Gemini-style tool call signature must survive the reasoning layer",
+                );
+            }
+            RespondResult::Text(_) => {
+                panic!("Expected RespondResult::ToolCalls when provider returned tool calls");
             }
         }
     }
@@ -3549,6 +3654,7 @@ That's my plan."#;
             RespondResult::ToolCalls {
                 tool_calls,
                 content,
+                reasoning_content: _,
             } => {
                 assert_eq!(tool_calls.len(), 1);
                 assert_eq!(tool_calls[0].name, "tool_list");
@@ -3582,6 +3688,7 @@ That's my plan."#;
             RespondResult::ToolCalls {
                 tool_calls,
                 content,
+                reasoning_content: _,
             } => {
                 assert_eq!(tool_calls.len(), 1);
                 assert_eq!(tool_calls[0].name, "tool_list");
@@ -3743,12 +3850,14 @@ That's my plan."#;
                     name: "memory_write".to_string(),
                     arguments: serde_json::json!({}),
                     reasoning: None,
+                    signature: None,
                 }],
                 input_tokens: 5000,
                 output_tokens: 1024,
                 finish_reason: self.finish_reason,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }

--- a/src/llm/response_cache.rs
+++ b/src/llm/response_cache.rs
@@ -381,6 +381,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -376,6 +376,7 @@ fn extract_response(
                     name: tc.function.name.clone(),
                     arguments: tc.function.arguments.clone(),
                     reasoning: None,
+                    signature: None,
                 });
             }
             // Reasoning and Image variants are not mapped to IronClaw types
@@ -678,6 +679,7 @@ where
             finish_reason: finish,
             cache_read_input_tokens: saturate_u32(response.usage.cached_input_tokens),
             cache_creation_input_tokens: extract_cache_creation(&response.raw_response),
+            reasoning_content: None,
         };
 
         if resp.cache_read_input_tokens > 0 {
@@ -1540,6 +1542,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"query": "test"}),
             reasoning: None,
+            signature: None,
         };
         let msg = ChatMessage::assistant_with_tool_calls(Some("thinking".to_string()), vec![tc]);
         let messages = vec![msg];
@@ -1568,6 +1571,7 @@ mod tests {
             tool_call_id: None,
             name: Some("search".to_string()),
             tool_calls: None,
+            reasoning_content: None,
         }];
         let (_preamble, history) = convert_messages(&messages);
         match &history[0] {
@@ -1730,6 +1734,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"query": "test"}),
             reasoning: None,
+            signature: None,
         };
         let messages = vec![ChatMessage::assistant_with_tool_calls(None, vec![tc])];
         let (_preamble, history) = convert_messages(&messages);
@@ -1762,6 +1767,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"query": "test"}),
             reasoning: None,
+            signature: None,
         };
         let messages = vec![ChatMessage::assistant_with_tool_calls(None, vec![tc])];
         let (_preamble, history) = convert_messages(&messages);
@@ -1796,6 +1802,7 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"query": "test"}),
             reasoning: None,
+            signature: None,
         };
         let assistant_msg = ChatMessage::assistant_with_tool_calls(None, vec![tc]);
         let tool_result_msg = ChatMessage {
@@ -1805,6 +1812,7 @@ mod tests {
             tool_call_id: None,
             name: Some("search".to_string()),
             tool_calls: None,
+            reasoning_content: None,
         };
         let messages = vec![assistant_msg, tool_result_msg];
         let (_preamble, history) = convert_messages(&messages);
@@ -2116,12 +2124,14 @@ mod tests {
             name: "search".to_string(),
             arguments: serde_json::json!({"q": "rust"}),
             reasoning: None,
+            signature: None,
         };
         let tc2 = IronToolCall {
             id: "call_b".to_string(),
             name: "fetch".to_string(),
             arguments: serde_json::json!({"url": "https://example.com"}),
             reasoning: None,
+            signature: None,
         };
         let assistant = ChatMessage::assistant_with_tool_calls(None, vec![tc1, tc2]);
         let result_a = ChatMessage::tool_result("call_a", "search", "search results");
@@ -2204,6 +2214,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             content_parts: vec![],
+            reasoning_content: None,
         };
         let non_empty = ChatMessage::user("hi");
         let messages = vec![empty_asst, non_empty];
@@ -2224,6 +2235,7 @@ mod tests {
             tool_call_id: None,
             name: None,
             content_parts: vec![],
+            reasoning_content: None,
         };
         let user2 = ChatMessage::user("");
         let asst = ChatMessage::assistant("response");

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -233,6 +233,7 @@ impl LlmProvider for StubLlm {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 }

--- a/src/tools/builder/core.rs
+++ b/src/tools/builder/core.rs
@@ -770,16 +770,16 @@ Create alongside the .wasm file to grant capabilities:
                 RespondResult::ToolCalls {
                     tool_calls,
                     content,
+                    reasoning_content,
                 } => {
                     tools_executed = true;
 
-                    // Add assistant message with tool_calls (OpenAI protocol)
-                    reason_ctx
-                        .messages
-                        .push(ChatMessage::assistant_with_tool_calls(
-                            content,
-                            tool_calls.clone(),
-                        ));
+                    // Add assistant message with tool_calls (OpenAI protocol).
+                    // Round-trip provider-specific reasoning artifact (#3201).
+                    reason_ctx.messages.push(
+                        ChatMessage::assistant_with_tool_calls(content, tool_calls.clone())
+                            .with_reasoning_content(reasoning_content),
+                    );
 
                     // Execute each tool call
                     for tc in tool_calls {

--- a/src/worker/api.rs
+++ b/src/worker/api.rs
@@ -268,6 +268,7 @@ impl WorkerHttpClient {
             finish_reason: parse_finish_reason(&proxy_resp.finish_reason),
             cache_read_input_tokens: proxy_resp.cache_read_input_tokens,
             cache_creation_input_tokens: proxy_resp.cache_creation_input_tokens,
+            reasoning_content: None,
         })
     }
 

--- a/src/worker/container.rs
+++ b/src/worker/container.rs
@@ -509,6 +509,7 @@ impl LoopDelegate for ContainerDelegate {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        reasoning_content: Option<String>,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, crate::error::Error> {
         {
@@ -527,13 +528,12 @@ impl LoopDelegate for ContainerDelegate {
             .await;
         }
 
-        // Add assistant message with tool_calls (OpenAI protocol)
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        // Add assistant message with tool_calls (OpenAI protocol).
+        // `reasoning_content` round-trips provider-specific thinking artifacts.
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone())
+                .with_reasoning_content(reasoning_content),
+        );
 
         // Execute tools sequentially (container context — no parallel execution)
         let mut tool_failure_count: usize = 0;

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -967,6 +967,7 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
                         } else {
                             Some(action.reasoning.clone())
                         },
+                        signature: None,
                     }],
                 ));
 
@@ -1503,6 +1504,10 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
                     result: RespondResult::ToolCalls {
                         tool_calls,
                         content: reasoning_text,
+                        // Planning-mode synthetic responses don't carry
+                        // provider-specific reasoning artifacts; that pathway
+                        // doesn't go through the wire round-trip.
+                        reasoning_content: None,
                     },
                     usage: crate::llm::TokenUsage::default(),
                     finish_reason: crate::llm::FinishReason::ToolUse,
@@ -1670,6 +1675,7 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        reasoning_content: Option<String>,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, crate::error::Error> {
         {
@@ -1732,13 +1738,14 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
             );
         }
 
-        // Add assistant message with tool_calls (OpenAI protocol)
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        // Add assistant message with tool_calls (OpenAI protocol).
+        // `reasoning_content` round-trips provider-specific thinking artifacts
+        // (DeepSeek's `reasoning_content`) so the next iteration's API call
+        // includes them — required by some providers (#3201).
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone())
+                .with_reasoning_content(reasoning_content),
+        );
 
         // Convert to ToolSelections
         let selections: Vec<ToolSelection> = tool_calls
@@ -1816,6 +1823,7 @@ fn selections_to_tool_calls(selections: &[ToolSelection]) -> Vec<ToolCall> {
             } else {
                 Some(s.reasoning.clone())
             },
+            signature: None,
         })
         .collect()
 }

--- a/tests/admin_tool_policy_e2e.rs
+++ b/tests/admin_tool_policy_e2e.rs
@@ -70,6 +70,7 @@ mod tests {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }

--- a/tests/openai_compat_integration.rs
+++ b/tests/openai_compat_integration.rs
@@ -97,12 +97,14 @@ impl LlmProvider for MockLlmProvider {
                     name: tool.name.clone(),
                     arguments: serde_json::json!({"test": true}),
                     reasoning: None,
+                    signature: None,
                 }],
                 input_tokens: 15,
                 output_tokens: 8,
                 finish_reason: FinishReason::ToolUse,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         } else {
             Ok(ToolCompletionResponse {
@@ -113,6 +115,7 @@ impl LlmProvider for MockLlmProvider {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             })
         }
     }
@@ -168,6 +171,7 @@ impl LlmProvider for FixedModelProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 

--- a/tests/provider_chaos.rs
+++ b/tests/provider_chaos.rs
@@ -119,6 +119,7 @@ impl LlmProvider for FlakeyProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 }
@@ -214,6 +215,7 @@ impl LlmProvider for GarbageProvider {
             finish_reason: FinishReason::Unknown,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 }
@@ -274,6 +276,7 @@ impl LlmProvider for ReliableProvider {
             finish_reason: FinishReason::Stop,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_content: None,
         })
     }
 }

--- a/tests/support/trace_llm.rs
+++ b/tests/support/trace_llm.rs
@@ -739,6 +739,7 @@ impl LlmProvider for TraceLlm {
                 finish_reason: FinishReason::Stop,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_content: None,
             }),
             TraceResponse::ToolCalls {
                 tool_calls,
@@ -752,6 +753,7 @@ impl LlmProvider for TraceLlm {
                         name: tc.name,
                         arguments: tc.arguments,
                         reasoning: None,
+                        signature: None,
                     })
                     .collect();
                 Ok(ToolCompletionResponse {
@@ -762,6 +764,7 @@ impl LlmProvider for TraceLlm {
                     finish_reason: FinishReason::ToolUse,
                     cache_read_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_content: None,
                 })
             }
             TraceResponse::UserInput { .. } => Err(LlmError::RequestFailed {


### PR DESCRIPTION
## Summary

Fixes #3225 and #3201 — both Gemini (via OpenAI-compat) and DeepSeek thinking-mode tool-calling failed deterministically on the second turn because rig-core's OpenAI Completions client silently strips two provider-specific fields the API requires to be echoed back:

- **Gemini** (#3225): HTTP 400 `Function call is missing a thought_signature in functionCall parts`
- **DeepSeek** (#3201): HTTP 400 `The reasoning_content in the thinking mode must be passed back to the API`

## Fix

Replaced the rig-core OpenAI Completions path in `create_openai_compat_from_registry` with a focused custom provider built on `reqwest` (`src/llm/openai_compat.rs`) that captures `reasoning_content` and per-tool-call `thought_signature` on the response and writes them back onto the wire on subsequent turns.

To prevent the same bug class for future OpenAI-compat providers (Qwen, Hunyuan, etc.), the round-trip data has typed homes end-to-end through the agentic loop:

- `ChatMessage.reasoning_content` (assistant message extension)
- `ToolCall.signature` (per-tool-call extension)
- `ToolCompletionResponse.reasoning_content` (provider boundary)
- `RespondResult::ToolCalls { reasoning_content, .. }` (reasoning layer)
- `LoopDelegate::execute_tool_calls(.., reasoning_content, ..)` (agentic loop)

Anthropic, Ollama, GitHub Copilot, NEAR AI, Bedrock, and the Codex ChatGPT provider chains are unchanged — they don't go through `OpenAiCompletions`.

## Regression coverage

Per `.claude/rules/testing.md` "test through the caller":

- Wire layer: `tool_call_signature_round_trips_through_wire_format`, `reasoning_content_is_serialized_on_assistant_messages`, `reasoning_content_is_omitted_when_none`
- Response capture: `tool_call_signature_captured_from_response_payload`, `assistant_reasoning_content_captured_from_response_payload`
- Build-request layer: `build_request_body_carries_round_trip_extensions_for_assistant_turn`
- Reasoning layer (cross-layer): `test_thinking_mode_reasoning_and_signature_propagate_to_respond_result`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib` — 5632 passed
- [x] `scripts/pre-commit-safety.sh` — clean
- [ ] Manual verification: run against `gemini-3.1-flash-lite-preview` with API-key auth and confirm tool-calling continues across iterations
- [ ] Manual verification: run against `deepseek-v4-flash` and confirm tool-calling continues across iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)