### PR TITLE
feat(reborn): add durable conversation state backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,12 +4056,17 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "deadpool-postgres",
  "ironclaw_host_api",
  "ironclaw_turns",
+ "libsql",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
  "uuid",
 ]
 

--- a/crates/ironclaw_conversations/Cargo.toml
+++ b/crates/ironclaw_conversations/Cargo.toml
@@ -13,12 +13,23 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+deadpool-postgres = { version = "0.14", optional = true }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 thiserror = "2"
+tokio = { version = "1", features = ["sync"] }
+tokio-postgres = { version = "0.7", optional = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 
+[features]
+default = []
+libsql = ["dep:libsql"]
+postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
+
 [dev-dependencies]
-serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt"] }
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/crates/ironclaw_conversations/src/error.rs
+++ b/crates/ironclaw_conversations/src/error.rs
@@ -23,4 +23,6 @@ pub enum InboundTurnError {
     InvalidCanonicalRef { reason: String },
     #[error("turn submission failed: {error}")]
     TurnSubmissionFailed { error: TurnError },
+    #[error("durable conversation state failed: {reason}")]
+    DurableState { reason: String },
 }

--- a/crates/ironclaw_conversations/src/ids.rs
+++ b/crates/ironclaw_conversations/src/ids.rs
@@ -75,11 +75,22 @@ pub struct ExternalConversationRef {
     message_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct ExternalConversationIdentity {
-    space_id: Option<String>,
-    conversation_id: String,
-    thread_id: Option<String>,
+    pub(crate) space_id: Option<String>,
+    pub(crate) conversation_id: String,
+    pub(crate) thread_id: Option<String>,
+}
+
+impl ExternalConversationIdentity {
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    pub(crate) fn conversation_fingerprint(&self) -> String {
+        length_prefixed_fingerprint(&[
+            self.space_id.as_deref().unwrap_or(""),
+            &self.conversation_id,
+            self.thread_id.as_deref().unwrap_or(""),
+        ])
+    }
 }
 
 impl ExternalConversationRef {
@@ -177,6 +188,30 @@ impl<'de> Deserialize<'de> for ExternalActorRef {
 
         let raw = RawExternalActorRef::deserialize(deserializer)?;
         Self::new(raw.kind, raw.id).map_err(serde::de::Error::custom)
+    }
+}
+
+impl<'de> Deserialize<'de> for ExternalConversationIdentity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawExternalConversationIdentity {
+            space_id: Option<String>,
+            conversation_id: String,
+            thread_id: Option<String>,
+        }
+
+        let raw = RawExternalConversationIdentity::deserialize(deserializer)?;
+        ExternalConversationRef::new(
+            raw.space_id.as_deref(),
+            raw.conversation_id.as_str(),
+            raw.thread_id.as_deref(),
+            None,
+        )
+        .map(|conversation_ref| conversation_ref.identity())
+        .map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/ironclaw_conversations/src/lib.rs
+++ b/crates/ironclaw_conversations/src/lib.rs
@@ -9,7 +9,13 @@
 mod error;
 mod ids;
 mod inbound;
+#[cfg(feature = "libsql")]
+mod libsql;
 mod memory;
+#[cfg(feature = "postgres")]
+mod postgres;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+mod state_store;
 mod traits;
 mod types;
 
@@ -19,7 +25,11 @@ pub use ids::{
     ExternalConversationRef, ExternalEventId, InboundMessageContentRef,
 };
 pub use inbound::InboundTurnService;
+#[cfg(feature = "libsql")]
+pub use libsql::{RebornLibSqlConversationServices, RebornLibSqlConversationStateStore};
 pub use memory::InMemoryConversationServices;
+#[cfg(feature = "postgres")]
+pub use postgres::{RebornPostgresConversationServices, RebornPostgresConversationStateStore};
 pub use traits::{ConversationBindingService, ConversationBindingServiceExt, SessionThreadService};
 pub use types::{
     AcceptInboundMessageRequest, AcceptedInboundMessage, AcceptedInboundMessageLookup,

--- a/crates/ironclaw_conversations/src/libsql.rs
+++ b/crates/ironclaw_conversations/src/libsql.rs
@@ -1,0 +1,787 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    InMemoryConversationServices, InboundTurnError, ThreadMessageRecord,
+    memory::{
+        ActorKey, BindingKey, BindingRecord, InMemoryState, MessageIdempotencyKey,
+        ReplyTargetRecord, ThreadKey, ThreadRecord,
+    },
+    state_store::{ConversationStateRepository, PersistedConversationState},
+};
+
+const STATE_KEY: &str = "default";
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS reborn_conversation_state_meta (
+    state_key TEXT PRIMARY KEY,
+    version INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO reborn_conversation_state_meta (state_key, version) VALUES ('default', 0);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_actor_pairings (
+    tenant_id TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    external_actor_kind TEXT NOT NULL,
+    external_actor_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    key_payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, adapter_kind, adapter_installation_id, external_actor_kind, external_actor_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_threads (
+    tenant_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    agent_id TEXT,
+    project_id TEXT,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, thread_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_thread_participants (
+    tenant_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, thread_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_bindings (
+    tenant_id TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    conversation_fingerprint TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    source_binding_ref TEXT NOT NULL UNIQUE,
+    reply_target_binding_ref TEXT NOT NULL,
+    owner_external_actor_kind TEXT NOT NULL,
+    owner_external_actor_id TEXT NOT NULL,
+    shared INTEGER NOT NULL,
+    key_payload TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, adapter_kind, adapter_installation_id, conversation_key)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_conversation_bindings_thread
+    ON reborn_conversation_bindings(tenant_id, thread_id);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_reply_targets (
+    reply_target_binding_ref TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    source_binding_ref TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    conversation_fingerprint TEXT NOT NULL,
+    owner_external_actor_kind TEXT NOT NULL,
+    owner_external_actor_id TEXT NOT NULL,
+    shared INTEGER NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_conversation_reply_targets_thread
+    ON reborn_conversation_reply_targets(tenant_id, thread_id);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_external_event_routes (
+    tenant_id TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    external_event_id TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    conversation_fingerprint TEXT NOT NULL,
+    key_payload TEXT NOT NULL,
+    identity_payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, adapter_kind, adapter_installation_id, external_event_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_accepted_messages (
+    message_ref TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    source_binding_ref TEXT NOT NULL,
+    reply_target_binding_ref TEXT NOT NULL,
+    external_event_id TEXT NOT NULL,
+    actor_user_id TEXT NOT NULL,
+    content_ref TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    UNIQUE (tenant_id, source_binding_ref, external_event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_conversation_accepted_messages_thread
+    ON reborn_conversation_accepted_messages(tenant_id, thread_id);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_message_replays (
+    tenant_id TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    external_actor_kind TEXT NOT NULL,
+    external_actor_id TEXT NOT NULL,
+    external_event_id TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    conversation_fingerprint TEXT NOT NULL,
+    message_ref TEXT NOT NULL,
+    key_payload TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, adapter_kind, adapter_installation_id, external_actor_kind, external_actor_id, external_event_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_submission_keys (
+    message_ref TEXT PRIMARY KEY,
+    idempotency_key TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_submit_responses (
+    message_ref TEXT PRIMARY KEY,
+    payload TEXT NOT NULL
+);
+"#;
+
+const TABLES: &[&str] = &[
+    "reborn_conversation_submit_responses",
+    "reborn_conversation_submission_keys",
+    "reborn_conversation_message_replays",
+    "reborn_conversation_accepted_messages",
+    "reborn_conversation_external_event_routes",
+    "reborn_conversation_reply_targets",
+    "reborn_conversation_bindings",
+    "reborn_conversation_thread_participants",
+    "reborn_conversation_threads",
+    "reborn_conversation_actor_pairings",
+];
+
+pub struct RebornLibSqlConversationStateStore {
+    db: Arc<::libsql::Database>,
+}
+
+impl RebornLibSqlConversationStateStore {
+    pub fn new(db: Arc<::libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), InboundTurnError> {
+        let conn = self.connect().await?;
+        conn.execute_batch(SCHEMA).await.map_err(db_error)?;
+        Ok(())
+    }
+
+    async fn connect(&self) -> Result<::libsql::Connection, InboundTurnError> {
+        let conn = self.db.connect().map_err(db_error)?;
+        conn.query("PRAGMA busy_timeout = 5000", ())
+            .await
+            .map_err(db_error)?;
+        Ok(conn)
+    }
+
+    async fn begin_immediate(&self) -> Result<::libsql::Connection, InboundTurnError> {
+        let conn = self.connect().await?;
+        conn.execute("BEGIN IMMEDIATE", ())
+            .await
+            .map_err(db_error)?;
+        Ok(conn)
+    }
+}
+
+#[async_trait]
+impl ConversationStateRepository for RebornLibSqlConversationStateStore {
+    async fn load_state(&self) -> Result<PersistedConversationState, InboundTurnError> {
+        self.run_migrations().await?;
+        let conn = self.connect().await?;
+        conn.execute("BEGIN", ()).await.map_err(db_error)?;
+        let result = load_state_from_conn(&conn).await;
+        finish_transaction(&conn, result).await
+    }
+
+    async fn save_state(
+        &self,
+        expected_revision: i64,
+        state: &InMemoryState,
+    ) -> Result<i64, InboundTurnError> {
+        self.run_migrations().await?;
+        let conn = self.begin_immediate().await?;
+        let result = save_state_to_conn(&conn, expected_revision, state).await;
+        finish_transaction(&conn, result).await
+    }
+}
+
+#[derive(Clone)]
+pub struct RebornLibSqlConversationServices {
+    inner: InMemoryConversationServices,
+}
+
+impl RebornLibSqlConversationServices {
+    pub async fn new(db: Arc<::libsql::Database>) -> Result<Self, InboundTurnError> {
+        let store = Arc::new(RebornLibSqlConversationStateStore::new(db));
+        store.run_migrations().await?;
+        Ok(Self {
+            inner: InMemoryConversationServices::with_state_repository(store).await?,
+        })
+    }
+
+    pub fn inner(&self) -> &InMemoryConversationServices {
+        &self.inner
+    }
+
+    pub async fn pair_external_actor(
+        &self,
+        tenant_id: ironclaw_host_api::TenantId,
+        adapter_kind: crate::AdapterKind,
+        adapter_installation_id: crate::AdapterInstallationId,
+        external_actor_ref: crate::ExternalActorRef,
+        user_id: ironclaw_host_api::UserId,
+    ) -> Result<(), InboundTurnError> {
+        self.inner
+            .try_pair_external_actor(
+                tenant_id,
+                adapter_kind,
+                adapter_installation_id,
+                external_actor_ref,
+                user_id,
+            )
+            .await
+    }
+
+    pub async fn unpair_external_actor(
+        &self,
+        tenant_id: &ironclaw_host_api::TenantId,
+        adapter_kind: &crate::AdapterKind,
+        adapter_installation_id: &crate::AdapterInstallationId,
+        external_actor_ref: &crate::ExternalActorRef,
+    ) -> Result<(), InboundTurnError> {
+        self.inner
+            .try_unpair_external_actor(
+                tenant_id,
+                adapter_kind,
+                adapter_installation_id,
+                external_actor_ref,
+            )
+            .await
+    }
+}
+
+#[async_trait]
+impl crate::ConversationBindingService for RebornLibSqlConversationServices {
+    async fn resolve_or_create_binding(
+        &self,
+        request: crate::ResolveConversationRequest,
+    ) -> Result<crate::ConversationBindingResolution, InboundTurnError> {
+        self.inner.resolve_or_create_binding(request).await
+    }
+
+    async fn link_conversation_to_thread(
+        &self,
+        request: crate::LinkConversationRequest,
+    ) -> Result<crate::LinkedConversationBinding, InboundTurnError> {
+        self.inner.link_conversation_to_thread(request).await
+    }
+
+    async fn validate_reply_target(
+        &self,
+        request: crate::ValidateReplyTargetRequest,
+    ) -> Result<crate::ReplyTargetBinding, InboundTurnError> {
+        self.inner.validate_reply_target(request).await
+    }
+}
+
+#[async_trait]
+impl crate::SessionThreadService for RebornLibSqlConversationServices {
+    async fn accept_inbound_message(
+        &self,
+        request: crate::AcceptInboundMessageRequest,
+    ) -> Result<crate::AcceptedInboundMessage, InboundTurnError> {
+        self.inner.accept_inbound_message(request).await
+    }
+
+    async fn replay_accepted_inbound_message(
+        &self,
+        lookup: crate::AcceptedInboundMessageLookup,
+    ) -> Result<Option<crate::AcceptedInboundMessageReplay>, InboundTurnError> {
+        self.inner.replay_accepted_inbound_message(lookup).await
+    }
+
+    async fn inbound_message_turn_submission(
+        &self,
+        message_ref: &ironclaw_turns::AcceptedMessageRef,
+    ) -> Result<Option<ironclaw_turns::SubmitTurnResponse>, InboundTurnError> {
+        self.inner
+            .inbound_message_turn_submission(message_ref)
+            .await
+    }
+
+    async fn inbound_message_turn_submission_key(
+        &self,
+        message_ref: &ironclaw_turns::AcceptedMessageRef,
+    ) -> Result<ironclaw_turns::IdempotencyKey, InboundTurnError> {
+        self.inner
+            .inbound_message_turn_submission_key(message_ref)
+            .await
+    }
+
+    async fn rotate_inbound_message_turn_submission_key(
+        &self,
+        message_ref: &ironclaw_turns::AcceptedMessageRef,
+    ) -> Result<(), InboundTurnError> {
+        self.inner
+            .rotate_inbound_message_turn_submission_key(message_ref)
+            .await
+    }
+
+    async fn mark_inbound_message_turn_submitted(
+        &self,
+        message_ref: &ironclaw_turns::AcceptedMessageRef,
+        response: ironclaw_turns::SubmitTurnResponse,
+    ) -> Result<(), InboundTurnError> {
+        self.inner
+            .mark_inbound_message_turn_submitted(message_ref, response)
+            .await
+    }
+}
+
+async fn load_state_from_conn(
+    conn: &::libsql::Connection,
+) -> Result<PersistedConversationState, InboundTurnError> {
+    let revision = load_revision(conn).await?;
+    let mut state = InMemoryState::default();
+
+    let mut rows = conn
+        .query(
+            "SELECT key_payload, user_id FROM reborn_conversation_actor_pairings",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let key: ActorKey = from_json(&row.get::<String>(0).map_err(db_error)?)?;
+        let user_id = ironclaw_host_api::UserId::new(row.get::<String>(1).map_err(db_error)?)
+            .map_err(|error| InboundTurnError::DurableState {
+                reason: error.to_string(),
+            })?;
+        state.pairings.insert(key, user_id);
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT key_payload, payload FROM reborn_conversation_bindings",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let key: BindingKey = from_json(&row.get::<String>(0).map_err(db_error)?)?;
+        let binding: BindingRecord = from_json(&row.get::<String>(1).map_err(db_error)?)?;
+        state.source_bindings.insert(
+            binding.source_binding_ref.as_str().to_string(),
+            binding.clone(),
+        );
+        state.bindings.insert(key, binding);
+    }
+
+    let mut rows = conn
+        .query("SELECT payload FROM reborn_conversation_reply_targets", ())
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let reply_target: ReplyTargetRecord = from_json(&row.get::<String>(0).map_err(db_error)?)?;
+        state.reply_targets.insert(
+            reply_target.reply_target_binding_ref.as_str().to_string(),
+            reply_target,
+        );
+    }
+
+    let mut rows = conn
+        .query("SELECT payload FROM reborn_conversation_threads", ())
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let thread_key_and_record: (ThreadKey, ThreadRecord) =
+            from_json(&row.get::<String>(0).map_err(db_error)?)?;
+        state
+            .threads
+            .insert(thread_key_and_record.0, thread_key_and_record.1);
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT tenant_id, thread_id, user_id FROM reborn_conversation_thread_participants",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let tenant_id = ironclaw_host_api::TenantId::new(row.get::<String>(0).map_err(db_error)?)
+            .map_err(|error| InboundTurnError::DurableState {
+            reason: error.to_string(),
+        })?;
+        let thread_id = ironclaw_host_api::ThreadId::new(row.get::<String>(1).map_err(db_error)?)
+            .map_err(|error| InboundTurnError::DurableState {
+            reason: error.to_string(),
+        })?;
+        let user_id = ironclaw_host_api::UserId::new(row.get::<String>(2).map_err(db_error)?)
+            .map_err(|error| InboundTurnError::DurableState {
+                reason: error.to_string(),
+            })?;
+        if let Some(thread) = state
+            .threads
+            .get_mut(&ThreadKey::new(&tenant_id, &thread_id))
+        {
+            thread.participants.insert(user_id);
+        }
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT key_payload, identity_payload FROM reborn_conversation_external_event_routes",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        state.external_event_routes.insert(
+            from_json(&row.get::<String>(0).map_err(db_error)?)?,
+            from_json(&row.get::<String>(1).map_err(db_error)?)?,
+        );
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT payload FROM reborn_conversation_accepted_messages",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let message: ThreadMessageRecord = from_json(&row.get::<String>(0).map_err(db_error)?)?;
+        let idempotency_key = MessageIdempotencyKey {
+            tenant_id: message.accepted.tenant_id.clone(),
+            source_binding_ref: message.accepted.source_binding_ref.as_str().to_string(),
+            external_event_id: message.external_event_id.clone(),
+        };
+        state
+            .message_idempotency
+            .insert(idempotency_key, message.accepted.clone());
+        state.messages.push(message);
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT key_payload, payload FROM reborn_conversation_message_replays",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        state.message_replays.insert(
+            from_json(&row.get::<String>(0).map_err(db_error)?)?,
+            from_json(&row.get::<String>(1).map_err(db_error)?)?,
+        );
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT message_ref, idempotency_key FROM reborn_conversation_submission_keys",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let message_ref =
+            ironclaw_turns::AcceptedMessageRef::new(row.get::<String>(0).map_err(db_error)?)
+                .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+        let key = ironclaw_turns::IdempotencyKey::new(row.get::<String>(1).map_err(db_error)?)
+            .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+        state.submission_keys.insert(message_ref, key);
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT message_ref, payload FROM reborn_conversation_submit_responses",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let message_ref =
+            ironclaw_turns::AcceptedMessageRef::new(row.get::<String>(0).map_err(db_error)?)
+                .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+        state.submitted_message_responses.insert(
+            message_ref,
+            from_json(&row.get::<String>(1).map_err(db_error)?)?,
+        );
+    }
+
+    Ok(PersistedConversationState { state, revision })
+}
+
+async fn save_state_to_conn(
+    conn: &::libsql::Connection,
+    expected_revision: i64,
+    state: &InMemoryState,
+) -> Result<i64, InboundTurnError> {
+    let new_revision = expected_revision + 1;
+    let updated = conn
+        .execute(
+            "UPDATE reborn_conversation_state_meta SET version = ?2 WHERE state_key = ?1 AND version = ?3",
+            ::libsql::params![STATE_KEY, new_revision, expected_revision],
+        )
+        .await
+        .map_err(db_error)?;
+    if updated == 0 {
+        return Err(InboundTurnError::DurableState {
+            reason: "stale conversation state revision".to_string(),
+        });
+    }
+    for table in TABLES {
+        conn.execute(&format!("DELETE FROM {table}"), ())
+            .await
+            .map_err(db_error)?;
+    }
+
+    for (key, user_id) in &state.pairings {
+        conn.execute(
+            "INSERT INTO reborn_conversation_actor_pairings \
+             (tenant_id, adapter_kind, adapter_installation_id, external_actor_kind, external_actor_id, user_id, key_payload) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            ::libsql::params![
+                key.tenant_id.as_str(),
+                key.adapter_kind.as_str(),
+                key.adapter_installation_id.as_str(),
+                key.external_actor_ref.kind(),
+                key.external_actor_ref.id(),
+                user_id.as_str(),
+                to_json(key)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+
+    for (key, thread) in &state.threads {
+        conn.execute(
+            "INSERT INTO reborn_conversation_threads (tenant_id, thread_id, agent_id, project_id, payload) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            ::libsql::params![
+                key.tenant_id.as_str(),
+                key.thread_id.as_str(),
+                thread.agent_id.as_ref().map(|id| id.as_str()),
+                thread.project_id.as_ref().map(|id| id.as_str()),
+                to_json(&(key, thread))?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+        for participant in &thread.participants {
+            conn.execute(
+                "INSERT INTO reborn_conversation_thread_participants (tenant_id, thread_id, user_id) VALUES (?1, ?2, ?3)",
+                ::libsql::params![key.tenant_id.as_str(), key.thread_id.as_str(), participant.as_str()],
+            )
+            .await
+            .map_err(db_error)?;
+        }
+    }
+
+    for (key, binding) in &state.bindings {
+        let conversation_fingerprint = key
+            .external_conversation_identity
+            .conversation_fingerprint();
+        conn.execute(
+            "INSERT INTO reborn_conversation_bindings \
+             (tenant_id, adapter_kind, adapter_installation_id, conversation_key, conversation_fingerprint, thread_id, source_binding_ref, reply_target_binding_ref, owner_external_actor_kind, owner_external_actor_id, shared, key_payload, payload) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            ::libsql::params![
+                key.tenant_id.as_str(),
+                key.adapter_kind.as_str(),
+                key.adapter_installation_id.as_str(),
+                conversation_digest(&conversation_fingerprint),
+                conversation_fingerprint,
+                binding.thread_id.as_str(),
+                binding.source_binding_ref.as_str(),
+                binding.reply_target_binding_ref.as_str(),
+                binding.route_access.owner_actor_key.external_actor_ref.kind(),
+                binding.route_access.owner_actor_key.external_actor_ref.id(),
+                if binding.route_access.shared { 1_i64 } else { 0_i64 },
+                to_json(key)?,
+                to_json(binding)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+
+    for reply_target in state.reply_targets.values() {
+        let conversation_fingerprint = reply_target
+            .external_conversation_ref
+            .conversation_fingerprint();
+        conn.execute(
+            "INSERT INTO reborn_conversation_reply_targets \
+             (reply_target_binding_ref, tenant_id, thread_id, source_binding_ref, adapter_kind, adapter_installation_id, conversation_key, conversation_fingerprint, owner_external_actor_kind, owner_external_actor_id, shared, payload) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            ::libsql::params![
+                reply_target.reply_target_binding_ref.as_str(),
+                reply_target.tenant_id.as_str(),
+                reply_target.thread_id.as_str(),
+                reply_target.source_binding_ref.as_str(),
+                reply_target.adapter_kind.as_str(),
+                reply_target.adapter_installation_id.as_str(),
+                conversation_digest(&conversation_fingerprint),
+                conversation_fingerprint,
+                reply_target.route_access.owner_actor_key.external_actor_ref.kind(),
+                reply_target.route_access.owner_actor_key.external_actor_ref.id(),
+                if reply_target.route_access.shared { 1_i64 } else { 0_i64 },
+                to_json(reply_target)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+
+    for (key, identity) in &state.external_event_routes {
+        let conversation_fingerprint = identity.conversation_fingerprint();
+        conn.execute(
+            "INSERT INTO reborn_conversation_external_event_routes \
+             (tenant_id, adapter_kind, adapter_installation_id, external_event_id, conversation_key, conversation_fingerprint, key_payload, identity_payload) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            ::libsql::params![
+                key.tenant_id.as_str(),
+                key.adapter_kind.as_str(),
+                key.adapter_installation_id.as_str(),
+                key.external_event_id.as_str(),
+                conversation_digest(&conversation_fingerprint),
+                conversation_fingerprint,
+                to_json(key)?,
+                to_json(identity)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+
+    for message in &state.messages {
+        conn.execute(
+            "INSERT INTO reborn_conversation_accepted_messages \
+             (message_ref, tenant_id, thread_id, source_binding_ref, reply_target_binding_ref, external_event_id, actor_user_id, content_ref, received_at, payload) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            ::libsql::params![
+                message.accepted.message_ref.as_str(),
+                message.accepted.tenant_id.as_str(),
+                message.accepted.thread_id.as_str(),
+                message.accepted.source_binding_ref.as_str(),
+                message.accepted.reply_target_binding_ref.as_str(),
+                message.external_event_id.as_str(),
+                message.actor.user_id.as_str(),
+                message.content_ref.as_str(),
+                message.received_at.to_rfc3339(),
+                to_json(message)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+
+    for (key, replay) in &state.message_replays {
+        let conversation_fingerprint = replay
+            .external_conversation_identity
+            .conversation_fingerprint();
+        conn.execute(
+            "INSERT INTO reborn_conversation_message_replays \
+             (tenant_id, adapter_kind, adapter_installation_id, external_actor_kind, external_actor_id, external_event_id, conversation_key, conversation_fingerprint, message_ref, key_payload, payload) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            ::libsql::params![
+                key.tenant_id.as_str(),
+                key.adapter_kind.as_str(),
+                key.adapter_installation_id.as_str(),
+                key.external_actor_ref.kind(),
+                key.external_actor_ref.id(),
+                key.external_event_id.as_str(),
+                conversation_digest(&conversation_fingerprint),
+                conversation_fingerprint,
+                replay.replay.accepted_message.message_ref.as_str(),
+                to_json(key)?,
+                to_json(replay)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+
+    for (message_ref, key) in &state.submission_keys {
+        conn.execute(
+            "INSERT INTO reborn_conversation_submission_keys (message_ref, idempotency_key) VALUES (?1, ?2)",
+            ::libsql::params![message_ref.as_str(), key.as_str()],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+
+    for (message_ref, response) in &state.submitted_message_responses {
+        conn.execute(
+            "INSERT INTO reborn_conversation_submit_responses (message_ref, payload) VALUES (?1, ?2)",
+            ::libsql::params![message_ref.as_str(), to_json(response)?],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+
+    Ok(new_revision)
+}
+
+async fn load_revision(conn: &::libsql::Connection) -> Result<i64, InboundTurnError> {
+    let mut rows = conn
+        .query(
+            "SELECT version FROM reborn_conversation_state_meta WHERE state_key = ?1",
+            ::libsql::params![STATE_KEY],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = rows.next().await.map_err(db_error)? else {
+        return Err(InboundTurnError::DurableState {
+            reason: "missing conversation state metadata row".to_string(),
+        });
+    };
+    row.get(0).map_err(db_error)
+}
+
+async fn finish_transaction<T>(
+    conn: &::libsql::Connection,
+    result: Result<T, InboundTurnError>,
+) -> Result<T, InboundTurnError> {
+    match result {
+        Ok(value) => {
+            conn.execute("COMMIT", ()).await.map_err(db_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(error)
+        }
+    }
+}
+
+fn conversation_digest(fingerprint: &str) -> String {
+    let digest = Sha256::digest(fingerprint.as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn to_json<T: Serialize>(value: &T) -> Result<String, InboundTurnError> {
+    serde_json::to_string(value).map_err(|error| InboundTurnError::DurableState {
+        reason: error.to_string(),
+    })
+}
+
+fn from_json<T: DeserializeOwned>(value: &str) -> Result<T, InboundTurnError> {
+    serde_json::from_str(value).map_err(|error| InboundTurnError::DurableState {
+        reason: error.to_string(),
+    })
+}
+
+fn db_error(error: impl std::error::Error) -> InboundTurnError {
+    InboundTurnError::DurableState {
+        reason: error.to_string(),
+    }
+}

--- a/crates/ironclaw_conversations/src/memory.rs
+++ b/crates/ironclaw_conversations/src/memory.rs
@@ -3,12 +3,16 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use tokio::sync::Mutex as AsyncMutex;
+
 use async_trait::async_trait;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
     AcceptedMessageRef, IdempotencyKey, ReplyTargetBindingRef, SourceBindingRef,
     SubmitTurnResponse, TurnActor, TurnScope,
 };
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
@@ -21,12 +25,87 @@ use crate::{
     ThreadMessageRecord, ValidateReplyTargetRequest,
 };
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct InMemoryConversationServices {
     state: Arc<Mutex<InMemoryState>>,
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    state_repository: Option<Arc<dyn crate::state_store::ConversationStateRepository>>,
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    mutation_lock: Arc<AsyncMutex<()>>,
+}
+
+impl Default for InMemoryConversationServices {
+    fn default() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(InMemoryState::default())),
+            #[cfg(any(feature = "libsql", feature = "postgres"))]
+            state_repository: None,
+            #[cfg(any(feature = "libsql", feature = "postgres"))]
+            mutation_lock: Arc::new(AsyncMutex::new(())),
+        }
+    }
 }
 
 impl InMemoryConversationServices {
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    pub(crate) async fn with_state_repository(
+        state_repository: Arc<dyn crate::state_store::ConversationStateRepository>,
+    ) -> Result<Self, InboundTurnError> {
+        let persisted = state_repository.load_state().await?;
+        let mut state = persisted.state;
+        state.persistence_revision = persisted.revision;
+        Ok(Self {
+            state: Arc::new(Mutex::new(state)),
+            state_repository: Some(state_repository),
+            mutation_lock: Arc::new(AsyncMutex::new(())),
+        })
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    async fn refresh_state_from_repository(&self) -> Result<(), InboundTurnError> {
+        let Some(state_repository) = &self.state_repository else {
+            return Ok(());
+        };
+        let persisted = state_repository.load_state().await?;
+        let mut state = persisted.state;
+        state.persistence_revision = persisted.revision;
+        *self.lock_state()? = state;
+        Ok(())
+    }
+
+    async fn persist_state(
+        &self,
+        old_state: InMemoryState,
+        new_state: InMemoryState,
+    ) -> Result<(), InboundTurnError> {
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        {
+            let mut new_state = new_state;
+            let Some(state_repository) = &self.state_repository else {
+                return Ok(());
+            };
+            match state_repository
+                .save_state(new_state.persistence_revision, &new_state)
+                .await
+            {
+                Ok(revision) => {
+                    new_state.persistence_revision = revision;
+                    *self.lock_state()? = new_state;
+                    Ok(())
+                }
+                Err(error) => {
+                    *self.lock_state()? = old_state;
+                    Err(error)
+                }
+            }
+        }
+        #[cfg(not(any(feature = "libsql", feature = "postgres")))]
+        {
+            let _ = old_state;
+            let _ = new_state;
+            Ok(())
+        }
+    }
     pub async fn pair_external_actor(
         &self,
         tenant_id: TenantId,
@@ -35,7 +114,32 @@ impl InMemoryConversationServices {
         external_actor_ref: ExternalActorRef,
         user_id: UserId,
     ) {
-        if let Ok(mut state) = self.state.lock() {
+        let _ = self
+            .try_pair_external_actor(
+                tenant_id,
+                adapter_kind,
+                adapter_installation_id,
+                external_actor_ref,
+                user_id,
+            )
+            .await;
+    }
+
+    pub async fn try_pair_external_actor(
+        &self,
+        tenant_id: TenantId,
+        adapter_kind: AdapterKind,
+        adapter_installation_id: AdapterInstallationId,
+        external_actor_ref: ExternalActorRef,
+        user_id: UserId,
+    ) -> Result<(), InboundTurnError> {
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let snapshot = {
+            let mut state = self.lock_state()?;
             state.pairings.insert(
                 ActorKey::new(
                     &tenant_id,
@@ -45,7 +149,9 @@ impl InMemoryConversationServices {
                 ),
                 user_id,
             );
-        }
+            state.clone()
+        };
+        self.persist_state(old_state, snapshot).await
     }
 
     pub async fn accepted_messages(&self) -> Vec<ThreadMessageRecord> {
@@ -62,14 +168,39 @@ impl InMemoryConversationServices {
         adapter_installation_id: &AdapterInstallationId,
         external_actor_ref: &ExternalActorRef,
     ) {
-        if let Ok(mut state) = self.state.lock() {
+        let _ = self
+            .try_unpair_external_actor(
+                tenant_id,
+                adapter_kind,
+                adapter_installation_id,
+                external_actor_ref,
+            )
+            .await;
+    }
+
+    pub async fn try_unpair_external_actor(
+        &self,
+        tenant_id: &TenantId,
+        adapter_kind: &AdapterKind,
+        adapter_installation_id: &AdapterInstallationId,
+        external_actor_ref: &ExternalActorRef,
+    ) -> Result<(), InboundTurnError> {
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let snapshot = {
+            let mut state = self.lock_state()?;
             state.pairings.remove(&ActorKey::new(
                 tenant_id,
                 adapter_kind,
                 adapter_installation_id,
                 external_actor_ref,
             ));
-        }
+            state.clone()
+        };
+        self.persist_state(old_state, snapshot).await
     }
 
     pub async fn add_thread_participant(
@@ -78,13 +209,22 @@ impl InMemoryConversationServices {
         thread_id: &ThreadId,
         user_id: UserId,
     ) -> Result<(), InboundTurnError> {
-        let mut state = self.lock_state()?;
-        let Some(thread) = state.threads.get_mut(&ThreadKey::new(tenant_id, thread_id)) else {
-            return Err(InboundTurnError::ThreadNotFound {
-                thread_id: thread_id.to_string(),
-            });
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let snapshot = {
+            let mut state = self.lock_state()?;
+            let Some(thread) = state.threads.get_mut(&ThreadKey::new(tenant_id, thread_id)) else {
+                return Err(InboundTurnError::ThreadNotFound {
+                    thread_id: thread_id.to_string(),
+                });
+            };
+            thread.participants.insert(user_id);
+            state.clone()
         };
-        thread.participants.insert(user_id);
+        self.persist_state(old_state, snapshot).await?;
         Ok(())
     }
 }
@@ -95,79 +235,107 @@ impl ConversationBindingService for InMemoryConversationServices {
         &self,
         request: ResolveConversationRequest,
     ) -> Result<ConversationBindingResolution, InboundTurnError> {
-        let mut state = self.lock_state()?;
-        let actor_user_id = state.resolve_actor(
-            &request.tenant_id,
-            &request.adapter_kind,
-            &request.adapter_installation_id,
-            &request.external_actor_ref,
-        )?;
-        let binding_key = BindingKey::from_request(&request);
-        state.record_external_event_route(
-            &request.tenant_id,
-            &request.adapter_kind,
-            &request.adapter_installation_id,
-            &request.external_event_id,
-            &request.external_conversation_ref.identity(),
-            &actor_user_id,
-        )?;
-        let route_actor_key = ActorKey::new(
-            &request.tenant_id,
-            &request.adapter_kind,
-            &request.adapter_installation_id,
-            &request.external_actor_ref,
-        );
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let (resolution, snapshot) = {
+            let mut state = self.lock_state()?;
+            let actor_user_id = state.resolve_actor(
+                &request.tenant_id,
+                &request.adapter_kind,
+                &request.adapter_installation_id,
+                &request.external_actor_ref,
+            )?;
+            let binding_key = BindingKey::from_request(&request);
+            let external_conversation_identity = request.external_conversation_ref.identity();
+            state.ensure_external_event_route(
+                &request.tenant_id,
+                &request.adapter_kind,
+                &request.adapter_installation_id,
+                &request.external_event_id,
+                &external_conversation_identity,
+                &actor_user_id,
+            )?;
+            let route_actor_key = ActorKey::new(
+                &request.tenant_id,
+                &request.adapter_kind,
+                &request.adapter_installation_id,
+                &request.external_actor_ref,
+            );
 
-        if state.bindings.contains_key(&binding_key) {
-            let binding = state
-                .bindings
-                .get(&binding_key)
-                .cloned()
-                .ok_or(InboundTurnError::StatePoisoned)?;
-            state.ensure_participant(&request.tenant_id, &actor_user_id, &binding.thread_id)?;
-            if !binding
-                .route_access
-                .allows(&route_actor_key, request.route_kind)
-            {
-                return Err(InboundTurnError::AccessDenied {
-                    actor_id: actor_user_id.to_string(),
-                    thread_id: binding.thread_id.to_string(),
-                });
+            if state.bindings.contains_key(&binding_key) {
+                let binding = state
+                    .bindings
+                    .get(&binding_key)
+                    .cloned()
+                    .ok_or(InboundTurnError::StatePoisoned)?;
+                state.ensure_participant(&request.tenant_id, &actor_user_id, &binding.thread_id)?;
+                if !binding
+                    .route_access
+                    .allows(&route_actor_key, request.route_kind)
+                {
+                    return Err(InboundTurnError::AccessDenied {
+                        actor_id: actor_user_id.to_string(),
+                        thread_id: binding.thread_id.to_string(),
+                    });
+                }
+                if request.route_kind == ConversationRouteKind::Shared {
+                    state.widen_binding_route_access(&binding_key)?;
+                }
+                state.record_external_event_route(
+                    &request.tenant_id,
+                    &request.adapter_kind,
+                    &request.adapter_installation_id,
+                    &request.external_event_id,
+                    &external_conversation_identity,
+                    &actor_user_id,
+                )?;
+                let binding = state
+                    .bindings
+                    .get(&binding_key)
+                    .cloned()
+                    .ok_or(InboundTurnError::StatePoisoned)?;
+                let resolution = binding.resolution(actor_user_id, request.tenant_id);
+                (resolution, state.clone())
+            } else {
+                let thread_id = ThreadId::new(Uuid::new_v4().to_string()).map_err(|error| {
+                    InboundTurnError::InvalidCanonicalRef {
+                        reason: error.to_string(),
+                    }
+                })?;
+                let thread = ThreadRecord {
+                    agent_id: None,
+                    project_id: None,
+                    participants: HashSet::from([actor_user_id.clone()]),
+                };
+                state
+                    .threads
+                    .insert(ThreadKey::new(&request.tenant_id, &thread_id), thread);
+                let binding = BindingRecord::new(
+                    request.tenant_id.clone(),
+                    request.adapter_kind.clone(),
+                    request.adapter_installation_id.clone(),
+                    request.external_conversation_ref,
+                    ReplyRouteAccess::new(route_actor_key, request.route_kind),
+                    BindingTarget::new(thread_id, None, None),
+                )?;
+                let resolution =
+                    binding.resolution(actor_user_id.clone(), request.tenant_id.clone());
+                state.store_binding(binding_key, binding);
+                state.record_external_event_route(
+                    &request.tenant_id,
+                    &request.adapter_kind,
+                    &request.adapter_installation_id,
+                    &request.external_event_id,
+                    &external_conversation_identity,
+                    &actor_user_id,
+                )?;
+                (resolution, state.clone())
             }
-            if request.route_kind == ConversationRouteKind::Shared {
-                state.widen_binding_route_access(&binding_key)?;
-            }
-            let binding = state
-                .bindings
-                .get(&binding_key)
-                .cloned()
-                .ok_or(InboundTurnError::StatePoisoned)?;
-            return Ok(binding.resolution(actor_user_id, request.tenant_id));
-        }
-
-        let thread_id = ThreadId::new(Uuid::new_v4().to_string()).map_err(|error| {
-            InboundTurnError::InvalidCanonicalRef {
-                reason: error.to_string(),
-            }
-        })?;
-        let thread = ThreadRecord {
-            agent_id: None,
-            project_id: None,
-            participants: HashSet::from([actor_user_id.clone()]),
         };
-        state
-            .threads
-            .insert(ThreadKey::new(&request.tenant_id, &thread_id), thread);
-        let binding = BindingRecord::new(
-            request.tenant_id.clone(),
-            request.adapter_kind,
-            request.adapter_installation_id,
-            request.external_conversation_ref,
-            ReplyRouteAccess::new(route_actor_key, request.route_kind),
-            BindingTarget::new(thread_id, None, None),
-        )?;
-        let resolution = binding.resolution(actor_user_id, request.tenant_id.clone());
-        state.store_binding(binding_key, binding);
+        self.persist_state(old_state, snapshot).await?;
         Ok(resolution)
     }
 
@@ -175,88 +343,100 @@ impl ConversationBindingService for InMemoryConversationServices {
         &self,
         request: LinkConversationRequest,
     ) -> Result<LinkedConversationBinding, InboundTurnError> {
-        let mut state = self.lock_state()?;
-        let actor_user_id = state.resolve_actor(
-            &request.tenant_id,
-            &request.adapter_kind,
-            &request.adapter_installation_id,
-            &request.external_actor_ref,
-        )?;
-        let target_thread = state.thread_for_participant(
-            &request.tenant_id,
-            &actor_user_id,
-            &request.target_thread_id,
-        )?;
-        let binding_key = BindingKey {
-            tenant_id: request.tenant_id.clone(),
-            adapter_kind: request.adapter_kind.clone(),
-            adapter_installation_id: request.adapter_installation_id.clone(),
-            external_conversation_identity: request.external_conversation_ref.identity(),
-        };
-        if state.bindings.contains_key(&binding_key) {
-            let existing = state
-                .bindings
-                .get(&binding_key)
-                .cloned()
-                .ok_or(InboundTurnError::StatePoisoned)?;
-            if existing.thread_id == request.target_thread_id {
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let (linked, snapshot) = {
+            let mut state = self.lock_state()?;
+            let actor_user_id = state.resolve_actor(
+                &request.tenant_id,
+                &request.adapter_kind,
+                &request.adapter_installation_id,
+                &request.external_actor_ref,
+            )?;
+            let target_thread = state.thread_for_participant(
+                &request.tenant_id,
+                &actor_user_id,
+                &request.target_thread_id,
+            )?;
+            let binding_key = BindingKey {
+                tenant_id: request.tenant_id.clone(),
+                adapter_kind: request.adapter_kind.clone(),
+                adapter_installation_id: request.adapter_installation_id.clone(),
+                external_conversation_identity: request.external_conversation_ref.identity(),
+            };
+            if state.bindings.contains_key(&binding_key) {
+                let existing = state
+                    .bindings
+                    .get(&binding_key)
+                    .cloned()
+                    .ok_or(InboundTurnError::StatePoisoned)?;
+                if existing.thread_id == request.target_thread_id {
+                    let route_actor_key = ActorKey::new(
+                        &request.tenant_id,
+                        &request.adapter_kind,
+                        &request.adapter_installation_id,
+                        &request.external_actor_ref,
+                    );
+                    if !existing
+                        .route_access
+                        .allows(&route_actor_key, request.route_kind)
+                    {
+                        return Err(InboundTurnError::AccessDenied {
+                            actor_id: actor_user_id.to_string(),
+                            thread_id: existing.thread_id.to_string(),
+                        });
+                    }
+                    if request.route_kind == ConversationRouteKind::Shared {
+                        state.widen_binding_route_access(&binding_key)?;
+                    }
+                    let existing = state
+                        .bindings
+                        .get(&binding_key)
+                        .cloned()
+                        .ok_or(InboundTurnError::StatePoisoned)?;
+                    let linked = LinkedConversationBinding {
+                        thread_id: existing.thread_id,
+                        source_binding_ref: existing.source_binding_ref,
+                        reply_target_binding_ref: existing.reply_target_binding_ref,
+                    };
+                    (linked, state.clone())
+                } else {
+                    return Err(InboundTurnError::BindingConflict {
+                        thread_id: existing.thread_id.to_string(),
+                    });
+                }
+            } else {
                 let route_actor_key = ActorKey::new(
                     &request.tenant_id,
                     &request.adapter_kind,
                     &request.adapter_installation_id,
                     &request.external_actor_ref,
                 );
-                if !existing
-                    .route_access
-                    .allows(&route_actor_key, request.route_kind)
-                {
-                    return Err(InboundTurnError::AccessDenied {
-                        actor_id: actor_user_id.to_string(),
-                        thread_id: existing.thread_id.to_string(),
-                    });
-                }
-                if request.route_kind == ConversationRouteKind::Shared {
-                    state.widen_binding_route_access(&binding_key)?;
-                }
-                let existing = state
-                    .bindings
-                    .get(&binding_key)
-                    .cloned()
-                    .ok_or(InboundTurnError::StatePoisoned)?;
-                return Ok(LinkedConversationBinding {
-                    thread_id: existing.thread_id,
-                    source_binding_ref: existing.source_binding_ref,
-                    reply_target_binding_ref: existing.reply_target_binding_ref,
-                });
+                let binding = BindingRecord::new(
+                    request.tenant_id,
+                    request.adapter_kind,
+                    request.adapter_installation_id,
+                    request.external_conversation_ref,
+                    ReplyRouteAccess::new(route_actor_key, request.route_kind),
+                    BindingTarget::new(
+                        request.target_thread_id,
+                        target_thread.agent_id,
+                        target_thread.project_id,
+                    ),
+                )?;
+                let linked = LinkedConversationBinding {
+                    thread_id: binding.thread_id.clone(),
+                    source_binding_ref: binding.source_binding_ref.clone(),
+                    reply_target_binding_ref: binding.reply_target_binding_ref.clone(),
+                };
+                state.store_binding(binding_key, binding);
+                (linked, state.clone())
             }
-            return Err(InboundTurnError::BindingConflict {
-                thread_id: existing.thread_id.to_string(),
-            });
-        }
-        let route_actor_key = ActorKey::new(
-            &request.tenant_id,
-            &request.adapter_kind,
-            &request.adapter_installation_id,
-            &request.external_actor_ref,
-        );
-        let binding = BindingRecord::new(
-            request.tenant_id,
-            request.adapter_kind,
-            request.adapter_installation_id,
-            request.external_conversation_ref,
-            ReplyRouteAccess::new(route_actor_key, request.route_kind),
-            BindingTarget::new(
-                request.target_thread_id,
-                target_thread.agent_id,
-                target_thread.project_id,
-            ),
-        )?;
-        let linked = LinkedConversationBinding {
-            thread_id: binding.thread_id.clone(),
-            source_binding_ref: binding.source_binding_ref.clone(),
-            reply_target_binding_ref: binding.reply_target_binding_ref.clone(),
         };
-        state.store_binding(binding_key, binding);
+        self.persist_state(old_state, snapshot).await?;
         Ok(linked)
     }
 
@@ -264,6 +444,10 @@ impl ConversationBindingService for InMemoryConversationServices {
         &self,
         request: ValidateReplyTargetRequest,
     ) -> Result<ReplyTargetBinding, InboundTurnError> {
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
         let state = self.lock_state()?;
         let Some(binding) = state
             .reply_targets
@@ -323,125 +507,144 @@ impl SessionThreadService for InMemoryConversationServices {
         &self,
         request: AcceptInboundMessageRequest,
     ) -> Result<AcceptedInboundMessage, InboundTurnError> {
-        let mut state = self.lock_state()?;
-        let paired_user_id = state.resolve_actor(
-            &request.tenant_id,
-            &request.adapter_kind,
-            &request.adapter_installation_id,
-            &request.external_actor_ref,
-        )?;
-        if paired_user_id != request.actor.user_id {
-            return Err(InboundTurnError::AccessDenied {
-                actor_id: request.actor.user_id.to_string(),
-                thread_id: request.thread_id.to_string(),
-            });
-        }
-        state.ensure_participant(&request.tenant_id, &paired_user_id, &request.thread_id)?;
-        state.ensure_binding_refs_match(BindingRefValidation {
-            tenant_id: &request.tenant_id,
-            thread_id: &request.thread_id,
-            source_binding_ref: request.source_binding_ref.as_str(),
-            reply_target_binding_ref: request.reply_target_binding_ref.as_str(),
-            actor_user_id: &request.actor.user_id,
-            route_actor_key: &ActorKey::new(
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let (accepted, snapshot) = {
+            let mut state = self.lock_state()?;
+            let paired_user_id = state.resolve_actor(
                 &request.tenant_id,
                 &request.adapter_kind,
                 &request.adapter_installation_id,
                 &request.external_actor_ref,
-            ),
-            route_kind: request.route_kind,
-        })?;
-        let source_binding = state
-            .source_bindings
-            .get(request.source_binding_ref.as_str())
-            .cloned()
-            .ok_or_else(|| InboundTurnError::ThreadNotFound {
-                thread_id: request.source_binding_ref.as_str().to_string(),
+            )?;
+            if paired_user_id != request.actor.user_id {
+                return Err(InboundTurnError::AccessDenied {
+                    actor_id: request.actor.user_id.to_string(),
+                    thread_id: request.thread_id.to_string(),
+                });
+            }
+            state.ensure_participant(&request.tenant_id, &paired_user_id, &request.thread_id)?;
+            state.ensure_binding_refs_match(BindingRefValidation {
+                tenant_id: &request.tenant_id,
+                thread_id: &request.thread_id,
+                source_binding_ref: request.source_binding_ref.as_str(),
+                reply_target_binding_ref: request.reply_target_binding_ref.as_str(),
+                actor_user_id: &request.actor.user_id,
+                route_actor_key: &ActorKey::new(
+                    &request.tenant_id,
+                    &request.adapter_kind,
+                    &request.adapter_installation_id,
+                    &request.external_actor_ref,
+                ),
+                route_kind: request.route_kind,
             })?;
-        let external_conversation_identity = request.external_conversation_ref.identity();
-        if source_binding.external_conversation_identity != external_conversation_identity {
-            return Err(InboundTurnError::AccessDenied {
-                actor_id: request.actor.user_id.to_string(),
-                thread_id: request.thread_id.to_string(),
-            });
-        }
-        state.record_external_event_route(
-            &request.tenant_id,
-            &source_binding.adapter_kind,
-            &source_binding.adapter_installation_id,
-            &request.external_event_id,
-            &external_conversation_identity,
-            &request.actor.user_id,
-        )?;
-        let replay_key = AcceptedMessageReplayKey::new(
-            &request.tenant_id,
-            &request.adapter_kind,
-            &request.adapter_installation_id,
-            &request.external_actor_ref,
-            &request.external_event_id,
-        );
-        let idempotency_key = MessageIdempotencyKey {
-            tenant_id: request.tenant_id.clone(),
-            source_binding_ref: request.source_binding_ref.as_str().to_string(),
-            external_event_id: request.external_event_id.clone(),
+            let source_binding = state
+                .source_bindings
+                .get(request.source_binding_ref.as_str())
+                .cloned()
+                .ok_or_else(|| InboundTurnError::ThreadNotFound {
+                    thread_id: request.source_binding_ref.as_str().to_string(),
+                })?;
+            let external_conversation_identity = request.external_conversation_ref.identity();
+            if source_binding.external_conversation_identity != external_conversation_identity {
+                return Err(InboundTurnError::AccessDenied {
+                    actor_id: request.actor.user_id.to_string(),
+                    thread_id: request.thread_id.to_string(),
+                });
+            }
+            state.ensure_external_event_route(
+                &request.tenant_id,
+                &source_binding.adapter_kind,
+                &source_binding.adapter_installation_id,
+                &request.external_event_id,
+                &external_conversation_identity,
+                &request.actor.user_id,
+            )?;
+            let replay_key = AcceptedMessageReplayKey::new(
+                &request.tenant_id,
+                &request.adapter_kind,
+                &request.adapter_installation_id,
+                &request.external_actor_ref,
+                &request.external_event_id,
+            );
+            let idempotency_key = MessageIdempotencyKey {
+                tenant_id: request.tenant_id.clone(),
+                source_binding_ref: request.source_binding_ref.as_str().to_string(),
+                external_event_id: request.external_event_id.clone(),
+            };
+            if let Some(existing) = state.message_idempotency.get(&idempotency_key) {
+                let mut duplicate = existing.clone();
+                duplicate.idempotency = MessageIdempotencyStatus::Duplicate;
+                (duplicate, state.clone())
+            } else {
+                let message_ref = AcceptedMessageRef::new(format!("message:{}", Uuid::new_v4()))
+                    .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+                let reply_target_record = state
+                    .reply_targets
+                    .get(request.reply_target_binding_ref.as_str())
+                    .cloned()
+                    .ok_or_else(|| InboundTurnError::ThreadNotFound {
+                        thread_id: request.reply_target_binding_ref.as_str().to_string(),
+                    })?;
+                state.record_external_event_route(
+                    &request.tenant_id,
+                    &source_binding.adapter_kind,
+                    &source_binding.adapter_installation_id,
+                    &request.external_event_id,
+                    &external_conversation_identity,
+                    &request.actor.user_id,
+                )?;
+                let message_reply_target_binding_ref =
+                    ReplyTargetBindingRef::new(format!("reply:{}", Uuid::new_v4()))
+                        .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+                state.reply_targets.insert(
+                    message_reply_target_binding_ref.as_str().to_string(),
+                    reply_target_record.with_reply_target(
+                        message_reply_target_binding_ref.clone(),
+                        request.external_conversation_ref.clone(),
+                    ),
+                );
+                let accepted = AcceptedInboundMessage {
+                    tenant_id: request.tenant_id,
+                    thread_id: request.thread_id,
+                    actor: request.actor.clone(),
+                    message_ref,
+                    source_binding_ref: request.source_binding_ref,
+                    reply_target_binding_ref: message_reply_target_binding_ref,
+                    received_at: request.received_at,
+                    requested_run_profile: request.requested_run_profile,
+                    idempotency: MessageIdempotencyStatus::Inserted,
+                };
+                state
+                    .message_idempotency
+                    .insert(idempotency_key, accepted.clone());
+                state.message_replays.insert(
+                    replay_key,
+                    StoredAcceptedMessageReplay {
+                        external_conversation_identity,
+                        replay: AcceptedInboundMessageReplay {
+                            resolution: source_binding.resolution(
+                                accepted.actor.user_id.clone(),
+                                accepted.tenant_id.clone(),
+                            ),
+                            accepted_message: accepted.clone(),
+                        },
+                    },
+                );
+                state.messages.push(ThreadMessageRecord {
+                    accepted: accepted.clone(),
+                    actor: request.actor,
+                    external_event_id: request.external_event_id,
+                    content_ref: request.content_ref,
+                    received_at: request.received_at,
+                });
+                (accepted, state.clone())
+            }
         };
-        if let Some(existing) = state.message_idempotency.get(&idempotency_key) {
-            let mut duplicate = existing.clone();
-            duplicate.idempotency = MessageIdempotencyStatus::Duplicate;
-            return Ok(duplicate);
-        }
-
-        let message_ref = AcceptedMessageRef::new(format!("message:{}", Uuid::new_v4()))
-            .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
-        let reply_target_record = state
-            .reply_targets
-            .get(request.reply_target_binding_ref.as_str())
-            .cloned()
-            .ok_or_else(|| InboundTurnError::ThreadNotFound {
-                thread_id: request.reply_target_binding_ref.as_str().to_string(),
-            })?;
-        let message_reply_target_binding_ref =
-            ReplyTargetBindingRef::new(format!("reply:{}", Uuid::new_v4()))
-                .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
-        state.reply_targets.insert(
-            message_reply_target_binding_ref.as_str().to_string(),
-            reply_target_record.with_reply_target(
-                message_reply_target_binding_ref.clone(),
-                request.external_conversation_ref.clone(),
-            ),
-        );
-        let accepted = AcceptedInboundMessage {
-            tenant_id: request.tenant_id,
-            thread_id: request.thread_id,
-            actor: request.actor.clone(),
-            message_ref,
-            source_binding_ref: request.source_binding_ref,
-            reply_target_binding_ref: message_reply_target_binding_ref,
-            received_at: request.received_at,
-            requested_run_profile: request.requested_run_profile,
-            idempotency: MessageIdempotencyStatus::Inserted,
-        };
-        state
-            .message_idempotency
-            .insert(idempotency_key, accepted.clone());
-        state.message_replays.insert(
-            replay_key,
-            StoredAcceptedMessageReplay {
-                external_conversation_identity,
-                replay: AcceptedInboundMessageReplay {
-                    resolution: source_binding
-                        .resolution(accepted.actor.user_id.clone(), accepted.tenant_id.clone()),
-                    accepted_message: accepted.clone(),
-                },
-            },
-        );
-        state.messages.push(ThreadMessageRecord {
-            accepted: accepted.clone(),
-            actor: request.actor,
-            external_event_id: request.external_event_id,
-            content_ref: request.content_ref,
-            received_at: request.received_at,
-        });
+        self.persist_state(old_state, snapshot).await?;
         Ok(accepted)
     }
 
@@ -449,6 +652,10 @@ impl SessionThreadService for InMemoryConversationServices {
         &self,
         lookup: AcceptedInboundMessageLookup,
     ) -> Result<Option<AcceptedInboundMessageReplay>, InboundTurnError> {
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
         let state = self.lock_state()?;
         let key = AcceptedMessageReplayKey::new(
             &lookup.tenant_id,
@@ -475,6 +682,10 @@ impl SessionThreadService for InMemoryConversationServices {
         &self,
         message_ref: &AcceptedMessageRef,
     ) -> Result<Option<SubmitTurnResponse>, InboundTurnError> {
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
         let state = self.lock_state()?;
         Ok(state.submitted_message_responses.get(message_ref).cloned())
     }
@@ -483,26 +694,45 @@ impl SessionThreadService for InMemoryConversationServices {
         &self,
         message_ref: &AcceptedMessageRef,
     ) -> Result<IdempotencyKey, InboundTurnError> {
-        let mut state = self.lock_state()?;
-        if let Some(key) = state.submission_keys.get(message_ref).cloned() {
-            return Ok(key);
-        }
-        let key = IdempotencyKey::new(message_ref.as_str().to_string())
-            .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
-        state
-            .submission_keys
-            .insert(message_ref.clone(), key.clone());
-        Ok(key)
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let maybe_key_and_snapshot = {
+            let mut state = self.lock_state()?;
+            if let Some(key) = state.submission_keys.get(message_ref).cloned() {
+                return Ok(key);
+            }
+            let key = IdempotencyKey::new(message_ref.as_str().to_string())
+                .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+            state
+                .submission_keys
+                .insert(message_ref.clone(), key.clone());
+            (key, state.clone())
+        };
+        self.persist_state(old_state, maybe_key_and_snapshot.1)
+            .await?;
+        Ok(maybe_key_and_snapshot.0)
     }
 
     async fn rotate_inbound_message_turn_submission_key(
         &self,
         message_ref: &AcceptedMessageRef,
     ) -> Result<(), InboundTurnError> {
-        let mut state = self.lock_state()?;
-        state
-            .submission_keys
-            .insert(message_ref.clone(), state_generated_submission_key()?);
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let snapshot = {
+            let mut state = self.lock_state()?;
+            state
+                .submission_keys
+                .insert(message_ref.clone(), state_generated_submission_key()?);
+            state.clone()
+        };
+        self.persist_state(old_state, snapshot).await?;
         Ok(())
     }
 
@@ -511,10 +741,19 @@ impl SessionThreadService for InMemoryConversationServices {
         message_ref: &AcceptedMessageRef,
         response: SubmitTurnResponse,
     ) -> Result<(), InboundTurnError> {
-        let mut state = self.lock_state()?;
-        state
-            .submitted_message_responses
-            .insert(message_ref.clone(), response);
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        let _mutation = self.mutation_lock.lock().await;
+        #[cfg(any(feature = "libsql", feature = "postgres"))]
+        self.refresh_state_from_repository().await?;
+        let old_state = self.lock_state()?.clone();
+        let snapshot = {
+            let mut state = self.lock_state()?;
+            state
+                .submitted_message_responses
+                .insert(message_ref.clone(), response);
+            state.clone()
+        };
+        self.persist_state(old_state, snapshot).await?;
         Ok(())
     }
 }
@@ -532,19 +771,22 @@ impl InMemoryConversationServices {
     }
 }
 
-#[derive(Default)]
-struct InMemoryState {
-    pairings: HashMap<ActorKey, UserId>,
-    bindings: HashMap<BindingKey, BindingRecord>,
-    source_bindings: HashMap<String, BindingRecord>,
-    reply_targets: HashMap<String, ReplyTargetRecord>,
-    threads: HashMap<ThreadKey, ThreadRecord>,
-    external_event_routes: HashMap<ExternalEventRouteKey, ExternalConversationIdentity>,
-    message_idempotency: HashMap<MessageIdempotencyKey, AcceptedInboundMessage>,
-    message_replays: HashMap<AcceptedMessageReplayKey, StoredAcceptedMessageReplay>,
-    submission_keys: HashMap<AcceptedMessageRef, IdempotencyKey>,
-    submitted_message_responses: HashMap<AcceptedMessageRef, SubmitTurnResponse>,
-    messages: Vec<ThreadMessageRecord>,
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct InMemoryState {
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    #[serde(default, skip)]
+    pub(crate) persistence_revision: i64,
+    pub(crate) pairings: HashMap<ActorKey, UserId>,
+    pub(crate) bindings: HashMap<BindingKey, BindingRecord>,
+    pub(crate) source_bindings: HashMap<String, BindingRecord>,
+    pub(crate) reply_targets: HashMap<String, ReplyTargetRecord>,
+    pub(crate) threads: HashMap<ThreadKey, ThreadRecord>,
+    pub(crate) external_event_routes: HashMap<ExternalEventRouteKey, ExternalConversationIdentity>,
+    pub(crate) message_idempotency: HashMap<MessageIdempotencyKey, AcceptedInboundMessage>,
+    pub(crate) message_replays: HashMap<AcceptedMessageReplayKey, StoredAcceptedMessageReplay>,
+    pub(crate) submission_keys: HashMap<AcceptedMessageRef, IdempotencyKey>,
+    pub(crate) submitted_message_responses: HashMap<AcceptedMessageRef, SubmitTurnResponse>,
+    pub(crate) messages: Vec<ThreadMessageRecord>,
 }
 
 impl InMemoryState {
@@ -744,16 +986,16 @@ struct BindingRefValidation<'a> {
     route_kind: ConversationRouteKind,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ActorKey {
-    tenant_id: TenantId,
-    adapter_kind: AdapterKind,
-    adapter_installation_id: AdapterInstallationId,
-    external_actor_ref: ExternalActorRef,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct ActorKey {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) adapter_kind: AdapterKind,
+    pub(crate) adapter_installation_id: AdapterInstallationId,
+    pub(crate) external_actor_ref: ExternalActorRef,
 }
 
 impl ActorKey {
-    fn new(
+    pub(crate) fn new(
         tenant_id: &TenantId,
         adapter_kind: &AdapterKind,
         adapter_installation_id: &AdapterInstallationId,
@@ -768,16 +1010,16 @@ impl ActorKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct BindingKey {
-    tenant_id: TenantId,
-    adapter_kind: AdapterKind,
-    adapter_installation_id: AdapterInstallationId,
-    external_conversation_identity: ExternalConversationIdentity,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct BindingKey {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) adapter_kind: AdapterKind,
+    pub(crate) adapter_installation_id: AdapterInstallationId,
+    pub(crate) external_conversation_identity: ExternalConversationIdentity,
 }
 
 impl BindingKey {
-    fn from_request(request: &ResolveConversationRequest) -> Self {
+    pub(crate) fn from_request(request: &ResolveConversationRequest) -> Self {
         Self {
             tenant_id: request.tenant_id.clone(),
             adapter_kind: request.adapter_kind.clone(),
@@ -787,16 +1029,16 @@ impl BindingKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ExternalEventRouteKey {
-    tenant_id: TenantId,
-    adapter_kind: AdapterKind,
-    adapter_installation_id: AdapterInstallationId,
-    external_event_id: crate::ExternalEventId,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct ExternalEventRouteKey {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) adapter_kind: AdapterKind,
+    pub(crate) adapter_installation_id: AdapterInstallationId,
+    pub(crate) external_event_id: crate::ExternalEventId,
 }
 
 impl ExternalEventRouteKey {
-    fn new(
+    pub(crate) fn new(
         tenant_id: &TenantId,
         adapter_kind: &AdapterKind,
         adapter_installation_id: &AdapterInstallationId,
@@ -811,14 +1053,14 @@ impl ExternalEventRouteKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ThreadKey {
-    tenant_id: TenantId,
-    thread_id: ThreadId,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct ThreadKey {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) thread_id: ThreadId,
 }
 
 impl ThreadKey {
-    fn new(tenant_id: &TenantId, thread_id: &ThreadId) -> Self {
+    pub(crate) fn new(tenant_id: &TenantId, thread_id: &ThreadId) -> Self {
         Self {
             tenant_id: tenant_id.clone(),
             thread_id: thread_id.clone(),
@@ -826,21 +1068,21 @@ impl ThreadKey {
     }
 }
 
-#[derive(Debug, Clone)]
-struct ThreadRecord {
-    agent_id: Option<AgentId>,
-    project_id: Option<ProjectId>,
-    participants: HashSet<UserId>,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ThreadRecord {
+    pub(crate) agent_id: Option<AgentId>,
+    pub(crate) project_id: Option<ProjectId>,
+    pub(crate) participants: HashSet<UserId>,
 }
 
-#[derive(Debug, Clone)]
-struct ReplyRouteAccess {
-    owner_actor_key: ActorKey,
-    shared: bool,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ReplyRouteAccess {
+    pub(crate) owner_actor_key: ActorKey,
+    pub(crate) shared: bool,
 }
 
 impl ReplyRouteAccess {
-    fn new(owner_actor_key: ActorKey, route_kind: ConversationRouteKind) -> Self {
+    pub(crate) fn new(owner_actor_key: ActorKey, route_kind: ConversationRouteKind) -> Self {
         Self {
             owner_actor_key,
             shared: route_kind == ConversationRouteKind::Shared,
@@ -857,16 +1099,16 @@ impl ReplyRouteAccess {
     }
 }
 
-#[derive(Debug, Clone)]
-struct ReplyTargetRecord {
-    tenant_id: TenantId,
-    adapter_kind: AdapterKind,
-    adapter_installation_id: AdapterInstallationId,
-    external_conversation_ref: ExternalConversationRef,
-    thread_id: ThreadId,
-    source_binding_ref: SourceBindingRef,
-    reply_target_binding_ref: ReplyTargetBindingRef,
-    route_access: ReplyRouteAccess,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ReplyTargetRecord {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) adapter_kind: AdapterKind,
+    pub(crate) adapter_installation_id: AdapterInstallationId,
+    pub(crate) external_conversation_ref: ExternalConversationRef,
+    pub(crate) thread_id: ThreadId,
+    pub(crate) source_binding_ref: SourceBindingRef,
+    pub(crate) reply_target_binding_ref: ReplyTargetBindingRef,
+    pub(crate) route_access: ReplyRouteAccess,
 }
 
 impl ReplyTargetRecord {
@@ -904,15 +1146,19 @@ impl ReplyTargetRecord {
     }
 }
 
-#[derive(Debug, Clone)]
-struct BindingTarget {
-    thread_id: ThreadId,
-    agent_id: Option<AgentId>,
-    project_id: Option<ProjectId>,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BindingTarget {
+    pub(crate) thread_id: ThreadId,
+    pub(crate) agent_id: Option<AgentId>,
+    pub(crate) project_id: Option<ProjectId>,
 }
 
 impl BindingTarget {
-    fn new(thread_id: ThreadId, agent_id: Option<AgentId>, project_id: Option<ProjectId>) -> Self {
+    pub(crate) fn new(
+        thread_id: ThreadId,
+        agent_id: Option<AgentId>,
+        project_id: Option<ProjectId>,
+    ) -> Self {
         Self {
             thread_id,
             agent_id,
@@ -921,23 +1167,23 @@ impl BindingTarget {
     }
 }
 
-#[derive(Debug, Clone)]
-struct BindingRecord {
-    tenant_id: TenantId,
-    adapter_kind: AdapterKind,
-    adapter_installation_id: AdapterInstallationId,
-    external_conversation_ref: ExternalConversationRef,
-    external_conversation_identity: ExternalConversationIdentity,
-    thread_id: ThreadId,
-    agent_id: Option<AgentId>,
-    project_id: Option<ProjectId>,
-    route_access: ReplyRouteAccess,
-    source_binding_ref: SourceBindingRef,
-    reply_target_binding_ref: ReplyTargetBindingRef,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BindingRecord {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) adapter_kind: AdapterKind,
+    pub(crate) adapter_installation_id: AdapterInstallationId,
+    pub(crate) external_conversation_ref: ExternalConversationRef,
+    pub(crate) external_conversation_identity: ExternalConversationIdentity,
+    pub(crate) thread_id: ThreadId,
+    pub(crate) agent_id: Option<AgentId>,
+    pub(crate) project_id: Option<ProjectId>,
+    pub(crate) route_access: ReplyRouteAccess,
+    pub(crate) source_binding_ref: SourceBindingRef,
+    pub(crate) reply_target_binding_ref: ReplyTargetBindingRef,
 }
 
 impl BindingRecord {
-    fn new(
+    pub(crate) fn new(
         tenant_id: TenantId,
         adapter_kind: AdapterKind,
         adapter_installation_id: AdapterInstallationId,
@@ -987,23 +1233,23 @@ impl BindingRecord {
     }
 }
 
-#[derive(Debug, Clone)]
-struct StoredAcceptedMessageReplay {
-    external_conversation_identity: ExternalConversationIdentity,
-    replay: AcceptedInboundMessageReplay,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct StoredAcceptedMessageReplay {
+    pub(crate) external_conversation_identity: ExternalConversationIdentity,
+    pub(crate) replay: AcceptedInboundMessageReplay,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct AcceptedMessageReplayKey {
-    tenant_id: TenantId,
-    adapter_kind: AdapterKind,
-    adapter_installation_id: AdapterInstallationId,
-    external_actor_ref: ExternalActorRef,
-    external_event_id: crate::ExternalEventId,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct AcceptedMessageReplayKey {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) adapter_kind: AdapterKind,
+    pub(crate) adapter_installation_id: AdapterInstallationId,
+    pub(crate) external_actor_ref: ExternalActorRef,
+    pub(crate) external_event_id: crate::ExternalEventId,
 }
 
 impl AcceptedMessageReplayKey {
-    fn new(
+    pub(crate) fn new(
         tenant_id: &TenantId,
         adapter_kind: &AdapterKind,
         adapter_installation_id: &AdapterInstallationId,
@@ -1020,9 +1266,9 @@ impl AcceptedMessageReplayKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct MessageIdempotencyKey {
-    tenant_id: TenantId,
-    source_binding_ref: String,
-    external_event_id: crate::ExternalEventId,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct MessageIdempotencyKey {
+    pub(crate) tenant_id: TenantId,
+    pub(crate) source_binding_ref: String,
+    pub(crate) external_event_id: crate::ExternalEventId,
 }

--- a/crates/ironclaw_conversations/src/postgres.rs
+++ b/crates/ironclaw_conversations/src/postgres.rs
@@ -1,0 +1,785 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    InMemoryConversationServices, InboundTurnError, ThreadMessageRecord,
+    memory::{
+        ActorKey, BindingKey, BindingRecord, InMemoryState, MessageIdempotencyKey,
+        ReplyTargetRecord, ThreadKey, ThreadRecord,
+    },
+    state_store::{ConversationStateRepository, PersistedConversationState},
+};
+
+const STATE_KEY: &str = "default";
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS reborn_conversation_state_meta (
+    state_key TEXT PRIMARY KEY,
+    version BIGINT NOT NULL
+);
+INSERT INTO reborn_conversation_state_meta (state_key, version) VALUES ('default', 0)
+ON CONFLICT (state_key) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_actor_pairings (
+    tenant_id TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    external_actor_kind TEXT NOT NULL,
+    external_actor_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    key_payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, adapter_kind, adapter_installation_id, external_actor_kind, external_actor_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_threads (
+    tenant_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    agent_id TEXT,
+    project_id TEXT,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, thread_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_thread_participants (
+    tenant_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, thread_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_bindings (
+    tenant_id TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    conversation_fingerprint TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    source_binding_ref TEXT NOT NULL UNIQUE,
+    reply_target_binding_ref TEXT NOT NULL,
+    owner_external_actor_kind TEXT NOT NULL,
+    owner_external_actor_id TEXT NOT NULL,
+    shared BOOLEAN NOT NULL,
+    key_payload TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, adapter_kind, adapter_installation_id, conversation_key)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_conversation_bindings_thread
+    ON reborn_conversation_bindings(tenant_id, thread_id);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_reply_targets (
+    reply_target_binding_ref TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    source_binding_ref TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    conversation_fingerprint TEXT NOT NULL,
+    owner_external_actor_kind TEXT NOT NULL,
+    owner_external_actor_id TEXT NOT NULL,
+    shared BOOLEAN NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_conversation_reply_targets_thread
+    ON reborn_conversation_reply_targets(tenant_id, thread_id);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_external_event_routes (
+    tenant_id TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    external_event_id TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    conversation_fingerprint TEXT NOT NULL,
+    key_payload TEXT NOT NULL,
+    identity_payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, adapter_kind, adapter_installation_id, external_event_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_accepted_messages (
+    message_ref TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    source_binding_ref TEXT NOT NULL,
+    reply_target_binding_ref TEXT NOT NULL,
+    external_event_id TEXT NOT NULL,
+    actor_user_id TEXT NOT NULL,
+    content_ref TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    UNIQUE (tenant_id, source_binding_ref, external_event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_conversation_accepted_messages_thread
+    ON reborn_conversation_accepted_messages(tenant_id, thread_id);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_message_replays (
+    tenant_id TEXT NOT NULL,
+    adapter_kind TEXT NOT NULL,
+    adapter_installation_id TEXT NOT NULL,
+    external_actor_kind TEXT NOT NULL,
+    external_actor_id TEXT NOT NULL,
+    external_event_id TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    conversation_fingerprint TEXT NOT NULL,
+    message_ref TEXT NOT NULL,
+    key_payload TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, adapter_kind, adapter_installation_id, external_actor_kind, external_actor_id, external_event_id)
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_submission_keys (
+    message_ref TEXT PRIMARY KEY,
+    idempotency_key TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS reborn_conversation_submit_responses (
+    message_ref TEXT PRIMARY KEY,
+    payload TEXT NOT NULL
+);
+"#;
+
+const TABLES: &[&str] = &[
+    "reborn_conversation_submit_responses",
+    "reborn_conversation_submission_keys",
+    "reborn_conversation_message_replays",
+    "reborn_conversation_accepted_messages",
+    "reborn_conversation_external_event_routes",
+    "reborn_conversation_reply_targets",
+    "reborn_conversation_bindings",
+    "reborn_conversation_thread_participants",
+    "reborn_conversation_threads",
+    "reborn_conversation_actor_pairings",
+];
+
+fn pg_error(error: impl std::error::Error) -> InboundTurnError {
+    InboundTurnError::DurableState {
+        reason: error.to_string(),
+    }
+}
+
+pub struct RebornPostgresConversationStateStore {
+    pool: deadpool_postgres::Pool,
+}
+
+impl RebornPostgresConversationStateStore {
+    pub fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), InboundTurnError> {
+        let client = self.client().await?;
+        client.batch_execute(SCHEMA).await.map_err(pg_error)?;
+        Ok(())
+    }
+
+    async fn client(&self) -> Result<deadpool_postgres::Object, InboundTurnError> {
+        self.pool.get().await.map_err(pg_error)
+    }
+}
+
+#[async_trait]
+impl ConversationStateRepository for RebornPostgresConversationStateStore {
+    async fn load_state(&self) -> Result<PersistedConversationState, InboundTurnError> {
+        self.run_migrations().await?;
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(pg_error)?;
+        let result = load_state_from_txn(&txn).await;
+        finish_transaction(txn, result).await
+    }
+
+    async fn save_state(
+        &self,
+        expected_revision: i64,
+        state: &InMemoryState,
+    ) -> Result<i64, InboundTurnError> {
+        self.run_migrations().await?;
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(pg_error)?;
+        let result = save_state_to_txn(&txn, expected_revision, state).await;
+        finish_transaction(txn, result).await
+    }
+}
+
+#[derive(Clone)]
+pub struct RebornPostgresConversationServices {
+    inner: InMemoryConversationServices,
+}
+
+impl RebornPostgresConversationServices {
+    pub async fn new(pool: deadpool_postgres::Pool) -> Result<Self, InboundTurnError> {
+        let store = Arc::new(RebornPostgresConversationStateStore::new(pool));
+        store.run_migrations().await?;
+        Ok(Self {
+            inner: InMemoryConversationServices::with_state_repository(store).await?,
+        })
+    }
+
+    pub fn inner(&self) -> &InMemoryConversationServices {
+        &self.inner
+    }
+
+    pub async fn pair_external_actor(
+        &self,
+        tenant_id: ironclaw_host_api::TenantId,
+        adapter_kind: crate::AdapterKind,
+        adapter_installation_id: crate::AdapterInstallationId,
+        external_actor_ref: crate::ExternalActorRef,
+        user_id: ironclaw_host_api::UserId,
+    ) -> Result<(), InboundTurnError> {
+        self.inner
+            .try_pair_external_actor(
+                tenant_id,
+                adapter_kind,
+                adapter_installation_id,
+                external_actor_ref,
+                user_id,
+            )
+            .await
+    }
+
+    pub async fn unpair_external_actor(
+        &self,
+        tenant_id: &ironclaw_host_api::TenantId,
+        adapter_kind: &crate::AdapterKind,
+        adapter_installation_id: &crate::AdapterInstallationId,
+        external_actor_ref: &crate::ExternalActorRef,
+    ) -> Result<(), InboundTurnError> {
+        self.inner
+            .try_unpair_external_actor(
+                tenant_id,
+                adapter_kind,
+                adapter_installation_id,
+                external_actor_ref,
+            )
+            .await
+    }
+}
+
+#[async_trait]
+impl crate::ConversationBindingService for RebornPostgresConversationServices {
+    async fn resolve_or_create_binding(
+        &self,
+        request: crate::ResolveConversationRequest,
+    ) -> Result<crate::ConversationBindingResolution, InboundTurnError> {
+        self.inner.resolve_or_create_binding(request).await
+    }
+
+    async fn link_conversation_to_thread(
+        &self,
+        request: crate::LinkConversationRequest,
+    ) -> Result<crate::LinkedConversationBinding, InboundTurnError> {
+        self.inner.link_conversation_to_thread(request).await
+    }
+
+    async fn validate_reply_target(
+        &self,
+        request: crate::ValidateReplyTargetRequest,
+    ) -> Result<crate::ReplyTargetBinding, InboundTurnError> {
+        self.inner.validate_reply_target(request).await
+    }
+}
+
+#[async_trait]
+impl crate::SessionThreadService for RebornPostgresConversationServices {
+    async fn accept_inbound_message(
+        &self,
+        request: crate::AcceptInboundMessageRequest,
+    ) -> Result<crate::AcceptedInboundMessage, InboundTurnError> {
+        self.inner.accept_inbound_message(request).await
+    }
+
+    async fn replay_accepted_inbound_message(
+        &self,
+        lookup: crate::AcceptedInboundMessageLookup,
+    ) -> Result<Option<crate::AcceptedInboundMessageReplay>, InboundTurnError> {
+        self.inner.replay_accepted_inbound_message(lookup).await
+    }
+
+    async fn inbound_message_turn_submission(
+        &self,
+        message_ref: &ironclaw_turns::AcceptedMessageRef,
+    ) -> Result<Option<ironclaw_turns::SubmitTurnResponse>, InboundTurnError> {
+        self.inner
+            .inbound_message_turn_submission(message_ref)
+            .await
+    }
+
+    async fn inbound_message_turn_submission_key(
+        &self,
+        message_ref: &ironclaw_turns::AcceptedMessageRef,
+    ) -> Result<ironclaw_turns::IdempotencyKey, InboundTurnError> {
+        self.inner
+            .inbound_message_turn_submission_key(message_ref)
+            .await
+    }
+
+    async fn rotate_inbound_message_turn_submission_key(
+        &self,
+        message_ref: &ironclaw_turns::AcceptedMessageRef,
+    ) -> Result<(), InboundTurnError> {
+        self.inner
+            .rotate_inbound_message_turn_submission_key(message_ref)
+            .await
+    }
+
+    async fn mark_inbound_message_turn_submitted(
+        &self,
+        message_ref: &ironclaw_turns::AcceptedMessageRef,
+        response: ironclaw_turns::SubmitTurnResponse,
+    ) -> Result<(), InboundTurnError> {
+        self.inner
+            .mark_inbound_message_turn_submitted(message_ref, response)
+            .await
+    }
+}
+
+async fn load_state_from_txn(
+    txn: &deadpool_postgres::Transaction<'_>,
+) -> Result<PersistedConversationState, InboundTurnError> {
+    let revision = load_revision(txn).await?;
+    let mut state = InMemoryState::default();
+
+    for row in txn
+        .query(
+            "SELECT key_payload, user_id FROM reborn_conversation_actor_pairings",
+            &[],
+        )
+        .await
+        .map_err(pg_error)?
+    {
+        let key: ActorKey = from_json(row.get::<_, &str>(0))?;
+        let user_id = ironclaw_host_api::UserId::new(row.get::<_, String>(1)).map_err(|error| {
+            InboundTurnError::DurableState {
+                reason: error.to_string(),
+            }
+        })?;
+        state.pairings.insert(key, user_id);
+    }
+
+    for row in txn
+        .query(
+            "SELECT key_payload, payload FROM reborn_conversation_bindings",
+            &[],
+        )
+        .await
+        .map_err(pg_error)?
+    {
+        let key: BindingKey = from_json(row.get::<_, &str>(0))?;
+        let binding: BindingRecord = from_json(row.get::<_, &str>(1))?;
+        state.source_bindings.insert(
+            binding.source_binding_ref.as_str().to_string(),
+            binding.clone(),
+        );
+        state.bindings.insert(key, binding);
+    }
+
+    for row in txn
+        .query("SELECT payload FROM reborn_conversation_reply_targets", &[])
+        .await
+        .map_err(pg_error)?
+    {
+        let reply_target: ReplyTargetRecord = from_json(row.get::<_, &str>(0))?;
+        state.reply_targets.insert(
+            reply_target.reply_target_binding_ref.as_str().to_string(),
+            reply_target,
+        );
+    }
+
+    for row in txn
+        .query("SELECT payload FROM reborn_conversation_threads", &[])
+        .await
+        .map_err(pg_error)?
+    {
+        let (key, record): (ThreadKey, ThreadRecord) = from_json(row.get::<_, &str>(0))?;
+        state.threads.insert(key, record);
+    }
+
+    for row in txn
+        .query(
+            "SELECT tenant_id, thread_id, user_id FROM reborn_conversation_thread_participants",
+            &[],
+        )
+        .await
+        .map_err(pg_error)?
+    {
+        let tenant_id =
+            ironclaw_host_api::TenantId::new(row.get::<_, String>(0)).map_err(|error| {
+                InboundTurnError::DurableState {
+                    reason: error.to_string(),
+                }
+            })?;
+        let thread_id =
+            ironclaw_host_api::ThreadId::new(row.get::<_, String>(1)).map_err(|error| {
+                InboundTurnError::DurableState {
+                    reason: error.to_string(),
+                }
+            })?;
+        let user_id = ironclaw_host_api::UserId::new(row.get::<_, String>(2)).map_err(|error| {
+            InboundTurnError::DurableState {
+                reason: error.to_string(),
+            }
+        })?;
+        if let Some(thread) = state
+            .threads
+            .get_mut(&ThreadKey::new(&tenant_id, &thread_id))
+        {
+            thread.participants.insert(user_id);
+        }
+    }
+
+    for row in txn
+        .query(
+            "SELECT key_payload, identity_payload FROM reborn_conversation_external_event_routes",
+            &[],
+        )
+        .await
+        .map_err(pg_error)?
+    {
+        state.external_event_routes.insert(
+            from_json(row.get::<_, &str>(0))?,
+            from_json(row.get::<_, &str>(1))?,
+        );
+    }
+
+    for row in txn
+        .query(
+            "SELECT payload FROM reborn_conversation_accepted_messages",
+            &[],
+        )
+        .await
+        .map_err(pg_error)?
+    {
+        let message: ThreadMessageRecord = from_json(row.get::<_, &str>(0))?;
+        let idempotency_key = MessageIdempotencyKey {
+            tenant_id: message.accepted.tenant_id.clone(),
+            source_binding_ref: message.accepted.source_binding_ref.as_str().to_string(),
+            external_event_id: message.external_event_id.clone(),
+        };
+        state
+            .message_idempotency
+            .insert(idempotency_key, message.accepted.clone());
+        state.messages.push(message);
+    }
+
+    for row in txn
+        .query(
+            "SELECT key_payload, payload FROM reborn_conversation_message_replays",
+            &[],
+        )
+        .await
+        .map_err(pg_error)?
+    {
+        state.message_replays.insert(
+            from_json(row.get::<_, &str>(0))?,
+            from_json(row.get::<_, &str>(1))?,
+        );
+    }
+
+    for row in txn
+        .query(
+            "SELECT message_ref, idempotency_key FROM reborn_conversation_submission_keys",
+            &[],
+        )
+        .await
+        .map_err(pg_error)?
+    {
+        let message_ref = ironclaw_turns::AcceptedMessageRef::new(row.get::<_, String>(0))
+            .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+        let key = ironclaw_turns::IdempotencyKey::new(row.get::<_, String>(1))
+            .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+        state.submission_keys.insert(message_ref, key);
+    }
+
+    for row in txn
+        .query(
+            "SELECT message_ref, payload FROM reborn_conversation_submit_responses",
+            &[],
+        )
+        .await
+        .map_err(pg_error)?
+    {
+        let message_ref = ironclaw_turns::AcceptedMessageRef::new(row.get::<_, String>(0))
+            .map_err(|reason| InboundTurnError::InvalidCanonicalRef { reason })?;
+        state
+            .submitted_message_responses
+            .insert(message_ref, from_json(row.get::<_, &str>(1))?);
+    }
+
+    Ok(PersistedConversationState { state, revision })
+}
+
+async fn save_state_to_txn(
+    txn: &deadpool_postgres::Transaction<'_>,
+    expected_revision: i64,
+    state: &InMemoryState,
+) -> Result<i64, InboundTurnError> {
+    let new_revision = expected_revision + 1;
+    let updated = txn
+        .execute(
+            "UPDATE reborn_conversation_state_meta SET version = $2 WHERE state_key = $1 AND version = $3",
+            &[&STATE_KEY, &new_revision, &expected_revision],
+        )
+        .await
+        .map_err(pg_error)?;
+    if updated == 0 {
+        return Err(InboundTurnError::DurableState {
+            reason: "stale conversation state revision".to_string(),
+        });
+    }
+    for table in TABLES {
+        txn.execute(&format!("DELETE FROM {table}"), &[])
+            .await
+            .map_err(pg_error)?;
+    }
+
+    for (key, user_id) in &state.pairings {
+        let key_payload = to_json(key)?;
+        txn.execute(
+            "INSERT INTO reborn_conversation_actor_pairings \
+             (tenant_id, adapter_kind, adapter_installation_id, external_actor_kind, external_actor_id, user_id, key_payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            &[
+                &key.tenant_id.as_str(),
+                &key.adapter_kind.as_str(),
+                &key.adapter_installation_id.as_str(),
+                &key.external_actor_ref.kind(),
+                &key.external_actor_ref.id(),
+                &user_id.as_str(),
+                &key_payload,
+            ],
+        )
+        .await
+        .map_err(pg_error)?;
+    }
+
+    for (key, thread) in &state.threads {
+        let agent_id = thread.agent_id.as_ref().map(|id| id.as_str());
+        let project_id = thread.project_id.as_ref().map(|id| id.as_str());
+        let payload = to_json(&(key, thread))?;
+        txn.execute(
+            "INSERT INTO reborn_conversation_threads (tenant_id, thread_id, agent_id, project_id, payload) VALUES ($1, $2, $3, $4, $5)",
+            &[&key.tenant_id.as_str(), &key.thread_id.as_str(), &agent_id, &project_id, &payload],
+        )
+        .await
+        .map_err(pg_error)?;
+        for participant in &thread.participants {
+            txn.execute(
+                "INSERT INTO reborn_conversation_thread_participants (tenant_id, thread_id, user_id) VALUES ($1, $2, $3)",
+                &[&key.tenant_id.as_str(), &key.thread_id.as_str(), &participant.as_str()],
+            )
+            .await
+            .map_err(pg_error)?;
+        }
+    }
+
+    for (key, binding) in &state.bindings {
+        let key_payload = to_json(key)?;
+        let payload = to_json(binding)?;
+        let conversation_fingerprint = key
+            .external_conversation_identity
+            .conversation_fingerprint();
+        let conversation_key = conversation_digest(&conversation_fingerprint);
+        txn.execute(
+            "INSERT INTO reborn_conversation_bindings \
+             (tenant_id, adapter_kind, adapter_installation_id, conversation_key, conversation_fingerprint, thread_id, source_binding_ref, reply_target_binding_ref, owner_external_actor_kind, owner_external_actor_id, shared, key_payload, payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+            &[
+                &key.tenant_id.as_str(),
+                &key.adapter_kind.as_str(),
+                &key.adapter_installation_id.as_str(),
+                &conversation_key,
+                &conversation_fingerprint,
+                &binding.thread_id.as_str(),
+                &binding.source_binding_ref.as_str(),
+                &binding.reply_target_binding_ref.as_str(),
+                &binding.route_access.owner_actor_key.external_actor_ref.kind(),
+                &binding.route_access.owner_actor_key.external_actor_ref.id(),
+                &binding.route_access.shared,
+                &key_payload,
+                &payload,
+            ],
+        )
+        .await
+        .map_err(pg_error)?;
+    }
+
+    for reply_target in state.reply_targets.values() {
+        let payload = to_json(reply_target)?;
+        let conversation_fingerprint = reply_target
+            .external_conversation_ref
+            .conversation_fingerprint();
+        let conversation_key = conversation_digest(&conversation_fingerprint);
+        txn.execute(
+            "INSERT INTO reborn_conversation_reply_targets \
+             (reply_target_binding_ref, tenant_id, thread_id, source_binding_ref, adapter_kind, adapter_installation_id, conversation_key, conversation_fingerprint, owner_external_actor_kind, owner_external_actor_id, shared, payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+            &[
+                &reply_target.reply_target_binding_ref.as_str(),
+                &reply_target.tenant_id.as_str(),
+                &reply_target.thread_id.as_str(),
+                &reply_target.source_binding_ref.as_str(),
+                &reply_target.adapter_kind.as_str(),
+                &reply_target.adapter_installation_id.as_str(),
+                &conversation_key,
+                &conversation_fingerprint,
+                &reply_target.route_access.owner_actor_key.external_actor_ref.kind(),
+                &reply_target.route_access.owner_actor_key.external_actor_ref.id(),
+                &reply_target.route_access.shared,
+                &payload,
+            ],
+        )
+        .await
+        .map_err(pg_error)?;
+    }
+
+    for (key, identity) in &state.external_event_routes {
+        let key_payload = to_json(key)?;
+        let identity_payload = to_json(identity)?;
+        let conversation_fingerprint = identity.conversation_fingerprint();
+        let conversation_key = conversation_digest(&conversation_fingerprint);
+        txn.execute(
+            "INSERT INTO reborn_conversation_external_event_routes \
+             (tenant_id, adapter_kind, adapter_installation_id, external_event_id, conversation_key, conversation_fingerprint, key_payload, identity_payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            &[
+                &key.tenant_id.as_str(),
+                &key.adapter_kind.as_str(),
+                &key.adapter_installation_id.as_str(),
+                &key.external_event_id.as_str(),
+                &conversation_key,
+                &conversation_fingerprint,
+                &key_payload,
+                &identity_payload,
+            ],
+        )
+        .await
+        .map_err(pg_error)?;
+    }
+
+    for message in &state.messages {
+        let payload = to_json(message)?;
+        txn.execute(
+            "INSERT INTO reborn_conversation_accepted_messages \
+             (message_ref, tenant_id, thread_id, source_binding_ref, reply_target_binding_ref, external_event_id, actor_user_id, content_ref, received_at, payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+            &[
+                &message.accepted.message_ref.as_str(),
+                &message.accepted.tenant_id.as_str(),
+                &message.accepted.thread_id.as_str(),
+                &message.accepted.source_binding_ref.as_str(),
+                &message.accepted.reply_target_binding_ref.as_str(),
+                &message.external_event_id.as_str(),
+                &message.actor.user_id.as_str(),
+                &message.content_ref.as_str(),
+                &message.received_at.to_rfc3339(),
+                &payload,
+            ],
+        )
+        .await
+        .map_err(pg_error)?;
+    }
+
+    for (key, replay) in &state.message_replays {
+        let key_payload = to_json(key)?;
+        let payload = to_json(replay)?;
+        let conversation_fingerprint = replay
+            .external_conversation_identity
+            .conversation_fingerprint();
+        let conversation_key = conversation_digest(&conversation_fingerprint);
+        txn.execute(
+            "INSERT INTO reborn_conversation_message_replays \
+             (tenant_id, adapter_kind, adapter_installation_id, external_actor_kind, external_actor_id, external_event_id, conversation_key, conversation_fingerprint, message_ref, key_payload, payload) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            &[
+                &key.tenant_id.as_str(),
+                &key.adapter_kind.as_str(),
+                &key.adapter_installation_id.as_str(),
+                &key.external_actor_ref.kind(),
+                &key.external_actor_ref.id(),
+                &key.external_event_id.as_str(),
+                &conversation_key,
+                &conversation_fingerprint,
+                &replay.replay.accepted_message.message_ref.as_str(),
+                &key_payload,
+                &payload,
+            ],
+        )
+        .await
+        .map_err(pg_error)?;
+    }
+
+    for (message_ref, key) in &state.submission_keys {
+        txn.execute(
+            "INSERT INTO reborn_conversation_submission_keys (message_ref, idempotency_key) VALUES ($1, $2)",
+            &[&message_ref.as_str(), &key.as_str()],
+        )
+        .await
+        .map_err(pg_error)?;
+    }
+
+    for (message_ref, response) in &state.submitted_message_responses {
+        let payload = to_json(response)?;
+        txn.execute(
+            "INSERT INTO reborn_conversation_submit_responses (message_ref, payload) VALUES ($1, $2)",
+            &[&message_ref.as_str(), &payload],
+        )
+        .await
+        .map_err(pg_error)?;
+    }
+
+    Ok(new_revision)
+}
+
+async fn load_revision(txn: &deadpool_postgres::Transaction<'_>) -> Result<i64, InboundTurnError> {
+    let row = txn
+        .query_opt(
+            "SELECT version FROM reborn_conversation_state_meta WHERE state_key = $1",
+            &[&STATE_KEY],
+        )
+        .await
+        .map_err(pg_error)?
+        .ok_or_else(|| InboundTurnError::DurableState {
+            reason: "missing conversation state metadata row".to_string(),
+        })?;
+    Ok(row.get(0))
+}
+
+async fn finish_transaction<T>(
+    txn: deadpool_postgres::Transaction<'_>,
+    result: Result<T, InboundTurnError>,
+) -> Result<T, InboundTurnError> {
+    match result {
+        Ok(value) => {
+            txn.commit().await.map_err(pg_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = txn.rollback().await;
+            Err(error)
+        }
+    }
+}
+
+fn conversation_digest(fingerprint: &str) -> String {
+    let digest = Sha256::digest(fingerprint.as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn to_json<T: Serialize>(value: &T) -> Result<String, InboundTurnError> {
+    serde_json::to_string(value).map_err(|error| InboundTurnError::DurableState {
+        reason: error.to_string(),
+    })
+}
+
+fn from_json<T: DeserializeOwned>(value: &str) -> Result<T, InboundTurnError> {
+    serde_json::from_str(value).map_err(|error| InboundTurnError::DurableState {
+        reason: error.to_string(),
+    })
+}

--- a/crates/ironclaw_conversations/src/state_store.rs
+++ b/crates/ironclaw_conversations/src/state_store.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+use crate::{InboundTurnError, memory::InMemoryState};
+
+pub(crate) struct PersistedConversationState {
+    pub(crate) state: InMemoryState,
+    pub(crate) revision: i64,
+}
+
+#[async_trait]
+pub(crate) trait ConversationStateRepository: Send + Sync {
+    async fn load_state(&self) -> Result<PersistedConversationState, InboundTurnError>;
+    async fn save_state(
+        &self,
+        expected_revision: i64,
+        state: &InMemoryState,
+    ) -> Result<i64, InboundTurnError>;
+}

--- a/crates/ironclaw_conversations/tests/inbound_contract.rs
+++ b/crates/ironclaw_conversations/tests/inbound_contract.rs
@@ -6,10 +6,11 @@ use ironclaw_conversations::{
     AcceptInboundMessageRequest, AcceptedInboundMessage, AcceptedInboundMessageLookup,
     AcceptedInboundMessageReplay, AdapterInstallationId, AdapterKind,
     ConversationBindingResolution, ConversationBindingService, ConversationRouteKind,
-    ExternalActorRef, ExternalConversationRef, ExternalEventId, InMemoryConversationServices,
-    InboundMessageContentRef, InboundTurnError, InboundTurnRequest, InboundTurnService,
-    LinkConversationRequest, LinkedConversationBinding, MessageIdempotencyStatus,
-    ReplyTargetBinding, SessionThreadService, ThreadAccessDecision, ValidateReplyTargetRequest,
+    ExternalActorRef, ExternalConversationIdentity, ExternalConversationRef, ExternalEventId,
+    InMemoryConversationServices, InboundMessageContentRef, InboundTurnError, InboundTurnRequest,
+    InboundTurnService, LinkConversationRequest, LinkedConversationBinding,
+    MessageIdempotencyStatus, ReplyTargetBinding, SessionThreadService, ThreadAccessDecision,
+    ValidateReplyTargetRequest,
 };
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
@@ -844,6 +845,266 @@ async fn explicit_link_uses_existing_thread_scope_not_spoofed_link_scope() {
     assert_eq!(telegram_resolution.turn_scope, web_resolution.turn_scope);
 }
 
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_conversation_services_survive_restart_for_retry_replay() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("conversations.db");
+    let db = Arc::new(
+        libsql::Builder::new_local(db_path.display().to_string())
+            .build()
+            .await
+            .unwrap(),
+    );
+    let services = ironclaw_conversations::RebornLibSqlConversationServices::new(db)
+        .await
+        .unwrap();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("telegram-user-1"),
+            user("alice"),
+        )
+        .await
+        .unwrap();
+    let coordinator = Arc::new(FailFirstTurnCoordinator::default());
+    let inbound = InboundTurnService::new(services.clone(), services.clone(), coordinator.clone());
+    let request = inbound_request(
+        telegram(),
+        external_actor("telegram-user-1"),
+        external_conversation("durable-chat", None),
+        "durable-event-1",
+    );
+
+    let err = inbound
+        .handle_inbound_turn(request.clone())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, InboundTurnError::TurnSubmissionFailed { .. }));
+    drop(inbound);
+    drop(services);
+
+    let reopened_db = Arc::new(
+        libsql::Builder::new_local(db_path.display().to_string())
+            .build()
+            .await
+            .unwrap(),
+    );
+    let reopened = ironclaw_conversations::RebornLibSqlConversationServices::new(reopened_db)
+        .await
+        .unwrap();
+    reopened
+        .unpair_external_actor(
+            &tenant(),
+            &telegram(),
+            &default_installation(),
+            &external_actor("telegram-user-1"),
+        )
+        .await
+        .unwrap();
+    let retry_inbound = InboundTurnService::new(reopened.clone(), reopened, coordinator.clone());
+
+    let retry = retry_inbound.handle_inbound_turn(request).await.unwrap();
+
+    assert_eq!(
+        retry.accepted_message.idempotency,
+        MessageIdempotencyStatus::Duplicate
+    );
+    assert_eq!(coordinator.submissions().len(), 2);
+    assert_eq!(
+        coordinator.submissions()[1].actor,
+        TurnActor::new(user("alice"))
+    );
+
+    let inspect_db = libsql::Builder::new_local(db_path.display().to_string())
+        .build()
+        .await
+        .unwrap();
+    let inspect_conn = inspect_db.connect().unwrap();
+    assert_eq!(
+        table_count(&inspect_conn, "reborn_conversation_actor_pairings").await,
+        0
+    );
+    assert_eq!(
+        table_count(&inspect_conn, "reborn_conversation_bindings").await,
+        1
+    );
+    assert_eq!(
+        table_count(&inspect_conn, "reborn_conversation_reply_targets").await,
+        2
+    );
+    assert_eq!(
+        table_count(&inspect_conn, "reborn_conversation_accepted_messages").await,
+        1
+    );
+    assert_eq!(
+        table_count(&inspect_conn, "reborn_conversation_message_replays").await,
+        1
+    );
+    assert_eq!(
+        table_count(&inspect_conn, "reborn_conversation_submission_keys").await,
+        1
+    );
+    assert_eq!(
+        table_count(&inspect_conn, "reborn_conversation_submit_responses").await,
+        1
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_stale_service_write_fails_without_overwriting_newer_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("stale-conversations.db");
+    let db_a = Arc::new(
+        libsql::Builder::new_local(db_path.display().to_string())
+            .build()
+            .await
+            .unwrap(),
+    );
+    let db_b = Arc::new(
+        libsql::Builder::new_local(db_path.display().to_string())
+            .build()
+            .await
+            .unwrap(),
+    );
+    let services_a = ironclaw_conversations::RebornLibSqlConversationServices::new(db_a)
+        .await
+        .unwrap();
+    let services_b = ironclaw_conversations::RebornLibSqlConversationServices::new(db_b)
+        .await
+        .unwrap();
+
+    services_a
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("alice-telegram"),
+            user("alice"),
+        )
+        .await
+        .unwrap();
+
+    services_b
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("bob-telegram"),
+            user("bob"),
+        )
+        .await
+        .unwrap();
+    let bob = services_b
+        .resolve_or_create_binding(resolve_request(
+            telegram(),
+            external_actor("bob-telegram"),
+            external_conversation("stale-chat", None),
+            "stale-event",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(bob.actor, TurnActor::new(user("bob")));
+
+    let inspect_db = libsql::Builder::new_local(db_path.display().to_string())
+        .build()
+        .await
+        .unwrap();
+    let inspect_conn = inspect_db.connect().unwrap();
+    assert_eq!(
+        table_count(&inspect_conn, "reborn_conversation_actor_pairings").await,
+        2
+    );
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_conversation_services_round_trip_restart_replay_when_available() {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipping Postgres conversation contract: DATABASE_URL is not set");
+        return;
+    };
+    let config: tokio_postgres::Config = database_url
+        .parse()
+        .expect("DATABASE_URL must parse as a Postgres connection string");
+    let manager = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
+    let pool = deadpool_postgres::Pool::builder(manager)
+        .max_size(2)
+        .build()
+        .expect("Postgres pool must build");
+    let _connection = pool
+        .get()
+        .await
+        .expect("DATABASE_URL must point at a reachable Postgres test database");
+
+    let suffix = Utc::now().timestamp_nanos_opt().unwrap_or_default();
+    let actor_ref = external_actor(&format!("pg-telegram-user-{suffix}"));
+    let conversation_ref = external_conversation(&format!("pg-durable-chat-{suffix}"), None);
+    let event_id = format!("pg-durable-event-{suffix}");
+    let services = ironclaw_conversations::RebornPostgresConversationServices::new(pool.clone())
+        .await
+        .unwrap();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            actor_ref.clone(),
+            user("alice"),
+        )
+        .await
+        .unwrap();
+    let coordinator = Arc::new(FailFirstTurnCoordinator::default());
+    let inbound = InboundTurnService::new(services.clone(), services.clone(), coordinator.clone());
+    let request = inbound_request(
+        telegram(),
+        actor_ref.clone(),
+        conversation_ref.clone(),
+        &event_id,
+    );
+
+    let err = inbound
+        .handle_inbound_turn(request.clone())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, InboundTurnError::TurnSubmissionFailed { .. }));
+    drop(inbound);
+    drop(services);
+
+    let reopened = ironclaw_conversations::RebornPostgresConversationServices::new(pool)
+        .await
+        .unwrap();
+    reopened
+        .unpair_external_actor(&tenant(), &telegram(), &default_installation(), &actor_ref)
+        .await
+        .unwrap();
+    let retry_inbound = InboundTurnService::new(reopened.clone(), reopened, coordinator.clone());
+    let retry = retry_inbound.handle_inbound_turn(request).await.unwrap();
+
+    assert_eq!(
+        retry.accepted_message.idempotency,
+        MessageIdempotencyStatus::Duplicate
+    );
+    assert_eq!(coordinator.submissions().len(), 2);
+    assert_eq!(
+        coordinator.submissions()[1].actor,
+        TurnActor::new(user("alice"))
+    );
+}
+
+#[cfg(feature = "libsql")]
+async fn table_count(conn: &libsql::Connection, table: &str) -> i64 {
+    let mut rows = conn
+        .query(&format!("SELECT COUNT(*) FROM {table}"), ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    row.get(0).unwrap()
+}
+
 #[tokio::test]
 async fn duplicate_retry_after_submit_failure_survives_pairing_churn() {
     let services = InMemoryConversationServices::default();
@@ -1478,6 +1739,68 @@ async fn duplicate_external_event_route_is_reserved_before_binding_creation() {
 }
 
 #[tokio::test]
+async fn failed_resolve_does_not_reserve_external_event_route() {
+    let services = InMemoryConversationServices::default();
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("alice-telegram"),
+            user("alice"),
+        )
+        .await;
+    services
+        .pair_external_actor(
+            tenant(),
+            telegram(),
+            default_installation(),
+            external_actor("bob-telegram"),
+            user("bob"),
+        )
+        .await;
+    let alice_direct = services
+        .resolve_or_create_binding(resolve_request(
+            telegram(),
+            external_actor("alice-telegram"),
+            external_conversation("alice-direct-poison-source", None),
+            "alice-direct-poison-source-event",
+        ))
+        .await
+        .unwrap();
+    services
+        .add_thread_participant(&tenant(), &alice_direct.turn_scope.thread_id, user("bob"))
+        .await
+        .unwrap();
+
+    let mut denied = resolve_request(
+        telegram(),
+        external_actor("bob-telegram"),
+        external_conversation("alice-direct-poison-source", None),
+        "denied-event-must-not-reserve-route",
+    );
+    denied.route_kind = ConversationRouteKind::Shared;
+    assert!(matches!(
+        services
+            .resolve_or_create_binding(denied)
+            .await
+            .unwrap_err(),
+        InboundTurnError::AccessDenied { .. }
+    ));
+
+    let legitimate = services
+        .resolve_or_create_binding(resolve_request(
+            telegram(),
+            external_actor("alice-telegram"),
+            external_conversation("alice-legitimate-after-denied", None),
+            "denied-event-must-not-reserve-route",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(legitimate.actor, TurnActor::new(user("alice")));
+}
+
+#[tokio::test]
 async fn shared_route_marker_widens_existing_direct_binding_for_participants() {
     let services = InMemoryConversationServices::default();
     services
@@ -2048,6 +2371,12 @@ fn serde_deserialization_revalidates_external_ref_invariants() {
         r#"{"space_id":null,"conversation_id":"chat-1","thread_id":"ok","message_id":"bad\u0001"}"#
     )
     .is_err());
+    assert!(
+        serde_json::from_str::<ExternalConversationIdentity>(
+            r#"{"space_id":null,"conversation_id":"","thread_id":null}"#
+        )
+        .is_err()
+    );
 }
 
 #[tokio::test]

--- a/docs/reborn/contracts/conversation-binding.md
+++ b/docs/reborn/contracts/conversation-binding.md
@@ -40,9 +40,10 @@ Adapters pass structured external actor/conversation refs to this boundary. The 
 - typed external refs: `AdapterKind`, `AdapterInstallationId`, `ExternalActorRef`, `ExternalConversationRef`, `ExternalEventId`;
 - `ConversationBindingService`, `SessionThreadService`, and `InboundTurnService` traits/DTOs;
 - `InMemoryConversationServices` for semantic contract tests and future adapter wiring spikes;
+- optional `RebornLibSqlConversationServices` and `RebornPostgresConversationServices` durable wrappers backed by normalized PostgreSQL/libSQL tables for pairings, threads/participants, bindings, reply targets, event routes, accepted messages, replay records, submit idempotency keys, and submit responses;
 - caller-level tests proving the facade submits only canonical refs to `TurnCoordinator`.
 
-This is not the final durable transcript store. PostgreSQL/libSQL storage and lazy v1 transcript migration remain downstream of #3204.
+This is not the final durable transcript store. The conversation contract stores accepted-message refs and content refs; durable raw transcript content and lazy v1 transcript migration remain downstream of the transcript/thread storage boundary (#3204).
 
 ---
 


### PR DESCRIPTION
## Summary
- add normalized libSQL/Postgres durable backends for `ironclaw_conversations`
- persist pairings, thread participants, conversation bindings, reply targets, event routes, accepted messages, replay records, submit keys, and submit responses in separate tables
- prove libSQL restart retry replay survives pairing churn and writes normalized rows

## Verification
- `cargo test -p ironclaw_conversations`
- `cargo test -p ironclaw_conversations --features libsql,postgres --test inbound_contract`
- `cargo test -p ironclaw_conversations --features postgres --no-run`
- `cargo test -p ironclaw_architecture`
- `cargo clippy -p ironclaw_conversations --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_conversations --all-targets --features libsql,postgres -- -D warnings`
- `git diff --check`
