### PR TITLE
test(reborn): require turn replay rebase gaps

### DIFF
--- a/crates/ironclaw_turns/src/db.rs
+++ b/crates/ironclaw_turns/src/db.rs
@@ -106,6 +106,11 @@ CREATE TABLE IF NOT EXISTS turn_lifecycle_events (
     payload TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_turn_events_scope_cursor ON turn_lifecycle_events(scope_key, event_cursor);
+
+CREATE TABLE IF NOT EXISTS turn_store_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
 "#;
 
 #[cfg(feature = "postgres")]
@@ -164,6 +169,11 @@ CREATE TABLE IF NOT EXISTS turn_lifecycle_events (
     payload JSONB NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_turn_events_scope_cursor ON turn_lifecycle_events(scope_key, event_cursor);
+
+CREATE TABLE IF NOT EXISTS turn_store_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
 "#;
 
 #[cfg(feature = "libsql")]
@@ -307,11 +317,13 @@ impl TurnEventProjectionSource for LibSqlTurnStateStore {
         after: Option<EventCursor>,
         limit: usize,
     ) -> Result<TurnEventPage, TurnError> {
+        let snapshot = self.load_snapshot().await?;
         Ok(project_turn_events(
-            &self.load_snapshot().await?.events,
+            &snapshot.events,
             scope,
             after,
             limit,
+            snapshot.event_retention_floor,
         ))
     }
 }
@@ -575,11 +587,13 @@ impl TurnEventProjectionSource for PostgresTurnStateStore {
         after: Option<EventCursor>,
         limit: usize,
     ) -> Result<TurnEventPage, TurnError> {
+        let snapshot = self.load_snapshot().await?;
         Ok(project_turn_events(
-            &self.load_snapshot().await?.events,
+            &snapshot.events,
             scope,
             after,
             limit,
+            snapshot.event_retention_floor,
         ))
     }
 }
@@ -720,6 +734,24 @@ where
 }
 
 #[cfg(feature = "libsql")]
+async fn libsql_load_event_retention_floor(
+    conn: &libsql::Connection,
+) -> Result<EventCursor, TurnError> {
+    let mut rows = conn
+        .query(
+            "SELECT value FROM turn_store_metadata WHERE key = 'event_retention_floor'",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = rows.next().await.map_err(db_error)? else {
+        return Ok(EventCursor::default());
+    };
+    let value: String = row.get(0).map_err(db_error)?;
+    value.parse::<u64>().map(EventCursor).map_err(db_error)
+}
+
+#[cfg(feature = "libsql")]
 async fn libsql_load_snapshot(
     conn: &libsql::Connection,
 ) -> Result<TurnPersistenceSnapshot, TurnError> {
@@ -753,6 +785,7 @@ async fn libsql_load_snapshot(
         "SELECT payload FROM turn_lifecycle_events ORDER BY event_cursor, event_key",
     )
     .await?;
+    let event_retention_floor = libsql_load_event_retention_floor(conn).await?;
     Ok(TurnPersistenceSnapshot {
         turns,
         runs,
@@ -760,6 +793,7 @@ async fn libsql_load_snapshot(
         checkpoints,
         idempotency_records,
         events,
+        event_retention_floor,
     })
 }
 
@@ -786,6 +820,7 @@ async fn libsql_replace_snapshot(
     snapshot: &TurnPersistenceSnapshot,
 ) -> Result<(), TurnError> {
     for table in [
+        "turn_store_metadata",
         "turn_lifecycle_events",
         "turn_idempotency_records",
         "turn_checkpoints",
@@ -882,6 +917,12 @@ async fn libsql_replace_snapshot(
         .await
         .map_err(db_error)?;
     }
+    conn.execute(
+        "INSERT INTO turn_store_metadata (key, value) VALUES ('event_retention_floor', ?1)",
+        libsql::params![snapshot.event_retention_floor.0.to_string()],
+    )
+    .await
+    .map_err(db_error)?;
     Ok(())
 }
 
@@ -891,7 +932,7 @@ async fn lock_postgres_turn_tables(
     mode: &str,
 ) -> Result<(), TurnError> {
     let statement = format!(
-        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_idempotency_records, turn_lifecycle_events IN {mode}"
+        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_idempotency_records, turn_lifecycle_events, turn_store_metadata IN {mode}"
     );
     client.batch_execute(&statement).await.map_err(db_error)
 }
@@ -911,6 +952,24 @@ where
             serde_json::from_str(&payload).map_err(db_error)
         })
         .collect()
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_load_event_retention_floor(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<EventCursor, TurnError> {
+    let Some(row) = client
+        .query_opt(
+            "SELECT value FROM turn_store_metadata WHERE key = 'event_retention_floor'",
+            &[],
+        )
+        .await
+        .map_err(db_error)?
+    else {
+        return Ok(EventCursor::default());
+    };
+    let value: String = row.get(0);
+    value.parse::<u64>().map(EventCursor).map_err(db_error)
 }
 
 #[cfg(feature = "postgres")]
@@ -947,6 +1006,7 @@ async fn postgres_load_snapshot(
         "SELECT payload::text FROM turn_lifecycle_events ORDER BY event_cursor, event_key",
     )
     .await?;
+    let event_retention_floor = postgres_load_event_retention_floor(client).await?;
     Ok(TurnPersistenceSnapshot {
         turns,
         runs,
@@ -954,6 +1014,7 @@ async fn postgres_load_snapshot(
         checkpoints,
         idempotency_records,
         events,
+        event_retention_floor,
     })
 }
 
@@ -963,6 +1024,7 @@ async fn postgres_replace_snapshot(
     snapshot: &TurnPersistenceSnapshot,
 ) -> Result<(), TurnError> {
     for table in [
+        "turn_store_metadata",
         "turn_lifecycle_events",
         "turn_idempotency_records",
         "turn_checkpoints",
@@ -1065,6 +1127,12 @@ async fn postgres_replace_snapshot(
         .await
         .map_err(db_error)?;
     }
+    txn.execute(
+        "INSERT INTO turn_store_metadata (key, value) VALUES ('event_retention_floor', $1)",
+        &[&snapshot.event_retention_floor.0.to_string()],
+    )
+    .await
+    .map_err(db_error)?;
     Ok(())
 }
 

--- a/crates/ironclaw_turns/src/events.rs
+++ b/crates/ironclaw_turns/src/events.rs
@@ -114,6 +114,7 @@ pub struct TurnEventPage {
     pub entries: Vec<TurnLifecycleEvent>,
     pub next_cursor: EventCursor,
     pub truncated: bool,
+    pub rebase_required: Option<EventCursor>,
 }
 
 #[derive(Debug, Error)]
@@ -195,6 +196,17 @@ where
             .map_err(|_| TurnEventProjectionError::Source {
                 operation: "read_turn_events_after",
             })?;
+        if let Some(rebase_cursor) = page.rebase_required {
+            return Err(TurnEventProjectionError::RebaseRequired {
+                requested: Box::new(request.after.unwrap_or_else(|| {
+                    TurnEventProjectionCursor::origin_for_scope(request.scope.clone())
+                })),
+                earliest: Box::new(TurnEventProjectionCursor::for_scope(
+                    request.scope,
+                    rebase_cursor,
+                )),
+            });
+        }
         Ok(TurnEventProjectionSnapshot {
             entries: page.entries,
             next_cursor: TurnEventProjectionCursor::for_scope(request.scope, page.next_cursor),
@@ -208,14 +220,38 @@ pub(crate) fn project_turn_events(
     scope: &TurnScope,
     after: Option<EventCursor>,
     limit: usize,
+    retention_floor: EventCursor,
 ) -> TurnEventPage {
     let after = after.unwrap_or_default();
-    let mut matching = events
+    let mut scoped_events = events
         .iter()
-        .filter(|event| &event.scope == scope && event.cursor > after)
+        .filter(|event| &event.scope == scope)
         .cloned()
         .collect::<Vec<_>>();
-    matching.sort_by_key(|event| event.cursor);
+    scoped_events.sort_by_key(|event| event.cursor);
+
+    let latest_scoped_cursor = scoped_events.last().map(|event| event.cursor);
+    let rebase_required = if retention_floor > EventCursor::default() && after <= retention_floor {
+        Some(retention_floor)
+    } else if let Some(latest) = latest_scoped_cursor {
+        (after > latest).then_some(latest)
+    } else {
+        (after > retention_floor).then_some(retention_floor)
+    };
+
+    if let Some(rebase_cursor) = rebase_required {
+        return TurnEventPage {
+            entries: Vec::new(),
+            next_cursor: rebase_cursor,
+            truncated: false,
+            rebase_required: Some(rebase_cursor),
+        };
+    }
+
+    let mut matching = scoped_events
+        .into_iter()
+        .filter(|event| event.cursor > after)
+        .collect::<Vec<_>>();
     let truncated = matching.len() > limit;
     if truncated {
         matching.truncate(limit);
@@ -225,5 +261,6 @@ pub(crate) fn project_turn_events(
         entries: matching,
         next_cursor,
         truncated,
+        rebase_required: None,
     }
 }

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -81,6 +81,7 @@ struct Inner {
     cancel_idempotency_order: VecDeque<RunIdempotencyKey>,
     idempotency_record_order: VecDeque<PersistedIdempotencyKey>,
     events: Vec<TurnLifecycleEvent>,
+    event_retention_floor: EventCursor,
     limits: InMemoryTurnStateStoreLimits,
 }
 
@@ -239,7 +240,14 @@ impl TurnEventProjectionSource for InMemoryTurnStateStore {
         after: Option<EventCursor>,
         limit: usize,
     ) -> Result<TurnEventPage, TurnError> {
-        Ok(project_turn_events(&self.events(), scope, after, limit))
+        let inner = self.lock_inner()?;
+        Ok(project_turn_events(
+            &inner.events,
+            scope,
+            after,
+            limit,
+            inner.event_retention_floor,
+        ))
     }
 }
 
@@ -723,6 +731,7 @@ impl Inner {
 
         let events = snapshot.events;
         cursor = cursor.max(events.iter().map(|event| event.cursor.0).max().unwrap_or(0));
+        cursor = cursor.max(snapshot.event_retention_floor.0);
 
         Ok(Self {
             cursor,
@@ -742,6 +751,7 @@ impl Inner {
             cancel_idempotency_order,
             idempotency_record_order,
             events,
+            event_retention_floor: snapshot.event_retention_floor,
             limits,
         })
     }
@@ -772,6 +782,9 @@ impl Inner {
         });
         if self.events.len() > self.limits.max_events {
             let excess = self.events.len() - self.limits.max_events;
+            if let Some(last_pruned) = self.events.get(excess.saturating_sub(1)) {
+                self.event_retention_floor = self.event_retention_floor.max(last_pruned.cursor);
+            }
             self.events.drain(0..excess);
         }
     }
@@ -806,6 +819,7 @@ impl Inner {
             checkpoints,
             idempotency_records,
             events: self.events.clone(),
+            event_retention_floor: self.event_retention_floor,
         }
     }
 

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -277,4 +277,6 @@ pub struct TurnPersistenceSnapshot {
     pub idempotency_records: Vec<TurnIdempotencyRecord>,
     #[serde(default)]
     pub events: Vec<TurnLifecycleEvent>,
+    #[serde(default)]
+    pub event_retention_floor: EventCursor,
 }

--- a/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
@@ -13,16 +13,18 @@ use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, DefaultTurnCoordinator, IdempotencyKey,
-    InMemoryRunProfileResolver, LoopCompleted, LoopCompletionKind, LoopExit,
-    LoopExitInvalidHandling, LoopExitValidationPolicy, LoopMessageRef, ReplyTargetBindingRef,
-    ResolvedRunProfile, RunProfileRequest, RunProfileResolutionError, RunProfileResolutionRequest,
-    RunProfileResolver, SanitizedCancelReason, SanitizedFailure, SourceBindingRef,
-    SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor, TurnCoordinator, TurnError,
-    TurnEventKind, TurnEventProjectionRequest, TurnEventProjectionService, TurnRunId, TurnScope,
-    TurnStatus,
+    InMemoryRunProfileResolver, InMemoryTurnStateStoreLimits, LoopCompleted, LoopCompletionKind,
+    LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy, LoopMessageRef,
+    ReplyTargetBindingRef, ResolvedRunProfile, RunProfileRequest, RunProfileResolutionError,
+    RunProfileResolutionRequest, RunProfileResolver, SanitizedCancelReason, SanitizedFailure,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
+    TurnCoordinator, TurnError, TurnEventKind, TurnEventProjectionCursor, TurnEventProjectionError,
+    TurnEventProjectionRequest, TurnEventProjectionService, TurnLeaseToken, TurnRunId,
+    TurnRunnerId, TurnScope, TurnStatus,
+    events::EventCursor,
     runner::{
-        ApplyLoopExitRequest, ClaimRunRequest, RecoverExpiredLeasesRequest, TurnRunTransitionPort,
-        apply_loop_exit,
+        ApplyLoopExitRequest, ClaimRunRequest, HeartbeatRequest, RecoverExpiredLeasesRequest,
+        TurnRunTransitionPort, apply_loop_exit,
     },
 };
 
@@ -105,6 +107,73 @@ async fn libsql_turn_event_projection_replays_submit_after_reopen_without_raw_re
             "libSQL turn lifecycle projection leaked {forbidden}: {serialized}"
         );
     }
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_turn_event_projection_replays_gap_rebase_after_reopen() {
+    let (db, _dir) = libsql_db().await;
+    let limits = InMemoryTurnStateStoreLimits {
+        max_events: 2,
+        ..InMemoryTurnStateStoreLimits::default()
+    };
+    let store = Arc::new(LibSqlTurnStateStore::new(db.clone()).with_limits(limits));
+    store.run_migrations().await.unwrap();
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let request = submit_request("thread-turn-event-db-gap", "idem-turn-event-db-gap");
+    let accepted = coordinator.submit_turn(request.clone()).await.unwrap();
+    let run_id = accepted_run_id(&accepted);
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(request.scope.clone()),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .heartbeat(HeartbeatRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let projection = TurnEventProjectionService::new(Arc::new(LibSqlTurnStateStore::new(db)));
+    let pruned_origin = projection
+        .snapshot(TurnEventProjectionRequest {
+            scope: request.scope.clone(),
+            after: Some(TurnEventProjectionCursor::origin_for_scope(
+                request.scope.clone(),
+            )),
+            limit: 10,
+        })
+        .await
+        .expect_err("libSQL retained turn event tail must persist rebase metadata");
+    assert!(matches!(
+        pruned_origin,
+        TurnEventProjectionError::RebaseRequired { .. }
+    ));
+
+    let fabricated = projection
+        .updates(TurnEventProjectionRequest {
+            scope: request.scope.clone(),
+            after: Some(TurnEventProjectionCursor::for_scope(
+                request.scope,
+                EventCursor(999),
+            )),
+            limit: 10,
+        })
+        .await
+        .expect_err("libSQL turn event projection must reject beyond-head cursors");
+    assert!(matches!(
+        fabricated,
+        TurnEventProjectionError::RebaseRequired { .. }
+    ));
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -20,11 +20,12 @@ use ironclaw_turns::{
     RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion,
     SanitizedCancelReason, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
     SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnCheckpointId,
-    TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventProjectionError,
-    TurnEventProjectionRequest, TurnEventProjectionService, TurnEventSink,
-    TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnLeaseToken, TurnLifecycleEvent,
-    TurnLockVersion, TurnRunId, TurnRunProfile, TurnRunState, TurnRunWake, TurnRunWakeNotifier,
-    TurnRunWakeNotifyError, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
+    TurnCoordinator, TurnError, TurnErrorCategory, TurnEventKind, TurnEventProjectionCursor,
+    TurnEventProjectionError, TurnEventProjectionRequest, TurnEventProjectionService,
+    TurnEventSink, TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnLeaseToken,
+    TurnLifecycleEvent, TurnLockVersion, TurnRunId, TurnRunProfile, TurnRunState, TurnRunWake,
+    TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnRunnerId, TurnScope, TurnStateStore,
+    TurnStatus,
     events::EventCursor,
     runner::{
         ApplyLoopExitRequest, ApplyValidatedLoopExitRequest, BlockRunRequest,
@@ -201,6 +202,86 @@ async fn turn_lifecycle_projection_replays_submit_block_resume_complete_without_
         assert!(
             !serialized.contains(forbidden),
             "turn lifecycle projection leaked {forbidden}: {serialized}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn turn_lifecycle_projection_requires_rebase_for_pruned_or_fabricated_cursors() {
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            max_events: 2,
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let mut request = submit_request("thread-turn-gap", "idem-turn-gap-submit");
+    request.accepted_message_ref =
+        AcceptedMessageRef::new("message-TURN_GAP_RAW_SENTINEL_3022 /tmp/turn-gap-private")
+            .unwrap();
+
+    let run_id = accepted_run_id(&coordinator.submit_turn(request.clone()).await.unwrap());
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(request.scope.clone()),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .heartbeat(HeartbeatRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap();
+
+    let projection = TurnEventProjectionService::new(store.clone());
+    let origin = TurnEventProjectionCursor::origin_for_scope(request.scope.clone());
+    let pruned_origin = projection
+        .snapshot(TurnEventProjectionRequest {
+            scope: request.scope.clone(),
+            after: Some(origin),
+            limit: 10,
+        })
+        .await
+        .expect_err("pruned turn lifecycle origin cursor must require rebase");
+    assert!(matches!(
+        pruned_origin,
+        TurnEventProjectionError::RebaseRequired { .. }
+    ));
+
+    let fabricated = projection
+        .updates(TurnEventProjectionRequest {
+            scope: request.scope.clone(),
+            after: Some(TurnEventProjectionCursor::for_scope(
+                request.scope.clone(),
+                EventCursor(999),
+            )),
+            limit: 10,
+        })
+        .await
+        .expect_err("fabricated beyond-head turn lifecycle cursor must require rebase");
+    assert!(matches!(
+        fabricated,
+        TurnEventProjectionError::RebaseRequired { .. }
+    ));
+
+    let serialized_events = serde_json::to_string(&store.events()).unwrap();
+    let debug_errors = format!("{pruned_origin:?} {fabricated:?}");
+    for forbidden in ["TURN_GAP_RAW_SENTINEL_3022", "/tmp/turn-gap-private"] {
+        assert!(
+            !serialized_events.contains(forbidden),
+            "retained turn events leaked {forbidden}: {serialized_events}"
+        );
+        assert!(
+            !debug_errors.contains(forbidden),
+            "turn projection rebase error leaked {forbidden}: {debug_errors}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- track a retained turn-event floor and reject pruned-origin / beyond-head cursors with `RebaseRequired`
- persist the turn-event retention floor through libSQL/Postgres turn-state metadata
- add in-memory and libSQL reopen tests proving replay gaps do not silently return partial turn lifecycle history or leak sentinels

Part of #3022. Follows #3350.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ironclaw_turns --tests --no-fail-fast`
- `cargo test -p ironclaw_turns --all-features --tests --no-fail-fast`
- `cargo clippy -p ironclaw_turns --all-targets --all-features -- -D warnings`
- `python3.11 scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`
