### PR TITLE
Add durable run-state database stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4348,13 +4348,17 @@ name = "ironclaw_run_state"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "deadpool-postgres",
  "ironclaw_filesystem",
  "ironclaw_host_api",
+ "libsql",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/ironclaw_capabilities/src/helpers.rs
+++ b/crates/ironclaw_capabilities/src/helpers.rs
@@ -202,5 +202,6 @@ pub(crate) fn run_state_error_kind(error: &RunStateError) -> &'static str {
         RunStateError::Filesystem(_) => "Filesystem",
         RunStateError::Serialization(_) => "Serialization",
         RunStateError::Deserialization(_) => "Deserialization",
+        RunStateError::Backend(_) => "Backend",
     }
 }

--- a/crates/ironclaw_capabilities/src/host.rs
+++ b/crates/ironclaw_capabilities/src/host.rs
@@ -6,7 +6,8 @@ use ironclaw_host_api::{
 };
 use ironclaw_processes::{ProcessManager, ProcessStart};
 use ironclaw_run_state::{
-    ApprovalRequestStore, ApprovalStatus, RunStart, RunStateError, RunStateStore, RunStatus,
+    ApprovalRequestStore, ApprovalStatus, RunStart, RunStateApprovalStore, RunStateError,
+    RunStateStore, RunStatus,
 };
 use tracing::warn;
 
@@ -34,6 +35,7 @@ where
     authorizer: &'a dyn TrustAwareCapabilityDispatchAuthorizer,
     run_state: Option<&'a dyn RunStateStore>,
     approval_requests: Option<&'a dyn ApprovalRequestStore>,
+    run_state_approval_store: Option<&'a dyn RunStateApprovalStore>,
     capability_leases: Option<&'a dyn CapabilityLeaseStore>,
     process_manager: Option<&'a dyn ProcessManager>,
     obligation_handler: Option<&'a dyn CapabilityObligationHandler>,
@@ -54,6 +56,7 @@ where
             authorizer,
             run_state: None,
             approval_requests: None,
+            run_state_approval_store: None,
             capability_leases: None,
             process_manager: None,
             obligation_handler: None,
@@ -69,6 +72,7 @@ where
     /// error but no run record is persisted.
     pub fn with_run_state(mut self, run_state: &'a dyn RunStateStore) -> Self {
         self.run_state = Some(run_state);
+        self.run_state_approval_store = None;
         self
     }
 
@@ -83,6 +87,18 @@ where
         approval_requests: &'a dyn ApprovalRequestStore,
     ) -> Self {
         self.approval_requests = Some(approval_requests);
+        self.run_state_approval_store = None;
+        self
+    }
+
+    /// Attaches a combined durable run-state/approval store that can persist a
+    /// pending approval and transition the invocation to `BlockedApproval` in one
+    /// transaction. Production composition should prefer this over separate
+    /// stores when both records live in the same backend.
+    pub fn with_run_state_approval_store(mut self, store: &'a dyn RunStateApprovalStore) -> Self {
+        self.run_state = Some(store);
+        self.approval_requests = Some(store);
+        self.run_state_approval_store = Some(store);
         self
     }
 
@@ -254,42 +270,62 @@ where
 
                 match (self.run_state, self.approval_requests) {
                     (Some(run_state), Some(approval_requests)) => {
-                        let approval_id = approval.id;
-                        if let Err(error) = approval_requests
-                            .save_pending(scope.clone(), approval.clone())
-                            .await
-                        {
-                            fail_run_if_configured(
-                                Some(run_state),
-                                &scope,
-                                invocation_id,
-                                "ApprovalStore",
-                            )
-                            .await;
-                            return Err(CapabilityInvocationError::from(error));
-                        }
-                        if let Err(error) = run_state
-                            .block_approval(&scope, invocation_id, approval)
-                            .await
-                        {
-                            if let Err(discard_error) =
-                                approval_requests.discard_pending(&scope, approval_id).await
+                        if let Some(combined_store) = self.run_state_approval_store {
+                            if let Err(error) = combined_store
+                                .save_pending_and_block_approval(
+                                    scope.clone(),
+                                    invocation_id,
+                                    approval,
+                                )
+                                .await
                             {
-                                warn!(
-                                    approval_request_id = %approval_id,
-                                    invocation_id = %invocation_id,
-                                    transition_error_kind = run_state_error_kind(&discard_error),
-                                    "approval rollback failed after run-state block transition failed",
-                                );
+                                fail_run_if_configured(
+                                    Some(run_state),
+                                    &scope,
+                                    invocation_id,
+                                    "ApprovalBlock",
+                                )
+                                .await;
+                                return Err(CapabilityInvocationError::from(error));
                             }
-                            fail_run_if_configured(
-                                Some(run_state),
-                                &scope,
-                                invocation_id,
-                                "ApprovalBlock",
-                            )
-                            .await;
-                            return Err(CapabilityInvocationError::from(error));
+                        } else {
+                            let approval_id = approval.id;
+                            if let Err(error) = approval_requests
+                                .save_pending(scope.clone(), approval.clone())
+                                .await
+                            {
+                                fail_run_if_configured(
+                                    Some(run_state),
+                                    &scope,
+                                    invocation_id,
+                                    "ApprovalStore",
+                                )
+                                .await;
+                                return Err(CapabilityInvocationError::from(error));
+                            }
+                            if let Err(error) = run_state
+                                .block_approval(&scope, invocation_id, approval)
+                                .await
+                            {
+                                if let Err(discard_error) =
+                                    approval_requests.discard_pending(&scope, approval_id).await
+                                {
+                                    warn!(
+                                        approval_request_id = %approval_id,
+                                        invocation_id = %invocation_id,
+                                        transition_error_kind = run_state_error_kind(&discard_error),
+                                        "approval rollback failed after run-state block transition failed",
+                                    );
+                                }
+                                fail_run_if_configured(
+                                    Some(run_state),
+                                    &scope,
+                                    invocation_id,
+                                    "ApprovalBlock",
+                                )
+                                .await;
+                                return Err(CapabilityInvocationError::from(error));
+                            }
                         }
                     }
                     (Some(run_state), None) => {
@@ -1245,42 +1281,62 @@ where
 
                 match (self.run_state, self.approval_requests) {
                     (Some(run_state), Some(approval_requests)) => {
-                        let approval_id = approval.id;
-                        if let Err(error) = approval_requests
-                            .save_pending(scope.clone(), approval.clone())
-                            .await
-                        {
-                            fail_run_if_configured(
-                                Some(run_state),
-                                &scope,
-                                invocation_id,
-                                "ApprovalStore",
-                            )
-                            .await;
-                            return Err(CapabilityInvocationError::from(error));
-                        }
-                        if let Err(error) = run_state
-                            .block_approval(&scope, invocation_id, approval)
-                            .await
-                        {
-                            if let Err(discard_error) =
-                                approval_requests.discard_pending(&scope, approval_id).await
+                        if let Some(combined_store) = self.run_state_approval_store {
+                            if let Err(error) = combined_store
+                                .save_pending_and_block_approval(
+                                    scope.clone(),
+                                    invocation_id,
+                                    approval,
+                                )
+                                .await
                             {
-                                warn!(
-                                    approval_request_id = %approval_id,
-                                    invocation_id = %invocation_id,
-                                    transition_error_kind = run_state_error_kind(&discard_error),
-                                    "approval rollback failed after spawn run-state block transition failed",
-                                );
+                                fail_run_if_configured(
+                                    Some(run_state),
+                                    &scope,
+                                    invocation_id,
+                                    "ApprovalBlock",
+                                )
+                                .await;
+                                return Err(CapabilityInvocationError::from(error));
                             }
-                            fail_run_if_configured(
-                                Some(run_state),
-                                &scope,
-                                invocation_id,
-                                "ApprovalBlock",
-                            )
-                            .await;
-                            return Err(CapabilityInvocationError::from(error));
+                        } else {
+                            let approval_id = approval.id;
+                            if let Err(error) = approval_requests
+                                .save_pending(scope.clone(), approval.clone())
+                                .await
+                            {
+                                fail_run_if_configured(
+                                    Some(run_state),
+                                    &scope,
+                                    invocation_id,
+                                    "ApprovalStore",
+                                )
+                                .await;
+                                return Err(CapabilityInvocationError::from(error));
+                            }
+                            if let Err(error) = run_state
+                                .block_approval(&scope, invocation_id, approval)
+                                .await
+                            {
+                                if let Err(discard_error) =
+                                    approval_requests.discard_pending(&scope, approval_id).await
+                                {
+                                    warn!(
+                                        approval_request_id = %approval_id,
+                                        invocation_id = %invocation_id,
+                                        transition_error_kind = run_state_error_kind(&discard_error),
+                                        "approval rollback failed after spawn run-state block transition failed",
+                                    );
+                                }
+                                fail_run_if_configured(
+                                    Some(run_state),
+                                    &scope,
+                                    invocation_id,
+                                    "ApprovalBlock",
+                                )
+                                .await;
+                                return Err(CapabilityInvocationError::from(error));
+                            }
                         }
                     }
                     (Some(run_state), None) => {

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -62,6 +62,99 @@ async fn capability_host_blocks_for_approval_without_dispatch() {
 }
 
 #[tokio::test]
+async fn capability_host_uses_combined_store_for_atomic_approval_block() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let store = RecordingCombinedRunStateApprovalStore::new();
+    let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
+        .with_run_state_approval_store(&store);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "needs atomic approval"});
+
+    let err = host
+        .invoke_json(CapabilityInvocationRequest {
+            context,
+            capability_id: capability_id(),
+            estimate: estimate.clone(),
+            input: input.clone(),
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::AuthorizationRequiresApproval { .. }
+    ));
+    assert_eq!(store.combined_calls(), 1);
+    assert_eq!(store.separate_save_calls(), 0);
+    let run = RunStateStore::get(&store, &scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, RunStatus::BlockedApproval);
+    let approval_id = run.approval_request_id.unwrap();
+    let approval = ApprovalRequestStore::get(&store, &scope, approval_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(approval.status, ApprovalStatus::Pending);
+    assert_eq!(
+        approval.request.invocation_fingerprint,
+        Some(
+            InvocationFingerprint::for_dispatch(&scope, &capability_id(), &estimate, &input)
+                .unwrap()
+        )
+    );
+}
+
+#[tokio::test]
+async fn capability_host_separate_store_setters_clear_combined_atomic_path() {
+    let registry = registry_with_echo_capability();
+    let dispatcher = RecordingDispatcher::default();
+    let combined = RecordingCombinedRunStateApprovalStore::new();
+    let separate_run_state = InMemoryRunStateStore::new();
+    let host = CapabilityHost::new(&registry, &dispatcher, &ApprovalAuthorizer)
+        .with_run_state_approval_store(&combined)
+        .with_run_state(&separate_run_state);
+    let context = execution_context(CapabilitySet::default());
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message": "split stores by explicit setter order"});
+
+    let err = host
+        .invoke_json(CapabilityInvocationRequest {
+            context,
+            capability_id: capability_id(),
+            estimate,
+            input,
+            trust_decision: trust_decision(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityInvocationError::AuthorizationRequiresApproval { .. }
+    ));
+    assert_eq!(combined.combined_calls(), 0);
+    assert_eq!(combined.separate_save_calls(), 1);
+    assert_eq!(
+        separate_run_state
+            .get(&scope, invocation_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        RunStatus::BlockedApproval
+    );
+}
+
+#[tokio::test]
 async fn capability_host_leaves_run_blocked_when_resume_is_attempted_before_approval_resolves() {
     let registry = registry_with_echo_capability();
     let dispatcher = RecordingDispatcher::default();
@@ -1281,6 +1374,160 @@ impl ApprovalRequestStore for HangingSaveApprovalRequestStore {
         scope: &ResourceScope,
     ) -> Result<Vec<ApprovalRecord>, RunStateError> {
         self.inner.records_for_scope(scope).await
+    }
+}
+
+struct RecordingCombinedRunStateApprovalStore {
+    runs: InMemoryRunStateStore,
+    approvals: InMemoryApprovalRequestStore,
+    combined_calls: AtomicUsize,
+    separate_save_calls: AtomicUsize,
+}
+
+impl RecordingCombinedRunStateApprovalStore {
+    fn new() -> Self {
+        Self {
+            runs: InMemoryRunStateStore::new(),
+            approvals: InMemoryApprovalRequestStore::new(),
+            combined_calls: AtomicUsize::new(0),
+            separate_save_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn combined_calls(&self) -> usize {
+        self.combined_calls.load(Ordering::SeqCst)
+    }
+
+    fn separate_save_calls(&self) -> usize {
+        self.separate_save_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl RunStateStore for RecordingCombinedRunStateApprovalStore {
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        self.runs.start(start).await
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .block_approval(scope, invocation_id, approval)
+            .await
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.block_auth(scope, invocation_id, error_kind).await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.complete(scope, invocation_id).await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.fail(scope, invocation_id, error_kind).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        self.runs.get(scope, invocation_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        self.runs.records_for_scope(scope).await
+    }
+}
+
+#[async_trait]
+impl ApprovalRequestStore for RecordingCombinedRunStateApprovalStore {
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.separate_save_calls.fetch_add(1, Ordering::SeqCst);
+        self.approvals.save_pending(scope, request).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        self.approvals.get(scope, request_id).await
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.approve(scope, request_id).await
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.deny(scope, request_id).await
+    }
+
+    async fn discard_pending(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.discard_pending(scope, request_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        self.approvals.records_for_scope(scope).await
+    }
+}
+
+#[async_trait]
+impl RunStateApprovalStore for RecordingCombinedRunStateApprovalStore {
+    async fn save_pending_and_block_approval(
+        &self,
+        scope: ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.combined_calls.fetch_add(1, Ordering::SeqCst);
+        self.approvals
+            .save_pending(scope.clone(), approval.clone())
+            .await?;
+        self.runs
+            .block_approval(&scope, invocation_id, approval)
+            .await
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -30,7 +30,9 @@ use ironclaw_processes::{
     ProcessCancellationRegistry, ProcessError, ProcessHost, ProcessManager, ProcessResultStore,
     ProcessStatus, ProcessStore,
 };
-use ironclaw_run_state::{ApprovalRequestStore, RunStateError, RunStateStore, RunStatus};
+use ironclaw_run_state::{
+    ApprovalRequestStore, RunStateApprovalStore, RunStateError, RunStateStore, RunStatus,
+};
 use ironclaw_trust::{HostTrustPolicy, TrustDecision, TrustError, TrustPolicy, TrustProvenance};
 
 use crate::{
@@ -51,6 +53,7 @@ pub struct DefaultHostRuntime {
     trust_policy: Arc<dyn TrustPolicy>,
     run_state: Option<Arc<dyn RunStateStore>>,
     approval_requests: Option<Arc<dyn ApprovalRequestStore>>,
+    run_state_approval_store: Option<Arc<dyn RunStateApprovalStore>>,
     capability_leases: Option<Arc<dyn CapabilityLeaseStore>>,
     process_manager: Option<Arc<dyn ProcessManager>>,
     process_store: Option<Arc<dyn ProcessStore>>,
@@ -68,9 +71,11 @@ impl DefaultHostRuntime {
     /// dispatch fails closed until composition attaches a concrete policy with
     /// [`Self::with_trust_policy`] or [`Self::with_trust_policy_dyn`].
     ///
-    /// Callers must additionally attach a run-state store and approval-
-    /// request store via [`with_run_state`](Self::with_run_state) and
-    /// [`with_approval_requests`](Self::with_approval_requests) before
+    /// Callers must additionally attach either a combined
+    /// [`RunStateApprovalStore`] via
+    /// [`with_run_state_approval_store`](Self::with_run_state_approval_store),
+    /// or separate stores via [`with_run_state`](Self::with_run_state) and
+    /// [`with_approval_requests`](Self::with_approval_requests), before
     /// invoking any capability whose authorizer may return
     /// `RequireApproval`. Without those stores the capability host fails
     /// closed with `ApprovalStoreMissing`, which surfaces here as a
@@ -89,6 +94,7 @@ impl DefaultHostRuntime {
             trust_policy: Arc::new(HostTrustPolicy::empty()),
             run_state: None,
             approval_requests: None,
+            run_state_approval_store: None,
             capability_leases: None,
             process_manager: None,
             process_store: None,
@@ -119,6 +125,7 @@ impl DefaultHostRuntime {
     /// Attaches the run-state store used to record invocation lifecycle.
     pub fn with_run_state(mut self, run_state: Arc<dyn RunStateStore>) -> Self {
         self.run_state = Some(run_state);
+        self.run_state_approval_store = None;
         self
     }
 
@@ -128,6 +135,16 @@ impl DefaultHostRuntime {
         approval_requests: Arc<dyn ApprovalRequestStore>,
     ) -> Self {
         self.approval_requests = Some(approval_requests);
+        self.run_state_approval_store = None;
+        self
+    }
+
+    /// Attaches a combined durable run-state/approval-request store with an
+    /// atomic approval-block transition.
+    pub fn with_run_state_approval_store(mut self, store: Arc<dyn RunStateApprovalStore>) -> Self {
+        self.run_state = Some(store.clone());
+        self.approval_requests = Some(store.clone());
+        self.run_state_approval_store = Some(store);
         self
     }
 
@@ -537,11 +554,15 @@ impl DefaultHostRuntime {
             self.dispatcher.as_ref(),
             self.authorizer.as_ref(),
         );
-        if let Some(run_state) = &self.run_state {
-            host = host.with_run_state(run_state.as_ref());
-        }
-        if let Some(approval_requests) = &self.approval_requests {
-            host = host.with_approval_requests(approval_requests.as_ref());
+        if let Some(run_state_approval_store) = &self.run_state_approval_store {
+            host = host.with_run_state_approval_store(run_state_approval_store.as_ref());
+        } else {
+            if let Some(run_state) = &self.run_state {
+                host = host.with_run_state(run_state.as_ref());
+            }
+            if let Some(approval_requests) = &self.approval_requests {
+                host = host.with_approval_requests(approval_requests.as_ref());
+            }
         }
         if let Some(capability_leases) = &self.capability_leases {
             host = host.with_capability_leases(capability_leases.as_ref());
@@ -823,6 +844,7 @@ fn unavailable_from_run_state(error: RunStateError) -> HostRuntimeError {
         RunStateError::Filesystem(_) => "run-state filesystem unavailable",
         RunStateError::Serialization(_) => "run-state serialization failed",
         RunStateError::Deserialization(_) => "run-state deserialization failed",
+        RunStateError::Backend(_) => "run-state backend unavailable",
     };
     HostRuntimeError::unavailable(reason)
 }

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -43,7 +43,7 @@ use ironclaw_reborn_event_store::{
     build_reborn_event_stores,
 };
 use ironclaw_resources::ResourceGovernor;
-use ironclaw_run_state::{ApprovalRequestStore, RunStateStore};
+use ironclaw_run_state::{ApprovalRequestStore, RunStateApprovalStore, RunStateStore};
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
 use ironclaw_secrets::SecretStore;
 use ironclaw_trust::{HostTrustPolicy, TrustPolicy};
@@ -271,6 +271,7 @@ where
     surface_version: CapabilitySurfaceVersion,
     run_state: Option<Arc<dyn RunStateStore>>,
     approval_requests: Option<Arc<dyn ApprovalRequestStore>>,
+    run_state_approval_store: Option<Arc<dyn RunStateApprovalStore>>,
     capability_leases: Option<Arc<dyn CapabilityLeaseStore>>,
     event_sink: Option<Arc<dyn EventSink>>,
     audit_sink: Option<Arc<dyn AuditSink>>,
@@ -321,6 +322,7 @@ where
             surface_version,
             run_state: None,
             approval_requests: None,
+            run_state_approval_store: None,
             capability_leases: None,
             event_sink: None,
             audit_sink: None,
@@ -461,6 +463,7 @@ where
     {
         self.component_types.run_state = Some(type_name::<T>());
         self.run_state = Some(run_state);
+        self.run_state_approval_store = None;
         self
     }
 
@@ -470,6 +473,19 @@ where
     {
         self.component_types.approval_requests = Some(type_name::<T>());
         self.approval_requests = Some(approval_requests);
+        self.run_state_approval_store = None;
+        self
+    }
+
+    pub fn with_run_state_approval_store<T>(mut self, store: Arc<T>) -> Self
+    where
+        T: RunStateApprovalStore + 'static,
+    {
+        self.component_types.run_state = Some(type_name::<T>());
+        self.component_types.approval_requests = Some(type_name::<T>());
+        self.run_state = Some(store.clone());
+        self.approval_requests = Some(store.clone());
+        self.run_state_approval_store = Some(store);
         self
     }
 
@@ -1077,11 +1093,15 @@ where
         .with_process_cancellation_registry(self.process_services.cancellation_registry())
         .with_runtime_health(runtime_health);
 
-        if let Some(run_state) = &self.run_state {
-            runtime = runtime.with_run_state(Arc::clone(run_state));
-        }
-        if let Some(approval_requests) = &self.approval_requests {
-            runtime = runtime.with_approval_requests(Arc::clone(approval_requests));
+        if let Some(run_state_approval_store) = &self.run_state_approval_store {
+            runtime = runtime.with_run_state_approval_store(Arc::clone(run_state_approval_store));
+        } else {
+            if let Some(run_state) = &self.run_state {
+                runtime = runtime.with_run_state(Arc::clone(run_state));
+            }
+            if let Some(approval_requests) = &self.approval_requests {
+                runtime = runtime.with_approval_requests(Arc::clone(approval_requests));
+            }
         }
         if let Some(capability_leases) = &self.capability_leases {
             runtime = runtime.with_capability_leases(Arc::clone(capability_leases));

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -360,6 +360,7 @@ where
         }
     }
 
+    #[cfg(any(feature = "postgres", feature = "libsql"))]
     fn with_root_filesystem<T>(self, filesystem: Arc<T>) -> HostRuntimeServices<T, G, S, R>
     where
         T: RootFilesystem + 'static,
@@ -375,6 +376,7 @@ where
             surface_version,
             run_state,
             approval_requests,
+            run_state_approval_store,
             capability_leases,
             event_sink,
             audit_sink,
@@ -402,6 +404,7 @@ where
             surface_version,
             run_state,
             approval_requests,
+            run_state_approval_store,
             capability_leases,
             event_sink,
             audit_sink,

--- a/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_contract.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -17,8 +20,8 @@ use ironclaw_processes::{
     ProcessResultStore, ProcessStart, ProcessStatus, ProcessStore,
 };
 use ironclaw_run_state::{
-    InMemoryApprovalRequestStore, InMemoryRunStateStore, RunRecord, RunStart, RunStateError,
-    RunStateStore,
+    ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, InMemoryRunStateStore,
+    RunRecord, RunStart, RunStateApprovalStore, RunStateError, RunStateStore,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -125,6 +128,64 @@ async fn default_runtime_surfaces_approval_required_with_persisted_request_id() 
                 .unwrap()
                 .expect("run record persisted");
             assert_eq!(record.approval_request_id, Some(gate.approval_request_id));
+        }
+        other => panic!("expected ApprovalRequired outcome, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn default_runtime_uses_combined_store_for_atomic_approval_block() {
+    let registry = Arc::new(registry_with_echo_capability());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> = Arc::new(ApprovalAuthorizer);
+    let combined_store = Arc::new(RecordingCombinedRunStateApprovalStore::new());
+    let leases: Arc<dyn ironclaw_authorization::CapabilityLeaseStore> =
+        Arc::new(InMemoryCapabilityLeaseStore::new());
+
+    let runtime = DefaultHostRuntime::new(
+        registry,
+        dispatcher,
+        authorizer,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_run_state_approval_store(combined_store.clone())
+    .with_capability_leases(leases);
+
+    let context = execution_context_with_dispatch_grant();
+    let request = RuntimeCapabilityRequest::new(
+        context.clone(),
+        capability_id(),
+        ResourceEstimate::default(),
+        json!({"message": "hello"}),
+        trust_decision_with_dispatch_authority(),
+    );
+
+    let outcome = runtime.invoke_capability(request).await.unwrap();
+
+    match outcome {
+        ironclaw_host_runtime::RuntimeCapabilityOutcome::ApprovalRequired(gate) => {
+            assert_eq!(gate.capability_id, capability_id());
+            assert_eq!(combined_store.combined_calls(), 1);
+            assert_eq!(combined_store.separate_save_calls(), 0);
+            let record = RunStateStore::get(
+                combined_store.as_ref(),
+                &context.resource_scope,
+                context.invocation_id,
+            )
+            .await
+            .unwrap()
+            .expect("run record persisted");
+            assert_eq!(record.approval_request_id, Some(gate.approval_request_id));
+            assert!(
+                ApprovalRequestStore::get(
+                    combined_store.as_ref(),
+                    &context.resource_scope,
+                    gate.approval_request_id,
+                )
+                .await
+                .unwrap()
+                .is_some()
+            );
         }
         other => panic!("expected ApprovalRequired outcome, got {:?}", other),
     }
@@ -982,6 +1043,160 @@ impl RunStateStore for FailingGetRunStateStore {
         scope: &ResourceScope,
     ) -> Result<Vec<RunRecord>, RunStateError> {
         self.inner.records_for_scope(scope).await
+    }
+}
+
+struct RecordingCombinedRunStateApprovalStore {
+    runs: InMemoryRunStateStore,
+    approvals: InMemoryApprovalRequestStore,
+    combined_calls: AtomicUsize,
+    separate_save_calls: AtomicUsize,
+}
+
+impl RecordingCombinedRunStateApprovalStore {
+    fn new() -> Self {
+        Self {
+            runs: InMemoryRunStateStore::new(),
+            approvals: InMemoryApprovalRequestStore::new(),
+            combined_calls: AtomicUsize::new(0),
+            separate_save_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn combined_calls(&self) -> usize {
+        self.combined_calls.load(Ordering::SeqCst)
+    }
+
+    fn separate_save_calls(&self) -> usize {
+        self.separate_save_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl RunStateStore for RecordingCombinedRunStateApprovalStore {
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        self.runs.start(start).await
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .block_approval(scope, invocation_id, approval)
+            .await
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.block_auth(scope, invocation_id, error_kind).await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.complete(scope, invocation_id).await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.fail(scope, invocation_id, error_kind).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        self.runs.get(scope, invocation_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        self.runs.records_for_scope(scope).await
+    }
+}
+
+#[async_trait]
+impl ApprovalRequestStore for RecordingCombinedRunStateApprovalStore {
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.separate_save_calls.fetch_add(1, Ordering::SeqCst);
+        self.approvals.save_pending(scope, request).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        self.approvals.get(scope, request_id).await
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.approve(scope, request_id).await
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.deny(scope, request_id).await
+    }
+
+    async fn discard_pending(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.discard_pending(scope, request_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        self.approvals.records_for_scope(scope).await
+    }
+}
+
+#[async_trait]
+impl RunStateApprovalStore for RecordingCombinedRunStateApprovalStore {
+    async fn save_pending_and_block_approval(
+        &self,
+        scope: ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.combined_calls.fetch_add(1, Ordering::SeqCst);
+        self.approvals
+            .save_pending(scope.clone(), approval.clone())
+            .await?;
+        self.runs
+            .block_approval(&scope, invocation_id, approval)
+            .await
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -784,7 +784,32 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
 
 #[tokio::test]
 async fn host_runtime_services_wires_combined_store_for_atomic_approval_block() {
-    let combined_store = Arc::new(InMemoryRecordingCombinedRunStateApprovalStore::new());
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ApprovalThenGrantAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+
+    assert_services_use_combined_store_for_atomic_approval_block(
+        services,
+        "approval from services",
+    )
+    .await;
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn host_runtime_services_preserves_combined_store_after_root_filesystem_selection() {
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir
+        .path()
+        .join("root-filesystem-preserves-combined-store.db");
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let filesystem = Arc::new(LibSqlRootFilesystem::new(db));
+    filesystem.run_migrations().await.unwrap();
     let services = HostRuntimeServices::new(
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
@@ -793,15 +818,35 @@ async fn host_runtime_services_wires_combined_store_for_atomic_approval_block() 
         ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
-    .with_trust_policy(Arc::new(local_manifest_trust_policy(
-        "script",
-        vec![EffectKind::DispatchCapability],
-    )))
-    .with_run_state_approval_store(Arc::clone(&combined_store))
-    .with_script_runtime(Arc::new(ScriptRuntime::new(
-        ScriptRuntimeConfig::for_testing(),
-        EchoScriptBackend,
-    )));
+    .with_libsql_root_filesystem(filesystem);
+
+    assert_services_use_combined_store_for_atomic_approval_block(
+        services,
+        "approval after root filesystem selection",
+    )
+    .await;
+}
+
+async fn assert_services_use_combined_store_for_atomic_approval_block<
+    F: RootFilesystem + 'static,
+    G: ResourceGovernor + 'static,
+    S: ProcessStore + 'static,
+    R: ProcessResultStore + 'static,
+>(
+    services: HostRuntimeServices<F, G, S, R>,
+    message: &str,
+) {
+    let combined_store = Arc::new(InMemoryRecordingCombinedRunStateApprovalStore::new());
+    let services = services
+        .with_trust_policy(Arc::new(local_manifest_trust_policy(
+            "script",
+            vec![EffectKind::DispatchCapability],
+        )))
+        .with_run_state_approval_store(Arc::clone(&combined_store))
+        .with_script_runtime(Arc::new(ScriptRuntime::new(
+            ScriptRuntimeConfig::for_testing(),
+            EchoScriptBackend,
+        )));
 
     let runtime = services.host_runtime_for_local_testing();
     let context = execution_context_without_grants();
@@ -810,7 +855,7 @@ async fn host_runtime_services_wires_combined_store_for_atomic_approval_block() 
             context.clone(),
             script_capability_id(),
             ResourceEstimate::default(),
-            json!({"message": "approval from services"}),
+            json!({"message": message}),
             trust_decision_with_dispatch_authority(),
         ))
         .await

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1,4 +1,11 @@
-use std::{sync::Arc, thread, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use chrono::{Duration as ChronoDuration, Utc};
@@ -49,7 +56,8 @@ use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
 };
 use ironclaw_run_state::{
-    InMemoryApprovalRequestStore, InMemoryRunStateStore, RunStateStore, RunStatus,
+    ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, InMemoryRunStateStore,
+    RunRecord, RunStart, RunStateApprovalStore, RunStateError, RunStateStore, RunStatus,
 };
 use ironclaw_scripts::{
     ScriptBackend, ScriptBackendOutput, ScriptBackendRequest, ScriptExecutionRequest,
@@ -160,6 +168,54 @@ fn production_wiring_validation_rejects_missing_components_and_local_only_defaul
             ProductionWiringIssueKind::LocalOnlyImplementation
         ),
         "in-memory process result store should be reported as local-only: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_classifies_combined_store_as_run_state_and_approvals() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_run_state_approval_store(Arc::new(
+        InMemoryRecordingCombinedRunStateApprovalStore::new(),
+    ));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("local/test combined store must not pass production validation");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::RunState,
+            ProductionWiringIssueKind::LocalOnlyImplementation,
+        ),
+        "combined store should be classified for run-state guardrails: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::ApprovalRequests,
+            ProductionWiringIssueKind::LocalOnlyImplementation,
+        ),
+        "combined store should be classified for approval guardrails: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::RunState,
+            ProductionWiringIssueKind::Missing,
+        ),
+        "combined store should satisfy run-state presence: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::ApprovalRequests,
+            ProductionWiringIssueKind::Missing,
+        ),
+        "combined store should satisfy approval-store presence: {report:?}"
     );
 }
 
@@ -724,6 +780,72 @@ async fn host_runtime_services_builds_dispatcher_runtime_and_health_from_registe
             RuntimeEventKind::DispatchSucceeded,
         ]
     );
+}
+
+#[tokio::test]
+async fn host_runtime_services_wires_combined_store_for_atomic_approval_block() {
+    let combined_store = Arc::new(InMemoryRecordingCombinedRunStateApprovalStore::new());
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ApprovalThenGrantAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
+    .with_run_state_approval_store(Arc::clone(&combined_store))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )));
+
+    let runtime = services.host_runtime_for_local_testing();
+    let context = execution_context_without_grants();
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context.clone(),
+            script_capability_id(),
+            ResourceEstimate::default(),
+            json!({"message": "approval from services"}),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::ApprovalRequired(gate) => {
+            assert_eq!(combined_store.combined_calls(), 1);
+            assert_eq!(combined_store.separate_save_calls(), 0);
+            let run_record = RunStateStore::get(
+                combined_store.as_ref(),
+                &context.resource_scope,
+                context.invocation_id,
+            )
+            .await
+            .unwrap()
+            .expect("run record persisted");
+            assert_eq!(run_record.status, RunStatus::BlockedApproval);
+            assert_eq!(
+                run_record.approval_request_id,
+                Some(gate.approval_request_id)
+            );
+            assert!(
+                ApprovalRequestStore::get(
+                    combined_store.as_ref(),
+                    &context.resource_scope,
+                    gate.approval_request_id,
+                )
+                .await
+                .unwrap()
+                .is_some()
+            );
+        }
+        other => panic!("expected approval gate, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -3979,6 +4101,160 @@ type InMemoryHostRuntimeServices = HostRuntimeServices<
     InMemoryProcessStore,
     InMemoryProcessResultStore,
 >;
+
+struct InMemoryRecordingCombinedRunStateApprovalStore {
+    runs: InMemoryRunStateStore,
+    approvals: InMemoryApprovalRequestStore,
+    combined_calls: AtomicUsize,
+    separate_save_calls: AtomicUsize,
+}
+
+impl InMemoryRecordingCombinedRunStateApprovalStore {
+    fn new() -> Self {
+        Self {
+            runs: InMemoryRunStateStore::new(),
+            approvals: InMemoryApprovalRequestStore::new(),
+            combined_calls: AtomicUsize::new(0),
+            separate_save_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn combined_calls(&self) -> usize {
+        self.combined_calls.load(Ordering::SeqCst)
+    }
+
+    fn separate_save_calls(&self) -> usize {
+        self.separate_save_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl RunStateStore for InMemoryRecordingCombinedRunStateApprovalStore {
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        self.runs.start(start).await
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs
+            .block_approval(scope, invocation_id, approval)
+            .await
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.block_auth(scope, invocation_id, error_kind).await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.complete(scope, invocation_id).await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.runs.fail(scope, invocation_id, error_kind).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        self.runs.get(scope, invocation_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        self.runs.records_for_scope(scope).await
+    }
+}
+
+#[async_trait]
+impl ApprovalRequestStore for InMemoryRecordingCombinedRunStateApprovalStore {
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.separate_save_calls.fetch_add(1, Ordering::SeqCst);
+        self.approvals.save_pending(scope, request).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        self.approvals.get(scope, request_id).await
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.approve(scope, request_id).await
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.deny(scope, request_id).await
+    }
+
+    async fn discard_pending(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.approvals.discard_pending(scope, request_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        self.approvals.records_for_scope(scope).await
+    }
+}
+
+#[async_trait]
+impl RunStateApprovalStore for InMemoryRecordingCombinedRunStateApprovalStore {
+    async fn save_pending_and_block_approval(
+        &self,
+        scope: ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.combined_calls.fetch_add(1, Ordering::SeqCst);
+        self.approvals
+            .save_pending(scope.clone(), approval.clone())
+            .await?;
+        self.runs
+            .block_approval(&scope, invocation_id, approval)
+            .await
+    }
+}
 
 struct ApprovalResumeFixture {
     services: InMemoryHostRuntimeServices,

--- a/crates/ironclaw_run_state/CLAUDE.md
+++ b/crates/ironclaw_run_state/CLAUDE.md
@@ -3,6 +3,6 @@
 - Own durable invocation state and approval request records.
 - Do not own authorization policy, approval resolution, dispatch, runtime execution, process lifecycle, or product workflow.
 - All lookups and transitions are resource-owner scoped (tenant/user/agent/project/mission/thread); wrong-scope access must look unknown.
-- Filesystem-backed run/approval stores use process-local serialization only; production shared roots need transactional/CAS backends before real multi-process callers.
+- Filesystem-backed run/approval stores use process-local serialization only; production shared callers should use the feature-gated PostgreSQL/libSQL stores with transactional writes.
 - Do not persist raw replay input or runtime output in run-state records.
 - Keep approval records as control-plane state, not authority by themselves.

--- a/crates/ironclaw_run_state/Cargo.toml
+++ b/crates/ironclaw_run_state/Cargo.toml
@@ -4,14 +4,23 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+default = []
+postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
+libsql = ["dep:libsql"]
+
 [dependencies]
 async-trait = "0.1"
+deadpool-postgres = { version = "0.14", optional = true }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
+tokio-postgres = { version = "0.7", optional = true }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironclaw_run_state/src/db.rs
+++ b/crates/ironclaw_run_state/src/db.rs
@@ -1309,11 +1309,40 @@ async fn libsql_update_approval(
 
 #[cfg(feature = "postgres")]
 async fn run_postgres_migrations(pool: &deadpool_postgres::Pool) -> Result<(), RunStateError> {
-    let client = pool.get().await.map_err(db_error)?;
-    client
-        .batch_execute(POSTGRES_RUN_STATE_SCHEMA)
+    const MIGRATION_LOCK_ID: i64 = 0x1c10_0001;
+
+    let mut client = pool.get().await.map_err(db_error)?;
+    let txn = client.transaction().await.map_err(db_error)?;
+    txn.query_one("SELECT pg_advisory_xact_lock($1)", &[&MIGRATION_LOCK_ID])
         .await
-        .map_err(db_error)
+        .map_err(db_error)?;
+    if !postgres_schema_present(&txn).await? {
+        txn.batch_execute(POSTGRES_RUN_STATE_SCHEMA)
+            .await
+            .map_err(db_error)?;
+    }
+    txn.commit().await.map_err(db_error)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_schema_present(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<bool, RunStateError> {
+    let row = client
+        .query_one(
+            "SELECT
+                to_regclass('public.reborn_run_state_records') IS NOT NULL,
+                to_regclass('public.idx_reborn_run_state_records_owner_status') IS NOT NULL,
+                to_regclass('public.reborn_approval_request_records') IS NOT NULL,
+                to_regclass('public.idx_reborn_approval_request_records_owner_status') IS NOT NULL",
+            &[],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(row.get::<_, bool>(0)
+        && row.get::<_, bool>(1)
+        && row.get::<_, bool>(2)
+        && row.get::<_, bool>(3))
 }
 
 #[cfg(feature = "postgres")]
@@ -1390,7 +1419,7 @@ async fn postgres_insert_run(
     let payload = to_json(record)?;
     let affected = client
         .execute(
-            "INSERT INTO reborn_run_state_records (owner_key, invocation_id, capability_id, status, approval_request_id, error_kind, payload) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb) ON CONFLICT DO NOTHING",
+            "INSERT INTO reborn_run_state_records (owner_key, invocation_id, capability_id, status, approval_request_id, error_kind, payload) VALUES ($1, $2, $3, $4, $5, $6, $7::text::jsonb) ON CONFLICT DO NOTHING",
             &[
                 &owner_key(&record.scope)?,
                 &record.invocation_id.to_string(),
@@ -1414,7 +1443,7 @@ async fn postgres_update_run(
     let payload = to_json(record)?;
     let affected = client
         .execute(
-            "UPDATE reborn_run_state_records SET capability_id = $3, status = $4, approval_request_id = $5, error_kind = $6, payload = $7::jsonb WHERE owner_key = $1 AND invocation_id = $2",
+            "UPDATE reborn_run_state_records SET capability_id = $3, status = $4, approval_request_id = $5, error_kind = $6, payload = $7::text::jsonb WHERE owner_key = $1 AND invocation_id = $2",
             &[
                 &owner_key(&record.scope)?,
                 &record.invocation_id.to_string(),
@@ -1492,7 +1521,7 @@ async fn postgres_insert_approval(
     let payload = to_json(record)?;
     let affected = client
         .execute(
-            "INSERT INTO reborn_approval_request_records (owner_key, request_id, status, payload) VALUES ($1, $2, $3, $4::jsonb) ON CONFLICT DO NOTHING",
+            "INSERT INTO reborn_approval_request_records (owner_key, request_id, status, payload) VALUES ($1, $2, $3, $4::text::jsonb) ON CONFLICT DO NOTHING",
             &[
                 &owner_key(&record.scope)?,
                 &record.request.id.to_string(),
@@ -1513,7 +1542,7 @@ async fn postgres_update_approval(
     let payload = to_json(record)?;
     let affected = client
         .execute(
-            "UPDATE reborn_approval_request_records SET status = $3, payload = $4::jsonb WHERE owner_key = $1 AND request_id = $2",
+            "UPDATE reborn_approval_request_records SET status = $3, payload = $4::text::jsonb WHERE owner_key = $1 AND request_id = $2",
             &[
                 &owner_key(&record.scope)?,
                 &record.request.id.to_string(),

--- a/crates/ironclaw_run_state/src/db.rs
+++ b/crates/ironclaw_run_state/src/db.rs
@@ -182,18 +182,30 @@ impl RunStateStore for LibSqlRunStateStore {
         let owner_key = owner_key(scope)?;
         let mut rows = conn
             .query(
-                "SELECT payload FROM reborn_run_state_records WHERE owner_key = ?1 ORDER BY invocation_id",
+                "SELECT invocation_id, capability_id, status, approval_request_id, error_kind, payload FROM reborn_run_state_records WHERE owner_key = ?1 ORDER BY invocation_id",
                 libsql::params![owner_key],
             )
             .await
             .map_err(db_error)?;
         let mut records = Vec::new();
         while let Some(row) = rows.next().await.map_err(db_error)? {
-            let payload: String = row.get(0).map_err(db_error)?;
-            let record = from_json::<RunRecord>(&payload)?;
-            if crate::same_scope_owner(&record.scope, scope) {
-                records.push(record);
-            }
+            let row_invocation_id: String = row.get(0).map_err(db_error)?;
+            let row_invocation_id = parse_invocation_id_column(&row_invocation_id)?;
+            let capability_id: String = row.get(1).map_err(db_error)?;
+            let status: String = row.get(2).map_err(db_error)?;
+            let approval_request_id: Option<String> = row.get(3).map_err(db_error)?;
+            let error_kind: Option<String> = row.get(4).map_err(db_error)?;
+            let payload: String = row.get(5).map_err(db_error)?;
+            let record = validate_run_row(
+                from_json::<RunRecord>(&payload)?,
+                scope,
+                row_invocation_id,
+                &capability_id,
+                &status,
+                approval_request_id.as_deref(),
+                error_kind.as_deref(),
+            )?;
+            records.push(record);
         }
         records.sort_by_key(|record| record.invocation_id.as_uuid());
         Ok(records)
@@ -507,12 +519,14 @@ impl ApprovalRequestStore for LibSqlApprovalRequestStore {
                     status: record.status,
                 });
             }
-            conn.execute(
-                "DELETE FROM reborn_approval_request_records WHERE owner_key = ?1 AND request_id = ?2",
-                libsql::params![owner_key(scope)?, request_id.to_string()],
-            )
-            .await
-            .map_err(db_error)?;
+            let affected = conn
+                .execute(
+                    "DELETE FROM reborn_approval_request_records WHERE owner_key = ?1 AND request_id = ?2",
+                    libsql::params![owner_key(scope)?, request_id.to_string()],
+                )
+                .await
+                .map_err(db_error)?;
+            require_single_affected_row(affected, "discard approval")?;
             Ok(record)
         }
         .await;
@@ -527,18 +541,24 @@ impl ApprovalRequestStore for LibSqlApprovalRequestStore {
         let owner_key = owner_key(scope)?;
         let mut rows = conn
             .query(
-                "SELECT payload FROM reborn_approval_request_records WHERE owner_key = ?1 ORDER BY request_id",
+                "SELECT request_id, status, payload FROM reborn_approval_request_records WHERE owner_key = ?1 ORDER BY request_id",
                 libsql::params![owner_key],
             )
             .await
             .map_err(db_error)?;
         let mut records = Vec::new();
         while let Some(row) = rows.next().await.map_err(db_error)? {
-            let payload: String = row.get(0).map_err(db_error)?;
-            let record = from_json::<ApprovalRecord>(&payload)?;
-            if crate::same_scope_owner(&record.scope, scope) {
-                records.push(record);
-            }
+            let request_id: String = row.get(0).map_err(db_error)?;
+            let request_id = parse_approval_request_id_column(&request_id)?;
+            let status: String = row.get(1).map_err(db_error)?;
+            let payload: String = row.get(2).map_err(db_error)?;
+            let record = validate_approval_row(
+                from_json::<ApprovalRecord>(&payload)?,
+                scope,
+                request_id,
+                &status,
+            )?;
+            records.push(record);
         }
         records.sort_by_key(|record| record.request.id.as_uuid());
         Ok(records)
@@ -686,7 +706,7 @@ impl RunStateStore for PostgresRunStateStore {
         let client = self.client().await?;
         let rows = client
             .query(
-                "SELECT payload::text FROM reborn_run_state_records WHERE owner_key = $1 ORDER BY invocation_id",
+                "SELECT invocation_id, capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE owner_key = $1 ORDER BY invocation_id",
                 &[&owner_key(scope)?],
             )
             .await
@@ -694,11 +714,24 @@ impl RunStateStore for PostgresRunStateStore {
         let mut records = rows
             .into_iter()
             .map(|row| {
-                let payload: String = row.get(0);
-                from_json::<RunRecord>(&payload)
+                let row_invocation_id: String = row.get(0);
+                let row_invocation_id = parse_invocation_id_column(&row_invocation_id)?;
+                let capability_id: String = row.get(1);
+                let status: String = row.get(2);
+                let approval_request_id: Option<String> = row.get(3);
+                let error_kind: Option<String> = row.get(4);
+                let payload: String = row.get(5);
+                validate_run_row(
+                    from_json::<RunRecord>(&payload)?,
+                    scope,
+                    row_invocation_id,
+                    &capability_id,
+                    &status,
+                    approval_request_id.as_deref(),
+                    error_kind.as_deref(),
+                )
             })
             .collect::<Result<Vec<_>, _>>()?;
-        records.retain(|record| crate::same_scope_owner(&record.scope, scope));
         records.sort_by_key(|record| record.invocation_id.as_uuid());
         Ok(records)
     }
@@ -1009,12 +1042,14 @@ impl ApprovalRequestStore for PostgresApprovalRequestStore {
                 status: record.status,
             });
         }
-        txn.execute(
-            "DELETE FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2",
-            &[&owner_key(scope)?, &request_id.to_string()],
-        )
-        .await
-        .map_err(db_error)?;
+        let affected = txn
+            .execute(
+                "DELETE FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2",
+                &[&owner_key(scope)?, &request_id.to_string()],
+            )
+            .await
+            .map_err(db_error)?;
+        require_single_affected_row(affected, "discard approval")?;
         txn.commit().await.map_err(db_error)?;
         Ok(record)
     }
@@ -1026,7 +1061,7 @@ impl ApprovalRequestStore for PostgresApprovalRequestStore {
         let client = self.client().await?;
         let rows = client
             .query(
-                "SELECT payload::text FROM reborn_approval_request_records WHERE owner_key = $1 ORDER BY request_id",
+                "SELECT request_id, status, payload::text FROM reborn_approval_request_records WHERE owner_key = $1 ORDER BY request_id",
                 &[&owner_key(scope)?],
             )
             .await
@@ -1034,11 +1069,18 @@ impl ApprovalRequestStore for PostgresApprovalRequestStore {
         let mut records = rows
             .into_iter()
             .map(|row| {
-                let payload: String = row.get(0);
-                from_json::<ApprovalRecord>(&payload)
+                let request_id: String = row.get(0);
+                let request_id = parse_approval_request_id_column(&request_id)?;
+                let status: String = row.get(1);
+                let payload: String = row.get(2);
+                validate_approval_row(
+                    from_json::<ApprovalRecord>(&payload)?,
+                    scope,
+                    request_id,
+                    &status,
+                )
             })
             .collect::<Result<Vec<_>, _>>()?;
-        records.retain(|record| crate::same_scope_owner(&record.scope, scope));
         records.sort_by_key(|record| record.request.id.as_uuid());
         Ok(records)
     }
@@ -1129,7 +1171,7 @@ async fn libsql_get_run(
 ) -> Result<Option<RunRecord>, RunStateError> {
     let mut rows = conn
         .query(
-            "SELECT payload FROM reborn_run_state_records WHERE owner_key = ?1 AND invocation_id = ?2",
+            "SELECT capability_id, status, approval_request_id, error_kind, payload FROM reborn_run_state_records WHERE owner_key = ?1 AND invocation_id = ?2",
             libsql::params![owner_key(scope)?, invocation_id.to_string()],
         )
         .await
@@ -1137,13 +1179,21 @@ async fn libsql_get_run(
     let Some(row) = rows.next().await.map_err(db_error)? else {
         return Ok(None);
     };
-    let payload: String = row.get(0).map_err(db_error)?;
-    let record = from_json::<RunRecord>(&payload)?;
-    if crate::same_scope_owner(&record.scope, scope) {
-        Ok(Some(record))
-    } else {
-        Ok(None)
-    }
+    let capability_id: String = row.get(0).map_err(db_error)?;
+    let status: String = row.get(1).map_err(db_error)?;
+    let approval_request_id: Option<String> = row.get(2).map_err(db_error)?;
+    let error_kind: Option<String> = row.get(3).map_err(db_error)?;
+    let payload: String = row.get(4).map_err(db_error)?;
+    validate_run_row(
+        from_json::<RunRecord>(&payload)?,
+        scope,
+        invocation_id,
+        &capability_id,
+        &status,
+        approval_request_id.as_deref(),
+        error_kind.as_deref(),
+    )
+    .map(Some)
 }
 
 #[cfg(feature = "libsql")]
@@ -1173,21 +1223,22 @@ async fn libsql_update_run(
     conn: &libsql::Connection,
     record: &RunRecord,
 ) -> Result<(), RunStateError> {
-    conn.execute(
-        "UPDATE reborn_run_state_records SET capability_id = ?3, status = ?4, approval_request_id = ?5, error_kind = ?6, payload = ?7 WHERE owner_key = ?1 AND invocation_id = ?2",
-        libsql::params![
-            owner_key(&record.scope)?,
-            record.invocation_id.to_string(),
-            record.capability_id.as_str(),
-            run_status_key(record.status),
-            record.approval_request_id.map(|id| id.to_string()),
-            record.error_kind.clone(),
-            to_json(record)?,
-        ],
-    )
-    .await
-    .map_err(db_error)?;
-    Ok(())
+    let affected = conn
+        .execute(
+            "UPDATE reborn_run_state_records SET capability_id = ?3, status = ?4, approval_request_id = ?5, error_kind = ?6, payload = ?7 WHERE owner_key = ?1 AND invocation_id = ?2",
+            libsql::params![
+                owner_key(&record.scope)?,
+                record.invocation_id.to_string(),
+                record.capability_id.as_str(),
+                run_status_key(record.status),
+                record.approval_request_id.map(|id| id.to_string()),
+                record.error_kind.clone(),
+                to_json(record)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    require_single_affected_row(affected, "update run")
 }
 
 #[cfg(feature = "libsql")]
@@ -1198,7 +1249,7 @@ async fn libsql_get_approval(
 ) -> Result<Option<ApprovalRecord>, RunStateError> {
     let mut rows = conn
         .query(
-            "SELECT payload FROM reborn_approval_request_records WHERE owner_key = ?1 AND request_id = ?2",
+            "SELECT status, payload FROM reborn_approval_request_records WHERE owner_key = ?1 AND request_id = ?2",
             libsql::params![owner_key(scope)?, request_id.to_string()],
         )
         .await
@@ -1206,13 +1257,15 @@ async fn libsql_get_approval(
     let Some(row) = rows.next().await.map_err(db_error)? else {
         return Ok(None);
     };
-    let payload: String = row.get(0).map_err(db_error)?;
-    let record = from_json::<ApprovalRecord>(&payload)?;
-    if crate::same_scope_owner(&record.scope, scope) {
-        Ok(Some(record))
-    } else {
-        Ok(None)
-    }
+    let status: String = row.get(0).map_err(db_error)?;
+    let payload: String = row.get(1).map_err(db_error)?;
+    validate_approval_row(
+        from_json::<ApprovalRecord>(&payload)?,
+        scope,
+        request_id,
+        &status,
+    )
+    .map(Some)
 }
 
 #[cfg(feature = "libsql")]
@@ -1239,18 +1292,19 @@ async fn libsql_update_approval(
     conn: &libsql::Connection,
     record: &ApprovalRecord,
 ) -> Result<(), RunStateError> {
-    conn.execute(
-        "UPDATE reborn_approval_request_records SET status = ?3, payload = ?4 WHERE owner_key = ?1 AND request_id = ?2",
-        libsql::params![
-            owner_key(&record.scope)?,
-            record.request.id.to_string(),
-            approval_status_key(record.status),
-            to_json(record)?,
-        ],
-    )
-    .await
-    .map_err(db_error)?;
-    Ok(())
+    let affected = conn
+        .execute(
+            "UPDATE reborn_approval_request_records SET status = ?3, payload = ?4 WHERE owner_key = ?1 AND request_id = ?2",
+            libsql::params![
+                owner_key(&record.scope)?,
+                record.request.id.to_string(),
+                approval_status_key(record.status),
+                to_json(record)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    require_single_affected_row(affected, "update approval")
 }
 
 #[cfg(feature = "postgres")]
@@ -1270,7 +1324,7 @@ async fn postgres_get_run(
 ) -> Result<Option<RunRecord>, RunStateError> {
     let row = client
         .query_opt(
-            "SELECT payload::text FROM reborn_run_state_records WHERE owner_key = $1 AND invocation_id = $2",
+            "SELECT capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE owner_key = $1 AND invocation_id = $2",
             &[&owner_key(scope)?, &invocation_id.to_string()],
         )
         .await
@@ -1278,13 +1332,21 @@ async fn postgres_get_run(
     let Some(row) = row else {
         return Ok(None);
     };
-    let payload: String = row.get(0);
-    let record = from_json::<RunRecord>(&payload)?;
-    if crate::same_scope_owner(&record.scope, scope) {
-        Ok(Some(record))
-    } else {
-        Ok(None)
-    }
+    let capability_id: String = row.get(0);
+    let status: String = row.get(1);
+    let approval_request_id: Option<String> = row.get(2);
+    let error_kind: Option<String> = row.get(3);
+    let payload: String = row.get(4);
+    validate_run_row(
+        from_json::<RunRecord>(&payload)?,
+        scope,
+        invocation_id,
+        &capability_id,
+        &status,
+        approval_request_id.as_deref(),
+        error_kind.as_deref(),
+    )
+    .map(Some)
 }
 
 #[cfg(feature = "postgres")]
@@ -1295,7 +1357,7 @@ async fn postgres_get_run_for_update(
 ) -> Result<Option<RunRecord>, RunStateError> {
     let row = client
         .query_opt(
-            "SELECT payload::text FROM reborn_run_state_records WHERE owner_key = $1 AND invocation_id = $2 FOR UPDATE",
+            "SELECT capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE owner_key = $1 AND invocation_id = $2 FOR UPDATE",
             &[&owner_key(scope)?, &invocation_id.to_string()],
         )
         .await
@@ -1303,13 +1365,21 @@ async fn postgres_get_run_for_update(
     let Some(row) = row else {
         return Ok(None);
     };
-    let payload: String = row.get(0);
-    let record = from_json::<RunRecord>(&payload)?;
-    if crate::same_scope_owner(&record.scope, scope) {
-        Ok(Some(record))
-    } else {
-        Ok(None)
-    }
+    let capability_id: String = row.get(0);
+    let status: String = row.get(1);
+    let approval_request_id: Option<String> = row.get(2);
+    let error_kind: Option<String> = row.get(3);
+    let payload: String = row.get(4);
+    validate_run_row(
+        from_json::<RunRecord>(&payload)?,
+        scope,
+        invocation_id,
+        &capability_id,
+        &status,
+        approval_request_id.as_deref(),
+        error_kind.as_deref(),
+    )
+    .map(Some)
 }
 
 #[cfg(feature = "postgres")]
@@ -1342,7 +1412,7 @@ async fn postgres_update_run(
     record: &RunRecord,
 ) -> Result<(), RunStateError> {
     let payload = to_json(record)?;
-    client
+    let affected = client
         .execute(
             "UPDATE reborn_run_state_records SET capability_id = $3, status = $4, approval_request_id = $5, error_kind = $6, payload = $7::jsonb WHERE owner_key = $1 AND invocation_id = $2",
             &[
@@ -1357,7 +1427,7 @@ async fn postgres_update_run(
         )
         .await
         .map_err(db_error)?;
-    Ok(())
+    require_single_affected_row(affected, "update run")
 }
 
 #[cfg(feature = "postgres")]
@@ -1368,7 +1438,7 @@ async fn postgres_get_approval(
 ) -> Result<Option<ApprovalRecord>, RunStateError> {
     let row = client
         .query_opt(
-            "SELECT payload::text FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2",
+            "SELECT status, payload::text FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2",
             &[&owner_key(scope)?, &request_id.to_string()],
         )
         .await
@@ -1376,13 +1446,15 @@ async fn postgres_get_approval(
     let Some(row) = row else {
         return Ok(None);
     };
-    let payload: String = row.get(0);
-    let record = from_json::<ApprovalRecord>(&payload)?;
-    if crate::same_scope_owner(&record.scope, scope) {
-        Ok(Some(record))
-    } else {
-        Ok(None)
-    }
+    let status: String = row.get(0);
+    let payload: String = row.get(1);
+    validate_approval_row(
+        from_json::<ApprovalRecord>(&payload)?,
+        scope,
+        request_id,
+        &status,
+    )
+    .map(Some)
 }
 
 #[cfg(feature = "postgres")]
@@ -1393,7 +1465,7 @@ async fn postgres_get_approval_for_update(
 ) -> Result<Option<ApprovalRecord>, RunStateError> {
     let row = client
         .query_opt(
-            "SELECT payload::text FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2 FOR UPDATE",
+            "SELECT status, payload::text FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2 FOR UPDATE",
             &[&owner_key(scope)?, &request_id.to_string()],
         )
         .await
@@ -1401,13 +1473,15 @@ async fn postgres_get_approval_for_update(
     let Some(row) = row else {
         return Ok(None);
     };
-    let payload: String = row.get(0);
-    let record = from_json::<ApprovalRecord>(&payload)?;
-    if crate::same_scope_owner(&record.scope, scope) {
-        Ok(Some(record))
-    } else {
-        Ok(None)
-    }
+    let status: String = row.get(0);
+    let payload: String = row.get(1);
+    validate_approval_row(
+        from_json::<ApprovalRecord>(&payload)?,
+        scope,
+        request_id,
+        &status,
+    )
+    .map(Some)
 }
 
 #[cfg(feature = "postgres")]
@@ -1437,7 +1511,7 @@ async fn postgres_update_approval(
     record: &ApprovalRecord,
 ) -> Result<(), RunStateError> {
     let payload = to_json(record)?;
-    client
+    let affected = client
         .execute(
             "UPDATE reborn_approval_request_records SET status = $3, payload = $4::jsonb WHERE owner_key = $1 AND request_id = $2",
             &[
@@ -1449,7 +1523,87 @@ async fn postgres_update_approval(
         )
         .await
         .map_err(db_error)?;
-    Ok(())
+    require_single_affected_row(affected, "update approval")
+}
+
+fn parse_invocation_id_column(value: &str) -> Result<InvocationId, RunStateError> {
+    InvocationId::parse(value).map_err(|error| {
+        RunStateError::Deserialization(format!("invalid invocation_id column: {error}"))
+    })
+}
+
+fn parse_approval_request_id_column(value: &str) -> Result<ApprovalRequestId, RunStateError> {
+    ApprovalRequestId::parse(value).map_err(|error| {
+        RunStateError::Deserialization(format!("invalid request_id column: {error}"))
+    })
+}
+
+fn validate_run_row(
+    record: RunRecord,
+    expected_scope: &ResourceScope,
+    row_invocation_id: InvocationId,
+    row_capability_id: &str,
+    row_status: &str,
+    row_approval_request_id: Option<&str>,
+    row_error_kind: Option<&str>,
+) -> Result<RunRecord, RunStateError> {
+    if !crate::same_scope_owner(&record.scope, expected_scope) {
+        return Err(row_integrity_error("run-state", "owner_key"));
+    }
+    if record.invocation_id != row_invocation_id {
+        return Err(row_integrity_error("run-state", "invocation_id"));
+    }
+    if record.capability_id.as_str() != row_capability_id {
+        return Err(row_integrity_error("run-state", "capability_id"));
+    }
+    if run_status_key(record.status) != row_status {
+        return Err(row_integrity_error("run-state", "status"));
+    }
+    let record_approval_request_id = record.approval_request_id.map(|id| id.to_string());
+    if record_approval_request_id.as_deref() != row_approval_request_id {
+        return Err(row_integrity_error("run-state", "approval_request_id"));
+    }
+    if record.error_kind.as_deref() != row_error_kind {
+        return Err(row_integrity_error("run-state", "error_kind"));
+    }
+    Ok(record)
+}
+
+fn validate_approval_row(
+    record: ApprovalRecord,
+    expected_scope: &ResourceScope,
+    row_request_id: ApprovalRequestId,
+    row_status: &str,
+) -> Result<ApprovalRecord, RunStateError> {
+    if !crate::same_scope_owner(&record.scope, expected_scope) {
+        return Err(row_integrity_error("approval-request", "owner_key"));
+    }
+    if record.request.id != row_request_id {
+        return Err(row_integrity_error("approval-request", "request_id"));
+    }
+    if approval_status_key(record.status) != row_status {
+        return Err(row_integrity_error("approval-request", "status"));
+    }
+    Ok(record)
+}
+
+fn row_integrity_error(entity: &'static str, field: &'static str) -> RunStateError {
+    RunStateError::Deserialization(format!(
+        "{entity} row payload does not match {field} column"
+    ))
+}
+
+fn require_single_affected_row(
+    affected: u64,
+    operation: &'static str,
+) -> Result<(), RunStateError> {
+    if affected == 1 {
+        Ok(())
+    } else {
+        Err(RunStateError::Backend(format!(
+            "{operation} affected unexpected row count"
+        )))
+    }
 }
 
 fn owner_key(scope: &ResourceScope) -> Result<String, RunStateError> {

--- a/crates/ironclaw_run_state/src/db.rs
+++ b/crates/ironclaw_run_state/src/db.rs
@@ -1,0 +1,1512 @@
+use ironclaw_host_api::{ApprovalRequest, ApprovalRequestId, InvocationId, ResourceScope};
+
+use crate::{
+    ApprovalRecord, ApprovalRequestStore, ApprovalStatus, RunRecord, RunStart,
+    RunStateApprovalStore, RunStateError, RunStateStore, RunStatus,
+};
+
+#[cfg(feature = "libsql")]
+use std::sync::Arc;
+
+#[cfg(feature = "libsql")]
+const LIBSQL_RUN_STATE_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS reborn_run_state_records (
+    owner_key TEXT NOT NULL,
+    invocation_id TEXT NOT NULL,
+    capability_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    approval_request_id TEXT,
+    error_kind TEXT,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (owner_key, invocation_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_run_state_records_owner_status
+    ON reborn_run_state_records(owner_key, status);
+
+CREATE TABLE IF NOT EXISTS reborn_approval_request_records (
+    owner_key TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (owner_key, request_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_approval_request_records_owner_status
+    ON reborn_approval_request_records(owner_key, status);
+"#;
+
+#[cfg(feature = "postgres")]
+const POSTGRES_RUN_STATE_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS reborn_run_state_records (
+    owner_key TEXT NOT NULL,
+    invocation_id TEXT NOT NULL,
+    capability_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    approval_request_id TEXT,
+    error_kind TEXT,
+    payload JSONB NOT NULL,
+    PRIMARY KEY (owner_key, invocation_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_run_state_records_owner_status
+    ON reborn_run_state_records(owner_key, status);
+
+CREATE TABLE IF NOT EXISTS reborn_approval_request_records (
+    owner_key TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    PRIMARY KEY (owner_key, request_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_approval_request_records_owner_status
+    ON reborn_approval_request_records(owner_key, status);
+"#;
+
+/// libSQL-backed invocation lifecycle store.
+#[cfg(feature = "libsql")]
+pub struct LibSqlRunStateStore {
+    db: Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlRunStateStore {
+    pub fn new(db: Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), RunStateError> {
+        run_libsql_migrations(&self.db).await
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, RunStateError> {
+        libsql_connect(&self.db).await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait::async_trait]
+impl RunStateStore for LibSqlRunStateStore {
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        let conn = libsql_begin_immediate(&self.db).await?;
+        let result = async {
+            if libsql_get_run(&conn, &start.scope, start.invocation_id)
+                .await?
+                .is_some()
+            {
+                return Err(RunStateError::InvocationAlreadyExists {
+                    invocation_id: start.invocation_id,
+                });
+            }
+            let record = RunRecord {
+                invocation_id: start.invocation_id,
+                capability_id: start.capability_id,
+                scope: start.scope,
+                status: RunStatus::Running,
+                approval_request_id: None,
+                error_kind: None,
+            };
+            libsql_insert_run(&conn, &record).await?;
+            Ok(record)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update_run(scope, invocation_id, |record| {
+            record.status = RunStatus::BlockedApproval;
+            record.approval_request_id = Some(approval.id);
+            record.error_kind = None;
+        })
+        .await
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update_run(scope, invocation_id, |record| {
+            record.status = RunStatus::BlockedAuth;
+            record.approval_request_id = None;
+            record.error_kind = Some(error_kind);
+        })
+        .await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update_run(scope, invocation_id, |record| {
+            record.status = RunStatus::Completed;
+            record.approval_request_id = None;
+            record.error_kind = None;
+        })
+        .await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update_run(scope, invocation_id, |record| {
+            record.status = RunStatus::Failed;
+            record.approval_request_id = None;
+            record.error_kind = Some(error_kind);
+        })
+        .await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        let conn = self.connect().await?;
+        libsql_get_run(&conn, scope, invocation_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        let conn = self.connect().await?;
+        let owner_key = owner_key(scope)?;
+        let mut rows = conn
+            .query(
+                "SELECT payload FROM reborn_run_state_records WHERE owner_key = ?1 ORDER BY invocation_id",
+                libsql::params![owner_key],
+            )
+            .await
+            .map_err(db_error)?;
+        let mut records = Vec::new();
+        while let Some(row) = rows.next().await.map_err(db_error)? {
+            let payload: String = row.get(0).map_err(db_error)?;
+            let record = from_json::<RunRecord>(&payload)?;
+            if crate::same_scope_owner(&record.scope, scope) {
+                records.push(record);
+            }
+        }
+        records.sort_by_key(|record| record.invocation_id.as_uuid());
+        Ok(records)
+    }
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlRunStateStore {
+    async fn update_run(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        update: impl FnOnce(&mut RunRecord),
+    ) -> Result<RunRecord, RunStateError> {
+        let conn = libsql_begin_immediate(&self.db).await?;
+        let result = async {
+            let mut record = libsql_get_run(&conn, scope, invocation_id)
+                .await?
+                .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+            update(&mut record);
+            libsql_update_run(&conn, &record).await?;
+            Ok(record)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await
+    }
+}
+
+/// Combined libSQL run-state and approval-request store.
+#[cfg(feature = "libsql")]
+pub struct LibSqlRunStateApprovalStore {
+    db: Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlRunStateApprovalStore {
+    pub fn new(db: Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), RunStateError> {
+        run_libsql_migrations(&self.db).await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait::async_trait]
+impl RunStateStore for LibSqlRunStateApprovalStore {
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        LibSqlRunStateStore::new(Arc::clone(&self.db))
+            .start(start)
+            .await
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        LibSqlRunStateStore::new(Arc::clone(&self.db))
+            .block_approval(scope, invocation_id, approval)
+            .await
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        LibSqlRunStateStore::new(Arc::clone(&self.db))
+            .block_auth(scope, invocation_id, error_kind)
+            .await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        LibSqlRunStateStore::new(Arc::clone(&self.db))
+            .complete(scope, invocation_id)
+            .await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        LibSqlRunStateStore::new(Arc::clone(&self.db))
+            .fail(scope, invocation_id, error_kind)
+            .await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        LibSqlRunStateStore::new(Arc::clone(&self.db))
+            .get(scope, invocation_id)
+            .await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        LibSqlRunStateStore::new(Arc::clone(&self.db))
+            .records_for_scope(scope)
+            .await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait::async_trait]
+impl ApprovalRequestStore for LibSqlRunStateApprovalStore {
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        LibSqlApprovalRequestStore::new(Arc::clone(&self.db))
+            .save_pending(scope, request)
+            .await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        LibSqlApprovalRequestStore::new(Arc::clone(&self.db))
+            .get(scope, request_id)
+            .await
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        LibSqlApprovalRequestStore::new(Arc::clone(&self.db))
+            .approve(scope, request_id)
+            .await
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        LibSqlApprovalRequestStore::new(Arc::clone(&self.db))
+            .deny(scope, request_id)
+            .await
+    }
+
+    async fn discard_pending(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        LibSqlApprovalRequestStore::new(Arc::clone(&self.db))
+            .discard_pending(scope, request_id)
+            .await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        LibSqlApprovalRequestStore::new(Arc::clone(&self.db))
+            .records_for_scope(scope)
+            .await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait::async_trait]
+impl RunStateApprovalStore for LibSqlRunStateApprovalStore {
+    async fn save_pending_and_block_approval(
+        &self,
+        scope: ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        let conn = libsql_begin_immediate(&self.db).await?;
+        let result = async {
+            if libsql_get_approval(&conn, &scope, approval.id)
+                .await?
+                .is_some()
+            {
+                return Err(RunStateError::ApprovalRequestAlreadyExists {
+                    request_id: approval.id,
+                });
+            }
+            let mut run = libsql_get_run(&conn, &scope, invocation_id)
+                .await?
+                .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+            let approval_record = ApprovalRecord {
+                scope: scope.clone(),
+                request: approval.clone(),
+                status: ApprovalStatus::Pending,
+            };
+            libsql_insert_approval(&conn, &approval_record).await?;
+            run.status = RunStatus::BlockedApproval;
+            run.approval_request_id = Some(approval.id);
+            run.error_kind = None;
+            libsql_update_run(&conn, &run).await?;
+            Ok(run)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await
+    }
+}
+
+/// libSQL-backed approval request store.
+#[cfg(feature = "libsql")]
+pub struct LibSqlApprovalRequestStore {
+    db: Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlApprovalRequestStore {
+    pub fn new(db: Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), RunStateError> {
+        run_libsql_migrations(&self.db).await
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, RunStateError> {
+        libsql_connect(&self.db).await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait::async_trait]
+impl ApprovalRequestStore for LibSqlApprovalRequestStore {
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let conn = libsql_begin_immediate(&self.db).await?;
+        let result = async {
+            if libsql_get_approval(&conn, &scope, request.id)
+                .await?
+                .is_some()
+            {
+                return Err(RunStateError::ApprovalRequestAlreadyExists {
+                    request_id: request.id,
+                });
+            }
+            let record = ApprovalRecord {
+                scope,
+                request,
+                status: ApprovalStatus::Pending,
+            };
+            libsql_insert_approval(&conn, &record).await?;
+            Ok(record)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        let conn = self.connect().await?;
+        libsql_get_approval(&conn, scope, request_id).await
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.update_status(scope, request_id, ApprovalStatus::Approved)
+            .await
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.update_status(scope, request_id, ApprovalStatus::Denied)
+            .await
+    }
+
+    async fn discard_pending(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let conn = libsql_begin_immediate(&self.db).await?;
+        let result = async {
+            let record = libsql_get_approval(&conn, scope, request_id)
+                .await?
+                .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
+            if record.status != ApprovalStatus::Pending {
+                return Err(RunStateError::ApprovalNotPending {
+                    request_id,
+                    status: record.status,
+                });
+            }
+            conn.execute(
+                "DELETE FROM reborn_approval_request_records WHERE owner_key = ?1 AND request_id = ?2",
+                libsql::params![owner_key(scope)?, request_id.to_string()],
+            )
+            .await
+            .map_err(db_error)?;
+            Ok(record)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        let conn = self.connect().await?;
+        let owner_key = owner_key(scope)?;
+        let mut rows = conn
+            .query(
+                "SELECT payload FROM reborn_approval_request_records WHERE owner_key = ?1 ORDER BY request_id",
+                libsql::params![owner_key],
+            )
+            .await
+            .map_err(db_error)?;
+        let mut records = Vec::new();
+        while let Some(row) = rows.next().await.map_err(db_error)? {
+            let payload: String = row.get(0).map_err(db_error)?;
+            let record = from_json::<ApprovalRecord>(&payload)?;
+            if crate::same_scope_owner(&record.scope, scope) {
+                records.push(record);
+            }
+        }
+        records.sort_by_key(|record| record.request.id.as_uuid());
+        Ok(records)
+    }
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlApprovalRequestStore {
+    async fn update_status(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+        status: ApprovalStatus,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let conn = libsql_begin_immediate(&self.db).await?;
+        let result = async {
+            let mut record = libsql_get_approval(&conn, scope, request_id)
+                .await?
+                .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
+            if record.status != ApprovalStatus::Pending {
+                return Err(RunStateError::ApprovalNotPending {
+                    request_id,
+                    status: record.status,
+                });
+            }
+            record.status = status;
+            libsql_update_approval(&conn, &record).await?;
+            Ok(record)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await
+    }
+}
+
+/// PostgreSQL-backed invocation lifecycle store.
+#[cfg(feature = "postgres")]
+pub struct PostgresRunStateStore {
+    pool: deadpool_postgres::Pool,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresRunStateStore {
+    pub fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), RunStateError> {
+        run_postgres_migrations(&self.pool).await
+    }
+
+    async fn client(&self) -> Result<deadpool_postgres::Object, RunStateError> {
+        self.pool.get().await.map_err(db_error)
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl RunStateStore for PostgresRunStateStore {
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        let client = self.client().await?;
+        let record = RunRecord {
+            invocation_id: start.invocation_id,
+            capability_id: start.capability_id,
+            scope: start.scope,
+            status: RunStatus::Running,
+            approval_request_id: None,
+            error_kind: None,
+        };
+        if !postgres_insert_run(&client, &record).await? {
+            return Err(RunStateError::InvocationAlreadyExists {
+                invocation_id: record.invocation_id,
+            });
+        }
+        Ok(record)
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update_run(scope, invocation_id, |record| {
+            record.status = RunStatus::BlockedApproval;
+            record.approval_request_id = Some(approval.id);
+            record.error_kind = None;
+        })
+        .await
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update_run(scope, invocation_id, |record| {
+            record.status = RunStatus::BlockedAuth;
+            record.approval_request_id = None;
+            record.error_kind = Some(error_kind);
+        })
+        .await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update_run(scope, invocation_id, |record| {
+            record.status = RunStatus::Completed;
+            record.approval_request_id = None;
+            record.error_kind = None;
+        })
+        .await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update_run(scope, invocation_id, |record| {
+            record.status = RunStatus::Failed;
+            record.approval_request_id = None;
+            record.error_kind = Some(error_kind);
+        })
+        .await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        let client = self.client().await?;
+        postgres_get_run(&client, scope, invocation_id).await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        let client = self.client().await?;
+        let rows = client
+            .query(
+                "SELECT payload::text FROM reborn_run_state_records WHERE owner_key = $1 ORDER BY invocation_id",
+                &[&owner_key(scope)?],
+            )
+            .await
+            .map_err(db_error)?;
+        let mut records = rows
+            .into_iter()
+            .map(|row| {
+                let payload: String = row.get(0);
+                from_json::<RunRecord>(&payload)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        records.retain(|record| crate::same_scope_owner(&record.scope, scope));
+        records.sort_by_key(|record| record.invocation_id.as_uuid());
+        Ok(records)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresRunStateStore {
+    async fn update_run(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        update: impl FnOnce(&mut RunRecord),
+    ) -> Result<RunRecord, RunStateError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        let mut record = match postgres_get_run_for_update(&txn, scope, invocation_id).await? {
+            Some(record) => record,
+            None => {
+                txn.rollback().await.map_err(db_error)?;
+                return Err(RunStateError::UnknownInvocation { invocation_id });
+            }
+        };
+        update(&mut record);
+        postgres_update_run(&txn, &record).await?;
+        txn.commit().await.map_err(db_error)?;
+        Ok(record)
+    }
+}
+
+/// Combined PostgreSQL run-state and approval-request store.
+#[cfg(feature = "postgres")]
+pub struct PostgresRunStateApprovalStore {
+    pool: deadpool_postgres::Pool,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresRunStateApprovalStore {
+    pub fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), RunStateError> {
+        run_postgres_migrations(&self.pool).await
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl RunStateStore for PostgresRunStateApprovalStore {
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        PostgresRunStateStore::new(self.pool.clone())
+            .start(start)
+            .await
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        PostgresRunStateStore::new(self.pool.clone())
+            .block_approval(scope, invocation_id, approval)
+            .await
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        PostgresRunStateStore::new(self.pool.clone())
+            .block_auth(scope, invocation_id, error_kind)
+            .await
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        PostgresRunStateStore::new(self.pool.clone())
+            .complete(scope, invocation_id)
+            .await
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        PostgresRunStateStore::new(self.pool.clone())
+            .fail(scope, invocation_id, error_kind)
+            .await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        PostgresRunStateStore::new(self.pool.clone())
+            .get(scope, invocation_id)
+            .await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        PostgresRunStateStore::new(self.pool.clone())
+            .records_for_scope(scope)
+            .await
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl ApprovalRequestStore for PostgresRunStateApprovalStore {
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        PostgresApprovalRequestStore::new(self.pool.clone())
+            .save_pending(scope, request)
+            .await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        PostgresApprovalRequestStore::new(self.pool.clone())
+            .get(scope, request_id)
+            .await
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        PostgresApprovalRequestStore::new(self.pool.clone())
+            .approve(scope, request_id)
+            .await
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        PostgresApprovalRequestStore::new(self.pool.clone())
+            .deny(scope, request_id)
+            .await
+    }
+
+    async fn discard_pending(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        PostgresApprovalRequestStore::new(self.pool.clone())
+            .discard_pending(scope, request_id)
+            .await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        PostgresApprovalRequestStore::new(self.pool.clone())
+            .records_for_scope(scope)
+            .await
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl RunStateApprovalStore for PostgresRunStateApprovalStore {
+    async fn save_pending_and_block_approval(
+        &self,
+        scope: ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        let mut client = self.pool.get().await.map_err(db_error)?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        let mut run = match postgres_get_run_for_update(&txn, &scope, invocation_id).await? {
+            Some(run) => run,
+            None => {
+                txn.rollback().await.map_err(db_error)?;
+                return Err(RunStateError::UnknownInvocation { invocation_id });
+            }
+        };
+        let approval_record = ApprovalRecord {
+            scope: scope.clone(),
+            request: approval.clone(),
+            status: ApprovalStatus::Pending,
+        };
+        if !postgres_insert_approval(&txn, &approval_record).await? {
+            txn.rollback().await.map_err(db_error)?;
+            return Err(RunStateError::ApprovalRequestAlreadyExists {
+                request_id: approval.id,
+            });
+        }
+        run.status = RunStatus::BlockedApproval;
+        run.approval_request_id = Some(approval.id);
+        run.error_kind = None;
+        postgres_update_run(&txn, &run).await?;
+        txn.commit().await.map_err(db_error)?;
+        Ok(run)
+    }
+}
+
+/// PostgreSQL-backed approval request store.
+#[cfg(feature = "postgres")]
+pub struct PostgresApprovalRequestStore {
+    pool: deadpool_postgres::Pool,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresApprovalRequestStore {
+    pub fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), RunStateError> {
+        run_postgres_migrations(&self.pool).await
+    }
+
+    async fn client(&self) -> Result<deadpool_postgres::Object, RunStateError> {
+        self.pool.get().await.map_err(db_error)
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl ApprovalRequestStore for PostgresApprovalRequestStore {
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let client = self.client().await?;
+        let record = ApprovalRecord {
+            scope,
+            request,
+            status: ApprovalStatus::Pending,
+        };
+        if !postgres_insert_approval(&client, &record).await? {
+            return Err(RunStateError::ApprovalRequestAlreadyExists {
+                request_id: record.request.id,
+            });
+        }
+        Ok(record)
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        let client = self.client().await?;
+        postgres_get_approval(&client, scope, request_id).await
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.update_status(scope, request_id, ApprovalStatus::Approved)
+            .await
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.update_status(scope, request_id, ApprovalStatus::Denied)
+            .await
+    }
+
+    async fn discard_pending(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        let record = match postgres_get_approval_for_update(&txn, scope, request_id).await? {
+            Some(record) => record,
+            None => {
+                txn.rollback().await.map_err(db_error)?;
+                return Err(RunStateError::UnknownApprovalRequest { request_id });
+            }
+        };
+        if record.status != ApprovalStatus::Pending {
+            txn.rollback().await.map_err(db_error)?;
+            return Err(RunStateError::ApprovalNotPending {
+                request_id,
+                status: record.status,
+            });
+        }
+        txn.execute(
+            "DELETE FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2",
+            &[&owner_key(scope)?, &request_id.to_string()],
+        )
+        .await
+        .map_err(db_error)?;
+        txn.commit().await.map_err(db_error)?;
+        Ok(record)
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        let client = self.client().await?;
+        let rows = client
+            .query(
+                "SELECT payload::text FROM reborn_approval_request_records WHERE owner_key = $1 ORDER BY request_id",
+                &[&owner_key(scope)?],
+            )
+            .await
+            .map_err(db_error)?;
+        let mut records = rows
+            .into_iter()
+            .map(|row| {
+                let payload: String = row.get(0);
+                from_json::<ApprovalRecord>(&payload)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        records.retain(|record| crate::same_scope_owner(&record.scope, scope));
+        records.sort_by_key(|record| record.request.id.as_uuid());
+        Ok(records)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresApprovalRequestStore {
+    async fn update_status(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+        status: ApprovalStatus,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        let mut record = match postgres_get_approval_for_update(&txn, scope, request_id).await? {
+            Some(record) => record,
+            None => {
+                txn.rollback().await.map_err(db_error)?;
+                return Err(RunStateError::UnknownApprovalRequest { request_id });
+            }
+        };
+        if record.status != ApprovalStatus::Pending {
+            txn.rollback().await.map_err(db_error)?;
+            return Err(RunStateError::ApprovalNotPending {
+                request_id,
+                status: record.status,
+            });
+        }
+        record.status = status;
+        postgres_update_approval(&txn, &record).await?;
+        txn.commit().await.map_err(db_error)?;
+        Ok(record)
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn run_libsql_migrations(db: &libsql::Database) -> Result<(), RunStateError> {
+    let conn = libsql_connect(db).await?;
+    conn.execute_batch(LIBSQL_RUN_STATE_SCHEMA)
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_connect(db: &libsql::Database) -> Result<libsql::Connection, RunStateError> {
+    let conn = db.connect().map_err(db_error)?;
+    conn.query("PRAGMA busy_timeout = 5000", ())
+        .await
+        .map_err(db_error)?;
+    Ok(conn)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_begin_immediate(
+    db: &libsql::Database,
+) -> Result<libsql::Connection, RunStateError> {
+    let conn = libsql_connect(db).await?;
+    conn.execute("BEGIN IMMEDIATE", ())
+        .await
+        .map_err(db_error)?;
+    Ok(conn)
+}
+
+#[cfg(feature = "libsql")]
+async fn finish_libsql_transaction<T>(
+    conn: &libsql::Connection,
+    result: Result<T, RunStateError>,
+) -> Result<T, RunStateError> {
+    match result {
+        Ok(value) => {
+            conn.execute("COMMIT", ()).await.map_err(db_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(error)
+        }
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_get_run(
+    conn: &libsql::Connection,
+    scope: &ResourceScope,
+    invocation_id: InvocationId,
+) -> Result<Option<RunRecord>, RunStateError> {
+    let mut rows = conn
+        .query(
+            "SELECT payload FROM reborn_run_state_records WHERE owner_key = ?1 AND invocation_id = ?2",
+            libsql::params![owner_key(scope)?, invocation_id.to_string()],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = rows.next().await.map_err(db_error)? else {
+        return Ok(None);
+    };
+    let payload: String = row.get(0).map_err(db_error)?;
+    let record = from_json::<RunRecord>(&payload)?;
+    if crate::same_scope_owner(&record.scope, scope) {
+        Ok(Some(record))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_insert_run(
+    conn: &libsql::Connection,
+    record: &RunRecord,
+) -> Result<(), RunStateError> {
+    conn.execute(
+        "INSERT INTO reborn_run_state_records (owner_key, invocation_id, capability_id, status, approval_request_id, error_kind, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        libsql::params![
+            owner_key(&record.scope)?,
+            record.invocation_id.to_string(),
+            record.capability_id.as_str(),
+            run_status_key(record.status),
+            record.approval_request_id.map(|id| id.to_string()),
+            record.error_kind.clone(),
+            to_json(record)?,
+        ],
+    )
+    .await
+    .map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_update_run(
+    conn: &libsql::Connection,
+    record: &RunRecord,
+) -> Result<(), RunStateError> {
+    conn.execute(
+        "UPDATE reborn_run_state_records SET capability_id = ?3, status = ?4, approval_request_id = ?5, error_kind = ?6, payload = ?7 WHERE owner_key = ?1 AND invocation_id = ?2",
+        libsql::params![
+            owner_key(&record.scope)?,
+            record.invocation_id.to_string(),
+            record.capability_id.as_str(),
+            run_status_key(record.status),
+            record.approval_request_id.map(|id| id.to_string()),
+            record.error_kind.clone(),
+            to_json(record)?,
+        ],
+    )
+    .await
+    .map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_get_approval(
+    conn: &libsql::Connection,
+    scope: &ResourceScope,
+    request_id: ApprovalRequestId,
+) -> Result<Option<ApprovalRecord>, RunStateError> {
+    let mut rows = conn
+        .query(
+            "SELECT payload FROM reborn_approval_request_records WHERE owner_key = ?1 AND request_id = ?2",
+            libsql::params![owner_key(scope)?, request_id.to_string()],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = rows.next().await.map_err(db_error)? else {
+        return Ok(None);
+    };
+    let payload: String = row.get(0).map_err(db_error)?;
+    let record = from_json::<ApprovalRecord>(&payload)?;
+    if crate::same_scope_owner(&record.scope, scope) {
+        Ok(Some(record))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_insert_approval(
+    conn: &libsql::Connection,
+    record: &ApprovalRecord,
+) -> Result<(), RunStateError> {
+    conn.execute(
+        "INSERT INTO reborn_approval_request_records (owner_key, request_id, status, payload) VALUES (?1, ?2, ?3, ?4)",
+        libsql::params![
+            owner_key(&record.scope)?,
+            record.request.id.to_string(),
+            approval_status_key(record.status),
+            to_json(record)?,
+        ],
+    )
+    .await
+    .map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_update_approval(
+    conn: &libsql::Connection,
+    record: &ApprovalRecord,
+) -> Result<(), RunStateError> {
+    conn.execute(
+        "UPDATE reborn_approval_request_records SET status = ?3, payload = ?4 WHERE owner_key = ?1 AND request_id = ?2",
+        libsql::params![
+            owner_key(&record.scope)?,
+            record.request.id.to_string(),
+            approval_status_key(record.status),
+            to_json(record)?,
+        ],
+    )
+    .await
+    .map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+async fn run_postgres_migrations(pool: &deadpool_postgres::Pool) -> Result<(), RunStateError> {
+    let client = pool.get().await.map_err(db_error)?;
+    client
+        .batch_execute(POSTGRES_RUN_STATE_SCHEMA)
+        .await
+        .map_err(db_error)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get_run(
+    client: &impl deadpool_postgres::GenericClient,
+    scope: &ResourceScope,
+    invocation_id: InvocationId,
+) -> Result<Option<RunRecord>, RunStateError> {
+    let row = client
+        .query_opt(
+            "SELECT payload::text FROM reborn_run_state_records WHERE owner_key = $1 AND invocation_id = $2",
+            &[&owner_key(scope)?, &invocation_id.to_string()],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let payload: String = row.get(0);
+    let record = from_json::<RunRecord>(&payload)?;
+    if crate::same_scope_owner(&record.scope, scope) {
+        Ok(Some(record))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get_run_for_update(
+    client: &impl deadpool_postgres::GenericClient,
+    scope: &ResourceScope,
+    invocation_id: InvocationId,
+) -> Result<Option<RunRecord>, RunStateError> {
+    let row = client
+        .query_opt(
+            "SELECT payload::text FROM reborn_run_state_records WHERE owner_key = $1 AND invocation_id = $2 FOR UPDATE",
+            &[&owner_key(scope)?, &invocation_id.to_string()],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let payload: String = row.get(0);
+    let record = from_json::<RunRecord>(&payload)?;
+    if crate::same_scope_owner(&record.scope, scope) {
+        Ok(Some(record))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_insert_run(
+    client: &impl deadpool_postgres::GenericClient,
+    record: &RunRecord,
+) -> Result<bool, RunStateError> {
+    let payload = to_json(record)?;
+    let affected = client
+        .execute(
+            "INSERT INTO reborn_run_state_records (owner_key, invocation_id, capability_id, status, approval_request_id, error_kind, payload) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb) ON CONFLICT DO NOTHING",
+            &[
+                &owner_key(&record.scope)?,
+                &record.invocation_id.to_string(),
+                &record.capability_id.as_str(),
+                &run_status_key(record.status),
+                &record.approval_request_id.map(|id| id.to_string()),
+                &record.error_kind,
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(affected == 1)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_update_run(
+    client: &impl deadpool_postgres::GenericClient,
+    record: &RunRecord,
+) -> Result<(), RunStateError> {
+    let payload = to_json(record)?;
+    client
+        .execute(
+            "UPDATE reborn_run_state_records SET capability_id = $3, status = $4, approval_request_id = $5, error_kind = $6, payload = $7::jsonb WHERE owner_key = $1 AND invocation_id = $2",
+            &[
+                &owner_key(&record.scope)?,
+                &record.invocation_id.to_string(),
+                &record.capability_id.as_str(),
+                &run_status_key(record.status),
+                &record.approval_request_id.map(|id| id.to_string()),
+                &record.error_kind,
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get_approval(
+    client: &impl deadpool_postgres::GenericClient,
+    scope: &ResourceScope,
+    request_id: ApprovalRequestId,
+) -> Result<Option<ApprovalRecord>, RunStateError> {
+    let row = client
+        .query_opt(
+            "SELECT payload::text FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2",
+            &[&owner_key(scope)?, &request_id.to_string()],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let payload: String = row.get(0);
+    let record = from_json::<ApprovalRecord>(&payload)?;
+    if crate::same_scope_owner(&record.scope, scope) {
+        Ok(Some(record))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get_approval_for_update(
+    client: &impl deadpool_postgres::GenericClient,
+    scope: &ResourceScope,
+    request_id: ApprovalRequestId,
+) -> Result<Option<ApprovalRecord>, RunStateError> {
+    let row = client
+        .query_opt(
+            "SELECT payload::text FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2 FOR UPDATE",
+            &[&owner_key(scope)?, &request_id.to_string()],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let payload: String = row.get(0);
+    let record = from_json::<ApprovalRecord>(&payload)?;
+    if crate::same_scope_owner(&record.scope, scope) {
+        Ok(Some(record))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_insert_approval(
+    client: &impl deadpool_postgres::GenericClient,
+    record: &ApprovalRecord,
+) -> Result<bool, RunStateError> {
+    let payload = to_json(record)?;
+    let affected = client
+        .execute(
+            "INSERT INTO reborn_approval_request_records (owner_key, request_id, status, payload) VALUES ($1, $2, $3, $4::jsonb) ON CONFLICT DO NOTHING",
+            &[
+                &owner_key(&record.scope)?,
+                &record.request.id.to_string(),
+                &approval_status_key(record.status),
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(affected == 1)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_update_approval(
+    client: &impl deadpool_postgres::GenericClient,
+    record: &ApprovalRecord,
+) -> Result<(), RunStateError> {
+    let payload = to_json(record)?;
+    client
+        .execute(
+            "UPDATE reborn_approval_request_records SET status = $3, payload = $4::jsonb WHERE owner_key = $1 AND request_id = $2",
+            &[
+                &owner_key(&record.scope)?,
+                &record.request.id.to_string(),
+                &approval_status_key(record.status),
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn owner_key(scope: &ResourceScope) -> Result<String, RunStateError> {
+    #[derive(serde::Serialize)]
+    struct OwnerKey<'a> {
+        tenant_id: &'a str,
+        user_id: &'a str,
+        agent_id: Option<&'a str>,
+        project_id: Option<&'a str>,
+        mission_id: Option<&'a str>,
+        thread_id: Option<&'a str>,
+    }
+
+    to_json(&OwnerKey {
+        tenant_id: scope.tenant_id.as_str(),
+        user_id: scope.user_id.as_str(),
+        agent_id: scope.agent_id.as_ref().map(|id| id.as_str()),
+        project_id: scope.project_id.as_ref().map(|id| id.as_str()),
+        mission_id: scope.mission_id.as_ref().map(|id| id.as_str()),
+        thread_id: scope.thread_id.as_ref().map(|id| id.as_str()),
+    })
+}
+
+fn run_status_key(status: RunStatus) -> &'static str {
+    match status {
+        RunStatus::Running => "running",
+        RunStatus::BlockedApproval => "blocked_approval",
+        RunStatus::BlockedAuth => "blocked_auth",
+        RunStatus::Completed => "completed",
+        RunStatus::Failed => "failed",
+    }
+}
+
+fn approval_status_key(status: ApprovalStatus) -> &'static str {
+    match status {
+        ApprovalStatus::Pending => "pending",
+        ApprovalStatus::Approved => "approved",
+        ApprovalStatus::Denied => "denied",
+        ApprovalStatus::Expired => "expired",
+    }
+}
+
+fn to_json<T>(value: &T) -> Result<String, RunStateError>
+where
+    T: serde::Serialize,
+{
+    serde_json::to_string(value).map_err(|error| RunStateError::Serialization(error.to_string()))
+}
+
+fn from_json<T>(payload: &str) -> Result<T, RunStateError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    serde_json::from_str(payload).map_err(|error| RunStateError::Deserialization(error.to_string()))
+}
+
+fn db_error(error: impl std::fmt::Display) -> RunStateError {
+    tracing::debug!(%error, "run-state database operation failed");
+    RunStateError::Backend("run-state database unavailable".to_string())
+}

--- a/crates/ironclaw_run_state/src/db.rs
+++ b/crates/ironclaw_run_state/src/db.rs
@@ -11,53 +11,73 @@ use std::sync::Arc;
 #[cfg(feature = "libsql")]
 const LIBSQL_RUN_STATE_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS reborn_run_state_records (
-    owner_key TEXT NOT NULL,
+    tenant_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    mission_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
     invocation_id TEXT NOT NULL,
     capability_id TEXT NOT NULL,
     status TEXT NOT NULL,
     approval_request_id TEXT,
     error_kind TEXT,
     payload TEXT NOT NULL,
-    PRIMARY KEY (owner_key, invocation_id)
+    PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id)
 );
-CREATE INDEX IF NOT EXISTS idx_reborn_run_state_records_owner_status
-    ON reborn_run_state_records(owner_key, status);
+CREATE INDEX IF NOT EXISTS idx_reborn_run_state_records_scope_status
+    ON reborn_run_state_records(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, status);
 
 CREATE TABLE IF NOT EXISTS reborn_approval_request_records (
-    owner_key TEXT NOT NULL,
+    tenant_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    mission_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
     request_id TEXT NOT NULL,
     status TEXT NOT NULL,
     payload TEXT NOT NULL,
-    PRIMARY KEY (owner_key, request_id)
+    PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, request_id)
 );
-CREATE INDEX IF NOT EXISTS idx_reborn_approval_request_records_owner_status
-    ON reborn_approval_request_records(owner_key, status);
+CREATE INDEX IF NOT EXISTS idx_reborn_approval_request_records_scope_status
+    ON reborn_approval_request_records(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, status);
 "#;
 
 #[cfg(feature = "postgres")]
 const POSTGRES_RUN_STATE_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS reborn_run_state_records (
-    owner_key TEXT NOT NULL,
+    tenant_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    mission_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
     invocation_id TEXT NOT NULL,
     capability_id TEXT NOT NULL,
     status TEXT NOT NULL,
     approval_request_id TEXT,
     error_kind TEXT,
     payload JSONB NOT NULL,
-    PRIMARY KEY (owner_key, invocation_id)
+    PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id)
 );
-CREATE INDEX IF NOT EXISTS idx_reborn_run_state_records_owner_status
-    ON reborn_run_state_records(owner_key, status);
+CREATE INDEX IF NOT EXISTS idx_reborn_run_state_records_scope_status
+    ON reborn_run_state_records(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, status);
 
 CREATE TABLE IF NOT EXISTS reborn_approval_request_records (
-    owner_key TEXT NOT NULL,
+    tenant_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    mission_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
     request_id TEXT NOT NULL,
     status TEXT NOT NULL,
     payload JSONB NOT NULL,
-    PRIMARY KEY (owner_key, request_id)
+    PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, request_id)
 );
-CREATE INDEX IF NOT EXISTS idx_reborn_approval_request_records_owner_status
-    ON reborn_approval_request_records(owner_key, status);
+CREATE INDEX IF NOT EXISTS idx_reborn_approval_request_records_scope_status
+    ON reborn_approval_request_records(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, status);
 "#;
 
 /// libSQL-backed invocation lifecycle store.
@@ -179,11 +199,18 @@ impl RunStateStore for LibSqlRunStateStore {
         scope: &ResourceScope,
     ) -> Result<Vec<RunRecord>, RunStateError> {
         let conn = self.connect().await?;
-        let owner_key = owner_key(scope)?;
+        let key = ScopeKey::new(scope);
         let mut rows = conn
             .query(
-                "SELECT invocation_id, capability_id, status, approval_request_id, error_kind, payload FROM reborn_run_state_records WHERE owner_key = ?1 ORDER BY invocation_id",
-                libsql::params![owner_key],
+                "SELECT invocation_id, capability_id, status, approval_request_id, error_kind, payload FROM reborn_run_state_records WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 ORDER BY invocation_id",
+                libsql::params![
+                    key.tenant_id,
+                    key.user_id,
+                    key.agent_id,
+                    key.project_id,
+                    key.mission_id,
+                    key.thread_id,
+                ],
             )
             .await
             .map_err(db_error)?;
@@ -207,7 +234,6 @@ impl RunStateStore for LibSqlRunStateStore {
             )?;
             records.push(record);
         }
-        records.sort_by_key(|record| record.invocation_id.as_uuid());
         Ok(records)
     }
 }
@@ -519,10 +545,19 @@ impl ApprovalRequestStore for LibSqlApprovalRequestStore {
                     status: record.status,
                 });
             }
+            let key = ScopeKey::new(scope);
             let affected = conn
                 .execute(
-                    "DELETE FROM reborn_approval_request_records WHERE owner_key = ?1 AND request_id = ?2",
-                    libsql::params![owner_key(scope)?, request_id.to_string()],
+                    "DELETE FROM reborn_approval_request_records WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND request_id = ?7",
+                    libsql::params![
+                        key.tenant_id,
+                        key.user_id,
+                        key.agent_id,
+                        key.project_id,
+                        key.mission_id,
+                        key.thread_id,
+                        request_id.to_string(),
+                    ],
                 )
                 .await
                 .map_err(db_error)?;
@@ -538,11 +573,18 @@ impl ApprovalRequestStore for LibSqlApprovalRequestStore {
         scope: &ResourceScope,
     ) -> Result<Vec<ApprovalRecord>, RunStateError> {
         let conn = self.connect().await?;
-        let owner_key = owner_key(scope)?;
+        let key = ScopeKey::new(scope);
         let mut rows = conn
             .query(
-                "SELECT request_id, status, payload FROM reborn_approval_request_records WHERE owner_key = ?1 ORDER BY request_id",
-                libsql::params![owner_key],
+                "SELECT request_id, status, payload FROM reborn_approval_request_records WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 ORDER BY request_id",
+                libsql::params![
+                    key.tenant_id,
+                    key.user_id,
+                    key.agent_id,
+                    key.project_id,
+                    key.mission_id,
+                    key.thread_id,
+                ],
             )
             .await
             .map_err(db_error)?;
@@ -560,7 +602,6 @@ impl ApprovalRequestStore for LibSqlApprovalRequestStore {
             )?;
             records.push(record);
         }
-        records.sort_by_key(|record| record.request.id.as_uuid());
         Ok(records)
     }
 }
@@ -704,14 +745,22 @@ impl RunStateStore for PostgresRunStateStore {
         scope: &ResourceScope,
     ) -> Result<Vec<RunRecord>, RunStateError> {
         let client = self.client().await?;
+        let key = ScopeKey::new(scope);
         let rows = client
             .query(
-                "SELECT invocation_id, capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE owner_key = $1 ORDER BY invocation_id",
-                &[&owner_key(scope)?],
+                "SELECT invocation_id, capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 ORDER BY invocation_id",
+                &[
+                    &key.tenant_id,
+                    &key.user_id,
+                    &key.agent_id,
+                    &key.project_id,
+                    &key.mission_id,
+                    &key.thread_id,
+                ],
             )
             .await
             .map_err(db_error)?;
-        let mut records = rows
+        let records = rows
             .into_iter()
             .map(|row| {
                 let row_invocation_id: String = row.get(0);
@@ -732,7 +781,6 @@ impl RunStateStore for PostgresRunStateStore {
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
-        records.sort_by_key(|record| record.invocation_id.as_uuid());
         Ok(records)
     }
 }
@@ -1042,10 +1090,19 @@ impl ApprovalRequestStore for PostgresApprovalRequestStore {
                 status: record.status,
             });
         }
+        let key = ScopeKey::new(scope);
         let affected = txn
             .execute(
-                "DELETE FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2",
-                &[&owner_key(scope)?, &request_id.to_string()],
+                "DELETE FROM reborn_approval_request_records WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND request_id = $7",
+                &[
+                    &key.tenant_id,
+                    &key.user_id,
+                    &key.agent_id,
+                    &key.project_id,
+                    &key.mission_id,
+                    &key.thread_id,
+                    &request_id.to_string(),
+                ],
             )
             .await
             .map_err(db_error)?;
@@ -1059,14 +1116,22 @@ impl ApprovalRequestStore for PostgresApprovalRequestStore {
         scope: &ResourceScope,
     ) -> Result<Vec<ApprovalRecord>, RunStateError> {
         let client = self.client().await?;
+        let key = ScopeKey::new(scope);
         let rows = client
             .query(
-                "SELECT request_id, status, payload::text FROM reborn_approval_request_records WHERE owner_key = $1 ORDER BY request_id",
-                &[&owner_key(scope)?],
+                "SELECT request_id, status, payload::text FROM reborn_approval_request_records WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 ORDER BY request_id",
+                &[
+                    &key.tenant_id,
+                    &key.user_id,
+                    &key.agent_id,
+                    &key.project_id,
+                    &key.mission_id,
+                    &key.thread_id,
+                ],
             )
             .await
             .map_err(db_error)?;
-        let mut records = rows
+        let records = rows
             .into_iter()
             .map(|row| {
                 let request_id: String = row.get(0);
@@ -1081,7 +1146,6 @@ impl ApprovalRequestStore for PostgresApprovalRequestStore {
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
-        records.sort_by_key(|record| record.request.id.as_uuid());
         Ok(records)
     }
 }
@@ -1169,10 +1233,19 @@ async fn libsql_get_run(
     scope: &ResourceScope,
     invocation_id: InvocationId,
 ) -> Result<Option<RunRecord>, RunStateError> {
+    let key = ScopeKey::new(scope);
     let mut rows = conn
         .query(
-            "SELECT capability_id, status, approval_request_id, error_kind, payload FROM reborn_run_state_records WHERE owner_key = ?1 AND invocation_id = ?2",
-            libsql::params![owner_key(scope)?, invocation_id.to_string()],
+            "SELECT capability_id, status, approval_request_id, error_kind, payload FROM reborn_run_state_records WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND invocation_id = ?7",
+            libsql::params![
+                key.tenant_id,
+                key.user_id,
+                key.agent_id,
+                key.project_id,
+                key.mission_id,
+                key.thread_id,
+                invocation_id.to_string(),
+            ],
         )
         .await
         .map_err(db_error)?;
@@ -1201,10 +1274,16 @@ async fn libsql_insert_run(
     conn: &libsql::Connection,
     record: &RunRecord,
 ) -> Result<(), RunStateError> {
+    let key = ScopeKey::new(&record.scope);
     conn.execute(
-        "INSERT INTO reborn_run_state_records (owner_key, invocation_id, capability_id, status, approval_request_id, error_kind, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        "INSERT INTO reborn_run_state_records (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, capability_id, status, approval_request_id, error_kind, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         libsql::params![
-            owner_key(&record.scope)?,
+            key.tenant_id,
+            key.user_id,
+            key.agent_id,
+            key.project_id,
+            key.mission_id,
+            key.thread_id,
             record.invocation_id.to_string(),
             record.capability_id.as_str(),
             run_status_key(record.status),
@@ -1223,11 +1302,17 @@ async fn libsql_update_run(
     conn: &libsql::Connection,
     record: &RunRecord,
 ) -> Result<(), RunStateError> {
+    let key = ScopeKey::new(&record.scope);
     let affected = conn
         .execute(
-            "UPDATE reborn_run_state_records SET capability_id = ?3, status = ?4, approval_request_id = ?5, error_kind = ?6, payload = ?7 WHERE owner_key = ?1 AND invocation_id = ?2",
+            "UPDATE reborn_run_state_records SET capability_id = ?8, status = ?9, approval_request_id = ?10, error_kind = ?11, payload = ?12 WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND invocation_id = ?7",
             libsql::params![
-                owner_key(&record.scope)?,
+                key.tenant_id,
+                key.user_id,
+                key.agent_id,
+                key.project_id,
+                key.mission_id,
+                key.thread_id,
                 record.invocation_id.to_string(),
                 record.capability_id.as_str(),
                 run_status_key(record.status),
@@ -1247,10 +1332,19 @@ async fn libsql_get_approval(
     scope: &ResourceScope,
     request_id: ApprovalRequestId,
 ) -> Result<Option<ApprovalRecord>, RunStateError> {
+    let key = ScopeKey::new(scope);
     let mut rows = conn
         .query(
-            "SELECT status, payload FROM reborn_approval_request_records WHERE owner_key = ?1 AND request_id = ?2",
-            libsql::params![owner_key(scope)?, request_id.to_string()],
+            "SELECT status, payload FROM reborn_approval_request_records WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND request_id = ?7",
+            libsql::params![
+                key.tenant_id,
+                key.user_id,
+                key.agent_id,
+                key.project_id,
+                key.mission_id,
+                key.thread_id,
+                request_id.to_string(),
+            ],
         )
         .await
         .map_err(db_error)?;
@@ -1273,10 +1367,16 @@ async fn libsql_insert_approval(
     conn: &libsql::Connection,
     record: &ApprovalRecord,
 ) -> Result<(), RunStateError> {
+    let key = ScopeKey::new(&record.scope);
     conn.execute(
-        "INSERT INTO reborn_approval_request_records (owner_key, request_id, status, payload) VALUES (?1, ?2, ?3, ?4)",
+        "INSERT INTO reborn_approval_request_records (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, request_id, status, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         libsql::params![
-            owner_key(&record.scope)?,
+            key.tenant_id,
+            key.user_id,
+            key.agent_id,
+            key.project_id,
+            key.mission_id,
+            key.thread_id,
             record.request.id.to_string(),
             approval_status_key(record.status),
             to_json(record)?,
@@ -1292,11 +1392,17 @@ async fn libsql_update_approval(
     conn: &libsql::Connection,
     record: &ApprovalRecord,
 ) -> Result<(), RunStateError> {
+    let key = ScopeKey::new(&record.scope);
     let affected = conn
         .execute(
-            "UPDATE reborn_approval_request_records SET status = ?3, payload = ?4 WHERE owner_key = ?1 AND request_id = ?2",
+            "UPDATE reborn_approval_request_records SET status = ?8, payload = ?9 WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND request_id = ?7",
             libsql::params![
-                owner_key(&record.scope)?,
+                key.tenant_id,
+                key.user_id,
+                key.agent_id,
+                key.project_id,
+                key.mission_id,
+                key.thread_id,
                 record.request.id.to_string(),
                 approval_status_key(record.status),
                 to_json(record)?,
@@ -1316,12 +1422,113 @@ async fn run_postgres_migrations(pool: &deadpool_postgres::Pool) -> Result<(), R
     txn.query_one("SELECT pg_advisory_xact_lock($1)", &[&MIGRATION_LOCK_ID])
         .await
         .map_err(db_error)?;
+    if postgres_table_has_column(&txn, "reborn_run_state_records", "owner_key").await? {
+        postgres_migrate_run_owner_key_schema(&txn).await?;
+    }
+    if postgres_table_has_column(&txn, "reborn_approval_request_records", "owner_key").await? {
+        postgres_migrate_approval_owner_key_schema(&txn).await?;
+    }
     if !postgres_schema_present(&txn).await? {
         txn.batch_execute(POSTGRES_RUN_STATE_SCHEMA)
             .await
             .map_err(db_error)?;
     }
     txn.commit().await.map_err(db_error)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_table_has_column(
+    client: &impl deadpool_postgres::GenericClient,
+    table_name: &str,
+    column_name: &str,
+) -> Result<bool, RunStateError> {
+    let row = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = $1
+                  AND column_name = $2
+            )",
+            &[&table_name, &column_name],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(row.get(0))
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_migrate_run_owner_key_schema(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<(), RunStateError> {
+    client
+        .batch_execute(
+            "ALTER TABLE reborn_run_state_records DROP CONSTRAINT IF EXISTS reborn_run_state_records_pkey;
+             ALTER TABLE reborn_run_state_records ADD COLUMN IF NOT EXISTS tenant_id TEXT;
+             ALTER TABLE reborn_run_state_records ADD COLUMN IF NOT EXISTS user_id TEXT;
+             ALTER TABLE reborn_run_state_records ADD COLUMN IF NOT EXISTS agent_id TEXT;
+             ALTER TABLE reborn_run_state_records ADD COLUMN IF NOT EXISTS project_id TEXT;
+             ALTER TABLE reborn_run_state_records ADD COLUMN IF NOT EXISTS mission_id TEXT;
+             ALTER TABLE reborn_run_state_records ADD COLUMN IF NOT EXISTS thread_id TEXT;
+             UPDATE reborn_run_state_records
+                SET tenant_id = owner_key::jsonb->>'tenant_id',
+                    user_id = owner_key::jsonb->>'user_id',
+                    agent_id = COALESCE(owner_key::jsonb->>'agent_id', ''),
+                    project_id = COALESCE(owner_key::jsonb->>'project_id', ''),
+                    mission_id = COALESCE(owner_key::jsonb->>'mission_id', ''),
+                    thread_id = COALESCE(owner_key::jsonb->>'thread_id', '')
+              WHERE owner_key IS NOT NULL;
+             ALTER TABLE reborn_run_state_records ALTER COLUMN tenant_id SET NOT NULL;
+             ALTER TABLE reborn_run_state_records ALTER COLUMN user_id SET NOT NULL;
+             ALTER TABLE reborn_run_state_records ALTER COLUMN agent_id SET NOT NULL;
+             ALTER TABLE reborn_run_state_records ALTER COLUMN project_id SET NOT NULL;
+             ALTER TABLE reborn_run_state_records ALTER COLUMN mission_id SET NOT NULL;
+             ALTER TABLE reborn_run_state_records ALTER COLUMN thread_id SET NOT NULL;
+             ALTER TABLE reborn_run_state_records DROP COLUMN IF EXISTS owner_key;
+             ALTER TABLE reborn_run_state_records ADD PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id);
+             DROP INDEX IF EXISTS idx_reborn_run_state_records_owner_status;
+             CREATE INDEX IF NOT EXISTS idx_reborn_run_state_records_scope_status
+                ON reborn_run_state_records(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, status);",
+        )
+        .await
+        .map_err(db_error)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_migrate_approval_owner_key_schema(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<(), RunStateError> {
+    client
+        .batch_execute(
+            "ALTER TABLE reborn_approval_request_records DROP CONSTRAINT IF EXISTS reborn_approval_request_records_pkey;
+             ALTER TABLE reborn_approval_request_records ADD COLUMN IF NOT EXISTS tenant_id TEXT;
+             ALTER TABLE reborn_approval_request_records ADD COLUMN IF NOT EXISTS user_id TEXT;
+             ALTER TABLE reborn_approval_request_records ADD COLUMN IF NOT EXISTS agent_id TEXT;
+             ALTER TABLE reborn_approval_request_records ADD COLUMN IF NOT EXISTS project_id TEXT;
+             ALTER TABLE reborn_approval_request_records ADD COLUMN IF NOT EXISTS mission_id TEXT;
+             ALTER TABLE reborn_approval_request_records ADD COLUMN IF NOT EXISTS thread_id TEXT;
+             UPDATE reborn_approval_request_records
+                SET tenant_id = owner_key::jsonb->>'tenant_id',
+                    user_id = owner_key::jsonb->>'user_id',
+                    agent_id = COALESCE(owner_key::jsonb->>'agent_id', ''),
+                    project_id = COALESCE(owner_key::jsonb->>'project_id', ''),
+                    mission_id = COALESCE(owner_key::jsonb->>'mission_id', ''),
+                    thread_id = COALESCE(owner_key::jsonb->>'thread_id', '')
+              WHERE owner_key IS NOT NULL;
+             ALTER TABLE reborn_approval_request_records ALTER COLUMN tenant_id SET NOT NULL;
+             ALTER TABLE reborn_approval_request_records ALTER COLUMN user_id SET NOT NULL;
+             ALTER TABLE reborn_approval_request_records ALTER COLUMN agent_id SET NOT NULL;
+             ALTER TABLE reborn_approval_request_records ALTER COLUMN project_id SET NOT NULL;
+             ALTER TABLE reborn_approval_request_records ALTER COLUMN mission_id SET NOT NULL;
+             ALTER TABLE reborn_approval_request_records ALTER COLUMN thread_id SET NOT NULL;
+             ALTER TABLE reborn_approval_request_records DROP COLUMN IF EXISTS owner_key;
+             ALTER TABLE reborn_approval_request_records ADD PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, request_id);
+             DROP INDEX IF EXISTS idx_reborn_approval_request_records_owner_status;
+             CREATE INDEX IF NOT EXISTS idx_reborn_approval_request_records_scope_status
+                ON reborn_approval_request_records(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, status);",
+        )
+        .await
+        .map_err(db_error)
 }
 
 #[cfg(feature = "postgres")]
@@ -1332,9 +1539,21 @@ async fn postgres_schema_present(
         .query_one(
             "SELECT
                 to_regclass('public.reborn_run_state_records') IS NOT NULL,
-                to_regclass('public.idx_reborn_run_state_records_owner_status') IS NOT NULL,
+                to_regclass('public.idx_reborn_run_state_records_scope_status') IS NOT NULL,
                 to_regclass('public.reborn_approval_request_records') IS NOT NULL,
-                to_regclass('public.idx_reborn_approval_request_records_owner_status') IS NOT NULL",
+                to_regclass('public.idx_reborn_approval_request_records_scope_status') IS NOT NULL,
+                NOT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name IN ('reborn_run_state_records', 'reborn_approval_request_records')
+                      AND column_name = 'owner_key'
+                ),
+                (
+                    SELECT count(*) FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name IN ('reborn_run_state_records', 'reborn_approval_request_records')
+                      AND column_name IN ('tenant_id', 'user_id', 'agent_id', 'project_id', 'mission_id', 'thread_id')
+                ) = 12",
             &[],
         )
         .await
@@ -1342,7 +1561,9 @@ async fn postgres_schema_present(
     Ok(row.get::<_, bool>(0)
         && row.get::<_, bool>(1)
         && row.get::<_, bool>(2)
-        && row.get::<_, bool>(3))
+        && row.get::<_, bool>(3)
+        && row.get::<_, bool>(4)
+        && row.get::<_, bool>(5))
 }
 
 #[cfg(feature = "postgres")]
@@ -1351,10 +1572,19 @@ async fn postgres_get_run(
     scope: &ResourceScope,
     invocation_id: InvocationId,
 ) -> Result<Option<RunRecord>, RunStateError> {
+    let key = ScopeKey::new(scope);
     let row = client
         .query_opt(
-            "SELECT capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE owner_key = $1 AND invocation_id = $2",
-            &[&owner_key(scope)?, &invocation_id.to_string()],
+            "SELECT capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND invocation_id = $7",
+            &[
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
+                &invocation_id.to_string(),
+            ],
         )
         .await
         .map_err(db_error)?;
@@ -1384,10 +1614,19 @@ async fn postgres_get_run_for_update(
     scope: &ResourceScope,
     invocation_id: InvocationId,
 ) -> Result<Option<RunRecord>, RunStateError> {
+    let key = ScopeKey::new(scope);
     let row = client
         .query_opt(
-            "SELECT capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE owner_key = $1 AND invocation_id = $2 FOR UPDATE",
-            &[&owner_key(scope)?, &invocation_id.to_string()],
+            "SELECT capability_id, status, approval_request_id, error_kind, payload::text FROM reborn_run_state_records WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND invocation_id = $7 FOR UPDATE",
+            &[
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
+                &invocation_id.to_string(),
+            ],
         )
         .await
         .map_err(db_error)?;
@@ -1416,12 +1655,18 @@ async fn postgres_insert_run(
     client: &impl deadpool_postgres::GenericClient,
     record: &RunRecord,
 ) -> Result<bool, RunStateError> {
+    let key = ScopeKey::new(&record.scope);
     let payload = to_json(record)?;
     let affected = client
         .execute(
-            "INSERT INTO reborn_run_state_records (owner_key, invocation_id, capability_id, status, approval_request_id, error_kind, payload) VALUES ($1, $2, $3, $4, $5, $6, $7::text::jsonb) ON CONFLICT DO NOTHING",
+            "INSERT INTO reborn_run_state_records (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, capability_id, status, approval_request_id, error_kind, payload) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::text::jsonb) ON CONFLICT DO NOTHING",
             &[
-                &owner_key(&record.scope)?,
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
                 &record.invocation_id.to_string(),
                 &record.capability_id.as_str(),
                 &run_status_key(record.status),
@@ -1440,12 +1685,18 @@ async fn postgres_update_run(
     client: &impl deadpool_postgres::GenericClient,
     record: &RunRecord,
 ) -> Result<(), RunStateError> {
+    let key = ScopeKey::new(&record.scope);
     let payload = to_json(record)?;
     let affected = client
         .execute(
-            "UPDATE reborn_run_state_records SET capability_id = $3, status = $4, approval_request_id = $5, error_kind = $6, payload = $7::text::jsonb WHERE owner_key = $1 AND invocation_id = $2",
+            "UPDATE reborn_run_state_records SET capability_id = $8, status = $9, approval_request_id = $10, error_kind = $11, payload = $12::text::jsonb WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND invocation_id = $7",
             &[
-                &owner_key(&record.scope)?,
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
                 &record.invocation_id.to_string(),
                 &record.capability_id.as_str(),
                 &run_status_key(record.status),
@@ -1465,10 +1716,19 @@ async fn postgres_get_approval(
     scope: &ResourceScope,
     request_id: ApprovalRequestId,
 ) -> Result<Option<ApprovalRecord>, RunStateError> {
+    let key = ScopeKey::new(scope);
     let row = client
         .query_opt(
-            "SELECT status, payload::text FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2",
-            &[&owner_key(scope)?, &request_id.to_string()],
+            "SELECT status, payload::text FROM reborn_approval_request_records WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND request_id = $7",
+            &[
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
+                &request_id.to_string(),
+            ],
         )
         .await
         .map_err(db_error)?;
@@ -1492,10 +1752,19 @@ async fn postgres_get_approval_for_update(
     scope: &ResourceScope,
     request_id: ApprovalRequestId,
 ) -> Result<Option<ApprovalRecord>, RunStateError> {
+    let key = ScopeKey::new(scope);
     let row = client
         .query_opt(
-            "SELECT status, payload::text FROM reborn_approval_request_records WHERE owner_key = $1 AND request_id = $2 FOR UPDATE",
-            &[&owner_key(scope)?, &request_id.to_string()],
+            "SELECT status, payload::text FROM reborn_approval_request_records WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND request_id = $7 FOR UPDATE",
+            &[
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
+                &request_id.to_string(),
+            ],
         )
         .await
         .map_err(db_error)?;
@@ -1518,12 +1787,18 @@ async fn postgres_insert_approval(
     client: &impl deadpool_postgres::GenericClient,
     record: &ApprovalRecord,
 ) -> Result<bool, RunStateError> {
+    let key = ScopeKey::new(&record.scope);
     let payload = to_json(record)?;
     let affected = client
         .execute(
-            "INSERT INTO reborn_approval_request_records (owner_key, request_id, status, payload) VALUES ($1, $2, $3, $4::text::jsonb) ON CONFLICT DO NOTHING",
+            "INSERT INTO reborn_approval_request_records (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, request_id, status, payload) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::text::jsonb) ON CONFLICT DO NOTHING",
             &[
-                &owner_key(&record.scope)?,
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
                 &record.request.id.to_string(),
                 &approval_status_key(record.status),
                 &payload,
@@ -1539,12 +1814,18 @@ async fn postgres_update_approval(
     client: &impl deadpool_postgres::GenericClient,
     record: &ApprovalRecord,
 ) -> Result<(), RunStateError> {
+    let key = ScopeKey::new(&record.scope);
     let payload = to_json(record)?;
     let affected = client
         .execute(
-            "UPDATE reborn_approval_request_records SET status = $3, payload = $4::text::jsonb WHERE owner_key = $1 AND request_id = $2",
+            "UPDATE reborn_approval_request_records SET status = $8, payload = $9::text::jsonb WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND request_id = $7",
             &[
-                &owner_key(&record.scope)?,
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
                 &record.request.id.to_string(),
                 &approval_status_key(record.status),
                 &payload,
@@ -1577,7 +1858,7 @@ fn validate_run_row(
     row_error_kind: Option<&str>,
 ) -> Result<RunRecord, RunStateError> {
     if !crate::same_scope_owner(&record.scope, expected_scope) {
-        return Err(row_integrity_error("run-state", "owner_key"));
+        return Err(row_integrity_error("run-state", "scope columns"));
     }
     if record.invocation_id != row_invocation_id {
         return Err(row_integrity_error("run-state", "invocation_id"));
@@ -1605,7 +1886,7 @@ fn validate_approval_row(
     row_status: &str,
 ) -> Result<ApprovalRecord, RunStateError> {
     if !crate::same_scope_owner(&record.scope, expected_scope) {
-        return Err(row_integrity_error("approval-request", "owner_key"));
+        return Err(row_integrity_error("approval-request", "scope columns"));
     }
     if record.request.id != row_request_id {
         return Err(row_integrity_error("approval-request", "request_id"));
@@ -1635,25 +1916,26 @@ fn require_single_affected_row(
     }
 }
 
-fn owner_key(scope: &ResourceScope) -> Result<String, RunStateError> {
-    #[derive(serde::Serialize)]
-    struct OwnerKey<'a> {
-        tenant_id: &'a str,
-        user_id: &'a str,
-        agent_id: Option<&'a str>,
-        project_id: Option<&'a str>,
-        mission_id: Option<&'a str>,
-        thread_id: Option<&'a str>,
-    }
+struct ScopeKey<'a> {
+    tenant_id: &'a str,
+    user_id: &'a str,
+    agent_id: &'a str,
+    project_id: &'a str,
+    mission_id: &'a str,
+    thread_id: &'a str,
+}
 
-    to_json(&OwnerKey {
-        tenant_id: scope.tenant_id.as_str(),
-        user_id: scope.user_id.as_str(),
-        agent_id: scope.agent_id.as_ref().map(|id| id.as_str()),
-        project_id: scope.project_id.as_ref().map(|id| id.as_str()),
-        mission_id: scope.mission_id.as_ref().map(|id| id.as_str()),
-        thread_id: scope.thread_id.as_ref().map(|id| id.as_str()),
-    })
+impl<'a> ScopeKey<'a> {
+    fn new(scope: &'a ResourceScope) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.as_str(),
+            user_id: scope.user_id.as_str(),
+            agent_id: scope.agent_id.as_ref().map_or("", |id| id.as_str()),
+            project_id: scope.project_id.as_ref().map_or("", |id| id.as_str()),
+            mission_id: scope.mission_id.as_ref().map_or("", |id| id.as_str()),
+            thread_id: scope.thread_id.as_ref().map_or("", |id| id.as_str()),
+        }
+    }
 }
 
 fn run_status_key(status: RunStatus) -> &'static str {

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -3,6 +3,17 @@
 //! `ironclaw_run_state` stores the current lifecycle state for host-managed
 //! invocations. It is separate from runtime events: events are append-only
 //! history, while run state answers "what is this invocation waiting on now?".
+//! Feature-gated PostgreSQL and libSQL stores provide transactional durable
+//! backends for production composition; in-memory and filesystem stores remain
+//! useful for tests, local demos, and single-process profiles.
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+mod db;
+
+#[cfg(feature = "libsql")]
+pub use db::{LibSqlApprovalRequestStore, LibSqlRunStateApprovalStore, LibSqlRunStateStore};
+#[cfg(feature = "postgres")]
+pub use db::{PostgresApprovalRequestStore, PostgresRunStateApprovalStore, PostgresRunStateStore};
 
 use std::{
     collections::HashMap,
@@ -140,6 +151,8 @@ pub enum RunStateError {
     Serialization(String),
     #[error("deserialization error: {0}")]
     Deserialization(String),
+    #[error("run-state backend error: {0}")]
+    Backend(String),
 }
 
 impl From<FilesystemError> for RunStateError {
@@ -248,6 +261,22 @@ pub trait ApprovalRequestStore: Send + Sync {
         &self,
         scope: &ResourceScope,
     ) -> Result<Vec<ApprovalRecord>, RunStateError>;
+}
+
+/// Combined run-state + approval request store with an atomic approval-block transition.
+///
+/// Production composition should prefer this interface when the same durable backend
+/// owns both invocation state and approval records. It prevents a crash between
+/// `ApprovalRequestStore::save_pending` and `RunStateStore::block_approval` from
+/// leaving a user-actionable approval disconnected from a blocked run.
+#[async_trait]
+pub trait RunStateApprovalStore: RunStateStore + ApprovalRequestStore {
+    async fn save_pending_and_block_approval(
+        &self,
+        scope: ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError>;
 }
 
 /// In-memory run-state store for tests and early host wiring.

--- a/crates/ironclaw_run_state/tests/db_run_state_store_contract.rs
+++ b/crates/ironclaw_run_state/tests/db_run_state_store_contract.rs
@@ -320,6 +320,30 @@ async fn libsql_rejects_approval_rows_when_payload_request_id_does_not_match_row
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
+async fn postgres_migrations_are_serialized_when_called_concurrently() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let store_a = PostgresRunStateStore::new(pool.clone());
+    let store_b = PostgresRunStateStore::new(pool.clone());
+    let store_c = PostgresApprovalRequestStore::new(pool.clone());
+    let store_d = PostgresRunStateApprovalStore::new(pool);
+
+    let (a, b, c, d) = tokio::join!(
+        store_a.run_migrations(),
+        store_b.run_migrations(),
+        store_c.run_migrations(),
+        store_d.run_migrations(),
+    );
+
+    a.unwrap();
+    b.unwrap();
+    c.unwrap();
+    d.unwrap();
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
 async fn postgres_run_state_and_approval_stores_persist_across_instances_when_configured() {
     let Some(pool) = postgres_pool().await else {
         return;
@@ -514,7 +538,7 @@ async fn postgres_rejects_run_rows_when_payload_invocation_id_does_not_match_row
     let client = pool.get().await.unwrap();
     client
         .execute(
-            "UPDATE reborn_run_state_records SET payload = $1::jsonb WHERE invocation_id = $2",
+            "UPDATE reborn_run_state_records SET payload = $1::text::jsonb WHERE invocation_id = $2",
             &[&payload, &invocation_id.to_string()],
         )
         .await
@@ -558,7 +582,7 @@ async fn postgres_rejects_approval_rows_when_payload_request_id_does_not_match_r
     let client = pool.get().await.unwrap();
     client
         .execute(
-            "UPDATE reborn_approval_request_records SET payload = $1::jsonb WHERE request_id = $2",
+            "UPDATE reborn_approval_request_records SET payload = $1::text::jsonb WHERE request_id = $2",
             &[&payload, &request_id.to_string()],
         )
         .await

--- a/crates/ironclaw_run_state/tests/db_run_state_store_contract.rs
+++ b/crates/ironclaw_run_state/tests/db_run_state_store_contract.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 
 use ironclaw_host_api::*;
 use ironclaw_run_state::{
-    ApprovalRequestStore, ApprovalStatus, RunStart, RunStateApprovalStore, RunStateStore,
+    ApprovalRecord, ApprovalRequestStore, ApprovalStatus, RunRecord, RunStart,
+    RunStateApprovalStore, RunStateError, RunStateStore,
 };
 
 #[cfg(feature = "libsql")]
@@ -240,6 +241,83 @@ async fn libsql_stores_preserve_scope_isolation_and_pending_discard() {
     assert!(approvals.get(&scope, request_id).await.unwrap().is_none());
 }
 
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_rejects_run_rows_when_payload_invocation_id_does_not_match_row_key() {
+    let (db_path, _dir) = libsql_db_path();
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let runs = LibSqlRunStateStore::new(Arc::clone(&db));
+    runs.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant-libsql-mismatch", "user-a");
+    let record = runs
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    let mismatched_payload = RunRecord {
+        invocation_id: InvocationId::new(),
+        ..record
+    };
+    let payload = serde_json::to_string(&mismatched_payload).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute(
+        "UPDATE reborn_run_state_records SET payload = ?1 WHERE invocation_id = ?2",
+        libsql::params![payload, invocation_id.to_string()],
+    )
+    .await
+    .unwrap();
+
+    let err = runs.get(&scope, invocation_id).await.unwrap_err();
+    assert!(
+        matches!(err, RunStateError::Deserialization(_)),
+        "expected deserialization integrity error, got {err:?}"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_rejects_approval_rows_when_payload_request_id_does_not_match_row_key() {
+    let (db_path, _dir) = libsql_db_path();
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let approvals = LibSqlApprovalRequestStore::new(Arc::clone(&db));
+    approvals.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant-libsql-approval-mismatch", "user-a");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+    let mut mismatched_request = approval;
+    mismatched_request.id = ApprovalRequestId::new();
+    let mismatched_payload = ApprovalRecord {
+        scope: scope.clone(),
+        request: mismatched_request,
+        status: ApprovalStatus::Pending,
+    };
+    let payload = serde_json::to_string(&mismatched_payload).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute(
+        "UPDATE reborn_approval_request_records SET payload = ?1 WHERE request_id = ?2",
+        libsql::params![payload, request_id.to_string()],
+    )
+    .await
+    .unwrap();
+
+    let err = approvals.get(&scope, request_id).await.unwrap_err();
+    assert!(
+        matches!(err, RunStateError::Deserialization(_)),
+        "expected deserialization integrity error, got {err:?}"
+    );
+}
+
 #[cfg(feature = "postgres")]
 #[tokio::test]
 async fn postgres_run_state_and_approval_stores_persist_across_instances_when_configured() {
@@ -404,6 +482,93 @@ async fn postgres_combined_store_blocks_with_pending_approval_atomically_when_co
         .unwrap();
     assert_eq!(saved.status, ApprovalStatus::Pending);
     assert_eq!(saved.request, approval);
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_rejects_run_rows_when_payload_invocation_id_does_not_match_row_key() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let tenant = format!("tenant-pg-run-mismatch-{suffix}");
+    let user = format!("user-pg-run-mismatch-{suffix}");
+    let runs = PostgresRunStateStore::new(pool.clone());
+    runs.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, &tenant, &user);
+    let record = runs
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    let mismatched_payload = RunRecord {
+        invocation_id: InvocationId::new(),
+        ..record
+    };
+    let payload = serde_json::to_string(&mismatched_payload).unwrap();
+    let client = pool.get().await.unwrap();
+    client
+        .execute(
+            "UPDATE reborn_run_state_records SET payload = $1::jsonb WHERE invocation_id = $2",
+            &[&payload, &invocation_id.to_string()],
+        )
+        .await
+        .unwrap();
+
+    let err = runs.get(&scope, invocation_id).await.unwrap_err();
+    assert!(
+        matches!(err, RunStateError::Deserialization(_)),
+        "expected deserialization integrity error, got {err:?}"
+    );
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_rejects_approval_rows_when_payload_request_id_does_not_match_row_key() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let tenant = format!("tenant-pg-approval-mismatch-{suffix}");
+    let user = format!("user-pg-approval-mismatch-{suffix}");
+    let approvals = PostgresApprovalRequestStore::new(pool.clone());
+    approvals.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, &tenant, &user);
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+    let mut mismatched_request = approval;
+    mismatched_request.id = ApprovalRequestId::new();
+    let mismatched_payload = ApprovalRecord {
+        scope: scope.clone(),
+        request: mismatched_request,
+        status: ApprovalStatus::Pending,
+    };
+    let payload = serde_json::to_string(&mismatched_payload).unwrap();
+    let client = pool.get().await.unwrap();
+    client
+        .execute(
+            "UPDATE reborn_approval_request_records SET payload = $1::jsonb WHERE request_id = $2",
+            &[&payload, &request_id.to_string()],
+        )
+        .await
+        .unwrap();
+
+    let err = approvals.get(&scope, request_id).await.unwrap_err();
+    assert!(
+        matches!(err, RunStateError::Deserialization(_)),
+        "expected deserialization integrity error, got {err:?}"
+    );
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_run_state/tests/db_run_state_store_contract.rs
+++ b/crates/ironclaw_run_state/tests/db_run_state_store_contract.rs
@@ -1,0 +1,505 @@
+#![cfg(any(feature = "libsql", feature = "postgres"))]
+
+#[cfg(feature = "libsql")]
+use std::sync::Arc;
+
+use ironclaw_host_api::*;
+use ironclaw_run_state::{
+    ApprovalRequestStore, ApprovalStatus, RunStart, RunStateApprovalStore, RunStateStore,
+};
+
+#[cfg(feature = "libsql")]
+use ironclaw_run_state::{
+    LibSqlApprovalRequestStore, LibSqlRunStateApprovalStore, LibSqlRunStateStore,
+};
+#[cfg(feature = "postgres")]
+use ironclaw_run_state::{
+    PostgresApprovalRequestStore, PostgresRunStateApprovalStore, PostgresRunStateStore,
+};
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_run_state_and_approval_stores_persist_across_database_reopen() {
+    let (db_path, _dir) = libsql_db_path();
+    let db = Arc::new(
+        libsql::Builder::new_local(db_path.clone())
+            .build()
+            .await
+            .unwrap(),
+    );
+    let runs = LibSqlRunStateStore::new(Arc::clone(&db));
+    runs.run_migrations().await.unwrap();
+    let approvals = LibSqlApprovalRequestStore::new(db);
+    approvals.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant-libsql", "user-libsql");
+    let capability_id = CapabilityId::new("echo.say").unwrap();
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    let running = runs
+        .start(RunStart {
+            invocation_id,
+            capability_id: capability_id.clone(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(running.status, ironclaw_run_state::RunStatus::Running);
+    let blocked = runs
+        .block_approval(&scope, invocation_id, approval.clone())
+        .await
+        .unwrap();
+    assert_eq!(blocked.approval_request_id, Some(request_id));
+    approvals
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+    approvals.approve(&scope, request_id).await.unwrap();
+
+    drop(runs);
+    drop(approvals);
+
+    let reopened_db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let reopened_runs = LibSqlRunStateStore::new(Arc::clone(&reopened_db));
+    let reopened_approvals = LibSqlApprovalRequestStore::new(reopened_db);
+
+    let reloaded_run = reopened_runs
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        reloaded_run.status,
+        ironclaw_run_state::RunStatus::BlockedApproval
+    );
+    assert_eq!(reloaded_run.capability_id, capability_id);
+    assert_eq!(reloaded_run.approval_request_id, Some(request_id));
+    assert_eq!(
+        reopened_runs.records_for_scope(&scope).await.unwrap(),
+        vec![reloaded_run]
+    );
+
+    let reloaded_approval = reopened_approvals
+        .get(&scope, request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reloaded_approval.status, ApprovalStatus::Approved);
+    assert_eq!(reloaded_approval.request, approval);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_stores_serialize_duplicate_creates_across_instances() {
+    let (db_path, _dir) = libsql_db_path();
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let runs_a = LibSqlRunStateStore::new(Arc::clone(&db));
+    runs_a.run_migrations().await.unwrap();
+    let runs_b = LibSqlRunStateStore::new(Arc::clone(&db));
+    let approvals_a = LibSqlApprovalRequestStore::new(Arc::clone(&db));
+    let approvals_b = LibSqlApprovalRequestStore::new(db);
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant-libsql-duplicates", "user-a");
+    let start = RunStart {
+        invocation_id,
+        capability_id: CapabilityId::new("echo.say").unwrap(),
+        scope: scope.clone(),
+    };
+    let (first_run, second_run) = tokio::join!(runs_a.start(start.clone()), runs_b.start(start));
+    assert_eq!(
+        [&first_run, &second_run]
+            .into_iter()
+            .filter(|result| result.is_ok())
+            .count(),
+        1
+    );
+    assert_eq!(
+        [&first_run, &second_run]
+            .into_iter()
+            .filter(|result| matches!(result, Err(ironclaw_run_state::RunStateError::InvocationAlreadyExists { invocation_id: id }) if *id == invocation_id))
+            .count(),
+        1
+    );
+
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+    let (first_approval, second_approval) = tokio::join!(
+        approvals_a.save_pending(scope.clone(), approval.clone()),
+        approvals_b.save_pending(scope.clone(), approval),
+    );
+    assert_eq!(
+        [&first_approval, &second_approval]
+            .into_iter()
+            .filter(|result| result.is_ok())
+            .count(),
+        1
+    );
+    assert_eq!(
+        [&first_approval, &second_approval]
+            .into_iter()
+            .filter(|result| matches!(result, Err(ironclaw_run_state::RunStateError::ApprovalRequestAlreadyExists { request_id: id }) if *id == request_id))
+            .count(),
+        1
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_combined_store_blocks_with_pending_approval_atomically() {
+    let (db_path, _dir) = libsql_db_path();
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let store = LibSqlRunStateApprovalStore::new(db);
+    store.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant-libsql-combined", "user-a");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+
+    let blocked = store
+        .save_pending_and_block_approval(scope.clone(), invocation_id, approval.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        blocked.status,
+        ironclaw_run_state::RunStatus::BlockedApproval
+    );
+    assert_eq!(blocked.approval_request_id, Some(request_id));
+    let saved = ApprovalRequestStore::get(&store, &scope, request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(saved.status, ApprovalStatus::Pending);
+    assert_eq!(saved.request, approval);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_stores_preserve_scope_isolation_and_pending_discard() {
+    let (db_path, _dir) = libsql_db_path();
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let runs = LibSqlRunStateStore::new(Arc::clone(&db));
+    runs.run_migrations().await.unwrap();
+    let approvals = LibSqlApprovalRequestStore::new(db);
+    approvals.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant-libsql-isolated", "user-a");
+    let other_user = sample_scope(invocation_id, "tenant-libsql-isolated", "user-b");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    runs.start(RunStart {
+        invocation_id,
+        capability_id: CapabilityId::new("echo.say").unwrap(),
+        scope: scope.clone(),
+    })
+    .await
+    .unwrap();
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
+
+    assert!(
+        runs.get(&other_user, invocation_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        runs.records_for_scope(&other_user).await.unwrap(),
+        Vec::new()
+    );
+    assert!(
+        approvals
+            .get(&other_user, request_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        approvals.records_for_scope(&other_user).await.unwrap(),
+        Vec::new()
+    );
+
+    let discarded = approvals.discard_pending(&scope, request_id).await.unwrap();
+    assert_eq!(discarded.status, ApprovalStatus::Pending);
+    assert!(approvals.get(&scope, request_id).await.unwrap().is_none());
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_run_state_and_approval_stores_persist_across_instances_when_configured() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let tenant = format!("tenant-pg-{suffix}");
+    let user = format!("user-pg-{suffix}");
+    let runs = PostgresRunStateStore::new(pool.clone());
+    runs.run_migrations().await.unwrap();
+    let approvals = PostgresApprovalRequestStore::new(pool.clone());
+    approvals.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, &tenant, &user);
+    let capability_id = CapabilityId::new("echo.say").unwrap();
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    runs.start(RunStart {
+        invocation_id,
+        capability_id: capability_id.clone(),
+        scope: scope.clone(),
+    })
+    .await
+    .unwrap();
+    runs.block_auth(&scope, invocation_id, "ExternalAuth".to_string())
+        .await
+        .unwrap();
+    approvals
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+    approvals.deny(&scope, request_id).await.unwrap();
+
+    let reopened_runs = PostgresRunStateStore::new(pool.clone());
+    let reopened_approvals = PostgresApprovalRequestStore::new(pool);
+    let reloaded_run = reopened_runs
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        reloaded_run.status,
+        ironclaw_run_state::RunStatus::BlockedAuth
+    );
+    assert_eq!(reloaded_run.error_kind.as_deref(), Some("ExternalAuth"));
+    assert_eq!(reloaded_run.capability_id, capability_id);
+    assert_eq!(
+        reopened_runs.records_for_scope(&scope).await.unwrap(),
+        vec![reloaded_run]
+    );
+
+    let reloaded_approval = reopened_approvals
+        .get(&scope, request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reloaded_approval.status, ApprovalStatus::Denied);
+    assert_eq!(reloaded_approval.request, approval);
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_stores_reject_duplicate_creates_across_instances_when_configured() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let tenant = format!("tenant-pg-duplicates-{suffix}");
+    let user = format!("user-pg-duplicates-{suffix}");
+    let runs_a = PostgresRunStateStore::new(pool.clone());
+    runs_a.run_migrations().await.unwrap();
+    let runs_b = PostgresRunStateStore::new(pool.clone());
+    let approvals_a = PostgresApprovalRequestStore::new(pool.clone());
+    let approvals_b = PostgresApprovalRequestStore::new(pool);
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, &tenant, &user);
+    let start = RunStart {
+        invocation_id,
+        capability_id: CapabilityId::new("echo.say").unwrap(),
+        scope: scope.clone(),
+    };
+    let (first_run, second_run) = tokio::join!(runs_a.start(start.clone()), runs_b.start(start));
+    assert_eq!(
+        [&first_run, &second_run]
+            .into_iter()
+            .filter(|result| result.is_ok())
+            .count(),
+        1
+    );
+    assert_eq!(
+        [&first_run, &second_run]
+            .into_iter()
+            .filter(|result| matches!(result, Err(ironclaw_run_state::RunStateError::InvocationAlreadyExists { invocation_id: id }) if *id == invocation_id))
+            .count(),
+        1
+    );
+
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+    let (first_approval, second_approval) = tokio::join!(
+        approvals_a.save_pending(scope.clone(), approval.clone()),
+        approvals_b.save_pending(scope.clone(), approval),
+    );
+    assert_eq!(
+        [&first_approval, &second_approval]
+            .into_iter()
+            .filter(|result| result.is_ok())
+            .count(),
+        1
+    );
+    assert_eq!(
+        [&first_approval, &second_approval]
+            .into_iter()
+            .filter(|result| matches!(result, Err(ironclaw_run_state::RunStateError::ApprovalRequestAlreadyExists { request_id: id }) if *id == request_id))
+            .count(),
+        1
+    );
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_combined_store_blocks_with_pending_approval_atomically_when_configured() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let tenant = format!("tenant-pg-combined-{suffix}");
+    let user = format!("user-pg-combined-{suffix}");
+    let store = PostgresRunStateApprovalStore::new(pool);
+    store.run_migrations().await.unwrap();
+
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, &tenant, &user);
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+
+    let blocked = store
+        .save_pending_and_block_approval(scope.clone(), invocation_id, approval.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        blocked.status,
+        ironclaw_run_state::RunStatus::BlockedApproval
+    );
+    assert_eq!(blocked.approval_request_id, Some(request_id));
+    let saved = ApprovalRequestStore::get(&store, &scope, request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(saved.status, ApprovalStatus::Pending);
+    assert_eq!(saved.request, approval);
+}
+
+#[cfg(feature = "postgres")]
+#[test]
+fn postgres_stores_implement_run_state_contract_traits() {
+    fn assert_run_state<T: RunStateStore>() {}
+    fn assert_approval<T: ApprovalRequestStore>() {}
+    fn assert_combined<T: RunStateApprovalStore>() {}
+    assert_run_state::<PostgresRunStateStore>();
+    assert_approval::<PostgresApprovalRequestStore>();
+    assert_combined::<PostgresRunStateApprovalStore>();
+}
+
+#[cfg(feature = "libsql")]
+#[test]
+fn libsql_stores_implement_run_state_contract_traits() {
+    fn assert_run_state<T: RunStateStore>() {}
+    fn assert_approval<T: ApprovalRequestStore>() {}
+    fn assert_combined<T: RunStateApprovalStore>() {}
+    assert_run_state::<LibSqlRunStateStore>();
+    assert_approval::<LibSqlApprovalRequestStore>();
+    assert_combined::<LibSqlRunStateApprovalStore>();
+}
+
+#[cfg(feature = "libsql")]
+fn libsql_db_path() -> (String, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("run-state.db");
+    (db_path.to_string_lossy().into_owned(), dir)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_pool() -> Option<deadpool_postgres::Pool> {
+    let url = std::env::var("IRONCLAW_RUN_STATE_POSTGRES_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .unwrap_or_else(|_| "postgres://localhost/ironclaw_test".to_string());
+    let config: tokio_postgres::Config = url
+        .parse()
+        .expect("run-state postgres test URL must be valid");
+    let manager = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
+    let pool = deadpool_postgres::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .unwrap();
+    match pool.get().await {
+        Ok(_) => Some(pool),
+        Err(error) if skip_postgres_requested() => {
+            eprintln!(
+                "skipping postgres run-state contract (IRONCLAW_SKIP_POSTGRES_TESTS=1): {error}"
+            );
+            None
+        }
+        Err(error) => panic!(
+            "postgres run-state contract could not reach Postgres ({error}); set \
+             IRONCLAW_RUN_STATE_POSTGRES_URL or DATABASE_URL, or set \
+             IRONCLAW_SKIP_POSTGRES_TESTS=1 to explicitly skip."
+        ),
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn skip_postgres_requested() -> bool {
+    std::env::var("IRONCLAW_SKIP_POSTGRES_TESTS").is_ok_and(|value| value == "1" || value == "true")
+}
+
+#[cfg(feature = "postgres")]
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos()
+}
+
+fn sample_scope(invocation_id: InvocationId, tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: Some(AgentId::new("agent-a").unwrap()),
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: Some(MissionId::new("mission1").unwrap()),
+        thread_id: Some(ThreadId::new("thread1").unwrap()),
+        invocation_id,
+    }
+}
+
+fn approval_request(invocation_id: InvocationId) -> ApprovalRequest {
+    ApprovalRequest {
+        id: ApprovalRequestId::new(),
+        correlation_id: CorrelationId::new(),
+        requested_by: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        action: Box::new(Action::Dispatch {
+            capability: CapabilityId::new("echo.say").unwrap(),
+            estimated_resources: ResourceEstimate::default(),
+        }),
+        invocation_fingerprint: None,
+        reason: format!("approval for {invocation_id}"),
+        reusable_scope: None,
+    }
+}

--- a/crates/ironclaw_run_state/tests/db_run_state_store_contract.rs
+++ b/crates/ironclaw_run_state/tests/db_run_state_store_contract.rs
@@ -20,6 +20,29 @@ use ironclaw_run_state::{
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn libsql_schema_uses_structured_scope_columns_instead_of_serialized_owner_key() {
+    let (db_path, _dir) = libsql_db_path();
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let runs = LibSqlRunStateStore::new(Arc::clone(&db));
+    runs.run_migrations().await.unwrap();
+    let conn = db.connect().unwrap();
+
+    let run_columns = libsql_table_columns(&conn, "reborn_run_state_records").await;
+    let approval_columns = libsql_table_columns(&conn, "reborn_approval_request_records").await;
+
+    for columns in [&run_columns, &approval_columns] {
+        assert!(columns.contains(&"tenant_id".to_string()));
+        assert!(columns.contains(&"user_id".to_string()));
+        assert!(columns.contains(&"agent_id".to_string()));
+        assert!(columns.contains(&"project_id".to_string()));
+        assert!(columns.contains(&"mission_id".to_string()));
+        assert!(columns.contains(&"thread_id".to_string()));
+        assert!(!columns.contains(&"owner_key".to_string()));
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn libsql_run_state_and_approval_stores_persist_across_database_reopen() {
     let (db_path, _dir) = libsql_db_path();
     let db = Arc::new(
@@ -320,6 +343,30 @@ async fn libsql_rejects_approval_rows_when_payload_request_id_does_not_match_row
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
+async fn postgres_schema_uses_structured_scope_columns_instead_of_serialized_owner_key() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let store = PostgresRunStateStore::new(pool.clone());
+    store.run_migrations().await.unwrap();
+    let client = pool.get().await.unwrap();
+
+    let run_columns = postgres_table_columns(&client, "reborn_run_state_records").await;
+    let approval_columns = postgres_table_columns(&client, "reborn_approval_request_records").await;
+
+    for columns in [&run_columns, &approval_columns] {
+        assert!(columns.contains(&"tenant_id".to_string()));
+        assert!(columns.contains(&"user_id".to_string()));
+        assert!(columns.contains(&"agent_id".to_string()));
+        assert!(columns.contains(&"project_id".to_string()));
+        assert!(columns.contains(&"mission_id".to_string()));
+        assert!(columns.contains(&"thread_id".to_string()));
+        assert!(!columns.contains(&"owner_key".to_string()));
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
 async fn postgres_migrations_are_serialized_when_called_concurrently() {
     let Some(pool) = postgres_pool().await else {
         return;
@@ -615,6 +662,34 @@ fn libsql_stores_implement_run_state_contract_traits() {
     assert_run_state::<LibSqlRunStateStore>();
     assert_approval::<LibSqlApprovalRequestStore>();
     assert_combined::<LibSqlRunStateApprovalStore>();
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_table_columns(conn: &libsql::Connection, table_name: &str) -> Vec<String> {
+    let sql = format!("PRAGMA table_info({table_name})");
+    let mut rows = conn.query(&sql, ()).await.unwrap();
+    let mut columns = Vec::new();
+    while let Some(row) = rows.next().await.unwrap() {
+        columns.push(row.get::<String>(1).unwrap());
+    }
+    columns
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_table_columns(
+    client: &deadpool_postgres::Object,
+    table_name: &str,
+) -> Vec<String> {
+    client
+        .query(
+            "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1 ORDER BY ordinal_position",
+            &[&table_name],
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| row.get(0))
+        .collect()
 }
 
 #[cfg(feature = "libsql")]


### PR DESCRIPTION
## Summary
- add feature-gated PostgreSQL/libSQL run-state and approval request stores for `ironclaw_run_state`
- add combined `RunStateApprovalStore` for atomic approval persistence + run blocking and wire it through `CapabilityHost`, `DefaultHostRuntime`, and `HostRuntimeServices`
- replace PostgreSQL table-wide update locks with row-level `FOR UPDATE`, add duplicate-create handling, serialize Postgres migrations, and make Postgres test skipping explicit via `IRONCLAW_SKIP_POSTGRES_TESTS=1`

## Verification
- `cargo fmt --check --quiet`
- `git diff --check`
- live PostgreSQL 16.13 on `127.0.0.1:55432` with fresh `ironclaw_test` DB:
  - `IRONCLAW_RUN_STATE_POSTGRES_URL=postgres://postgres@127.0.0.1:55432/ironclaw_test CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo test -q -p ironclaw_run_state --features postgres --test db_run_state_store_contract` (7 passed)
  - `IRONCLAW_RUN_STATE_POSTGRES_URL=postgres://postgres@127.0.0.1:55432/ironclaw_test CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo test -q -p ironclaw_run_state --features 'libsql,postgres' --test db_run_state_store_contract` (14 passed)
- `CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo test -q -p ironclaw_run_state`
- `CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo test -q -p ironclaw_capabilities --test capability_host_run_state_contract`
- `CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo test -q -p ironclaw_host_runtime --test host_runtime_contract`
- `CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo test -q -p ironclaw_host_runtime --test host_runtime_services_contract`
- `CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo test -q -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo clippy -q -p ironclaw_run_state --features 'libsql,postgres' --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo clippy -q -p ironclaw_capabilities --tests -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-run-state-db-target cargo clippy -q -p ironclaw_host_runtime --tests -- -D warnings`
