### PR TITLE
test(reborn): add host managed model port

### DIFF
--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -1,6 +1,7 @@
 mod driver;
 mod host;
 mod milestones;
+mod model;
 mod policy;
 mod refs;
 mod resolver;
@@ -28,6 +29,9 @@ pub use host::{
 pub use milestones::{
     InMemoryLoopHostMilestoneSink, LoopHostMilestone, LoopHostMilestoneEmitter,
     LoopHostMilestoneKind, LoopHostMilestoneSink,
+};
+pub use model::{
+    HostManagedLoopModelPort, LoopModelGateway, LoopModelGatewayError, LoopModelGatewayRequest,
 };
 pub use policy::{
     CancellationPolicy, CheckpointPolicy, PrivilegedRunProfileDimension,

--- a/crates/ironclaw_turns/src/run_profile/model.rs
+++ b/crates/ironclaw_turns/src/run_profile/model.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::LoopDiagnosticRef;
+
+use super::host::{
+    AgentLoopHostError, AgentLoopHostErrorKind, LoopModelPort, LoopModelRequest, LoopModelResponse,
+    LoopRunContext, LoopSafeSummary,
+};
+use super::milestones::{LoopHostMilestoneEmitter, LoopHostMilestoneSink};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopModelGatewayRequest {
+    pub context: LoopRunContext,
+    pub request: LoopModelRequest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
+#[error("loop model gateway {kind:?}: {safe_summary}")]
+pub struct LoopModelGatewayError {
+    pub kind: AgentLoopHostErrorKind,
+    pub safe_summary: LoopSafeSummary,
+    pub diagnostic_ref: Option<LoopDiagnosticRef>,
+}
+
+impl LoopModelGatewayError {
+    pub fn new(
+        kind: AgentLoopHostErrorKind,
+        safe_summary: impl Into<String>,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            kind,
+            safe_summary: LoopSafeSummary::new(safe_summary)?,
+            diagnostic_ref: None,
+        })
+    }
+
+    pub fn with_diagnostic_ref(mut self, diagnostic_ref: LoopDiagnosticRef) -> Self {
+        self.diagnostic_ref = Some(diagnostic_ref);
+        self
+    }
+
+    fn into_host_error(self) -> AgentLoopHostError {
+        let mut error = AgentLoopHostError::new(self.kind, self.safe_summary.as_str().to_string());
+        if let Some(diagnostic_ref) = self.diagnostic_ref {
+            error = error.with_diagnostic_ref(diagnostic_ref);
+        }
+        error
+    }
+}
+
+#[async_trait]
+pub trait LoopModelGateway: Send + Sync {
+    async fn stream_model(
+        &self,
+        request: LoopModelGatewayRequest,
+    ) -> Result<LoopModelResponse, LoopModelGatewayError>;
+}
+
+#[derive(Clone)]
+pub struct HostManagedLoopModelPort<G, S>
+where
+    G: LoopModelGateway + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    context: LoopRunContext,
+    gateway: Arc<G>,
+    milestones: LoopHostMilestoneEmitter<S>,
+}
+
+impl<G, S> HostManagedLoopModelPort<G, S>
+where
+    G: LoopModelGateway + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    pub fn new(context: LoopRunContext, gateway: Arc<G>, milestone_sink: Arc<S>) -> Self {
+        let milestones = LoopHostMilestoneEmitter::new(context.clone(), milestone_sink);
+        Self {
+            context,
+            gateway,
+            milestones,
+        }
+    }
+}
+
+#[async_trait]
+impl<G, S> LoopModelPort for HostManagedLoopModelPort<G, S>
+where
+    G: LoopModelGateway + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    async fn stream_model(
+        &self,
+        request: LoopModelRequest,
+    ) -> Result<LoopModelResponse, AgentLoopHostError> {
+        self.milestones
+            .model_started(request.model_preference.clone())
+            .await?;
+        let response = self
+            .gateway
+            .stream_model(LoopModelGatewayRequest {
+                context: self.context.clone(),
+                request,
+            })
+            .await
+            .map_err(LoopModelGatewayError::into_host_error)?;
+        if let Err(error) = self
+            .milestones
+            .model_completed(response.effective_model_profile_id.clone())
+            .await
+        {
+            tracing::debug!(
+                kind = ?error.kind,
+                diagnostic_ref = ?error.diagnostic_ref,
+                "loop model_completed milestone failed after successful model response"
+            );
+        }
+        Ok(response)
+    }
+}

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -16,14 +16,15 @@ use ironclaw_turns::{
         AgentLoopDriverHost, AgentLoopHostError, AgentLoopHostErrorKind, AssistantReply,
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDescriptorView,
         CapabilityInputRef, CapabilityInvocation, CapabilityOutcome, CapabilitySurfaceVersion,
-        FinalizeAssistantMessage, InMemoryLoopHostMilestoneSink, LoopCapabilityPort,
-        LoopCheckpointKind, LoopCheckpointPort, LoopCheckpointRequest, LoopCheckpointStateRef,
-        LoopContextBundle, LoopContextMessage, LoopContextPort, LoopContextRequest,
-        LoopDriverNoteKind, LoopHostMilestoneEmitter, LoopHostMilestoneKind, LoopInputBatch,
-        LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelMessage, LoopModelPort,
-        LoopModelRequest, LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopRunContext,
-        LoopRunInfoPort, LoopTranscriptPort, ParentLoopOutput, VisibleCapabilityRequest,
-        VisibleCapabilitySurface,
+        FinalizeAssistantMessage, HostManagedLoopModelPort, InMemoryLoopHostMilestoneSink,
+        LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort, LoopCheckpointRequest,
+        LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage, LoopContextPort,
+        LoopContextRequest, LoopDriverNoteKind, LoopHostMilestone, LoopHostMilestoneEmitter,
+        LoopHostMilestoneKind, LoopHostMilestoneSink, LoopInputBatch, LoopInputCursor,
+        LoopInputCursorToken, LoopInputPort, LoopModelGateway, LoopModelGatewayError,
+        LoopModelGatewayRequest, LoopModelMessage, LoopModelPort, LoopModelRequest,
+        LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopRunContext, LoopRunInfoPort,
+        LoopTranscriptPort, ParentLoopOutput, VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
     runner::{ClaimRunRequest, TurnRunTransitionPort},
 };
@@ -97,6 +98,131 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
     let serialized = serde_json::to_string(&milestones).unwrap();
     assert!(!serialized.contains("done"));
     assert!(!serialized.contains("RAW_AGENT_LOOP_HOST_SENTINEL"));
+}
+
+#[tokio::test]
+async fn host_managed_model_port_routes_gateway_and_emits_model_milestones() {
+    let context = claimed_run_context().await;
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let gateway = Arc::new(RecordingLoopModelGateway::default());
+    gateway.push_response(Ok(LoopModelResponse {
+        chunks: vec![ironclaw_turns::run_profile::ModelStreamChunk {
+            safe_text_delta: "safe delta".to_string(),
+        }],
+        output: ParentLoopOutput::AssistantReply(AssistantReply {
+            content: "RAW_ASSISTANT_CONTENT_SENTINEL".to_string(),
+        }),
+        effective_model_profile_id: context.resolved_run_profile.model_profile_id.clone(),
+    }));
+    let port =
+        HostManagedLoopModelPort::new(context.clone(), gateway.clone(), milestone_sink.clone());
+
+    let response = port
+        .stream_model(LoopModelRequest {
+            messages: vec![LoopModelMessage {
+                role: "user".to_string(),
+                content_ref: LoopMessageRef::new("msg:user-message").unwrap(),
+            }],
+            surface_version: Some(CapabilitySurfaceVersion::new("surface-v1").unwrap()),
+            model_preference: Some(context.resolved_run_profile.model_profile_id.clone()),
+        })
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        response.output,
+        ParentLoopOutput::AssistantReply(_)
+    ));
+    let requests = gateway.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].context.run_id, context.run_id);
+    assert_eq!(requests[0].context.scope, context.scope);
+    assert_eq!(
+        milestone_sink
+            .milestones()
+            .iter()
+            .map(|milestone| milestone.kind.kind_name())
+            .collect::<Vec<_>>(),
+        vec!["model_started", "model_completed"]
+    );
+    let serialized_milestones = serde_json::to_string(&milestone_sink.milestones()).unwrap();
+    assert!(!serialized_milestones.contains("RAW_ASSISTANT_CONTENT_SENTINEL"));
+}
+
+#[tokio::test]
+async fn host_managed_model_port_returns_response_when_model_completed_milestone_fails() {
+    let context = claimed_run_context().await;
+    let milestone_sink = Arc::new(FailingOnModelCompletedMilestoneSink::default());
+    let gateway = Arc::new(RecordingLoopModelGateway::default());
+    gateway.push_response(Ok(LoopModelResponse {
+        chunks: vec![ironclaw_turns::run_profile::ModelStreamChunk {
+            safe_text_delta: "safe delta".to_string(),
+        }],
+        output: ParentLoopOutput::AssistantReply(AssistantReply {
+            content: "model response survived milestone failure".to_string(),
+        }),
+        effective_model_profile_id: context.resolved_run_profile.model_profile_id.clone(),
+    }));
+    let port =
+        HostManagedLoopModelPort::new(context.clone(), gateway.clone(), milestone_sink.clone());
+
+    let response = port
+        .stream_model(LoopModelRequest {
+            messages: Vec::new(),
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap();
+
+    let ParentLoopOutput::AssistantReply(reply) = response.output else {
+        panic!("expected assistant reply");
+    };
+    assert_eq!(reply.content, "model response survived milestone failure");
+    assert_eq!(gateway.requests().len(), 1);
+    assert_eq!(milestone_sink.kind_names(), vec!["model_started"]);
+}
+
+#[tokio::test]
+async fn host_managed_model_port_sanitizes_gateway_errors() {
+    let context = claimed_run_context().await;
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let gateway = Arc::new(RecordingLoopModelGateway::default());
+    assert!(
+        LoopModelGatewayError::new(
+            AgentLoopHostErrorKind::Unavailable,
+            "openai request failed: invalid api key",
+        )
+        .is_err()
+    );
+    gateway.push_response(Err(LoopModelGatewayError::new(
+        AgentLoopHostErrorKind::Unavailable,
+        "model unavailable",
+    )
+    .unwrap()));
+    let port = HostManagedLoopModelPort::new(context.clone(), gateway, milestone_sink.clone());
+
+    let error = port
+        .stream_model(LoopModelRequest {
+            messages: Vec::new(),
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::Unavailable);
+    assert_eq!(error.safe_summary, "model unavailable");
+    let serialized_error = serde_json::to_string(&error).unwrap();
+    assert!(!serialized_error.contains("invalid api key"));
+    assert_eq!(
+        milestone_sink
+            .milestones()
+            .iter()
+            .map(|milestone| milestone.kind.kind_name())
+            .collect::<Vec<_>>(),
+        vec!["model_started"]
+    );
 }
 
 #[tokio::test]
@@ -371,6 +497,64 @@ impl AgentLoopDriver for CapabilityDriver {
             host,
         )
         .await
+    }
+}
+
+#[derive(Default)]
+struct FailingOnModelCompletedMilestoneSink {
+    kind_names: Mutex<Vec<&'static str>>,
+}
+
+impl FailingOnModelCompletedMilestoneSink {
+    fn kind_names(&self) -> Vec<&'static str> {
+        self.kind_names.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl LoopHostMilestoneSink for FailingOnModelCompletedMilestoneSink {
+    async fn publish_loop_milestone(
+        &self,
+        milestone: LoopHostMilestone,
+    ) -> Result<(), AgentLoopHostError> {
+        if matches!(milestone.kind, LoopHostMilestoneKind::ModelCompleted { .. }) {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::Unavailable,
+                "milestone sink unavailable",
+            ));
+        }
+        self.kind_names
+            .lock()
+            .unwrap()
+            .push(milestone.kind.kind_name());
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct RecordingLoopModelGateway {
+    requests: Mutex<Vec<LoopModelGatewayRequest>>,
+    responses: Mutex<Vec<Result<LoopModelResponse, LoopModelGatewayError>>>,
+}
+
+impl RecordingLoopModelGateway {
+    fn push_response(&self, response: Result<LoopModelResponse, LoopModelGatewayError>) {
+        self.responses.lock().unwrap().push(response);
+    }
+
+    fn requests(&self) -> Vec<LoopModelGatewayRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl LoopModelGateway for RecordingLoopModelGateway {
+    async fn stream_model(
+        &self,
+        request: LoopModelGatewayRequest,
+    ) -> Result<LoopModelResponse, LoopModelGatewayError> {
+        self.requests.lock().unwrap().push(request);
+        self.responses.lock().unwrap().pop().unwrap()
     }
 }
 


### PR DESCRIPTION
## Summary
- add a `LoopModelGateway` seam plus sanitized `LoopModelGatewayError` and scoped `LoopModelGatewayRequest`
- add `HostManagedLoopModelPort` that wraps gateway calls with host-owned model milestones
- extend AgentLoopHost contract coverage for gateway delegation, model start/completion milestones, sanitized errors, and no assistant-content milestone leak

## Issue
Continues #3016 after #3393 by adding the concrete host-managed model-port adapter seam behind the AgentLoopHost facade, while still default-off and contract-level.

## Tests
- `cargo fmt --all -- --check`
- `git diff --check HEAD~1..HEAD`
- `cargo test -p ironclaw_turns --all-features --tests --no-fail-fast`
- `cargo test -p ironclaw_architecture --tests --no-fail-fast`
- `cargo clippy -p ironclaw_turns --all-targets --all-features -- -D warnings`
- `python3.11 scripts/check_no_panics.py --base HEAD~1 --head HEAD`
