### PR TITLE
Wire durable run-state store selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4206,6 +4206,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "deadpool-postgres",
  "ironclaw_approvals",
  "ironclaw_authorization",
  "ironclaw_capabilities",

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -6,12 +6,13 @@ publish = false
 
 [features]
 default = []
-postgres = ["ironclaw_filesystem/postgres"]
-libsql = ["ironclaw_filesystem/libsql"]
+postgres = ["dep:deadpool-postgres", "ironclaw_filesystem/postgres", "ironclaw_run_state/postgres"]
+libsql = ["dep:libsql", "ironclaw_filesystem/libsql", "ironclaw_run_state/libsql"]
 
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+deadpool-postgres = { version = "0.14", optional = true }
 ironclaw_approvals = { path = "../ironclaw_approvals" }
 ironclaw_authorization = { path = "../ironclaw_authorization" }
 ironclaw_capabilities = { path = "../ironclaw_capabilities" }
@@ -32,6 +33,7 @@ ironclaw_scripts = { path = "../ironclaw_scripts" }
 ironclaw_secrets = { path = "../ironclaw_secrets" }
 ironclaw_trust = { path = "../ironclaw_trust" }
 ironclaw_wasm = { path = "../ironclaw_wasm" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
 secrecy = "0.10"
 serde_json = "1"
@@ -42,7 +44,6 @@ url = "2"
 
 [dev-dependencies]
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
-libsql = { version = "0.6", default-features = false, features = ["core", "replication", "remote", "tls"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "time"] }
 wat = "1.245.1"

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -43,6 +43,12 @@ use ironclaw_reborn_event_store::{
     build_reborn_event_stores,
 };
 use ironclaw_resources::ResourceGovernor;
+#[cfg(feature = "libsql")]
+use ironclaw_run_state::LibSqlRunStateApprovalStore;
+#[cfg(feature = "postgres")]
+use ironclaw_run_state::PostgresRunStateApprovalStore;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_run_state::RunStateError;
 use ironclaw_run_state::{ApprovalRequestStore, RunStateApprovalStore, RunStateStore};
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
 use ironclaw_secrets::SecretStore;
@@ -490,6 +496,30 @@ where
         self.approval_requests = Some(store.clone());
         self.run_state_approval_store = Some(store);
         self
+    }
+
+    /// Builds and attaches the libSQL transactional combined run-state and
+    /// approval-request store for production/shared callers.
+    #[cfg(feature = "libsql")]
+    pub async fn with_libsql_run_state_approval_store(
+        self,
+        db: Arc<libsql::Database>,
+    ) -> Result<Self, RunStateError> {
+        let store = Arc::new(LibSqlRunStateApprovalStore::new(db));
+        store.run_migrations().await?;
+        Ok(self.with_run_state_approval_store(store))
+    }
+
+    /// Builds and attaches the PostgreSQL transactional combined run-state and
+    /// approval-request store for production/shared callers.
+    #[cfg(feature = "postgres")]
+    pub async fn with_postgres_run_state_approval_store(
+        self,
+        pool: deadpool_postgres::Pool,
+    ) -> Result<Self, RunStateError> {
+        let store = Arc::new(PostgresRunStateApprovalStore::new(pool));
+        store.run_migrations().await?;
+        Ok(self.with_run_state_approval_store(store))
     }
 
     pub fn with_capability_leases<T>(mut self, capability_leases: Arc<T>) -> Self

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -55,6 +55,8 @@ use ironclaw_reborn_event_store::{
 use ironclaw_resources::{
     InMemoryResourceGovernor, ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
 };
+#[cfg(feature = "libsql")]
+use ironclaw_run_state::LibSqlRunStateApprovalStore;
 use ironclaw_run_state::{
     ApprovalRecord, ApprovalRequestStore, InMemoryApprovalRequestStore, InMemoryRunStateStore,
     RunRecord, RunStart, RunStateApprovalStore, RunStateError, RunStateStore, RunStatus,
@@ -240,6 +242,120 @@ fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
             ProductionWiringIssueKind::UnsupportedRequirement
         ),
         "unsupported runtime backend requirement should be reported: {report:?}"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_run_state_store_selection_satisfies_production_run_state_guardrails() {
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("run-state-selection.db");
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_libsql_run_state_approval_store(Arc::clone(&db))
+    .await
+    .unwrap();
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("other local services remain intentionally unready");
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::RunState,
+            ProductionWiringIssueKind::Missing
+        ),
+        "LibSqlRunStateApprovalStore must satisfy run-state presence: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::ApprovalRequests,
+            ProductionWiringIssueKind::Missing
+        ),
+        "LibSqlRunStateApprovalStore must satisfy approval-store presence: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::RunState,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "LibSqlRunStateApprovalStore must not be classified local-only: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::ApprovalRequests,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "LibSqlRunStateApprovalStore must not be classified local-only: {report:?}"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_run_state_store_selection_persists_runtime_approval_block() {
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("run-state-runtime-approval.db");
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ApprovalThenGrantAuthorizer),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_libsql_run_state_approval_store(Arc::clone(&db))
+    .await
+    .unwrap()
+    .with_trust_policy(Arc::new(local_manifest_trust_policy(
+        "script",
+        vec![EffectKind::DispatchCapability],
+    )))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )));
+
+    let runtime = services.host_runtime_for_local_testing();
+    let context = execution_context_without_grants();
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context.clone(),
+            script_capability_id(),
+            ResourceEstimate::default(),
+            json!({"message": "durable approval"}),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::ApprovalRequired(gate) = outcome else {
+        panic!("expected approval gate, got {outcome:?}");
+    };
+    let store = LibSqlRunStateApprovalStore::new(db);
+    let run_record = RunStateStore::get(&store, &context.resource_scope, context.invocation_id)
+        .await
+        .unwrap()
+        .expect("run record persisted");
+    assert_eq!(run_record.status, RunStatus::BlockedApproval);
+    assert_eq!(
+        run_record.approval_request_id,
+        Some(gate.approval_request_id)
+    );
+    let approval_record =
+        ApprovalRequestStore::get(&store, &context.resource_scope, gate.approval_request_id)
+            .await
+            .unwrap()
+            .expect("approval record persisted");
+    assert_eq!(
+        approval_record.status,
+        ironclaw_run_state::ApprovalStatus::Pending
     );
 }
 

--- a/docs/reborn/contracts/run-state.md
+++ b/docs/reborn/contracts/run-state.md
@@ -133,13 +133,22 @@ The filesystem store is durable current-state storage. It is not a transition lo
 
 ## 6. Capability host integration
 
-`CapabilityHost` may be configured with run-state and approval stores:
+`CapabilityHost` may be configured with run-state and approval stores. Production/shared callers should prefer a combined `RunStateApprovalStore` so the pending approval record and `BlockedApproval` run-state transition commit atomically:
+
+```rust
+CapabilityHost::new(&registry, &dispatcher, &authorizer)
+    .with_run_state_approval_store(&run_state_approvals)
+```
+
+Local or single-process callers may still attach separate stores:
 
 ```rust
 CapabilityHost::new(&registry, &dispatcher, &authorizer)
     .with_run_state(&run_state)
     .with_approval_requests(&approval_requests)
 ```
+
+`HostRuntimeServices` provides backend-selection helpers for production composition (`with_postgres_run_state_approval_store` / `with_libsql_run_state_approval_store`) that run run-state migrations and install the combined store into the runtime facade.
 
 When configured, `invoke_json` records under the caller's `ExecutionContext.resource_scope`:
 
@@ -177,8 +186,7 @@ This slice does not implement:
 
 - durable grant/lease persistence
 - append-only transition history
-- atomic transactions across run-state and approval stores
-- project/thread secondary indexes
+- project/thread secondary indexes beyond the resource-owner-scoped DB keys
 - auth/OAuth blocking semantics beyond reserving `BlockedAuth`
 - cancellation
 - retries


### PR DESCRIPTION
## Summary
- add `HostRuntimeServices` helpers that build/migrate PostgreSQL and libSQL `RunStateApprovalStore` backends from production DB handles
- propagate host-runtime `postgres`/`libsql` features into `ironclaw_run_state` so DB-backed run-state stores are available at composition
- add libSQL caller-level coverage proving the wired store satisfies production guardrails and persists atomic approval blocks
- update the run-state contract to prefer combined transactional stores for shared/production callers

## Test Plan
- [x] `cargo fmt --check --quiet`
- [x] `git diff --check`
- [x] `cargo test -q -p ironclaw_host_runtime --features libsql --test host_runtime_services_contract libsql_run_state_store_selection_satisfies_production_run_state_guardrails`
- [x] `cargo test -q -p ironclaw_host_runtime --features libsql --test host_runtime_services_contract libsql_run_state_store_selection_persists_runtime_approval_block`
- [x] `cargo test -q -p ironclaw_host_runtime --features 'libsql,postgres' --test host_runtime_services_contract`
- [x] `cargo test -q -p ironclaw_host_runtime --features 'libsql,postgres' --test host_runtime_contract`
- [x] `IRONCLAW_RUN_STATE_POSTGRES_URL=postgres://postgres@127.0.0.1:55432/ironclaw_test cargo test -q -p ironclaw_run_state --features 'libsql,postgres' --test db_run_state_store_contract`
- [x] `cargo clippy -q -p ironclaw_host_runtime --features 'libsql,postgres' --tests -- -D warnings`
- [x] `cargo clippy -q -p ironclaw_run_state --features 'libsql,postgres' --tests -- -D warnings`
- [x] `cargo test -q -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
