### PR TITLE
Add checkpoint state staging store

### DIFF
--- a/crates/ironclaw_turns/src/checkpoint_state.rs
+++ b/crates/ironclaw_turns/src/checkpoint_state.rs
@@ -1,0 +1,231 @@
+use std::{collections::HashMap, fmt, sync::Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::{
+    CheckpointSchemaId, LoopCheckpointKind, LoopCheckpointStateRef, RunProfileVersion, TurnError,
+    TurnId, TurnRunId, TurnScope, TurnTimestamp,
+};
+
+pub const MAX_CHECKPOINT_STATE_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Internal loop checkpoint payload bytes.
+///
+/// This value is intentionally not serializable. It is host-owned resume state,
+/// not public turn status, event, milestone, or transcript content.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RedactedCheckpointPayload {
+    bytes: Vec<u8>,
+}
+
+impl RedactedCheckpointPayload {
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Result<Self, String> {
+        let bytes = bytes.into();
+        validate_checkpoint_payload_len(bytes.len())?;
+        Ok(Self { bytes })
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+impl fmt::Debug for RedactedCheckpointPayload {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RedactedCheckpointPayload")
+            .field("len", &self.bytes.len())
+            .field("payload", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckpointStateRecord {
+    pub state_ref: LoopCheckpointStateRef,
+    pub scope: TurnScope,
+    pub turn_id: TurnId,
+    pub run_id: TurnRunId,
+    pub schema_id: CheckpointSchemaId,
+    pub schema_version: RunProfileVersion,
+    pub kind: LoopCheckpointKind,
+    pub payload: RedactedCheckpointPayload,
+    pub created_at: TurnTimestamp,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PutCheckpointStateRequest {
+    pub scope: TurnScope,
+    pub turn_id: TurnId,
+    pub run_id: TurnRunId,
+    pub schema_id: CheckpointSchemaId,
+    pub schema_version: RunProfileVersion,
+    pub kind: LoopCheckpointKind,
+    payload: Vec<u8>,
+}
+
+impl PutCheckpointStateRequest {
+    pub fn new(
+        scope: TurnScope,
+        turn_id: TurnId,
+        run_id: TurnRunId,
+        schema_id: CheckpointSchemaId,
+        schema_version: RunProfileVersion,
+        kind: LoopCheckpointKind,
+        payload: impl Into<Vec<u8>>,
+    ) -> Self {
+        Self {
+            scope,
+            turn_id,
+            run_id,
+            schema_id,
+            schema_version,
+            kind,
+            payload: payload.into(),
+        }
+    }
+
+    pub fn payload_len(&self) -> usize {
+        self.payload.len()
+    }
+
+    pub fn payload_bytes(&self) -> &[u8] {
+        &self.payload
+    }
+
+    pub fn into_payload_bytes(self) -> Vec<u8> {
+        self.payload
+    }
+}
+
+impl fmt::Debug for PutCheckpointStateRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PutCheckpointStateRequest")
+            .field("scope", &self.scope)
+            .field("turn_id", &self.turn_id)
+            .field("run_id", &self.run_id)
+            .field("schema_id", &self.schema_id)
+            .field("schema_version", &self.schema_version)
+            .field("kind", &self.kind)
+            .field("payload_len", &self.payload.len())
+            .field("payload", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetCheckpointStateRequest {
+    pub scope: TurnScope,
+    pub turn_id: TurnId,
+    pub run_id: TurnRunId,
+    pub state_ref: LoopCheckpointStateRef,
+    pub schema_id: CheckpointSchemaId,
+    pub schema_version: RunProfileVersion,
+    pub kind: LoopCheckpointKind,
+}
+
+#[async_trait]
+pub trait CheckpointStateStore: Send + Sync {
+    async fn put_checkpoint_state(
+        &self,
+        request: PutCheckpointStateRequest,
+    ) -> Result<CheckpointStateRecord, TurnError>;
+
+    async fn get_checkpoint_state(
+        &self,
+        request: GetCheckpointStateRequest,
+    ) -> Result<Option<CheckpointStateRecord>, TurnError>;
+}
+
+#[derive(Default)]
+pub struct InMemoryCheckpointStateStore {
+    records: Mutex<HashMap<LoopCheckpointStateRef, CheckpointStateRecord>>,
+}
+
+#[async_trait]
+impl CheckpointStateStore for InMemoryCheckpointStateStore {
+    async fn put_checkpoint_state(
+        &self,
+        request: PutCheckpointStateRequest,
+    ) -> Result<CheckpointStateRecord, TurnError> {
+        validate_checkpoint_payload_len(request.payload.len())
+            .map_err(|reason| TurnError::InvalidRequest { reason })?;
+        let state_ref = new_state_ref()?;
+        let payload = RedactedCheckpointPayload::new(request.payload)
+            .map_err(|reason| TurnError::InvalidRequest { reason })?;
+        let record = CheckpointStateRecord {
+            state_ref: state_ref.clone(),
+            scope: request.scope,
+            turn_id: request.turn_id,
+            run_id: request.run_id,
+            schema_id: request.schema_id,
+            schema_version: request.schema_version,
+            kind: request.kind,
+            payload,
+            created_at: Utc::now(),
+        };
+
+        let mut records = self.records.lock().map_err(|_| TurnError::Unavailable {
+            reason: "checkpoint state store lock poisoned".to_string(),
+        })?;
+        records.insert(state_ref, record.clone());
+        Ok(record)
+    }
+
+    async fn get_checkpoint_state(
+        &self,
+        request: GetCheckpointStateRequest,
+    ) -> Result<Option<CheckpointStateRecord>, TurnError> {
+        let records = self.records.lock().map_err(|_| TurnError::Unavailable {
+            reason: "checkpoint state store lock poisoned".to_string(),
+        })?;
+        let Some(record) = records.get(&request.state_ref) else {
+            return Ok(None);
+        };
+        if record_matches_request(record, &request) {
+            Ok(Some(record.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn record_matches_request(
+    record: &CheckpointStateRecord,
+    request: &GetCheckpointStateRequest,
+) -> bool {
+    record.scope == request.scope
+        && record.turn_id == request.turn_id
+        && record.run_id == request.run_id
+        && record.schema_id == request.schema_id
+        && record.schema_version == request.schema_version
+        && record.kind == request.kind
+}
+
+fn new_state_ref() -> Result<LoopCheckpointStateRef, TurnError> {
+    LoopCheckpointStateRef::new(format!("checkpoint:{}", Uuid::new_v4())).map_err(|reason| {
+        TurnError::Unavailable {
+            reason: format!("generated checkpoint state ref was invalid: {reason}"),
+        }
+    })
+}
+
+fn validate_checkpoint_payload_len(len: usize) -> Result<(), String> {
+    if len > MAX_CHECKPOINT_STATE_PAYLOAD_BYTES {
+        return Err(format!(
+            "checkpoint payload must be at most {MAX_CHECKPOINT_STATE_PAYLOAD_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -6,6 +6,7 @@
 //! transition APIs are intentionally not re-exported from this crate prelude.
 
 pub mod admission;
+pub mod checkpoint_state;
 pub mod coordinator;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub mod db;
@@ -27,6 +28,11 @@ pub use admission::{
     TurnAdmissionCapacityDenial, TurnAdmissionClass, TurnAdmissionLimit,
     TurnAdmissionLimitProvider, TurnAdmissionLimitUnavailable, TurnAdmissionReservationRecord,
 };
+pub use checkpoint_state::{
+    CheckpointStateRecord, CheckpointStateStore, GetCheckpointStateRequest,
+    InMemoryCheckpointStateStore, MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, PutCheckpointStateRequest,
+    RedactedCheckpointPayload,
+};
 pub use coordinator::{
     AllowAllTurnAdmissionPolicy, DefaultTurnCoordinator, NoopTurnRunWakeNotifier,
     TurnAdmissionPolicy, TurnCoordinator, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError,
@@ -36,7 +42,7 @@ pub use db::LibSqlTurnStateStore;
 #[cfg(feature = "postgres")]
 pub use db::PostgresTurnStateStore;
 pub use events::{
-    InMemoryTurnEventSink, TurnEventKind, TurnEventPage, TurnEventProjectionCursor,
+    EventCursor, InMemoryTurnEventSink, TurnEventKind, TurnEventPage, TurnEventProjectionCursor,
     TurnEventProjectionError, TurnEventProjectionRequest, TurnEventProjectionService,
     TurnEventProjectionSnapshot, TurnEventProjectionSource, TurnEventSink, TurnLifecycleEvent,
 };
@@ -61,12 +67,12 @@ pub use run_profile::{
     AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverResumeRequest,
     AgentLoopDriverRunRequest, CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy,
     CheckpointSchemaId, ConcurrencyClass, ContextProfileId, InMemoryRunProfileRegistry,
-    InMemoryRunProfileResolver, LoopDriverId, ModelProfileId, PrivilegedRunProfileDimension,
-    RedactedRunProfileProvenance, RedactedRunProfileSource, ResolvedRunProfile,
-    ResourceBudgetPolicy, ResourceBudgetTier, RunClassId, RunProfileFingerprint,
-    RunProfileRequestAuthority, RunProfileResolutionError, RunProfileResolutionRequest,
-    RunProfileResolver, RunProfileSourceLayer, RunProfileSourceRef, RunnerPoolId,
-    RuntimeProfileConstraints, SchedulingClass, SteeringPolicy,
+    InMemoryRunProfileResolver, LoopCheckpointKind, LoopCheckpointStateRef, LoopDriverId,
+    ModelProfileId, PrivilegedRunProfileDimension, RedactedRunProfileProvenance,
+    RedactedRunProfileSource, ResolvedRunProfile, ResourceBudgetPolicy, ResourceBudgetTier,
+    RunClassId, RunProfileFingerprint, RunProfileRequestAuthority, RunProfileResolutionError,
+    RunProfileResolutionRequest, RunProfileResolver, RunProfileSourceLayer, RunProfileSourceRef,
+    RunnerPoolId, RuntimeProfileConstraints, SchedulingClass, SteeringPolicy,
 };
 pub use scope::{TurnActor, TurnScope};
 pub use status::{

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -1,0 +1,305 @@
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
+use ironclaw_turns::{
+    AcceptedMessageRef, CheckpointSchemaId, CheckpointStateRecord, CheckpointStateStore,
+    EventCursor, GateRef, GetCheckpointStateRequest, InMemoryCheckpointStateStore,
+    LoopCheckpointStateRef, MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, PutCheckpointStateRequest,
+    RedactedCheckpointPayload, ReplyTargetBindingRef, RunProfileId, RunProfileVersion,
+    SourceBindingRef, TurnCheckpointId, TurnCheckpointRecord, TurnEventKind, TurnId,
+    TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRunId, TurnRunState, TurnScope, TurnStatus,
+    TurnTimestamp, run_profile::LoopCheckpointKind,
+};
+
+#[tokio::test]
+async fn checkpoint_state_store_round_trips_scoped_state_ref() {
+    let store = InMemoryCheckpointStateStore::default();
+    let scope = turn_scope("thread-checkpoint-roundtrip");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let schema_id = CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap();
+    let schema_version = RunProfileVersion::new(7);
+    let payload = b"RAW_PROMPT_SENTINEL sk-secret /host/path tool_input".to_vec();
+
+    let record = store
+        .put_checkpoint_state(PutCheckpointStateRequest::new(
+            scope.clone(),
+            turn_id,
+            run_id,
+            schema_id.clone(),
+            schema_version,
+            LoopCheckpointKind::BeforeModel,
+            payload.clone(),
+        ))
+        .await
+        .unwrap();
+
+    assert!(record.state_ref.as_str().starts_with("checkpoint:"));
+    assert!(!record.state_ref.as_str().contains(&turn_id.to_string()));
+    assert!(!record.state_ref.as_str().contains(&run_id.to_string()));
+    assert_eq!(record.scope, scope);
+    assert_eq!(record.turn_id, turn_id);
+    assert_eq!(record.run_id, run_id);
+    assert_eq!(record.schema_id, schema_id);
+    assert_eq!(record.schema_version, schema_version);
+    assert_eq!(record.kind, LoopCheckpointKind::BeforeModel);
+    assert_eq!(record.payload.as_bytes(), payload.as_slice());
+
+    let loaded = store
+        .get_checkpoint_state(get_request(&record, scope, turn_id, run_id))
+        .await
+        .unwrap()
+        .expect("stored checkpoint state should be returned for matching scope/run");
+
+    assert_eq!(loaded, record);
+}
+
+#[tokio::test]
+async fn checkpoint_state_store_rejects_cross_scope_ref() {
+    let store = InMemoryCheckpointStateStore::default();
+    let scope = turn_scope("thread-checkpoint-scope-a");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let record = put_test_state(&store, scope.clone(), turn_id, run_id).await;
+
+    let cross_scope = turn_scope("thread-checkpoint-scope-b");
+    let loaded = store
+        .get_checkpoint_state(get_request(&record, cross_scope, turn_id, run_id))
+        .await
+        .unwrap();
+
+    assert!(loaded.is_none());
+}
+
+#[tokio::test]
+async fn checkpoint_state_store_rejects_cross_run_ref() {
+    let store = InMemoryCheckpointStateStore::default();
+    let scope = turn_scope("thread-checkpoint-run");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let record = put_test_state(&store, scope.clone(), turn_id, run_id).await;
+
+    let loaded = store
+        .get_checkpoint_state(get_request(&record, scope, turn_id, TurnRunId::new()))
+        .await
+        .unwrap();
+
+    assert!(loaded.is_none());
+}
+
+#[tokio::test]
+async fn checkpoint_state_store_rejects_schema_version_or_kind_mismatch() {
+    let store = InMemoryCheckpointStateStore::default();
+    let scope = turn_scope("thread-checkpoint-schema");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let record = put_test_state(&store, scope.clone(), turn_id, run_id).await;
+
+    let mut wrong_schema = get_request(&record, scope.clone(), turn_id, run_id);
+    wrong_schema.schema_id = CheckpointSchemaId::new("other_checkpoint_v1").unwrap();
+    assert!(
+        store
+            .get_checkpoint_state(wrong_schema)
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let mut wrong_version = get_request(&record, scope.clone(), turn_id, run_id);
+    wrong_version.schema_version = RunProfileVersion::new(2);
+    assert!(
+        store
+            .get_checkpoint_state(wrong_version)
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let mut wrong_kind = get_request(&record, scope, turn_id, run_id);
+    wrong_kind.kind = LoopCheckpointKind::BeforeModel;
+    assert!(
+        store
+            .get_checkpoint_state(wrong_kind)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_state_store_rejects_oversized_payload() {
+    let store = InMemoryCheckpointStateStore::default();
+    let error = store
+        .put_checkpoint_state(PutCheckpointStateRequest::new(
+            turn_scope("thread-checkpoint-oversized"),
+            TurnId::new(),
+            TurnRunId::new(),
+            CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            RunProfileVersion::new(1),
+            LoopCheckpointKind::BeforeSideEffect,
+            vec![b'x'; MAX_CHECKPOINT_STATE_PAYLOAD_BYTES + 1],
+        ))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ironclaw_turns::TurnError::InvalidRequest { .. }
+    ));
+    assert!(!format!("{error:?}").contains("xxxx"));
+}
+
+#[test]
+fn checkpoint_state_record_debug_redacts_payload() {
+    let raw_payload =
+        b"RAW_PROMPT_SENTINEL sk-secret /host/path tool_input provider_error".to_vec();
+    let payload = RedactedCheckpointPayload::new(raw_payload.clone()).unwrap();
+    let record = CheckpointStateRecord {
+        state_ref: LoopCheckpointStateRef::new("checkpoint:debug-redaction").unwrap(),
+        scope: turn_scope("thread-checkpoint-debug"),
+        turn_id: TurnId::new(),
+        run_id: TurnRunId::new(),
+        schema_id: CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+        schema_version: RunProfileVersion::new(1),
+        kind: LoopCheckpointKind::BeforeModel,
+        payload: payload.clone(),
+        created_at: fixed_time(),
+    };
+    let request = PutCheckpointStateRequest::new(
+        turn_scope("thread-checkpoint-debug-request"),
+        TurnId::new(),
+        TurnRunId::new(),
+        CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+        RunProfileVersion::new(1),
+        LoopCheckpointKind::BeforeModel,
+        raw_payload,
+    );
+    let debug = format!("{payload:?}{record:?}{request:?}");
+
+    for forbidden in [
+        "RAW_PROMPT_SENTINEL",
+        "sk-secret",
+        "/host/path",
+        "tool_input",
+        "provider_error",
+    ] {
+        assert!(!debug.contains(forbidden), "debug leaked {forbidden}");
+    }
+    assert!(debug.contains("redacted"));
+}
+
+#[test]
+fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
+    let payload = b"RAW_CHECKPOINT_PAYLOAD sk-secret /host/path tool_input".to_vec();
+    let payload = RedactedCheckpointPayload::new(payload).unwrap();
+    let scope = turn_scope("thread-checkpoint-public-status");
+    let checkpoint_id = TurnCheckpointId::new();
+    let run_id = TurnRunId::new();
+
+    let state = TurnRunState {
+        scope: scope.clone(),
+        turn_id: TurnId::new(),
+        run_id,
+        status: TurnStatus::BlockedApproval,
+        accepted_message_ref: AcceptedMessageRef::new("accepted-checkpoint-public").unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-checkpoint-public").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-checkpoint-public").unwrap(),
+        resolved_run_profile_id: RunProfileId::default_profile(),
+        resolved_run_profile_version: RunProfileVersion::new(1),
+        received_at: fixed_time(),
+        checkpoint_id: Some(checkpoint_id),
+        gate_ref: Some(GateRef::new("gate-checkpoint-public").unwrap()),
+        failure: None,
+        event_cursor: EventCursor(1),
+    };
+    let event = TurnLifecycleEvent {
+        cursor: EventCursor(2),
+        scope,
+        run_id,
+        status: TurnStatus::BlockedApproval,
+        kind: TurnEventKind::Blocked,
+        sanitized_reason: Some("checkpointed".to_string()),
+    };
+    let snapshot = TurnPersistenceSnapshot {
+        checkpoints: vec![TurnCheckpointRecord {
+            checkpoint_id,
+            run_id,
+            sequence: 1,
+            status: TurnStatus::BlockedApproval,
+            gate_ref: GateRef::new("gate-checkpoint-public").unwrap(),
+            created_at: fixed_time(),
+        }],
+        events: vec![event.clone()],
+        ..TurnPersistenceSnapshot::default()
+    };
+
+    let public_wire = format!(
+        "{}{}{}{:?}",
+        serde_json::to_string(&state).unwrap(),
+        serde_json::to_string(&event).unwrap(),
+        serde_json::to_string(&snapshot).unwrap(),
+        payload,
+    );
+
+    for forbidden in [
+        "RAW_CHECKPOINT_PAYLOAD",
+        "sk-secret",
+        "/host/path",
+        "tool_input",
+    ] {
+        assert!(
+            !public_wire.contains(forbidden),
+            "public checkpoint/status surface leaked {forbidden}"
+        );
+    }
+}
+
+fn get_request(
+    record: &CheckpointStateRecord,
+    scope: TurnScope,
+    turn_id: TurnId,
+    run_id: TurnRunId,
+) -> GetCheckpointStateRequest {
+    GetCheckpointStateRequest {
+        scope,
+        turn_id,
+        run_id,
+        state_ref: record.state_ref.clone(),
+        schema_id: record.schema_id.clone(),
+        schema_version: record.schema_version,
+        kind: record.kind,
+    }
+}
+
+async fn put_test_state(
+    store: &InMemoryCheckpointStateStore,
+    scope: TurnScope,
+    turn_id: TurnId,
+    run_id: TurnRunId,
+) -> CheckpointStateRecord {
+    store
+        .put_checkpoint_state(PutCheckpointStateRequest::new(
+            scope,
+            turn_id,
+            run_id,
+            CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            RunProfileVersion::new(1),
+            LoopCheckpointKind::BeforeBlock,
+            b"checkpoint-state".to_vec(),
+        ))
+        .await
+        .unwrap()
+}
+
+fn turn_scope(thread_id: &str) -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant-checkpoint").unwrap(),
+        Some(AgentId::new("agent-checkpoint").unwrap()),
+        Some(ProjectId::new("project-checkpoint").unwrap()),
+        ThreadId::new(thread_id).unwrap(),
+    )
+}
+
+fn fixed_time() -> TurnTimestamp {
+    chrono::DateTime::parse_from_rfc3339("2026-05-08T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc)
+}

--- a/docs/reborn/contracts/turn-persistence.md
+++ b/docs/reborn/contracts/turn-persistence.md
@@ -84,6 +84,9 @@ A duplicate idempotency key must replay prior accepted submit and admission-reje
 - Heartbeats only renew metadata for matching, unexpired runner ID/lease token; successful heartbeats refresh `last_heartbeat_at` and extend `lease_expires_at`.
 - Expired `Running` and `CancelRequested` leases transition to `RecoveryRequired`, clear current runner ownership, emit a redacted recovery event, and keep the active lock so uncertain side-effecting work is not auto-retried.
 - Blocking a running run requires a matching, unexpired lease, writes a checkpoint record, stores the latest checkpoint/gate refs on the run, clears current lease ownership, and keeps the active lock.
+- Loop-driver resume payloads are staged in a host-owned `CheckpointStateStore` before a public checkpoint record is written. The store returns an opaque `LoopCheckpointStateRef`; callers cannot choose arbitrary refs for durable records.
+- Checkpoint-state records are scoped by `TurnScope`, `TurnId`, and `TurnRunId`. Reads with a matching ref but foreign scope or run return no state, preserving tenant/thread/run isolation.
+- Checkpoint-state payload bytes are bounded and debug-redacted. Public checkpoint/run/event/idempotency records may store only metadata and refs, never raw checkpoint payload bytes.
 - Terminal runner outcomes require the matching, unexpired runner ID/lease token and release the active lock only if the run still owns it.
 
 ---


### PR DESCRIPTION
## Summary
- add `CheckpointStateStore` contract and in-memory implementation for Reborn loop checkpoint payload staging
- add bounded/redacted payload handling plus scoped schema/kind/version-aware put/get semantics
- document checkpoint-state staging in the Reborn turn-persistence contract

Closes #3406

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p ironclaw_turns --tests
- cargo clippy -p ironclaw_turns --all-targets -- -D warnings
- cargo test -p ironclaw_reborn --tests

## Review
- code-quality-reviewer re-review: no Critical/High/Medium findings