### PR TITLE
test(reborn): add approval audit projection e2e slice

### DIFF
--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -10,12 +10,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_events::{
-    DurableEventLog, EventCursor, EventError, EventLogEntry, EventStreamKey, ReadScope,
-    RuntimeEvent, RuntimeEventKind, sanitize_error_kind,
+    DurableAuditLog, DurableEventLog, EventCursor, EventError, EventLogEntry, EventStreamKey,
+    ReadScope, RuntimeEvent, RuntimeEventKind, sanitize_error_kind,
 };
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, InvocationId, ProcessId, ResourceScope, RuntimeKind, ThreadId,
-    Timestamp,
+    ApprovalRequestId, AuditEnvelope, AuditEventId, AuditStage, CapabilityId, ExtensionId,
+    InvocationId, ProcessId, ResourceScope, RuntimeKind, ThreadId, Timestamp,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -235,6 +235,238 @@ pub enum ProjectionError {
     },
     #[error("projection source failed during {operation}")]
     Source { operation: &'static str },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AuditProjectionCursor {
+    pub audit: EventCursor,
+    pub scope: ProjectionScope,
+}
+
+impl AuditProjectionCursor {
+    pub fn for_scope(scope: ProjectionScope, audit: EventCursor) -> Self {
+        Self { audit, scope }
+    }
+
+    pub fn origin_for_scope(scope: ProjectionScope) -> Self {
+        Self {
+            audit: EventCursor::origin(),
+            scope,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditProjectionRequest {
+    pub scope: ProjectionScope,
+    pub after: Option<AuditProjectionCursor>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditProjectionSnapshot {
+    pub entries: Vec<AuditProjectionEntry>,
+    pub next_cursor: AuditProjectionCursor,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditProjectionReplay {
+    pub entries: Vec<AuditProjectionEntry>,
+    pub next_cursor: AuditProjectionCursor,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditProjectionEntry {
+    pub cursor: EventCursor,
+    pub event_id: AuditEventId,
+    pub timestamp: Timestamp,
+    pub stage: AuditProjectionStage,
+    pub invocation_id: InvocationId,
+    pub thread_id: Option<ThreadId>,
+    pub process_id: Option<ProcessId>,
+    pub approval_request_id: Option<ApprovalRequestId>,
+    pub extension_id: Option<ExtensionId>,
+    pub action_kind: String,
+    pub action_target: Option<String>,
+    pub decision_kind: String,
+    pub result_status: Option<String>,
+    pub output_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditProjectionStage {
+    Before,
+    After,
+    Denied,
+    ApprovalRequested,
+    ApprovalResolved,
+    ResourceReserved,
+    ResourceReconciled,
+    ResourceReleased,
+}
+
+impl From<AuditStage> for AuditProjectionStage {
+    fn from(stage: AuditStage) -> Self {
+        match stage {
+            AuditStage::Before => Self::Before,
+            AuditStage::After => Self::After,
+            AuditStage::Denied => Self::Denied,
+            AuditStage::ApprovalRequested => Self::ApprovalRequested,
+            AuditStage::ApprovalResolved => Self::ApprovalResolved,
+            AuditStage::ResourceReserved => Self::ResourceReserved,
+            AuditStage::ResourceReconciled => Self::ResourceReconciled,
+            AuditStage::ResourceReleased => Self::ResourceReleased,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AuditProjectionError {
+    #[error("audit projection request rejected: {reason}")]
+    InvalidRequest { reason: &'static str },
+    #[error(
+        "audit projection rebase required: requested audit cursor {requested:?} cannot replay from earliest retained audit cursor {earliest:?}"
+    )]
+    RebaseRequired {
+        requested: Box<AuditProjectionCursor>,
+        earliest: Box<AuditProjectionCursor>,
+    },
+    #[error("audit projection source failed during {operation}")]
+    Source { operation: &'static str },
+}
+
+#[async_trait]
+pub trait AuditProjectionService: Send + Sync {
+    async fn snapshot(
+        &self,
+        request: AuditProjectionRequest,
+    ) -> Result<AuditProjectionSnapshot, AuditProjectionError>;
+
+    async fn updates(
+        &self,
+        request: AuditProjectionRequest,
+    ) -> Result<AuditProjectionReplay, AuditProjectionError>;
+}
+
+#[derive(Clone)]
+pub struct ReplayAuditProjectionService {
+    audit_log: Arc<dyn DurableAuditLog>,
+}
+
+impl ReplayAuditProjectionService {
+    pub fn new<T>(audit_log: Arc<T>) -> Self
+    where
+        T: DurableAuditLog + 'static,
+    {
+        let audit_log: Arc<dyn DurableAuditLog> = audit_log;
+        Self { audit_log }
+    }
+
+    pub fn from_audit_log(audit_log: Arc<dyn DurableAuditLog>) -> Self {
+        Self { audit_log }
+    }
+
+    async fn read_audit(
+        &self,
+        request: AuditProjectionRequest,
+    ) -> Result<ProjectedAuditPage, AuditProjectionError> {
+        if request.limit == 0 {
+            return Err(AuditProjectionError::InvalidRequest {
+                reason: "limit must be greater than zero",
+            });
+        }
+        if request.limit > MAX_PROJECTION_PAGE_LIMIT {
+            return Err(AuditProjectionError::InvalidRequest {
+                reason: "limit exceeds MAX_PROJECTION_PAGE_LIMIT",
+            });
+        }
+        if let Some(cursor) = request.after.as_ref()
+            && cursor.scope != request.scope
+        {
+            return Err(AuditProjectionError::RebaseRequired {
+                requested: Box::new(cursor.clone()),
+                earliest: Box::new(AuditProjectionCursor::origin_for_scope(
+                    request.scope.clone(),
+                )),
+            });
+        }
+        let fetch_limit =
+            request
+                .limit
+                .checked_add(1)
+                .ok_or(AuditProjectionError::InvalidRequest {
+                    reason: "limit is too large",
+                })?;
+        let after = request.after.as_ref().map(|cursor| cursor.audit);
+        let replay = self
+            .audit_log
+            .read_after_cursor(
+                &request.scope.stream,
+                &request.scope.read_scope,
+                after,
+                fetch_limit,
+            )
+            .await
+            .map_err(|error| map_audit_projection_error(error, "audit replay", &request.scope))?;
+        let mut entries = replay.entries;
+        let truncated = entries.len() > request.limit;
+        if truncated {
+            entries.truncate(request.limit);
+        }
+        let next_cursor = if truncated {
+            entries
+                .last()
+                .map(|entry| entry.cursor)
+                .unwrap_or_else(|| after.unwrap_or_else(EventCursor::origin))
+        } else {
+            replay.next_cursor
+        };
+        Ok(ProjectedAuditPage {
+            entries,
+            next_cursor: AuditProjectionCursor::for_scope(request.scope.clone(), next_cursor),
+            truncated,
+        })
+    }
+}
+
+impl std::fmt::Debug for ReplayAuditProjectionService {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ReplayAuditProjectionService")
+            .field("audit_log", &"<durable_audit_log>")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl AuditProjectionService for ReplayAuditProjectionService {
+    async fn snapshot(
+        &self,
+        request: AuditProjectionRequest,
+    ) -> Result<AuditProjectionSnapshot, AuditProjectionError> {
+        let page = self.read_audit(request).await?;
+        Ok(AuditProjectionSnapshot {
+            entries: project_audit_entries(&page.entries),
+            next_cursor: page.next_cursor,
+            truncated: page.truncated,
+        })
+    }
+
+    async fn updates(
+        &self,
+        request: AuditProjectionRequest,
+    ) -> Result<AuditProjectionReplay, AuditProjectionError> {
+        let page = self.read_audit(request).await?;
+        Ok(AuditProjectionReplay {
+            entries: project_audit_entries(&page.entries),
+            next_cursor: page.next_cursor,
+            truncated: page.truncated,
+        })
+    }
 }
 
 #[async_trait]
@@ -531,6 +763,52 @@ impl EventProjectionService for ReplayEventProjectionService {
     }
 }
 
+struct ProjectedAuditPage {
+    entries: Vec<EventLogEntry<AuditEnvelope>>,
+    next_cursor: AuditProjectionCursor,
+    truncated: bool,
+}
+
+fn project_audit_entries(entries: &[EventLogEntry<AuditEnvelope>]) -> Vec<AuditProjectionEntry> {
+    entries.iter().map(project_audit_entry).collect()
+}
+
+fn project_audit_entry(entry: &EventLogEntry<AuditEnvelope>) -> AuditProjectionEntry {
+    let audit = &entry.record;
+    let action_kind = sanitize_error_kind(audit.action.kind.clone());
+    AuditProjectionEntry {
+        cursor: entry.cursor,
+        event_id: audit.event_id,
+        timestamp: audit.timestamp,
+        stage: audit.stage.into(),
+        invocation_id: audit.invocation_id,
+        thread_id: audit.thread_id.clone(),
+        process_id: audit.process_id,
+        approval_request_id: audit.approval_request_id,
+        extension_id: audit.extension_id.clone(),
+        action_target: safe_audit_action_target(&action_kind, audit.action.target.as_ref()),
+        action_kind,
+        decision_kind: sanitize_error_kind(audit.decision.kind.clone()),
+        result_status: audit
+            .result
+            .as_ref()
+            .and_then(|result| result.status.clone())
+            .map(sanitize_error_kind),
+        output_bytes: audit.result.as_ref().and_then(|result| result.output_bytes),
+    }
+}
+
+fn safe_audit_action_target(action_kind: &str, target: Option<&String>) -> Option<String> {
+    match action_kind {
+        "dispatch" | "spawn_capability" => target.and_then(|target| {
+            CapabilityId::new(target.clone())
+                .ok()
+                .map(|capability| capability.into_string())
+        }),
+        _ => None,
+    }
+}
+
 struct ProjectedRuntimePage {
     entries: Vec<EventLogEntry<RuntimeEvent>>,
     next_cursor: ProjectionCursor,
@@ -656,6 +934,28 @@ fn run_status_for_event(
             RunProjectionStatus::Failed
         }
         RuntimeEventKind::ProcessKilled => RunProjectionStatus::Killed,
+    }
+}
+
+fn map_audit_projection_error(
+    error: EventError,
+    operation: &'static str,
+    scope: &ProjectionScope,
+) -> AuditProjectionError {
+    match error {
+        EventError::ReplayGap {
+            requested,
+            earliest,
+        } => AuditProjectionError::RebaseRequired {
+            requested: Box::new(AuditProjectionCursor::for_scope(scope.clone(), requested)),
+            earliest: Box::new(AuditProjectionCursor::for_scope(scope.clone(), earliest)),
+        },
+        EventError::InvalidReplayRequest { .. } => AuditProjectionError::InvalidRequest {
+            reason: "invalid durable replay request",
+        },
+        EventError::Serialize { .. } | EventError::Sink { .. } | EventError::DurableLog { .. } => {
+            AuditProjectionError::Source { operation }
+        }
     }
 }
 

--- a/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
@@ -3,19 +3,92 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_event_projections::{
-    EventProjectionService, MAX_PROJECTION_PAGE_LIMIT, ProjectionCursor, ProjectionError,
-    ProjectionRequest, ProjectionScope, ReplayEventProjectionService, RunProjectionStatus,
-    TimelineEntryKind,
+    AuditProjectionRequest, AuditProjectionService, AuditProjectionStage, EventProjectionService,
+    MAX_PROJECTION_PAGE_LIMIT, ProjectionCursor, ProjectionError, ProjectionRequest,
+    ProjectionScope, ReplayAuditProjectionService, ReplayEventProjectionService,
+    RunProjectionStatus, TimelineEntryKind,
 };
 use ironclaw_events::{
-    DurableEventLog, EventCursor, EventError, EventLogEntry, EventReplay, EventStreamKey,
-    InMemoryDurableEventLog, ReadScope, RuntimeEvent, RuntimeEventId, RuntimeEventKind,
-    UNCLASSIFIED_ERROR_KIND,
+    DurableAuditLog, DurableEventLog, EventCursor, EventError, EventLogEntry, EventReplay,
+    EventStreamKey, InMemoryDurableAuditLog, InMemoryDurableEventLog, ReadScope, RuntimeEvent,
+    RuntimeEventId, RuntimeEventKind, UNCLASSIFIED_ERROR_KIND,
 };
 use ironclaw_host_api::{
-    AgentId, CapabilityId, ExtensionId, InvocationId, ProcessId, ProjectId, ResourceScope,
-    RuntimeKind, TenantId, ThreadId, UserId,
+    Action, ActionSummary, AgentId, AuditEnvelope, AuditStage, CapabilityId, CapabilitySet,
+    CorrelationId, DenyReason, ExtensionId, InvocationId, MountView, ProcessId, ProjectId,
+    ResourceScope, RuntimeKind, ScopedPath, TenantId, ThreadId, TrustClass, UserId,
 };
+
+#[tokio::test]
+async fn replay_audit_projection_preserves_valid_capability_targets() {
+    let log = Arc::new(InMemoryDurableAuditLog::new());
+    let service = ReplayAuditProjectionService::new(Arc::clone(&log));
+    let ctx = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-a").unwrap()));
+    let action = Action::Dispatch {
+        capability: CapabilityId::new("1234567890123456789012345-cap.echo").unwrap(),
+        estimated_resources: Default::default(),
+    };
+
+    log.append(AuditEnvelope::denied(
+        &ctx,
+        AuditStage::Denied,
+        ActionSummary::from_action(&action),
+        DenyReason::PolicyDenied,
+    ))
+    .await
+    .unwrap();
+
+    let snapshot = service
+        .snapshot(AuditProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&ctx.resource_scope),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.entries.len(), 1);
+    assert_eq!(snapshot.entries[0].action_kind, "dispatch");
+    assert_eq!(
+        snapshot.entries[0].action_target.as_deref(),
+        Some("1234567890123456789012345-cap.echo")
+    );
+}
+
+#[tokio::test]
+async fn replay_audit_projection_does_not_expose_unsafe_action_targets() {
+    let log = Arc::new(InMemoryDurableAuditLog::new());
+    let service = ReplayAuditProjectionService::new(Arc::clone(&log));
+    let ctx = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-a").unwrap()));
+    let action = Action::ReadFile {
+        path: ScopedPath::new("/workspace/AUDIT_TARGET_SENTINEL_3022.md").unwrap(),
+    };
+
+    log.append(AuditEnvelope::denied(
+        &ctx,
+        AuditStage::Denied,
+        ActionSummary::from_action(&action),
+        DenyReason::PolicyDenied,
+    ))
+    .await
+    .unwrap();
+
+    let snapshot = service
+        .snapshot(AuditProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&ctx.resource_scope),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.entries.len(), 1);
+    assert_eq!(snapshot.entries[0].stage, AuditProjectionStage::Denied);
+    assert_eq!(snapshot.entries[0].action_kind, "read_file");
+    assert_eq!(snapshot.entries[0].action_target, None);
+    let serialized = serde_json::to_string(&snapshot).unwrap();
+    assert!(!serialized.contains("AUDIT_TARGET_SENTINEL_3022"));
+}
 
 #[tokio::test]
 async fn replay_projection_service_projects_timeline_and_run_status_by_scope() {
@@ -445,6 +518,29 @@ fn scope_for_thread_with_invocation(
         thread_id: Some(thread_id),
         invocation_id,
     }
+}
+
+fn execution_context_for_scope(scope: ResourceScope) -> ironclaw_host_api::ExecutionContext {
+    let context = ironclaw_host_api::ExecutionContext {
+        invocation_id: scope.invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: scope.tenant_id.clone(),
+        user_id: scope.user_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        project_id: scope.project_id.clone(),
+        mission_id: scope.mission_id.clone(),
+        thread_id: scope.thread_id.clone(),
+        extension_id: ExtensionId::new("caller").unwrap(),
+        runtime: RuntimeKind::Script,
+        trust: TrustClass::UserTrusted,
+        grants: CapabilitySet::default(),
+        mounts: MountView::default(),
+        resource_scope: scope,
+    };
+    context.validate().unwrap();
+    context
 }
 
 fn capability_id() -> CapabilityId {

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -9,8 +9,10 @@ use ironclaw_authorization::{
 };
 use ironclaw_capabilities::{CapabilityHost, CapabilitySpawnRequest};
 use ironclaw_event_projections::{
+    AuditProjectionError, AuditProjectionRequest, AuditProjectionService, AuditProjectionStage,
     EventProjectionService, ProjectionCursor, ProjectionError, ProjectionRequest, ProjectionScope,
-    ReplayEventProjectionService, RunProjectionStatus, TimelineEntryKind,
+    ReplayAuditProjectionService, ReplayEventProjectionService, RunProjectionStatus,
+    TimelineEntryKind,
 };
 use ironclaw_events::{
     DurableAuditLog, DurableEventLog, DurableEventSink, EventCursor, EventError, EventReplay,
@@ -681,6 +683,213 @@ async fn host_runtime_services_jsonl_event_store_projects_same_runtime_sequence_
         assert!(
             !jsonl_bytes.contains(forbidden),
             "JSONL durable event bytes leaked {forbidden}: {jsonl_bytes}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn host_runtime_services_approval_resolution_projects_durable_audit_metadata_only() {
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let audit_log = Arc::new(InMemoryDurableAuditLog::new());
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(SentinelApprovalAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
+    .with_run_state(Arc::clone(&run_state))
+    .with_approval_requests(Arc::clone(&approval_requests))
+    .with_capability_leases(Arc::clone(&capability_leases))
+    .with_durable_audit_log(Arc::clone(&audit_log))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )));
+    let runtime = services.host_runtime();
+    let scope = sample_scope(InvocationId::new());
+    let context = execution_context_without_grants_for_scope(scope.clone());
+    let input = json!({
+        "message": "APPROVAL_RAW_INPUT_SENTINEL_3022 /tmp/private-approval-path",
+        "secret": "APPROVAL_SECRET_SENTINEL_3022_sk_live_secret",
+        "output": "APPROVAL_OUTPUT_SENTINEL_3022",
+    });
+
+    let gate = block_for_approval(
+        &runtime,
+        context.clone(),
+        ResourceEstimate::default(),
+        input.clone(),
+    )
+    .await;
+    approve_dispatch_for_services(&services, &scope, gate.approval_request_id, None).await;
+    let resumed = runtime
+        .resume_capability(RuntimeCapabilityResumeRequest::new(
+            context,
+            gate.approval_request_id,
+            script_capability_id(),
+            ResourceEstimate::default(),
+            input.clone(),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        matches!(resumed, RuntimeCapabilityOutcome::Completed(completed) if completed.output == input)
+    );
+
+    let projection = ReplayAuditProjectionService::new(Arc::clone(&audit_log));
+    let snapshot = projection
+        .snapshot(AuditProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&scope),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.entries.len(), 1);
+    let entry = &snapshot.entries[0];
+    assert_eq!(entry.stage, AuditProjectionStage::ApprovalResolved);
+    assert_eq!(entry.invocation_id, scope.invocation_id);
+    assert_eq!(entry.thread_id, scope.thread_id);
+    assert_eq!(entry.approval_request_id, Some(gate.approval_request_id));
+    assert_eq!(entry.action_kind, "dispatch");
+    assert_eq!(
+        entry.action_target.as_deref(),
+        Some(script_capability_id().as_str())
+    );
+    assert_eq!(entry.decision_kind, "approved");
+
+    let serialized = serde_json::to_string(&snapshot).unwrap();
+    for forbidden in [
+        "APPROVAL_REASON_SENTINEL_3022",
+        "APPROVAL_RAW_INPUT_SENTINEL_3022",
+        "/tmp/private-approval-path",
+        "APPROVAL_SECRET_SENTINEL_3022",
+        "APPROVAL_OUTPUT_SENTINEL_3022",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "approval audit projection leaked {forbidden}: {serialized}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn host_runtime_services_jsonl_approval_audit_projection_rejects_foreign_cursor_without_leaks()
+ {
+    let temp = tempfile::tempdir().unwrap();
+    let store_root = temp.path().join("reborn-event-store");
+    let stores = build_reborn_event_stores(
+        RebornProfile::LocalDev,
+        RebornEventStoreConfig::Jsonl {
+            root: store_root.clone(),
+            accept_single_node_durable: false,
+        },
+    )
+    .await
+    .unwrap();
+    let audit_log = Arc::clone(&stores.audit);
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let approval_requests = Arc::new(InMemoryApprovalRequestStore::new());
+    let capability_leases = Arc::new(InMemoryCapabilityLeaseStore::new());
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(SentinelApprovalAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
+    .with_run_state(Arc::clone(&run_state))
+    .with_approval_requests(Arc::clone(&approval_requests))
+    .with_capability_leases(Arc::clone(&capability_leases))
+    .with_audit_sink(Arc::new(ironclaw_events::DurableAuditSink::new(
+        Arc::clone(&audit_log),
+    )))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )));
+    let runtime = services.host_runtime();
+    let scope_a = sample_scope(InvocationId::new());
+    let scope_b = ResourceScope {
+        thread_id: Some(ThreadId::new("approval-thread-b").unwrap()),
+        invocation_id: InvocationId::new(),
+        ..scope_a.clone()
+    };
+    let context = execution_context_without_grants_for_scope(scope_a.clone());
+    let input = json!({"message": "JSONL_APPROVAL_INPUT_SENTINEL_3022"});
+
+    let gate = block_for_approval(
+        &runtime,
+        context.clone(),
+        ResourceEstimate::default(),
+        input.clone(),
+    )
+    .await;
+    approve_dispatch_for_services(&services, &scope_a, gate.approval_request_id, None).await;
+
+    let projection = ReplayAuditProjectionService::from_audit_log(Arc::clone(&audit_log));
+    let scope_a_projection = ProjectionScope::from_resource_scope(&scope_a);
+    let scope_b_projection = ProjectionScope::from_resource_scope(&scope_b);
+    let snapshot_a = projection
+        .snapshot(AuditProjectionRequest {
+            scope: scope_a_projection,
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert_eq!(snapshot_a.entries.len(), 1);
+    let snapshot_b = projection
+        .snapshot(AuditProjectionRequest {
+            scope: scope_b_projection.clone(),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert!(snapshot_b.entries.is_empty());
+
+    let foreign_cursor = projection
+        .updates(AuditProjectionRequest {
+            scope: scope_b_projection,
+            after: Some(snapshot_a.next_cursor.clone()),
+            limit: 10,
+        })
+        .await
+        .expect_err("foreign audit projection cursor must force rebase");
+    assert!(matches!(
+        foreign_cursor,
+        AuditProjectionError::RebaseRequired { .. }
+    ));
+
+    let projection_json = serde_json::to_string(&snapshot_a).unwrap();
+    let jsonl_bytes = read_directory_text(&store_root);
+    for forbidden in [
+        "APPROVAL_REASON_SENTINEL_3022",
+        "JSONL_APPROVAL_INPUT_SENTINEL_3022",
+    ] {
+        assert!(
+            !projection_json.contains(forbidden),
+            "JSONL approval audit projection leaked {forbidden}: {projection_json}"
+        );
+        assert!(
+            !jsonl_bytes.contains(forbidden),
+            "JSONL durable audit bytes leaked {forbidden}: {jsonl_bytes}"
         );
     }
 }
@@ -2963,6 +3172,41 @@ async fn approve_dispatch_for_services(
         )
         .await
         .unwrap()
+}
+
+struct SentinelApprovalAuthorizer;
+
+#[async_trait]
+impl TrustAwareCapabilityDispatchAuthorizer for SentinelApprovalAuthorizer {
+    async fn authorize_dispatch_with_trust(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+        trust_decision: &TrustDecision,
+    ) -> Decision {
+        if context.grants.grants.is_empty() {
+            Decision::RequireApproval {
+                request: ApprovalRequest {
+                    id: ApprovalRequestId::new(),
+                    correlation_id: context.correlation_id,
+                    requested_by: Principal::Extension(context.extension_id.clone()),
+                    action: Box::new(Action::Dispatch {
+                        capability: descriptor.id.clone(),
+                        estimated_resources: estimate.clone(),
+                    }),
+                    invocation_fingerprint: None,
+                    reason: "APPROVAL_REASON_SENTINEL_3022 /tmp/private-approval-reason"
+                        .to_string(),
+                    reusable_scope: None,
+                },
+            }
+        } else {
+            GrantAuthorizer::new()
+                .authorize_dispatch_with_trust(context, descriptor, estimate, trust_decision)
+                .await
+        }
+    }
 }
 
 struct ApprovalThenGrantAuthorizer;


### PR DESCRIPTION
## Summary

- add `ReplayAuditProjectionService` as the transport-agnostic audit replay/read-model facade
- add caller-level approval audit E2E coverage through `HostRuntimeServices -> ApprovalResolver -> DurableAuditLog -> ReplayAuditProjectionService`
- cover metadata-only projection, JSONL durable audit bytes, foreign cursor rebase behavior, and sentinel no-exposure checks

Refs #3022

## Verification

- `cargo fmt --check`
- `cargo test -p ironclaw_event_projections`
- `cargo test -p ironclaw_host_runtime --test host_runtime_services_contract host_runtime_services_`
- `cargo clippy -p ironclaw_event_projections --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_host_runtime --test host_runtime_services_contract -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`

## Notes

This is the approval/audit follow-up slice after #3337. It still does not close #3022; turn/model/transcript/memory/extension/resource/network/secrets producer coverage remains for later slices as their Reborn producers/read facades land.
