### PR TITLE
feat(reborn): add loop driver registry readiness

### DIFF
--- a/crates/ironclaw_reborn/src/driver_registry.rs
+++ b/crates/ironclaw_reborn/src/driver_registry.rs
@@ -1,0 +1,534 @@
+//! Reborn agent-loop driver registry and readiness validation.
+//!
+//! `ironclaw_turns` owns the neutral driver/profile contracts. This module is
+//! the Reborn composition layer that stores concrete driver instances, freezes
+//! descriptor metadata at startup, and validates that configured and persisted
+//! run identities can be served before traffic is accepted.
+
+use std::{collections::HashMap, error::Error, fmt, sync::Arc};
+
+use ironclaw_turns::{
+    AgentLoopDriver, AgentLoopDriverDescriptor, RunProfileVersion, TurnStatus,
+    run_profile::{CheckpointSchemaId, LoopDriverId},
+};
+
+/// Exact persisted identity for a registered loop driver.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LoopDriverRegistryKey {
+    pub id: LoopDriverId,
+    pub version: RunProfileVersion,
+    pub checkpoint_schema_id: Option<CheckpointSchemaId>,
+    pub checkpoint_schema_version: Option<RunProfileVersion>,
+}
+
+impl LoopDriverRegistryKey {
+    pub fn from_descriptor(descriptor: &AgentLoopDriverDescriptor) -> Result<Self, String> {
+        validate_descriptor(descriptor)?;
+        Ok(Self {
+            id: descriptor.id.clone(),
+            version: descriptor.version,
+            checkpoint_schema_id: descriptor.checkpoint_schema_id.clone(),
+            checkpoint_schema_version: descriptor.checkpoint_schema_version,
+        })
+    }
+}
+
+impl fmt::Display for LoopDriverRegistryKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.id.as_str(), self.version.as_u64())?;
+        if let (Some(schema_id), Some(schema_version)) = (
+            self.checkpoint_schema_id.as_ref(),
+            self.checkpoint_schema_version,
+        ) {
+            write!(
+                f,
+                " checkpoint {}@{}",
+                schema_id.as_str(),
+                schema_version.as_u64()
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Host-service dependency level for a driver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequirementLevel {
+    Required,
+    Optional,
+    Unsupported,
+}
+
+/// Static requirements Reborn checks before selecting a driver.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriverRequirements {
+    pub model: RequirementLevel,
+    pub transcript: RequirementLevel,
+    pub checkpoint: RequirementLevel,
+    pub input_polling: RequirementLevel,
+    pub capabilities: RequirementLevel,
+    pub progress_events: RequirementLevel,
+}
+
+impl DriverRequirements {
+    pub fn all_optional() -> Self {
+        Self {
+            model: RequirementLevel::Optional,
+            transcript: RequirementLevel::Optional,
+            checkpoint: RequirementLevel::Optional,
+            input_polling: RequirementLevel::Optional,
+            capabilities: RequirementLevel::Optional,
+            progress_events: RequirementLevel::Optional,
+        }
+    }
+
+    pub fn all_required() -> Self {
+        Self {
+            model: RequirementLevel::Required,
+            transcript: RequirementLevel::Required,
+            checkpoint: RequirementLevel::Required,
+            input_polling: RequirementLevel::Required,
+            capabilities: RequirementLevel::Required,
+            progress_events: RequirementLevel::Required,
+        }
+    }
+}
+
+impl Default for DriverRequirements {
+    fn default() -> Self {
+        Self::all_optional()
+    }
+}
+
+/// Whether a driver can satisfy production readiness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriverKind {
+    Production,
+    /// Fake/reference drivers are allowed only in explicit local-dev/test readiness.
+    Reference,
+}
+
+/// Concrete driver plus registration-time metadata snapshot.
+pub struct RegisteredDriver {
+    key: LoopDriverRegistryKey,
+    driver: Arc<dyn AgentLoopDriver>,
+    descriptor: AgentLoopDriverDescriptor,
+    requirements: DriverRequirements,
+    kind: DriverKind,
+}
+
+impl RegisteredDriver {
+    pub fn key(&self) -> &LoopDriverRegistryKey {
+        &self.key
+    }
+
+    pub fn driver(&self) -> Arc<dyn AgentLoopDriver> {
+        Arc::clone(&self.driver)
+    }
+
+    pub fn descriptor(&self) -> &AgentLoopDriverDescriptor {
+        &self.descriptor
+    }
+
+    pub fn requirements(&self) -> &DriverRequirements {
+        &self.requirements
+    }
+
+    pub fn kind(&self) -> DriverKind {
+        self.kind
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DriverRegistryError {
+    InvalidDescriptor { reason: String },
+    DuplicateRegistration { key: LoopDriverRegistryKey },
+}
+
+impl fmt::Display for DriverRegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidDescriptor { reason } => write!(f, "invalid driver descriptor: {reason}"),
+            Self::DuplicateRegistration { key } => {
+                write!(f, "duplicate driver registration for {key}")
+            }
+        }
+    }
+}
+
+impl Error for DriverRegistryError {}
+
+#[derive(Default)]
+pub struct DriverRegistry {
+    entries: HashMap<LoopDriverRegistryKey, RegisteredDriver>,
+}
+
+impl DriverRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a concrete driver and cache its validated descriptor snapshot.
+    pub fn register_driver(
+        &mut self,
+        driver: Arc<dyn AgentLoopDriver>,
+        requirements: DriverRequirements,
+        kind: DriverKind,
+    ) -> Result<LoopDriverRegistryKey, DriverRegistryError> {
+        let descriptor = driver.descriptor();
+        let key = LoopDriverRegistryKey::from_descriptor(&descriptor)
+            .map_err(|reason| DriverRegistryError::InvalidDescriptor { reason })?;
+        if self.entries.contains_key(&key) {
+            return Err(DriverRegistryError::DuplicateRegistration { key });
+        }
+
+        self.entries.insert(
+            key.clone(),
+            RegisteredDriver {
+                key: key.clone(),
+                driver,
+                descriptor,
+                requirements,
+                kind,
+            },
+        );
+        Ok(key)
+    }
+
+    pub fn get(&self, key: &LoopDriverRegistryKey) -> Option<&RegisteredDriver> {
+        self.entries.get(key)
+    }
+
+    pub fn validate_readiness(
+        &self,
+        mode: DriverReadinessMode,
+        inputs: DriverReadinessInputs,
+    ) -> DriverReadinessReport {
+        let mut diagnostics = Vec::new();
+        let mut has_reference_driver = false;
+
+        for profile in inputs
+            .configured_profiles
+            .iter()
+            .filter(|profile| profile.enabled)
+        {
+            match self.get(&profile.driver_identity) {
+                Some(entry) => {
+                    validate_entry_readiness(
+                        mode,
+                        &inputs.host_graph,
+                        &profile.name,
+                        &profile.driver_identity,
+                        entry,
+                        &mut has_reference_driver,
+                        &mut diagnostics,
+                    );
+                }
+                None => diagnostics.push(DriverReadinessDiagnostic::new(
+                    "missing_configured_driver",
+                    profile.name.clone(),
+                    Some(profile.driver_identity.clone()),
+                    "enabled run profile references an unregistered loop driver identity",
+                )),
+            }
+        }
+
+        for persisted_run in inputs
+            .persisted_runs
+            .iter()
+            .filter(|run| !run.status.is_terminal())
+        {
+            match self.get(&persisted_run.driver_identity) {
+                Some(entry) => {
+                    validate_entry_readiness(
+                        mode,
+                        &inputs.host_graph,
+                        &persisted_run.run_id,
+                        &persisted_run.driver_identity,
+                        entry,
+                        &mut has_reference_driver,
+                        &mut diagnostics,
+                    );
+                }
+                None => diagnostics.push(DriverReadinessDiagnostic::new(
+                    "missing_non_terminal_run_driver",
+                    persisted_run.run_id.clone(),
+                    Some(persisted_run.driver_identity.clone()),
+                    "non-terminal persisted run requires an unregistered loop driver identity",
+                )),
+            }
+        }
+
+        let status = if diagnostics.iter().any(|diagnostic| diagnostic.blocks_ready) {
+            DriverReadinessStatus::NotReady
+        } else if has_reference_driver {
+            DriverReadinessStatus::LocalDevDegradedReference
+        } else {
+            DriverReadinessStatus::ProductionReady
+        };
+
+        DriverReadinessReport {
+            status,
+            diagnostics,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriverReadinessMode {
+    Production,
+    LocalDevTest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriverReadinessInputs {
+    pub host_graph: HostGraphReadiness,
+    pub configured_profiles: Vec<ConfiguredRunProfile>,
+    pub persisted_runs: Vec<PersistedRunDriverIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfiguredRunProfile {
+    pub name: String,
+    pub enabled: bool,
+    pub driver_identity: LoopDriverRegistryKey,
+}
+
+impl ConfiguredRunProfile {
+    pub fn enabled(name: impl Into<String>, driver_identity: LoopDriverRegistryKey) -> Self {
+        Self {
+            name: name.into(),
+            enabled: true,
+            driver_identity,
+        }
+    }
+
+    pub fn disabled(name: impl Into<String>, driver_identity: LoopDriverRegistryKey) -> Self {
+        Self {
+            name: name.into(),
+            enabled: false,
+            driver_identity,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedRunDriverIdentity {
+    pub run_id: String,
+    pub status: TurnStatus,
+    pub driver_identity: LoopDriverRegistryKey,
+}
+
+impl PersistedRunDriverIdentity {
+    pub fn new(
+        run_id: impl Into<String>,
+        status: TurnStatus,
+        driver_identity: LoopDriverRegistryKey,
+    ) -> Self {
+        Self {
+            run_id: run_id.into(),
+            status,
+            driver_identity,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostGraphReadiness {
+    pub model: bool,
+    pub transcript: bool,
+    pub checkpoint: bool,
+    pub input_polling: bool,
+    pub capabilities: bool,
+    pub progress_events: bool,
+}
+
+impl HostGraphReadiness {
+    pub fn all_available() -> Self {
+        Self {
+            model: true,
+            transcript: true,
+            checkpoint: true,
+            input_polling: true,
+            capabilities: true,
+            progress_events: true,
+        }
+    }
+
+    pub fn without_model(mut self) -> Self {
+        self.model = false;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriverReadinessStatus {
+    ProductionReady,
+    LocalDevDegradedReference,
+    NotReady,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriverReadinessReport {
+    pub status: DriverReadinessStatus,
+    pub diagnostics: Vec<DriverReadinessDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriverReadinessDiagnostic {
+    pub code: &'static str,
+    pub subject: String,
+    pub driver_identity: Option<LoopDriverRegistryKey>,
+    pub message: String,
+    pub blocks_ready: bool,
+}
+
+impl DriverReadinessDiagnostic {
+    fn new(
+        code: &'static str,
+        subject: String,
+        driver_identity: Option<LoopDriverRegistryKey>,
+        message: &'static str,
+    ) -> Self {
+        Self {
+            code,
+            subject,
+            driver_identity,
+            message: message.to_string(),
+            blocks_ready: true,
+        }
+    }
+
+    fn non_blocking(
+        code: &'static str,
+        subject: String,
+        driver_identity: Option<LoopDriverRegistryKey>,
+        message: &'static str,
+    ) -> Self {
+        Self {
+            code,
+            subject,
+            driver_identity,
+            message: message.to_string(),
+            blocks_ready: false,
+        }
+    }
+}
+
+fn validate_descriptor(descriptor: &AgentLoopDriverDescriptor) -> Result<(), String> {
+    if descriptor.version.as_u64() == 0 {
+        return Err("driver version must be greater than zero".to_string());
+    }
+    match (
+        descriptor.checkpoint_schema_id.as_ref(),
+        descriptor.checkpoint_schema_version,
+    ) {
+        (Some(_), Some(version)) if version.as_u64() == 0 => {
+            Err("checkpoint schema version must be greater than zero".to_string())
+        }
+        (Some(_), Some(_)) | (None, None) => Ok(()),
+        (Some(_), None) | (None, Some(_)) => Err(
+            "checkpoint schema id and checkpoint schema version must both be present or both absent"
+                .to_string(),
+        ),
+    }
+}
+
+fn validate_entry_readiness(
+    mode: DriverReadinessMode,
+    host_graph: &HostGraphReadiness,
+    subject: &str,
+    driver_identity: &LoopDriverRegistryKey,
+    entry: &RegisteredDriver,
+    has_reference_driver: &mut bool,
+    diagnostics: &mut Vec<DriverReadinessDiagnostic>,
+) {
+    match (mode, entry.kind()) {
+        (DriverReadinessMode::Production, DriverKind::Reference) => {
+            diagnostics.push(DriverReadinessDiagnostic::new(
+                "reference_driver_not_production_ready",
+                subject.to_string(),
+                Some(driver_identity.clone()),
+                "fake/reference loop driver cannot satisfy production readiness",
+            ))
+        }
+        (DriverReadinessMode::LocalDevTest, DriverKind::Reference) => {
+            *has_reference_driver = true;
+            diagnostics.push(DriverReadinessDiagnostic::non_blocking(
+                "reference_driver_allowed_for_local_dev",
+                subject.to_string(),
+                Some(driver_identity.clone()),
+                "fake/reference loop driver allowed only for explicit local-dev/test readiness",
+            ));
+        }
+        (_, DriverKind::Production) => {}
+    }
+
+    for requirement in missing_requirements(entry.requirements(), host_graph) {
+        diagnostics.push(DriverReadinessDiagnostic::new(
+            "missing_required_driver_requirement",
+            subject.to_string(),
+            Some(driver_identity.clone()),
+            requirement.message,
+        ));
+    }
+}
+
+struct MissingRequirement {
+    message: &'static str,
+}
+
+fn missing_requirements(
+    requirements: &DriverRequirements,
+    host_graph: &HostGraphReadiness,
+) -> Vec<MissingRequirement> {
+    let mut missing = Vec::new();
+    push_missing(
+        &mut missing,
+        requirements.model,
+        host_graph.model,
+        "driver requires a model gateway, but the host graph does not provide one",
+    );
+    push_missing(
+        &mut missing,
+        requirements.transcript,
+        host_graph.transcript,
+        "driver requires transcript storage, but the host graph does not provide it",
+    );
+    push_missing(
+        &mut missing,
+        requirements.checkpoint,
+        host_graph.checkpoint,
+        "driver requires checkpoint storage, but the host graph does not provide it",
+    );
+    push_missing(
+        &mut missing,
+        requirements.input_polling,
+        host_graph.input_polling,
+        "driver requires input polling, but the host graph does not provide it",
+    );
+    push_missing(
+        &mut missing,
+        requirements.capabilities,
+        host_graph.capabilities,
+        "driver requires capability execution, but the host graph does not provide it",
+    );
+    push_missing(
+        &mut missing,
+        requirements.progress_events,
+        host_graph.progress_events,
+        "driver requires progress events, but the host graph does not provide them",
+    );
+    missing
+}
+
+fn push_missing(
+    missing: &mut Vec<MissingRequirement>,
+    level: RequirementLevel,
+    available: bool,
+    message: &'static str,
+) {
+    if level == RequirementLevel::Required && !available {
+        missing.push(MissingRequirement { message });
+    }
+}

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -4,6 +4,8 @@
 //! to existing root IronClaw services while keeping the normal `/src` app graph
 //! free of Reborn loop-support wiring.
 
+pub mod driver_registry;
+
 #[cfg(feature = "root-llm-provider")]
 pub mod model_gateway;
 

--- a/crates/ironclaw_reborn/tests/driver_registry.rs
+++ b/crates/ironclaw_reborn/tests/driver_registry.rs
@@ -1,0 +1,403 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_reborn::driver_registry::{
+    ConfiguredRunProfile, DriverKind, DriverReadinessInputs, DriverReadinessMode,
+    DriverReadinessStatus, DriverRegistry, DriverRegistryError, DriverRequirements,
+    HostGraphReadiness, LoopDriverRegistryKey, PersistedRunDriverIdentity, RequirementLevel,
+};
+use ironclaw_turns::{
+    AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverResumeRequest,
+    AgentLoopDriverRunRequest, LoopExit, RunProfileVersion, TurnStatus,
+    run_profile::{AgentLoopDriverHost, CheckpointSchemaId, LoopDriverId},
+};
+
+#[test]
+fn driver_registry_rejects_duplicate_exact_identity() {
+    let mut registry = DriverRegistry::new();
+    let requirements = DriverRequirements::all_optional();
+
+    registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "lightweight_loop",
+                1,
+                "checkpoint_v1",
+                1,
+            ))),
+            requirements.clone(),
+            DriverKind::Production,
+        )
+        .expect("first registration should succeed");
+
+    let error = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "lightweight_loop",
+                1,
+                "checkpoint_v1",
+                1,
+            ))),
+            requirements,
+            DriverKind::Production,
+        )
+        .expect_err("duplicate exact identity must be rejected");
+
+    assert!(matches!(
+        error,
+        DriverRegistryError::DuplicateRegistration { .. }
+    ));
+}
+
+#[test]
+fn driver_registry_allows_side_by_side_versions() {
+    let mut registry = DriverRegistry::new();
+    let requirements = DriverRequirements::all_optional();
+
+    let v1 = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "lightweight_loop",
+                1,
+                "checkpoint_v1",
+                1,
+            ))),
+            requirements.clone(),
+            DriverKind::Production,
+        )
+        .expect("v1 registration should succeed");
+    let v2 = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "lightweight_loop",
+                2,
+                "checkpoint_v2",
+                2,
+            ))),
+            requirements,
+            DriverKind::Production,
+        )
+        .expect("v2 registration should succeed");
+
+    assert_ne!(v1, v2);
+    assert!(registry.get(&v1).is_some());
+    assert!(registry.get(&v2).is_some());
+}
+
+#[test]
+fn production_readiness_rejects_missing_configured_driver() {
+    let registry = DriverRegistry::new();
+    let missing_key = key("lightweight_loop", 1, "checkpoint_v1", 1);
+
+    let report = registry.validate_readiness(
+        DriverReadinessMode::Production,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available(),
+            configured_profiles: vec![ConfiguredRunProfile::enabled(
+                "interactive_default",
+                missing_key,
+            )],
+            persisted_runs: Vec::new(),
+        },
+    );
+
+    assert_eq!(report.status, DriverReadinessStatus::NotReady);
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "missing_configured_driver")
+    );
+}
+
+#[test]
+fn production_readiness_rejects_fake_driver() {
+    let mut registry = DriverRegistry::new();
+    let fake_key = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "reference_echo_loop",
+                1,
+                "checkpoint_v1",
+                1,
+            ))),
+            DriverRequirements::all_optional(),
+            DriverKind::Reference,
+        )
+        .expect("reference driver registration should succeed");
+
+    let report = registry.validate_readiness(
+        DriverReadinessMode::Production,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available(),
+            configured_profiles: vec![ConfiguredRunProfile::enabled("local_reference", fake_key)],
+            persisted_runs: Vec::new(),
+        },
+    );
+
+    assert_eq!(report.status, DriverReadinessStatus::NotReady);
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "reference_driver_not_production_ready")
+    );
+}
+
+#[test]
+fn local_dev_readiness_allows_fake_driver_with_degraded_status() {
+    let mut registry = DriverRegistry::new();
+    let fake_key = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "reference_echo_loop",
+                1,
+                "checkpoint_v1",
+                1,
+            ))),
+            DriverRequirements::all_optional(),
+            DriverKind::Reference,
+        )
+        .expect("reference driver registration should succeed");
+
+    let report = registry.validate_readiness(
+        DriverReadinessMode::LocalDevTest,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available(),
+            configured_profiles: vec![ConfiguredRunProfile::enabled("local_reference", fake_key)],
+            persisted_runs: Vec::new(),
+        },
+    );
+
+    assert_eq!(
+        report.status,
+        DriverReadinessStatus::LocalDevDegradedReference
+    );
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "reference_driver_allowed_for_local_dev")
+    );
+}
+
+#[test]
+fn readiness_requires_driver_for_non_terminal_run_identity() {
+    let registry = DriverRegistry::new();
+    let old_driver_key = key("lightweight_loop", 1, "checkpoint_v1", 1);
+
+    let report = registry.validate_readiness(
+        DriverReadinessMode::Production,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available(),
+            configured_profiles: Vec::new(),
+            persisted_runs: vec![PersistedRunDriverIdentity::new(
+                "run-1",
+                TurnStatus::RecoveryRequired,
+                old_driver_key,
+            )],
+        },
+    );
+
+    assert_eq!(report.status, DriverReadinessStatus::NotReady);
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "missing_non_terminal_run_driver")
+    );
+}
+
+#[test]
+fn readiness_ignores_terminal_run_driver_identity() {
+    let registry = DriverRegistry::new();
+    let old_driver_key = key("lightweight_loop", 1, "checkpoint_v1", 1);
+
+    let report = registry.validate_readiness(
+        DriverReadinessMode::Production,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available(),
+            configured_profiles: Vec::new(),
+            persisted_runs: vec![PersistedRunDriverIdentity::new(
+                "run-1",
+                TurnStatus::Completed,
+                old_driver_key,
+            )],
+        },
+    );
+
+    assert_eq!(report.status, DriverReadinessStatus::ProductionReady);
+    assert!(report.diagnostics.is_empty());
+}
+
+#[test]
+fn registry_uses_registration_time_descriptor_snapshot() {
+    let mut registry = DriverRegistry::new();
+    let driver = Arc::new(TestDriver::new(descriptor(
+        "lightweight_loop",
+        1,
+        "checkpoint_v1",
+        1,
+    )));
+
+    let registered_key = registry
+        .register_driver(
+            driver.clone(),
+            DriverRequirements::all_optional(),
+            DriverKind::Production,
+        )
+        .expect("registration should succeed");
+    driver.set_descriptor(descriptor("lightweight_loop", 2, "checkpoint_v2", 2));
+
+    let registered = registry
+        .get(&registered_key)
+        .expect("registered entry should remain available by original key");
+    assert_eq!(registered.descriptor().version, RunProfileVersion::new(1));
+    assert_eq!(registered.key(), &registered_key);
+    assert!(
+        registry
+            .get(&key("lightweight_loop", 2, "checkpoint_v2", 2))
+            .is_none()
+    );
+}
+
+#[test]
+fn production_readiness_rejects_missing_required_host_component() {
+    let mut registry = DriverRegistry::new();
+    let driver_key = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "lightweight_loop",
+                1,
+                "checkpoint_v1",
+                1,
+            ))),
+            DriverRequirements {
+                model: RequirementLevel::Required,
+                transcript: RequirementLevel::Optional,
+                checkpoint: RequirementLevel::Optional,
+                input_polling: RequirementLevel::Optional,
+                capabilities: RequirementLevel::Optional,
+                progress_events: RequirementLevel::Optional,
+            },
+            DriverKind::Production,
+        )
+        .expect("registration should succeed");
+
+    let report = registry.validate_readiness(
+        DriverReadinessMode::Production,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available().without_model(),
+            configured_profiles: vec![ConfiguredRunProfile::enabled(
+                "interactive_default",
+                driver_key,
+            )],
+            persisted_runs: Vec::new(),
+        },
+    );
+
+    assert_eq!(report.status, DriverReadinessStatus::NotReady);
+    assert!(
+        report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "missing_required_driver_requirement")
+    );
+}
+
+#[test]
+fn registry_rejects_descriptor_with_partial_checkpoint_identity() {
+    let mut registry = DriverRegistry::new();
+    let error = registry
+        .register_driver(
+            Arc::new(TestDriver::new(AgentLoopDriverDescriptor {
+                id: LoopDriverId::new("lightweight_loop").expect("valid driver id"),
+                version: RunProfileVersion::new(1),
+                checkpoint_schema_id: Some(
+                    CheckpointSchemaId::new("checkpoint_v1").expect("valid checkpoint id"),
+                ),
+                checkpoint_schema_version: None,
+            })),
+            DriverRequirements::all_optional(),
+            DriverKind::Production,
+        )
+        .expect_err("partial checkpoint identity should be invalid");
+
+    assert!(matches!(
+        error,
+        DriverRegistryError::InvalidDescriptor { .. }
+    ));
+}
+
+fn descriptor(
+    driver_id: &str,
+    driver_version: u64,
+    checkpoint_schema_id: &str,
+    checkpoint_schema_version: u64,
+) -> AgentLoopDriverDescriptor {
+    AgentLoopDriverDescriptor {
+        id: LoopDriverId::new(driver_id).expect("valid driver id"),
+        version: RunProfileVersion::new(driver_version),
+        checkpoint_schema_id: Some(
+            CheckpointSchemaId::new(checkpoint_schema_id).expect("valid checkpoint schema id"),
+        ),
+        checkpoint_schema_version: Some(RunProfileVersion::new(checkpoint_schema_version)),
+    }
+}
+
+fn key(
+    driver_id: &str,
+    driver_version: u64,
+    checkpoint_schema_id: &str,
+    checkpoint_schema_version: u64,
+) -> LoopDriverRegistryKey {
+    LoopDriverRegistryKey::from_descriptor(&descriptor(
+        driver_id,
+        driver_version,
+        checkpoint_schema_id,
+        checkpoint_schema_version,
+    ))
+    .expect("descriptor should produce a valid registry key")
+}
+
+struct TestDriver {
+    descriptor: Mutex<AgentLoopDriverDescriptor>,
+}
+
+impl TestDriver {
+    fn new(descriptor: AgentLoopDriverDescriptor) -> Self {
+        Self {
+            descriptor: Mutex::new(descriptor),
+        }
+    }
+
+    fn set_descriptor(&self, descriptor: AgentLoopDriverDescriptor) {
+        *self.descriptor.lock().expect("test descriptor mutex") = descriptor;
+    }
+}
+
+#[async_trait]
+impl AgentLoopDriver for TestDriver {
+    fn descriptor(&self) -> AgentLoopDriverDescriptor {
+        self.descriptor
+            .lock()
+            .expect("test descriptor mutex")
+            .clone()
+    }
+
+    async fn run(
+        &self,
+        _request: AgentLoopDriverRunRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        unreachable!("test driver is never executed")
+    }
+
+    async fn resume(
+        &self,
+        _request: AgentLoopDriverResumeRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        unreachable!("test driver is never executed")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ironclaw_reborn::driver_registry` for concrete Reborn loop-driver registration.
- Key registrations by exact driver/profile/checkpoint schema identity and cache validated descriptor snapshots at startup.
- Add readiness validation for configured profiles, non-terminal persisted runs, reference/fake driver policy, and host graph requirements.

Closes #3402

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo test -p ironclaw_reborn --tests`
- [x] `cargo clippy -p ironclaw_reborn --all-targets -- -D warnings`
