### PR TITLE
feat(reborn): add database capability lease stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,14 +4006,18 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "deadpool-postgres",
  "ironclaw_filesystem",
  "ironclaw_host_api",
  "ironclaw_trust",
+ "libsql",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/ironclaw_authorization/Cargo.toml
+++ b/crates/ironclaw_authorization/Cargo.toml
@@ -4,16 +4,25 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+default = []
+postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
+libsql = ["dep:libsql"]
+
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+deadpool-postgres = { version = "0.14", optional = true }
 ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 ironclaw_host_api = { path = "../ironclaw_host_api" }
 ironclaw_trust = { path = "../ironclaw_trust" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
+tokio-postgres = { version = "0.7", optional = true }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironclaw_authorization/src/db.rs
+++ b/crates/ironclaw_authorization/src/db.rs
@@ -1,0 +1,554 @@
+#[cfg(feature = "libsql")]
+use std::sync::Arc;
+
+use ironclaw_host_api::{
+    CapabilityGrantId, ExecutionContext, InvocationFingerprint, ResourceScope,
+};
+
+use crate::{
+    CapabilityLease, CapabilityLeaseError, CapabilityLeaseStatus, CapabilityLeaseStore,
+    ensure_claimable, ensure_consumable, lease_is_authorizing, same_scope_owner,
+};
+
+#[cfg(feature = "libsql")]
+const LIBSQL_LEASE_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS reborn_capability_lease_records (
+    owner_key TEXT NOT NULL,
+    invocation_id TEXT NOT NULL,
+    lease_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (owner_key, invocation_id, lease_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_capability_lease_records_owner
+    ON reborn_capability_lease_records(owner_key, lease_id);
+"#;
+
+#[cfg(feature = "postgres")]
+const POSTGRES_LEASE_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS reborn_capability_lease_records (
+    owner_key TEXT NOT NULL,
+    invocation_id TEXT NOT NULL,
+    lease_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    PRIMARY KEY (owner_key, invocation_id, lease_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_capability_lease_records_owner
+    ON reborn_capability_lease_records(owner_key, lease_id);
+"#;
+
+#[cfg(feature = "libsql")]
+pub struct LibSqlCapabilityLeaseStore {
+    db: Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlCapabilityLeaseStore {
+    pub fn new(db: Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), CapabilityLeaseError> {
+        let conn = libsql_connect(&self.db).await?;
+        conn.execute_batch(LIBSQL_LEASE_SCHEMA)
+            .await
+            .map_err(db_error)?;
+        Ok(())
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, CapabilityLeaseError> {
+        libsql_connect(&self.db).await
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait::async_trait]
+impl CapabilityLeaseStore for LibSqlCapabilityLeaseStore {
+    async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let conn = libsql_begin_immediate(&self.db).await?;
+        let result = async {
+            libsql_upsert_lease(&conn, &lease).await?;
+            Ok(lease)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await
+    }
+
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        self.update_lease(scope, lease_id, |lease| {
+            lease.status = CapabilityLeaseStatus::Revoked;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Option<CapabilityLease> {
+        let conn = self.connect().await.ok()?;
+        libsql_get_lease(&conn, scope, lease_id)
+            .await
+            .ok()
+            .flatten()
+    }
+
+    async fn claim(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        self.update_lease(scope, lease_id, |lease| {
+            ensure_claimable(lease, invocation_fingerprint)?;
+            lease.status = CapabilityLeaseStatus::Claimed;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        self.update_lease(scope, lease_id, consume_lease).await
+    }
+
+    async fn leases_for_scope(&self, scope: &ResourceScope) -> Vec<CapabilityLease> {
+        let Ok(conn) = self.connect().await else {
+            return Vec::new();
+        };
+        libsql_leases_for_scope(&conn, scope)
+            .await
+            .unwrap_or_default()
+    }
+
+    async fn active_leases_for_context(&self, context: &ExecutionContext) -> Vec<CapabilityLease> {
+        self.leases_for_scope(&context.resource_scope)
+            .await
+            .into_iter()
+            .filter(|lease| lease_is_authorizing(lease, context))
+            .collect()
+    }
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlCapabilityLeaseStore {
+    async fn update_lease<F>(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+        update: F,
+    ) -> Result<CapabilityLease, CapabilityLeaseError>
+    where
+        F: FnOnce(&mut CapabilityLease) -> Result<(), CapabilityLeaseError>,
+    {
+        let conn = libsql_begin_immediate(&self.db).await?;
+        let result = async {
+            let mut lease = libsql_get_lease(&conn, scope, lease_id)
+                .await?
+                .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
+            update(&mut lease)?;
+            libsql_upsert_lease(&conn, &lease).await?;
+            Ok(lease)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub struct PostgresCapabilityLeaseStore {
+    pool: deadpool_postgres::Pool,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresCapabilityLeaseStore {
+    pub fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), CapabilityLeaseError> {
+        let client = self.pool.get().await.map_err(db_error)?;
+        client
+            .batch_execute(POSTGRES_LEASE_SCHEMA)
+            .await
+            .map_err(db_error)
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl CapabilityLeaseStore for PostgresCapabilityLeaseStore {
+    async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let client = self.pool.get().await.map_err(db_error)?;
+        postgres_upsert_lease(&client, &lease).await?;
+        Ok(lease)
+    }
+
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        self.update_lease(scope, lease_id, |lease| {
+            lease.status = CapabilityLeaseStatus::Revoked;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Option<CapabilityLease> {
+        let client = self.pool.get().await.ok()?;
+        postgres_get_lease(&client, scope, lease_id, false)
+            .await
+            .ok()
+            .flatten()
+    }
+
+    async fn claim(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        self.update_lease(scope, lease_id, |lease| {
+            ensure_claimable(lease, invocation_fingerprint)?;
+            lease.status = CapabilityLeaseStatus::Claimed;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        self.update_lease(scope, lease_id, consume_lease).await
+    }
+
+    async fn leases_for_scope(&self, scope: &ResourceScope) -> Vec<CapabilityLease> {
+        let Ok(client) = self.pool.get().await else {
+            return Vec::new();
+        };
+        postgres_leases_for_scope(&client, scope)
+            .await
+            .unwrap_or_default()
+    }
+
+    async fn active_leases_for_context(&self, context: &ExecutionContext) -> Vec<CapabilityLease> {
+        self.leases_for_scope(&context.resource_scope)
+            .await
+            .into_iter()
+            .filter(|lease| lease_is_authorizing(lease, context))
+            .collect()
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresCapabilityLeaseStore {
+    async fn update_lease<F>(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+        update: F,
+    ) -> Result<CapabilityLease, CapabilityLeaseError>
+    where
+        F: FnOnce(&mut CapabilityLease) -> Result<(), CapabilityLeaseError>,
+    {
+        let mut client = self.pool.get().await.map_err(db_error)?;
+        let transaction = client.transaction().await.map_err(db_error)?;
+        let result = async {
+            let mut lease = postgres_get_lease(&transaction, scope, lease_id, true)
+                .await?
+                .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
+            update(&mut lease)?;
+            postgres_upsert_lease(&transaction, &lease).await?;
+            Ok(lease)
+        }
+        .await;
+        match result {
+            Ok(lease) => {
+                transaction.commit().await.map_err(db_error)?;
+                Ok(lease)
+            }
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                Err(error)
+            }
+        }
+    }
+}
+
+fn consume_lease(lease: &mut CapabilityLease) -> Result<(), CapabilityLeaseError> {
+    let was_claimed = lease.status == CapabilityLeaseStatus::Claimed;
+    ensure_consumable(lease)?;
+    if lease.invocation_fingerprint.is_some() {
+        if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
+            *remaining = 0;
+        }
+        lease.status = CapabilityLeaseStatus::Consumed;
+    } else if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
+        *remaining -= 1;
+        if *remaining == 0 {
+            lease.status = CapabilityLeaseStatus::Consumed;
+        } else if was_claimed {
+            lease.status = CapabilityLeaseStatus::Active;
+        }
+    } else if was_claimed {
+        lease.status = CapabilityLeaseStatus::Active;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_connect(db: &libsql::Database) -> Result<libsql::Connection, CapabilityLeaseError> {
+    let conn = db.connect().map_err(db_error)?;
+    conn.query("PRAGMA busy_timeout = 5000", ())
+        .await
+        .map_err(db_error)?;
+    Ok(conn)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_begin_immediate(
+    db: &libsql::Database,
+) -> Result<libsql::Connection, CapabilityLeaseError> {
+    let conn = libsql_connect(db).await?;
+    conn.execute("BEGIN IMMEDIATE", ())
+        .await
+        .map_err(db_error)?;
+    Ok(conn)
+}
+
+#[cfg(feature = "libsql")]
+async fn finish_libsql_transaction<T>(
+    conn: &libsql::Connection,
+    result: Result<T, CapabilityLeaseError>,
+) -> Result<T, CapabilityLeaseError> {
+    match result {
+        Ok(value) => {
+            conn.execute("COMMIT", ()).await.map_err(db_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(error)
+        }
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_get_lease(
+    conn: &libsql::Connection,
+    scope: &ResourceScope,
+    lease_id: CapabilityGrantId,
+) -> Result<Option<CapabilityLease>, CapabilityLeaseError> {
+    let mut rows = conn.query("SELECT invocation_id, status, payload FROM reborn_capability_lease_records WHERE owner_key = ?1 AND invocation_id = ?2 AND lease_id = ?3", libsql::params![owner_key(scope)?, scope.invocation_id.to_string(), lease_id.to_string()]).await.map_err(db_error)?;
+    let Some(row) = rows.next().await.map_err(db_error)? else {
+        return Ok(None);
+    };
+    let invocation_id: String = row.get(0).map_err(db_error)?;
+    let status: String = row.get(1).map_err(db_error)?;
+    let payload: String = row.get(2).map_err(db_error)?;
+    validate_lease_row(
+        from_json(&payload)?,
+        scope,
+        lease_id,
+        &invocation_id,
+        &status,
+    )
+    .map(Some)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_upsert_lease(
+    conn: &libsql::Connection,
+    lease: &CapabilityLease,
+) -> Result<(), CapabilityLeaseError> {
+    conn.execute("INSERT INTO reborn_capability_lease_records (owner_key, invocation_id, lease_id, status, payload) VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(owner_key, invocation_id, lease_id) DO UPDATE SET status = excluded.status, payload = excluded.payload", libsql::params![owner_key(&lease.scope)?, lease.scope.invocation_id.to_string(), lease.grant.id.to_string(), lease_status_key(lease.status), to_json(lease)?]).await.map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_leases_for_scope(
+    conn: &libsql::Connection,
+    scope: &ResourceScope,
+) -> Result<Vec<CapabilityLease>, CapabilityLeaseError> {
+    let mut rows = conn.query("SELECT invocation_id, lease_id, status, payload FROM reborn_capability_lease_records WHERE owner_key = ?1 ORDER BY lease_id", libsql::params![owner_key(scope)?]).await.map_err(db_error)?;
+    let mut leases = Vec::new();
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let invocation_id: String = row.get(0).map_err(db_error)?;
+        let lease_id: String = row.get(1).map_err(db_error)?;
+        let lease_id = parse_lease_id(&lease_id)?;
+        let status: String = row.get(2).map_err(db_error)?;
+        let payload: String = row.get(3).map_err(db_error)?;
+        leases.push(validate_lease_row(
+            from_json(&payload)?,
+            scope,
+            lease_id,
+            &invocation_id,
+            &status,
+        )?);
+    }
+    leases.sort_by_key(|lease| lease.grant.id.as_uuid());
+    Ok(leases)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get_lease(
+    client: &impl deadpool_postgres::GenericClient,
+    scope: &ResourceScope,
+    lease_id: CapabilityGrantId,
+    for_update: bool,
+) -> Result<Option<CapabilityLease>, CapabilityLeaseError> {
+    let query = if for_update {
+        "SELECT invocation_id, status, payload::text FROM reborn_capability_lease_records WHERE owner_key = $1 AND invocation_id = $2 AND lease_id = $3 FOR UPDATE"
+    } else {
+        "SELECT invocation_id, status, payload::text FROM reborn_capability_lease_records WHERE owner_key = $1 AND invocation_id = $2 AND lease_id = $3"
+    };
+    let row = client
+        .query_opt(
+            query,
+            &[
+                &owner_key(scope)?,
+                &scope.invocation_id.to_string(),
+                &lease_id.to_string(),
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let invocation_id: String = row.get(0);
+    let status: String = row.get(1);
+    let payload: String = row.get(2);
+    validate_lease_row(
+        from_json(&payload)?,
+        scope,
+        lease_id,
+        &invocation_id,
+        &status,
+    )
+    .map(Some)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_upsert_lease(
+    client: &impl deadpool_postgres::GenericClient,
+    lease: &CapabilityLease,
+) -> Result<(), CapabilityLeaseError> {
+    client.execute("INSERT INTO reborn_capability_lease_records (owner_key, invocation_id, lease_id, status, payload) VALUES ($1, $2, $3, $4, $5::jsonb) ON CONFLICT(owner_key, invocation_id, lease_id) DO UPDATE SET status = EXCLUDED.status, payload = EXCLUDED.payload", &[&owner_key(&lease.scope)?, &lease.scope.invocation_id.to_string(), &lease.grant.id.to_string(), &lease_status_key(lease.status), &to_json(lease)?]).await.map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_leases_for_scope(
+    client: &impl deadpool_postgres::GenericClient,
+    scope: &ResourceScope,
+) -> Result<Vec<CapabilityLease>, CapabilityLeaseError> {
+    let rows = client.query("SELECT invocation_id, lease_id, status, payload::text FROM reborn_capability_lease_records WHERE owner_key = $1 ORDER BY lease_id", &[&owner_key(scope)?]).await.map_err(db_error)?;
+    let mut leases = Vec::new();
+    for row in rows {
+        let invocation_id: String = row.get(0);
+        let lease_id: String = row.get(1);
+        let lease_id = parse_lease_id(&lease_id)?;
+        let status: String = row.get(2);
+        let payload: String = row.get(3);
+        leases.push(validate_lease_row(
+            from_json(&payload)?,
+            scope,
+            lease_id,
+            &invocation_id,
+            &status,
+        )?);
+    }
+    leases.sort_by_key(|lease| lease.grant.id.as_uuid());
+    Ok(leases)
+}
+
+fn validate_lease_row(
+    lease: CapabilityLease,
+    expected_scope: &ResourceScope,
+    expected_lease_id: CapabilityGrantId,
+    row_invocation_id: &str,
+    row_status: &str,
+) -> Result<CapabilityLease, CapabilityLeaseError> {
+    if !same_scope_owner(&lease.scope, expected_scope)
+        || lease.scope.invocation_id.to_string() != row_invocation_id
+        || lease.grant.id != expected_lease_id
+        || lease_status_key(lease.status) != row_status
+    {
+        return Err(CapabilityLeaseError::Persistence {
+            reason: "capability lease row payload mismatch".to_string(),
+        });
+    }
+    Ok(lease)
+}
+
+fn owner_key(scope: &ResourceScope) -> Result<String, CapabilityLeaseError> {
+    #[derive(serde::Serialize)]
+    struct OwnerKey<'a> {
+        tenant_id: &'a str,
+        user_id: &'a str,
+        agent_id: Option<&'a str>,
+        project_id: Option<&'a str>,
+        mission_id: Option<&'a str>,
+        thread_id: Option<&'a str>,
+    }
+    to_json(&OwnerKey {
+        tenant_id: scope.tenant_id.as_str(),
+        user_id: scope.user_id.as_str(),
+        agent_id: scope.agent_id.as_ref().map(|id| id.as_str()),
+        project_id: scope.project_id.as_ref().map(|id| id.as_str()),
+        mission_id: scope.mission_id.as_ref().map(|id| id.as_str()),
+        thread_id: scope.thread_id.as_ref().map(|id| id.as_str()),
+    })
+}
+
+fn lease_status_key(status: CapabilityLeaseStatus) -> &'static str {
+    match status {
+        CapabilityLeaseStatus::Active => "active",
+        CapabilityLeaseStatus::Claimed => "claimed",
+        CapabilityLeaseStatus::Consumed => "consumed",
+        CapabilityLeaseStatus::Revoked => "revoked",
+    }
+}
+
+fn parse_lease_id(value: &str) -> Result<CapabilityGrantId, CapabilityLeaseError> {
+    CapabilityGrantId::parse(value).map_err(|error| CapabilityLeaseError::Persistence {
+        reason: error.to_string(),
+    })
+}
+
+fn to_json<T: serde::Serialize>(value: &T) -> Result<String, CapabilityLeaseError> {
+    serde_json::to_string(value).map_err(|error| CapabilityLeaseError::Persistence {
+        reason: error.to_string(),
+    })
+}
+
+fn from_json<T: serde::de::DeserializeOwned>(payload: &str) -> Result<T, CapabilityLeaseError> {
+    serde_json::from_str(payload).map_err(|error| CapabilityLeaseError::Persistence {
+        reason: error.to_string(),
+    })
+}
+
+fn db_error(error: impl std::fmt::Display) -> CapabilityLeaseError {
+    tracing::debug!(%error, "capability lease database operation failed");
+    CapabilityLeaseError::Persistence {
+        reason: "capability lease database unavailable".to_string(),
+    }
+}

--- a/crates/ironclaw_authorization/src/db.rs
+++ b/crates/ironclaw_authorization/src/db.rs
@@ -392,7 +392,7 @@ async fn libsql_leases_for_scope(
     while let Some(row) = rows.next().await.map_err(db_error)? {
         let invocation_id: String = row.get(0).map_err(db_error)?;
         let lease_id: String = row.get(1).map_err(db_error)?;
-        let lease_id = parse_lease_id(&lease_id)?;
+        let lease_id = parse_lease_id_column(&lease_id)?;
         let status: String = row.get(2).map_err(db_error)?;
         let payload: String = row.get(3).map_err(db_error)?;
         leases.push(validate_lease_row(
@@ -465,7 +465,7 @@ async fn postgres_leases_for_scope(
     for row in rows {
         let invocation_id: String = row.get(0);
         let lease_id: String = row.get(1);
-        let lease_id = parse_lease_id(&lease_id)?;
+        let lease_id = parse_lease_id_column(&lease_id)?;
         let status: String = row.get(2);
         let payload: String = row.get(3);
         leases.push(validate_lease_row(
@@ -528,10 +528,17 @@ fn lease_status_key(status: CapabilityLeaseStatus) -> &'static str {
     }
 }
 
-fn parse_lease_id(value: &str) -> Result<CapabilityGrantId, CapabilityLeaseError> {
-    CapabilityGrantId::parse(value).map_err(|error| CapabilityLeaseError::Persistence {
-        reason: error.to_string(),
-    })
+fn parse_lease_id_column(value: &str) -> Result<CapabilityGrantId, CapabilityLeaseError> {
+    let lease_id =
+        CapabilityGrantId::parse(value).map_err(|error| CapabilityLeaseError::Persistence {
+            reason: error.to_string(),
+        })?;
+    if value != lease_id.to_string() {
+        return Err(CapabilityLeaseError::Persistence {
+            reason: "capability lease row has non-canonical lease_id column".to_string(),
+        });
+    }
+    Ok(lease_id)
 }
 
 fn to_json<T: serde::Serialize>(value: &T) -> Result<String, CapabilityLeaseError> {

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -5,6 +5,14 @@
 //! runtime internals. The first slices implement grant- and lease-backed gates
 //! for capability dispatch.
 
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+mod db;
+
+#[cfg(feature = "libsql")]
+pub use db::LibSqlCapabilityLeaseStore;
+#[cfg(feature = "postgres")]
+pub use db::PostgresCapabilityLeaseStore;
+
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex, MutexGuard},
@@ -1174,14 +1182,14 @@ where
     }
 }
 
-fn lease_is_authorizing(lease: &CapabilityLease, context: &ExecutionContext) -> bool {
+pub(crate) fn lease_is_authorizing(lease: &CapabilityLease, context: &ExecutionContext) -> bool {
     lease.status == CapabilityLeaseStatus::Active
         && lease.scope.invocation_id == context.invocation_id
         && !lease_is_expired(lease)
         && lease.grant.constraints.max_invocations != Some(0)
 }
 
-fn ensure_claimable(
+pub(crate) fn ensure_claimable(
     lease: &CapabilityLease,
     invocation_fingerprint: &InvocationFingerprint,
 ) -> Result<(), CapabilityLeaseError> {
@@ -1198,7 +1206,7 @@ fn ensure_claimable(
     ensure_not_expired_or_exhausted(lease)
 }
 
-fn ensure_consumable(lease: &CapabilityLease) -> Result<(), CapabilityLeaseError> {
+pub(crate) fn ensure_consumable(lease: &CapabilityLease) -> Result<(), CapabilityLeaseError> {
     let lease_id = lease.grant.id;
     match lease.status {
         CapabilityLeaseStatus::Active | CapabilityLeaseStatus::Claimed => {}
@@ -1241,7 +1249,7 @@ fn lease_is_expired(lease: &CapabilityLease) -> bool {
         .is_some_and(|expires_at| expires_at <= Utc::now())
 }
 
-fn same_scope_owner(left: &ResourceScope, right: &ResourceScope) -> bool {
+pub(crate) fn same_scope_owner(left: &ResourceScope, right: &ResourceScope) -> bool {
     left.tenant_id == right.tenant_id
         && left.user_id == right.user_id
         && left.agent_id == right.agent_id

--- a/crates/ironclaw_authorization/tests/db_capability_lease_store_contract.rs
+++ b/crates/ironclaw_authorization/tests/db_capability_lease_store_contract.rs
@@ -89,7 +89,43 @@ async fn libsql_capability_lease_store_preserves_fingerprint_claim_guard() {
     ));
 }
 
+#[tokio::test]
+async fn libsql_capability_lease_store_ignores_non_canonical_lease_id_rows() {
+    let (store, db) = libsql_store_with_db().await;
+    let context = execution_context(CapabilitySet::default());
+    let lease = lease_for(&context);
+    let canonical_lease_id = lease.grant.id.to_string();
+    let non_canonical_lease_id = canonical_lease_id.to_uppercase();
+    assert_ne!(canonical_lease_id, non_canonical_lease_id);
+
+    let conn = db.connect().unwrap();
+    conn.execute(
+        "INSERT INTO reborn_capability_lease_records (owner_key, invocation_id, lease_id, status, payload) VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params![
+            owner_key(&context.resource_scope),
+            context.resource_scope.invocation_id.to_string(),
+            non_canonical_lease_id,
+            "active",
+            serde_json::to_string(&lease).unwrap(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        store
+            .leases_for_scope(&context.resource_scope)
+            .await
+            .is_empty(),
+        "non-canonical row keys must not produce authorizing leases that exact consume/revoke lookups cannot find"
+    );
+}
+
 async fn libsql_store() -> LibSqlCapabilityLeaseStore {
+    libsql_store_with_db().await.0
+}
+
+async fn libsql_store_with_db() -> (LibSqlCapabilityLeaseStore, Arc<libsql::Database>) {
     let dir = tempfile::tempdir().unwrap().keep();
     let db = Arc::new(
         libsql::Builder::new_local(dir.join("capability-leases.db"))
@@ -97,9 +133,30 @@ async fn libsql_store() -> LibSqlCapabilityLeaseStore {
             .await
             .unwrap(),
     );
-    let store = LibSqlCapabilityLeaseStore::new(db);
+    let store = LibSqlCapabilityLeaseStore::new(Arc::clone(&db));
     store.run_migrations().await.unwrap();
-    store
+    (store, db)
+}
+
+fn owner_key(scope: &ResourceScope) -> String {
+    #[derive(serde::Serialize)]
+    struct OwnerKey<'a> {
+        tenant_id: &'a str,
+        user_id: &'a str,
+        agent_id: Option<&'a str>,
+        project_id: Option<&'a str>,
+        mission_id: Option<&'a str>,
+        thread_id: Option<&'a str>,
+    }
+    serde_json::to_string(&OwnerKey {
+        tenant_id: scope.tenant_id.as_str(),
+        user_id: scope.user_id.as_str(),
+        agent_id: scope.agent_id.as_ref().map(|id| id.as_str()),
+        project_id: scope.project_id.as_ref().map(|id| id.as_str()),
+        mission_id: scope.mission_id.as_ref().map(|id| id.as_str()),
+        thread_id: scope.thread_id.as_ref().map(|id| id.as_str()),
+    })
+    .unwrap()
 }
 
 fn lease_for(context: &ExecutionContext) -> CapabilityLease {

--- a/crates/ironclaw_authorization/tests/db_capability_lease_store_contract.rs
+++ b/crates/ironclaw_authorization/tests/db_capability_lease_store_contract.rs
@@ -1,0 +1,159 @@
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+
+use ironclaw_authorization::{
+    CapabilityLease, CapabilityLeaseError, CapabilityLeaseStatus, CapabilityLeaseStore,
+    LibSqlCapabilityLeaseStore,
+};
+use ironclaw_host_api::*;
+
+#[tokio::test]
+async fn libsql_capability_lease_store_persists_and_reloads_issued_leases() {
+    let store = libsql_store().await;
+    let context = execution_context(CapabilitySet::default());
+    let lease = lease_for(&context);
+    let lease_id = lease.grant.id;
+
+    store.issue(lease.clone()).await.unwrap();
+    assert_eq!(
+        store.get(&context.resource_scope, lease_id).await,
+        Some(lease)
+    );
+    assert_eq!(
+        store.leases_for_scope(&context.resource_scope).await.len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn libsql_capability_lease_store_persists_revoke_claim_and_consume() {
+    let store = libsql_store().await;
+    let context = execution_context(CapabilitySet::default());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &capability_id(),
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message":"approved"}),
+    )
+    .unwrap();
+    let mut lease = lease_for(&context);
+    lease.invocation_fingerprint = Some(fingerprint.clone());
+    lease.grant.constraints.max_invocations = Some(1);
+    let lease_id = lease.grant.id;
+    store.issue(lease).await.unwrap();
+
+    let claimed = store
+        .claim(&context.resource_scope, lease_id, &fingerprint)
+        .await
+        .unwrap();
+    assert_eq!(claimed.status, CapabilityLeaseStatus::Claimed);
+
+    let consumed = store
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+    assert_eq!(consumed.status, CapabilityLeaseStatus::Consumed);
+    assert_eq!(consumed.grant.constraints.max_invocations, Some(0));
+
+    let revoked = store
+        .revoke(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+    assert_eq!(revoked.status, CapabilityLeaseStatus::Revoked);
+}
+
+#[tokio::test]
+async fn libsql_capability_lease_store_preserves_fingerprint_claim_guard() {
+    let store = libsql_store().await;
+    let context = execution_context(CapabilitySet::default());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &capability_id(),
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message":"approved"}),
+    )
+    .unwrap();
+    let mut lease = lease_for(&context);
+    lease.invocation_fingerprint = Some(fingerprint);
+    let lease_id = lease.grant.id;
+    store.issue(lease).await.unwrap();
+
+    let err = store
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        CapabilityLeaseError::UnclaimedFingerprintLease { lease_id: id } if id == lease_id
+    ));
+}
+
+async fn libsql_store() -> LibSqlCapabilityLeaseStore {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db = Arc::new(
+        libsql::Builder::new_local(dir.join("capability-leases.db"))
+            .build()
+            .await
+            .unwrap(),
+    );
+    let store = LibSqlCapabilityLeaseStore::new(db);
+    store.run_migrations().await.unwrap();
+    store
+}
+
+fn lease_for(context: &ExecutionContext) -> CapabilityLease {
+    CapabilityLease::new(
+        context.resource_scope.clone(),
+        CapabilityGrant {
+            id: CapabilityGrantId::new(),
+            capability: capability_id(),
+            grantee: Principal::Extension(context.extension_id.clone()),
+            issued_by: Principal::HostRuntime,
+            constraints: GrantConstraints {
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: MountView::default(),
+                network: NetworkPolicy::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at: None,
+                max_invocations: None,
+            },
+        },
+    )
+}
+
+fn execution_context(grants: CapabilitySet) -> ExecutionContext {
+    let invocation_id = InvocationId::new();
+    let resource_scope = ResourceScope {
+        tenant_id: TenantId::new("tenant1").unwrap(),
+        user_id: UserId::new("user1").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id,
+    };
+    ExecutionContext {
+        invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: resource_scope.tenant_id.clone(),
+        user_id: resource_scope.user_id.clone(),
+        agent_id: resource_scope.agent_id.clone(),
+        project_id: resource_scope.project_id.clone(),
+        mission_id: resource_scope.mission_id.clone(),
+        thread_id: resource_scope.thread_id.clone(),
+        extension_id: ExtensionId::new("caller").unwrap(),
+        runtime: RuntimeKind::Wasm,
+        trust: TrustClass::Sandbox,
+        grants,
+        mounts: MountView::default(),
+        resource_scope,
+    }
+}
+
+fn capability_id() -> CapabilityId {
+    CapabilityId::new("echo.say").unwrap()
+}


### PR DESCRIPTION
## Summary
- add feature-gated libSQL/Postgres `CapabilityLeaseStore` implementations
- persist scoped capability leases with owner/invocation/lease columns plus validated JSON payloads
- preserve lease lifecycle semantics for issue, revoke, claim, consume, scope listing, and active context lookup
- add libSQL contract tests for persistence, lifecycle mutation, and fingerprint claim guards

## Verification
- `cargo test -p ironclaw_authorization --features libsql --test db_capability_lease_store_contract`
- `cargo test -p ironclaw_authorization --features libsql`
- `cargo clippy -p ironclaw_authorization --features postgres --tests -- -D warnings`
- `cargo clippy -p ironclaw_authorization --features libsql,postgres --tests -- -D warnings`

Stacked on #3349 because run-state/approval DB stores are the adjacent control-store slice.

Refs #3333, #3026, #3087