### PR TITLE
Add Reborn production loop model gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,7 +4375,9 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "ironclaw",
+ "ironclaw_host_api",
  "ironclaw_loop_support",
+ "ironclaw_threads",
  "ironclaw_turns",
  "rust_decimal",
  "tokio",

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -18,9 +18,11 @@ root-llm-provider = ["dep:ironclaw"]
 async-trait = "0.1"
 ironclaw = { path = "../..", version = "0.27.0", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support", version = "0.1.0" }
+ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
 
 [dev-dependencies]
+ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 rust_decimal = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
 

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -8,4 +8,6 @@
 pub mod model_gateway;
 
 #[cfg(feature = "root-llm-provider")]
-pub use model_gateway::{LlmModelProfilePolicy, LlmProviderModelGateway};
+pub use model_gateway::{
+    LlmModelProfilePolicy, LlmProviderModelGateway, ThreadBackedLoopModelGateway,
+};

--- a/crates/ironclaw_reborn/src/model_gateway.rs
+++ b/crates/ironclaw_reborn/src/model_gateway.rs
@@ -13,9 +13,13 @@ use ironclaw::llm::{
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelErrorKind, HostManagedModelGateway,
     HostManagedModelMessage, HostManagedModelMessageRole, HostManagedModelRequest,
-    HostManagedModelResponse,
+    HostManagedModelResponse, ThreadBackedLoopModelPort,
 };
-use ironclaw_turns::run_profile::ModelProfileId;
+use ironclaw_threads::{SessionThreadService, ThreadScope};
+use ironclaw_turns::run_profile::{
+    AgentLoopHostError, LoopModelGateway, LoopModelGatewayError, LoopModelGatewayRequest,
+    LoopModelPort, LoopModelResponse, LoopSafeSummary, ModelProfileId,
+};
 
 /// Fail-closed routing policy from resolved Reborn model profile ids to the
 /// host-selected provider/model envelope.
@@ -47,6 +51,67 @@ impl LlmModelProfilePolicy {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LlmModelProfileRoute {
     model_override: Option<String>,
+}
+
+/// Production Reborn model gateway backed by durable session-thread context.
+///
+/// This is the concrete adapter intended to sit behind
+/// [`HostManagedLoopModelPort`](ironclaw_turns::run_profile::HostManagedLoopModelPort):
+/// it resolves loop message refs from the durable thread service, then delegates
+/// provider routing and sanitization to the host-managed model gateway.
+#[derive(Clone)]
+pub struct ThreadBackedLoopModelGateway<S, G>
+where
+    S: SessionThreadService + ?Sized,
+    G: HostManagedModelGateway + ?Sized,
+{
+    thread_service: Arc<S>,
+    thread_scope: ThreadScope,
+    host_gateway: Arc<G>,
+    max_messages: usize,
+}
+
+impl<S, G> ThreadBackedLoopModelGateway<S, G>
+where
+    S: SessionThreadService + ?Sized,
+    G: HostManagedModelGateway + ?Sized,
+{
+    pub fn new(
+        thread_service: Arc<S>,
+        thread_scope: ThreadScope,
+        host_gateway: Arc<G>,
+        max_messages: usize,
+    ) -> Self {
+        Self {
+            thread_service,
+            thread_scope,
+            host_gateway,
+            max_messages,
+        }
+    }
+}
+
+#[async_trait]
+impl<S, G> LoopModelGateway for ThreadBackedLoopModelGateway<S, G>
+where
+    S: SessionThreadService + ?Sized + Send + Sync,
+    G: HostManagedModelGateway + ?Sized + Send + Sync,
+{
+    async fn stream_model(
+        &self,
+        request: LoopModelGatewayRequest,
+    ) -> Result<LoopModelResponse, LoopModelGatewayError> {
+        ThreadBackedLoopModelPort::new(
+            Arc::clone(&self.thread_service),
+            self.thread_scope.clone(),
+            request.context,
+            Arc::clone(&self.host_gateway),
+            self.max_messages,
+        )
+        .stream_model(request.request)
+        .await
+        .map_err(host_error_to_model_gateway_error)
+    }
 }
 
 /// Host-managed model gateway backed by the root `LlmProvider` abstraction.
@@ -107,6 +172,22 @@ where
             .map_err(map_provider_error)?;
         response_to_host_reply(response)
     }
+}
+
+fn host_error_to_model_gateway_error(error: AgentLoopHostError) -> LoopModelGatewayError {
+    let diagnostic_ref = error.diagnostic_ref;
+    let mut converted = match LoopModelGatewayError::new(error.kind, error.safe_summary) {
+        Ok(error) => error,
+        Err(_) => LoopModelGatewayError {
+            kind: error.kind,
+            safe_summary: LoopSafeSummary::model_gateway_failed(),
+            diagnostic_ref: None,
+        },
+    };
+    if let Some(diagnostic_ref) = diagnostic_ref {
+        converted = converted.with_diagnostic_ref(diagnostic_ref);
+    }
+    converted
 }
 
 fn pinned_model_override(route: &LlmModelProfileRoute) -> Result<&str, HostManagedModelError> {

--- a/crates/ironclaw_reborn/tests/llm_gateway.rs
+++ b/crates/ironclaw_reborn/tests/llm_gateway.rs
@@ -5,12 +5,26 @@ use ironclaw::llm::{
     CompletionRequest, CompletionResponse, FinishReason, LlmError, LlmProvider,
     ToolCompletionRequest, ToolCompletionResponse,
 };
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_loop_support::{
     HostManagedModelErrorKind, HostManagedModelGateway, HostManagedModelMessage,
     HostManagedModelMessageRole, HostManagedModelRequest,
 };
-use ironclaw_reborn::{LlmModelProfilePolicy, LlmProviderModelGateway};
-use ironclaw_turns::{LoopMessageRef, run_profile::ModelProfileId};
+use ironclaw_reborn::{
+    LlmModelProfilePolicy, LlmProviderModelGateway, ThreadBackedLoopModelGateway,
+};
+use ironclaw_threads::{
+    AcceptInboundMessageRequest, EnsureThreadRequest, InMemorySessionThreadService, MessageContent,
+    SessionThreadService, ThreadScope,
+};
+use ironclaw_turns::{
+    LoopMessageRef, RunProfileResolutionRequest, RunProfileResolver, TurnId, TurnRunId, TurnScope,
+    run_profile::{
+        AgentLoopHostErrorKind, HostManagedLoopModelPort, InMemoryLoopHostMilestoneSink,
+        InMemoryRunProfileResolver, LoopHostMilestoneKind, LoopModelMessage, LoopModelPort,
+        LoopModelRequest, LoopRunContext, ModelProfileId,
+    },
+};
 use rust_decimal::Decimal;
 
 #[tokio::test]
@@ -160,6 +174,143 @@ async fn gateway_rejects_unknown_finish_reason_provider_responses() {
 }
 
 #[tokio::test]
+async fn production_loop_model_gateway_resolves_thread_refs_and_emits_milestones() {
+    let fixture = ThreadFixture::new().await;
+    let provider = Arc::new(RecordingLlmProvider::reply("production response"));
+    let provider_gateway = Arc::new(LlmProviderModelGateway::new(
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    ));
+    let model_gateway = Arc::new(ThreadBackedLoopModelGateway::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        provider_gateway,
+        16,
+    ));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let port = HostManagedLoopModelPort::new(
+        fixture.run_context.clone(),
+        model_gateway,
+        milestones.clone(),
+    );
+
+    let response = port
+        .stream_model(LoopModelRequest {
+            messages: vec![LoopModelMessage {
+                role: "user".to_string(),
+                content_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
+                    .unwrap(),
+            }],
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(response.chunks[0].safe_text_delta, "production response");
+    let requests = provider.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].model.as_deref(), Some("host-selected-model"));
+    assert_eq!(requests[0].messages[0].content, "hello production gateway");
+    let milestone_kinds = milestones
+        .milestones()
+        .into_iter()
+        .map(|milestone| milestone.kind)
+        .collect::<Vec<_>>();
+    assert!(matches!(
+        milestone_kinds.as_slice(),
+        [
+            LoopHostMilestoneKind::ModelStarted {
+                requested_model_profile_id: None
+            },
+            LoopHostMilestoneKind::ModelCompleted {
+                effective_model_profile_id
+            }
+        ] if effective_model_profile_id.as_str() == "interactive_model"
+    ));
+}
+
+#[tokio::test]
+async fn production_loop_model_gateway_fails_closed_before_provider_call() {
+    let fixture = ThreadFixture::new().await;
+    let provider = Arc::new(RecordingLlmProvider::reply("unused"));
+    let provider_gateway = Arc::new(LlmProviderModelGateway::new(
+        provider.clone(),
+        LlmModelProfilePolicy::new()
+            .allow_model_profile(interactive_model(), Some("host-selected-model".to_string())),
+    ));
+    let model_gateway = Arc::new(ThreadBackedLoopModelGateway::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        provider_gateway,
+        16,
+    ));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let port = HostManagedLoopModelPort::new(
+        fixture.run_context.clone(),
+        model_gateway,
+        milestones.clone(),
+    );
+
+    let error = port
+        .stream_model(LoopModelRequest {
+            messages: vec![LoopModelMessage {
+                role: "user".to_string(),
+                content_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
+                    .unwrap(),
+            }],
+            surface_version: None,
+            model_preference: Some(ModelProfileId::new("mission_model").unwrap()),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    assert!(provider.requests.lock().unwrap().is_empty());
+    let milestone_kinds = milestones
+        .milestones()
+        .into_iter()
+        .map(|milestone| milestone.kind.kind_name())
+        .collect::<Vec<_>>();
+    assert_eq!(milestone_kinds, vec!["model_started"]);
+}
+
+#[tokio::test]
+async fn production_loop_model_gateway_preserves_error_kind_when_summary_is_resanitized() {
+    let fixture = ThreadFixture::new().await;
+    let invalid_summary_gateway = Arc::new(InvalidSummaryModelGateway {
+        kind: HostManagedModelErrorKind::PolicyDenied,
+        safe_summary: "RAW_PROVIDER_SECRET".to_string(),
+    });
+    let model_gateway = Arc::new(ThreadBackedLoopModelGateway::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        invalid_summary_gateway,
+        16,
+    ));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let port =
+        HostManagedLoopModelPort::new(fixture.run_context.clone(), model_gateway, milestones);
+
+    let error = port
+        .stream_model(LoopModelRequest {
+            messages: vec![LoopModelMessage {
+                role: "user".to_string(),
+                content_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
+                    .unwrap(),
+            }],
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    assert_eq!(error.safe_summary, "model gateway failed");
+}
+
+#[tokio::test]
 async fn gateway_sanitizes_provider_errors() {
     let provider = Arc::new(RecordingLlmProvider::fail(LlmError::RequestFailed {
         provider: "raw-provider".to_string(),
@@ -179,6 +330,71 @@ async fn gateway_sanitizes_provider_errors() {
     assert_eq!(error.kind, HostManagedModelErrorKind::Unavailable);
     assert!(!error.safe_summary.contains("RAW_PROVIDER_SECRET"));
     assert!(!format!("{error:?}").contains("RAW_PROVIDER_SECRET"));
+}
+
+struct ThreadFixture {
+    thread_service: Arc<InMemorySessionThreadService>,
+    thread_scope: ThreadScope,
+    user_message_id: ironclaw_threads::ThreadMessageId,
+    run_context: LoopRunContext,
+}
+
+impl ThreadFixture {
+    async fn new() -> Self {
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let tenant_id = TenantId::new("tenant-production-gateway").unwrap();
+        let agent_id = AgentId::new("agent-production-gateway").unwrap();
+        let project_id = ProjectId::new("project-production-gateway").unwrap();
+        let user_id = UserId::new("user-production-gateway").unwrap();
+        let thread_id = ThreadId::new("thread-production-gateway").unwrap();
+        let thread_scope = ThreadScope {
+            tenant_id: tenant_id.clone(),
+            agent_id: agent_id.clone(),
+            project_id: Some(project_id.clone()),
+            owner_user_id: Some(user_id.clone()),
+            mission_id: None,
+        };
+        thread_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: thread_scope.clone(),
+                thread_id: Some(thread_id.clone()),
+                created_by_actor_id: user_id.as_str().to_string(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        let accepted = thread_service
+            .accept_inbound_message(AcceptInboundMessageRequest {
+                scope: thread_scope.clone(),
+                thread_id: thread_id.clone(),
+                actor_id: user_id.as_str().to_string(),
+                source_binding_id: Some("source-web".to_string()),
+                reply_target_binding_id: Some("reply-web".to_string()),
+                external_event_id: Some("event-production-gateway-1".to_string()),
+                content: MessageContent::text("hello production gateway"),
+            })
+            .await
+            .unwrap();
+        let turn_scope = TurnScope::new(
+            tenant_id,
+            Some(agent_id),
+            Some(project_id),
+            thread_id.clone(),
+        );
+        let resolved = InMemoryRunProfileResolver::default()
+            .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+            .await
+            .unwrap();
+        let run_context =
+            LoopRunContext::new(turn_scope, TurnId::new(), TurnRunId::new(), resolved);
+        Self {
+            thread_service,
+            thread_scope,
+            user_message_id: accepted.message_id,
+            run_context,
+        }
+    }
 }
 
 fn interactive_model() -> ModelProfileId {
@@ -205,6 +421,27 @@ fn model_request(model_profile_id: ModelProfileId) -> HostManagedModelRequest {
         surface_version: None,
         run_id: "run-1".to_string(),
         turn_id: "turn-1".to_string(),
+    }
+}
+
+struct InvalidSummaryModelGateway {
+    kind: HostManagedModelErrorKind,
+    safe_summary: String,
+}
+
+#[async_trait]
+impl HostManagedModelGateway for InvalidSummaryModelGateway {
+    async fn stream_model(
+        &self,
+        _request: HostManagedModelRequest,
+    ) -> Result<
+        ironclaw_loop_support::HostManagedModelResponse,
+        ironclaw_loop_support::HostManagedModelError,
+    > {
+        Err(ironclaw_loop_support::HostManagedModelError::safe(
+            self.kind,
+            self.safe_summary.clone(),
+        ))
     }
 }
 

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -159,6 +159,10 @@ impl LoopSafeSummary {
         validate_loop_safe_summary(value.into()).map(Self)
     }
 
+    pub fn model_gateway_failed() -> Self {
+        Self("model gateway failed".to_string())
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }


### PR DESCRIPTION
## Summary
- add `ThreadBackedLoopModelGateway`, a concrete `LoopModelGateway` adapter over durable session-thread context and the host-managed LLM provider gateway
- drive the adapter through `HostManagedLoopModelPort` so model milestones, durable ref resolution, provider routing, and fail-closed profile policy are exercised together
- preserve error kind and diagnostic refs when resanitizing invalid model-gateway summaries

## Verification
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target-prod-gateway cargo test -p ironclaw_reborn --all-features`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target-prod-gateway cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target-prod-gateway cargo test -p ironclaw_loop_support --all-features`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target-prod-gateway cargo clippy -p ironclaw_reborn --all-targets --all-features --no-deps -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target-prod-gateway cargo test -p ironclaw_reborn`
- `CARGO_TARGET_DIR=/tmp/ironclaw-cargo-target-prod-gateway cargo clippy -p ironclaw_reborn --all-targets --no-deps -- -D warnings`
- `cargo fmt --check --package ironclaw_reborn`
- `git diff --check`

## Review
- Code-reviewer pass: clean for Medium+ after addressing one Medium fallback-kind finding.
