### PR TITLE
test(reborn): add process projection e2e slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4271,9 +4271,11 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
+ "ironclaw_event_projections",
  "ironclaw_events",
  "ironclaw_filesystem",
  "ironclaw_host_api",
+ "ironclaw_reborn_event_store",
  "ironclaw_resources",
  "serde",
  "serde_json",

--- a/crates/ironclaw_processes/Cargo.toml
+++ b/crates/ironclaw_processes/Cargo.toml
@@ -17,5 +17,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 
 [dev-dependencies]
+ironclaw_event_projections = { path = "../ironclaw_event_projections" }
+ironclaw_reborn_event_store = { path = "../ironclaw_reborn_event_store" }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "time"] }

--- a/crates/ironclaw_processes/src/filesystem_store.rs
+++ b/crates/ironclaw_processes/src/filesystem_store.rs
@@ -14,6 +14,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use ironclaw_events::sanitize_error_kind;
 use ironclaw_filesystem::{FilesystemError, RootFilesystem};
 use ironclaw_host_api::{ProcessId, ResourceScope, VirtualPath};
 use serde::{Deserialize, Serialize};
@@ -163,8 +164,13 @@ where
         process_id: ProcessId,
         error_kind: String,
     ) -> Result<ProcessRecord, ProcessError> {
-        self.update_status(scope, process_id, ProcessStatus::Failed, Some(error_kind))
-            .await
+        self.update_status(
+            scope,
+            process_id,
+            ProcessStatus::Failed,
+            Some(sanitize_error_kind(error_kind)),
+        )
+        .await
     }
 
     async fn kill(
@@ -329,7 +335,7 @@ where
             ProcessStatus::Failed,
             None,
             None,
-            Some(error_kind),
+            Some(sanitize_error_kind(error_kind)),
         )
         .await
     }

--- a/crates/ironclaw_processes/src/memory_store.rs
+++ b/crates/ironclaw_processes/src/memory_store.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use ironclaw_events::sanitize_error_kind;
 use ironclaw_host_api::{ProcessId, ResourceScope};
 use serde_json::Value;
 
@@ -96,7 +97,12 @@ impl ProcessStore for InMemoryProcessStore {
         process_id: ProcessId,
         error_kind: String,
     ) -> Result<ProcessRecord, ProcessError> {
-        self.update_status(scope, process_id, ProcessStatus::Failed, Some(error_kind))
+        self.update_status(
+            scope,
+            process_id,
+            ProcessStatus::Failed,
+            Some(sanitize_error_kind(error_kind)),
+        )
     }
 
     async fn kill(
@@ -199,7 +205,7 @@ impl ProcessResultStore for InMemoryProcessResultStore {
             process_id,
             ProcessStatus::Failed,
             None,
-            Some(error_kind),
+            Some(sanitize_error_kind(error_kind)),
         ))
     }
 

--- a/crates/ironclaw_processes/src/services.rs
+++ b/crates/ironclaw_processes/src/services.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::FutureExt;
+use ironclaw_events::sanitize_error_kind;
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{ProcessId, ResourceReservation, ResourceScope};
 
@@ -315,7 +316,7 @@ impl ProcessManager for BackgroundProcessManager {
                         }
                     }
                     Ok(Err(error)) => {
-                        let error_kind = error.kind;
+                        let error_kind = sanitize_error_kind(error.kind);
                         let result_persisted = if let Some(result_store) = &result_store {
                             match result_store
                                 .fail(&scope, process_id, error_kind.clone())

--- a/crates/ironclaw_processes/tests/process_dispatch_integration.rs
+++ b/crates/ironclaw_processes/tests/process_dispatch_integration.rs
@@ -7,9 +7,19 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_events::{EventSink, InMemoryEventSink, RuntimeEventKind};
+use ironclaw_event_projections::{
+    EventProjectionService, ProjectionRequest, ProjectionScope, ReplayEventProjectionService,
+    RunProjectionStatus, TimelineEntryKind,
+};
+use ironclaw_events::{
+    DurableEventLog, DurableEventSink, EventSink, EventStreamKey, InMemoryDurableEventLog,
+    InMemoryEventSink, ReadScope, RuntimeEventKind,
+};
 use ironclaw_host_api::*;
 use ironclaw_processes::*;
+use ironclaw_reborn_event_store::{
+    RebornEventStoreConfig, RebornProfile, build_reborn_event_stores,
+};
 use serde_json::json;
 use tokio::{sync::Notify, time::timeout};
 
@@ -68,6 +78,187 @@ async fn process_services_complete_background_process_through_process_host_and_e
         Some(ExtensionId::new("echo").unwrap())
     );
     assert_eq!(recorded[1].runtime, Some(RuntimeKind::Wasm));
+}
+
+#[tokio::test]
+async fn process_services_completed_lifecycle_projects_from_jsonl_durable_log_metadata_only() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_root = temp.path().join("reborn-event-store");
+    let stores = build_reborn_event_stores(
+        RebornProfile::LocalDev,
+        RebornEventStoreConfig::Jsonl {
+            root: store_root.clone(),
+            accept_single_node_durable: false,
+        },
+    )
+    .await
+    .unwrap();
+    let event_log = Arc::clone(&stores.events);
+    let event_sink: Arc<dyn EventSink> = Arc::new(DurableEventSink::new(Arc::clone(&event_log)));
+    let process_store = Arc::new(EventingProcessStore::new(
+        InMemoryProcessStore::new(),
+        event_sink,
+    ));
+    let result_store = Arc::new(InMemoryProcessResultStore::new());
+    let services = ProcessServices::new(Arc::clone(&process_store), Arc::clone(&result_store));
+    let manager = services.background_manager(Arc::new(SentinelSuccessExecutor));
+    let host = services.host().with_poll_interval(Duration::from_millis(5));
+    let invocation_id = InvocationId::new();
+    let process_id = ProcessId::new();
+    let scope = sample_scope(invocation_id, "tenant-a", "user-a");
+    let start = process_start_with_input(
+        process_id,
+        invocation_id,
+        scope.clone(),
+        json!({
+            "message": "PROCESS_INPUT_SENTINEL_3022 /tmp/private-process-path",
+            "secret": "PROCESS_SECRET_SENTINEL_3022_sk_live_secret",
+        }),
+    );
+
+    let started = manager.spawn(start).await.unwrap();
+    assert_eq!(started.status, ProcessStatus::Running);
+    let result = host.await_result(&scope, process_id).await.unwrap();
+    assert_eq!(result.status, ProcessStatus::Completed);
+    assert_eq!(
+        result.output,
+        Some(json!({"ok": true, "raw": "PROCESS_OUTPUT_SENTINEL_3022"}))
+    );
+
+    let projection = ReplayEventProjectionService::from_runtime_log(Arc::clone(&event_log));
+    let snapshot = projection
+        .snapshot(ProjectionRequest {
+            scope: ProjectionScope::for_process(&scope, process_id),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        snapshot
+            .timeline
+            .entries
+            .iter()
+            .map(|entry| entry.kind)
+            .collect::<Vec<_>>(),
+        vec![
+            TimelineEntryKind::ProcessStarted,
+            TimelineEntryKind::ProcessCompleted,
+        ]
+    );
+    assert!(snapshot.timeline.entries.iter().all(|entry| {
+        entry.process_id == Some(process_id) && entry.invocation_id == invocation_id
+    }));
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.runs[0].status, RunProjectionStatus::Completed);
+    assert_eq!(snapshot.runs[0].process_id, Some(process_id));
+
+    let projection_json = serde_json::to_string(&snapshot).unwrap();
+    let jsonl_bytes = read_directory_text(&store_root);
+    for forbidden in [
+        "PROCESS_INPUT_SENTINEL_3022",
+        "/tmp/private-process-path",
+        "PROCESS_SECRET_SENTINEL_3022",
+        "PROCESS_OUTPUT_SENTINEL_3022",
+    ] {
+        assert!(
+            !projection_json.contains(forbidden),
+            "process projection leaked {forbidden}: {projection_json}"
+        );
+        assert!(
+            !jsonl_bytes.contains(forbidden),
+            "durable process event bytes leaked {forbidden}: {jsonl_bytes}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn process_services_failed_lifecycle_projection_sanitizes_error_and_filters_process_scope() {
+    let event_log: Arc<dyn DurableEventLog> = Arc::new(InMemoryDurableEventLog::new());
+    let event_sink: Arc<dyn EventSink> = Arc::new(DurableEventSink::new(Arc::clone(&event_log)));
+    let process_store = Arc::new(EventingProcessStore::new(
+        InMemoryProcessStore::new(),
+        event_sink,
+    ));
+    let result_store = Arc::new(InMemoryProcessResultStore::new());
+    let services = ProcessServices::new(Arc::clone(&process_store), Arc::clone(&result_store));
+    let manager = services.background_manager(Arc::new(SentinelFailureExecutor));
+    let host = services.host().with_poll_interval(Duration::from_millis(5));
+    let invocation_id = InvocationId::new();
+    let process_id = ProcessId::new();
+    let sibling_process_id = ProcessId::new();
+    let scope = sample_scope(invocation_id, "tenant-a", "user-a");
+
+    manager
+        .spawn(process_start(process_id, invocation_id, scope.clone()))
+        .await
+        .unwrap();
+    let result = host.await_result(&scope, process_id).await.unwrap();
+    assert_eq!(result.status, ProcessStatus::Failed);
+    assert_eq!(result.error_kind.as_deref(), Some("Unclassified"));
+
+    let projection = ReplayEventProjectionService::from_runtime_log(Arc::clone(&event_log));
+    let visible = projection
+        .snapshot(ProjectionRequest {
+            scope: ProjectionScope::for_process(&scope, process_id),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        visible
+            .timeline
+            .entries
+            .iter()
+            .map(|entry| entry.kind)
+            .collect::<Vec<_>>(),
+        vec![
+            TimelineEntryKind::ProcessStarted,
+            TimelineEntryKind::ProcessFailed,
+        ]
+    );
+    assert_eq!(visible.runs.len(), 1);
+    assert_eq!(visible.runs[0].status, RunProjectionStatus::Failed);
+    assert_eq!(visible.runs[0].error_kind.as_deref(), Some("Unclassified"));
+    let serialized = serde_json::to_string(&visible).unwrap();
+    for forbidden in [
+        "PROCESS_ERROR_SENTINEL_3022",
+        "/tmp/private-process-error",
+        "sk_live_secret",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "failed process projection leaked {forbidden}: {serialized}"
+        );
+    }
+
+    let sibling = projection
+        .snapshot(ProjectionRequest {
+            scope: ProjectionScope::for_process(&scope, sibling_process_id),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert!(sibling.timeline.entries.is_empty());
+    assert!(sibling.runs.is_empty());
+    let raw_sibling_replay = event_log
+        .read_after_cursor(
+            &EventStreamKey::from_scope(&scope),
+            &ReadScope {
+                project_id: scope.project_id.clone(),
+                mission_id: scope.mission_id.clone(),
+                thread_id: scope.thread_id.clone(),
+                process_id: Some(sibling_process_id),
+            },
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+    assert!(raw_sibling_replay.entries.is_empty());
 }
 
 #[tokio::test]
@@ -139,6 +330,41 @@ async fn process_host_kill_preserves_terminal_state_and_suppresses_late_completi
         !kinds.contains(&RuntimeEventKind::ProcessCompleted),
         "late executor success must not emit a misleading completion event"
     );
+}
+
+struct SentinelSuccessExecutor;
+
+#[async_trait]
+impl ProcessExecutor for SentinelSuccessExecutor {
+    async fn execute(
+        &self,
+        request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        assert_eq!(
+            request.input,
+            json!({
+                "message": "PROCESS_INPUT_SENTINEL_3022 /tmp/private-process-path",
+                "secret": "PROCESS_SECRET_SENTINEL_3022_sk_live_secret",
+            })
+        );
+        Ok(ProcessExecutionResult {
+            output: json!({"ok": true, "raw": "PROCESS_OUTPUT_SENTINEL_3022"}),
+        })
+    }
+}
+
+struct SentinelFailureExecutor;
+
+#[async_trait]
+impl ProcessExecutor for SentinelFailureExecutor {
+    async fn execute(
+        &self,
+        _request: ProcessExecutionRequest,
+    ) -> Result<ProcessExecutionResult, ProcessExecutionError> {
+        Err(ProcessExecutionError::new(
+            "PROCESS_ERROR_SENTINEL_3022 /tmp/private-process-error sk_live_secret",
+        ))
+    }
 }
 
 struct SuccessExecutor;
@@ -292,6 +518,20 @@ fn process_start(
     invocation_id: InvocationId,
     scope: ResourceScope,
 ) -> ProcessStart {
+    process_start_with_input(
+        process_id,
+        invocation_id,
+        scope,
+        json!({"message": "runtime payload"}),
+    )
+}
+
+fn process_start_with_input(
+    process_id: ProcessId,
+    invocation_id: InvocationId,
+    scope: ResourceScope,
+    input: serde_json::Value,
+) -> ProcessStart {
     ProcessStart {
         process_id,
         parent_process_id: None,
@@ -304,8 +544,29 @@ fn process_start(
         mounts: MountView::default(),
         estimated_resources: ResourceEstimate::default(),
         resource_reservation_id: None,
-        input: json!({"message": "runtime payload"}),
+        input,
     }
+}
+
+fn read_directory_text(root: &std::path::Path) -> String {
+    let mut output = String::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let entries = std::fs::read_dir(&path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        for entry in entries {
+            let entry = entry.unwrap_or_else(|err| panic!("failed to read dir entry: {err}"));
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                output.push_str(&std::fs::read_to_string(&path).unwrap_or_else(|err| {
+                    panic!("failed to read {} as utf-8 text: {err}", path.display())
+                }));
+            }
+        }
+    }
+    output
 }
 
 fn sample_scope(invocation_id: InvocationId, tenant: &str, user: &str) -> ResourceScope {

--- a/crates/ironclaw_processes/tests/process_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_store_contract.rs
@@ -235,6 +235,42 @@ async fn background_process_manager_stores_success_output_result() {
 }
 
 #[tokio::test]
+async fn process_stores_sanitize_failure_error_kind_before_persistence() {
+    let scope = sample_scope(InvocationId::new(), "tenant1", "user1");
+    let process_id = ProcessId::new();
+    let lifecycle_store = InMemoryProcessStore::new();
+    lifecycle_store
+        .start(process_start(
+            process_id,
+            scope.invocation_id,
+            scope.clone(),
+        ))
+        .await
+        .unwrap();
+
+    let failed = lifecycle_store
+        .fail(
+            &scope,
+            process_id,
+            "RAW_PROCESS_ERROR_SENTINEL_3022 /tmp/private-process sk_live".to_string(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(failed.error_kind.as_deref(), Some("Unclassified"));
+
+    let result_store = InMemoryProcessResultStore::new();
+    let result = result_store
+        .fail(
+            &scope,
+            process_id,
+            "RAW_PROCESS_RESULT_SENTINEL_3022 /tmp/private-result sk_live".to_string(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.error_kind.as_deref(), Some("Unclassified"));
+}
+
+#[tokio::test]
 async fn background_process_manager_stores_failure_error_result() {
     let store = Arc::new(InMemoryProcessStore::new());
     let result_store = Arc::new(InMemoryProcessResultStore::new());


### PR DESCRIPTION
## Summary

- add caller-level process lifecycle projection E2E coverage through `ProcessServices -> BackgroundProcessManager/ProcessHost -> EventingProcessStore -> DurableEventLog -> ReplayEventProjectionService`
- verify completed process lifecycle projection via JSONL durable event store with raw byte no-exposure checks
- verify failed process lifecycle projection sanitizes error kind and process-scope filtering hides sibling processes
- sanitize process failure `error_kind` at manager/store boundaries before process result/lifecycle persistence

Refs #3022

## Verification

- `cargo fmt --check`
- `cargo test -p ironclaw_processes --test process_dispatch_integration`
- `cargo test -p ironclaw_processes --test process_store_contract`
- `cargo clippy -p ironclaw_processes --test process_dispatch_integration --test process_store_contract -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`

## Review

- paranoid review found a High no-exposure issue in the first draft: raw process execution error kind was visible through `ProcessHost::await_result()`
- fixed by sanitizing `ProcessExecutionError.kind` before result/lifecycle persistence and by sanitizing `fail(error_kind)` in both process stores
- re-review found no Critical/High/Medium findings

## Notes

This is the process lifecycle follow-up slice after #3337/#3339. It still does not close #3022; turn/model/transcript/memory/extension/resource/network/secrets producer coverage remains for later slices as their Reborn producers/read facades land.
