### PR TITLE
feat(reborn): wire durable event store selection

### DIFF
--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -18,6 +18,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_mcp = { path = "../ironclaw_mcp" }
 ironclaw_network = { path = "../ironclaw_network" }
 ironclaw_processes = { path = "../ironclaw_processes" }
+ironclaw_reborn_event_store = { path = "../ironclaw_reborn_event_store" }
 ironclaw_resources = { path = "../ironclaw_resources" }
 ironclaw_run_state = { path = "../ironclaw_run_state" }
 ironclaw_runtime_policy = { path = "../ironclaw_runtime_policy" }
@@ -36,7 +37,6 @@ url = "2"
 
 [dev-dependencies]
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
-ironclaw_reborn_event_store = { path = "../ironclaw_reborn_event_store" }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "time"] }
 wat = "1.245.1"

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -34,6 +34,10 @@ use ironclaw_processes::{
     BackgroundFailureStage, ProcessExecutionError, ProcessExecutionRequest, ProcessExecutionResult,
     ProcessExecutor, ProcessManager, ProcessResultStore, ProcessServices, ProcessStore,
 };
+use ironclaw_reborn_event_store::{
+    RebornEventStoreConfig, RebornEventStoreError, RebornEventStores, RebornProfile,
+    build_reborn_event_stores,
+};
 use ironclaw_resources::ResourceGovernor;
 use ironclaw_run_state::{ApprovalRequestStore, RunStateStore};
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
@@ -45,6 +49,8 @@ use ironclaw_wasm::{
     WitToolRequest, WitToolRuntime, WitToolRuntimeConfig,
 };
 
+use thiserror::Error;
+
 use crate::{
     BuiltinObligationHandler, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntimeError,
     NetworkObligationPolicyStore, ProcessObligationLifecycleStore, RuntimeBackendHealth,
@@ -52,6 +58,20 @@ use crate::{
 };
 
 type SharedRuntimeHttpEgress = Arc<Mutex<Option<Arc<dyn RuntimeHttpEgress>>>>;
+
+#[derive(Debug, Error)]
+pub enum ProductionEventStoreWiringError {
+    #[error("failed to build Reborn event stores: {0}")]
+    EventStore(#[from] RebornEventStoreError),
+    #[error("host runtime production wiring failed")]
+    ProductionWiring(ProductionWiringReport),
+}
+
+impl From<ProductionWiringReport> for ProductionEventStoreWiringError {
+    fn from(report: ProductionWiringReport) -> Self {
+        Self::ProductionWiring(report)
+    }
+}
 
 /// Production wiring requirements used by composition roots before exposing a
 /// [`HostRuntimeServices`] graph as production-ready.
@@ -419,6 +439,46 @@ where
         let audit_log: Arc<dyn DurableAuditLog> = audit_log;
         self.audit_sink = Some(Arc::new(DurableAuditSink::new(audit_log)));
         self
+    }
+
+    /// Attaches a pre-built Reborn durable event/audit store pair to the host
+    /// runtime graph. This is the production composition seam for store
+    /// selection: callers choose Postgres/libSQL/accepted-JSONL through
+    /// `ironclaw_reborn_event_store`, then this method adapts the durable logs
+    /// into the live sink traits consumed by runtime services.
+    pub fn with_reborn_event_stores(self, stores: RebornEventStores) -> Self {
+        self.with_reborn_event_stores_verified(stores, false)
+    }
+
+    fn with_reborn_event_stores_verified(
+        mut self,
+        stores: RebornEventStores,
+        production_verified: bool,
+    ) -> Self {
+        if production_verified {
+            self.component_types.event_sink = Some(type_name::<RebornEventStores>());
+            self.component_types.audit_sink = Some(type_name::<RebornEventStores>());
+        } else {
+            // Prebuilt/LocalDev/Test stores are useful for tests and lower-level
+            // composition, but must not silently satisfy production guardrails.
+            self.component_types.event_sink = Some(type_name::<DurableEventSink>());
+            self.component_types.audit_sink = Some(type_name::<DurableAuditSink>());
+        }
+        self.event_sink = Some(Arc::new(DurableEventSink::new(stores.events)));
+        self.audit_sink = Some(Arc::new(DurableAuditSink::new(stores.audit)));
+        self
+    }
+
+    /// Builds Reborn event/audit stores from profile/config and attaches them
+    /// to this service graph. Production JSONL/in-memory restrictions are
+    /// enforced by `build_reborn_event_stores` before sinks are installed.
+    pub async fn with_reborn_event_store_config(
+        self,
+        profile: RebornProfile,
+        config: RebornEventStoreConfig,
+    ) -> Result<Self, RebornEventStoreError> {
+        let stores = build_reborn_event_stores(profile, config).await?;
+        Ok(self.with_reborn_event_stores_verified(stores, profile == RebornProfile::Production))
     }
 
     pub fn with_secret_store<T>(mut self, secret_store: Arc<T>) -> Self
@@ -819,6 +879,19 @@ where
     ) -> Result<DefaultHostRuntime, ProductionWiringReport> {
         self.validate_production_wiring(config)?;
         Ok(self.build_host_runtime())
+    }
+
+    /// Builds and attaches the configured Reborn durable event/audit stores,
+    /// validates production wiring, and returns the host runtime facade.
+    pub async fn host_runtime_for_production_with_event_store_config(
+        self,
+        event_store_config: RebornEventStoreConfig,
+        production_config: &ProductionWiringConfig,
+    ) -> Result<DefaultHostRuntime, ProductionEventStoreWiringError> {
+        let services = self
+            .with_reborn_event_store_config(RebornProfile::Production, event_store_config)
+            .await?;
+        Ok(services.host_runtime_for_production(production_config)?)
     }
 
     /// Builds a runtime dispatcher with every configured runtime adapter.

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -41,7 +41,7 @@ use ironclaw_processes::{
     ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_reborn_event_store::{
-    RebornEventStoreConfig, RebornProfile, build_reborn_event_stores,
+    RebornEventStoreConfig, RebornEventStoreError, RebornProfile, build_reborn_event_stores,
 };
 use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
@@ -182,6 +182,130 @@ fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
             ProductionWiringIssueKind::UnsupportedRequirement
         ),
         "unsupported runtime backend requirement should be reported: {report:?}"
+    );
+}
+
+#[tokio::test]
+async fn production_event_store_config_rejects_jsonl_without_single_node_acceptance() {
+    let temp = tempfile::tempdir().unwrap();
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+
+    let result = services
+        .with_reborn_event_store_config(
+            RebornProfile::Production,
+            RebornEventStoreConfig::Jsonl {
+                root: temp.path().join("reborn-event-store"),
+                accept_single_node_durable: false,
+            },
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(RebornEventStoreError::ProductionJsonlRequiresAcceptance)
+    ));
+}
+
+#[tokio::test]
+async fn local_reborn_event_store_config_does_not_satisfy_production_wiring() {
+    let temp = tempfile::tempdir().unwrap();
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_reborn_event_store_config(
+        RebornProfile::LocalDev,
+        RebornEventStoreConfig::Jsonl {
+            root: temp.path().join("local-reborn-event-store"),
+            accept_single_node_durable: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("LocalDev stores are not production-verified event/audit sinks");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::EventSink,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "LocalDev Reborn event store must not satisfy production event sink guardrail: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::AuditSink,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "LocalDev Reborn audit store must not satisfy production audit sink guardrail: {report:?}"
+    );
+}
+
+#[tokio::test]
+async fn production_event_store_config_installs_verified_event_and_audit_sinks() {
+    let temp = tempfile::tempdir().unwrap();
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_reborn_event_store_config(
+        RebornProfile::Production,
+        RebornEventStoreConfig::Jsonl {
+            root: temp.path().join("accepted-reborn-event-store"),
+            accept_single_node_durable: true,
+        },
+    )
+    .await
+    .unwrap();
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("other local test services are still not production-ready");
+
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::EventSink,
+            ProductionWiringIssueKind::Missing
+        ),
+        "event sink must be installed from Reborn event store config: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::AuditSink,
+            ProductionWiringIssueKind::Missing
+        ),
+        "audit sink must be installed from Reborn event store config: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::EventSink,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "Reborn durable event store adapter must not be treated as erased unverified sink: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::AuditSink,
+            ProductionWiringIssueKind::UnverifiedProductionImplementation
+        ),
+        "Reborn durable audit store adapter must not be treated as erased unverified sink: {report:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- add HostRuntimeServices helpers that build and attach Reborn durable event/audit stores from RebornEventStoreConfig
- add a production-facing helper that always builds event stores under RebornProfile::Production before running production wiring validation
- keep prebuilt or LocalDev/Test RebornEventStores from satisfying production guardrails as verified event/audit sinks
- cover production JSONL fail-closed behavior and accepted single-node JSONL wiring through production guardrails

## Tests

- cargo test -p ironclaw_host_runtime event_store_config -- --nocapture
- cargo clippy -p ironclaw_host_runtime --all-features --all-targets -- -D warnings

Refs #3022
Refs #3067
Refs #3087
Refs #3281