### PR TITLE
fix(common): clarify crate-level doc wording

### DIFF
--- a/crates/ironclaw_common/src/lib.rs
+++ b/crates/ironclaw_common/src/lib.rs
@@ -1,4 +1,4 @@
-//! Shared types and utilities for the IronClaw workspace.
+//! Shared types and utilities used across the IronClaw workspace.
 
 mod event;
 mod identity;


### PR DESCRIPTION
## Summary

Tiny wording tweak in the `ironclaw_common` crate-level doc comment: `for the IronClaw workspace` → `used across the IronClaw workspace`.

## Why

This is a deliberate one-word change to give release-plz a leaf-crate source change to detect. Since `ironclaw-v0.27.0` (Apr 29), zero commits have touched `crates/ironclaw_common/`, `crates/ironclaw_safety/`, or `crates/ironclaw_skills/` — and release-plz only proposes a release PR when at least one leaf crate has source-path changes since its last tag (the root `ironclaw` package is suppressed by the `local > registry` guard at `release_plz_core/src/command/update/updater.rs:688`).

Every prior release window happened to have leaf-crate churn (v0.24→25: 6/6/6 commits, v0.25→26: 14/0/6, v0.26→27: 6/2/3). v0.27→HEAD is the first window with 0/0/0 — all ~100 commits since v0.27.0 have been in `src/` or workspace plumbing.

After this merges, release-plz will detect the leaf change, propose a patch bump for `ironclaw_common`, and cascade the root `ironclaw` package to `0.28.0`. From there the standard release flow takes over (review the bot's chore PR → merge → tag → cargo-dist).

A more durable fix (e.g. `release_always = true` on the `ironclaw` `[[package]]` in `release-plz.toml`) is a separate conversation; this PR only unblocks the v0.28.0 cut.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a `chore: release` PR appears from `app/ironclaw-ci` proposing `ironclaw 0.27.0 → 0.28.0`