### PR TITLE
fix(secrets): harden durable credential stores

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,6 +188,47 @@ jobs:
           timeout --signal=INT --kill-after=30s 40m \
             cargo test ${{ matrix.flags }} -- --nocapture
 
+  credential-store-postgres-tests:
+    name: Credential Store Postgres Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.has_core_code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ironclaw_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      DATABASE_URL: postgres://postgres:postgres@localhost/ironclaw_test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: credential-store-postgres
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Run credential store Postgres contract
+        run: |
+          timeout --signal=INT --kill-after=30s 10m \
+            cargo test -p ironclaw_secrets --no-default-features --features postgres --test db_credential_store_contract -- --nocapture
+
   heavy-integration-tests:
     name: Heavy Integration Tests
     needs: changes

--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -149,7 +149,7 @@ impl CredentialAccountStore for LibSqlCredentialStore {
         &self,
         account: CredentialAccount,
     ) -> Result<CredentialAccount, CredentialBrokerError> {
-        let conn = libsql_begin_exclusive(&self.db).await?;
+        let conn = libsql_begin_immediate(&self.db).await?;
         let result = async {
             libsql_upsert_account(&conn, &self.crypto, &account).await?;
             Ok(account)
@@ -183,7 +183,7 @@ impl CredentialSessionStore for LibSqlCredentialStore {
         &self,
         session: CredentialSession,
     ) -> Result<CredentialSession, CredentialBrokerError> {
-        let conn = libsql_begin_exclusive(&self.db).await?;
+        let conn = libsql_begin_immediate(&self.db).await?;
         let result = async {
             libsql_upsert_session(&conn, &self.crypto, &session, 0).await?;
             Ok(session)
@@ -225,7 +225,7 @@ impl CredentialSessionStore for LibSqlCredentialStore {
         session_id: CredentialSessionId,
         now: ironclaw_host_api::Timestamp,
     ) -> Result<CredentialSession, CredentialBrokerError> {
-        let conn = libsql_begin_exclusive(&self.db).await?;
+        let conn = libsql_begin_immediate(&self.db).await?;
         let result = async {
             if let Some(record) =
                 libsql_consume_session_record(&conn, &self.crypto, scope, session_id, now).await?
@@ -435,11 +435,11 @@ async fn libsql_connect(
 }
 
 #[cfg(feature = "libsql")]
-async fn libsql_begin_exclusive(
+async fn libsql_begin_immediate(
     db: &libsql::Database,
 ) -> Result<libsql::Connection, CredentialBrokerError> {
     let conn = libsql_connect(db).await?;
-    conn.execute("BEGIN EXCLUSIVE", ())
+    conn.execute("BEGIN IMMEDIATE", ())
         .await
         .map_err(db_error)?;
     Ok(conn)
@@ -893,8 +893,10 @@ async fn libsql_ensure_session_account_foreign_key(
     if libsql_session_account_foreign_key_exists(conn).await? {
         return Ok(());
     }
-    conn.execute_batch(
-        r#"
+    let migration_result = conn
+        .execute_batch(
+            r#"
+        BEGIN IMMEDIATE;
         DROP TABLE IF EXISTS reborn_credential_sessions_with_account_fk;
         CREATE TABLE reborn_credential_sessions_with_account_fk (
             tenant_id TEXT NOT NULL,
@@ -933,10 +935,14 @@ async fn libsql_ensure_session_account_foreign_key(
         ALTER TABLE reborn_credential_sessions_with_account_fk RENAME TO reborn_credential_sessions;
         CREATE INDEX IF NOT EXISTS idx_reborn_credential_sessions_account
             ON reborn_credential_sessions(tenant_id, user_id, agent_id, project_id, account_id);
+        COMMIT;
         "#,
-    )
-    .await
-    .map_err(db_error)?;
+        )
+        .await;
+    if let Err(error) = migration_result {
+        let _ = conn.execute("ROLLBACK", ()).await;
+        return Err(db_error(error));
+    }
     Ok(())
 }
 

--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -1,6 +1,20 @@
+//! Durable credential-store backends for IronClaw Reborn.
+//!
+//! Account and session payloads are encrypted with [`SecretsCrypto`] before they
+//! are written to libSQL or PostgreSQL. Operators must still enable
+//! storage-layer encryption for database files, WALs, snapshots, and backups
+//! because scope keys, account ids, encrypted blobs, and indexes remain durable
+//! metadata outside the encrypted payload.
+
 use std::sync::Arc;
 
-use ironclaw_host_api::ResourceScope;
+use ironclaw_host_api::{
+    CapabilityId, ExtensionId, InvocationId, ResourceScope, SecretHandle, Timestamp,
+};
+use serde::{Deserialize, Serialize};
+
+const CREDENTIAL_ACCOUNTS_FOR_SCOPE_LIMIT: usize = 1000;
+const CREDENTIAL_ACCOUNTS_FOR_SCOPE_QUERY_LIMIT: i64 = 1001;
 
 use crate::{
     CredentialAccount, CredentialAccountId, CredentialAccountStatus, CredentialAccountStore,
@@ -43,7 +57,12 @@ CREATE TABLE IF NOT EXISTS reborn_credential_sessions (
     payload TEXT NOT NULL DEFAULT '{}',
     encrypted_payload BLOB NOT NULL DEFAULT X'',
     payload_key_salt BLOB NOT NULL DEFAULT X'',
-    PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id)
+    PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id),
+    CONSTRAINT reborn_credential_sessions_account_fk
+        FOREIGN KEY (tenant_id, user_id, agent_id, project_id, account_id)
+        REFERENCES reborn_credential_accounts(tenant_id, user_id, agent_id, project_id, account_id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT
 );
 CREATE INDEX IF NOT EXISTS idx_reborn_credential_sessions_account
     ON reborn_credential_sessions(tenant_id, user_id, agent_id, project_id, account_id);
@@ -84,7 +103,12 @@ CREATE TABLE IF NOT EXISTS reborn_credential_sessions (
     payload JSONB NOT NULL DEFAULT '{}'::jsonb,
     encrypted_payload BYTEA NOT NULL DEFAULT '\x'::bytea,
     payload_key_salt BYTEA NOT NULL DEFAULT '\x'::bytea,
-    PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id)
+    PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id),
+    CONSTRAINT reborn_credential_sessions_account_fk
+        FOREIGN KEY (tenant_id, user_id, agent_id, project_id, account_id)
+        REFERENCES reborn_credential_accounts(tenant_id, user_id, agent_id, project_id, account_id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT
 );
 CREATE INDEX IF NOT EXISTS idx_reborn_credential_sessions_account
     ON reborn_credential_sessions(tenant_id, user_id, agent_id, project_id, account_id);
@@ -108,6 +132,7 @@ impl LibSqlCredentialStore {
             .await
             .map_err(db_error)?;
         libsql_ensure_encrypted_payload_columns(&conn).await?;
+        libsql_ensure_session_account_foreign_key(&conn).await?;
         libsql_reject_unencrypted_payload_rows(&conn).await?;
         Ok(())
     }
@@ -124,7 +149,7 @@ impl CredentialAccountStore for LibSqlCredentialStore {
         &self,
         account: CredentialAccount,
     ) -> Result<CredentialAccount, CredentialBrokerError> {
-        let conn = libsql_begin_immediate(&self.db).await?;
+        let conn = libsql_begin_exclusive(&self.db).await?;
         let result = async {
             libsql_upsert_account(&conn, &self.crypto, &account).await?;
             Ok(account)
@@ -158,7 +183,7 @@ impl CredentialSessionStore for LibSqlCredentialStore {
         &self,
         session: CredentialSession,
     ) -> Result<CredentialSession, CredentialBrokerError> {
-        let conn = libsql_begin_immediate(&self.db).await?;
+        let conn = libsql_begin_exclusive(&self.db).await?;
         let result = async {
             libsql_upsert_session(&conn, &self.crypto, &session, 0).await?;
             Ok(session)
@@ -200,15 +225,15 @@ impl CredentialSessionStore for LibSqlCredentialStore {
         session_id: CredentialSessionId,
         now: ironclaw_host_api::Timestamp,
     ) -> Result<CredentialSession, CredentialBrokerError> {
-        let conn = libsql_begin_immediate(&self.db).await?;
+        let conn = libsql_begin_exclusive(&self.db).await?;
         let result = async {
-            let record = libsql_get_session_record(&conn, &self.crypto, scope, session_id)
-                .await?
-                .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
-            ensure_session_usable(&record, session_id, now)?;
-            let new_uses = record.uses + 1;
-            libsql_update_session_uses(&conn, scope, session_id, new_uses).await?;
-            Ok(record.session)
+            if let Some(record) =
+                libsql_consume_session_record(&conn, &self.crypto, scope, session_id, now).await?
+            {
+                return Ok(record.session);
+            }
+            let record = libsql_get_session_record(&conn, &self.crypto, scope, session_id).await?;
+            session_use_denial_result(record, session_id, now)
         }
         .await;
         finish_libsql_transaction(&conn, result).await
@@ -234,6 +259,7 @@ impl PostgresCredentialStore {
             .await
             .map_err(db_error)?;
         postgres_ensure_encrypted_payload_columns(&client).await?;
+        postgres_ensure_session_account_foreign_key(&client).await?;
         postgres_reject_unencrypted_payload_rows(&client).await
     }
 }
@@ -287,7 +313,7 @@ impl CredentialSessionStore for PostgresCredentialStore {
     ) -> Result<Option<CredentialSession>, CredentialBrokerError> {
         let client = self.pool.get().await.map_err(db_error)?;
         Ok(
-            postgres_get_session_record(&client, &self.crypto, scope, session_id, false)
+            postgres_get_session_record(&client, &self.crypto, scope, session_id)
                 .await?
                 .map(|record| record.session),
         )
@@ -300,7 +326,7 @@ impl CredentialSessionStore for PostgresCredentialStore {
         now: ironclaw_host_api::Timestamp,
     ) -> Result<CredentialSession, CredentialBrokerError> {
         let client = self.pool.get().await.map_err(db_error)?;
-        let record = postgres_get_session_record(&client, &self.crypto, scope, session_id, false)
+        let record = postgres_get_session_record(&client, &self.crypto, scope, session_id)
             .await?
             .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
         ensure_session_usable(&record, session_id, now)?;
@@ -314,16 +340,22 @@ impl CredentialSessionStore for PostgresCredentialStore {
         now: ironclaw_host_api::Timestamp,
     ) -> Result<CredentialSession, CredentialBrokerError> {
         let mut client = self.pool.get().await.map_err(db_error)?;
-        let transaction = client.transaction().await.map_err(db_error)?;
+        let transaction = client
+            .build_transaction()
+            .isolation_level(tokio_postgres::IsolationLevel::Serializable)
+            .start()
+            .await
+            .map_err(db_error)?;
         let result = async {
-            let record =
-                postgres_get_session_record(&transaction, &self.crypto, scope, session_id, true)
+            if let Some(record) =
+                postgres_consume_session_record(&transaction, &self.crypto, scope, session_id, now)
                     .await?
-                    .ok_or(CredentialBrokerError::UnknownSession { session_id })?;
-            ensure_session_usable(&record, session_id, now)?;
-            let new_uses = record.uses + 1;
-            postgres_update_session_uses(&transaction, scope, session_id, new_uses).await?;
-            Ok(record.session)
+            {
+                return Ok(record.session);
+            }
+            let record =
+                postgres_get_session_record(&transaction, &self.crypto, scope, session_id).await?;
+            session_use_denial_result(record, session_id, now)
         }
         .await;
         match result {
@@ -367,11 +399,35 @@ fn ensure_session_usable(
     Ok(())
 }
 
+fn session_use_denial_result(
+    record: Option<SessionRecord>,
+    session_id: CredentialSessionId,
+    now: ironclaw_host_api::Timestamp,
+) -> Result<CredentialSession, CredentialBrokerError> {
+    let record = record.ok_or(CredentialBrokerError::UnknownSession { session_id })?;
+    ensure_session_usable(&record, session_id, now)?;
+    Err(persistence_error(
+        "credential session use was not consumed atomically",
+    ))
+}
+
+fn ensure_account_result_within_limit(count: usize) -> Result<(), CredentialBrokerError> {
+    if count > CREDENTIAL_ACCOUNTS_FOR_SCOPE_LIMIT {
+        return Err(persistence_error(
+            "scope contains more than 1000 credential accounts; add pagination before listing",
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(feature = "libsql")]
 async fn libsql_connect(
     db: &libsql::Database,
 ) -> Result<libsql::Connection, CredentialBrokerError> {
     let conn = db.connect().map_err(db_error)?;
+    conn.execute("PRAGMA foreign_keys = ON", ())
+        .await
+        .map_err(db_error)?;
     conn.query("PRAGMA busy_timeout = 5000", ())
         .await
         .map_err(db_error)?;
@@ -379,11 +435,11 @@ async fn libsql_connect(
 }
 
 #[cfg(feature = "libsql")]
-async fn libsql_begin_immediate(
+async fn libsql_begin_exclusive(
     db: &libsql::Database,
 ) -> Result<libsql::Connection, CredentialBrokerError> {
     let conn = libsql_connect(db).await?;
-    conn.execute("BEGIN IMMEDIATE", ())
+    conn.execute("BEGIN EXCLUSIVE", ())
         .await
         .map_err(db_error)?;
     Ok(conn)
@@ -477,8 +533,14 @@ async fn libsql_accounts_for_scope(
     let key = DbScopeKey::from_account_scope(scope);
     let mut rows = conn
         .query(
-            "SELECT account_id, status, provider_or_extension_id, updated_at, encrypted_payload, payload_key_salt FROM reborn_credential_accounts WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 ORDER BY account_id",
-            libsql::params![key.tenant_id, key.user_id, key.agent_id, key.project_id],
+            "SELECT account_id, status, provider_or_extension_id, updated_at, encrypted_payload, payload_key_salt FROM reborn_credential_accounts WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 ORDER BY account_id LIMIT ?5",
+            libsql::params![
+                key.tenant_id,
+                key.user_id,
+                key.agent_id,
+                key.project_id,
+                CREDENTIAL_ACCOUNTS_FOR_SCOPE_QUERY_LIMIT,
+            ],
         )
         .await
         .map_err(db_error)?;
@@ -500,6 +562,7 @@ async fn libsql_accounts_for_scope(
             &updated_at,
         )?);
     }
+    ensure_account_result_within_limit(accounts.len())?;
     Ok(accounts)
 }
 
@@ -511,7 +574,7 @@ async fn libsql_upsert_session(
     uses: u64,
 ) -> Result<(), CredentialBrokerError> {
     let key = DbScopeKey::from_full_scope(session.scope());
-    let payload = encrypt_json_payload(crypto, session)?;
+    let payload = encrypt_session_payload(crypto, session)?;
     conn.execute(
         "INSERT INTO reborn_credential_sessions (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id, account_id, expires_at, max_uses, uses, payload, encrypted_payload, payload_key_salt) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, '{}', ?13, ?14) ON CONFLICT(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id) DO UPDATE SET account_id = EXCLUDED.account_id, expires_at = EXCLUDED.expires_at, max_uses = EXCLUDED.max_uses, uses = EXCLUDED.uses, payload = '{}', encrypted_payload = EXCLUDED.encrypted_payload, payload_key_salt = EXCLUDED.payload_key_salt",
         libsql::params![
@@ -561,7 +624,7 @@ async fn libsql_get_session_record(
     let encrypted_payload: Vec<u8> = row.get(4).map_err(db_error)?;
     let payload_key_salt: Vec<u8> = row.get(5).map_err(db_error)?;
     validate_session_row(
-        decrypt_json_payload(crypto, &encrypted_payload, &payload_key_salt)?,
+        decrypt_session_payload(crypto, &encrypted_payload, &payload_key_salt)?,
         scope,
         session_id,
         &account_id,
@@ -573,20 +636,50 @@ async fn libsql_get_session_record(
 }
 
 #[cfg(feature = "libsql")]
-async fn libsql_update_session_uses(
+async fn libsql_consume_session_record(
     conn: &libsql::Connection,
+    crypto: &SecretsCrypto,
     scope: &ResourceScope,
     session_id: CredentialSessionId,
-    uses: u64,
-) -> Result<(), CredentialBrokerError> {
+    now: ironclaw_host_api::Timestamp,
+) -> Result<Option<SessionRecord>, CredentialBrokerError> {
     let key = DbScopeKey::from_full_scope(scope);
-    conn.execute(
-        "UPDATE reborn_credential_sessions SET uses = ?1 WHERE tenant_id = ?2 AND user_id = ?3 AND agent_id = ?4 AND project_id = ?5 AND mission_id = ?6 AND thread_id = ?7 AND invocation_id = ?8 AND session_id = ?9",
-        libsql::params![uses as i64, key.tenant_id, key.user_id, key.agent_id, key.project_id, key.mission_id, key.thread_id, key.invocation_id, session_id.to_string()],
+    let mut rows = conn
+        .query(
+            "UPDATE reborn_credential_sessions SET uses = uses + 1 WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND invocation_id = ?7 AND session_id = ?8 AND (expires_at IS NULL OR expires_at > ?9) AND (max_uses IS NULL OR uses < max_uses) RETURNING account_id, expires_at, max_uses, uses, encrypted_payload, payload_key_salt",
+            libsql::params![
+                key.tenant_id,
+                key.user_id,
+                key.agent_id,
+                key.project_id,
+                key.mission_id,
+                key.thread_id,
+                key.invocation_id,
+                session_id.to_string(),
+                now.to_rfc3339(),
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = rows.next().await.map_err(db_error)? else {
+        return Ok(None);
+    };
+    let account_id: String = row.get(0).map_err(db_error)?;
+    let expires_at: Option<String> = row.get(1).map_err(db_error)?;
+    let max_uses: Option<i64> = row.get(2).map_err(db_error)?;
+    let uses: i64 = row.get(3).map_err(db_error)?;
+    let encrypted_payload: Vec<u8> = row.get(4).map_err(db_error)?;
+    let payload_key_salt: Vec<u8> = row.get(5).map_err(db_error)?;
+    validate_session_row(
+        decrypt_session_payload(crypto, &encrypted_payload, &payload_key_salt)?,
+        scope,
+        session_id,
+        &account_id,
+        expires_at.as_deref(),
+        max_uses,
+        uses,
     )
-    .await
-    .map_err(db_error)?;
-    Ok(())
+    .map(Some)
 }
 
 #[cfg(feature = "postgres")]
@@ -636,7 +729,7 @@ async fn postgres_accounts_for_scope(
     scope: &ResourceScope,
 ) -> Result<Vec<CredentialAccount>, CredentialBrokerError> {
     let key = DbScopeKey::from_account_scope(scope);
-    let rows = client.query("SELECT account_id, status, provider_or_extension_id, updated_at, encrypted_payload, payload_key_salt FROM reborn_credential_accounts WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 ORDER BY account_id", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id]).await.map_err(db_error)?;
+    let rows = client.query("SELECT account_id, status, provider_or_extension_id, updated_at, encrypted_payload, payload_key_salt FROM reborn_credential_accounts WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 ORDER BY account_id LIMIT $5", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &CREDENTIAL_ACCOUNTS_FOR_SCOPE_QUERY_LIMIT]).await.map_err(db_error)?;
     let mut accounts = Vec::new();
     for row in rows {
         let account_id: String = row.get(0);
@@ -655,6 +748,7 @@ async fn postgres_accounts_for_scope(
             &updated_at,
         )?);
     }
+    ensure_account_result_within_limit(accounts.len())?;
     Ok(accounts)
 }
 
@@ -667,7 +761,7 @@ async fn postgres_upsert_session(
 ) -> Result<(), CredentialBrokerError> {
     let key = DbScopeKey::from_full_scope(session.scope());
     let max_uses = session.max_uses().map(|value| value as i64);
-    let payload = encrypt_json_payload(crypto, session)?;
+    let payload = encrypt_session_payload(crypto, session)?;
     client.execute("INSERT INTO reborn_credential_sessions (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id, account_id, expires_at, max_uses, uses, payload, encrypted_payload, payload_key_salt) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, '{}'::jsonb, $13, $14) ON CONFLICT(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id) DO UPDATE SET account_id = EXCLUDED.account_id, expires_at = EXCLUDED.expires_at, max_uses = EXCLUDED.max_uses, uses = EXCLUDED.uses, payload = '{}'::jsonb, encrypted_payload = EXCLUDED.encrypted_payload, payload_key_salt = EXCLUDED.payload_key_salt", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &key.mission_id, &key.thread_id, &key.invocation_id, &session.correlation_id().to_string(), &session.account_id().as_str(), &session.expires_at().map(|value| value.to_rfc3339()), &max_uses, &(uses as i64), &payload.encrypted_value, &payload.key_salt]).await.map_err(db_error)?;
     Ok(())
 }
@@ -678,16 +772,11 @@ async fn postgres_get_session_record(
     crypto: &SecretsCrypto,
     scope: &ResourceScope,
     session_id: CredentialSessionId,
-    for_update: bool,
 ) -> Result<Option<SessionRecord>, CredentialBrokerError> {
     let key = DbScopeKey::from_full_scope(scope);
-    let suffix = if for_update { " FOR UPDATE" } else { "" };
-    let query = format!(
-        "SELECT account_id, expires_at, max_uses, uses, encrypted_payload, payload_key_salt FROM reborn_credential_sessions WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND invocation_id = $7 AND session_id = $8{suffix}"
-    );
     let row = client
         .query_opt(
-            &query,
+            "SELECT account_id, expires_at, max_uses, uses, encrypted_payload, payload_key_salt FROM reborn_credential_sessions WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND invocation_id = $7 AND session_id = $8",
             &[
                 &key.tenant_id,
                 &key.user_id,
@@ -711,7 +800,7 @@ async fn postgres_get_session_record(
     let encrypted_payload: Vec<u8> = row.get(4);
     let payload_key_salt: Vec<u8> = row.get(5);
     validate_session_row(
-        decrypt_json_payload(crypto, &encrypted_payload, &payload_key_salt)?,
+        decrypt_session_payload(crypto, &encrypted_payload, &payload_key_salt)?,
         scope,
         session_id,
         &account_id,
@@ -723,15 +812,50 @@ async fn postgres_get_session_record(
 }
 
 #[cfg(feature = "postgres")]
-async fn postgres_update_session_uses(
+async fn postgres_consume_session_record(
     client: &impl deadpool_postgres::GenericClient,
+    crypto: &SecretsCrypto,
     scope: &ResourceScope,
     session_id: CredentialSessionId,
-    uses: u64,
-) -> Result<(), CredentialBrokerError> {
+    now: ironclaw_host_api::Timestamp,
+) -> Result<Option<SessionRecord>, CredentialBrokerError> {
     let key = DbScopeKey::from_full_scope(scope);
-    client.execute("UPDATE reborn_credential_sessions SET uses = $1 WHERE tenant_id = $2 AND user_id = $3 AND agent_id = $4 AND project_id = $5 AND mission_id = $6 AND thread_id = $7 AND invocation_id = $8 AND session_id = $9", &[&(uses as i64), &key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &key.mission_id, &key.thread_id, &key.invocation_id, &session_id.to_string()]).await.map_err(db_error)?;
-    Ok(())
+    let row = client
+        .query_opt(
+            "UPDATE reborn_credential_sessions SET uses = uses + 1 WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND project_id = $4 AND mission_id = $5 AND thread_id = $6 AND invocation_id = $7 AND session_id = $8 AND (expires_at IS NULL OR expires_at > $9) AND (max_uses IS NULL OR uses < max_uses) RETURNING account_id, expires_at, max_uses, uses, encrypted_payload, payload_key_salt",
+            &[
+                &key.tenant_id,
+                &key.user_id,
+                &key.agent_id,
+                &key.project_id,
+                &key.mission_id,
+                &key.thread_id,
+                &key.invocation_id,
+                &session_id.to_string(),
+                &now.to_rfc3339(),
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let account_id: String = row.get(0);
+    let expires_at: Option<String> = row.get(1);
+    let max_uses: Option<i64> = row.get(2);
+    let uses: i64 = row.get(3);
+    let encrypted_payload: Vec<u8> = row.get(4);
+    let payload_key_salt: Vec<u8> = row.get(5);
+    validate_session_row(
+        decrypt_session_payload(crypto, &encrypted_payload, &payload_key_salt)?,
+        scope,
+        session_id,
+        &account_id,
+        expires_at.as_deref(),
+        max_uses,
+        uses,
+    )
+    .map(Some)
 }
 
 #[cfg(feature = "libsql")]
@@ -760,6 +884,77 @@ fn ignore_duplicate_column_error(error: libsql::Error) -> Result<(), CredentialB
     } else {
         Err(db_error(error))
     }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_ensure_session_account_foreign_key(
+    conn: &libsql::Connection,
+) -> Result<(), CredentialBrokerError> {
+    if libsql_session_account_foreign_key_exists(conn).await? {
+        return Ok(());
+    }
+    conn.execute_batch(
+        r#"
+        DROP TABLE IF EXISTS reborn_credential_sessions_with_account_fk;
+        CREATE TABLE reborn_credential_sessions_with_account_fk (
+            tenant_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            mission_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            invocation_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            expires_at TEXT,
+            max_uses INTEGER,
+            uses INTEGER NOT NULL DEFAULT 0,
+            payload TEXT NOT NULL DEFAULT '{}',
+            encrypted_payload BLOB NOT NULL DEFAULT X'',
+            payload_key_salt BLOB NOT NULL DEFAULT X'',
+            PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id),
+            CONSTRAINT reborn_credential_sessions_account_fk
+                FOREIGN KEY (tenant_id, user_id, agent_id, project_id, account_id)
+                REFERENCES reborn_credential_accounts(tenant_id, user_id, agent_id, project_id, account_id)
+                ON UPDATE CASCADE
+                ON DELETE RESTRICT
+        );
+        INSERT INTO reborn_credential_sessions_with_account_fk (
+            tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id,
+            session_id, account_id, expires_at, max_uses, uses, payload, encrypted_payload,
+            payload_key_salt
+        )
+        SELECT
+            tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id,
+            session_id, account_id, expires_at, max_uses, uses, payload, encrypted_payload,
+            payload_key_salt
+        FROM reborn_credential_sessions;
+        DROP TABLE reborn_credential_sessions;
+        ALTER TABLE reborn_credential_sessions_with_account_fk RENAME TO reborn_credential_sessions;
+        CREATE INDEX IF NOT EXISTS idx_reborn_credential_sessions_account
+            ON reborn_credential_sessions(tenant_id, user_id, agent_id, project_id, account_id);
+        "#,
+    )
+    .await
+    .map_err(db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_session_account_foreign_key_exists(
+    conn: &libsql::Connection,
+) -> Result<bool, CredentialBrokerError> {
+    let mut rows = conn
+        .query("PRAGMA foreign_key_list(reborn_credential_sessions)", ())
+        .await
+        .map_err(db_error)?;
+    while let Some(row) = rows.next().await.map_err(db_error)? {
+        let table: String = row.get(2).map_err(db_error)?;
+        if table == "reborn_credential_accounts" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 #[cfg(feature = "libsql")]
@@ -811,6 +1006,30 @@ async fn postgres_ensure_encrypted_payload_columns(
 }
 
 #[cfg(feature = "postgres")]
+async fn postgres_ensure_session_account_foreign_key(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<(), CredentialBrokerError> {
+    client
+        .batch_execute(
+            r#"
+            DO $$
+            BEGIN
+                ALTER TABLE reborn_credential_sessions
+                    ADD CONSTRAINT reborn_credential_sessions_account_fk
+                    FOREIGN KEY (tenant_id, user_id, agent_id, project_id, account_id)
+                    REFERENCES reborn_credential_accounts(tenant_id, user_id, agent_id, project_id, account_id)
+                    ON UPDATE CASCADE
+                    ON DELETE RESTRICT;
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END $$;
+            "#,
+        )
+        .await
+        .map_err(db_error)
+}
+
+#[cfg(feature = "postgres")]
 async fn postgres_reject_unencrypted_payload_rows(
     client: &impl deadpool_postgres::GenericClient,
 ) -> Result<(), CredentialBrokerError> {
@@ -847,6 +1066,74 @@ async fn postgres_has_unencrypted_rows(
 struct EncryptedPayload {
     encrypted_value: Vec<u8>,
     key_salt: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedCredentialSession {
+    scope: ResourceScope,
+    invocation_id: InvocationId,
+    capability_id: CapabilityId,
+    extension_id: ExtensionId,
+    account_id: CredentialAccountId,
+    secret_handles: Vec<SecretHandle>,
+    allowed_targets: Vec<crate::CredentialTargetPolicy>,
+    expires_at: Option<Timestamp>,
+    max_uses: Option<u64>,
+    correlation_id: String,
+}
+
+impl From<&CredentialSession> for PersistedCredentialSession {
+    fn from(session: &CredentialSession) -> Self {
+        Self {
+            scope: session.scope.clone(),
+            invocation_id: session.invocation_id,
+            capability_id: session.capability_id.clone(),
+            extension_id: session.extension_id.clone(),
+            account_id: session.account_id.clone(),
+            secret_handles: session.secret_handles.clone(),
+            allowed_targets: session.allowed_targets.clone(),
+            expires_at: session.expires_at,
+            max_uses: session.max_uses,
+            correlation_id: session.correlation_id.to_string(),
+        }
+    }
+}
+
+impl TryFrom<PersistedCredentialSession> for CredentialSession {
+    type Error = CredentialBrokerError;
+
+    fn try_from(value: PersistedCredentialSession) -> Result<Self, Self::Error> {
+        Ok(Self {
+            scope: value.scope,
+            invocation_id: value.invocation_id,
+            capability_id: value.capability_id,
+            extension_id: value.extension_id,
+            account_id: value.account_id,
+            secret_handles: value.secret_handles,
+            allowed_targets: value.allowed_targets,
+            expires_at: value.expires_at,
+            max_uses: value.max_uses,
+            correlation_id: CredentialSessionId::parse(&value.correlation_id)
+                .map_err(|error| persistence_error(error.to_string()))?,
+        })
+    }
+}
+
+fn encrypt_session_payload(
+    crypto: &SecretsCrypto,
+    session: &CredentialSession,
+) -> Result<EncryptedPayload, CredentialBrokerError> {
+    encrypt_json_payload(crypto, &PersistedCredentialSession::from(session))
+}
+
+fn decrypt_session_payload(
+    crypto: &SecretsCrypto,
+    encrypted_value: &[u8],
+    key_salt: &[u8],
+) -> Result<CredentialSession, CredentialBrokerError> {
+    let persisted: PersistedCredentialSession =
+        decrypt_json_payload(crypto, encrypted_value, key_salt)?;
+    persisted.try_into()
 }
 
 fn encrypt_json_payload<T: serde::Serialize>(

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -228,19 +228,33 @@ impl fmt::Display for CredentialAccountId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
+/// Opaque bearer-like identifier for a credential session.
+///
+/// This id is intentionally not `Serialize`: durable stores persist it through
+/// private encrypted DTOs only, and public API/log surfaces must not emit it as
+/// a reusable session credential.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CredentialSessionId(Uuid);
 
 impl CredentialSessionId {
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
+
+    pub fn parse(value: &str) -> Result<Self, uuid::Error> {
+        Uuid::parse_str(value).map(Self)
+    }
 }
 
 impl Default for CredentialSessionId {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl fmt::Debug for CredentialSessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CredentialSessionId([REDACTED])")
     }
 }
 
@@ -253,8 +267,12 @@ impl fmt::Display for CredentialSessionId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CredentialAccountStatus {
+    /// Account can issue new sessions and satisfy matching credential requests.
     Active,
+    /// Account can no longer issue sessions because its upstream credential or
+    /// configured lifetime has expired.
     Expired,
+    /// Account was explicitly disabled and must not issue new sessions.
     Revoked,
 }
 
@@ -323,7 +341,7 @@ pub struct CredentialAccount {
     pub updated_at: Timestamp,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CredentialSession {
     scope: ResourceScope,
     invocation_id: InvocationId,
@@ -1528,6 +1546,7 @@ mod tests {
         let debug = format!("{session:?}");
         assert!(!debug.contains("sk-live-sentinel"));
         assert!(!debug.contains("token"));
+        assert!(!debug.contains(&session.correlation_id().to_string()));
     }
 
     #[test]

--- a/crates/ironclaw_secrets/tests/db_credential_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_credential_store_contract.rs
@@ -228,6 +228,88 @@ async fn libsql_credential_store_rejects_sql_injected_scope_values() {
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn libsql_credential_store_keeps_legacy_session_table_when_fk_migration_fails() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("credentials.db");
+    let db = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let conn = db.connect().unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE reborn_credential_accounts (
+            tenant_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            provider_or_extension_id TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            payload TEXT NOT NULL DEFAULT '{}',
+            encrypted_payload BLOB NOT NULL DEFAULT X'',
+            payload_key_salt BLOB NOT NULL DEFAULT X'',
+            PRIMARY KEY (tenant_id, user_id, agent_id, project_id, account_id)
+        );
+        CREATE TABLE reborn_credential_sessions (
+            tenant_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            mission_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            invocation_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            expires_at TEXT,
+            max_uses INTEGER,
+            uses INTEGER NOT NULL DEFAULT 0,
+            payload TEXT NOT NULL DEFAULT '{}',
+            encrypted_payload BLOB NOT NULL DEFAULT X'00',
+            payload_key_salt BLOB NOT NULL DEFAULT X'00',
+            PRIMARY KEY (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id)
+        );
+        INSERT INTO reborn_credential_sessions (
+            tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id,
+            session_id, account_id, encrypted_payload, payload_key_salt
+        ) VALUES (
+            'tenant-a', 'user-a', 'agent-a', 'project-a', 'mission-a', 'thread-a', 'invocation-a',
+            'session-orphan', 'missing-account', X'01', X'02'
+        );
+        "#,
+    )
+    .await
+    .unwrap();
+    drop(conn);
+
+    let store = LibSqlCredentialStore::new(db.clone(), test_crypto());
+    let error = store.run_migrations().await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("constraint"),
+        "orphan legacy sessions should fail FK backfill: {error}"
+    );
+
+    let conn = db.connect().unwrap();
+    let mut rows = conn
+        .query("SELECT account_id FROM reborn_credential_sessions", ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    let account_id: String = row.get(0).unwrap();
+    assert_eq!(account_id, "missing-account");
+    let mut temp_rows = conn
+        .query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'reborn_credential_sessions_with_account_fk'",
+            (),
+        )
+        .await
+        .unwrap();
+    assert!(temp_rows.next().await.unwrap().is_none());
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn libsql_credential_store_rejects_sessions_without_matching_account_row() {
     let dir = tempfile::tempdir().unwrap().keep();
     let db_path = dir.join("credentials.db");

--- a/crates/ironclaw_secrets/tests/db_credential_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_credential_store_contract.rs
@@ -54,6 +54,10 @@ async fn libsql_credential_store_persists_sessions_and_enforces_use_limits_acros
     let store = libsql_store(&db_path).await;
     let scope = sample_scope("tenant-a", "user-a");
     let account_id = CredentialAccountId::new("openai_prod").unwrap();
+    store
+        .put_account(sample_account(scope.clone(), account_id.clone()))
+        .await
+        .unwrap();
     let session = broker_session(scope.clone(), account_id, Some(1), None);
     let session_id = session.correlation_id();
 
@@ -193,12 +197,152 @@ async fn libsql_credential_store_rejects_existing_plaintext_payload_rows() {
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn libsql_credential_store_rejects_sql_injected_scope_values() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("credentials.db");
+    let store = libsql_store(&db_path).await;
+    let scope = sample_scope("tenant-a", "user-a");
+    let injected_scope = sample_scope("tenant-a' OR '1'='1", "user-a");
+    let account_id = CredentialAccountId::new("openai_prod").unwrap();
+    let account = sample_account(scope.clone(), account_id.clone());
+
+    store.put_account(account).await.unwrap();
+
+    assert_eq!(
+        store
+            .get_account(&injected_scope, &account_id)
+            .await
+            .unwrap(),
+        None,
+        "scope fields must be bound parameters, not SQL string fragments"
+    );
+    assert!(
+        store
+            .accounts_for_scope(&injected_scope)
+            .await
+            .unwrap()
+            .is_empty(),
+        "injected tenant ids must not escape scope isolation"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_credential_store_rejects_sessions_without_matching_account_row() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("credentials.db");
+    let store = libsql_store(&db_path).await;
+    let scope = sample_scope("tenant-a", "user-a");
+    let account_id = CredentialAccountId::new("openai_prod").unwrap();
+    let session = broker_session(scope.clone(), account_id.clone(), Some(1), None);
+
+    let error = store.issue_session(session.clone()).await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("constraint"),
+        "sessions must be constrained to an existing credential account row: {error}"
+    );
+
+    store
+        .put_account(sample_account(scope, account_id))
+        .await
+        .unwrap();
+    store.issue_session(session).await.unwrap();
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_credential_store_concurrent_session_consumption_respects_max_uses() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("credentials.db");
+    let store = Arc::new(libsql_store(&db_path).await);
+    let scope = sample_scope("tenant-a", "user-a");
+    let account_id = CredentialAccountId::new("openai_prod").unwrap();
+    store
+        .put_account(sample_account(scope.clone(), account_id.clone()))
+        .await
+        .unwrap();
+    let session = broker_session(scope.clone(), account_id, Some(1), None);
+    let session_id = session.correlation_id();
+    store.issue_session(session).await.unwrap();
+
+    let first = {
+        let store = Arc::clone(&store);
+        let scope = scope.clone();
+        tokio::spawn(async move {
+            store
+                .consume_session_use(&scope, session_id, Utc::now())
+                .await
+        })
+    };
+    let second = {
+        let store = Arc::clone(&store);
+        let scope = scope.clone();
+        tokio::spawn(async move {
+            store
+                .consume_session_use(&scope, session_id, Utc::now())
+                .await
+        })
+    };
+
+    let results = [first.await.unwrap(), second.await.unwrap()];
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| matches!(result, Err(error) if error.is_use_limit_exceeded()))
+            .count(),
+        1
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_credential_store_accounts_for_scope_rejects_over_limit_result_sets() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("credentials.db");
+    let store = libsql_store(&db_path).await;
+    let scope = sample_scope("tenant-a", "user-a");
+
+    for index in 0..1000 {
+        let account_id = CredentialAccountId::new(format!("acct_{index:04}")).unwrap();
+        store
+            .put_account(sample_account(scope.clone(), account_id))
+            .await
+            .unwrap();
+    }
+    assert_eq!(store.accounts_for_scope(&scope).await.unwrap().len(), 1000);
+
+    store
+        .put_account(sample_account(
+            scope.clone(),
+            CredentialAccountId::new("acct_overflow").unwrap(),
+        ))
+        .await
+        .unwrap();
+    let error = store.accounts_for_scope(&scope).await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("more than 1000 credential accounts"),
+        "large account listings must fail closed before unbounded allocation: {error}"
+    );
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn libsql_credential_store_persists_session_expiry_across_reopen() {
     let dir = tempfile::tempdir().unwrap().keep();
     let db_path = dir.join("credentials.db");
     let store = libsql_store(&db_path).await;
     let scope = sample_scope("tenant-a", "user-a");
     let account_id = CredentialAccountId::new("openai_prod").unwrap();
+    store
+        .put_account(sample_account(scope.clone(), account_id.clone()))
+        .await
+        .unwrap();
     let session = broker_session(
         scope.clone(),
         account_id,
@@ -259,6 +403,69 @@ async fn postgres_credential_store_persists_accounts_and_sessions_when_database_
     assert_eq!(
         store.get_session(&scope, session_id).await.unwrap(),
         Some(session)
+    );
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_credential_store_rejects_sessions_without_matching_account_row_when_database_url_is_set()
+ {
+    let Some(store) = postgres_store().await else {
+        return;
+    };
+    let suffix = Utc::now().timestamp_nanos_opt().unwrap_or_default();
+    let scope = sample_scope(&format!("tenant-missing-{suffix}"), "user-a");
+    let account_id = CredentialAccountId::new(format!("openai_missing_{suffix}")).unwrap();
+    let session = broker_session(scope.clone(), account_id.clone(), Some(1), None);
+
+    let error = store.issue_session(session.clone()).await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("constraint"),
+        "sessions must be constrained to an existing credential account row: {error}"
+    );
+
+    store
+        .put_account(sample_account(scope, account_id))
+        .await
+        .unwrap();
+    store.issue_session(session).await.unwrap();
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_credential_store_accounts_for_scope_rejects_over_limit_result_sets_when_database_url_is_set()
+ {
+    let Some(store) = postgres_store().await else {
+        return;
+    };
+    let suffix = Utc::now().timestamp_nanos_opt().unwrap_or_default();
+    let scope = sample_scope(&format!("tenant-many-{suffix}"), "user-a");
+
+    for index in 0..1000 {
+        let account_id = CredentialAccountId::new(format!("acct_{suffix}_{index:04}")).unwrap();
+        store
+            .put_account(sample_account(scope.clone(), account_id))
+            .await
+            .unwrap();
+    }
+    assert_eq!(store.accounts_for_scope(&scope).await.unwrap().len(), 1000);
+
+    store
+        .put_account(sample_account(
+            scope.clone(),
+            CredentialAccountId::new(format!("acct_{suffix}_overflow")).unwrap(),
+        ))
+        .await
+        .unwrap();
+    let error = store.accounts_for_scope(&scope).await.unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("more than 1000 credential accounts"),
+        "large account listings must fail closed before unbounded allocation: {error}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Hardens Reborn durable credential stores after #3401 review feedback: scope lookups stay parameterized, session consumption uses atomic `UPDATE ... WHERE uses < max_uses RETURNING ...`, libSQL uses exclusive write transactions, and Postgres consumption uses serializable transactions.
- Adds session/account foreign-key enforcement for libSQL and Postgres, including libSQL rebuild migration for existing session tables without the FK.
- Keeps credential session ids out of public serde/debug surfaces by removing `CredentialSessionId`/`CredentialSession` serialization and using a private encrypted persistence DTO.
- Caps `accounts_for_scope` reads at 1000 rows, documents storage-layer encryption requirements, adds status lifecycle docs, and adds Postgres CI coverage for the credential-store contract.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Related #3401. Addresses review comment: https://github.com/nearai/ironclaw/pull/3401#issuecomment-4410172319

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass:
  - `cargo test -p ironclaw_secrets --no-default-features --features libsql --test db_credential_store_contract -- --nocapture`
  - `cargo test -p ironclaw_secrets --all-features -- --nocapture`
  - `cargo test -p ironclaw_secrets --no-default-features --features postgres --test db_credential_store_contract --no-run`
  - `cargo test -p ironclaw_secrets --lib -- --nocapture`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: red/green verified new libSQL FK and account-limit tests failed before the implementation and passed after.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional safety checks:
- `bash scripts/pre-commit-safety.sh`

Known unrelated workspace check result:
- `cargo test --lib --all-features -q` currently fails on pre-existing CLI help snapshot drift (`src/cli/snapshots/ironclaw__cli__tests__help_output.snap`, `long_help_output.snap`) from runtime-profile/deployment-mode flags. Generated `.snap.new` files were removed; no CLI files are touched here.

## Security Impact

Security-sensitive. This PR hardens credential persistence and session-use enforcement:
- Keeps SQL statements parameterized for scope/session lookups.
- Converts session consumption to one atomic guarded update instead of read/check/write.
- Enables libSQL FK enforcement and adds session -> account FK constraints for both DB backends.
- Avoids public serde/debug exposure of credential session ids.
- Fails closed on oversized account listings instead of unbounded reads.

## Database Impact

Affects both libSQL and PostgreSQL durable credential-store schemas:
- Adds `reborn_credential_sessions_account_fk` on `(tenant_id, user_id, agent_id, project_id, account_id)` referencing `reborn_credential_accounts`.
- libSQL migration rebuilds existing `reborn_credential_sessions` tables when the FK is missing.
- Existing orphan session rows will fail migration instead of being silently accepted.

## Blast Radius

`ironclaw_secrets` durable credential stores and `.github/workflows/test.yml` only. Risk is limited to Reborn credential DB persistence, session consumption, and credential-store CI. Consumers with orphan durable credential session rows must repair/rotate those rows before enabling the hardened store.

## Rollback Plan

Revert this PR. If a libSQL database has already been rebuilt with the FK, the prior code can still read the table shape because columns are unchanged; only the FK constraint remains stricter.

## Review Follow-Through

Reviewer should focus on DB migration behavior for existing libSQL/Postgres credential stores, the 1000-row account-listing cap, and whether the session id serde removal is acceptable for any pending Reborn caller.

## Reborn finalization checklist

### Done

- Phase 1 dispatcher/process integration coverage: PR #3076.
- Phase 2 Script/MCP/WASM runtime-lane smoke: PR #3109.
- Phase 3a CapabilityHost integration coverage: PR #3110.
- Phase 5 memory substrate vertical coverage: PR #3114.
- HostRuntime invoke vertical slice / unsupported obligations: PR #3151.
- HostRuntime approval resume facade and negative paths: PR #3160.
- Background process obligation reconciliation lifecycle: PR #3161.
- Configured built-in obligation services composition: PR #3152.
- Production trust decision dispatch: PR #3153.
- Post-3080 staged network/secret handoff vertical coverage: PR #3338; issue #3148 closed.
- Durable/restart HostRuntime service-graph coverage: PR #3340 merged.
- Process lifecycle event substrate coverage: PR #3344 merged.
- Obligation audit event substrate coverage: PR #3346 merged.
- Durable event-store production selection: PR #3347 merged.
- Turn lifecycle event replay: PR #3350 merged.
- Turn lifecycle replay gap handling: PR #3359 merged.
- Extension lifecycle event substrate coverage: PR #3367 merged.
- EventStreamManager transport-agnostic replay facade: PR #3375 merged.
- AgentLoopHost facade contract: PR #3377 merged.
- AgentLoopHost facade hardening follow-up: PR #3382 merged.
- AgentLoopHost model/reply milestone seam: PR #3393 merged.
- AgentLoopHost host-managed model port seam: PR #3394 merged.

### Still to do

1. Event substrate integration blocker #3022: remaining caller-level producers need redacted, scoped, replayable durable events; no cross-scope replay visibility across remaining projections.
2. AgentLoopHost / model-reply path #3016: wire concrete production model gateway and real reply transcript service behind the seam.
3. No-exposure safeguard blocker #3032: sentinel harness for secrets, host paths, raw output, backend/provider errors.
4. Production composition smoke #3026/#3101/#3333 path: default-off behavior, Reborn mode fails closed when required services are missing, no in-memory/no-op/test seams in production graph.
5. Optional strict WASM dispatcher-bound follow-up from #3067.
6. Final #3067 evidence comment and closure.

---

**Review track**: C (security/runtime/DB/CI)
