### PR TITLE
feat(reborn): add durable encrypted secret store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,9 +4504,13 @@ dependencies = [
  "ironclaw_host_api",
  "ironclaw_llm",
  "ironclaw_loop_support",
+ "ironclaw_secrets",
  "ironclaw_threads",
  "ironclaw_turns",
+ "libsql",
  "rust_decimal",
+ "secrecy",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -13,17 +13,22 @@ publish = false
 [features]
 default = []
 root-llm-provider = ["dep:ironclaw_llm"]
+libsql-secrets = ["dep:ironclaw_secrets", "ironclaw_secrets/libsql", "dep:libsql", "dep:secrecy"]
 
 [dependencies]
 async-trait = "0.1"
-ironclaw_llm = { path = "../ironclaw_llm", version = "0.1.0", optional = true }
+ironclaw_llm = { path = "../ironclaw_llm", version = "0.1.0", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support", version = "0.1.0" }
+ironclaw_secrets = { path = "../ironclaw_secrets", version = "0.1.0", optional = true }
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+secrecy = { version = "0.10", optional = true }
 
 [dev-dependencies]
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 rust_decimal = "1"
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }
 
 [[test]]

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -8,6 +8,8 @@ pub mod driver_registry;
 
 #[cfg(feature = "root-llm-provider")]
 pub mod model_gateway;
+#[cfg(feature = "libsql-secrets")]
+pub mod secrets;
 
 #[cfg(feature = "root-llm-provider")]
 pub use model_gateway::{

--- a/crates/ironclaw_reborn/src/secrets.rs
+++ b/crates/ironclaw_reborn/src/secrets.rs
@@ -38,7 +38,7 @@ pub enum RebornSecretStoreHealthStatus {
 pub enum RebornSecretStoreError {
     MissingMasterKey,
     InvalidMasterKey,
-    BackendUnavailable { reason: String },
+    BackendUnavailable,
 }
 
 impl fmt::Display for RebornSecretStoreError {
@@ -49,11 +49,8 @@ impl fmt::Display for RebornSecretStoreError {
             Self::InvalidMasterKey => {
                 formatter.write_str("reborn secret store master key is invalid")
             }
-            Self::BackendUnavailable { reason } => {
-                write!(
-                    formatter,
-                    "reborn secret store backend unavailable: {reason}"
-                )
+            Self::BackendUnavailable => {
+                formatter.write_str("reborn secret store backend unavailable")
             }
         }
     }
@@ -104,9 +101,7 @@ pub async fn build_libsql_reborn_secret_store(
         .ok_or(RebornSecretStoreError::MissingMasterKey)?;
     let crypto = Arc::new(SecretsCrypto::new(master_key).map_err(|error| match error {
         SecretError::InvalidMasterKey => RebornSecretStoreError::InvalidMasterKey,
-        other => RebornSecretStoreError::BackendUnavailable {
-            reason: other.to_string(),
-        },
+        _ => RebornSecretStoreError::BackendUnavailable,
     })?);
     let backend = Arc::new(LibSqlSecretsStore::new(config.database, crypto));
     backend
@@ -123,9 +118,7 @@ pub async fn build_libsql_reborn_secret_store(
 fn map_secret_store_error(error: SecretError) -> RebornSecretStoreError {
     match error {
         SecretError::InvalidMasterKey => RebornSecretStoreError::InvalidMasterKey,
-        other => RebornSecretStoreError::BackendUnavailable {
-            reason: other.to_string(),
-        },
+        _ => RebornSecretStoreError::BackendUnavailable,
     }
 }
 

--- a/crates/ironclaw_reborn/src/secrets.rs
+++ b/crates/ironclaw_reborn/src/secrets.rs
@@ -64,7 +64,7 @@ impl std::error::Error for RebornSecretStoreError {}
 /// Probe the libSQL Reborn secret-store wiring.
 ///
 /// This uses the same fail-closed construction path as the builder, including
-/// migration and decryptability verification. `config.master_key = None` is
+/// migration and secret-store key-check verification. `config.master_key = None` is
 /// reported as [`RebornSecretStoreHealthStatus::MissingMasterKey`], not treated
 /// as a healthy local/default configuration.
 pub async fn check_libsql_reborn_secret_store_health(
@@ -85,9 +85,9 @@ pub async fn check_libsql_reborn_secret_store_health(
                 "operator master key is invalid or cannot decrypt existing secret rows".to_string(),
             ),
         },
-        Err(error) => RebornSecretStoreHealth {
+        Err(_) => RebornSecretStoreHealth {
             status: RebornSecretStoreHealthStatus::Unavailable,
-            reason: Some(error.to_string()),
+            reason: Some("secret store backend unavailable".to_string()),
         },
     }
 }
@@ -95,8 +95,7 @@ pub async fn check_libsql_reborn_secret_store_health(
 /// Build the libSQL Reborn secret store.
 ///
 /// Requires explicit operator-provided master key material. The returned store
-/// has completed schema migration and sampled decryptability verification for
-/// existing encrypted rows.
+/// has completed schema migration and secret-store key-check verification.
 pub async fn build_libsql_reborn_secret_store(
     config: RebornLibSqlSecretStoreConfig,
 ) -> Result<Arc<dyn SecretStore>, RebornSecretStoreError> {

--- a/crates/ironclaw_reborn/src/secrets.rs
+++ b/crates/ironclaw_reborn/src/secrets.rs
@@ -12,6 +12,11 @@ use ironclaw_secrets::{
 /// decryptable across restarts, matching v1's encrypted-at-rest invariant.
 pub struct RebornLibSqlSecretStoreConfig {
     pub database: Arc<libsql::Database>,
+    /// Operator-provided durable master key material.
+    ///
+    /// `None` is accepted only so builders and health checks can fail closed
+    /// with [`RebornSecretStoreError::MissingMasterKey`]. Production
+    /// composition must pass `Some`.
     pub master_key: Option<SecretMaterial>,
 }
 
@@ -25,6 +30,7 @@ pub struct RebornSecretStoreHealth {
 pub enum RebornSecretStoreHealthStatus {
     Ready,
     MissingMasterKey,
+    InvalidMasterKey,
     Unavailable,
 }
 
@@ -55,6 +61,12 @@ impl fmt::Display for RebornSecretStoreError {
 
 impl std::error::Error for RebornSecretStoreError {}
 
+/// Probe the libSQL Reborn secret-store wiring.
+///
+/// This uses the same fail-closed construction path as the builder, including
+/// migration and decryptability verification. `config.master_key = None` is
+/// reported as [`RebornSecretStoreHealthStatus::MissingMasterKey`], not treated
+/// as a healthy local/default configuration.
 pub async fn check_libsql_reborn_secret_store_health(
     config: RebornLibSqlSecretStoreConfig,
 ) -> RebornSecretStoreHealth {
@@ -67,6 +79,12 @@ pub async fn check_libsql_reborn_secret_store_health(
             status: RebornSecretStoreHealthStatus::MissingMasterKey,
             reason: Some("explicit operator master key is required".to_string()),
         },
+        Err(RebornSecretStoreError::InvalidMasterKey) => RebornSecretStoreHealth {
+            status: RebornSecretStoreHealthStatus::InvalidMasterKey,
+            reason: Some(
+                "operator master key is invalid or cannot decrypt existing secret rows".to_string(),
+            ),
+        },
         Err(error) => RebornSecretStoreHealth {
             status: RebornSecretStoreHealthStatus::Unavailable,
             reason: Some(error.to_string()),
@@ -74,6 +92,11 @@ pub async fn check_libsql_reborn_secret_store_health(
     }
 }
 
+/// Build the libSQL Reborn secret store.
+///
+/// Requires explicit operator-provided master key material. The returned store
+/// has completed schema migration and sampled decryptability verification for
+/// existing encrypted rows.
 pub async fn build_libsql_reborn_secret_store(
     config: RebornLibSqlSecretStoreConfig,
 ) -> Result<Arc<dyn SecretStore>, RebornSecretStoreError> {
@@ -94,7 +117,7 @@ pub async fn build_libsql_reborn_secret_store(
     backend
         .verify_can_decrypt_existing_secrets()
         .await
-        .map_err(map_secret_store_error)?;
+        .map_err(map_existing_secret_decryptability_error)?;
     Ok(Arc::new(ScopedSecretsStoreAdapter::new(backend)))
 }
 
@@ -104,5 +127,14 @@ fn map_secret_store_error(error: SecretError) -> RebornSecretStoreError {
         other => RebornSecretStoreError::BackendUnavailable {
             reason: other.to_string(),
         },
+    }
+}
+
+fn map_existing_secret_decryptability_error(error: SecretError) -> RebornSecretStoreError {
+    match error {
+        SecretError::InvalidMasterKey
+        | SecretError::DecryptionFailed(_)
+        | SecretError::InvalidUtf8 => RebornSecretStoreError::InvalidMasterKey,
+        other => map_secret_store_error(other),
     }
 }

--- a/crates/ironclaw_reborn/src/secrets.rs
+++ b/crates/ironclaw_reborn/src/secrets.rs
@@ -1,0 +1,108 @@
+use std::{fmt, sync::Arc};
+
+use ironclaw_secrets::{
+    LibSqlSecretsStore, ScopedSecretsStoreAdapter, SecretError, SecretMaterial, SecretStore,
+    SecretsCrypto,
+};
+
+/// Explicit standalone-Reborn secret store configuration.
+///
+/// Reborn does not auto-generate a durable master key. Production composition
+/// must pass operator-controlled key material so encrypted rows remain
+/// decryptable across restarts, matching v1's encrypted-at-rest invariant.
+pub struct RebornLibSqlSecretStoreConfig {
+    pub database: Arc<libsql::Database>,
+    pub master_key: Option<SecretMaterial>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebornSecretStoreHealth {
+    pub status: RebornSecretStoreHealthStatus,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebornSecretStoreHealthStatus {
+    Ready,
+    MissingMasterKey,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RebornSecretStoreError {
+    MissingMasterKey,
+    InvalidMasterKey,
+    BackendUnavailable { reason: String },
+}
+
+impl fmt::Display for RebornSecretStoreError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingMasterKey => formatter
+                .write_str("reborn secret store requires an explicit operator-provided master key"),
+            Self::InvalidMasterKey => {
+                formatter.write_str("reborn secret store master key is invalid")
+            }
+            Self::BackendUnavailable { reason } => {
+                write!(
+                    formatter,
+                    "reborn secret store backend unavailable: {reason}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RebornSecretStoreError {}
+
+pub async fn check_libsql_reborn_secret_store_health(
+    config: RebornLibSqlSecretStoreConfig,
+) -> RebornSecretStoreHealth {
+    match build_libsql_reborn_secret_store(config).await {
+        Ok(_) => RebornSecretStoreHealth {
+            status: RebornSecretStoreHealthStatus::Ready,
+            reason: None,
+        },
+        Err(RebornSecretStoreError::MissingMasterKey) => RebornSecretStoreHealth {
+            status: RebornSecretStoreHealthStatus::MissingMasterKey,
+            reason: Some("explicit operator master key is required".to_string()),
+        },
+        Err(error) => RebornSecretStoreHealth {
+            status: RebornSecretStoreHealthStatus::Unavailable,
+            reason: Some(error.to_string()),
+        },
+    }
+}
+
+pub async fn build_libsql_reborn_secret_store(
+    config: RebornLibSqlSecretStoreConfig,
+) -> Result<Arc<dyn SecretStore>, RebornSecretStoreError> {
+    let master_key = config
+        .master_key
+        .ok_or(RebornSecretStoreError::MissingMasterKey)?;
+    let crypto = Arc::new(SecretsCrypto::new(master_key).map_err(|error| match error {
+        SecretError::InvalidMasterKey => RebornSecretStoreError::InvalidMasterKey,
+        other => RebornSecretStoreError::BackendUnavailable {
+            reason: other.to_string(),
+        },
+    })?);
+    let backend = Arc::new(LibSqlSecretsStore::new(config.database, crypto));
+    backend
+        .run_migrations()
+        .await
+        .map_err(map_secret_store_error)?;
+    backend
+        .verify_can_decrypt_existing_secrets()
+        .await
+        .map_err(map_secret_store_error)?;
+    Ok(Arc::new(ScopedSecretsStoreAdapter::new(backend)))
+}
+
+fn map_secret_store_error(error: SecretError) -> RebornSecretStoreError {
+    match error {
+        SecretError::InvalidMasterKey => RebornSecretStoreError::InvalidMasterKey,
+        other => RebornSecretStoreError::BackendUnavailable {
+            reason: other.to_string(),
+        },
+    }
+}

--- a/crates/ironclaw_reborn/tests/secrets.rs
+++ b/crates/ironclaw_reborn/tests/secrets.rs
@@ -52,6 +52,18 @@ async fn reborn_secret_store_requires_explicit_operator_master_key() {
 }
 
 #[tokio::test]
+async fn reborn_secret_store_backend_unavailable_error_does_not_format_backend_details() {
+    let error = RebornSecretStoreError::BackendUnavailable;
+
+    let display = error.to_string();
+    let debug = format!("{error:?}");
+
+    assert!(!display.contains("/tmp/operator/private/reborn-secrets.db"));
+    assert!(!debug.contains("/tmp/operator/private/reborn-secrets.db"));
+    assert_eq!(display, "reborn secret store backend unavailable");
+}
+
+#[tokio::test]
 async fn reborn_secret_store_fails_closed_when_existing_rows_use_another_master_key() {
     let dir = tempfile::tempdir().unwrap().keep();
     let db_path = dir.join("reborn-secrets.db");

--- a/crates/ironclaw_reborn/tests/secrets.rs
+++ b/crates/ironclaw_reborn/tests/secrets.rs
@@ -76,22 +76,61 @@ async fn reborn_secret_store_fails_closed_when_existing_rows_use_another_master_
         .unwrap();
     drop(store);
 
+    let wrong_key = Some(SecretMaterial::from(
+        "abcdef0123456789abcdef0123456789".to_string(),
+    ));
     let error = match build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
-        database,
-        master_key: Some(SecretMaterial::from(
-            "abcdef0123456789abcdef0123456789".to_string(),
-        )),
+        database: Arc::clone(&database),
+        master_key: wrong_key.clone(),
     })
     .await
     {
         Ok(_) => panic!("secret store must fail closed when existing rows cannot decrypt"),
         Err(error) => error,
     };
-    assert!(matches!(
-        error,
-        RebornSecretStoreError::BackendUnavailable { .. }
-    ));
+    assert!(matches!(error, RebornSecretStoreError::InvalidMasterKey));
     assert!(!format!("{error:?}").contains("sk-live-existing-secret"));
+
+    let health = check_libsql_reborn_secret_store_health(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key: wrong_key,
+    })
+    .await;
+    assert_eq!(
+        health.status,
+        RebornSecretStoreHealthStatus::InvalidMasterKey
+    );
+    assert!(!format!("{health:?}").contains("sk-live-existing-secret"));
+}
+
+#[tokio::test]
+async fn reborn_secret_store_reports_malformed_master_key_as_invalid_master_key() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let short_key = Some(SecretMaterial::from("short".to_string()));
+
+    let error = match build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database: Arc::clone(&database),
+        master_key: short_key.clone(),
+    })
+    .await
+    {
+        Ok(_) => panic!("secret store must reject malformed operator master key"),
+        Err(error) => error,
+    };
+    assert!(matches!(error, RebornSecretStoreError::InvalidMasterKey));
+
+    let health = check_libsql_reborn_secret_store_health(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key: short_key,
+    })
+    .await;
+    assert_eq!(
+        health.status,
+        RebornSecretStoreHealthStatus::InvalidMasterKey
+    );
+    assert!(!format!("{health:?}").contains("short"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/tests/secrets.rs
+++ b/crates/ironclaw_reborn/tests/secrets.rs
@@ -2,12 +2,12 @@
 
 use std::sync::Arc;
 
-use ironclaw_host_api::{InvocationId, ResourceScope, TenantId, UserId};
+use ironclaw_host_api::{InvocationId, ResourceScope, SecretHandle, TenantId, UserId};
 use ironclaw_reborn::secrets::{
     RebornLibSqlSecretStoreConfig, RebornSecretStoreError, RebornSecretStoreHealthStatus,
     build_libsql_reborn_secret_store, check_libsql_reborn_secret_store_health,
 };
-use ironclaw_secrets::SecretMaterial;
+use ironclaw_secrets::{SecretMaterial, SecretStoreError};
 use secrecy::ExposeSecret;
 
 #[tokio::test]
@@ -146,6 +146,150 @@ async fn reborn_secret_store_reports_malformed_master_key_as_invalid_master_key(
 }
 
 #[tokio::test]
+async fn reborn_secret_store_health_is_ready_for_empty_and_existing_rows_with_same_key() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let master_key = Some(test_master_key());
+
+    let empty_health = check_libsql_reborn_secret_store_health(RebornLibSqlSecretStoreConfig {
+        database: Arc::clone(&database),
+        master_key: master_key.clone(),
+    })
+    .await;
+    assert_eq!(empty_health.status, RebornSecretStoreHealthStatus::Ready);
+    assert!(empty_health.reason.is_none());
+
+    let store = build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database: Arc::clone(&database),
+        master_key: master_key.clone(),
+    })
+    .await
+    .unwrap();
+    store
+        .put(
+            sample_scope(),
+            SecretHandle::new("openai_key").unwrap(),
+            SecretMaterial::from("sk-live-health-ready-existing"),
+        )
+        .await
+        .unwrap();
+    drop(store);
+
+    let existing_health = check_libsql_reborn_secret_store_health(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key,
+    })
+    .await;
+    assert_eq!(existing_health.status, RebornSecretStoreHealthStatus::Ready);
+    assert!(existing_health.reason.is_none());
+    assert!(!format!("{existing_health:?}").contains("sk-live-health-ready-existing"));
+}
+
+#[tokio::test]
+async fn reborn_secret_store_reopens_with_scope_isolation_and_one_shot_leases() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let master_key = Some(test_master_key());
+    let store = build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database: Arc::clone(&database),
+        master_key: master_key.clone(),
+    })
+    .await
+    .unwrap();
+    let scope_a = sample_scope_for("tenant-a", "user-a");
+    let scope_b = sample_scope_for("tenant-b", "user-a");
+    let missing_scope = sample_scope_for("tenant-a", "user-b");
+    let handle = SecretHandle::new("openai_key").unwrap();
+
+    store
+        .put(
+            scope_a.clone(),
+            handle.clone(),
+            SecretMaterial::from("sk-live-scope-a"),
+        )
+        .await
+        .unwrap();
+    store
+        .put(
+            scope_b.clone(),
+            handle.clone(),
+            SecretMaterial::from("sk-live-scope-b"),
+        )
+        .await
+        .unwrap();
+    drop(store);
+
+    let reopened = build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key,
+    })
+    .await
+    .unwrap();
+    assert!(
+        reopened
+            .metadata(&scope_a, &handle)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        reopened
+            .metadata(&scope_b, &handle)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        reopened
+            .metadata(&missing_scope, &handle)
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let lease_a = reopened.lease_once(&scope_a, &handle).await.unwrap();
+    assert!(matches!(
+        reopened.consume(&scope_b, lease_a.id).await,
+        Err(SecretStoreError::UnknownLease { .. })
+    ));
+    let material_a = reopened.consume(&scope_a, lease_a.id).await.unwrap();
+    assert_eq!(material_a.expose_secret(), "sk-live-scope-a");
+    assert!(matches!(
+        reopened.consume(&scope_a, lease_a.id).await,
+        Err(SecretStoreError::LeaseConsumed { .. })
+    ));
+
+    let lease_b = reopened.lease_once(&scope_b, &handle).await.unwrap();
+    let material_b = reopened.consume(&scope_b, lease_b.id).await.unwrap();
+    assert_eq!(material_b.expose_secret(), "sk-live-scope-b");
+}
+
+#[tokio::test]
+async fn reborn_secret_store_missing_secret_does_not_create_lease() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let store = build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key: Some(test_master_key()),
+    })
+    .await
+    .unwrap();
+    let scope = sample_scope();
+    let missing = SecretHandle::new("missing_key").unwrap();
+
+    assert!(store.metadata(&scope, &missing).await.unwrap().is_none());
+    let error = store
+        .lease_once(&scope, &missing)
+        .await
+        .expect_err("missing durable secret must not lease");
+    assert!(matches!(error, SecretStoreError::UnknownSecret { .. }));
+    assert!(store.leases_for_scope(&scope).await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn reborn_secret_store_persists_material_encrypted_and_exposes_only_through_secret_store() {
     let dir = tempfile::tempdir().unwrap().keep();
     let db_path = dir.join("reborn-secrets.db");
@@ -177,10 +321,18 @@ async fn reborn_secret_store_persists_material_encrypted_and_exposes_only_throug
     assert_eq!(material.expose_secret(), "sk-live-reborn-secret-parity");
 }
 
+fn test_master_key() -> SecretMaterial {
+    SecretMaterial::from("0123456789abcdef0123456789abcdef".to_string())
+}
+
 fn sample_scope() -> ResourceScope {
+    sample_scope_for("tenant-a", "user-a")
+}
+
+fn sample_scope_for(tenant: &str, user: &str) -> ResourceScope {
     ResourceScope {
-        tenant_id: TenantId::new("tenant-a").unwrap(),
-        user_id: UserId::new("user-a").unwrap(),
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
         agent_id: None,
         project_id: None,
         mission_id: None,

--- a/crates/ironclaw_reborn/tests/secrets.rs
+++ b/crates/ironclaw_reborn/tests/secrets.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "libsql-secrets")]
+
+use std::sync::Arc;
+
+use ironclaw_host_api::{InvocationId, ResourceScope, TenantId, UserId};
+use ironclaw_reborn::secrets::{
+    RebornLibSqlSecretStoreConfig, RebornSecretStoreError, RebornSecretStoreHealthStatus,
+    build_libsql_reborn_secret_store, check_libsql_reborn_secret_store_health,
+};
+use ironclaw_secrets::SecretMaterial;
+use secrecy::ExposeSecret;
+
+#[tokio::test]
+async fn reborn_secret_store_health_fails_closed_without_explicit_operator_master_key() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+
+    let health = check_libsql_reborn_secret_store_health(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key: None,
+    })
+    .await;
+
+    assert_eq!(
+        health.status,
+        RebornSecretStoreHealthStatus::MissingMasterKey
+    );
+    let debug = format!("{health:?}");
+    assert!(!debug.contains("0123456789abcdef"));
+    assert!(!debug.contains("sk-live"));
+}
+
+#[tokio::test]
+async fn reborn_secret_store_requires_explicit_operator_master_key() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+
+    let error = match build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key: None,
+    })
+    .await
+    {
+        Ok(_) => panic!("secret store must not build without an explicit master key"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, RebornSecretStoreError::MissingMasterKey));
+    assert!(!format!("{error:?}").contains("0123456789abcdef"));
+}
+
+#[tokio::test]
+async fn reborn_secret_store_fails_closed_when_existing_rows_use_another_master_key() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let store = build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database: Arc::clone(&database),
+        master_key: Some(SecretMaterial::from(
+            "0123456789abcdef0123456789abcdef".to_string(),
+        )),
+    })
+    .await
+    .unwrap();
+    let scope = sample_scope();
+    let handle = ironclaw_host_api::SecretHandle::new("openai_key").unwrap();
+    store
+        .put(
+            scope,
+            handle,
+            SecretMaterial::from("sk-live-existing-secret"),
+        )
+        .await
+        .unwrap();
+    drop(store);
+
+    let error = match build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key: Some(SecretMaterial::from(
+            "abcdef0123456789abcdef0123456789".to_string(),
+        )),
+    })
+    .await
+    {
+        Ok(_) => panic!("secret store must fail closed when existing rows cannot decrypt"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        RebornSecretStoreError::BackendUnavailable { .. }
+    ));
+    assert!(!format!("{error:?}").contains("sk-live-existing-secret"));
+}
+
+#[tokio::test]
+async fn reborn_secret_store_persists_material_encrypted_and_exposes_only_through_secret_store() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let store = build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key: Some(SecretMaterial::from(
+            "0123456789abcdef0123456789abcdef".to_string(),
+        )),
+    })
+    .await
+    .unwrap();
+    let scope = sample_scope();
+    let handle = ironclaw_host_api::SecretHandle::new("openai_key").unwrap();
+
+    store
+        .put(
+            scope.clone(),
+            handle.clone(),
+            SecretMaterial::from("sk-live-reborn-secret-parity"),
+        )
+        .await
+        .unwrap();
+    let raw_database = String::from_utf8_lossy(&std::fs::read(&db_path).unwrap()).to_string();
+    assert!(!raw_database.contains("sk-live-reborn-secret-parity"));
+
+    let lease = store.lease_once(&scope, &handle).await.unwrap();
+    let material = store.consume(&scope, lease.id).await.unwrap();
+    assert_eq!(material.expose_secret(), "sk-live-reborn-secret-parity");
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("user-a").unwrap(),
+        agent_id: None,
+        project_id: None,
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}

--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -1509,7 +1509,13 @@ async fn libsql_verify_or_bootstrap_secret_store_key_check(
     if let Some((encrypted_value, key_salt)) = libsql_first_secret_payload(conn).await? {
         crypto.decrypt(&encrypted_value, &key_salt)?;
     }
-    libsql_insert_secret_store_key_check(conn, crypto).await
+    libsql_insert_secret_store_key_check(conn, crypto).await?;
+    let Some((encrypted_value, key_salt)) = libsql_secret_store_key_check(conn).await? else {
+        return Err(SecretError::Database(
+            "secret store key check missing after bootstrap".to_string(),
+        ));
+    };
+    verify_secret_store_key_check(crypto, &encrypted_value, &key_salt)
 }
 
 #[cfg(feature = "libsql")]
@@ -1663,7 +1669,13 @@ async fn postgres_verify_or_bootstrap_secret_store_key_check(
     if let Some((encrypted_value, key_salt)) = postgres_first_secret_payload(client).await? {
         crypto.decrypt(&encrypted_value, &key_salt)?;
     }
-    postgres_insert_secret_store_key_check(client, crypto).await
+    postgres_insert_secret_store_key_check(client, crypto).await?;
+    let Some((encrypted_value, key_salt)) = postgres_secret_store_key_check(client).await? else {
+        return Err(SecretError::Database(
+            "secret store key check missing after bootstrap".to_string(),
+        ));
+    };
+    verify_secret_store_key_check(crypto, &encrypted_value, &key_salt)
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -18,6 +18,8 @@ use uuid::Uuid;
 
 const CREDENTIAL_ACCOUNTS_FOR_SCOPE_LIMIT: usize = 1000;
 const CREDENTIAL_ACCOUNTS_FOR_SCOPE_QUERY_LIMIT: i64 = 1001;
+const SECRET_STORE_KEY_CHECK_ID: &str = "active";
+const SECRET_STORE_KEY_CHECK_PLAINTEXT: &str = "reborn-secret-store-key-check-v1";
 
 use crate::{
     CreateSecretParams, CredentialAccount, CredentialAccountId, CredentialAccountStatus,
@@ -1091,6 +1093,13 @@ CREATE TABLE IF NOT EXISTS reborn_secret_records (
 );
 CREATE INDEX IF NOT EXISTS idx_reborn_secret_records_id
     ON reborn_secret_records(id);
+CREATE TABLE IF NOT EXISTS reborn_secret_store_key_check (
+    id TEXT PRIMARY KEY,
+    encrypted_value BLOB NOT NULL,
+    key_salt BLOB NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
 "#;
 
 #[cfg(feature = "postgres")]
@@ -1111,6 +1120,13 @@ CREATE TABLE IF NOT EXISTS reborn_secret_records (
 );
 CREATE INDEX IF NOT EXISTS idx_reborn_secret_records_id
     ON reborn_secret_records(id);
+CREATE TABLE IF NOT EXISTS reborn_secret_store_key_check (
+    id TEXT PRIMARY KEY,
+    encrypted_value BYTEA NOT NULL,
+    key_salt BYTEA NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
 "#;
 
 #[cfg(feature = "libsql")]
@@ -1137,23 +1153,13 @@ impl LibSqlSecretsStore {
         libsql_secret_connect(&self.db).await
     }
 
+    /// Verifies the durable store key-check sentinel.
+    ///
+    /// Stores that predate the sentinel are bootstrapped by decrypting one
+    /// deterministic existing secret row before installing the key-check record.
     pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
         let conn = self.connect().await?;
-        // Sample one existing row to validate the configured master key without
-        // turning readiness checks into an O(N) table scan/decryption pass.
-        let mut rows = conn
-            .query(
-                "SELECT encrypted_value, key_salt FROM reborn_secret_records LIMIT 1",
-                (),
-            )
-            .await
-            .map_err(secret_db_error)?;
-        while let Some(row) = rows.next().await.map_err(secret_db_error)? {
-            let encrypted_value: Vec<u8> = row.get(0).map_err(secret_db_error)?;
-            let key_salt: Vec<u8> = row.get(1).map_err(secret_db_error)?;
-            self.crypto.decrypt(&encrypted_value, &key_salt)?;
-        }
-        Ok(())
+        libsql_verify_or_bootstrap_secret_store_key_check(&conn, &self.crypto).await
     }
 }
 
@@ -1306,23 +1312,13 @@ impl PostgresSecretsStore {
             .map_err(secret_db_error)
     }
 
+    /// Verifies the durable store key-check sentinel.
+    ///
+    /// Stores that predate the sentinel are bootstrapped by decrypting one
+    /// deterministic existing secret row before installing the key-check record.
     pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
         let client = self.pool.get().await.map_err(secret_db_error)?;
-        // Sample one existing row to validate the configured master key without
-        // turning readiness checks into an O(N) table scan/decryption pass.
-        let rows = client
-            .query(
-                "SELECT encrypted_value, key_salt FROM reborn_secret_records LIMIT 1",
-                &[],
-            )
-            .await
-            .map_err(secret_db_error)?;
-        for row in rows {
-            let encrypted_value: Vec<u8> = row.get(0);
-            let key_salt: Vec<u8> = row.get(1);
-            self.crypto.decrypt(&encrypted_value, &key_salt)?;
-        }
-        Ok(())
+        postgres_verify_or_bootstrap_secret_store_key_check(&client, &self.crypto).await
     }
 }
 
@@ -1501,6 +1497,79 @@ async fn finish_libsql_secret_transaction<T>(
 }
 
 #[cfg(feature = "libsql")]
+async fn libsql_verify_or_bootstrap_secret_store_key_check(
+    conn: &libsql::Connection,
+    crypto: &SecretsCrypto,
+) -> Result<(), SecretError> {
+    if let Some((encrypted_value, key_salt)) = libsql_secret_store_key_check(conn).await? {
+        return verify_secret_store_key_check(crypto, &encrypted_value, &key_salt);
+    }
+    // Legacy/bootstrap path for stores created before the key-check row existed:
+    // validate one deterministic existing row before installing the sentinel.
+    if let Some((encrypted_value, key_salt)) = libsql_first_secret_payload(conn).await? {
+        crypto.decrypt(&encrypted_value, &key_salt)?;
+    }
+    libsql_insert_secret_store_key_check(conn, crypto).await
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_secret_store_key_check(
+    conn: &libsql::Connection,
+) -> Result<Option<(Vec<u8>, Vec<u8>)>, SecretError> {
+    let mut rows = conn
+        .query(
+            "SELECT encrypted_value, key_salt FROM reborn_secret_store_key_check WHERE id = ?1",
+            libsql::params![SECRET_STORE_KEY_CHECK_ID],
+        )
+        .await
+        .map_err(secret_db_error)?;
+    let Some(row) = rows.next().await.map_err(secret_db_error)? else {
+        return Ok(None);
+    };
+    Ok(Some((
+        row.get(0).map_err(secret_db_error)?,
+        row.get(1).map_err(secret_db_error)?,
+    )))
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_first_secret_payload(
+    conn: &libsql::Connection,
+) -> Result<Option<(Vec<u8>, Vec<u8>)>, SecretError> {
+    let mut rows = conn
+        .query(
+            "SELECT encrypted_value, key_salt FROM reborn_secret_records ORDER BY user_id, name LIMIT 1",
+            (),
+        )
+        .await
+        .map_err(secret_db_error)?;
+    let Some(row) = rows.next().await.map_err(secret_db_error)? else {
+        return Ok(None);
+    };
+    Ok(Some((
+        row.get(0).map_err(secret_db_error)?,
+        row.get(1).map_err(secret_db_error)?,
+    )))
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_insert_secret_store_key_check(
+    conn: &libsql::Connection,
+    crypto: &SecretsCrypto,
+) -> Result<(), SecretError> {
+    let (encrypted_value, key_salt) =
+        crypto.encrypt(SECRET_STORE_KEY_CHECK_PLAINTEXT.as_bytes())?;
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT OR IGNORE INTO reborn_secret_store_key_check (id, encrypted_value, key_salt, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?4)",
+        libsql::params![SECRET_STORE_KEY_CHECK_ID, encrypted_value, key_salt, now],
+    )
+    .await
+    .map_err(secret_db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
 async fn libsql_upsert_secret(
     conn: &libsql::Connection,
     secret: &Secret,
@@ -1582,6 +1651,68 @@ async fn libsql_delete_secret(
 }
 
 #[cfg(feature = "postgres")]
+async fn postgres_verify_or_bootstrap_secret_store_key_check(
+    client: &impl deadpool_postgres::GenericClient,
+    crypto: &SecretsCrypto,
+) -> Result<(), SecretError> {
+    if let Some((encrypted_value, key_salt)) = postgres_secret_store_key_check(client).await? {
+        return verify_secret_store_key_check(crypto, &encrypted_value, &key_salt);
+    }
+    // Legacy/bootstrap path for stores created before the key-check row existed:
+    // validate one deterministic existing row before installing the sentinel.
+    if let Some((encrypted_value, key_salt)) = postgres_first_secret_payload(client).await? {
+        crypto.decrypt(&encrypted_value, &key_salt)?;
+    }
+    postgres_insert_secret_store_key_check(client, crypto).await
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_secret_store_key_check(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<Option<(Vec<u8>, Vec<u8>)>, SecretError> {
+    let row = client
+        .query_opt(
+            "SELECT encrypted_value, key_salt FROM reborn_secret_store_key_check WHERE id = $1",
+            &[&SECRET_STORE_KEY_CHECK_ID],
+        )
+        .await
+        .map_err(secret_db_error)?;
+    Ok(row.map(|row| (row.get(0), row.get(1))))
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_first_secret_payload(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<Option<(Vec<u8>, Vec<u8>)>, SecretError> {
+    let row = client
+        .query_opt(
+            "SELECT encrypted_value, key_salt FROM reborn_secret_records ORDER BY user_id, name LIMIT 1",
+            &[],
+        )
+        .await
+        .map_err(secret_db_error)?;
+    Ok(row.map(|row| (row.get(0), row.get(1))))
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_insert_secret_store_key_check(
+    client: &impl deadpool_postgres::GenericClient,
+    crypto: &SecretsCrypto,
+) -> Result<(), SecretError> {
+    let (encrypted_value, key_salt) =
+        crypto.encrypt(SECRET_STORE_KEY_CHECK_PLAINTEXT.as_bytes())?;
+    let now = Utc::now().to_rfc3339();
+    client
+        .execute(
+            "INSERT INTO reborn_secret_store_key_check (id, encrypted_value, key_salt, created_at, updated_at) VALUES ($1, $2, $3, $4, $4) ON CONFLICT(id) DO NOTHING",
+            &[&SECRET_STORE_KEY_CHECK_ID, &encrypted_value, &key_salt, &now],
+        )
+        .await
+        .map_err(secret_db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
 async fn postgres_upsert_secret(
     client: &impl deadpool_postgres::GenericClient,
     secret: &Secret,
@@ -1660,6 +1791,20 @@ async fn postgres_delete_secret(
         .await
         .map_err(secret_db_error)?;
     Ok(changed > 0)
+}
+
+fn verify_secret_store_key_check(
+    crypto: &SecretsCrypto,
+    encrypted_value: &[u8],
+    key_salt: &[u8],
+) -> Result<(), SecretError> {
+    let decrypted = crypto.decrypt(encrypted_value, key_salt)?;
+    if decrypted.expose() != SECRET_STORE_KEY_CHECK_PLAINTEXT {
+        return Err(SecretError::DecryptionFailed(
+            "secret store key check mismatch".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn build_encrypted_secret(

--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -1139,9 +1139,11 @@ impl LibSqlSecretsStore {
 
     pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
         let conn = self.connect().await?;
+        // Sample one existing row to validate the configured master key without
+        // turning readiness checks into an O(N) table scan/decryption pass.
         let mut rows = conn
             .query(
-                "SELECT encrypted_value, key_salt FROM reborn_secret_records",
+                "SELECT encrypted_value, key_salt FROM reborn_secret_records LIMIT 1",
                 (),
             )
             .await
@@ -1306,9 +1308,11 @@ impl PostgresSecretsStore {
 
     pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
         let client = self.pool.get().await.map_err(secret_db_error)?;
+        // Sample one existing row to validate the configured master key without
+        // turning readiness checks into an O(N) table scan/decryption pass.
         let rows = client
             .query(
-                "SELECT encrypted_value, key_salt FROM reborn_secret_records",
+                "SELECT encrypted_value, key_salt FROM reborn_secret_records LIMIT 1",
                 &[],
             )
             .await

--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -8,18 +8,22 @@
 
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, InvocationId, ResourceScope, SecretHandle, Timestamp,
 };
+use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 const CREDENTIAL_ACCOUNTS_FOR_SCOPE_LIMIT: usize = 1000;
 const CREDENTIAL_ACCOUNTS_FOR_SCOPE_QUERY_LIMIT: i64 = 1001;
 
 use crate::{
-    CredentialAccount, CredentialAccountId, CredentialAccountStatus, CredentialAccountStore,
-    CredentialBrokerError, CredentialSession, CredentialSessionId, CredentialSessionStore,
-    SecretsCrypto,
+    CreateSecretParams, CredentialAccount, CredentialAccountId, CredentialAccountStatus,
+    CredentialAccountStore, CredentialBrokerError, CredentialSession, CredentialSessionId,
+    CredentialSessionStore, DecryptedSecret, Secret, SecretConsumeResult, SecretError, SecretRef,
+    SecretsCrypto, SecretsStore,
 };
 
 #[cfg(feature = "libsql")]
@@ -1067,6 +1071,669 @@ async fn postgres_has_unencrypted_rows(
         .await
         .map_err(db_error)?
         .is_some())
+}
+
+#[cfg(feature = "libsql")]
+const LIBSQL_SECRET_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS reborn_secret_records (
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    id TEXT NOT NULL,
+    encrypted_value BLOB NOT NULL,
+    key_salt BLOB NOT NULL,
+    provider TEXT,
+    expires_at TEXT,
+    last_used_at TEXT,
+    usage_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (user_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_secret_records_id
+    ON reborn_secret_records(id);
+"#;
+
+#[cfg(feature = "postgres")]
+const POSTGRES_SECRET_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS reborn_secret_records (
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    id TEXT NOT NULL,
+    encrypted_value BYTEA NOT NULL,
+    key_salt BYTEA NOT NULL,
+    provider TEXT,
+    expires_at TEXT,
+    last_used_at TEXT,
+    usage_count BIGINT NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (user_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_reborn_secret_records_id
+    ON reborn_secret_records(id);
+"#;
+
+#[cfg(feature = "libsql")]
+pub struct LibSqlSecretsStore {
+    db: Arc<libsql::Database>,
+    crypto: Arc<SecretsCrypto>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlSecretsStore {
+    pub fn new(db: Arc<libsql::Database>, crypto: Arc<SecretsCrypto>) -> Self {
+        Self { db, crypto }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), SecretError> {
+        let conn = libsql_secret_connect(&self.db).await?;
+        conn.execute_batch(LIBSQL_SECRET_SCHEMA)
+            .await
+            .map_err(secret_db_error)?;
+        Ok(())
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, SecretError> {
+        libsql_secret_connect(&self.db).await
+    }
+
+    pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT encrypted_value, key_salt FROM reborn_secret_records",
+                (),
+            )
+            .await
+            .map_err(secret_db_error)?;
+        while let Some(row) = rows.next().await.map_err(secret_db_error)? {
+            let encrypted_value: Vec<u8> = row.get(0).map_err(secret_db_error)?;
+            let key_salt: Vec<u8> = row.get(1).map_err(secret_db_error)?;
+            self.crypto.decrypt(&encrypted_value, &key_salt)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait::async_trait]
+impl SecretsStore for LibSqlSecretsStore {
+    async fn create(
+        &self,
+        user_id: &str,
+        params: CreateSecretParams,
+    ) -> Result<Secret, SecretError> {
+        let conn = libsql_secret_begin_immediate(&self.db).await?;
+        let result = async {
+            let secret = build_encrypted_secret(user_id, params, &self.crypto)?;
+            libsql_upsert_secret(&conn, &secret).await?;
+            Ok(secret)
+        }
+        .await;
+        finish_libsql_secret_transaction(&conn, result).await
+    }
+
+    async fn get(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
+        let conn = self.connect().await?;
+        let name = normalize_secret_name(name);
+        let secret = libsql_get_secret(&conn, user_id, &name)
+            .await?
+            .ok_or_else(|| SecretError::NotFound(name.clone()))?;
+        ensure_secret_not_expired(&secret)?;
+        Ok(secret)
+    }
+
+    async fn get_decrypted(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<DecryptedSecret, SecretError> {
+        let secret = self.get(user_id, name).await?;
+        self.crypto
+            .decrypt(&secret.encrypted_value, &secret.key_salt)
+    }
+
+    async fn consume_if_matches(
+        &self,
+        user_id: &str,
+        name: &str,
+        expected_value: &str,
+    ) -> Result<SecretConsumeResult, SecretError> {
+        let conn = libsql_secret_begin_immediate(&self.db).await?;
+        let result = async {
+            let name = normalize_secret_name(name);
+            let Some(secret) = libsql_get_secret(&conn, user_id, &name).await? else {
+                return Ok(SecretConsumeResult::NotFound);
+            };
+            ensure_secret_not_expired(&secret)?;
+            let decrypted = self
+                .crypto
+                .decrypt(&secret.encrypted_value, &secret.key_salt)?;
+            if decrypted.expose() != expected_value {
+                return Ok(SecretConsumeResult::Mismatched);
+            }
+            libsql_delete_secret(&conn, user_id, &name).await?;
+            Ok(SecretConsumeResult::Matched)
+        }
+        .await;
+        finish_libsql_secret_transaction(&conn, result).await
+    }
+
+    async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
+        let conn = self.connect().await?;
+        let name = normalize_secret_name(name);
+        Ok(libsql_get_secret(&conn, user_id, &name).await?.is_some())
+    }
+
+    async fn any_exist(&self) -> Result<bool, SecretError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query("SELECT 1 FROM reborn_secret_records LIMIT 1", ())
+            .await
+            .map_err(secret_db_error)?;
+        Ok(rows.next().await.map_err(secret_db_error)?.is_some())
+    }
+
+    async fn list(&self, user_id: &str) -> Result<Vec<SecretRef>, SecretError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT name, provider FROM reborn_secret_records WHERE user_id = ?1 ORDER BY name",
+                libsql::params![user_id],
+            )
+            .await
+            .map_err(secret_db_error)?;
+        let mut refs = Vec::new();
+        while let Some(row) = rows.next().await.map_err(secret_db_error)? {
+            refs.push(SecretRef {
+                name: row.get(0).map_err(secret_db_error)?,
+                provider: row.get(1).map_err(secret_db_error)?,
+            });
+        }
+        Ok(refs)
+    }
+
+    async fn delete(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
+        let conn = self.connect().await?;
+        let name = normalize_secret_name(name);
+        libsql_delete_secret(&conn, user_id, &name).await
+    }
+
+    async fn record_usage(&self, secret_id: Uuid) -> Result<(), SecretError> {
+        let conn = self.connect().await?;
+        let changed = conn
+            .execute(
+                "UPDATE reborn_secret_records SET last_used_at = ?1, usage_count = usage_count + 1, updated_at = ?1 WHERE id = ?2",
+                libsql::params![Utc::now().to_rfc3339(), secret_id.to_string()],
+            )
+            .await
+            .map_err(secret_db_error)?;
+        if changed == 0 {
+            return Err(SecretError::NotFound(secret_id.to_string()));
+        }
+        Ok(())
+    }
+
+    async fn is_accessible(
+        &self,
+        user_id: &str,
+        secret_name: &str,
+        allowed_secrets: &[String],
+    ) -> Result<bool, SecretError> {
+        secret_accessible(self, user_id, secret_name, allowed_secrets).await
+    }
+}
+
+#[cfg(feature = "postgres")]
+pub struct PostgresSecretsStore {
+    pool: deadpool_postgres::Pool,
+    crypto: Arc<SecretsCrypto>,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresSecretsStore {
+    pub fn new(pool: deadpool_postgres::Pool, crypto: Arc<SecretsCrypto>) -> Self {
+        Self { pool, crypto }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        client
+            .batch_execute(POSTGRES_SECRET_SCHEMA)
+            .await
+            .map_err(secret_db_error)
+    }
+
+    pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        let rows = client
+            .query(
+                "SELECT encrypted_value, key_salt FROM reborn_secret_records",
+                &[],
+            )
+            .await
+            .map_err(secret_db_error)?;
+        for row in rows {
+            let encrypted_value: Vec<u8> = row.get(0);
+            let key_salt: Vec<u8> = row.get(1);
+            self.crypto.decrypt(&encrypted_value, &key_salt)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl SecretsStore for PostgresSecretsStore {
+    async fn create(
+        &self,
+        user_id: &str,
+        params: CreateSecretParams,
+    ) -> Result<Secret, SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        let secret = build_encrypted_secret(user_id, params, &self.crypto)?;
+        postgres_upsert_secret(&client, &secret).await?;
+        Ok(secret)
+    }
+
+    async fn get(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        let name = normalize_secret_name(name);
+        let secret = postgres_get_secret(&client, user_id, &name)
+            .await?
+            .ok_or_else(|| SecretError::NotFound(name.clone()))?;
+        ensure_secret_not_expired(&secret)?;
+        Ok(secret)
+    }
+
+    async fn get_decrypted(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<DecryptedSecret, SecretError> {
+        let secret = self.get(user_id, name).await?;
+        self.crypto
+            .decrypt(&secret.encrypted_value, &secret.key_salt)
+    }
+
+    async fn consume_if_matches(
+        &self,
+        user_id: &str,
+        name: &str,
+        expected_value: &str,
+    ) -> Result<SecretConsumeResult, SecretError> {
+        let mut client = self.pool.get().await.map_err(secret_db_error)?;
+        let transaction = client.transaction().await.map_err(secret_db_error)?;
+        let result = async {
+            let name = normalize_secret_name(name);
+            let Some(secret) = postgres_get_secret_for_update(&transaction, user_id, &name).await?
+            else {
+                return Ok(SecretConsumeResult::NotFound);
+            };
+            ensure_secret_not_expired(&secret)?;
+            let decrypted = self
+                .crypto
+                .decrypt(&secret.encrypted_value, &secret.key_salt)?;
+            if decrypted.expose() != expected_value {
+                return Ok(SecretConsumeResult::Mismatched);
+            }
+            postgres_delete_secret(&transaction, user_id, &name).await?;
+            Ok(SecretConsumeResult::Matched)
+        }
+        .await;
+        match result {
+            Ok(value) => {
+                transaction.commit().await.map_err(secret_db_error)?;
+                Ok(value)
+            }
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        let name = normalize_secret_name(name);
+        Ok(postgres_get_secret(&client, user_id, &name)
+            .await?
+            .is_some())
+    }
+
+    async fn any_exist(&self) -> Result<bool, SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        Ok(client
+            .query_opt("SELECT 1 FROM reborn_secret_records LIMIT 1", &[])
+            .await
+            .map_err(secret_db_error)?
+            .is_some())
+    }
+
+    async fn list(&self, user_id: &str) -> Result<Vec<SecretRef>, SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        let rows = client
+            .query(
+                "SELECT name, provider FROM reborn_secret_records WHERE user_id = $1 ORDER BY name",
+                &[&user_id],
+            )
+            .await
+            .map_err(secret_db_error)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| SecretRef {
+                name: row.get(0),
+                provider: row.get(1),
+            })
+            .collect())
+    }
+
+    async fn delete(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        let name = normalize_secret_name(name);
+        postgres_delete_secret(&client, user_id, &name).await
+    }
+
+    async fn record_usage(&self, secret_id: Uuid) -> Result<(), SecretError> {
+        let client = self.pool.get().await.map_err(secret_db_error)?;
+        let changed = client
+            .execute(
+                "UPDATE reborn_secret_records SET last_used_at = $1, usage_count = usage_count + 1, updated_at = $1 WHERE id = $2",
+                &[&Utc::now().to_rfc3339(), &secret_id.to_string()],
+            )
+            .await
+            .map_err(secret_db_error)?;
+        if changed == 0 {
+            return Err(SecretError::NotFound(secret_id.to_string()));
+        }
+        Ok(())
+    }
+
+    async fn is_accessible(
+        &self,
+        user_id: &str,
+        secret_name: &str,
+        allowed_secrets: &[String],
+    ) -> Result<bool, SecretError> {
+        secret_accessible(self, user_id, secret_name, allowed_secrets).await
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_secret_connect(db: &libsql::Database) -> Result<libsql::Connection, SecretError> {
+    let conn = db.connect().map_err(secret_db_error)?;
+    conn.query("PRAGMA busy_timeout = 5000", ())
+        .await
+        .map_err(secret_db_error)?;
+    Ok(conn)
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_secret_begin_immediate(
+    db: &libsql::Database,
+) -> Result<libsql::Connection, SecretError> {
+    let conn = libsql_secret_connect(db).await?;
+    conn.execute("BEGIN IMMEDIATE", ())
+        .await
+        .map_err(secret_db_error)?;
+    Ok(conn)
+}
+
+#[cfg(feature = "libsql")]
+async fn finish_libsql_secret_transaction<T>(
+    conn: &libsql::Connection,
+    result: Result<T, SecretError>,
+) -> Result<T, SecretError> {
+    match result {
+        Ok(value) => {
+            conn.execute("COMMIT", ()).await.map_err(secret_db_error)?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(error)
+        }
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_upsert_secret(
+    conn: &libsql::Connection,
+    secret: &Secret,
+) -> Result<(), SecretError> {
+    conn.execute(
+        "INSERT INTO reborn_secret_records (user_id, name, id, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) ON CONFLICT(user_id, name) DO UPDATE SET id = EXCLUDED.id, encrypted_value = EXCLUDED.encrypted_value, key_salt = EXCLUDED.key_salt, provider = EXCLUDED.provider, expires_at = EXCLUDED.expires_at, last_used_at = NULL, usage_count = 0, created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at",
+        libsql::params![
+            secret.user_id.clone(),
+            secret.name.clone(),
+            secret.id.to_string(),
+            secret.encrypted_value.clone(),
+            secret.key_salt.clone(),
+            secret.provider.clone(),
+            secret.expires_at.map(|value| value.to_rfc3339()),
+            secret.last_used_at.map(|value| value.to_rfc3339()),
+            secret.usage_count,
+            secret.created_at.to_rfc3339(),
+            secret.updated_at.to_rfc3339(),
+        ],
+    )
+    .await
+    .map_err(secret_db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_get_secret(
+    conn: &libsql::Connection,
+    user_id: &str,
+    name: &str,
+) -> Result<Option<Secret>, SecretError> {
+    let mut rows = conn
+        .query(
+            "SELECT id, user_id, name, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at FROM reborn_secret_records WHERE user_id = ?1 AND name = ?2",
+            libsql::params![user_id, name],
+        )
+        .await
+        .map_err(secret_db_error)?;
+    let Some(row) = rows.next().await.map_err(secret_db_error)? else {
+        return Ok(None);
+    };
+    libsql_secret_from_row(&row).map(Some)
+}
+
+#[cfg(feature = "libsql")]
+fn libsql_secret_from_row(row: &libsql::Row) -> Result<Secret, SecretError> {
+    let id: String = row.get(0).map_err(secret_db_error)?;
+    let expires_at: Option<String> = row.get(6).map_err(secret_db_error)?;
+    let last_used_at: Option<String> = row.get(7).map_err(secret_db_error)?;
+    Ok(Secret {
+        id: parse_secret_uuid(&id)?,
+        user_id: row.get(1).map_err(secret_db_error)?,
+        name: row.get(2).map_err(secret_db_error)?,
+        encrypted_value: row.get(3).map_err(secret_db_error)?,
+        key_salt: row.get(4).map_err(secret_db_error)?,
+        provider: row.get(5).map_err(secret_db_error)?,
+        expires_at: parse_optional_timestamp(expires_at.as_deref())?,
+        last_used_at: parse_optional_timestamp(last_used_at.as_deref())?,
+        usage_count: row.get(8).map_err(secret_db_error)?,
+        created_at: parse_timestamp(&row.get::<String>(9).map_err(secret_db_error)?)?,
+        updated_at: parse_timestamp(&row.get::<String>(10).map_err(secret_db_error)?)?,
+    })
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_delete_secret(
+    conn: &libsql::Connection,
+    user_id: &str,
+    name: &str,
+) -> Result<bool, SecretError> {
+    let changed = conn
+        .execute(
+            "DELETE FROM reborn_secret_records WHERE user_id = ?1 AND name = ?2",
+            libsql::params![user_id, name],
+        )
+        .await
+        .map_err(secret_db_error)?;
+    Ok(changed > 0)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_upsert_secret(
+    client: &impl deadpool_postgres::GenericClient,
+    secret: &Secret,
+) -> Result<(), SecretError> {
+    client.execute("INSERT INTO reborn_secret_records (user_id, name, id, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) ON CONFLICT(user_id, name) DO UPDATE SET id = EXCLUDED.id, encrypted_value = EXCLUDED.encrypted_value, key_salt = EXCLUDED.key_salt, provider = EXCLUDED.provider, expires_at = EXCLUDED.expires_at, last_used_at = NULL, usage_count = 0, created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at", &[&secret.user_id, &secret.name, &secret.id.to_string(), &secret.encrypted_value, &secret.key_salt, &secret.provider, &secret.expires_at.map(|value| value.to_rfc3339()), &secret.last_used_at.map(|value| value.to_rfc3339()), &secret.usage_count, &secret.created_at.to_rfc3339(), &secret.updated_at.to_rfc3339()]).await.map_err(secret_db_error)?;
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get_secret(
+    client: &impl deadpool_postgres::GenericClient,
+    user_id: &str,
+    name: &str,
+) -> Result<Option<Secret>, SecretError> {
+    postgres_get_secret_query(client, user_id, name, false).await
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get_secret_for_update(
+    client: &impl deadpool_postgres::GenericClient,
+    user_id: &str,
+    name: &str,
+) -> Result<Option<Secret>, SecretError> {
+    postgres_get_secret_query(client, user_id, name, true).await
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_get_secret_query(
+    client: &impl deadpool_postgres::GenericClient,
+    user_id: &str,
+    name: &str,
+    for_update: bool,
+) -> Result<Option<Secret>, SecretError> {
+    let suffix = if for_update { " FOR UPDATE" } else { "" };
+    let query = format!(
+        "SELECT id, user_id, name, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at FROM reborn_secret_records WHERE user_id = $1 AND name = $2{suffix}"
+    );
+    let row = client
+        .query_opt(&query, &[&user_id, &name])
+        .await
+        .map_err(secret_db_error)?;
+    row.map(|row| postgres_secret_from_row(&row)).transpose()
+}
+
+#[cfg(feature = "postgres")]
+fn postgres_secret_from_row(row: &tokio_postgres::Row) -> Result<Secret, SecretError> {
+    let id: String = row.get(0);
+    let expires_at: Option<String> = row.get(6);
+    let last_used_at: Option<String> = row.get(7);
+    Ok(Secret {
+        id: parse_secret_uuid(&id)?,
+        user_id: row.get(1),
+        name: row.get(2),
+        encrypted_value: row.get(3),
+        key_salt: row.get(4),
+        provider: row.get(5),
+        expires_at: parse_optional_timestamp(expires_at.as_deref())?,
+        last_used_at: parse_optional_timestamp(last_used_at.as_deref())?,
+        usage_count: row.get(8),
+        created_at: parse_timestamp(&row.get::<_, String>(9))?,
+        updated_at: parse_timestamp(&row.get::<_, String>(10))?,
+    })
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_delete_secret(
+    client: &impl deadpool_postgres::GenericClient,
+    user_id: &str,
+    name: &str,
+) -> Result<bool, SecretError> {
+    let changed = client
+        .execute(
+            "DELETE FROM reborn_secret_records WHERE user_id = $1 AND name = $2",
+            &[&user_id, &name],
+        )
+        .await
+        .map_err(secret_db_error)?;
+    Ok(changed > 0)
+}
+
+fn build_encrypted_secret(
+    user_id: &str,
+    params: CreateSecretParams,
+    crypto: &SecretsCrypto,
+) -> Result<Secret, SecretError> {
+    let plaintext = params.value.expose_secret().as_bytes();
+    let (encrypted_value, key_salt) = crypto.encrypt(plaintext)?;
+    let now = Utc::now();
+    Ok(Secret {
+        id: Uuid::new_v4(),
+        user_id: user_id.to_string(),
+        name: normalize_secret_name(&params.name),
+        encrypted_value,
+        key_salt,
+        provider: params.provider,
+        expires_at: params.expires_at,
+        last_used_at: None,
+        usage_count: 0,
+        created_at: now,
+        updated_at: now,
+    })
+}
+
+fn normalize_secret_name(name: &str) -> String {
+    name.to_lowercase()
+}
+
+fn ensure_secret_not_expired(secret: &Secret) -> Result<(), SecretError> {
+    if let Some(expires_at) = secret.expires_at
+        && expires_at < Utc::now()
+    {
+        return Err(SecretError::Expired);
+    }
+    Ok(())
+}
+
+async fn secret_accessible<S: SecretsStore + ?Sized>(
+    store: &S,
+    user_id: &str,
+    secret_name: &str,
+    allowed_secrets: &[String],
+) -> Result<bool, SecretError> {
+    let secret_name_lower = normalize_secret_name(secret_name);
+    if !store.exists(user_id, &secret_name_lower).await? {
+        return Ok(false);
+    }
+    for pattern in allowed_secrets {
+        let pattern_lower = pattern.to_lowercase();
+        if pattern_lower == secret_name_lower {
+            return Ok(true);
+        }
+        if let Some(prefix) = pattern_lower.strip_suffix('*')
+            && secret_name_lower.starts_with(prefix)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn parse_secret_uuid(value: &str) -> Result<Uuid, SecretError> {
+    Uuid::parse_str(value).map_err(secret_db_error)
+}
+
+fn parse_optional_timestamp(value: Option<&str>) -> Result<Option<DateTime<Utc>>, SecretError> {
+    value.map(parse_timestamp).transpose()
+}
+
+fn parse_timestamp(value: &str) -> Result<DateTime<Utc>, SecretError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(secret_db_error)
+}
+
+fn secret_db_error(error: impl std::fmt::Display) -> SecretError {
+    SecretError::Database(error.to_string())
 }
 
 struct EncryptedPayload {

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -12,9 +12,9 @@ mod db;
 mod legacy_store;
 
 #[cfg(feature = "libsql")]
-pub use db::LibSqlCredentialStore;
+pub use db::{LibSqlCredentialStore, LibSqlSecretsStore};
 #[cfg(feature = "postgres")]
-pub use db::PostgresCredentialStore;
+pub use db::{PostgresCredentialStore, PostgresSecretsStore};
 
 use std::collections::HashMap;
 use std::fmt;

--- a/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
@@ -68,6 +68,37 @@ async fn libsql_secret_store_verify_can_decrypt_existing_secrets_rejects_wrong_k
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn libsql_secret_store_key_check_rejects_concurrent_conflict_winner_with_wrong_key() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let store = LibSqlSecretsStore::new(Arc::clone(&database), test_crypto());
+    store.run_migrations().await.unwrap();
+
+    let conn = database.connect().unwrap();
+    conn.execute("BEGIN IMMEDIATE", ()).await.unwrap();
+    insert_libsql_secret_store_key_check(&conn, test_crypto()).await;
+
+    let losing_store = LibSqlSecretsStore::new(Arc::clone(&database), wrong_crypto());
+    let verification = tokio::task::spawn_blocking(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(losing_store.verify_can_decrypt_existing_secrets())
+    });
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    conn.execute("COMMIT", ()).await.unwrap();
+
+    let error = verification
+        .await
+        .unwrap()
+        .expect_err("wrong key must verify the committed key-check conflict winner");
+    assert!(matches!(error, SecretError::DecryptionFailed(_)));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn libsql_secret_store_consume_if_matches_is_one_shot_and_durable() {
     let dir = tempfile::tempdir().unwrap().keep();
     let db_path = dir.join("secrets.db");
@@ -157,6 +188,50 @@ async fn postgres_secret_store_verify_can_decrypt_existing_secrets_rejects_wrong
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
+async fn postgres_secret_store_key_check_rejects_concurrent_conflict_winner_with_wrong_key() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let store = PostgresSecretsStore::new(pool.clone(), test_crypto());
+    store.run_migrations().await.unwrap();
+
+    let mut client = pool.get().await.unwrap();
+    client
+        .execute(
+            "DELETE FROM reborn_secret_store_key_check WHERE id = $1",
+            &[&"active"],
+        )
+        .await
+        .unwrap();
+    let transaction = client.transaction().await.unwrap();
+    insert_postgres_secret_store_key_check(&transaction, test_crypto()).await;
+
+    let losing_store = PostgresSecretsStore::new(pool.clone(), wrong_crypto());
+    let verification =
+        tokio::spawn(async move { losing_store.verify_can_decrypt_existing_secrets().await });
+    for _ in 0..1000 {
+        tokio::task::yield_now().await;
+    }
+    transaction.commit().await.unwrap();
+
+    let error = verification
+        .await
+        .unwrap()
+        .expect_err("wrong key must verify the committed key-check conflict winner");
+    assert!(matches!(error, SecretError::DecryptionFailed(_)));
+
+    let cleanup = pool.get().await.unwrap();
+    cleanup
+        .execute(
+            "DELETE FROM reborn_secret_store_key_check WHERE id = $1",
+            &[&"active"],
+        )
+        .await
+        .unwrap();
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
 async fn postgres_secret_store_consume_if_matches_is_one_shot_and_durable() {
     let Some(store) = postgres_store().await else {
         return;
@@ -197,6 +272,21 @@ async fn libsql_store(path: &std::path::Path, crypto: Arc<SecretsCrypto>) -> Lib
     store
 }
 
+#[cfg(feature = "libsql")]
+async fn insert_libsql_secret_store_key_check(
+    conn: &libsql::Connection,
+    crypto: Arc<SecretsCrypto>,
+) {
+    let (encrypted_value, key_salt) = crypto.encrypt(b"reborn-secret-store-key-check-v1").unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO reborn_secret_store_key_check (id, encrypted_value, key_salt, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?4)",
+        libsql::params!["active", encrypted_value, key_salt, now],
+    )
+    .await
+    .unwrap();
+}
+
 #[cfg(feature = "postgres")]
 async fn postgres_store() -> Option<PostgresSecretsStore> {
     postgres_store_with_crypto(test_crypto()).await
@@ -204,6 +294,17 @@ async fn postgres_store() -> Option<PostgresSecretsStore> {
 
 #[cfg(feature = "postgres")]
 async fn postgres_store_with_crypto(crypto: Arc<SecretsCrypto>) -> Option<PostgresSecretsStore> {
+    let pool = postgres_pool().await?;
+    let store = PostgresSecretsStore::new(pool, crypto);
+    store
+        .run_migrations()
+        .await
+        .expect("DATABASE_URL must point at a reachable Postgres test database");
+    Some(store)
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_pool() -> Option<deadpool_postgres::Pool> {
     let Ok(database_url) = std::env::var("DATABASE_URL") else {
         eprintln!("skipping Postgres secret store contract: DATABASE_URL is not set");
         return None;
@@ -212,16 +313,28 @@ async fn postgres_store_with_crypto(crypto: Arc<SecretsCrypto>) -> Option<Postgr
         .parse()
         .expect("DATABASE_URL must parse as a Postgres connection string");
     let manager = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
-    let pool = deadpool_postgres::Pool::builder(manager)
-        .max_size(4)
-        .build()
-        .expect("Postgres pool must build");
-    let store = PostgresSecretsStore::new(pool, crypto);
-    store
-        .run_migrations()
+    Some(
+        deadpool_postgres::Pool::builder(manager)
+            .max_size(4)
+            .build()
+            .expect("Postgres pool must build"),
+    )
+}
+
+#[cfg(feature = "postgres")]
+async fn insert_postgres_secret_store_key_check(
+    client: &impl deadpool_postgres::GenericClient,
+    crypto: Arc<SecretsCrypto>,
+) {
+    let (encrypted_value, key_salt) = crypto.encrypt(b"reborn-secret-store-key-check-v1").unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    client
+        .execute(
+            "INSERT INTO reborn_secret_store_key_check (id, encrypted_value, key_salt, created_at, updated_at) VALUES ($1, $2, $3, $4, $4)",
+            &[&"active", &encrypted_value, &key_salt, &now],
+        )
         .await
-        .expect("DATABASE_URL must point at a reachable Postgres test database");
-    Some(store)
+        .unwrap();
 }
 
 fn test_crypto() -> Arc<SecretsCrypto> {

--- a/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use ironclaw_secrets::LibSqlSecretsStore;
 #[cfg(feature = "postgres")]
 use ironclaw_secrets::PostgresSecretsStore;
-use ironclaw_secrets::{CreateSecretParams, SecretMaterial, SecretsCrypto, SecretsStore};
+use ironclaw_secrets::{
+    CreateSecretParams, SecretError, SecretMaterial, SecretsCrypto, SecretsStore,
+};
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
@@ -37,6 +39,37 @@ async fn libsql_secret_store_persists_encrypted_secret_material_across_reopen() 
         .await
         .unwrap();
     assert_eq!(decrypted.expose(), "sk-live-reborn-secret-sentinel");
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_secret_store_verify_can_decrypt_existing_secrets_rejects_wrong_key() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("secrets.db");
+    let store = libsql_store(&db_path, test_crypto()).await;
+
+    store
+        .create(
+            "reborn-user",
+            CreateSecretParams::new("openai_key", "sk-live-wrong-key-sentinel"),
+        )
+        .await
+        .unwrap();
+    drop(store);
+
+    let wrong_crypto = Arc::new(
+        SecretsCrypto::new(SecretMaterial::from(
+            "abcdef0123456789abcdef0123456789".to_string(),
+        ))
+        .unwrap(),
+    );
+    let reopened = libsql_store(&db_path, wrong_crypto).await;
+    let error = reopened
+        .verify_can_decrypt_existing_secrets()
+        .await
+        .expect_err("wrong key must fail existing row decryptability check");
+    assert!(matches!(error, SecretError::DecryptionFailed(_)));
+    assert!(!format!("{error:?}").contains("sk-live-wrong-key-sentinel"));
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
@@ -57,13 +57,7 @@ async fn libsql_secret_store_verify_can_decrypt_existing_secrets_rejects_wrong_k
         .unwrap();
     drop(store);
 
-    let wrong_crypto = Arc::new(
-        SecretsCrypto::new(SecretMaterial::from(
-            "abcdef0123456789abcdef0123456789".to_string(),
-        ))
-        .unwrap(),
-    );
-    let reopened = libsql_store(&db_path, wrong_crypto).await;
+    let reopened = libsql_store(&db_path, wrong_crypto()).await;
     let error = reopened
         .verify_can_decrypt_existing_secrets()
         .await
@@ -113,7 +107,7 @@ async fn postgres_secret_store_persists_encrypted_secret_material_when_database_
     let Some(store) = postgres_store().await else {
         return;
     };
-    let suffix = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
+    let suffix = unique_suffix();
     let user_id = format!("reborn-user-{suffix}");
     let secret_name = format!("openai_key_{suffix}");
 
@@ -131,6 +125,70 @@ async fn postgres_secret_store_persists_encrypted_secret_material_when_database_
     );
 }
 
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_secret_store_verify_can_decrypt_existing_secrets_rejects_wrong_key() {
+    let Some(store) = postgres_store().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let user_id = format!("reborn-user-wrong-key-{suffix}");
+    let secret_name = format!("openai_key_{suffix}");
+
+    store
+        .create(
+            &user_id,
+            CreateSecretParams::new(&secret_name, "sk-live-postgres-wrong-key-sentinel"),
+        )
+        .await
+        .unwrap();
+    drop(store);
+
+    let Some(reopened) = postgres_store_with_crypto(wrong_crypto()).await else {
+        return;
+    };
+    let error = reopened
+        .verify_can_decrypt_existing_secrets()
+        .await
+        .expect_err("wrong key must fail existing row decryptability check");
+    assert!(matches!(error, SecretError::DecryptionFailed(_)));
+    assert!(!format!("{error:?}").contains("sk-live-postgres-wrong-key-sentinel"));
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_secret_store_consume_if_matches_is_one_shot_and_durable() {
+    let Some(store) = postgres_store().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let user_id = format!("reborn-user-oauth-{suffix}");
+    let secret_name = format!("oauth_state_{suffix}");
+
+    store
+        .create(
+            &user_id,
+            CreateSecretParams::new(&secret_name, "state-postgres-secret-sentinel"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .consume_if_matches(&user_id, &secret_name, "wrong")
+            .await
+            .unwrap(),
+        ironclaw_secrets::SecretConsumeResult::Mismatched
+    );
+    assert_eq!(
+        store
+            .consume_if_matches(&user_id, &secret_name, "state-postgres-secret-sentinel")
+            .await
+            .unwrap(),
+        ironclaw_secrets::SecretConsumeResult::Matched
+    );
+    assert!(!store.exists(&user_id, &secret_name).await.unwrap());
+}
+
 #[cfg(feature = "libsql")]
 async fn libsql_store(path: &std::path::Path, crypto: Arc<SecretsCrypto>) -> LibSqlSecretsStore {
     let db = Arc::new(libsql::Builder::new_local(path).build().await.unwrap());
@@ -141,6 +199,11 @@ async fn libsql_store(path: &std::path::Path, crypto: Arc<SecretsCrypto>) -> Lib
 
 #[cfg(feature = "postgres")]
 async fn postgres_store() -> Option<PostgresSecretsStore> {
+    postgres_store_with_crypto(test_crypto()).await
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_store_with_crypto(crypto: Arc<SecretsCrypto>) -> Option<PostgresSecretsStore> {
     let Ok(database_url) = std::env::var("DATABASE_URL") else {
         eprintln!("skipping Postgres secret store contract: DATABASE_URL is not set");
         return None;
@@ -153,7 +216,7 @@ async fn postgres_store() -> Option<PostgresSecretsStore> {
         .max_size(4)
         .build()
         .expect("Postgres pool must build");
-    let store = PostgresSecretsStore::new(pool, test_crypto());
+    let store = PostgresSecretsStore::new(pool, crypto);
     store
         .run_migrations()
         .await
@@ -168,4 +231,18 @@ fn test_crypto() -> Arc<SecretsCrypto> {
         ))
         .unwrap(),
     )
+}
+
+fn wrong_crypto() -> Arc<SecretsCrypto> {
+    Arc::new(
+        SecretsCrypto::new(SecretMaterial::from(
+            "abcdef0123456789abcdef0123456789".to_string(),
+        ))
+        .unwrap(),
+    )
+}
+
+#[cfg(feature = "postgres")]
+fn unique_suffix() -> i64 {
+    chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
 }

--- a/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
@@ -1,0 +1,138 @@
+#![cfg(any(feature = "libsql", feature = "postgres"))]
+
+use std::sync::Arc;
+
+#[cfg(feature = "libsql")]
+use ironclaw_secrets::LibSqlSecretsStore;
+#[cfg(feature = "postgres")]
+use ironclaw_secrets::PostgresSecretsStore;
+use ironclaw_secrets::{CreateSecretParams, SecretMaterial, SecretsCrypto, SecretsStore};
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_secret_store_persists_encrypted_secret_material_across_reopen() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("secrets.db");
+    let crypto = test_crypto();
+    let store = libsql_store(&db_path, Arc::clone(&crypto)).await;
+
+    store
+        .create(
+            "reborn-user",
+            CreateSecretParams::new("openai_key", "sk-live-reborn-secret-sentinel"),
+        )
+        .await
+        .unwrap();
+    drop(store);
+
+    let raw_database = String::from_utf8_lossy(&std::fs::read(&db_path).unwrap()).to_string();
+    assert!(
+        !raw_database.contains("sk-live-reborn-secret-sentinel"),
+        "raw secret material must be encrypted at rest"
+    );
+
+    let reopened = libsql_store(&db_path, crypto).await;
+    let decrypted = reopened
+        .get_decrypted("reborn-user", "openai_key")
+        .await
+        .unwrap();
+    assert_eq!(decrypted.expose(), "sk-live-reborn-secret-sentinel");
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_secret_store_consume_if_matches_is_one_shot_and_durable() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("secrets.db");
+    let crypto = test_crypto();
+    let store = libsql_store(&db_path, Arc::clone(&crypto)).await;
+
+    store
+        .create(
+            "reborn-user",
+            CreateSecretParams::new("oauth_state", "state-secret-sentinel"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .consume_if_matches("reborn-user", "oauth_state", "wrong")
+            .await
+            .unwrap(),
+        ironclaw_secrets::SecretConsumeResult::Mismatched
+    );
+    assert_eq!(
+        store
+            .consume_if_matches("reborn-user", "oauth_state", "state-secret-sentinel")
+            .await
+            .unwrap(),
+        ironclaw_secrets::SecretConsumeResult::Matched
+    );
+    drop(store);
+
+    let reopened = libsql_store(&db_path, crypto).await;
+    assert!(!reopened.exists("reborn-user", "oauth_state").await.unwrap());
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_secret_store_persists_encrypted_secret_material_when_database_url_is_set() {
+    let Some(store) = postgres_store().await else {
+        return;
+    };
+    let suffix = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
+    let user_id = format!("reborn-user-{suffix}");
+    let secret_name = format!("openai_key_{suffix}");
+
+    store
+        .create(
+            &user_id,
+            CreateSecretParams::new(&secret_name, "sk-live-postgres-reborn-secret-sentinel"),
+        )
+        .await
+        .unwrap();
+    let decrypted = store.get_decrypted(&user_id, &secret_name).await.unwrap();
+    assert_eq!(
+        decrypted.expose(),
+        "sk-live-postgres-reborn-secret-sentinel"
+    );
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_store(path: &std::path::Path, crypto: Arc<SecretsCrypto>) -> LibSqlSecretsStore {
+    let db = Arc::new(libsql::Builder::new_local(path).build().await.unwrap());
+    let store = LibSqlSecretsStore::new(db, crypto);
+    store.run_migrations().await.unwrap();
+    store
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_store() -> Option<PostgresSecretsStore> {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipping Postgres secret store contract: DATABASE_URL is not set");
+        return None;
+    };
+    let config: tokio_postgres::Config = database_url
+        .parse()
+        .expect("DATABASE_URL must parse as a Postgres connection string");
+    let manager = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
+    let pool = deadpool_postgres::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("Postgres pool must build");
+    let store = PostgresSecretsStore::new(pool, test_crypto());
+    store
+        .run_migrations()
+        .await
+        .expect("DATABASE_URL must point at a reachable Postgres test database");
+    Some(store)
+}
+
+fn test_crypto() -> Arc<SecretsCrypto> {
+    Arc::new(
+        SecretsCrypto::new(SecretMaterial::from(
+            "0123456789abcdef0123456789abcdef".to_string(),
+        ))
+        .unwrap(),
+    )
+}

--- a/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use chrono::{Duration, Utc};
+
 #[cfg(feature = "libsql")]
 use ironclaw_secrets::LibSqlSecretsStore;
 #[cfg(feature = "postgres")]
@@ -39,6 +41,46 @@ async fn libsql_secret_store_persists_encrypted_secret_material_across_reopen() 
         .await
         .unwrap();
     assert_eq!(decrypted.expose(), "sk-live-reborn-secret-sentinel");
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_secret_store_tracks_metadata_usage_overwrite_and_empty_state_edges() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("secrets.db");
+    let store = libsql_store(&db_path, test_crypto()).await;
+
+    assert!(!store.any_exist().await.unwrap());
+    assert_secret_store_tracks_metadata_usage_and_overwrite_edges(&store, "reborn-user-metadata")
+        .await;
+    assert!(!store.any_exist().await.unwrap());
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_secret_store_preserves_mismatched_and_expired_one_shot_values() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("secrets.db");
+    let store = libsql_store(&db_path, test_crypto()).await;
+
+    assert_secret_store_preserves_mismatched_and_expired_one_shot_values(
+        &store,
+        "reborn-user-edge",
+        "oauth_state",
+        "expired_state",
+    )
+    .await;
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_secret_store_enforces_access_patterns_without_exposing_missing_names() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("secrets.db");
+    let store = libsql_store(&db_path, test_crypto()).await;
+
+    assert_secret_store_enforces_access_patterns(&store, "reborn-user-access", "OpenAI_Prod_Key")
+        .await;
 }
 
 #[cfg(feature = "libsql")]
@@ -158,6 +200,51 @@ async fn postgres_secret_store_persists_encrypted_secret_material_when_database_
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
+async fn postgres_secret_store_tracks_metadata_usage_and_overwrite_edges() {
+    let Some(store) = postgres_store().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let user_id = format!("reborn-user-metadata-{suffix}");
+
+    assert_secret_store_tracks_metadata_usage_and_overwrite_edges(&store, &user_id).await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_secret_store_preserves_mismatched_and_expired_one_shot_values() {
+    let Some(store) = postgres_store().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let user_id = format!("reborn-user-edge-{suffix}");
+    let mismatch_name = format!("oauth_state_{suffix}");
+    let expired_name = format!("expired_state_{suffix}");
+
+    assert_secret_store_preserves_mismatched_and_expired_one_shot_values(
+        &store,
+        &user_id,
+        &mismatch_name,
+        &expired_name,
+    )
+    .await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_secret_store_enforces_access_patterns_without_exposing_missing_names() {
+    let Some(store) = postgres_store().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let user_id = format!("reborn-user-access-{suffix}");
+    let secret_name = format!("OpenAI_Prod_Key_{suffix}");
+
+    assert_secret_store_enforces_access_patterns(&store, &user_id, &secret_name).await;
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
 async fn postgres_secret_store_verify_can_decrypt_existing_secrets_rejects_wrong_key() {
     let Some(store) = postgres_store().await else {
         return;
@@ -262,6 +349,160 @@ async fn postgres_secret_store_consume_if_matches_is_one_shot_and_durable() {
         ironclaw_secrets::SecretConsumeResult::Matched
     );
     assert!(!store.exists(&user_id, &secret_name).await.unwrap());
+}
+
+async fn assert_secret_store_tracks_metadata_usage_and_overwrite_edges<S>(store: &S, user_id: &str)
+where
+    S: SecretsStore + ?Sized,
+{
+    let expires_at = Utc::now() + Duration::hours(1);
+    let created = store
+        .create(
+            user_id,
+            CreateSecretParams::new("Beta_Key", "sk-live-first-value")
+                .with_provider("openai")
+                .with_expiry(expires_at),
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.name, "beta_key");
+    assert_eq!(created.provider.as_deref(), Some("openai"));
+    assert_eq!(created.usage_count, 0);
+    assert!(created.last_used_at.is_none());
+
+    let fetched = store.get(user_id, "BETA_KEY").await.unwrap();
+    assert_eq!(fetched.id, created.id);
+    assert_eq!(fetched.name, "beta_key");
+    assert_eq!(fetched.provider.as_deref(), Some("openai"));
+    assert_eq!(fetched.expires_at, Some(expires_at));
+
+    let refs = store.list(user_id).await.unwrap();
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].name, "beta_key");
+    assert_eq!(refs[0].provider.as_deref(), Some("openai"));
+
+    store.record_usage(fetched.id).await.unwrap();
+    let used = store.get(user_id, "beta_key").await.unwrap();
+    assert_eq!(used.usage_count, 1);
+    assert!(used.last_used_at.is_some());
+
+    let overwritten = store
+        .create(
+            user_id,
+            CreateSecretParams::new("BETA_KEY", "sk-live-second-value").with_provider("anthropic"),
+        )
+        .await
+        .unwrap();
+    assert_ne!(overwritten.id, created.id);
+    assert_eq!(overwritten.name, "beta_key");
+
+    let after_overwrite = store.get(user_id, "beta_key").await.unwrap();
+    assert_eq!(after_overwrite.id, overwritten.id);
+    assert_eq!(after_overwrite.usage_count, 0);
+    assert!(after_overwrite.last_used_at.is_none());
+    assert_eq!(after_overwrite.provider.as_deref(), Some("anthropic"));
+    let decrypted = store.get_decrypted(user_id, "beta_key").await.unwrap();
+    assert_eq!(decrypted.expose(), "sk-live-second-value");
+
+    assert!(store.delete(user_id, "BETA_KEY").await.unwrap());
+    assert!(!store.exists(user_id, "beta_key").await.unwrap());
+    assert!(!store.delete(user_id, "beta_key").await.unwrap());
+    assert!(matches!(
+        store.record_usage(overwritten.id).await,
+        Err(SecretError::NotFound(_))
+    ));
+}
+
+async fn assert_secret_store_preserves_mismatched_and_expired_one_shot_values<S>(
+    store: &S,
+    user_id: &str,
+    mismatch_name: &str,
+    expired_name: &str,
+) where
+    S: SecretsStore + ?Sized,
+{
+    store
+        .create(
+            user_id,
+            CreateSecretParams::new(mismatch_name, "state-secret-sentinel"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .consume_if_matches(user_id, mismatch_name, "wrong-state")
+            .await
+            .unwrap(),
+        ironclaw_secrets::SecretConsumeResult::Mismatched
+    );
+    assert!(store.exists(user_id, mismatch_name).await.unwrap());
+    let still_decrypts = store.get_decrypted(user_id, mismatch_name).await.unwrap();
+    assert_eq!(still_decrypts.expose(), "state-secret-sentinel");
+
+    store
+        .create(
+            user_id,
+            CreateSecretParams::new(expired_name, "expired-state-sentinel")
+                .with_expiry(Utc::now() - Duration::seconds(1)),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        store.get(user_id, expired_name).await,
+        Err(SecretError::Expired)
+    ));
+    assert!(matches!(
+        store.get_decrypted(user_id, expired_name).await,
+        Err(SecretError::Expired)
+    ));
+    assert!(matches!(
+        store
+            .consume_if_matches(user_id, expired_name, "expired-state-sentinel")
+            .await,
+        Err(SecretError::Expired)
+    ));
+    assert!(
+        store.exists(user_id, expired_name).await.unwrap(),
+        "expired rows stay durable for cleanup/rotation rather than disappearing during reads"
+    );
+}
+
+async fn assert_secret_store_enforces_access_patterns<S>(store: &S, user_id: &str, name: &str)
+where
+    S: SecretsStore + ?Sized,
+{
+    store
+        .create(
+            user_id,
+            CreateSecretParams::new(name, "sk-live-access-sentinel"),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        store
+            .is_accessible(user_id, name, &[name.to_ascii_uppercase()])
+            .await
+            .unwrap()
+    );
+    assert!(
+        store
+            .is_accessible(user_id, name, &["openai_*".to_string()])
+            .await
+            .unwrap()
+    );
+    assert!(
+        !store
+            .is_accessible(user_id, name, &["github_*".to_string()])
+            .await
+            .unwrap()
+    );
+    assert!(
+        !store
+            .is_accessible(user_id, "missing_secret", &["missing_*".to_string()])
+            .await
+            .unwrap()
+    );
 }
 
 #[cfg(feature = "libsql")]

--- a/docs/reborn/contracts/secrets.md
+++ b/docs/reborn/contracts/secrets.md
@@ -38,6 +38,8 @@ SecretLease
 SecretStoreError
 SecretStore
 InMemorySecretStore
+LibSqlSecretsStore     // durable backend when the libsql feature is enabled
+PostgresSecretsStore   // durable backend when the postgres feature is enabled
 ```
 
 `SecretMaterial` is backed by `secrecy::SecretString`, so access to raw values is explicit through `ExposeSecret`. Metadata, lease records, and errors never contain raw values.
@@ -87,6 +89,8 @@ let material = secrets.consume(&scope, lease.id).await?;
 
 `SecretStore::put(...)` is for trusted setup, composition, migration, or storage-code paths that are already allowed to manage secret material. It is not a runtime/plugin API, and it intentionally does not perform authorization itself.
 
+Durable libSQL/PostgreSQL stores persist only encrypted values and per-row salts in `reborn_secret_records`; names, providers, expiry, and usage metadata remain queryable. Store readiness must fail closed when the configured master key is missing, malformed, cannot decrypt existing rows, or loses a first-boot key-check race to another process with a different key. Bootstrap inserts of the `reborn_secret_store_key_check` sentinel must re-read and decrypt the committed row before reporting ready.
+
 The shared Reborn runtime HTTP egress service uses this surface to:
 
 - check metadata for required or optional credential handles
@@ -135,7 +139,6 @@ preferred when a credential is only valid for specific destinations.
 
 This slice does not implement:
 
-- durable encrypted secret persistence
 - platform keychain integration
 - secret rotation/versioning
 - secret audit emission
@@ -159,4 +162,6 @@ The crate tests cover:
 - consumed and revoked lease records drop retained secret material
 - revoked leases cannot be consumed
 - missing secrets fail without creating leases
+- durable libSQL/PostgreSQL stores keep raw material encrypted at rest
+- durable key-check readiness rejects wrong, malformed, or concurrently conflicting master keys
 - crate boundary remains low-level and does not depend on workflow/runtime/observability crates


### PR DESCRIPTION
## Summary

- add libSQL/Postgres `SecretsStore` implementations for Reborn secret material using v1 `SecretsCrypto` semantics
- persist only encrypted secret values + per-row salts, with names/providers/usage metadata queryable as in v1
- add atomic libSQL/Postgres `consume_if_matches` paths for OAuth/state-style one-shot secrets
- add standalone `ironclaw_reborn` libSQL secret-store composition with an explicit operator master key
- add health/readiness helper that fails closed when the master key is missing or existing rows cannot decrypt

Refs #2987
Refs #3067

## Verification

- `cargo fmt --check -p ironclaw_secrets -p ironclaw_reborn`
- `cargo test -p ironclaw_secrets`
- `cargo test -p ironclaw_secrets --features libsql --test db_secret_store_contract`
- `cargo test -p ironclaw_secrets --features postgres --test db_secret_store_contract`
- `cargo test -p ironclaw_reborn --features libsql-secrets --test secrets`
- `cargo test -p ironclaw_secrets --features libsql --test db_credential_store_contract`
- `cargo test -p ironclaw_secrets --features postgres --test db_credential_store_contract`
- `cargo check -p ironclaw_secrets --features 'libsql postgres'`
- `cargo check -p ironclaw_reborn --features libsql-secrets`
- `cargo clippy -p ironclaw_secrets --all-targets --features libsql -- -D warnings`
- `cargo clippy -p ironclaw_secrets --all-targets --features postgres -- -D warnings`
- `cargo clippy -p ironclaw_reborn --all-targets --features libsql-secrets -- -D warnings`
- `cargo test -p ironclaw_architecture --test reborn_dependency_boundaries reborn_crate_dependency_boundaries_hold -- --nocapture`

## Reborn finalization checklist

Done in this slice:
- raw Reborn secret material can now use durable encrypted libSQL/Postgres stores
- standalone Reborn composition requires an explicit operator master key
- startup/readiness fails closed when configured key cannot decrypt existing rows
- sentinel tests cover raw DB non-exposure and health/error redaction

Still to do:
- connect this helper to any future `ironclaw-reborn` binary/daemon command once that surface lands on `reborn-integration`
- expand no-exposure sentinel coverage across event/log/replay surfaces as those surfaces wire real secret material
