### PR TITLE
test(reborn): add loop host model milestones

### DIFF
--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -46,6 +46,55 @@ fn validate_prefixed_loop_ref(
     Ok(value)
 }
 
+fn validate_loop_safe_summary(value: String) -> Result<String, String> {
+    let value = validate_bounded_loop_string(value, "loop safe summary", 512)?;
+    if value.chars().any(|character| {
+        matches!(
+            character,
+            '{' | '}' | '[' | ']' | '`' | '<' | '>' | '/' | '\\'
+        )
+    }) {
+        return Err(
+            "loop safe summary must not contain raw payload or path delimiters".to_string(),
+        );
+    }
+
+    let lower = value.to_ascii_lowercase();
+    for forbidden in [
+        "access token",
+        "api key",
+        "api_key",
+        "apikey",
+        "authorization:",
+        "bearer ",
+        "host path",
+        "invalid api key",
+        "invalid_api_key",
+        "password",
+        "passwd",
+        "provider error",
+        "raw runtime",
+        "secret",
+        "stack trace",
+        "tool input",
+        "tool_input",
+        "traceback",
+    ] {
+        if lower.contains(forbidden) {
+            return Err(format!(
+                "loop safe summary must not contain sensitive marker `{forbidden}`"
+            ));
+        }
+    }
+    if lower
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '-')
+        .any(|token| token.starts_with("sk-"))
+    {
+        return Err("loop safe summary must not contain API-key-like tokens".to_string());
+    }
+    Ok(value)
+}
+
 macro_rules! bounded_loop_ref {
     ($name:ident, $label:literal, $prefix:literal, $max:expr) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
@@ -100,6 +149,42 @@ bounded_loop_ref!(
     256
 );
 bounded_loop_ref!(LoopProcessRef, "loop process ref", "process:", 256);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct LoopSafeSummary(String);
+
+impl LoopSafeSummary {
+    pub fn new(value: impl Into<String>) -> Result<Self, String> {
+        validate_loop_safe_summary(value.into()).map(Self)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for LoopSafeSummary {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for LoopSafeSummary {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for LoopSafeSummary {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
 
 fn origin_input_cursor_token() -> LoopInputCursorToken {
     LoopInputCursorToken("input-cursor:origin".to_string())
@@ -610,16 +695,19 @@ pub trait LoopCheckpointPort: Send + Sync {
 pub enum LoopProgressEvent {
     DriverNote {
         kind: LoopDriverNoteKind,
-        safe_summary: String,
+        safe_summary: LoopSafeSummary,
     },
 }
 
 impl LoopProgressEvent {
-    pub fn driver_note(kind: LoopDriverNoteKind, safe_summary: impl Into<String>) -> Self {
-        Self::DriverNote {
+    pub fn driver_note(
+        kind: LoopDriverNoteKind,
+        safe_summary: impl Into<String>,
+    ) -> Result<Self, String> {
+        Ok(Self::DriverNote {
             kind,
-            safe_summary: safe_summary.into(),
-        }
+            safe_summary: LoopSafeSummary::new(safe_summary)?,
+        })
     }
 
     pub fn kind_name(&self) -> &'static str {

--- a/crates/ironclaw_turns/src/run_profile/milestones.rs
+++ b/crates/ironclaw_turns/src/run_profile/milestones.rs
@@ -1,0 +1,246 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_host_api::CapabilityId;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    LoopExitId, LoopGateRef, LoopMessageRef, TurnCheckpointId, TurnId, TurnRunId, TurnScope,
+};
+
+use super::host::{
+    AgentLoopHostError, AgentLoopHostErrorKind, LoopCheckpointKind, LoopDriverNoteKind,
+    LoopRunContext, LoopSafeSummary,
+};
+use super::refs::{LoopDriverId, ModelProfileId};
+use crate::{LoopCompletionKind, LoopFailureKind};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopHostMilestone {
+    pub scope: TurnScope,
+    pub turn_id: TurnId,
+    pub run_id: TurnRunId,
+    pub loop_driver_id: LoopDriverId,
+    pub kind: LoopHostMilestoneKind,
+}
+
+impl LoopHostMilestone {
+    fn from_context(context: &LoopRunContext, kind: LoopHostMilestoneKind) -> Self {
+        Self {
+            scope: context.scope.clone(),
+            turn_id: context.turn_id,
+            run_id: context.run_id,
+            loop_driver_id: context.loop_driver_id.clone(),
+            kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopHostMilestoneKind {
+    ModelStarted {
+        requested_model_profile_id: Option<ModelProfileId>,
+    },
+    ModelCompleted {
+        effective_model_profile_id: ModelProfileId,
+    },
+    CapabilityInvoked {
+        capability_id: CapabilityId,
+    },
+    CheckpointCreated {
+        checkpoint_id: TurnCheckpointId,
+        checkpoint_kind: LoopCheckpointKind,
+    },
+    AssistantReplyFinalized {
+        message_ref: LoopMessageRef,
+    },
+    Blocked {
+        gate_ref: LoopGateRef,
+        checkpoint_id: TurnCheckpointId,
+    },
+    Completed {
+        completion_kind: LoopCompletionKind,
+        exit_id: LoopExitId,
+    },
+    Failed {
+        reason_kind: LoopFailureKind,
+        exit_id: LoopExitId,
+    },
+    DriverNote {
+        kind: LoopDriverNoteKind,
+        safe_summary: LoopSafeSummary,
+    },
+}
+
+impl LoopHostMilestoneKind {
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Self::ModelStarted { .. } => "model_started",
+            Self::ModelCompleted { .. } => "model_completed",
+            Self::CapabilityInvoked { .. } => "capability_invoked",
+            Self::CheckpointCreated { .. } => "checkpoint_created",
+            Self::AssistantReplyFinalized { .. } => "assistant_reply_finalized",
+            Self::Blocked { .. } => "blocked",
+            Self::Completed { .. } => "completed",
+            Self::Failed { .. } => "failed",
+            Self::DriverNote { .. } => "driver_note",
+        }
+    }
+}
+
+#[async_trait]
+pub trait LoopHostMilestoneSink: Send + Sync {
+    async fn publish_loop_milestone(
+        &self,
+        milestone: LoopHostMilestone,
+    ) -> Result<(), AgentLoopHostError>;
+}
+
+#[derive(Default)]
+pub struct InMemoryLoopHostMilestoneSink {
+    milestones: Mutex<Vec<LoopHostMilestone>>,
+}
+
+impl InMemoryLoopHostMilestoneSink {
+    pub fn milestones(&self) -> Vec<LoopHostMilestone> {
+        match self.milestones.lock() {
+            Ok(milestones) => milestones.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl LoopHostMilestoneSink for InMemoryLoopHostMilestoneSink {
+    async fn publish_loop_milestone(
+        &self,
+        milestone: LoopHostMilestone,
+    ) -> Result<(), AgentLoopHostError> {
+        let mut milestones = self.milestones.lock().map_err(|_| {
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::Unavailable,
+                "loop milestone sink mutex poisoned",
+            )
+        })?;
+        milestones.push(milestone);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct LoopHostMilestoneEmitter<S>
+where
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    context: LoopRunContext,
+    sink: Arc<S>,
+}
+
+impl<S> LoopHostMilestoneEmitter<S>
+where
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    pub fn new(context: LoopRunContext, sink: Arc<S>) -> Self {
+        Self { context, sink }
+    }
+
+    pub async fn model_started(
+        &self,
+        requested_model_profile_id: Option<ModelProfileId>,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::ModelStarted {
+            requested_model_profile_id,
+        })
+        .await
+    }
+
+    pub async fn model_completed(
+        &self,
+        effective_model_profile_id: ModelProfileId,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::ModelCompleted {
+            effective_model_profile_id,
+        })
+        .await
+    }
+
+    pub async fn capability_invoked(
+        &self,
+        capability_id: CapabilityId,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::CapabilityInvoked { capability_id })
+            .await
+    }
+
+    pub async fn checkpoint_created(
+        &self,
+        checkpoint_id: TurnCheckpointId,
+        checkpoint_kind: LoopCheckpointKind,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::CheckpointCreated {
+            checkpoint_id,
+            checkpoint_kind,
+        })
+        .await
+    }
+
+    pub async fn assistant_reply_finalized(
+        &self,
+        message_ref: LoopMessageRef,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::AssistantReplyFinalized { message_ref })
+            .await
+    }
+
+    pub async fn blocked(
+        &self,
+        gate_ref: LoopGateRef,
+        checkpoint_id: TurnCheckpointId,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::Blocked {
+            gate_ref,
+            checkpoint_id,
+        })
+        .await
+    }
+
+    pub async fn completed(
+        &self,
+        completion_kind: LoopCompletionKind,
+        exit_id: LoopExitId,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::Completed {
+            completion_kind,
+            exit_id,
+        })
+        .await
+    }
+
+    pub async fn failed(
+        &self,
+        reason_kind: LoopFailureKind,
+        exit_id: LoopExitId,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::Failed {
+            reason_kind,
+            exit_id,
+        })
+        .await
+    }
+
+    pub async fn driver_note(
+        &self,
+        kind: LoopDriverNoteKind,
+        safe_summary: LoopSafeSummary,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::DriverNote { kind, safe_summary })
+            .await
+    }
+
+    async fn publish(&self, kind: LoopHostMilestoneKind) -> Result<(), AgentLoopHostError> {
+        self.sink
+            .publish_loop_milestone(LoopHostMilestone::from_context(&self.context, kind))
+            .await
+    }
+}

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -1,5 +1,6 @@
 mod driver;
 mod host;
+mod milestones;
 mod policy;
 mod refs;
 mod resolver;
@@ -20,9 +21,13 @@ pub use host::{
     LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopDriverNoteKind, LoopInput,
     LoopInputBatch, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopInterruptKind,
     LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelResponse, LoopProcessRef,
-    LoopProgressEvent, LoopProgressPort, LoopRunContext, LoopRunInfoPort, LoopTranscriptPort,
-    ModelStreamChunk, ParentLoopOutput, ProcessHandleSummary, UpdateAssistantDraft,
-    VisibleCapabilityRequest, VisibleCapabilitySurface,
+    LoopProgressEvent, LoopProgressPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
+    LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, ProcessHandleSummary,
+    UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
+};
+pub use milestones::{
+    InMemoryLoopHostMilestoneSink, LoopHostMilestone, LoopHostMilestoneEmitter,
+    LoopHostMilestoneKind, LoopHostMilestoneSink,
 };
 pub use policy::{
     CancellationPolicy, CheckpointPolicy, PrivilegedRunProfileDimension,

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -16,12 +16,14 @@ use ironclaw_turns::{
         AgentLoopDriverHost, AgentLoopHostError, AgentLoopHostErrorKind, AssistantReply,
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDescriptorView,
         CapabilityInputRef, CapabilityInvocation, CapabilityOutcome, CapabilitySurfaceVersion,
-        FinalizeAssistantMessage, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
-        LoopCheckpointRequest, LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage,
-        LoopContextPort, LoopContextRequest, LoopDriverNoteKind, LoopInputBatch, LoopInputCursor,
-        LoopInputCursorToken, LoopInputPort, LoopModelMessage, LoopModelPort, LoopModelRequest,
-        LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopRunContext, LoopRunInfoPort,
-        LoopTranscriptPort, ParentLoopOutput, VisibleCapabilityRequest, VisibleCapabilitySurface,
+        FinalizeAssistantMessage, InMemoryLoopHostMilestoneSink, LoopCapabilityPort,
+        LoopCheckpointKind, LoopCheckpointPort, LoopCheckpointRequest, LoopCheckpointStateRef,
+        LoopContextBundle, LoopContextMessage, LoopContextPort, LoopContextRequest,
+        LoopDriverNoteKind, LoopHostMilestoneEmitter, LoopHostMilestoneKind, LoopInputBatch,
+        LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelMessage, LoopModelPort,
+        LoopModelRequest, LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopRunContext,
+        LoopRunInfoPort, LoopTranscriptPort, ParentLoopOutput, VisibleCapabilityRequest,
+        VisibleCapabilitySurface,
     },
     runner::{ClaimRunRequest, TurnRunTransitionPort},
 };
@@ -58,7 +60,10 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
             "context",
             "visible_capabilities",
             "model",
+            "milestone:model_started",
+            "milestone:model_completed",
             "finalize_assistant",
+            "milestone:assistant_reply_finalized",
             "progress:driver_note",
             "visible_capabilities",
             "invoke:demo.echo",
@@ -71,6 +76,27 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
         host.run_context().thread_id,
         ThreadId::new("thread-loop-host").unwrap()
     );
+    assert_eq!(
+        host.milestone_kind_names(),
+        vec![
+            "model_started",
+            "model_completed",
+            "assistant_reply_finalized",
+        ]
+    );
+    let milestones = host.milestones();
+    assert!(matches!(
+        &milestones[0].kind,
+        LoopHostMilestoneKind::ModelStarted { .. }
+    ));
+    assert!(milestones.iter().all(|milestone| {
+        milestone.scope == host.context.scope
+            && milestone.turn_id == host.context.turn_id
+            && milestone.run_id == host.context.run_id
+    }));
+    let serialized = serde_json::to_string(&milestones).unwrap();
+    assert!(!serialized.contains("done"));
+    assert!(!serialized.contains("RAW_AGENT_LOOP_HOST_SENTINEL"));
 }
 
 #[tokio::test]
@@ -102,6 +128,48 @@ fn loop_host_refs_are_bounded_opaque_tokens() {
     assert!(LoopCheckpointStateRef::new("/host/path/checkpoint.json").is_err());
     assert!(LoopInputCursorToken::new("input-cursor:seen-1").is_ok());
     assert!(LoopInputCursorToken::new("999").is_err());
+    assert!(LoopProgressEvent::driver_note(LoopDriverNoteKind::Planning, "safe note").is_ok());
+    assert!(LoopProgressEvent::driver_note(LoopDriverNoteKind::Planning, "x".repeat(513)).is_err());
+    assert!(
+        LoopProgressEvent::driver_note(LoopDriverNoteKind::Planning, "{\"tool_input\":\"raw\"}")
+            .is_err()
+    );
+    assert!(
+        LoopProgressEvent::driver_note(
+            LoopDriverNoteKind::Planning,
+            "/Users/alice/project/secret.txt"
+        )
+        .is_err()
+    );
+    assert!(
+        LoopProgressEvent::driver_note(LoopDriverNoteKind::Planning, "api_key=sk-test-secret")
+            .is_err()
+    );
+    assert!(
+        LoopProgressEvent::driver_note(
+            LoopDriverNoteKind::Planning,
+            "provider error: 401 invalid_api_key"
+        )
+        .is_err()
+    );
+    assert!(
+        LoopProgressEvent::driver_note(
+            LoopDriverNoteKind::Planning,
+            "openai request failed: invalid api key"
+        )
+        .is_err()
+    );
+    assert!(
+        LoopProgressEvent::driver_note(
+            LoopDriverNoteKind::Planning,
+            "access token expired for provider"
+        )
+        .is_err()
+    );
+    assert!(
+        LoopProgressEvent::driver_note(LoopDriverNoteKind::Planning, "token:sk-test-secret")
+            .is_err()
+    );
 }
 
 #[test]
@@ -121,6 +189,16 @@ fn loop_host_refs_validate_when_deserialized() {
 
     let invalid_surface = serde_json::json!("surface\n1");
     assert!(serde_json::from_value::<CapabilitySurfaceVersion>(invalid_surface).is_err());
+
+    let forged_host_milestone = serde_json::json!({
+        "model_started": {"requested_model_profile_id": null}
+    });
+    assert!(serde_json::from_value::<LoopProgressEvent>(forged_host_milestone).is_err());
+
+    let unsafe_note = serde_json::json!({
+        "driver_note": {"kind": "planning", "safe_summary": "raw\nprovider error"}
+    });
+    assert!(serde_json::from_value::<LoopProgressEvent>(unsafe_note).is_err());
 }
 
 #[tokio::test]
@@ -192,10 +270,13 @@ impl AgentLoopDriver for ReplyDriver {
             .finalize_assistant_message(FinalizeAssistantMessage { reply })
             .await
             .map_err(driver_error)?;
-        host.emit_loop_progress(LoopProgressEvent::driver_note(
-            LoopDriverNoteKind::Planning,
-            "assistant transcript finalized",
-        ))
+        host.emit_loop_progress(
+            LoopProgressEvent::driver_note(
+                LoopDriverNoteKind::Planning,
+                "assistant transcript finalized",
+            )
+            .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })?,
+        )
         .await
         .map_err(driver_error)?;
         Ok(LoopExit::Completed(LoopCompleted {
@@ -262,10 +343,10 @@ impl AgentLoopDriver for CapabilityDriver {
             })
             .await
             .map_err(driver_error)?;
-        host.emit_loop_progress(LoopProgressEvent::driver_note(
-            LoopDriverNoteKind::Waiting,
-            "blocked on approval gate",
-        ))
+        host.emit_loop_progress(
+            LoopProgressEvent::driver_note(LoopDriverNoteKind::Waiting, "blocked on approval gate")
+                .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })?,
+        )
         .await
         .map_err(driver_error)?;
         Ok(LoopExit::Blocked(LoopBlocked {
@@ -299,6 +380,7 @@ struct RecordingAgentLoopHost {
     model_responses: Mutex<Vec<LoopModelResponse>>,
     capability_outcomes: Mutex<Vec<CapabilityOutcome>>,
     visible_surface: VisibleCapabilitySurface,
+    milestone_sink: Arc<InMemoryLoopHostMilestoneSink>,
 }
 
 impl RecordingAgentLoopHost {
@@ -308,6 +390,7 @@ impl RecordingAgentLoopHost {
             effects: Mutex::new(Vec::new()),
             model_responses: Mutex::new(Vec::new()),
             capability_outcomes: Mutex::new(Vec::new()),
+            milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
             visible_surface: VisibleCapabilitySurface {
                 version: CapabilitySurfaceVersion::new("surface-v1").unwrap(),
                 descriptors: vec![CapabilityDescriptorView {
@@ -331,6 +414,21 @@ impl RecordingAgentLoopHost {
 
     fn effects(&self) -> Vec<String> {
         self.effects.lock().unwrap().clone()
+    }
+
+    fn milestones(&self) -> Vec<ironclaw_turns::run_profile::LoopHostMilestone> {
+        self.milestone_sink.milestones()
+    }
+
+    fn milestone_kind_names(&self) -> Vec<&'static str> {
+        self.milestones()
+            .iter()
+            .map(|milestone| milestone.kind.kind_name())
+            .collect()
+    }
+
+    fn milestone_emitter(&self) -> LoopHostMilestoneEmitter<InMemoryLoopHostMilestoneSink> {
+        LoopHostMilestoneEmitter::new(self.context.clone(), self.milestone_sink.clone())
     }
 
     fn record(&self, effect: impl Into<String>) {
@@ -388,15 +486,25 @@ impl LoopInputPort for RecordingAgentLoopHost {
 impl LoopModelPort for RecordingAgentLoopHost {
     async fn stream_model(
         &self,
-        _request: LoopModelRequest,
+        request: LoopModelRequest,
     ) -> Result<LoopModelResponse, AgentLoopHostError> {
         self.record("model");
-        self.model_responses.lock().unwrap().pop().ok_or_else(|| {
+        let emitter = self.milestone_emitter();
+        emitter
+            .model_started(request.model_preference.clone())
+            .await?;
+        self.record("milestone:model_started");
+        let response = self.model_responses.lock().unwrap().pop().ok_or_else(|| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Unavailable,
                 "model response unavailable",
             )
-        })
+        })?;
+        emitter
+            .model_completed(response.effective_model_profile_id.clone())
+            .await?;
+        self.record("milestone:model_completed");
+        Ok(response)
     }
 }
 
@@ -458,8 +566,13 @@ impl LoopTranscriptPort for RecordingAgentLoopHost {
     ) -> Result<LoopMessageRef, AgentLoopHostError> {
         assert_eq!(request.reply.content, "done");
         self.record("finalize_assistant");
-        LoopMessageRef::new("msg:assistant-final")
-            .map_err(|reason| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, reason))
+        let message_ref = LoopMessageRef::new("msg:assistant-final")
+            .map_err(|reason| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, reason))?;
+        self.milestone_emitter()
+            .assistant_reply_finalized(message_ref.clone())
+            .await?;
+        self.record("milestone:assistant_reply_finalized");
+        Ok(message_ref)
     }
 }
 


### PR DESCRIPTION
## Summary
- add a host-owned `LoopHostMilestoneEmitter` plus milestone sink/DTO contracts for AgentLoopHost model, checkpoint, transcript, block, complete, fail, capability, and driver-note milestones
- prove the fake model-reply driver emits host-managed `model_started`, `model_completed`, and `assistant_reply_finalized` milestones without serializing assistant content
- constrain driver-authored progress to bounded `LoopSafeSummary` values and reject raw JSON/tool input, host paths, secret/API-key shapes, and provider-error details

## Issue
Continues #3016 after #3377/#3382 by adding the host-managed model/reply milestone producer seam called out by the AgentLoopHost progress-port acceptance criteria.

## Tests
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `cargo test -p ironclaw_turns --all-features --tests --no-fail-fast`
- `cargo test -p ironclaw_architecture --tests --no-fail-fast`
- `cargo clippy -p ironclaw_turns --all-targets --all-features -- -D warnings`
- `python3.11 scripts/check_no_panics.py --base HEAD~1 --head HEAD`
