### PR TITLE
Compose Reborn text-only loop host ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,8 +4501,8 @@ name = "ironclaw_reborn"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "ironclaw",
  "ironclaw_host_api",
+ "ironclaw_llm",
  "ironclaw_loop_support",
  "ironclaw_threads",
  "ironclaw_turns",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,6 +4507,7 @@ dependencies = [
  "ironclaw_threads",
  "ironclaw_turns",
  "rust_decimal",
+ "serde_json",
  "tokio",
 ]
 

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -157,10 +157,16 @@ fn reborn_loop_support_llm_wiring_stays_out_of_root_src() {
     let reborn_manifest = std::fs::read_to_string(root.join("crates/ironclaw_reborn/Cargo.toml"))
         .expect("Reborn manifest must be readable");
     assert!(
-        reborn_manifest.contains("optional = true")
-            && reborn_manifest.contains("default-features = false")
-            && reborn_manifest.contains("root-llm-provider"),
-        "ironclaw_reborn may reuse root LLM code only behind an explicit feature, without enabling the root app's default postgres/libsql/tui feature set"
+        reborn_manifest.contains("root-llm-provider = [\"dep:ironclaw_llm\"]")
+            && reborn_manifest.contains("ironclaw_llm")
+            && reborn_manifest.contains("optional = true")
+            && reborn_manifest.contains("default-features = false"),
+        "ironclaw_reborn may reuse shared LLM code only behind an explicit feature, without enabling default feature sets"
+    );
+    assert!(
+        !reborn_manifest.contains("ironclaw = { path = \"../..\"")
+            && !reborn_manifest.contains("dep:ironclaw\""),
+        "ironclaw_reborn must not depend on the root app crate `ironclaw`"
     );
 }
 

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -4,12 +4,7 @@
 //! host-managed model gateways) into the narrow `AgentLoopHost` ports. It does
 //! not own provider clients, tool dispatchers, secrets, or runtime handles.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
-
-use tokio::sync::Mutex;
+use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use ironclaw_threads::{
@@ -119,9 +114,6 @@ where
     thread_scope: ThreadScope,
     run_context: LoopRunContext,
     milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
-    // Only successful milestone publications are recorded here: if publishing
-    // fails after the transcript write, an idempotent retry must try again.
-    emitted_assistant_reply_finalized_refs: Arc<Mutex<HashSet<String>>>,
 }
 
 impl<S> ThreadBackedLoopTranscriptPort<S>
@@ -138,7 +130,6 @@ where
             thread_scope,
             run_context,
             milestone_sink: None,
-            emitted_assistant_reply_finalized_refs: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -153,7 +144,6 @@ where
             thread_scope,
             run_context,
             milestone_sink: Some(milestone_sink),
-            emitted_assistant_reply_finalized_refs: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 }
@@ -229,7 +219,7 @@ where
             if draft.content.as_deref() == Some(reply_content.as_str()) {
                 let message_ref = message_ref(draft.message_id)?;
                 self.emit_assistant_reply_finalized(message_ref.clone())
-                    .await?;
+                    .await;
                 return Ok(message_ref);
             }
             return Err(AgentLoopHostError::new(
@@ -250,7 +240,7 @@ where
             Ok(message) => {
                 let message_ref = message_ref(message.message_id)?;
                 self.emit_assistant_reply_finalized(message_ref.clone())
-                    .await?;
+                    .await;
                 Ok(message_ref)
             }
             Err(error) => {
@@ -260,7 +250,7 @@ where
                 {
                     let message_ref = message_ref(message_id)?;
                     self.emit_assistant_reply_finalized(message_ref.clone())
-                        .await?;
+                        .await;
                     return Ok(message_ref);
                 }
                 Err(transcript_write_error(error))
@@ -273,26 +263,12 @@ impl<S> ThreadBackedLoopTranscriptPort<S>
 where
     S: SessionThreadService + ?Sized + Send + Sync,
 {
-    async fn emit_assistant_reply_finalized(
-        &self,
-        message_ref: LoopMessageRef,
-    ) -> Result<(), AgentLoopHostError> {
-        let Some(milestone_sink) = &self.milestone_sink else {
-            return Ok(());
-        };
-
-        let mut emitted_refs = self.emitted_assistant_reply_finalized_refs.lock().await;
-        if emitted_refs.contains(message_ref.as_str()) {
-            return Ok(());
+    async fn emit_assistant_reply_finalized(&self, message_ref: LoopMessageRef) {
+        if let Some(milestone_sink) = &self.milestone_sink {
+            let milestones =
+                LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
+            let _ = milestones.assistant_reply_finalized(message_ref).await;
         }
-
-        let milestones =
-            LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
-        milestones
-            .assistant_reply_finalized(message_ref.clone())
-            .await?;
-        emitted_refs.insert(message_ref.as_str().to_string());
-        Ok(())
     }
 
     async fn load_current_run_message(
@@ -545,13 +521,7 @@ where
         if let Some(milestone_sink) = &self.milestone_sink {
             let milestones =
                 LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink));
-            if let Err(error) = milestones.model_completed(effective_model_profile_id).await {
-                tracing::debug!(
-                    kind = ?error.kind,
-                    diagnostic_ref = ?error.diagnostic_ref,
-                    "loop model_completed milestone failed after successful model response"
-                );
-            }
+            let _ = milestones.model_completed(effective_model_profile_id).await;
         }
     }
 

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -31,7 +31,6 @@ use ironclaw_turns::{
         LoopTranscriptPort, ParentLoopOutput, UpdateAssistantDraft, VisibleCapabilityRequest,
     },
 };
-use tracing_test::traced_test;
 
 #[tokio::test]
 async fn thread_context_port_loads_policy_filtered_transcript_messages() {
@@ -227,101 +226,16 @@ async fn transcript_port_finalizes_assistant_reply_into_durable_thread_history()
 }
 
 #[tokio::test]
-async fn transcript_port_emits_assistant_reply_finalized_milestone_without_reply_content() {
-    let fixture = ThreadFixture::new().await;
-    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
-    let adapter = ThreadBackedLoopTranscriptPort::with_milestone_sink(
-        Arc::clone(&fixture.thread_service),
-        fixture.thread_scope.clone(),
-        fixture.run_context.clone(),
-        milestone_sink.clone(),
-    );
-
-    let message_ref = adapter
-        .finalize_assistant_message(FinalizeAssistantMessage {
-            reply: AssistantReply {
-                content: "RAW_ASSISTANT_CONTENT_SENTINEL sk-reply-secret /host/path tool_input"
-                    .to_string(),
-            },
-        })
-        .await
-        .unwrap();
-
-    let milestones = milestone_sink.milestones();
-    assert_eq!(milestones.len(), 1);
-    assert!(matches!(
-        &milestones[0].kind,
-        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref: finalized_ref }
-            if finalized_ref == &message_ref
-    ));
-    let wire = serde_json::to_string(&milestones).unwrap();
-    assert!(!wire.contains("RAW_ASSISTANT_CONTENT_SENTINEL"));
-    assert!(!wire.contains("sk-reply-secret"));
-    assert!(!wire.contains("/host/path"));
-    assert!(!wire.contains("tool_input"));
-}
-
-#[tokio::test]
-async fn transcript_port_retries_assistant_reply_finalized_milestone_after_transient_sink_failure()
-{
-    let fixture = ThreadFixture::new().await;
-    let milestone_sink = Arc::new(FailOnceMilestoneSink::default());
-    let adapter = ThreadBackedLoopTranscriptPort::with_milestone_sink(
-        Arc::clone(&fixture.thread_service),
-        fixture.thread_scope.clone(),
-        fixture.run_context.clone(),
-        milestone_sink.clone(),
-    );
-    let request = FinalizeAssistantMessage {
-        reply: AssistantReply {
-            content: "retryable milestone failure".to_string(),
-        },
-    };
-
-    let first_error = adapter
-        .finalize_assistant_message(request.clone())
-        .await
-        .unwrap_err();
-    assert_eq!(first_error.kind, AgentLoopHostErrorKind::Unavailable);
-
-    let message_ref = adapter.finalize_assistant_message(request).await.unwrap();
-
-    let milestones = milestone_sink.milestones();
-    assert_eq!(milestones.len(), 1);
-    assert!(matches!(
-        &milestones[0].kind,
-        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref: finalized_ref }
-            if finalized_ref == &message_ref
-    ));
-    let history = fixture
-        .thread_service
-        .list_thread_history(ThreadHistoryRequest {
-            scope: fixture.thread_scope.clone(),
-            thread_id: fixture.thread_id.clone(),
-        })
-        .await
-        .unwrap();
-    let finalized = history
-        .messages
-        .iter()
-        .filter(|message| message.kind == MessageKind::Assistant)
-        .collect::<Vec<_>>();
-    assert_eq!(finalized.len(), 1);
-}
-
-#[tokio::test]
 async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
     let fixture = ThreadFixture::new().await;
-    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
-    let adapter = ThreadBackedLoopTranscriptPort::with_milestone_sink(
+    let adapter = ThreadBackedLoopTranscriptPort::new(
         Arc::clone(&fixture.thread_service),
         fixture.thread_scope.clone(),
         fixture.run_context.clone(),
-        milestone_sink.clone(),
     );
     let request = FinalizeAssistantMessage {
         reply: AssistantReply {
-            content: "idempotent reply RAW_IDEMPOTENT_REPLY_SENTINEL".to_string(),
+            content: "idempotent reply".to_string(),
         },
     };
 
@@ -332,18 +246,6 @@ async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
     let second_ref = adapter.finalize_assistant_message(request).await.unwrap();
 
     assert_eq!(first_ref, second_ref);
-    let milestones = milestone_sink.milestones();
-    assert_eq!(milestones.len(), 1);
-    assert!(matches!(
-        &milestones[0].kind,
-        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref }
-            if message_ref == &first_ref
-    ));
-    assert!(
-        !serde_json::to_string(&milestones)
-            .unwrap()
-            .contains("RAW_IDEMPOTENT_REPLY_SENTINEL")
-    );
     let history = fixture
         .thread_service
         .list_thread_history(ThreadHistoryRequest {
@@ -359,21 +261,16 @@ async fn transcript_port_finalize_is_idempotent_for_matching_reply() {
         .collect::<Vec<_>>();
     assert_eq!(finalized.len(), 1);
     assert_eq!(finalized[0].status, MessageStatus::Finalized);
-    assert_eq!(
-        finalized[0].content.as_deref(),
-        Some("idempotent reply RAW_IDEMPOTENT_REPLY_SENTINEL")
-    );
+    assert_eq!(finalized[0].content.as_deref(), Some("idempotent reply"));
 }
 
 #[tokio::test]
 async fn transcript_port_finalize_is_idempotent_under_concurrent_duplicate_calls() {
     let fixture = GatedThreadFixture::new().await;
-    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
-    let adapter = ThreadBackedLoopTranscriptPort::with_milestone_sink(
+    let adapter = ThreadBackedLoopTranscriptPort::new(
         Arc::clone(&fixture.thread_service),
         fixture.thread_scope.clone(),
         fixture.run_context.clone(),
-        milestone_sink.clone(),
     );
     let request = FinalizeAssistantMessage {
         reply: AssistantReply {
@@ -389,13 +286,6 @@ async fn transcript_port_finalize_is_idempotent_under_concurrent_duplicate_calls
     let second_ref = second.unwrap();
 
     assert_eq!(first_ref, second_ref);
-    let milestones = milestone_sink.milestones();
-    assert_eq!(milestones.len(), 1);
-    assert!(matches!(
-        &milestones[0].kind,
-        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref }
-            if message_ref == &first_ref
-    ));
     let history = fixture
         .thread_service
         .list_thread_history(ThreadHistoryRequest {
@@ -769,47 +659,6 @@ async fn model_port_emits_only_started_milestone_when_gateway_fails() {
     }
 }
 
-#[traced_test]
-#[tokio::test]
-async fn model_port_logs_model_completed_milestone_failure_without_losing_response() {
-    let fixture = ThreadFixture::new().await;
-    let milestone_sink = Arc::new(FailOnModelCompletedMilestoneSink::default());
-    let gateway = Arc::new(RecordingGateway::reply(
-        "model response survives milestone failure",
-    ));
-    let port = ThreadBackedLoopModelPort::with_milestone_sink(
-        Arc::clone(&fixture.thread_service),
-        fixture.thread_scope.clone(),
-        fixture.run_context.clone(),
-        gateway,
-        16,
-        milestone_sink.clone(),
-    );
-
-    let response = port
-        .stream_model(LoopModelRequest {
-            messages: vec![LoopModelMessage {
-                role: "user".to_string(),
-                content_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
-                    .unwrap(),
-            }],
-            surface_version: None,
-            model_preference: None,
-        })
-        .await
-        .unwrap();
-
-    assert!(matches!(
-        response.output,
-        ParentLoopOutput::AssistantReply(AssistantReply { ref content })
-            if content == "model response survives milestone failure"
-    ));
-    assert_eq!(milestone_sink.kind_names(), vec!["model_started"]);
-    assert!(logs_contain(
-        "loop model_completed milestone failed after successful model response"
-    ));
-}
-
 #[tokio::test]
 async fn model_port_rejects_message_role_that_disagrees_with_thread_record() {
     let fixture = ThreadFixture::new().await;
@@ -882,7 +731,7 @@ impl ThreadFixture {
         Self::new_with_user_content("hello reborn").await
     }
 
-    async fn new_with_user_content(user_content: &str) -> Self {
+    async fn new_with_user_content(content: impl Into<String>) -> Self {
         let thread_service = Arc::new(InMemorySessionThreadService::default());
         let tenant_id = TenantId::new("tenant-loop-support").unwrap();
         let agent_id = AgentId::new("agent-loop-support").unwrap();
@@ -914,7 +763,7 @@ impl ThreadFixture {
                 source_binding_id: Some("source-web".to_string()),
                 reply_target_binding_id: Some("reply-web".to_string()),
                 external_event_id: Some("event-1".to_string()),
-                content: MessageContent::text(user_content),
+                content: MessageContent::text(content.into()),
             })
             .await
             .unwrap();
@@ -1167,75 +1016,6 @@ impl SessionThreadService for StaticContextThreadService {
         _request: CreateSummaryArtifactRequest,
     ) -> Result<SummaryArtifact, SessionThreadError> {
         panic!("static context service does not create summaries")
-    }
-}
-
-#[derive(Default)]
-struct FailOnceMilestoneSink {
-    attempts: Mutex<Vec<ironclaw_turns::run_profile::LoopHostMilestone>>,
-}
-
-impl FailOnceMilestoneSink {
-    fn milestones(&self) -> Vec<ironclaw_turns::run_profile::LoopHostMilestone> {
-        self.attempts
-            .lock()
-            .unwrap()
-            .iter()
-            .skip(1)
-            .cloned()
-            .collect()
-    }
-}
-
-#[async_trait]
-impl ironclaw_turns::run_profile::LoopHostMilestoneSink for FailOnceMilestoneSink {
-    async fn publish_loop_milestone(
-        &self,
-        milestone: ironclaw_turns::run_profile::LoopHostMilestone,
-    ) -> Result<(), ironclaw_turns::run_profile::AgentLoopHostError> {
-        let mut attempts = self.attempts.lock().unwrap();
-        if attempts.is_empty() {
-            attempts.push(milestone);
-            return Err(ironclaw_turns::run_profile::AgentLoopHostError::new(
-                AgentLoopHostErrorKind::Unavailable,
-                "loop milestone sink unavailable",
-            ));
-        }
-        attempts.push(milestone);
-        Ok(())
-    }
-}
-
-#[derive(Default)]
-struct FailOnModelCompletedMilestoneSink {
-    published: Mutex<Vec<ironclaw_turns::run_profile::LoopHostMilestone>>,
-}
-
-impl FailOnModelCompletedMilestoneSink {
-    fn kind_names(&self) -> Vec<&'static str> {
-        self.published
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|milestone| milestone.kind.kind_name())
-            .collect()
-    }
-}
-
-#[async_trait]
-impl ironclaw_turns::run_profile::LoopHostMilestoneSink for FailOnModelCompletedMilestoneSink {
-    async fn publish_loop_milestone(
-        &self,
-        milestone: ironclaw_turns::run_profile::LoopHostMilestone,
-    ) -> Result<(), ironclaw_turns::run_profile::AgentLoopHostError> {
-        if matches!(milestone.kind, LoopHostMilestoneKind::ModelCompleted { .. }) {
-            return Err(ironclaw_turns::run_profile::AgentLoopHostError::new(
-                AgentLoopHostErrorKind::Unavailable,
-                "loop milestone sink unavailable",
-            ));
-        }
-        self.published.lock().unwrap().push(milestone);
-        Ok(())
     }
 }
 

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -12,11 +12,11 @@ publish = false
 
 [features]
 default = []
-root-llm-provider = ["dep:ironclaw"]
+root-llm-provider = ["dep:ironclaw_llm"]
 
 [dependencies]
 async-trait = "0.1"
-ironclaw = { path = "../..", version = "0.28.0", optional = true, default-features = false }
+ironclaw_llm = { path = "../ironclaw_llm", version = "0.1.0", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support", version = "0.1.0" }
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -24,6 +24,7 @@ ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
 [dev-dependencies]
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 rust_decimal = "1"
+serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
 
 [[test]]

--- a/crates/ironclaw_reborn/src/driver_registry.rs
+++ b/crates/ironclaw_reborn/src/driver_registry.rs
@@ -63,6 +63,7 @@ pub enum RequirementLevel {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriverRequirements {
     pub model: RequirementLevel,
+    pub prompt: RequirementLevel,
     pub transcript: RequirementLevel,
     pub checkpoint: RequirementLevel,
     pub input_polling: RequirementLevel,
@@ -74,6 +75,7 @@ impl DriverRequirements {
     pub fn all_optional() -> Self {
         Self {
             model: RequirementLevel::Optional,
+            prompt: RequirementLevel::Optional,
             transcript: RequirementLevel::Optional,
             checkpoint: RequirementLevel::Optional,
             input_polling: RequirementLevel::Optional,
@@ -85,6 +87,7 @@ impl DriverRequirements {
     pub fn all_required() -> Self {
         Self {
             model: RequirementLevel::Required,
+            prompt: RequirementLevel::Required,
             transcript: RequirementLevel::Required,
             checkpoint: RequirementLevel::Required,
             input_polling: RequirementLevel::Required,
@@ -336,6 +339,7 @@ impl PersistedRunDriverIdentity {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostGraphReadiness {
     pub model: bool,
+    pub prompt: bool,
     pub transcript: bool,
     pub checkpoint: bool,
     pub input_polling: bool,
@@ -347,6 +351,7 @@ impl HostGraphReadiness {
     pub fn all_available() -> Self {
         Self {
             model: true,
+            prompt: true,
             transcript: true,
             checkpoint: true,
             input_polling: true,
@@ -357,6 +362,11 @@ impl HostGraphReadiness {
 
     pub fn without_model(mut self) -> Self {
         self.model = false;
+        self
+    }
+
+    pub fn without_prompt(mut self) -> Self {
+        self.prompt = false;
         self
     }
 }
@@ -488,6 +498,12 @@ fn missing_requirements(
         requirements.model,
         host_graph.model,
         "driver requires a model gateway, but the host graph does not provide one",
+    );
+    push_missing(
+        &mut missing,
+        requirements.prompt,
+        host_graph.prompt,
+        "driver requires a prompt bundle port, but the host graph does not provide one",
     );
     push_missing(
         &mut missing,

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -8,8 +8,10 @@ pub mod driver_registry;
 
 #[cfg(feature = "root-llm-provider")]
 pub mod model_gateway;
+pub mod text_loop_host;
 
 #[cfg(feature = "root-llm-provider")]
 pub use model_gateway::{
     LlmModelProfilePolicy, LlmProviderModelGateway, ThreadBackedLoopModelGateway,
 };
+pub use text_loop_host::{TextOnlyLoopHostConfig, TextOnlyLoopHostPorts};

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -2,12 +2,12 @@
 //!
 //! The loop-support crate owns the host-facing model gateway contract. This
 //! adapter lives in the standalone Reborn composition crate because it bridges
-//! that contract to the existing root `src/llm` provider abstraction.
+//! that contract to the shared `ironclaw_llm` provider abstraction.
 
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use ironclaw::llm::{
+use ironclaw_llm::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmError, LlmProvider,
 };
 use ironclaw_loop_support::{

--- a/crates/ironclaw_reborn/src/text_loop_host.rs
+++ b/crates/ironclaw_reborn/src/text_loop_host.rs
@@ -1,0 +1,81 @@
+//! Reborn-side text-only loop host composition.
+//!
+//! This module keeps the concrete Reborn loop-support wiring out of the root
+//! `/src` app graph while giving callers one small factory for the context,
+//! model, transcript, and empty capability ports needed by the text-only loop
+//! path.
+
+use std::sync::Arc;
+
+use ironclaw_loop_support::{
+    EmptyLoopCapabilityPort, HostManagedModelGateway, ThreadBackedLoopContextPort,
+    ThreadBackedLoopModelPort, ThreadBackedLoopTranscriptPort,
+};
+use ironclaw_threads::{SessionThreadService, ThreadScope};
+use ironclaw_turns::run_profile::{LoopHostMilestoneSink, LoopRunContext};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextOnlyLoopHostConfig {
+    pub max_context_messages: usize,
+    pub max_model_messages: usize,
+}
+
+impl Default for TextOnlyLoopHostConfig {
+    fn default() -> Self {
+        Self {
+            max_context_messages: 16,
+            max_model_messages: 16,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TextOnlyLoopHostPorts<S, G>
+where
+    S: SessionThreadService + ?Sized,
+    G: HostManagedModelGateway + ?Sized,
+{
+    pub context: ThreadBackedLoopContextPort<S>,
+    pub model: ThreadBackedLoopModelPort<S, G>,
+    pub transcript: ThreadBackedLoopTranscriptPort<S>,
+    pub capabilities: EmptyLoopCapabilityPort,
+}
+
+impl<S, G> TextOnlyLoopHostPorts<S, G>
+where
+    S: SessionThreadService + ?Sized,
+    G: HostManagedModelGateway + ?Sized,
+{
+    pub fn new(
+        thread_service: Arc<S>,
+        thread_scope: ThreadScope,
+        run_context: LoopRunContext,
+        gateway: Arc<G>,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+        config: TextOnlyLoopHostConfig,
+    ) -> Self {
+        Self {
+            context: ThreadBackedLoopContextPort::new(
+                Arc::clone(&thread_service),
+                thread_scope.clone(),
+                run_context.clone(),
+                config.max_context_messages,
+            ),
+            model: ThreadBackedLoopModelPort::with_milestone_sink(
+                Arc::clone(&thread_service),
+                thread_scope.clone(),
+                run_context.clone(),
+                gateway,
+                config.max_model_messages,
+                Arc::clone(&milestone_sink),
+            ),
+            transcript: ThreadBackedLoopTranscriptPort::with_milestone_sink(
+                thread_service,
+                thread_scope,
+                run_context,
+                milestone_sink,
+            ),
+            capabilities: EmptyLoopCapabilityPort,
+        }
+    }
+}

--- a/crates/ironclaw_reborn/src/text_loop_host.rs
+++ b/crates/ironclaw_reborn/src/text_loop_host.rs
@@ -2,8 +2,8 @@
 //!
 //! This module keeps the concrete Reborn loop-support wiring out of the root
 //! `/src` app graph while giving callers one small factory for the context,
-//! model, transcript, and empty capability ports needed by the text-only loop
-//! path.
+//! prompt, model, transcript, and empty capability ports needed by the text-only
+//! loop path.
 
 use std::sync::Arc;
 
@@ -12,7 +12,9 @@ use ironclaw_loop_support::{
     ThreadBackedLoopModelPort, ThreadBackedLoopTranscriptPort,
 };
 use ironclaw_threads::{SessionThreadService, ThreadScope};
-use ironclaw_turns::run_profile::{LoopHostMilestoneSink, LoopRunContext};
+use ironclaw_turns::run_profile::{
+    HostManagedLoopPromptPort, LoopHostMilestoneSink, LoopRunContext,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TextOnlyLoopHostConfig {
@@ -29,13 +31,14 @@ impl Default for TextOnlyLoopHostConfig {
     }
 }
 
-#[derive(Clone)]
 pub struct TextOnlyLoopHostPorts<S, G>
 where
     S: SessionThreadService + ?Sized,
     G: HostManagedModelGateway + ?Sized,
 {
-    pub context: ThreadBackedLoopContextPort<S>,
+    pub context: Arc<ThreadBackedLoopContextPort<S>>,
+    pub prompt:
+        HostManagedLoopPromptPort<ThreadBackedLoopContextPort<S>, dyn LoopHostMilestoneSink>,
     pub model: ThreadBackedLoopModelPort<S, G>,
     pub transcript: ThreadBackedLoopTranscriptPort<S>,
     pub capabilities: EmptyLoopCapabilityPort,
@@ -54,13 +57,21 @@ where
         milestone_sink: Arc<dyn LoopHostMilestoneSink>,
         config: TextOnlyLoopHostConfig,
     ) -> Self {
+        let context = Arc::new(ThreadBackedLoopContextPort::new(
+            Arc::clone(&thread_service),
+            thread_scope.clone(),
+            run_context.clone(),
+            config.max_context_messages,
+        ));
+        let prompt = HostManagedLoopPromptPort::new(
+            run_context.clone(),
+            Arc::clone(&context),
+            Arc::clone(&milestone_sink),
+        )
+        .with_default_message_limit(config.max_context_messages);
         Self {
-            context: ThreadBackedLoopContextPort::new(
-                Arc::clone(&thread_service),
-                thread_scope.clone(),
-                run_context.clone(),
-                config.max_context_messages,
-            ),
+            context,
+            prompt,
             model: ThreadBackedLoopModelPort::with_milestone_sink(
                 Arc::clone(&thread_service),
                 thread_scope.clone(),

--- a/crates/ironclaw_reborn/tests/driver_registry.rs
+++ b/crates/ironclaw_reborn/tests/driver_registry.rs
@@ -274,6 +274,7 @@ fn production_readiness_rejects_missing_required_host_component() {
             ))),
             DriverRequirements {
                 model: RequirementLevel::Required,
+                prompt: RequirementLevel::Optional,
                 transcript: RequirementLevel::Optional,
                 checkpoint: RequirementLevel::Optional,
                 input_polling: RequirementLevel::Optional,
@@ -303,6 +304,49 @@ fn production_readiness_rejects_missing_required_host_component() {
             .iter()
             .any(|diagnostic| diagnostic.code == "missing_required_driver_requirement")
     );
+}
+
+#[test]
+fn production_readiness_rejects_missing_required_prompt_port() {
+    let mut registry = DriverRegistry::new();
+    let driver_key = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "lightweight_loop",
+                1,
+                "checkpoint_v1",
+                1,
+            ))),
+            DriverRequirements {
+                model: RequirementLevel::Optional,
+                prompt: RequirementLevel::Required,
+                transcript: RequirementLevel::Optional,
+                checkpoint: RequirementLevel::Optional,
+                input_polling: RequirementLevel::Optional,
+                capabilities: RequirementLevel::Optional,
+                progress_events: RequirementLevel::Optional,
+            },
+            DriverKind::Production,
+        )
+        .expect("registration should succeed");
+
+    let report = registry.validate_readiness(
+        DriverReadinessMode::Production,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available().without_prompt(),
+            configured_profiles: vec![ConfiguredRunProfile::enabled(
+                "interactive_default",
+                driver_key,
+            )],
+            persisted_runs: Vec::new(),
+        },
+    );
+
+    assert_eq!(report.status, DriverReadinessStatus::NotReady);
+    assert!(report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "missing_required_driver_requirement"
+            && diagnostic.message.contains("prompt bundle")
+    }));
 }
 
 #[test]

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use ironclaw::llm::{
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_llm::{
     CompletionRequest, CompletionResponse, FinishReason, LlmError, LlmProvider,
     ToolCompletionRequest, ToolCompletionResponse,
 };
-use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_loop_support::{
     HostManagedModelErrorKind, HostManagedModelGateway, HostManagedModelMessage,
     HostManagedModelMessageRole, HostManagedModelRequest,

--- a/crates/ironclaw_reborn/tests/text_loop_host.rs
+++ b/crates/ironclaw_reborn/tests/text_loop_host.rs
@@ -1,0 +1,322 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_loop_support::{
+    HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
+    HostManagedModelRequest, HostManagedModelResponse,
+};
+use ironclaw_reborn::{TextOnlyLoopHostConfig, TextOnlyLoopHostPorts};
+use ironclaw_threads::{
+    AcceptInboundMessageRequest, EnsureThreadRequest, InMemorySessionThreadService, MessageContent,
+    MessageKind, MessageStatus, SessionThreadService, ThreadHistoryRequest, ThreadScope,
+};
+use ironclaw_turns::{
+    RunProfileResolutionRequest, RunProfileResolver, TurnId, TurnRunId, TurnScope,
+    run_profile::{
+        AgentLoopHostErrorKind, FinalizeAssistantMessage, InMemoryLoopHostMilestoneSink,
+        InMemoryRunProfileResolver, LoopCapabilityPort, LoopContextPort, LoopContextRequest,
+        LoopHostMilestone, LoopHostMilestoneKind, LoopModelMessage, LoopModelPort,
+        LoopModelRequest, LoopRunContext, LoopTranscriptPort, ParentLoopOutput,
+        VisibleCapabilityRequest,
+    },
+};
+
+#[tokio::test]
+async fn text_only_loop_host_ports_drive_model_reply_transcript_and_safe_milestones() {
+    let fixture = ThreadFixture::new_with_user_content(
+        "RAW_PROMPT_TEXT_SENTINEL sk-prompt-secret /host/path tool_input",
+    )
+    .await;
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let gateway = Arc::new(RecordingGateway::reply(
+        "RAW_ASSISTANT_CONTENT_SENTINEL sk-output-secret /host/path tool_input",
+    ));
+    let ports = TextOnlyLoopHostPorts::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway.clone(),
+        milestone_sink.clone(),
+        TextOnlyLoopHostConfig {
+            max_context_messages: 8,
+            max_model_messages: 8,
+        },
+    );
+
+    let surface = ports
+        .capabilities
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+    assert!(surface.descriptors.is_empty());
+
+    let context = ports
+        .context
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 8,
+        })
+        .await
+        .unwrap();
+    assert_eq!(context.messages.len(), 1);
+    assert_eq!(context.messages[0].safe_summary, "user message available");
+
+    let model_response = ports
+        .model
+        .stream_model(LoopModelRequest {
+            messages: context
+                .messages
+                .iter()
+                .map(|message| LoopModelMessage {
+                    role: message.role.clone(),
+                    content_ref: message.message_ref.clone(),
+                })
+                .collect(),
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap();
+    let ParentLoopOutput::AssistantReply(reply) = model_response.output else {
+        panic!("expected assistant reply");
+    };
+
+    let finalized_ref = ports
+        .transcript
+        .finalize_assistant_message(FinalizeAssistantMessage { reply })
+        .await
+        .unwrap();
+
+    let history = fixture
+        .thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: fixture.thread_scope.clone(),
+            thread_id: fixture.thread_id.clone(),
+        })
+        .await
+        .unwrap();
+    let assistant = history
+        .messages
+        .iter()
+        .find(|message| message.kind == MessageKind::Assistant)
+        .expect("assistant reply must be written by the composed transcript port");
+    assert_eq!(assistant.status, MessageStatus::Finalized);
+    assert_eq!(
+        assistant.content.as_deref(),
+        Some("RAW_ASSISTANT_CONTENT_SENTINEL sk-output-secret /host/path tool_input")
+    );
+    assert_eq!(
+        finalized_ref.as_str(),
+        format!("msg:{}", assistant.message_id)
+    );
+
+    let requests = gateway.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].messages.len(), 1);
+    assert_eq!(
+        requests[0].messages[0].content,
+        "RAW_PROMPT_TEXT_SENTINEL sk-prompt-secret /host/path tool_input"
+    );
+    drop(requests);
+
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 3);
+    assert!(matches!(
+        &milestones[0].kind,
+        LoopHostMilestoneKind::ModelStarted {
+            requested_model_profile_id: None
+        }
+    ));
+    assert!(matches!(
+        &milestones[1].kind,
+        LoopHostMilestoneKind::ModelCompleted { effective_model_profile_id }
+            if effective_model_profile_id == &fixture.run_context.resolved_run_profile.model_profile_id
+    ));
+    assert!(matches!(
+        &milestones[2].kind,
+        LoopHostMilestoneKind::AssistantReplyFinalized { message_ref }
+            if message_ref == &finalized_ref
+    ));
+    assert!(milestones.iter().all(|milestone| {
+        milestone.scope == fixture.run_context.scope
+            && milestone.turn_id == fixture.run_context.turn_id
+            && milestone.run_id == fixture.run_context.run_id
+    }));
+
+    assert_serialized_milestones_hide_sentinels(&milestones);
+}
+
+#[tokio::test]
+async fn text_only_loop_host_ports_keep_failed_model_milestones_safe() {
+    let fixture = ThreadFixture::new_with_user_content("RAW_PROMPT_TEXT_SENTINEL").await;
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let gateway = Arc::new(RecordingGateway::deny(
+        "RAW_PROVIDER_ERROR invalid api key sk-provider-secret /host/path tool_input",
+    ));
+    let ports = TextOnlyLoopHostPorts::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway,
+        milestone_sink.clone(),
+        TextOnlyLoopHostConfig::default(),
+    );
+
+    let context = ports
+        .context
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 8,
+        })
+        .await
+        .unwrap();
+    let error = ports
+        .model
+        .stream_model(LoopModelRequest {
+            messages: context
+                .messages
+                .iter()
+                .map(|message| LoopModelMessage {
+                    role: message.role.clone(),
+                    content_ref: message.message_ref.clone(),
+                })
+                .collect(),
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    let serialized_error = serde_json::to_string(&error).unwrap();
+    assert!(!serialized_error.contains("RAW_PROVIDER_ERROR"));
+    assert!(!serialized_error.contains("sk-provider-secret"));
+
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 1);
+    assert!(matches!(
+        &milestones[0].kind,
+        LoopHostMilestoneKind::ModelStarted {
+            requested_model_profile_id: None
+        }
+    ));
+    assert_serialized_milestones_hide_sentinels(&milestones);
+}
+
+fn assert_serialized_milestones_hide_sentinels(milestones: &[LoopHostMilestone]) {
+    let wire = serde_json::to_string(milestones).unwrap();
+    for forbidden in [
+        "RAW_PROMPT_TEXT_SENTINEL",
+        "RAW_ASSISTANT_CONTENT_SENTINEL",
+        "RAW_PROVIDER_ERROR",
+        "invalid api key",
+        "sk-prompt-secret",
+        "sk-output-secret",
+        "sk-provider-secret",
+        "/host/path",
+        "tool_input",
+    ] {
+        assert!(!wire.contains(forbidden), "milestone leaked {forbidden}");
+    }
+}
+
+struct ThreadFixture {
+    thread_service: Arc<InMemorySessionThreadService>,
+    thread_scope: ThreadScope,
+    thread_id: ThreadId,
+    run_context: LoopRunContext,
+}
+
+impl ThreadFixture {
+    async fn new_with_user_content(user_content: &str) -> Self {
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let tenant_id = TenantId::new("tenant-reborn-composition").unwrap();
+        let agent_id = AgentId::new("agent-reborn-composition").unwrap();
+        let project_id = ProjectId::new("project-reborn-composition").unwrap();
+        let user_id = UserId::new("user-reborn-composition").unwrap();
+        let thread_id = ThreadId::new("thread-reborn-composition").unwrap();
+        let thread_scope = ThreadScope {
+            tenant_id: tenant_id.clone(),
+            agent_id: agent_id.clone(),
+            project_id: Some(project_id.clone()),
+            owner_user_id: Some(user_id.clone()),
+            mission_id: None,
+        };
+        thread_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: thread_scope.clone(),
+                thread_id: Some(thread_id.clone()),
+                created_by_actor_id: user_id.as_str().to_string(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        thread_service
+            .accept_inbound_message(AcceptInboundMessageRequest {
+                scope: thread_scope.clone(),
+                thread_id: thread_id.clone(),
+                actor_id: user_id.as_str().to_string(),
+                source_binding_id: Some("source-cli".to_string()),
+                reply_target_binding_id: Some("reply-cli".to_string()),
+                external_event_id: Some("event-1".to_string()),
+                content: MessageContent::text(user_content),
+            })
+            .await
+            .unwrap();
+        let turn_scope = TurnScope::new(
+            tenant_id,
+            Some(agent_id),
+            Some(project_id),
+            thread_id.clone(),
+        );
+        let resolved = InMemoryRunProfileResolver::default()
+            .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+            .await
+            .unwrap();
+        let run_context =
+            LoopRunContext::new(turn_scope, TurnId::new(), TurnRunId::new(), resolved);
+        Self {
+            thread_service,
+            thread_scope,
+            thread_id,
+            run_context,
+        }
+    }
+}
+
+struct RecordingGateway {
+    requests: Mutex<Vec<HostManagedModelRequest>>,
+    response: Result<HostManagedModelResponse, HostManagedModelError>,
+}
+
+impl RecordingGateway {
+    fn reply(content: &str) -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            response: Ok(HostManagedModelResponse::assistant_reply(content)),
+        }
+    }
+
+    fn deny(raw_detail: &str) -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            response: Err(HostManagedModelError::new(
+                HostManagedModelErrorKind::PolicyDenied,
+                raw_detail,
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl HostManagedModelGateway for RecordingGateway {
+    async fn stream_model(
+        &self,
+        request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        self.requests.lock().unwrap().push(request);
+        self.response.clone()
+    }
+}

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -63,6 +63,47 @@ fn validate_loop_opaque_token(
     Ok(value)
 }
 
+fn validate_loop_safe_identifier(
+    value: String,
+    label: &'static str,
+    max_bytes: usize,
+) -> Result<String, String> {
+    let value = validate_bounded_loop_string(value, label, max_bytes)?;
+    if !value.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | ':')
+    }) {
+        return Err(format!(
+            "{label} must contain only ASCII letters, digits, _, -, ., or :"
+        ));
+    }
+
+    let lower = value.to_ascii_lowercase();
+    for forbidden in [
+        "access_token",
+        "access-token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "bearer",
+        "password",
+        "passwd",
+        "secret",
+    ] {
+        if lower.contains(forbidden) {
+            return Err(format!(
+                "{label} must not contain sensitive marker `{forbidden}`"
+            ));
+        }
+    }
+    if lower
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '-')
+        .any(|token| token.starts_with("sk-"))
+    {
+        return Err(format!("{label} must not contain API-key-like tokens"));
+    }
+    Ok(value)
+}
+
 fn validate_loop_safe_summary(value: String) -> Result<String, String> {
     let value = validate_bounded_loop_string(value, "loop safe summary", 512)?;
     if value.chars().any(|character| {
@@ -513,7 +554,7 @@ pub struct CapabilitySurfaceVersion(String);
 
 impl CapabilitySurfaceVersion {
     pub fn new(value: impl Into<String>) -> Result<Self, String> {
-        validate_bounded_loop_string(value.into(), "capability surface version", 128).map(Self)
+        validate_loop_safe_identifier(value.into(), "capability surface version", 128).map(Self)
     }
 
     pub fn as_str(&self) -> &str {
@@ -579,7 +620,7 @@ pub struct LoopPromptBundleRequest {
     pub context_cursor: Option<LoopInputCursor>,
     pub surface_version: Option<CapabilitySurfaceVersion>,
     pub checkpoint_state_ref: Option<LoopCheckpointStateRef>,
-    pub max_tokens: Option<u32>,
+    pub max_messages: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -46,6 +46,23 @@ fn validate_prefixed_loop_ref(
     Ok(value)
 }
 
+fn validate_loop_opaque_token(
+    value: String,
+    label: &'static str,
+    max_bytes: usize,
+) -> Result<String, String> {
+    let value = validate_bounded_loop_string(value, label, max_bytes)?;
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.'))
+    {
+        return Err(format!(
+            "{label} must contain only ASCII letters, digits, _, -, or ."
+        ));
+    }
+    Ok(value)
+}
+
 fn validate_loop_safe_summary(value: String) -> Result<String, String> {
     let value = validate_bounded_loop_string(value, "loop safe summary", 512)?;
     if value.chars().any(|character| {
@@ -149,6 +166,87 @@ bounded_loop_ref!(
     256
 );
 bounded_loop_ref!(LoopProcessRef, "loop process ref", "process:", 256);
+
+impl LoopCheckpointStateRef {
+    pub fn for_run(context: &LoopRunContext, token: impl Into<String>) -> Result<Self, String> {
+        let token = validate_loop_opaque_token(token.into(), "loop checkpoint state token", 96)?;
+        Self::new(format!("checkpoint:{}:{token}", context.run_id))
+    }
+
+    pub fn is_for_run(&self, context: &LoopRunContext) -> bool {
+        let Some(token) = self
+            .0
+            .strip_prefix(&format!("checkpoint:{}:", context.run_id))
+        else {
+            return false;
+        };
+        validate_loop_opaque_token(token.to_string(), "loop checkpoint state token", 96).is_ok()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct LoopPromptBundleRef(String);
+
+impl LoopPromptBundleRef {
+    pub fn new(value: impl Into<String>) -> Result<Self, String> {
+        let value =
+            validate_prefixed_loop_ref("loop prompt bundle ref", "prompt:", 256, value.into())?;
+        let suffix = value
+            .strip_prefix("prompt:")
+            .ok_or_else(|| "loop prompt bundle ref must start with `prompt:`".to_string())?;
+        let (run_id, token) = suffix.split_once(':').ok_or_else(|| {
+            "loop prompt bundle ref must include scoped run id and opaque token".to_string()
+        })?;
+        uuid::Uuid::parse_str(run_id)
+            .map_err(|_| "loop prompt bundle ref run id must be a UUID".to_string())?;
+        validate_loop_opaque_token(token.to_string(), "loop prompt bundle token", 96)?;
+        Ok(Self(value))
+    }
+
+    pub fn for_run(context: &LoopRunContext, token: impl Into<String>) -> Result<Self, String> {
+        let token = validate_loop_opaque_token(token.into(), "loop prompt bundle token", 96)?;
+        Self::new(format!("prompt:{}:{token}", context.run_id))
+    }
+
+    pub(crate) fn fresh_for_run(context: &LoopRunContext) -> Self {
+        Self(format!(
+            "prompt:{}:{}",
+            context.run_id,
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_for_run(&self, context: &LoopRunContext) -> bool {
+        self.0.starts_with(&format!("prompt:{}:", context.run_id))
+    }
+}
+
+impl AsRef<str> for LoopPromptBundleRef {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for LoopPromptBundleRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for LoopPromptBundleRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
@@ -458,6 +556,47 @@ pub struct LoopModelMessage {
     pub content_ref: LoopMessageRef,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptMode {
+    TextOnly,
+    #[serde(rename = "codeact")]
+    CodeAct,
+}
+
+impl PromptMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TextOnly => "text_only",
+            Self::CodeAct => "codeact",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopPromptBundleRequest {
+    pub mode: PromptMode,
+    pub context_cursor: Option<LoopInputCursor>,
+    pub surface_version: Option<CapabilitySurfaceVersion>,
+    pub checkpoint_state_ref: Option<LoopCheckpointStateRef>,
+    pub max_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopPromptBundle {
+    pub bundle_ref: LoopPromptBundleRef,
+    pub messages: Vec<LoopModelMessage>,
+    pub surface_version: Option<CapabilitySurfaceVersion>,
+}
+
+#[async_trait]
+pub trait LoopPromptPort: Send + Sync {
+    async fn build_prompt_bundle(
+        &self,
+        request: LoopPromptBundleRequest,
+    ) -> Result<LoopPromptBundle, AgentLoopHostError>;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopModelResponse {
     pub chunks: Vec<ModelStreamChunk>,
@@ -737,6 +876,7 @@ pub trait LoopProgressPort: Send + Sync {
 pub trait AgentLoopDriverHost:
     LoopRunInfoPort
     + LoopContextPort
+    + LoopPromptPort
     + LoopInputPort
     + LoopModelPort
     + LoopCapabilityPort
@@ -751,6 +891,7 @@ pub trait AgentLoopDriverHost:
 impl<T> AgentLoopDriverHost for T where
     T: LoopRunInfoPort
         + LoopContextPort
+        + LoopPromptPort
         + LoopInputPort
         + LoopModelPort
         + LoopCapabilityPort

--- a/crates/ironclaw_turns/src/run_profile/milestones.rs
+++ b/crates/ironclaw_turns/src/run_profile/milestones.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 use super::host::{
-    AgentLoopHostError, AgentLoopHostErrorKind, LoopCheckpointKind, LoopDriverNoteKind,
-    LoopRunContext, LoopSafeSummary,
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilitySurfaceVersion, LoopCheckpointKind,
+    LoopDriverNoteKind, LoopPromptBundleRef, LoopRunContext, LoopSafeSummary, PromptMode,
 };
 use super::refs::{LoopDriverId, ModelProfileId};
 use crate::{LoopCompletionKind, LoopFailureKind};
@@ -39,6 +39,12 @@ impl LoopHostMilestone {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LoopHostMilestoneKind {
+    PromptBundleBuilt {
+        bundle_ref: LoopPromptBundleRef,
+        mode: PromptMode,
+        surface_version: Option<CapabilitySurfaceVersion>,
+        message_count: usize,
+    },
     ModelStarted {
         requested_model_profile_id: Option<ModelProfileId>,
     },
@@ -76,6 +82,7 @@ pub enum LoopHostMilestoneKind {
 impl LoopHostMilestoneKind {
     pub fn kind_name(&self) -> &'static str {
         match self {
+            Self::PromptBundleBuilt { .. } => "prompt_bundle_built",
             Self::ModelStarted { .. } => "model_started",
             Self::ModelCompleted { .. } => "model_completed",
             Self::CapabilityInvoked { .. } => "capability_invoked",
@@ -143,6 +150,22 @@ where
 {
     pub fn new(context: LoopRunContext, sink: Arc<S>) -> Self {
         Self { context, sink }
+    }
+
+    pub async fn prompt_bundle_built(
+        &self,
+        bundle_ref: LoopPromptBundleRef,
+        mode: PromptMode,
+        surface_version: Option<CapabilitySurfaceVersion>,
+        message_count: usize,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::PromptBundleBuilt {
+            bundle_ref,
+            mode,
+            surface_version,
+            message_count,
+        })
+        .await
     }
 
     pub async fn model_started(

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -3,6 +3,7 @@ mod host;
 mod milestones;
 mod model;
 mod policy;
+mod prompt;
 mod refs;
 mod resolver;
 mod snapshot;
@@ -22,8 +23,9 @@ pub use host::{
     LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopDriverNoteKind, LoopInput,
     LoopInputBatch, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopInterruptKind,
     LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelResponse, LoopProcessRef,
-    LoopProgressEvent, LoopProgressPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
-    LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, ProcessHandleSummary,
+    LoopProgressEvent, LoopProgressPort, LoopPromptBundle, LoopPromptBundleRef,
+    LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
+    LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, ProcessHandleSummary, PromptMode,
     UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
 };
 pub use milestones::{
@@ -39,6 +41,7 @@ pub use policy::{
     RunProfileRequestAuthority, RunProfileResolutionError, RuntimeProfileConstraints,
     SteeringPolicy,
 };
+pub use prompt::HostManagedLoopPromptPort;
 pub use refs::{
     CapabilitySurfaceProfileId, CheckpointSchemaId, ConcurrencyClass, ContextProfileId,
     LoopDriverId, ModelProfileId, ResourceBudgetTier, RunClassId, RunProfileFingerprint,

--- a/crates/ironclaw_turns/src/run_profile/prompt.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::host::{
+    AgentLoopHostError, AgentLoopHostErrorKind, LoopContextPort, LoopContextRequest,
+    LoopModelMessage, LoopPromptBundle, LoopPromptBundleRef, LoopPromptBundleRequest,
+    LoopPromptPort, LoopRunContext, PromptMode,
+};
+use super::milestones::{LoopHostMilestoneEmitter, LoopHostMilestoneSink};
+
+const DEFAULT_TEXT_ONLY_MESSAGE_LIMIT: usize = 32;
+const MAX_TEXT_ONLY_MESSAGE_LIMIT: usize = 128;
+
+#[derive(Clone)]
+pub struct HostManagedLoopPromptPort<C, S>
+where
+    C: LoopContextPort + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    context: LoopRunContext,
+    context_port: Arc<C>,
+    milestones: LoopHostMilestoneEmitter<S>,
+    default_message_limit: usize,
+}
+
+impl<C, S> HostManagedLoopPromptPort<C, S>
+where
+    C: LoopContextPort + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    pub fn new(context: LoopRunContext, context_port: Arc<C>, milestone_sink: Arc<S>) -> Self {
+        Self {
+            context: context.clone(),
+            context_port,
+            milestones: LoopHostMilestoneEmitter::new(context, milestone_sink),
+            default_message_limit: DEFAULT_TEXT_ONLY_MESSAGE_LIMIT,
+        }
+    }
+
+    pub fn with_default_message_limit(mut self, default_message_limit: usize) -> Self {
+        self.default_message_limit = default_message_limit.clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT);
+        self
+    }
+
+    fn validate_request(
+        &self,
+        request: &LoopPromptBundleRequest,
+    ) -> Result<(), AgentLoopHostError> {
+        if request.mode != PromptMode::TextOnly {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::PolicyDenied,
+                "prompt mode is not supported by the text-only prompt port",
+            ));
+        }
+
+        if request
+            .context_cursor
+            .as_ref()
+            .is_some_and(|cursor| !cursor.is_for_run(&self.context))
+        {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::ScopeMismatch,
+                "prompt context cursor is not scoped to this loop run",
+            ));
+        }
+
+        if let Some(state_ref) = request.checkpoint_state_ref.as_ref() {
+            let run_prefix = format!("checkpoint:{}:", self.context.run_id);
+            if !state_ref.as_str().starts_with(&run_prefix) {
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::ScopeMismatch,
+                    "prompt checkpoint state ref is not scoped to this loop run",
+                ));
+            }
+            if !state_ref.is_for_run(&self.context) {
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::InvalidInvocation,
+                    "prompt checkpoint state ref is malformed",
+                ));
+            }
+        }
+
+        if matches!(request.max_tokens, Some(0)) {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::BudgetExceeded,
+                "prompt token budget must be greater than zero",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn message_limit(&self, request: &LoopPromptBundleRequest) -> usize {
+        request
+            .max_tokens
+            .map(|tokens| tokens as usize)
+            .unwrap_or(self.default_message_limit)
+            .clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT)
+    }
+}
+
+#[async_trait]
+impl<C, S> LoopPromptPort for HostManagedLoopPromptPort<C, S>
+where
+    C: LoopContextPort + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    async fn build_prompt_bundle(
+        &self,
+        request: LoopPromptBundleRequest,
+    ) -> Result<LoopPromptBundle, AgentLoopHostError> {
+        self.validate_request(&request)?;
+        let context = self
+            .context_port
+            .load_loop_context(LoopContextRequest {
+                after: request.context_cursor.clone(),
+                limit: self.message_limit(&request),
+            })
+            .await?;
+        let messages = context
+            .messages
+            .into_iter()
+            .map(|message| LoopModelMessage {
+                role: message.role,
+                content_ref: message.message_ref,
+            })
+            .collect::<Vec<_>>();
+        let bundle = LoopPromptBundle {
+            bundle_ref: LoopPromptBundleRef::fresh_for_run(&self.context),
+            messages,
+            surface_version: request.surface_version.clone(),
+        };
+        self.milestones
+            .prompt_bundle_built(
+                bundle.bundle_ref.clone(),
+                request.mode,
+                bundle.surface_version.clone(),
+                bundle.messages.len(),
+            )
+            .await?;
+        Ok(bundle)
+    }
+}

--- a/crates/ironclaw_turns/src/run_profile/prompt.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use super::host::{
-    AgentLoopHostError, AgentLoopHostErrorKind, LoopContextPort, LoopContextRequest,
-    LoopModelMessage, LoopPromptBundle, LoopPromptBundleRef, LoopPromptBundleRequest,
-    LoopPromptPort, LoopRunContext, PromptMode,
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilitySurfaceVersion, LoopContextBundle,
+    LoopContextPort, LoopContextRequest, LoopModelMessage, LoopPromptBundle, LoopPromptBundleRef,
+    LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, PromptMode,
 };
 use super::milestones::{LoopHostMilestoneEmitter, LoopHostMilestoneSink};
 
@@ -22,6 +22,7 @@ where
     context_port: Arc<C>,
     milestones: LoopHostMilestoneEmitter<S>,
     default_message_limit: usize,
+    current_surface_version: Option<CapabilitySurfaceVersion>,
 }
 
 impl<C, S> HostManagedLoopPromptPort<C, S>
@@ -35,11 +36,20 @@ where
             context_port,
             milestones: LoopHostMilestoneEmitter::new(context, milestone_sink),
             default_message_limit: DEFAULT_TEXT_ONLY_MESSAGE_LIMIT,
+            current_surface_version: None,
         }
     }
 
     pub fn with_default_message_limit(mut self, default_message_limit: usize) -> Self {
         self.default_message_limit = default_message_limit.clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT);
+        self
+    }
+
+    pub fn with_current_surface_version(
+        mut self,
+        current_surface_version: CapabilitySurfaceVersion,
+    ) -> Self {
+        self.current_surface_version = Some(current_surface_version);
         self
     }
 
@@ -65,6 +75,21 @@ where
             ));
         }
 
+        if let Some(surface_version) = request.surface_version.as_ref() {
+            let Some(current_surface_version) = self.current_surface_version.as_ref() else {
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::InvalidInvocation,
+                    "prompt surface version cannot be validated by this prompt port",
+                ));
+            };
+            if surface_version != current_surface_version {
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::StaleSurface,
+                    "prompt surface version is stale or unknown",
+                ));
+            }
+        }
+
         if let Some(state_ref) = request.checkpoint_state_ref.as_ref() {
             let run_prefix = format!("checkpoint:{}:", self.context.run_id);
             if !state_ref.as_str().starts_with(&run_prefix) {
@@ -79,12 +104,16 @@ where
                     "prompt checkpoint state ref is malformed",
                 ));
             }
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "checkpoint prompt state is not supported by the text-only prompt port",
+            ));
         }
 
-        if matches!(request.max_tokens, Some(0)) {
+        if matches!(request.max_messages, Some(0)) {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::BudgetExceeded,
-                "prompt token budget must be greater than zero",
+                "prompt message limit must be greater than zero",
             ));
         }
 
@@ -93,10 +122,22 @@ where
 
     fn message_limit(&self, request: &LoopPromptBundleRequest) -> usize {
         request
-            .max_tokens
-            .map(|tokens| tokens as usize)
+            .max_messages
+            .map(|messages| messages as usize)
             .unwrap_or(self.default_message_limit)
             .clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT)
+    }
+
+    fn ensure_supported_context_shape(
+        context: &LoopContextBundle,
+    ) -> Result<(), AgentLoopHostError> {
+        if !context.instruction_snippets.is_empty() || !context.memory_snippets.is_empty() {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::PolicyDenied,
+                "text-only prompt port cannot materialize instruction or memory snippets",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -118,6 +159,7 @@ where
                 limit: self.message_limit(&request),
             })
             .await?;
+        Self::ensure_supported_context_shape(&context)?;
         let messages = context
             .messages
             .into_iter()

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -11,20 +11,23 @@ use ironclaw_turns::{
     LoopCompleted, LoopCompletionKind, LoopExit, LoopExitId, LoopGateRef, LoopMessageRef,
     ReplyTargetBindingRef, RunProfileRequest, RunProfileVersion, SourceBindingRef,
     SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCheckpointId, TurnCoordinator,
-    TurnLeaseToken, TurnRunId, TurnRunnerId,
+    TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnStatus,
+    events::EventCursor,
     run_profile::{
         AgentLoopDriverHost, AgentLoopHostError, AgentLoopHostErrorKind, AssistantReply,
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDescriptorView,
         CapabilityInputRef, CapabilityInvocation, CapabilityOutcome, CapabilitySurfaceVersion,
-        FinalizeAssistantMessage, HostManagedLoopModelPort, InMemoryLoopHostMilestoneSink,
-        LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort, LoopCheckpointRequest,
-        LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage, LoopContextPort,
-        LoopContextRequest, LoopDriverNoteKind, LoopHostMilestone, LoopHostMilestoneEmitter,
-        LoopHostMilestoneKind, LoopHostMilestoneSink, LoopInputBatch, LoopInputCursor,
-        LoopInputCursorToken, LoopInputPort, LoopModelGateway, LoopModelGatewayError,
-        LoopModelGatewayRequest, LoopModelMessage, LoopModelPort, LoopModelRequest,
-        LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopRunContext, LoopRunInfoPort,
-        LoopTranscriptPort, ParentLoopOutput, VisibleCapabilityRequest, VisibleCapabilitySurface,
+        FinalizeAssistantMessage, HostManagedLoopModelPort, HostManagedLoopPromptPort,
+        InMemoryLoopHostMilestoneSink, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
+        LoopCheckpointRequest, LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage,
+        LoopContextPort, LoopContextRequest, LoopDriverId, LoopDriverNoteKind, LoopHostMilestone,
+        LoopHostMilestoneEmitter, LoopHostMilestoneKind, LoopHostMilestoneSink, LoopInputBatch,
+        LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelGateway,
+        LoopModelGatewayError, LoopModelGatewayRequest, LoopModelMessage, LoopModelPort,
+        LoopModelRequest, LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopPromptBundle,
+        LoopPromptBundleRef, LoopPromptBundleRequest, LoopPromptPort, LoopRunContext,
+        LoopRunInfoPort, LoopTranscriptPort, ParentLoopOutput, PromptMode,
+        VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
     runner::{ClaimRunRequest, TurnRunTransitionPort},
 };
@@ -58,8 +61,10 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
     assert_eq!(
         host.effects(),
         vec![
-            "context",
             "visible_capabilities",
+            "prompt_bundle",
+            "context",
+            "milestone:prompt_bundle_built",
             "model",
             "milestone:model_started",
             "milestone:model_completed",
@@ -80,6 +85,7 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
     assert_eq!(
         host.milestone_kind_names(),
         vec![
+            "prompt_bundle_built",
             "model_started",
             "model_completed",
             "assistant_reply_finalized",
@@ -88,7 +94,7 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
     let milestones = host.milestones();
     assert!(matches!(
         &milestones[0].kind,
-        LoopHostMilestoneKind::ModelStarted { .. }
+        LoopHostMilestoneKind::PromptBundleBuilt { .. }
     ));
     assert!(milestones.iter().all(|milestone| {
         milestone.scope == host.context.scope
@@ -226,6 +232,198 @@ async fn host_managed_model_port_sanitizes_gateway_errors() {
 }
 
 #[tokio::test]
+async fn loop_prompt_port_builds_text_only_bundle_from_context_refs() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let surface_version = CapabilitySurfaceVersion::new("surface-v1").unwrap();
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let bundle = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(surface_version.clone()),
+            checkpoint_state_ref: None,
+            max_tokens: Some(8),
+        })
+        .await
+        .unwrap();
+
+    assert!(bundle.bundle_ref.is_for_run(&host.context));
+    assert_eq!(bundle.surface_version, Some(surface_version));
+    assert_eq!(
+        bundle.messages,
+        vec![LoopModelMessage {
+            role: "user".to_string(),
+            content_ref: LoopMessageRef::new("msg:user-message").unwrap(),
+        }]
+    );
+    assert_eq!(host.effects(), vec!["context"]);
+    assert_eq!(host.milestone_kind_names(), vec!["prompt_bundle_built"]);
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_unsupported_prompt_mode() {
+    let host = Arc::new(RecordingAgentLoopHost::new(codeact_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::CodeAct,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_tokens: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_malformed_same_run_checkpoint_ref() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: Some(
+                LoopCheckpointStateRef::new(format!(
+                    "checkpoint:{}:/host/path",
+                    host.context.run_id
+                ))
+                .unwrap(),
+            ),
+            max_tokens: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_cross_run_checkpoint_ref() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let other_context = LoopRunContext::new(
+        host.context.scope.clone(),
+        host.context.turn_id,
+        TurnRunId::new(),
+        host.context.resolved_run_profile.clone(),
+    );
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: Some(
+                LoopCheckpointStateRef::for_run(&other_context, "foreign-state").unwrap(),
+            ),
+            max_tokens: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
+    assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_bundle_public_serialization_hides_raw_content() {
+    let host = Arc::new(
+        RecordingAgentLoopHost::new(claimed_run_context().await)
+            .with_context_message_safe_summary("RAW_PROMPT_SENTINEL /host/path secret"),
+    );
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let bundle = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_tokens: None,
+        })
+        .await
+        .unwrap();
+
+    let status = TurnRunState {
+        scope: host.context.scope.clone(),
+        turn_id: host.context.turn_id,
+        run_id: host.context.run_id,
+        status: TurnStatus::Running,
+        accepted_message_ref: AcceptedMessageRef::new("message-loop-host").unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-loop-host").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-loop-host").unwrap(),
+        resolved_run_profile_id: host.context.resolved_run_profile.profile_id.clone(),
+        resolved_run_profile_version: host.context.resolved_run_profile.profile_version,
+        received_at: Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap(),
+        checkpoint_id: None,
+        gate_ref: None,
+        failure: None,
+        event_cursor: EventCursor(0),
+    };
+    let public_json = serde_json::to_string(&(bundle, host.milestones(), status)).unwrap();
+    assert!(public_json.contains("prompt_bundle_built"));
+    assert!(!public_json.contains("RAW_PROMPT_SENTINEL"));
+    assert!(!public_json.contains("/host/path"));
+    assert!(!public_json.contains("secret"));
+}
+
+#[test]
+fn prompt_mode_wire_shape_uses_issue_contract_spelling() {
+    assert_eq!(
+        serde_json::to_string(&PromptMode::TextOnly).unwrap(),
+        "\"text_only\""
+    );
+    assert_eq!(
+        serde_json::to_string(&PromptMode::CodeAct).unwrap(),
+        "\"codeact\""
+    );
+    assert_eq!(
+        serde_json::from_str::<PromptMode>("\"codeact\"").unwrap(),
+        PromptMode::CodeAct
+    );
+}
+
+#[tokio::test]
+async fn prompt_bundle_refs_are_scoped_and_bounded() {
+    let context = claimed_run_context().await;
+    let bundle_ref = LoopPromptBundleRef::for_run(&context, "bundle-one").unwrap();
+
+    assert!(bundle_ref.is_for_run(&context));
+    assert!(LoopPromptBundleRef::new("prompt:missing-run-scope").is_err());
+    assert!(LoopPromptBundleRef::for_run(&context, "x".repeat(200)).is_err());
+}
+
+#[tokio::test]
 async fn capability_invocations_must_cite_visible_surface_before_host_dispatch() {
     let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
     let foreign = CapabilityId::new("demo.foreign").unwrap();
@@ -360,24 +558,25 @@ impl AgentLoopDriver for ReplyDriver {
     ) -> Result<LoopExit, AgentLoopDriverError> {
         assert_eq!(host.run_context().turn_id, request.turn_id);
         assert_eq!(host.run_context().run_id, request.run_id);
-        let context = host
-            .load_loop_context(LoopContextRequest {
-                after: None,
-                limit: 8,
+        let surface = host
+            .visible_capabilities(VisibleCapabilityRequest)
+            .await
+            .map_err(driver_error)?;
+        let prompt = host
+            .build_prompt_bundle(LoopPromptBundleRequest {
+                mode: PromptMode::TextOnly,
+                context_cursor: None,
+                surface_version: Some(surface.version),
+                checkpoint_state_ref: None,
+                max_tokens: Some(8),
             })
             .await
             .map_err(driver_error)?;
-        assert_eq!(context.messages.len(), 1);
-        host.visible_capabilities(VisibleCapabilityRequest)
-            .await
-            .map_err(driver_error)?;
+        assert_eq!(prompt.messages.len(), 1);
         let response = host
             .stream_model(LoopModelRequest {
-                messages: vec![LoopModelMessage {
-                    role: "user".to_string(),
-                    content_ref: context.messages[0].message_ref.clone(),
-                }],
-                surface_version: Some(CapabilitySurfaceVersion::new("surface-v1").unwrap()),
+                messages: prompt.messages,
+                surface_version: prompt.surface_version,
                 model_preference: Some(
                     host.run_context()
                         .resolved_run_profile
@@ -565,6 +764,7 @@ struct RecordingAgentLoopHost {
     capability_outcomes: Mutex<Vec<CapabilityOutcome>>,
     visible_surface: VisibleCapabilitySurface,
     milestone_sink: Arc<InMemoryLoopHostMilestoneSink>,
+    context_message_safe_summary: String,
 }
 
 impl RecordingAgentLoopHost {
@@ -585,7 +785,13 @@ impl RecordingAgentLoopHost {
                     safe_description: "Returns an opaque result ref".to_string(),
                 }],
             },
+            context_message_safe_summary: "hello".to_string(),
         }
+    }
+
+    fn with_context_message_safe_summary(mut self, safe_summary: impl Into<String>) -> Self {
+        self.context_message_safe_summary = safe_summary.into();
+        self
     }
 
     fn push_model_response(&self, response: LoopModelResponse) {
@@ -637,7 +843,7 @@ impl LoopContextPort for RecordingAgentLoopHost {
             messages: vec![LoopContextMessage {
                 message_ref: LoopMessageRef::new("msg:user-message").unwrap(),
                 role: "user".to_string(),
-                safe_summary: "hello".to_string(),
+                safe_summary: self.context_message_safe_summary.clone(),
             }],
             instruction_snippets: Vec::new(),
             memory_snippets: Vec::new(),
@@ -663,6 +869,46 @@ impl LoopInputPort for RecordingAgentLoopHost {
 
     async fn ack_inputs(&self, _cursor: LoopInputCursor) -> Result<(), AgentLoopHostError> {
         Ok(())
+    }
+}
+
+#[async_trait]
+impl LoopPromptPort for RecordingAgentLoopHost {
+    async fn build_prompt_bundle(
+        &self,
+        request: LoopPromptBundleRequest,
+    ) -> Result<LoopPromptBundle, AgentLoopHostError> {
+        self.record("prompt_bundle");
+        let context = self
+            .load_loop_context(LoopContextRequest {
+                after: request.context_cursor,
+                limit: request.max_tokens.unwrap_or(8) as usize,
+            })
+            .await?;
+        let bundle = LoopPromptBundle {
+            bundle_ref: LoopPromptBundleRef::for_run(&self.context, "recording-host").map_err(
+                |reason| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, reason),
+            )?,
+            messages: context
+                .messages
+                .into_iter()
+                .map(|message| LoopModelMessage {
+                    role: message.role,
+                    content_ref: message.message_ref,
+                })
+                .collect(),
+            surface_version: request.surface_version,
+        };
+        self.milestone_emitter()
+            .prompt_bundle_built(
+                bundle.bundle_ref.clone(),
+                request.mode,
+                bundle.surface_version.clone(),
+                bundle.messages.len(),
+            )
+            .await?;
+        self.record("milestone:prompt_bundle_built");
+        Ok(bundle)
     }
 }
 
@@ -777,6 +1023,16 @@ impl LoopProgressPort for RecordingAgentLoopHost {
         self.record(format!("progress:{}", event.kind_name()));
         Ok(())
     }
+}
+
+async fn codeact_run_context() -> LoopRunContext {
+    let mut context = claimed_run_context().await;
+    let codeact_descriptor =
+        AgentLoopDriverDescriptor::new("codeact_loop", RunProfileVersion::new(1)).unwrap();
+    context.loop_driver_id = LoopDriverId::new("codeact_loop").unwrap();
+    context.loop_driver_version = codeact_descriptor.version;
+    context.resolved_run_profile.loop_driver = codeact_descriptor;
+    context
 }
 
 async fn claimed_run_context() -> LoopRunContext {

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -20,9 +20,9 @@ use ironclaw_turns::{
         FinalizeAssistantMessage, HostManagedLoopModelPort, HostManagedLoopPromptPort,
         InMemoryLoopHostMilestoneSink, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
         LoopCheckpointRequest, LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage,
-        LoopContextPort, LoopContextRequest, LoopDriverId, LoopDriverNoteKind, LoopHostMilestone,
-        LoopHostMilestoneEmitter, LoopHostMilestoneKind, LoopHostMilestoneSink, LoopInputBatch,
-        LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelGateway,
+        LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopDriverId, LoopDriverNoteKind,
+        LoopHostMilestone, LoopHostMilestoneEmitter, LoopHostMilestoneKind, LoopHostMilestoneSink,
+        LoopInputBatch, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelGateway,
         LoopModelGatewayError, LoopModelGatewayRequest, LoopModelMessage, LoopModelPort,
         LoopModelRequest, LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopPromptBundle,
         LoopPromptBundleRef, LoopPromptBundleRequest, LoopPromptPort, LoopRunContext,
@@ -239,7 +239,8 @@ async fn loop_prompt_port_builds_text_only_bundle_from_context_refs() {
         host.context.clone(),
         host.clone(),
         host.milestone_sink.clone(),
-    );
+    )
+    .with_current_surface_version(surface_version.clone());
 
     let bundle = port
         .build_prompt_bundle(LoopPromptBundleRequest {
@@ -247,7 +248,7 @@ async fn loop_prompt_port_builds_text_only_bundle_from_context_refs() {
             context_cursor: None,
             surface_version: Some(surface_version.clone()),
             checkpoint_state_ref: None,
-            max_tokens: Some(8),
+            max_messages: Some(8),
         })
         .await
         .unwrap();
@@ -280,7 +281,7 @@ async fn loop_prompt_port_rejects_unsupported_prompt_mode() {
             context_cursor: None,
             surface_version: None,
             checkpoint_state_ref: None,
-            max_tokens: None,
+            max_messages: None,
         })
         .await
         .unwrap_err();
@@ -310,7 +311,7 @@ async fn loop_prompt_port_rejects_malformed_same_run_checkpoint_ref() {
                 ))
                 .unwrap(),
             ),
-            max_tokens: None,
+            max_messages: None,
         })
         .await
         .unwrap_err();
@@ -342,13 +343,155 @@ async fn loop_prompt_port_rejects_cross_run_checkpoint_ref() {
             checkpoint_state_ref: Some(
                 LoopCheckpointStateRef::for_run(&other_context, "foreign-state").unwrap(),
             ),
-            max_tokens: None,
+            max_messages: None,
         })
         .await
         .unwrap_err();
 
     assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
     assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_checkpoint_state_ref_until_supported() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: Some(
+                LoopCheckpointStateRef::for_run(&host.context, "resume-state").unwrap(),
+            ),
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert_eq!(host.effects(), Vec::<String>::new());
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_unvalidated_surface_version() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(CapabilitySurfaceVersion::new("surface-v1").unwrap()),
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert_eq!(host.effects(), Vec::<String>::new());
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_stale_surface_version() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    )
+    .with_current_surface_version(CapabilitySurfaceVersion::new("surface-v2").unwrap());
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(CapabilitySurfaceVersion::new("surface-v1").unwrap()),
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::StaleSurface);
+    assert_eq!(host.effects(), Vec::<String>::new());
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_snippets_it_cannot_materialize() {
+    let host = Arc::new(
+        RecordingAgentLoopHost::new(claimed_run_context().await)
+            .with_context_instruction_snippet("instruction:system", "system instruction available")
+            .with_context_memory_snippet("memory:project", "project memory available"),
+    );
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    assert_eq!(host.effects(), vec!["context"]);
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_zero_message_limit() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(0),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::BudgetExceeded);
+    assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[test]
+fn capability_surface_versions_are_public_safe_tokens() {
+    assert!(CapabilitySurfaceVersion::new("surface-v1").is_ok());
+    assert!(CapabilitySurfaceVersion::new("empty:v1").is_ok());
+    assert!(CapabilitySurfaceVersion::new("/host/path/surface").is_err());
+    assert!(CapabilitySurfaceVersion::new("api_key:sk-test-secret").is_err());
+    assert!(CapabilitySurfaceVersion::new("bearer:sk-test-secret").is_err());
+    assert!(CapabilitySurfaceVersion::new("secret:v1").is_err());
+    assert!(CapabilitySurfaceVersion::new("surface v1").is_err());
 }
 
 #[tokio::test]
@@ -369,7 +512,7 @@ async fn loop_prompt_bundle_public_serialization_hides_raw_content() {
             context_cursor: None,
             surface_version: None,
             checkpoint_state_ref: None,
-            max_tokens: None,
+            max_messages: None,
         })
         .await
         .unwrap();
@@ -568,7 +711,7 @@ impl AgentLoopDriver for ReplyDriver {
                 context_cursor: None,
                 surface_version: Some(surface.version),
                 checkpoint_state_ref: None,
-                max_tokens: Some(8),
+                max_messages: Some(8),
             })
             .await
             .map_err(driver_error)?;
@@ -765,6 +908,8 @@ struct RecordingAgentLoopHost {
     visible_surface: VisibleCapabilitySurface,
     milestone_sink: Arc<InMemoryLoopHostMilestoneSink>,
     context_message_safe_summary: String,
+    context_instruction_snippets: Vec<LoopContextSnippet>,
+    context_memory_snippets: Vec<LoopContextSnippet>,
 }
 
 impl RecordingAgentLoopHost {
@@ -786,11 +931,37 @@ impl RecordingAgentLoopHost {
                 }],
             },
             context_message_safe_summary: "hello".to_string(),
+            context_instruction_snippets: Vec::new(),
+            context_memory_snippets: Vec::new(),
         }
     }
 
     fn with_context_message_safe_summary(mut self, safe_summary: impl Into<String>) -> Self {
         self.context_message_safe_summary = safe_summary.into();
+        self
+    }
+
+    fn with_context_instruction_snippet(
+        mut self,
+        snippet_ref: impl Into<String>,
+        safe_summary: impl Into<String>,
+    ) -> Self {
+        self.context_instruction_snippets.push(LoopContextSnippet {
+            snippet_ref: snippet_ref.into(),
+            safe_summary: safe_summary.into(),
+        });
+        self
+    }
+
+    fn with_context_memory_snippet(
+        mut self,
+        snippet_ref: impl Into<String>,
+        safe_summary: impl Into<String>,
+    ) -> Self {
+        self.context_memory_snippets.push(LoopContextSnippet {
+            snippet_ref: snippet_ref.into(),
+            safe_summary: safe_summary.into(),
+        });
         self
     }
 
@@ -845,8 +1016,8 @@ impl LoopContextPort for RecordingAgentLoopHost {
                 role: "user".to_string(),
                 safe_summary: self.context_message_safe_summary.clone(),
             }],
-            instruction_snippets: Vec::new(),
-            memory_snippets: Vec::new(),
+            instruction_snippets: self.context_instruction_snippets.clone(),
+            memory_snippets: self.context_memory_snippets.clone(),
         })
     }
 }
@@ -882,7 +1053,7 @@ impl LoopPromptPort for RecordingAgentLoopHost {
         let context = self
             .load_loop_context(LoopContextRequest {
                 after: request.context_cursor,
-                limit: request.max_tokens.unwrap_or(8) as usize,
+                limit: request.max_messages.unwrap_or(8) as usize,
             })
             .await?;
         let bundle = LoopPromptBundle {


### PR DESCRIPTION
## Summary
- Stack on #3397: add a Reborn-side `TextOnlyLoopHostPorts` composition helper
- Compose thread-backed context, model, transcript, and empty capability ports with a shared milestone sink
- Add integration coverage for context -> model -> transcript success and sanitized model-failure milestones
- Keep Reborn loop-host wiring in `crates/ironclaw_reborn`, outside the root `/src` app graph

## Test plan
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_reborn --tests`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo clippy -p ironclaw_reborn --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_architecture --test reborn_dependency_boundaries -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_reborn --features root-llm-provider --test llm_gateway`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_loop_support --tests`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo clippy -p ironclaw_loop_support --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-pr3391-target cargo test -p ironclaw_turns --test agent_loop_host_contract`
- `git diff --check`

Depends on #3397, which depends on #3391.