### PR TITLE
feat: add WeChat registry artifact metadata

### DIFF
--- a/registry/channels/wechat.json
+++ b/registry/channels/wechat.json
@@ -16,6 +16,12 @@
     "capabilities": "wechat.capabilities.json",
     "crate_name": "wechat-channel"
   },
+  "artifacts": {
+    "wasm32-wasip2": {
+      "url": "https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.28.0/channel-wechat-0.1.0-wasm32-wasip2.tar.gz",
+      "sha256": "1538dfd3554b533f5617475d4c88d2666615bf87c7f0a732df520d442f29e7c2"
+    }
+  },
   "auth_summary": {
     "method": "interactive",
     "provider": "WeChat",

--- a/src/channels/wasm/bundled.rs
+++ b/src/channels/wasm/bundled.rs
@@ -23,6 +23,7 @@ const KNOWN_CHANNELS: &[(&str, &str)] = &[
     ("discord", "discord_channel"),
     ("whatsapp", "whatsapp_channel"),
     ("feishu", "feishu_channel"),
+    ("wechat", "wechat_channel"),
 ];
 
 /// Names of known channels that can be installed.
@@ -143,12 +144,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_known_channels_includes_all_four() {
+    fn test_known_channels_include_supported_bundles() {
         let names = bundled_channel_names();
         assert!(names.contains(&"telegram"));
         assert!(names.contains(&"slack"));
         assert!(names.contains(&"discord"));
         assert!(names.contains(&"whatsapp"));
+        assert!(names.contains(&"feishu"));
+        assert!(names.contains(&"wechat"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `artifacts.wasm32-wasip2` metadata to `registry/channels/wechat.json` so WeChat installs can download the prebuilt WASM bundle instead of failing into source-build mode in hosted/prod environments.
- Point the WeChat channel manifest at the existing `ironclaw-v0.28.0` GitHub release asset and its SHA256 checksum.
- Add `wechat` to `src/channels/wasm/bundled.rs` `KNOWN_CHANNELS` so bundled/dev/onboarding flows treat it consistently with other built-in WASM channels.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: not run in this follow-up
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: confirmed the `ironclaw-v0.28.0` GitHub release already contains `channel-wechat-0.1.0-wasm32-wasip2.tar.gz`, verified `registry/channels/wechat.json` now points to that asset with the matching SHA256, and verified `bundled.rs` includes `wechat` in `KNOWN_CHANNELS`
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None. This change only points the WeChat registry manifest at an existing GitHub release artifact and checksum. It does not change permissions, secret handling, sandbox policy, or network allowlists.

## Database Impact

None.

## Blast Radius

Limited to WeChat channel installation and bundled-channel discovery:
- Registry install path for `wechat`
- Bundled/dev/onboarding path that enumerates known prebuilt WASM channels

Other channels are unaffected.

## Rollback Plan

Revert this commit to restore the previous behavior:
- remove the WeChat `artifacts.wasm32-wasip2` manifest entry
- remove `wechat` from `KNOWN_CHANNELS`

Rollback impact is low: WeChat installs in hosted/prod environments would go back to requiring local source builds.

## Review Follow-Through

This fixes the immediate prod install failure, which was caused by `wechat` being the only channel manifest without artifact metadata even though the `v0.28.0` GitHub release already contains the prebuilt bundle.

Known follow-up:
- ensure the deployed/prod binary is rebuilt with the updated embedded registry/catalog; otherwise the old manifest may still be used at runtime

---

**Review track**: B
