### PR TITLE
ci: extend nightly e2e timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
     name: E2E (${{ matrix.group }})
     needs: [matrix-config, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- increase the E2E matrix job timeout from 30 to 90 minutes
- gives the nightly v2-engine shard enough time to finish instead of being cancelled at the previous job timeout

## Context
- Nightly E2E issue #3323 showed `Full E2E / E2E (v2-engine)` cancelled at the 30-minute job timeout while the shard was still running.

## Testing
- `git diff --check -- .github/workflows/e2e.yml`
