### PR TITLE
test(reborn): add extension lifecycle projection e2e slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4111,6 +4111,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "ironclaw_events",
+ "ironclaw_extensions",
  "ironclaw_filesystem",
  "ironclaw_host_api",
  "ironclaw_memory",
@@ -4140,6 +4141,7 @@ dependencies = [
 name = "ironclaw_extensions"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "ironclaw_filesystem",
  "ironclaw_host_api",
  "ironclaw_trust",

--- a/crates/ironclaw_event_projections/Cargo.toml
+++ b/crates/ironclaw_event_projections/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = "2"
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+ironclaw_extensions = { path = "../ironclaw_extensions" }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_memory = { path = "../ironclaw_memory" }
 ironclaw_reborn_event_store = { path = "../ironclaw_reborn_event_store" }

--- a/crates/ironclaw_event_projections/tests/extension_lifecycle_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/extension_lifecycle_projection_contract.rs
@@ -1,0 +1,235 @@
+use std::{fs, path::Path, sync::Arc};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_event_projections::{
+    AuditProjectionRequest, AuditProjectionService, AuditProjectionStage, ProjectionScope,
+    ReplayAuditProjectionService,
+};
+use ironclaw_events::{AuditSink, DurableAuditSink, EventError};
+use ironclaw_extensions::{
+    ExtensionError, ExtensionLifecycleEvent, ExtensionLifecycleEventSink,
+    ExtensionLifecycleService, ExtensionManifest, ExtensionPackage, ExtensionRegistry,
+};
+use ironclaw_host_api::{
+    ActionSummary, AgentId, AuditEnvelope, AuditEventId, AuditStage, CorrelationId,
+    DecisionSummary, EffectKind, ExtensionId, ExtensionLifecycleOperation, InvocationId, ProjectId,
+    ResourceScope, TenantId, UserId, VirtualPath,
+};
+use ironclaw_reborn_event_store::{
+    RebornEventStoreConfig, RebornProfile, build_reborn_event_stores,
+};
+
+#[tokio::test]
+async fn extension_lifecycle_projects_metadata_only_from_durable_audit_log() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_root = temp.path().join("reborn-event-store");
+    let stores = build_reborn_event_stores(
+        RebornProfile::LocalDev,
+        RebornEventStoreConfig::Jsonl {
+            root: store_root.clone(),
+            accept_single_node_durable: false,
+        },
+    )
+    .await
+    .unwrap();
+    let audit_log = Arc::clone(&stores.audit);
+    let lifecycle_sink = Arc::new(DurableExtensionLifecycleAuditSink::new(Arc::new(
+        DurableAuditSink::new(Arc::clone(&audit_log)),
+    )));
+    let package = ExtensionPackage::from_manifest(
+        ExtensionManifest::parse(EXTENSION_MANIFEST_WITH_RAW_SENTINELS).unwrap(),
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let updated_package = ExtensionPackage::from_manifest(
+        ExtensionManifest::parse(
+            &EXTENSION_MANIFEST_WITH_RAW_SENTINELS
+                .replace("version = \"0.1.0\"", "version = \"0.2.0\"")
+                .replace("echo.say", "echo.reply"),
+        )
+        .unwrap(),
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let mut service =
+        ExtensionLifecycleService::new(ExtensionRegistry::new()).with_event_sink(lifecycle_sink);
+
+    let extension_id = ExtensionId::new("echo").unwrap();
+    service.install(package).await.unwrap();
+    service.update(updated_package).await.unwrap();
+    service.disable(&extension_id).await.unwrap();
+    service.enable(&extension_id).await.unwrap();
+    service.remove(&extension_id).await.unwrap();
+
+    assert!(service.registry().get_extension(&extension_id).is_none());
+    let projection = ReplayAuditProjectionService::from_audit_log(Arc::clone(&audit_log));
+    let snapshot = projection
+        .snapshot(AuditProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&extension_resource_scope()),
+            after: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.entries.len(), 5);
+    let decision_kinds = snapshot
+        .entries
+        .iter()
+        .map(|entry| entry.decision_kind.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        decision_kinds,
+        vec![
+            "extension_installed",
+            "extension_updated",
+            "extension_disabled",
+            "extension_enabled",
+            "extension_removed",
+        ]
+    );
+    assert!(snapshot.entries.iter().all(|entry| {
+        entry.stage == AuditProjectionStage::After
+            && entry.action_kind == "extension_lifecycle"
+            && entry.action_target.is_none()
+            && entry.extension_id.as_ref().unwrap().as_str() == "echo"
+            && entry.output_bytes.is_none()
+    }));
+
+    let projection_json = serde_json::to_string(&snapshot).unwrap();
+    let jsonl_bytes = read_directory_text(&store_root);
+    for forbidden in [
+        "extension_raw_description_sentinel_3022",
+        "extension_raw_asset_sentinel_3022",
+        "extension_raw_schema_sentinel_3022",
+    ] {
+        assert!(
+            !projection_json.contains(forbidden),
+            "extension lifecycle projection leaked {forbidden}: {projection_json}"
+        );
+        assert!(
+            !jsonl_bytes.contains(forbidden),
+            "durable extension lifecycle audit bytes leaked {forbidden}: {jsonl_bytes}"
+        );
+    }
+}
+
+struct DurableExtensionLifecycleAuditSink {
+    audit: Arc<dyn AuditSink>,
+}
+
+impl DurableExtensionLifecycleAuditSink {
+    fn new(audit: Arc<dyn AuditSink>) -> Self {
+        Self { audit }
+    }
+}
+
+#[async_trait]
+impl ExtensionLifecycleEventSink for DurableExtensionLifecycleAuditSink {
+    async fn record_extension_lifecycle_event(
+        &self,
+        event: ExtensionLifecycleEvent,
+    ) -> Result<(), ExtensionError> {
+        self.audit
+            .emit_audit(extension_lifecycle_audit(event))
+            .await
+            .map_err(extension_lifecycle_audit_error)
+    }
+}
+
+fn extension_lifecycle_audit(event: ExtensionLifecycleEvent) -> AuditEnvelope {
+    let extension_id = event.extension_id;
+    AuditEnvelope {
+        event_id: AuditEventId::new(),
+        correlation_id: CorrelationId::new(),
+        stage: AuditStage::After,
+        timestamp: Utc::now(),
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("alice").unwrap(),
+        agent_id: Some(AgentId::new("agent-a").unwrap()),
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+        process_id: None,
+        approval_request_id: None,
+        extension_id: Some(extension_id.clone()),
+        action: ActionSummary {
+            kind: "extension_lifecycle".to_string(),
+            target: None,
+            effects: vec![EffectKind::ModifyExtension],
+        },
+        decision: DecisionSummary {
+            kind: extension_lifecycle_decision_kind(event.operation).to_string(),
+            reason: None,
+            actor: None,
+        },
+        result: None,
+    }
+}
+
+fn extension_lifecycle_decision_kind(operation: ExtensionLifecycleOperation) -> &'static str {
+    match operation {
+        ExtensionLifecycleOperation::Install => "extension_installed",
+        ExtensionLifecycleOperation::Update => "extension_updated",
+        ExtensionLifecycleOperation::Remove => "extension_removed",
+        ExtensionLifecycleOperation::Enable => "extension_enabled",
+        ExtensionLifecycleOperation::Disable => "extension_disabled",
+    }
+}
+
+fn extension_lifecycle_audit_error(error: EventError) -> ExtensionError {
+    let _ = error;
+    ExtensionError::LifecycleEventSink {
+        extension_id: ExtensionId::new("echo").unwrap(),
+        operation: ExtensionLifecycleOperation::Install,
+    }
+}
+
+fn extension_resource_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("alice").unwrap(),
+        agent_id: Some(AgentId::new("agent-a").unwrap()),
+        project_id: Some(ProjectId::new("project-a").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn read_directory_text(root: &Path) -> String {
+    let mut output = String::new();
+    read_directory_text_into(root, &mut output);
+    output
+}
+
+fn read_directory_text_into(path: &Path, output: &mut String) {
+    if path.is_dir() {
+        for entry in fs::read_dir(path).unwrap() {
+            read_directory_text_into(&entry.unwrap().path(), output);
+        }
+    } else if path.is_file() {
+        output.push_str(&fs::read_to_string(path).unwrap_or_default());
+    }
+}
+
+const EXTENSION_MANIFEST_WITH_RAW_SENTINELS: &str = r#"
+id = "echo"
+name = "Echo"
+version = "0.1.0"
+description = "extension_raw_description_sentinel_3022"
+trust = "untrusted"
+
+[runtime]
+kind = "wasm"
+module = "wasm/extension_raw_asset_sentinel_3022.wasm"
+
+[[capabilities]]
+id = "echo.say"
+description = "Echo safely"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+parameters_schema = { type = "object", description = "extension_raw_schema_sentinel_3022" }
+"#;

--- a/crates/ironclaw_extensions/Cargo.toml
+++ b/crates/ironclaw_extensions/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/nearai/ironclaw"
 publish = false
 
 [dependencies]
+async-trait = "0.1"
 ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_trust = { path = "../ironclaw_trust", version = "0.1.0" }

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -5,16 +5,15 @@
 //! execute WASM modules, start Docker containers, connect to MCP servers, resolve
 //! secrets, or reserve resources.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
-
 use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
 use ironclaw_host_api::{
-    CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, HostApiError, PackageId,
-    PackageIdentity, PackageSource, PermissionMode, RequestedTrustClass, ResourceProfile,
-    RuntimeKind, TrustClass, VirtualPath,
+    CapabilityDescriptor, CapabilityId, EffectKind, ExtensionId, ExtensionLifecycleOperation,
+    HostApiError, PackageId, PackageIdentity, PackageSource, PermissionMode, RequestedTrustClass,
+    ResourceProfile, RuntimeKind, TrustClass, VirtualPath,
 };
 use ironclaw_trust::TrustPolicyInput;
 use serde::{Deserialize, Deserializer};
+use std::collections::{BTreeSet, HashSet};
 use thiserror::Error;
 
 /// Extension manifest and registry failures.
@@ -36,8 +35,15 @@ pub enum ExtensionError {
     },
     #[error("duplicate extension id {id}")]
     DuplicateExtension { id: ExtensionId },
+    #[error("extension id {id} was not found")]
+    ExtensionNotFound { id: ExtensionId },
     #[error("duplicate capability id {id}")]
     DuplicateCapability { id: CapabilityId },
+    #[error("extension lifecycle event sink failed during {operation} for {extension_id}")]
+    LifecycleEventSink {
+        extension_id: ExtensionId,
+        operation: ExtensionLifecycleOperation,
+    },
     #[error(transparent)]
     Filesystem(#[from] FilesystemError),
 }
@@ -273,7 +279,7 @@ impl ExtensionPackage {
         digest: Option<String>,
         signer: Option<String>,
     ) -> Result<PackageIdentity, ExtensionError> {
-        validate_package_consistency(self)?;
+        registry::validate_package_consistency(self)?;
         Ok(PackageIdentity::new(
             PackageId::new(self.manifest.id.as_str().to_string())?,
             source,
@@ -306,94 +312,13 @@ impl ExtensionPackage {
     }
 }
 
-/// Registry of validated extension packages and declared capabilities.
-#[derive(Debug, Default)]
-pub struct ExtensionRegistry {
-    packages: HashMap<ExtensionId, ExtensionPackage>,
-    capabilities: HashMap<CapabilityId, CapabilityDescriptor>,
-    extension_order: Vec<ExtensionId>,
-    capability_order: Vec<CapabilityId>,
-}
+mod lifecycle;
+mod registry;
 
-impl ExtensionRegistry {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn insert(&mut self, package: ExtensionPackage) -> Result<(), ExtensionError> {
-        validate_package_consistency(&package)?;
-
-        if self.packages.contains_key(&package.id) {
-            return Err(ExtensionError::DuplicateExtension { id: package.id });
-        }
-
-        let mut seen_capabilities = HashSet::new();
-        for descriptor in &package.capabilities {
-            if !seen_capabilities.insert(descriptor.id.clone())
-                || self.capabilities.contains_key(&descriptor.id)
-            {
-                return Err(ExtensionError::DuplicateCapability {
-                    id: descriptor.id.clone(),
-                });
-            }
-            if descriptor.provider != package.id {
-                return Err(ExtensionError::InvalidManifest {
-                    reason: format!(
-                        "descriptor {} provider {} does not match package {}",
-                        descriptor.id, descriptor.provider, package.id
-                    ),
-                });
-            }
-        }
-
-        for descriptor in &package.capabilities {
-            self.capability_order.push(descriptor.id.clone());
-            self.capabilities
-                .insert(descriptor.id.clone(), descriptor.clone());
-        }
-        self.extension_order.push(package.id.clone());
-        self.packages.insert(package.id.clone(), package);
-        Ok(())
-    }
-
-    pub fn get_extension(&self, id: &ExtensionId) -> Option<&ExtensionPackage> {
-        self.packages.get(id)
-    }
-
-    pub fn get_capability(&self, id: &CapabilityId) -> Option<&CapabilityDescriptor> {
-        self.capabilities.get(id)
-    }
-
-    pub fn extensions(&self) -> impl Iterator<Item = &ExtensionPackage> {
-        self.extension_order
-            .iter()
-            .filter_map(|id| self.packages.get(id))
-    }
-
-    pub fn capabilities(&self) -> impl Iterator<Item = &CapabilityDescriptor> {
-        self.capability_order
-            .iter()
-            .filter_map(|id| self.capabilities.get(id))
-    }
-}
-
-fn validate_package_consistency(package: &ExtensionPackage) -> Result<(), ExtensionError> {
-    let expected = ExtensionPackage::from_manifest(package.manifest.clone(), package.root.clone())?;
-    if package.id != expected.id {
-        return Err(ExtensionError::InvalidManifest {
-            reason: format!(
-                "package id {} does not match manifest/root id {}",
-                package.id, expected.id
-            ),
-        });
-    }
-    if package.capabilities != expected.capabilities {
-        return Err(ExtensionError::InvalidManifest {
-            reason: "package capability descriptors do not match manifest declarations".to_string(),
-        });
-    }
-    Ok(())
-}
+pub use lifecycle::{
+    ExtensionLifecycleEvent, ExtensionLifecycleEventSink, ExtensionLifecycleService,
+};
+pub use registry::ExtensionRegistry;
 
 /// Filesystem-backed extension discovery.
 pub struct ExtensionDiscovery;

--- a/crates/ironclaw_extensions/src/lifecycle.rs
+++ b/crates/ironclaw_extensions/src/lifecycle.rs
@@ -1,0 +1,173 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{ExtensionId, ExtensionLifecycleOperation, RuntimeKind};
+
+use crate::{ExtensionError, ExtensionPackage, ExtensionRegistry};
+
+/// Redacted extension lifecycle event emitted by host-composed lifecycle services.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionLifecycleEvent {
+    pub operation: ExtensionLifecycleOperation,
+    pub extension_id: ExtensionId,
+    pub version: String,
+    pub runtime: RuntimeKind,
+    pub capability_count: usize,
+    pub capability_surface_changed: bool,
+}
+
+impl ExtensionLifecycleEvent {
+    fn from_package(
+        operation: ExtensionLifecycleOperation,
+        package: &ExtensionPackage,
+        capability_surface_changed: bool,
+    ) -> Self {
+        Self {
+            operation,
+            extension_id: package.id.clone(),
+            version: package.manifest.version.clone(),
+            runtime: package.manifest.runtime_kind(),
+            capability_count: package.capabilities.len(),
+            capability_surface_changed,
+        }
+    }
+}
+
+/// Host-composed sink for redacted extension lifecycle events.
+#[async_trait]
+pub trait ExtensionLifecycleEventSink: Send + Sync {
+    async fn record_extension_lifecycle_event(
+        &self,
+        event: ExtensionLifecycleEvent,
+    ) -> Result<(), ExtensionError>;
+}
+
+/// Host-facing lifecycle wrapper over the deterministic extension registry.
+pub struct ExtensionLifecycleService {
+    registry: ExtensionRegistry,
+    event_sink: Option<Arc<dyn ExtensionLifecycleEventSink>>,
+    disabled_extensions: HashSet<ExtensionId>,
+}
+
+impl std::fmt::Debug for ExtensionLifecycleService {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ExtensionLifecycleService")
+            .field("registry", &self.registry)
+            .field(
+                "event_sink",
+                &self.event_sink.as_ref().map(|_| "<event_sink>"),
+            )
+            .field("disabled_extensions", &self.disabled_extensions)
+            .finish()
+    }
+}
+
+impl ExtensionLifecycleService {
+    pub fn new(registry: ExtensionRegistry) -> Self {
+        Self {
+            registry,
+            event_sink: None,
+            disabled_extensions: HashSet::new(),
+        }
+    }
+
+    pub fn with_event_sink<S>(mut self, event_sink: Arc<S>) -> Self
+    where
+        S: ExtensionLifecycleEventSink + 'static,
+    {
+        let event_sink: Arc<dyn ExtensionLifecycleEventSink> = event_sink;
+        self.event_sink = Some(event_sink);
+        self
+    }
+
+    pub fn registry(&self) -> &ExtensionRegistry {
+        &self.registry
+    }
+
+    pub fn is_enabled(&self, id: &ExtensionId) -> bool {
+        self.registry.get_extension(id).is_some() && !self.disabled_extensions.contains(id)
+    }
+
+    pub async fn install(&mut self, package: ExtensionPackage) -> Result<(), ExtensionError> {
+        self.registry.validate_insertable(&package)?;
+        self.emit_lifecycle_event(ExtensionLifecycleEvent::from_package(
+            ExtensionLifecycleOperation::Install,
+            &package,
+            true,
+        ))
+        .await?;
+        self.registry.insert_validated(package);
+        Ok(())
+    }
+
+    pub async fn update(&mut self, package: ExtensionPackage) -> Result<(), ExtensionError> {
+        let current = self.registry.existing_package(&package.id)?.clone();
+        self.registry.validate_replacement(&package)?;
+        let capability_surface_changed = current.capabilities != package.capabilities;
+        self.emit_lifecycle_event(ExtensionLifecycleEvent::from_package(
+            ExtensionLifecycleOperation::Update,
+            &package,
+            capability_surface_changed,
+        ))
+        .await?;
+        self.registry.replace_validated(package);
+        Ok(())
+    }
+
+    pub async fn remove(&mut self, id: &ExtensionId) -> Result<(), ExtensionError> {
+        let package = self.registry.existing_package(id)?.clone();
+        self.emit_lifecycle_event(ExtensionLifecycleEvent::from_package(
+            ExtensionLifecycleOperation::Remove,
+            &package,
+            !package.capabilities.is_empty(),
+        ))
+        .await?;
+        self.registry.remove_validated(id);
+        self.disabled_extensions.remove(id);
+        Ok(())
+    }
+
+    pub async fn enable(&mut self, id: &ExtensionId) -> Result<(), ExtensionError> {
+        let package = self.registry.existing_package(id)?.clone();
+        self.emit_lifecycle_event(ExtensionLifecycleEvent::from_package(
+            ExtensionLifecycleOperation::Enable,
+            &package,
+            true,
+        ))
+        .await?;
+        self.disabled_extensions.remove(id);
+        Ok(())
+    }
+
+    pub async fn disable(&mut self, id: &ExtensionId) -> Result<(), ExtensionError> {
+        let package = self.registry.existing_package(id)?.clone();
+        self.emit_lifecycle_event(ExtensionLifecycleEvent::from_package(
+            ExtensionLifecycleOperation::Disable,
+            &package,
+            true,
+        ))
+        .await?;
+        self.disabled_extensions.insert(id.clone());
+        Ok(())
+    }
+
+    async fn emit_lifecycle_event(
+        &self,
+        event: ExtensionLifecycleEvent,
+    ) -> Result<(), ExtensionError> {
+        if let Some(event_sink) = &self.event_sink {
+            let extension_id = event.extension_id.clone();
+            let operation = event.operation;
+            event_sink
+                .record_extension_lifecycle_event(event)
+                .await
+                .map_err(|_| ExtensionError::LifecycleEventSink {
+                    extension_id,
+                    operation,
+                })?;
+        }
+        Ok(())
+    }
+}

--- a/crates/ironclaw_extensions/src/registry.rs
+++ b/crates/ironclaw_extensions/src/registry.rs
@@ -1,0 +1,197 @@
+use std::collections::{HashMap, HashSet};
+
+use ironclaw_host_api::{CapabilityDescriptor, CapabilityId, ExtensionId};
+
+use crate::{ExtensionError, ExtensionPackage};
+
+/// Registry of validated extension packages and declared capabilities.
+#[derive(Debug, Default)]
+pub struct ExtensionRegistry {
+    packages: HashMap<ExtensionId, ExtensionPackage>,
+    capabilities: HashMap<CapabilityId, CapabilityDescriptor>,
+    extension_order: Vec<ExtensionId>,
+    capability_order: Vec<CapabilityId>,
+}
+
+impl ExtensionRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, package: ExtensionPackage) -> Result<(), ExtensionError> {
+        self.validate_insertable(&package)?;
+        self.insert_validated(package);
+        Ok(())
+    }
+
+    pub(crate) fn validate_insertable(
+        &self,
+        package: &ExtensionPackage,
+    ) -> Result<(), ExtensionError> {
+        validate_package_consistency(package)?;
+
+        if self.packages.contains_key(&package.id) {
+            return Err(ExtensionError::DuplicateExtension {
+                id: package.id.clone(),
+            });
+        }
+
+        self.validate_capabilities_available(package, None)
+    }
+
+    pub(crate) fn validate_replacement(
+        &self,
+        package: &ExtensionPackage,
+    ) -> Result<(), ExtensionError> {
+        validate_package_consistency(package)?;
+        self.existing_package(&package.id)?;
+        self.validate_capabilities_available(package, Some(&package.id))
+    }
+
+    fn validate_capabilities_available(
+        &self,
+        package: &ExtensionPackage,
+        replacing: Option<&ExtensionId>,
+    ) -> Result<(), ExtensionError> {
+        let mut seen_capabilities = HashSet::new();
+        for descriptor in &package.capabilities {
+            let capability_belongs_to_replaced_package = replacing
+                .and_then(|id| self.packages.get(id))
+                .map(|current| {
+                    current
+                        .capabilities
+                        .iter()
+                        .any(|current| current.id == descriptor.id)
+                })
+                .unwrap_or(false);
+            if !seen_capabilities.insert(descriptor.id.clone())
+                || (self.capabilities.contains_key(&descriptor.id)
+                    && !capability_belongs_to_replaced_package)
+            {
+                return Err(ExtensionError::DuplicateCapability {
+                    id: descriptor.id.clone(),
+                });
+            }
+            if descriptor.provider != package.id {
+                return Err(ExtensionError::InvalidManifest {
+                    reason: format!(
+                        "descriptor {} provider {} does not match package {}",
+                        descriptor.id, descriptor.provider, package.id
+                    ),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn existing_package(
+        &self,
+        id: &ExtensionId,
+    ) -> Result<&ExtensionPackage, ExtensionError> {
+        self.packages
+            .get(id)
+            .ok_or_else(|| ExtensionError::ExtensionNotFound { id: id.clone() })
+    }
+
+    pub(crate) fn insert_validated(&mut self, package: ExtensionPackage) {
+        for descriptor in &package.capabilities {
+            self.capability_order.push(descriptor.id.clone());
+            self.capabilities
+                .insert(descriptor.id.clone(), descriptor.clone());
+        }
+        self.extension_order.push(package.id.clone());
+        self.packages.insert(package.id.clone(), package);
+    }
+
+    pub(crate) fn replace_validated(&mut self, package: ExtensionPackage) {
+        let id = package.id.clone();
+        let extension_index = self
+            .extension_order
+            .iter()
+            .position(|extension_id| extension_id == &id);
+        let Some(current) = self.packages.remove(&id) else {
+            return;
+        };
+        let current_capability_ids = current
+            .capabilities
+            .iter()
+            .map(|descriptor| descriptor.id.clone())
+            .collect::<HashSet<_>>();
+        let capability_insert_index = self
+            .capability_order
+            .iter()
+            .position(|capability_id| current_capability_ids.contains(capability_id))
+            .unwrap_or(self.capability_order.len());
+
+        for capability_id in &current_capability_ids {
+            self.capabilities.remove(capability_id);
+        }
+        self.capability_order
+            .retain(|capability_id| !current_capability_ids.contains(capability_id));
+        for (offset, descriptor) in package.capabilities.iter().enumerate() {
+            self.capability_order
+                .insert(capability_insert_index + offset, descriptor.id.clone());
+            self.capabilities
+                .insert(descriptor.id.clone(), descriptor.clone());
+        }
+        if let Some(index) = extension_index {
+            self.extension_order[index] = id.clone();
+        } else {
+            self.extension_order.push(id.clone());
+        }
+        self.packages.insert(id, package);
+    }
+
+    pub(crate) fn remove_validated(&mut self, id: &ExtensionId) -> Option<ExtensionPackage> {
+        let package = self.packages.remove(id)?;
+        self.extension_order
+            .retain(|extension_id| extension_id != id);
+        for descriptor in &package.capabilities {
+            self.capabilities.remove(&descriptor.id);
+            self.capability_order
+                .retain(|capability_id| capability_id != &descriptor.id);
+        }
+        Some(package)
+    }
+
+    pub fn get_extension(&self, id: &ExtensionId) -> Option<&ExtensionPackage> {
+        self.packages.get(id)
+    }
+
+    pub fn get_capability(&self, id: &CapabilityId) -> Option<&CapabilityDescriptor> {
+        self.capabilities.get(id)
+    }
+
+    pub fn extensions(&self) -> impl Iterator<Item = &ExtensionPackage> {
+        self.extension_order
+            .iter()
+            .filter_map(|id| self.packages.get(id))
+    }
+
+    pub fn capabilities(&self) -> impl Iterator<Item = &CapabilityDescriptor> {
+        self.capability_order
+            .iter()
+            .filter_map(|id| self.capabilities.get(id))
+    }
+}
+
+pub(crate) fn validate_package_consistency(
+    package: &ExtensionPackage,
+) -> Result<(), ExtensionError> {
+    let expected = ExtensionPackage::from_manifest(package.manifest.clone(), package.root.clone())?;
+    if package.id != expected.id {
+        return Err(ExtensionError::InvalidManifest {
+            reason: format!(
+                "package id {} does not match manifest/root id {}",
+                package.id, expected.id
+            ),
+        });
+    }
+    if package.capabilities != expected.capabilities {
+        return Err(ExtensionError::InvalidManifest {
+            reason: "package capability descriptors do not match manifest declarations".to_string(),
+        });
+    }
+    Ok(())
+}

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -1035,3 +1035,219 @@ effects = ["network", "dispatch_capability"]
 default_permission = "ask"
 parameters_schema = { type = "object" }
 "#;
+
+#[tokio::test]
+async fn lifecycle_service_installs_package_and_records_metadata_only_event() {
+    let events = std::sync::Arc::new(RecordingExtensionLifecycleEventSink::default());
+    let package = ExtensionPackage::from_manifest(
+        ExtensionManifest::parse(
+            &WASM_MANIFEST
+                .replace(
+                    "Echo demo extension",
+                    "extension_raw_description_sentinel_3022",
+                )
+                .replace(
+                    "wasm/echo.wasm",
+                    "wasm/extension_raw_asset_sentinel_3022.wasm",
+                )
+                .replace(
+                    "parameters_schema = { type = \"object\" }",
+                    "parameters_schema = { type = \"object\", description = \"extension_raw_schema_sentinel_3022\" }",
+                ),
+        )
+        .unwrap(),
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let mut service = ExtensionLifecycleService::new(ExtensionRegistry::new())
+        .with_event_sink(std::sync::Arc::clone(&events));
+
+    service.install(package).await.unwrap();
+
+    assert!(
+        service
+            .registry()
+            .get_extension(&ExtensionId::new("echo").unwrap())
+            .is_some()
+    );
+    assert!(
+        service
+            .registry()
+            .get_capability(&CapabilityId::new("echo.say").unwrap())
+            .is_some()
+    );
+    let recorded = events.events();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].operation, ExtensionLifecycleOperation::Install);
+    assert_eq!(recorded[0].extension_id.as_str(), "echo");
+    assert_eq!(recorded[0].version, "0.1.0");
+    assert_eq!(recorded[0].runtime, RuntimeKind::Wasm);
+    assert_eq!(recorded[0].capability_count, 1);
+    assert!(recorded[0].capability_surface_changed);
+    let serialized = format!("{recorded:?}");
+    assert!(!serialized.contains("extension_raw_description_sentinel_3022"));
+    assert!(!serialized.contains("extension_raw_asset_sentinel_3022"));
+    assert!(!serialized.contains("extension_raw_schema_sentinel_3022"));
+}
+
+#[tokio::test]
+async fn lifecycle_service_records_update_disable_enable_and_remove_events() {
+    let events = std::sync::Arc::new(RecordingExtensionLifecycleEventSink::default());
+    let installed = ExtensionPackage::from_manifest(
+        ExtensionManifest::parse(WASM_MANIFEST).unwrap(),
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let updated = ExtensionPackage::from_manifest(
+        ExtensionManifest::parse(
+            &WASM_MANIFEST
+                .replace("version = \"0.1.0\"", "version = \"0.2.0\"")
+                .replace("echo.say", "echo.reply"),
+        )
+        .unwrap(),
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let extension_id = ExtensionId::new("echo").unwrap();
+    let mut service = ExtensionLifecycleService::new(ExtensionRegistry::new())
+        .with_event_sink(std::sync::Arc::clone(&events));
+
+    service.install(installed).await.unwrap();
+    service.update(updated).await.unwrap();
+    service.disable(&extension_id).await.unwrap();
+    assert!(!service.is_enabled(&extension_id));
+    service.enable(&extension_id).await.unwrap();
+    assert!(service.is_enabled(&extension_id));
+    service.remove(&extension_id).await.unwrap();
+
+    assert!(service.registry().get_extension(&extension_id).is_none());
+    assert!(
+        service
+            .registry()
+            .get_capability(&CapabilityId::new("echo.say").unwrap())
+            .is_none()
+    );
+    assert!(
+        service
+            .registry()
+            .get_capability(&CapabilityId::new("echo.reply").unwrap())
+            .is_none()
+    );
+    let recorded = events.events();
+    assert_eq!(recorded.len(), 5);
+    assert_eq!(recorded[0].operation, ExtensionLifecycleOperation::Install);
+    assert_eq!(recorded[1].operation, ExtensionLifecycleOperation::Update);
+    assert_eq!(recorded[1].version, "0.2.0");
+    assert!(recorded[1].capability_surface_changed);
+    assert_eq!(recorded[2].operation, ExtensionLifecycleOperation::Disable);
+    assert!(recorded[2].capability_surface_changed);
+    assert_eq!(recorded[3].operation, ExtensionLifecycleOperation::Enable);
+    assert!(recorded[3].capability_surface_changed);
+    assert_eq!(recorded[4].operation, ExtensionLifecycleOperation::Remove);
+    assert_eq!(recorded[4].version, "0.2.0");
+    assert!(recorded[4].capability_surface_changed);
+}
+
+#[tokio::test]
+async fn lifecycle_update_preserves_registry_iteration_order() {
+    let alpha = lifecycle_package("alpha", "alpha.say", "0.1.0");
+    let beta = lifecycle_package("beta", "beta.say", "0.1.0");
+    let alpha_update = lifecycle_package("alpha", "alpha.reply", "0.2.0");
+    let mut service = ExtensionLifecycleService::new(ExtensionRegistry::new());
+
+    service.install(alpha).await.unwrap();
+    service.install(beta).await.unwrap();
+    service.update(alpha_update).await.unwrap();
+
+    let extension_ids = service
+        .registry()
+        .extensions()
+        .map(|package| package.id.as_str().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(extension_ids, vec!["alpha", "beta"]);
+    let capability_ids = service
+        .registry()
+        .capabilities()
+        .map(|descriptor| descriptor.id.as_str().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(capability_ids, vec!["alpha.reply", "beta.say"]);
+}
+
+#[tokio::test]
+async fn lifecycle_service_does_not_install_when_required_event_sink_fails() {
+    let package = ExtensionPackage::from_manifest(
+        ExtensionManifest::parse(WASM_MANIFEST).unwrap(),
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let mut service = ExtensionLifecycleService::new(ExtensionRegistry::new())
+        .with_event_sink(std::sync::Arc::new(FailingExtensionLifecycleEventSink));
+
+    let err = service.install(package).await.unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::LifecycleEventSink {
+            ref extension_id,
+            operation: ExtensionLifecycleOperation::Install,
+        } if extension_id.as_str() == "echo"
+    ));
+    assert!(!err.to_string().contains("raw_sink_failure_sentinel_3022"));
+    assert!(
+        service
+            .registry()
+            .get_extension(&ExtensionId::new("echo").unwrap())
+            .is_none()
+    );
+}
+
+fn lifecycle_package(id: &str, capability: &str, version: &str) -> ExtensionPackage {
+    ExtensionPackage::from_manifest(
+        ExtensionManifest::parse(
+            &WASM_MANIFEST
+                .replace("id = \"echo\"", &format!("id = \"{id}\""))
+                .replace("version = \"0.1.0\"", &format!("version = \"{version}\""))
+                .replace("echo.say", capability),
+        )
+        .unwrap(),
+        VirtualPath::new(format!("/system/extensions/{id}")).unwrap(),
+    )
+    .unwrap()
+}
+
+#[derive(Default)]
+struct RecordingExtensionLifecycleEventSink {
+    events: std::sync::Mutex<Vec<ExtensionLifecycleEvent>>,
+}
+
+impl RecordingExtensionLifecycleEventSink {
+    fn events(&self) -> Vec<ExtensionLifecycleEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl ExtensionLifecycleEventSink for RecordingExtensionLifecycleEventSink {
+    async fn record_extension_lifecycle_event(
+        &self,
+        event: ExtensionLifecycleEvent,
+    ) -> Result<(), ExtensionError> {
+        self.events.lock().unwrap().push(event);
+        Ok(())
+    }
+}
+
+struct FailingExtensionLifecycleEventSink;
+
+#[async_trait::async_trait]
+impl ExtensionLifecycleEventSink for FailingExtensionLifecycleEventSink {
+    async fn record_extension_lifecycle_event(
+        &self,
+        event: ExtensionLifecycleEvent,
+    ) -> Result<(), ExtensionError> {
+        let _ = event;
+        Err(ExtensionError::InvalidManifest {
+            reason: "raw_sink_failure_sentinel_3022".to_string(),
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a declarative extension lifecycle producer seam in `ironclaw_extensions`: `ExtensionLifecycleEvent`, `ExtensionLifecycleEventSink`, and `ExtensionLifecycleService`.
- Supports install, update, remove, enable, and disable lifecycle operations.
- Keeps lifecycle records metadata-only: operation, extension id, version, runtime kind, capability count, and capability-surface-changed flag.
- Ensures lifecycle sink failures are redacted and fail closed before registry mutation.
- Preserves deterministic registry iteration order across update/remove.
- Adds a #3022 caller-level E2E slice: `ExtensionLifecycleService -> ExtensionLifecycleEventSink -> DurableAuditLog(JSONL) -> ReplayAuditProjectionService` with projection and JSONL no-exposure checks for all lifecycle operations.

Refs #3022

## Verification
- `cargo fmt --check`
- `cargo test -p ironclaw_extensions lifecycle`
- `cargo test -p ironclaw_event_projections --test extension_lifecycle_projection_contract`
- `cargo clippy -p ironclaw_extensions --test extension_contract -- -D warnings`
- `cargo clippy -p ironclaw_event_projections --test extension_lifecycle_projection_contract -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold -q`

## Review
- Reviewer pass after extending all lifecycle operations: no Critical/High/Medium findings.
