### PR TITLE
test(reborn): add obligation audit projection e2e slice

### DIFF
--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use ironclaw_events::{
     DurableAuditLog, DurableEventLog, EventCursor, EventError, EventLogEntry, EventStreamKey,
-    ReadScope, RuntimeEvent, RuntimeEventKind, sanitize_error_kind,
+    ReadScope, RuntimeEvent, RuntimeEventKind, UNCLASSIFIED_ERROR_KIND, sanitize_error_kind,
 };
 use ironclaw_host_api::{
     ApprovalRequestId, AuditEnvelope, AuditEventId, AuditStage, CapabilityId, ExtensionId,
@@ -792,9 +792,41 @@ fn project_audit_entry(entry: &EventLogEntry<AuditEnvelope>) -> AuditProjectionE
         result_status: audit
             .result
             .as_ref()
-            .and_then(|result| result.status.clone())
-            .map(sanitize_error_kind),
+            .and_then(|result| result.status.as_deref())
+            .map(sanitize_audit_status),
         output_bytes: audit.result.as_ref().and_then(|result| result.output_bytes),
+    }
+}
+
+const SAFE_AUDIT_STATUS_LABELS: &[&str] = &[
+    "audit_before",
+    "audit_after",
+    "redact_output",
+    "apply_network_policy",
+    "inject_secret_once",
+    "enforce_output_limit",
+    "reserve_resources",
+    "use_scoped_mounts",
+    "enforce_resource_ceiling",
+];
+const MAX_AUDIT_STATUS_LABELS: usize = SAFE_AUDIT_STATUS_LABELS.len();
+const MAX_AUDIT_STATUS_BYTES: usize = 192;
+
+fn sanitize_audit_status(status: &str) -> String {
+    if status.len() > MAX_AUDIT_STATUS_BYTES {
+        return UNCLASSIFIED_ERROR_KIND.to_string();
+    }
+
+    let labels = status.split(',').collect::<Vec<_>>();
+    if labels.is_empty()
+        || labels.len() > MAX_AUDIT_STATUS_LABELS
+        || labels
+            .iter()
+            .any(|label| !SAFE_AUDIT_STATUS_LABELS.contains(label))
+    {
+        UNCLASSIFIED_ERROR_KIND.to_string()
+    } else {
+        labels.join(",")
     }
 }
 

--- a/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
@@ -14,9 +14,9 @@ use ironclaw_events::{
     RuntimeEventId, RuntimeEventKind, UNCLASSIFIED_ERROR_KIND,
 };
 use ironclaw_host_api::{
-    Action, ActionSummary, AgentId, AuditEnvelope, AuditStage, CapabilityId, CapabilitySet,
-    CorrelationId, DenyReason, ExtensionId, InvocationId, MountView, ProcessId, ProjectId,
-    ResourceScope, RuntimeKind, ScopedPath, TenantId, ThreadId, TrustClass, UserId,
+    Action, ActionResultSummary, ActionSummary, AgentId, AuditEnvelope, AuditStage, CapabilityId,
+    CapabilitySet, CorrelationId, DenyReason, ExtensionId, InvocationId, MountView, ProcessId,
+    ProjectId, ResourceScope, RuntimeKind, ScopedPath, TenantId, ThreadId, TrustClass, UserId,
 };
 
 #[tokio::test]
@@ -88,6 +88,64 @@ async fn replay_audit_projection_does_not_expose_unsafe_action_targets() {
     assert_eq!(snapshot.entries[0].action_target, None);
     let serialized = serde_json::to_string(&snapshot).unwrap();
     assert!(!serialized.contains("AUDIT_TARGET_SENTINEL_3022"));
+}
+
+#[tokio::test]
+async fn replay_audit_projection_preserves_only_safe_obligation_status_labels() {
+    let log = Arc::new(InMemoryDurableAuditLog::new());
+    let service = ReplayAuditProjectionService::new(Arc::clone(&log));
+    let ctx = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-a").unwrap()));
+    let action = Action::Dispatch {
+        capability: capability_id(),
+        estimated_resources: Default::default(),
+    };
+    let mut safe_audit = AuditEnvelope::denied(
+        &ctx,
+        AuditStage::After,
+        ActionSummary::from_action(&action),
+        DenyReason::PolicyDenied,
+    );
+    safe_audit.result = Some(ActionResultSummary {
+        success: true,
+        status: Some("audit_before,apply_network_policy,inject_secret_once".to_string()),
+        output_bytes: Some(10),
+    });
+    log.append(safe_audit).await.unwrap();
+
+    let mut unsafe_audit = AuditEnvelope::denied(
+        &ctx,
+        AuditStage::After,
+        ActionSummary::from_action(&action),
+        DenyReason::PolicyDenied,
+    );
+    unsafe_audit.result = Some(ActionResultSummary {
+        success: false,
+        status: Some("api.internal,secret_token".to_string()),
+        output_bytes: None,
+    });
+    log.append(unsafe_audit).await.unwrap();
+
+    let snapshot = service
+        .snapshot(AuditProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&ctx.resource_scope),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.entries.len(), 2);
+    assert_eq!(
+        snapshot.entries[0].result_status.as_deref(),
+        Some("audit_before,apply_network_policy,inject_secret_once")
+    );
+    assert_eq!(
+        snapshot.entries[1].result_status.as_deref(),
+        Some(UNCLASSIFIED_ERROR_KIND)
+    );
+    let serialized = serde_json::to_string(&snapshot).unwrap();
+    assert!(!serialized.contains("api.internal"));
+    assert!(!serialized.contains("secret_token"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1961,6 +1961,150 @@ async fn host_runtime_services_writes_obligation_audit_records_to_durable_log_me
 }
 
 #[tokio::test]
+async fn host_runtime_services_projects_resource_network_secret_obligation_audit_metadata_only() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_root = temp.path().join("reborn-event-store");
+    let stores = build_reborn_event_stores(
+        RebornProfile::LocalDev,
+        RebornEventStoreConfig::Jsonl {
+            root: store_root.clone(),
+            accept_single_node_durable: false,
+        },
+    )
+    .await
+    .unwrap();
+    let audit_log = Arc::clone(&stores.audit);
+    let governor = Arc::new(governor_with_default_limit(sample_account()));
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let secret_handle = SecretHandle::new("obligation-api-token").unwrap();
+    let reservation_id = ResourceReservationId::new();
+    let policy = NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "NETWORK_POLICY_SENTINEL_3022.example.test".to_string(),
+            port: Some(443),
+        }],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(10_000),
+    };
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
+        Arc::new(ObligatingAuthorizer::new(vec![
+            Obligation::AuditBefore,
+            Obligation::ApplyNetworkPolicy { policy },
+            Obligation::InjectSecretOnce {
+                handle: secret_handle.clone(),
+            },
+            Obligation::ReserveResources { reservation_id },
+            Obligation::AuditAfter,
+        ]));
+    let services: InMemoryHostRuntimeServices = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::clone(&governor),
+        authorizer,
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability, EffectKind::Network],
+    )))
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_audit_sink(Arc::new(DurableAuditSink::new(Arc::clone(&audit_log))))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )));
+    let scope = sample_scope(InvocationId::new());
+    secret_store
+        .put(
+            scope.clone(),
+            secret_handle,
+            SecretMaterial::from("SECRET_MATERIAL_SENTINEL_3022_sk_live_secret"),
+        )
+        .await
+        .unwrap();
+    let payload = json!({
+        "message": "OBLIGATION_INPUT_SENTINEL_3022 /tmp/private-obligation-path",
+        "output": "OBLIGATION_OUTPUT_SENTINEL_3022",
+    });
+
+    let runtime = services.host_runtime_for_local_testing();
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context_with_dispatch_grant_for_scope(script_capability_id(), scope.clone()),
+            script_capability_id(),
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                network_egress_bytes: Some(10),
+                output_bytes: Some(100),
+                ..ResourceEstimate::default()
+            },
+            payload.clone(),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, RuntimeCapabilityOutcome::Completed(completed) if completed.output == payload)
+    );
+
+    let projection = ReplayAuditProjectionService::from_audit_log(Arc::clone(&audit_log));
+    let snapshot = projection
+        .snapshot(AuditProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&scope),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.entries.len(), 2);
+    assert_eq!(snapshot.entries[0].stage, AuditProjectionStage::Before);
+    assert_eq!(snapshot.entries[1].stage, AuditProjectionStage::After);
+    let mut status_labels = snapshot.entries[0]
+        .result_status
+        .as_deref()
+        .unwrap()
+        .split(',')
+        .collect::<Vec<_>>();
+    status_labels.sort_unstable();
+    assert_eq!(
+        status_labels,
+        vec![
+            "apply_network_policy",
+            "audit_after",
+            "audit_before",
+            "inject_secret_once",
+            "reserve_resources",
+        ]
+    );
+    assert_eq!(
+        snapshot.entries[1].output_bytes,
+        Some(serde_json::to_vec(&payload).unwrap().len() as u64)
+    );
+
+    let projection_json = serde_json::to_string(&snapshot).unwrap();
+    let jsonl_bytes = read_directory_text(&store_root);
+    for forbidden in [
+        "NETWORK_POLICY_SENTINEL_3022",
+        "SECRET_MATERIAL_SENTINEL_3022",
+        "OBLIGATION_INPUT_SENTINEL_3022",
+        "/tmp/private-obligation-path",
+        "OBLIGATION_OUTPUT_SENTINEL_3022",
+    ] {
+        assert!(
+            !projection_json.contains(forbidden),
+            "obligation audit projection leaked {forbidden}: {projection_json}"
+        );
+        assert!(
+            !jsonl_bytes.contains(forbidden),
+            "durable obligation audit bytes leaked {forbidden}: {jsonl_bytes}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn host_runtime_services_enforces_output_limit_and_reconciles_resource_usage() {
     let registry = Arc::new(registry_with_manifest(SCRIPT_MANIFEST));
     let governor = Arc::new(InMemoryResourceGovernor::new());


### PR DESCRIPTION
## Summary
- Adds a #3022 caller-level E2E slice for HostRuntime obligation audit projection.
- Drives `HostRuntimeServices -> HostRuntime -> BuiltinObligationHandler -> DurableAuditLog(JSONL) -> ReplayAuditProjectionService` with audit, network policy, one-shot secret injection, and resource reservation obligations.
- Verifies projections and durable JSONL bytes stay metadata-only for network policy, secret material, raw input/path, and output sentinels.
- Tightens audit projection `result_status` sanitization to preserve only known obligation labels with count/byte bounds and redact unsafe comma-separated values.

Refs #3022

## Verification
- `cargo fmt --check`
- `cargo test -p ironclaw_event_projections --test replay_projection_contract replay_audit_projection_preserves_only_safe_obligation_status_labels`
- `cargo test -p ironclaw_host_runtime --test host_runtime_services_contract host_runtime_services_projects_resource_network_secret_obligation_audit_metadata_only`
- `cargo clippy -p ironclaw_event_projections --test replay_projection_contract -- -D warnings`
- `cargo clippy -p ironclaw_host_runtime --test host_runtime_services_contract -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold -q`

## Review
- Paranoid/code review re-run after fixing status sanitization: no Critical/High/Medium findings.
