### PR TITLE
feat(reborn): add durable resource governor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4336,6 +4336,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
  "tracing",
  "url",
  "wat",
@@ -4565,6 +4566,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2923,6 +2923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs4"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,10 +4553,18 @@ dependencies = [
 name = "ironclaw_resources"
 version = "0.1.0"
 dependencies = [
+ "deadpool-postgres",
+ "fs2",
  "ironclaw_host_api",
+ "libsql",
  "rust_decimal",
  "rust_decimal_macros",
+ "serde",
+ "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]

--- a/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/dispatch_contract.rs
@@ -19,14 +19,16 @@ async fn dispatcher_routes_wasm_capability_through_registered_adapter() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            max_output_bytes: Some(10_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
         .with_runtime_adapter(RuntimeKind::Wasm, &adapter);
@@ -81,15 +83,17 @@ async fn dispatcher_routes_script_capability_through_registered_adapter() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            max_process_count: Some(10),
-            max_output_bytes: Some(10_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_process_count: Some(10),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
         .with_runtime_adapter(RuntimeKind::Script, &adapter);
@@ -133,15 +137,17 @@ async fn dispatcher_redacts_runtime_adapter_failure_details() {
         RecordingAdapter::failing(RuntimeKind::Script, RuntimeDispatchErrorKind::ExitFailure);
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
-    governor.set_limit(
-        ResourceAccount::tenant(scope.tenant_id.clone()),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            max_process_count: Some(10),
-            max_output_bytes: Some(10_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            ResourceAccount::tenant(scope.tenant_id.clone()),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_process_count: Some(10),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
         .with_runtime_adapter(RuntimeKind::Script, &adapter);
@@ -189,15 +195,17 @@ async fn dispatcher_routes_mcp_capability_through_registered_adapter() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            max_process_count: Some(1),
-            max_output_bytes: Some(10_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_process_count: Some(1),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor)
         .with_runtime_adapter(RuntimeKind::Mcp, &adapter);

--- a/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
+++ b/crates/ironclaw_dispatcher/tests/runtime_dispatcher_integration.rs
@@ -28,14 +28,16 @@ async fn runtime_dispatcher_routes_already_authorized_request_through_public_tra
     )])
     .unwrap();
 
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            max_output_bytes: Some(10_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let dispatcher = RuntimeDispatcher::from_arcs(
         Arc::clone(&registry),

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [features]
 default = []
-postgres = ["dep:deadpool-postgres", "ironclaw_filesystem/postgres", "ironclaw_run_state/postgres", "ironclaw_turns/postgres"]
-libsql = ["dep:libsql", "ironclaw_filesystem/libsql", "ironclaw_run_state/libsql", "ironclaw_turns/libsql"]
+postgres = ["dep:deadpool-postgres", "ironclaw_filesystem/postgres", "ironclaw_resources/postgres", "ironclaw_run_state/postgres", "ironclaw_turns/postgres"]
+libsql = ["dep:libsql", "ironclaw_filesystem/libsql", "ironclaw_resources/libsql", "ironclaw_run_state/libsql", "ironclaw_turns/libsql"]
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -47,6 +47,7 @@ url = "2"
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "time"] }
+tokio-postgres = "0.7"
 wat = "1.245.1"
 wit-component = "0.245.1"
 wit-parser = "0.245.1"

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -42,7 +42,13 @@ use ironclaw_reborn_event_store::{
     RebornEventStoreConfig, RebornEventStoreError, RebornEventStores, RebornProfile,
     build_reborn_event_stores,
 };
+#[cfg(feature = "libsql")]
+use ironclaw_resources::LibSqlResourceGovernorStore;
+#[cfg(feature = "postgres")]
+use ironclaw_resources::PostgresResourceGovernorStore;
 use ironclaw_resources::ResourceGovernor;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_resources::{PersistentResourceGovernor, ResourceError};
 #[cfg(feature = "libsql")]
 use ironclaw_run_state::LibSqlRunStateApprovalStore;
 #[cfg(feature = "postgres")]
@@ -463,6 +469,102 @@ where
         filesystem: Arc<LibSqlRootFilesystem>,
     ) -> HostRuntimeServices<LibSqlRootFilesystem, G, S, R> {
         self.with_root_filesystem(filesystem)
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    fn with_resource_governor<T>(self, governor: Arc<T>) -> HostRuntimeServices<F, T, S, R>
+    where
+        T: ResourceGovernor + 'static,
+    {
+        let Self {
+            registry,
+            trust_policy,
+            trust_policy_configured,
+            filesystem,
+            governor: _,
+            authorizer,
+            process_services,
+            surface_version,
+            run_state,
+            approval_requests,
+            run_state_approval_store,
+            capability_leases,
+            event_sink,
+            audit_sink,
+            secret_store,
+            network_policy_store,
+            secret_injection_store,
+            process_lifecycle_store,
+            runtime_http_egress,
+            wasm_credential_provider,
+            runtime_health,
+            script_runtime,
+            mcp_runtime,
+            wasm_runtime,
+            turn_state,
+            turn_run_wake_notifier,
+            mut component_types,
+        } = self;
+        component_types.resource_governor = type_name::<T>();
+        HostRuntimeServices {
+            registry,
+            trust_policy,
+            trust_policy_configured,
+            filesystem,
+            governor,
+            authorizer,
+            process_services,
+            surface_version,
+            run_state,
+            approval_requests,
+            run_state_approval_store,
+            capability_leases,
+            event_sink,
+            audit_sink,
+            secret_store,
+            network_policy_store,
+            secret_injection_store,
+            process_lifecycle_store,
+            runtime_http_egress,
+            wasm_credential_provider,
+            runtime_health,
+            script_runtime,
+            mcp_runtime,
+            wasm_runtime,
+            turn_state,
+            turn_run_wake_notifier,
+            component_types,
+        }
+    }
+
+    #[cfg(feature = "libsql")]
+    pub async fn with_libsql_resource_governor(
+        self,
+        db: Arc<libsql::Database>,
+    ) -> Result<
+        HostRuntimeServices<F, PersistentResourceGovernor<LibSqlResourceGovernorStore>, S, R>,
+        ResourceError,
+    > {
+        let store = LibSqlResourceGovernorStore::new(db);
+        store.run_migrations().await?;
+        Ok(self.with_resource_governor(Arc::new(PersistentResourceGovernor::new(store))))
+    }
+
+    #[cfg(feature = "postgres")]
+    pub async fn with_postgres_resource_governor(
+        self,
+        pool: deadpool_postgres::Pool,
+    ) -> Result<
+        HostRuntimeServices<F, PersistentResourceGovernor<PostgresResourceGovernorStore>, S, R>,
+        ResourceError,
+    > {
+        let store = PostgresResourceGovernorStore::new(pool);
+        store.run_migrations().await?;
+        Ok(self.with_resource_governor(Arc::new(PersistentResourceGovernor::new(store))))
+    }
+
+    pub fn resource_governor(&self) -> Arc<G> {
+        Arc::clone(&self.governor)
     }
 
     /// Attaches the host-owned trust policy used by the produced

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -53,7 +53,8 @@ use ironclaw_reborn_event_store::{
     RebornEventStoreConfig, RebornEventStoreError, RebornProfile, build_reborn_event_stores,
 };
 use ironclaw_resources::{
-    InMemoryResourceGovernor, ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
+    InMemoryResourceGovernor, JsonFileResourceGovernorStore, PersistentResourceGovernor,
+    ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
 };
 #[cfg(feature = "libsql")]
 use ironclaw_run_state::LibSqlRunStateApprovalStore;
@@ -192,6 +193,34 @@ fn production_wiring_validation_rejects_missing_components_and_local_only_defaul
             ProductionWiringIssueKind::LocalOnlyImplementation
         ),
         "in-memory process result store should be reported as local-only: {report:?}"
+    );
+}
+
+#[test]
+fn production_wiring_validation_accepts_persistent_resource_governor_component() {
+    let dir = tempfile::tempdir().unwrap();
+    let governor = Arc::new(PersistentResourceGovernor::new(
+        JsonFileResourceGovernorStore::new(dir.path().join("resource-governor.json")),
+    ));
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        governor,
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    );
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([]))
+        .expect_err("other local/test defaults still prevent production validation");
+
+    assert!(
+        !report.contains(
+            ProductionWiringComponent::ResourceGovernor,
+            ProductionWiringIssueKind::LocalOnlyImplementation,
+        ),
+        "persistent resource governor should satisfy resource guardrail: {report:?}"
     );
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -224,6 +224,146 @@ fn production_wiring_validation_accepts_persistent_resource_governor_component()
     );
 }
 
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn with_libsql_resource_governor_runs_migrations_before_first_reserve() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(
+        libsql::Builder::new_local(dir.path().join("resources.db"))
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_libsql_resource_governor(Arc::clone(&db))
+    .await
+    .unwrap();
+
+    let governor = services.resource_governor();
+    let scope = sample_scope(InvocationId::new());
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    let reservation = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    governor.release(reservation.id).unwrap();
+}
+
+#[cfg(feature = "postgres")]
+const POSTGRES_SKIP_ENV: &str = "IRONCLAW_SKIP_POSTGRES_TESTS";
+
+#[cfg(feature = "postgres")]
+fn postgres_skip_requested() -> bool {
+    std::env::var(POSTGRES_SKIP_ENV).is_ok_and(|value| value == "1" || value == "true")
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_pool_or_skip() -> Option<deadpool_postgres::Pool> {
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://localhost/ironclaw_test".to_string());
+    let config: tokio_postgres::Config = database_url
+        .parse()
+        .expect("DATABASE_URL must be a valid Postgres URL");
+    let mgr = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
+    let pool = deadpool_postgres::Pool::builder(mgr)
+        .max_size(2)
+        .build()
+        .expect("build deadpool");
+    match pool.get().await {
+        Ok(_) => Some(pool),
+        Err(error) => {
+            if postgres_skip_requested() {
+                eprintln!(
+                    "skipping host-runtime Postgres resource governor test ({POSTGRES_SKIP_ENV}=1): {error}"
+                );
+                None
+            } else {
+                panic!(
+                    "host-runtime Postgres resource governor test could not reach Postgres ({error}); \
+                     set DATABASE_URL to a reachable Postgres test database, or set \
+                     {POSTGRES_SKIP_ENV}=1 to explicitly skip."
+                );
+            }
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn drop_postgres_resource_governor_table(pool: &deadpool_postgres::Pool) {
+    let client = pool.get().await.expect("cleanup client");
+    client
+        .batch_execute("DROP TABLE IF EXISTS ironclaw_resource_governor_snapshots")
+        .await
+        .expect("drop resource governor snapshots table");
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn with_postgres_resource_governor_runs_migrations_before_first_reserve() {
+    let Some(pool) = postgres_pool_or_skip().await else {
+        return;
+    };
+    drop_postgres_resource_governor_table(&pool).await;
+
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_postgres_resource_governor(pool.clone())
+    .await
+    .unwrap();
+
+    let governor = services.resource_governor();
+    let scope = sample_scope(InvocationId::new());
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    let reservation = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    governor.release(reservation.id).unwrap();
+    drop_postgres_resource_governor_table(&pool).await;
+}
+
 #[test]
 fn production_wiring_validation_classifies_combined_store_as_run_state_and_approvals() {
     let services = HostRuntimeServices::new(
@@ -2972,14 +3112,16 @@ async fn host_runtime_services_enforces_output_limit_and_reconciles_resource_usa
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let scope = sample_scope(InvocationId::new());
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            max_output_bytes: Some(10_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let reservation_id = ResourceReservationId::new();
     let authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer> =
@@ -3044,13 +3186,15 @@ async fn host_runtime_services_releases_reservation_when_dispatch_preflight_fail
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let scope = sample_scope(InvocationId::new());
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let reservation_id = ResourceReservationId::new();
     let services = HostRuntimeServices::new(
@@ -5148,7 +5292,13 @@ struct FailingProcessResultStore {
 struct FailingCleanupResourceGovernor;
 
 impl ResourceGovernor for FailingCleanupResourceGovernor {
-    fn set_limit(&self, _account: ResourceAccount, _limits: ResourceLimits) {}
+    fn set_limit(
+        &self,
+        _account: ResourceAccount,
+        _limits: ResourceLimits,
+    ) -> Result<(), ResourceError> {
+        Ok(())
+    }
 
     fn reserve(
         &self,
@@ -5902,15 +6052,17 @@ fn mounted_empty_extension_root() -> LocalFilesystem {
 
 fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGovernor {
     let governor = InMemoryResourceGovernor::new();
-    governor.set_limit(
-        account,
-        ResourceLimits {
-            max_concurrency_slots: Some(10),
-            max_network_egress_bytes: Some(10_000),
-            max_output_bytes: Some(100_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account,
+            ResourceLimits {
+                max_concurrency_slots: Some(10),
+                max_network_egress_bytes: Some(10_000),
+                max_output_bytes: Some(100_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     governor
 }
 

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -17,15 +17,17 @@ async fn mcp_runtime_reserves_calls_adapter_and_reconciles_success() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            max_process_count: Some(1),
-            max_output_bytes: Some(10_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_process_count: Some(1),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let result = runtime
         .execute_extension_json(
@@ -591,13 +593,15 @@ async fn mcp_runtime_denies_budget_before_adapter_call() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(0),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(0),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let err = runtime
         .execute_extension_json(
@@ -692,13 +696,15 @@ async fn mcp_runtime_rejects_non_mcp_or_undeclared_capability_before_reserving()
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(0),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(0),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let non_mcp_err = runtime
         .execute_extension_json(
@@ -1319,8 +1325,12 @@ impl ReleaseFailingGovernor {
 }
 
 impl ResourceGovernor for ReleaseFailingGovernor {
-    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
-        self.inner.set_limit(account, limits);
+    fn set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ResourceLimits,
+    ) -> Result<(), ResourceError> {
+        self.inner.set_limit(account, limits)
     }
 
     fn reserve(

--- a/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
+++ b/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
@@ -266,15 +266,17 @@ fn mounted_empty_extension_root() -> LocalFilesystem {
 
 fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGovernor {
     let governor = InMemoryResourceGovernor::new();
-    governor.set_limit(
-        account,
-        ResourceLimits {
-            max_concurrency_slots: Some(10),
-            max_process_count: Some(10),
-            max_output_bytes: Some(100_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account,
+            ResourceLimits {
+                max_concurrency_slots: Some(10),
+                max_process_count: Some(10),
+                max_output_bytes: Some(100_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     governor
 }
 

--- a/crates/ironclaw_processes/tests/process_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_store_contract.rs
@@ -706,13 +706,15 @@ async fn resource_managed_store_denies_before_process_record_creation() {
     let invocation_id = InvocationId::new();
     let process_id = ProcessId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
-    governor.set_limit(
-        ResourceAccount::tenant(scope.tenant_id.clone()),
-        ResourceLimits {
-            max_process_count: Some(0),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            ResourceAccount::tenant(scope.tenant_id.clone()),
+            ResourceLimits {
+                max_process_count: Some(0),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let store = ResourceManagedProcessStore::new(InMemoryProcessStore::new(), governor.clone());
 
     let err = store
@@ -1534,13 +1536,15 @@ async fn assert_unowned_process_reservation_rejected(transition: UnownedTransiti
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_process_count: Some(2),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_process_count: Some(2),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let estimate = ResourceEstimate {
         process_count: Some(1),
         ..ResourceEstimate::default()
@@ -1762,8 +1766,12 @@ struct ReleaseFailingGovernor {
 }
 
 impl ResourceGovernor for ReleaseFailingGovernor {
-    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
-        self.inner.set_limit(account, limits);
+    fn set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ResourceLimits,
+    ) -> Result<(), ResourceError> {
+        self.inner.set_limit(account, limits)
     }
 
     fn reserve(
@@ -1805,8 +1813,12 @@ struct ReconcileFailingGovernor {
 }
 
 impl ResourceGovernor for ReconcileFailingGovernor {
-    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
-        self.inner.set_limit(account, limits);
+    fn set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ResourceLimits,
+    ) -> Result<(), ResourceError> {
+        self.inner.set_limit(account, limits)
     }
 
     fn reserve(

--- a/crates/ironclaw_resources/Cargo.toml
+++ b/crates/ironclaw_resources/Cargo.toml
@@ -11,10 +11,23 @@ homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
 publish = false
 
+[features]
+default = []
+libsql = ["dep:libsql", "dep:tokio"]
+postgres = ["dep:deadpool-postgres", "dep:tokio", "dep:tokio-postgres"]
+
 [dependencies]
+deadpool-postgres = { version = "0.14", optional = true }
+fs2 = "0.4"
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
+tokio = { version = "1", optional = true, features = ["rt", "time"] }
+tokio-postgres = { version = "0.7", optional = true }
 
 [dev-dependencies]
 rust_decimal_macros = "1"
+tempfile = "3"

--- a/crates/ironclaw_resources/Cargo.toml
+++ b/crates/ironclaw_resources/Cargo.toml
@@ -25,8 +25,11 @@ rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-tokio = { version = "1", optional = true, features = ["rt", "time"] }
+tokio = { version = "1", optional = true, features = ["macros", "rt", "time"] }
 tokio-postgres = { version = "0.7", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 rust_decimal_macros = "1"

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -12,6 +12,8 @@ use std::future::Future;
 use std::io::{ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use std::sync::{OnceLock, mpsc};
 
 use fs2::FileExt;
 
@@ -527,21 +529,78 @@ CREATE TABLE IF NOT EXISTS ironclaw_resource_governor_snapshots (\
 );";
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-fn run_async_in_storage_thread<T, Fut, F>(build: F) -> Result<T, ResourceError>
+type AsyncStorageJob = Box<dyn FnOnce(&tokio::runtime::Runtime) + Send + 'static>;
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+#[derive(Debug, Clone)]
+struct AsyncStorageWorker {
+    sender: mpsc::Sender<AsyncStorageJob>,
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+impl AsyncStorageWorker {
+    fn spawn(name: &'static str) -> Result<Self, ResourceError> {
+        let (sender, receiver) = mpsc::channel::<AsyncStorageJob>();
+        let (ready_sender, ready_receiver) = mpsc::channel();
+        std::thread::Builder::new()
+            .name(name.to_string())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        let _ = ready_sender.send(Err(storage_error(error)));
+                        return;
+                    }
+                };
+                let _ = ready_sender.send(Ok(()));
+                while let Ok(job) = receiver.recv() {
+                    job(&runtime);
+                }
+            })
+            .map_err(storage_error)?;
+        ready_receiver
+            .recv()
+            .map_err(|_| storage_error("resource governor storage worker failed to start"))??;
+        Ok(Self { sender })
+    }
+
+    fn run<T, Fut, F>(&self, build: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        Fut: Future<Output = Result<T, ResourceError>> + Send + 'static,
+        F: FnOnce() -> Fut + Send + 'static,
+    {
+        let (result_sender, result_receiver) = mpsc::channel();
+        self.sender
+            .send(Box::new(move |runtime| {
+                let result = runtime.block_on(build());
+                let _ = result_sender.send(result);
+            }))
+            .map_err(|_| storage_error("resource governor storage worker stopped"))?;
+        result_receiver
+            .recv()
+            .map_err(|_| storage_error("resource governor storage worker stopped"))?
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+fn run_async_on_shared_storage_worker<T, Fut, F>(build: F) -> Result<T, ResourceError>
 where
     T: Send + 'static,
     Fut: Future<Output = Result<T, ResourceError>> + Send + 'static,
     F: FnOnce() -> Fut + Send + 'static,
 {
-    std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(storage_error)?;
-        runtime.block_on(build())
-    })
-    .join()
-    .map_err(|_| storage_error("resource governor storage worker panicked"))?
+    static WORKER: OnceLock<Result<AsyncStorageWorker, String>> = OnceLock::new();
+    let worker = WORKER.get_or_init(|| {
+        AsyncStorageWorker::spawn("resource-governor-storage").map_err(|error| error.to_string())
+    });
+    match worker {
+        Ok(worker) => worker.run(build),
+        Err(error) => Err(storage_error(error)),
+    }
 }
 
 #[cfg(feature = "libsql")]
@@ -558,10 +617,21 @@ impl LibSqlResourceGovernorStore {
 
     pub async fn run_migrations(&self) -> Result<(), ResourceError> {
         let conn = self.connect().await?;
-        conn.execute_batch(RESOURCE_GOVERNOR_SCHEMA)
+        conn.execute_batch("BEGIN IMMEDIATE")
             .await
             .map_err(storage_error)?;
-        Ok(())
+        let result = conn.execute_batch(RESOURCE_GOVERNOR_SCHEMA).await;
+        match result {
+            Ok(_) => conn
+                .execute_batch("COMMIT")
+                .await
+                .map(|_| ())
+                .map_err(storage_error),
+            Err(error) => {
+                let _ = conn.execute_batch("ROLLBACK").await;
+                Err(storage_error(error))
+            }
+        }
     }
 
     async fn connect(&self) -> Result<libsql::Connection, ResourceError> {
@@ -581,8 +651,7 @@ impl ResourceGovernorStore for LibSqlResourceGovernorStore {
         F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
     {
         let store = self.clone();
-        run_async_in_storage_thread(move || async move {
-            store.run_migrations().await?;
+        run_async_on_shared_storage_worker(move || async move {
             let conn = store.connect().await?;
             conn.execute_batch("BEGIN IMMEDIATE")
                 .await
@@ -651,12 +720,16 @@ impl PostgresResourceGovernorStore {
     }
 
     pub async fn run_migrations(&self) -> Result<(), ResourceError> {
-        let client = self.pool.get().await.map_err(storage_error)?;
-        client
-            .batch_execute(RESOURCE_GOVERNOR_SCHEMA)
-            .await
-            .map_err(storage_error)?;
-        Ok(())
+        let mut client = self.pool.get().await.map_err(storage_error)?;
+        let transaction = client.transaction().await.map_err(storage_error)?;
+        let result = transaction.batch_execute(RESOURCE_GOVERNOR_SCHEMA).await;
+        match result {
+            Ok(()) => transaction.commit().await.map_err(storage_error),
+            Err(error) => {
+                let _ = transaction.rollback().await;
+                Err(storage_error(error))
+            }
+        }
     }
 }
 
@@ -668,8 +741,7 @@ impl ResourceGovernorStore for PostgresResourceGovernorStore {
         F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
     {
         let store = self.clone();
-        run_async_in_storage_thread(move || async move {
-            store.run_migrations().await?;
+        run_async_on_shared_storage_worker(move || async move {
             let mut client = store.pool.get().await.map_err(storage_error)?;
             let transaction = client.transaction().await.map_err(storage_error)?;
             transaction

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -341,7 +341,11 @@ pub trait ResourceGovernor: Send + Sync {
     ///
     /// Persistent governors also expose `try_set_limit` so callers that need
     /// durable write confirmation can observe storage errors.
-    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits);
+    fn set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ResourceLimits,
+    ) -> Result<(), ResourceError>;
 
     /// Reserves estimated resources before costed/quota-limited work starts.
     ///
@@ -486,7 +490,7 @@ fn write_file_snapshot_atomically(
     let temp_path = temp_path_for(path);
     let encoded = serde_json::to_vec_pretty(snapshot).map_err(storage_error)?;
     let write_result = write_temp_snapshot(&temp_path, &encoded)
-        .and_then(|()| std::fs::rename(&temp_path, path).map_err(storage_error))
+        .and_then(|()| replace_file_atomically(&temp_path, path))
         .and_then(|()| sync_parent_dir(path));
     if write_result.is_err() {
         let _ = std::fs::remove_file(&temp_path);
@@ -505,11 +509,133 @@ fn write_temp_snapshot(temp_path: &Path, encoded: &[u8]) -> Result<(), ResourceE
     temp_file.sync_all().map_err(storage_error)
 }
 
+#[cfg(not(windows))]
+fn replace_file_atomically(temp_path: &Path, path: &Path) -> Result<(), ResourceError> {
+    std::fs::rename(temp_path, path).map_err(storage_error)
+}
+
+#[cfg(windows)]
+fn replace_file_atomically(temp_path: &Path, path: &Path) -> Result<(), ResourceError> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let temp_path = path_to_nul_terminated_wide(temp_path)?;
+    let target_path = path_to_nul_terminated_wide(path)?;
+    // SAFETY: Both arguments are valid NUL-terminated UTF-16 buffers that live
+    // for the duration of the call. The temp file lives beside the target, so
+    // MoveFileExW performs an atomic same-volume replacement when the target
+    // already exists instead of failing like std::fs::rename on Windows.
+    let moved = unsafe {
+        MoveFileExW(
+            temp_path.as_ptr(),
+            target_path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved == 0 {
+        Err(storage_error(std::io::Error::last_os_error()))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn path_to_nul_terminated_wide(path: &Path) -> Result<Vec<u16>, ResourceError> {
+    use std::os::windows::ffi::OsStrExt;
+
+    let absolute = std::path::absolute(path).map_err(storage_error)?;
+    let mut wide: Vec<u16> = absolute.as_os_str().encode_wide().collect();
+    if wide.contains(&0) {
+        return Err(ResourceError::Storage {
+            reason: "path contains an interior NUL byte".to_string(),
+        });
+    }
+
+    normalize_windows_path_separators(&mut wide);
+    if !has_windows_namespace_prefix(&wide) {
+        wide = verbatim_windows_path(wide);
+    }
+    wide.push(0);
+    Ok(wide)
+}
+
+#[cfg(windows)]
+fn has_windows_namespace_prefix(wide: &[u16]) -> bool {
+    wide.len() >= 4
+        && is_windows_path_separator(wide[0])
+        && is_windows_path_separator(wide[1])
+        && (wide[2] == b'?' as u16 || wide[2] == b'.' as u16)
+        && is_windows_path_separator(wide[3])
+}
+
+#[cfg(windows)]
+fn normalize_windows_path_separators(wide: &mut [u16]) {
+    for code_unit in wide {
+        if *code_unit == b'/' as u16 {
+            *code_unit = b'\\' as u16;
+        }
+    }
+}
+
+#[cfg(windows)]
+fn verbatim_windows_path(wide: Vec<u16>) -> Vec<u16> {
+    if wide.len() >= 2 && is_windows_path_separator(wide[0]) && is_windows_path_separator(wide[1]) {
+        let mut prefixed = wide_literal(r"\\?\UNC\");
+        prefixed.extend_from_slice(&wide[2..]);
+        prefixed
+    } else if wide.len() >= 3 && wide[1] == b':' as u16 && is_windows_path_separator(wide[2]) {
+        let mut prefixed = wide_literal(r"\\?\");
+        prefixed.extend_from_slice(&wide);
+        prefixed
+    } else {
+        wide
+    }
+}
+
+#[cfg(windows)]
+fn wide_literal(value: &str) -> Vec<u16> {
+    value.encode_utf16().collect()
+}
+
+#[cfg(windows)]
+fn is_windows_path_separator(code_unit: u16) -> bool {
+    code_unit == b'\\' as u16 || code_unit == b'/' as u16
+}
+
 fn sync_parent_dir(path: &Path) -> Result<(), ResourceError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    File::open(parent)
-        .and_then(|dir| dir.sync_all())
-        .map_err(storage_error)
+    normalize_parent_dir_sync_result(File::open(parent).and_then(|dir| dir.sync_all()))
+}
+
+fn normalize_parent_dir_sync_result(result: std::io::Result<()>) -> Result<(), ResourceError> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) if is_unsupported_parent_dir_sync_error(&error) => Ok(()),
+        Err(error) => Err(storage_error(error)),
+    }
+}
+
+fn is_unsupported_parent_dir_sync_error(error: &std::io::Error) -> bool {
+    if matches!(error.kind(), ErrorKind::Unsupported) {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        const ERROR_INVALID_FUNCTION: i32 = 1;
+        const ERROR_ACCESS_DENIED: i32 = 5;
+        if matches!(error.kind(), ErrorKind::PermissionDenied)
+            || matches!(
+                error.raw_os_error(),
+                Some(ERROR_INVALID_FUNCTION) | Some(ERROR_ACCESS_DENIED)
+            )
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn storage_error(error: impl std::fmt::Display) -> ResourceError {
@@ -587,14 +713,24 @@ impl AsyncStorageWorker {
 }
 
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-fn run_async_on_shared_storage_worker<T, Fut, F>(build: F) -> Result<T, ResourceError>
+type AsyncStorageWorkerCell = std::sync::Arc<OnceLock<Result<AsyncStorageWorker, String>>>;
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+fn new_storage_worker_cell() -> AsyncStorageWorkerCell {
+    std::sync::Arc::new(OnceLock::new())
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+fn run_async_on_storage_worker<T, Fut, F>(
+    worker_cell: &AsyncStorageWorkerCell,
+    build: F,
+) -> Result<T, ResourceError>
 where
     T: Send + 'static,
     Fut: Future<Output = Result<T, ResourceError>> + Send + 'static,
     F: FnOnce() -> Fut + Send + 'static,
 {
-    static WORKER: OnceLock<Result<AsyncStorageWorker, String>> = OnceLock::new();
-    let worker = WORKER.get_or_init(|| {
+    let worker = worker_cell.get_or_init(|| {
         AsyncStorageWorker::spawn("resource-governor-storage").map_err(|error| error.to_string())
     });
     match worker {
@@ -607,12 +743,16 @@ where
 #[derive(Debug, Clone)]
 pub struct LibSqlResourceGovernorStore {
     db: std::sync::Arc<libsql::Database>,
+    worker: AsyncStorageWorkerCell,
 }
 
 #[cfg(feature = "libsql")]
 impl LibSqlResourceGovernorStore {
     pub fn new(db: std::sync::Arc<libsql::Database>) -> Self {
-        Self { db }
+        Self {
+            db,
+            worker: new_storage_worker_cell(),
+        }
     }
 
     pub async fn run_migrations(&self) -> Result<(), ResourceError> {
@@ -651,7 +791,7 @@ impl ResourceGovernorStore for LibSqlResourceGovernorStore {
         F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
     {
         let store = self.clone();
-        run_async_on_shared_storage_worker(move || async move {
+        run_async_on_storage_worker(&self.worker, move || async move {
             let conn = store.connect().await?;
             conn.execute_batch("BEGIN IMMEDIATE")
                 .await
@@ -711,12 +851,16 @@ where
 #[derive(Debug, Clone)]
 pub struct PostgresResourceGovernorStore {
     pool: deadpool_postgres::Pool,
+    worker: AsyncStorageWorkerCell,
 }
 
 #[cfg(feature = "postgres")]
 impl PostgresResourceGovernorStore {
     pub fn new(pool: deadpool_postgres::Pool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            worker: new_storage_worker_cell(),
+        }
     }
 
     pub async fn run_migrations(&self) -> Result<(), ResourceError> {
@@ -741,7 +885,7 @@ impl ResourceGovernorStore for PostgresResourceGovernorStore {
         F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
     {
         let store = self.clone();
-        run_async_on_shared_storage_worker(move || async move {
+        run_async_on_storage_worker(&self.worker, move || async move {
             let mut client = store.pool.get().await.map_err(storage_error)?;
             let transaction = client.transaction().await.map_err(storage_error)?;
             transaction
@@ -857,8 +1001,12 @@ impl<S> ResourceGovernor for PersistentResourceGovernor<S>
 where
     S: ResourceGovernorStore,
 {
-    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
-        let _ = self.try_set_limit(account, limits);
+    fn set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ResourceLimits,
+    ) -> Result<(), ResourceError> {
+        self.try_set_limit(account, limits)
     }
 
     fn reserve(
@@ -1004,8 +1152,13 @@ impl InMemoryResourceGovernor {
 }
 
 impl ResourceGovernor for InMemoryResourceGovernor {
-    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
+    fn set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ResourceLimits,
+    ) -> Result<(), ResourceError> {
         set_limit_in_state(&mut self.lock_state(), account, limits);
+        Ok(())
     }
 
     fn reserve(
@@ -1358,5 +1511,73 @@ fn check_integer(
         })
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_snapshot_replace_overwrites_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("resources.json");
+        let temp_path = temp_path_for(&path);
+        std::fs::write(&path, b"old").unwrap();
+        write_temp_snapshot(&temp_path, b"new").unwrap();
+
+        replace_file_atomically(&temp_path, &path).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new\n");
+        assert!(!temp_path.exists());
+    }
+
+    #[test]
+    fn unsupported_parent_directory_sync_is_best_effort() {
+        let error = std::io::Error::new(ErrorKind::Unsupported, "directory sync unsupported");
+
+        assert!(normalize_parent_dir_sync_result(Err(error)).is_ok());
+    }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    #[test]
+    fn independent_storage_worker_cells_do_not_head_of_line_block() {
+        let first_worker = new_storage_worker_cell();
+        let second_worker = new_storage_worker_cell();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let blocked = std::thread::spawn({
+            let first_worker = first_worker.clone();
+            move || {
+                run_async_on_storage_worker(&first_worker, move || async move {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    Ok::<(), ResourceError>(())
+                })
+            }
+        });
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("first worker job should start");
+
+        let (done_tx, done_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let result = run_async_on_storage_worker(&second_worker, || async {
+                Ok::<u8, ResourceError>(7)
+            });
+            done_tx.send(result).unwrap();
+        });
+
+        assert_eq!(
+            done_rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("independent worker should not wait behind blocked worker")
+                .unwrap(),
+            7
+        );
+
+        release_tx.send(()).unwrap();
+        blocked.join().unwrap().unwrap();
     }
 }

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -4,6 +4,11 @@
 //! runtime lanes before they spend money or consume scarce sandbox capacity:
 //! reserve estimated resources, execute work, then reconcile actual usage or
 //! release the unused hold.
+//!
+//! Persistent governors fail closed when snapshot reads, writes, locks, or
+//! schema validation fail. Callers must handle [`ResourceError::Storage`] the
+//! same way as quota denials: do not start costed or quota-limited work until a
+//! reservation operation succeeds.
 
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
@@ -28,6 +33,7 @@ use thiserror::Error;
 
 /// Durable account level that can carry resource limits and ledgers.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub enum ResourceAccount {
     Tenant {
         tenant_id: TenantId,
@@ -178,6 +184,7 @@ impl ResourceAccount {
 
 /// Optional maximums for each resource dimension.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ResourceLimits {
     pub max_usd: Option<Decimal>,
     pub max_input_tokens: Option<u64>,
@@ -256,12 +263,15 @@ pub enum ResourceError {
         id: ResourceReservationId,
         status: ReservationStatus,
     },
+    /// Durable storage or snapshot schema validation failed. Governors must
+    /// fail closed when this is returned.
     #[error("resource governor storage error: {reason}")]
     Storage { reason: String },
 }
 
 /// Aggregated resource usage/reservation tally.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ResourceTally {
     pub usd: Decimal,
     pub input_tokens: u64,
@@ -336,11 +346,13 @@ impl ResourceTally {
 }
 
 /// Synchronous resource governor contract.
+///
+/// Persistent implementations may return [`ResourceError::Storage`] from any
+/// method when durable reads, writes, locking, serialization, or schema
+/// validation fail. Callers must treat storage failures as fail-closed and avoid
+/// starting quota-limited work without a successful reservation.
 pub trait ResourceGovernor: Send + Sync {
     /// Sets or replaces limits for a scoped resource account without mutating existing reservations.
-    ///
-    /// Persistent governors also expose `try_set_limit` so callers that need
-    /// durable write confirmation can observe storage errors.
     fn set_limit(
         &self,
         account: ResourceAccount,
@@ -381,10 +393,54 @@ pub trait ResourceGovernor: Send + Sync {
     ) -> Result<ResourceReceipt, ResourceError>;
 }
 
+const RESOURCE_GOVERNOR_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
 /// Serializable governor snapshot stored by durable stores.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ResourceGovernorSnapshot {
+    schema_version: u32,
     state: ResourceState,
+}
+
+impl Default for ResourceGovernorSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: RESOURCE_GOVERNOR_SNAPSHOT_SCHEMA_VERSION,
+            state: ResourceState::default(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ResourceGovernorSnapshotSerde {
+    #[serde(default = "current_resource_governor_snapshot_schema_version")]
+    schema_version: u32,
+    state: ResourceState,
+}
+
+impl<'de> Deserialize<'de> for ResourceGovernorSnapshot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let snapshot = ResourceGovernorSnapshotSerde::deserialize(deserializer)?;
+        if snapshot.schema_version != RESOURCE_GOVERNOR_SNAPSHOT_SCHEMA_VERSION {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported resource governor snapshot schema version {}; expected {}",
+                snapshot.schema_version, RESOURCE_GOVERNOR_SNAPSHOT_SCHEMA_VERSION
+            )));
+        }
+
+        Ok(Self {
+            schema_version: snapshot.schema_version,
+            state: snapshot.state,
+        })
+    }
+}
+
+fn current_resource_governor_snapshot_schema_version() -> u32 {
+    RESOURCE_GOVERNOR_SNAPSHOT_SCHEMA_VERSION
 }
 
 /// Transactional storage primitive for [`PersistentResourceGovernor`].
@@ -479,7 +535,7 @@ fn read_file_snapshot(path: &Path) -> Result<ResourceGovernorSnapshot, ResourceE
     if contents.trim().is_empty() {
         Ok(ResourceGovernorSnapshot::default())
     } else {
-        serde_json::from_str(&contents).map_err(storage_error)
+        serde_json::from_str(&contents).map_err(snapshot_decode_error)
     }
 }
 
@@ -641,6 +697,12 @@ fn is_unsupported_parent_dir_sync_error(error: &std::io::Error) -> bool {
 fn storage_error(error: impl std::fmt::Display) -> ResourceError {
     ResourceError::Storage {
         reason: error.to_string(),
+    }
+}
+
+fn snapshot_decode_error(error: impl std::fmt::Display) -> ResourceError {
+    ResourceError::Storage {
+        reason: format!("malformed resource governor snapshot: {error}"),
     }
 }
 
@@ -828,7 +890,7 @@ where
         .map_err(storage_error)?;
     let mut snapshot = if let Some(row) = rows.next().await.map_err(storage_error)? {
         let state_json: String = row.get(0).map_err(storage_error)?;
-        serde_json::from_str(&state_json).map_err(storage_error)?
+        serde_json::from_str(&state_json).map_err(snapshot_decode_error)?
     } else {
         ResourceGovernorSnapshot::default()
     };
@@ -924,7 +986,7 @@ where
         .map_err(storage_error)?;
     let mut snapshot = if let Some(row) = row {
         let state_json: String = row.get(0);
-        serde_json::from_str(&state_json).map_err(storage_error)?
+        serde_json::from_str(&state_json).map_err(snapshot_decode_error)?
     } else {
         ResourceGovernorSnapshot::default()
     };
@@ -1060,7 +1122,7 @@ struct ResourceState {
     reservations: HashMap<ResourceReservationId, ReservationRecord>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct ReservationRecord {
     reservation: ResourceReservation,
     accounts: Vec<ResourceAccount>,
@@ -1069,7 +1131,111 @@ struct ReservationRecord {
     actual: Option<ResourceUsage>,
 }
 
+#[derive(Deserialize)]
+#[serde(remote = "ResourceScope", deny_unknown_fields)]
+struct StrictResourceScope {
+    tenant_id: TenantId,
+    user_id: UserId,
+    #[serde(default)]
+    agent_id: Option<AgentId>,
+    #[serde(default)]
+    project_id: Option<ProjectId>,
+    #[serde(default)]
+    mission_id: Option<MissionId>,
+    #[serde(default)]
+    thread_id: Option<ThreadId>,
+    invocation_id: ironclaw_host_api::InvocationId,
+}
+
+#[derive(Deserialize)]
+#[serde(remote = "ResourceEstimate", deny_unknown_fields)]
+struct StrictResourceEstimate {
+    #[serde(default)]
+    usd: Option<Decimal>,
+    #[serde(default)]
+    input_tokens: Option<u64>,
+    #[serde(default)]
+    output_tokens: Option<u64>,
+    #[serde(default)]
+    wall_clock_ms: Option<u64>,
+    #[serde(default)]
+    output_bytes: Option<u64>,
+    #[serde(default)]
+    network_egress_bytes: Option<u64>,
+    #[serde(default)]
+    process_count: Option<u32>,
+    #[serde(default)]
+    concurrency_slots: Option<u32>,
+}
+
+#[derive(Deserialize)]
+#[serde(remote = "ResourceUsage", deny_unknown_fields)]
+struct StrictResourceUsage {
+    usd: Decimal,
+    input_tokens: u64,
+    output_tokens: u64,
+    wall_clock_ms: u64,
+    output_bytes: u64,
+    network_egress_bytes: u64,
+    process_count: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(remote = "ResourceReservation", deny_unknown_fields)]
+struct StrictResourceReservation {
+    id: ResourceReservationId,
+    #[serde(with = "StrictResourceScope")]
+    scope: ResourceScope,
+    #[serde(with = "StrictResourceEstimate")]
+    estimate: ResourceEstimate,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReservationRecordSerde {
+    #[serde(with = "StrictResourceReservation")]
+    reservation: ResourceReservation,
+    accounts: Vec<ResourceAccount>,
+    tally: ResourceTally,
+    status: ReservationStatus,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_strict_resource_usage"
+    )]
+    actual: Option<ResourceUsage>,
+}
+
+impl<'de> Deserialize<'de> for ReservationRecord {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = ReservationRecordSerde::deserialize(deserializer)?;
+        Ok(Self {
+            reservation: value.reservation,
+            accounts: value.accounts,
+            tally: value.tally,
+            status: value.status,
+            actual: value.actual,
+        })
+    }
+}
+
+fn deserialize_optional_strict_resource_usage<'de, D>(
+    deserializer: D,
+) -> Result<Option<ResourceUsage>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct StrictResourceUsageOption(#[serde(with = "StrictResourceUsage")] ResourceUsage);
+
+    Option::<StrictResourceUsageOption>::deserialize(deserializer)
+        .map(|value| value.map(|wrapper| wrapper.0))
+}
+
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ResourceStateSerde {
     limits: Vec<(ResourceAccount, ResourceLimits)>,
     reserved_by_account: Vec<(ResourceAccount, ResourceTally)>,

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -6,7 +6,14 @@
 //! release the unused hold.
 
 use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use std::future::Future;
+use std::io::{ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
+
+use fs2::FileExt;
 
 use ironclaw_host_api::{
     AgentId, MissionId, ProjectId, ResourceEstimate, ResourceReservationId, ResourceScope,
@@ -14,10 +21,11 @@ use ironclaw_host_api::{
 };
 pub use ironclaw_host_api::{ReservationStatus, ResourceReceipt, ResourceReservation};
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Durable account level that can carry resource limits and ledgers.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ResourceAccount {
     Tenant {
         tenant_id: TenantId,
@@ -167,7 +175,7 @@ impl ResourceAccount {
 }
 
 /// Optional maximums for each resource dimension.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResourceLimits {
     pub max_usd: Option<Decimal>,
     pub max_input_tokens: Option<u64>,
@@ -246,10 +254,12 @@ pub enum ResourceError {
         id: ResourceReservationId,
         status: ReservationStatus,
     },
+    #[error("resource governor storage error: {reason}")]
+    Storage { reason: String },
 }
 
 /// Aggregated resource usage/reservation tally.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResourceTally {
     pub usd: Decimal,
     pub input_tokens: u64,
@@ -326,6 +336,9 @@ impl ResourceTally {
 /// Synchronous resource governor contract.
 pub trait ResourceGovernor: Send + Sync {
     /// Sets or replaces limits for a scoped resource account without mutating existing reservations.
+    ///
+    /// Persistent governors also expose `try_set_limit` so callers that need
+    /// durable write confirmation can observe storage errors.
     fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits);
 
     /// Reserves estimated resources before costed/quota-limited work starts.
@@ -362,13 +375,464 @@ pub trait ResourceGovernor: Send + Sync {
     ) -> Result<ResourceReceipt, ResourceError>;
 }
 
+/// Serializable governor snapshot stored by durable stores.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceGovernorSnapshot {
+    state: ResourceState,
+}
+
+/// Transactional storage primitive for [`PersistentResourceGovernor`].
+///
+/// Implementations must serialize the whole closure with any other readers or
+/// writers over the same account-wide ledger before writing the updated
+/// snapshot back durably.
+pub trait ResourceGovernorStore: Send + Sync + 'static {
+    fn update<T, F>(&self, update: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static;
+}
+
+/// File-backed resource-governor store using a stable sidecar lock file around
+/// each load/update/atomic-rename transaction.
+#[derive(Debug, Clone)]
+pub struct JsonFileResourceGovernorStore {
+    path: PathBuf,
+}
+
+impl JsonFileResourceGovernorStore {
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+impl ResourceGovernorStore for JsonFileResourceGovernorStore {
+    fn update<T, F>(&self, update: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).map_err(storage_error)?;
+        }
+
+        let lock_path = lock_path_for(&self.path);
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .map_err(storage_error)?;
+        lock_file.lock_exclusive().map_err(storage_error)?;
+
+        let result = update_file_snapshot(&self.path, update);
+        let unlock_result = lock_file.unlock().map_err(storage_error);
+        match (result, unlock_result) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+        }
+    }
+}
+
+fn lock_path_for(path: &Path) -> PathBuf {
+    let mut lock_path = path.as_os_str().to_owned();
+    lock_path.push(".lock");
+    PathBuf::from(lock_path)
+}
+
+fn temp_path_for(path: &Path) -> PathBuf {
+    let mut temp_path = path.as_os_str().to_owned();
+    temp_path.push(format!(".{}.tmp", ResourceReservationId::new()));
+    PathBuf::from(temp_path)
+}
+
+fn update_file_snapshot<T, F>(path: &Path, update: F) -> Result<T, ResourceError>
+where
+    F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError>,
+{
+    let mut snapshot = read_file_snapshot(path)?;
+    let value = update(&mut snapshot)?;
+    write_file_snapshot_atomically(path, &snapshot)?;
+    Ok(value)
+}
+
+fn read_file_snapshot(path: &Path) -> Result<ResourceGovernorSnapshot, ResourceError> {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return Ok(ResourceGovernorSnapshot::default());
+        }
+        Err(error) => return Err(storage_error(error)),
+    };
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).map_err(storage_error)?;
+    if contents.trim().is_empty() {
+        Ok(ResourceGovernorSnapshot::default())
+    } else {
+        serde_json::from_str(&contents).map_err(storage_error)
+    }
+}
+
+fn write_file_snapshot_atomically(
+    path: &Path,
+    snapshot: &ResourceGovernorSnapshot,
+) -> Result<(), ResourceError> {
+    let temp_path = temp_path_for(path);
+    let encoded = serde_json::to_vec_pretty(snapshot).map_err(storage_error)?;
+    let write_result = write_temp_snapshot(&temp_path, &encoded)
+        .and_then(|()| std::fs::rename(&temp_path, path).map_err(storage_error))
+        .and_then(|()| sync_parent_dir(path));
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    write_result
+}
+
+fn write_temp_snapshot(temp_path: &Path, encoded: &[u8]) -> Result<(), ResourceError> {
+    let mut temp_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(temp_path)
+        .map_err(storage_error)?;
+    temp_file.write_all(encoded).map_err(storage_error)?;
+    temp_file.write_all(b"\n").map_err(storage_error)?;
+    temp_file.sync_all().map_err(storage_error)
+}
+
+fn sync_parent_dir(path: &Path) -> Result<(), ResourceError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    File::open(parent)
+        .and_then(|dir| dir.sync_all())
+        .map_err(storage_error)
+}
+
+fn storage_error(error: impl std::fmt::Display) -> ResourceError {
+    ResourceError::Storage {
+        reason: error.to_string(),
+    }
+}
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+const SNAPSHOT_ID: &str = "default";
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+const RESOURCE_GOVERNOR_SCHEMA: &str = "\
+CREATE TABLE IF NOT EXISTS ironclaw_resource_governor_snapshots (\
+    snapshot_id TEXT PRIMARY KEY,\
+    state_json TEXT NOT NULL,\
+    updated_at_ms BIGINT NOT NULL DEFAULT 0\
+);";
+
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+fn run_async_in_storage_thread<T, Fut, F>(build: F) -> Result<T, ResourceError>
+where
+    T: Send + 'static,
+    Fut: Future<Output = Result<T, ResourceError>> + Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(storage_error)?;
+        runtime.block_on(build())
+    })
+    .join()
+    .map_err(|_| storage_error("resource governor storage worker panicked"))?
+}
+
+#[cfg(feature = "libsql")]
+#[derive(Debug, Clone)]
+pub struct LibSqlResourceGovernorStore {
+    db: std::sync::Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlResourceGovernorStore {
+    pub fn new(db: std::sync::Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), ResourceError> {
+        let conn = self.connect().await?;
+        conn.execute_batch(RESOURCE_GOVERNOR_SCHEMA)
+            .await
+            .map_err(storage_error)?;
+        Ok(())
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, ResourceError> {
+        let conn = self.db.connect().map_err(storage_error)?;
+        conn.query("PRAGMA busy_timeout = 5000", ())
+            .await
+            .map_err(storage_error)?;
+        Ok(conn)
+    }
+}
+
+#[cfg(feature = "libsql")]
+impl ResourceGovernorStore for LibSqlResourceGovernorStore {
+    fn update<T, F>(&self, update: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        let store = self.clone();
+        run_async_in_storage_thread(move || async move {
+            store.run_migrations().await?;
+            let conn = store.connect().await?;
+            conn.execute_batch("BEGIN IMMEDIATE")
+                .await
+                .map_err(storage_error)?;
+            let result = update_libsql_snapshot(&conn, update).await;
+            match result {
+                Ok(value) => {
+                    conn.execute_batch("COMMIT").await.map_err(storage_error)?;
+                    Ok(value)
+                }
+                Err(error) => {
+                    let _ = conn.execute_batch("ROLLBACK").await;
+                    Err(error)
+                }
+            }
+        })
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn update_libsql_snapshot<T, F>(
+    conn: &libsql::Connection,
+    update: F,
+) -> Result<T, ResourceError>
+where
+    F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError>,
+{
+    let mut rows = conn
+        .query(
+            "SELECT state_json FROM ironclaw_resource_governor_snapshots WHERE snapshot_id = ?1",
+            libsql::params![SNAPSHOT_ID],
+        )
+        .await
+        .map_err(storage_error)?;
+    let mut snapshot = if let Some(row) = rows.next().await.map_err(storage_error)? {
+        let state_json: String = row.get(0).map_err(storage_error)?;
+        serde_json::from_str(&state_json).map_err(storage_error)?
+    } else {
+        ResourceGovernorSnapshot::default()
+    };
+
+    let value = update(&mut snapshot)?;
+    let encoded = serde_json::to_string(&snapshot).map_err(storage_error)?;
+    conn.execute(
+        "INSERT INTO ironclaw_resource_governor_snapshots (snapshot_id, state_json, updated_at_ms) \
+         VALUES (?1, ?2, strftime('%s','now') * 1000) \
+         ON CONFLICT(snapshot_id) DO UPDATE SET \
+         state_json = excluded.state_json, updated_at_ms = excluded.updated_at_ms",
+        libsql::params![SNAPSHOT_ID, encoded],
+    )
+    .await
+    .map_err(storage_error)?;
+    Ok(value)
+}
+
+#[cfg(feature = "postgres")]
+#[derive(Debug, Clone)]
+pub struct PostgresResourceGovernorStore {
+    pool: deadpool_postgres::Pool,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresResourceGovernorStore {
+    pub fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), ResourceError> {
+        let client = self.pool.get().await.map_err(storage_error)?;
+        client
+            .batch_execute(RESOURCE_GOVERNOR_SCHEMA)
+            .await
+            .map_err(storage_error)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl ResourceGovernorStore for PostgresResourceGovernorStore {
+    fn update<T, F>(&self, update: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        let store = self.clone();
+        run_async_in_storage_thread(move || async move {
+            store.run_migrations().await?;
+            let mut client = store.pool.get().await.map_err(storage_error)?;
+            let transaction = client.transaction().await.map_err(storage_error)?;
+            transaction
+                .batch_execute("LOCK TABLE ironclaw_resource_governor_snapshots IN EXCLUSIVE MODE")
+                .await
+                .map_err(storage_error)?;
+            let result = update_postgres_snapshot(&transaction, update).await;
+            match result {
+                Ok(value) => {
+                    transaction.commit().await.map_err(storage_error)?;
+                    Ok(value)
+                }
+                Err(error) => {
+                    let _ = transaction.rollback().await;
+                    Err(error)
+                }
+            }
+        })
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn update_postgres_snapshot<T, F>(
+    transaction: &tokio_postgres::Transaction<'_>,
+    update: F,
+) -> Result<T, ResourceError>
+where
+    F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError>,
+{
+    let row = transaction
+        .query_opt(
+            "SELECT state_json FROM ironclaw_resource_governor_snapshots WHERE snapshot_id = $1",
+            &[&SNAPSHOT_ID],
+        )
+        .await
+        .map_err(storage_error)?;
+    let mut snapshot = if let Some(row) = row {
+        let state_json: String = row.get(0);
+        serde_json::from_str(&state_json).map_err(storage_error)?
+    } else {
+        ResourceGovernorSnapshot::default()
+    };
+
+    let value = update(&mut snapshot)?;
+    let encoded = serde_json::to_string(&snapshot).map_err(storage_error)?;
+    transaction
+        .execute(
+            "INSERT INTO ironclaw_resource_governor_snapshots (snapshot_id, state_json, updated_at_ms) \
+             VALUES ($1, $2, (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT) \
+             ON CONFLICT(snapshot_id) DO UPDATE SET \
+             state_json = excluded.state_json, updated_at_ms = excluded.updated_at_ms",
+            &[&SNAPSHOT_ID, &encoded],
+        )
+        .await
+        .map_err(storage_error)?;
+    Ok(value)
+}
+
+/// Durable resource governor backed by a transactional [`ResourceGovernorStore`].
+#[derive(Debug)]
+pub struct PersistentResourceGovernor<S>
+where
+    S: ResourceGovernorStore,
+{
+    store: S,
+}
+
+impl<S> PersistentResourceGovernor<S>
+where
+    S: ResourceGovernorStore,
+{
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+
+    pub fn try_set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ResourceLimits,
+    ) -> Result<(), ResourceError> {
+        self.store.update(move |snapshot| {
+            set_limit_in_state(&mut snapshot.state, account, limits);
+            Ok(())
+        })
+    }
+
+    pub fn reserved_for(&self, account: &ResourceAccount) -> Result<ResourceTally, ResourceError> {
+        let account = account.clone();
+        self.store.update(move |snapshot| {
+            Ok(snapshot
+                .state
+                .reserved_by_account
+                .get(&account)
+                .cloned()
+                .unwrap_or_default())
+        })
+    }
+
+    pub fn usage_for(&self, account: &ResourceAccount) -> Result<ResourceTally, ResourceError> {
+        let account = account.clone();
+        self.store.update(move |snapshot| {
+            Ok(snapshot
+                .state
+                .usage_by_account
+                .get(&account)
+                .cloned()
+                .unwrap_or_default())
+        })
+    }
+}
+
+impl<S> ResourceGovernor for PersistentResourceGovernor<S>
+where
+    S: ResourceGovernorStore,
+{
+    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
+        let _ = self.try_set_limit(account, limits);
+    }
+
+    fn reserve(
+        &self,
+        scope: ResourceScope,
+        estimate: ResourceEstimate,
+    ) -> Result<ResourceReservation, ResourceError> {
+        self.reserve_with_id(scope, estimate, ResourceReservationId::new())
+    }
+
+    fn reserve_with_id(
+        &self,
+        scope: ResourceScope,
+        estimate: ResourceEstimate,
+        reservation_id: ResourceReservationId,
+    ) -> Result<ResourceReservation, ResourceError> {
+        self.store.update(move |snapshot| {
+            reserve_in_state(&mut snapshot.state, scope, estimate, reservation_id)
+        })
+    }
+
+    fn reconcile(
+        &self,
+        reservation_id: ResourceReservationId,
+        actual: ResourceUsage,
+    ) -> Result<ResourceReceipt, ResourceError> {
+        self.store
+            .update(move |snapshot| reconcile_in_state(&mut snapshot.state, reservation_id, actual))
+    }
+
+    fn release(
+        &self,
+        reservation_id: ResourceReservationId,
+    ) -> Result<ResourceReceipt, ResourceError> {
+        self.store
+            .update(move |snapshot| release_in_state(&mut snapshot.state, reservation_id))
+    }
+}
+
 /// In-memory governor used by early Reborn contract tests.
 #[derive(Debug, Default)]
 pub struct InMemoryResourceGovernor {
     state: Mutex<ResourceState>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct ResourceState {
     limits: HashMap<ResourceAccount, ResourceLimits>,
     reserved_by_account: HashMap<ResourceAccount, ResourceTally>,
@@ -376,13 +840,67 @@ struct ResourceState {
     reservations: HashMap<ResourceReservationId, ReservationRecord>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct ReservationRecord {
     reservation: ResourceReservation,
     accounts: Vec<ResourceAccount>,
     tally: ResourceTally,
     status: ReservationStatus,
     actual: Option<ResourceUsage>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ResourceStateSerde {
+    limits: Vec<(ResourceAccount, ResourceLimits)>,
+    reserved_by_account: Vec<(ResourceAccount, ResourceTally)>,
+    usage_by_account: Vec<(ResourceAccount, ResourceTally)>,
+    reservations: Vec<(ResourceReservationId, ReservationRecord)>,
+}
+
+impl Serialize for ResourceState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        ResourceStateSerde {
+            limits: self
+                .limits
+                .iter()
+                .map(|(account, limits)| (account.clone(), limits.clone()))
+                .collect(),
+            reserved_by_account: self
+                .reserved_by_account
+                .iter()
+                .map(|(account, tally)| (account.clone(), tally.clone()))
+                .collect(),
+            usage_by_account: self
+                .usage_by_account
+                .iter()
+                .map(|(account, tally)| (account.clone(), tally.clone()))
+                .collect(),
+            reservations: self
+                .reservations
+                .iter()
+                .map(|(id, record)| (*id, record.clone()))
+                .collect(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ResourceState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = ResourceStateSerde::deserialize(deserializer)?;
+        Ok(Self {
+            limits: value.limits.into_iter().collect(),
+            reserved_by_account: value.reserved_by_account.into_iter().collect(),
+            usage_by_account: value.usage_by_account.into_iter().collect(),
+            reservations: value.reservations.into_iter().collect(),
+        })
+    }
 }
 
 impl InMemoryResourceGovernor {
@@ -415,7 +933,7 @@ impl InMemoryResourceGovernor {
 
 impl ResourceGovernor for InMemoryResourceGovernor {
     fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
-        self.lock_state().limits.insert(account, limits);
+        set_limit_in_state(&mut self.lock_state(), account, limits);
     }
 
     fn reserve(
@@ -432,59 +950,7 @@ impl ResourceGovernor for InMemoryResourceGovernor {
         estimate: ResourceEstimate,
         reservation_id: ResourceReservationId,
     ) -> Result<ResourceReservation, ResourceError> {
-        validate_estimate(&estimate)?;
-
-        let mut state = self.lock_state();
-        if state.reservations.contains_key(&reservation_id) {
-            return Err(ResourceError::ReservationAlreadyExists { id: reservation_id });
-        }
-        let accounts = ResourceAccount::cascade(&scope);
-        let requested = ResourceTally::from_estimate(&estimate);
-
-        for account in &accounts {
-            if let Some(limits) = state.limits.get(account) {
-                let usage = state
-                    .usage_by_account
-                    .get(account)
-                    .cloned()
-                    .unwrap_or_default();
-                let reserved = state
-                    .reserved_by_account
-                    .get(account)
-                    .cloned()
-                    .unwrap_or_default();
-                if let Some(denial) = check_limits(account, limits, &usage, &reserved, &requested) {
-                    return Err(ResourceError::LimitExceeded(Box::new(denial)));
-                }
-            }
-        }
-
-        let reservation = ResourceReservation {
-            id: reservation_id,
-            scope,
-            estimate,
-        };
-
-        for account in &accounts {
-            state
-                .reserved_by_account
-                .entry(account.clone())
-                .or_default()
-                .add_assign(&requested);
-        }
-
-        state.reservations.insert(
-            reservation.id,
-            ReservationRecord {
-                reservation: reservation.clone(),
-                accounts,
-                tally: requested,
-                status: ReservationStatus::Active,
-                actual: None,
-            },
-        );
-
-        Ok(reservation)
+        reserve_in_state(&mut self.lock_state(), scope, estimate, reservation_id)
     }
 
     fn reconcile(
@@ -492,90 +958,167 @@ impl ResourceGovernor for InMemoryResourceGovernor {
         reservation_id: ResourceReservationId,
         actual: ResourceUsage,
     ) -> Result<ResourceReceipt, ResourceError> {
-        let mut state = self.lock_state();
-        let mut record = state
-            .reservations
-            .remove(&reservation_id)
-            .ok_or(ResourceError::UnknownReservation { id: reservation_id })?;
-
-        if record.status != ReservationStatus::Active {
-            let status = record.status;
-            state.reservations.insert(reservation_id, record);
-            return Err(ResourceError::ReservationClosed {
-                id: reservation_id,
-                status,
-            });
-        }
-
-        if let Err(error) = validate_usage(&actual) {
-            state.reservations.insert(reservation_id, record);
-            return Err(error);
-        }
-
-        for account in &record.accounts {
-            state
-                .reserved_by_account
-                .entry(account.clone())
-                .or_default()
-                .sub_assign(&record.tally);
-            state
-                .usage_by_account
-                .entry(account.clone())
-                .or_default()
-                .add_assign(&ResourceTally::from_usage(&actual));
-        }
-
-        record.status = ReservationStatus::Reconciled;
-        record.actual = Some(actual.clone());
-        let receipt = ResourceReceipt {
-            id: reservation_id,
-            scope: record.reservation.scope.clone(),
-            status: ReservationStatus::Reconciled,
-            estimate: record.reservation.estimate.clone(),
-            actual: Some(actual),
-        };
-        state.reservations.insert(reservation_id, record);
-        Ok(receipt)
+        reconcile_in_state(&mut self.lock_state(), reservation_id, actual)
     }
 
     fn release(
         &self,
         reservation_id: ResourceReservationId,
     ) -> Result<ResourceReceipt, ResourceError> {
-        let mut state = self.lock_state();
-        let mut record = state
-            .reservations
-            .remove(&reservation_id)
-            .ok_or(ResourceError::UnknownReservation { id: reservation_id })?;
-
-        if record.status != ReservationStatus::Active {
-            let status = record.status;
-            state.reservations.insert(reservation_id, record);
-            return Err(ResourceError::ReservationClosed {
-                id: reservation_id,
-                status,
-            });
-        }
-
-        for account in &record.accounts {
-            state
-                .reserved_by_account
-                .entry(account.clone())
-                .or_default()
-                .sub_assign(&record.tally);
-        }
-
-        record.status = ReservationStatus::Released;
-        let receipt = ResourceReceipt {
-            id: reservation_id,
-            scope: record.reservation.scope.clone(),
-            status: ReservationStatus::Released,
-            estimate: record.reservation.estimate.clone(),
-            actual: None,
-        };
-        state.reservations.insert(reservation_id, record);
-        Ok(receipt)
+        release_in_state(&mut self.lock_state(), reservation_id)
     }
+}
+
+fn set_limit_in_state(state: &mut ResourceState, account: ResourceAccount, limits: ResourceLimits) {
+    state.limits.insert(account, limits);
+}
+
+fn reserve_in_state(
+    state: &mut ResourceState,
+    scope: ResourceScope,
+    estimate: ResourceEstimate,
+    reservation_id: ResourceReservationId,
+) -> Result<ResourceReservation, ResourceError> {
+    validate_estimate(&estimate)?;
+
+    if state.reservations.contains_key(&reservation_id) {
+        return Err(ResourceError::ReservationAlreadyExists { id: reservation_id });
+    }
+    let accounts = ResourceAccount::cascade(&scope);
+    let requested = ResourceTally::from_estimate(&estimate);
+
+    for account in &accounts {
+        if let Some(limits) = state.limits.get(account) {
+            let usage = state
+                .usage_by_account
+                .get(account)
+                .cloned()
+                .unwrap_or_default();
+            let reserved = state
+                .reserved_by_account
+                .get(account)
+                .cloned()
+                .unwrap_or_default();
+            if let Some(denial) = check_limits(account, limits, &usage, &reserved, &requested) {
+                return Err(ResourceError::LimitExceeded(Box::new(denial)));
+            }
+        }
+    }
+
+    let reservation = ResourceReservation {
+        id: reservation_id,
+        scope,
+        estimate,
+    };
+
+    for account in &accounts {
+        state
+            .reserved_by_account
+            .entry(account.clone())
+            .or_default()
+            .add_assign(&requested);
+    }
+
+    state.reservations.insert(
+        reservation.id,
+        ReservationRecord {
+            reservation: reservation.clone(),
+            accounts,
+            tally: requested,
+            status: ReservationStatus::Active,
+            actual: None,
+        },
+    );
+
+    Ok(reservation)
+}
+
+fn reconcile_in_state(
+    state: &mut ResourceState,
+    reservation_id: ResourceReservationId,
+    actual: ResourceUsage,
+) -> Result<ResourceReceipt, ResourceError> {
+    let mut record = state
+        .reservations
+        .remove(&reservation_id)
+        .ok_or(ResourceError::UnknownReservation { id: reservation_id })?;
+
+    if record.status != ReservationStatus::Active {
+        let status = record.status;
+        state.reservations.insert(reservation_id, record);
+        return Err(ResourceError::ReservationClosed {
+            id: reservation_id,
+            status,
+        });
+    }
+
+    if let Err(error) = validate_usage(&actual) {
+        state.reservations.insert(reservation_id, record);
+        return Err(error);
+    }
+
+    for account in &record.accounts {
+        state
+            .reserved_by_account
+            .entry(account.clone())
+            .or_default()
+            .sub_assign(&record.tally);
+        state
+            .usage_by_account
+            .entry(account.clone())
+            .or_default()
+            .add_assign(&ResourceTally::from_usage(&actual));
+    }
+
+    record.status = ReservationStatus::Reconciled;
+    record.actual = Some(actual.clone());
+    let receipt = ResourceReceipt {
+        id: reservation_id,
+        scope: record.reservation.scope.clone(),
+        status: ReservationStatus::Reconciled,
+        estimate: record.reservation.estimate.clone(),
+        actual: Some(actual),
+    };
+    state.reservations.insert(reservation_id, record);
+    Ok(receipt)
+}
+
+fn release_in_state(
+    state: &mut ResourceState,
+    reservation_id: ResourceReservationId,
+) -> Result<ResourceReceipt, ResourceError> {
+    let mut record = state
+        .reservations
+        .remove(&reservation_id)
+        .ok_or(ResourceError::UnknownReservation { id: reservation_id })?;
+
+    if record.status != ReservationStatus::Active {
+        let status = record.status;
+        state.reservations.insert(reservation_id, record);
+        return Err(ResourceError::ReservationClosed {
+            id: reservation_id,
+            status,
+        });
+    }
+
+    for account in &record.accounts {
+        state
+            .reserved_by_account
+            .entry(account.clone())
+            .or_default()
+            .sub_assign(&record.tally);
+    }
+
+    record.status = ReservationStatus::Released;
+    let receipt = ResourceReceipt {
+        id: reservation_id,
+        scope: record.reservation.scope.clone(),
+        status: ReservationStatus::Released,
+        estimate: record.reservation.estimate.clone(),
+        actual: None,
+    };
+    state.reservations.insert(reservation_id, record);
+    Ok(receipt)
 }
 
 fn validate_estimate(estimate: &ResourceEstimate) -> Result<(), ResourceError> {

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -1,6 +1,8 @@
 use std::sync::{Arc, Barrier};
 use std::thread;
 
+use tempfile::tempdir;
+
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
 use rust_decimal_macros::dec;
@@ -571,6 +573,210 @@ fn resource_governor_enforces_agent_scoped_limits_independently() {
             ..ResourceTally::default()
         }
     );
+}
+
+#[test]
+fn persistent_governor_reloads_active_holds_and_usage_from_store() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    governor
+        .try_set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    let active = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.20)),
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let reloaded = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let concurrency_denial = reloaded
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(
+        concurrency_denial,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account
+                && denial.dimension == ResourceDimension::ConcurrencySlots
+                && denial.active_reserved == ResourceValue::Integer(1)
+    ));
+
+    reloaded
+        .reconcile(
+            active.id,
+            ResourceUsage {
+                usd: dec!(0.95),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+
+    let reloaded_again = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let usd_denial = reloaded_again
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.10)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(
+        usd_denial,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account
+                && denial.dimension == ResourceDimension::Usd
+                && denial.current_usage == ResourceValue::Decimal(dec!(0.95))
+    ));
+}
+
+#[test]
+fn persistent_governor_serializes_concurrent_reservations_across_handles() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    governor
+        .try_set_limit(
+            account,
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+
+    let barrier = Arc::new(Barrier::new(8));
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let path = path.clone();
+        let barrier = Arc::clone(&barrier);
+        let mut scope = scope.clone();
+        scope.invocation_id = InvocationId::new();
+        handles.push(thread::spawn(move || {
+            let governor =
+                PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(path));
+            barrier.wait();
+            governor
+                .reserve(
+                    scope,
+                    ResourceEstimate {
+                        concurrency_slots: Some(1),
+                        ..ResourceEstimate::default()
+                    },
+                )
+                .is_ok()
+        }));
+    }
+
+    let successes = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .filter(|success| *success)
+        .count();
+    assert_eq!(successes, 1);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_persistent_governor_reloads_active_holds_and_usage_from_store() {
+    let dir = tempdir().unwrap();
+    let db = std::sync::Arc::new(
+        libsql::Builder::new_local(dir.path().join("resources.db"))
+            .build()
+            .await
+            .unwrap(),
+    );
+    let store = LibSqlResourceGovernorStore::new(std::sync::Arc::clone(&db));
+    store.run_migrations().await.unwrap();
+
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let governor = PersistentResourceGovernor::new(store);
+    governor
+        .try_set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    let active = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let reloaded = PersistentResourceGovernor::new(LibSqlResourceGovernorStore::new(db));
+    let concurrency_denial = reloaded
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(
+        concurrency_denial,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account && denial.dimension == ResourceDimension::ConcurrencySlots
+    ));
+
+    reloaded
+        .reconcile(
+            active.id,
+            ResourceUsage {
+                usd: dec!(0.95),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+    let usd_denial = reloaded
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.10)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(
+        usd_denial,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account
+                && denial.dimension == ResourceDimension::Usd
+                && denial.current_usage == ResourceValue::Decimal(dec!(0.95))
+    ));
 }
 
 fn sample_scope(tenant: &str, user: &str, project: Option<&str>) -> ResourceScope {

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -1,5 +1,8 @@
-use std::sync::{Arc, Barrier};
-use std::thread;
+use std::{
+    fs,
+    sync::{Arc, Barrier},
+    thread,
+};
 
 use tempfile::tempdir;
 
@@ -754,6 +757,313 @@ fn persistent_governor_serializes_concurrent_reservations_across_handles() {
         .filter(|success| *success)
         .count();
     assert_eq!(successes, 1);
+}
+
+#[test]
+fn persistent_governor_writes_versioned_snapshot_schema() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id);
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    governor
+        .try_set_limit(
+            account,
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+
+    let snapshot: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(snapshot["schema_version"], serde_json::json!(1));
+}
+
+#[test]
+fn persistent_governor_upgrades_legacy_unversioned_snapshot() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    fs::write(
+        &path,
+        r#"{
+            "state": {
+                "limits": [],
+                "reserved_by_account": [],
+                "usage_by_account": [],
+                "reservations": []
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    governor
+        .try_set_limit(
+            ResourceAccount::tenant(TenantId::new("tenant1").unwrap()),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+
+    let snapshot: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(snapshot["schema_version"], serde_json::json!(1));
+}
+
+#[test]
+fn persistent_governor_rejects_malformed_snapshot_with_storage_error() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    fs::write(&path, "{not valid json").unwrap();
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let error = governor
+        .try_set_limit(
+            ResourceAccount::tenant(TenantId::new("tenant1").unwrap()),
+            ResourceLimits::default(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ResourceError::Storage { reason } if reason.contains("malformed resource governor snapshot")
+    ));
+}
+
+#[test]
+fn persistent_governor_rejects_unknown_snapshot_fields() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    fs::write(
+        &path,
+        r#"{
+            "schema_version": 1,
+            "state": {
+                "limits": [],
+                "reserved_by_account": [],
+                "usage_by_account": [],
+                "reservations": []
+            },
+            "unexpected": true
+        }"#,
+    )
+    .unwrap();
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let error = governor
+        .try_set_limit(
+            ResourceAccount::tenant(TenantId::new("tenant1").unwrap()),
+            ResourceLimits::default(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ResourceError::Storage { reason } if reason.contains("unknown field")
+    ));
+}
+
+#[test]
+fn persistent_governor_rejects_unknown_persisted_resource_fields() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    fs::write(
+        &path,
+        r#"{
+            "schema_version": 1,
+            "state": {
+                "limits": [
+                    [
+                        { "Tenant": { "tenant_id": "tenant1" } },
+                        { "max_usd": "1.00", "unexpected_limit": true }
+                    ]
+                ],
+                "reserved_by_account": [],
+                "usage_by_account": [],
+                "reservations": []
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let error = governor
+        .try_set_limit(
+            ResourceAccount::tenant(TenantId::new("tenant1").unwrap()),
+            ResourceLimits::default(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ResourceError::Storage { reason } if reason.contains("unknown field")
+    ));
+}
+
+#[test]
+fn persistent_governor_rejects_unknown_reservation_scope_fields() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    governor
+        .reserve(scope.clone(), ResourceEstimate::default())
+        .unwrap();
+
+    let mut snapshot: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    snapshot["state"]["reservations"].as_array_mut().unwrap()[0][1]["reservation"]["scope"]["unexpected_scope"] =
+        serde_json::json!(true);
+    fs::write(&path, serde_json::to_string_pretty(&snapshot).unwrap()).unwrap();
+
+    let reloaded = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let error = reloaded
+        .try_set_limit(
+            ResourceAccount::tenant(scope.tenant_id),
+            ResourceLimits::default(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ResourceError::Storage { reason } if reason.contains("unknown field")
+    ));
+}
+
+#[test]
+fn persistent_governor_rejects_unknown_reservation_estimate_fields() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.20)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let mut snapshot: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    snapshot["state"]["reservations"].as_array_mut().unwrap()[0][1]["reservation"]["estimate"]["unexpected_estimate"] =
+        serde_json::json!(true);
+    fs::write(&path, serde_json::to_string_pretty(&snapshot).unwrap()).unwrap();
+
+    let reloaded = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let error = reloaded
+        .try_set_limit(
+            ResourceAccount::tenant(scope.tenant_id),
+            ResourceLimits::default(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ResourceError::Storage { reason } if reason.contains("unknown field")
+    ));
+}
+
+#[test]
+fn persistent_governor_rejects_unknown_reservation_actual_fields() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let reservation = governor
+        .reserve(scope.clone(), ResourceEstimate::default())
+        .unwrap();
+    governor
+        .reconcile(
+            reservation.id,
+            ResourceUsage {
+                usd: dec!(0.20),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+
+    let mut snapshot: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    snapshot["state"]["reservations"].as_array_mut().unwrap()[0][1]["actual"]["unexpected_actual"] =
+        serde_json::json!(true);
+    fs::write(&path, serde_json::to_string_pretty(&snapshot).unwrap()).unwrap();
+
+    let reloaded = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let error = reloaded
+        .try_set_limit(
+            ResourceAccount::tenant(scope.tenant_id),
+            ResourceLimits::default(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ResourceError::Storage { reason } if reason.contains("unknown field")
+    ));
+}
+
+#[test]
+fn persistent_governor_rejects_partial_snapshot_fields() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    fs::write(&path, r#"{"schema_version": 1}"#).unwrap();
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let error = governor
+        .try_set_limit(
+            ResourceAccount::tenant(TenantId::new("tenant1").unwrap()),
+            ResourceLimits::default(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ResourceError::Storage { reason } if reason.contains("missing field")
+    ));
+}
+
+#[test]
+fn persistent_governor_rejects_unsupported_snapshot_schema_version() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resource-governor.json");
+    fs::write(
+        &path,
+        r#"{
+            "schema_version": 999,
+            "state": {
+                "limits": [],
+                "reserved_by_account": [],
+                "usage_by_account": [],
+                "reservations": []
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let governor = PersistentResourceGovernor::new(JsonFileResourceGovernorStore::new(&path));
+    let error = governor
+        .try_set_limit(
+            ResourceAccount::tenant(TenantId::new("tenant1").unwrap()),
+            ResourceLimits::default(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ResourceError::Storage { reason }
+            if reason.contains("unsupported resource governor snapshot schema version 999")
+    ));
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -7,20 +7,58 @@ use ironclaw_host_api::*;
 use ironclaw_resources::*;
 use rust_decimal_macros::dec;
 
+#[derive(Clone)]
+struct AlwaysFailingStore;
+
+impl ResourceGovernorStore for AlwaysFailingStore {
+    fn update<T, F>(&self, _update: F) -> Result<T, ResourceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut ResourceGovernorSnapshot) -> Result<T, ResourceError> + Send + 'static,
+    {
+        Err(ResourceError::Storage {
+            reason: "forced durable write failure".to_string(),
+        })
+    }
+}
+
+#[test]
+fn persistent_trait_set_limit_surfaces_storage_errors() {
+    let governor: Arc<dyn ResourceGovernor> =
+        Arc::new(PersistentResourceGovernor::new(AlwaysFailingStore));
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+
+    let error = governor
+        .set_limit(
+            ResourceAccount::tenant(scope.tenant_id),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(
+        matches!(error, ResourceError::Storage { reason } if reason == "forced durable write failure")
+    );
+}
+
 #[test]
 fn reserve_succeeds_when_budget_is_available() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
 
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            max_concurrency_slots: Some(2),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                max_concurrency_slots: Some(2),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let reservation = governor
         .reserve(
@@ -162,13 +200,15 @@ fn usd_limit_check_denies_instead_of_panicking_on_decimal_overflow() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_usd: Some(rust_decimal::Decimal::MAX),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(rust_decimal::Decimal::MAX),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     governor
         .reserve(
@@ -202,13 +242,15 @@ fn reserve_denies_when_usd_limit_would_be_exceeded() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(0.50)),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(0.50)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let err = governor
         .reserve(
@@ -236,14 +278,16 @@ fn reserve_denies_runtime_quota_even_without_usd() {
         scope.user_id.clone(),
         scope.project_id.clone().unwrap(),
     );
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_wall_clock_ms: Some(1_000),
-            max_process_count: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_wall_clock_ms: Some(1_000),
+                max_process_count: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let err = governor
         .reserve(
@@ -272,13 +316,15 @@ fn active_reservations_consume_concurrency_until_released() {
         scope.user_id.clone(),
         scope.project_id.clone().unwrap(),
     );
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let first = governor
         .reserve(
@@ -327,13 +373,15 @@ fn concurrent_reservations_cannot_oversubscribe_scope() {
         scope.user_id.clone(),
         scope.project_id.clone().unwrap(),
     );
-    governor.set_limit(
-        account,
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account,
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let barrier = Arc::new(Barrier::new(8));
     let mut handles = Vec::new();
@@ -369,14 +417,16 @@ fn reconcile_records_actual_usage_and_closes_reservation() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            max_concurrency_slots: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let reservation = governor
         .reserve(
@@ -428,14 +478,16 @@ fn release_frees_reserved_capacity_without_recording_spend() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            max_concurrency_slots: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let reservation = governor
         .reserve(
@@ -479,13 +531,15 @@ fn tenant_limit_applies_across_projects() {
     let project_a = sample_scope("tenant1", "user1", Some("project_a"));
     let project_b = sample_scope("tenant1", "user1", Some("project_b"));
     let tenant_account = ResourceAccount::tenant(project_a.tenant_id.clone());
-    governor.set_limit(
-        tenant_account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            tenant_account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     governor
         .reserve(
@@ -521,13 +575,15 @@ fn resource_governor_enforces_agent_scoped_limits_independently() {
     let user = UserId::new("user1").unwrap();
     let agent_a = AgentId::new("agent-a").unwrap();
     let agent_b = AgentId::new("agent-b").unwrap();
-    governor.set_limit(
-        ResourceAccount::agent(tenant.clone(), user.clone(), None, agent_a.clone()),
-        ResourceLimits {
-            max_output_bytes: Some(10),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            ResourceAccount::agent(tenant.clone(), user.clone(), None, agent_a.clone()),
+            ResourceLimits {
+                max_output_bytes: Some(10),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let estimate = ResourceEstimate {
         output_bytes: Some(8),
@@ -779,6 +835,133 @@ async fn libsql_persistent_governor_reloads_active_holds_and_usage_from_store() 
     ));
 }
 
+#[cfg(feature = "postgres")]
+const POSTGRES_SKIP_ENV: &str = "IRONCLAW_SKIP_POSTGRES_TESTS";
+
+#[cfg(feature = "postgres")]
+fn postgres_skip_requested() -> bool {
+    std::env::var(POSTGRES_SKIP_ENV).is_ok_and(|value| value == "1" || value == "true")
+}
+
+#[cfg(feature = "postgres")]
+async fn postgres_pool_or_skip() -> Option<deadpool_postgres::Pool> {
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://localhost/ironclaw_test".to_string());
+    let config: tokio_postgres::Config = database_url
+        .parse()
+        .expect("DATABASE_URL must be a valid Postgres URL");
+    let mgr = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
+    let pool = deadpool_postgres::Pool::builder(mgr)
+        .max_size(2)
+        .build()
+        .expect("build deadpool");
+    match pool.get().await {
+        Ok(_) => Some(pool),
+        Err(error) => {
+            if postgres_skip_requested() {
+                eprintln!(
+                    "skipping Postgres resource governor contract ({POSTGRES_SKIP_ENV}=1): {error}"
+                );
+                None
+            } else {
+                panic!(
+                    "Postgres resource governor contract could not reach Postgres ({error}); \
+                     set DATABASE_URL to a reachable Postgres test database, or set \
+                     {POSTGRES_SKIP_ENV}=1 to explicitly skip."
+                );
+            }
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn clear_postgres_resource_snapshots(pool: &deadpool_postgres::Pool) {
+    let client = pool.get().await.expect("cleanup client");
+    client
+        .batch_execute("DELETE FROM ironclaw_resource_governor_snapshots")
+        .await
+        .expect("cleanup resource governor snapshots");
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_persistent_governor_reloads_active_holds_and_usage_from_store() {
+    let Some(pool) = postgres_pool_or_skip().await else {
+        return;
+    };
+    let store = PostgresResourceGovernorStore::new(pool.clone());
+    store.run_migrations().await.unwrap();
+    clear_postgres_resource_snapshots(&pool).await;
+
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let governor = PersistentResourceGovernor::new(store);
+    governor
+        .try_set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    let active = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let reloaded =
+        PersistentResourceGovernor::new(PostgresResourceGovernorStore::new(pool.clone()));
+    let concurrency_denial = reloaded
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(
+        concurrency_denial,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account && denial.dimension == ResourceDimension::ConcurrencySlots
+    ));
+
+    reloaded
+        .reconcile(
+            active.id,
+            ResourceUsage {
+                usd: dec!(0.95),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+    let usd_denial = reloaded
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.10)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(
+        usd_denial,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account
+                && denial.dimension == ResourceDimension::Usd
+                && denial.current_usage == ResourceValue::Decimal(dec!(0.95))
+    ));
+
+    clear_postgres_resource_snapshots(&pool).await;
+}
+
 fn sample_scope(tenant: &str, user: &str, project: Option<&str>) -> ResourceScope {
     ResourceScope {
         tenant_id: TenantId::new(tenant).unwrap(),
@@ -818,20 +1001,24 @@ fn project_and_agent_limits_both_apply_without_override() {
         scope.agent_id.clone().unwrap(),
     );
 
-    governor.set_limit(
-        project_account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(0.50)),
-            ..ResourceLimits::default()
-        },
-    );
-    governor.set_limit(
-        agent_account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            project_account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(0.50)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    governor
+        .set_limit(
+            agent_account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let err = governor
         .reserve(
@@ -849,20 +1036,24 @@ fn project_and_agent_limits_both_apply_without_override() {
             if denial.account == project_account && denial.dimension == ResourceDimension::Usd
     ));
 
-    governor.set_limit(
-        project_account,
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            ..ResourceLimits::default()
-        },
-    );
-    governor.set_limit(
-        agent_account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(0.50)),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            project_account,
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    governor
+        .set_limit(
+            agent_account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(0.50)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let err = governor
         .reserve(
@@ -949,20 +1140,24 @@ fn project_limit_denies_leaf_even_when_tenant_allows() {
         scope.user_id.clone(),
         scope.project_id.clone().unwrap(),
     );
-    governor.set_limit(
-        tenant,
-        ResourceLimits {
-            max_usd: Some(dec!(10.00)),
-            ..ResourceLimits::default()
-        },
-    );
-    governor.set_limit(
-        project.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            tenant,
+            ResourceLimits {
+                max_usd: Some(dec!(10.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    governor
+        .set_limit(
+            project.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let err = governor
         .reserve(
@@ -986,13 +1181,15 @@ fn reconciled_usage_counts_against_future_reservations() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let reservation = governor
         .reserve(
@@ -1039,13 +1236,15 @@ fn active_reserved_and_usage_appear_in_denial_details() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let completed = governor
         .reserve(
@@ -1103,13 +1302,15 @@ fn actual_usage_above_estimate_is_recorded_and_blocks_future_work() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_usd: Some(dec!(1.00)),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_usd: Some(dec!(1.00)),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
 
     let reservation = governor
         .reserve(
@@ -1243,7 +1444,7 @@ fn assert_denied_dimension(
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(account.clone(), limits);
+    governor.set_limit(account.clone(), limits).unwrap();
 
     let err = governor.reserve(scope, estimate).unwrap_err();
     assert!(matches!(

--- a/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
+++ b/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
@@ -256,15 +256,17 @@ fn mounted_empty_extension_root() -> LocalFilesystem {
 
 fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGovernor {
     let governor = InMemoryResourceGovernor::new();
-    governor.set_limit(
-        account,
-        ResourceLimits {
-            max_concurrency_slots: Some(10),
-            max_process_count: Some(10),
-            max_output_bytes: Some(100_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account,
+            ResourceLimits {
+                max_concurrency_slots: Some(10),
+                max_process_count: Some(10),
+                max_output_bytes: Some(100_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     governor
 }
 

--- a/crates/ironclaw_scripts/tests/script_runner_contract.rs
+++ b/crates/ironclaw_scripts/tests/script_runner_contract.rs
@@ -18,15 +18,17 @@ fn script_runtime_reserves_executes_and_reconciles_success() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            max_process_count: Some(10),
-            max_output_bytes: Some(10_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_process_count: Some(10),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let capability_id = CapabilityId::new("script.echo").unwrap();
 
     let execution = runtime
@@ -87,13 +89,15 @@ fn script_runtime_denies_budget_before_backend_execution() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_output_bytes: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_output_bytes: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let capability_id = CapabilityId::new("script.echo").unwrap();
 
     let err = runtime
@@ -132,13 +136,15 @@ fn script_runtime_releases_reservation_when_backend_exits_nonzero() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let capability_id = CapabilityId::new("script.echo").unwrap();
 
     let err = runtime
@@ -210,13 +216,15 @@ fn script_runtime_releases_reservation_when_output_limit_fails() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(1),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let capability_id = CapabilityId::new("script.echo").unwrap();
 
     let err = runtime
@@ -249,13 +257,15 @@ fn script_runtime_rejects_non_script_package_before_reserving() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(0),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(0),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let capability_id = CapabilityId::new("echo.say").unwrap();
 
     let err = runtime
@@ -288,13 +298,15 @@ fn script_runtime_rejects_undeclared_capability_before_reserving() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
-    governor.set_limit(
-        account.clone(),
-        ResourceLimits {
-            max_concurrency_slots: Some(0),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(0),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     let capability_id = CapabilityId::new("script.missing").unwrap();
 
     let err = runtime
@@ -362,8 +374,12 @@ impl ReleaseFailingGovernor {
 }
 
 impl ResourceGovernor for ReleaseFailingGovernor {
-    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
-        self.inner.set_limit(account, limits);
+    fn set_limit(
+        &self,
+        account: ResourceAccount,
+        limits: ResourceLimits,
+    ) -> Result<(), ResourceError> {
+        self.inner.set_limit(account, limits)
     }
 
     fn reserve(

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -590,15 +590,17 @@ async fn filesystem_with_wasm_component(
 
 fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGovernor {
     let governor = InMemoryResourceGovernor::new();
-    governor.set_limit(
-        account,
-        ResourceLimits {
-            max_concurrency_slots: Some(10),
-            max_process_count: Some(10),
-            max_output_bytes: Some(100_000),
-            ..ResourceLimits::default()
-        },
-    );
+    governor
+        .set_limit(
+            account,
+            ResourceLimits {
+                max_concurrency_slots: Some(10),
+                max_process_count: Some(10),
+                max_output_bytes: Some(100_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
     governor
 }
 

--- a/docs/reborn/contracts/resources.md
+++ b/docs/reborn/contracts/resources.md
@@ -242,7 +242,7 @@ pub enum ResourceAccount {
 }
 
 pub trait ResourceGovernor {
-    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits);
+    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) -> Result<(), ResourceError>;
     fn reserve(
         &self,
         scope: ResourceScope,

--- a/docs/reborn/contracts/resources.md
+++ b/docs/reborn/contracts/resources.md
@@ -265,6 +265,8 @@ pub trait ResourceGovernor {
 
 The V1 crate started with an in-memory implementation for contract tests. The production seam now also includes `PersistentResourceGovernor`, backed by transactional `ResourceGovernorStore` implementations. `JsonFileResourceGovernorStore` uses an exclusive OS file lock for single-node durability; `LibSqlResourceGovernorStore` and `PostgresResourceGovernorStore` persist the same account-wide snapshot through database transactions/locks so active holds and reconciled usage survive restart and are shared across governors.
 
+Persistent implementations add a storage failure mode to every governor operation that touches durable state, including `set_limit`. Lock, read, write, serialization, deserialization, or snapshot schema validation failures return `ResourceError::Storage` and must fail closed: callers must not start costed or quota-limited work when storage state cannot be trusted. Durable snapshots are versioned with `schema_version`; unknown top-level fields, partial snapshots, malformed JSON, and unsupported future schema versions are rejected instead of being silently ignored.
+
 ---
 
 ## 12. Minimum TDD coverage
@@ -275,6 +277,8 @@ Local contract tests should prove:
 - reservation denies when USD would exceed limit
 - reservation denies when runtime quota would exceed limit even with zero USD
 - active reservations consume concurrency slots
+- persistent snapshots reload limits, active holds, and reconciled usage across governor instances
+- persistent snapshots reject malformed JSON, unknown fields, partial snapshots, and unsupported schema versions with `ResourceError::Storage`
 - concurrent reservations cannot oversubscribe a scope
 - release frees reserved-but-unused capacity and records no spend
 - reconcile records actual usage and releases active reservation

--- a/docs/reborn/contracts/resources.md
+++ b/docs/reborn/contracts/resources.md
@@ -263,7 +263,7 @@ pub trait ResourceGovernor {
 }
 ```
 
-The V1 crate should start with an in-memory implementation for contract tests. Persistence, PostgreSQL/libSQL backends, and distributed locks can come later.
+The V1 crate started with an in-memory implementation for contract tests. The production seam now also includes `PersistentResourceGovernor`, backed by transactional `ResourceGovernorStore` implementations. `JsonFileResourceGovernorStore` uses an exclusive OS file lock for single-node durability; `LibSqlResourceGovernorStore` and `PostgresResourceGovernorStore` persist the same account-wide snapshot through database transactions/locks so active holds and reconciled usage survive restart and are shared across governors.
 
 ---
 
@@ -291,7 +291,6 @@ Do not add in `ironclaw_resources` V1:
 - payment processing
 - subscription plans
 - provider-specific LLM price catalogs
-- database schema/migrations
 - Docker/WASM/MCP execution
 - approval UI
 - auth/secret storage


### PR DESCRIPTION
## Summary
- adds `PersistentResourceGovernor` with transactional store abstraction
- adds JSON-file, libSQL, and PostgreSQL durable resource-governor stores
- updates host-runtime production wiring coverage so persistent governor is not treated as local-only
- documents durable governor storage semantics for Reborn resources

## Verification
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-rg cargo test -p ironclaw_resources`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-rg cargo test -p ironclaw_resources --features libsql`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-rg cargo clippy -p ironclaw_resources --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-rg cargo test -p ironclaw_host_runtime production_wiring_validation_accepts_persistent_resource_governor_component -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-rg cargo check -p ironclaw_host_runtime --all-features`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-rg cargo test -p ironclaw_architecture`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-rg cargo fmt --all --check`
- `git diff --check`

Part of #3333.
