### PR TITLE
feat(reborn): add loop prompt bundle port

### DIFF
--- a/crates/ironclaw_reborn/src/driver_registry.rs
+++ b/crates/ironclaw_reborn/src/driver_registry.rs
@@ -63,6 +63,7 @@ pub enum RequirementLevel {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriverRequirements {
     pub model: RequirementLevel,
+    pub prompt: RequirementLevel,
     pub transcript: RequirementLevel,
     pub checkpoint: RequirementLevel,
     pub input_polling: RequirementLevel,
@@ -74,6 +75,7 @@ impl DriverRequirements {
     pub fn all_optional() -> Self {
         Self {
             model: RequirementLevel::Optional,
+            prompt: RequirementLevel::Optional,
             transcript: RequirementLevel::Optional,
             checkpoint: RequirementLevel::Optional,
             input_polling: RequirementLevel::Optional,
@@ -85,6 +87,7 @@ impl DriverRequirements {
     pub fn all_required() -> Self {
         Self {
             model: RequirementLevel::Required,
+            prompt: RequirementLevel::Required,
             transcript: RequirementLevel::Required,
             checkpoint: RequirementLevel::Required,
             input_polling: RequirementLevel::Required,
@@ -336,6 +339,7 @@ impl PersistedRunDriverIdentity {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostGraphReadiness {
     pub model: bool,
+    pub prompt: bool,
     pub transcript: bool,
     pub checkpoint: bool,
     pub input_polling: bool,
@@ -347,6 +351,7 @@ impl HostGraphReadiness {
     pub fn all_available() -> Self {
         Self {
             model: true,
+            prompt: true,
             transcript: true,
             checkpoint: true,
             input_polling: true,
@@ -357,6 +362,11 @@ impl HostGraphReadiness {
 
     pub fn without_model(mut self) -> Self {
         self.model = false;
+        self
+    }
+
+    pub fn without_prompt(mut self) -> Self {
+        self.prompt = false;
         self
     }
 }
@@ -488,6 +498,12 @@ fn missing_requirements(
         requirements.model,
         host_graph.model,
         "driver requires a model gateway, but the host graph does not provide one",
+    );
+    push_missing(
+        &mut missing,
+        requirements.prompt,
+        host_graph.prompt,
+        "driver requires a prompt bundle port, but the host graph does not provide one",
     );
     push_missing(
         &mut missing,

--- a/crates/ironclaw_reborn/tests/driver_registry.rs
+++ b/crates/ironclaw_reborn/tests/driver_registry.rs
@@ -274,6 +274,7 @@ fn production_readiness_rejects_missing_required_host_component() {
             ))),
             DriverRequirements {
                 model: RequirementLevel::Required,
+                prompt: RequirementLevel::Optional,
                 transcript: RequirementLevel::Optional,
                 checkpoint: RequirementLevel::Optional,
                 input_polling: RequirementLevel::Optional,
@@ -303,6 +304,49 @@ fn production_readiness_rejects_missing_required_host_component() {
             .iter()
             .any(|diagnostic| diagnostic.code == "missing_required_driver_requirement")
     );
+}
+
+#[test]
+fn production_readiness_rejects_missing_required_prompt_port() {
+    let mut registry = DriverRegistry::new();
+    let driver_key = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "lightweight_loop",
+                1,
+                "checkpoint_v1",
+                1,
+            ))),
+            DriverRequirements {
+                model: RequirementLevel::Optional,
+                prompt: RequirementLevel::Required,
+                transcript: RequirementLevel::Optional,
+                checkpoint: RequirementLevel::Optional,
+                input_polling: RequirementLevel::Optional,
+                capabilities: RequirementLevel::Optional,
+                progress_events: RequirementLevel::Optional,
+            },
+            DriverKind::Production,
+        )
+        .expect("registration should succeed");
+
+    let report = registry.validate_readiness(
+        DriverReadinessMode::Production,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available().without_prompt(),
+            configured_profiles: vec![ConfiguredRunProfile::enabled(
+                "interactive_default",
+                driver_key,
+            )],
+            persisted_runs: Vec::new(),
+        },
+    );
+
+    assert_eq!(report.status, DriverReadinessStatus::NotReady);
+    assert!(report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "missing_required_driver_requirement"
+            && diagnostic.message.contains("prompt bundle")
+    }));
 }
 
 #[test]

--- a/crates/ironclaw_reborn/tests/driver_registry.rs
+++ b/crates/ironclaw_reborn/tests/driver_registry.rs
@@ -307,7 +307,7 @@ fn production_readiness_rejects_missing_required_host_component() {
 }
 
 #[test]
-fn production_readiness_rejects_missing_required_prompt_port() {
+fn production_readiness_enforces_required_prompt_port_availability() {
     let mut registry = DriverRegistry::new();
     let driver_key = registry
         .register_driver(
@@ -336,7 +336,7 @@ fn production_readiness_rejects_missing_required_prompt_port() {
             host_graph: HostGraphReadiness::all_available().without_prompt(),
             configured_profiles: vec![ConfiguredRunProfile::enabled(
                 "interactive_default",
-                driver_key,
+                driver_key.clone(),
             )],
             persisted_runs: Vec::new(),
         },
@@ -347,6 +347,21 @@ fn production_readiness_rejects_missing_required_prompt_port() {
         diagnostic.code == "missing_required_driver_requirement"
             && diagnostic.message.contains("prompt bundle")
     }));
+
+    let ready_report = registry.validate_readiness(
+        DriverReadinessMode::Production,
+        DriverReadinessInputs {
+            host_graph: HostGraphReadiness::all_available(),
+            configured_profiles: vec![ConfiguredRunProfile::enabled(
+                "interactive_default",
+                driver_key,
+            )],
+            persisted_runs: Vec::new(),
+        },
+    );
+
+    assert_eq!(ready_report.status, DriverReadinessStatus::ProductionReady);
+    assert!(ready_report.diagnostics.is_empty());
 }
 
 #[test]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -63,6 +63,47 @@ fn validate_loop_opaque_token(
     Ok(value)
 }
 
+fn validate_loop_safe_identifier(
+    value: String,
+    label: &'static str,
+    max_bytes: usize,
+) -> Result<String, String> {
+    let value = validate_bounded_loop_string(value, label, max_bytes)?;
+    if !value.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | ':')
+    }) {
+        return Err(format!(
+            "{label} must contain only ASCII letters, digits, _, -, ., or :"
+        ));
+    }
+
+    let lower = value.to_ascii_lowercase();
+    for forbidden in [
+        "access_token",
+        "access-token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "bearer",
+        "password",
+        "passwd",
+        "secret",
+    ] {
+        if lower.contains(forbidden) {
+            return Err(format!(
+                "{label} must not contain sensitive marker `{forbidden}`"
+            ));
+        }
+    }
+    if lower
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '-')
+        .any(|token| token.starts_with("sk-"))
+    {
+        return Err(format!("{label} must not contain API-key-like tokens"));
+    }
+    Ok(value)
+}
+
 fn validate_loop_safe_summary(value: String) -> Result<String, String> {
     let value = validate_bounded_loop_string(value, "loop safe summary", 512)?;
     if value.chars().any(|character| {
@@ -513,7 +554,7 @@ pub struct CapabilitySurfaceVersion(String);
 
 impl CapabilitySurfaceVersion {
     pub fn new(value: impl Into<String>) -> Result<Self, String> {
-        validate_bounded_loop_string(value.into(), "capability surface version", 128).map(Self)
+        validate_loop_safe_identifier(value.into(), "capability surface version", 128).map(Self)
     }
 
     pub fn as_str(&self) -> &str {
@@ -579,7 +620,7 @@ pub struct LoopPromptBundleRequest {
     pub context_cursor: Option<LoopInputCursor>,
     pub surface_version: Option<CapabilitySurfaceVersion>,
     pub checkpoint_state_ref: Option<LoopCheckpointStateRef>,
-    pub max_tokens: Option<u32>,
+    pub max_messages: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -46,6 +46,23 @@ fn validate_prefixed_loop_ref(
     Ok(value)
 }
 
+fn validate_loop_opaque_token(
+    value: String,
+    label: &'static str,
+    max_bytes: usize,
+) -> Result<String, String> {
+    let value = validate_bounded_loop_string(value, label, max_bytes)?;
+    if !value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.'))
+    {
+        return Err(format!(
+            "{label} must contain only ASCII letters, digits, _, -, or ."
+        ));
+    }
+    Ok(value)
+}
+
 fn validate_loop_safe_summary(value: String) -> Result<String, String> {
     let value = validate_bounded_loop_string(value, "loop safe summary", 512)?;
     if value.chars().any(|character| {
@@ -149,6 +166,87 @@ bounded_loop_ref!(
     256
 );
 bounded_loop_ref!(LoopProcessRef, "loop process ref", "process:", 256);
+
+impl LoopCheckpointStateRef {
+    pub fn for_run(context: &LoopRunContext, token: impl Into<String>) -> Result<Self, String> {
+        let token = validate_loop_opaque_token(token.into(), "loop checkpoint state token", 96)?;
+        Self::new(format!("checkpoint:{}:{token}", context.run_id))
+    }
+
+    pub fn is_for_run(&self, context: &LoopRunContext) -> bool {
+        let Some(token) = self
+            .0
+            .strip_prefix(&format!("checkpoint:{}:", context.run_id))
+        else {
+            return false;
+        };
+        validate_loop_opaque_token(token.to_string(), "loop checkpoint state token", 96).is_ok()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct LoopPromptBundleRef(String);
+
+impl LoopPromptBundleRef {
+    pub fn new(value: impl Into<String>) -> Result<Self, String> {
+        let value =
+            validate_prefixed_loop_ref("loop prompt bundle ref", "prompt:", 256, value.into())?;
+        let suffix = value
+            .strip_prefix("prompt:")
+            .ok_or_else(|| "loop prompt bundle ref must start with `prompt:`".to_string())?;
+        let (run_id, token) = suffix.split_once(':').ok_or_else(|| {
+            "loop prompt bundle ref must include scoped run id and opaque token".to_string()
+        })?;
+        uuid::Uuid::parse_str(run_id)
+            .map_err(|_| "loop prompt bundle ref run id must be a UUID".to_string())?;
+        validate_loop_opaque_token(token.to_string(), "loop prompt bundle token", 96)?;
+        Ok(Self(value))
+    }
+
+    pub fn for_run(context: &LoopRunContext, token: impl Into<String>) -> Result<Self, String> {
+        let token = validate_loop_opaque_token(token.into(), "loop prompt bundle token", 96)?;
+        Self::new(format!("prompt:{}:{token}", context.run_id))
+    }
+
+    pub(crate) fn fresh_for_run(context: &LoopRunContext) -> Self {
+        Self(format!(
+            "prompt:{}:{}",
+            context.run_id,
+            uuid::Uuid::new_v4()
+        ))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn is_for_run(&self, context: &LoopRunContext) -> bool {
+        self.0.starts_with(&format!("prompt:{}:", context.run_id))
+    }
+}
+
+impl AsRef<str> for LoopPromptBundleRef {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for LoopPromptBundleRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for LoopPromptBundleRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
@@ -458,6 +556,47 @@ pub struct LoopModelMessage {
     pub content_ref: LoopMessageRef,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptMode {
+    TextOnly,
+    #[serde(rename = "codeact")]
+    CodeAct,
+}
+
+impl PromptMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TextOnly => "text_only",
+            Self::CodeAct => "codeact",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopPromptBundleRequest {
+    pub mode: PromptMode,
+    pub context_cursor: Option<LoopInputCursor>,
+    pub surface_version: Option<CapabilitySurfaceVersion>,
+    pub checkpoint_state_ref: Option<LoopCheckpointStateRef>,
+    pub max_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoopPromptBundle {
+    pub bundle_ref: LoopPromptBundleRef,
+    pub messages: Vec<LoopModelMessage>,
+    pub surface_version: Option<CapabilitySurfaceVersion>,
+}
+
+#[async_trait]
+pub trait LoopPromptPort: Send + Sync {
+    async fn build_prompt_bundle(
+        &self,
+        request: LoopPromptBundleRequest,
+    ) -> Result<LoopPromptBundle, AgentLoopHostError>;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopModelResponse {
     pub chunks: Vec<ModelStreamChunk>,
@@ -737,6 +876,7 @@ pub trait LoopProgressPort: Send + Sync {
 pub trait AgentLoopDriverHost:
     LoopRunInfoPort
     + LoopContextPort
+    + LoopPromptPort
     + LoopInputPort
     + LoopModelPort
     + LoopCapabilityPort
@@ -751,6 +891,7 @@ pub trait AgentLoopDriverHost:
 impl<T> AgentLoopDriverHost for T where
     T: LoopRunInfoPort
         + LoopContextPort
+        + LoopPromptPort
         + LoopInputPort
         + LoopModelPort
         + LoopCapabilityPort

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -225,6 +225,11 @@ impl LoopCheckpointStateRef {
     }
 }
 
+/// Opaque reference to a host-built prompt bundle for one loop run.
+///
+/// Serialized refs use `prompt:{run_id}:{opaque_token}`. Consumers must treat
+/// the token as opaque metadata and must not infer or persist raw prompt text
+/// from this value.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct LoopPromptBundleRef(String);
@@ -597,6 +602,12 @@ pub struct LoopModelMessage {
     pub content_ref: LoopMessageRef,
 }
 
+/// Prompt construction mode requested by an agent-loop driver.
+///
+/// `TextOnly` builds a prompt from transcript/context message refs and is the
+/// only mode supported by [`crate::run_profile::HostManagedLoopPromptPort`]
+/// today. `CodeAct` is reserved for a future checkpoint/tool-aware prompt
+/// bundle flow and is rejected by the text-only host port.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PromptMode {
@@ -614,6 +625,11 @@ impl PromptMode {
     }
 }
 
+/// Request for a host-managed prompt bundle.
+///
+/// The optional cursor and checkpoint refs are run-scoped and are validated by
+/// host ports before context is loaded. `max_messages` is a host budget hint;
+/// zero is rejected and oversized values may be clamped by the implementation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopPromptBundleRequest {
     pub mode: PromptMode,
@@ -623,6 +639,11 @@ pub struct LoopPromptBundleRequest {
     pub max_messages: Option<u32>,
 }
 
+/// Prompt bundle returned to a driver.
+///
+/// The bundle carries model-message references rather than raw prompt text.
+/// Drivers pass these refs to [`LoopModelPort`], allowing the host to resolve
+/// content under the same run scope and policy checks.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopPromptBundle {
     pub bundle_ref: LoopPromptBundleRef,
@@ -630,6 +651,11 @@ pub struct LoopPromptBundle {
     pub surface_version: Option<CapabilitySurfaceVersion>,
 }
 
+/// Host boundary for building prompt bundles before model invocation.
+///
+/// Implementations own context loading, scoping, prompt-shape policy, and
+/// milestone emission. Drivers should not assemble raw prompt strings when a
+/// prompt port is available.
 #[async_trait]
 pub trait LoopPromptPort: Send + Sync {
     async fn build_prompt_bundle(

--- a/crates/ironclaw_turns/src/run_profile/milestones.rs
+++ b/crates/ironclaw_turns/src/run_profile/milestones.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 use super::host::{
-    AgentLoopHostError, AgentLoopHostErrorKind, LoopCheckpointKind, LoopDriverNoteKind,
-    LoopRunContext, LoopSafeSummary,
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilitySurfaceVersion, LoopCheckpointKind,
+    LoopDriverNoteKind, LoopPromptBundleRef, LoopRunContext, LoopSafeSummary, PromptMode,
 };
 use super::refs::{LoopDriverId, ModelProfileId};
 use crate::{LoopCompletionKind, LoopFailureKind};
@@ -39,6 +39,12 @@ impl LoopHostMilestone {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LoopHostMilestoneKind {
+    PromptBundleBuilt {
+        bundle_ref: LoopPromptBundleRef,
+        mode: PromptMode,
+        surface_version: Option<CapabilitySurfaceVersion>,
+        message_count: usize,
+    },
     ModelStarted {
         requested_model_profile_id: Option<ModelProfileId>,
     },
@@ -76,6 +82,7 @@ pub enum LoopHostMilestoneKind {
 impl LoopHostMilestoneKind {
     pub fn kind_name(&self) -> &'static str {
         match self {
+            Self::PromptBundleBuilt { .. } => "prompt_bundle_built",
             Self::ModelStarted { .. } => "model_started",
             Self::ModelCompleted { .. } => "model_completed",
             Self::CapabilityInvoked { .. } => "capability_invoked",
@@ -143,6 +150,22 @@ where
 {
     pub fn new(context: LoopRunContext, sink: Arc<S>) -> Self {
         Self { context, sink }
+    }
+
+    pub async fn prompt_bundle_built(
+        &self,
+        bundle_ref: LoopPromptBundleRef,
+        mode: PromptMode,
+        surface_version: Option<CapabilitySurfaceVersion>,
+        message_count: usize,
+    ) -> Result<(), AgentLoopHostError> {
+        self.publish(LoopHostMilestoneKind::PromptBundleBuilt {
+            bundle_ref,
+            mode,
+            surface_version,
+            message_count,
+        })
+        .await
     }
 
     pub async fn model_started(

--- a/crates/ironclaw_turns/src/run_profile/milestones.rs
+++ b/crates/ironclaw_turns/src/run_profile/milestones.rs
@@ -36,6 +36,15 @@ impl LoopHostMilestone {
     }
 }
 
+/// Public wire shape for host-loop milestones.
+///
+/// Milestones may be serialized into traces or delivered across process
+/// boundaries. Consumers must treat this enum as extensible and prefer
+/// [`LoopHostMilestoneKind::kind_name`] plus a catch-all branch rather than
+/// assuming the historical closed set. `PromptBundleBuilt` was added as an
+/// additive wire-format variant for prompt-bundle construction; it carries only
+/// refs, mode, optional surface version, and counts, never raw prompt/model
+/// content.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LoopHostMilestoneKind {

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -3,6 +3,7 @@ mod host;
 mod milestones;
 mod model;
 mod policy;
+mod prompt;
 mod refs;
 mod resolver;
 mod snapshot;
@@ -22,8 +23,9 @@ pub use host::{
     LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopDriverNoteKind, LoopInput,
     LoopInputBatch, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopInterruptKind,
     LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelResponse, LoopProcessRef,
-    LoopProgressEvent, LoopProgressPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
-    LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, ProcessHandleSummary,
+    LoopProgressEvent, LoopProgressPort, LoopPromptBundle, LoopPromptBundleRef,
+    LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
+    LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, ProcessHandleSummary, PromptMode,
     UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
 };
 pub use milestones::{
@@ -39,6 +41,7 @@ pub use policy::{
     RunProfileRequestAuthority, RunProfileResolutionError, RuntimeProfileConstraints,
     SteeringPolicy,
 };
+pub use prompt::HostManagedLoopPromptPort;
 pub use refs::{
     CapabilitySurfaceProfileId, CheckpointSchemaId, ConcurrencyClass, ContextProfileId,
     LoopDriverId, ModelProfileId, ResourceBudgetTier, RunClassId, RunProfileFingerprint,

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -1,3 +1,13 @@
+//! Agent-loop driver, host-port, prompt-bundle, and run-profile contracts.
+//!
+//! Prompt bundle APIs are host-managed: drivers request a bounded bundle of
+//! context message references from [`LoopPromptPort`] and then pass those refs to
+//! the model port. Prompt APIs intentionally move prompt construction out of
+//! driver-owned string assembly without exposing raw prompt text in milestones.
+//! The initial host-managed implementation supports only [`PromptMode::TextOnly`]
+//! and rejects checkpoint-backed prompt state until a durable checkpoint prompt
+//! store is introduced.
+
 mod driver;
 mod host;
 mod milestones;

--- a/crates/ironclaw_turns/src/run_profile/prompt.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::host::{
+    AgentLoopHostError, AgentLoopHostErrorKind, LoopContextPort, LoopContextRequest,
+    LoopModelMessage, LoopPromptBundle, LoopPromptBundleRef, LoopPromptBundleRequest,
+    LoopPromptPort, LoopRunContext, PromptMode,
+};
+use super::milestones::{LoopHostMilestoneEmitter, LoopHostMilestoneSink};
+
+const DEFAULT_TEXT_ONLY_MESSAGE_LIMIT: usize = 32;
+const MAX_TEXT_ONLY_MESSAGE_LIMIT: usize = 128;
+
+#[derive(Clone)]
+pub struct HostManagedLoopPromptPort<C, S>
+where
+    C: LoopContextPort + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    context: LoopRunContext,
+    context_port: Arc<C>,
+    milestones: LoopHostMilestoneEmitter<S>,
+    default_message_limit: usize,
+}
+
+impl<C, S> HostManagedLoopPromptPort<C, S>
+where
+    C: LoopContextPort + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    pub fn new(context: LoopRunContext, context_port: Arc<C>, milestone_sink: Arc<S>) -> Self {
+        Self {
+            context: context.clone(),
+            context_port,
+            milestones: LoopHostMilestoneEmitter::new(context, milestone_sink),
+            default_message_limit: DEFAULT_TEXT_ONLY_MESSAGE_LIMIT,
+        }
+    }
+
+    pub fn with_default_message_limit(mut self, default_message_limit: usize) -> Self {
+        self.default_message_limit = default_message_limit.clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT);
+        self
+    }
+
+    fn validate_request(
+        &self,
+        request: &LoopPromptBundleRequest,
+    ) -> Result<(), AgentLoopHostError> {
+        if request.mode != PromptMode::TextOnly {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::PolicyDenied,
+                "prompt mode is not supported by the text-only prompt port",
+            ));
+        }
+
+        if request
+            .context_cursor
+            .as_ref()
+            .is_some_and(|cursor| !cursor.is_for_run(&self.context))
+        {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::ScopeMismatch,
+                "prompt context cursor is not scoped to this loop run",
+            ));
+        }
+
+        if let Some(state_ref) = request.checkpoint_state_ref.as_ref() {
+            let run_prefix = format!("checkpoint:{}:", self.context.run_id);
+            if !state_ref.as_str().starts_with(&run_prefix) {
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::ScopeMismatch,
+                    "prompt checkpoint state ref is not scoped to this loop run",
+                ));
+            }
+            if !state_ref.is_for_run(&self.context) {
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::InvalidInvocation,
+                    "prompt checkpoint state ref is malformed",
+                ));
+            }
+        }
+
+        if matches!(request.max_tokens, Some(0)) {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::BudgetExceeded,
+                "prompt token budget must be greater than zero",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn message_limit(&self, request: &LoopPromptBundleRequest) -> usize {
+        request
+            .max_tokens
+            .map(|tokens| tokens as usize)
+            .unwrap_or(self.default_message_limit)
+            .clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT)
+    }
+}
+
+#[async_trait]
+impl<C, S> LoopPromptPort for HostManagedLoopPromptPort<C, S>
+where
+    C: LoopContextPort + ?Sized,
+    S: LoopHostMilestoneSink + ?Sized,
+{
+    async fn build_prompt_bundle(
+        &self,
+        request: LoopPromptBundleRequest,
+    ) -> Result<LoopPromptBundle, AgentLoopHostError> {
+        self.validate_request(&request)?;
+        let context = self
+            .context_port
+            .load_loop_context(LoopContextRequest {
+                after: request.context_cursor.clone(),
+                limit: self.message_limit(&request),
+            })
+            .await?;
+        let messages = context
+            .messages
+            .into_iter()
+            .map(|message| LoopModelMessage {
+                role: message.role,
+                content_ref: message.message_ref,
+            })
+            .collect::<Vec<_>>();
+        let bundle = LoopPromptBundle {
+            bundle_ref: LoopPromptBundleRef::fresh_for_run(&self.context),
+            messages,
+            surface_version: request.surface_version.clone(),
+        };
+        self.milestones
+            .prompt_bundle_built(
+                bundle.bundle_ref.clone(),
+                request.mode,
+                bundle.surface_version.clone(),
+                bundle.messages.len(),
+            )
+            .await?;
+        Ok(bundle)
+    }
+}

--- a/crates/ironclaw_turns/src/run_profile/prompt.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use super::host::{
-    AgentLoopHostError, AgentLoopHostErrorKind, LoopContextPort, LoopContextRequest,
-    LoopModelMessage, LoopPromptBundle, LoopPromptBundleRef, LoopPromptBundleRequest,
-    LoopPromptPort, LoopRunContext, PromptMode,
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilitySurfaceVersion, LoopContextBundle,
+    LoopContextPort, LoopContextRequest, LoopModelMessage, LoopPromptBundle, LoopPromptBundleRef,
+    LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, PromptMode,
 };
 use super::milestones::{LoopHostMilestoneEmitter, LoopHostMilestoneSink};
 
@@ -22,6 +22,7 @@ where
     context_port: Arc<C>,
     milestones: LoopHostMilestoneEmitter<S>,
     default_message_limit: usize,
+    current_surface_version: Option<CapabilitySurfaceVersion>,
 }
 
 impl<C, S> HostManagedLoopPromptPort<C, S>
@@ -35,11 +36,20 @@ where
             context_port,
             milestones: LoopHostMilestoneEmitter::new(context, milestone_sink),
             default_message_limit: DEFAULT_TEXT_ONLY_MESSAGE_LIMIT,
+            current_surface_version: None,
         }
     }
 
     pub fn with_default_message_limit(mut self, default_message_limit: usize) -> Self {
         self.default_message_limit = default_message_limit.clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT);
+        self
+    }
+
+    pub fn with_current_surface_version(
+        mut self,
+        current_surface_version: CapabilitySurfaceVersion,
+    ) -> Self {
+        self.current_surface_version = Some(current_surface_version);
         self
     }
 
@@ -65,6 +75,21 @@ where
             ));
         }
 
+        if let Some(surface_version) = request.surface_version.as_ref() {
+            let Some(current_surface_version) = self.current_surface_version.as_ref() else {
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::InvalidInvocation,
+                    "prompt surface version cannot be validated by this prompt port",
+                ));
+            };
+            if surface_version != current_surface_version {
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::StaleSurface,
+                    "prompt surface version is stale or unknown",
+                ));
+            }
+        }
+
         if let Some(state_ref) = request.checkpoint_state_ref.as_ref() {
             let run_prefix = format!("checkpoint:{}:", self.context.run_id);
             if !state_ref.as_str().starts_with(&run_prefix) {
@@ -79,12 +104,16 @@ where
                     "prompt checkpoint state ref is malformed",
                 ));
             }
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "checkpoint prompt state is not supported by the text-only prompt port",
+            ));
         }
 
-        if matches!(request.max_tokens, Some(0)) {
+        if matches!(request.max_messages, Some(0)) {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::BudgetExceeded,
-                "prompt token budget must be greater than zero",
+                "prompt message limit must be greater than zero",
             ));
         }
 
@@ -93,10 +122,22 @@ where
 
     fn message_limit(&self, request: &LoopPromptBundleRequest) -> usize {
         request
-            .max_tokens
-            .map(|tokens| tokens as usize)
+            .max_messages
+            .map(|messages| messages as usize)
             .unwrap_or(self.default_message_limit)
             .clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT)
+    }
+
+    fn ensure_supported_context_shape(
+        context: &LoopContextBundle,
+    ) -> Result<(), AgentLoopHostError> {
+        if !context.instruction_snippets.is_empty() || !context.memory_snippets.is_empty() {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::PolicyDenied,
+                "text-only prompt port cannot materialize instruction or memory snippets",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -118,6 +159,7 @@ where
                 limit: self.message_limit(&request),
             })
             .await?;
+        Self::ensure_supported_context_shape(&context)?;
         let messages = context
             .messages
             .into_iter()

--- a/crates/ironclaw_turns/src/run_profile/prompt.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt.rs
@@ -12,6 +12,15 @@ use super::milestones::{LoopHostMilestoneEmitter, LoopHostMilestoneSink};
 const DEFAULT_TEXT_ONLY_MESSAGE_LIMIT: usize = 32;
 const MAX_TEXT_ONLY_MESSAGE_LIMIT: usize = 128;
 
+/// Text-only host-managed prompt bundle port.
+///
+/// This adapter validates that prompt requests are scoped to the current
+/// [`LoopRunContext`], loads bounded transcript context through a
+/// [`LoopContextPort`], returns model-message references, and emits a
+/// `prompt_bundle_built` milestone containing only metadata. It currently
+/// supports [`PromptMode::TextOnly`] only; checkpoint-backed prompt state and
+/// instruction/memory snippet materialization fail closed until dedicated host
+/// stores are wired.
 #[derive(Clone)]
 pub struct HostManagedLoopPromptPort<C, S>
 where

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -11,20 +11,23 @@ use ironclaw_turns::{
     LoopCompleted, LoopCompletionKind, LoopExit, LoopExitId, LoopGateRef, LoopMessageRef,
     ReplyTargetBindingRef, RunProfileRequest, RunProfileVersion, SourceBindingRef,
     SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCheckpointId, TurnCoordinator,
-    TurnLeaseToken, TurnRunId, TurnRunnerId,
+    TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnStatus,
+    events::EventCursor,
     run_profile::{
         AgentLoopDriverHost, AgentLoopHostError, AgentLoopHostErrorKind, AssistantReply,
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDescriptorView,
         CapabilityInputRef, CapabilityInvocation, CapabilityOutcome, CapabilitySurfaceVersion,
-        FinalizeAssistantMessage, HostManagedLoopModelPort, InMemoryLoopHostMilestoneSink,
-        LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort, LoopCheckpointRequest,
-        LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage, LoopContextPort,
-        LoopContextRequest, LoopDriverNoteKind, LoopHostMilestone, LoopHostMilestoneEmitter,
-        LoopHostMilestoneKind, LoopHostMilestoneSink, LoopInputBatch, LoopInputCursor,
-        LoopInputCursorToken, LoopInputPort, LoopModelGateway, LoopModelGatewayError,
-        LoopModelGatewayRequest, LoopModelMessage, LoopModelPort, LoopModelRequest,
-        LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopRunContext, LoopRunInfoPort,
-        LoopTranscriptPort, ParentLoopOutput, VisibleCapabilityRequest, VisibleCapabilitySurface,
+        FinalizeAssistantMessage, HostManagedLoopModelPort, HostManagedLoopPromptPort,
+        InMemoryLoopHostMilestoneSink, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
+        LoopCheckpointRequest, LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage,
+        LoopContextPort, LoopContextRequest, LoopDriverId, LoopDriverNoteKind, LoopHostMilestone,
+        LoopHostMilestoneEmitter, LoopHostMilestoneKind, LoopHostMilestoneSink, LoopInputBatch,
+        LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelGateway,
+        LoopModelGatewayError, LoopModelGatewayRequest, LoopModelMessage, LoopModelPort,
+        LoopModelRequest, LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopPromptBundle,
+        LoopPromptBundleRef, LoopPromptBundleRequest, LoopPromptPort, LoopRunContext,
+        LoopRunInfoPort, LoopTranscriptPort, ParentLoopOutput, PromptMode,
+        VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
     runner::{ClaimRunRequest, TurnRunTransitionPort},
 };
@@ -58,8 +61,10 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
     assert_eq!(
         host.effects(),
         vec![
-            "context",
             "visible_capabilities",
+            "prompt_bundle",
+            "context",
+            "milestone:prompt_bundle_built",
             "model",
             "milestone:model_started",
             "milestone:model_completed",
@@ -80,6 +85,7 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
     assert_eq!(
         host.milestone_kind_names(),
         vec![
+            "prompt_bundle_built",
             "model_started",
             "model_completed",
             "assistant_reply_finalized",
@@ -88,7 +94,7 @@ async fn two_fake_drivers_use_the_same_per_run_agent_loop_host_contract() {
     let milestones = host.milestones();
     assert!(matches!(
         &milestones[0].kind,
-        LoopHostMilestoneKind::ModelStarted { .. }
+        LoopHostMilestoneKind::PromptBundleBuilt { .. }
     ));
     assert!(milestones.iter().all(|milestone| {
         milestone.scope == host.context.scope
@@ -226,6 +232,198 @@ async fn host_managed_model_port_sanitizes_gateway_errors() {
 }
 
 #[tokio::test]
+async fn loop_prompt_port_builds_text_only_bundle_from_context_refs() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let surface_version = CapabilitySurfaceVersion::new("surface-v1").unwrap();
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let bundle = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(surface_version.clone()),
+            checkpoint_state_ref: None,
+            max_tokens: Some(8),
+        })
+        .await
+        .unwrap();
+
+    assert!(bundle.bundle_ref.is_for_run(&host.context));
+    assert_eq!(bundle.surface_version, Some(surface_version));
+    assert_eq!(
+        bundle.messages,
+        vec![LoopModelMessage {
+            role: "user".to_string(),
+            content_ref: LoopMessageRef::new("msg:user-message").unwrap(),
+        }]
+    );
+    assert_eq!(host.effects(), vec!["context"]);
+    assert_eq!(host.milestone_kind_names(), vec!["prompt_bundle_built"]);
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_unsupported_prompt_mode() {
+    let host = Arc::new(RecordingAgentLoopHost::new(codeact_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::CodeAct,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_tokens: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_malformed_same_run_checkpoint_ref() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: Some(
+                LoopCheckpointStateRef::new(format!(
+                    "checkpoint:{}:/host/path",
+                    host.context.run_id
+                ))
+                .unwrap(),
+            ),
+            max_tokens: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_cross_run_checkpoint_ref() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let other_context = LoopRunContext::new(
+        host.context.scope.clone(),
+        host.context.turn_id,
+        TurnRunId::new(),
+        host.context.resolved_run_profile.clone(),
+    );
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: Some(
+                LoopCheckpointStateRef::for_run(&other_context, "foreign-state").unwrap(),
+            ),
+            max_tokens: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
+    assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_bundle_public_serialization_hides_raw_content() {
+    let host = Arc::new(
+        RecordingAgentLoopHost::new(claimed_run_context().await)
+            .with_context_message_safe_summary("RAW_PROMPT_SENTINEL /host/path secret"),
+    );
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let bundle = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_tokens: None,
+        })
+        .await
+        .unwrap();
+
+    let status = TurnRunState {
+        scope: host.context.scope.clone(),
+        turn_id: host.context.turn_id,
+        run_id: host.context.run_id,
+        status: TurnStatus::Running,
+        accepted_message_ref: AcceptedMessageRef::new("message-loop-host").unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-loop-host").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-loop-host").unwrap(),
+        resolved_run_profile_id: host.context.resolved_run_profile.profile_id.clone(),
+        resolved_run_profile_version: host.context.resolved_run_profile.profile_version,
+        received_at: Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap(),
+        checkpoint_id: None,
+        gate_ref: None,
+        failure: None,
+        event_cursor: EventCursor(0),
+    };
+    let public_json = serde_json::to_string(&(bundle, host.milestones(), status)).unwrap();
+    assert!(public_json.contains("prompt_bundle_built"));
+    assert!(!public_json.contains("RAW_PROMPT_SENTINEL"));
+    assert!(!public_json.contains("/host/path"));
+    assert!(!public_json.contains("secret"));
+}
+
+#[test]
+fn prompt_mode_wire_shape_uses_issue_contract_spelling() {
+    assert_eq!(
+        serde_json::to_string(&PromptMode::TextOnly).unwrap(),
+        "\"text_only\""
+    );
+    assert_eq!(
+        serde_json::to_string(&PromptMode::CodeAct).unwrap(),
+        "\"codeact\""
+    );
+    assert_eq!(
+        serde_json::from_str::<PromptMode>("\"codeact\"").unwrap(),
+        PromptMode::CodeAct
+    );
+}
+
+#[tokio::test]
+async fn prompt_bundle_refs_are_scoped_and_bounded() {
+    let context = claimed_run_context().await;
+    let bundle_ref = LoopPromptBundleRef::for_run(&context, "bundle-one").unwrap();
+
+    assert!(bundle_ref.is_for_run(&context));
+    assert!(LoopPromptBundleRef::new("prompt:missing-run-scope").is_err());
+    assert!(LoopPromptBundleRef::for_run(&context, "x".repeat(200)).is_err());
+}
+
+#[tokio::test]
 async fn capability_invocations_must_cite_visible_surface_before_host_dispatch() {
     let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
     let foreign = CapabilityId::new("demo.foreign").unwrap();
@@ -360,24 +558,25 @@ impl AgentLoopDriver for ReplyDriver {
     ) -> Result<LoopExit, AgentLoopDriverError> {
         assert_eq!(host.run_context().turn_id, request.turn_id);
         assert_eq!(host.run_context().run_id, request.run_id);
-        let context = host
-            .load_loop_context(LoopContextRequest {
-                after: None,
-                limit: 8,
+        let surface = host
+            .visible_capabilities(VisibleCapabilityRequest)
+            .await
+            .map_err(driver_error)?;
+        let prompt = host
+            .build_prompt_bundle(LoopPromptBundleRequest {
+                mode: PromptMode::TextOnly,
+                context_cursor: None,
+                surface_version: Some(surface.version),
+                checkpoint_state_ref: None,
+                max_tokens: Some(8),
             })
             .await
             .map_err(driver_error)?;
-        assert_eq!(context.messages.len(), 1);
-        host.visible_capabilities(VisibleCapabilityRequest)
-            .await
-            .map_err(driver_error)?;
+        assert_eq!(prompt.messages.len(), 1);
         let response = host
             .stream_model(LoopModelRequest {
-                messages: vec![LoopModelMessage {
-                    role: "user".to_string(),
-                    content_ref: context.messages[0].message_ref.clone(),
-                }],
-                surface_version: Some(CapabilitySurfaceVersion::new("surface-v1").unwrap()),
+                messages: prompt.messages,
+                surface_version: prompt.surface_version,
                 model_preference: Some(
                     host.run_context()
                         .resolved_run_profile
@@ -565,6 +764,7 @@ struct RecordingAgentLoopHost {
     capability_outcomes: Mutex<Vec<CapabilityOutcome>>,
     visible_surface: VisibleCapabilitySurface,
     milestone_sink: Arc<InMemoryLoopHostMilestoneSink>,
+    context_message_safe_summary: String,
 }
 
 impl RecordingAgentLoopHost {
@@ -585,7 +785,13 @@ impl RecordingAgentLoopHost {
                     safe_description: "Returns an opaque result ref".to_string(),
                 }],
             },
+            context_message_safe_summary: "hello".to_string(),
         }
+    }
+
+    fn with_context_message_safe_summary(mut self, safe_summary: impl Into<String>) -> Self {
+        self.context_message_safe_summary = safe_summary.into();
+        self
     }
 
     fn push_model_response(&self, response: LoopModelResponse) {
@@ -637,7 +843,7 @@ impl LoopContextPort for RecordingAgentLoopHost {
             messages: vec![LoopContextMessage {
                 message_ref: LoopMessageRef::new("msg:user-message").unwrap(),
                 role: "user".to_string(),
-                safe_summary: "hello".to_string(),
+                safe_summary: self.context_message_safe_summary.clone(),
             }],
             instruction_snippets: Vec::new(),
             memory_snippets: Vec::new(),
@@ -663,6 +869,46 @@ impl LoopInputPort for RecordingAgentLoopHost {
 
     async fn ack_inputs(&self, _cursor: LoopInputCursor) -> Result<(), AgentLoopHostError> {
         Ok(())
+    }
+}
+
+#[async_trait]
+impl LoopPromptPort for RecordingAgentLoopHost {
+    async fn build_prompt_bundle(
+        &self,
+        request: LoopPromptBundleRequest,
+    ) -> Result<LoopPromptBundle, AgentLoopHostError> {
+        self.record("prompt_bundle");
+        let context = self
+            .load_loop_context(LoopContextRequest {
+                after: request.context_cursor,
+                limit: request.max_tokens.unwrap_or(8) as usize,
+            })
+            .await?;
+        let bundle = LoopPromptBundle {
+            bundle_ref: LoopPromptBundleRef::for_run(&self.context, "recording-host").map_err(
+                |reason| AgentLoopHostError::new(AgentLoopHostErrorKind::Internal, reason),
+            )?,
+            messages: context
+                .messages
+                .into_iter()
+                .map(|message| LoopModelMessage {
+                    role: message.role,
+                    content_ref: message.message_ref,
+                })
+                .collect(),
+            surface_version: request.surface_version,
+        };
+        self.milestone_emitter()
+            .prompt_bundle_built(
+                bundle.bundle_ref.clone(),
+                request.mode,
+                bundle.surface_version.clone(),
+                bundle.messages.len(),
+            )
+            .await?;
+        self.record("milestone:prompt_bundle_built");
+        Ok(bundle)
     }
 }
 
@@ -777,6 +1023,16 @@ impl LoopProgressPort for RecordingAgentLoopHost {
         self.record(format!("progress:{}", event.kind_name()));
         Ok(())
     }
+}
+
+async fn codeact_run_context() -> LoopRunContext {
+    let mut context = claimed_run_context().await;
+    let codeact_descriptor =
+        AgentLoopDriverDescriptor::new("codeact_loop", RunProfileVersion::new(1)).unwrap();
+    context.loop_driver_id = LoopDriverId::new("codeact_loop").unwrap();
+    context.loop_driver_version = codeact_descriptor.version;
+    context.resolved_run_profile.loop_driver = codeact_descriptor;
+    context
 }
 
 async fn claimed_run_context() -> LoopRunContext {

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -20,9 +20,9 @@ use ironclaw_turns::{
         FinalizeAssistantMessage, HostManagedLoopModelPort, HostManagedLoopPromptPort,
         InMemoryLoopHostMilestoneSink, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
         LoopCheckpointRequest, LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage,
-        LoopContextPort, LoopContextRequest, LoopDriverId, LoopDriverNoteKind, LoopHostMilestone,
-        LoopHostMilestoneEmitter, LoopHostMilestoneKind, LoopHostMilestoneSink, LoopInputBatch,
-        LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelGateway,
+        LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopDriverId, LoopDriverNoteKind,
+        LoopHostMilestone, LoopHostMilestoneEmitter, LoopHostMilestoneKind, LoopHostMilestoneSink,
+        LoopInputBatch, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelGateway,
         LoopModelGatewayError, LoopModelGatewayRequest, LoopModelMessage, LoopModelPort,
         LoopModelRequest, LoopModelResponse, LoopProgressEvent, LoopProgressPort, LoopPromptBundle,
         LoopPromptBundleRef, LoopPromptBundleRequest, LoopPromptPort, LoopRunContext,
@@ -239,7 +239,8 @@ async fn loop_prompt_port_builds_text_only_bundle_from_context_refs() {
         host.context.clone(),
         host.clone(),
         host.milestone_sink.clone(),
-    );
+    )
+    .with_current_surface_version(surface_version.clone());
 
     let bundle = port
         .build_prompt_bundle(LoopPromptBundleRequest {
@@ -247,7 +248,7 @@ async fn loop_prompt_port_builds_text_only_bundle_from_context_refs() {
             context_cursor: None,
             surface_version: Some(surface_version.clone()),
             checkpoint_state_ref: None,
-            max_tokens: Some(8),
+            max_messages: Some(8),
         })
         .await
         .unwrap();
@@ -280,7 +281,7 @@ async fn loop_prompt_port_rejects_unsupported_prompt_mode() {
             context_cursor: None,
             surface_version: None,
             checkpoint_state_ref: None,
-            max_tokens: None,
+            max_messages: None,
         })
         .await
         .unwrap_err();
@@ -310,7 +311,7 @@ async fn loop_prompt_port_rejects_malformed_same_run_checkpoint_ref() {
                 ))
                 .unwrap(),
             ),
-            max_tokens: None,
+            max_messages: None,
         })
         .await
         .unwrap_err();
@@ -342,13 +343,155 @@ async fn loop_prompt_port_rejects_cross_run_checkpoint_ref() {
             checkpoint_state_ref: Some(
                 LoopCheckpointStateRef::for_run(&other_context, "foreign-state").unwrap(),
             ),
-            max_tokens: None,
+            max_messages: None,
         })
         .await
         .unwrap_err();
 
     assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
     assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_checkpoint_state_ref_until_supported() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: Some(
+                LoopCheckpointStateRef::for_run(&host.context, "resume-state").unwrap(),
+            ),
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert_eq!(host.effects(), Vec::<String>::new());
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_unvalidated_surface_version() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(CapabilitySurfaceVersion::new("surface-v1").unwrap()),
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+    assert_eq!(host.effects(), Vec::<String>::new());
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_stale_surface_version() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    )
+    .with_current_surface_version(CapabilitySurfaceVersion::new("surface-v2").unwrap());
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(CapabilitySurfaceVersion::new("surface-v1").unwrap()),
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::StaleSurface);
+    assert_eq!(host.effects(), Vec::<String>::new());
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_snippets_it_cannot_materialize() {
+    let host = Arc::new(
+        RecordingAgentLoopHost::new(claimed_run_context().await)
+            .with_context_instruction_snippet("instruction:system", "system instruction available")
+            .with_context_memory_snippet("memory:project", "project memory available"),
+    );
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    assert_eq!(host.effects(), vec!["context"]);
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_rejects_zero_message_limit() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(0),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::BudgetExceeded);
+    assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[test]
+fn capability_surface_versions_are_public_safe_tokens() {
+    assert!(CapabilitySurfaceVersion::new("surface-v1").is_ok());
+    assert!(CapabilitySurfaceVersion::new("empty:v1").is_ok());
+    assert!(CapabilitySurfaceVersion::new("/host/path/surface").is_err());
+    assert!(CapabilitySurfaceVersion::new("api_key:sk-test-secret").is_err());
+    assert!(CapabilitySurfaceVersion::new("bearer:sk-test-secret").is_err());
+    assert!(CapabilitySurfaceVersion::new("secret:v1").is_err());
+    assert!(CapabilitySurfaceVersion::new("surface v1").is_err());
 }
 
 #[tokio::test]
@@ -369,7 +512,7 @@ async fn loop_prompt_bundle_public_serialization_hides_raw_content() {
             context_cursor: None,
             surface_version: None,
             checkpoint_state_ref: None,
-            max_tokens: None,
+            max_messages: None,
         })
         .await
         .unwrap();
@@ -568,7 +711,7 @@ impl AgentLoopDriver for ReplyDriver {
                 context_cursor: None,
                 surface_version: Some(surface.version),
                 checkpoint_state_ref: None,
-                max_tokens: Some(8),
+                max_messages: Some(8),
             })
             .await
             .map_err(driver_error)?;
@@ -765,6 +908,8 @@ struct RecordingAgentLoopHost {
     visible_surface: VisibleCapabilitySurface,
     milestone_sink: Arc<InMemoryLoopHostMilestoneSink>,
     context_message_safe_summary: String,
+    context_instruction_snippets: Vec<LoopContextSnippet>,
+    context_memory_snippets: Vec<LoopContextSnippet>,
 }
 
 impl RecordingAgentLoopHost {
@@ -786,11 +931,37 @@ impl RecordingAgentLoopHost {
                 }],
             },
             context_message_safe_summary: "hello".to_string(),
+            context_instruction_snippets: Vec::new(),
+            context_memory_snippets: Vec::new(),
         }
     }
 
     fn with_context_message_safe_summary(mut self, safe_summary: impl Into<String>) -> Self {
         self.context_message_safe_summary = safe_summary.into();
+        self
+    }
+
+    fn with_context_instruction_snippet(
+        mut self,
+        snippet_ref: impl Into<String>,
+        safe_summary: impl Into<String>,
+    ) -> Self {
+        self.context_instruction_snippets.push(LoopContextSnippet {
+            snippet_ref: snippet_ref.into(),
+            safe_summary: safe_summary.into(),
+        });
+        self
+    }
+
+    fn with_context_memory_snippet(
+        mut self,
+        snippet_ref: impl Into<String>,
+        safe_summary: impl Into<String>,
+    ) -> Self {
+        self.context_memory_snippets.push(LoopContextSnippet {
+            snippet_ref: snippet_ref.into(),
+            safe_summary: safe_summary.into(),
+        });
         self
     }
 
@@ -845,8 +1016,8 @@ impl LoopContextPort for RecordingAgentLoopHost {
                 role: "user".to_string(),
                 safe_summary: self.context_message_safe_summary.clone(),
             }],
-            instruction_snippets: Vec::new(),
-            memory_snippets: Vec::new(),
+            instruction_snippets: self.context_instruction_snippets.clone(),
+            memory_snippets: self.context_memory_snippets.clone(),
         })
     }
 }
@@ -882,7 +1053,7 @@ impl LoopPromptPort for RecordingAgentLoopHost {
         let context = self
             .load_loop_context(LoopContextRequest {
                 after: request.context_cursor,
-                limit: request.max_tokens.unwrap_or(8) as usize,
+                limit: request.max_messages.unwrap_or(8) as usize,
             })
             .await?;
         let bundle = LoopPromptBundle {

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -353,6 +353,38 @@ async fn loop_prompt_port_rejects_cross_run_checkpoint_ref() {
 }
 
 #[tokio::test]
+async fn loop_prompt_port_rejects_cross_run_context_cursor() {
+    let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let other_context = LoopRunContext::new(
+        host.context.scope.clone(),
+        host.context.turn_id,
+        TurnRunId::new(),
+        host.context.resolved_run_profile.clone(),
+    );
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let error = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: Some(LoopInputCursor::origin_for_run(&other_context)),
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
+    assert_eq!(host.effects(), Vec::<String>::new());
+    assert!(host.context_requests().is_empty());
+    assert!(host.milestones().is_empty());
+}
+
+#[tokio::test]
 async fn loop_prompt_port_rejects_checkpoint_state_ref_until_supported() {
     let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
     let port = HostManagedLoopPromptPort::new(
@@ -481,6 +513,68 @@ async fn loop_prompt_port_rejects_zero_message_limit() {
 
     assert_eq!(error.kind, AgentLoopHostErrorKind::BudgetExceeded);
     assert_eq!(host.effects(), Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn loop_prompt_port_clamps_default_and_requested_message_limits() {
+    let zero_default_host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let zero_default_port = HostManagedLoopPromptPort::new(
+        zero_default_host.context.clone(),
+        zero_default_host.clone(),
+        zero_default_host.milestone_sink.clone(),
+    )
+    .with_default_message_limit(0);
+
+    zero_default_port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(zero_default_host.context_request_limits(), vec![1]);
+
+    let high_default_host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let high_default_port = HostManagedLoopPromptPort::new(
+        high_default_host.context.clone(),
+        high_default_host.clone(),
+        high_default_host.milestone_sink.clone(),
+    )
+    .with_default_message_limit(usize::MAX);
+
+    high_default_port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(high_default_host.context_request_limits(), vec![128]);
+
+    let high_request_host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
+    let high_request_port = HostManagedLoopPromptPort::new(
+        high_request_host.context.clone(),
+        high_request_host.clone(),
+        high_request_host.milestone_sink.clone(),
+    );
+
+    high_request_port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(u32::MAX),
+        })
+        .await
+        .unwrap();
+    assert_eq!(high_request_host.context_request_limits(), vec![128]);
 }
 
 #[test]
@@ -903,6 +997,7 @@ impl LoopModelGateway for RecordingLoopModelGateway {
 struct RecordingAgentLoopHost {
     context: LoopRunContext,
     effects: Mutex<Vec<String>>,
+    context_requests: Mutex<Vec<LoopContextRequest>>,
     model_responses: Mutex<Vec<LoopModelResponse>>,
     capability_outcomes: Mutex<Vec<CapabilityOutcome>>,
     visible_surface: VisibleCapabilitySurface,
@@ -917,6 +1012,7 @@ impl RecordingAgentLoopHost {
         Self {
             context,
             effects: Mutex::new(Vec::new()),
+            context_requests: Mutex::new(Vec::new()),
             model_responses: Mutex::new(Vec::new()),
             capability_outcomes: Mutex::new(Vec::new()),
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
@@ -977,6 +1073,17 @@ impl RecordingAgentLoopHost {
         self.effects.lock().unwrap().clone()
     }
 
+    fn context_requests(&self) -> Vec<LoopContextRequest> {
+        self.context_requests.lock().unwrap().clone()
+    }
+
+    fn context_request_limits(&self) -> Vec<usize> {
+        self.context_requests()
+            .into_iter()
+            .map(|request| request.limit)
+            .collect()
+    }
+
     fn milestones(&self) -> Vec<ironclaw_turns::run_profile::LoopHostMilestone> {
         self.milestone_sink.milestones()
     }
@@ -1007,8 +1114,9 @@ impl LoopRunInfoPort for RecordingAgentLoopHost {
 impl LoopContextPort for RecordingAgentLoopHost {
     async fn load_loop_context(
         &self,
-        _request: LoopContextRequest,
+        request: LoopContextRequest,
     ) -> Result<LoopContextBundle, AgentLoopHostError> {
+        self.context_requests.lock().unwrap().push(request);
         self.record("context");
         Ok(LoopContextBundle {
             messages: vec![LoopContextMessage {


### PR DESCRIPTION
## Summary
- add `LoopPromptPort` and prompt bundle DTOs for host-owned prompt materialization
- add scoped/bounded `LoopPromptBundleRef` plus checkpoint-state scope validation for prompt requests
- add a text-only `HostManagedLoopPromptPort` that wraps existing context refs without exposing raw prompt content
- extend `AgentLoopDriverHost` with the prompt port and emit safe prompt bundle milestones

Closes #3409

## Tests
- `cargo fmt --check`
- `cargo test --manifest-path crates/ironclaw_turns/Cargo.toml`
- `cargo clippy --manifest-path crates/ironclaw_turns/Cargo.toml --all-targets -- -D warnings`
- `cargo test -p ironclaw_loop_support`
- `cargo test -p ironclaw_reborn --tests`
