### PR TITLE
fix(canary): seed github_token_scopes companion in auth-live-seeded

### DIFF
--- a/scripts/auth_live_canary/.gitignore
+++ b/scripts/auth_live_canary/.gitignore
@@ -1,0 +1,1 @@
+config.env

--- a/scripts/auth_live_canary/run_live_canary.py
+++ b/scripts/auth_live_canary/run_live_canary.py
@@ -325,6 +325,17 @@ async def seed_non_oauth_credentials(
             value=github_token,
             provider="github",
         )
+        # Companion scopes record — without it, needs_scope_expansion() in
+        # src/extensions/manager.rs treats the seeded PAT as a legacy token
+        # and forces re-auth, leaving the extension stuck at
+        # authenticated=False. Match the github tool's merged_scopes.
+        await put_secret(
+            base_url, token,
+            user_id=owner_user_id,
+            name="github_token_scopes",
+            value="read:org repo workflow",
+            provider="github",
+        )
 
     notion_access = env_str("AUTH_LIVE_NOTION_ACCESS_TOKEN")
     notion_refresh = env_str("AUTH_LIVE_NOTION_REFRESH_TOKEN")


### PR DESCRIPTION
## Summary

The scheduled \`auth-live-seeded\` lane has been failing every 6h cron for ~30 consecutive runs, all with the same signature:

\`\`\`
ERROR: Timed out waiting for extension state: github
       (expected authenticated=True, active=True;
        last observed: authenticated=False, active=False)
\`\`\`

Root cause: \`seed_non_oauth_credentials\` writes \`github_token\` but never the companion \`github_token_scopes\` record. \`needs_scope_expansion()\` in \`src/extensions/manager.rs:4915\` treats a missing scopes record as a "legacy token" and returns \`needs_reauth=true\`, which surfaces as \`authenticated=False, active=False\` in \`/api/extensions\`.

## Fix

Seed \`github_token_scopes = "read:org repo workflow"\` (the github WASM tool's \`merged_scopes\`) right after the \`github_token\` PUT — same pattern as the existing google-side seeding in \`tests/e2e_live.rs\`.

Also gitignores \`scripts/auth_live_canary/config.env\` so local credentials staged via \`README cp config.example.env config.env\` can't be committed.

## Verification

Reproduced locally first (same ERROR signature as CI), then confirmed green with the fix applied:

\`\`\`
github/responses_api: success=True latency=510ms
github/browser:       success=True latency=1137ms
\`\`\`

## Out of scope (separate)

This PR does **not** address the unrelated regression that started ~2026-05-07 07 UTC affecting Auth Smoke / Auth Full / Persona lanes (\`Timed out waiting for … tool call\` after MCP/gmail tool dispatch hangs on a pending auth gate). Suspected commit: \`b8e6caa3f #3157 fix(engine): inline gate await for Tier 0 + Tier 1 Approval gates\` — needs a separate bisect.

## Regression test

\`[skip-regression-check]\` — fix lives in a CI canary runner script; the next scheduled \`auth-live-seeded\` run is the regression check. The underlying gate contract is already locked in by \`test_shared_google_oauth_status_requires_scope_expansion_for_second_tool\` in \`src/extensions/manager.rs\` — this PR fixes a caller that wasn't honoring it, not the gate itself.

## Test plan

- [ ] Manual workflow_dispatch of \`live-canary.yml\` lane=\`auth-live-seeded\` against this branch passes
- [ ] Next scheduled cron after merge stays green for github case
- [ ] Other seeded cases (gmail, calendar, notion) remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)