### PR TITLE
Avoid REPL auth retry race in E2E

### DIFF
--- a/tests/e2e/scenarios/test_v2_auth_oauth_matrix.py
+++ b/tests/e2e/scenarios/test_v2_auth_oauth_matrix.py
@@ -802,6 +802,18 @@ async def _read_repl_until_any(
     raise AssertionError(f"Matched union {union!r} but no individual pattern matched")
 
 
+async def _try_read_repl_until_any(
+    repl: dict,
+    patterns: list[str],
+    *,
+    timeout: float = 30.0,
+) -> tuple[str, str] | None:
+    try:
+        return await _read_repl_until_any(repl, patterns, timeout=timeout)
+    except AssertionError:
+        return None
+
+
 async def _drain_repl_output(repl: dict, *, idle_secs: float = 0.4) -> str:
     chunks: list[str] = []
     while True:
@@ -2019,16 +2031,29 @@ async def test_repl_http_auth_prompt_accepts_token_and_retries(auth_matrix_repl)
             "OAuth callback paths are covered by other auth-matrix tests."
         )
 
-    await _drain_repl_output(repl)
-    await _send_repl_line(repl, prompt)
-    output, matched = await _read_repl_until_any(
-        repl,
-        [
-            r"The http tool returned:|Budget Q1\.xlsx|Roadmap\.md",
-            r"requires approval|Reply .*yes.*approve",
-        ],
-        timeout=60.0,
-    )
+    result_patterns = [
+        r"The http tool returned:|Budget Q1\.xlsx|Roadmap\.md",
+        r"requires approval|Reply .*yes.*approve",
+    ]
+
+    # Token entry resolves the inline auth gate and the suspended CodeAct turn
+    # resumes asynchronously. Under coverage CI that resume can still be
+    # processing after the secret row appears; sending a duplicate prompt at
+    # that point races the active REPL turn and can leave the test waiting on
+    # the duplicate while the original turn owns the spinner. Prefer the
+    # resumed original output, and only fall back to a manual retry if no
+    # output appears.
+    resumed = await _try_read_repl_until_any(repl, result_patterns, timeout=60.0)
+    if resumed is None:
+        await _drain_repl_output(repl)
+        await _send_repl_line(repl, prompt)
+        output, matched = await _read_repl_until_any(
+            repl,
+            result_patterns,
+            timeout=60.0,
+        )
+    else:
+        output, matched = resumed
     if "requires approval" in matched.lower() or "reply" in matched.lower():
         output += await _drain_repl_output(repl)
         await _send_repl_line(repl, "yes")


### PR DESCRIPTION
## Summary
- Fix the remaining main E2E failure in `test_repl_http_auth_prompt_accepts_token_and_retries`.
- After token entry, wait for the resumed inline auth-gated REPL turn to produce output before sending a manual retry.
- Keep the manual retry fallback for environments where REPL token entry persists the secret but does not resume the original turn.

## Root cause
The test treated secret persistence as equivalent to the suspended CodeAct turn being complete. Under coverage CI the inline auth gate can resume more slowly, so the test sent a duplicate `list google drive files` prompt while the original REPL turn still owned the spinner. The duplicate then timed out at `Processing...`.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python -m py_compile scenarios/test_v2_auth_oauth_matrix.py`
- `CARGO_TARGET_DIR=/Volumes/NVME/ironclaw-upstream/target python -m pytest scenarios/test_v2_auth_oauth_matrix.py::test_repl_http_auth_prompt_accepts_token_and_retries -q` → skipped locally because this environment does not persist the REPL OAuth token; CI exercises the persistence path that failed.
