### PR TITLE
Fix E2E auth and approval coverage

### DIFF
--- a/src/bridge/gate_controller.rs
+++ b/src/bridge/gate_controller.rs
@@ -509,21 +509,52 @@ impl BridgeGateController {
             ); // projection-exempt: bridge dispatcher, inline-await gate prompt for live VM waiting on user input
         }
 
-        if let ResumeKind::Approval { allow_always } = &pending.resume_kind {
-            let _ = self
-                .channels
-                .send_status(
-                    &pending.source_channel,
-                    StatusUpdate::ApprovalNeeded {
-                        request_id: pending.request_id.to_string(),
-                        tool_name: pending.action_name.clone(),
-                        description: pending.description.clone(),
-                        parameters: display_parameters,
-                        allow_always: *allow_always,
-                    },
-                    channel_metadata,
-                )
-                .await;
+        match &pending.resume_kind {
+            ResumeKind::Approval { allow_always } => {
+                let _ = self
+                    .channels
+                    .send_status(
+                        &pending.source_channel,
+                        StatusUpdate::ApprovalNeeded {
+                            request_id: pending.request_id.to_string(),
+                            tool_name: pending.action_name.clone(),
+                            description: pending.description.clone(),
+                            parameters: display_parameters,
+                            allow_always: *allow_always,
+                        },
+                        channel_metadata,
+                    )
+                    .await;
+            }
+            ResumeKind::Authentication {
+                instructions,
+                auth_url,
+                ..
+            } => {
+                let Some(extension_name) = extension_name else {
+                    debug!(
+                        gate = %pending.gate_name,
+                        request_id = %pending.request_id,
+                        "Authentication gate reached emit_gate_prompt without a resolved extension name"
+                    );
+                    return;
+                };
+                let _ = self
+                    .channels
+                    .send_status(
+                        &pending.source_channel,
+                        StatusUpdate::AuthRequired {
+                            extension_name,
+                            instructions: Some(instructions.clone()),
+                            auth_url: auth_url.clone(),
+                            setup_url: None,
+                            request_id: Some(pending.request_id.to_string()),
+                        },
+                        channel_metadata,
+                    )
+                    .await;
+            }
+            ResumeKind::External { .. } => {}
         }
     }
 }

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -14,6 +14,11 @@ import time
 import uuid
 from aiohttp import web
 
+DENIAL_PATTERN = re.compile(
+    r"user denied action|user denied tool|denied:\s*",
+    re.IGNORECASE,
+)
+
 CANNED_RESPONSES = [
     (re.compile(r"empty routine response", re.IGNORECASE), ""),
     (re.compile(r"\bhello\b|\bhi\b|\bhey\b", re.IGNORECASE), "Hello! How can I help you today?"),
@@ -866,6 +871,24 @@ def _conversation_has_active_skill(messages: list[dict], skill_name: str) -> boo
     return False
 
 
+def _conversation_uses_codeact(messages: list[dict]) -> bool:
+    for msg in messages:
+        if msg.get("role") != "system":
+            continue
+        text = _message_text(msg)
+        if "Python REPL environment" in text and "```repl" in text:
+            return True
+    return False
+
+
+def _conversation_includes_denial(messages: list[dict]) -> bool:
+    for msg in messages:
+        text = f"{_message_text(msg)}\n{_message_payload_text(msg)}"
+        if DENIAL_PATTERN.search(text):
+            return True
+    return False
+
+
 def _active_skill_names(messages: list[dict]) -> set[str]:
     names = set()
     for msg in messages:
@@ -1036,9 +1059,20 @@ def match_response(messages: list[dict]) -> str:
     resumed = _resumed_action_summary(messages)
     if resumed:
         return resumed
-    if "user denied action" in content.lower():
-        action_match = re.search(r"User denied action '([^']+)'", content)
-        action_name = action_match.group(1) if action_match else "that action"
+    denial_text = f"{content}\n{payload_text}"
+    if DENIAL_PATTERN.search(denial_text):
+        action_match = re.search(
+            r"User denied action '([^']+)'", denial_text, re.IGNORECASE
+        )
+        tool_match = re.search(
+            r"user denied tool '([^']+)'", denial_text, re.IGNORECASE
+        )
+        if action_match:
+            action_name = action_match.group(1)
+        elif tool_match:
+            action_name = tool_match.group(1)
+        else:
+            action_name = "that action"
         return (
             f"The request for {action_name} was denied. "
             "No installation or setup was performed."
@@ -1310,6 +1344,10 @@ def _find_tool_result(messages: list[dict]) -> dict | None:
     """Backward-compat single-result helper used by the special-response path."""
     results = _find_tool_results(messages)
     return results[0] if results else None
+
+
+def _tool_results_include_denial(tool_results: list[dict]) -> bool:
+    return any(DENIAL_PATTERN.search(tr.get("content", "")) for tr in tool_results)
 
 
 def _recent_tool_names(messages: list[dict]) -> set[str]:
@@ -1801,9 +1839,36 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
         if special and _conversation_has_user_trigger(messages, lifecycle_trigger):
             return await _dispatch_special_response(request, cid, stream, special)
 
-    # Tool result(s) in messages -> text summary covering every fresh result
     tool_results = _find_tool_results(messages)
+    if (
+        not tool_results
+        and _conversation_uses_codeact(messages)
+        and re.search(
+            r"list.*(?:google|drive).*files|show.*drive",
+            _last_user_content(messages),
+            re.IGNORECASE,
+        )
+    ):
+        text = (
+            "```repl\n"
+            f"result = await http(method=\"GET\", url=\"{_github_api_url}/drive/v3/files\")\n"
+            "FINAL(str(result))\n"
+            "```"
+        )
+        if not stream:
+            return _text_response(cid, text)
+        return await _stream_text(request, cid, text)
+
+    # Tool result(s) in messages -> text summary covering every fresh result
     if _conversation_has_active_skill(messages, "pikastream-video-meeting"):
+        if _conversation_includes_denial(messages) or _tool_results_include_denial(tool_results):
+            text = (
+                "The request for shell was denied. "
+                "No installation or setup was performed."
+            )
+            if not stream:
+                return _text_response(cid, text)
+            return await _stream_text(request, cid, text)
         recent_tool_names = _recent_tool_names(messages)
         if "shell" in recent_tool_names:
             text = (
@@ -1816,6 +1881,14 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
             return await _stream_text(request, cid, text)
     if tool_results:
         if _conversation_has_active_skill(messages, "pikastream-video-meeting"):
+            if _tool_results_include_denial(tool_results):
+                text = (
+                    "The request for shell was denied. "
+                    "No installation or setup was performed."
+                )
+                if not stream:
+                    return _text_response(cid, text)
+                return await _stream_text(request, cid, text)
             if any(tr["name"] == "shell" for tr in tool_results):
                 text = (
                     "Python dependencies are prepared for the Pika video-meeting skill. "

--- a/tests/e2e/scenarios/test_auth_no_duplicate_response.py
+++ b/tests/e2e/scenarios/test_auth_no_duplicate_response.py
@@ -11,7 +11,8 @@ This test:
 2. Connects to the SSE stream
 3. Sends a chat message that triggers the GitHub skill → HTTP 401 → auth onboarding
 4. Collects SSE events and asserts:
-   - onboarding_state/auth_required event IS present
+   - an auth prompt event is present (gate_required/Authentication or
+     onboarding_state/auth_required)
    - No response event contains auth instruction text (the regression)
 """
 
@@ -94,11 +95,12 @@ def _write_skill(skills_dir: str, mock_api_host: str):
         f.write(f"""---
 name: github
 version: "1.0.0"
-keywords:
-  - github
-  - issues
-tags:
-  - github
+activation:
+  keywords:
+    - github
+    - issues
+  tags:
+    - github
 credentials:
   - name: github_token
     provider: github
@@ -231,8 +233,22 @@ async def _pin_mock_github_api_url(mock_llm_server, mock_api):
 # Test
 # ---------------------------------------------------------------------------
 
+def _is_auth_prompt_event(event: dict) -> bool:
+    if (
+        event.get("type") == "onboarding_state"
+        and event.get("state") == "auth_required"
+    ):
+        return True
+    if event.get("type") != "gate_required":
+        return False
+    resume = event.get("resume_kind") or {}
+    return (event.get("gate_name") or "").lower() == "authentication" or (
+        isinstance(resume, dict) and isinstance(resume.get("Authentication"), dict)
+    )
+
+
 async def test_auth_required_sse_without_duplicate_response(auth_sse_server):
-    """When auth is triggered, SSE emits onboarding_state but NOT a response with instructions."""
+    """Auth emits an auth gate but NOT a response with instructions."""
     base_url = auth_sse_server
 
     # Create thread
@@ -275,15 +291,14 @@ async def test_auth_required_sse_without_duplicate_response(auth_sse_server):
     )
     assert send_r.status_code == 202
 
-    # Wait for onboarding_state/auth_required, then collect for a grace period to catch any
-    # trailing duplicate response events that might arrive shortly after.
+    # Wait for an auth prompt event, then collect for a grace period to catch any
+    # trailing duplicate response events that might arrive shortly after. Engine-v2
+    # auth gates are surfaced as gate_required/Authentication; legacy paths may
+    # still emit onboarding_state/auth_required.
     deadline = asyncio.get_running_loop().time() + 45
     auth_seen_at = None
     while asyncio.get_running_loop().time() < deadline:
-        has_auth_event = any(
-            e.get("type") == "onboarding_state" and e.get("state") == "auth_required"
-            for e in collected_events
-        )
+        has_auth_event = any(_is_auth_prompt_event(e) for e in collected_events)
         if has_auth_event and auth_seen_at is None:
             auth_seen_at = asyncio.get_running_loop().time()
         if auth_seen_at and (asyncio.get_running_loop().time() - auth_seen_at) > 3:
@@ -296,13 +311,10 @@ async def test_auth_required_sse_without_duplicate_response(auth_sse_server):
     except asyncio.CancelledError:
         pass
 
-    # Assert onboarding_state/auth_required event was emitted
-    has_auth_event = any(
-        e.get("type") == "onboarding_state" and e.get("state") == "auth_required"
-        for e in collected_events
-    )
+    # Assert an auth prompt event was emitted.
+    has_auth_event = any(_is_auth_prompt_event(e) for e in collected_events)
     assert has_auth_event, (
-        f"Expected onboarding_state/auth_required in SSE events, got: {collected_events}"
+        f"Expected auth prompt SSE event, got: {collected_events}"
     )
 
     # Assert NO response event contains auth instruction text.

--- a/tests/e2e/scenarios/test_tool_approval.py
+++ b/tests/e2e/scenarios/test_tool_approval.py
@@ -113,7 +113,7 @@ async def test_approval_card_appears(page):
 
     # Check card contents
     header = card.locator(SEL["approval_header"].replace(".approval-card ", ""))
-    assert await header.text_content() == "Tool requires approval"
+    assert await header.text_content() == "Approve tool call"
 
     tool_name = card.locator(".approval-tool-name")
     assert await tool_name.text_content() == "shell"

--- a/tests/e2e/scenarios/test_v2_auth_oauth_matrix.py
+++ b/tests/e2e/scenarios/test_v2_auth_oauth_matrix.py
@@ -212,10 +212,11 @@ def _write_google_skill(skills_dir: str, mock_api_host: str) -> None:
             f"""---
 name: google_auth_matrix
 version: "1.0.0"
-keywords:
-  - google
-  - drive
-  - gmail
+activation:
+  keywords:
+    - google
+    - drive
+    - gmail
 credentials:
   - name: google_oauth_token
     provider: google

--- a/tests/e2e/scenarios/test_v2_engine_auth_cancel.py
+++ b/tests/e2e/scenarios/test_v2_engine_auth_cancel.py
@@ -89,7 +89,8 @@ def _write_skill(skills_dir, mock_api_host):
         f.write(f"""---
 name: github
 version: "1.0.0"
-keywords: [github, issues]
+activation:
+  keywords: [github, issues]
 credentials:
   - name: github_token
     provider: github

--- a/tests/e2e/scenarios/test_v2_engine_auth_flow.py
+++ b/tests/e2e/scenarios/test_v2_engine_auth_flow.py
@@ -176,15 +176,16 @@ def _write_test_skill(skills_dir: str, mock_api_host: str):
     skill_content = f"""---
 name: github
 version: "1.0.0"
-keywords:
-  - github
-  - issues
-  - pull request
-  - repo
-  - repository
-tags:
-  - github
-  - api
+activation:
+  keywords:
+    - github
+    - issues
+    - pull request
+    - repo
+    - repository
+  tags:
+    - github
+    - api
 credentials:
   - name: github_token
     provider: github

--- a/tests/e2e/scenarios/test_v2_engine_oauth_google.py
+++ b/tests/e2e/scenarios/test_v2_engine_oauth_google.py
@@ -180,14 +180,15 @@ def _write_google_skill(skills_dir: str, mock_api_host: str):
     skill_content = f"""---
 name: google_drive
 version: "1.0.0"
-keywords:
-  - google
-  - drive
-  - files
-  - docs
-tags:
-  - google
-  - api
+activation:
+  keywords:
+    - google
+    - drive
+    - files
+    - docs
+  tags:
+    - google
+    - api
 credentials:
   - name: google_drive_token
     provider: google

--- a/tests/e2e/scenarios/test_v2_kernel_auth_gateway_flow.py
+++ b/tests/e2e/scenarios/test_v2_kernel_auth_gateway_flow.py
@@ -112,12 +112,13 @@ def _write_github_skill(skills_dir: str, mock_api_host: str):
     skill_content = f"""---
 name: github
 version: "1.0.0"
-keywords:
-  - github
-  - issues
-  - repo
-tags:
-  - github
+activation:
+  keywords:
+    - github
+    - issues
+    - repo
+  tags:
+    - github
 credentials:
   - name: github_token
     provider: github


### PR DESCRIPTION
## Summary
- Emit channel `AuthRequired` status for inline engine-v2 authentication gates so REPL/CodeAct waits surface an auth prompt instead of silently parking.
- Update E2E expectations for the current gateway contracts (`Approve tool call`, `gate_required` auth events) while retaining legacy auth-event compatibility.
- Refresh E2E skill fixtures to use `activation.keywords/tags` and make the mock LLM cover CodeAct HTTP auth plus denial/tool-result variants.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python -m py_compile mock_llm.py scenarios/test_auth_no_duplicate_response.py scenarios/test_v2_auth_oauth_matrix.py scenarios/test_v2_engine_auth_flow.py scenarios/test_v2_engine_auth_cancel.py scenarios/test_v2_engine_oauth_google.py scenarios/test_v2_kernel_auth_gateway_flow.py scenarios/test_tool_approval.py`
- `CARGO_TARGET_DIR=/Volumes/NVME/ironclaw-upstream/target python -m pytest scenarios/test_tool_approval.py::test_approval_card_appears scenarios/test_auth_no_duplicate_response.py::test_auth_required_sse_without_duplicate_response scenarios/test_v2_auth_oauth_matrix.py::test_repl_http_auth_prompt_accepts_token_and_retries scenarios/test_v2_engine_oauth_google.py::test_invalid_token_paste -q` → `3 passed, 1 skipped`
- `python -m pytest scenarios/test_v2_engine_auth_flow.py -q` → `21 passed` (earlier local run)

## Notes
A later broader local rerun that included live GitHub skill-install paths hit GitHub API `403` while fetching `Pika-Labs/Pika-Skills`; that appears environment/rate-limit related rather than a regression in this patch.
