### PR TITLE
feat(reborn): add production wiring guardrails

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -711,6 +711,24 @@ impl<N, S> HostHttpEgressService<N, S> {
         self
     }
 
+    pub(crate) fn is_production_wired_with(
+        &self,
+        network_policy_store: &Arc<NetworkObligationPolicyStore>,
+        secret_injections: &Arc<RuntimeSecretInjectionStore>,
+    ) -> bool {
+        matches!(
+            self.network_policy_source,
+            NetworkPolicySource::StagedObligation
+        ) && self
+            .network_policy_store
+            .as_ref()
+            .is_some_and(|store| Arc::ptr_eq(store, network_policy_store))
+            && self
+                .secret_injections
+                .as_ref()
+                .is_some_and(|store| Arc::ptr_eq(store, secret_injections))
+    }
+
     pub fn network(&self) -> &N {
         &self.network
     }

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -56,7 +56,10 @@ pub use obligations::{
 };
 pub use planner::{ExecutionPlan, PlannerError, plan_capability};
 pub use production::DefaultHostRuntime;
-pub use services::{HostRuntimeServices, RegisteredRuntimeHealth};
+pub use services::{
+    HostRuntimeServices, ProductionWiringComponent, ProductionWiringConfig, ProductionWiringIssue,
+    ProductionWiringIssueKind, ProductionWiringReport, RegisteredRuntimeHealth,
+};
 
 /// Stable, validated idempotency key supplied by upper turn/loop services.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -29,6 +29,7 @@ use ironclaw_host_api::{
     RuntimeHttpEgress, RuntimeKind,
 };
 use ironclaw_mcp::{McpError, McpExecutionRequest, McpExecutor, McpInvocation};
+use ironclaw_network::NetworkHttpEgress;
 use ironclaw_processes::{
     BackgroundFailureStage, ProcessExecutionError, ProcessExecutionRequest, ProcessExecutionResult,
     ProcessExecutor, ProcessManager, ProcessResultStore, ProcessServices, ProcessStore,
@@ -40,8 +41,8 @@ use ironclaw_secrets::SecretStore;
 use ironclaw_trust::{HostTrustPolicy, TrustPolicy};
 use ironclaw_wasm::{
     DenyWasmHostHttp, PreparedWitTool, WasmError, WasmRuntimeCredentialProvider,
-    WasmRuntimeHttpAdapter, WasmRuntimePolicyDiscarder, WitToolHost, WitToolRequest,
-    WitToolRuntime, WitToolRuntimeConfig,
+    WasmRuntimeHttpAdapter, WasmRuntimePolicyDiscarder, WasmStagedRuntimeCredentials, WitToolHost,
+    WitToolRequest, WitToolRuntime, WitToolRuntimeConfig,
 };
 
 use crate::{
@@ -91,6 +92,7 @@ impl ProductionWiringConfig {
 /// Production component tracked by the host-runtime production wiring guardrail.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProductionWiringComponent {
+    RuntimeBackend,
     TrustPolicy,
     Filesystem,
     ResourceGovernor,
@@ -112,6 +114,7 @@ pub enum ProductionWiringComponent {
 impl ProductionWiringComponent {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::RuntimeBackend => "runtime_backend",
             Self::TrustPolicy => "trust_policy",
             Self::Filesystem => "filesystem",
             Self::ResourceGovernor => "resource_governor",
@@ -136,6 +139,7 @@ impl ProductionWiringComponent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProductionWiringIssueKind {
     Missing,
+    UnsupportedRequirement,
     LocalOnlyImplementation,
     UnverifiedProductionImplementation,
 }
@@ -186,6 +190,8 @@ impl ProductionWiringReport {
 
 #[derive(Debug, Clone)]
 struct ProductionComponentTypes {
+    trust_policy: Option<&'static str>,
+    trust_policy_verified: bool,
     filesystem: &'static str,
     resource_governor: &'static str,
     process_store: &'static str,
@@ -199,6 +205,7 @@ struct ProductionComponentTypes {
     runtime_http_egress: Option<&'static str>,
     runtime_http_egress_verified: bool,
     wasm_credential_provider: Option<&'static str>,
+    wasm_credential_provider_verified: bool,
     wasm_runtime_credential_provider_captured: bool,
     script_runtime: Option<&'static str>,
     mcp_runtime: Option<&'static str>,
@@ -304,6 +311,8 @@ where
             mcp_runtime: None,
             wasm_runtime: None,
             component_types: ProductionComponentTypes {
+                trust_policy: None,
+                trust_policy_verified: false,
                 filesystem: type_name::<F>(),
                 resource_governor: type_name::<G>(),
                 process_store: type_name::<S>(),
@@ -317,6 +326,7 @@ where
                 runtime_http_egress: None,
                 runtime_http_egress_verified: false,
                 wasm_credential_provider: None,
+                wasm_credential_provider_verified: false,
                 wasm_runtime_credential_provider_captured: false,
                 script_runtime: None,
                 mcp_runtime: None,
@@ -331,12 +341,16 @@ where
     where
         T: TrustPolicy + 'static,
     {
+        self.component_types.trust_policy = Some(type_name::<T>());
+        self.component_types.trust_policy_verified = true;
         self.trust_policy = trust_policy;
         self.trust_policy_configured = true;
         self
     }
 
     pub fn with_trust_policy_dyn(mut self, trust_policy: Arc<dyn TrustPolicy>) -> Self {
+        self.component_types.trust_policy = Some("dyn TrustPolicy");
+        self.component_types.trust_policy_verified = false;
         self.trust_policy = trust_policy;
         self.trust_policy_configured = true;
         self
@@ -427,15 +441,21 @@ where
         self
     }
 
-    /// Attaches a runtime HTTP egress that the composition root has already
-    /// verified as production-wired (for example, host-mediated policy and
-    /// secret stores are attached rather than test/request-local policy).
-    pub fn with_verified_runtime_http_egress<T>(mut self, runtime_http_egress: Arc<T>) -> Self
+    /// Attaches the host HTTP egress shape required for production runtime
+    /// adapters. The service must use staged network-policy handoffs and secret
+    /// injection handoffs, not request-local/test policy fallback.
+    pub fn with_host_http_egress_service<N, SecretBackend>(
+        mut self,
+        runtime_http_egress: Arc<crate::HostHttpEgressService<N, SecretBackend>>,
+    ) -> Self
     where
-        T: RuntimeHttpEgress + 'static,
+        N: NetworkHttpEgress + 'static,
+        SecretBackend: SecretStore + 'static,
     {
-        self.component_types.runtime_http_egress = Some(type_name::<T>());
-        self.component_types.runtime_http_egress_verified = true;
+        self.component_types.runtime_http_egress =
+            Some(type_name::<crate::HostHttpEgressService<N, SecretBackend>>());
+        self.component_types.runtime_http_egress_verified = runtime_http_egress
+            .is_production_wired_with(&self.network_policy_store, &self.secret_injection_store);
         let runtime_http_egress: Arc<dyn RuntimeHttpEgress> = runtime_http_egress;
         set_runtime_http_egress(&self.runtime_http_egress, runtime_http_egress);
         self
@@ -454,6 +474,21 @@ where
         T: WasmRuntimeCredentialProvider + 'static,
     {
         self.component_types.wasm_credential_provider = Some(type_name::<T>());
+        self.component_types.wasm_credential_provider_verified = false;
+        let provider: Arc<dyn WasmRuntimeCredentialProvider> = provider;
+        self.wasm_credential_provider = Some(provider);
+        self.component_types
+            .wasm_runtime_credential_provider_captured = self.wasm_runtime.is_none();
+        self
+    }
+
+    pub fn with_verified_wasm_runtime_credentials(
+        mut self,
+        provider: Arc<WasmStagedRuntimeCredentials>,
+    ) -> Self {
+        self.component_types.wasm_credential_provider =
+            Some(type_name::<WasmStagedRuntimeCredentials>());
+        self.component_types.wasm_credential_provider_verified = !provider.credentials().is_empty();
         let provider: Arc<dyn WasmRuntimeCredentialProvider> = provider;
         self.wasm_credential_provider = Some(provider);
         self.component_types
@@ -463,6 +498,10 @@ where
 
     pub fn secret_injection_store(&self) -> Arc<RuntimeSecretInjectionStore> {
         Arc::clone(&self.secret_injection_store)
+    }
+
+    pub fn network_policy_store(&self) -> Arc<NetworkObligationPolicyStore> {
+        Arc::clone(&self.network_policy_store)
     }
 
     pub fn with_script_runtime<T>(mut self, runtime: Arc<T>) -> Self
@@ -573,6 +612,16 @@ where
                 ProductionWiringComponent::WasmCredentialProvider,
                 self.wasm_credential_provider.is_some(),
             );
+            if self.wasm_credential_provider.is_some()
+                && !self.component_types.wasm_credential_provider_verified
+            {
+                self.push_issue(
+                    &mut issues,
+                    ProductionWiringComponent::WasmCredentialProvider,
+                    ProductionWiringIssueKind::UnverifiedProductionImplementation,
+                    self.component_types.wasm_credential_provider,
+                );
+            }
             if self.wasm_runtime.is_some()
                 && self.wasm_credential_provider.is_some()
                 && !self
@@ -585,6 +634,17 @@ where
                     ProductionWiringIssueKind::UnverifiedProductionImplementation,
                     self.component_types.wasm_credential_provider,
                 );
+            }
+        }
+        for runtime in &config.required_runtime_backends {
+            match runtime {
+                RuntimeKind::Script | RuntimeKind::Mcp | RuntimeKind::Wasm => {}
+                RuntimeKind::FirstParty | RuntimeKind::System => self.push_issue(
+                    &mut issues,
+                    ProductionWiringComponent::RuntimeBackend,
+                    ProductionWiringIssueKind::UnsupportedRequirement,
+                    None,
+                ),
             }
         }
         if config.requires_runtime(RuntimeKind::Script) {
@@ -609,6 +669,19 @@ where
             );
         }
 
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::TrustPolicy,
+            self.component_types.trust_policy,
+        );
+        if self.trust_policy_configured && !self.component_types.trust_policy_verified {
+            self.push_issue(
+                &mut issues,
+                ProductionWiringComponent::TrustPolicy,
+                ProductionWiringIssueKind::UnverifiedProductionImplementation,
+                self.component_types.trust_policy,
+            );
+        }
         self.push_local_only(
             &mut issues,
             ProductionWiringComponent::Filesystem,
@@ -738,14 +811,14 @@ where
     }
 
     /// Validates this graph and then builds the upper facade for production
-    /// callers. Composition roots should use this instead of [`Self::host_runtime`]
-    /// once they claim a graph is production-ready.
+    /// callers. This consumes the service graph so callers cannot mutate shared
+    /// runtime-adapter handoff slots after validation.
     pub fn host_runtime_for_production(
-        &self,
+        self,
         config: &ProductionWiringConfig,
     ) -> Result<DefaultHostRuntime, ProductionWiringReport> {
         self.validate_production_wiring(config)?;
-        Ok(self.host_runtime())
+        Ok(self.build_host_runtime())
     }
 
     /// Builds a runtime dispatcher with every configured runtime adapter.
@@ -779,9 +852,15 @@ where
         dispatcher
     }
 
+    /// Builds the upper facade without production validation.
+    #[doc(hidden)]
+    pub fn host_runtime_for_local_testing(&self) -> DefaultHostRuntime {
+        self.build_host_runtime()
+    }
+
     /// Builds the upper facade with the same dispatcher, process services,
     /// stores, cancellation registry, result store, and runtime health graph.
-    pub fn host_runtime(&self) -> DefaultHostRuntime {
+    fn build_host_runtime(&self) -> DefaultHostRuntime {
         let dispatcher: Arc<dyn CapabilityDispatcher> = Arc::new(self.runtime_dispatcher());
         let process_executor =
             Arc::new(RuntimeDispatchProcessExecutor::new(Arc::clone(&dispatcher)));

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -7,6 +7,7 @@
 //! lifecycle, and runtime execution semantics remain in their owning crates.
 
 use std::{
+    any::type_name,
     collections::HashMap,
     sync::{Arc, Mutex, MutexGuard},
 };
@@ -51,6 +52,170 @@ use crate::{
 
 type SharedRuntimeHttpEgress = Arc<Mutex<Option<Arc<dyn RuntimeHttpEgress>>>>;
 
+/// Production wiring requirements used by composition roots before exposing a
+/// [`HostRuntimeServices`] graph as production-ready.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductionWiringConfig {
+    required_runtime_backends: Vec<RuntimeKind>,
+    require_runtime_http_egress: bool,
+    require_wasm_credentials: bool,
+}
+
+impl ProductionWiringConfig {
+    pub fn new<I>(required_runtime_backends: I) -> Self
+    where
+        I: IntoIterator<Item = RuntimeKind>,
+    {
+        Self {
+            required_runtime_backends: required_runtime_backends.into_iter().collect(),
+            require_runtime_http_egress: false,
+            require_wasm_credentials: false,
+        }
+    }
+
+    pub fn require_runtime_http_egress(mut self) -> Self {
+        self.require_runtime_http_egress = true;
+        self
+    }
+
+    pub fn require_wasm_credentials(mut self) -> Self {
+        self.require_wasm_credentials = true;
+        self
+    }
+
+    fn requires_runtime(&self, runtime: RuntimeKind) -> bool {
+        self.required_runtime_backends.contains(&runtime)
+    }
+}
+
+/// Production component tracked by the host-runtime production wiring guardrail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProductionWiringComponent {
+    TrustPolicy,
+    Filesystem,
+    ResourceGovernor,
+    ProcessStore,
+    ProcessResultStore,
+    RunState,
+    ApprovalRequests,
+    CapabilityLeases,
+    EventSink,
+    AuditSink,
+    SecretStore,
+    RuntimeHttpEgress,
+    WasmCredentialProvider,
+    ScriptRuntime,
+    McpRuntime,
+    WasmRuntime,
+}
+
+impl ProductionWiringComponent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TrustPolicy => "trust_policy",
+            Self::Filesystem => "filesystem",
+            Self::ResourceGovernor => "resource_governor",
+            Self::ProcessStore => "process_store",
+            Self::ProcessResultStore => "process_result_store",
+            Self::RunState => "run_state",
+            Self::ApprovalRequests => "approval_requests",
+            Self::CapabilityLeases => "capability_leases",
+            Self::EventSink => "event_sink",
+            Self::AuditSink => "audit_sink",
+            Self::SecretStore => "secret_store",
+            Self::RuntimeHttpEgress => "runtime_http_egress",
+            Self::WasmCredentialProvider => "wasm_credential_provider",
+            Self::ScriptRuntime => "script_runtime",
+            Self::McpRuntime => "mcp_runtime",
+            Self::WasmRuntime => "wasm_runtime",
+        }
+    }
+}
+
+/// Category of production wiring issue found in a service graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProductionWiringIssueKind {
+    Missing,
+    LocalOnlyImplementation,
+    UnverifiedProductionImplementation,
+}
+
+/// One production wiring issue for a component in the host-runtime graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductionWiringIssue {
+    component: ProductionWiringComponent,
+    kind: ProductionWiringIssueKind,
+    implementation: Option<&'static str>,
+}
+
+impl ProductionWiringIssue {
+    pub fn component(&self) -> ProductionWiringComponent {
+        self.component
+    }
+
+    pub fn kind(&self) -> ProductionWiringIssueKind {
+        self.kind
+    }
+
+    pub fn implementation(&self) -> Option<&'static str> {
+        self.implementation
+    }
+}
+
+/// Report returned when a host-runtime graph is not production-ready.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductionWiringReport {
+    issues: Vec<ProductionWiringIssue>,
+}
+
+impl ProductionWiringReport {
+    pub fn issues(&self) -> &[ProductionWiringIssue] {
+        &self.issues
+    }
+
+    pub fn contains(
+        &self,
+        component: ProductionWiringComponent,
+        kind: ProductionWiringIssueKind,
+    ) -> bool {
+        self.issues
+            .iter()
+            .any(|issue| issue.component == component && issue.kind == kind)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProductionComponentTypes {
+    filesystem: &'static str,
+    resource_governor: &'static str,
+    process_store: &'static str,
+    process_result_store: &'static str,
+    run_state: Option<&'static str>,
+    approval_requests: Option<&'static str>,
+    capability_leases: Option<&'static str>,
+    event_sink: Option<&'static str>,
+    audit_sink: Option<&'static str>,
+    secret_store: Option<&'static str>,
+    runtime_http_egress: Option<&'static str>,
+    runtime_http_egress_verified: bool,
+    wasm_credential_provider: Option<&'static str>,
+    wasm_runtime_credential_provider_captured: bool,
+    script_runtime: Option<&'static str>,
+    mcp_runtime: Option<&'static str>,
+}
+
+fn is_local_only_component(type_name: &str) -> bool {
+    type_name.contains("InMemory")
+        || type_name.contains("Noop")
+        || type_name.contains("DenyWasm")
+        || type_name.contains("EmptyWasm")
+        || type_name.contains("LocalFilesystem")
+}
+
+fn is_erased_durable_sink_wrapper(type_name: &str) -> bool {
+    type_name.contains("DurableEventSink") || type_name.contains("DurableAuditSink")
+}
+
 /// Concrete composition bundle for one Reborn host-runtime vertical slice.
 ///
 /// The bundle owns shared `Arc` handles for the configured substrate services
@@ -67,6 +232,7 @@ where
 {
     registry: Arc<ExtensionRegistry>,
     trust_policy: Arc<dyn TrustPolicy>,
+    trust_policy_configured: bool,
     filesystem: Arc<F>,
     governor: Arc<G>,
     authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer>,
@@ -87,6 +253,7 @@ where
     script_runtime: Option<Arc<dyn ScriptExecutor>>,
     mcp_runtime: Option<Arc<dyn McpExecutor>>,
     wasm_runtime: Option<Arc<WasmRuntimeAdapter>>,
+    component_types: ProductionComponentTypes,
 }
 
 impl<F, G, S, R> HostRuntimeServices<F, G, S, R>
@@ -115,6 +282,7 @@ where
         Self {
             registry,
             trust_policy: Arc::new(HostTrustPolicy::empty()),
+            trust_policy_configured: false,
             filesystem,
             governor,
             authorizer,
@@ -135,6 +303,24 @@ where
             script_runtime: None,
             mcp_runtime: None,
             wasm_runtime: None,
+            component_types: ProductionComponentTypes {
+                filesystem: type_name::<F>(),
+                resource_governor: type_name::<G>(),
+                process_store: type_name::<S>(),
+                process_result_store: type_name::<R>(),
+                run_state: None,
+                approval_requests: None,
+                capability_leases: None,
+                event_sink: None,
+                audit_sink: None,
+                secret_store: None,
+                runtime_http_egress: None,
+                runtime_http_egress_verified: false,
+                wasm_credential_provider: None,
+                wasm_runtime_credential_provider_captured: false,
+                script_runtime: None,
+                mcp_runtime: None,
+            },
         }
     }
 
@@ -146,11 +332,13 @@ where
         T: TrustPolicy + 'static,
     {
         self.trust_policy = trust_policy;
+        self.trust_policy_configured = true;
         self
     }
 
     pub fn with_trust_policy_dyn(mut self, trust_policy: Arc<dyn TrustPolicy>) -> Self {
         self.trust_policy = trust_policy;
+        self.trust_policy_configured = true;
         self
     }
 
@@ -158,6 +346,7 @@ where
     where
         T: RunStateStore + 'static,
     {
+        self.component_types.run_state = Some(type_name::<T>());
         self.run_state = Some(run_state);
         self
     }
@@ -166,6 +355,7 @@ where
     where
         T: ApprovalRequestStore + 'static,
     {
+        self.component_types.approval_requests = Some(type_name::<T>());
         self.approval_requests = Some(approval_requests);
         self
     }
@@ -174,6 +364,7 @@ where
     where
         T: CapabilityLeaseStore + 'static,
     {
+        self.component_types.capability_leases = Some(type_name::<T>());
         self.capability_leases = Some(capability_leases);
         self
     }
@@ -182,46 +373,69 @@ where
     where
         T: EventSink + 'static,
     {
+        self.component_types.event_sink = Some(type_name::<T>());
         self.event_sink = Some(event_sink);
         self
     }
 
-    pub fn with_durable_event_log<T>(self, event_log: Arc<T>) -> Self
+    pub fn with_durable_event_log<T>(mut self, event_log: Arc<T>) -> Self
     where
         T: DurableEventLog + 'static,
     {
+        self.component_types.event_sink = Some(type_name::<T>());
         let event_log: Arc<dyn DurableEventLog> = event_log;
-        self.with_event_sink(Arc::new(DurableEventSink::new(event_log)))
+        self.event_sink = Some(Arc::new(DurableEventSink::new(event_log)));
+        self
     }
 
     pub fn with_audit_sink<T>(mut self, audit_sink: Arc<T>) -> Self
     where
         T: AuditSink + 'static,
     {
+        self.component_types.audit_sink = Some(type_name::<T>());
         self.audit_sink = Some(audit_sink);
         self
     }
 
-    pub fn with_durable_audit_log<T>(self, audit_log: Arc<T>) -> Self
+    pub fn with_durable_audit_log<T>(mut self, audit_log: Arc<T>) -> Self
     where
         T: DurableAuditLog + 'static,
     {
+        self.component_types.audit_sink = Some(type_name::<T>());
         let audit_log: Arc<dyn DurableAuditLog> = audit_log;
-        self.with_audit_sink(Arc::new(DurableAuditSink::new(audit_log)))
+        self.audit_sink = Some(Arc::new(DurableAuditSink::new(audit_log)));
+        self
     }
 
     pub fn with_secret_store<T>(mut self, secret_store: Arc<T>) -> Self
     where
         T: SecretStore + 'static,
     {
+        self.component_types.secret_store = Some(type_name::<T>());
         self.secret_store = Some(secret_store);
         self
     }
 
-    pub fn with_runtime_http_egress<T>(self, runtime_http_egress: Arc<T>) -> Self
+    pub fn with_runtime_http_egress<T>(mut self, runtime_http_egress: Arc<T>) -> Self
     where
         T: RuntimeHttpEgress + 'static,
     {
+        self.component_types.runtime_http_egress = Some(type_name::<T>());
+        self.component_types.runtime_http_egress_verified = false;
+        let runtime_http_egress: Arc<dyn RuntimeHttpEgress> = runtime_http_egress;
+        set_runtime_http_egress(&self.runtime_http_egress, runtime_http_egress);
+        self
+    }
+
+    /// Attaches a runtime HTTP egress that the composition root has already
+    /// verified as production-wired (for example, host-mediated policy and
+    /// secret stores are attached rather than test/request-local policy).
+    pub fn with_verified_runtime_http_egress<T>(mut self, runtime_http_egress: Arc<T>) -> Self
+    where
+        T: RuntimeHttpEgress + 'static,
+    {
+        self.component_types.runtime_http_egress = Some(type_name::<T>());
+        self.component_types.runtime_http_egress_verified = true;
         let runtime_http_egress: Arc<dyn RuntimeHttpEgress> = runtime_http_egress;
         set_runtime_http_egress(&self.runtime_http_egress, runtime_http_egress);
         self
@@ -239,8 +453,11 @@ where
     where
         T: WasmRuntimeCredentialProvider + 'static,
     {
+        self.component_types.wasm_credential_provider = Some(type_name::<T>());
         let provider: Arc<dyn WasmRuntimeCredentialProvider> = provider;
         self.wasm_credential_provider = Some(provider);
+        self.component_types
+            .wasm_runtime_credential_provider_captured = self.wasm_runtime.is_none();
         self
     }
 
@@ -252,6 +469,7 @@ where
     where
         T: ScriptExecutor + 'static,
     {
+        self.component_types.script_runtime = Some(type_name::<T>());
         self.script_runtime = Some(runtime);
         self
     }
@@ -260,11 +478,14 @@ where
     where
         T: McpExecutor + 'static,
     {
+        self.component_types.mcp_runtime = Some(type_name::<T>());
         self.mcp_runtime = Some(runtime);
         self
     }
 
     fn with_wasm_runtime(mut self, runtime: Arc<WasmRuntimeAdapter>) -> Self {
+        self.component_types
+            .wasm_runtime_credential_provider_captured = self.wasm_credential_provider.is_some();
         self.wasm_runtime = Some(runtime);
         self
     }
@@ -282,6 +503,249 @@ where
             self.wasm_credential_provider.clone(),
         )?);
         Ok(self.with_wasm_runtime(adapter))
+    }
+
+    /// Validates that this service graph is explicitly wired for production
+    /// instead of relying on local/test defaults. This is a guardrail for
+    /// composition roots; it does not build or mutate the runtime graph.
+    pub fn validate_production_wiring(
+        &self,
+        config: &ProductionWiringConfig,
+    ) -> Result<(), ProductionWiringReport> {
+        let mut issues = Vec::new();
+
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::TrustPolicy,
+            self.trust_policy_configured,
+        );
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::RunState,
+            self.run_state.is_some(),
+        );
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::ApprovalRequests,
+            self.approval_requests.is_some(),
+        );
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::CapabilityLeases,
+            self.capability_leases.is_some(),
+        );
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::EventSink,
+            self.event_sink.is_some(),
+        );
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::AuditSink,
+            self.audit_sink.is_some(),
+        );
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::SecretStore,
+            self.secret_store.is_some(),
+        );
+
+        if config.require_runtime_http_egress {
+            let runtime_http_configured =
+                runtime_http_egress_is_configured(&self.runtime_http_egress);
+            self.push_missing(
+                &mut issues,
+                ProductionWiringComponent::RuntimeHttpEgress,
+                runtime_http_configured,
+            );
+            if runtime_http_configured && !self.component_types.runtime_http_egress_verified {
+                self.push_issue(
+                    &mut issues,
+                    ProductionWiringComponent::RuntimeHttpEgress,
+                    ProductionWiringIssueKind::UnverifiedProductionImplementation,
+                    self.component_types.runtime_http_egress,
+                );
+            }
+        }
+        if config.require_wasm_credentials {
+            self.push_missing(
+                &mut issues,
+                ProductionWiringComponent::WasmCredentialProvider,
+                self.wasm_credential_provider.is_some(),
+            );
+            if self.wasm_runtime.is_some()
+                && self.wasm_credential_provider.is_some()
+                && !self
+                    .component_types
+                    .wasm_runtime_credential_provider_captured
+            {
+                self.push_issue(
+                    &mut issues,
+                    ProductionWiringComponent::WasmCredentialProvider,
+                    ProductionWiringIssueKind::UnverifiedProductionImplementation,
+                    self.component_types.wasm_credential_provider,
+                );
+            }
+        }
+        if config.requires_runtime(RuntimeKind::Script) {
+            self.push_missing(
+                &mut issues,
+                ProductionWiringComponent::ScriptRuntime,
+                self.script_runtime.is_some(),
+            );
+        }
+        if config.requires_runtime(RuntimeKind::Mcp) {
+            self.push_missing(
+                &mut issues,
+                ProductionWiringComponent::McpRuntime,
+                self.mcp_runtime.is_some(),
+            );
+        }
+        if config.requires_runtime(RuntimeKind::Wasm) {
+            self.push_missing(
+                &mut issues,
+                ProductionWiringComponent::WasmRuntime,
+                self.wasm_runtime.is_some(),
+            );
+        }
+
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::Filesystem,
+            Some(self.component_types.filesystem),
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::ResourceGovernor,
+            Some(self.component_types.resource_governor),
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::ProcessStore,
+            Some(self.component_types.process_store),
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::ProcessResultStore,
+            Some(self.component_types.process_result_store),
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::RunState,
+            self.component_types.run_state,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::ApprovalRequests,
+            self.component_types.approval_requests,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::CapabilityLeases,
+            self.component_types.capability_leases,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::EventSink,
+            self.component_types.event_sink,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::AuditSink,
+            self.component_types.audit_sink,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::SecretStore,
+            self.component_types.secret_store,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::RuntimeHttpEgress,
+            self.component_types.runtime_http_egress,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::WasmCredentialProvider,
+            self.component_types.wasm_credential_provider,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::ScriptRuntime,
+            self.component_types.script_runtime,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::McpRuntime,
+            self.component_types.mcp_runtime,
+        );
+
+        if issues.is_empty() {
+            Ok(())
+        } else {
+            Err(ProductionWiringReport { issues })
+        }
+    }
+
+    fn push_missing(
+        &self,
+        issues: &mut Vec<ProductionWiringIssue>,
+        component: ProductionWiringComponent,
+        present: bool,
+    ) {
+        if !present {
+            self.push_issue(issues, component, ProductionWiringIssueKind::Missing, None);
+        }
+    }
+
+    fn push_local_only(
+        &self,
+        issues: &mut Vec<ProductionWiringIssue>,
+        component: ProductionWiringComponent,
+        implementation: Option<&'static str>,
+    ) {
+        if let Some(implementation) = implementation {
+            if is_local_only_component(implementation) {
+                self.push_issue(
+                    issues,
+                    component,
+                    ProductionWiringIssueKind::LocalOnlyImplementation,
+                    Some(implementation),
+                );
+            } else if is_erased_durable_sink_wrapper(implementation) {
+                self.push_issue(
+                    issues,
+                    component,
+                    ProductionWiringIssueKind::UnverifiedProductionImplementation,
+                    Some(implementation),
+                );
+            }
+        }
+    }
+
+    fn push_issue(
+        &self,
+        issues: &mut Vec<ProductionWiringIssue>,
+        component: ProductionWiringComponent,
+        kind: ProductionWiringIssueKind,
+        implementation: Option<&'static str>,
+    ) {
+        issues.push(ProductionWiringIssue {
+            component,
+            kind,
+            implementation,
+        });
+    }
+
+    /// Validates this graph and then builds the upper facade for production
+    /// callers. Composition roots should use this instead of [`Self::host_runtime`]
+    /// once they claim a graph is production-ready.
+    pub fn host_runtime_for_production(
+        &self,
+        config: &ProductionWiringConfig,
+    ) -> Result<DefaultHostRuntime, ProductionWiringReport> {
+        self.validate_production_wiring(config)?;
+        Ok(self.host_runtime())
     }
 
     /// Builds a runtime dispatcher with every configured runtime adapter.
@@ -455,6 +919,10 @@ fn runtime_http_egress(slot: &SharedRuntimeHttpEgress) -> Option<Arc<dyn Runtime
         Ok(guard) => guard.clone(),
         Err(poisoned) => poisoned.into_inner().clone(),
     }
+}
+
+fn runtime_http_egress_is_configured(slot: &SharedRuntimeHttpEgress) -> bool {
+    runtime_http_egress(slot).is_some()
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -496,10 +496,6 @@ where
         self
     }
 
-    pub fn network_policy_store(&self) -> Arc<NetworkObligationPolicyStore> {
-        Arc::clone(&self.network_policy_store)
-    }
-
     pub fn secret_injection_store(&self) -> Arc<RuntimeSecretInjectionStore> {
         Arc::clone(&self.secret_injection_store)
     }

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -156,6 +156,30 @@ fn production_wiring_validation_rejects_missing_components_and_local_only_defaul
 }
 
 #[test]
+fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([RuntimeKind::FirstParty]))
+        .expect_err("first-party runtime requirements are not dispatcher backend requirements");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::RuntimeBackend,
+            ProductionWiringIssueKind::UnsupportedRequirement
+        ),
+        "unsupported runtime backend requirement should be reported: {report:?}"
+    );
+}
+
+#[test]
 fn production_wiring_validation_uses_configured_runtime_requirements() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -272,6 +296,71 @@ fn production_wiring_validation_rejects_direct_durable_sink_wrappers_as_unverifi
 }
 
 #[test]
+fn production_wiring_validation_accepts_verified_host_http_egress_shape() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+    let runtime_http = Arc::new(
+        HostHttpEgressService::new(
+            RecordingNetworkHttpEgress::new(),
+            InMemorySecretStore::new(),
+        )
+        .with_secret_injection_store(services.secret_injection_store())
+        .with_network_policy_store(services.network_policy_store()),
+    );
+    let services = services.with_host_http_egress_service(runtime_http);
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]).require_runtime_http_egress());
+
+    assert!(
+        report.as_ref().err().is_none_or(|report| !report.contains(
+            ProductionWiringComponent::RuntimeHttpEgress,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        )),
+        "verified host HTTP egress should satisfy the runtime egress guardrail: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_rejects_host_http_egress_with_unrelated_handoff_store() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+    let runtime_http = Arc::new(
+        HostHttpEgressService::new(
+            RecordingNetworkHttpEgress::new(),
+            InMemorySecretStore::new(),
+        )
+        .with_secret_injection_store(services.secret_injection_store())
+        .with_network_policy_store(Arc::new(NetworkObligationPolicyStore::new())),
+    );
+    let services = services.with_host_http_egress_service(runtime_http);
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]).require_runtime_http_egress())
+        .expect_err("runtime HTTP egress must share the graph-owned network policy handoff store");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::RuntimeHttpEgress,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "runtime HTTP egress with unrelated handoff stores should be unverified: {report:?}"
+    );
+}
+
+#[test]
 fn production_wiring_validation_rejects_unverified_runtime_http_egress() {
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
@@ -300,6 +389,35 @@ fn production_wiring_validation_rejects_unverified_runtime_http_egress() {
             ProductionWiringIssueKind::UnverifiedProductionImplementation
         ),
         "runtime HTTP egress should require production verification: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_rejects_empty_verified_wasm_credentials() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_verified_wasm_runtime_credentials(Arc::new(WasmStagedRuntimeCredentials::new(vec![])))
+    .try_with_wasm_runtime(WitToolRuntimeConfig::for_testing(), WitToolHost::deny_all())
+    .unwrap();
+
+    let report = services
+        .validate_production_wiring(
+            &ProductionWiringConfig::new([RuntimeKind::Wasm]).require_wasm_credentials(),
+        )
+        .expect_err("empty verified credential provider must not satisfy credential requirement");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::WasmCredentialProvider,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "empty WASM credentials should be reported as unverified: {report:?}"
     );
 }
 
@@ -401,7 +519,7 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
     .with_script_runtime(script_runtime)
     .with_event_sink(Arc::new(events.clone()));
 
-    let runtime = services.host_runtime();
+    let runtime = services.host_runtime_for_local_testing();
     let context = execution_context_with_dispatch_grant(script_capability_id());
     let request = RuntimeCapabilityRequest::new(
         context,
@@ -475,7 +593,7 @@ async fn host_runtime_services_writes_runtime_events_to_durable_event_log_metada
     });
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
@@ -572,7 +690,7 @@ async fn host_runtime_services_consumes_reborn_jsonl_event_store_without_v1_comp
 
     let scope = sample_scope(InvocationId::new());
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
@@ -639,7 +757,7 @@ async fn host_runtime_services_durable_event_replay_cursor_and_gap_behavior() {
     let stream = EventStreamKey::from_scope(&scope);
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
@@ -707,7 +825,7 @@ async fn host_runtime_services_durable_event_replay_cursor_and_gap_behavior() {
 #[tokio::test]
 async fn host_runtime_services_resumes_approved_capability_and_consumes_lease_once() {
     let fixture = approval_resume_fixture();
-    let runtime = fixture.services.host_runtime();
+    let runtime = fixture.services.host_runtime_for_local_testing();
     let context = execution_context_without_grants();
     let scope = context.resource_scope.clone();
     let estimate = ResourceEstimate::default();
@@ -784,7 +902,7 @@ async fn host_runtime_services_resumes_approved_capability_and_consumes_lease_on
 #[tokio::test]
 async fn host_runtime_services_resume_changed_input_fails_before_lease_claim_or_dispatch() {
     let fixture = approval_resume_fixture();
-    let runtime = fixture.services.host_runtime();
+    let runtime = fixture.services.host_runtime_for_local_testing();
     let context = execution_context_without_grants();
     let scope = context.resource_scope.clone();
     let estimate = ResourceEstimate::default();
@@ -827,7 +945,7 @@ async fn host_runtime_services_resume_changed_input_fails_before_lease_claim_or_
 #[tokio::test]
 async fn host_runtime_services_resume_wrong_user_scope_is_hidden_before_dispatch() {
     let fixture = approval_resume_fixture();
-    let runtime = fixture.services.host_runtime();
+    let runtime = fixture.services.host_runtime_for_local_testing();
     let context = execution_context_without_grants();
     let scope = context.resource_scope.clone();
     let estimate = ResourceEstimate::default();
@@ -883,7 +1001,7 @@ async fn host_runtime_services_resume_wrong_user_scope_is_hidden_before_dispatch
 #[tokio::test]
 async fn host_runtime_services_resume_expired_lease_fails_before_dispatch() {
     let fixture = approval_resume_fixture();
-    let runtime = fixture.services.host_runtime();
+    let runtime = fixture.services.host_runtime_for_local_testing();
     let context = execution_context_without_grants();
     let scope = context.resource_scope.clone();
     let estimate = ResourceEstimate::default();
@@ -926,7 +1044,7 @@ async fn host_runtime_services_resume_expired_lease_fails_before_dispatch() {
 #[tokio::test]
 async fn host_runtime_services_resume_trust_preflight_failure_fails_only_matching_blocked_run() {
     let fixture = approval_resume_fixture();
-    let runtime = fixture.services.host_runtime();
+    let runtime = fixture.services.host_runtime_for_local_testing();
     let context = execution_context_without_grants();
     let scope = context.resource_scope.clone();
     let estimate = ResourceEstimate::default();
@@ -1038,7 +1156,7 @@ async fn host_runtime_services_resume_without_backing_stores_fails_closed() {
         ScriptRuntimeConfig::for_testing(),
         EchoScriptBackend,
     )))
-    .host_runtime();
+    .host_runtime_for_local_testing();
 
     let outcome = runtime
         .resume_capability(RuntimeCapabilityResumeRequest::new(
@@ -1077,7 +1195,7 @@ async fn host_runtime_services_registered_runtime_health_tracks_script_mcp_and_w
     .with_mcp_runtime(Arc::new(PanicMcpExecutor))
     .try_with_wasm_runtime(WitToolRuntimeConfig::for_testing(), WitToolHost::deny_all())
     .unwrap()
-    .host_runtime();
+    .host_runtime_for_local_testing();
 
     let health = runtime.health().await.unwrap();
 
@@ -1095,7 +1213,7 @@ async fn host_runtime_services_health_fails_closed_for_unregistered_required_run
         ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
-    .host_runtime();
+    .host_runtime_for_local_testing();
 
     let health = runtime.health().await.unwrap();
 
@@ -1127,7 +1245,7 @@ async fn host_runtime_services_installs_builtin_obligation_handler_with_audit_si
     .with_script_runtime(script_runtime);
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant(script_capability_id()),
             script_capability_id(),
@@ -1186,7 +1304,7 @@ async fn host_runtime_services_applies_scoped_mount_obligation_to_script_runtime
     .with_script_runtime(Arc::clone(&script_runtime));
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             context,
             script_capability_id(),
@@ -1239,7 +1357,7 @@ async fn host_runtime_services_rejects_broader_scoped_mount_before_dispatch() {
     .with_script_runtime(Arc::clone(&script_runtime));
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             context,
             script_capability_id(),
@@ -1290,7 +1408,7 @@ async fn host_runtime_services_writes_obligation_audit_records_to_durable_log_me
     });
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
@@ -1387,7 +1505,7 @@ async fn host_runtime_services_enforces_output_limit_and_reconciles_resource_usa
     let input = json!({"message": "this output is deliberately too large"});
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
@@ -1449,7 +1567,7 @@ async fn host_runtime_services_releases_reservation_when_dispatch_preflight_fail
     )));
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
@@ -1504,7 +1622,7 @@ async fn host_runtime_services_fails_closed_when_durable_obligation_audit_append
     .with_script_runtime(script_runtime);
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant(script_capability_id()),
             script_capability_id(),
@@ -1565,7 +1683,7 @@ async fn host_runtime_services_routes_wasm_http_through_per_invocation_policy_ha
     let scope = sample_scope(InvocationId::new());
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(wasm_runtime_request_for_scope(
             capability_id.clone(),
             scope.clone(),
@@ -1623,7 +1741,7 @@ async fn host_runtime_services_routes_cached_wasm_http_through_per_invocation_po
     .with_runtime_http_egress(Arc::clone(&egress))
     .try_with_wasm_runtime(WitToolRuntimeConfig::for_testing(), WitToolHost::deny_all())
     .unwrap();
-    let runtime = services.host_runtime();
+    let runtime = services.host_runtime_for_local_testing();
     let capability_id = CapabilityId::new("wasm-http.success").unwrap();
     let first_scope = sample_scope(InvocationId::new());
     let second_scope = sample_scope(InvocationId::new());
@@ -1724,7 +1842,7 @@ async fn host_runtime_services_routes_wasm_http_with_staged_network_and_secret_h
         .unwrap();
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(wasm_runtime_request_for_scope(
             capability_id.clone(),
             scope.clone(),
@@ -1803,7 +1921,7 @@ async fn host_runtime_services_wasm_http_missing_staged_secret_stays_before_tran
     let capability_id = CapabilityId::new("wasm-http.success").unwrap();
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(wasm_runtime_request(
             capability_id.clone(),
             json!({"call": "http-missing-staged-secret"}),
@@ -1860,7 +1978,7 @@ async fn host_runtime_services_denies_wasm_http_when_shared_egress_has_no_policy
     let capability_id = CapabilityId::new("wasm-http.success").unwrap();
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(wasm_runtime_request(
             capability_id,
             json!({"call": "http-without-policy"}),
@@ -1922,7 +2040,7 @@ async fn host_runtime_services_cancel_and_status_share_process_result_and_cancel
         process_services,
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
-    .host_runtime();
+    .host_runtime_for_local_testing();
     let invocation_id = InvocationId::new();
     let process_id = ProcessId::new();
     let scope = sample_scope(invocation_id);
@@ -1975,7 +2093,7 @@ async fn host_runtime_services_cancel_writes_killed_result_when_reservation_is_s
         process_services,
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
-    .host_runtime();
+    .host_runtime_for_local_testing();
     let invocation_id = InvocationId::new();
     let process_id = ProcessId::new();
     let stale_reservation_id = ResourceReservationId::new();
@@ -2024,7 +2142,7 @@ async fn host_runtime_services_cancel_records_kill_side_effects_when_cleanup_fai
         process_services,
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
-    .host_runtime();
+    .host_runtime_for_local_testing();
     let invocation_id = InvocationId::new();
     let process_id = ProcessId::new();
     let scope = sample_scope(invocation_id);
@@ -2901,7 +3019,7 @@ fn resume_runtime_with_empty_registry(fixture: &ApprovalResumeFixture) -> Defaul
         ScriptRuntimeConfig::for_testing(),
         EchoScriptBackend,
     )))
-    .host_runtime()
+    .host_runtime_for_local_testing()
 }
 
 async fn assert_blocked_approval_run(
@@ -3983,7 +4101,7 @@ async fn wasm_runtime_for_component(
     .unwrap();
 
     WasmRuntimeFixture {
-        runtime: services.host_runtime(),
+        runtime: services.host_runtime_for_local_testing(),
         governor,
         http,
         capability_id: CapabilityId::new(capability).unwrap(),
@@ -4020,7 +4138,7 @@ async fn wasm_runtime_for_component_with_slow_zero_body_http(
     .unwrap();
 
     WasmWallClockRuntimeFixture {
-        runtime: services.host_runtime(),
+        runtime: services.host_runtime_for_local_testing(),
         governor,
         http,
         capability_id: CapabilityId::new(capability).unwrap(),

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -9,9 +9,9 @@ use ironclaw_authorization::{
 };
 use ironclaw_capabilities::{CapabilityHost, CapabilitySpawnRequest};
 use ironclaw_events::{
-    DurableAuditLog, DurableEventLog, DurableEventSink, EventCursor, EventError, EventReplay,
-    EventStreamKey, InMemoryAuditSink, InMemoryDurableAuditLog, InMemoryDurableEventLog,
-    InMemoryEventSink, ReadScope, RuntimeEventKind,
+    DurableAuditLog, DurableAuditSink, DurableEventLog, DurableEventSink, EventCursor, EventError,
+    EventReplay, EventStreamKey, InMemoryAuditSink, InMemoryDurableAuditLog,
+    InMemoryDurableEventLog, InMemoryEventSink, ReadScope, RuntimeEventKind,
 };
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry};
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
@@ -19,7 +19,8 @@ use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     BuiltinObligationHandler, CancelReason, CancelRuntimeWorkRequest, CapabilitySurfaceVersion,
     DefaultHostRuntime, HostHttpEgressService, HostRuntime, HostRuntimeServices,
-    NetworkObligationPolicyStore, ProcessObligationLifecycleStore, RuntimeCapabilityOutcome,
+    NetworkObligationPolicyStore, ProcessObligationLifecycleStore, ProductionWiringComponent,
+    ProductionWiringConfig, ProductionWiringIssueKind, RuntimeCapabilityOutcome,
     RuntimeCapabilityRequest, RuntimeCapabilityResumeRequest, RuntimeFailureKind,
     RuntimeSecretInjectionStore, RuntimeStatusRequest, RuntimeWorkId,
 };
@@ -58,6 +59,312 @@ use ironclaw_wasm::{
 use serde_json::json;
 use wit_component::{ComponentEncoder, StringEncoding, embed_component_metadata};
 use wit_parser::Resolve;
+
+#[test]
+fn production_wiring_validation_rejects_missing_components_and_local_only_defaults() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+
+    let report = match services.host_runtime_for_production(&ProductionWiringConfig::new([])) {
+        Ok(_) => panic!("bare local/test service graph must not pass production validation"),
+        Err(report) => report,
+    };
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::TrustPolicy,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing explicit trust policy should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::RunState,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing run-state store should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::ApprovalRequests,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing approval store should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::CapabilityLeases,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing capability lease store should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::EventSink,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing event sink should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::AuditSink,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing audit sink should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::SecretStore,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing secret store should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::Filesystem,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "local filesystem should be reported as local-only: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::ResourceGovernor,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "in-memory resource governor should be reported as local-only: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::ProcessStore,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "in-memory process store should be reported as local-only: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::ProcessResultStore,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "in-memory process result store should be reported as local-only: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_uses_configured_runtime_requirements() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+    let config = ProductionWiringConfig::new([RuntimeKind::Script, RuntimeKind::Wasm])
+        .require_runtime_http_egress()
+        .require_wasm_credentials();
+
+    let report = services
+        .validate_production_wiring(&config)
+        .expect_err("required runtime backends and egress must be reported when absent");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::ScriptRuntime,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing script runtime should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::WasmRuntime,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing wasm runtime should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::RuntimeHttpEgress,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing runtime HTTP egress should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::WasmCredentialProvider,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing WASM credential provider should be reported: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_sees_underlying_in_memory_durable_logs() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_durable_event_log(Arc::new(InMemoryDurableEventLog::new()))
+    .with_durable_audit_log(Arc::new(InMemoryDurableAuditLog::new()));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("in-memory durable logs must not be hidden behind durable sink wrappers");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::EventSink,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "in-memory durable event log should be reported through with_durable_event_log: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::AuditSink,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "in-memory durable audit log should be reported through with_durable_audit_log: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_rejects_direct_durable_sink_wrappers_as_unverified() {
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let audit_log: Arc<dyn DurableAuditLog> = Arc::new(InMemoryDurableAuditLog::new());
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_event_sink(Arc::new(DurableEventSink::new(event_log)))
+    .with_audit_sink(Arc::new(DurableAuditSink::new(audit_log)));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("direct durable sink wrappers must not hide erased underlying log types");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::EventSink,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "direct durable event sink wrapper should require typed with_durable_event_log path: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::AuditSink,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "direct durable audit sink wrapper should require typed with_durable_audit_log path: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_rejects_unverified_runtime_http_egress() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_runtime_http_egress(Arc::new(
+        HostHttpEgressService::new_with_request_policy_for_tests(
+            RecordingNetworkHttpEgress::new(),
+            InMemorySecretStore::new(),
+        ),
+    ));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]).require_runtime_http_egress())
+        .expect_err(
+            "generic/test runtime HTTP egress must not satisfy production egress guardrail",
+        );
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::RuntimeHttpEgress,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "runtime HTTP egress should require production verification: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_rejects_wasm_credentials_added_after_adapter() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .try_with_wasm_runtime(WitToolRuntimeConfig::for_testing(), WitToolHost::deny_all())
+    .unwrap()
+    .with_wasm_runtime_credential_provider(Arc::new(WasmStagedRuntimeCredentials::new(vec![])));
+
+    let report = services
+        .validate_production_wiring(
+            &ProductionWiringConfig::new([RuntimeKind::Wasm]).require_wasm_credentials(),
+        )
+        .expect_err(
+            "credentials added after WASM adapter construction are not captured by the adapter",
+        );
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::WasmCredentialProvider,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "WASM credentials must be configured before adapter construction: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_rejects_wasm_credentials_replaced_after_adapter() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(WASM_HTTP_SUCCESS_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_wasm_runtime_credential_provider(Arc::new(WasmStagedRuntimeCredentials::new(vec![])))
+    .try_with_wasm_runtime(WitToolRuntimeConfig::for_testing(), WitToolHost::deny_all())
+    .unwrap()
+    .with_wasm_runtime_credential_provider(Arc::new(WasmStagedRuntimeCredentials::new(vec![])));
+
+    let report = services
+        .validate_production_wiring(
+            &ProductionWiringConfig::new([RuntimeKind::Wasm]).require_wasm_credentials(),
+        )
+        .expect_err(
+            "replacing credentials after WASM adapter construction is not captured by the adapter",
+        );
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::WasmCredentialProvider,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "WASM credentials must not be replaced after adapter construction: {report:?}"
+    );
+}
 
 #[tokio::test]
 async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registered_adapters() {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -857,7 +857,7 @@ async fn host_runtime_services_runtime_events_project_through_replay_projection_
     });
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
@@ -945,7 +945,7 @@ async fn host_runtime_services_projection_rejects_foreign_cursor_and_surfaces_re
     };
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(
                 script_capability_id(),
@@ -1054,7 +1054,7 @@ async fn host_runtime_services_jsonl_event_store_projects_same_runtime_sequence_
     });
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),
@@ -1138,7 +1138,7 @@ async fn host_runtime_services_approval_resolution_projects_durable_audit_metada
         ScriptRuntimeConfig::for_testing(),
         EchoScriptBackend,
     )));
-    let runtime = services.host_runtime();
+    let runtime = services.host_runtime_for_local_testing();
     let scope = sample_scope(InvocationId::new());
     let context = execution_context_without_grants_for_scope(scope.clone());
     let input = json!({
@@ -1248,7 +1248,7 @@ async fn host_runtime_services_jsonl_approval_audit_projection_rejects_foreign_c
         ScriptRuntimeConfig::for_testing(),
         EchoScriptBackend,
     )));
-    let runtime = services.host_runtime();
+    let runtime = services.host_runtime_for_local_testing();
     let scope_a = sample_scope(InvocationId::new());
     let scope_b = ResourceScope {
         thread_id: Some(ThreadId::new("approval-thread-b").unwrap()),

--- a/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_durable_restart_integration.rs
@@ -45,7 +45,7 @@ async fn approval_resume_survives_filesystem_service_restart_and_consumes_lease_
     let engine_root = temp.path().join("engine");
     let event_root = temp.path().join("events");
     let first = durable_services(&engine_root, &event_root).await;
-    let first_runtime = first.services.host_runtime();
+    let first_runtime = first.services.host_runtime_for_local_testing();
     let context = execution_context_without_grants_for_scope(sample_scope(InvocationId::new()));
     let scope = context.resource_scope.clone();
     let estimate = ResourceEstimate::default();
@@ -88,7 +88,7 @@ async fn approval_resume_survives_filesystem_service_restart_and_consumes_lease_
 
     let resumed = second
         .services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .resume_capability(RuntimeCapabilityResumeRequest::new(
             context.clone(),
             gate.approval_request_id,
@@ -163,7 +163,7 @@ async fn approval_resume_survives_filesystem_service_restart_and_consumes_lease_
 
     let second_resume = third
         .services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .resume_capability(RuntimeCapabilityResumeRequest::new(
             context,
             gate.approval_request_id,
@@ -265,7 +265,7 @@ async fn jsonl_event_and_audit_replay_survive_reopen_without_raw_sentinels() {
     });
 
     let outcome = services
-        .host_runtime()
+        .host_runtime_for_local_testing()
         .invoke_capability(RuntimeCapabilityRequest::new(
             execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
             script_capability_id(),


### PR DESCRIPTION
## Summary

Implements issue #3333 Task 0: production wiring guardrails + config shape for Reborn host-runtime composition.

Adds a production validation surface to `HostRuntimeServices` so composition roots can fail before exposing a service graph as production-ready when it still relies on local/test defaults or unverified runtime wiring.

## What changed

- Adds `ProductionWiringConfig` to declare required runtime backends and production egress/credential requirements.
- Adds `ProductionWiringComponent`, `ProductionWiringIssueKind`, `ProductionWiringIssue`, and `ProductionWiringReport` for typed guardrail diagnostics.
- Adds `HostRuntimeServices::validate_production_wiring` and `host_runtime_for_production`.
- Tracks configured component implementation types enough to reject obvious local/test seams:
  - `InMemory*`
  - `Noop*`
  - `DenyWasm*`
  - `EmptyWasm*`
  - `LocalFilesystem`
- Keeps direct `DurableEventSink` / `DurableAuditSink` wrappers unverified so they cannot hide an erased in-memory durable log; typed `with_durable_*_log` preserves the underlying log type for validation.
- Requires runtime HTTP egress to be attached through an explicitly verified path for production configs.
- Detects WASM credential provider ordering/replacement problems where the adapter has not captured the current provider.

## Tests

- `cargo test -p ironclaw_host_runtime --tests --no-fail-fast`
- `cargo clippy -p ironclaw_host_runtime --tests -- -D warnings`

## Notes

This PR only adds the guardrail/API shape. It does not yet wire the production app composition root; follow-up DAG steps in #3333 should use `host_runtime_for_production` from the production builder.

Closes part of #3333.
