### PR TITLE
test(reborn): cover production obligation HTTP handoffs

### DIFF
--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -244,6 +244,10 @@ where
         self
     }
 
+    pub fn network_policy_store(&self) -> Arc<NetworkObligationPolicyStore> {
+        Arc::clone(&self.network_policy_store)
+    }
+
     pub fn secret_injection_store(&self) -> Arc<RuntimeSecretInjectionStore> {
         Arc::clone(&self.secret_injection_store)
     }

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1349,7 +1349,7 @@ async fn host_runtime_services_routes_cached_wasm_http_through_per_invocation_po
 }
 
 #[tokio::test]
-async fn host_runtime_services_routes_wasm_http_with_staged_network_and_secret_handoffs() {
+async fn host_runtime_services_wasm_http_uses_production_staged_network_and_secret_handoffs() {
     let parsed_manifest = ExtensionManifest::parse(WASM_HTTP_SUCCESS_MANIFEST).unwrap();
     let component = tool_component(HTTP_TOOL_WAT);
     let filesystem = Arc::new(
@@ -1395,11 +1395,9 @@ async fn host_runtime_services_routes_wasm_http_with_staged_network_and_secret_h
         ),
     ])));
     let runtime_http = Arc::new(
-        HostHttpEgressService::new_with_request_policy_for_tests(
-            network.clone(),
-            InMemorySecretStore::new(),
-        )
-        .with_secret_injection_store(services.secret_injection_store()),
+        HostHttpEgressService::new(network.clone(), InMemorySecretStore::new())
+            .with_network_policy_store(services.network_policy_store())
+            .with_secret_injection_store(services.secret_injection_store()),
     );
     let services = services
         .with_runtime_http_egress(runtime_http)
@@ -1410,7 +1408,7 @@ async fn host_runtime_services_routes_wasm_http_with_staged_network_and_secret_h
     secret_store
         .put(
             scope.clone(),
-            secret_handle,
+            secret_handle.clone(),
             SecretMaterial::from("sk-vertical-secret"),
         )
         .await
@@ -1440,6 +1438,21 @@ async fn host_runtime_services_routes_wasm_http_with_staged_network_and_secret_h
             "authorization".to_string(),
             "Bearer sk-vertical-secret".to_string(),
         ))
+    );
+    assert!(
+        services
+            .network_policy_store()
+            .take(&scope, &capability_id)
+            .is_none(),
+        "completed invoke must discard staged network policy after shared egress uses it"
+    );
+    assert!(
+        services
+            .secret_injection_store()
+            .take(&scope, &capability_id, &secret_handle)
+            .unwrap()
+            .is_none(),
+        "completed invoke must consume staged secret material once"
     );
 }
 


### PR DESCRIPTION
## Summary

- Expose the HostRuntimeServices network-obligation policy store so shared production HTTP egress can be wired to the same staged handoff store used by the built-in obligation handler.
- Tighten the HostRuntimeServices WASM HTTP vertical test to use production `HostHttpEgressService::new(...)` instead of the request-policy test fallback.
- Assert completed invocation cleanup leaves neither staged network policy nor staged secret material reusable.

Fixes #3148.

## Test Plan

- [x] `CARGO_TARGET_DIR=/tmp/ironclaw-issue-3148-target cargo test -p ironclaw_host_runtime --test host_runtime_services_contract`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `CARGO_TARGET_DIR=/tmp/ironclaw-issue-3148-target cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings`
- [x] `python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
