### PR TITLE
feat(reborn): wire production root filesystem selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,6 +4216,7 @@ dependencies = [
  "ironclaw_secrets",
  "ironclaw_trust",
  "ironclaw_wasm",
+ "libsql",
  "rust_decimal",
  "secrecy",
  "serde_json",

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+default = []
+postgres = ["ironclaw_filesystem/postgres"]
+libsql = ["ironclaw_filesystem/libsql"]
+
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
@@ -37,6 +42,7 @@ url = "2"
 
 [dev-dependencies]
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
+libsql = { version = "0.6", default-features = false, features = ["core", "replication", "remote", "tls"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "time"] }
 wat = "1.245.1"

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -22,6 +22,10 @@ use ironclaw_events::{
     AuditSink, DurableAuditLog, DurableAuditSink, DurableEventLog, DurableEventSink, EventSink,
 };
 use ironclaw_extensions::{ExtensionRegistry, ExtensionRuntime};
+#[cfg(feature = "libsql")]
+use ironclaw_filesystem::LibSqlRootFilesystem;
+#[cfg(feature = "postgres")]
+use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     CapabilityDispatchRequest, CapabilityDispatcher, CapabilityId, DispatchError,
@@ -352,6 +356,81 @@ where
                 mcp_runtime: None,
             },
         }
+    }
+
+    fn with_root_filesystem<T>(self, filesystem: Arc<T>) -> HostRuntimeServices<T, G, S, R>
+    where
+        T: RootFilesystem + 'static,
+    {
+        let Self {
+            registry,
+            trust_policy,
+            trust_policy_configured,
+            filesystem: _,
+            governor,
+            authorizer,
+            process_services,
+            surface_version,
+            run_state,
+            approval_requests,
+            capability_leases,
+            event_sink,
+            audit_sink,
+            secret_store,
+            network_policy_store,
+            secret_injection_store,
+            process_lifecycle_store,
+            runtime_http_egress,
+            wasm_credential_provider,
+            runtime_health,
+            script_runtime,
+            mcp_runtime,
+            wasm_runtime,
+            mut component_types,
+        } = self;
+        component_types.filesystem = type_name::<T>();
+        HostRuntimeServices {
+            registry,
+            trust_policy,
+            trust_policy_configured,
+            filesystem,
+            governor,
+            authorizer,
+            process_services,
+            surface_version,
+            run_state,
+            approval_requests,
+            capability_leases,
+            event_sink,
+            audit_sink,
+            secret_store,
+            network_policy_store,
+            secret_injection_store,
+            process_lifecycle_store,
+            runtime_http_egress,
+            wasm_credential_provider,
+            runtime_health,
+            script_runtime,
+            mcp_runtime,
+            wasm_runtime,
+            component_types,
+        }
+    }
+
+    #[cfg(feature = "postgres")]
+    pub fn with_postgres_root_filesystem(
+        self,
+        filesystem: Arc<PostgresRootFilesystem>,
+    ) -> HostRuntimeServices<PostgresRootFilesystem, G, S, R> {
+        self.with_root_filesystem(filesystem)
+    }
+
+    #[cfg(feature = "libsql")]
+    pub fn with_libsql_root_filesystem(
+        self,
+        filesystem: Arc<LibSqlRootFilesystem>,
+    ) -> HostRuntimeServices<LibSqlRootFilesystem, G, S, R> {
+        self.with_root_filesystem(filesystem)
     }
 
     /// Attaches the host-owned trust policy used by the produced

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -20,6 +20,8 @@ use ironclaw_events::{
     InMemoryDurableEventLog, InMemoryEventSink, ReadScope, RuntimeEventKind,
 };
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry};
+#[cfg(feature = "libsql")]
+use ironclaw_filesystem::LibSqlRootFilesystem;
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
@@ -182,6 +184,41 @@ fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
             ProductionWiringIssueKind::UnsupportedRequirement
         ),
         "unsupported runtime backend requirement should be reported: {report:?}"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn production_root_filesystem_selection_accepts_libsql_root_filesystem() {
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("root-filesystem.db");
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let filesystem = Arc::new(LibSqlRootFilesystem::new(db));
+    filesystem.run_migrations().await.unwrap();
+
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_libsql_root_filesystem(Arc::clone(&filesystem));
+
+    let path = VirtualPath::new("/engine/tenants/t1/users/u1/root-selection.txt").unwrap();
+    filesystem.write_file(&path, b"selected").await.unwrap();
+    assert_eq!(filesystem.read_file(&path).await.unwrap(), b"selected");
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("other local services remain intentionally unready");
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::Filesystem,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "LibSqlRootFilesystem must satisfy production filesystem selection: {report:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- add HostRuntimeServices helpers to swap LocalFilesystem composition for production root filesystem implementations
- support libSQL and Postgres root filesystem selection behind matching feature gates
- preserve existing configured runtime services while changing the filesystem generic
- add a libSQL selection test proving DB-backed root filesystem read/write and production guardrail acceptance

## Tests

- cargo test -p ironclaw_host_runtime production_root_filesystem_selection --features libsql -- --nocapture
- cargo clippy -p ironclaw_host_runtime --all-features --all-targets -- -D warnings

Refs #3333
Refs #3026
Refs #3087