### PR TITLE
feat(reborn): port encrypted secrets store and add credential account sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,11 +4379,19 @@ dependencies = [
 name = "ironclaw_secrets"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "async-trait",
+ "chrono",
+ "hkdf",
  "ironclaw_host_api",
+ "rand 0.8.5",
  "secrecy",
+ "serde",
+ "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -978,6 +978,12 @@ fn sanitized_secret_error(error: &SecretStoreError) -> String {
         SecretStoreError::UnknownLease { .. } => "credential lease is unavailable".to_string(),
         SecretStoreError::LeaseConsumed { .. } => "credential lease was already used".to_string(),
         SecretStoreError::LeaseRevoked { .. } => "credential lease was revoked".to_string(),
+        SecretStoreError::LeaseExpired { .. } | SecretStoreError::SecretExpired => {
+            "credential expired".to_string()
+        }
+        SecretStoreError::BackendMisconfigured { .. } => {
+            "credential store is misconfigured".to_string()
+        }
         SecretStoreError::StoreUnavailable { .. } => "credential store unavailable".to_string(),
     }
 }

--- a/crates/ironclaw_secrets/Cargo.toml
+++ b/crates/ironclaw_secrets/Cargo.toml
@@ -5,11 +5,17 @@ edition = "2024"
 publish = false
 
 [dependencies]
+aes-gcm = "0.10"
 async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+hkdf = "0.12"
 ironclaw_host_api = { path = "../ironclaw_host_api" }
+rand = "0.8"
 secrecy = "0.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 thiserror = "2"
+tokio = { version = "1", features = ["macros", "rt", "sync"] }
+url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
-
-[dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_secrets/src/crypto.rs
+++ b/crates/ironclaw_secrets/src/crypto.rs
@@ -31,6 +31,15 @@ impl SecretsCrypto {
         Ok(Self { master_key })
     }
 
+    pub(crate) fn from_valid_master_key_literal(master_key: &'static str) -> Self {
+        // The caller is limited to crate-owned literals whose length is reviewed
+        // at compile time. This keeps infallible test/demo store construction out
+        // of production panic paths while preserving `new` validation for dynamic keys.
+        Self {
+            master_key: SecretString::from(master_key.to_string()),
+        }
+    }
+
     pub fn generate_salt() -> Vec<u8> {
         let mut salt = vec![0u8; SALT_SIZE];
         rand::RngCore::fill_bytes(&mut OsRng, &mut salt);

--- a/crates/ironclaw_secrets/src/crypto.rs
+++ b/crates/ironclaw_secrets/src/crypto.rs
@@ -31,12 +31,12 @@ impl SecretsCrypto {
         Ok(Self { master_key })
     }
 
-    pub(crate) fn from_valid_master_key_literal(master_key: &'static str) -> Self {
-        // The caller is limited to crate-owned literals whose length is reviewed
-        // at compile time. This keeps infallible test/demo store construction out
-        // of production panic paths while preserving `new` validation for dynamic keys.
+    pub(crate) fn from_valid_master_key(master_key: String) -> Self {
+        // The caller is limited to crate-owned key generation whose byte length is reviewed.
+        // This keeps infallible test/demo store construction out of production panic paths
+        // while preserving `new` validation for externally supplied dynamic keys.
         Self {
-            master_key: SecretString::from(master_key.to_string()),
+            master_key: SecretString::from(master_key),
         }
     }
 

--- a/crates/ironclaw_secrets/src/crypto.rs
+++ b/crates/ironclaw_secrets/src/crypto.rs
@@ -1,0 +1,92 @@
+//! Port of IronClaw's battle-tested secret crypto.
+//!
+//! Uses AES-256-GCM with per-secret HKDF-SHA256 key derivation, matching the
+//! existing `src/secrets/crypto.rs` implementation so Reborn does not introduce
+//! a parallel encryption scheme.
+
+use aes_gcm::{
+    Aes256Gcm, KeyInit, Nonce,
+    aead::{Aead, AeadCore, OsRng},
+};
+use hkdf::Hkdf;
+use secrecy::{ExposeSecret, SecretString};
+use sha2::Sha256;
+
+use crate::{DecryptedSecret, SecretError};
+
+const KEY_SIZE: usize = 32;
+const NONCE_SIZE: usize = 12;
+const SALT_SIZE: usize = 32;
+const TAG_SIZE: usize = 16;
+
+pub struct SecretsCrypto {
+    master_key: SecretString,
+}
+
+impl SecretsCrypto {
+    pub fn new(master_key: SecretString) -> Result<Self, SecretError> {
+        if master_key.expose_secret().len() < KEY_SIZE {
+            return Err(SecretError::InvalidMasterKey);
+        }
+        Ok(Self { master_key })
+    }
+
+    pub fn generate_salt() -> Vec<u8> {
+        let mut salt = vec![0u8; SALT_SIZE];
+        rand::RngCore::fill_bytes(&mut OsRng, &mut salt);
+        salt
+    }
+
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<(Vec<u8>, Vec<u8>), SecretError> {
+        let salt = Self::generate_salt();
+        let derived_key = self.derive_key(&salt)?;
+        let cipher = Aes256Gcm::new_from_slice(&derived_key)
+            .map_err(|error| SecretError::EncryptionFailed(error.to_string()))?;
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|error| SecretError::EncryptionFailed(error.to_string()))?;
+        let mut encrypted = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+        encrypted.extend_from_slice(&nonce);
+        encrypted.extend_from_slice(&ciphertext);
+        Ok((encrypted, salt))
+    }
+
+    pub fn decrypt(
+        &self,
+        encrypted_value: &[u8],
+        salt: &[u8],
+    ) -> Result<DecryptedSecret, SecretError> {
+        if encrypted_value.len() < NONCE_SIZE + TAG_SIZE {
+            return Err(SecretError::DecryptionFailed(
+                "encrypted value too short".to_string(),
+            ));
+        }
+        let derived_key = self.derive_key(salt)?;
+        let cipher = Aes256Gcm::new_from_slice(&derived_key)
+            .map_err(|error| SecretError::DecryptionFailed(error.to_string()))?;
+        let (nonce_bytes, ciphertext) = encrypted_value.split_at(NONCE_SIZE);
+        let nonce = Nonce::from_slice(nonce_bytes);
+        let plaintext = cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|error| SecretError::DecryptionFailed(error.to_string()))?;
+        DecryptedSecret::from_bytes(plaintext)
+    }
+
+    fn derive_key(&self, salt: &[u8]) -> Result<[u8; KEY_SIZE], SecretError> {
+        let hk = Hkdf::<Sha256>::new(Some(salt), self.master_key.expose_secret().as_bytes());
+        let mut derived = [0u8; KEY_SIZE];
+        hk.expand(b"near-agent-secrets-v1", &mut derived)
+            .map_err(|_| SecretError::EncryptionFailed("HKDF expansion failed".to_string()))?;
+        Ok(derived)
+    }
+}
+
+impl std::fmt::Debug for SecretsCrypto {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SecretsCrypto")
+            .field("master_key", &"[REDACTED]")
+            .finish()
+    }
+}

--- a/crates/ironclaw_secrets/src/legacy_store.rs
+++ b/crates/ironclaw_secrets/src/legacy_store.rs
@@ -345,7 +345,13 @@ impl SecretsStore for InMemorySecretsStore {
             .is_some())
     }
 
-    async fn record_usage(&self, _secret_id: Uuid) -> Result<(), SecretError> {
+    async fn record_usage(&self, secret_id: Uuid) -> Result<(), SecretError> {
+        let mut secrets = self.secrets.write().await;
+        let Some(secret) = secrets.values_mut().find(|secret| secret.id == secret_id) else {
+            return Err(SecretError::NotFound(secret_id.to_string()));
+        };
+        secret.last_used_at = Some(Utc::now());
+        secret.usage_count += 1;
         Ok(())
     }
 

--- a/crates/ironclaw_secrets/src/legacy_store.rs
+++ b/crates/ironclaw_secrets/src/legacy_store.rs
@@ -1,0 +1,375 @@
+//! Ported legacy secret storage contracts used by Reborn adapters.
+//!
+//! These types mirror the existing `src/secrets/{types,store}.rs` behavior:
+//! encrypted records, redacted Debug output, decrypted material exposed only via
+//! an explicit host-boundary method, and an encrypted in-memory store for tests.
+
+use std::{collections::HashMap, fmt, sync::Arc};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use crate::SecretsCrypto;
+
+#[derive(Clone)]
+pub struct Secret {
+    pub id: Uuid,
+    pub user_id: String,
+    pub name: String,
+    pub encrypted_value: Vec<u8>,
+    pub key_salt: Vec<u8>,
+    pub provider: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub usage_count: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for Secret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Secret")
+            .field("id", &self.id)
+            .field("user_id", &self.user_id)
+            .field("name", &self.name)
+            .field("encrypted_value", &"[REDACTED]")
+            .field("key_salt", &"[REDACTED]")
+            .field("provider", &self.provider)
+            .field("expires_at", &self.expires_at)
+            .field("last_used_at", &self.last_used_at)
+            .field("usage_count", &self.usage_count)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecretRef {
+    pub name: String,
+    pub provider: Option<String>,
+}
+
+pub struct DecryptedSecret {
+    value: SecretString,
+}
+
+impl DecryptedSecret {
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, SecretError> {
+        let value = String::from_utf8(bytes).map_err(|_| SecretError::InvalidUtf8)?;
+        Ok(Self {
+            value: SecretString::from(value),
+        })
+    }
+
+    pub fn expose(&self) -> &str {
+        self.value.expose_secret()
+    }
+
+    pub fn len(&self) -> usize {
+        self.value.expose_secret().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl fmt::Debug for DecryptedSecret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "DecryptedSecret([REDACTED, {} bytes])",
+            self.len()
+        )
+    }
+}
+
+impl Clone for DecryptedSecret {
+    fn clone(&self) -> Self {
+        Self {
+            value: SecretString::from(self.value.expose_secret().to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SecretError {
+    #[error("Secret not found: {0}")]
+    NotFound(String),
+    #[error("Secret has expired")]
+    Expired,
+    #[error("Decryption failed: {0}")]
+    DecryptionFailed(String),
+    #[error("Encryption failed: {0}")]
+    EncryptionFailed(String),
+    #[error("Invalid master key")]
+    InvalidMasterKey,
+    #[error("Secret value is not valid UTF-8")]
+    InvalidUtf8,
+    #[error("Database error: {0}")]
+    Database(String),
+    #[error("Secret access denied for tool")]
+    AccessDenied,
+    #[error("Keychain error: {0}")]
+    KeychainError(String),
+}
+
+#[derive(Debug)]
+pub struct CreateSecretParams {
+    pub name: String,
+    pub value: SecretString,
+    pub provider: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+impl CreateSecretParams {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into().to_lowercase(),
+            value: SecretString::from(value.into()),
+            provider: None,
+            expires_at: None,
+        }
+    }
+
+    pub fn from_secret(name: impl Into<String>, value: SecretString) -> Self {
+        Self {
+            name: name.into().to_lowercase(),
+            value,
+            provider: None,
+            expires_at: None,
+        }
+    }
+
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = Some(provider.into());
+        self
+    }
+
+    pub fn with_expiry(mut self, expires_at: DateTime<Utc>) -> Self {
+        self.expires_at = Some(expires_at);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretConsumeResult {
+    Matched,
+    Mismatched,
+    NotFound,
+}
+
+#[async_trait]
+pub trait SecretsStore: Send + Sync {
+    async fn create(
+        &self,
+        user_id: &str,
+        params: CreateSecretParams,
+    ) -> Result<Secret, SecretError>;
+    async fn get(&self, user_id: &str, name: &str) -> Result<Secret, SecretError>;
+    async fn get_decrypted(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<DecryptedSecret, SecretError>;
+
+    async fn consume_if_matches(
+        &self,
+        user_id: &str,
+        name: &str,
+        expected_value: &str,
+    ) -> Result<SecretConsumeResult, SecretError> {
+        match self.get_decrypted(user_id, name).await {
+            Ok(secret) => {
+                if secret.expose() != expected_value {
+                    return Ok(SecretConsumeResult::Mismatched);
+                }
+                self.delete(user_id, name).await?;
+                Ok(SecretConsumeResult::Matched)
+            }
+            Err(SecretError::NotFound(_)) => Ok(SecretConsumeResult::NotFound),
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError>;
+    async fn any_exist(&self) -> Result<bool, SecretError> {
+        Ok(false)
+    }
+    async fn list(&self, user_id: &str) -> Result<Vec<SecretRef>, SecretError>;
+    async fn delete(&self, user_id: &str, name: &str) -> Result<bool, SecretError>;
+    async fn record_usage(&self, secret_id: Uuid) -> Result<(), SecretError>;
+    async fn is_accessible(
+        &self,
+        user_id: &str,
+        secret_name: &str,
+        allowed_secrets: &[String],
+    ) -> Result<bool, SecretError>;
+}
+
+#[derive(Debug)]
+pub struct InMemorySecretsStore {
+    secrets: RwLock<HashMap<(String, String), Secret>>,
+    crypto: Arc<SecretsCrypto>,
+}
+
+impl InMemorySecretsStore {
+    pub fn new(crypto: Arc<SecretsCrypto>) -> Self {
+        Self {
+            secrets: RwLock::new(HashMap::new()),
+            crypto,
+        }
+    }
+}
+
+#[async_trait]
+impl SecretsStore for InMemorySecretsStore {
+    async fn create(
+        &self,
+        user_id: &str,
+        params: CreateSecretParams,
+    ) -> Result<Secret, SecretError> {
+        let plaintext = params.value.expose_secret().as_bytes();
+        let (encrypted_value, key_salt) = self.crypto.encrypt(plaintext)?;
+        let now = Utc::now();
+        let secret = Secret {
+            id: Uuid::new_v4(),
+            user_id: user_id.to_string(),
+            name: params.name.clone(),
+            encrypted_value,
+            key_salt,
+            provider: params.provider,
+            expires_at: params.expires_at,
+            last_used_at: None,
+            usage_count: 0,
+            created_at: now,
+            updated_at: now,
+        };
+        self.secrets
+            .write()
+            .await
+            .insert((user_id.to_string(), params.name), secret.clone());
+        Ok(secret)
+    }
+
+    async fn get(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
+        let name = name.to_lowercase();
+        let secret = self
+            .secrets
+            .read()
+            .await
+            .get(&(user_id.to_string(), name.clone()))
+            .cloned()
+            .ok_or_else(|| SecretError::NotFound(name.clone()))?;
+        if let Some(expires_at) = secret.expires_at
+            && expires_at < Utc::now()
+        {
+            return Err(SecretError::Expired);
+        }
+        Ok(secret)
+    }
+
+    async fn get_decrypted(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<DecryptedSecret, SecretError> {
+        let secret = self.get(user_id, name).await?;
+        self.crypto
+            .decrypt(&secret.encrypted_value, &secret.key_salt)
+    }
+
+    async fn consume_if_matches(
+        &self,
+        user_id: &str,
+        name: &str,
+        expected_value: &str,
+    ) -> Result<SecretConsumeResult, SecretError> {
+        let name = name.to_lowercase();
+        let mut secrets = self.secrets.write().await;
+        let key = (user_id.to_string(), name.clone());
+        let Some(secret) = secrets.get(&key).cloned() else {
+            return Ok(SecretConsumeResult::NotFound);
+        };
+        if let Some(expires_at) = secret.expires_at
+            && expires_at < Utc::now()
+        {
+            return Err(SecretError::Expired);
+        }
+        let decrypted = self
+            .crypto
+            .decrypt(&secret.encrypted_value, &secret.key_salt)?;
+        if decrypted.expose() != expected_value {
+            return Ok(SecretConsumeResult::Mismatched);
+        }
+        secrets.remove(&key);
+        Ok(SecretConsumeResult::Matched)
+    }
+
+    async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
+        Ok(self
+            .secrets
+            .read()
+            .await
+            .contains_key(&(user_id.to_string(), name.to_lowercase())))
+    }
+
+    async fn any_exist(&self) -> Result<bool, SecretError> {
+        Ok(!self.secrets.read().await.is_empty())
+    }
+
+    async fn list(&self, user_id: &str) -> Result<Vec<SecretRef>, SecretError> {
+        Ok(self
+            .secrets
+            .read()
+            .await
+            .iter()
+            .filter(|((stored_user_id, _), _)| stored_user_id == user_id)
+            .map(|(_, secret)| SecretRef {
+                name: secret.name.clone(),
+                provider: secret.provider.clone(),
+            })
+            .collect())
+    }
+
+    async fn delete(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
+        Ok(self
+            .secrets
+            .write()
+            .await
+            .remove(&(user_id.to_string(), name.to_lowercase()))
+            .is_some())
+    }
+
+    async fn record_usage(&self, _secret_id: Uuid) -> Result<(), SecretError> {
+        Ok(())
+    }
+
+    async fn is_accessible(
+        &self,
+        user_id: &str,
+        secret_name: &str,
+        allowed_secrets: &[String],
+    ) -> Result<bool, SecretError> {
+        let secret_name_lower = secret_name.to_lowercase();
+        if !self.exists(user_id, &secret_name_lower).await? {
+            return Ok(false);
+        }
+        for pattern in allowed_secrets {
+            let pattern_lower = pattern.to_lowercase();
+            if pattern_lower == secret_name_lower {
+                return Ok(true);
+            }
+            if let Some(prefix) = pattern_lower.strip_suffix('*')
+                && secret_name_lower.starts_with(prefix)
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -324,7 +324,9 @@ impl InMemoryCredentialBroker {
             .ok_or_else(|| CredentialBrokerError::MissingCredential {
                 account_id: request.account_id.clone(),
             })?;
-        if account.scope != request.scope {
+        if CredentialAccountKey::new(&account.scope, &account.id)
+            != CredentialAccountKey::new(&request.scope, &request.account_id)
+        {
             return Err(CredentialBrokerError::CredentialScopeMismatch {
                 account_id: request.account_id,
             });
@@ -721,12 +723,9 @@ pub struct InMemorySecretStore {
 
 impl InMemorySecretStore {
     pub fn new() -> Self {
-        let crypto = Arc::new(
-            SecretsCrypto::new(SecretMaterial::from(
-                "0123456789abcdef0123456789abcdef".to_string(),
-            ))
-            .expect("test crypto key is a valid 32-byte literal"),
-        );
+        let crypto = Arc::new(SecretsCrypto::from_valid_master_key_literal(
+            "0123456789abcdef0123456789abcdef",
+        ));
         Self {
             inner: ScopedSecretsStoreAdapter::new(Arc::new(InMemorySecretsStore::new(crypto))),
         }
@@ -902,6 +901,38 @@ mod tests {
         let debug = format!("{session:?}");
         assert!(!debug.contains("sk-live-sentinel"));
         assert!(!debug.contains("token"));
+    }
+
+    #[test]
+    fn credential_session_creation_accepts_project_scoped_account_across_invocations() {
+        let broker = InMemoryCredentialBroker::new();
+        let account_scope = sample_scope("tenant-a", "user-a");
+        let request_scope = ResourceScope {
+            mission_id: Some(MissionId::new("mission-b").unwrap()),
+            thread_id: Some(ThreadId::new("thread-b").unwrap()),
+            invocation_id: InvocationId::new(),
+            ..account_scope.clone()
+        };
+        let account_id = CredentialAccountId::new("openai_prod").unwrap();
+        let secret_handle = SecretHandle::new("openai_key").unwrap();
+        broker
+            .put_account(sample_account(
+                account_scope,
+                account_id.clone(),
+                secret_handle.clone(),
+            ))
+            .unwrap();
+
+        let session = broker
+            .create_session(session_request(
+                request_scope.clone(),
+                account_id,
+                "https://api.example.com/v1/models",
+            ))
+            .unwrap();
+
+        assert_eq!(session.scope, request_scope);
+        assert_eq!(session.secret_handles, vec![secret_handle]);
     }
 
     #[test]

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use async_trait::async_trait;
+use chrono::{Duration, Utc};
 pub use crypto::SecretsCrypto;
 use ironclaw_host_api::{
     AgentId, CapabilityId, ExtensionId, InvocationId, MissionId, NetworkMethod, ProjectId,
@@ -24,9 +25,13 @@ pub use legacy_store::{
     SecretError, SecretRef, SecretsStore,
 };
 pub use secrecy::SecretString as SecretMaterial;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 use uuid::Uuid;
+
+const CREDENTIAL_ID_MAX_LEN: usize = 128;
+const DEFAULT_SECRET_LEASE_TTL_SECONDS: i64 = 300;
 
 /// Opaque identifier for a one-shot secret lease.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -91,6 +96,12 @@ pub enum SecretStoreError {
     LeaseConsumed { lease_id: SecretLeaseId },
     #[error("secret lease {lease_id} was revoked")]
     LeaseRevoked { lease_id: SecretLeaseId },
+    #[error("secret lease {lease_id} expired")]
+    LeaseExpired { lease_id: SecretLeaseId },
+    #[error("secret expired")]
+    SecretExpired,
+    #[error("secret backend is misconfigured: {reason}")]
+    BackendMisconfigured { reason: String },
     #[error("secret store state is unavailable: {reason}")]
     StoreUnavailable { reason: String },
 }
@@ -102,6 +113,9 @@ impl SecretStoreError {
             Self::UnknownLease { .. } => "MissingCredential",
             Self::LeaseConsumed { .. } => "CredentialExpired",
             Self::LeaseRevoked { .. } => "CredentialRevoked",
+            Self::LeaseExpired { .. } => "CredentialExpired",
+            Self::SecretExpired => "CredentialExpired",
+            Self::BackendMisconfigured { .. } => "BackendMisconfigured",
             Self::StoreUnavailable { .. } => "BackendUnavailable",
         }
     }
@@ -123,7 +137,31 @@ impl SecretStoreError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RedactedJson(Value);
+
+impl RedactedJson {
+    pub fn new(value: Value) -> Self {
+        Self(value)
+    }
+
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
+
+    pub fn into_value(self) -> Value {
+        self.0
+    }
+}
+
+impl fmt::Debug for RedactedJson {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[REDACTED_JSON]")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct CredentialAccountId(String);
 
 impl CredentialAccountId {
@@ -135,6 +173,40 @@ impl CredentialAccountId {
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for CredentialAccountId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl TryFrom<String> for CredentialAccountId {
+    type Error = CredentialBrokerError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<CredentialAccountId> for String {
+    fn from(value: CredentialAccountId) -> Self {
+        value.0
+    }
+}
+
+impl<'de> Deserialize<'de> for CredentialAccountId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -156,6 +228,12 @@ impl CredentialSessionId {
 impl Default for CredentialSessionId {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl fmt::Display for CredentialSessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
     }
 }
 
@@ -186,6 +264,12 @@ impl CredentialTargetPolicy {
         let Ok(parsed) = url::Url::parse(url) else {
             return false;
         };
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            return false;
+        }
+        if raw_url_path(url).is_some_and(path_has_encoded_traversal) {
+            return false;
+        }
         if self.scheme != parsed.scheme() {
             return false;
         }
@@ -220,22 +304,55 @@ pub struct CredentialAccount {
     pub status: CredentialAccountStatus,
     pub secret_handles: Vec<SecretHandle>,
     pub allowed_targets: Vec<CredentialTargetPolicy>,
-    pub redacted_metadata: Value,
+    pub redacted_metadata: RedactedJson,
     pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CredentialSession {
-    pub scope: ResourceScope,
-    pub invocation_id: InvocationId,
-    pub capability_id: CapabilityId,
-    pub extension_id: ExtensionId,
-    pub account_id: CredentialAccountId,
-    pub secret_handles: Vec<SecretHandle>,
-    pub allowed_targets: Vec<CredentialTargetPolicy>,
-    pub expires_at: Option<Timestamp>,
-    pub max_uses: Option<u64>,
-    pub correlation_id: CredentialSessionId,
+    scope: ResourceScope,
+    invocation_id: InvocationId,
+    capability_id: CapabilityId,
+    extension_id: ExtensionId,
+    account_id: CredentialAccountId,
+    secret_handles: Vec<SecretHandle>,
+    allowed_targets: Vec<CredentialTargetPolicy>,
+    expires_at: Option<Timestamp>,
+    max_uses: Option<u64>,
+    correlation_id: CredentialSessionId,
+}
+
+impl CredentialSession {
+    pub fn scope(&self) -> &ResourceScope {
+        &self.scope
+    }
+    pub fn invocation_id(&self) -> InvocationId {
+        self.invocation_id
+    }
+    pub fn capability_id(&self) -> &CapabilityId {
+        &self.capability_id
+    }
+    pub fn extension_id(&self) -> &ExtensionId {
+        &self.extension_id
+    }
+    pub fn account_id(&self) -> &CredentialAccountId {
+        &self.account_id
+    }
+    pub fn secret_handles(&self) -> &[SecretHandle] {
+        &self.secret_handles
+    }
+    pub fn allowed_targets(&self) -> &[CredentialTargetPolicy] {
+        &self.allowed_targets
+    }
+    pub fn expires_at(&self) -> Option<Timestamp> {
+        self.expires_at
+    }
+    pub fn max_uses(&self) -> Option<u64> {
+        self.max_uses
+    }
+    pub fn correlation_id(&self) -> CredentialSessionId {
+        self.correlation_id
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -246,6 +363,16 @@ pub enum CredentialBrokerError {
     MissingCredential { account_id: CredentialAccountId },
     #[error("credential account {account_id} does not match caller scope")]
     CredentialScopeMismatch { account_id: CredentialAccountId },
+    #[error("credential session request invocation does not match caller scope for {account_id}")]
+    CredentialInvocationMismatch { account_id: CredentialAccountId },
+    #[error("credential broker state is unavailable: {reason}")]
+    BrokerUnavailable { reason: String },
+    #[error("credential session {session_id} is unknown")]
+    UnknownSession { session_id: CredentialSessionId },
+    #[error("credential session {session_id} is expired")]
+    SessionExpired { session_id: CredentialSessionId },
+    #[error("credential session {session_id} has no uses remaining")]
+    SessionUseLimitExceeded { session_id: CredentialSessionId },
     #[error("credential account {account_id} is expired")]
     CredentialExpired { account_id: CredentialAccountId },
     #[error("credential account {account_id} is revoked")]
@@ -262,6 +389,11 @@ impl CredentialBrokerError {
             Self::InvalidAccountId { .. } => "MissingCredential",
             Self::MissingCredential { .. } => "MissingCredential",
             Self::CredentialScopeMismatch { .. } => "CredentialScopeMismatch",
+            Self::CredentialInvocationMismatch { .. } => "CredentialScopeMismatch",
+            Self::BrokerUnavailable { .. } => "BackendUnavailable",
+            Self::UnknownSession { .. } => "MissingCredential",
+            Self::SessionExpired { .. } => "CredentialExpired",
+            Self::SessionUseLimitExceeded { .. } => "CredentialExpired",
             Self::CredentialExpired { .. } => "CredentialExpired",
             Self::CredentialRevoked { .. } => "CredentialRevoked",
             Self::CredentialExtensionMismatch { .. } => "CredentialPolicyMismatch",
@@ -286,6 +418,13 @@ pub struct CredentialSessionRequest {
 #[derive(Debug, Default)]
 pub struct InMemoryCredentialBroker {
     accounts: Mutex<HashMap<CredentialAccountKey, CredentialAccount>>,
+    sessions: Mutex<HashMap<CredentialSessionId, CredentialSessionRecord>>,
+}
+
+#[derive(Debug, Clone)]
+struct CredentialSessionRecord {
+    session: CredentialSession,
+    uses: u64,
 }
 
 impl InMemoryCredentialBroker {
@@ -296,8 +435,8 @@ impl InMemoryCredentialBroker {
     pub fn put_account(&self, account: CredentialAccount) -> Result<(), CredentialBrokerError> {
         self.accounts
             .lock()
-            .map_err(|_| CredentialBrokerError::MissingCredential {
-                account_id: account.id.clone(),
+            .map_err(|error| CredentialBrokerError::BrokerUnavailable {
+                reason: error.to_string(),
             })?
             .insert(
                 CredentialAccountKey::new(&account.scope, &account.id),
@@ -310,11 +449,16 @@ impl InMemoryCredentialBroker {
         &self,
         request: CredentialSessionRequest,
     ) -> Result<CredentialSession, CredentialBrokerError> {
+        if request.invocation_id != request.scope.invocation_id {
+            return Err(CredentialBrokerError::CredentialInvocationMismatch {
+                account_id: request.account_id,
+            });
+        }
         let accounts =
             self.accounts
                 .lock()
-                .map_err(|_| CredentialBrokerError::MissingCredential {
-                    account_id: request.account_id.clone(),
+                .map_err(|error| CredentialBrokerError::BrokerUnavailable {
+                    reason: error.to_string(),
                 })?;
         let account = accounts
             .get(&CredentialAccountKey::new(
@@ -358,7 +502,7 @@ impl InMemoryCredentialBroker {
                 account_id: request.account_id,
             });
         }
-        Ok(CredentialSession {
+        let session = CredentialSession {
             scope: request.scope,
             invocation_id: request.invocation_id,
             capability_id: request.capability_id,
@@ -369,7 +513,84 @@ impl InMemoryCredentialBroker {
             expires_at: request.expires_at,
             max_uses: request.max_uses,
             correlation_id: CredentialSessionId::new(),
-        })
+        };
+        drop(accounts);
+        self.sessions
+            .lock()
+            .map_err(|error| CredentialBrokerError::BrokerUnavailable {
+                reason: error.to_string(),
+            })?
+            .insert(
+                session.correlation_id,
+                CredentialSessionRecord {
+                    session: session.clone(),
+                    uses: 0,
+                },
+            );
+        Ok(session)
+    }
+
+    pub fn validate_session(
+        &self,
+        session_id: CredentialSessionId,
+        now: Timestamp,
+    ) -> Result<CredentialSession, CredentialBrokerError> {
+        let mut sessions =
+            self.sessions
+                .lock()
+                .map_err(|error| CredentialBrokerError::BrokerUnavailable {
+                    reason: error.to_string(),
+                })?;
+        let record = sessions
+            .get_mut(&session_id)
+            .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
+        if record
+            .session
+            .expires_at
+            .is_some_and(|expires_at| expires_at <= now)
+        {
+            return Err(CredentialBrokerError::SessionExpired { session_id });
+        }
+        if record
+            .session
+            .max_uses
+            .is_some_and(|max_uses| record.uses >= max_uses)
+        {
+            return Err(CredentialBrokerError::SessionUseLimitExceeded { session_id });
+        }
+        Ok(record.session.clone())
+    }
+
+    pub fn consume_session_use(
+        &self,
+        session_id: CredentialSessionId,
+        now: Timestamp,
+    ) -> Result<CredentialSession, CredentialBrokerError> {
+        let mut sessions =
+            self.sessions
+                .lock()
+                .map_err(|error| CredentialBrokerError::BrokerUnavailable {
+                    reason: error.to_string(),
+                })?;
+        let record = sessions
+            .get_mut(&session_id)
+            .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
+        if record
+            .session
+            .expires_at
+            .is_some_and(|expires_at| expires_at <= now)
+        {
+            return Err(CredentialBrokerError::SessionExpired { session_id });
+        }
+        if record
+            .session
+            .max_uses
+            .is_some_and(|max_uses| record.uses >= max_uses)
+        {
+            return Err(CredentialBrokerError::SessionUseLimitExceeded { session_id });
+        }
+        record.uses += 1;
+        Ok(record.session.clone())
     }
 }
 
@@ -395,6 +616,9 @@ impl CredentialAccountKey {
 }
 
 fn path_matches_prefix(path: &str, prefix: &str) -> bool {
+    if path_has_encoded_traversal(path) {
+        return false;
+    }
     let path = path.strip_suffix('/').unwrap_or(path);
     let prefix = prefix.strip_suffix('/').unwrap_or(prefix);
     if path == prefix {
@@ -407,15 +631,73 @@ fn path_matches_prefix(path: &str, prefix: &str) -> bool {
     false
 }
 
+fn raw_url_path(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://")?.1;
+    let path_start = after_scheme.find('/')?;
+    let path_and_suffix = &after_scheme[path_start..];
+    Some(
+        path_and_suffix
+            .split(['?', '#'])
+            .next()
+            .unwrap_or(path_and_suffix),
+    )
+}
+
+fn path_has_encoded_traversal(path: &str) -> bool {
+    path.split('/').any(|segment| {
+        let decoded = percent_decode_bytes(segment.as_bytes());
+        matches!(decoded.as_slice(), b"." | b"..") || decoded.contains(&b'/')
+    })
+}
+
+fn percent_decode_bytes(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) =
+                (hex_nibble(bytes[index + 1]), hex_nibble(bytes[index + 2]))
+        {
+            out.push((hi << 4) | lo);
+            index += 3;
+            continue;
+        }
+        out.push(bytes[index]);
+        index += 1;
+    }
+    out
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 fn validate_credential_id(kind: &'static str, value: &str) -> Result<(), CredentialBrokerError> {
-    if value.is_empty()
-        || !value
-            .chars()
-            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+    if value.is_empty() {
+        return Err(CredentialBrokerError::InvalidAccountId {
+            value: value.to_string(),
+            reason: format!("{kind} must not be empty"),
+        });
+    }
+    if value.len() > CREDENTIAL_ID_MAX_LEN {
+        return Err(CredentialBrokerError::InvalidAccountId {
+            value: value.to_string(),
+            reason: format!("{kind} must be at most {CREDENTIAL_ID_MAX_LEN} bytes"),
+        });
+    }
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
     {
         return Err(CredentialBrokerError::InvalidAccountId {
             value: value.to_string(),
-            reason: format!("{kind} must contain only ASCII letters, digits, '-' or '_"),
+            reason: format!("{kind} must contain only ASCII letters, digits, '-' or '_'"),
         });
     }
     Ok(())
@@ -512,6 +794,8 @@ impl SecretLeaseKey {
 struct LeaseRecord {
     lease: SecretLease,
     material: Option<SecretMaterial>,
+    secret_id: Uuid,
+    expires_at: Timestamp,
 }
 
 /// Adapter that exposes the battle-tested encrypted [`SecretsStore`] contract
@@ -599,9 +883,10 @@ where
         scope: &ResourceScope,
         handle: &SecretHandle,
     ) -> Result<SecretLease, SecretStoreError> {
-        let material = self
+        let legacy_user_id = scoped_legacy_user_id(scope);
+        let secret = self
             .inner
-            .get_decrypted(&scoped_legacy_user_id(scope), handle.as_str())
+            .get(&legacy_user_id, handle.as_str())
             .await
             .map_err(|error| match error {
                 SecretError::NotFound(_) => SecretStoreError::UnknownSecret {
@@ -610,6 +895,11 @@ where
                 },
                 other => map_legacy_secret_error(other),
             })?;
+        let material = self
+            .inner
+            .get_decrypted(&legacy_user_id, handle.as_str())
+            .await
+            .map_err(map_legacy_secret_error)?;
         let lease = SecretLease {
             id: SecretLeaseId::new(),
             scope: scope.clone(),
@@ -621,6 +911,8 @@ where
             LeaseRecord {
                 lease: lease.clone(),
                 material: Some(SecretMaterial::from(material.expose().to_string())),
+                secret_id: secret.id,
+                expires_at: Utc::now() + Duration::seconds(DEFAULT_SECRET_LEASE_TTL_SECONDS),
             },
         );
         Ok(lease)
@@ -631,28 +923,44 @@ where
         scope: &ResourceScope,
         lease_id: SecretLeaseId,
     ) -> Result<SecretMaterial, SecretStoreError> {
-        let mut leases = self.lock_leases()?;
-        let key = SecretLeaseKey::new(scope, lease_id);
-        let record = leases
-            .get_mut(&key)
-            .ok_or_else(|| SecretStoreError::UnknownLease {
-                scope: Box::new(scope.clone()),
-                lease_id,
-            })?;
-        match record.lease.status {
-            SecretLeaseStatus::Active => {
-                let Some(material) = record.material.take() else {
+        let (material, secret_id) = {
+            let mut leases = self.lock_leases()?;
+            let key = SecretLeaseKey::new(scope, lease_id);
+            let record = leases
+                .get_mut(&key)
+                .ok_or_else(|| SecretStoreError::UnknownLease {
+                    scope: Box::new(scope.clone()),
+                    lease_id,
+                })?;
+            match record.lease.status {
+                SecretLeaseStatus::Active => {
+                    if record.expires_at <= Utc::now() {
+                        record.material = None;
+                        record.lease.status = SecretLeaseStatus::Revoked;
+                        return Err(SecretStoreError::LeaseExpired { lease_id });
+                    }
+                    let Some(material) = record.material.take() else {
+                        record.lease.status = SecretLeaseStatus::Consumed;
+                        return Err(SecretStoreError::StoreUnavailable {
+                            reason: "active lease material unavailable".to_string(),
+                        });
+                    };
                     record.lease.status = SecretLeaseStatus::Consumed;
-                    return Err(SecretStoreError::StoreUnavailable {
-                        reason: "active lease material unavailable".to_string(),
-                    });
-                };
-                record.lease.status = SecretLeaseStatus::Consumed;
-                Ok(material)
+                    (material, record.secret_id)
+                }
+                SecretLeaseStatus::Consumed => {
+                    return Err(SecretStoreError::LeaseConsumed { lease_id });
+                }
+                SecretLeaseStatus::Revoked => {
+                    return Err(SecretStoreError::LeaseRevoked { lease_id });
+                }
             }
-            SecretLeaseStatus::Consumed => Err(SecretStoreError::LeaseConsumed { lease_id }),
-            SecretLeaseStatus::Revoked => Err(SecretStoreError::LeaseRevoked { lease_id }),
-        }
+        };
+        self.inner
+            .record_usage(secret_id)
+            .await
+            .map_err(map_legacy_secret_error)?;
+        Ok(material)
     }
 
     async fn revoke(
@@ -661,6 +969,7 @@ where
         lease_id: SecretLeaseId,
     ) -> Result<SecretLease, SecretStoreError> {
         let mut leases = self.lock_leases()?;
+        prune_inactive_or_expired_leases(&mut leases);
         let key = SecretLeaseKey::new(scope, lease_id);
         let record = leases
             .get_mut(&key)
@@ -679,8 +988,9 @@ where
         &self,
         scope: &ResourceScope,
     ) -> Result<Vec<SecretLease>, SecretStoreError> {
-        Ok(self
-            .lock_leases()?
+        let mut leases = self.lock_leases()?;
+        prune_inactive_or_expired_leases(&mut leases);
+        Ok(leases
             .iter()
             .filter(|(key, _)| key.matches_scope(scope))
             .map(|(_, record)| record.lease.clone())
@@ -688,15 +998,20 @@ where
     }
 }
 
+fn prune_inactive_or_expired_leases(leases: &mut HashMap<SecretLeaseKey, LeaseRecord>) {
+    let now = Utc::now();
+    leases.retain(|_, record| {
+        record.lease.status != SecretLeaseStatus::Active || record.expires_at > now
+    });
+}
+
 fn map_legacy_secret_error(error: SecretError) -> SecretStoreError {
     match error {
         SecretError::NotFound(name) => SecretStoreError::StoreUnavailable {
             reason: format!("legacy secret missing: {name}"),
         },
-        SecretError::Expired => SecretStoreError::StoreUnavailable {
-            reason: "legacy secret expired".to_string(),
-        },
-        SecretError::InvalidMasterKey => SecretStoreError::StoreUnavailable {
+        SecretError::Expired => SecretStoreError::SecretExpired,
+        SecretError::InvalidMasterKey => SecretStoreError::BackendMisconfigured {
             reason: "legacy secrets master key unavailable".to_string(),
         },
         SecretError::AccessDenied => SecretStoreError::StoreUnavailable {
@@ -723,9 +1038,15 @@ pub struct InMemorySecretStore {
 
 impl InMemorySecretStore {
     pub fn new() -> Self {
-        let crypto = Arc::new(SecretsCrypto::from_valid_master_key_literal(
-            "0123456789abcdef0123456789abcdef",
+        let crypto = Arc::new(SecretsCrypto::from_valid_master_key(
+            Uuid::new_v4().simple().to_string(),
         ));
+        Self {
+            inner: ScopedSecretsStoreAdapter::new(Arc::new(InMemorySecretsStore::new(crypto))),
+        }
+    }
+
+    pub fn with_crypto(crypto: Arc<SecretsCrypto>) -> Self {
         Self {
             inner: ScopedSecretsStoreAdapter::new(Arc::new(InMemorySecretsStore::new(crypto))),
         }
@@ -802,11 +1123,12 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        CredentialAccount, CredentialAccountId, CredentialAccountStatus, CredentialBrokerError,
-        CredentialPathPolicy, CredentialSessionRequest, CredentialTargetPolicy,
-        InMemoryCredentialBroker, InMemorySecretStore, InMemorySecretsStore,
-        ScopedSecretsStoreAdapter, SecretMaterial, SecretStore, SecretStoreError, SecretsCrypto,
-        SecretsStore, scoped_legacy_user_id,
+        CREDENTIAL_ID_MAX_LEN, CredentialAccount, CredentialAccountId, CredentialAccountStatus,
+        CredentialBrokerError, CredentialPathPolicy, CredentialSessionRequest,
+        CredentialTargetPolicy, InMemoryCredentialBroker, InMemorySecretStore,
+        InMemorySecretsStore, RedactedJson, ScopedSecretsStoreAdapter, SecretLeaseKey,
+        SecretMaterial, SecretStore, SecretStoreError, SecretsCrypto, SecretsStore,
+        scoped_legacy_user_id,
     };
 
     #[test]
@@ -827,6 +1149,23 @@ mod tests {
             scoped_legacy_user_id(&delimiter_scope)
         );
         assert!(scoped_legacy_user_id(&none_agent).contains("\"agent_id\":null"));
+    }
+
+    #[test]
+    fn credential_account_id_validates_and_round_trips() {
+        let id = CredentialAccountId::new("openai_prod-1").unwrap();
+        assert_eq!(id.as_ref(), "openai_prod-1");
+        assert_eq!(String::from(id.clone()), "openai_prod-1");
+        assert_eq!(serde_json::to_string(&id).unwrap(), "\"openai_prod-1\"");
+        assert_eq!(
+            serde_json::from_str::<CredentialAccountId>("\"openai_prod-1\"").unwrap(),
+            id
+        );
+
+        for invalid in ["", "a/b", "a b", "a.b"] {
+            assert!(CredentialAccountId::new(invalid).is_err());
+        }
+        assert!(CredentialAccountId::new("a".repeat(CREDENTIAL_ID_MAX_LEN + 1)).is_err());
     }
 
     #[test]
@@ -853,6 +1192,15 @@ mod tests {
         ));
         assert!(!policy.matches(&NetworkMethod::Get, "http://api.example.com/v1/models"));
         assert!(!policy.matches(&NetworkMethod::Get, "https://evil.example.com/v1/models"));
+        assert!(!policy.matches(
+            &NetworkMethod::Get,
+            "https://user:pass@api.example.com/v1/models"
+        ));
+        assert!(!policy.matches(
+            &NetworkMethod::Get,
+            "https://api.example.com/v1/%2e%2e%2fadmin"
+        ));
+        assert!(!policy.matches(&NetworkMethod::Get, "https://api.example.com/v1/%2e/admin"));
 
         let policy_without_port_constraint = CredentialTargetPolicy {
             port: None,
@@ -866,6 +1214,46 @@ mod tests {
             &NetworkMethod::Get,
             "https://api.example.com:8443/v1/models"
         ));
+    }
+
+    #[test]
+    fn credential_account_debug_redacts_metadata() {
+        let account = sample_account(
+            sample_scope("tenant-a", "user-a"),
+            CredentialAccountId::new("openai_prod").unwrap(),
+            SecretHandle::new("openai_key").unwrap(),
+        );
+        let debug = format!("{account:?}");
+        assert!(!debug.contains("refresh_token"));
+        assert!(!debug.contains("sk-live-sentinel"));
+        assert!(debug.contains("[REDACTED_JSON]"));
+    }
+
+    #[test]
+    fn stable_reason_tokens_are_locked() {
+        let account_id = CredentialAccountId::new("openai_prod").unwrap();
+        assert_eq!(
+            CredentialBrokerError::BrokerUnavailable {
+                reason: "poisoned".to_string()
+            }
+            .stable_reason(),
+            "BackendUnavailable"
+        );
+        assert_eq!(
+            CredentialBrokerError::CredentialExpired { account_id }.stable_reason(),
+            "CredentialExpired"
+        );
+        assert_eq!(
+            SecretStoreError::SecretExpired.stable_reason(),
+            "CredentialExpired"
+        );
+        assert_eq!(
+            SecretStoreError::BackendMisconfigured {
+                reason: "missing key".to_string()
+            }
+            .stable_reason(),
+            "BackendMisconfigured"
+        );
     }
 
     #[test]
@@ -896,11 +1284,89 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(session.scope, scope);
-        assert_eq!(session.secret_handles, vec![secret_handle]);
+        assert_eq!(session.scope(), &scope);
+        assert_eq!(session.secret_handles(), &[secret_handle]);
         let debug = format!("{session:?}");
         assert!(!debug.contains("sk-live-sentinel"));
         assert!(!debug.contains("token"));
+    }
+
+    #[test]
+    fn credential_session_validation_enforces_expiry_and_use_limits() {
+        let broker = InMemoryCredentialBroker::new();
+        let scope = sample_scope("tenant-a", "user-a");
+        let account_id = CredentialAccountId::new("openai_prod").unwrap();
+        broker
+            .put_account(sample_account(
+                scope.clone(),
+                account_id.clone(),
+                SecretHandle::new("openai_key").unwrap(),
+            ))
+            .unwrap();
+        let session = broker
+            .create_session(CredentialSessionRequest {
+                expires_at: Some(Utc::now() + chrono::Duration::seconds(60)),
+                max_uses: Some(1),
+                ..session_request(
+                    scope.clone(),
+                    account_id,
+                    "https://api.example.com/v1/models",
+                )
+            })
+            .unwrap();
+
+        broker
+            .validate_session(session.correlation_id(), Utc::now())
+            .unwrap();
+        broker
+            .consume_session_use(session.correlation_id(), Utc::now())
+            .unwrap();
+        assert!(matches!(
+            broker.consume_session_use(session.correlation_id(), Utc::now()),
+            Err(CredentialBrokerError::SessionUseLimitExceeded { .. })
+        ));
+
+        let expired_id = CredentialAccountId::new("openai_expiring").unwrap();
+        broker
+            .put_account(sample_account(
+                scope.clone(),
+                expired_id.clone(),
+                SecretHandle::new("openai_expiring_key").unwrap(),
+            ))
+            .unwrap();
+        let expired = broker
+            .create_session(CredentialSessionRequest {
+                expires_at: Some(Utc::now() - chrono::Duration::seconds(1)),
+                ..session_request(scope, expired_id, "https://api.example.com/v1/models")
+            })
+            .unwrap();
+        assert!(matches!(
+            broker.validate_session(expired.correlation_id(), Utc::now()),
+            Err(CredentialBrokerError::SessionExpired { .. })
+        ));
+    }
+
+    #[test]
+    fn credential_session_creation_rejects_invocation_mismatch() {
+        let broker = InMemoryCredentialBroker::new();
+        let scope = sample_scope("tenant-a", "user-a");
+        let account_id = CredentialAccountId::new("openai_prod").unwrap();
+        broker
+            .put_account(sample_account(
+                scope.clone(),
+                account_id.clone(),
+                SecretHandle::new("openai_key").unwrap(),
+            ))
+            .unwrap();
+
+        let result = broker.create_session(CredentialSessionRequest {
+            invocation_id: InvocationId::new(),
+            ..session_request(scope, account_id, "https://api.example.com/v1/models")
+        });
+        assert!(matches!(
+            result,
+            Err(CredentialBrokerError::CredentialInvocationMismatch { .. })
+        ));
     }
 
     #[test]
@@ -931,8 +1397,8 @@ mod tests {
             ))
             .unwrap();
 
-        assert_eq!(session.scope, request_scope);
-        assert_eq!(session.secret_handles, vec![secret_handle]);
+        assert_eq!(session.scope(), &request_scope);
+        assert_eq!(session.secret_handles(), &[secret_handle]);
     }
 
     #[test]
@@ -991,6 +1457,24 @@ mod tests {
         assert!(matches!(
             extension_mismatch,
             Err(CredentialBrokerError::CredentialExtensionMismatch { .. })
+        ));
+
+        let expired_id = CredentialAccountId::new("github_expired").unwrap();
+        let mut expired = sample_account(
+            scope.clone(),
+            expired_id.clone(),
+            SecretHandle::new("github_expired_key").unwrap(),
+        );
+        expired.status = CredentialAccountStatus::Expired;
+        broker.put_account(expired).unwrap();
+        let expired_result = broker.create_session(session_request(
+            scope.clone(),
+            expired_id,
+            "https://api.example.com/v1/models",
+        ));
+        assert!(matches!(
+            expired_result,
+            Err(CredentialBrokerError::CredentialExpired { .. })
         ));
 
         let revoked_id = CredentialAccountId::new("github_revoked").unwrap();
@@ -1055,11 +1539,48 @@ mod tests {
         let lease = adapter.lease_once(&scope, &handle).await.unwrap();
         let material = adapter.consume(&scope, lease.id).await.unwrap();
         assert_eq!(material.expose_secret(), "sk-live-sentinel");
+        let used_secret = legacy
+            .get(&scoped_legacy_user_id(&scope), handle.as_str())
+            .await
+            .unwrap();
+        assert_eq!(used_secret.usage_count, 1);
+        assert!(used_secret.last_used_at.is_some());
         let second_consume = adapter.consume(&scope, lease.id).await;
         assert!(matches!(
             second_consume,
             Err(SecretStoreError::LeaseConsumed { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn expired_lease_drops_material_and_cannot_be_consumed() {
+        let store = InMemorySecretStore::new();
+        let scope = sample_scope("tenant-a", "user-a");
+        let handle = SecretHandle::new("api_key").unwrap();
+        store
+            .put(
+                scope.clone(),
+                handle.clone(),
+                SecretMaterial::from("super-secret"),
+            )
+            .await
+            .unwrap();
+
+        let lease = store.lease_once(&scope, &handle).await.unwrap();
+        {
+            let mut leases = store.inner.leases.lock().unwrap();
+            let record = leases
+                .get_mut(&SecretLeaseKey::new(&scope, lease.id))
+                .unwrap();
+            record.expires_at = Utc::now() - chrono::Duration::seconds(1);
+        }
+
+        assert!(matches!(
+            store.consume(&scope, lease.id).await,
+            Err(SecretStoreError::LeaseExpired { .. })
+        ));
+        let leases_debug = format!("{store:?}");
+        assert!(!leases_debug.contains("SecretBox"));
     }
 
     #[tokio::test]
@@ -1129,7 +1650,10 @@ mod tests {
                 path: CredentialPathPolicy::Prefix("/v1/".to_string()),
                 methods: vec![NetworkMethod::Get],
             }],
-            redacted_metadata: json!({ "last_four": "1234" }),
+            redacted_metadata: RedactedJson::new(json!({
+                "last_four": "1234",
+                "refresh_token": "sk-live-sentinel"
+            })),
             updated_at: Utc::now(),
         }
     }

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -6,16 +6,25 @@
 //! injection is not enforced until a higher-level obligation-handler/runtime
 //! composition slice consumes these primitives.
 
+mod crypto;
+mod legacy_store;
+
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use async_trait::async_trait;
+pub use crypto::SecretsCrypto;
 use ironclaw_host_api::{
-    AgentId, InvocationId, MissionId, ProjectId, ResourceScope, SecretHandle, TenantId, ThreadId,
-    UserId,
+    AgentId, CapabilityId, ExtensionId, InvocationId, MissionId, NetworkMethod, ProjectId,
+    ResourceScope, SecretHandle, TenantId, ThreadId, Timestamp, UserId,
+};
+pub use legacy_store::{
+    CreateSecretParams, DecryptedSecret, InMemorySecretsStore, Secret, SecretConsumeResult,
+    SecretError, SecretRef, SecretsStore,
 };
 pub use secrecy::SecretString as SecretMaterial;
+use serde_json::Value;
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -87,6 +96,16 @@ pub enum SecretStoreError {
 }
 
 impl SecretStoreError {
+    pub fn stable_reason(&self) -> &'static str {
+        match self {
+            Self::UnknownSecret { .. } => "MissingCredential",
+            Self::UnknownLease { .. } => "MissingCredential",
+            Self::LeaseConsumed { .. } => "CredentialExpired",
+            Self::LeaseRevoked { .. } => "CredentialRevoked",
+            Self::StoreUnavailable { .. } => "BackendUnavailable",
+        }
+    }
+
     pub fn is_unknown_secret(&self) -> bool {
         matches!(self, Self::UnknownSecret { .. })
     }
@@ -102,6 +121,302 @@ impl SecretStoreError {
     pub fn is_revoked(&self) -> bool {
         matches!(self, Self::LeaseRevoked { .. })
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CredentialAccountId(String);
+
+impl CredentialAccountId {
+    pub fn new(value: impl Into<String>) -> Result<Self, CredentialBrokerError> {
+        let value = value.into();
+        validate_credential_id("credential_account", &value)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CredentialAccountId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CredentialSessionId(Uuid);
+
+impl CredentialSessionId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for CredentialSessionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialAccountStatus {
+    Active,
+    Expired,
+    Revoked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialPathPolicy {
+    Exact(String),
+    Prefix(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialTargetPolicy {
+    pub scheme: String,
+    pub host: String,
+    pub port: Option<u16>,
+    pub path: CredentialPathPolicy,
+    pub methods: Vec<NetworkMethod>,
+}
+
+impl CredentialTargetPolicy {
+    pub fn matches(&self, method: &NetworkMethod, url: &str) -> bool {
+        let Ok(parsed) = url::Url::parse(url) else {
+            return false;
+        };
+        if self.scheme != parsed.scheme() {
+            return false;
+        }
+        if !parsed
+            .host_str()
+            .is_some_and(|host| host.eq_ignore_ascii_case(&self.host))
+        {
+            return false;
+        }
+        if self
+            .port
+            .is_some_and(|port| Some(port) != parsed.port_or_known_default())
+        {
+            return false;
+        }
+        if !self.methods.iter().any(|allowed| allowed == method) {
+            return false;
+        }
+        match &self.path {
+            CredentialPathPolicy::Exact(path) => parsed.path() == path,
+            CredentialPathPolicy::Prefix(prefix) => path_matches_prefix(parsed.path(), prefix),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CredentialAccount {
+    pub scope: ResourceScope,
+    pub id: CredentialAccountId,
+    pub provider_or_extension_id: ExtensionId,
+    pub label: String,
+    pub status: CredentialAccountStatus,
+    pub secret_handles: Vec<SecretHandle>,
+    pub allowed_targets: Vec<CredentialTargetPolicy>,
+    pub redacted_metadata: Value,
+    pub updated_at: Timestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialSession {
+    pub scope: ResourceScope,
+    pub invocation_id: InvocationId,
+    pub capability_id: CapabilityId,
+    pub extension_id: ExtensionId,
+    pub account_id: CredentialAccountId,
+    pub secret_handles: Vec<SecretHandle>,
+    pub allowed_targets: Vec<CredentialTargetPolicy>,
+    pub expires_at: Option<Timestamp>,
+    pub max_uses: Option<u64>,
+    pub correlation_id: CredentialSessionId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CredentialBrokerError {
+    #[error("invalid credential account id {value}: {reason}")]
+    InvalidAccountId { value: String, reason: String },
+    #[error("missing credential account {account_id} for tenant/user scope")]
+    MissingCredential { account_id: CredentialAccountId },
+    #[error("credential account {account_id} does not match caller scope")]
+    CredentialScopeMismatch { account_id: CredentialAccountId },
+    #[error("credential account {account_id} is expired")]
+    CredentialExpired { account_id: CredentialAccountId },
+    #[error("credential account {account_id} is revoked")]
+    CredentialRevoked { account_id: CredentialAccountId },
+    #[error("credential account {account_id} is not allowed for requested extension")]
+    CredentialExtensionMismatch { account_id: CredentialAccountId },
+    #[error("credential account {account_id} is not allowed for requested target")]
+    CredentialPolicyMismatch { account_id: CredentialAccountId },
+}
+
+impl CredentialBrokerError {
+    pub fn stable_reason(&self) -> &'static str {
+        match self {
+            Self::InvalidAccountId { .. } => "MissingCredential",
+            Self::MissingCredential { .. } => "MissingCredential",
+            Self::CredentialScopeMismatch { .. } => "CredentialScopeMismatch",
+            Self::CredentialExpired { .. } => "CredentialExpired",
+            Self::CredentialRevoked { .. } => "CredentialRevoked",
+            Self::CredentialExtensionMismatch { .. } => "CredentialPolicyMismatch",
+            Self::CredentialPolicyMismatch { .. } => "CredentialPolicyMismatch",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialSessionRequest {
+    pub scope: ResourceScope,
+    pub invocation_id: InvocationId,
+    pub capability_id: CapabilityId,
+    pub extension_id: ExtensionId,
+    pub account_id: CredentialAccountId,
+    pub method: NetworkMethod,
+    pub url: String,
+    pub expires_at: Option<Timestamp>,
+    pub max_uses: Option<u64>,
+}
+
+#[derive(Debug, Default)]
+pub struct InMemoryCredentialBroker {
+    accounts: Mutex<HashMap<CredentialAccountKey, CredentialAccount>>,
+}
+
+impl InMemoryCredentialBroker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn put_account(&self, account: CredentialAccount) -> Result<(), CredentialBrokerError> {
+        self.accounts
+            .lock()
+            .map_err(|_| CredentialBrokerError::MissingCredential {
+                account_id: account.id.clone(),
+            })?
+            .insert(
+                CredentialAccountKey::new(&account.scope, &account.id),
+                account,
+            );
+        Ok(())
+    }
+
+    pub fn create_session(
+        &self,
+        request: CredentialSessionRequest,
+    ) -> Result<CredentialSession, CredentialBrokerError> {
+        let accounts =
+            self.accounts
+                .lock()
+                .map_err(|_| CredentialBrokerError::MissingCredential {
+                    account_id: request.account_id.clone(),
+                })?;
+        let account = accounts
+            .get(&CredentialAccountKey::new(
+                &request.scope,
+                &request.account_id,
+            ))
+            .ok_or_else(|| CredentialBrokerError::MissingCredential {
+                account_id: request.account_id.clone(),
+            })?;
+        if account.scope != request.scope {
+            return Err(CredentialBrokerError::CredentialScopeMismatch {
+                account_id: request.account_id,
+            });
+        }
+        if account.provider_or_extension_id != request.extension_id {
+            return Err(CredentialBrokerError::CredentialExtensionMismatch {
+                account_id: request.account_id,
+            });
+        }
+        match account.status {
+            CredentialAccountStatus::Active => {}
+            CredentialAccountStatus::Expired => {
+                return Err(CredentialBrokerError::CredentialExpired {
+                    account_id: request.account_id,
+                });
+            }
+            CredentialAccountStatus::Revoked => {
+                return Err(CredentialBrokerError::CredentialRevoked {
+                    account_id: request.account_id,
+                });
+            }
+        }
+        if !account
+            .allowed_targets
+            .iter()
+            .any(|target| target.matches(&request.method, &request.url))
+        {
+            return Err(CredentialBrokerError::CredentialPolicyMismatch {
+                account_id: request.account_id,
+            });
+        }
+        Ok(CredentialSession {
+            scope: request.scope,
+            invocation_id: request.invocation_id,
+            capability_id: request.capability_id,
+            extension_id: request.extension_id,
+            account_id: account.id.clone(),
+            secret_handles: account.secret_handles.clone(),
+            allowed_targets: account.allowed_targets.clone(),
+            expires_at: request.expires_at,
+            max_uses: request.max_uses,
+            correlation_id: CredentialSessionId::new(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CredentialAccountKey {
+    tenant_id: TenantId,
+    user_id: UserId,
+    agent_id: Option<AgentId>,
+    project_id: Option<ProjectId>,
+    account_id: CredentialAccountId,
+}
+
+impl CredentialAccountKey {
+    fn new(scope: &ResourceScope, account_id: &CredentialAccountId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: scope.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            account_id: account_id.clone(),
+        }
+    }
+}
+
+fn path_matches_prefix(path: &str, prefix: &str) -> bool {
+    let path = path.strip_suffix('/').unwrap_or(path);
+    let prefix = prefix.strip_suffix('/').unwrap_or(prefix);
+    if path == prefix {
+        return true;
+    }
+    if path.len() > prefix.len() && path.starts_with(prefix) {
+        let next_char = path.as_bytes()[prefix.len()];
+        return next_char == b'/';
+    }
+    false
+}
+
+fn validate_credential_id(kind: &'static str, value: &str) -> Result<(), CredentialBrokerError> {
+    if value.is_empty()
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+    {
+        return Err(CredentialBrokerError::InvalidAccountId {
+            value: value.to_string(),
+            reason: format!("{kind} must contain only ASCII letters, digits, '-' or '_"),
+        });
+    }
+    Ok(())
 }
 
 /// Scoped secret store contract.
@@ -154,53 +469,6 @@ pub trait SecretStore: Send + Sync {
     ) -> Result<Vec<SecretLease>, SecretStoreError>;
 }
 
-/// In-memory secret store for contract tests and non-durable demos.
-#[derive(Debug, Default)]
-pub struct InMemorySecretStore {
-    state: Mutex<SecretState>,
-}
-
-impl InMemorySecretStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn lock_state(&self) -> Result<MutexGuard<'_, SecretState>, SecretStoreError> {
-        self.state
-            .lock()
-            .map_err(|error| SecretStoreError::StoreUnavailable {
-                reason: error.to_string(),
-            })
-    }
-}
-
-#[derive(Debug, Default)]
-struct SecretState {
-    secrets: HashMap<SecretKey, SecretRecord>,
-    leases: HashMap<SecretLeaseKey, LeaseRecord>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct SecretKey {
-    tenant_id: TenantId,
-    user_id: UserId,
-    agent_id: Option<AgentId>,
-    project_id: Option<ProjectId>,
-    handle: SecretHandle,
-}
-
-impl SecretKey {
-    fn new(scope: &ResourceScope, handle: &SecretHandle) -> Self {
-        Self {
-            tenant_id: scope.tenant_id.clone(),
-            user_id: scope.user_id.clone(),
-            agent_id: scope.agent_id.clone(),
-            project_id: scope.project_id.clone(),
-            handle: handle.clone(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct SecretLeaseKey {
     tenant_id: TenantId,
@@ -239,37 +507,70 @@ impl SecretLeaseKey {
 }
 
 #[derive(Debug, Clone)]
-struct SecretRecord {
-    metadata: SecretMetadata,
-    material: SecretMaterial,
-}
-
-#[derive(Debug, Clone)]
 struct LeaseRecord {
     lease: SecretLease,
     material: Option<SecretMaterial>,
 }
 
+/// Adapter that exposes the battle-tested encrypted [`SecretsStore`] contract
+/// through the scoped Reborn [`SecretStore`] lease boundary.
+#[derive(Debug)]
+pub struct ScopedSecretsStoreAdapter<S> {
+    inner: Arc<S>,
+    leases: Mutex<HashMap<SecretLeaseKey, LeaseRecord>>,
+}
+
+impl<S> ScopedSecretsStoreAdapter<S>
+where
+    S: SecretsStore + 'static,
+{
+    pub fn new(inner: Arc<S>) -> Self {
+        Self {
+            inner,
+            leases: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn lock_leases(
+        &self,
+    ) -> Result<MutexGuard<'_, HashMap<SecretLeaseKey, LeaseRecord>>, SecretStoreError> {
+        self.leases
+            .lock()
+            .map_err(|error| SecretStoreError::StoreUnavailable {
+                reason: error.to_string(),
+            })
+    }
+}
+
+fn scoped_legacy_user_id(scope: &ResourceScope) -> String {
+    serde_json::json!({
+        "tenant_id": scope.tenant_id.to_string(),
+        "user_id": scope.user_id.to_string(),
+        "agent_id": scope.agent_id.as_ref().map(ToString::to_string),
+        "project_id": scope.project_id.as_ref().map(ToString::to_string),
+    })
+    .to_string()
+}
+
 #[async_trait]
-impl SecretStore for InMemorySecretStore {
+impl<S> SecretStore for ScopedSecretsStoreAdapter<S>
+where
+    S: SecretsStore + 'static,
+{
     async fn put(
         &self,
         scope: ResourceScope,
         handle: SecretHandle,
         material: SecretMaterial,
     ) -> Result<SecretMetadata, SecretStoreError> {
-        let metadata = SecretMetadata {
-            scope: scope.clone(),
-            handle: handle.clone(),
-        };
-        let record = SecretRecord {
-            metadata: metadata.clone(),
-            material,
-        };
-        self.lock_state()?
-            .secrets
-            .insert(SecretKey::new(&scope, &handle), record);
-        Ok(metadata)
+        self.inner
+            .create(
+                &scoped_legacy_user_id(&scope),
+                CreateSecretParams::from_secret(handle.to_string(), material),
+            )
+            .await
+            .map_err(map_legacy_secret_error)?;
+        Ok(SecretMetadata { scope, handle })
     }
 
     async fn metadata(
@@ -277,11 +578,18 @@ impl SecretStore for InMemorySecretStore {
         scope: &ResourceScope,
         handle: &SecretHandle,
     ) -> Result<Option<SecretMetadata>, SecretStoreError> {
-        Ok(self
-            .lock_state()?
-            .secrets
-            .get(&SecretKey::new(scope, handle))
-            .map(|record| record.metadata.clone()))
+        match self
+            .inner
+            .get(&scoped_legacy_user_id(scope), handle.as_str())
+            .await
+        {
+            Ok(_) => Ok(Some(SecretMetadata {
+                scope: scope.clone(),
+                handle: handle.clone(),
+            })),
+            Err(SecretError::NotFound(_)) => Ok(None),
+            Err(error) => Err(map_legacy_secret_error(error)),
+        }
     }
 
     async fn lease_once(
@@ -289,13 +597,16 @@ impl SecretStore for InMemorySecretStore {
         scope: &ResourceScope,
         handle: &SecretHandle,
     ) -> Result<SecretLease, SecretStoreError> {
-        let mut state = self.lock_state()?;
-        let secret = state
-            .secrets
-            .get(&SecretKey::new(scope, handle))
-            .ok_or_else(|| SecretStoreError::UnknownSecret {
-                scope: Box::new(scope.clone()),
-                handle: handle.clone(),
+        let material = self
+            .inner
+            .get_decrypted(&scoped_legacy_user_id(scope), handle.as_str())
+            .await
+            .map_err(|error| match error {
+                SecretError::NotFound(_) => SecretStoreError::UnknownSecret {
+                    scope: Box::new(scope.clone()),
+                    handle: handle.clone(),
+                },
+                other => map_legacy_secret_error(other),
             })?;
         let lease = SecretLease {
             id: SecretLeaseId::new(),
@@ -303,13 +614,13 @@ impl SecretStore for InMemorySecretStore {
             handle: handle.clone(),
             status: SecretLeaseStatus::Active,
         };
-        let record = LeaseRecord {
-            lease: lease.clone(),
-            material: Some(secret.material.clone()),
-        };
-        state
-            .leases
-            .insert(SecretLeaseKey::new(scope, lease.id), record);
+        self.lock_leases()?.insert(
+            SecretLeaseKey::new(scope, lease.id),
+            LeaseRecord {
+                lease: lease.clone(),
+                material: Some(SecretMaterial::from(material.expose().to_string())),
+            },
+        );
         Ok(lease)
     }
 
@@ -318,10 +629,9 @@ impl SecretStore for InMemorySecretStore {
         scope: &ResourceScope,
         lease_id: SecretLeaseId,
     ) -> Result<SecretMaterial, SecretStoreError> {
-        let mut state = self.lock_state()?;
+        let mut leases = self.lock_leases()?;
         let key = SecretLeaseKey::new(scope, lease_id);
-        let record = state
-            .leases
+        let record = leases
             .get_mut(&key)
             .ok_or_else(|| SecretStoreError::UnknownLease {
                 scope: Box::new(scope.clone()),
@@ -348,10 +658,9 @@ impl SecretStore for InMemorySecretStore {
         scope: &ResourceScope,
         lease_id: SecretLeaseId,
     ) -> Result<SecretLease, SecretStoreError> {
-        let mut state = self.lock_state()?;
+        let mut leases = self.lock_leases()?;
         let key = SecretLeaseKey::new(scope, lease_id);
-        let record = state
-            .leases
+        let record = leases
             .get_mut(&key)
             .ok_or_else(|| SecretStoreError::UnknownLease {
                 scope: Box::new(scope.clone()),
@@ -369,8 +678,7 @@ impl SecretStore for InMemorySecretStore {
         scope: &ResourceScope,
     ) -> Result<Vec<SecretLease>, SecretStoreError> {
         Ok(self
-            .lock_state()?
-            .leases
+            .lock_leases()?
             .iter()
             .filter(|(key, _)| key.matches_scope(scope))
             .map(|(_, record)| record.lease.clone())
@@ -378,13 +686,350 @@ impl SecretStore for InMemorySecretStore {
     }
 }
 
+fn map_legacy_secret_error(error: SecretError) -> SecretStoreError {
+    match error {
+        SecretError::NotFound(name) => SecretStoreError::StoreUnavailable {
+            reason: format!("legacy secret missing: {name}"),
+        },
+        SecretError::Expired => SecretStoreError::StoreUnavailable {
+            reason: "legacy secret expired".to_string(),
+        },
+        SecretError::InvalidMasterKey => SecretStoreError::StoreUnavailable {
+            reason: "legacy secrets master key unavailable".to_string(),
+        },
+        SecretError::AccessDenied => SecretStoreError::StoreUnavailable {
+            reason: "legacy secret access denied".to_string(),
+        },
+        SecretError::InvalidUtf8
+        | SecretError::Database(_)
+        | SecretError::DecryptionFailed(_)
+        | SecretError::EncryptionFailed(_)
+        | SecretError::KeychainError(_) => SecretStoreError::StoreUnavailable {
+            reason: error.to_string(),
+        },
+    }
+}
+
+/// In-memory secret store for contract tests and non-durable demos.
+///
+/// This is a thin encrypted adapter over the ported legacy [`InMemorySecretsStore`];
+/// it intentionally does not keep a second raw-material store implementation.
+#[derive(Debug)]
+pub struct InMemorySecretStore {
+    inner: ScopedSecretsStoreAdapter<InMemorySecretsStore>,
+}
+
+impl InMemorySecretStore {
+    pub fn new() -> Self {
+        let crypto = Arc::new(
+            SecretsCrypto::new(SecretMaterial::from(
+                "0123456789abcdef0123456789abcdef".to_string(),
+            ))
+            .expect("test crypto key is a valid 32-byte literal"),
+        );
+        Self {
+            inner: ScopedSecretsStoreAdapter::new(Arc::new(InMemorySecretsStore::new(crypto))),
+        }
+    }
+}
+
+impl Default for InMemorySecretStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SecretStore for InMemorySecretStore {
+    async fn put(
+        &self,
+        scope: ResourceScope,
+        handle: SecretHandle,
+        material: SecretMaterial,
+    ) -> Result<SecretMetadata, SecretStoreError> {
+        self.inner.put(scope, handle, material).await
+    }
+
+    async fn metadata(
+        &self,
+        scope: &ResourceScope,
+        handle: &SecretHandle,
+    ) -> Result<Option<SecretMetadata>, SecretStoreError> {
+        self.inner.metadata(scope, handle).await
+    }
+
+    async fn lease_once(
+        &self,
+        scope: &ResourceScope,
+        handle: &SecretHandle,
+    ) -> Result<SecretLease, SecretStoreError> {
+        self.inner.lease_once(scope, handle).await
+    }
+
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretMaterial, SecretStoreError> {
+        self.inner.consume(scope, lease_id).await
+    }
+
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretLease, SecretStoreError> {
+        self.inner.revoke(scope, lease_id).await
+    }
+
+    async fn leases_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<SecretLease>, SecretStoreError> {
+        self.inner.leases_for_scope(scope).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
     use ironclaw_host_api::{
-        InvocationId, MissionId, ProjectId, ResourceScope, SecretHandle, TenantId, ThreadId, UserId,
+        AgentId, CapabilityId, ExtensionId, InvocationId, MissionId, NetworkMethod, ProjectId,
+        ResourceScope, SecretHandle, TenantId, ThreadId, UserId,
+    };
+    use secrecy::ExposeSecret;
+    use serde_json::json;
+
+    use crate::{
+        CredentialAccount, CredentialAccountId, CredentialAccountStatus, CredentialBrokerError,
+        CredentialPathPolicy, CredentialSessionRequest, CredentialTargetPolicy,
+        InMemoryCredentialBroker, InMemorySecretStore, InMemorySecretsStore,
+        ScopedSecretsStoreAdapter, SecretMaterial, SecretStore, SecretStoreError, SecretsCrypto,
+        SecretsStore, scoped_legacy_user_id,
     };
 
-    use crate::{InMemorySecretStore, SecretMaterial, SecretStore};
+    #[test]
+    fn scoped_legacy_user_id_uses_unambiguous_json_encoding() {
+        let none_agent = sample_scope("tenant-a", "user-a");
+        let dash_agent = ResourceScope {
+            agent_id: Some(AgentId::new("-").unwrap()),
+            ..none_agent.clone()
+        };
+        let delimiter_scope = sample_scope("tenant=a;agent=-", "user=a;project=-");
+
+        assert_ne!(
+            scoped_legacy_user_id(&none_agent),
+            scoped_legacy_user_id(&dash_agent)
+        );
+        assert_ne!(
+            scoped_legacy_user_id(&none_agent),
+            scoped_legacy_user_id(&delimiter_scope)
+        );
+        assert!(scoped_legacy_user_id(&none_agent).contains("\"agent_id\":null"));
+    }
+
+    #[test]
+    fn credential_target_policy_matches_scheme_host_port_path_and_method() {
+        let policy = CredentialTargetPolicy {
+            scheme: "https".to_string(),
+            host: "api.example.com".to_string(),
+            port: Some(443),
+            path: CredentialPathPolicy::Prefix("/v1/".to_string()),
+            methods: vec![NetworkMethod::Get],
+        };
+
+        assert!(policy.matches(&NetworkMethod::Get, "https://api.example.com/v1/models"));
+        assert!(policy.matches(&NetworkMethod::Get, "https://api.example.com:443/v1/models"));
+        assert!(!policy.matches(
+            &NetworkMethod::Get,
+            "https://api.example.com:8443/v1/models"
+        ));
+        assert!(!policy.matches(&NetworkMethod::Post, "https://api.example.com/v1/models"));
+        assert!(!policy.matches(&NetworkMethod::Get, "https://api.example.com/v2/models"));
+        assert!(!policy.matches(
+            &NetworkMethod::Get,
+            "https://api.example.com/v1-evil/models"
+        ));
+        assert!(!policy.matches(&NetworkMethod::Get, "http://api.example.com/v1/models"));
+        assert!(!policy.matches(&NetworkMethod::Get, "https://evil.example.com/v1/models"));
+
+        let policy_without_port_constraint = CredentialTargetPolicy {
+            port: None,
+            ..policy
+        };
+        assert!(
+            policy_without_port_constraint
+                .matches(&NetworkMethod::Get, "https://api.example.com/v1/models")
+        );
+        assert!(policy_without_port_constraint.matches(
+            &NetworkMethod::Get,
+            "https://api.example.com:8443/v1/models"
+        ));
+    }
+
+    #[test]
+    fn credential_session_creation_requires_explicit_scoped_account_and_redacts_material() {
+        let broker = InMemoryCredentialBroker::new();
+        let scope = sample_scope("tenant-a", "user-a");
+        let account_id = CredentialAccountId::new("openai_prod").unwrap();
+        let secret_handle = SecretHandle::new("openai_key").unwrap();
+        broker
+            .put_account(sample_account(
+                scope.clone(),
+                account_id.clone(),
+                secret_handle.clone(),
+            ))
+            .unwrap();
+
+        let session = broker
+            .create_session(CredentialSessionRequest {
+                scope: scope.clone(),
+                invocation_id: scope.invocation_id,
+                capability_id: CapabilityId::new("openai.chat").unwrap(),
+                extension_id: ExtensionId::new("openai").unwrap(),
+                account_id,
+                method: NetworkMethod::Get,
+                url: "https://api.example.com/v1/models".to_string(),
+                expires_at: None,
+                max_uses: Some(1),
+            })
+            .unwrap();
+
+        assert_eq!(session.scope, scope);
+        assert_eq!(session.secret_handles, vec![secret_handle]);
+        let debug = format!("{session:?}");
+        assert!(!debug.contains("sk-live-sentinel"));
+        assert!(!debug.contains("token"));
+    }
+
+    #[test]
+    fn credential_session_creation_denies_missing_cross_scope_revoked_and_policy_mismatch() {
+        let broker = InMemoryCredentialBroker::new();
+        let scope = sample_scope("tenant-a", "user-a");
+        let other_scope = sample_scope("tenant-b", "user-b");
+        let account_id = CredentialAccountId::new("github_prod").unwrap();
+        let secret_handle = SecretHandle::new("github_key").unwrap();
+        broker
+            .put_account(sample_account(
+                scope.clone(),
+                account_id.clone(),
+                secret_handle,
+            ))
+            .unwrap();
+
+        let missing = broker.create_session(session_request(
+            scope.clone(),
+            CredentialAccountId::new("missing").unwrap(),
+            "https://api.example.com/v1/models",
+        ));
+        assert!(matches!(
+            missing,
+            Err(CredentialBrokerError::MissingCredential { .. })
+        ));
+
+        let cross_scope = broker.create_session(session_request(
+            other_scope,
+            account_id.clone(),
+            "https://api.example.com/v1/models",
+        ));
+        assert!(matches!(
+            cross_scope,
+            Err(CredentialBrokerError::MissingCredential { .. })
+        ));
+
+        let policy_mismatch = broker.create_session(session_request(
+            scope.clone(),
+            account_id.clone(),
+            "https://api.example.com/v2/models",
+        ));
+        assert!(matches!(
+            policy_mismatch,
+            Err(CredentialBrokerError::CredentialPolicyMismatch { .. })
+        ));
+
+        let extension_mismatch = broker.create_session(CredentialSessionRequest {
+            extension_id: ExtensionId::new("other_extension").unwrap(),
+            ..session_request(
+                scope.clone(),
+                account_id.clone(),
+                "https://api.example.com/v1/models",
+            )
+        });
+        assert!(matches!(
+            extension_mismatch,
+            Err(CredentialBrokerError::CredentialExtensionMismatch { .. })
+        ));
+
+        let revoked_id = CredentialAccountId::new("github_revoked").unwrap();
+        let mut revoked = sample_account(
+            scope.clone(),
+            revoked_id.clone(),
+            SecretHandle::new("github_revoked_key").unwrap(),
+        );
+        revoked.status = CredentialAccountStatus::Revoked;
+        broker.put_account(revoked).unwrap();
+        let revoked_result = broker.create_session(session_request(
+            scope,
+            revoked_id,
+            "https://api.example.com/v1/models",
+        ));
+        assert!(matches!(
+            revoked_result,
+            Err(CredentialBrokerError::CredentialRevoked { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn scoped_adapter_reuses_encrypted_legacy_store_for_scoped_leases() {
+        let crypto = Arc::new(
+            SecretsCrypto::new(SecretMaterial::from(
+                "0123456789abcdef0123456789abcdef".to_string(),
+            ))
+            .unwrap(),
+        );
+        let legacy = Arc::new(InMemorySecretsStore::new(crypto));
+        let adapter = ScopedSecretsStoreAdapter::new(Arc::clone(&legacy));
+        let scope = sample_scope("tenant-a", "user-a");
+        let other_scope = sample_scope("tenant-b", "user-a");
+        let handle = SecretHandle::new("api_key").unwrap();
+
+        adapter
+            .put(
+                scope.clone(),
+                handle.clone(),
+                SecretMaterial::from("sk-live-sentinel".to_string()),
+            )
+            .await
+            .unwrap();
+
+        assert!(adapter.metadata(&scope, &handle).await.unwrap().is_some());
+        assert!(
+            adapter
+                .metadata(&other_scope, &handle)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let legacy_debug = format!(
+            "{:?}",
+            legacy
+                .get(&scoped_legacy_user_id(&scope), handle.as_str())
+                .await
+                .unwrap()
+        );
+        assert!(!legacy_debug.contains("sk-live-sentinel"));
+
+        let lease = adapter.lease_once(&scope, &handle).await.unwrap();
+        let material = adapter.consume(&scope, lease.id).await.unwrap();
+        assert_eq!(material.expose_secret(), "sk-live-sentinel");
+        let second_consume = adapter.consume(&scope, lease.id).await;
+        assert!(matches!(
+            second_consume,
+            Err(SecretStoreError::LeaseConsumed { .. })
+        ));
+    }
 
     #[tokio::test]
     async fn consumed_lease_record_drops_retained_material() {
@@ -403,8 +1048,7 @@ mod tests {
         let lease = store.lease_once(&scope, &handle).await.unwrap();
         store.consume(&scope, lease.id).await.unwrap();
 
-        let state = store.state.lock().unwrap();
-        let leases_debug = format!("{:?}", state.leases);
+        let leases_debug = format!("{store:?}");
         assert!(
             !leases_debug.contains("SecretBox"),
             "consumed lease records must not retain cloned secret material: {leases_debug}"
@@ -428,12 +1072,53 @@ mod tests {
         let lease = store.lease_once(&scope, &handle).await.unwrap();
         store.revoke(&scope, lease.id).await.unwrap();
 
-        let state = store.state.lock().unwrap();
-        let leases_debug = format!("{:?}", state.leases);
+        let leases_debug = format!("{store:?}");
         assert!(
             !leases_debug.contains("SecretBox"),
             "revoked lease records must not retain cloned secret material: {leases_debug}"
         );
+    }
+
+    fn sample_account(
+        scope: ResourceScope,
+        id: CredentialAccountId,
+        secret_handle: SecretHandle,
+    ) -> CredentialAccount {
+        CredentialAccount {
+            scope,
+            id,
+            provider_or_extension_id: ExtensionId::new("openai").unwrap(),
+            label: "Production".to_string(),
+            status: CredentialAccountStatus::Active,
+            secret_handles: vec![secret_handle],
+            allowed_targets: vec![CredentialTargetPolicy {
+                scheme: "https".to_string(),
+                host: "api.example.com".to_string(),
+                port: Some(443),
+                path: CredentialPathPolicy::Prefix("/v1/".to_string()),
+                methods: vec![NetworkMethod::Get],
+            }],
+            redacted_metadata: json!({ "last_four": "1234" }),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn session_request(
+        scope: ResourceScope,
+        account_id: CredentialAccountId,
+        url: &str,
+    ) -> CredentialSessionRequest {
+        CredentialSessionRequest {
+            invocation_id: scope.invocation_id,
+            scope,
+            capability_id: CapabilityId::new("openai.chat").unwrap(),
+            extension_id: ExtensionId::new("openai").unwrap(),
+            account_id,
+            method: NetworkMethod::Get,
+            url: url.to_string(),
+            expires_at: None,
+            max_uses: Some(1),
+        }
     }
 
     fn sample_scope(tenant: &str, user: &str) -> ResourceScope {

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -68,6 +68,7 @@ pub enum SecretLeaseStatus {
     Active,
     Consumed,
     Revoked,
+    Expired,
 }
 
 /// Metadata for a scoped one-shot secret lease.
@@ -134,6 +135,10 @@ impl SecretStoreError {
 
     pub fn is_revoked(&self) -> bool {
         matches!(self, Self::LeaseRevoked { .. })
+    }
+
+    pub fn is_expired(&self) -> bool {
+        matches!(self, Self::SecretExpired | Self::LeaseExpired { .. })
     }
 }
 
@@ -646,7 +651,9 @@ fn raw_url_path(url: &str) -> Option<&str> {
 fn path_has_encoded_traversal(path: &str) -> bool {
     path.split('/').any(|segment| {
         let decoded = percent_decode_bytes(segment.as_bytes());
-        matches!(decoded.as_slice(), b"." | b"..") || decoded.contains(&b'/')
+        matches!(decoded.as_slice(), b"." | b"..")
+            || decoded.contains(&b'/')
+            || decoded.contains(&b'%')
     })
 }
 
@@ -793,9 +800,9 @@ impl SecretLeaseKey {
 #[derive(Debug, Clone)]
 struct LeaseRecord {
     lease: SecretLease,
-    material: Option<SecretMaterial>,
     secret_id: Uuid,
-    expires_at: Timestamp,
+    lease_expires_at: Timestamp,
+    secret_expires_at: Option<Timestamp>,
 }
 
 /// Adapter that exposes the battle-tested encrypted [`SecretsStore`] contract
@@ -804,6 +811,7 @@ struct LeaseRecord {
 pub struct ScopedSecretsStoreAdapter<S> {
     inner: Arc<S>,
     leases: Mutex<HashMap<SecretLeaseKey, LeaseRecord>>,
+    lease_ttl: Duration,
 }
 
 impl<S> ScopedSecretsStoreAdapter<S>
@@ -811,9 +819,14 @@ where
     S: SecretsStore + 'static,
 {
     pub fn new(inner: Arc<S>) -> Self {
+        Self::with_lease_ttl(inner, Duration::seconds(DEFAULT_SECRET_LEASE_TTL_SECONDS))
+    }
+
+    pub fn with_lease_ttl(inner: Arc<S>, lease_ttl: Duration) -> Self {
         Self {
             inner,
             leases: Mutex::new(HashMap::new()),
+            lease_ttl,
         }
     }
 
@@ -825,6 +838,26 @@ where
             .map_err(|error| SecretStoreError::StoreUnavailable {
                 reason: error.to_string(),
             })
+    }
+
+    fn mark_consumed_lease(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+        status: SecretLeaseStatus,
+    ) -> Result<(), SecretStoreError> {
+        let mut leases = self.lock_leases()?;
+        let key = SecretLeaseKey::new(scope, lease_id);
+        let record = leases
+            .get_mut(&key)
+            .ok_or_else(|| SecretStoreError::UnknownLease {
+                scope: Box::new(scope.clone()),
+                lease_id,
+            })?;
+        if record.lease.status == SecretLeaseStatus::Consumed {
+            record.lease.status = status;
+        }
+        Ok(())
     }
 }
 
@@ -895,11 +928,6 @@ where
                 },
                 other => map_legacy_secret_error(other),
             })?;
-        let material = self
-            .inner
-            .get_decrypted(&legacy_user_id, handle.as_str())
-            .await
-            .map_err(map_legacy_secret_error)?;
         let lease = SecretLease {
             id: SecretLeaseId::new(),
             scope: scope.clone(),
@@ -910,9 +938,9 @@ where
             SecretLeaseKey::new(scope, lease.id),
             LeaseRecord {
                 lease: lease.clone(),
-                material: Some(SecretMaterial::from(material.expose().to_string())),
                 secret_id: secret.id,
-                expires_at: Utc::now() + Duration::seconds(DEFAULT_SECRET_LEASE_TTL_SECONDS),
+                lease_expires_at: Utc::now() + self.lease_ttl,
+                secret_expires_at: secret.expires_at,
             },
         );
         Ok(lease)
@@ -923,8 +951,9 @@ where
         scope: &ResourceScope,
         lease_id: SecretLeaseId,
     ) -> Result<SecretMaterial, SecretStoreError> {
-        let (material, secret_id) = {
+        let (handle, secret_id) = {
             let mut leases = self.lock_leases()?;
+            expire_stale_active_leases(&mut leases, Utc::now());
             let key = SecretLeaseKey::new(scope, lease_id);
             let record = leases
                 .get_mut(&key)
@@ -934,19 +963,8 @@ where
                 })?;
             match record.lease.status {
                 SecretLeaseStatus::Active => {
-                    if record.expires_at <= Utc::now() {
-                        record.material = None;
-                        record.lease.status = SecretLeaseStatus::Revoked;
-                        return Err(SecretStoreError::LeaseExpired { lease_id });
-                    }
-                    let Some(material) = record.material.take() else {
-                        record.lease.status = SecretLeaseStatus::Consumed;
-                        return Err(SecretStoreError::StoreUnavailable {
-                            reason: "active lease material unavailable".to_string(),
-                        });
-                    };
                     record.lease.status = SecretLeaseStatus::Consumed;
-                    (material, record.secret_id)
+                    (record.lease.handle.clone(), record.secret_id)
                 }
                 SecretLeaseStatus::Consumed => {
                     return Err(SecretStoreError::LeaseConsumed { lease_id });
@@ -954,13 +972,31 @@ where
                 SecretLeaseStatus::Revoked => {
                     return Err(SecretStoreError::LeaseRevoked { lease_id });
                 }
+                SecretLeaseStatus::Expired => {
+                    return Err(SecretStoreError::LeaseExpired { lease_id });
+                }
             }
         };
-        self.inner
-            .record_usage(secret_id)
+        let material = match self
+            .inner
+            .get_decrypted(&scoped_legacy_user_id(scope), handle.as_str())
             .await
-            .map_err(map_legacy_secret_error)?;
-        Ok(material)
+        {
+            Ok(material) => material,
+            Err(SecretError::Expired) => {
+                self.mark_consumed_lease(scope, lease_id, SecretLeaseStatus::Expired)?;
+                return Err(SecretStoreError::LeaseExpired { lease_id });
+            }
+            Err(error) => {
+                self.mark_consumed_lease(scope, lease_id, SecretLeaseStatus::Active)?;
+                return Err(map_legacy_secret_error(error));
+            }
+        };
+        if let Err(error) = self.inner.record_usage(secret_id).await {
+            self.mark_consumed_lease(scope, lease_id, SecretLeaseStatus::Active)?;
+            return Err(map_legacy_secret_error(error));
+        }
+        Ok(SecretMaterial::from(material.expose().to_string()))
     }
 
     async fn revoke(
@@ -969,7 +1005,7 @@ where
         lease_id: SecretLeaseId,
     ) -> Result<SecretLease, SecretStoreError> {
         let mut leases = self.lock_leases()?;
-        prune_inactive_or_expired_leases(&mut leases);
+        expire_stale_active_leases(&mut leases, Utc::now());
         let key = SecretLeaseKey::new(scope, lease_id);
         let record = leases
             .get_mut(&key)
@@ -978,7 +1014,6 @@ where
                 lease_id,
             })?;
         if record.lease.status == SecretLeaseStatus::Active {
-            record.material = None;
             record.lease.status = SecretLeaseStatus::Revoked;
         }
         Ok(record.lease.clone())
@@ -989,7 +1024,7 @@ where
         scope: &ResourceScope,
     ) -> Result<Vec<SecretLease>, SecretStoreError> {
         let mut leases = self.lock_leases()?;
-        prune_inactive_or_expired_leases(&mut leases);
+        expire_stale_active_leases(&mut leases, Utc::now());
         Ok(leases
             .iter()
             .filter(|(key, _)| key.matches_scope(scope))
@@ -998,11 +1033,16 @@ where
     }
 }
 
-fn prune_inactive_or_expired_leases(leases: &mut HashMap<SecretLeaseKey, LeaseRecord>) {
-    let now = Utc::now();
-    leases.retain(|_, record| {
-        record.lease.status != SecretLeaseStatus::Active || record.expires_at > now
-    });
+fn expire_stale_active_leases(leases: &mut HashMap<SecretLeaseKey, LeaseRecord>, now: Timestamp) {
+    for record in leases.values_mut() {
+        let lease_expired = record.lease_expires_at <= now;
+        let secret_expired = record
+            .secret_expires_at
+            .is_some_and(|secret_expires_at| secret_expires_at <= now);
+        if record.lease.status == SecretLeaseStatus::Active && (lease_expired || secret_expired) {
+            record.lease.status = SecretLeaseStatus::Expired;
+        }
+    }
 }
 
 fn map_legacy_secret_error(error: SecretError) -> SecretStoreError {
@@ -1199,6 +1239,10 @@ mod tests {
         assert!(!policy.matches(
             &NetworkMethod::Get,
             "https://api.example.com/v1/%2e%2e%2fadmin"
+        ));
+        assert!(!policy.matches(
+            &NetworkMethod::Get,
+            "https://api.example.com/v1/%252e%252e%252fadmin"
         ));
         assert!(!policy.matches(&NetworkMethod::Get, "https://api.example.com/v1/%2e/admin"));
 
@@ -1572,7 +1616,7 @@ mod tests {
             let record = leases
                 .get_mut(&SecretLeaseKey::new(&scope, lease.id))
                 .unwrap();
-            record.expires_at = Utc::now() - chrono::Duration::seconds(1);
+            record.lease_expires_at = Utc::now() - chrono::Duration::seconds(1);
         }
 
         assert!(matches!(


### PR DESCRIPTION
## Summary

Implements the PR B slice from #3088:

- port the encrypted legacy secrets crypto/store contracts into `ironclaw_secrets`
- add scoped CredentialAccount metadata and CredentialSession model in `ironclaw_secrets`
- require explicit account selection and enforce scope, extension/provider, account status, and target policy before issuing sessions
- add strict credential target matching for scheme, host, optional port, path policy, and method
- add sanitized credential broker error taxonomy and stable public reason tokens
- keep credential sessions metadata-only with SecretHandle references and no raw material

## Tests

- cargo test -p ironclaw_secrets
- cargo clippy -p ironclaw_secrets --all-targets -- -D warnings
- cargo check --workspace --all-targets

Refs #3088 (PR B slice)