### PR TITLE
fix(reborn): encrypt durable credential payloads

### DIFF
--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "libsql")]
 use std::sync::Arc;
 
 use ironclaw_host_api::ResourceScope;
@@ -6,6 +5,7 @@ use ironclaw_host_api::ResourceScope;
 use crate::{
     CredentialAccount, CredentialAccountId, CredentialAccountStatus, CredentialAccountStore,
     CredentialBrokerError, CredentialSession, CredentialSessionId, CredentialSessionStore,
+    SecretsCrypto,
 };
 
 #[cfg(feature = "libsql")]
@@ -19,7 +19,9 @@ CREATE TABLE IF NOT EXISTS reborn_credential_accounts (
     status TEXT NOT NULL,
     provider_or_extension_id TEXT NOT NULL,
     updated_at TEXT NOT NULL,
-    payload TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    encrypted_payload BLOB NOT NULL DEFAULT X'',
+    payload_key_salt BLOB NOT NULL DEFAULT X'',
     PRIMARY KEY (tenant_id, user_id, agent_id, project_id, account_id)
 );
 CREATE INDEX IF NOT EXISTS idx_reborn_credential_accounts_scope_status
@@ -38,7 +40,9 @@ CREATE TABLE IF NOT EXISTS reborn_credential_sessions (
     expires_at TEXT,
     max_uses INTEGER,
     uses INTEGER NOT NULL DEFAULT 0,
-    payload TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    encrypted_payload BLOB NOT NULL DEFAULT X'',
+    payload_key_salt BLOB NOT NULL DEFAULT X'',
     PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id)
 );
 CREATE INDEX IF NOT EXISTS idx_reborn_credential_sessions_account
@@ -56,7 +60,9 @@ CREATE TABLE IF NOT EXISTS reborn_credential_accounts (
     status TEXT NOT NULL,
     provider_or_extension_id TEXT NOT NULL,
     updated_at TEXT NOT NULL,
-    payload JSONB NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    encrypted_payload BYTEA NOT NULL DEFAULT '\x'::bytea,
+    payload_key_salt BYTEA NOT NULL DEFAULT '\x'::bytea,
     PRIMARY KEY (tenant_id, user_id, agent_id, project_id, account_id)
 );
 CREATE INDEX IF NOT EXISTS idx_reborn_credential_accounts_scope_status
@@ -75,7 +81,9 @@ CREATE TABLE IF NOT EXISTS reborn_credential_sessions (
     expires_at TEXT,
     max_uses BIGINT,
     uses BIGINT NOT NULL DEFAULT 0,
-    payload JSONB NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    encrypted_payload BYTEA NOT NULL DEFAULT '\x'::bytea,
+    payload_key_salt BYTEA NOT NULL DEFAULT '\x'::bytea,
     PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id)
 );
 CREATE INDEX IF NOT EXISTS idx_reborn_credential_sessions_account
@@ -85,12 +93,13 @@ CREATE INDEX IF NOT EXISTS idx_reborn_credential_sessions_account
 #[cfg(feature = "libsql")]
 pub struct LibSqlCredentialStore {
     db: Arc<libsql::Database>,
+    crypto: Arc<SecretsCrypto>,
 }
 
 #[cfg(feature = "libsql")]
 impl LibSqlCredentialStore {
-    pub fn new(db: Arc<libsql::Database>) -> Self {
-        Self { db }
+    pub fn new(db: Arc<libsql::Database>, crypto: Arc<SecretsCrypto>) -> Self {
+        Self { db, crypto }
     }
 
     pub async fn run_migrations(&self) -> Result<(), CredentialBrokerError> {
@@ -98,6 +107,8 @@ impl LibSqlCredentialStore {
         conn.execute_batch(LIBSQL_CREDENTIAL_SCHEMA)
             .await
             .map_err(db_error)?;
+        libsql_ensure_encrypted_payload_columns(&conn).await?;
+        libsql_reject_unencrypted_payload_rows(&conn).await?;
         Ok(())
     }
 
@@ -115,7 +126,7 @@ impl CredentialAccountStore for LibSqlCredentialStore {
     ) -> Result<CredentialAccount, CredentialBrokerError> {
         let conn = libsql_begin_immediate(&self.db).await?;
         let result = async {
-            libsql_upsert_account(&conn, &account).await?;
+            libsql_upsert_account(&conn, &self.crypto, &account).await?;
             Ok(account)
         }
         .await;
@@ -128,7 +139,7 @@ impl CredentialAccountStore for LibSqlCredentialStore {
         account_id: &CredentialAccountId,
     ) -> Result<Option<CredentialAccount>, CredentialBrokerError> {
         let conn = self.connect().await?;
-        libsql_get_account(&conn, scope, account_id).await
+        libsql_get_account(&conn, &self.crypto, scope, account_id).await
     }
 
     async fn accounts_for_scope(
@@ -136,7 +147,7 @@ impl CredentialAccountStore for LibSqlCredentialStore {
         scope: &ResourceScope,
     ) -> Result<Vec<CredentialAccount>, CredentialBrokerError> {
         let conn = self.connect().await?;
-        libsql_accounts_for_scope(&conn, scope).await
+        libsql_accounts_for_scope(&conn, &self.crypto, scope).await
     }
 }
 
@@ -149,7 +160,7 @@ impl CredentialSessionStore for LibSqlCredentialStore {
     ) -> Result<CredentialSession, CredentialBrokerError> {
         let conn = libsql_begin_immediate(&self.db).await?;
         let result = async {
-            libsql_upsert_session(&conn, &session, 0).await?;
+            libsql_upsert_session(&conn, &self.crypto, &session, 0).await?;
             Ok(session)
         }
         .await;
@@ -162,9 +173,11 @@ impl CredentialSessionStore for LibSqlCredentialStore {
         session_id: CredentialSessionId,
     ) -> Result<Option<CredentialSession>, CredentialBrokerError> {
         let conn = self.connect().await?;
-        Ok(libsql_get_session_record(&conn, scope, session_id)
-            .await?
-            .map(|record| record.session))
+        Ok(
+            libsql_get_session_record(&conn, &self.crypto, scope, session_id)
+                .await?
+                .map(|record| record.session),
+        )
     }
 
     async fn validate_session(
@@ -174,7 +187,7 @@ impl CredentialSessionStore for LibSqlCredentialStore {
         now: ironclaw_host_api::Timestamp,
     ) -> Result<CredentialSession, CredentialBrokerError> {
         let conn = self.connect().await?;
-        let record = libsql_get_session_record(&conn, scope, session_id)
+        let record = libsql_get_session_record(&conn, &self.crypto, scope, session_id)
             .await?
             .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
         ensure_session_usable(&record, session_id, now)?;
@@ -189,7 +202,7 @@ impl CredentialSessionStore for LibSqlCredentialStore {
     ) -> Result<CredentialSession, CredentialBrokerError> {
         let conn = libsql_begin_immediate(&self.db).await?;
         let result = async {
-            let record = libsql_get_session_record(&conn, scope, session_id)
+            let record = libsql_get_session_record(&conn, &self.crypto, scope, session_id)
                 .await?
                 .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
             ensure_session_usable(&record, session_id, now)?;
@@ -205,12 +218,13 @@ impl CredentialSessionStore for LibSqlCredentialStore {
 #[cfg(feature = "postgres")]
 pub struct PostgresCredentialStore {
     pool: deadpool_postgres::Pool,
+    crypto: Arc<SecretsCrypto>,
 }
 
 #[cfg(feature = "postgres")]
 impl PostgresCredentialStore {
-    pub fn new(pool: deadpool_postgres::Pool) -> Self {
-        Self { pool }
+    pub fn new(pool: deadpool_postgres::Pool, crypto: Arc<SecretsCrypto>) -> Self {
+        Self { pool, crypto }
     }
 
     pub async fn run_migrations(&self) -> Result<(), CredentialBrokerError> {
@@ -218,7 +232,9 @@ impl PostgresCredentialStore {
         client
             .batch_execute(POSTGRES_CREDENTIAL_SCHEMA)
             .await
-            .map_err(db_error)
+            .map_err(db_error)?;
+        postgres_ensure_encrypted_payload_columns(&client).await?;
+        postgres_reject_unencrypted_payload_rows(&client).await
     }
 }
 
@@ -230,7 +246,7 @@ impl CredentialAccountStore for PostgresCredentialStore {
         account: CredentialAccount,
     ) -> Result<CredentialAccount, CredentialBrokerError> {
         let client = self.pool.get().await.map_err(db_error)?;
-        postgres_upsert_account(&client, &account).await?;
+        postgres_upsert_account(&client, &self.crypto, &account).await?;
         Ok(account)
     }
 
@@ -240,7 +256,7 @@ impl CredentialAccountStore for PostgresCredentialStore {
         account_id: &CredentialAccountId,
     ) -> Result<Option<CredentialAccount>, CredentialBrokerError> {
         let client = self.pool.get().await.map_err(db_error)?;
-        postgres_get_account(&client, scope, account_id).await
+        postgres_get_account(&client, &self.crypto, scope, account_id).await
     }
 
     async fn accounts_for_scope(
@@ -248,7 +264,7 @@ impl CredentialAccountStore for PostgresCredentialStore {
         scope: &ResourceScope,
     ) -> Result<Vec<CredentialAccount>, CredentialBrokerError> {
         let client = self.pool.get().await.map_err(db_error)?;
-        postgres_accounts_for_scope(&client, scope).await
+        postgres_accounts_for_scope(&client, &self.crypto, scope).await
     }
 }
 
@@ -260,7 +276,7 @@ impl CredentialSessionStore for PostgresCredentialStore {
         session: CredentialSession,
     ) -> Result<CredentialSession, CredentialBrokerError> {
         let client = self.pool.get().await.map_err(db_error)?;
-        postgres_upsert_session(&client, &session, 0).await?;
+        postgres_upsert_session(&client, &self.crypto, &session, 0).await?;
         Ok(session)
     }
 
@@ -271,7 +287,7 @@ impl CredentialSessionStore for PostgresCredentialStore {
     ) -> Result<Option<CredentialSession>, CredentialBrokerError> {
         let client = self.pool.get().await.map_err(db_error)?;
         Ok(
-            postgres_get_session_record(&client, scope, session_id, false)
+            postgres_get_session_record(&client, &self.crypto, scope, session_id, false)
                 .await?
                 .map(|record| record.session),
         )
@@ -284,7 +300,7 @@ impl CredentialSessionStore for PostgresCredentialStore {
         now: ironclaw_host_api::Timestamp,
     ) -> Result<CredentialSession, CredentialBrokerError> {
         let client = self.pool.get().await.map_err(db_error)?;
-        let record = postgres_get_session_record(&client, scope, session_id, false)
+        let record = postgres_get_session_record(&client, &self.crypto, scope, session_id, false)
             .await?
             .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
         ensure_session_usable(&record, session_id, now)?;
@@ -300,9 +316,10 @@ impl CredentialSessionStore for PostgresCredentialStore {
         let mut client = self.pool.get().await.map_err(db_error)?;
         let transaction = client.transaction().await.map_err(db_error)?;
         let result = async {
-            let record = postgres_get_session_record(&transaction, scope, session_id, true)
-                .await?
-                .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
+            let record =
+                postgres_get_session_record(&transaction, &self.crypto, scope, session_id, true)
+                    .await?
+                    .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
             ensure_session_usable(&record, session_id, now)?;
             let new_uses = record.uses + 1;
             postgres_update_session_uses(&transaction, scope, session_id, new_uses).await?;
@@ -392,11 +409,13 @@ async fn finish_libsql_transaction<T>(
 #[cfg(feature = "libsql")]
 async fn libsql_upsert_account(
     conn: &libsql::Connection,
+    crypto: &SecretsCrypto,
     account: &CredentialAccount,
 ) -> Result<(), CredentialBrokerError> {
     let key = DbScopeKey::from_account_scope(&account.scope);
+    let payload = encrypt_json_payload(crypto, account)?;
     conn.execute(
-        "INSERT INTO reborn_credential_accounts (tenant_id, user_id, agent_id, project_id, account_id, status, provider_or_extension_id, updated_at, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9) ON CONFLICT(tenant_id, user_id, agent_id, project_id, account_id) DO UPDATE SET status = EXCLUDED.status, provider_or_extension_id = EXCLUDED.provider_or_extension_id, updated_at = EXCLUDED.updated_at, payload = EXCLUDED.payload",
+        "INSERT INTO reborn_credential_accounts (tenant_id, user_id, agent_id, project_id, account_id, status, provider_or_extension_id, updated_at, payload, encrypted_payload, payload_key_salt) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, '{}', ?9, ?10) ON CONFLICT(tenant_id, user_id, agent_id, project_id, account_id) DO UPDATE SET status = EXCLUDED.status, provider_or_extension_id = EXCLUDED.provider_or_extension_id, updated_at = EXCLUDED.updated_at, payload = '{}', encrypted_payload = EXCLUDED.encrypted_payload, payload_key_salt = EXCLUDED.payload_key_salt",
         libsql::params![
             key.tenant_id,
             key.user_id,
@@ -406,7 +425,8 @@ async fn libsql_upsert_account(
             account_status_key(account.status),
             account.provider_or_extension_id.as_str(),
             account.updated_at.to_rfc3339(),
-            to_json(account)?,
+            payload.encrypted_value,
+            payload.key_salt,
         ],
     )
     .await
@@ -417,13 +437,14 @@ async fn libsql_upsert_account(
 #[cfg(feature = "libsql")]
 async fn libsql_get_account(
     conn: &libsql::Connection,
+    crypto: &SecretsCrypto,
     scope: &ResourceScope,
     account_id: &CredentialAccountId,
 ) -> Result<Option<CredentialAccount>, CredentialBrokerError> {
     let key = DbScopeKey::from_account_scope(scope);
     let mut rows = conn
         .query(
-            "SELECT status, provider_or_extension_id, updated_at, payload FROM reborn_credential_accounts WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND account_id = ?5",
+            "SELECT status, provider_or_extension_id, updated_at, encrypted_payload, payload_key_salt FROM reborn_credential_accounts WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND account_id = ?5",
             libsql::params![key.tenant_id, key.user_id, key.agent_id, key.project_id, account_id.as_str()],
         )
         .await
@@ -434,9 +455,10 @@ async fn libsql_get_account(
     let status: String = row.get(0).map_err(db_error)?;
     let provider: String = row.get(1).map_err(db_error)?;
     let updated_at: String = row.get(2).map_err(db_error)?;
-    let payload: String = row.get(3).map_err(db_error)?;
+    let encrypted_payload: Vec<u8> = row.get(3).map_err(db_error)?;
+    let payload_key_salt: Vec<u8> = row.get(4).map_err(db_error)?;
     validate_account_row(
-        from_json(&payload)?,
+        decrypt_json_payload(crypto, &encrypted_payload, &payload_key_salt)?,
         scope,
         account_id,
         &status,
@@ -449,12 +471,13 @@ async fn libsql_get_account(
 #[cfg(feature = "libsql")]
 async fn libsql_accounts_for_scope(
     conn: &libsql::Connection,
+    crypto: &SecretsCrypto,
     scope: &ResourceScope,
 ) -> Result<Vec<CredentialAccount>, CredentialBrokerError> {
     let key = DbScopeKey::from_account_scope(scope);
     let mut rows = conn
         .query(
-            "SELECT account_id, status, provider_or_extension_id, updated_at, payload FROM reborn_credential_accounts WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 ORDER BY account_id",
+            "SELECT account_id, status, provider_or_extension_id, updated_at, encrypted_payload, payload_key_salt FROM reborn_credential_accounts WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 ORDER BY account_id",
             libsql::params![key.tenant_id, key.user_id, key.agent_id, key.project_id],
         )
         .await
@@ -466,9 +489,10 @@ async fn libsql_accounts_for_scope(
         let status: String = row.get(1).map_err(db_error)?;
         let provider: String = row.get(2).map_err(db_error)?;
         let updated_at: String = row.get(3).map_err(db_error)?;
-        let payload: String = row.get(4).map_err(db_error)?;
+        let encrypted_payload: Vec<u8> = row.get(4).map_err(db_error)?;
+        let payload_key_salt: Vec<u8> = row.get(5).map_err(db_error)?;
         accounts.push(validate_account_row(
-            from_json(&payload)?,
+            decrypt_json_payload(crypto, &encrypted_payload, &payload_key_salt)?,
             scope,
             &account_id,
             &status,
@@ -482,12 +506,14 @@ async fn libsql_accounts_for_scope(
 #[cfg(feature = "libsql")]
 async fn libsql_upsert_session(
     conn: &libsql::Connection,
+    crypto: &SecretsCrypto,
     session: &CredentialSession,
     uses: u64,
 ) -> Result<(), CredentialBrokerError> {
     let key = DbScopeKey::from_full_scope(session.scope());
+    let payload = encrypt_json_payload(crypto, session)?;
     conn.execute(
-        "INSERT INTO reborn_credential_sessions (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id, account_id, expires_at, max_uses, uses, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) ON CONFLICT(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id) DO UPDATE SET account_id = EXCLUDED.account_id, expires_at = EXCLUDED.expires_at, max_uses = EXCLUDED.max_uses, uses = EXCLUDED.uses, payload = EXCLUDED.payload",
+        "INSERT INTO reborn_credential_sessions (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id, account_id, expires_at, max_uses, uses, payload, encrypted_payload, payload_key_salt) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, '{}', ?13, ?14) ON CONFLICT(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id) DO UPDATE SET account_id = EXCLUDED.account_id, expires_at = EXCLUDED.expires_at, max_uses = EXCLUDED.max_uses, uses = EXCLUDED.uses, payload = '{}', encrypted_payload = EXCLUDED.encrypted_payload, payload_key_salt = EXCLUDED.payload_key_salt",
         libsql::params![
             key.tenant_id,
             key.user_id,
@@ -501,7 +527,8 @@ async fn libsql_upsert_session(
             session.expires_at().map(|value| value.to_rfc3339()),
             session.max_uses().map(|value| value as i64),
             uses as i64,
-            to_json(session)?,
+            payload.encrypted_value,
+            payload.key_salt,
         ],
     )
     .await
@@ -512,13 +539,14 @@ async fn libsql_upsert_session(
 #[cfg(feature = "libsql")]
 async fn libsql_get_session_record(
     conn: &libsql::Connection,
+    crypto: &SecretsCrypto,
     scope: &ResourceScope,
     session_id: CredentialSessionId,
 ) -> Result<Option<SessionRecord>, CredentialBrokerError> {
     let key = DbScopeKey::from_full_scope(scope);
     let mut rows = conn
         .query(
-            "SELECT account_id, expires_at, max_uses, uses, payload FROM reborn_credential_sessions WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND invocation_id = ?7 AND session_id = ?8",
+            "SELECT account_id, expires_at, max_uses, uses, encrypted_payload, payload_key_salt FROM reborn_credential_sessions WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND invocation_id = ?7 AND session_id = ?8",
             libsql::params![key.tenant_id, key.user_id, key.agent_id, key.project_id, key.mission_id, key.thread_id, key.invocation_id, session_id.to_string()],
         )
         .await
@@ -530,9 +558,10 @@ async fn libsql_get_session_record(
     let expires_at: Option<String> = row.get(1).map_err(db_error)?;
     let max_uses: Option<i64> = row.get(2).map_err(db_error)?;
     let uses: i64 = row.get(3).map_err(db_error)?;
-    let payload: String = row.get(4).map_err(db_error)?;
+    let encrypted_payload: Vec<u8> = row.get(4).map_err(db_error)?;
+    let payload_key_salt: Vec<u8> = row.get(5).map_err(db_error)?;
     validate_session_row(
-        from_json(&payload)?,
+        decrypt_json_payload(crypto, &encrypted_payload, &payload_key_salt)?,
         scope,
         session_id,
         &account_id,
@@ -563,30 +592,34 @@ async fn libsql_update_session_uses(
 #[cfg(feature = "postgres")]
 async fn postgres_upsert_account(
     client: &impl deadpool_postgres::GenericClient,
+    crypto: &SecretsCrypto,
     account: &CredentialAccount,
 ) -> Result<(), CredentialBrokerError> {
     let key = DbScopeKey::from_account_scope(&account.scope);
-    client.execute("INSERT INTO reborn_credential_accounts (tenant_id, user_id, agent_id, project_id, account_id, status, provider_or_extension_id, updated_at, payload) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb) ON CONFLICT(tenant_id, user_id, agent_id, project_id, account_id) DO UPDATE SET status = EXCLUDED.status, provider_or_extension_id = EXCLUDED.provider_or_extension_id, updated_at = EXCLUDED.updated_at, payload = EXCLUDED.payload", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &account.id.as_str(), &account_status_key(account.status), &account.provider_or_extension_id.as_str(), &account.updated_at.to_rfc3339(), &to_json(account)?]).await.map_err(db_error)?;
+    let payload = encrypt_json_payload(crypto, account)?;
+    client.execute("INSERT INTO reborn_credential_accounts (tenant_id, user_id, agent_id, project_id, account_id, status, provider_or_extension_id, updated_at, payload, encrypted_payload, payload_key_salt) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '{}'::jsonb, $9, $10) ON CONFLICT(tenant_id, user_id, agent_id, project_id, account_id) DO UPDATE SET status = EXCLUDED.status, provider_or_extension_id = EXCLUDED.provider_or_extension_id, updated_at = EXCLUDED.updated_at, payload = '{}'::jsonb, encrypted_payload = EXCLUDED.encrypted_payload, payload_key_salt = EXCLUDED.payload_key_salt", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &account.id.as_str(), &account_status_key(account.status), &account.provider_or_extension_id.as_str(), &account.updated_at.to_rfc3339(), &payload.encrypted_value, &payload.key_salt]).await.map_err(db_error)?;
     Ok(())
 }
 
 #[cfg(feature = "postgres")]
 async fn postgres_get_account(
     client: &impl deadpool_postgres::GenericClient,
+    crypto: &SecretsCrypto,
     scope: &ResourceScope,
     account_id: &CredentialAccountId,
 ) -> Result<Option<CredentialAccount>, CredentialBrokerError> {
     let key = DbScopeKey::from_account_scope(scope);
-    let row = client.query_opt("SELECT status, provider_or_extension_id, updated_at, payload::text FROM reborn_credential_accounts WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND account_id = $5", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &account_id.as_str()]).await.map_err(db_error)?;
+    let row = client.query_opt("SELECT status, provider_or_extension_id, updated_at, encrypted_payload, payload_key_salt FROM reborn_credential_accounts WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND account_id = $5", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &account_id.as_str()]).await.map_err(db_error)?;
     let Some(row) = row else {
         return Ok(None);
     };
     let status: String = row.get(0);
     let provider: String = row.get(1);
     let updated_at: String = row.get(2);
-    let payload: String = row.get(3);
+    let encrypted_payload: Vec<u8> = row.get(3);
+    let payload_key_salt: Vec<u8> = row.get(4);
     validate_account_row(
-        from_json(&payload)?,
+        decrypt_json_payload(crypto, &encrypted_payload, &payload_key_salt)?,
         scope,
         account_id,
         &status,
@@ -599,10 +632,11 @@ async fn postgres_get_account(
 #[cfg(feature = "postgres")]
 async fn postgres_accounts_for_scope(
     client: &impl deadpool_postgres::GenericClient,
+    crypto: &SecretsCrypto,
     scope: &ResourceScope,
 ) -> Result<Vec<CredentialAccount>, CredentialBrokerError> {
     let key = DbScopeKey::from_account_scope(scope);
-    let rows = client.query("SELECT account_id, status, provider_or_extension_id, updated_at, payload::text FROM reborn_credential_accounts WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 ORDER BY account_id", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id]).await.map_err(db_error)?;
+    let rows = client.query("SELECT account_id, status, provider_or_extension_id, updated_at, encrypted_payload, payload_key_salt FROM reborn_credential_accounts WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 ORDER BY account_id", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id]).await.map_err(db_error)?;
     let mut accounts = Vec::new();
     for row in rows {
         let account_id: String = row.get(0);
@@ -610,9 +644,10 @@ async fn postgres_accounts_for_scope(
         let status: String = row.get(1);
         let provider: String = row.get(2);
         let updated_at: String = row.get(3);
-        let payload: String = row.get(4);
+        let encrypted_payload: Vec<u8> = row.get(4);
+        let payload_key_salt: Vec<u8> = row.get(5);
         accounts.push(validate_account_row(
-            from_json(&payload)?,
+            decrypt_json_payload(crypto, &encrypted_payload, &payload_key_salt)?,
             scope,
             &account_id,
             &status,
@@ -626,18 +661,21 @@ async fn postgres_accounts_for_scope(
 #[cfg(feature = "postgres")]
 async fn postgres_upsert_session(
     client: &impl deadpool_postgres::GenericClient,
+    crypto: &SecretsCrypto,
     session: &CredentialSession,
     uses: u64,
 ) -> Result<(), CredentialBrokerError> {
     let key = DbScopeKey::from_full_scope(session.scope());
     let max_uses = session.max_uses().map(|value| value as i64);
-    client.execute("INSERT INTO reborn_credential_sessions (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id, account_id, expires_at, max_uses, uses, payload) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb) ON CONFLICT(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id) DO UPDATE SET account_id = EXCLUDED.account_id, expires_at = EXCLUDED.expires_at, max_uses = EXCLUDED.max_uses, uses = EXCLUDED.uses, payload = EXCLUDED.payload", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &key.mission_id, &key.thread_id, &key.invocation_id, &session.correlation_id().to_string(), &session.account_id().as_str(), &session.expires_at().map(|value| value.to_rfc3339()), &max_uses, &(uses as i64), &to_json(session)?]).await.map_err(db_error)?;
+    let payload = encrypt_json_payload(crypto, session)?;
+    client.execute("INSERT INTO reborn_credential_sessions (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id, account_id, expires_at, max_uses, uses, payload, encrypted_payload, payload_key_salt) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, '{}'::jsonb, $13, $14) ON CONFLICT(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id) DO UPDATE SET account_id = EXCLUDED.account_id, expires_at = EXCLUDED.expires_at, max_uses = EXCLUDED.max_uses, uses = EXCLUDED.uses, payload = '{}'::jsonb, encrypted_payload = EXCLUDED.encrypted_payload, payload_key_salt = EXCLUDED.payload_key_salt", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &key.mission_id, &key.thread_id, &key.invocation_id, &session.correlation_id().to_string(), &session.account_id().as_str(), &session.expires_at().map(|value| value.to_rfc3339()), &max_uses, &(uses as i64), &payload.encrypted_value, &payload.key_salt]).await.map_err(db_error)?;
     Ok(())
 }
 
 #[cfg(feature = "postgres")]
 async fn postgres_get_session_record(
     client: &impl deadpool_postgres::GenericClient,
+    crypto: &SecretsCrypto,
     scope: &ResourceScope,
     session_id: CredentialSessionId,
     for_update: bool,
@@ -645,7 +683,7 @@ async fn postgres_get_session_record(
     let key = DbScopeKey::from_full_scope(scope);
     let suffix = if for_update { " FOR UPDATE" } else { "" };
     let query = format!(
-        "SELECT account_id, expires_at, max_uses, uses, payload::text FROM reborn_credential_sessions WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND invocation_id = $7 AND session_id = $8{suffix}"
+        "SELECT account_id, expires_at, max_uses, uses, encrypted_payload, payload_key_salt FROM reborn_credential_sessions WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND invocation_id = $7 AND session_id = $8{suffix}"
     );
     let row = client
         .query_opt(
@@ -670,9 +708,10 @@ async fn postgres_get_session_record(
     let expires_at: Option<String> = row.get(1);
     let max_uses: Option<i64> = row.get(2);
     let uses: i64 = row.get(3);
-    let payload: String = row.get(4);
+    let encrypted_payload: Vec<u8> = row.get(4);
+    let payload_key_salt: Vec<u8> = row.get(5);
     validate_session_row(
-        from_json(&payload)?,
+        decrypt_json_payload(crypto, &encrypted_payload, &payload_key_salt)?,
         scope,
         session_id,
         &account_id,
@@ -693,6 +732,162 @@ async fn postgres_update_session_uses(
     let key = DbScopeKey::from_full_scope(scope);
     client.execute("UPDATE reborn_credential_sessions SET uses = $1 WHERE tenant_id = $2 AND user_id = $3 AND agent_id = $4 AND project_id = $5 AND mission_id = $6 AND thread_id = $7 AND invocation_id = $8 AND session_id = $9", &[&(uses as i64), &key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &key.mission_id, &key.thread_id, &key.invocation_id, &session_id.to_string()]).await.map_err(db_error)?;
     Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_ensure_encrypted_payload_columns(
+    conn: &libsql::Connection,
+) -> Result<(), CredentialBrokerError> {
+    for statement in [
+        "ALTER TABLE reborn_credential_accounts ADD COLUMN encrypted_payload BLOB NOT NULL DEFAULT X''",
+        "ALTER TABLE reborn_credential_accounts ADD COLUMN payload_key_salt BLOB NOT NULL DEFAULT X''",
+        "ALTER TABLE reborn_credential_sessions ADD COLUMN encrypted_payload BLOB NOT NULL DEFAULT X''",
+        "ALTER TABLE reborn_credential_sessions ADD COLUMN payload_key_salt BLOB NOT NULL DEFAULT X''",
+    ] {
+        match conn.execute(statement, ()).await {
+            Ok(_) => {}
+            Err(error) => ignore_duplicate_column_error(error)?,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+fn ignore_duplicate_column_error(error: libsql::Error) -> Result<(), CredentialBrokerError> {
+    let message = error.to_string();
+    if message.contains("duplicate column name") {
+        Ok(())
+    } else {
+        Err(db_error(error))
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_reject_unencrypted_payload_rows(
+    conn: &libsql::Connection,
+) -> Result<(), CredentialBrokerError> {
+    let unencrypted_accounts = libsql_has_unencrypted_rows(
+        conn,
+        "SELECT 1 FROM reborn_credential_accounts WHERE length(encrypted_payload) = 0 OR payload <> '{}' LIMIT 1",
+    )
+    .await?;
+    let unencrypted_sessions = libsql_has_unencrypted_rows(
+        conn,
+        "SELECT 1 FROM reborn_credential_sessions WHERE length(encrypted_payload) = 0 OR payload <> '{}' LIMIT 1",
+    )
+    .await?;
+    if unencrypted_accounts || unencrypted_sessions {
+        return Err(persistence_error(
+            "credential store contains unencrypted legacy payload rows; rotate or migrate credentials before enabling the durable Reborn credential store",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_has_unencrypted_rows(
+    conn: &libsql::Connection,
+    query: &str,
+) -> Result<bool, CredentialBrokerError> {
+    let mut rows = conn.query(query, ()).await.map_err(db_error)?;
+    Ok(rows.next().await.map_err(db_error)?.is_some())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_ensure_encrypted_payload_columns(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<(), CredentialBrokerError> {
+    client
+        .batch_execute(
+            r#"
+            ALTER TABLE reborn_credential_accounts ADD COLUMN IF NOT EXISTS encrypted_payload BYTEA NOT NULL DEFAULT '\x'::bytea;
+            ALTER TABLE reborn_credential_accounts ADD COLUMN IF NOT EXISTS payload_key_salt BYTEA NOT NULL DEFAULT '\x'::bytea;
+            ALTER TABLE reborn_credential_sessions ADD COLUMN IF NOT EXISTS encrypted_payload BYTEA NOT NULL DEFAULT '\x'::bytea;
+            ALTER TABLE reborn_credential_sessions ADD COLUMN IF NOT EXISTS payload_key_salt BYTEA NOT NULL DEFAULT '\x'::bytea;
+            "#,
+        )
+        .await
+        .map_err(db_error)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_reject_unencrypted_payload_rows(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<(), CredentialBrokerError> {
+    let unencrypted_accounts = postgres_has_unencrypted_rows(
+        client,
+        "SELECT 1 FROM reborn_credential_accounts WHERE octet_length(encrypted_payload) = 0 OR payload <> '{}'::jsonb LIMIT 1",
+    )
+    .await?;
+    let unencrypted_sessions = postgres_has_unencrypted_rows(
+        client,
+        "SELECT 1 FROM reborn_credential_sessions WHERE octet_length(encrypted_payload) = 0 OR payload <> '{}'::jsonb LIMIT 1",
+    )
+    .await?;
+    if unencrypted_accounts || unencrypted_sessions {
+        return Err(persistence_error(
+            "credential store contains unencrypted legacy payload rows; rotate or migrate credentials before enabling the durable Reborn credential store",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_has_unencrypted_rows(
+    client: &impl deadpool_postgres::GenericClient,
+    query: &str,
+) -> Result<bool, CredentialBrokerError> {
+    Ok(client
+        .query_opt(query, &[])
+        .await
+        .map_err(db_error)?
+        .is_some())
+}
+
+struct EncryptedPayload {
+    encrypted_value: Vec<u8>,
+    key_salt: Vec<u8>,
+}
+
+fn encrypt_json_payload<T: serde::Serialize>(
+    crypto: &SecretsCrypto,
+    value: &T,
+) -> Result<EncryptedPayload, CredentialBrokerError> {
+    let json = serde_json::to_vec(value).map_err(|error| persistence_error(error.to_string()))?;
+    encrypt_payload_bytes(crypto, &json)
+}
+
+fn encrypt_payload_bytes(
+    crypto: &SecretsCrypto,
+    bytes: &[u8],
+) -> Result<EncryptedPayload, CredentialBrokerError> {
+    let (encrypted_value, key_salt) = crypto.encrypt(bytes).map_err(credential_crypto_error)?;
+    Ok(EncryptedPayload {
+        encrypted_value,
+        key_salt,
+    })
+}
+
+fn decrypt_json_payload<T: serde::de::DeserializeOwned>(
+    crypto: &SecretsCrypto,
+    encrypted_value: &[u8],
+    key_salt: &[u8],
+) -> Result<T, CredentialBrokerError> {
+    let decrypted = crypto
+        .decrypt(encrypted_value, key_salt)
+        .map_err(credential_crypto_error)?;
+    from_json(decrypted.expose())
+}
+
+fn credential_crypto_error(error: crate::SecretError) -> CredentialBrokerError {
+    match error {
+        crate::SecretError::InvalidMasterKey => CredentialBrokerError::BrokerUnavailable {
+            reason: "credential payload encryption key is invalid".to_string(),
+        },
+        other => CredentialBrokerError::BrokerUnavailable {
+            reason: other.to_string(),
+        },
+    }
 }
 
 fn validate_account_row(
@@ -812,10 +1007,6 @@ fn account_status_key(status: CredentialAccountStatus) -> &'static str {
         CredentialAccountStatus::Expired => "expired",
         CredentialAccountStatus::Revoked => "revoked",
     }
-}
-
-fn to_json<T: serde::Serialize>(value: &T) -> Result<String, CredentialBrokerError> {
-    serde_json::to_string(value).map_err(|error| persistence_error(error.to_string()))
 }
 
 fn from_json<T: serde::de::DeserializeOwned>(payload: &str) -> Result<T, CredentialBrokerError> {

--- a/crates/ironclaw_secrets/tests/db_credential_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_credential_store_contract.rs
@@ -1,6 +1,5 @@
 #![cfg(any(feature = "libsql", feature = "postgres"))]
 
-#[cfg(feature = "libsql")]
 use std::sync::Arc;
 
 use chrono::Utc;
@@ -15,7 +14,7 @@ use ironclaw_secrets::PostgresCredentialStore;
 use ironclaw_secrets::{
     CredentialAccount, CredentialAccountId, CredentialAccountStatus, CredentialAccountStore,
     CredentialPathPolicy, CredentialSessionRequest, CredentialSessionStore, CredentialTargetPolicy,
-    InMemoryCredentialBroker, RedactedJson,
+    InMemoryCredentialBroker, RedactedJson, SecretMaterial, SecretsCrypto,
 };
 use serde_json::json;
 
@@ -76,6 +75,119 @@ async fn libsql_credential_store_persists_sessions_and_enforces_use_limits_acros
     assert_eq!(
         reopened.get_session(&scope, session_id).await.unwrap(),
         Some(session)
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_credential_store_does_not_persist_sensitive_payload_plaintext() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("credentials.db");
+    let store = libsql_store(&db_path).await;
+    let scope = sample_scope("tenant-a", "user-a");
+    let account_id = CredentialAccountId::new("openai_prod").unwrap();
+    let mut account = sample_account(scope.clone(), account_id.clone());
+    account.redacted_metadata = RedactedJson::new(json!({
+        "last_four": "1234",
+        "refresh_token": "sk-live-sentinel-refresh-token"
+    }));
+    account.allowed_targets = vec![CredentialTargetPolicy {
+        scheme: "https".to_string(),
+        host: "sentinel-api.example.com".to_string(),
+        port: Some(443),
+        path: CredentialPathPolicy::Prefix("/v1/".to_string()),
+        methods: vec![NetworkMethod::Get],
+    }];
+    let session = broker_session(scope.clone(), account_id.clone(), Some(1), None);
+
+    store.put_account(account).await.unwrap();
+    store.issue_session(session).await.unwrap();
+    drop(store);
+
+    let raw_database = std::fs::read(&db_path).unwrap();
+    let raw_database = String::from_utf8_lossy(&raw_database);
+    assert!(
+        !raw_database.contains("sk-live-sentinel-refresh-token"),
+        "credential account metadata must be encrypted at rest"
+    );
+    assert!(
+        !raw_database.contains("sentinel-api.example.com"),
+        "credential target policy payload must be encrypted at rest"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_credential_store_rejects_existing_plaintext_payload_rows() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("credentials.db");
+    let db = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let conn = db.connect().unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE reborn_credential_accounts (
+            tenant_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            provider_or_extension_id TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, user_id, agent_id, project_id, account_id)
+        );
+        CREATE TABLE reborn_credential_sessions (
+            tenant_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            mission_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            invocation_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            expires_at TEXT,
+            max_uses INTEGER,
+            uses INTEGER NOT NULL DEFAULT 0,
+            payload TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id)
+        );
+        "#,
+    )
+    .await
+    .unwrap();
+    let scope = sample_scope("tenant-a", "user-a");
+    let account_id = CredentialAccountId::new("openai_prod").unwrap();
+    let mut account = sample_account(scope.clone(), account_id.clone());
+    account.redacted_metadata = RedactedJson::new(json!({
+        "refresh_token": "legacy-sk-live-sentinel-refresh-token"
+    }));
+    let key = db_scope_key(&scope);
+    conn.execute(
+        "INSERT INTO reborn_credential_accounts (tenant_id, user_id, agent_id, project_id, account_id, status, provider_or_extension_id, updated_at, payload) VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6, ?7, ?8)",
+        libsql::params![
+            key.tenant_id,
+            key.user_id,
+            key.agent_id,
+            key.project_id,
+            account_id.as_str(),
+            account.provider_or_extension_id.as_str(),
+            account.updated_at.to_rfc3339(),
+            serde_json::to_string(&account).unwrap(),
+        ],
+    )
+    .await
+    .unwrap();
+    drop(conn);
+
+    let store = LibSqlCredentialStore::new(db, test_crypto());
+    let error = store.run_migrations().await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("unencrypted legacy payload rows"),
+        "durable Reborn credential stores must fail closed instead of pretending to securely scrub prior plaintext rows: {error}"
     );
 }
 
@@ -153,7 +265,7 @@ async fn postgres_credential_store_persists_accounts_and_sessions_when_database_
 #[cfg(feature = "libsql")]
 async fn libsql_store(path: &std::path::Path) -> LibSqlCredentialStore {
     let db = Arc::new(libsql::Builder::new_local(path).build().await.unwrap());
-    let store = LibSqlCredentialStore::new(db);
+    let store = LibSqlCredentialStore::new(db, test_crypto());
     store.run_migrations().await.unwrap();
     store
 }
@@ -172,12 +284,21 @@ async fn postgres_store() -> Option<PostgresCredentialStore> {
         .max_size(4)
         .build()
         .expect("Postgres pool must build");
-    let store = PostgresCredentialStore::new(pool);
+    let store = PostgresCredentialStore::new(pool, test_crypto());
     store
         .run_migrations()
         .await
         .expect("DATABASE_URL must point at a reachable Postgres test database");
     Some(store)
+}
+
+fn test_crypto() -> Arc<SecretsCrypto> {
+    Arc::new(
+        SecretsCrypto::new(SecretMaterial::from(
+            "0123456789abcdef0123456789abcdef".to_string(),
+        ))
+        .unwrap(),
+    )
 }
 
 fn broker_session(
@@ -203,6 +324,32 @@ fn broker_session(
             max_uses,
         })
         .unwrap()
+}
+
+#[cfg(feature = "libsql")]
+struct TestDbScopeKey {
+    tenant_id: String,
+    user_id: String,
+    agent_id: String,
+    project_id: String,
+}
+
+#[cfg(feature = "libsql")]
+fn db_scope_key(scope: &ResourceScope) -> TestDbScopeKey {
+    TestDbScopeKey {
+        tenant_id: scope.tenant_id.to_string(),
+        user_id: scope.user_id.to_string(),
+        agent_id: scope
+            .agent_id
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default(),
+        project_id: scope
+            .project_id
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default(),
+    }
 }
 
 fn sample_account(scope: ResourceScope, id: CredentialAccountId) -> CredentialAccount {


### PR DESCRIPTION
## Summary

- encrypt durable Reborn credential account/session payloads with `SecretsCrypto`
- require explicit crypto material when constructing libSQL/Postgres credential stores
- add encrypted payload/salt columns while keeping indexed scope/status/session fields queryable
- fail closed when existing plaintext credential payload rows are detected instead of claiming secure in-place scrubbing
- add libSQL raw-file sentinel regression coverage for encrypted credential metadata/policies

Refs #2987
Refs #3067

## Verification

- `cargo test -p ironclaw_secrets`
- `cargo test -p ironclaw_secrets --features libsql --test db_credential_store_contract`
- `cargo test -p ironclaw_secrets --features postgres --test db_credential_store_contract`
- `cargo check -p ironclaw_secrets --features 'libsql postgres'`
- `cargo clippy -p ironclaw_secrets --all-targets --features libsql -- -D warnings`
- `cargo clippy -p ironclaw_secrets --all-targets --features postgres -- -D warnings`

## Reborn finalization checklist

Done in this slice:
- durable credential account/session metadata is encrypted at rest for new libSQL/Postgres rows
- Reborn durable credential stores now align with v1's explicit encryption-at-rest requirement
- legacy plaintext payload rows fail closed and require rotation/operator migration

Still to do:
- wire encrypted stores into standalone `ironclaw-reborn` composition/health
- add a durable Reborn `SecretStore`/secret-material composition path with an operator-provided master key
- add broader no-exposure sentinel harness across health/status/events/logs/replay/API surfaces
