### PR TITLE
feat(reborn): wire filesystem control stores

### DIFF
--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -371,12 +371,32 @@ impl CapabilityLeaseStore for InMemoryCapabilityLeaseStore {
     }
 }
 
+enum FilesystemStoreHandle<'a, F>
+where
+    F: RootFilesystem,
+{
+    Borrowed(&'a F),
+    Shared(Arc<F>),
+}
+
+impl<F> FilesystemStoreHandle<'_, F>
+where
+    F: RootFilesystem,
+{
+    fn filesystem(&self) -> &F {
+        match self {
+            Self::Borrowed(filesystem) => filesystem,
+            Self::Shared(filesystem) => filesystem.as_ref(),
+        }
+    }
+}
+
 /// Filesystem-backed capability lease store under resource-owner/invocation-scoped `/engine` paths.
 pub struct FilesystemCapabilityLeaseStore<'a, F>
 where
     F: RootFilesystem,
 {
-    filesystem: &'a F,
+    filesystem: FilesystemStoreHandle<'a, F>,
     mutation_locks: Mutex<HashMap<CapabilityLeaseOwnerKey, Arc<tokio::sync::Mutex<()>>>>,
 }
 
@@ -386,9 +406,20 @@ where
 {
     pub fn new(filesystem: &'a F) -> Self {
         Self {
-            filesystem,
+            filesystem: FilesystemStoreHandle::Borrowed(filesystem),
             mutation_locks: Mutex::new(HashMap::new()),
         }
+    }
+
+    pub fn new_shared(filesystem: Arc<F>) -> FilesystemCapabilityLeaseStore<'static, F> {
+        FilesystemCapabilityLeaseStore {
+            filesystem: FilesystemStoreHandle::Shared(filesystem),
+            mutation_locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn filesystem(&self) -> &F {
+        self.filesystem.filesystem()
     }
 
     fn mutation_lock(&self, scope: &ResourceScope) -> Arc<tokio::sync::Mutex<()>> {
@@ -407,7 +438,7 @@ where
         lease_id: CapabilityGrantId,
     ) -> Result<Option<CapabilityLease>, CapabilityLeaseError> {
         let path = lease_path(scope, lease_id)?;
-        let bytes = match self.filesystem.read_file(&path).await {
+        let bytes = match self.filesystem().read_file(&path).await {
             Ok(bytes) => bytes,
             Err(error) if is_not_found(&error) => return Ok(None),
             Err(error) => return Err(lease_persistence_error(error)),
@@ -418,7 +449,7 @@ where
     async fn write_lease(&self, lease: &CapabilityLease) -> Result<(), CapabilityLeaseError> {
         let path = lease_path(&lease.scope, lease.grant.id)?;
         let bytes = serialize_pretty(lease)?;
-        self.filesystem
+        self.filesystem()
             .write_file(&path, &bytes)
             .await
             .map_err(lease_persistence_error)
@@ -429,7 +460,7 @@ where
         scope: &ResourceScope,
     ) -> Result<Option<Vec<VirtualPath>>, CapabilityLeaseError> {
         let path = lease_index_path(scope)?;
-        let bytes = match self.filesystem.read_file(&path).await {
+        let bytes = match self.filesystem().read_file(&path).await {
             Ok(bytes) => bytes,
             Err(error) if is_not_found(&error) => return Ok(None),
             Err(error) => return Err(lease_persistence_error(error)),
@@ -447,7 +478,7 @@ where
         paths.dedup_by(|left, right| left.as_str() == right.as_str());
         let path = lease_index_path(scope)?;
         let bytes = serialize_pretty(&CapabilityLeaseIndex { paths })?;
-        self.filesystem
+        self.filesystem()
             .write_file(&path, &bytes)
             .await
             .map_err(lease_persistence_error)
@@ -492,7 +523,7 @@ where
         scope: &ResourceScope,
     ) -> Result<Vec<VirtualPath>, CapabilityLeaseError> {
         let root = lease_tenant_user_root(scope)?;
-        let entries = match self.filesystem.list_dir(&root).await {
+        let entries = match self.filesystem().list_dir(&root).await {
             Ok(entries) => entries,
             Err(error) if is_not_found(&error) => return Ok(Vec::new()),
             Err(error) => return Err(lease_persistence_error(error)),
@@ -508,7 +539,7 @@ where
         &self,
         root: &VirtualPath,
     ) -> Result<Vec<VirtualPath>, CapabilityLeaseError> {
-        let entries = match self.filesystem.list_dir(root).await {
+        let entries = match self.filesystem().list_dir(root).await {
             Ok(entries) => entries,
             Err(error) if is_not_found(&error) => return Ok(Vec::new()),
             Err(error) => return Err(lease_persistence_error(error)),
@@ -525,7 +556,7 @@ where
         path: &VirtualPath,
     ) -> Result<CapabilityLease, CapabilityLeaseError> {
         let bytes = self
-            .filesystem
+            .filesystem()
             .read_file(path)
             .await
             .map_err(lease_persistence_error)?;

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -14,7 +14,9 @@ use std::{
 
 use async_trait::async_trait;
 use ironclaw_approvals::ApprovalResolver;
-use ironclaw_authorization::{CapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer};
+use ironclaw_authorization::{
+    CapabilityLeaseStore, FilesystemCapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer,
+};
 use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
 };
@@ -43,7 +45,9 @@ use ironclaw_reborn_event_store::{
     build_reborn_event_stores,
 };
 use ironclaw_resources::ResourceGovernor;
-use ironclaw_run_state::{ApprovalRequestStore, RunStateStore};
+use ironclaw_run_state::{
+    ApprovalRequestStore, FilesystemApprovalRequestStore, FilesystemRunStateStore, RunStateStore,
+};
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
 use ironclaw_secrets::SecretStore;
 use ironclaw_trust::{HostTrustPolicy, TrustPolicy};
@@ -431,6 +435,30 @@ where
         filesystem: Arc<LibSqlRootFilesystem>,
     ) -> HostRuntimeServices<LibSqlRootFilesystem, G, S, R> {
         self.with_root_filesystem(filesystem)
+    }
+
+    /// Attaches filesystem-backed run-state, approval-request, and capability-lease
+    /// stores over the currently selected root filesystem.
+    pub fn with_filesystem_control_stores(mut self) -> Self {
+        let run_state = Arc::new(FilesystemRunStateStore::new_shared(Arc::clone(
+            &self.filesystem,
+        )));
+        let approval_requests = Arc::new(FilesystemApprovalRequestStore::new_shared(Arc::clone(
+            &self.filesystem,
+        )));
+        let capability_leases = Arc::new(FilesystemCapabilityLeaseStore::new_shared(Arc::clone(
+            &self.filesystem,
+        )));
+
+        self.component_types.run_state = Some(type_name::<FilesystemRunStateStore<'static, F>>());
+        self.component_types.approval_requests =
+            Some(type_name::<FilesystemApprovalRequestStore<'static, F>>());
+        self.component_types.capability_leases =
+            Some(type_name::<FilesystemCapabilityLeaseStore<'static, F>>());
+        self.run_state = Some(run_state);
+        self.approval_requests = Some(approval_requests);
+        self.capability_leases = Some(capability_leases);
+        self
     }
 
     /// Attaches the host-owned trust policy used by the produced

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -189,7 +189,7 @@ fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
-async fn production_root_filesystem_selection_accepts_libsql_root_filesystem() {
+async fn production_filesystem_control_store_selection_accepts_libsql_root_filesystem() {
     let db_dir = tempfile::tempdir().unwrap();
     let db_path = db_dir.path().join("root-filesystem.db");
     let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
@@ -204,7 +204,8 @@ async fn production_root_filesystem_selection_accepts_libsql_root_filesystem() {
         ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
-    .with_libsql_root_filesystem(Arc::clone(&filesystem));
+    .with_libsql_root_filesystem(Arc::clone(&filesystem))
+    .with_filesystem_control_stores();
 
     let path = VirtualPath::new("/engine/tenants/t1/users/u1/root-selection.txt").unwrap();
     filesystem.write_file(&path, b"selected").await.unwrap();
@@ -220,6 +221,23 @@ async fn production_root_filesystem_selection_accepts_libsql_root_filesystem() {
         ),
         "LibSqlRootFilesystem must satisfy production filesystem selection: {report:?}"
     );
+    for component in [
+        ProductionWiringComponent::RunState,
+        ProductionWiringComponent::ApprovalRequests,
+        ProductionWiringComponent::CapabilityLeases,
+    ] {
+        assert!(
+            !report.contains(component, ProductionWiringIssueKind::Missing),
+            "filesystem-backed control stores must satisfy {component:?}: {report:?}"
+        );
+        assert!(
+            !report.contains(
+                component,
+                ProductionWiringIssueKind::LocalOnlyImplementation
+            ),
+            "filesystem-backed control stores must not be reported as local-only for {component:?}: {report:?}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -506,12 +506,32 @@ impl ApprovalRequestStore for InMemoryApprovalRequestStore {
     }
 }
 
+enum FilesystemStoreHandle<'a, F>
+where
+    F: RootFilesystem,
+{
+    Borrowed(&'a F),
+    Shared(Arc<F>),
+}
+
+impl<F> FilesystemStoreHandle<'_, F>
+where
+    F: RootFilesystem,
+{
+    fn filesystem(&self) -> &F {
+        match self {
+            Self::Borrowed(filesystem) => filesystem,
+            Self::Shared(filesystem) => filesystem.as_ref(),
+        }
+    }
+}
+
 /// Filesystem-backed run-state store under resource-owner-scoped `/engine` paths.
 pub struct FilesystemRunStateStore<'a, F>
 where
     F: RootFilesystem,
 {
-    filesystem: &'a F,
+    filesystem: FilesystemStoreHandle<'a, F>,
 }
 
 impl<'a, F> FilesystemRunStateStore<'a, F>
@@ -519,13 +539,25 @@ where
     F: RootFilesystem,
 {
     pub fn new(filesystem: &'a F) -> Self {
-        Self { filesystem }
+        Self {
+            filesystem: FilesystemStoreHandle::Borrowed(filesystem),
+        }
+    }
+
+    pub fn new_shared(filesystem: Arc<F>) -> FilesystemRunStateStore<'static, F> {
+        FilesystemRunStateStore {
+            filesystem: FilesystemStoreHandle::Shared(filesystem),
+        }
+    }
+
+    fn filesystem(&self) -> &F {
+        self.filesystem.filesystem()
     }
 
     async fn write_record(&self, record: &RunRecord) -> Result<(), RunStateError> {
         let path = run_record_path(&record.scope, record.invocation_id)?;
         let bytes = serialize_pretty(record)?;
-        self.filesystem.write_file(&path, &bytes).await?;
+        self.filesystem().write_file(&path, &bytes).await?;
         Ok(())
     }
 }
@@ -641,7 +673,7 @@ where
         invocation_id: InvocationId,
     ) -> Result<Option<RunRecord>, RunStateError> {
         let path = run_record_path(scope, invocation_id)?;
-        let bytes = match self.filesystem.read_file(&path).await {
+        let bytes = match self.filesystem().read_file(&path).await {
             Ok(bytes) => bytes,
             Err(error) if is_not_found(&error) => return Ok(None),
             Err(error) => return Err(error.into()),
@@ -659,7 +691,7 @@ where
         scope: &ResourceScope,
     ) -> Result<Vec<RunRecord>, RunStateError> {
         let root = run_records_root(scope)?;
-        let entries = match self.filesystem.list_dir(&root).await {
+        let entries = match self.filesystem().list_dir(&root).await {
             Ok(entries) => entries,
             Err(error) if is_not_found(&error) => return Ok(Vec::new()),
             Err(error) => return Err(error.into()),
@@ -667,7 +699,7 @@ where
         let mut records = Vec::new();
         for entry in entries {
             if entry.name.ends_with(".json") {
-                let bytes = match self.filesystem.read_file(&entry.path).await {
+                let bytes = match self.filesystem().read_file(&entry.path).await {
                     Ok(bytes) => bytes,
                     Err(error) if is_not_found(&error) => continue,
                     Err(error) => return Err(error.into()),
@@ -688,7 +720,7 @@ pub struct FilesystemApprovalRequestStore<'a, F>
 where
     F: RootFilesystem,
 {
-    filesystem: &'a F,
+    filesystem: FilesystemStoreHandle<'a, F>,
 }
 
 impl<'a, F> FilesystemApprovalRequestStore<'a, F>
@@ -696,7 +728,19 @@ where
     F: RootFilesystem,
 {
     pub fn new(filesystem: &'a F) -> Self {
-        Self { filesystem }
+        Self {
+            filesystem: FilesystemStoreHandle::Borrowed(filesystem),
+        }
+    }
+
+    pub fn new_shared(filesystem: Arc<F>) -> FilesystemApprovalRequestStore<'static, F> {
+        FilesystemApprovalRequestStore {
+            filesystem: FilesystemStoreHandle::Shared(filesystem),
+        }
+    }
+
+    fn filesystem(&self) -> &F {
+        self.filesystem.filesystem()
     }
 
     async fn update_status(
@@ -726,7 +770,7 @@ where
     async fn write_record(&self, record: &ApprovalRecord) -> Result<(), RunStateError> {
         let path = approval_record_path(&record.scope, record.request.id)?;
         let bytes = serialize_pretty(record)?;
-        self.filesystem.write_file(&path, &bytes).await?;
+        self.filesystem().write_file(&path, &bytes).await?;
         Ok(())
     }
 }
@@ -764,7 +808,7 @@ where
         request_id: ApprovalRequestId,
     ) -> Result<Option<ApprovalRecord>, RunStateError> {
         let path = approval_record_path(scope, request_id)?;
-        let bytes = match self.filesystem.read_file(&path).await {
+        let bytes = match self.filesystem().read_file(&path).await {
             Ok(bytes) => bytes,
             Err(error) if is_not_found(&error) => return Ok(None),
             Err(error) => return Err(error.into()),
@@ -814,7 +858,7 @@ where
             });
         }
         let path = approval_record_path(scope, request_id)?;
-        self.filesystem.delete(&path).await?;
+        self.filesystem().delete(&path).await?;
         Ok(record)
     }
 
@@ -823,7 +867,7 @@ where
         scope: &ResourceScope,
     ) -> Result<Vec<ApprovalRecord>, RunStateError> {
         let root = approval_records_root(scope)?;
-        let entries = match self.filesystem.list_dir(&root).await {
+        let entries = match self.filesystem().list_dir(&root).await {
             Ok(entries) => entries,
             Err(error) if is_not_found(&error) => return Ok(Vec::new()),
             Err(error) => return Err(error.into()),
@@ -831,7 +875,7 @@ where
         let mut records = Vec::new();
         for entry in entries {
             if entry.name.ends_with(".json") {
-                let bytes = match self.filesystem.read_file(&entry.path).await {
+                let bytes = match self.filesystem().read_file(&entry.path).await {
                     Ok(bytes) => bytes,
                     Err(error) if is_not_found(&error) => continue,
                     Err(error) => return Err(error.into()),


### PR DESCRIPTION
## Summary
- add owned `Arc` constructors for filesystem-backed run-state, approval request, and capability lease stores
- add `HostRuntimeServices::with_filesystem_control_stores()` to attach all persistent control stores over the selected root filesystem
- extend the libSQL production wiring test to prove filesystem-backed control stores satisfy missing/local-only guardrails

## Verification
- `cargo test -p ironclaw_host_runtime production_filesystem_control_store_selection --features libsql -- --nocapture`
- `cargo test -p ironclaw_run_state -p ironclaw_authorization`
- `cargo clippy -p ironclaw_host_runtime --all-features --all-targets -- -D warnings`

Refs #3333, #3026, #3087