### PR TITLE
test(reborn): project process lifecycle events

### DIFF
--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -12,7 +12,7 @@ use ironclaw_capabilities::{
     CapabilityObligationError, CapabilityObligationFailureKind, CapabilityObligationHandler,
     CapabilityObligationOutcome, CapabilityObligationPhase, CapabilityObligationRequest,
 };
-use ironclaw_events::AuditSink;
+use ironclaw_events::{AuditSink, EventSink, RuntimeEvent};
 use ironclaw_host_api::{
     ActionResultSummary, ActionSummary, AuditEnvelope, AuditEventId, AuditStage,
     CapabilityDispatchResult, CapabilityId, DecisionSummary, EffectKind, MountView, NetworkPolicy,
@@ -452,6 +452,7 @@ pub struct ProcessObligationLifecycleStore {
     network_policies: Arc<NetworkObligationPolicyStore>,
     secret_injections: Arc<RuntimeSecretInjectionStore>,
     resource_governor: Arc<dyn ResourceGovernor>,
+    event_sink: Mutex<Option<Arc<dyn EventSink>>>,
     active_process_handoffs: Mutex<HashMap<ProcessObligationHandoffKey, ProcessId>>,
     cleaned_process_handoffs: Mutex<HashSet<ProcessObligationProcessKey>>,
 }
@@ -486,8 +487,40 @@ impl ProcessObligationLifecycleStore {
             network_policies,
             secret_injections,
             resource_governor,
+            event_sink: Mutex::new(None),
             active_process_handoffs: Mutex::new(HashMap::new()),
             cleaned_process_handoffs: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// Attaches a best-effort event sink for process lifecycle transitions.
+    pub fn set_event_sink(&self, event_sink: Arc<dyn EventSink>) {
+        match self.event_sink.lock() {
+            Ok(mut slot) => {
+                *slot = Some(event_sink);
+            }
+            Err(error) => {
+                tracing::debug!(
+                    error = %error,
+                    "process lifecycle event sink registry unavailable"
+                );
+            }
+        }
+    }
+
+    async fn emit_process_event(&self, event: RuntimeEvent) {
+        let event_sink = match self.event_sink.lock() {
+            Ok(slot) => slot.clone(),
+            Err(error) => {
+                tracing::debug!(
+                    error = %error,
+                    "process lifecycle event sink registry unavailable"
+                );
+                None
+            }
+        };
+        if let Some(event_sink) = event_sink {
+            let _ = event_sink.emit(event).await;
         }
     }
 
@@ -731,7 +764,17 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         let scope = start.scope.clone();
         let capability_id = start.capability_id.clone();
         match self.inner.start(start).await {
-            Ok(record) => Ok(record),
+            Ok(record) => {
+                self.emit_process_event(RuntimeEvent::process_started(
+                    record.scope.clone(),
+                    record.capability_id.clone(),
+                    record.extension_id.clone(),
+                    record.runtime,
+                    record.process_id,
+                ))
+                .await;
+                Ok(record)
+            }
             Err(error) => {
                 if claimed {
                     self.release_claimed_process_handoff(&scope, &capability_id, process_id)?;
@@ -747,6 +790,14 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         process_id: ProcessId,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.complete(scope, process_id).await?;
+        self.emit_process_event(RuntimeEvent::process_completed(
+            record.scope.clone(),
+            record.capability_id.clone(),
+            record.extension_id.clone(),
+            record.runtime,
+            record.process_id,
+        ))
+        .await;
         self.cleanup_terminal(&record, true)?;
         Ok(record)
     }
@@ -758,6 +809,18 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         error_kind: String,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.fail(scope, process_id, error_kind).await?;
+        self.emit_process_event(RuntimeEvent::process_failed(
+            record.scope.clone(),
+            record.capability_id.clone(),
+            record.extension_id.clone(),
+            record.runtime,
+            record.process_id,
+            record
+                .error_kind
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
+        ))
+        .await;
         self.cleanup_terminal(&record, false)?;
         Ok(record)
     }
@@ -768,6 +831,14 @@ impl ProcessStore for ProcessObligationLifecycleStore {
         process_id: ProcessId,
     ) -> Result<ProcessRecord, ProcessError> {
         let record = self.inner.kill(scope, process_id).await?;
+        self.emit_process_event(RuntimeEvent::process_killed(
+            record.scope.clone(),
+            record.capability_id.clone(),
+            record.extension_id.clone(),
+            record.runtime,
+            record.process_id,
+        ))
+        .await;
         self.cleanup_terminal(&record, false)?;
         Ok(record)
     }

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -388,6 +388,9 @@ where
         T: EventSink + 'static,
     {
         self.component_types.event_sink = Some(type_name::<T>());
+        let event_sink: Arc<dyn EventSink> = event_sink;
+        self.process_lifecycle_store
+            .set_event_sink(Arc::clone(&event_sink));
         self.event_sink = Some(event_sink);
         self
     }
@@ -398,7 +401,10 @@ where
     {
         self.component_types.event_sink = Some(type_name::<T>());
         let event_log: Arc<dyn DurableEventLog> = event_log;
-        self.event_sink = Some(Arc::new(DurableEventSink::new(event_log)));
+        let event_sink: Arc<dyn EventSink> = Arc::new(DurableEventSink::new(event_log));
+        self.process_lifecycle_store
+            .set_event_sink(Arc::clone(&event_sink));
+        self.event_sink = Some(event_sink);
         self
     }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -37,8 +37,8 @@ use ironclaw_network::{
 use ironclaw_processes::{
     BackgroundFailureStage, BackgroundProcessManager, InMemoryProcessResultStore,
     InMemoryProcessStore, ProcessError, ProcessExecutionRequest, ProcessExecutionResult,
-    ProcessExecutor, ProcessHost, ProcessResultRecord, ProcessResultStore, ProcessServices,
-    ProcessStart, ProcessStatus, ProcessStore,
+    ProcessExecutor, ProcessHost, ProcessManager, ProcessResultRecord, ProcessResultStore,
+    ProcessServices, ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_reborn_event_store::{
     RebornEventStoreConfig, RebornProfile, build_reborn_event_stores,
@@ -1315,6 +1315,215 @@ async fn host_runtime_services_jsonl_approval_audit_projection_rejects_foreign_c
         assert!(
             !jsonl_bytes.contains(forbidden),
             "JSONL durable audit bytes leaked {forbidden}: {jsonl_bytes}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn process_lifecycle_projects_through_durable_replay_without_output_leaks() {
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    let inner_process_store = Arc::new(InMemoryProcessStore::new());
+    let process_store = Arc::new(ProcessObligationLifecycleStore::new(
+        inner_process_store,
+        Arc::new(NetworkObligationPolicyStore::new()),
+        Arc::new(RuntimeSecretInjectionStore::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+    ));
+    let durable_event_log: Arc<dyn DurableEventLog> = event_log.clone();
+    process_store.set_event_sink(Arc::new(DurableEventSink::new(durable_event_log)));
+    let result_store = Arc::new(InMemoryProcessResultStore::new());
+    let manager = BackgroundProcessManager::new(
+        Arc::clone(&process_store),
+        Arc::new(BackgroundExecutor::success_with_output(json!({
+            "result": "PROCESS_OUTPUT_SENTINEL_3022 /tmp/process-output-private"
+        }))),
+    )
+    .with_result_store(Arc::clone(&result_store));
+    let process_id = ProcessId::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id);
+
+    let process = manager
+        .spawn(process_start(process_id, invocation_id, scope.clone()))
+        .await
+        .unwrap();
+    wait_for_status(
+        process_store.as_ref(),
+        &scope,
+        process.process_id,
+        ProcessStatus::Completed,
+    )
+    .await;
+
+    let host =
+        ProcessHost::new(process_store.as_ref()).with_result_store(Arc::clone(&result_store));
+    let output = host
+        .output(&scope, process.process_id)
+        .await
+        .unwrap()
+        .expect("process output should be available through ProcessHost");
+    assert_eq!(
+        output,
+        json!({"result": "PROCESS_OUTPUT_SENTINEL_3022 /tmp/process-output-private"})
+    );
+
+    let projection = ReplayEventProjectionService::new(Arc::clone(&event_log));
+    let snapshot = projection
+        .snapshot(ProjectionRequest {
+            scope: ProjectionScope::for_process(&scope, process.process_id),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        snapshot
+            .timeline
+            .entries
+            .iter()
+            .map(|entry| entry.kind)
+            .collect::<Vec<_>>(),
+        vec![
+            TimelineEntryKind::ProcessStarted,
+            TimelineEntryKind::ProcessCompleted,
+        ]
+    );
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.runs[0].status, RunProjectionStatus::Completed);
+    assert_eq!(snapshot.runs[0].process_id, Some(process.process_id));
+
+    let foreign_scope = ResourceScope {
+        project_id: Some(ProjectId::new("foreign-project").unwrap()),
+        ..scope.clone()
+    };
+    let foreign_snapshot = projection
+        .snapshot(ProjectionRequest {
+            scope: ProjectionScope::for_process(&foreign_scope, process.process_id),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert!(foreign_snapshot.timeline.entries.is_empty());
+
+    let projection_json = serde_json::to_string(&snapshot).unwrap();
+    let replay_json = serde_json::to_string(
+        &event_log
+            .read_after_cursor(
+                &EventStreamKey::from_scope(&scope),
+                &ReadScope::any(),
+                None,
+                10,
+            )
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    for forbidden in [
+        "PROCESS_OUTPUT_SENTINEL_3022",
+        "/tmp/process-output-private",
+    ] {
+        assert!(
+            !projection_json.contains(forbidden),
+            "process projection leaked {forbidden}: {projection_json}"
+        );
+        assert!(
+            !replay_json.contains(forbidden),
+            "process durable replay leaked {forbidden}: {replay_json}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn host_runtime_services_cancel_projects_kill_event_from_configured_event_sink() {
+    let event_log = Arc::new(InMemoryDurableEventLog::new());
+    let process_services = ProcessServices::new(
+        Arc::new(InMemoryProcessStore::new()),
+        Arc::new(InMemoryProcessResultStore::new()),
+    );
+    let process_store = process_services.process_store();
+    let result_store = process_services.result_store();
+    let runtime = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        process_services,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_durable_event_log(Arc::clone(&event_log))
+    .host_runtime_for_local_testing();
+    let process_id = ProcessId::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id);
+    let mut start = process_start(process_id, invocation_id, scope.clone());
+    start.input = json!({
+        "message": "KILL_PROCESS_INPUT_SENTINEL_3022 /tmp/process-kill-private"
+    });
+    process_store.start(start).await.unwrap();
+
+    let outcome = runtime
+        .cancel_work(CancelRuntimeWorkRequest::new(
+            scope.clone(),
+            CorrelationId::new(),
+            CancelReason::UserRequested,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(outcome.cancelled, vec![RuntimeWorkId::Process(process_id)]);
+    assert_eq!(
+        result_store
+            .get(&scope, process_id)
+            .await
+            .unwrap()
+            .expect("cancel should persist killed process result")
+            .status,
+        ProcessStatus::Killed
+    );
+
+    let projection = ReplayEventProjectionService::new(Arc::clone(&event_log));
+    let snapshot = projection
+        .snapshot(ProjectionRequest {
+            scope: ProjectionScope::for_process(&scope, process_id),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.timeline.entries.len(), 1);
+    assert_eq!(
+        snapshot.timeline.entries[0].kind,
+        TimelineEntryKind::ProcessKilled
+    );
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.runs[0].status, RunProjectionStatus::Killed);
+
+    let projection_json = serde_json::to_string(&snapshot).unwrap();
+    let replay_json = serde_json::to_string(
+        &event_log
+            .read_after_cursor(
+                &EventStreamKey::from_scope(&scope),
+                &ReadScope::any(),
+                None,
+                10,
+            )
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    for forbidden in [
+        "KILL_PROCESS_INPUT_SENTINEL_3022",
+        "/tmp/process-kill-private",
+    ] {
+        assert!(
+            !projection_json.contains(forbidden),
+            "kill projection leaked {forbidden}: {projection_json}"
+        );
+        assert!(
+            !replay_json.contains(forbidden),
+            "kill durable replay leaked {forbidden}: {replay_json}"
         );
     }
 }
@@ -4183,7 +4392,13 @@ struct BackgroundExecutor {
 impl BackgroundExecutor {
     fn success() -> Self {
         Self {
-            outcome: BackgroundExecutorOutcome::Success,
+            outcome: BackgroundExecutorOutcome::Success(json!({"ok": true})),
+        }
+    }
+
+    fn success_with_output(output: serde_json::Value) -> Self {
+        Self {
+            outcome: BackgroundExecutorOutcome::Success(output),
         }
     }
 
@@ -4201,7 +4416,7 @@ impl BackgroundExecutor {
 }
 
 enum BackgroundExecutorOutcome {
-    Success,
+    Success(serde_json::Value),
     Failure(String),
     DelayedSuccess(Duration),
 }
@@ -4213,8 +4428,8 @@ impl ProcessExecutor for BackgroundExecutor {
         _request: ProcessExecutionRequest,
     ) -> Result<ProcessExecutionResult, ironclaw_processes::ProcessExecutionError> {
         match &self.outcome {
-            BackgroundExecutorOutcome::Success => Ok(ProcessExecutionResult {
-                output: json!({"ok": true}),
+            BackgroundExecutorOutcome::Success(output) => Ok(ProcessExecutionResult {
+                output: output.clone(),
             }),
             BackgroundExecutorOutcome::Failure(kind) => {
                 Err(ironclaw_processes::ProcessExecutionError::new(kind.clone()))


### PR DESCRIPTION
## Summary

Adds the next Reborn event-substrate slice for #3022 / #3067: process lifecycle events now flow through the HostRuntime process lifecycle wrapper into the configured durable event sink.

- `ProcessObligationLifecycleStore` can attach a best-effort event sink.
- Start/complete/fail/kill lifecycle transitions emit metadata-only `RuntimeEvent`s without changing domain outcomes when observability delivery fails.
- `HostRuntimeServices::with_event_sink` now wires the same sink into both runtime dispatch and process lifecycle paths.
- Caller-level tests cover:
  - background process start -> complete projected through durable replay with raw output/path sentinels absent;
  - `HostRuntimeServices -> DefaultHostRuntime::cancel_work` kill transition projected through durable replay with raw input/path sentinels absent;
  - foreign project process projection remains empty.

Refs #3022. Updates #3067.

## TDD evidence

Initial targeted RED failed before implementation because `ProcessObligationLifecycleStore::set_event_sink` and the process-output test helper did not exist.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check HEAD`
- [x] `CARGO_TARGET_DIR=/tmp/ironclaw-issue-3022-process-events-target cargo test -p ironclaw_host_runtime --test host_runtime_services_contract process_lifecycle_projects_through_durable_replay_without_output_leaks`
- [x] `CARGO_TARGET_DIR=/tmp/ironclaw-issue-3022-process-events-target cargo test -p ironclaw_host_runtime --test host_runtime_services_contract host_runtime_services_cancel_projects_kill_event_from_configured_event_sink`
- [x] `CARGO_TARGET_DIR=/tmp/ironclaw-issue-3022-process-events-target cargo test -p ironclaw_host_runtime --tests --no-fail-fast`
- [x] `CARGO_TARGET_DIR=/tmp/ironclaw-issue-3022-process-events-target cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings`
- [x] `python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
