### PR TITLE
feat(reborn): wire production turn coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,7 @@ dependencies = [
  "ironclaw_scripts",
  "ironclaw_secrets",
  "ironclaw_trust",
+ "ironclaw_turns",
  "ironclaw_wasm",
  "libsql",
  "rust_decimal",

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [features]
 default = []
-postgres = ["dep:deadpool-postgres", "ironclaw_filesystem/postgres", "ironclaw_run_state/postgres"]
-libsql = ["dep:libsql", "ironclaw_filesystem/libsql", "ironclaw_run_state/libsql"]
+postgres = ["dep:deadpool-postgres", "ironclaw_filesystem/postgres", "ironclaw_run_state/postgres", "ironclaw_turns/postgres"]
+libsql = ["dep:libsql", "ironclaw_filesystem/libsql", "ironclaw_run_state/libsql", "ironclaw_turns/libsql"]
 
 [dependencies]
 async-trait = "0.1"
@@ -32,6 +32,7 @@ ironclaw_safety = { path = "../ironclaw_safety" }
 ironclaw_scripts = { path = "../ironclaw_scripts" }
 ironclaw_secrets = { path = "../ironclaw_secrets" }
 ironclaw_trust = { path = "../ironclaw_trust" }
+ironclaw_turns = { path = "../ironclaw_turns" }
 ironclaw_wasm = { path = "../ironclaw_wasm" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -53,6 +53,11 @@ use ironclaw_run_state::{ApprovalRequestStore, RunStateApprovalStore, RunStateSt
 use ironclaw_scripts::{ScriptError, ScriptExecutionRequest, ScriptExecutor, ScriptInvocation};
 use ironclaw_secrets::SecretStore;
 use ironclaw_trust::{HostTrustPolicy, TrustPolicy};
+#[cfg(feature = "libsql")]
+use ironclaw_turns::LibSqlTurnStateStore;
+#[cfg(feature = "postgres")]
+use ironclaw_turns::PostgresTurnStateStore;
+use ironclaw_turns::{DefaultTurnCoordinator, TurnRunWakeNotifier, TurnStateStore};
 use ironclaw_wasm::{
     DenyWasmHostHttp, PreparedWitTool, WasmError, WasmRuntimeCredentialProvider,
     WasmRuntimeHttpAdapter, WasmRuntimePolicyDiscarder, WasmStagedRuntimeCredentials, WitToolHost,
@@ -139,6 +144,8 @@ pub enum ProductionWiringComponent {
     ScriptRuntime,
     McpRuntime,
     WasmRuntime,
+    TurnState,
+    TurnRunWakeNotifier,
 }
 
 impl ProductionWiringComponent {
@@ -161,6 +168,8 @@ impl ProductionWiringComponent {
             Self::ScriptRuntime => "script_runtime",
             Self::McpRuntime => "mcp_runtime",
             Self::WasmRuntime => "wasm_runtime",
+            Self::TurnState => "turn_state",
+            Self::TurnRunWakeNotifier => "turn_run_wake_notifier",
         }
     }
 }
@@ -239,6 +248,8 @@ struct ProductionComponentTypes {
     wasm_runtime_credential_provider_captured: bool,
     script_runtime: Option<&'static str>,
     mcp_runtime: Option<&'static str>,
+    turn_state: Option<&'static str>,
+    turn_run_wake_notifier: Option<&'static str>,
 }
 
 fn is_local_only_component(type_name: &str) -> bool {
@@ -291,6 +302,8 @@ where
     script_runtime: Option<Arc<dyn ScriptExecutor>>,
     mcp_runtime: Option<Arc<dyn McpExecutor>>,
     wasm_runtime: Option<Arc<WasmRuntimeAdapter>>,
+    turn_state: Option<Arc<dyn TurnStateStore>>,
+    turn_run_wake_notifier: Option<Arc<dyn TurnRunWakeNotifier>>,
     component_types: ProductionComponentTypes,
 }
 
@@ -342,6 +355,8 @@ where
             script_runtime: None,
             mcp_runtime: None,
             wasm_runtime: None,
+            turn_state: None,
+            turn_run_wake_notifier: None,
             component_types: ProductionComponentTypes {
                 trust_policy: None,
                 trust_policy_verified: false,
@@ -362,6 +377,8 @@ where
                 wasm_runtime_credential_provider_captured: false,
                 script_runtime: None,
                 mcp_runtime: None,
+                turn_state: None,
+                turn_run_wake_notifier: None,
             },
         }
     }
@@ -396,6 +413,8 @@ where
             script_runtime,
             mcp_runtime,
             wasm_runtime,
+            turn_state,
+            turn_run_wake_notifier,
             mut component_types,
         } = self;
         component_types.filesystem = type_name::<T>();
@@ -424,6 +443,8 @@ where
             script_runtime,
             mcp_runtime,
             wasm_runtime,
+            turn_state,
+            turn_run_wake_notifier,
             component_types,
         }
     }
@@ -528,6 +549,44 @@ where
     {
         self.component_types.capability_leases = Some(type_name::<T>());
         self.capability_leases = Some(capability_leases);
+        self
+    }
+
+    pub fn with_turn_state<T>(mut self, turn_state: Arc<T>) -> Self
+    where
+        T: TurnStateStore + 'static,
+    {
+        self.component_types.turn_state = Some(type_name::<T>());
+        self.turn_state = Some(turn_state);
+        self
+    }
+
+    #[cfg(feature = "libsql")]
+    pub async fn with_libsql_turn_state_store(
+        self,
+        db: Arc<libsql::Database>,
+    ) -> Result<Self, ironclaw_turns::TurnError> {
+        let store = Arc::new(LibSqlTurnStateStore::new(db));
+        store.run_migrations().await?;
+        Ok(self.with_turn_state(store))
+    }
+
+    #[cfg(feature = "postgres")]
+    pub async fn with_postgres_turn_state_store(
+        self,
+        pool: deadpool_postgres::Pool,
+    ) -> Result<Self, ironclaw_turns::TurnError> {
+        let store = Arc::new(PostgresTurnStateStore::new(pool));
+        store.run_migrations().await?;
+        Ok(self.with_turn_state(store))
+    }
+
+    pub fn with_turn_run_wake_notifier<T>(mut self, notifier: Arc<T>) -> Self
+    where
+        T: TurnRunWakeNotifier + 'static,
+    {
+        self.component_types.turn_run_wake_notifier = Some(type_name::<T>());
+        self.turn_run_wake_notifier = Some(notifier);
         self
     }
 
@@ -769,6 +828,16 @@ where
         );
         self.push_missing(
             &mut issues,
+            ProductionWiringComponent::TurnState,
+            self.turn_state.is_some(),
+        );
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::TurnRunWakeNotifier,
+            self.turn_run_wake_notifier.is_some(),
+        );
+        self.push_missing(
+            &mut issues,
             ProductionWiringComponent::EventSink,
             self.event_sink.is_some(),
         );
@@ -913,6 +982,16 @@ where
         );
         self.push_local_only(
             &mut issues,
+            ProductionWiringComponent::TurnState,
+            self.component_types.turn_state,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::TurnRunWakeNotifier,
+            self.component_types.turn_run_wake_notifier,
+        );
+        self.push_local_only(
+            &mut issues,
             ProductionWiringComponent::EventSink,
             self.component_types.event_sink,
         );
@@ -1013,6 +1092,62 @@ where
     ) -> Result<DefaultHostRuntime, ProductionWiringReport> {
         self.validate_production_wiring(config)?;
         Ok(self.build_host_runtime())
+    }
+
+    /// Validates this graph and builds the production turn coordinator from
+    /// the configured durable turn-state store and wake notifier. This keeps
+    /// turn orchestration as an upper-layer artifact while still ensuring the
+    /// same production guardrail validates the actual handles returned to
+    /// callers.
+    pub fn turn_coordinator_for_production(
+        &self,
+    ) -> Result<DefaultTurnCoordinator<dyn TurnStateStore>, ProductionWiringReport> {
+        self.validate_production_turn_wiring()?;
+        let Some(turn_state) = self.turn_state.as_ref() else {
+            return Err(production_wiring_report(
+                ProductionWiringComponent::TurnState,
+                ProductionWiringIssueKind::Missing,
+                None,
+            ));
+        };
+        let Some(notifier) = self.turn_run_wake_notifier.as_ref() else {
+            return Err(production_wiring_report(
+                ProductionWiringComponent::TurnRunWakeNotifier,
+                ProductionWiringIssueKind::Missing,
+                None,
+            ));
+        };
+        Ok(DefaultTurnCoordinator::new(Arc::clone(turn_state))
+            .with_wake_notifier(Arc::clone(notifier)))
+    }
+
+    fn validate_production_turn_wiring(&self) -> Result<(), ProductionWiringReport> {
+        let mut issues = Vec::new();
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::TurnState,
+            self.turn_state.is_some(),
+        );
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::TurnRunWakeNotifier,
+            self.turn_run_wake_notifier.is_some(),
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::TurnState,
+            self.component_types.turn_state,
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::TurnRunWakeNotifier,
+            self.component_types.turn_run_wake_notifier,
+        );
+        if issues.is_empty() {
+            Ok(())
+        } else {
+            Err(ProductionWiringReport { issues })
+        }
     }
 
     /// Builds and attaches the configured Reborn durable event/audit stores,
@@ -1201,6 +1336,20 @@ fn set_runtime_http_egress(
         Err(poisoned) => {
             *poisoned.into_inner() = Some(runtime_http_egress);
         }
+    }
+}
+
+fn production_wiring_report(
+    component: ProductionWiringComponent,
+    kind: ProductionWiringIssueKind,
+    implementation: Option<&'static str>,
+) -> ProductionWiringReport {
+    ProductionWiringReport {
+        issues: vec![ProductionWiringIssue {
+            component,
+            kind,
+            implementation,
+        }],
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     thread,
@@ -70,6 +70,14 @@ use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustProvenance,
 };
+#[cfg(feature = "libsql")]
+use ironclaw_turns::LibSqlTurnStateStore;
+#[cfg(feature = "libsql")]
+use ironclaw_turns::{
+    AcceptedMessageRef, IdempotencyKey, ReplyTargetBindingRef, RunProfileRequest, SourceBindingRef,
+    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnScope, TurnStateStore,
+};
+use ironclaw_turns::{NoopTurnRunWakeNotifier, TurnRunWake, TurnRunWakeNotifier};
 use ironclaw_wasm::{
     RecordingWasmHostHttp, WasmHostError, WasmHostHttp, WasmHttpRequest, WasmHttpResponse,
     WasmStagedRuntimeCredential, WasmStagedRuntimeCredentials, WitToolHost, WitToolRuntimeConfig,
@@ -121,6 +129,20 @@ fn production_wiring_validation_rejects_missing_components_and_local_only_defaul
             ProductionWiringIssueKind::Missing
         ),
         "missing capability lease store should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::TurnState,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing turn-state store should be reported: {report:?}"
+    );
+    assert!(
+        report.contains(
+            ProductionWiringComponent::TurnRunWakeNotifier,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing turn wake notifier should be reported: {report:?}"
     );
     assert!(
         report.contains(
@@ -391,6 +413,164 @@ async fn production_root_filesystem_selection_accepts_libsql_root_filesystem() {
             ProductionWiringIssueKind::LocalOnlyImplementation
         ),
         "LibSqlRootFilesystem must satisfy production filesystem selection: {report:?}"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn production_turn_state_selection_accepts_libsql_turn_state_store() {
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("turn-state.db");
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let turn_state = Arc::new(LibSqlTurnStateStore::new(Arc::clone(&db)));
+    turn_state.run_migrations().await.unwrap();
+
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_libsql_turn_state_store(Arc::clone(&db))
+    .await
+    .unwrap();
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("other local services remain intentionally unready");
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::TurnState,
+            ProductionWiringIssueKind::Missing
+        ),
+        "LibSqlTurnStateStore must satisfy production turn-state presence: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::TurnState,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "LibSqlTurnStateStore must not be classified local-only: {report:?}"
+    );
+}
+
+#[derive(Debug, Default)]
+struct RecordingTurnRunWakeNotifier {
+    wakes: Mutex<Vec<TurnRunWake>>,
+}
+
+impl RecordingTurnRunWakeNotifier {
+    #[cfg(feature = "libsql")]
+    fn wakes(&self) -> Vec<TurnRunWake> {
+        self.wakes.lock().unwrap().clone()
+    }
+}
+
+impl TurnRunWakeNotifier for RecordingTurnRunWakeNotifier {
+    fn notify_queued_run(
+        &self,
+        wake: TurnRunWake,
+    ) -> Result<(), ironclaw_turns::TurnRunWakeNotifyError> {
+        self.wakes.lock().unwrap().push(wake);
+        Ok(())
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn production_turn_coordinator_uses_configured_store_and_notifier() {
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("turn-coordinator.db");
+    let db = Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let notifier = Arc::new(RecordingTurnRunWakeNotifier::default());
+
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_libsql_turn_state_store(Arc::clone(&db))
+    .await
+    .unwrap()
+    .with_turn_run_wake_notifier(Arc::clone(&notifier));
+
+    let coordinator = services
+        .turn_coordinator_for_production()
+        .expect("production-ready turn wiring should build coordinator");
+    let request = submit_turn_request("thread-production-turn-coordinator", "idem-production-turn");
+    let response = coordinator.submit_turn(request.clone()).await.unwrap();
+    let SubmitTurnResponse::Accepted { run_id, .. } = response;
+
+    let reopened = LibSqlTurnStateStore::new(Arc::clone(&db));
+    let state = reopened
+        .get_run_state(ironclaw_turns::GetRunStateRequest {
+            scope: request.scope,
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(state.run_id, run_id);
+    assert_eq!(notifier.wakes().len(), 1);
+    assert_eq!(notifier.wakes()[0].run_id, run_id);
+}
+
+#[test]
+fn production_wiring_validation_rejects_noop_turn_wake_notifier() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_turn_run_wake_notifier(Arc::new(NoopTurnRunWakeNotifier));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("other local services remain intentionally unready");
+    assert!(
+        report.contains(
+            ProductionWiringComponent::TurnRunWakeNotifier,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "NoopTurnRunWakeNotifier must not satisfy production turn wake wiring: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_accepts_configured_turn_wake_notifier() {
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_turn_run_wake_notifier(Arc::new(RecordingTurnRunWakeNotifier::default()));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("other local services remain intentionally unready");
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::TurnRunWakeNotifier,
+            ProductionWiringIssueKind::Missing
+        ),
+        "configured turn wake notifier must satisfy production presence: {report:?}"
+    );
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::TurnRunWakeNotifier,
+            ProductionWiringIssueKind::LocalOnlyImplementation
+        ),
+        "configured turn wake notifier must not be classified local-only: {report:?}"
     );
 }
 
@@ -5796,6 +5976,25 @@ fn http_without_body_then_guest_error_wat() -> String {
         "i32.const 1\n    i32.const 256\n    i32.const 5",
         "i32.const 0\n    i32.const 0\n    i32.const 0",
     )
+}
+
+#[cfg(feature = "libsql")]
+fn submit_turn_request(thread: &str, idempotency_key: &str) -> SubmitTurnRequest {
+    SubmitTurnRequest {
+        scope: TurnScope::new(
+            TenantId::new("tenant1").unwrap(),
+            Some(AgentId::new("agent1").unwrap()),
+            Some(ProjectId::new("project1").unwrap()),
+            ThreadId::new(thread).unwrap(),
+        ),
+        actor: TurnActor::new(UserId::new("user1").unwrap()),
+        accepted_message_ref: AcceptedMessageRef::new(format!("message-{thread}")).unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
+        requested_run_profile: Some(RunProfileRequest::new("default").unwrap()),
+        idempotency_key: IdempotencyKey::new(idempotency_key).unwrap(),
+        received_at: Utc::now(),
+    }
 }
 
 const SCRIPT_MANIFEST: &str = r#"

--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -80,7 +80,7 @@ pub trait TurnCoordinator: Send + Sync {
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError>;
 }
 
-pub struct DefaultTurnCoordinator<S> {
+pub struct DefaultTurnCoordinator<S: ?Sized> {
     store: Arc<S>,
     admission_policy: Arc<dyn TurnAdmissionPolicy>,
     run_profile_resolver: Arc<dyn RunProfileResolver>,
@@ -89,7 +89,7 @@ pub struct DefaultTurnCoordinator<S> {
 
 impl<S> DefaultTurnCoordinator<S>
 where
-    S: TurnStateStore,
+    S: TurnStateStore + ?Sized,
 {
     pub fn new(store: Arc<S>) -> Self {
         Self {
@@ -151,7 +151,7 @@ fn notify_queued_run_best_effort(notifier: &dyn TurnRunWakeNotifier, wake: TurnR
 #[async_trait]
 impl<S> TurnCoordinator for DefaultTurnCoordinator<S>
 where
-    S: TurnStateStore + 'static,
+    S: TurnStateStore + ?Sized + 'static,
 {
     async fn submit_turn(
         &self,


### PR DESCRIPTION
## Summary
- add host-runtime production wiring seams for durable turn-state stores and turn wake notifiers
- add libSQL/Postgres turn-state selection helpers that run migrations before attaching stores
- expose `turn_coordinator_for_production()` so validation returns an actual coordinator backed by the configured store/notifier
- reject missing/no-op turn wake wiring and local-only turn-state wiring in production guardrails

## Tests
- `cargo test -p ironclaw_host_runtime --features libsql turn_`
- `cargo test -p ironclaw_host_runtime production_wiring_validation_rejects_missing_components_and_local_only_defaults`
- `cargo test -p ironclaw_host_runtime --test host_runtime_services_contract --all-features`
- `cargo clippy -p ironclaw_host_runtime --features libsql,postgres --tests -- -D warnings`
- `cargo check -p ironclaw_host_runtime --all-features`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `git diff --check`

## Notes
- This intentionally stays out of PR #3345 admission-reservation internals; it only wires the production host-runtime selection path for existing turn state stores and wake delivery.
