### PR TITLE
feat(turns): add multi-tenant admission reservations

### DIFF
--- a/crates/ironclaw_turns/src/admission.rs
+++ b/crates/ironclaw_turns/src/admission.rs
@@ -5,9 +5,19 @@ use serde::{Deserialize, Serialize};
 
 use crate::{TurnActor, TurnRunId, TurnScope};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct TurnAdmissionClass(String);
+
+impl<'de> Deserialize<'de> for TurnAdmissionClass {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
 
 impl TurnAdmissionClass {
     pub fn new(value: impl Into<String>) -> Result<Self, String> {

--- a/crates/ironclaw_turns/src/admission.rs
+++ b/crates/ironclaw_turns/src/admission.rs
@@ -1,0 +1,296 @@
+use std::collections::HashMap;
+
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, UserId};
+use serde::{Deserialize, Serialize};
+
+use crate::{TurnActor, TurnRunId, TurnScope};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TurnAdmissionClass(String);
+
+impl TurnAdmissionClass {
+    pub fn new(value: impl Into<String>) -> Result<Self, String> {
+        let value = value.into();
+        validate_admission_class(&value)?;
+        Ok(Self(value))
+    }
+
+    pub fn interactive() -> Self {
+        Self("interactive".to_string())
+    }
+
+    pub fn mission() -> Self {
+        Self("mission".to_string())
+    }
+
+    pub fn admin_system() -> Self {
+        Self("admin_system".to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn validate_admission_class(value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err("turn admission class must not be empty".to_string());
+    }
+    if value.len() > 128 {
+        return Err("turn admission class must be at most 128 bytes".to_string());
+    }
+    if value.chars().any(|c| c == '\0' || c.is_control()) {
+        return Err("turn admission class must not contain control characters".to_string());
+    }
+    if !value
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(
+            "turn admission class must contain only lowercase ASCII letters, digits, or _"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnAdmissionAxisKind {
+    Tenant,
+    ActorUser,
+    Project,
+    Agent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnAdmissionBucketKind {
+    Total,
+    Class,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum TurnAdmissionBucketScope {
+    Tenant {
+        tenant_id: TenantId,
+    },
+    ActorUser {
+        tenant_id: TenantId,
+        user_id: UserId,
+    },
+    Project {
+        tenant_id: TenantId,
+        project_id: Option<ProjectId>,
+    },
+    Agent {
+        tenant_id: TenantId,
+        agent_id: Option<AgentId>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TurnAdmissionBucket {
+    pub axis_kind: TurnAdmissionAxisKind,
+    pub bucket_kind: TurnAdmissionBucketKind,
+    pub admission_class: Option<TurnAdmissionClass>,
+    pub scope: TurnAdmissionBucketScope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TurnAdmissionLimitSelector {
+    axis_kind: TurnAdmissionAxisKind,
+    bucket_kind: TurnAdmissionBucketKind,
+    admission_class: Option<TurnAdmissionClass>,
+}
+
+impl TurnAdmissionLimitSelector {
+    fn from_bucket(bucket: &TurnAdmissionBucket) -> Self {
+        Self {
+            axis_kind: bucket.axis_kind,
+            bucket_kind: bucket.bucket_kind,
+            admission_class: bucket.admission_class.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnAdmissionLimit {
+    pub max_active: Option<u64>,
+    pub retry_after_ms: Option<u64>,
+}
+
+impl TurnAdmissionLimit {
+    pub fn unlimited() -> Self {
+        Self {
+            max_active: None,
+            retry_after_ms: None,
+        }
+    }
+
+    pub fn max_active(max_active: u64) -> Self {
+        Self {
+            max_active: Some(max_active),
+            retry_after_ms: None,
+        }
+    }
+
+    pub fn with_retry_after_ms(mut self, retry_after_ms: u64) -> Self {
+        self.retry_after_ms = Some(retry_after_ms);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnAdmissionLimitUnavailable;
+
+pub trait TurnAdmissionLimitProvider: Send + Sync {
+    fn limit_for(
+        &self,
+        bucket: &TurnAdmissionBucket,
+    ) -> Result<TurnAdmissionLimit, TurnAdmissionLimitUnavailable>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AllowAllTurnAdmissionLimitProvider;
+
+impl TurnAdmissionLimitProvider for AllowAllTurnAdmissionLimitProvider {
+    fn limit_for(
+        &self,
+        _bucket: &TurnAdmissionBucket,
+    ) -> Result<TurnAdmissionLimit, TurnAdmissionLimitUnavailable> {
+        Ok(TurnAdmissionLimit::unlimited())
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StaticTurnAdmissionLimitProvider {
+    limits: HashMap<TurnAdmissionLimitSelector, TurnAdmissionLimit>,
+    unavailable: bool,
+}
+
+impl StaticTurnAdmissionLimitProvider {
+    pub fn with_total_limit(mut self, axis_kind: TurnAdmissionAxisKind, max_active: u64) -> Self {
+        self.limits.insert(
+            TurnAdmissionLimitSelector {
+                axis_kind,
+                bucket_kind: TurnAdmissionBucketKind::Total,
+                admission_class: None,
+            },
+            TurnAdmissionLimit::max_active(max_active),
+        );
+        self
+    }
+
+    pub fn with_class_limit(
+        mut self,
+        axis_kind: TurnAdmissionAxisKind,
+        admission_class: TurnAdmissionClass,
+        max_active: u64,
+    ) -> Self {
+        self.limits.insert(
+            TurnAdmissionLimitSelector {
+                axis_kind,
+                bucket_kind: TurnAdmissionBucketKind::Class,
+                admission_class: Some(admission_class),
+            },
+            TurnAdmissionLimit::max_active(max_active),
+        );
+        self
+    }
+
+    pub fn unavailable(mut self) -> Self {
+        self.unavailable = true;
+        self
+    }
+}
+
+impl TurnAdmissionLimitProvider for StaticTurnAdmissionLimitProvider {
+    fn limit_for(
+        &self,
+        bucket: &TurnAdmissionBucket,
+    ) -> Result<TurnAdmissionLimit, TurnAdmissionLimitUnavailable> {
+        if self.unavailable {
+            return Err(TurnAdmissionLimitUnavailable);
+        }
+        Ok(self
+            .limits
+            .get(&TurnAdmissionLimitSelector::from_bucket(bucket))
+            .copied()
+            .unwrap_or_else(TurnAdmissionLimit::unlimited))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnAdmissionCapacityDenial {
+    pub axis_kind: TurnAdmissionAxisKind,
+    pub bucket_kind: TurnAdmissionBucketKind,
+    pub admission_class: Option<TurnAdmissionClass>,
+    pub limit: u64,
+    pub active_count: u64,
+    pub retry_after_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnAdmissionReservationRecord {
+    pub run_id: TurnRunId,
+    pub admission_class: TurnAdmissionClass,
+    pub buckets: Vec<TurnAdmissionBucket>,
+    pub released: bool,
+}
+
+pub(crate) fn admission_buckets(
+    scope: &TurnScope,
+    actor: &TurnActor,
+    admission_class: &TurnAdmissionClass,
+) -> Vec<TurnAdmissionBucket> {
+    let tenant_id = scope.tenant_id.clone();
+    let total_and_class = |axis_kind: TurnAdmissionAxisKind, scope: TurnAdmissionBucketScope| {
+        [
+            TurnAdmissionBucket {
+                axis_kind,
+                bucket_kind: TurnAdmissionBucketKind::Total,
+                admission_class: None,
+                scope: scope.clone(),
+            },
+            TurnAdmissionBucket {
+                axis_kind,
+                bucket_kind: TurnAdmissionBucketKind::Class,
+                admission_class: Some(admission_class.clone()),
+                scope,
+            },
+        ]
+    };
+
+    let mut buckets = Vec::with_capacity(8);
+    buckets.extend(total_and_class(
+        TurnAdmissionAxisKind::Tenant,
+        TurnAdmissionBucketScope::Tenant {
+            tenant_id: tenant_id.clone(),
+        },
+    ));
+    buckets.extend(total_and_class(
+        TurnAdmissionAxisKind::ActorUser,
+        TurnAdmissionBucketScope::ActorUser {
+            tenant_id: tenant_id.clone(),
+            user_id: actor.user_id.clone(),
+        },
+    ));
+    buckets.extend(total_and_class(
+        TurnAdmissionAxisKind::Project,
+        TurnAdmissionBucketScope::Project {
+            tenant_id: tenant_id.clone(),
+            project_id: scope.project_id.clone(),
+        },
+    ));
+    buckets.extend(total_and_class(
+        TurnAdmissionAxisKind::Agent,
+        TurnAdmissionBucketScope::Agent {
+            tenant_id,
+            agent_id: scope.agent_id.clone(),
+        },
+    ));
+    buckets
+}

--- a/crates/ironclaw_turns/src/db.rs
+++ b/crates/ironclaw_turns/src/db.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
-#[cfg(feature = "libsql")]
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 use std::sync::Arc;
 
 use crate::{
-    CancelRunRequest, CancelRunResponse, GetRunStateRequest, InMemoryTurnStateStore,
-    InMemoryTurnStateStoreLimits, ResolvedRunProfile, ResumeTurnRequest, ResumeTurnResponse,
-    RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver, SubmitTurnRequest,
-    SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionPolicy, TurnCheckpointRecord, TurnError,
+    AllowAllTurnAdmissionLimitProvider, CancelRunRequest, CancelRunResponse, GetRunStateRequest,
+    InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, ResolvedRunProfile, ResumeTurnRequest,
+    ResumeTurnResponse, RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver,
+    SubmitTurnRequest, SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionLimitProvider,
+    TurnAdmissionPolicy, TurnAdmissionReservationRecord, TurnCheckpointRecord, TurnError,
     TurnIdempotencyRecord, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord,
     TurnRunState, TurnScope, TurnStateStore,
     events::{EventCursor, TurnEventPage, TurnEventProjectionSource, project_turn_events},
@@ -111,6 +112,13 @@ CREATE TABLE IF NOT EXISTS turn_store_metadata (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS turn_admission_reservations (
+    run_id TEXT PRIMARY KEY,
+    released INTEGER NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_admission_reservations_released ON turn_admission_reservations(released);
 "#;
 
 #[cfg(feature = "postgres")]
@@ -174,12 +182,20 @@ CREATE TABLE IF NOT EXISTS turn_store_metadata (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS turn_admission_reservations (
+    run_id TEXT PRIMARY KEY,
+    released BOOLEAN NOT NULL,
+    payload JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_admission_reservations_released ON turn_admission_reservations(released);
 "#;
 
 #[cfg(feature = "libsql")]
 pub struct LibSqlTurnStateStore {
     db: Arc<libsql::Database>,
     limits: InMemoryTurnStateStoreLimits,
+    admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
 }
 
 #[cfg(feature = "libsql")]
@@ -188,11 +204,20 @@ impl LibSqlTurnStateStore {
         Self {
             db,
             limits: InMemoryTurnStateStoreLimits::default(),
+            admission_limit_provider: Arc::new(AllowAllTurnAdmissionLimitProvider),
         }
     }
 
     pub fn with_limits(mut self, limits: InMemoryTurnStateStoreLimits) -> Self {
         self.limits = limits;
+        self
+    }
+
+    pub fn with_admission_limit_provider(
+        mut self,
+        admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
+    ) -> Self {
+        self.admission_limit_provider = admission_limit_provider;
         self
     }
 
@@ -228,9 +253,10 @@ impl LibSqlTurnStateStore {
         &self,
         conn: &libsql::Connection,
     ) -> Result<InMemoryTurnStateStore, TurnError> {
-        InMemoryTurnStateStore::from_persistence_snapshot(
+        InMemoryTurnStateStore::from_persistence_snapshot_with_admission_limit_provider(
             libsql_load_snapshot(conn).await?,
             self.limits,
+            self.admission_limit_provider.clone(),
         )
     }
 
@@ -462,6 +488,7 @@ impl TurnRunTransitionPort for LibSqlTurnStateStore {
 pub struct PostgresTurnStateStore {
     pool: deadpool_postgres::Pool,
     limits: InMemoryTurnStateStoreLimits,
+    admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
 }
 
 #[cfg(feature = "postgres")]
@@ -470,11 +497,20 @@ impl PostgresTurnStateStore {
         Self {
             pool,
             limits: InMemoryTurnStateStoreLimits::default(),
+            admission_limit_provider: Arc::new(AllowAllTurnAdmissionLimitProvider),
         }
     }
 
     pub fn with_limits(mut self, limits: InMemoryTurnStateStoreLimits) -> Self {
         self.limits = limits;
+        self
+    }
+
+    pub fn with_admission_limit_provider(
+        mut self,
+        admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
+    ) -> Self {
+        self.admission_limit_provider = admission_limit_provider;
         self
     }
 
@@ -499,9 +535,10 @@ impl PostgresTurnStateStore {
         &self,
         txn: &impl deadpool_postgres::GenericClient,
     ) -> Result<InMemoryTurnStateStore, TurnError> {
-        InMemoryTurnStateStore::from_persistence_snapshot(
+        InMemoryTurnStateStore::from_persistence_snapshot_with_admission_limit_provider(
             postgres_load_snapshot(txn).await?,
             self.limits,
+            self.admission_limit_provider.clone(),
         )
     }
 
@@ -786,6 +823,11 @@ async fn libsql_load_snapshot(
     )
     .await?;
     let event_retention_floor = libsql_load_event_retention_floor(conn).await?;
+    let admission_reservations = libsql_load_payloads::<TurnAdmissionReservationRecord>(
+        conn,
+        "SELECT payload FROM turn_admission_reservations ORDER BY run_id",
+    )
+    .await?;
     Ok(TurnPersistenceSnapshot {
         turns,
         runs,
@@ -794,6 +836,7 @@ async fn libsql_load_snapshot(
         idempotency_records,
         events,
         event_retention_floor,
+        admission_reservations,
     })
 }
 
@@ -822,6 +865,7 @@ async fn libsql_replace_snapshot(
     for table in [
         "turn_store_metadata",
         "turn_lifecycle_events",
+        "turn_admission_reservations",
         "turn_idempotency_records",
         "turn_checkpoints",
         "turn_active_locks",
@@ -917,6 +961,18 @@ async fn libsql_replace_snapshot(
         .await
         .map_err(db_error)?;
     }
+    for record in &snapshot.admission_reservations {
+        conn.execute(
+            "INSERT INTO turn_admission_reservations (run_id, released, payload) VALUES (?1, ?2, ?3)",
+            libsql::params![
+                record.run_id.to_string(),
+                if record.released { 1_i64 } else { 0_i64 },
+                to_json(record)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
     conn.execute(
         "INSERT INTO turn_store_metadata (key, value) VALUES ('event_retention_floor', ?1)",
         libsql::params![snapshot.event_retention_floor.0.to_string()],
@@ -932,7 +988,7 @@ async fn lock_postgres_turn_tables(
     mode: &str,
 ) -> Result<(), TurnError> {
     let statement = format!(
-        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_idempotency_records, turn_lifecycle_events, turn_store_metadata IN {mode}"
+        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_idempotency_records, turn_lifecycle_events, turn_store_metadata, turn_admission_reservations IN {mode}"
     );
     client.batch_execute(&statement).await.map_err(db_error)
 }
@@ -1007,6 +1063,11 @@ async fn postgres_load_snapshot(
     )
     .await?;
     let event_retention_floor = postgres_load_event_retention_floor(client).await?;
+    let admission_reservations = postgres_load_payloads::<TurnAdmissionReservationRecord>(
+        client,
+        "SELECT payload::text FROM turn_admission_reservations ORDER BY run_id",
+    )
+    .await?;
     Ok(TurnPersistenceSnapshot {
         turns,
         runs,
@@ -1015,6 +1076,7 @@ async fn postgres_load_snapshot(
         idempotency_records,
         events,
         event_retention_floor,
+        admission_reservations,
     })
 }
 
@@ -1026,6 +1088,7 @@ async fn postgres_replace_snapshot(
     for table in [
         "turn_store_metadata",
         "turn_lifecycle_events",
+        "turn_admission_reservations",
         "turn_idempotency_records",
         "turn_checkpoints",
         "turn_active_locks",
@@ -1123,6 +1186,15 @@ async fn postgres_replace_snapshot(
                 &turn_event_kind_key(event)?,
                 &payload,
             ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.admission_reservations {
+        let payload = to_json(record)?;
+        txn.execute(
+            "INSERT INTO turn_admission_reservations (run_id, released, payload) VALUES ($1, $2, $3::jsonb)",
+            &[&record.run_id.to_string(), &record.released, &payload],
         )
         .await
         .map_err(db_error)?;

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -5,6 +5,7 @@
 //! binding/session layer. Trusted workers use [`runner`] explicitly; runner
 //! transition APIs are intentionally not re-exported from this crate prelude.
 
+pub mod admission;
 pub mod coordinator;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub mod db;
@@ -20,6 +21,12 @@ pub mod scope;
 pub mod status;
 pub mod store;
 
+pub use admission::{
+    AllowAllTurnAdmissionLimitProvider, StaticTurnAdmissionLimitProvider, TurnAdmissionAxisKind,
+    TurnAdmissionBucket, TurnAdmissionBucketKind, TurnAdmissionBucketScope,
+    TurnAdmissionCapacityDenial, TurnAdmissionClass, TurnAdmissionLimit,
+    TurnAdmissionLimitProvider, TurnAdmissionLimitUnavailable, TurnAdmissionReservationRecord,
+};
 pub use coordinator::{
     AllowAllTurnAdmissionPolicy, DefaultTurnCoordinator, NoopTurnRunWakeNotifier,
     TurnAdmissionPolicy, TurnCoordinator, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError,

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -787,23 +787,37 @@ impl Inner {
         cursor = cursor.max(events.iter().map(|event| event.cursor.0).max().unwrap_or(0));
         cursor = cursor.max(snapshot.event_retention_floor.0);
         let mut admission_reservations = HashMap::new();
-        for reservation in snapshot.admission_reservations {
+        for mut reservation in snapshot.admission_reservations {
+            let Some(record) = records.get(&reservation.run_id) else {
+                continue;
+            };
+            if record.status.is_terminal() {
+                reservation.released = true;
+            }
             admission_reservations.insert(reservation.run_id, reservation);
         }
         for record in records.values() {
-            if record.status.keeps_active_lock()
-                && !admission_reservations.contains_key(&record.run_id)
-            {
+            if record.status.keeps_active_lock() {
                 let admission_class = record.profile.admission_class.clone();
-                admission_reservations.insert(
-                    record.run_id,
-                    TurnAdmissionReservationRecord {
-                        run_id: record.run_id,
-                        admission_class: admission_class.clone(),
-                        buckets: admission_buckets(&record.scope, &record.actor, &admission_class),
-                        released: false,
-                    },
-                );
+                let buckets = admission_buckets(&record.scope, &record.actor, &admission_class);
+                let needs_canonical_reservation = admission_reservations
+                    .get(&record.run_id)
+                    .is_none_or(|reservation| {
+                        reservation.released
+                            || reservation.admission_class != admission_class
+                            || reservation.buckets != buckets
+                    });
+                if needs_canonical_reservation {
+                    admission_reservations.insert(
+                        record.run_id,
+                        TurnAdmissionReservationRecord {
+                            run_id: record.run_id,
+                            admission_class,
+                            buckets,
+                            released: false,
+                        },
+                    );
+                }
             }
         }
 
@@ -1677,6 +1691,7 @@ impl Inner {
                 .is_some_and(|record| record.status.is_terminal())
             {
                 self.records.remove(&run_id);
+                self.admission_reservations.remove(&run_id);
             }
         }
     }

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -2,22 +2,25 @@ use async_trait::async_trait;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     hash::Hash,
-    sync::{Condvar, Mutex, MutexGuard},
+    sync::{Arc, Condvar, Mutex, MutexGuard},
 };
 
 use chrono::{Duration as ChronoDuration, Utc};
 
 use crate::{
-    AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, BlockedReason,
-    CancelRunRequest, CancelRunResponse, GetRunStateRequest, IdempotencyKey, LoopExitMapping,
-    ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse, RunProfileResolutionError,
-    RunProfileResolutionRequest, RunProfileResolver, SanitizedFailure, SourceBindingRef,
-    SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActiveLockKey, TurnActiveLockRecord,
-    TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnCheckpointRecord, TurnError,
-    TurnEventKind, TurnIdempotencyErrorReplay, TurnIdempotencyOperationKind,
-    TurnIdempotencyOutcomeKind, TurnIdempotencyRecord, TurnIdempotencyReplay, TurnLifecycleEvent,
-    TurnLockVersion, TurnPersistenceSnapshot, TurnRecord, TurnRunId, TurnRunProfile, TurnRunRecord,
-    TurnRunState, TurnScope, TurnStateStore, TurnStatus,
+    AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason,
+    AllowAllTurnAdmissionLimitProvider, BlockedReason, CancelRunRequest, CancelRunResponse,
+    GetRunStateRequest, IdempotencyKey, LoopExitMapping, ReplyTargetBindingRef, ResumeTurnRequest,
+    ResumeTurnResponse, RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver,
+    SanitizedFailure, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
+    TurnActiveLockKey, TurnActiveLockRecord, TurnActor, TurnAdmissionClass,
+    TurnAdmissionLimitProvider, TurnAdmissionPolicy, TurnAdmissionReservationRecord,
+    TurnCheckpointId, TurnCheckpointRecord, TurnError, TurnEventKind, TurnIdempotencyErrorReplay,
+    TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnIdempotencyRecord,
+    TurnIdempotencyReplay, TurnLifecycleEvent, TurnLockVersion, TurnPersistenceSnapshot,
+    TurnRecord, TurnRunId, TurnRunProfile, TurnRunRecord, TurnRunState, TurnScope, TurnStateStore,
+    TurnStatus,
+    admission::{TurnAdmissionBucket, admission_buckets},
     events::{EventCursor, TurnEventPage, TurnEventProjectionSource, project_turn_events},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -54,6 +57,7 @@ impl Default for InMemoryTurnStateStoreLimits {
 pub struct InMemoryTurnStateStore {
     inner: Mutex<Inner>,
     submit_idempotency_ready: Condvar,
+    admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
 }
 
 impl Default for InMemoryTurnStateStore {
@@ -82,6 +86,7 @@ struct Inner {
     idempotency_record_order: VecDeque<PersistedIdempotencyKey>,
     events: Vec<TurnLifecycleEvent>,
     event_retention_floor: EventCursor,
+    admission_reservations: HashMap<TurnRunId, TurnAdmissionReservationRecord>,
     limits: InMemoryTurnStateStoreLimits,
 }
 
@@ -187,6 +192,37 @@ impl InMemoryTurnStateStore {
                 ..Inner::default()
             }),
             submit_idempotency_ready: Condvar::new(),
+            admission_limit_provider: Arc::new(AllowAllTurnAdmissionLimitProvider),
+        }
+    }
+
+    pub fn with_admission_limit_provider(
+        admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
+    ) -> Self {
+        Self::with_limits_and_admission_limit_provider(
+            InMemoryTurnStateStoreLimits::default(),
+            admission_limit_provider,
+        )
+    }
+
+    pub fn with_limits_and_admission_limit_provider(
+        limits: InMemoryTurnStateStoreLimits,
+        admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
+    ) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                limits,
+                ..Inner::default()
+            }),
+            submit_idempotency_ready: Condvar::new(),
+            admission_limit_provider,
+        }
+    }
+
+    pub fn active_admission_reservations(&self) -> Vec<TurnAdmissionReservationRecord> {
+        match self.inner.lock() {
+            Ok(inner) => inner.active_admission_reservations(),
+            Err(poisoned) => poisoned.into_inner().active_admission_reservations(),
         }
     }
 
@@ -201,9 +237,22 @@ impl InMemoryTurnStateStore {
         snapshot: TurnPersistenceSnapshot,
         limits: InMemoryTurnStateStoreLimits,
     ) -> Result<Self, TurnError> {
+        Self::from_persistence_snapshot_with_admission_limit_provider(
+            snapshot,
+            limits,
+            Arc::new(AllowAllTurnAdmissionLimitProvider),
+        )
+    }
+
+    pub fn from_persistence_snapshot_with_admission_limit_provider(
+        snapshot: TurnPersistenceSnapshot,
+        limits: InMemoryTurnStateStoreLimits,
+        admission_limit_provider: Arc<dyn TurnAdmissionLimitProvider>,
+    ) -> Result<Self, TurnError> {
         Ok(Self {
             inner: Mutex::new(Inner::from_persistence_snapshot(snapshot, limits)?),
             submit_idempotency_ready: Condvar::new(),
+            admission_limit_provider,
         })
     }
 
@@ -336,15 +385,23 @@ impl TurnStateStore for InMemoryTurnStateStore {
         };
 
         let lock_key = TurnActiveLockKey::from(&request.scope);
-        if let Some(active_lock) = inner.active_locks.get(&lock_key)
-            && let Some(record) = inner.records.get(&active_lock.run_id)
-            && record.status.keeps_active_lock()
-        {
-            let response = Err(TurnError::ThreadBusy(ThreadBusy {
-                active_run_id: active_lock.run_id,
-                status: record.status,
-                event_cursor: record.event_cursor,
-            }));
+        if let Some(response) = inner.thread_busy(&lock_key) {
+            inner.submit_idempotency_in_flight.remove(&idempotency_key);
+            self.submit_idempotency_ready.notify_all();
+            return Err(TurnError::ThreadBusy(response));
+        }
+
+        let turn_id = crate::TurnId::new();
+        let run_id = TurnRunId::new();
+        let admission_class = profile.admission_class.clone();
+        if let Err(rejection) = inner.reserve_admission(
+            run_id,
+            admission_class.clone(),
+            &request.scope,
+            &request.actor,
+            self.admission_limit_provider.as_ref(),
+        ) {
+            let response = Err(TurnError::AdmissionRejected(rejection));
             inner.remember_submit_idempotency(
                 idempotency_key.clone(),
                 response.clone(),
@@ -354,9 +411,6 @@ impl TurnStateStore for InMemoryTurnStateStore {
             self.submit_idempotency_ready.notify_all();
             return response;
         }
-
-        let turn_id = crate::TurnId::new();
-        let run_id = TurnRunId::new();
         let cursor = inner.next_cursor();
         let turn_record = TurnRecord {
             turn_id,
@@ -732,6 +786,26 @@ impl Inner {
         let events = snapshot.events;
         cursor = cursor.max(events.iter().map(|event| event.cursor.0).max().unwrap_or(0));
         cursor = cursor.max(snapshot.event_retention_floor.0);
+        let mut admission_reservations = HashMap::new();
+        for reservation in snapshot.admission_reservations {
+            admission_reservations.insert(reservation.run_id, reservation);
+        }
+        for record in records.values() {
+            if record.status.keeps_active_lock()
+                && !admission_reservations.contains_key(&record.run_id)
+            {
+                let admission_class = record.profile.admission_class.clone();
+                admission_reservations.insert(
+                    record.run_id,
+                    TurnAdmissionReservationRecord {
+                        run_id: record.run_id,
+                        admission_class: admission_class.clone(),
+                        buckets: admission_buckets(&record.scope, &record.actor, &admission_class),
+                        released: false,
+                    },
+                );
+            }
+        }
 
         Ok(Self {
             cursor,
@@ -752,6 +826,7 @@ impl Inner {
             idempotency_record_order,
             events,
             event_retention_floor: snapshot.event_retention_floor,
+            admission_reservations,
             limits,
         })
     }
@@ -812,6 +887,12 @@ impl Inner {
             .cloned()
             .collect::<Vec<_>>();
         idempotency_records.sort_by_key(|record| record.created_at);
+        let mut admission_reservations = self
+            .admission_reservations
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        admission_reservations.sort_by_key(|reservation| reservation.run_id.to_string());
         TurnPersistenceSnapshot {
             turns,
             runs,
@@ -820,6 +901,7 @@ impl Inner {
             idempotency_records,
             events: self.events.clone(),
             event_retention_floor: self.event_retention_floor,
+            admission_reservations,
         }
     }
 
@@ -1466,6 +1548,85 @@ impl Inner {
         }
     }
 
+    fn thread_busy(&self, lock_key: &TurnActiveLockKey) -> Option<ThreadBusy> {
+        let active_lock = self.active_locks.get(lock_key)?;
+        let record = self.records.get(&active_lock.run_id)?;
+        record.status.keeps_active_lock().then_some(ThreadBusy {
+            active_run_id: active_lock.run_id,
+            status: record.status,
+            event_cursor: record.event_cursor,
+        })
+    }
+
+    fn reserve_admission(
+        &mut self,
+        run_id: TurnRunId,
+        admission_class: TurnAdmissionClass,
+        scope: &TurnScope,
+        actor: &TurnActor,
+        limit_provider: &dyn TurnAdmissionLimitProvider,
+    ) -> Result<(), AdmissionRejection> {
+        let buckets = admission_buckets(scope, actor, &admission_class);
+        for bucket in &buckets {
+            let limit = limit_provider
+                .limit_for(bucket)
+                .map_err(|_| AdmissionRejection::new(AdmissionRejectionReason::Unavailable))?;
+            if let Some(max_active) = limit.max_active {
+                let active_count = self.active_admission_count(bucket);
+                if active_count >= max_active {
+                    return Err(
+                        AdmissionRejection::new(AdmissionRejectionReason::TenantLimit)
+                            .with_capacity_denial(crate::TurnAdmissionCapacityDenial {
+                                axis_kind: bucket.axis_kind,
+                                bucket_kind: bucket.bucket_kind,
+                                admission_class: bucket.admission_class.clone(),
+                                limit: max_active,
+                                active_count,
+                                retry_after_ms: limit.retry_after_ms,
+                            }),
+                    );
+                }
+            }
+        }
+        self.admission_reservations.insert(
+            run_id,
+            TurnAdmissionReservationRecord {
+                run_id,
+                admission_class,
+                buckets,
+                released: false,
+            },
+        );
+        Ok(())
+    }
+
+    fn active_admission_count(&self, bucket: &TurnAdmissionBucket) -> u64 {
+        self.admission_reservations
+            .values()
+            .filter(|reservation| {
+                !reservation.released
+                    && reservation
+                        .buckets
+                        .iter()
+                        .any(|reserved| reserved == bucket)
+            })
+            .count() as u64
+    }
+
+    fn active_admission_reservations(&self) -> Vec<TurnAdmissionReservationRecord> {
+        self.admission_reservations
+            .values()
+            .filter(|reservation| !reservation.released)
+            .cloned()
+            .collect()
+    }
+
+    fn release_admission(&mut self, run_id: TurnRunId) {
+        if let Some(reservation) = self.admission_reservations.get_mut(&run_id) {
+            reservation.released = true;
+        }
+    }
+
     fn record_checkpoint(
         &mut self,
         record: &RunRecord,
@@ -1501,6 +1662,7 @@ impl Inner {
     }
 
     fn mark_terminal(&mut self, run_id: TurnRunId) {
+        self.release_admission(run_id);
         self.terminal_runs.push_back(run_id);
     }
 

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -3,8 +3,8 @@ use thiserror::Error;
 
 use crate::{
     AcceptedMessageRef, GateRef, ReplyTargetBindingRef, ResolvedRunProfile, RunProfileId,
-    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId, TurnRunId, TurnScope,
-    events::EventCursor, request::TurnTimestamp,
+    RunProfileVersion, SourceBindingRef, TurnAdmissionClass, TurnCheckpointId, TurnId, TurnRunId,
+    TurnScope, events::EventCursor, request::TurnTimestamp,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -35,6 +35,8 @@ impl TurnStatus {
 pub struct TurnRunProfile {
     pub id: RunProfileId,
     pub version: RunProfileVersion,
+    #[serde(default = "TurnAdmissionClass::interactive")]
+    pub admission_class: TurnAdmissionClass,
     pub allow_steering: bool,
     pub auto_queue_followups: bool,
     pub resolved: ResolvedRunProfile,
@@ -46,6 +48,7 @@ impl TurnRunProfile {
         Self {
             id,
             version: resolved.profile_version,
+            admission_class: TurnAdmissionClass::interactive(),
             allow_steering: resolved.steering_policy.allow_steering,
             auto_queue_followups: false,
             resolved,
@@ -62,6 +65,8 @@ impl<'de> Deserialize<'de> for TurnRunProfile {
         struct WireProfile {
             id: RunProfileId,
             version: RunProfileVersion,
+            #[serde(default = "TurnAdmissionClass::interactive")]
+            admission_class: TurnAdmissionClass,
             allow_steering: bool,
             auto_queue_followups: bool,
             resolved: Option<ResolvedRunProfile>,
@@ -78,6 +83,7 @@ impl<'de> Deserialize<'de> for TurnRunProfile {
         Ok(Self {
             id: wire.id,
             version: wire.version,
+            admission_class: wire.admission_class,
             allow_steering: wire.allow_steering,
             auto_queue_followups: wire.auto_queue_followups,
             resolved,
@@ -229,6 +235,8 @@ impl AdmissionRejectionReason {
 pub struct AdmissionRejection {
     pub reason: AdmissionRejectionReason,
     pub retry_after_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capacity_denial: Option<crate::TurnAdmissionCapacityDenial>,
 }
 
 impl AdmissionRejection {
@@ -236,11 +244,18 @@ impl AdmissionRejection {
         Self {
             reason,
             retry_after_ms: None,
+            capacity_denial: None,
         }
     }
 
     pub fn with_retry_after_ms(mut self, retry_after_ms: u64) -> Self {
         self.retry_after_ms = Some(retry_after_ms);
+        self
+    }
+
+    pub fn with_capacity_denial(mut self, denial: crate::TurnAdmissionCapacityDenial) -> Self {
+        self.retry_after_ms = denial.retry_after_ms;
+        self.capacity_denial = Some(denial);
         self
     }
 }

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -5,9 +5,10 @@ use crate::{
     AcceptedMessageRef, AdmissionRejection, CancelRunRequest, CancelRunResponse, GateRef,
     GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef, ResumeTurnRequest,
     ResumeTurnResponse, RunProfileResolver, SourceBindingRef, SubmitTurnRequest,
-    SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnError,
-    TurnErrorCategory, TurnId, TurnLeaseToken, TurnLifecycleEvent, TurnRunId, TurnRunProfile,
-    TurnRunState, TurnRunnerId, TurnScope, TurnStatus, TurnTimestamp, events::EventCursor,
+    SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnAdmissionReservationRecord,
+    TurnCheckpointId, TurnError, TurnErrorCategory, TurnId, TurnLeaseToken, TurnLifecycleEvent,
+    TurnRunId, TurnRunProfile, TurnRunState, TurnRunnerId, TurnScope, TurnStatus, TurnTimestamp,
+    events::EventCursor,
 };
 
 #[async_trait]
@@ -222,9 +223,9 @@ impl TurnIdempotencyRecord {
         }
         match &self.replay {
             TurnIdempotencyReplay::SubmitAccepted(response) => Some(Ok(response.clone())),
-            TurnIdempotencyReplay::SubmitThreadBusy(busy) => {
-                Some(Err(TurnError::ThreadBusy(busy.clone())))
-            }
+            // Legacy persisted busy submit records are intentionally not replayable.
+            // Same-thread busy is a transient lock state, not an idempotent submit outcome.
+            TurnIdempotencyReplay::SubmitThreadBusy(_) => None,
             TurnIdempotencyReplay::SubmitAdmissionRejected(rejection) => {
                 Some(Err(TurnError::AdmissionRejected(rejection.clone())))
             }
@@ -279,4 +280,6 @@ pub struct TurnPersistenceSnapshot {
     pub events: Vec<TurnLifecycleEvent>,
     #[serde(default)]
     pub event_retention_floor: EventCursor,
+    #[serde(default)]
+    pub admission_reservations: Vec<TurnAdmissionReservationRecord>,
 }

--- a/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
@@ -17,14 +17,15 @@ use ironclaw_turns::{
     LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy, LoopMessageRef,
     ReplyTargetBindingRef, ResolvedRunProfile, RunProfileRequest, RunProfileResolutionError,
     RunProfileResolutionRequest, RunProfileResolver, SanitizedCancelReason, SanitizedFailure,
-    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
-    TurnCoordinator, TurnError, TurnEventKind, TurnEventProjectionCursor, TurnEventProjectionError,
+    SourceBindingRef, StaticTurnAdmissionLimitProvider, SubmitTurnRequest, SubmitTurnResponse,
+    ThreadBusy, TurnActor, TurnAdmissionAxisKind, TurnAdmissionCapacityDenial, TurnCoordinator,
+    TurnError, TurnEventKind, TurnEventProjectionCursor, TurnEventProjectionError,
     TurnEventProjectionRequest, TurnEventProjectionService, TurnLeaseToken, TurnRunId,
     TurnRunnerId, TurnScope, TurnStatus,
     events::EventCursor,
     runner::{
-        ApplyLoopExitRequest, ClaimRunRequest, HeartbeatRequest, RecoverExpiredLeasesRequest,
-        TurnRunTransitionPort, apply_loop_exit,
+        ApplyLoopExitRequest, ClaimRunRequest, CompleteRunRequest, HeartbeatRequest,
+        RecoverExpiredLeasesRequest, TurnRunTransitionPort, apply_loop_exit,
     },
 };
 
@@ -210,6 +211,98 @@ async fn libsql_turn_state_store_persists_submit_and_busy_across_instances() {
         .await
         .unwrap();
     assert_eq!(duplicate, accepted);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_turn_state_store_persists_admission_reservations_across_instances() {
+    let (db, _dir) = libsql_db().await;
+    let limits = Arc::new(
+        StaticTurnAdmissionLimitProvider::default()
+            .with_total_limit(TurnAdmissionAxisKind::Tenant, 1),
+    );
+    let store = Arc::new(
+        LibSqlTurnStateStore::new(db.clone()).with_admission_limit_provider(limits.clone()),
+    );
+    store.run_migrations().await.unwrap();
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let first_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+
+    let reopened = Arc::new(
+        LibSqlTurnStateStore::new(db.clone()).with_admission_limit_provider(limits.clone()),
+    );
+    let reopened_coordinator = DefaultTurnCoordinator::new(reopened.clone());
+    let denied = reopened_coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        denied,
+        TurnError::AdmissionRejected(ironclaw_turns::AdmissionRejection {
+            capacity_denial: Some(TurnAdmissionCapacityDenial {
+                axis_kind: TurnAdmissionAxisKind::Tenant,
+                limit: 1,
+                active_count: 1,
+                ..
+            }),
+            ..
+        })
+    ));
+    assert_eq!(
+        reopened
+            .persistence_snapshot()
+            .await
+            .unwrap()
+            .admission_reservations
+            .iter()
+            .filter(|reservation| !reservation.released)
+            .count(),
+        1
+    );
+
+    let runner_id = ironclaw_turns::TurnRunnerId::new();
+    let lease_token = ironclaw_turns::TurnLeaseToken::new();
+    reopened
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(scope("thread-a")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    reopened
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let after_release =
+        Arc::new(LibSqlTurnStateStore::new(db).with_admission_limit_provider(limits));
+    let after_release_coordinator = DefaultTurnCoordinator::new(after_release.clone());
+    after_release_coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b-after-release"))
+        .await
+        .unwrap();
+    assert_eq!(
+        after_release
+            .persistence_snapshot()
+            .await
+            .unwrap()
+            .admission_reservations
+            .iter()
+            .filter(|reservation| !reservation.released)
+            .count(),
+        1
+    );
 }
 
 #[cfg(feature = "libsql")]
@@ -582,6 +675,98 @@ async fn postgres_turn_state_store_persists_submit_and_busy_across_instances_whe
             ..
         }) if active_run_id == run_id
     ));
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_turn_state_store_persists_admission_reservations_when_configured() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let limits = Arc::new(
+        StaticTurnAdmissionLimitProvider::default()
+            .with_total_limit(TurnAdmissionAxisKind::Tenant, 1),
+    );
+    let store = Arc::new(
+        PostgresTurnStateStore::new(pool.clone()).with_admission_limit_provider(limits.clone()),
+    );
+    store.run_migrations().await.unwrap();
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let tenant_id = TenantId::new(format!("tenant-admission-{suffix}")).unwrap();
+    let tenant_submit_request = |thread: &str, idempotency_key: &str| {
+        let mut request = submit_request(thread, idempotency_key);
+        request.scope.tenant_id = tenant_id.clone();
+        request
+    };
+    let first_thread = format!("pg-admission-a-{suffix}");
+    let second_thread = format!("pg-admission-b-{suffix}");
+    let first_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(tenant_submit_request(
+                &first_thread,
+                &format!("idem-submit-a-{suffix}"),
+            ))
+            .await
+            .unwrap(),
+    );
+
+    let reopened = Arc::new(
+        PostgresTurnStateStore::new(pool.clone()).with_admission_limit_provider(limits.clone()),
+    );
+    let reopened_coordinator = DefaultTurnCoordinator::new(reopened.clone());
+    let denied = reopened_coordinator
+        .submit_turn(tenant_submit_request(
+            &second_thread,
+            &format!("idem-submit-b-{suffix}"),
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        denied,
+        TurnError::AdmissionRejected(ironclaw_turns::AdmissionRejection {
+            capacity_denial: Some(TurnAdmissionCapacityDenial {
+                axis_kind: TurnAdmissionAxisKind::Tenant,
+                limit: 1,
+                active_count: 1,
+                ..
+            }),
+            ..
+        })
+    ));
+
+    let runner_id = ironclaw_turns::TurnRunnerId::new();
+    let lease_token = ironclaw_turns::TurnLeaseToken::new();
+    let mut first_scope = scope(&first_thread);
+    first_scope.tenant_id = tenant_id.clone();
+    reopened
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(first_scope),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    reopened
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let after_release =
+        Arc::new(PostgresTurnStateStore::new(pool).with_admission_limit_provider(limits));
+    let after_release_coordinator = DefaultTurnCoordinator::new(after_release);
+    after_release_coordinator
+        .submit_turn(tenant_submit_request(
+            &second_thread,
+            &format!("idem-submit-b-after-release-{suffix}"),
+        ))
+        .await
+        .unwrap();
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -974,6 +974,69 @@ async fn snapshot_load_synthesizes_reservations_for_legacy_active_runs() {
 }
 
 #[tokio::test]
+async fn snapshot_load_recovers_released_or_mismatched_reservations_for_active_runs() {
+    let source_store = Arc::new(InMemoryTurnStateStore::default());
+    let source_coordinator = DefaultTurnCoordinator::new(source_store.clone());
+    source_coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    let source_snapshot = source_store.persistence_snapshot();
+    assert_eq!(source_snapshot.admission_reservations.len(), 1);
+
+    for corrupt_reservation in ["released", "empty_buckets"] {
+        let mut snapshot = source_snapshot.clone();
+        match corrupt_reservation {
+            "released" => snapshot.admission_reservations[0].released = true,
+            "empty_buckets" => snapshot.admission_reservations[0].buckets.clear(),
+            _ => unreachable!(),
+        }
+        let limits = StaticTurnAdmissionLimitProvider::default()
+            .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+        let restored = Arc::new(
+            InMemoryTurnStateStore::from_persistence_snapshot_with_admission_limit_provider(
+                snapshot,
+                InMemoryTurnStateStoreLimits::default(),
+                Arc::new(limits),
+            )
+            .unwrap(),
+        );
+        let reservations = restored.active_admission_reservations();
+        assert_eq!(reservations.len(), 1, "case {corrupt_reservation}");
+        assert!(!reservations[0].released, "case {corrupt_reservation}");
+        assert_eq!(
+            reservations[0].buckets.len(),
+            8,
+            "case {corrupt_reservation}"
+        );
+
+        let restored_coordinator = DefaultTurnCoordinator::new(restored.clone());
+        let denied = restored_coordinator
+            .submit_turn(submit_request(
+                &format!("thread-b-{corrupt_reservation}"),
+                &format!("idem-submit-b-{corrupt_reservation}"),
+            ))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                denied,
+                TurnError::AdmissionRejected(AdmissionRejection {
+                    capacity_denial: Some(TurnAdmissionCapacityDenial {
+                        axis_kind: TurnAdmissionAxisKind::Tenant,
+                        limit: 1,
+                        active_count: 1,
+                        ..
+                    }),
+                    ..
+                })
+            ),
+            "case {corrupt_reservation}: {denied:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn terminal_run_releases_admission_reservation_for_new_thread() {
     let limits = StaticTurnAdmissionLimitProvider::default()
         .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
@@ -1014,6 +1077,126 @@ async fn terminal_run_releases_admission_reservation_for_new_thread() {
         .unwrap();
     assert_ne!(accepted_run_id(&second), first_run_id);
     assert_eq!(store.active_admission_reservations().len(), 1);
+}
+
+#[tokio::test]
+async fn snapshot_load_drops_released_reservations_without_retained_run_records() {
+    let source_store = Arc::new(InMemoryTurnStateStore::default());
+    let source_coordinator = DefaultTurnCoordinator::new(source_store.clone());
+    let run_id = accepted_run_id(
+        &source_coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    source_store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(scope("thread-a")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    source_store
+        .complete_run(CompleteRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+    let mut snapshot = source_store.persistence_snapshot();
+    assert_eq!(snapshot.admission_reservations.len(), 1);
+    assert!(snapshot.admission_reservations[0].released);
+    snapshot.runs.clear();
+
+    let restored = InMemoryTurnStateStore::from_persistence_snapshot(
+        snapshot,
+        InMemoryTurnStateStoreLimits::default(),
+    )
+    .unwrap();
+
+    assert!(
+        restored
+            .persistence_snapshot()
+            .admission_reservations
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn terminal_record_pruning_bounds_released_admission_reservations() {
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            max_terminal_records: 1,
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let first_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let first_runner_id = TurnRunnerId::new();
+    let first_lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: first_runner_id,
+            lease_token: first_lease_token,
+            scope_filter: Some(scope("thread-a")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id: first_runner_id,
+            lease_token: first_lease_token,
+        })
+        .await
+        .unwrap();
+
+    let second_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-b", "idem-submit-b"))
+            .await
+            .unwrap(),
+    );
+    let second_runner_id = TurnRunnerId::new();
+    let second_lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: second_runner_id,
+            lease_token: second_lease_token,
+            scope_filter: Some(scope("thread-b")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .complete_run(CompleteRunRequest {
+            run_id: second_run_id,
+            runner_id: second_runner_id,
+            lease_token: second_lease_token,
+        })
+        .await
+        .unwrap();
+
+    let snapshot = store.persistence_snapshot();
+    assert!(snapshot.runs.iter().all(|run| run.run_id != first_run_id));
+    assert!(
+        snapshot
+            .admission_reservations
+            .iter()
+            .all(|reservation| reservation.run_id != first_run_id)
+    );
+    assert_eq!(snapshot.admission_reservations.len(), 1);
 }
 
 #[tokio::test]
@@ -2922,6 +3105,11 @@ async fn sanitized_failure_rejects_empty_controlled_oversized_or_unsanitized_cat
 
 #[test]
 fn bounded_refs_validate_during_deserialization() {
+    assert!(serde_json::from_str::<TurnAdmissionClass>("\"interactive\"").is_ok());
+    assert!(serde_json::from_str::<TurnAdmissionClass>("\"\"").is_err());
+    assert!(serde_json::from_str::<TurnAdmissionClass>("\"Interactive\"").is_err());
+    assert!(serde_json::from_str::<TurnAdmissionClass>("\"admin-system\"").is_err());
+    assert!(serde_json::from_str::<TurnAdmissionClass>("\"class\\nsecret\"").is_err());
     assert!(serde_json::from_str::<AcceptedMessageRef>("\"message-ok\"").is_ok());
     assert!(serde_json::from_str::<AcceptedMessageRef>("\"\"").is_err());
     assert!(serde_json::from_str::<SourceBindingRef>("\"source\\nsecret\"").is_err());

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -18,14 +18,16 @@ use ironclaw_turns::{
     LoopExitInvalidHandling, LoopExitValidationPolicy, LoopGateRef, LoopMessageRef,
     ReplyTargetBindingRef, ResolvedRunProfile, ResumeTurnRequest, RunProfileId, RunProfileRequest,
     RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion,
-    SanitizedCancelReason, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
-    SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnCheckpointId,
-    TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventProjectionCursor,
-    TurnEventProjectionError, TurnEventProjectionRequest, TurnEventProjectionService,
-    TurnEventSink, TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnLeaseToken,
-    TurnLifecycleEvent, TurnLockVersion, TurnRunId, TurnRunProfile, TurnRunState, TurnRunWake,
-    TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnRunnerId, TurnScope, TurnStateStore,
-    TurnStatus,
+    SanitizedCancelReason, SanitizedFailure, SourceBindingRef, StaticTurnAdmissionLimitProvider,
+    SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionAxisKind,
+    TurnAdmissionBucketKind, TurnAdmissionBucketScope, TurnAdmissionCapacityDenial,
+    TurnAdmissionClass, TurnAdmissionPolicy, TurnCheckpointId, TurnCoordinator, TurnError,
+    TurnErrorCategory, TurnEventKind, TurnEventProjectionCursor, TurnEventProjectionError,
+    TurnEventProjectionRequest, TurnEventProjectionService, TurnEventSink,
+    TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnIdempotencyRecord,
+    TurnIdempotencyReplay, TurnLeaseToken, TurnLifecycleEvent, TurnLockVersion, TurnRunId,
+    TurnRunProfile, TurnRunState, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError,
+    TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
     events::EventCursor,
     runner::{
         ApplyLoopExitRequest, ApplyValidatedLoopExitRequest, BlockRunRequest,
@@ -700,8 +702,13 @@ async fn same_thread_lock_excludes_actor_identity() {
 }
 
 #[tokio::test]
-async fn submit_turn_busy_path_records_idempotent_thread_busy_without_new_run() {
-    let (coordinator, store) = coordinator();
+async fn same_thread_busy_is_transient_and_checked_before_admission_capacity() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
     let first_run_id = accepted_run_id(
         &coordinator
             .submit_turn(submit_request("thread-a", "idem-submit-a"))
@@ -714,26 +721,9 @@ async fn submit_turn_busy_path_records_idempotent_thread_busy_without_new_run() 
         .submit_turn(busy_request.clone())
         .await
         .unwrap_err();
-
-    let snapshot = store.persistence_snapshot();
-    assert_eq!(snapshot.turns.len(), 1);
-    assert_eq!(snapshot.runs.len(), 1);
-    let busy_idempotency = snapshot
-        .idempotency_records
-        .iter()
-        .find(|record| record.key == busy_request.idempotency_key)
-        .expect("busy submit idempotency result must be recorded");
-    assert_eq!(
-        busy_idempotency.operation,
-        TurnIdempotencyOperationKind::Submit
-    );
-    assert_eq!(busy_idempotency.turn_id, None);
-    assert_eq!(busy_idempotency.run_id, Some(first_run_id));
-    assert_eq!(
-        busy_idempotency.outcome,
-        TurnIdempotencyOutcomeKind::ThreadBusy
-    );
-    assert_eq!(busy_idempotency.created_at, busy_request.received_at);
+    assert!(matches!(busy, TurnError::ThreadBusy(_)));
+    assert_eq!(store.active_admission_reservations().len(), 1);
+    assert_eq!(store.persistence_snapshot().idempotency_records.len(), 1);
 
     let runner_id = TurnRunnerId::new();
     let lease_token = TurnLeaseToken::new();
@@ -755,9 +745,592 @@ async fn submit_turn_busy_path_records_idempotent_thread_busy_without_new_run() 
         .await
         .unwrap();
 
-    let duplicate = coordinator.submit_turn(busy_request).await.unwrap_err();
-    assert_eq!(duplicate, busy);
+    let duplicate_after_unlock = coordinator.submit_turn(busy_request).await.unwrap();
+    assert_ne!(accepted_run_id(&duplicate_after_unlock), first_run_id);
+    assert_eq!(store.persistence_snapshot().turns.len(), 2);
+}
+
+#[tokio::test]
+async fn tenant_capacity_denial_is_structured_idempotent_and_all_or_nothing() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    let denied_request = submit_request("thread-b", "idem-submit-b");
+
+    let denied = coordinator
+        .submit_turn(denied_request.clone())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        denied,
+        TurnError::AdmissionRejected(AdmissionRejection {
+            reason: AdmissionRejectionReason::TenantLimit,
+            capacity_denial: Some(TurnAdmissionCapacityDenial {
+                axis_kind: TurnAdmissionAxisKind::Tenant,
+                bucket_kind: TurnAdmissionBucketKind::Total,
+                limit: 1,
+                active_count: 1,
+                ..
+            }),
+            ..
+        })
+    ));
     assert_eq!(store.persistence_snapshot().turns.len(), 1);
+    assert_eq!(store.active_admission_reservations().len(), 1);
+
+    let duplicate_denied = coordinator.submit_turn(denied_request).await.unwrap_err();
+    assert_eq!(duplicate_denied, denied);
+    assert_eq!(store.persistence_snapshot().turns.len(), 1);
+    assert_eq!(store.active_admission_reservations().len(), 1);
+}
+
+#[tokio::test]
+async fn concurrent_submits_cannot_oversubscribe_admission_limit() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+
+    let (first, second) = tokio::join!(
+        coordinator.submit_turn(submit_request("thread-a", "idem-submit-a")),
+        coordinator.submit_turn(submit_request("thread-b", "idem-submit-b")),
+    );
+
+    let accepted = [first.as_ref(), second.as_ref()]
+        .into_iter()
+        .filter(|result| matches!(result, Ok(SubmitTurnResponse::Accepted { .. })))
+        .count();
+    let rejected = [first.as_ref(), second.as_ref()]
+        .into_iter()
+        .filter(|result| matches!(result, Err(TurnError::AdmissionRejected(_))))
+        .count();
+    assert_eq!(accepted, 1);
+    assert_eq!(rejected, 1);
+    assert_eq!(store.persistence_snapshot().turns.len(), 1);
+    assert_eq!(store.active_admission_reservations().len(), 1);
+}
+
+#[tokio::test]
+async fn capacity_denial_does_not_advance_event_cursor() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let first_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+
+    let denied = coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap_err();
+    assert!(matches!(denied, TurnError::AdmissionRejected(_)));
+
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(scope("thread-a")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let SubmitTurnResponse::Accepted { event_cursor, .. } = coordinator
+        .submit_turn(submit_request("thread-c", "idem-submit-c"))
+        .await
+        .unwrap();
+    assert_eq!(event_cursor, EventCursor(4));
+}
+
+#[tokio::test]
+async fn snapshot_load_ignores_legacy_submit_thread_busy_replays() {
+    let source_store = Arc::new(InMemoryTurnStateStore::default());
+    let source_coordinator = DefaultTurnCoordinator::new(source_store.clone());
+    let first_run_id = accepted_run_id(
+        &source_coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let mut snapshot = source_store.persistence_snapshot();
+    let legacy_busy_key = IdempotencyKey::new("idem-legacy-busy").unwrap();
+    snapshot.idempotency_records.push(TurnIdempotencyRecord {
+        scope: scope("thread-a"),
+        operation: TurnIdempotencyOperationKind::Submit,
+        key: legacy_busy_key.clone(),
+        turn_id: None,
+        run_id: Some(first_run_id),
+        outcome: TurnIdempotencyOutcomeKind::ThreadBusy,
+        replay: TurnIdempotencyReplay::SubmitThreadBusy(ThreadBusy {
+            active_run_id: first_run_id,
+            status: TurnStatus::Queued,
+            event_cursor: EventCursor(1),
+        }),
+        created_at: received_at(),
+        expires_at: None,
+    });
+    let restored = Arc::new(
+        InMemoryTurnStateStore::from_persistence_snapshot(
+            snapshot,
+            InMemoryTurnStateStoreLimits::default(),
+        )
+        .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    restored
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(scope("thread-a")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    restored
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let restored_coordinator = DefaultTurnCoordinator::new(restored.clone());
+    let accepted_after_unlock = restored_coordinator
+        .submit_turn(submit_request("thread-a", legacy_busy_key.as_str()))
+        .await
+        .unwrap();
+    assert_ne!(accepted_run_id(&accepted_after_unlock), first_run_id);
+}
+
+#[tokio::test]
+async fn snapshot_load_synthesizes_reservations_for_legacy_active_runs() {
+    let source_store = Arc::new(InMemoryTurnStateStore::default());
+    let source_coordinator = DefaultTurnCoordinator::new(source_store.clone());
+    source_coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    let mut snapshot = source_store.persistence_snapshot();
+    assert_eq!(snapshot.admission_reservations.len(), 1);
+    snapshot.admission_reservations.clear();
+
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+    let restored = Arc::new(
+        InMemoryTurnStateStore::from_persistence_snapshot_with_admission_limit_provider(
+            snapshot,
+            InMemoryTurnStateStoreLimits::default(),
+            Arc::new(limits),
+        )
+        .unwrap(),
+    );
+    assert_eq!(restored.active_admission_reservations().len(), 1);
+
+    let restored_coordinator = DefaultTurnCoordinator::new(restored.clone());
+    let denied = restored_coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        denied,
+        TurnError::AdmissionRejected(AdmissionRejection {
+            capacity_denial: Some(TurnAdmissionCapacityDenial {
+                axis_kind: TurnAdmissionAxisKind::Tenant,
+                limit: 1,
+                active_count: 1,
+                ..
+            }),
+            ..
+        })
+    ));
+    assert_eq!(restored.persistence_snapshot().turns.len(), 1);
+}
+
+#[tokio::test]
+async fn terminal_run_releases_admission_reservation_for_new_thread() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let first_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    assert!(store.active_admission_reservations().is_empty());
+    let second = coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap();
+    assert_ne!(accepted_run_id(&second), first_run_id);
+    assert_eq!(store.active_admission_reservations().len(), 1);
+}
+
+#[tokio::test]
+async fn actor_user_capacity_uses_submitting_actor_not_thread_scope() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::ActorUser, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+
+    let same_actor_denied = coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        same_actor_denied,
+        TurnError::AdmissionRejected(AdmissionRejection {
+            capacity_denial: Some(TurnAdmissionCapacityDenial {
+                axis_kind: TurnAdmissionAxisKind::ActorUser,
+                ..
+            }),
+            ..
+        })
+    ));
+
+    let mut different_actor = submit_request("thread-c", "idem-submit-c");
+    different_actor.actor = TurnActor::new(UserId::new("user2").unwrap());
+    coordinator.submit_turn(different_actor).await.unwrap();
+    assert_eq!(store.active_admission_reservations().len(), 2);
+}
+
+#[tokio::test]
+async fn class_capacity_denial_reports_admission_class() {
+    let limits = StaticTurnAdmissionLimitProvider::default().with_class_limit(
+        TurnAdmissionAxisKind::Tenant,
+        TurnAdmissionClass::interactive(),
+        1,
+    );
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store);
+    coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+
+    let denied = coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        denied,
+        TurnError::AdmissionRejected(AdmissionRejection {
+            capacity_denial: Some(TurnAdmissionCapacityDenial {
+                axis_kind: TurnAdmissionAxisKind::Tenant,
+                bucket_kind: TurnAdmissionBucketKind::Class,
+                admission_class: Some(ref class),
+                limit: 1,
+                active_count: 1,
+                ..
+            }),
+            ..
+        }) if class == &TurnAdmissionClass::interactive()
+    ));
+}
+
+#[tokio::test]
+async fn accepted_submit_reserves_unlimited_buckets_and_replay_does_not_reacquire() {
+    let (coordinator, store) = coordinator();
+    let first = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    let duplicate = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+
+    assert_eq!(duplicate, first);
+    let reservations = store.active_admission_reservations();
+    assert_eq!(reservations.len(), 1);
+    assert_eq!(reservations[0].buckets.len(), 8);
+    assert_eq!(
+        reservations[0].admission_class,
+        TurnAdmissionClass::interactive()
+    );
+}
+
+#[tokio::test]
+async fn project_none_consumes_unscoped_project_bucket() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Project, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let mut first = submit_request("thread-a", "idem-submit-a");
+    first.scope.project_id = None;
+    coordinator.submit_turn(first).await.unwrap();
+    let mut second = submit_request("thread-b", "idem-submit-b");
+    second.scope.project_id = None;
+
+    let denied = coordinator.submit_turn(second).await.unwrap_err();
+    assert!(matches!(
+        denied,
+        TurnError::AdmissionRejected(AdmissionRejection {
+            capacity_denial: Some(TurnAdmissionCapacityDenial {
+                axis_kind: TurnAdmissionAxisKind::Project,
+                bucket_kind: TurnAdmissionBucketKind::Total,
+                ..
+            }),
+            ..
+        })
+    ));
+    assert!(
+        store.active_admission_reservations()[0]
+            .buckets
+            .iter()
+            .any(|bucket| matches!(
+                bucket.scope,
+                TurnAdmissionBucketScope::Project {
+                    project_id: None,
+                    ..
+                }
+            ))
+    );
+}
+
+#[tokio::test]
+async fn agent_capacity_is_keyed_by_tenant_and_optional_agent() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Agent, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let first = submit_request("thread-a", "idem-submit-a");
+    coordinator.submit_turn(first).await.unwrap();
+    let denied = coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-b"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        denied,
+        TurnError::AdmissionRejected(AdmissionRejection {
+            capacity_denial: Some(TurnAdmissionCapacityDenial {
+                axis_kind: TurnAdmissionAxisKind::Agent,
+                ..
+            }),
+            ..
+        })
+    ));
+
+    let mut no_agent = submit_request("thread-c", "idem-submit-c");
+    no_agent.scope.agent_id = None;
+    coordinator.submit_turn(no_agent).await.unwrap();
+    assert_eq!(store.active_admission_reservations().len(), 2);
+}
+
+#[tokio::test]
+async fn admission_limit_provider_unavailable_fails_closed_without_run_or_reservation() {
+    let limits = StaticTurnAdmissionLimitProvider::default().unavailable();
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+
+    let denied = coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        denied,
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::Unavailable
+        ))
+    );
+    let snapshot = store.persistence_snapshot();
+    assert!(snapshot.turns.is_empty());
+    assert!(snapshot.runs.is_empty());
+    assert!(snapshot.admission_reservations.is_empty());
+}
+
+#[tokio::test]
+async fn blocked_resume_and_recovery_required_keep_existing_admission_reservation() {
+    let limits = StaticTurnAdmissionLimitProvider::default()
+        .with_total_limit(TurnAdmissionAxisKind::Tenant, 1);
+    let store = Arc::new(InMemoryTurnStateStore::with_admission_limit_provider(
+        Arc::new(limits),
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(scope("thread-a")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let gate_ref = GateRef::new("gate:approval").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+            checkpoint_id: TurnCheckpointId::new(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(store.active_admission_reservations().len(), 1);
+
+    let resumed = coordinator
+        .resume_turn(ResumeTurnRequest {
+            scope: scope("thread-a"),
+            actor: actor(),
+            run_id,
+            gate_resolution_ref: gate_ref,
+            source_binding_ref: SourceBindingRef::new("source-web-resumed").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web-resumed").unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-resume-a").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(resumed.status, TurnStatus::Queued);
+    assert_eq!(store.active_admission_reservations().len(), 1);
+
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(scope("thread-a")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .record_recovery_required(ironclaw_turns::runner::RecordRecoveryRequiredRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            failure: SanitizedFailure::new("driver_protocol_violation").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(store.active_admission_reservations().len(), 1);
+}
+
+#[tokio::test]
+async fn submit_turn_busy_path_is_transient_without_new_run_or_idempotency_record() {
+    let (coordinator, store) = coordinator();
+    let first_run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let busy_request = submit_request("thread-a", "idem-submit-b");
+
+    let busy = coordinator
+        .submit_turn(busy_request.clone())
+        .await
+        .unwrap_err();
+    assert!(matches!(busy, TurnError::ThreadBusy(_)));
+
+    let snapshot = store.persistence_snapshot();
+    assert_eq!(snapshot.turns.len(), 1);
+    assert_eq!(snapshot.runs.len(), 1);
+    assert!(
+        snapshot
+            .idempotency_records
+            .iter()
+            .all(|record| record.key != busy_request.idempotency_key),
+        "busy submit is transient and must not pin admission/idempotency capacity"
+    );
+
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .complete_run(CompleteRunRequest {
+            run_id: first_run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let accepted_after_unlock = coordinator.submit_turn(busy_request).await.unwrap();
+    assert_ne!(accepted_run_id(&accepted_after_unlock), first_run_id);
+    assert_eq!(store.persistence_snapshot().turns.len(), 2);
 }
 
 #[tokio::test]
@@ -909,20 +1482,24 @@ async fn resume_updates_persisted_run_binding_refs_and_replay_envelope() {
 }
 
 #[tokio::test]
-async fn persisted_submit_busy_and_cancel_replay_envelopes_are_reconstructable() {
-    let (coordinator, store) = coordinator();
+async fn persisted_admission_rejection_and_cancel_replay_envelopes_are_reconstructable() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_admission_policy(Arc::new(DenyAll));
+    let rejected_request = submit_request("thread-a", "idem-submit-rejected");
+    let rejected = coordinator
+        .submit_turn(rejected_request.clone())
+        .await
+        .unwrap_err();
+
+    let allowed_coordinator = DefaultTurnCoordinator::new(store.clone());
     let first_run_id = accepted_run_id(
-        &coordinator
+        &allowed_coordinator
             .submit_turn(submit_request("thread-a", "idem-submit-a"))
             .await
             .unwrap(),
     );
-    let busy_request = submit_request("thread-a", "idem-submit-b");
-    let busy = coordinator
-        .submit_turn(busy_request.clone())
-        .await
-        .unwrap_err();
-    let cancel = coordinator
+    let cancel = allowed_coordinator
         .cancel_run(cancel_request(
             "thread-a",
             first_run_id,
@@ -932,12 +1509,12 @@ async fn persisted_submit_busy_and_cancel_replay_envelopes_are_reconstructable()
         .unwrap();
 
     let snapshot = store.persistence_snapshot();
-    let busy_record = snapshot
+    let rejection_record = snapshot
         .idempotency_records
         .iter()
-        .find(|record| record.key == busy_request.idempotency_key)
-        .expect("busy submit idempotency record must be persisted");
-    assert_eq!(busy_record.replay_submit().unwrap(), Err(busy));
+        .find(|record| record.key == rejected_request.idempotency_key)
+        .expect("admission rejection idempotency record must be persisted");
+    assert_eq!(rejection_record.replay_submit().unwrap(), Err(rejected));
     let cancel_record = snapshot
         .idempotency_records
         .iter()
@@ -961,7 +1538,7 @@ async fn submit_turn_idempotency_replays_same_success_result() {
 }
 
 #[tokio::test]
-async fn submit_turn_busy_idempotency_replays_after_thread_unlocks() {
+async fn submit_turn_busy_idempotency_does_not_replay_after_thread_unlocks() {
     let (coordinator, store) = coordinator();
     let first_run_id = accepted_run_id(
         &coordinator
@@ -996,8 +1573,8 @@ async fn submit_turn_busy_idempotency_replays_after_thread_unlocks() {
         .await
         .unwrap();
 
-    let duplicate_after_unlock = coordinator.submit_turn(busy_request).await.unwrap_err();
-    assert_eq!(duplicate_after_unlock, busy);
+    let accepted_after_unlock = coordinator.submit_turn(busy_request).await.unwrap();
+    assert_ne!(accepted_run_id(&accepted_after_unlock), first_run_id);
 }
 
 #[test]
@@ -1500,6 +2077,30 @@ async fn admission_policy_rejection_is_typed_and_does_not_create_run() {
             .unwrap_err(),
         TurnError::ScopeNotFound
     );
+}
+
+#[tokio::test]
+async fn admission_policy_rejection_wins_over_busy_thread_metadata() {
+    let (coordinator, store) = coordinator();
+    coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-a"))
+        .await
+        .unwrap();
+    let unauthorized_coordinator = DefaultTurnCoordinator::new(store.clone())
+        .with_admission_policy(Arc::new(DenyUnauthorized));
+
+    let err = unauthorized_coordinator
+        .submit_turn(submit_request("thread-a", "idem-submit-unauthorized-busy"))
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::Unauthorized
+        ))
+    );
+    assert_eq!(store.persistence_snapshot().turns.len(), 1);
 }
 
 #[tokio::test]
@@ -2641,6 +3242,16 @@ impl TurnAdmissionPolicy for DenyFirstThenAllow {
         } else {
             Ok(())
         }
+    }
+}
+
+struct DenyUnauthorized;
+
+impl TurnAdmissionPolicy for DenyUnauthorized {
+    fn check_submit(&self, _request: &SubmitTurnRequest) -> Result<(), AdmissionRejection> {
+        Err(AdmissionRejection::new(
+            AdmissionRejectionReason::Unauthorized,
+        ))
     }
 }
 

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -72,7 +72,7 @@ A duplicate idempotency key must replay prior accepted submit and admission-reje
 - Capacity denial returns one deterministic safe `AdmissionRejected` payload with axis kind, total/class bucket, admission class when applicable, limit, active count, and optional retry hint. It must not expose foreign bucket IDs or raw provider internals.
 - Missing limits mean unlimited. A non-AllowAll provider that is unavailable fails closed with `AdmissionRejectionReason::Unavailable` and creates no run/reservation.
 - Queued, running, blocked, cancel-requested, and recovery-required runs keep reservations. Resume reuses the existing reservation.
-- Terminal transitions (`Completed`, `Failed`, `Cancelled`, and future terminal states) release reservations exactly once while retaining released reservation evidence.
+- Terminal transitions (`Completed`, `Failed`, `Cancelled`, and future terminal states) release reservations exactly once. Released reservation evidence is retained only while the corresponding terminal run remains within the bounded terminal-record retention window; active capacity accounting must not scan unbounded released history.
 - Limit changes do not evict existing runs; new admissions are denied until active reservations drop below the configured limit.
 - Snapshot/DB loaders must synthesize unreleased reservation evidence for legacy non-terminal runs that predate persisted reservation rows so active capacity is not bypassed after migration/restart.
 

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -14,6 +14,7 @@ Turn persistence owns durable control-plane state for host-layer turn coordinati
 - executable turn-run lifecycle state;
 - one-active-run-per-canonical-thread locks;
 - runner lease/checkpoint metadata;
+- durable turn-admission reservations for active accepted runs;
 - idempotency outcomes for adapter-facing mutations;
 - redacted lifecycle cursors needed for replay/recovery.
 
@@ -31,6 +32,7 @@ The `ironclaw_turns` contract models persistence with these record families:
 | `turn_runs` | Executable state for one run: current source/reply binding refs, status, resolved run-profile snapshot, latest checkpoint/gate refs, runner lease fields, event cursor. |
 | `turn_active_locks` | One lock per canonical scoped thread while a run is active or resumable. |
 | `turn_checkpoints` | Dedicated checkpoint/gate records written when a running run blocks. |
+| `turn_admission_reservations` | Reservation evidence tying each accepted run to tenant/actor/project/agent total and class buckets until terminal release. |
 | `turn_idempotency_keys` | Prior sanitized outcomes for scoped submit/resume/cancel idempotency keys. |
 
 The initial PostgreSQL/libSQL adapter slice stores each logical record family in its own table with indexed metadata columns plus a serialized contract payload. Mutations hold a backend transaction/write lock across snapshot load, in-memory contract mutation, and snapshot replacement so active-lock and idempotency semantics remain atomic. Backends must preserve the same semantics as the in-memory contract tests while later slices add incremental row-level updates, targeted read paths, and service-graph wiring.
@@ -53,16 +55,30 @@ The initial PostgreSQL/libSQL adapter slice stores each logical record family in
 Adapter-facing mutations persist sanitized idempotency outcomes:
 
 - `submit_turn` success records the accepted turn/run IDs and accepted response kind.
-- `submit_turn` busy path records a `ThreadBusy` outcome without creating a new turn/run.
-- Admission rejections are replayable and do not create turn/run records.
+- `submit_turn` same-thread busy is transient: it does not create a turn/run, does not acquire admission, and is not cached as a submit idempotency replay.
+- Capacity/policy admission rejections are replayable and do not create turn/run or reservation records.
 - `resume_turn` and `cancel_run` record scoped run-operation outcomes.
-- Idempotency records include a redacted replay envelope with response-critical fields such as status, event cursor, active run ID, admission reason/retry metadata, and cancellation `already_terminal` state.
+- Idempotency records include a redacted replay envelope with response-critical fields such as status, event cursor, admission reason/capacity metadata, retry metadata, and cancellation `already_terminal` state.
 
-A duplicate idempotency key must replay the prior sanitized success/error outcome instead of re-running admission, lock acquisition, or state transitions.
+A duplicate idempotency key must replay prior accepted submit and admission-rejection outcomes instead of re-running admission, lock acquisition, or state transitions. A duplicate same-thread busy submit with the same key may succeed later after the thread unlocks; legacy persisted `SubmitThreadBusy` replay rows are ignored on snapshot/DB load.
 
 ---
 
-## 5. Runner lease and checkpoint rules
+## 5. Turn-admission reservation rules
+
+- Admission reservation is not a predicate: all configured tenant, actor-user, project, and agent total/class buckets must be checked and inserted atomically with turn/run creation.
+- Each accepted V1 run records unlimited and limited canonical bucket reservations for telemetry and future limit changes.
+- Submit admission policy checks that can reject unauthorized/profile-invalid requests run before returning same-thread busy metadata; same-thread busy is still checked before capacity reservation and never consumes admission slots.
+- Capacity denial returns one deterministic safe `AdmissionRejected` payload with axis kind, total/class bucket, admission class when applicable, limit, active count, and optional retry hint. It must not expose foreign bucket IDs or raw provider internals.
+- Missing limits mean unlimited. A non-AllowAll provider that is unavailable fails closed with `AdmissionRejectionReason::Unavailable` and creates no run/reservation.
+- Queued, running, blocked, cancel-requested, and recovery-required runs keep reservations. Resume reuses the existing reservation.
+- Terminal transitions (`Completed`, `Failed`, `Cancelled`, and future terminal states) release reservations exactly once while retaining released reservation evidence.
+- Limit changes do not evict existing runs; new admissions are denied until active reservations drop below the configured limit.
+- Snapshot/DB loaders must synthesize unreleased reservation evidence for legacy non-terminal runs that predate persisted reservation rows so active capacity is not bypassed after migration/restart.
+
+---
+
+## 6. Runner lease and checkpoint rules
 
 - Claiming a queued run atomically moves it to `Running`, stores runner ID/lease token, increments `claim_count`, records `last_heartbeat_at`, records `lease_expires_at`, and updates active-lock metadata.
 - Heartbeats only renew metadata for matching, unexpired runner ID/lease token; successful heartbeats refresh `last_heartbeat_at` and extend `lease_expires_at`.
@@ -72,6 +88,6 @@ A duplicate idempotency key must replay the prior sanitized success/error outcom
 
 ---
 
-## 6. Redaction boundary
+## 7. Redaction boundary
 
 Turn persistence stores metadata and references only. It must not persist raw prompts, assistant content, tool input, secrets, host paths, or backend error details in turn/run/checkpoint/idempotency records.


### PR DESCRIPTION
## Summary

Closes #3264.

- add typed turn admission classes, axes, buckets, limits, and safe capacity-denial payloads
- reserve tenant / actor-user / project / agent total+class admission buckets atomically with accepted turn creation
- persist reservation evidence in in-memory snapshots plus libSQL/Postgres snapshot-backed stores, including legacy active-run synthesis
- keep same-thread busy transient/non-idempotent while preserving admission/policy rejections as replayable outcomes
- document admission reservation semantics in the turn persistence contract

## Issue linkage audit

- This PR implements issue #3264.
- The closing keyword is present above. GitHub may not populate `closingIssuesReferences` while the PR targets `reborn-integration` rather than the default branch.

## Tests

- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --test turn_coordinator_contract admission_policy_rejection_wins_over_busy_thread_metadata`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo test -p ironclaw_turns --all-features`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo fmt --check --package ironclaw_turns`
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target cargo clippy -p ironclaw_turns --all-targets --all-features -- -D warnings`

## Review

- read-only reviewer: no Critical/High/Medium findings after fixes
