### PR TITLE
Persist resolved turn run profiles

### DIFF
--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -7,9 +7,10 @@ use std::{
 use tracing::debug;
 
 use crate::{
-    AdmissionRejection, CancelRunRequest, CancelRunResponse, GetRunStateRequest, ResumeTurnRequest,
-    ResumeTurnResponse, SubmitTurnRequest, SubmitTurnResponse, TurnError, TurnRunId, TurnRunState,
-    TurnScope, TurnStateStore, TurnStatus, events::EventCursor,
+    AdmissionRejection, CancelRunRequest, CancelRunResponse, GetRunStateRequest,
+    InMemoryRunProfileResolver, ResumeTurnRequest, ResumeTurnResponse, RunProfileResolver,
+    SubmitTurnRequest, SubmitTurnResponse, TurnError, TurnRunId, TurnRunState, TurnScope,
+    TurnStateStore, TurnStatus, events::EventCursor,
 };
 
 pub trait TurnAdmissionPolicy: Send + Sync {
@@ -82,6 +83,7 @@ pub trait TurnCoordinator: Send + Sync {
 pub struct DefaultTurnCoordinator<S> {
     store: Arc<S>,
     admission_policy: Arc<dyn TurnAdmissionPolicy>,
+    run_profile_resolver: Arc<dyn RunProfileResolver>,
     wake_notifier: Arc<dyn TurnRunWakeNotifier>,
 }
 
@@ -93,12 +95,18 @@ where
         Self {
             store,
             admission_policy: Arc::new(AllowAllTurnAdmissionPolicy),
+            run_profile_resolver: Arc::new(InMemoryRunProfileResolver::default()),
             wake_notifier: Arc::new(NoopTurnRunWakeNotifier),
         }
     }
 
     pub fn with_admission_policy(mut self, policy: Arc<dyn TurnAdmissionPolicy>) -> Self {
         self.admission_policy = policy;
+        self
+    }
+
+    pub fn with_run_profile_resolver(mut self, resolver: Arc<dyn RunProfileResolver>) -> Self {
+        self.run_profile_resolver = resolver;
         self
     }
 
@@ -152,7 +160,11 @@ where
         let scope = request.scope.clone();
         let response = self
             .store
-            .submit_turn(request, self.admission_policy.as_ref())
+            .submit_turn(
+                request,
+                self.admission_policy.as_ref(),
+                self.run_profile_resolver.as_ref(),
+            )
             .await?;
         notify_queued_run_best_effort(self.wake_notifier.as_ref(), submit_wake(scope, &response));
         Ok(response)

--- a/crates/ironclaw_turns/src/db.rs
+++ b/crates/ironclaw_turns/src/db.rs
@@ -4,10 +4,11 @@ use std::sync::Arc;
 
 use crate::{
     CancelRunRequest, CancelRunResponse, GetRunStateRequest, InMemoryTurnStateStore,
-    InMemoryTurnStateStoreLimits, ResumeTurnRequest, ResumeTurnResponse, RunProfileResolver,
-    SubmitTurnRequest, SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionPolicy,
-    TurnCheckpointRecord, TurnError, TurnIdempotencyRecord, TurnLifecycleEvent,
-    TurnPersistenceSnapshot, TurnRecord, TurnRunRecord, TurnRunState, TurnScope, TurnStateStore,
+    InMemoryTurnStateStoreLimits, ResolvedRunProfile, ResumeTurnRequest, ResumeTurnResponse,
+    RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver, SubmitTurnRequest,
+    SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionPolicy, TurnCheckpointRecord, TurnError,
+    TurnIdempotencyRecord, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord,
+    TurnRunState, TurnScope, TurnStateStore,
     events::{EventCursor, TurnEventPage, TurnEventProjectionSource, project_turn_events},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -16,6 +17,38 @@ use crate::{
         TurnRunTransitionPort,
     },
 };
+
+struct PreResolvedRunProfileResolver {
+    result: Result<ResolvedRunProfile, RunProfileResolutionError>,
+}
+
+impl PreResolvedRunProfileResolver {
+    fn new(result: Result<ResolvedRunProfile, RunProfileResolutionError>) -> Self {
+        Self { result }
+    }
+}
+
+#[async_trait]
+impl RunProfileResolver for PreResolvedRunProfileResolver {
+    async fn resolve_run_profile(
+        &self,
+        _request: RunProfileResolutionRequest,
+    ) -> Result<ResolvedRunProfile, RunProfileResolutionError> {
+        self.result.clone()
+    }
+}
+
+async fn resolve_run_profile_for_submit(
+    request: &SubmitTurnRequest,
+    resolver: &dyn RunProfileResolver,
+) -> Result<ResolvedRunProfile, RunProfileResolutionError> {
+    resolver
+        .resolve_run_profile(RunProfileResolutionRequest {
+            requested_run_profile: request.requested_run_profile.clone(),
+            ..RunProfileResolutionRequest::interactive_default()
+        })
+        .await
+}
 
 #[cfg(feature = "libsql")]
 const LIBSQL_TURN_STATE_SCHEMA: &str = r#"
@@ -208,11 +241,14 @@ impl TurnStateStore for LibSqlTurnStateStore {
         admission_policy: &dyn TurnAdmissionPolicy,
         run_profile_resolver: &dyn RunProfileResolver,
     ) -> Result<SubmitTurnResponse, TurnError> {
+        let profile_resolution =
+            resolve_run_profile_for_submit(&request, run_profile_resolver).await;
+        let pre_resolved = PreResolvedRunProfileResolver::new(profile_resolution);
         let conn = self.begin_immediate().await?;
         let result = async {
             let store = self.load_store_from_conn(&conn).await?;
             let result = store
-                .submit_turn(request, admission_policy, run_profile_resolver)
+                .submit_turn(request, admission_policy, &pre_resolved)
                 .await;
             libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
             Ok(result)
@@ -476,12 +512,15 @@ impl TurnStateStore for PostgresTurnStateStore {
         admission_policy: &dyn TurnAdmissionPolicy,
         run_profile_resolver: &dyn RunProfileResolver,
     ) -> Result<SubmitTurnResponse, TurnError> {
+        let profile_resolution =
+            resolve_run_profile_for_submit(&request, run_profile_resolver).await;
+        let pre_resolved = PreResolvedRunProfileResolver::new(profile_resolution);
         let mut client = self.client().await?;
         let txn = client.transaction().await.map_err(db_error)?;
         lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
         let store = self.load_store_from_txn(&txn).await?;
         let result = store
-            .submit_turn(request, admission_policy, run_profile_resolver)
+            .submit_turn(request, admission_policy, &pre_resolved)
             .await;
         postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
         txn.commit().await.map_err(db_error)?;

--- a/crates/ironclaw_turns/src/db.rs
+++ b/crates/ironclaw_turns/src/db.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use crate::{
     CancelRunRequest, CancelRunResponse, GetRunStateRequest, InMemoryTurnStateStore,
-    InMemoryTurnStateStoreLimits, ResumeTurnRequest, ResumeTurnResponse, SubmitTurnRequest,
-    SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionPolicy, TurnCheckpointRecord, TurnError,
-    TurnIdempotencyRecord, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord,
-    TurnRunState, TurnScope, TurnStateStore,
+    InMemoryTurnStateStoreLimits, ResumeTurnRequest, ResumeTurnResponse, RunProfileResolver,
+    SubmitTurnRequest, SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionPolicy,
+    TurnCheckpointRecord, TurnError, TurnIdempotencyRecord, TurnLifecycleEvent,
+    TurnPersistenceSnapshot, TurnRecord, TurnRunRecord, TurnRunState, TurnScope, TurnStateStore,
     events::{EventCursor, TurnEventPage, TurnEventProjectionSource, project_turn_events},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -206,11 +206,14 @@ impl TurnStateStore for LibSqlTurnStateStore {
         &self,
         request: SubmitTurnRequest,
         admission_policy: &dyn TurnAdmissionPolicy,
+        run_profile_resolver: &dyn RunProfileResolver,
     ) -> Result<SubmitTurnResponse, TurnError> {
         let conn = self.begin_immediate().await?;
         let result = async {
             let store = self.load_store_from_conn(&conn).await?;
-            let result = store.submit_turn(request, admission_policy).await;
+            let result = store
+                .submit_turn(request, admission_policy, run_profile_resolver)
+                .await;
             libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
             Ok(result)
         }
@@ -471,12 +474,15 @@ impl TurnStateStore for PostgresTurnStateStore {
         &self,
         request: SubmitTurnRequest,
         admission_policy: &dyn TurnAdmissionPolicy,
+        run_profile_resolver: &dyn RunProfileResolver,
     ) -> Result<SubmitTurnResponse, TurnError> {
         let mut client = self.client().await?;
         let txn = client.transaction().await.map_err(db_error)?;
         lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
         let store = self.load_store_from_txn(&txn).await?;
-        let result = store.submit_turn(request, admission_policy).await;
+        let result = store
+            .submit_turn(request, admission_policy, run_profile_resolver)
+            .await;
         postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
         txn.commit().await.map_err(db_error)?;
         result

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -151,6 +151,33 @@ fn profile_resolution_error_to_turn_error(error: RunProfileResolutionError) -> T
     TurnError::AdmissionRejected(AdmissionRejection::new(reason))
 }
 
+struct SubmitInFlightGuard<'a> {
+    inner: &'a Mutex<Inner>,
+    ready: &'a Condvar,
+    key: SubmitIdempotencyKey,
+}
+
+impl<'a> SubmitInFlightGuard<'a> {
+    fn new(inner: &'a Mutex<Inner>, ready: &'a Condvar, key: SubmitIdempotencyKey) -> Self {
+        Self { inner, ready, key }
+    }
+}
+
+impl Drop for SubmitInFlightGuard<'_> {
+    fn drop(&mut self) {
+        let removed = match self.inner.lock() {
+            Ok(mut inner) => inner.submit_idempotency_in_flight.remove(&self.key),
+            Err(poisoned) => poisoned
+                .into_inner()
+                .submit_idempotency_in_flight
+                .remove(&self.key),
+        };
+        if removed {
+            self.ready.notify_all();
+        }
+    }
+}
+
 impl InMemoryTurnStateStore {
     pub fn with_limits(limits: InMemoryTurnStateStoreLimits) -> Self {
         Self {
@@ -243,6 +270,11 @@ impl TurnStateStore for InMemoryTurnStateStore {
                 inner = self.wait_for_submit_idempotency(inner)?;
             }
         }
+        let _in_flight_guard = SubmitInFlightGuard::new(
+            &self.inner,
+            &self.submit_idempotency_ready,
+            idempotency_key.clone(),
+        );
 
         let admission_result = admission_policy.check_submit(&request);
 

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -8,15 +8,16 @@ use std::{
 use chrono::{Duration as ChronoDuration, Utc};
 
 use crate::{
-    AcceptedMessageRef, BlockedReason, CancelRunRequest, CancelRunResponse, GetRunStateRequest,
-    IdempotencyKey, LoopExitMapping, ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse,
-    SanitizedFailure, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
-    TurnActiveLockKey, TurnActiveLockRecord, TurnActor, TurnAdmissionPolicy, TurnCheckpointId,
-    TurnCheckpointRecord, TurnError, TurnEventKind, TurnIdempotencyErrorReplay,
-    TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnIdempotencyRecord,
-    TurnIdempotencyReplay, TurnLifecycleEvent, TurnLockVersion, TurnPersistenceSnapshot,
-    TurnRecord, TurnRunId, TurnRunProfile, TurnRunRecord, TurnRunState, TurnScope, TurnStateStore,
-    TurnStatus,
+    AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, BlockedReason,
+    CancelRunRequest, CancelRunResponse, GetRunStateRequest, IdempotencyKey, LoopExitMapping,
+    ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse, RunProfileResolutionError,
+    RunProfileResolutionRequest, RunProfileResolver, SanitizedFailure, SourceBindingRef,
+    SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActiveLockKey, TurnActiveLockRecord,
+    TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnCheckpointRecord, TurnError,
+    TurnEventKind, TurnIdempotencyErrorReplay, TurnIdempotencyOperationKind,
+    TurnIdempotencyOutcomeKind, TurnIdempotencyRecord, TurnIdempotencyReplay, TurnLifecycleEvent,
+    TurnLockVersion, TurnPersistenceSnapshot, TurnRecord, TurnRunId, TurnRunProfile, TurnRunRecord,
+    TurnRunState, TurnScope, TurnStateStore, TurnStatus,
     events::{EventCursor, TurnEventPage, TurnEventProjectionSource, project_turn_events},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -139,6 +140,17 @@ struct PersistedIdempotencyKey {
     key: IdempotencyKey,
 }
 
+fn profile_resolution_error_to_turn_error(error: RunProfileResolutionError) -> TurnError {
+    let reason = match error {
+        RunProfileResolutionError::Unauthorized { .. } => AdmissionRejectionReason::Unauthorized,
+        RunProfileResolutionError::ProfileUnavailable { .. }
+        | RunProfileResolutionError::InvalidRequest { .. } => {
+            AdmissionRejectionReason::ProfileRejected
+        }
+    };
+    TurnError::AdmissionRejected(AdmissionRejection::new(reason))
+}
+
 impl InMemoryTurnStateStore {
     pub fn with_limits(limits: InMemoryTurnStateStoreLimits) -> Self {
         Self {
@@ -210,27 +222,57 @@ impl TurnStateStore for InMemoryTurnStateStore {
         &self,
         request: SubmitTurnRequest,
         admission_policy: &dyn TurnAdmissionPolicy,
+        run_profile_resolver: &dyn RunProfileResolver,
     ) -> Result<SubmitTurnResponse, TurnError> {
         let idempotency_key = SubmitIdempotencyKey {
             scope: request.scope.clone(),
             key: request.idempotency_key.clone(),
         };
-        let mut inner = self.lock_inner()?;
-        loop {
-            if let Some(result) = inner.submit_idempotency.get(&idempotency_key) {
-                return result.clone();
+        {
+            let mut inner = self.lock_inner()?;
+            loop {
+                if let Some(result) = inner.submit_idempotency.get(&idempotency_key) {
+                    return result.clone();
+                }
+                if inner
+                    .submit_idempotency_in_flight
+                    .insert(idempotency_key.clone())
+                {
+                    break;
+                }
+                inner = self.wait_for_submit_idempotency(inner)?;
             }
-            if inner
-                .submit_idempotency_in_flight
-                .insert(idempotency_key.clone())
-            {
-                break;
-            }
-            inner = self.wait_for_submit_idempotency(inner)?;
         }
-        drop(inner);
 
         let admission_result = admission_policy.check_submit(&request);
+
+        {
+            let mut inner = self.lock_inner()?;
+            if let Some(result) = inner.submit_idempotency.get(&idempotency_key).cloned() {
+                inner.submit_idempotency_in_flight.remove(&idempotency_key);
+                self.submit_idempotency_ready.notify_all();
+                return result;
+            }
+
+            if let Err(rejection) = admission_result {
+                let response = Err(TurnError::AdmissionRejected(rejection));
+                inner.remember_submit_idempotency(
+                    idempotency_key.clone(),
+                    response.clone(),
+                    request.received_at,
+                );
+                inner.submit_idempotency_in_flight.remove(&idempotency_key);
+                self.submit_idempotency_ready.notify_all();
+                return response;
+            }
+        }
+
+        let profile_resolution = run_profile_resolver
+            .resolve_run_profile(RunProfileResolutionRequest {
+                requested_run_profile: request.requested_run_profile.clone(),
+                ..RunProfileResolutionRequest::interactive_default()
+            })
+            .await;
 
         let mut inner = self.lock_inner()?;
         if let Some(result) = inner.submit_idempotency.get(&idempotency_key).cloned() {
@@ -238,18 +280,20 @@ impl TurnStateStore for InMemoryTurnStateStore {
             self.submit_idempotency_ready.notify_all();
             return result;
         }
-
-        if let Err(rejection) = admission_result {
-            let response = Err(TurnError::AdmissionRejected(rejection));
-            inner.remember_submit_idempotency(
-                idempotency_key.clone(),
-                response.clone(),
-                request.received_at,
-            );
-            inner.submit_idempotency_in_flight.remove(&idempotency_key);
-            self.submit_idempotency_ready.notify_all();
-            return response;
-        }
+        let profile = match profile_resolution {
+            Ok(resolved) => TurnRunProfile::from_resolved(resolved),
+            Err(error) => {
+                let response = Err(profile_resolution_error_to_turn_error(error));
+                inner.remember_submit_idempotency(
+                    idempotency_key.clone(),
+                    response.clone(),
+                    request.received_at,
+                );
+                inner.submit_idempotency_in_flight.remove(&idempotency_key);
+                self.submit_idempotency_ready.notify_all();
+                return response;
+            }
+        };
 
         let lock_key = TurnActiveLockKey::from(&request.scope);
         if let Some(active_lock) = inner.active_locks.get(&lock_key)
@@ -274,7 +318,6 @@ impl TurnStateStore for InMemoryTurnStateStore {
         let turn_id = crate::TurnId::new();
         let run_id = TurnRunId::new();
         let cursor = inner.next_cursor();
-        let profile = TurnRunProfile::resolve(request.requested_run_profile.as_ref());
         let turn_record = TurnRecord {
             turn_id,
             scope: request.scope.clone(),
@@ -410,6 +453,7 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
         inner.update_active_lock(&record, now);
         let claimed = ClaimedTurnRun {
             state: record.state(),
+            resolved_run_profile: record.profile.resolved.clone(),
             runner_id: request.runner_id,
             lease_token: request.lease_token,
         };

--- a/crates/ironclaw_turns/src/run_profile/snapshot.rs
+++ b/crates/ironclaw_turns/src/run_profile/snapshot.rs
@@ -5,12 +5,13 @@ use crate::{RunProfileId, RunProfileVersion};
 use super::{
     driver::AgentLoopDriverDescriptor,
     policy::{
-        CancellationPolicy, CheckpointPolicy, RedactedRunProfileProvenance, ResourceBudgetPolicy,
-        RuntimeProfileConstraints, SteeringPolicy,
+        CancellationPolicy, CheckpointPolicy, RedactedRunProfileProvenance,
+        RedactedRunProfileSource, ResourceBudgetPolicy, RuntimeProfileConstraints, SteeringPolicy,
     },
     refs::{
         CapabilitySurfaceProfileId, CheckpointSchemaId, ConcurrencyClass, ContextProfileId,
-        ModelProfileId, RunClassId, RunProfileFingerprint, RunnerPoolId, SchedulingClass,
+        LoopDriverId, ModelProfileId, ResourceBudgetTier, RunClassId, RunProfileFingerprint,
+        RunProfileSourceLayer, RunProfileSourceRef, RunnerPoolId, SchedulingClass,
     },
 };
 
@@ -35,4 +36,75 @@ pub struct ResolvedRunProfile {
     pub concurrency_class: ConcurrencyClass,
     pub resolution_fingerprint: RunProfileFingerprint,
     pub provenance: RedactedRunProfileProvenance,
+}
+
+impl ResolvedRunProfile {
+    pub(crate) fn legacy_compatibility(
+        profile_id: RunProfileId,
+        profile_version: RunProfileVersion,
+        allow_steering: bool,
+    ) -> Self {
+        let checkpoint_schema_id =
+            CheckpointSchemaId::from_trusted_static("interactive_checkpoint_v1");
+        let checkpoint_schema_version = RunProfileVersion::new(1);
+        Self {
+            run_class_id: RunClassId::from_trusted_static("legacy_interactive_coding"),
+            profile_id,
+            profile_version,
+            loop_driver: AgentLoopDriverDescriptor {
+                id: LoopDriverId::from_trusted_static("lightweight_loop"),
+                version: RunProfileVersion::new(1),
+                checkpoint_schema_id: Some(checkpoint_schema_id.clone()),
+                checkpoint_schema_version: Some(checkpoint_schema_version),
+            },
+            checkpoint_schema_id,
+            checkpoint_schema_version,
+            model_profile_id: ModelProfileId::from_trusted_static("interactive_model"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::from_trusted_static(
+                "interactive_tools",
+            ),
+            context_profile_id: ContextProfileId::from_trusted_static("interactive_context"),
+            steering_policy: SteeringPolicy {
+                allow_steering,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: true,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::from_trusted_static("interactive_standard"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::from_trusted_static("interactive"),
+            concurrency_class: ConcurrencyClass::from_trusted_static("thread_serial"),
+            resolution_fingerprint: RunProfileFingerprint::from_trusted_static(
+                "legacy-persisted-profile-v1",
+            ),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![RedactedRunProfileSource {
+                    layer: RunProfileSourceLayer::from_trusted_static("legacy_persistence"),
+                    source_ref: RunProfileSourceRef::from_trusted_static(
+                        "turn-run-profile:legacy:v1",
+                    ),
+                    summary: "legacy persisted turn run profile reconstructed without raw authority handles"
+                        .to_string(),
+                }],
+                effective_privileges: Vec::new(),
+            },
+        }
+    }
 }

--- a/crates/ironclaw_turns/src/runner.rs
+++ b/crates/ironclaw_turns/src/runner.rs
@@ -2,9 +2,9 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    BlockedReason, LoopExit, LoopExitMapping, LoopExitValidationPolicy, SanitizedFailure,
-    TurnCheckpointId, TurnError, TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope,
-    TurnTimestamp, events::EventCursor,
+    BlockedReason, LoopExit, LoopExitMapping, LoopExitValidationPolicy, ResolvedRunProfile,
+    SanitizedFailure, TurnCheckpointId, TurnError, TurnLeaseToken, TurnRunId, TurnRunState,
+    TurnRunnerId, TurnScope, TurnTimestamp, events::EventCursor,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -17,6 +17,7 @@ pub struct ClaimRunRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClaimedTurnRun {
     pub state: TurnRunState,
+    pub resolved_run_profile: ResolvedRunProfile,
     pub runner_id: TurnRunnerId,
     pub lease_token: TurnLeaseToken,
 }

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    AcceptedMessageRef, GateRef, ReplyTargetBindingRef, RunProfileId, RunProfileRequest,
+    AcceptedMessageRef, GateRef, ReplyTargetBindingRef, ResolvedRunProfile, RunProfileId,
     RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId, TurnRunId, TurnScope,
     events::EventCursor, request::TurnTimestamp,
 };
@@ -31,22 +31,65 @@ impl TurnStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TurnRunProfile {
     pub id: RunProfileId,
     pub version: RunProfileVersion,
     pub allow_steering: bool,
     pub auto_queue_followups: bool,
+    pub resolved: ResolvedRunProfile,
 }
 
 impl TurnRunProfile {
-    pub fn resolve(_request: Option<&RunProfileRequest>) -> Self {
+    pub fn from_resolved(resolved: ResolvedRunProfile) -> Self {
+        let id = compatibility_profile_id(&resolved);
         Self {
-            id: RunProfileId::default_profile(),
-            version: RunProfileVersion::new(1),
-            allow_steering: false,
+            id,
+            version: resolved.profile_version,
+            allow_steering: resolved.steering_policy.allow_steering,
             auto_queue_followups: false,
+            resolved,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for TurnRunProfile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireProfile {
+            id: RunProfileId,
+            version: RunProfileVersion,
+            allow_steering: bool,
+            auto_queue_followups: bool,
+            resolved: Option<ResolvedRunProfile>,
+        }
+
+        let wire = WireProfile::deserialize(deserializer)?;
+        let resolved = wire.resolved.unwrap_or_else(|| {
+            ResolvedRunProfile::legacy_compatibility(
+                wire.id.clone(),
+                wire.version,
+                wire.allow_steering,
+            )
+        });
+        Ok(Self {
+            id: wire.id,
+            version: wire.version,
+            allow_steering: wire.allow_steering,
+            auto_queue_followups: wire.auto_queue_followups,
+            resolved,
+        })
+    }
+}
+
+fn compatibility_profile_id(resolved: &ResolvedRunProfile) -> RunProfileId {
+    if resolved.profile_id.as_str() == "interactive_default" {
+        RunProfileId::default_profile()
+    } else {
+        resolved.profile_id.clone()
     }
 }
 

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 use crate::{
     AcceptedMessageRef, AdmissionRejection, CancelRunRequest, CancelRunResponse, GateRef,
     GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef, ResumeTurnRequest,
-    ResumeTurnResponse, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
-    TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnError, TurnErrorCategory, TurnId,
-    TurnLeaseToken, TurnLifecycleEvent, TurnRunId, TurnRunProfile, TurnRunState, TurnRunnerId,
-    TurnScope, TurnStatus, TurnTimestamp, events::EventCursor,
+    ResumeTurnResponse, RunProfileResolver, SourceBindingRef, SubmitTurnRequest,
+    SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnError,
+    TurnErrorCategory, TurnId, TurnLeaseToken, TurnLifecycleEvent, TurnRunId, TurnRunProfile,
+    TurnRunState, TurnRunnerId, TurnScope, TurnStatus, TurnTimestamp, events::EventCursor,
 };
 
 #[async_trait]
@@ -16,6 +16,7 @@ pub trait TurnStateStore: Send + Sync {
         &self,
         request: SubmitTurnRequest,
         admission_policy: &dyn TurnAdmissionPolicy,
+        run_profile_resolver: &dyn RunProfileResolver,
     ) -> Result<SubmitTurnResponse, TurnError>;
 
     async fn resume_turn(

--- a/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
@@ -4,17 +4,22 @@
     allow(dead_code, unused_imports)
 )]
 
-use std::sync::Arc;
+use std::{
+    sync::{Arc, Mutex, mpsc},
+    time::Duration,
+};
 
 use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
-    AcceptedMessageRef, CancelRunRequest, DefaultTurnCoordinator, IdempotencyKey, LoopCompleted,
-    LoopCompletionKind, LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy,
-    LoopMessageRef, ReplyTargetBindingRef, RunProfileRequest, SanitizedCancelReason,
-    SanitizedFailure, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
-    TurnActor, TurnCoordinator, TurnError, TurnEventKind, TurnEventProjectionRequest,
-    TurnEventProjectionService, TurnRunId, TurnScope, TurnStatus,
+    AcceptedMessageRef, CancelRunRequest, DefaultTurnCoordinator, IdempotencyKey,
+    InMemoryRunProfileResolver, LoopCompleted, LoopCompletionKind, LoopExit,
+    LoopExitInvalidHandling, LoopExitValidationPolicy, LoopMessageRef, ReplyTargetBindingRef,
+    ResolvedRunProfile, RunProfileRequest, RunProfileResolutionError, RunProfileResolutionRequest,
+    RunProfileResolver, SanitizedCancelReason, SanitizedFailure, SourceBindingRef,
+    SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor, TurnCoordinator, TurnError,
+    TurnEventKind, TurnEventProjectionRequest, TurnEventProjectionService, TurnRunId, TurnScope,
+    TurnStatus,
     runner::{
         ApplyLoopExitRequest, ClaimRunRequest, RecoverExpiredLeasesRequest, TurnRunTransitionPort,
         apply_loop_exit,
@@ -25,6 +30,34 @@ use ironclaw_turns::{
 use ironclaw_turns::LibSqlTurnStateStore;
 #[cfg(feature = "postgres")]
 use ironclaw_turns::PostgresTurnStateStore;
+
+struct BlockingRunProfileResolver {
+    started: mpsc::Sender<()>,
+    release: Mutex<mpsc::Receiver<()>>,
+}
+
+impl BlockingRunProfileResolver {
+    fn new(started: mpsc::Sender<()>, release: mpsc::Receiver<()>) -> Self {
+        Self {
+            started,
+            release: Mutex::new(release),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl RunProfileResolver for BlockingRunProfileResolver {
+    async fn resolve_run_profile(
+        &self,
+        request: RunProfileResolutionRequest,
+    ) -> Result<ResolvedRunProfile, RunProfileResolutionError> {
+        let _ = self.started.send(());
+        self.release.lock().unwrap().recv().unwrap();
+        InMemoryRunProfileResolver::default()
+            .resolve_run_profile(request)
+            .await
+    }
+}
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
@@ -140,6 +173,45 @@ async fn libsql_turn_state_store_serializes_concurrent_submits_for_same_thread()
     assert_eq!(snapshot.turns.len(), 1);
     assert_eq!(snapshot.runs.len(), 1);
     assert_eq!(snapshot.active_locks.len(), 1);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_submit_does_not_hold_write_lock_while_resolving_run_profile() {
+    let (db, _dir) = libsql_db().await;
+    let store_a = Arc::new(LibSqlTurnStateStore::new(db.clone()));
+    store_a.run_migrations().await.unwrap();
+    let store_b = Arc::new(LibSqlTurnStateStore::new(db));
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let resolver = Arc::new(BlockingRunProfileResolver::new(started_tx, release_rx));
+    let blocking_coordinator =
+        DefaultTurnCoordinator::new(store_a).with_run_profile_resolver(resolver.clone());
+    let independent_coordinator = DefaultTurnCoordinator::new(store_b);
+
+    let pending = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(
+            blocking_coordinator
+                .submit_turn(submit_request("thread-a", "idem-submit-blocking-profile")),
+        )
+    });
+    started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("first submit should start profile resolution");
+
+    let independent = independent_coordinator
+        .submit_turn(submit_request("thread-b", "idem-submit-independent"))
+        .await
+        .unwrap();
+
+    assert!(matches!(independent, SubmitTurnResponse::Accepted { .. }));
+    release_tx.send(()).unwrap();
+    let pending = pending.join().unwrap().unwrap();
+    assert!(matches!(pending, SubmitTurnResponse::Accepted { .. }));
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -4,6 +4,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         mpsc,
     },
+    task::{Context, Poll},
     time::Duration,
 };
 
@@ -15,7 +16,8 @@ use ironclaw_turns::{
     IdempotencyKey, InMemoryRunProfileResolver, InMemoryTurnEventSink, InMemoryTurnStateStore,
     InMemoryTurnStateStoreLimits, LoopCompleted, LoopCompletionKind, LoopExit,
     LoopExitInvalidHandling, LoopExitValidationPolicy, LoopGateRef, LoopMessageRef,
-    ReplyTargetBindingRef, ResumeTurnRequest, RunProfileId, RunProfileRequest, RunProfileVersion,
+    ReplyTargetBindingRef, ResolvedRunProfile, ResumeTurnRequest, RunProfileId, RunProfileRequest,
+    RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion,
     SanitizedCancelReason, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
     SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnCheckpointId,
     TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventProjectionError,
@@ -31,6 +33,27 @@ use ironclaw_turns::{
         RecoverExpiredLeasesResponse, TurnRunTransitionPort, apply_loop_exit,
     },
 };
+
+struct BlockingRunProfileResolver {
+    started: mpsc::Sender<()>,
+}
+
+impl BlockingRunProfileResolver {
+    fn new(started: mpsc::Sender<()>) -> Self {
+        Self { started }
+    }
+}
+
+#[async_trait::async_trait]
+impl RunProfileResolver for BlockingRunProfileResolver {
+    async fn resolve_run_profile(
+        &self,
+        _request: RunProfileResolutionRequest,
+    ) -> Result<ResolvedRunProfile, RunProfileResolutionError> {
+        let _ = self.started.send(());
+        std::future::pending::<Result<ResolvedRunProfile, RunProfileResolutionError>>().await
+    }
+}
 
 #[test]
 fn turn_scope_agent_id_is_optional() {
@@ -945,6 +968,47 @@ fn concurrent_duplicate_submit_waits_for_in_flight_admission_result() {
     let second = second.join().unwrap().unwrap();
     assert_eq!(second, first);
     assert_eq!(policy.calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn cancelled_submit_during_profile_resolution_clears_in_flight_idempotency() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let (started_tx, started_rx) = mpsc::channel();
+    let resolver = Arc::new(BlockingRunProfileResolver::new(started_tx));
+    let request = submit_request("thread-a", "idem-submit-cancelled-profile-resolution");
+    let mut pending = store.submit_turn(
+        request.clone(),
+        &AllowAllTurnAdmissionPolicy,
+        resolver.as_ref(),
+    );
+    let waker = std::task::Waker::noop();
+    let mut context = Context::from_waker(waker);
+    assert!(matches!(pending.as_mut().poll(&mut context), Poll::Pending));
+    started_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("first submit should start profile resolution");
+    drop(pending);
+
+    let retry_store = store.clone();
+    let (retry_tx, retry_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let retry = runtime.block_on(retry_store.submit_turn(
+            request,
+            &AllowAllTurnAdmissionPolicy,
+            &InMemoryRunProfileResolver::default(),
+        ));
+        retry_tx.send(retry).unwrap();
+    });
+    let retry = retry_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("retry should not wait on a stale in-flight idempotency key")
+        .unwrap();
+
+    assert!(matches!(retry, SubmitTurnResponse::Accepted { .. }));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -12,17 +12,17 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
     AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason, AllowAllTurnAdmissionPolicy,
     BlockedReason, CancelRunRequest, DefaultTurnCoordinator, GateRef, GetRunStateRequest,
-    IdempotencyKey, InMemoryTurnEventSink, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits,
-    LoopCompleted, LoopCompletionKind, LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy,
-    LoopGateRef, LoopMessageRef, ReplyTargetBindingRef, ResumeTurnRequest, RunProfileId,
-    RunProfileRequest, RunProfileVersion, SanitizedCancelReason, SanitizedFailure,
-    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
-    TurnAdmissionPolicy, TurnCheckpointId, TurnCoordinator, TurnError, TurnErrorCategory,
-    TurnEventKind, TurnEventProjectionError, TurnEventProjectionRequest,
-    TurnEventProjectionService, TurnEventSink, TurnIdempotencyOperationKind,
-    TurnIdempotencyOutcomeKind, TurnLeaseToken, TurnLifecycleEvent, TurnLockVersion, TurnRunId,
-    TurnRunState, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnRunnerId,
-    TurnScope, TurnStateStore, TurnStatus,
+    IdempotencyKey, InMemoryRunProfileResolver, InMemoryTurnEventSink, InMemoryTurnStateStore,
+    InMemoryTurnStateStoreLimits, LoopCompleted, LoopCompletionKind, LoopExit,
+    LoopExitInvalidHandling, LoopExitValidationPolicy, LoopGateRef, LoopMessageRef,
+    ReplyTargetBindingRef, ResumeTurnRequest, RunProfileId, RunProfileRequest, RunProfileVersion,
+    SanitizedCancelReason, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
+    SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnCheckpointId,
+    TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventProjectionError,
+    TurnEventProjectionRequest, TurnEventProjectionService, TurnEventSink,
+    TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnLeaseToken, TurnLifecycleEvent,
+    TurnLockVersion, TurnRunId, TurnRunProfile, TurnRunState, TurnRunWake, TurnRunWakeNotifier,
+    TurnRunWakeNotifyError, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
     events::EventCursor,
     runner::{
         ApplyLoopExitRequest, ApplyValidatedLoopExitRequest, BlockRunRequest,
@@ -208,7 +208,7 @@ async fn submit_turn_accepts_only_canonical_refs_and_returns_redacted_metadata()
 
     let state = coordinator
         .get_run_state(GetRunStateRequest {
-            scope: request.scope,
+            scope: request.scope.clone(),
             run_id,
         })
         .await
@@ -224,36 +224,89 @@ async fn submit_turn_accepts_only_canonical_refs_and_returns_redacted_metadata()
     );
     assert_eq!(state.received_at, received_at());
     assert_eq!(state.failure, None);
+
+    let snapshot = _store.persistence_snapshot();
+    let run = snapshot
+        .runs
+        .iter()
+        .find(|record| record.run_id == run_id)
+        .unwrap();
+    assert_eq!(run.profile.id.as_str(), "default");
+    assert_eq!(
+        run.profile.resolved.profile_id.as_str(),
+        "interactive_default"
+    );
+    assert_eq!(
+        run.profile.resolved.loop_driver.id.as_str(),
+        "lightweight_loop"
+    );
+
+    let claimed = _store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: TurnRunnerId::new(),
+            lease_token: TurnLeaseToken::new(),
+            scope_filter: Some(request.scope),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        claimed.resolved_run_profile.profile_id.as_str(),
+        "interactive_default"
+    );
+    assert_eq!(
+        claimed.resolved_run_profile.loop_driver.id.as_str(),
+        "lightweight_loop"
+    );
 }
 
 #[tokio::test]
-async fn requested_run_profile_is_a_hint_not_resolved_authority() {
-    let (coordinator, _store) = coordinator();
+async fn unauthorized_requested_run_profile_rejects_before_persisting_run() {
+    let (coordinator, store) = coordinator();
     let mut request = submit_request("thread-a", "idem-profile-hint");
-    request.requested_run_profile = Some(RunProfileRequest::new("experimental-fast-lane").unwrap());
+    request.requested_run_profile = Some(RunProfileRequest::new("long_running_mission").unwrap());
 
-    let response = coordinator.submit_turn(request.clone()).await.unwrap();
+    let err = coordinator.submit_turn(request.clone()).await.unwrap_err();
 
-    let SubmitTurnResponse::Accepted {
-        run_id,
-        resolved_run_profile_id,
-        resolved_run_profile_version,
-        ..
-    } = response;
-    assert_eq!(resolved_run_profile_id.as_str(), "default");
-    assert_eq!(resolved_run_profile_version, RunProfileVersion::new(1));
-
-    let state = coordinator
-        .get_run_state(GetRunStateRequest {
-            scope: request.scope,
-            run_id,
-        })
-        .await
-        .unwrap();
-    assert_eq!(state.resolved_run_profile_id.as_str(), "default");
     assert_eq!(
-        state.resolved_run_profile_version,
-        RunProfileVersion::new(1)
+        err,
+        TurnError::AdmissionRejected(AdmissionRejection::new(
+            AdmissionRejectionReason::Unauthorized
+        ))
+    );
+    assert!(store.events().is_empty());
+    assert!(store.persistence_snapshot().runs.is_empty());
+
+    let duplicate = coordinator.submit_turn(request).await.unwrap_err();
+    assert_eq!(duplicate, err);
+}
+
+#[test]
+fn legacy_turn_run_profile_payload_deserializes_with_synthetic_resolved_snapshot() {
+    let legacy = r#"{
+        "id":"default",
+        "version":1,
+        "allow_steering":false,
+        "auto_queue_followups":false
+    }"#;
+
+    let profile = serde_json::from_str::<TurnRunProfile>(legacy).unwrap();
+
+    assert_eq!(profile.id.as_str(), "default");
+    assert_eq!(profile.version, RunProfileVersion::new(1));
+    assert!(!profile.allow_steering);
+    assert_eq!(profile.resolved.profile_id.as_str(), "default");
+    assert_eq!(profile.resolved.profile_version, RunProfileVersion::new(1));
+    assert_eq!(profile.resolved.loop_driver.id.as_str(), "lightweight_loop");
+    assert!(!profile.resolved.steering_policy.allow_steering);
+    assert!(
+        profile
+            .resolved
+            .provenance
+            .sources
+            .iter()
+            .any(|source| source.summary
+                == "legacy persisted turn run profile reconstructed without raw authority handles")
     );
 }
 
@@ -416,6 +469,7 @@ async fn resume_turn_ignores_wake_notification_panic_after_requeue() {
         .submit_turn(
             submit_request("thread-a", "idem-submit-a"),
             &AllowAllTurnAdmissionPolicy,
+            &InMemoryRunProfileResolver::default(),
         )
         .await
         .map(|response| accepted_run_id(&response))


### PR DESCRIPTION
## Summary
- wire RunProfileResolver through turn submission/admission
- persist immutable ResolvedRunProfile snapshots on turn runs and expose them to claimed runners
- preserve legacy resolved_run_profile_id/version compatibility and deserialize old run-profile payloads with a safe synthetic snapshot

## Tests
- cargo test -p ironclaw_turns
- cargo test -p ironclaw_turns --features libsql --test db_turn_state_store_contract
- cargo fmt --check
- cargo clippy -p ironclaw_turns --all-targets --all-features -- -D warnings

Closes #3107