### PR TITLE
test(reborn): add event stream manager facade

### DIFF
--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,0 +1,17 @@
+## Summary
+- Add `EventStreamManager` as a transport-agnostic facade over Reborn runtime and audit projection services.
+- Keep runtime/audit replay domain-specific instead of introducing a generic all-events DTO.
+- Add caller-level tests for facade routing, scope-bound cursor rejection, stale cursor rebase propagation, and audit no-exposure behavior.
+- Update the events/projections contract with the facade boundary.
+
+Refs #3022
+
+## Verification
+- `cargo test -p ironclaw_event_projections event_stream_manager_ -q`
+- `cargo test -p ironclaw_event_projections -q`
+- `cargo fmt --check`
+- `cargo clippy -p ironclaw_event_projections --all-targets --all-features -- -D warnings`
+- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold -q`
+
+## Review
+- Reviewer subagent found no Critical / High / Medium findings.

--- a/crates/ironclaw_event_projections/src/lib.rs
+++ b/crates/ironclaw_event_projections/src/lib.rs
@@ -483,6 +483,82 @@ pub trait EventProjectionService: Send + Sync {
     ) -> Result<ProjectionReplay, ProjectionError>;
 }
 
+/// Transport-agnostic facade for scoped Reborn projection replay.
+///
+/// Product transports should enter through this manager rather than reaching
+/// directly into durable logs. The manager intentionally keeps runtime and
+/// audit projections domain-specific: it validates and routes requests to the
+/// owning projection services without flattening them into a generic event
+/// union DTO.
+#[derive(Clone)]
+pub struct EventStreamManager {
+    runtime_projection: Arc<dyn EventProjectionService>,
+    audit_projection: Arc<dyn AuditProjectionService>,
+}
+
+impl EventStreamManager {
+    pub fn new<R, A>(runtime_projection: Arc<R>, audit_projection: Arc<A>) -> Self
+    where
+        R: EventProjectionService + 'static,
+        A: AuditProjectionService + 'static,
+    {
+        let runtime_projection: Arc<dyn EventProjectionService> = runtime_projection;
+        let audit_projection: Arc<dyn AuditProjectionService> = audit_projection;
+        Self {
+            runtime_projection,
+            audit_projection,
+        }
+    }
+
+    pub fn from_services(
+        runtime_projection: Arc<dyn EventProjectionService>,
+        audit_projection: Arc<dyn AuditProjectionService>,
+    ) -> Self {
+        Self {
+            runtime_projection,
+            audit_projection,
+        }
+    }
+
+    pub async fn runtime_snapshot(
+        &self,
+        request: ProjectionRequest,
+    ) -> Result<ProjectionSnapshot, ProjectionError> {
+        self.runtime_projection.snapshot(request).await
+    }
+
+    pub async fn runtime_updates(
+        &self,
+        request: ProjectionRequest,
+    ) -> Result<ProjectionReplay, ProjectionError> {
+        self.runtime_projection.updates(request).await
+    }
+
+    pub async fn audit_snapshot(
+        &self,
+        request: AuditProjectionRequest,
+    ) -> Result<AuditProjectionSnapshot, AuditProjectionError> {
+        self.audit_projection.snapshot(request).await
+    }
+
+    pub async fn audit_updates(
+        &self,
+        request: AuditProjectionRequest,
+    ) -> Result<AuditProjectionReplay, AuditProjectionError> {
+        self.audit_projection.updates(request).await
+    }
+}
+
+impl std::fmt::Debug for EventStreamManager {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EventStreamManager")
+            .field("runtime_projection", &"<event_projection_service>")
+            .field("audit_projection", &"<audit_projection_service>")
+            .finish()
+    }
+}
+
 #[derive(Clone)]
 pub struct ReplayEventProjectionService {
     runtime_log: Arc<dyn DurableEventLog>,

--- a/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
+++ b/crates/ironclaw_event_projections/tests/replay_projection_contract.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_event_projections::{
-    AuditProjectionRequest, AuditProjectionService, AuditProjectionStage, EventProjectionService,
-    MAX_PROJECTION_PAGE_LIMIT, ProjectionCursor, ProjectionError, ProjectionRequest,
-    ProjectionScope, ReplayAuditProjectionService, ReplayEventProjectionService,
-    RunProjectionStatus, TimelineEntryKind,
+    AuditProjectionCursor, AuditProjectionError, AuditProjectionRequest, AuditProjectionService,
+    AuditProjectionStage, EventProjectionService, EventStreamManager, MAX_PROJECTION_PAGE_LIMIT,
+    ProjectionCursor, ProjectionError, ProjectionRequest, ProjectionScope,
+    ReplayAuditProjectionService, ReplayEventProjectionService, RunProjectionStatus,
+    TimelineEntryKind,
 };
 use ironclaw_events::{
     DurableAuditLog, DurableEventLog, EventCursor, EventError, EventLogEntry, EventReplay,
@@ -163,6 +164,255 @@ async fn replay_audit_projection_preserves_only_safe_obligation_status_labels() 
     let serialized = serde_json::to_string(&snapshot).unwrap();
     assert!(!serialized.contains("api.internal"));
     assert!(!serialized.contains("secret_token"));
+}
+
+#[tokio::test]
+async fn event_stream_manager_routes_runtime_projection_without_generic_event_payloads() {
+    let runtime_log = Arc::new(InMemoryDurableEventLog::new());
+    let audit_log = Arc::new(InMemoryDurableAuditLog::new());
+    let manager = event_stream_manager(Arc::clone(&runtime_log), audit_log);
+    let capability = capability_id();
+    let provider = provider_id();
+    let scope = scope_for_thread(ThreadId::new("thread-a").unwrap());
+
+    runtime_log
+        .append(RuntimeEvent::dispatch_requested(
+            scope.clone(),
+            capability.clone(),
+        ))
+        .await
+        .unwrap();
+    runtime_log
+        .append(RuntimeEvent::dispatch_succeeded(
+            scope.clone(),
+            capability.clone(),
+            provider,
+            RuntimeKind::Script,
+            42,
+        ))
+        .await
+        .unwrap();
+
+    let snapshot = manager
+        .runtime_snapshot(ProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&scope),
+            after: None,
+            limit: 16,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.timeline.entries.len(), 2);
+    assert_eq!(snapshot.runs.len(), 1);
+    assert_eq!(snapshot.runs[0].capability_id, capability);
+    assert_eq!(snapshot.runs[0].status, RunProjectionStatus::Completed);
+    assert_eq!(snapshot.next_cursor.runtime, EventCursor::new(2));
+}
+
+#[tokio::test]
+async fn event_stream_manager_rejects_cross_scope_runtime_resume_cursors() {
+    let runtime_log = Arc::new(InMemoryDurableEventLog::new());
+    let audit_log = Arc::new(InMemoryDurableAuditLog::new());
+    let manager = event_stream_manager(Arc::clone(&runtime_log), audit_log);
+    let capability = capability_id();
+    let scope_a = scope_for_thread(ThreadId::new("thread-a").unwrap());
+    let scope_b = scope_for_thread(ThreadId::new("thread-b").unwrap());
+
+    runtime_log
+        .append(RuntimeEvent::dispatch_requested(
+            scope_a.clone(),
+            capability.clone(),
+        ))
+        .await
+        .unwrap();
+    let foreign_event = runtime_log
+        .append(RuntimeEvent::dispatch_requested(
+            scope_b.clone(),
+            capability.clone(),
+        ))
+        .await
+        .unwrap();
+
+    let scope_a_projection = ProjectionScope::from_resource_scope(&scope_a);
+    let foreign_cursor = ProjectionCursor::for_scope(
+        ProjectionScope::from_resource_scope(&scope_b),
+        foreign_event.cursor,
+    );
+    let error = manager
+        .runtime_updates(ProjectionRequest {
+            scope: scope_a_projection.clone(),
+            after: Some(foreign_cursor.clone()),
+            limit: 16,
+        })
+        .await
+        .expect_err("manager must reject cursors minted for a sibling runtime scope");
+
+    match error {
+        ProjectionError::RebaseRequired {
+            requested,
+            earliest,
+        } => {
+            assert_eq!(*requested, foreign_cursor);
+            assert_eq!(earliest.scope, scope_a_projection);
+        }
+        other => panic!("expected RebaseRequired for cross-scope cursor, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn event_stream_manager_surfaces_domain_rebase_for_stale_resume_cursors() {
+    let runtime_log = Arc::new(InMemoryDurableEventLog::new());
+    let audit_log = Arc::new(InMemoryDurableAuditLog::new());
+    let manager = event_stream_manager(Arc::clone(&runtime_log), Arc::clone(&audit_log));
+    let ctx = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-a").unwrap()));
+    let projection_scope = ProjectionScope::from_resource_scope(&ctx.resource_scope);
+    let action = Action::Dispatch {
+        capability: capability_id(),
+        estimated_resources: Default::default(),
+    };
+
+    runtime_log
+        .append(RuntimeEvent::dispatch_requested(
+            ctx.resource_scope.clone(),
+            capability_id(),
+        ))
+        .await
+        .unwrap();
+    audit_log
+        .append(AuditEnvelope::denied(
+            &ctx,
+            AuditStage::Denied,
+            ActionSummary::from_action(&action),
+            DenyReason::PolicyDenied,
+        ))
+        .await
+        .unwrap();
+
+    let runtime_error = manager
+        .runtime_updates(ProjectionRequest {
+            scope: projection_scope.clone(),
+            after: Some(ProjectionCursor::for_scope(
+                projection_scope.clone(),
+                EventCursor::new(99),
+            )),
+            limit: 16,
+        })
+        .await
+        .expect_err("stale runtime cursor must require rebase");
+    assert!(matches!(
+        runtime_error,
+        ProjectionError::RebaseRequired { .. }
+    ));
+
+    let audit_error = manager
+        .audit_updates(AuditProjectionRequest {
+            scope: projection_scope.clone(),
+            after: Some(AuditProjectionCursor::for_scope(
+                projection_scope,
+                EventCursor::new(99),
+            )),
+            limit: 16,
+        })
+        .await
+        .expect_err("stale audit cursor must require rebase");
+    assert!(matches!(
+        audit_error,
+        AuditProjectionError::RebaseRequired { .. }
+    ));
+}
+
+#[tokio::test]
+async fn event_stream_manager_routes_audit_projection_and_preserves_no_exposure_boundary() {
+    let runtime_log = Arc::new(InMemoryDurableEventLog::new());
+    let audit_log = Arc::new(InMemoryDurableAuditLog::new());
+    let manager = event_stream_manager(runtime_log, Arc::clone(&audit_log));
+    let ctx = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-a").unwrap()));
+    let action = Action::ReadFile {
+        path: ScopedPath::new("/workspace/MANAGER_AUDIT_PATH_SENTINEL_3022.md").unwrap(),
+    };
+
+    audit_log
+        .append(AuditEnvelope::denied(
+            &ctx,
+            AuditStage::Denied,
+            ActionSummary::from_action(&action),
+            DenyReason::PolicyDenied,
+        ))
+        .await
+        .unwrap();
+
+    let snapshot = manager
+        .audit_snapshot(AuditProjectionRequest {
+            scope: ProjectionScope::from_resource_scope(&ctx.resource_scope),
+            after: None,
+            limit: 16,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.entries.len(), 1);
+    assert_eq!(snapshot.entries[0].stage, AuditProjectionStage::Denied);
+    assert_eq!(snapshot.entries[0].action_kind, "read_file");
+    assert_eq!(snapshot.entries[0].action_target, None);
+    let serialized = serde_json::to_string(&snapshot).unwrap();
+    assert!(!serialized.contains("MANAGER_AUDIT_PATH_SENTINEL_3022"));
+}
+
+#[tokio::test]
+async fn event_stream_manager_rejects_cross_scope_audit_resume_cursors() {
+    let runtime_log = Arc::new(InMemoryDurableEventLog::new());
+    let audit_log = Arc::new(InMemoryDurableAuditLog::new());
+    let manager = event_stream_manager(runtime_log, Arc::clone(&audit_log));
+    let ctx_a = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-a").unwrap()));
+    let ctx_b = execution_context_for_scope(scope_for_thread(ThreadId::new("thread-b").unwrap()));
+    let action = Action::Dispatch {
+        capability: capability_id(),
+        estimated_resources: Default::default(),
+    };
+
+    audit_log
+        .append(AuditEnvelope::denied(
+            &ctx_a,
+            AuditStage::Denied,
+            ActionSummary::from_action(&action),
+            DenyReason::PolicyDenied,
+        ))
+        .await
+        .unwrap();
+    let foreign_entry = audit_log
+        .append(AuditEnvelope::denied(
+            &ctx_b,
+            AuditStage::Denied,
+            ActionSummary::from_action(&action),
+            DenyReason::PolicyDenied,
+        ))
+        .await
+        .unwrap();
+
+    let scope_a_projection = ProjectionScope::from_resource_scope(&ctx_a.resource_scope);
+    let foreign_cursor = AuditProjectionCursor::for_scope(
+        ProjectionScope::from_resource_scope(&ctx_b.resource_scope),
+        foreign_entry.cursor,
+    );
+    let error = manager
+        .audit_updates(AuditProjectionRequest {
+            scope: scope_a_projection.clone(),
+            after: Some(foreign_cursor.clone()),
+            limit: 16,
+        })
+        .await
+        .expect_err("manager must reject cursors minted for a sibling audit scope");
+
+    match error {
+        AuditProjectionError::RebaseRequired {
+            requested,
+            earliest,
+        } => {
+            assert_eq!(*requested, foreign_cursor);
+            assert_eq!(earliest.scope, scope_a_projection);
+        }
+        other => panic!("expected audit RebaseRequired for cross-scope cursor, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -624,6 +874,16 @@ fn capability_id() -> CapabilityId {
 
 fn provider_id() -> ExtensionId {
     ExtensionId::new("script").unwrap()
+}
+
+fn event_stream_manager(
+    runtime_log: Arc<InMemoryDurableEventLog>,
+    audit_log: Arc<InMemoryDurableAuditLog>,
+) -> EventStreamManager {
+    EventStreamManager::new(
+        Arc::new(ReplayEventProjectionService::new(runtime_log)),
+        Arc::new(ReplayAuditProjectionService::new(audit_log)),
+    )
 }
 
 // -----------------------------------------------------------------------------

--- a/docs/reborn/contracts/events-projections.md
+++ b/docs/reborn/contracts/events-projections.md
@@ -122,6 +122,12 @@ client reconnects with last_event_id
 -> transport resumes live tail
 ```
 
+`EventStreamManager` is the transport-agnostic facade over domain projection
+services. It routes scoped runtime and audit replay requests through their
+owning projection services and preserves their domain-specific DTOs/cursors;
+it must not flatten runtime, audit, transcript, or future memory facts into a
+single generic event payload.
+
 Rules:
 
 - event ids are scoped; a user cannot replay another user's stream


### PR DESCRIPTION
## Summary
- Add `EventStreamManager` as a transport-agnostic facade over Reborn runtime and audit projection services.
- Keep runtime/audit replay domain-specific instead of introducing a generic all-events DTO.
- Add caller-level tests for facade routing, scope-bound cursor rejection, stale cursor rebase propagation, and audit no-exposure behavior.
- Update the events/projections contract with the facade boundary.

Refs #3022

## Verification
- `cargo test -p ironclaw_event_projections event_stream_manager_ -q`
- `cargo test -p ironclaw_event_projections -q`
- `cargo fmt --check`
- `cargo clippy -p ironclaw_event_projections --all-targets --all-features -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold -q`

## Review
- Reviewer subagent found no Critical / High / Medium findings.
