### PR TITLE
feat: add pairing_approve tool for Slack binding via chat

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1008,9 +1008,7 @@ impl AppBuilder {
             let manager = Arc::new(em);
             tools.register_extension_tools(Arc::clone(&manager));
             if let Some(ps) = pairing_store {
-                tools.register_sync(Arc::new(
-                    crate::tools::builtin::PairingApproveTool::new(ps),
-                ));
+                tools.register_sync(Arc::new(crate::tools::builtin::PairingApproveTool::new(ps)));
             }
 
             // Register permission management tool and upgrade tool_list with

--- a/src/app.rs
+++ b/src/app.rs
@@ -995,15 +995,23 @@ impl AppBuilder {
             if let Some(ref ss) = settings_store_override {
                 em = em.with_settings_store(Arc::clone(ss));
             }
-            if let Some(ref db) = self.db {
+            let pairing_store = if let Some(ref db) = self.db {
                 let ps = Arc::new(crate::pairing::PairingStore::new(
                     Arc::clone(db),
                     Arc::clone(&ownership_cache),
                 ));
-                em = em.with_pairing_store(ps);
-            }
+                em = em.with_pairing_store(Arc::clone(&ps));
+                Some(ps)
+            } else {
+                None
+            };
             let manager = Arc::new(em);
             tools.register_extension_tools(Arc::clone(&manager));
+            if let Some(ps) = pairing_store {
+                tools.register_sync(Arc::new(
+                    crate::tools::builtin::PairingApproveTool::new(ps),
+                ));
+            }
 
             // Register permission management tool and upgrade tool_list with
             // builtin registry support. Prefer the workspace-backed adapter

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -57,11 +57,13 @@ mod html_converter;
 pub mod image_analyze;
 pub mod image_edit;
 pub mod image_gen;
+mod pairing;
 
 pub use html_converter::convert_html_to_markdown;
 pub use image_analyze::ImageAnalyzeTool;
 pub use image_edit::ImageEditTool;
 pub use image_gen::ImageGenerateTool;
+pub use pairing::PairingApproveTool;
 
 /// Detect image media type from file extension via `mime_guess`.
 /// Falls back to `image/jpeg` for unrecognized or non-image extensions.

--- a/src/tools/builtin/pairing.rs
+++ b/src/tools/builtin/pairing.rs
@@ -5,6 +5,8 @@ use crate::context::JobContext;
 use crate::pairing::PairingStore;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
 
+const CHANNEL: &str = "slack-relay";
+
 pub struct PairingApproveTool {
     store: Arc<PairingStore>,
 }
@@ -22,7 +24,7 @@ impl Tool for PairingApproveTool {
     }
 
     fn description(&self) -> &str {
-        "Approve a channel pairing code to bind an external account (e.g. Slack) to the current IronClaw user. The user receives the code in their messaging app and provides it here."
+        "Approve a Slack pairing code to bind the user's Slack account to their IronClaw user. The user receives the code in Slack and provides it here."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -31,12 +33,7 @@ impl Tool for PairingApproveTool {
             "properties": {
                 "code": {
                     "type": "string",
-                    "description": "The pairing code received in the messaging app (e.g. WZG8LQAB)"
-                },
-                "channel": {
-                    "type": "string",
-                    "description": "The channel to pair with (default: slack-relay)",
-                    "default": "slack-relay"
+                    "description": "The pairing code received in Slack (e.g. WZG8LQAB)"
                 }
             },
             "required": ["code"]
@@ -51,10 +48,7 @@ impl Tool for PairingApproveTool {
         let start = std::time::Instant::now();
 
         let code = require_str(&params, "code")?;
-        let channel = params
-            .get("channel")
-            .and_then(|v| v.as_str())
-            .unwrap_or("slack-relay");
+        let channel = CHANNEL;
 
         let user_id =
             crate::ownership::UserId::new(&ctx.user_id, crate::ownership::UserRole::Regular)
@@ -82,25 +76,43 @@ impl Tool for PairingApproveTool {
     }
 
     fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
-        ApprovalRequirement::UnlessAutoApproved
+        ApprovalRequirement::Always
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::registry::is_protected_tool_name;
 
     #[test]
     fn tool_metadata() {
         let store = Arc::new(PairingStore::new_noop());
         let tool = PairingApproveTool::new(store);
         assert_eq!(tool.name(), "pairing_approve");
-        assert!(tool.description().contains("pairing code"));
+        assert!(tool.description().contains("Slack"));
         let schema = tool.parameters_schema();
         assert!(schema["properties"]["code"].is_object());
+        assert!(schema["properties"]["channel"].is_null());
+    }
+
+    #[test]
+    fn always_requires_approval() {
+        let store = Arc::new(PairingStore::new_noop());
+        let tool = PairingApproveTool::new(store);
         assert_eq!(
             tool.requires_approval(&serde_json::json!({})),
-            ApprovalRequirement::UnlessAutoApproved
+            ApprovalRequirement::Always
         );
+    }
+
+    #[test]
+    fn is_protected_builtin() {
+        assert!(is_protected_tool_name("pairing_approve"));
+    }
+
+    #[test]
+    fn channel_is_slack_relay() {
+        assert_eq!(CHANNEL, "slack-relay");
     }
 }

--- a/src/tools/builtin/pairing.rs
+++ b/src/tools/builtin/pairing.rs
@@ -85,3 +85,22 @@ impl Tool for PairingApproveTool {
         ApprovalRequirement::UnlessAutoApproved
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_metadata() {
+        let store = Arc::new(PairingStore::new_noop());
+        let tool = PairingApproveTool::new(store);
+        assert_eq!(tool.name(), "pairing_approve");
+        assert!(tool.description().contains("pairing code"));
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["code"].is_object());
+        assert_eq!(
+            tool.requires_approval(&serde_json::json!({})),
+            ApprovalRequirement::UnlessAutoApproved
+        );
+    }
+}

--- a/src/tools/builtin/pairing.rs
+++ b/src/tools/builtin/pairing.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::context::JobContext;
 use crate::pairing::PairingStore;
-use crate::tools::tool::{Tool, ToolError, ToolOutput, require_str};
+use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
 
 pub struct PairingApproveTool {
     store: Arc<PairingStore>,
@@ -56,11 +56,9 @@ impl Tool for PairingApproveTool {
             .and_then(|v| v.as_str())
             .unwrap_or("slack-relay");
 
-        let user_id = crate::ownership::UserId::new(
-            &ctx.user_id,
-            crate::ownership::UserRole::Regular,
-        )
-        .map_err(|e| ToolError::ExecutionFailed(format!("invalid user_id: {e}")))?;
+        let user_id =
+            crate::ownership::UserId::new(&ctx.user_id, crate::ownership::UserRole::Regular)
+                .map_err(|e| ToolError::ExecutionFailed(format!("invalid user_id: {e}")))?;
 
         match self.store.approve(channel, code, &user_id).await {
             Ok(approval) => {
@@ -71,7 +69,9 @@ impl Tool for PairingApproveTool {
                 Ok(ToolOutput::text(&msg, start.elapsed()))
             }
             Err(e) => {
-                let msg = format!("Pairing failed: {e}. Make sure the code is correct and hasn't expired.");
+                let msg = format!(
+                    "Pairing failed: {e}. Make sure the code is correct and hasn't expired."
+                );
                 Ok(ToolOutput::text(&msg, start.elapsed()))
             }
         }
@@ -79,5 +79,9 @@ impl Tool for PairingApproveTool {
 
     fn requires_sanitization(&self) -> bool {
         false
+    }
+
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        ApprovalRequirement::UnlessAutoApproved
     }
 }

--- a/src/tools/builtin/pairing.rs
+++ b/src/tools/builtin/pairing.rs
@@ -1,0 +1,83 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use crate::context::JobContext;
+use crate::pairing::PairingStore;
+use crate::tools::tool::{Tool, ToolError, ToolOutput, require_str};
+
+pub struct PairingApproveTool {
+    store: Arc<PairingStore>,
+}
+
+impl PairingApproveTool {
+    pub fn new(store: Arc<PairingStore>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl Tool for PairingApproveTool {
+    fn name(&self) -> &str {
+        "pairing_approve"
+    }
+
+    fn description(&self) -> &str {
+        "Approve a channel pairing code to bind an external account (e.g. Slack) to the current IronClaw user. The user receives the code in their messaging app and provides it here."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "The pairing code received in the messaging app (e.g. WZG8LQAB)"
+                },
+                "channel": {
+                    "type": "string",
+                    "description": "The channel to pair with (default: slack-relay)",
+                    "default": "slack-relay"
+                }
+            },
+            "required": ["code"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = std::time::Instant::now();
+
+        let code = require_str(&params, "code")?;
+        let channel = params
+            .get("channel")
+            .and_then(|v| v.as_str())
+            .unwrap_or("slack-relay");
+
+        let user_id = crate::ownership::UserId::new(
+            &ctx.user_id,
+            crate::ownership::UserRole::Regular,
+        )
+        .map_err(|e| ToolError::ExecutionFailed(format!("invalid user_id: {e}")))?;
+
+        match self.store.approve(channel, code, &user_id).await {
+            Ok(approval) => {
+                let msg = format!(
+                    "Pairing approved! Your {} account (external ID: {}) is now linked to your IronClaw user.",
+                    approval.channel, approval.external_id
+                );
+                Ok(ToolOutput::text(&msg, start.elapsed()))
+            }
+            Err(e) => {
+                let msg = format!("Pairing failed: {e}. Make sure the code is correct and hasn't expired.");
+                Ok(ToolOutput::text(&msg, start.elapsed()))
+            }
+        }
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        false
+    }
+}

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -108,6 +108,8 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "plan_update",
     // Permission tools
     "tool_permission_set",
+    // Pairing tools
+    "pairing_approve",
     // Aliases (web_fetch is an alias for http in some contexts)
     "web_fetch",
 ];


### PR DESCRIPTION
## Summary
Users can now paste their Slack pairing code in the IronClaw chat and the LLM will call `pairing_approve` to bind their accounts automatically.

When a user receives a pairing code in Slack (e.g. `WZG8LQAB`), they say something like "bind my Slack with code WZG8LQAB" in the IronClaw web UI, and the agent calls the tool to complete the pairing.

## Changes
- New `pairing_approve` tool in `src/tools/builtin/pairing.rs`
- Registered in `app.rs` when a PairingStore is available

## Test plan
- [ ] User receives pairing code in Slack DM
- [ ] User pastes code in IronClaw chat
- [ ] Agent calls pairing_approve tool
- [ ] Subsequent Slack messages resolve to the correct user

🤖 Generated with [Claude Code](https://claude.com/claude-code)