### PR TITLE
Emit Reborn loop support model and transcript milestones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4259,6 +4259,8 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-test",
 ]
 
 [[package]]

--- a/crates/ironclaw_loop_support/Cargo.toml
+++ b/crates/ironclaw_loop_support/Cargo.toml
@@ -12,6 +12,8 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+tracing = "0.1"
+tokio = { version = "1", features = ["sync"] }
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
@@ -21,3 +23,4 @@ thiserror = "2"
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
+tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -20,10 +20,10 @@ use ironclaw_turns::{
         AgentLoopHostError, AgentLoopHostErrorKind, AssistantReply, BeginAssistantDraft,
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDenied, CapabilityInvocation,
         CapabilityOutcome, CapabilitySurfaceVersion, FinalizeAssistantMessage, LoopContextBundle,
-        LoopContextMessage, LoopContextPort, LoopContextRequest, LoopInputCursor, LoopModelMessage,
-        LoopModelPort, LoopModelRequest, LoopModelResponse, LoopRunContext, LoopRunInfoPort,
-        LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, UpdateAssistantDraft,
-        VisibleCapabilityRequest, VisibleCapabilitySurface,
+        LoopContextMessage, LoopContextPort, LoopContextRequest, LoopHostMilestoneEmitter,
+        LoopHostMilestoneSink, LoopInputCursor, LoopModelMessage, LoopModelPort, LoopModelRequest,
+        LoopModelResponse, LoopRunContext, LoopRunInfoPort, LoopTranscriptPort, ModelStreamChunk,
+        ParentLoopOutput, UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -113,6 +113,7 @@ where
     thread_service: Arc<S>,
     thread_scope: ThreadScope,
     run_context: LoopRunContext,
+    milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
 }
 
 impl<S> ThreadBackedLoopTranscriptPort<S>
@@ -128,6 +129,21 @@ where
             thread_service,
             thread_scope,
             run_context,
+            milestone_sink: None,
+        }
+    }
+
+    pub fn with_milestone_sink(
+        thread_service: Arc<S>,
+        thread_scope: ThreadScope,
+        run_context: LoopRunContext,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+    ) -> Self {
+        Self {
+            thread_service,
+            thread_scope,
+            run_context,
+            milestone_sink: Some(milestone_sink),
         }
     }
 }
@@ -201,7 +217,10 @@ where
             .map_err(transcript_write_error)?;
         if draft.status == MessageStatus::Finalized {
             if draft.content.as_deref() == Some(reply_content.as_str()) {
-                return message_ref(draft.message_id);
+                let message_ref = message_ref(draft.message_id)?;
+                self.emit_assistant_reply_finalized(message_ref.clone())
+                    .await;
+                return Ok(message_ref);
             }
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::TranscriptWriteFailed,
@@ -218,13 +237,21 @@ where
             )
             .await;
         match finalized {
-            Ok(message) => message_ref(message.message_id),
+            Ok(message) => {
+                let message_ref = message_ref(message.message_id)?;
+                self.emit_assistant_reply_finalized(message_ref.clone())
+                    .await;
+                Ok(message_ref)
+            }
             Err(error) => {
                 if let Some(message_id) = self
                     .already_finalized_matching_reply(draft.message_id, &reply_content)
                     .await?
                 {
-                    return message_ref(message_id);
+                    let message_ref = message_ref(message_id)?;
+                    self.emit_assistant_reply_finalized(message_ref.clone())
+                        .await;
+                    return Ok(message_ref);
                 }
                 Err(transcript_write_error(error))
             }
@@ -236,6 +263,14 @@ impl<S> ThreadBackedLoopTranscriptPort<S>
 where
     S: SessionThreadService + ?Sized + Send + Sync,
 {
+    async fn emit_assistant_reply_finalized(&self, message_ref: LoopMessageRef) {
+        if let Some(milestone_sink) = &self.milestone_sink {
+            let milestones =
+                LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
+            let _ = milestones.assistant_reply_finalized(message_ref).await;
+        }
+    }
+
     async fn load_current_run_message(
         &self,
         message_id: ThreadMessageId,
@@ -365,6 +400,7 @@ where
     run_context: LoopRunContext,
     gateway: Arc<G>,
     max_messages: usize,
+    milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
 }
 
 impl<S, G> ThreadBackedLoopModelPort<S, G>
@@ -385,6 +421,25 @@ where
             run_context,
             gateway,
             max_messages,
+            milestone_sink: None,
+        }
+    }
+
+    pub fn with_milestone_sink(
+        thread_service: Arc<S>,
+        thread_scope: ThreadScope,
+        run_context: LoopRunContext,
+        gateway: Arc<G>,
+        max_messages: usize,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+    ) -> Self {
+        Self {
+            thread_service,
+            thread_scope,
+            run_context,
+            gateway,
+            max_messages,
+            milestone_sink: Some(milestone_sink),
         }
     }
 }
@@ -410,13 +465,15 @@ where
         request: LoopModelRequest,
     ) -> Result<LoopModelResponse, AgentLoopHostError> {
         validate_thread_scope_for_run(&self.thread_scope, &self.run_context)?;
-        let model_profile_id = request.model_preference.clone().unwrap_or_else(|| {
+        let requested_model_profile_id = request.model_preference.clone();
+        let model_profile_id = requested_model_profile_id.clone().unwrap_or_else(|| {
             self.run_context
                 .resolved_run_profile
                 .model_profile_id
                 .clone()
         });
         let resolved_messages = self.resolve_model_messages(request.messages).await?;
+        self.emit_model_started(requested_model_profile_id).await?;
         let gateway_response = self
             .gateway
             .stream_model(HostManagedModelRequest {
@@ -428,6 +485,8 @@ where
             })
             .await
             .map_err(model_gateway_error)?;
+
+        self.emit_model_completed(model_profile_id.clone()).await;
 
         Ok(LoopModelResponse {
             chunks: gateway_response
@@ -446,6 +505,26 @@ where
     S: SessionThreadService + ?Sized + Send + Sync,
     G: HostManagedModelGateway + ?Sized + Send + Sync,
 {
+    async fn emit_model_started(
+        &self,
+        requested_model_profile_id: Option<ModelProfileId>,
+    ) -> Result<(), AgentLoopHostError> {
+        if let Some(milestone_sink) = &self.milestone_sink {
+            let milestones =
+                LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
+            milestones.model_started(requested_model_profile_id).await?;
+        }
+        Ok(())
+    }
+
+    async fn emit_model_completed(&self, effective_model_profile_id: ModelProfileId) {
+        if let Some(milestone_sink) = &self.milestone_sink {
+            let milestones =
+                LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
+            let _ = milestones.model_completed(effective_model_profile_id).await;
+        }
+    }
+
     async fn resolve_model_messages(
         &self,
         requested_messages: Vec<LoopModelMessage>,

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -4,7 +4,12 @@
 //! host-managed model gateways) into the narrow `AgentLoopHost` ports. It does
 //! not own provider clients, tool dispatchers, secrets, or runtime handles.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use tokio::sync::Mutex;
 
 use async_trait::async_trait;
 use ironclaw_threads::{
@@ -114,6 +119,9 @@ where
     thread_scope: ThreadScope,
     run_context: LoopRunContext,
     milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+    // Only successful milestone publications are recorded here: if publishing
+    // fails after the transcript write, an idempotent retry must try again.
+    emitted_assistant_reply_finalized_refs: Arc<Mutex<HashSet<String>>>,
 }
 
 impl<S> ThreadBackedLoopTranscriptPort<S>
@@ -130,6 +138,7 @@ where
             thread_scope,
             run_context,
             milestone_sink: None,
+            emitted_assistant_reply_finalized_refs: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -144,6 +153,7 @@ where
             thread_scope,
             run_context,
             milestone_sink: Some(milestone_sink),
+            emitted_assistant_reply_finalized_refs: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 }
@@ -219,7 +229,7 @@ where
             if draft.content.as_deref() == Some(reply_content.as_str()) {
                 let message_ref = message_ref(draft.message_id)?;
                 self.emit_assistant_reply_finalized(message_ref.clone())
-                    .await;
+                    .await?;
                 return Ok(message_ref);
             }
             return Err(AgentLoopHostError::new(
@@ -240,7 +250,7 @@ where
             Ok(message) => {
                 let message_ref = message_ref(message.message_id)?;
                 self.emit_assistant_reply_finalized(message_ref.clone())
-                    .await;
+                    .await?;
                 Ok(message_ref)
             }
             Err(error) => {
@@ -250,7 +260,7 @@ where
                 {
                     let message_ref = message_ref(message_id)?;
                     self.emit_assistant_reply_finalized(message_ref.clone())
-                        .await;
+                        .await?;
                     return Ok(message_ref);
                 }
                 Err(transcript_write_error(error))
@@ -263,12 +273,26 @@ impl<S> ThreadBackedLoopTranscriptPort<S>
 where
     S: SessionThreadService + ?Sized + Send + Sync,
 {
-    async fn emit_assistant_reply_finalized(&self, message_ref: LoopMessageRef) {
-        if let Some(milestone_sink) = &self.milestone_sink {
-            let milestones =
-                LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
-            let _ = milestones.assistant_reply_finalized(message_ref).await;
+    async fn emit_assistant_reply_finalized(
+        &self,
+        message_ref: LoopMessageRef,
+    ) -> Result<(), AgentLoopHostError> {
+        let Some(milestone_sink) = &self.milestone_sink else {
+            return Ok(());
+        };
+
+        let mut emitted_refs = self.emitted_assistant_reply_finalized_refs.lock().await;
+        if emitted_refs.contains(message_ref.as_str()) {
+            return Ok(());
         }
+
+        let milestones =
+            LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
+        milestones
+            .assistant_reply_finalized(message_ref.clone())
+            .await?;
+        emitted_refs.insert(message_ref.as_str().to_string());
+        Ok(())
     }
 
     async fn load_current_run_message(
@@ -521,7 +545,13 @@ where
         if let Some(milestone_sink) = &self.milestone_sink {
             let milestones =
                 LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
-            let _ = milestones.model_completed(effective_model_profile_id).await;
+            if let Err(error) = milestones.model_completed(effective_model_profile_id).await {
+                tracing::debug!(
+                    kind = ?error.kind,
+                    diagnostic_ref = ?error.diagnostic_ref,
+                    "loop model_completed milestone failed after successful model response"
+                );
+            }
         }
     }
 

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -25,10 +25,10 @@ use ironclaw_turns::{
     run_profile::{
         AgentLoopHostErrorKind, AssistantReply, BeginAssistantDraft, CapabilityInputRef,
         CapabilityInvocation, CapabilitySurfaceVersion, FinalizeAssistantMessage,
-        InMemoryRunProfileResolver, LoopCapabilityPort, LoopContextPort, LoopContextRequest,
-        LoopInputCursor, LoopInputCursorToken, LoopModelMessage, LoopModelPort, LoopModelRequest,
-        LoopRunContext, LoopTranscriptPort, ParentLoopOutput, UpdateAssistantDraft,
-        VisibleCapabilityRequest,
+        InMemoryLoopHostMilestoneSink, InMemoryRunProfileResolver, LoopCapabilityPort,
+        LoopContextPort, LoopContextRequest, LoopHostMilestoneKind, LoopInputCursor,
+        LoopInputCursorToken, LoopModelMessage, LoopModelPort, LoopModelRequest, LoopRunContext,
+        LoopTranscriptPort, ParentLoopOutput, UpdateAssistantDraft, VisibleCapabilityRequest,
     },
 };
 
@@ -226,16 +226,53 @@ async fn transcript_port_finalizes_assistant_reply_into_durable_thread_history()
 }
 
 #[tokio::test]
-async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
+async fn transcript_port_emits_assistant_reply_finalized_milestone_without_reply_content() {
     let fixture = ThreadFixture::new().await;
-    let adapter = ThreadBackedLoopTranscriptPort::new(
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let adapter = ThreadBackedLoopTranscriptPort::with_milestone_sink(
         Arc::clone(&fixture.thread_service),
         fixture.thread_scope.clone(),
         fixture.run_context.clone(),
+        milestone_sink.clone(),
+    );
+
+    let message_ref = adapter
+        .finalize_assistant_message(FinalizeAssistantMessage {
+            reply: AssistantReply {
+                content: "RAW_ASSISTANT_CONTENT_SENTINEL sk-reply-secret /host/path tool_input"
+                    .to_string(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 1);
+    assert!(matches!(
+        &milestones[0].kind,
+        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref: finalized_ref }
+            if finalized_ref == &message_ref
+    ));
+    let wire = serde_json::to_string(&milestones).unwrap();
+    assert!(!wire.contains("RAW_ASSISTANT_CONTENT_SENTINEL"));
+    assert!(!wire.contains("sk-reply-secret"));
+    assert!(!wire.contains("/host/path"));
+    assert!(!wire.contains("tool_input"));
+}
+
+#[tokio::test]
+async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
+    let fixture = ThreadFixture::new().await;
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let adapter = ThreadBackedLoopTranscriptPort::with_milestone_sink(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        milestone_sink.clone(),
     );
     let request = FinalizeAssistantMessage {
         reply: AssistantReply {
-            content: "idempotent reply".to_string(),
+            content: "idempotent reply RAW_IDEMPOTENT_REPLY_SENTINEL".to_string(),
         },
     };
 
@@ -246,6 +283,18 @@ async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
     let second_ref = adapter.finalize_assistant_message(request).await.unwrap();
 
     assert_eq!(first_ref, second_ref);
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 2);
+    assert!(milestones.iter().all(|milestone| matches!(
+        &milestone.kind,
+        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref }
+            if message_ref == &first_ref
+    )));
+    assert!(
+        !serde_json::to_string(&milestones)
+            .unwrap()
+            .contains("RAW_IDEMPOTENT_REPLY_SENTINEL")
+    );
     let history = fixture
         .thread_service
         .list_thread_history(ThreadHistoryRequest {
@@ -261,16 +310,21 @@ async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
         .collect::<Vec<_>>();
     assert_eq!(finalized.len(), 1);
     assert_eq!(finalized[0].status, MessageStatus::Finalized);
-    assert_eq!(finalized[0].content.as_deref(), Some("idempotent reply"));
+    assert_eq!(
+        finalized[0].content.as_deref(),
+        Some("idempotent reply RAW_IDEMPOTENT_REPLY_SENTINEL")
+    );
 }
 
 #[tokio::test]
 async fn transcript_port_finalize_is_idempotent_under_concurrent_duplicate_calls() {
     let fixture = GatedThreadFixture::new().await;
-    let adapter = ThreadBackedLoopTranscriptPort::new(
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let adapter = ThreadBackedLoopTranscriptPort::with_milestone_sink(
         Arc::clone(&fixture.thread_service),
         fixture.thread_scope.clone(),
         fixture.run_context.clone(),
+        milestone_sink.clone(),
     );
     let request = FinalizeAssistantMessage {
         reply: AssistantReply {
@@ -286,6 +340,13 @@ async fn transcript_port_finalize_is_idempotent_under_concurrent_duplicate_calls
     let second_ref = second.unwrap();
 
     assert_eq!(first_ref, second_ref);
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 2);
+    assert!(milestones.iter().all(|milestone| matches!(
+        &milestone.kind,
+        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref }
+            if message_ref == &first_ref
+    )));
     let history = fixture
         .thread_service
         .list_thread_history(ThreadHistoryRequest {
@@ -542,6 +603,124 @@ async fn model_port_round_trips_tool_result_reference_context_as_system_model_in
 }
 
 #[tokio::test]
+async fn model_port_emits_model_milestones_without_prompt_or_output_payloads() {
+    let fixture = ThreadFixture::new_with_user_content(
+        "RAW_PROMPT_TEXT_SENTINEL sk-prompt-secret /host/path tool_input",
+    )
+    .await;
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let gateway = Arc::new(RecordingGateway::reply(
+        "RAW_ASSISTANT_CONTENT_SENTINEL sk-output-secret",
+    ));
+    let port = ThreadBackedLoopModelPort::with_milestone_sink(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway,
+        16,
+        milestone_sink.clone(),
+    );
+
+    let response = port
+        .stream_model(LoopModelRequest {
+            messages: vec![LoopModelMessage {
+                role: "user".to_string(),
+                content_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
+                    .unwrap(),
+            }],
+            surface_version: None,
+            model_preference: Some(
+                fixture
+                    .run_context
+                    .resolved_run_profile
+                    .model_profile_id
+                    .clone(),
+            ),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.effective_model_profile_id,
+        fixture.run_context.resolved_run_profile.model_profile_id
+    );
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 2);
+    assert!(matches!(
+        &milestones[0].kind,
+        LoopHostMilestoneKind::ModelStarted { requested_model_profile_id: Some(model_profile_id) }
+            if model_profile_id == &fixture.run_context.resolved_run_profile.model_profile_id
+    ));
+    assert!(matches!(
+        &milestones[1].kind,
+        LoopHostMilestoneKind::ModelCompleted { effective_model_profile_id }
+            if effective_model_profile_id == &fixture.run_context.resolved_run_profile.model_profile_id
+    ));
+    let wire = serde_json::to_string(&milestones).unwrap();
+    for forbidden in [
+        "RAW_PROMPT_TEXT_SENTINEL",
+        "RAW_ASSISTANT_CONTENT_SENTINEL",
+        "sk-prompt-secret",
+        "sk-output-secret",
+        "/host/path",
+        "tool_input",
+    ] {
+        assert!(!wire.contains(forbidden), "milestone leaked {forbidden}");
+    }
+}
+
+#[tokio::test]
+async fn model_port_emits_only_started_milestone_when_gateway_fails() {
+    let fixture = ThreadFixture::new_with_user_content("RAW_PROMPT_TEXT_SENTINEL").await;
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let gateway = Arc::new(RecordingGateway::deny(
+        "RAW_PROVIDER_ERROR invalid api key sk-provider-secret /host/path tool_input",
+    ));
+    let port = ThreadBackedLoopModelPort::with_milestone_sink(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway,
+        16,
+        milestone_sink.clone(),
+    );
+
+    let error = port
+        .stream_model(LoopModelRequest {
+            messages: vec![LoopModelMessage {
+                role: "user".to_string(),
+                content_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
+                    .unwrap(),
+            }],
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 1);
+    assert!(matches!(
+        &milestones[0].kind,
+        LoopHostMilestoneKind::ModelStarted {
+            requested_model_profile_id: None
+        }
+    ));
+    let wire = serde_json::to_string(&milestones).unwrap();
+    for forbidden in [
+        "RAW_PROMPT_TEXT_SENTINEL",
+        "RAW_PROVIDER_ERROR",
+        "invalid api key",
+        "sk-provider-secret",
+        "/host/path",
+        "tool_input",
+    ] {
+        assert!(!wire.contains(forbidden), "milestone leaked {forbidden}");
+    }
+}
+
+#[tokio::test]
 async fn model_port_rejects_message_role_that_disagrees_with_thread_record() {
     let fixture = ThreadFixture::new().await;
     let gateway = Arc::new(RecordingGateway::reply("should not be called"));
@@ -610,6 +789,10 @@ struct ThreadFixture {
 
 impl ThreadFixture {
     async fn new() -> Self {
+        Self::new_with_user_content("hello reborn").await
+    }
+
+    async fn new_with_user_content(user_content: &str) -> Self {
         let thread_service = Arc::new(InMemorySessionThreadService::default());
         let tenant_id = TenantId::new("tenant-loop-support").unwrap();
         let agent_id = AgentId::new("agent-loop-support").unwrap();
@@ -641,7 +824,7 @@ impl ThreadFixture {
                 source_binding_id: Some("source-web".to_string()),
                 reply_target_binding_id: Some("reply-web".to_string()),
                 external_event_id: Some("event-1".to_string()),
-                content: MessageContent::text("hello reborn"),
+                content: MessageContent::text(user_content),
             })
             .await
             .unwrap();

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -31,6 +31,7 @@ use ironclaw_turns::{
         LoopTranscriptPort, ParentLoopOutput, UpdateAssistantDraft, VisibleCapabilityRequest,
     },
 };
+use tracing_test::traced_test;
 
 #[tokio::test]
 async fn thread_context_port_loads_policy_filtered_transcript_messages() {
@@ -261,6 +262,54 @@ async fn transcript_port_emits_assistant_reply_finalized_milestone_without_reply
 }
 
 #[tokio::test]
+async fn transcript_port_retries_assistant_reply_finalized_milestone_after_transient_sink_failure()
+{
+    let fixture = ThreadFixture::new().await;
+    let milestone_sink = Arc::new(FailOnceMilestoneSink::default());
+    let adapter = ThreadBackedLoopTranscriptPort::with_milestone_sink(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        milestone_sink.clone(),
+    );
+    let request = FinalizeAssistantMessage {
+        reply: AssistantReply {
+            content: "retryable milestone failure".to_string(),
+        },
+    };
+
+    let first_error = adapter
+        .finalize_assistant_message(request.clone())
+        .await
+        .unwrap_err();
+    assert_eq!(first_error.kind, AgentLoopHostErrorKind::Unavailable);
+
+    let message_ref = adapter.finalize_assistant_message(request).await.unwrap();
+
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 1);
+    assert!(matches!(
+        &milestones[0].kind,
+        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref: finalized_ref }
+            if finalized_ref == &message_ref
+    ));
+    let history = fixture
+        .thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: fixture.thread_scope.clone(),
+            thread_id: fixture.thread_id.clone(),
+        })
+        .await
+        .unwrap();
+    let finalized = history
+        .messages
+        .iter()
+        .filter(|message| message.kind == MessageKind::Assistant)
+        .collect::<Vec<_>>();
+    assert_eq!(finalized.len(), 1);
+}
+
+#[tokio::test]
 async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
     let fixture = ThreadFixture::new().await;
     let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
@@ -284,12 +333,12 @@ async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
 
     assert_eq!(first_ref, second_ref);
     let milestones = milestone_sink.milestones();
-    assert_eq!(milestones.len(), 2);
-    assert!(milestones.iter().all(|milestone| matches!(
-        &milestone.kind,
+    assert_eq!(milestones.len(), 1);
+    assert!(matches!(
+        &milestones[0].kind,
         LoopHostMilestoneKind::AssistantReplyFinalized { message_ref }
             if message_ref == &first_ref
-    )));
+    ));
     assert!(
         !serde_json::to_string(&milestones)
             .unwrap()
@@ -341,12 +390,12 @@ async fn transcript_port_finalize_is_idempotent_under_concurrent_duplicate_calls
 
     assert_eq!(first_ref, second_ref);
     let milestones = milestone_sink.milestones();
-    assert_eq!(milestones.len(), 2);
-    assert!(milestones.iter().all(|milestone| matches!(
-        &milestone.kind,
+    assert_eq!(milestones.len(), 1);
+    assert!(matches!(
+        &milestones[0].kind,
         LoopHostMilestoneKind::AssistantReplyFinalized { message_ref }
             if message_ref == &first_ref
-    )));
+    ));
     let history = fixture
         .thread_service
         .list_thread_history(ThreadHistoryRequest {
@@ -720,6 +769,47 @@ async fn model_port_emits_only_started_milestone_when_gateway_fails() {
     }
 }
 
+#[traced_test]
+#[tokio::test]
+async fn model_port_logs_model_completed_milestone_failure_without_losing_response() {
+    let fixture = ThreadFixture::new().await;
+    let milestone_sink = Arc::new(FailOnModelCompletedMilestoneSink::default());
+    let gateway = Arc::new(RecordingGateway::reply(
+        "model response survives milestone failure",
+    ));
+    let port = ThreadBackedLoopModelPort::with_milestone_sink(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway,
+        16,
+        milestone_sink.clone(),
+    );
+
+    let response = port
+        .stream_model(LoopModelRequest {
+            messages: vec![LoopModelMessage {
+                role: "user".to_string(),
+                content_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
+                    .unwrap(),
+            }],
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        response.output,
+        ParentLoopOutput::AssistantReply(AssistantReply { ref content })
+            if content == "model response survives milestone failure"
+    ));
+    assert_eq!(milestone_sink.kind_names(), vec!["model_started"]);
+    assert!(logs_contain(
+        "loop model_completed milestone failed after successful model response"
+    ));
+}
+
 #[tokio::test]
 async fn model_port_rejects_message_role_that_disagrees_with_thread_record() {
     let fixture = ThreadFixture::new().await;
@@ -1077,6 +1167,75 @@ impl SessionThreadService for StaticContextThreadService {
         _request: CreateSummaryArtifactRequest,
     ) -> Result<SummaryArtifact, SessionThreadError> {
         panic!("static context service does not create summaries")
+    }
+}
+
+#[derive(Default)]
+struct FailOnceMilestoneSink {
+    attempts: Mutex<Vec<ironclaw_turns::run_profile::LoopHostMilestone>>,
+}
+
+impl FailOnceMilestoneSink {
+    fn milestones(&self) -> Vec<ironclaw_turns::run_profile::LoopHostMilestone> {
+        self.attempts
+            .lock()
+            .unwrap()
+            .iter()
+            .skip(1)
+            .cloned()
+            .collect()
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopHostMilestoneSink for FailOnceMilestoneSink {
+    async fn publish_loop_milestone(
+        &self,
+        milestone: ironclaw_turns::run_profile::LoopHostMilestone,
+    ) -> Result<(), ironclaw_turns::run_profile::AgentLoopHostError> {
+        let mut attempts = self.attempts.lock().unwrap();
+        if attempts.is_empty() {
+            attempts.push(milestone);
+            return Err(ironclaw_turns::run_profile::AgentLoopHostError::new(
+                AgentLoopHostErrorKind::Unavailable,
+                "loop milestone sink unavailable",
+            ));
+        }
+        attempts.push(milestone);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct FailOnModelCompletedMilestoneSink {
+    published: Mutex<Vec<ironclaw_turns::run_profile::LoopHostMilestone>>,
+}
+
+impl FailOnModelCompletedMilestoneSink {
+    fn kind_names(&self) -> Vec<&'static str> {
+        self.published
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|milestone| milestone.kind.kind_name())
+            .collect()
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopHostMilestoneSink for FailOnModelCompletedMilestoneSink {
+    async fn publish_loop_milestone(
+        &self,
+        milestone: ironclaw_turns::run_profile::LoopHostMilestone,
+    ) -> Result<(), ironclaw_turns::run_profile::AgentLoopHostError> {
+        if matches!(milestone.kind, LoopHostMilestoneKind::ModelCompleted { .. }) {
+            return Err(ironclaw_turns::run_profile::AgentLoopHostError::new(
+                AgentLoopHostErrorKind::Unavailable,
+                "loop milestone sink unavailable",
+            ));
+        }
+        self.published.lock().unwrap().push(milestone);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- Stack on #3391: add optional milestone sink wiring to thread-backed loop support ports
- Emit `model_started` / `model_completed` from `ThreadBackedLoopModelPort`
- Emit `assistant_reply_finalized` from `ThreadBackedLoopTranscriptPort`, including the idempotent finalized-message path
- Add regression tests that serialized milestones do not leak raw prompt/output/provider-error/tool-input/host-path/secret-shaped sentinels

## Test plan
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_loop_support --tests`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo clippy -p ironclaw_loop_support --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_reborn --tests`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_turns --test agent_loop_host_contract`
- `git diff --check`

Depends on #3391.