### PR TITLE
test(reborn): add turn lifecycle event replay

### DIFF
--- a/crates/ironclaw_turns/src/db.rs
+++ b/crates/ironclaw_turns/src/db.rs
@@ -6,8 +6,9 @@ use crate::{
     CancelRunRequest, CancelRunResponse, GetRunStateRequest, InMemoryTurnStateStore,
     InMemoryTurnStateStoreLimits, ResumeTurnRequest, ResumeTurnResponse, SubmitTurnRequest,
     SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionPolicy, TurnCheckpointRecord, TurnError,
-    TurnIdempotencyRecord, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord, TurnRunState,
-    TurnStateStore,
+    TurnIdempotencyRecord, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord,
+    TurnRunState, TurnScope, TurnStateStore,
+    events::{EventCursor, TurnEventPage, TurnEventProjectionSource, project_turn_events},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
         ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
@@ -62,6 +63,16 @@ CREATE TABLE IF NOT EXISTS turn_idempotency_records (
     payload TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_turn_idempotency_scope ON turn_idempotency_records(scope_key, operation);
+
+CREATE TABLE IF NOT EXISTS turn_lifecycle_events (
+    event_key TEXT PRIMARY KEY,
+    scope_key TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    event_cursor INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_events_scope_cursor ON turn_lifecycle_events(scope_key, event_cursor);
 "#;
 
 #[cfg(feature = "postgres")]
@@ -110,6 +121,16 @@ CREATE TABLE IF NOT EXISTS turn_idempotency_records (
     payload JSONB NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_turn_idempotency_scope ON turn_idempotency_records(scope_key, operation);
+
+CREATE TABLE IF NOT EXISTS turn_lifecycle_events (
+    event_key TEXT PRIMARY KEY,
+    scope_key TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    event_cursor BIGINT NOT NULL,
+    kind TEXT NOT NULL,
+    payload JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_events_scope_cursor ON turn_lifecycle_events(scope_key, event_cursor);
 "#;
 
 #[cfg(feature = "libsql")]
@@ -235,6 +256,24 @@ impl TurnStateStore for LibSqlTurnStateStore {
             })?
             .get_run_state(request)
             .await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl TurnEventProjectionSource for LibSqlTurnStateStore {
+    async fn read_turn_events_after(
+        &self,
+        scope: &TurnScope,
+        after: Option<EventCursor>,
+        limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        Ok(project_turn_events(
+            &self.load_snapshot().await?.events,
+            scope,
+            after,
+            limit,
+        ))
     }
 }
 
@@ -484,6 +523,24 @@ impl TurnStateStore for PostgresTurnStateStore {
 
 #[cfg(feature = "postgres")]
 #[async_trait]
+impl TurnEventProjectionSource for PostgresTurnStateStore {
+    async fn read_turn_events_after(
+        &self,
+        scope: &TurnScope,
+        after: Option<EventCursor>,
+        limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        Ok(project_turn_events(
+            &self.load_snapshot().await?.events,
+            scope,
+            after,
+            limit,
+        ))
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait]
 impl TurnRunTransitionPort for PostgresTurnStateStore {
     async fn claim_next_run(
         &self,
@@ -646,12 +703,18 @@ async fn libsql_load_snapshot(
         "SELECT payload FROM turn_idempotency_records ORDER BY created_at, record_key",
     )
     .await?;
+    let events = libsql_load_payloads::<TurnLifecycleEvent>(
+        conn,
+        "SELECT payload FROM turn_lifecycle_events ORDER BY event_cursor, event_key",
+    )
+    .await?;
     Ok(TurnPersistenceSnapshot {
         turns,
         runs,
         active_locks,
         checkpoints,
         idempotency_records,
+        events,
     })
 }
 
@@ -678,6 +741,7 @@ async fn libsql_replace_snapshot(
     snapshot: &TurnPersistenceSnapshot,
 ) -> Result<(), TurnError> {
     for table in [
+        "turn_lifecycle_events",
         "turn_idempotency_records",
         "turn_checkpoints",
         "turn_active_locks",
@@ -758,6 +822,21 @@ async fn libsql_replace_snapshot(
         .await
         .map_err(db_error)?;
     }
+    for event in &snapshot.events {
+        conn.execute(
+            "INSERT INTO turn_lifecycle_events (event_key, scope_key, run_id, event_cursor, kind, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            libsql::params![
+                turn_event_key(event)?,
+                scope_key(&event.scope)?,
+                event.run_id.to_string(),
+                event.cursor.0 as i64,
+                turn_event_kind_key(event)?,
+                to_json(event)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
     Ok(())
 }
 
@@ -767,7 +846,7 @@ async fn lock_postgres_turn_tables(
     mode: &str,
 ) -> Result<(), TurnError> {
     let statement = format!(
-        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_idempotency_records IN {mode}"
+        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_idempotency_records, turn_lifecycle_events IN {mode}"
     );
     client.batch_execute(&statement).await.map_err(db_error)
 }
@@ -818,12 +897,18 @@ async fn postgres_load_snapshot(
         "SELECT payload::text FROM turn_idempotency_records ORDER BY created_at, record_key",
     )
     .await?;
+    let events = postgres_load_payloads::<TurnLifecycleEvent>(
+        client,
+        "SELECT payload::text FROM turn_lifecycle_events ORDER BY event_cursor, event_key",
+    )
+    .await?;
     Ok(TurnPersistenceSnapshot {
         turns,
         runs,
         active_locks,
         checkpoints,
         idempotency_records,
+        events,
     })
 }
 
@@ -833,6 +918,7 @@ async fn postgres_replace_snapshot(
     snapshot: &TurnPersistenceSnapshot,
 ) -> Result<(), TurnError> {
     for table in [
+        "turn_lifecycle_events",
         "turn_idempotency_records",
         "turn_checkpoints",
         "turn_active_locks",
@@ -918,6 +1004,22 @@ async fn postgres_replace_snapshot(
         .await
         .map_err(db_error)?;
     }
+    for event in &snapshot.events {
+        let payload = to_json(event)?;
+        txn.execute(
+            "INSERT INTO turn_lifecycle_events (event_key, scope_key, run_id, event_cursor, kind, payload) VALUES ($1, $2, $3, $4, $5, $6::jsonb)",
+            &[
+                &turn_event_key(event)?,
+                &scope_key(&event.scope)?,
+                &event.run_id.to_string(),
+                &(event.cursor.0 as i64),
+                &turn_event_kind_key(event)?,
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
     Ok(())
 }
 
@@ -955,6 +1057,27 @@ fn idempotency_record_key(record: &TurnIdempotencyRecord) -> Result<String, Turn
         run_id: record.run_id.map(|run_id| run_id.to_string()),
         key: record.key.as_str(),
     })
+}
+
+fn turn_event_key(event: &TurnLifecycleEvent) -> Result<String, TurnError> {
+    #[derive(serde::Serialize)]
+    struct TurnEventKey<'a> {
+        scope: &'a crate::TurnScope,
+        cursor: EventCursor,
+        run_id: String,
+        kind: &'a crate::TurnEventKind,
+    }
+
+    to_json(&TurnEventKey {
+        scope: &event.scope,
+        cursor: event.cursor,
+        run_id: event.run_id.to_string(),
+        kind: &event.kind,
+    })
+}
+
+fn turn_event_kind_key(event: &TurnLifecycleEvent) -> Result<String, TurnError> {
+    to_json(&event.kind)
 }
 
 fn db_error(error: impl std::fmt::Display) -> TurnError {

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::sync::Mutex;
+use std::{sync::Arc, sync::Mutex};
+use thiserror::Error;
 
 use crate::{TurnError, TurnRunId, TurnScope, TurnStatus};
 
 const MAX_IN_MEMORY_EVENTS: usize = 10_000;
+pub const MAX_TURN_EVENT_PROJECTION_LIMIT: usize = 1_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
 #[serde(transparent)]
@@ -65,5 +67,163 @@ impl TurnEventSink for InMemoryTurnEventSink {
             events.drain(0..excess);
         }
         Ok(())
+    }
+}
+
+/// Scope-bound cursor for transport-agnostic turn lifecycle projections.
+///
+/// The cursor carries the exact [`TurnScope`] under which it was minted so a
+/// product adapter cannot use a cursor from one thread/project as bearer
+/// authority to skip or infer events from another scope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct TurnEventProjectionCursor {
+    pub event: EventCursor,
+    pub scope: TurnScope,
+}
+
+impl TurnEventProjectionCursor {
+    pub fn for_scope(scope: TurnScope, event: EventCursor) -> Self {
+        Self { event, scope }
+    }
+
+    pub fn origin_for_scope(scope: TurnScope) -> Self {
+        Self {
+            event: EventCursor::default(),
+            scope,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnEventProjectionRequest {
+    pub scope: TurnScope,
+    pub after: Option<TurnEventProjectionCursor>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnEventProjectionSnapshot {
+    pub entries: Vec<TurnLifecycleEvent>,
+    pub next_cursor: TurnEventProjectionCursor,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnEventPage {
+    pub entries: Vec<TurnLifecycleEvent>,
+    pub next_cursor: EventCursor,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum TurnEventProjectionError {
+    #[error("turn event projection request rejected: {reason}")]
+    InvalidRequest { reason: &'static str },
+    #[error("turn event projection rebase required")]
+    RebaseRequired {
+        requested: Box<TurnEventProjectionCursor>,
+        earliest: Box<TurnEventProjectionCursor>,
+    },
+    #[error("turn event projection source failed during {operation}")]
+    Source { operation: &'static str },
+}
+
+#[async_trait]
+pub trait TurnEventProjectionSource: Send + Sync {
+    async fn read_turn_events_after(
+        &self,
+        scope: &TurnScope,
+        after: Option<EventCursor>,
+        limit: usize,
+    ) -> Result<TurnEventPage, TurnError>;
+}
+
+pub struct TurnEventProjectionService<S>
+where
+    S: TurnEventProjectionSource,
+{
+    source: Arc<S>,
+}
+
+impl<S> TurnEventProjectionService<S>
+where
+    S: TurnEventProjectionSource,
+{
+    pub fn new(source: Arc<S>) -> Self {
+        Self { source }
+    }
+
+    pub async fn snapshot(
+        &self,
+        request: TurnEventProjectionRequest,
+    ) -> Result<TurnEventProjectionSnapshot, TurnEventProjectionError> {
+        self.read(request).await
+    }
+
+    pub async fn updates(
+        &self,
+        request: TurnEventProjectionRequest,
+    ) -> Result<TurnEventProjectionSnapshot, TurnEventProjectionError> {
+        self.read(request).await
+    }
+
+    async fn read(
+        &self,
+        request: TurnEventProjectionRequest,
+    ) -> Result<TurnEventProjectionSnapshot, TurnEventProjectionError> {
+        if request.limit == 0 || request.limit > MAX_TURN_EVENT_PROJECTION_LIMIT {
+            return Err(TurnEventProjectionError::InvalidRequest {
+                reason: "limit must be between 1 and MAX_TURN_EVENT_PROJECTION_LIMIT",
+            });
+        }
+        if let Some(cursor) = request.after.as_ref()
+            && cursor.scope != request.scope
+        {
+            return Err(TurnEventProjectionError::RebaseRequired {
+                requested: Box::new(cursor.clone()),
+                earliest: Box::new(TurnEventProjectionCursor::origin_for_scope(
+                    request.scope.clone(),
+                )),
+            });
+        }
+        let after = request.after.as_ref().map(|cursor| cursor.event);
+        let page = self
+            .source
+            .read_turn_events_after(&request.scope, after, request.limit)
+            .await
+            .map_err(|_| TurnEventProjectionError::Source {
+                operation: "read_turn_events_after",
+            })?;
+        Ok(TurnEventProjectionSnapshot {
+            entries: page.entries,
+            next_cursor: TurnEventProjectionCursor::for_scope(request.scope, page.next_cursor),
+            truncated: page.truncated,
+        })
+    }
+}
+
+pub(crate) fn project_turn_events(
+    events: &[TurnLifecycleEvent],
+    scope: &TurnScope,
+    after: Option<EventCursor>,
+    limit: usize,
+) -> TurnEventPage {
+    let after = after.unwrap_or_default();
+    let mut matching = events
+        .iter()
+        .filter(|event| &event.scope == scope && event.cursor > after)
+        .cloned()
+        .collect::<Vec<_>>();
+    matching.sort_by_key(|event| event.cursor);
+    let truncated = matching.len() > limit;
+    if truncated {
+        matching.truncate(limit);
+    }
+    let next_cursor = matching.last().map(|event| event.cursor).unwrap_or(after);
+    TurnEventPage {
+        entries: matching,
+        next_cursor,
+        truncated,
     }
 }

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -28,7 +28,11 @@ pub use coordinator::{
 pub use db::LibSqlTurnStateStore;
 #[cfg(feature = "postgres")]
 pub use db::PostgresTurnStateStore;
-pub use events::{InMemoryTurnEventSink, TurnEventKind, TurnEventSink, TurnLifecycleEvent};
+pub use events::{
+    InMemoryTurnEventSink, TurnEventKind, TurnEventPage, TurnEventProjectionCursor,
+    TurnEventProjectionError, TurnEventProjectionRequest, TurnEventProjectionService,
+    TurnEventProjectionSnapshot, TurnEventProjectionSource, TurnEventSink, TurnLifecycleEvent,
+};
 pub use ids::{
     AcceptedMessageRef, GateRef, IdempotencyKey, LoopDiagnosticRef, LoopExitId, LoopGateRef,
     LoopMessageRef, LoopResultRef, LoopUsageSummaryRef, ReplyTargetBindingRef, RunProfileId,

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -17,7 +17,7 @@ use crate::{
     TurnIdempotencyReplay, TurnLifecycleEvent, TurnLockVersion, TurnPersistenceSnapshot,
     TurnRecord, TurnRunId, TurnRunProfile, TurnRunRecord, TurnRunState, TurnScope, TurnStateStore,
     TurnStatus,
-    events::EventCursor,
+    events::{EventCursor, TurnEventPage, TurnEventProjectionSource, project_turn_events},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
         ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
@@ -189,6 +189,18 @@ impl InMemoryTurnStateStore {
             .map_err(|_| TurnError::Unavailable {
                 reason: "turn state store mutex poisoned".to_string(),
             })
+    }
+}
+
+#[async_trait]
+impl TurnEventProjectionSource for InMemoryTurnStateStore {
+    async fn read_turn_events_after(
+        &self,
+        scope: &TurnScope,
+        after: Option<EventCursor>,
+        limit: usize,
+    ) -> Result<TurnEventPage, TurnError> {
+        Ok(project_turn_events(&self.events(), scope, after, limit))
     }
 }
 
@@ -633,6 +645,9 @@ impl Inner {
             }
         }
 
+        let events = snapshot.events;
+        cursor = cursor.max(events.iter().map(|event| event.cursor.0).max().unwrap_or(0));
+
         Ok(Self {
             cursor,
             turns,
@@ -650,7 +665,7 @@ impl Inner {
             resume_idempotency_order,
             cancel_idempotency_order,
             idempotency_record_order,
-            events: Vec::new(),
+            events,
             limits,
         })
     }
@@ -714,6 +729,7 @@ impl Inner {
             active_locks,
             checkpoints,
             idempotency_records,
+            events: self.events.clone(),
         }
     }
 

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -6,8 +6,8 @@ use crate::{
     GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef, ResumeTurnRequest,
     ResumeTurnResponse, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
     TurnActor, TurnAdmissionPolicy, TurnCheckpointId, TurnError, TurnErrorCategory, TurnId,
-    TurnLeaseToken, TurnRunId, TurnRunProfile, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
-    TurnTimestamp, events::EventCursor,
+    TurnLeaseToken, TurnLifecycleEvent, TurnRunId, TurnRunProfile, TurnRunState, TurnRunnerId,
+    TurnScope, TurnStatus, TurnTimestamp, events::EventCursor,
 };
 
 #[async_trait]
@@ -274,4 +274,6 @@ pub struct TurnPersistenceSnapshot {
     pub active_locks: Vec<TurnActiveLockRecord>,
     pub checkpoints: Vec<TurnCheckpointRecord>,
     pub idempotency_records: Vec<TurnIdempotencyRecord>,
+    #[serde(default)]
+    pub events: Vec<TurnLifecycleEvent>,
 }

--- a/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
@@ -13,7 +13,8 @@ use ironclaw_turns::{
     LoopCompletionKind, LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy,
     LoopMessageRef, ReplyTargetBindingRef, RunProfileRequest, SanitizedCancelReason,
     SanitizedFailure, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
-    TurnActor, TurnCoordinator, TurnError, TurnRunId, TurnScope, TurnStatus,
+    TurnActor, TurnCoordinator, TurnError, TurnEventKind, TurnEventProjectionRequest,
+    TurnEventProjectionService, TurnRunId, TurnScope, TurnStatus,
     runner::{
         ApplyLoopExitRequest, ClaimRunRequest, RecoverExpiredLeasesRequest, TurnRunTransitionPort,
         apply_loop_exit,
@@ -24,6 +25,54 @@ use ironclaw_turns::{
 use ironclaw_turns::LibSqlTurnStateStore;
 #[cfg(feature = "postgres")]
 use ironclaw_turns::PostgresTurnStateStore;
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_turn_event_projection_replays_submit_after_reopen_without_raw_refs() {
+    let (db, _dir) = libsql_db().await;
+    let store = Arc::new(LibSqlTurnStateStore::new(db.clone()));
+    store.run_migrations().await.unwrap();
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let mut request = submit_request("thread-turn-event-db", "idem-turn-event-db");
+    request.accepted_message_ref =
+        AcceptedMessageRef::new("message-DB_TURN_RAW_SENTINEL_3022 /tmp/db-turn-private").unwrap();
+    request.source_binding_ref =
+        SourceBindingRef::new("source-DB_TURN_SOURCE_SENTINEL_3022").unwrap();
+    request.reply_target_binding_ref =
+        ReplyTargetBindingRef::new("reply-DB_TURN_REPLY_SENTINEL_3022").unwrap();
+
+    let accepted = coordinator.submit_turn(request.clone()).await.unwrap();
+    let run_id = accepted_run_id(&accepted);
+
+    let reopened = Arc::new(LibSqlTurnStateStore::new(db));
+    let projection = TurnEventProjectionService::new(reopened);
+    let snapshot = projection
+        .snapshot(TurnEventProjectionRequest {
+            scope: request.scope,
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.entries.len(), 1);
+    assert_eq!(snapshot.entries[0].kind, TurnEventKind::Submitted);
+    assert_eq!(snapshot.entries[0].run_id, run_id);
+    assert_eq!(snapshot.entries[0].status, TurnStatus::Queued);
+
+    let serialized = serde_json::to_string(&snapshot).unwrap();
+    for forbidden in [
+        "DB_TURN_RAW_SENTINEL_3022",
+        "/tmp/db-turn-private",
+        "DB_TURN_SOURCE_SENTINEL_3022",
+        "DB_TURN_REPLY_SENTINEL_3022",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "libSQL turn lifecycle projection leaked {forbidden}: {serialized}"
+        );
+    }
+}
 
 #[cfg(feature = "libsql")]
 #[tokio::test]

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -18,10 +18,11 @@ use ironclaw_turns::{
     RunProfileRequest, RunProfileVersion, SanitizedCancelReason, SanitizedFailure,
     SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
     TurnAdmissionPolicy, TurnCheckpointId, TurnCoordinator, TurnError, TurnErrorCategory,
-    TurnEventKind, TurnEventSink, TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind,
-    TurnLeaseToken, TurnLifecycleEvent, TurnLockVersion, TurnRunId, TurnRunState, TurnRunWake,
-    TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnRunnerId, TurnScope, TurnStateStore,
-    TurnStatus,
+    TurnEventKind, TurnEventProjectionError, TurnEventProjectionRequest,
+    TurnEventProjectionService, TurnEventSink, TurnIdempotencyOperationKind,
+    TurnIdempotencyOutcomeKind, TurnLeaseToken, TurnLifecycleEvent, TurnLockVersion, TurnRunId,
+    TurnRunState, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnRunnerId,
+    TurnScope, TurnStateStore, TurnStatus,
     events::EventCursor,
     runner::{
         ApplyLoopExitRequest, ApplyValidatedLoopExitRequest, BlockRunRequest,
@@ -41,6 +42,144 @@ fn turn_scope_agent_id_is_optional() {
     );
 
     assert_eq!(scope.agent_id, None);
+}
+
+#[tokio::test]
+async fn turn_lifecycle_projection_replays_submit_block_resume_complete_without_raw_refs() {
+    let (coordinator, store) = coordinator();
+    let mut request = submit_request("thread-turn-events", "idem-turn-events-submit");
+    request.accepted_message_ref =
+        AcceptedMessageRef::new("message-TURN_RAW_INPUT_SENTINEL_3022 /tmp/turn-private-path")
+            .unwrap();
+    request.source_binding_ref = SourceBindingRef::new("source-TURN_SOURCE_SENTINEL_3022").unwrap();
+    request.reply_target_binding_ref =
+        ReplyTargetBindingRef::new("reply-TURN_REPLY_SENTINEL_3022").unwrap();
+
+    let run_id = accepted_run_id(&coordinator.submit_turn(request.clone()).await.unwrap());
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(request.scope.clone()),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let gate_ref = GateRef::new("gate-TURN_GATE_SENTINEL_3022").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+    coordinator
+        .resume_turn(ResumeTurnRequest {
+            scope: request.scope.clone(),
+            actor: actor(),
+            run_id,
+            gate_resolution_ref: gate_ref,
+            source_binding_ref: SourceBindingRef::new("source-TURN_RESUME_SOURCE_SENTINEL_3022")
+                .unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new(
+                "reply-TURN_RESUME_REPLY_SENTINEL_3022",
+            )
+            .unwrap(),
+            idempotency_key: IdempotencyKey::new("idem-turn-events-resume").unwrap(),
+        })
+        .await
+        .unwrap();
+    let next_lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token: next_lease_token,
+            scope_filter: Some(request.scope.clone()),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .complete_run(CompleteRunRequest {
+            run_id,
+            runner_id,
+            lease_token: next_lease_token,
+        })
+        .await
+        .unwrap();
+
+    let projection = TurnEventProjectionService::new(store.clone());
+    let snapshot = projection
+        .snapshot(TurnEventProjectionRequest {
+            scope: request.scope.clone(),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        snapshot
+            .entries
+            .iter()
+            .map(|entry| entry.kind.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            TurnEventKind::Submitted,
+            TurnEventKind::RunnerClaimed,
+            TurnEventKind::Blocked,
+            TurnEventKind::Resumed,
+            TurnEventKind::RunnerClaimed,
+            TurnEventKind::Completed,
+        ]
+    );
+    assert!(
+        snapshot
+            .entries
+            .iter()
+            .all(|entry| entry.scope == request.scope)
+    );
+    assert!(snapshot.entries.iter().all(|entry| entry.run_id == run_id));
+    assert_eq!(
+        snapshot.entries.last().unwrap().status,
+        TurnStatus::Completed
+    );
+
+    let foreign = projection
+        .updates(TurnEventProjectionRequest {
+            scope: scope("thread-foreign-turn-events"),
+            after: Some(snapshot.next_cursor.clone()),
+            limit: 10,
+        })
+        .await
+        .expect_err("foreign turn projection cursor must force rebase");
+    assert!(matches!(
+        foreign,
+        TurnEventProjectionError::RebaseRequired { .. }
+    ));
+
+    let serialized = serde_json::to_string(&snapshot).unwrap();
+    for forbidden in [
+        "TURN_RAW_INPUT_SENTINEL_3022",
+        "/tmp/turn-private-path",
+        "TURN_SOURCE_SENTINEL_3022",
+        "TURN_REPLY_SENTINEL_3022",
+        "TURN_GATE_SENTINEL_3022",
+        "TURN_RESUME_SOURCE_SENTINEL_3022",
+        "TURN_RESUME_REPLY_SENTINEL_3022",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "turn lifecycle projection leaked {forbidden}: {serialized}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a scoped turn lifecycle projection API with cursor scope validation
- persist turn lifecycle events in in-memory snapshots and libSQL/Postgres turn stores
- cover coordinator/runner submit→claim→block→resume→claim→complete replay without raw ref leaks, plus libSQL reopen replay

Part of #3022.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ironclaw_turns --tests --no-fail-fast`
- `cargo test -p ironclaw_turns --features libsql --test db_turn_state_store_contract --no-fail-fast`
- `cargo test -p ironclaw_turns --all-features --tests --no-fail-fast`
- `cargo clippy -p ironclaw_turns --all-targets --all-features -- -D warnings`
- `python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
