### PR TITLE
Add Reborn turn run scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4307,6 +4307,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "deadpool-postgres",
+ "futures-util",
  "ironclaw_approvals",
  "ironclaw_authorization",
  "ironclaw_capabilities",

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -13,6 +13,7 @@ libsql = ["dep:libsql", "ironclaw_filesystem/libsql", "ironclaw_resources/libsql
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 deadpool-postgres = { version = "0.14", optional = true }
+futures-util = "0.3"
 ironclaw_approvals = { path = "../ironclaw_approvals" }
 ironclaw_authorization = { path = "../ironclaw_authorization" }
 ironclaw_capabilities = { path = "../ironclaw_capabilities" }
@@ -39,14 +40,14 @@ rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
 secrecy = "0.10"
 serde_json = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["rt", "time"] }
+tokio = { version = "1", features = ["rt", "sync", "time"] }
 tracing = "0.1"
 url = "2"
 
 [dev-dependencies]
 ironclaw_event_projections = { path = "../ironclaw_event_projections" }
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt", "time"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-postgres = "0.7"
 wat = "1.245.1"
 wit-component = "0.245.1"

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -50,6 +50,7 @@ mod planner;
 mod production;
 mod services;
 mod surface;
+mod turn_scheduler;
 
 pub use obligations::{
     BuiltinObligationHandler, BuiltinObligationServices, NetworkObligationPolicyStore,
@@ -62,6 +63,10 @@ pub use services::{
     ProductionWiringIssueKind, ProductionWiringReport, RegisteredRuntimeHealth,
 };
 pub use surface::{CapabilitySurfacePolicy, VisibleCapability, VisibleCapabilityAccess};
+pub use turn_scheduler::{
+    SchedulerTurnRunWakeNotifier, TurnRunExecutor, TurnRunExecutorError, TurnRunScheduler,
+    TurnRunSchedulerConfig, TurnRunSchedulerHandle,
+};
 
 /// Stable, validated idempotency key supplied by upper turn/loop services.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -512,6 +512,7 @@ where
             mcp_runtime,
             wasm_runtime,
             turn_state,
+            turn_run_transition_port,
             turn_run_wake_notifier,
             mut component_types,
         } = self;
@@ -552,6 +553,7 @@ where
             mcp_runtime,
             wasm_runtime,
             turn_state,
+            turn_run_transition_port,
             turn_run_wake_notifier,
             component_types,
         }

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -63,7 +63,9 @@ use ironclaw_trust::{HostTrustPolicy, TrustPolicy};
 use ironclaw_turns::LibSqlTurnStateStore;
 #[cfg(feature = "postgres")]
 use ironclaw_turns::PostgresTurnStateStore;
-use ironclaw_turns::{DefaultTurnCoordinator, TurnRunWakeNotifier, TurnStateStore};
+use ironclaw_turns::{
+    DefaultTurnCoordinator, TurnRunWakeNotifier, TurnStateStore, runner::TurnRunTransitionPort,
+};
 use ironclaw_wasm::{
     DenyWasmHostHttp, PreparedWitTool, WasmError, WasmRuntimeCredentialProvider,
     WasmRuntimeHttpAdapter, WasmRuntimePolicyDiscarder, WasmStagedRuntimeCredentials, WitToolHost,
@@ -75,7 +77,7 @@ use thiserror::Error;
 use crate::{
     BuiltinObligationHandler, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntimeError,
     NetworkObligationPolicyStore, ProcessObligationLifecycleStore, RuntimeBackendHealth,
-    RuntimeSecretInjectionStore,
+    RuntimeSecretInjectionStore, TurnRunExecutor, TurnRunScheduler, TurnRunSchedulerConfig,
 };
 
 type SharedRuntimeHttpEgress = Arc<Mutex<Option<Arc<dyn RuntimeHttpEgress>>>>;
@@ -309,6 +311,7 @@ where
     mcp_runtime: Option<Arc<dyn McpExecutor>>,
     wasm_runtime: Option<Arc<WasmRuntimeAdapter>>,
     turn_state: Option<Arc<dyn TurnStateStore>>,
+    turn_run_transition_port: Option<Arc<dyn TurnRunTransitionPort>>,
     turn_run_wake_notifier: Option<Arc<dyn TurnRunWakeNotifier>>,
     component_types: ProductionComponentTypes,
 }
@@ -362,6 +365,7 @@ where
             mcp_runtime: None,
             wasm_runtime: None,
             turn_state: None,
+            turn_run_transition_port: None,
             turn_run_wake_notifier: None,
             component_types: ProductionComponentTypes {
                 trust_policy: None,
@@ -420,6 +424,7 @@ where
             mcp_runtime,
             wasm_runtime,
             turn_state,
+            turn_run_transition_port,
             turn_run_wake_notifier,
             mut component_types,
         } = self;
@@ -450,6 +455,7 @@ where
             mcp_runtime,
             wasm_runtime,
             turn_state,
+            turn_run_transition_port,
             turn_run_wake_notifier,
             component_types,
         }
@@ -670,6 +676,27 @@ where
     {
         self.component_types.turn_state = Some(type_name::<T>());
         self.turn_state = Some(turn_state);
+        self.turn_run_transition_port = None;
+        self
+    }
+
+    pub fn with_turn_state_and_transition_port<T>(mut self, turn_state: Arc<T>) -> Self
+    where
+        T: TurnStateStore + TurnRunTransitionPort + 'static,
+    {
+        self.component_types.turn_state = Some(type_name::<T>());
+        let state: Arc<dyn TurnStateStore> = turn_state.clone();
+        let transition_port: Arc<dyn TurnRunTransitionPort> = turn_state;
+        self.turn_state = Some(state);
+        self.turn_run_transition_port = Some(transition_port);
+        self
+    }
+
+    pub fn with_turn_run_transition_port<T>(mut self, transition_port: Arc<T>) -> Self
+    where
+        T: TurnRunTransitionPort + 'static,
+    {
+        self.turn_run_transition_port = Some(transition_port);
         self
     }
 
@@ -680,7 +707,7 @@ where
     ) -> Result<Self, ironclaw_turns::TurnError> {
         let store = Arc::new(LibSqlTurnStateStore::new(db));
         store.run_migrations().await?;
-        Ok(self.with_turn_state(store))
+        Ok(self.with_turn_state_and_transition_port(store))
     }
 
     #[cfg(feature = "postgres")]
@@ -690,7 +717,7 @@ where
     ) -> Result<Self, ironclaw_turns::TurnError> {
         let store = Arc::new(PostgresTurnStateStore::new(pool));
         store.run_migrations().await?;
-        Ok(self.with_turn_state(store))
+        Ok(self.with_turn_state_and_transition_port(store))
     }
 
     pub fn with_turn_run_wake_notifier<T>(mut self, notifier: Arc<T>) -> Self
@@ -1231,6 +1258,50 @@ where
         };
         Ok(DefaultTurnCoordinator::new(Arc::clone(turn_state))
             .with_wake_notifier(Arc::clone(notifier)))
+    }
+
+    /// Validates turn persistence wiring and builds a scheduler over the
+    /// configured trusted runner transition port. The concrete executor stays
+    /// injected so product loop strategy remains above host-runtime.
+    pub fn turn_scheduler_for_production(
+        &self,
+        executor: Arc<dyn TurnRunExecutor>,
+        config: TurnRunSchedulerConfig,
+    ) -> Result<TurnRunScheduler, ProductionWiringReport> {
+        let mut issues = Vec::new();
+        self.push_missing(
+            &mut issues,
+            ProductionWiringComponent::TurnState,
+            self.turn_state.is_some(),
+        );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::TurnState,
+            self.component_types.turn_state,
+        );
+        if self.turn_run_transition_port.is_none() {
+            self.push_issue(
+                &mut issues,
+                ProductionWiringComponent::TurnState,
+                ProductionWiringIssueKind::UnsupportedRequirement,
+                self.component_types.turn_state,
+            );
+        }
+        if !issues.is_empty() {
+            return Err(ProductionWiringReport { issues });
+        }
+        let Some(transition_port) = self.turn_run_transition_port.as_ref() else {
+            return Err(production_wiring_report(
+                ProductionWiringComponent::TurnState,
+                ProductionWiringIssueKind::UnsupportedRequirement,
+                self.component_types.turn_state,
+            ));
+        };
+        Ok(TurnRunScheduler::new(
+            Arc::clone(transition_port),
+            executor,
+            config,
+        ))
     }
 
     fn validate_production_turn_wiring(&self) -> Result<(), ProductionWiringReport> {

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -257,6 +257,8 @@ struct ProductionComponentTypes {
     script_runtime: Option<&'static str>,
     mcp_runtime: Option<&'static str>,
     turn_state: Option<&'static str>,
+    turn_run_transition_port: Option<&'static str>,
+    turn_run_transition_port_verified: bool,
     turn_run_wake_notifier: Option<&'static str>,
 }
 
@@ -388,6 +390,8 @@ where
                 script_runtime: None,
                 mcp_runtime: None,
                 turn_state: None,
+                turn_run_transition_port: None,
+                turn_run_transition_port_verified: false,
                 turn_run_wake_notifier: None,
             },
         }
@@ -675,6 +679,8 @@ where
         T: TurnStateStore + 'static,
     {
         self.component_types.turn_state = Some(type_name::<T>());
+        self.component_types.turn_run_transition_port = None;
+        self.component_types.turn_run_transition_port_verified = false;
         self.turn_state = Some(turn_state);
         self.turn_run_transition_port = None;
         self
@@ -685,6 +691,8 @@ where
         T: TurnStateStore + TurnRunTransitionPort + 'static,
     {
         self.component_types.turn_state = Some(type_name::<T>());
+        self.component_types.turn_run_transition_port = Some(type_name::<T>());
+        self.component_types.turn_run_transition_port_verified = true;
         let state: Arc<dyn TurnStateStore> = turn_state.clone();
         let transition_port: Arc<dyn TurnRunTransitionPort> = turn_state;
         self.turn_state = Some(state);
@@ -696,6 +704,8 @@ where
     where
         T: TurnRunTransitionPort + 'static,
     {
+        self.component_types.turn_run_transition_port = Some(type_name::<T>());
+        self.component_types.turn_run_transition_port_verified = false;
         self.turn_run_transition_port = Some(transition_port);
         self
     }
@@ -1279,6 +1289,21 @@ where
             ProductionWiringComponent::TurnState,
             self.component_types.turn_state,
         );
+        self.push_local_only(
+            &mut issues,
+            ProductionWiringComponent::TurnState,
+            self.component_types.turn_run_transition_port,
+        );
+        if self.turn_run_transition_port.is_some()
+            && !self.component_types.turn_run_transition_port_verified
+        {
+            self.push_issue(
+                &mut issues,
+                ProductionWiringComponent::TurnState,
+                ProductionWiringIssueKind::UnverifiedProductionImplementation,
+                self.component_types.turn_run_transition_port,
+            );
+        }
         if self.turn_run_transition_port.is_none() {
             self.push_issue(
                 &mut issues,

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -233,6 +233,15 @@ enum SchedulerCommand {
     Shutdown,
 }
 
+struct SchedulerDrainContext {
+    transitions: Arc<dyn TurnRunTransitionPort>,
+    executor: Arc<dyn TurnRunExecutor>,
+    semaphore: Arc<Semaphore>,
+    command_tx: mpsc::Sender<SchedulerCommand>,
+    config: TurnRunSchedulerConfig,
+    runner_id: TurnRunnerId,
+}
+
 async fn run_scheduler_loop(
     mut command_rx: mpsc::Receiver<SchedulerCommand>,
     command_tx: mpsc::Sender<SchedulerCommand>,
@@ -247,6 +256,14 @@ async fn run_scheduler_loop(
     poll_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut recovery_tick = interval(config.lease_recovery_interval());
     recovery_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let context = SchedulerDrainContext {
+        transitions,
+        executor,
+        semaphore,
+        command_tx,
+        config,
+        runner_id,
+    };
     let mut claim_retry_pending = false;
 
     loop {
@@ -256,68 +273,60 @@ async fn run_scheduler_loop(
                     SchedulerCommand::Wake(wake) => {
                         // Prefer the woken scope for locality; if that scope has no
                         // claimable work, fall back to the global queue below.
-                        if !claim_retry_pending {
-                            if drain_queued_runs(
-                                Arc::clone(&transitions),
-                                Arc::clone(&executor),
-                                Arc::clone(&semaphore),
-                                command_tx.clone(),
-                                &config,
-                                runner_id,
+                        if !claim_retry_pending
+                            && drain_queued_runs(
+                                &context,
                                 Some(wake.scope),
                                 &mut executor_tasks,
-                            ).await {
-                                claim_retry_pending = true;
-                                schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
-                            }
+                            ).await
+                        {
+                            claim_retry_pending = true;
+                            schedule_drain_after(
+                                context.command_tx.clone(),
+                                context.config.claim_error_backoff(),
+                            );
                         }
                         if !claim_retry_pending
                             && drain_queued_runs(
-                                Arc::clone(&transitions),
-                                Arc::clone(&executor),
-                                Arc::clone(&semaphore),
-                                command_tx.clone(),
-                                &config,
-                                runner_id,
+                                &context,
                                 None,
                                 &mut executor_tasks,
                             ).await
                         {
                             claim_retry_pending = true;
-                            schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                            schedule_drain_after(
+                                context.command_tx.clone(),
+                                context.config.claim_error_backoff(),
+                            );
                         }
                     }
                     SchedulerCommand::Drain => {
                         if !claim_retry_pending
                             && drain_queued_runs(
-                                Arc::clone(&transitions),
-                                Arc::clone(&executor),
-                                Arc::clone(&semaphore),
-                                command_tx.clone(),
-                                &config,
-                                runner_id,
+                                &context,
                                 None,
                                 &mut executor_tasks,
                             ).await
                         {
                             claim_retry_pending = true;
-                            schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                            schedule_drain_after(
+                                context.command_tx.clone(),
+                                context.config.claim_error_backoff(),
+                            );
                         }
                     }
                     SchedulerCommand::RetryDrain => {
                         claim_retry_pending = false;
                         if drain_queued_runs(
-                            Arc::clone(&transitions),
-                            Arc::clone(&executor),
-                            Arc::clone(&semaphore),
-                            command_tx.clone(),
-                            &config,
-                            runner_id,
+                            &context,
                             None,
                             &mut executor_tasks,
                         ).await {
                             claim_retry_pending = true;
-                            schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                            schedule_drain_after(
+                                context.command_tx.clone(),
+                                context.config.claim_error_backoff(),
+                            );
                         }
                     }
                     SchedulerCommand::Shutdown => {
@@ -329,18 +338,16 @@ async fn run_scheduler_loop(
             _ = poll_tick.tick() => {
                 if !claim_retry_pending
                     && drain_queued_runs(
-                        Arc::clone(&transitions),
-                        Arc::clone(&executor),
-                        Arc::clone(&semaphore),
-                        command_tx.clone(),
-                        &config,
-                        runner_id,
+                        &context,
                         None,
                         &mut executor_tasks,
                     ).await
                 {
                     claim_retry_pending = true;
-                    schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                    schedule_drain_after(
+                        context.command_tx.clone(),
+                        context.config.claim_error_backoff(),
+                    );
                 }
             }
             Some(result) = executor_tasks.join_next(), if !executor_tasks.is_empty() => {
@@ -349,29 +356,25 @@ async fn run_scheduler_loop(
                 }
             }
             _ = recovery_tick.tick() => {
-                recover_expired_leases(Arc::clone(&transitions)).await;
+                recover_expired_leases(Arc::clone(&context.transitions)).await;
             }
         }
     }
 }
 
 async fn drain_queued_runs(
-    transitions: Arc<dyn TurnRunTransitionPort>,
-    executor: Arc<dyn TurnRunExecutor>,
-    semaphore: Arc<Semaphore>,
-    command_tx: mpsc::Sender<SchedulerCommand>,
-    config: &TurnRunSchedulerConfig,
-    runner_id: TurnRunnerId,
+    context: &SchedulerDrainContext,
     scope_filter: Option<TurnScope>,
     executor_tasks: &mut JoinSet<()>,
 ) -> bool {
     loop {
-        let Ok(permit) = Arc::clone(&semaphore).try_acquire_owned() else {
+        let Ok(permit) = Arc::clone(&context.semaphore).try_acquire_owned() else {
             return false;
         };
-        let claim = transitions
+        let claim = context
+            .transitions
             .claim_next_run(ClaimRunRequest {
-                runner_id,
+                runner_id: context.runner_id,
                 lease_token: ironclaw_turns::TurnLeaseToken::new(),
                 scope_filter: scope_filter.clone(),
             })
@@ -380,11 +383,11 @@ async fn drain_queued_runs(
             Ok(Some(claimed)) => {
                 spawn_executor_task(
                     claimed,
-                    Arc::clone(&transitions),
-                    Arc::clone(&executor),
-                    command_tx.clone(),
+                    Arc::clone(&context.transitions),
+                    Arc::clone(&context.executor),
+                    context.command_tx.clone(),
                     permit,
-                    config.runner_heartbeat_interval(),
+                    context.config.runner_heartbeat_interval(),
                     executor_tasks,
                 );
             }
@@ -399,7 +402,7 @@ async fn drain_queued_runs(
 
 enum ExecutorTaskOutcome {
     Completed,
-    RecoveryRequired(SanitizedFailure),
+    RecoveryRequired(Option<SanitizedFailure>),
 }
 
 fn spawn_executor_task(
@@ -426,9 +429,9 @@ fn spawn_executor_task(
                 result = &mut executor_result => {
                     break match result {
                         Ok(Ok(())) => ExecutorTaskOutcome::Completed,
-                        Ok(Err(error)) => ExecutorTaskOutcome::RecoveryRequired(
+                        Ok(Err(error)) => ExecutorTaskOutcome::RecoveryRequired(Some(
                             error.failure().clone(),
-                        ),
+                        )),
                         Err(_) => ExecutorTaskOutcome::RecoveryRequired(scheduler_failure(
                             "scheduler_executor_panic",
                         )),
@@ -451,15 +454,18 @@ fn spawn_executor_task(
 
         match outcome {
             ExecutorTaskOutcome::Completed => {}
-            ExecutorTaskOutcome::RecoveryRequired(category) => {
+            ExecutorTaskOutcome::RecoveryRequired(Some(failure)) => {
                 record_recovery_required(
                     Arc::clone(&transitions),
                     recovery_run_id,
                     recovery_runner_id,
                     recovery_lease_token,
-                    category,
+                    failure,
                 )
                 .await;
+            }
+            ExecutorTaskOutcome::RecoveryRequired(None) => {
+                debug!("turn run scheduler could not sanitize recovery category");
             }
         }
 
@@ -508,8 +514,17 @@ async fn record_recovery_required(
     }
 }
 
-fn scheduler_failure(category: &'static str) -> SanitizedFailure {
-    SanitizedFailure::new(category).expect("scheduler failure category must be sanitized")
+fn scheduler_failure(category: &'static str) -> Option<SanitizedFailure> {
+    match SanitizedFailure::new(category) {
+        Ok(failure) => Some(failure),
+        Err(error) => {
+            debug!(
+                category,
+                error, "turn run scheduler static recovery category failed validation"
+            );
+            None
+        }
+    }
 }
 
 async fn recover_expired_leases(transitions: Arc<dyn TurnRunTransitionPort>) {

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -222,6 +222,7 @@ impl TurnRunSchedulerHandle {
 enum SchedulerCommand {
     Wake(TurnRunWake),
     Drain,
+    RetryDrain,
     Shutdown,
 }
 
@@ -238,33 +239,61 @@ async fn run_scheduler_loop(
     poll_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut recovery_tick = interval(config.lease_recovery_interval());
     recovery_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut claim_retry_pending = false;
 
     loop {
         tokio::select! {
             Some(command) = command_rx.recv() => {
                 match command {
                     SchedulerCommand::Wake(wake) => {
-                        drain_queued_runs(
-                            Arc::clone(&transitions),
-                            Arc::clone(&executor),
-                            Arc::clone(&semaphore),
-                            command_tx.clone(),
-                            &config,
-                            Some(wake.scope),
-                            &mut executor_tasks,
-                        ).await;
-                        drain_queued_runs(
-                            Arc::clone(&transitions),
-                            Arc::clone(&executor),
-                            Arc::clone(&semaphore),
-                            command_tx.clone(),
-                            &config,
-                            None,
-                            &mut executor_tasks,
-                        ).await;
+                        if !claim_retry_pending {
+                            if drain_queued_runs(
+                                Arc::clone(&transitions),
+                                Arc::clone(&executor),
+                                Arc::clone(&semaphore),
+                                command_tx.clone(),
+                                &config,
+                                Some(wake.scope),
+                                &mut executor_tasks,
+                            ).await {
+                                claim_retry_pending = true;
+                                schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                            }
+                        }
+                        if !claim_retry_pending
+                            && drain_queued_runs(
+                                Arc::clone(&transitions),
+                                Arc::clone(&executor),
+                                Arc::clone(&semaphore),
+                                command_tx.clone(),
+                                &config,
+                                None,
+                                &mut executor_tasks,
+                            ).await
+                        {
+                            claim_retry_pending = true;
+                            schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                        }
                     }
                     SchedulerCommand::Drain => {
-                        drain_queued_runs(
+                        if !claim_retry_pending
+                            && drain_queued_runs(
+                                Arc::clone(&transitions),
+                                Arc::clone(&executor),
+                                Arc::clone(&semaphore),
+                                command_tx.clone(),
+                                &config,
+                                None,
+                                &mut executor_tasks,
+                            ).await
+                        {
+                            claim_retry_pending = true;
+                            schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                        }
+                    }
+                    SchedulerCommand::RetryDrain => {
+                        claim_retry_pending = false;
+                        if drain_queued_runs(
                             Arc::clone(&transitions),
                             Arc::clone(&executor),
                             Arc::clone(&semaphore),
@@ -272,7 +301,10 @@ async fn run_scheduler_loop(
                             &config,
                             None,
                             &mut executor_tasks,
-                        ).await;
+                        ).await {
+                            claim_retry_pending = true;
+                            schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                        }
                     }
                     SchedulerCommand::Shutdown => {
                         executor_tasks.shutdown().await;
@@ -281,15 +313,20 @@ async fn run_scheduler_loop(
                 }
             }
             _ = poll_tick.tick() => {
-                drain_queued_runs(
-                    Arc::clone(&transitions),
-                    Arc::clone(&executor),
-                    Arc::clone(&semaphore),
-                    command_tx.clone(),
-                    &config,
-                    None,
-                    &mut executor_tasks,
-                ).await;
+                if !claim_retry_pending
+                    && drain_queued_runs(
+                        Arc::clone(&transitions),
+                        Arc::clone(&executor),
+                        Arc::clone(&semaphore),
+                        command_tx.clone(),
+                        &config,
+                        None,
+                        &mut executor_tasks,
+                    ).await
+                {
+                    claim_retry_pending = true;
+                    schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
+                }
             }
             Some(result) = executor_tasks.join_next(), if !executor_tasks.is_empty() => {
                 if let Err(error) = result {
@@ -311,10 +348,10 @@ async fn drain_queued_runs(
     config: &TurnRunSchedulerConfig,
     scope_filter: Option<TurnScope>,
     executor_tasks: &mut JoinSet<()>,
-) {
+) -> bool {
     loop {
         let Ok(permit) = Arc::clone(&semaphore).try_acquire_owned() else {
-            break;
+            return false;
         };
         let claim = transitions
             .claim_next_run(ClaimRunRequest {
@@ -335,11 +372,10 @@ async fn drain_queued_runs(
                     executor_tasks,
                 );
             }
-            Ok(None) => break,
+            Ok(None) => return false,
             Err(error) => {
                 debug!(error = %error, "turn run scheduler claim failed");
-                schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
-                break;
+                return true;
             }
         }
     }
@@ -484,6 +520,6 @@ async fn recover_expired_leases(transitions: Arc<dyn TurnRunTransitionPort>) {
 fn schedule_drain_after(command_tx: mpsc::Sender<SchedulerCommand>, delay: Duration) {
     tokio::spawn(async move {
         sleep(delay).await;
-        let _ = command_tx.send(SchedulerCommand::Drain).await;
+        let _ = command_tx.send(SchedulerCommand::RetryDrain).await;
     });
 }

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -345,6 +345,11 @@ async fn drain_queued_runs(
     }
 }
 
+enum ExecutorTaskOutcome {
+    Completed,
+    RecoveryRequired(String),
+}
+
 fn spawn_executor_task(
     claimed: ClaimedTurnRun,
     transitions: Arc<dyn TurnRunTransitionPort>,
@@ -364,39 +369,43 @@ fn spawn_executor_task(
             AssertUnwindSafe(executor.execute_claimed_run(claimed, Arc::clone(&transitions)))
                 .catch_unwind();
         tokio::pin!(executor_result);
-        let executor_result = loop {
+        let outcome = loop {
             tokio::select! {
-                result = &mut executor_result => break result,
+                result = &mut executor_result => {
+                    break match result {
+                        Ok(Ok(())) => ExecutorTaskOutcome::Completed,
+                        Ok(Err(error)) => ExecutorTaskOutcome::RecoveryRequired(
+                            error.failure_category().to_string(),
+                        ),
+                        Err(_) => ExecutorTaskOutcome::RecoveryRequired(
+                            "scheduler_executor_panic".to_string(),
+                        ),
+                    };
+                }
                 _ = heartbeat_tick.tick() => {
-                    heartbeat_claimed_run(
+                    if !heartbeat_claimed_run(
                         Arc::clone(&transitions),
                         recovery_run_id,
                         recovery_runner_id,
                         recovery_lease_token,
-                    ).await;
+                    ).await {
+                        break ExecutorTaskOutcome::RecoveryRequired(
+                            "scheduler_heartbeat_failed".to_string(),
+                        );
+                    }
                 }
             }
         };
 
-        match executor_result {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) => {
+        match outcome {
+            ExecutorTaskOutcome::Completed => {}
+            ExecutorTaskOutcome::RecoveryRequired(category) => {
                 record_recovery_required(
                     Arc::clone(&transitions),
                     recovery_run_id,
                     recovery_runner_id,
                     recovery_lease_token,
-                    error.failure_category(),
-                )
-                .await;
-            }
-            Err(_) => {
-                record_recovery_required(
-                    Arc::clone(&transitions),
-                    recovery_run_id,
-                    recovery_runner_id,
-                    recovery_lease_token,
-                    "scheduler_executor_panic",
+                    &category,
                 )
                 .await;
             }
@@ -412,7 +421,7 @@ async fn heartbeat_claimed_run(
     run_id: ironclaw_turns::TurnRunId,
     runner_id: ironclaw_turns::TurnRunnerId,
     lease_token: ironclaw_turns::TurnLeaseToken,
-) {
+) -> bool {
     let result = transitions
         .heartbeat(HeartbeatRequest {
             run_id,
@@ -422,7 +431,9 @@ async fn heartbeat_claimed_run(
         .await;
     if let Err(error) = result {
         debug!(error = %error, "turn run scheduler heartbeat failed");
+        return false;
     }
+    true
 }
 
 async fn record_recovery_required(

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use futures_util::FutureExt;
 use ironclaw_turns::{
     SanitizedFailure, TurnError, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError,
-    TurnScope,
+    TurnRunnerId, TurnScope,
     runner::{
         ClaimRunRequest, ClaimedTurnRun, HeartbeatRequest, RecordRecoveryRequiredRequest,
         RecoverExpiredLeasesRequest, TurnRunTransitionPort,
@@ -107,18 +107,22 @@ impl TurnRunSchedulerConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TurnRunExecutorError {
-    failure_category: String,
+    failure: SanitizedFailure,
 }
 
 impl TurnRunExecutorError {
     pub fn new(failure_category: impl Into<String>) -> Result<Self, String> {
-        let failure_category = failure_category.into();
-        SanitizedFailure::new(failure_category.clone())?;
-        Ok(Self { failure_category })
+        Ok(Self {
+            failure: SanitizedFailure::new(failure_category)?,
+        })
+    }
+
+    pub fn failure(&self) -> &SanitizedFailure {
+        &self.failure
     }
 
     pub fn failure_category(&self) -> &str {
-        &self.failure_category
+        self.failure.category()
     }
 }
 
@@ -127,7 +131,7 @@ impl fmt::Display for TurnRunExecutorError {
         write!(
             formatter,
             "turn run executor failed: {}",
-            self.failure_category
+            self.failure.category()
         )
     }
 }
@@ -147,6 +151,7 @@ pub struct TurnRunScheduler {
     transitions: Arc<dyn TurnRunTransitionPort>,
     executor: Arc<dyn TurnRunExecutor>,
     config: TurnRunSchedulerConfig,
+    runner_id: TurnRunnerId,
 }
 
 impl TurnRunScheduler {
@@ -159,6 +164,7 @@ impl TurnRunScheduler {
             transitions,
             executor,
             config,
+            runner_id: TurnRunnerId::new(),
         }
     }
 
@@ -173,6 +179,7 @@ impl TurnRunScheduler {
             self.transitions,
             self.executor,
             self.config,
+            self.runner_id,
         ));
         TurnRunSchedulerHandle {
             notifier,
@@ -232,6 +239,7 @@ async fn run_scheduler_loop(
     transitions: Arc<dyn TurnRunTransitionPort>,
     executor: Arc<dyn TurnRunExecutor>,
     config: TurnRunSchedulerConfig,
+    runner_id: TurnRunnerId,
 ) {
     let semaphore = Arc::new(Semaphore::new(config.max_concurrent_runs()));
     let mut executor_tasks = JoinSet::new();
@@ -246,6 +254,8 @@ async fn run_scheduler_loop(
             Some(command) = command_rx.recv() => {
                 match command {
                     SchedulerCommand::Wake(wake) => {
+                        // Prefer the woken scope for locality; if that scope has no
+                        // claimable work, fall back to the global queue below.
                         if !claim_retry_pending {
                             if drain_queued_runs(
                                 Arc::clone(&transitions),
@@ -253,6 +263,7 @@ async fn run_scheduler_loop(
                                 Arc::clone(&semaphore),
                                 command_tx.clone(),
                                 &config,
+                                runner_id,
                                 Some(wake.scope),
                                 &mut executor_tasks,
                             ).await {
@@ -267,6 +278,7 @@ async fn run_scheduler_loop(
                                 Arc::clone(&semaphore),
                                 command_tx.clone(),
                                 &config,
+                                runner_id,
                                 None,
                                 &mut executor_tasks,
                             ).await
@@ -283,6 +295,7 @@ async fn run_scheduler_loop(
                                 Arc::clone(&semaphore),
                                 command_tx.clone(),
                                 &config,
+                                runner_id,
                                 None,
                                 &mut executor_tasks,
                             ).await
@@ -299,6 +312,7 @@ async fn run_scheduler_loop(
                             Arc::clone(&semaphore),
                             command_tx.clone(),
                             &config,
+                            runner_id,
                             None,
                             &mut executor_tasks,
                         ).await {
@@ -320,6 +334,7 @@ async fn run_scheduler_loop(
                         Arc::clone(&semaphore),
                         command_tx.clone(),
                         &config,
+                        runner_id,
                         None,
                         &mut executor_tasks,
                     ).await
@@ -346,6 +361,7 @@ async fn drain_queued_runs(
     semaphore: Arc<Semaphore>,
     command_tx: mpsc::Sender<SchedulerCommand>,
     config: &TurnRunSchedulerConfig,
+    runner_id: TurnRunnerId,
     scope_filter: Option<TurnScope>,
     executor_tasks: &mut JoinSet<()>,
 ) -> bool {
@@ -355,7 +371,7 @@ async fn drain_queued_runs(
         };
         let claim = transitions
             .claim_next_run(ClaimRunRequest {
-                runner_id: ironclaw_turns::TurnRunnerId::new(),
+                runner_id,
                 lease_token: ironclaw_turns::TurnLeaseToken::new(),
                 scope_filter: scope_filter.clone(),
             })
@@ -383,7 +399,7 @@ async fn drain_queued_runs(
 
 enum ExecutorTaskOutcome {
     Completed,
-    RecoveryRequired(String),
+    RecoveryRequired(SanitizedFailure),
 }
 
 fn spawn_executor_task(
@@ -411,11 +427,11 @@ fn spawn_executor_task(
                     break match result {
                         Ok(Ok(())) => ExecutorTaskOutcome::Completed,
                         Ok(Err(error)) => ExecutorTaskOutcome::RecoveryRequired(
-                            error.failure_category().to_string(),
+                            error.failure().clone(),
                         ),
-                        Err(_) => ExecutorTaskOutcome::RecoveryRequired(
-                            "scheduler_executor_panic".to_string(),
-                        ),
+                        Err(_) => ExecutorTaskOutcome::RecoveryRequired(scheduler_failure(
+                            "scheduler_executor_panic",
+                        )),
                     };
                 }
                 _ = heartbeat_tick.tick() => {
@@ -425,9 +441,9 @@ fn spawn_executor_task(
                         recovery_runner_id,
                         recovery_lease_token,
                     ).await {
-                        break ExecutorTaskOutcome::RecoveryRequired(
-                            "scheduler_heartbeat_failed".to_string(),
-                        );
+                        break ExecutorTaskOutcome::RecoveryRequired(scheduler_failure(
+                            "scheduler_heartbeat_failed",
+                        ));
                     }
                 }
             }
@@ -441,7 +457,7 @@ fn spawn_executor_task(
                     recovery_run_id,
                     recovery_runner_id,
                     recovery_lease_token,
-                    &category,
+                    category,
                 )
                 .await;
             }
@@ -477,15 +493,8 @@ async fn record_recovery_required(
     run_id: ironclaw_turns::TurnRunId,
     runner_id: ironclaw_turns::TurnRunnerId,
     lease_token: ironclaw_turns::TurnLeaseToken,
-    category: &str,
+    failure: SanitizedFailure,
 ) {
-    let Some(failure) = sanitized_failure(category) else {
-        debug!(
-            category,
-            "turn run scheduler could not sanitize recovery category"
-        );
-        return;
-    };
     let result = transitions
         .record_recovery_required(RecordRecoveryRequiredRequest {
             run_id,
@@ -499,16 +508,16 @@ async fn record_recovery_required(
     }
 }
 
-fn sanitized_failure(category: &str) -> Option<SanitizedFailure> {
-    SanitizedFailure::new(category.to_string())
-        .or_else(|_| SanitizedFailure::new("scheduler_executor_error"))
-        .ok()
+fn scheduler_failure(category: &'static str) -> SanitizedFailure {
+    SanitizedFailure::new(category).expect("scheduler failure category must be sanitized")
 }
 
 async fn recover_expired_leases(transitions: Arc<dyn TurnRunTransitionPort>) {
     let result: Result<_, TurnError> = transitions
         .recover_expired_leases(RecoverExpiredLeasesRequest {
             now: Utc::now(),
+            // Scheduler currently owns one global worker pool; if composition
+            // introduces per-tenant schedulers, thread that scope filter here.
             scope_filter: None,
         })
         .await;
@@ -518,6 +527,7 @@ async fn recover_expired_leases(transitions: Arc<dyn TurnRunTransitionPort>) {
 }
 
 fn schedule_drain_after(command_tx: mpsc::Sender<SchedulerCommand>, delay: Duration) {
+    // Best-effort timer: if shutdown closes the command channel first, send fails harmlessly.
     tokio::spawn(async move {
         sleep(delay).await;
         let _ = command_tx.send(SchedulerCommand::RetryDrain).await;

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -1,0 +1,431 @@
+use std::{error::Error, fmt, panic::AssertUnwindSafe, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use futures_util::FutureExt;
+use ironclaw_turns::{
+    SanitizedFailure, TurnError, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError,
+    TurnScope,
+    runner::{
+        ClaimRunRequest, ClaimedTurnRun, RecordRecoveryRequiredRequest,
+        RecoverExpiredLeasesRequest, TurnRunTransitionPort,
+    },
+};
+use tokio::{
+    sync::{Semaphore, mpsc},
+    task::{JoinHandle, JoinSet},
+    time::{MissedTickBehavior, interval, sleep},
+};
+use tracing::debug;
+
+#[derive(Debug, Clone)]
+pub struct TurnRunSchedulerConfig {
+    max_concurrent_runs: usize,
+    poll_interval: Duration,
+    lease_recovery_interval: Duration,
+    claim_error_backoff: Duration,
+    wake_channel_capacity: usize,
+}
+
+impl Default for TurnRunSchedulerConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_runs: 4,
+            poll_interval: Duration::from_secs(5),
+            lease_recovery_interval: Duration::from_secs(10),
+            claim_error_backoff: Duration::from_secs(1),
+            wake_channel_capacity: 128,
+        }
+    }
+}
+
+fn non_zero_duration(duration: Duration) -> Duration {
+    if duration.is_zero() {
+        Duration::from_millis(1)
+    } else {
+        duration
+    }
+}
+
+impl TurnRunSchedulerConfig {
+    pub fn max_concurrent_runs(&self) -> usize {
+        self.max_concurrent_runs
+    }
+
+    pub fn poll_interval(&self) -> Duration {
+        self.poll_interval
+    }
+
+    pub fn lease_recovery_interval(&self) -> Duration {
+        self.lease_recovery_interval
+    }
+
+    pub fn claim_error_backoff(&self) -> Duration {
+        self.claim_error_backoff
+    }
+
+    pub fn wake_channel_capacity(&self) -> usize {
+        self.wake_channel_capacity
+    }
+
+    pub fn with_max_concurrent_runs(mut self, max_concurrent_runs: usize) -> Self {
+        self.max_concurrent_runs = max_concurrent_runs.max(1);
+        self
+    }
+
+    pub fn with_poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = non_zero_duration(poll_interval);
+        self
+    }
+
+    pub fn with_lease_recovery_interval(mut self, lease_recovery_interval: Duration) -> Self {
+        self.lease_recovery_interval = non_zero_duration(lease_recovery_interval);
+        self
+    }
+
+    pub fn with_claim_error_backoff(mut self, claim_error_backoff: Duration) -> Self {
+        self.claim_error_backoff = non_zero_duration(claim_error_backoff);
+        self
+    }
+
+    pub fn with_wake_channel_capacity(mut self, wake_channel_capacity: usize) -> Self {
+        self.wake_channel_capacity = wake_channel_capacity.max(1);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnRunExecutorError {
+    failure_category: String,
+}
+
+impl TurnRunExecutorError {
+    pub fn new(failure_category: impl Into<String>) -> Result<Self, String> {
+        let failure_category = failure_category.into();
+        SanitizedFailure::new(failure_category.clone())?;
+        Ok(Self { failure_category })
+    }
+
+    pub fn failure_category(&self) -> &str {
+        &self.failure_category
+    }
+}
+
+impl fmt::Display for TurnRunExecutorError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "turn run executor failed: {}",
+            self.failure_category
+        )
+    }
+}
+
+impl Error for TurnRunExecutorError {}
+
+#[async_trait]
+pub trait TurnRunExecutor: Send + Sync {
+    async fn execute_claimed_run(
+        &self,
+        claimed: ClaimedTurnRun,
+        transitions: Arc<dyn TurnRunTransitionPort>,
+    ) -> Result<(), TurnRunExecutorError>;
+}
+
+pub struct TurnRunScheduler {
+    transitions: Arc<dyn TurnRunTransitionPort>,
+    executor: Arc<dyn TurnRunExecutor>,
+    config: TurnRunSchedulerConfig,
+}
+
+impl TurnRunScheduler {
+    pub fn new(
+        transitions: Arc<dyn TurnRunTransitionPort>,
+        executor: Arc<dyn TurnRunExecutor>,
+        config: TurnRunSchedulerConfig,
+    ) -> Self {
+        Self {
+            transitions,
+            executor,
+            config,
+        }
+    }
+
+    pub fn start(self) -> TurnRunSchedulerHandle {
+        let (command_tx, command_rx) = mpsc::channel(self.config.wake_channel_capacity());
+        let notifier = Arc::new(SchedulerTurnRunWakeNotifier {
+            command_tx: command_tx.clone(),
+        });
+        let supervisor = tokio::spawn(run_scheduler_loop(
+            command_rx,
+            command_tx.clone(),
+            self.transitions,
+            self.executor,
+            self.config,
+        ));
+        TurnRunSchedulerHandle {
+            notifier,
+            command_tx,
+            supervisor,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SchedulerTurnRunWakeNotifier {
+    command_tx: mpsc::Sender<SchedulerCommand>,
+}
+
+impl fmt::Debug for SchedulerTurnRunWakeNotifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SchedulerTurnRunWakeNotifier")
+    }
+}
+
+impl TurnRunWakeNotifier for SchedulerTurnRunWakeNotifier {
+    fn notify_queued_run(&self, wake: TurnRunWake) -> Result<(), TurnRunWakeNotifyError> {
+        self.command_tx
+            .try_send(SchedulerCommand::Wake(wake))
+            .map_err(|_| TurnRunWakeNotifyError::DeliveryUnavailable)
+    }
+}
+
+pub struct TurnRunSchedulerHandle {
+    notifier: Arc<SchedulerTurnRunWakeNotifier>,
+    command_tx: mpsc::Sender<SchedulerCommand>,
+    supervisor: JoinHandle<()>,
+}
+
+impl TurnRunSchedulerHandle {
+    pub fn wake_notifier(&self) -> Arc<SchedulerTurnRunWakeNotifier> {
+        Arc::clone(&self.notifier)
+    }
+
+    pub async fn shutdown(self) {
+        let _ = self.command_tx.send(SchedulerCommand::Shutdown).await;
+        let _ = self.supervisor.await;
+    }
+}
+
+#[derive(Debug)]
+enum SchedulerCommand {
+    Wake(TurnRunWake),
+    Drain,
+    Shutdown,
+}
+
+async fn run_scheduler_loop(
+    mut command_rx: mpsc::Receiver<SchedulerCommand>,
+    command_tx: mpsc::Sender<SchedulerCommand>,
+    transitions: Arc<dyn TurnRunTransitionPort>,
+    executor: Arc<dyn TurnRunExecutor>,
+    config: TurnRunSchedulerConfig,
+) {
+    let semaphore = Arc::new(Semaphore::new(config.max_concurrent_runs()));
+    let mut executor_tasks = JoinSet::new();
+    let mut poll_tick = interval(config.poll_interval());
+    poll_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut recovery_tick = interval(config.lease_recovery_interval());
+    recovery_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            Some(command) = command_rx.recv() => {
+                match command {
+                    SchedulerCommand::Wake(wake) => {
+                        drain_queued_runs(
+                            Arc::clone(&transitions),
+                            Arc::clone(&executor),
+                            Arc::clone(&semaphore),
+                            command_tx.clone(),
+                            config.claim_error_backoff(),
+                            Some(wake.scope),
+                            &mut executor_tasks,
+                        ).await;
+                        drain_queued_runs(
+                            Arc::clone(&transitions),
+                            Arc::clone(&executor),
+                            Arc::clone(&semaphore),
+                            command_tx.clone(),
+                            config.claim_error_backoff(),
+                            None,
+                            &mut executor_tasks,
+                        ).await;
+                    }
+                    SchedulerCommand::Drain => {
+                        drain_queued_runs(
+                            Arc::clone(&transitions),
+                            Arc::clone(&executor),
+                            Arc::clone(&semaphore),
+                            command_tx.clone(),
+                            config.claim_error_backoff(),
+                            None,
+                            &mut executor_tasks,
+                        ).await;
+                    }
+                    SchedulerCommand::Shutdown => {
+                        executor_tasks.shutdown().await;
+                        break;
+                    },
+                }
+            }
+            _ = poll_tick.tick() => {
+                drain_queued_runs(
+                    Arc::clone(&transitions),
+                    Arc::clone(&executor),
+                    Arc::clone(&semaphore),
+                    command_tx.clone(),
+                    config.claim_error_backoff(),
+                    None,
+                    &mut executor_tasks,
+                ).await;
+            }
+            Some(result) = executor_tasks.join_next(), if !executor_tasks.is_empty() => {
+                if let Err(error) = result {
+                    debug!(error = %error, "turn run scheduler executor supervisor task failed");
+                }
+            }
+            _ = recovery_tick.tick() => {
+                recover_expired_leases(Arc::clone(&transitions)).await;
+            }
+        }
+    }
+}
+
+async fn drain_queued_runs(
+    transitions: Arc<dyn TurnRunTransitionPort>,
+    executor: Arc<dyn TurnRunExecutor>,
+    semaphore: Arc<Semaphore>,
+    command_tx: mpsc::Sender<SchedulerCommand>,
+    claim_error_backoff: Duration,
+    scope_filter: Option<TurnScope>,
+    executor_tasks: &mut JoinSet<()>,
+) {
+    loop {
+        let Ok(permit) = Arc::clone(&semaphore).try_acquire_owned() else {
+            break;
+        };
+        let claim = transitions
+            .claim_next_run(ClaimRunRequest {
+                runner_id: ironclaw_turns::TurnRunnerId::new(),
+                lease_token: ironclaw_turns::TurnLeaseToken::new(),
+                scope_filter: scope_filter.clone(),
+            })
+            .await;
+        match claim {
+            Ok(Some(claimed)) => {
+                spawn_executor_task(
+                    claimed,
+                    Arc::clone(&transitions),
+                    Arc::clone(&executor),
+                    command_tx.clone(),
+                    permit,
+                    executor_tasks,
+                );
+            }
+            Ok(None) => break,
+            Err(error) => {
+                debug!(error = %error, "turn run scheduler claim failed");
+                schedule_drain_after(command_tx.clone(), claim_error_backoff);
+                break;
+            }
+        }
+    }
+}
+
+fn spawn_executor_task(
+    claimed: ClaimedTurnRun,
+    transitions: Arc<dyn TurnRunTransitionPort>,
+    executor: Arc<dyn TurnRunExecutor>,
+    command_tx: mpsc::Sender<SchedulerCommand>,
+    permit: tokio::sync::OwnedSemaphorePermit,
+    executor_tasks: &mut JoinSet<()>,
+) {
+    executor_tasks.spawn(async move {
+        let recovery_run_id = claimed.state.run_id;
+        let recovery_runner_id = claimed.runner_id;
+        let recovery_lease_token = claimed.lease_token;
+        let executor_result =
+            AssertUnwindSafe(executor.execute_claimed_run(claimed, Arc::clone(&transitions)))
+                .catch_unwind()
+                .await;
+
+        match executor_result {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                record_recovery_required(
+                    Arc::clone(&transitions),
+                    recovery_run_id,
+                    recovery_runner_id,
+                    recovery_lease_token,
+                    error.failure_category(),
+                )
+                .await;
+            }
+            Err(_) => {
+                record_recovery_required(
+                    Arc::clone(&transitions),
+                    recovery_run_id,
+                    recovery_runner_id,
+                    recovery_lease_token,
+                    "scheduler_executor_panic",
+                )
+                .await;
+            }
+        }
+
+        drop(permit);
+        let _ = command_tx.send(SchedulerCommand::Drain).await;
+    });
+}
+
+async fn record_recovery_required(
+    transitions: Arc<dyn TurnRunTransitionPort>,
+    run_id: ironclaw_turns::TurnRunId,
+    runner_id: ironclaw_turns::TurnRunnerId,
+    lease_token: ironclaw_turns::TurnLeaseToken,
+    category: &str,
+) {
+    let failure = sanitized_failure(category);
+    let result = transitions
+        .record_recovery_required(RecordRecoveryRequiredRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            failure,
+        })
+        .await;
+    if let Err(error) = result {
+        debug!(error = %error, "turn run scheduler recovery transition failed");
+    }
+}
+
+fn sanitized_failure(category: &str) -> SanitizedFailure {
+    match SanitizedFailure::new(category.to_string()) {
+        Ok(failure) => failure,
+        Err(_) => match SanitizedFailure::new("scheduler_executor_error") {
+            Ok(failure) => failure,
+            Err(_) => SanitizedFailure::new("scheduler_error")
+                .expect("SAFETY: hard-coded scheduler failure category is valid"),
+        },
+    }
+}
+
+async fn recover_expired_leases(transitions: Arc<dyn TurnRunTransitionPort>) {
+    let result: Result<_, TurnError> = transitions
+        .recover_expired_leases(RecoverExpiredLeasesRequest {
+            now: Utc::now(),
+            scope_filter: None,
+        })
+        .await;
+    if let Err(error) = result {
+        debug!(error = %error, "turn run scheduler lease recovery failed");
+    }
+}
+
+fn schedule_drain_after(command_tx: mpsc::Sender<SchedulerCommand>, delay: Duration) {
+    tokio::spawn(async move {
+        sleep(delay).await;
+        let _ = command_tx.send(SchedulerCommand::Drain).await;
+    });
+}

--- a/crates/ironclaw_host_runtime/src/turn_scheduler.rs
+++ b/crates/ironclaw_host_runtime/src/turn_scheduler.rs
@@ -7,7 +7,7 @@ use ironclaw_turns::{
     SanitizedFailure, TurnError, TurnRunWake, TurnRunWakeNotifier, TurnRunWakeNotifyError,
     TurnScope,
     runner::{
-        ClaimRunRequest, ClaimedTurnRun, RecordRecoveryRequiredRequest,
+        ClaimRunRequest, ClaimedTurnRun, HeartbeatRequest, RecordRecoveryRequiredRequest,
         RecoverExpiredLeasesRequest, TurnRunTransitionPort,
     },
 };
@@ -23,6 +23,7 @@ pub struct TurnRunSchedulerConfig {
     max_concurrent_runs: usize,
     poll_interval: Duration,
     lease_recovery_interval: Duration,
+    runner_heartbeat_interval: Duration,
     claim_error_backoff: Duration,
     wake_channel_capacity: usize,
 }
@@ -33,6 +34,7 @@ impl Default for TurnRunSchedulerConfig {
             max_concurrent_runs: 4,
             poll_interval: Duration::from_secs(5),
             lease_recovery_interval: Duration::from_secs(10),
+            runner_heartbeat_interval: Duration::from_secs(30),
             claim_error_backoff: Duration::from_secs(1),
             wake_channel_capacity: 128,
         }
@@ -60,6 +62,10 @@ impl TurnRunSchedulerConfig {
         self.lease_recovery_interval
     }
 
+    pub fn runner_heartbeat_interval(&self) -> Duration {
+        self.runner_heartbeat_interval
+    }
+
     pub fn claim_error_backoff(&self) -> Duration {
         self.claim_error_backoff
     }
@@ -80,6 +86,11 @@ impl TurnRunSchedulerConfig {
 
     pub fn with_lease_recovery_interval(mut self, lease_recovery_interval: Duration) -> Self {
         self.lease_recovery_interval = non_zero_duration(lease_recovery_interval);
+        self
+    }
+
+    pub fn with_runner_heartbeat_interval(mut self, runner_heartbeat_interval: Duration) -> Self {
+        self.runner_heartbeat_interval = non_zero_duration(runner_heartbeat_interval);
         self
     }
 
@@ -238,7 +249,7 @@ async fn run_scheduler_loop(
                             Arc::clone(&executor),
                             Arc::clone(&semaphore),
                             command_tx.clone(),
-                            config.claim_error_backoff(),
+                            &config,
                             Some(wake.scope),
                             &mut executor_tasks,
                         ).await;
@@ -247,7 +258,7 @@ async fn run_scheduler_loop(
                             Arc::clone(&executor),
                             Arc::clone(&semaphore),
                             command_tx.clone(),
-                            config.claim_error_backoff(),
+                            &config,
                             None,
                             &mut executor_tasks,
                         ).await;
@@ -258,7 +269,7 @@ async fn run_scheduler_loop(
                             Arc::clone(&executor),
                             Arc::clone(&semaphore),
                             command_tx.clone(),
-                            config.claim_error_backoff(),
+                            &config,
                             None,
                             &mut executor_tasks,
                         ).await;
@@ -275,7 +286,7 @@ async fn run_scheduler_loop(
                     Arc::clone(&executor),
                     Arc::clone(&semaphore),
                     command_tx.clone(),
-                    config.claim_error_backoff(),
+                    &config,
                     None,
                     &mut executor_tasks,
                 ).await;
@@ -297,7 +308,7 @@ async fn drain_queued_runs(
     executor: Arc<dyn TurnRunExecutor>,
     semaphore: Arc<Semaphore>,
     command_tx: mpsc::Sender<SchedulerCommand>,
-    claim_error_backoff: Duration,
+    config: &TurnRunSchedulerConfig,
     scope_filter: Option<TurnScope>,
     executor_tasks: &mut JoinSet<()>,
 ) {
@@ -320,13 +331,14 @@ async fn drain_queued_runs(
                     Arc::clone(&executor),
                     command_tx.clone(),
                     permit,
+                    config.runner_heartbeat_interval(),
                     executor_tasks,
                 );
             }
             Ok(None) => break,
             Err(error) => {
                 debug!(error = %error, "turn run scheduler claim failed");
-                schedule_drain_after(command_tx.clone(), claim_error_backoff);
+                schedule_drain_after(command_tx.clone(), config.claim_error_backoff());
                 break;
             }
         }
@@ -339,16 +351,32 @@ fn spawn_executor_task(
     executor: Arc<dyn TurnRunExecutor>,
     command_tx: mpsc::Sender<SchedulerCommand>,
     permit: tokio::sync::OwnedSemaphorePermit,
+    runner_heartbeat_interval: Duration,
     executor_tasks: &mut JoinSet<()>,
 ) {
     executor_tasks.spawn(async move {
         let recovery_run_id = claimed.state.run_id;
         let recovery_runner_id = claimed.runner_id;
         let recovery_lease_token = claimed.lease_token;
+        let mut heartbeat_tick = interval(runner_heartbeat_interval);
+        heartbeat_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
         let executor_result =
             AssertUnwindSafe(executor.execute_claimed_run(claimed, Arc::clone(&transitions)))
-                .catch_unwind()
-                .await;
+                .catch_unwind();
+        tokio::pin!(executor_result);
+        let executor_result = loop {
+            tokio::select! {
+                result = &mut executor_result => break result,
+                _ = heartbeat_tick.tick() => {
+                    heartbeat_claimed_run(
+                        Arc::clone(&transitions),
+                        recovery_run_id,
+                        recovery_runner_id,
+                        recovery_lease_token,
+                    ).await;
+                }
+            }
+        };
 
         match executor_result {
             Ok(Ok(())) => {}
@@ -379,6 +407,24 @@ fn spawn_executor_task(
     });
 }
 
+async fn heartbeat_claimed_run(
+    transitions: Arc<dyn TurnRunTransitionPort>,
+    run_id: ironclaw_turns::TurnRunId,
+    runner_id: ironclaw_turns::TurnRunnerId,
+    lease_token: ironclaw_turns::TurnLeaseToken,
+) {
+    let result = transitions
+        .heartbeat(HeartbeatRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await;
+    if let Err(error) = result {
+        debug!(error = %error, "turn run scheduler heartbeat failed");
+    }
+}
+
 async fn record_recovery_required(
     transitions: Arc<dyn TurnRunTransitionPort>,
     run_id: ironclaw_turns::TurnRunId,
@@ -386,7 +432,13 @@ async fn record_recovery_required(
     lease_token: ironclaw_turns::TurnLeaseToken,
     category: &str,
 ) {
-    let failure = sanitized_failure(category);
+    let Some(failure) = sanitized_failure(category) else {
+        debug!(
+            category,
+            "turn run scheduler could not sanitize recovery category"
+        );
+        return;
+    };
     let result = transitions
         .record_recovery_required(RecordRecoveryRequiredRequest {
             run_id,
@@ -400,15 +452,10 @@ async fn record_recovery_required(
     }
 }
 
-fn sanitized_failure(category: &str) -> SanitizedFailure {
-    match SanitizedFailure::new(category.to_string()) {
-        Ok(failure) => failure,
-        Err(_) => match SanitizedFailure::new("scheduler_executor_error") {
-            Ok(failure) => failure,
-            Err(_) => SanitizedFailure::new("scheduler_error")
-                .expect("SAFETY: hard-coded scheduler failure category is valid"),
-        },
-    }
+fn sanitized_failure(category: &str) -> Option<SanitizedFailure> {
+    SanitizedFailure::new(category.to_string())
+        .or_else(|_| SanitizedFailure::new("scheduler_executor_error"))
+        .ok()
 }
 
 async fn recover_expired_leases(transitions: Arc<dyn TurnRunTransitionPort>) {

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -114,6 +114,7 @@ struct FailingClaimTransitions {
     notify_claim: Notify,
 }
 
+#[derive(Default)]
 struct DurableLikeTurnStore {
     inner: InMemoryTurnStateStore,
 }
@@ -259,14 +260,6 @@ impl TurnRunTransitionPort for FailingClaimTransitions {
         _request: ApplyValidatedLoopExitRequest,
     ) -> Result<TurnRunState, TurnError> {
         panic!("failing claim transitions should not apply loop exits")
-    }
-}
-
-impl Default for DurableLikeTurnStore {
-    fn default() -> Self {
-        Self {
-            inner: InMemoryTurnStateStore::default(),
-        }
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -101,6 +101,18 @@ struct FailingExecutor {
     notify_started: Notify,
 }
 
+#[derive(Default)]
+struct PanickingExecutor {
+    started: AtomicUsize,
+    notify_started: Notify,
+}
+
+#[derive(Default)]
+struct FailingClaimTransitions {
+    claim_attempts: AtomicUsize,
+    notify_claim: Notify,
+}
+
 #[derive(Debug)]
 struct DurableTurnStoreStub;
 
@@ -132,6 +144,116 @@ impl TurnRunExecutor for FailingExecutor {
         self.started.fetch_add(1, Ordering::SeqCst);
         self.notify_started.notify_waiters();
         Err(TurnRunExecutorError::new("scheduler_test_error").unwrap())
+    }
+}
+
+impl PanickingExecutor {
+    async fn wait_for_started(&self) {
+        timeout(Duration::from_secs(2), async {
+            while self.started.load(Ordering::SeqCst) == 0 {
+                self.notify_started.notified().await;
+            }
+        })
+        .await
+        .expect("executor did not start");
+    }
+}
+
+#[async_trait]
+impl TurnRunExecutor for PanickingExecutor {
+    async fn execute_claimed_run(
+        &self,
+        _claimed: ClaimedTurnRun,
+        _transitions: Arc<dyn TurnRunTransitionPort>,
+    ) -> Result<(), TurnRunExecutorError> {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        self.notify_started.notify_waiters();
+        panic!("scheduler test panic");
+    }
+}
+
+impl FailingClaimTransitions {
+    async fn wait_for_claim_attempts(&self, expected: usize) {
+        assert!(
+            self.wait_for_claim_attempts_for(expected, Duration::from_secs(2))
+                .await,
+            "scheduler did not reach expected claim attempts"
+        );
+    }
+
+    async fn wait_for_claim_attempts_for(&self, expected: usize, duration: Duration) -> bool {
+        timeout(duration, async {
+            while self.claim_attempts.load(Ordering::SeqCst) < expected {
+                self.notify_claim.notified().await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    fn claim_attempts(&self) -> usize {
+        self.claim_attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TurnRunTransitionPort for FailingClaimTransitions {
+    async fn claim_next_run(
+        &self,
+        _request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        self.claim_attempts.fetch_add(1, Ordering::SeqCst);
+        self.notify_claim.notify_waiters();
+        Err(TurnError::Unavailable {
+            reason: "claim store unavailable".to_string(),
+        })
+    }
+
+    async fn heartbeat(
+        &self,
+        _request: HeartbeatRequest,
+    ) -> Result<ironclaw_turns::EventCursor, TurnError> {
+        panic!("failing claim transitions should not heartbeat")
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        _request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        Ok(RecoverExpiredLeasesResponse { recovered: vec![] })
+    }
+
+    async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        panic!("failing claim transitions should not block runs")
+    }
+
+    async fn complete_run(&self, _request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        panic!("failing claim transitions should not complete runs")
+    }
+
+    async fn cancel_run(
+        &self,
+        _request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("failing claim transitions should not cancel runs")
+    }
+
+    async fn fail_run(&self, _request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        panic!("failing claim transitions should not fail runs")
+    }
+
+    async fn record_recovery_required(
+        &self,
+        _request: RecordRecoveryRequiredRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("failing claim transitions should not record recovery")
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        _request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("failing claim transitions should not apply loop exits")
     }
 }
 
@@ -382,6 +504,50 @@ fn production_services_reject_unverified_scheduler_transition_port() {
 }
 
 #[tokio::test]
+async fn claim_errors_coalesce_wakes_during_backoff() {
+    let transitions = Arc::new(FailingClaimTransitions::default());
+    let transition_port: Arc<dyn TurnRunTransitionPort> = transitions.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        transition_port,
+        executor,
+        fast_config()
+            .with_poll_interval(Duration::from_secs(60))
+            .with_lease_recovery_interval(Duration::from_secs(60))
+            .with_claim_error_backoff(Duration::from_millis(200)),
+    );
+    let handle = scheduler.start();
+
+    transitions.wait_for_claim_attempts(1).await;
+    for _ in 0..8 {
+        handle
+            .wake_notifier()
+            .notify_queued_run(TurnRunWake {
+                scope: scope("thread-claim-backoff"),
+                run_id: ironclaw_turns::TurnRunId::new(),
+                status: TurnStatus::Queued,
+                event_cursor: ironclaw_turns::EventCursor::default(),
+            })
+            .unwrap();
+    }
+
+    assert!(
+        !transitions
+            .wait_for_claim_attempts_for(2, Duration::from_millis(50))
+            .await,
+        "wake storm retried claims before claim_error_backoff elapsed"
+    );
+    transitions.wait_for_claim_attempts(2).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        transitions.claim_attempts(),
+        2,
+        "claim retries should be coalesced while one backoff retry is pending"
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test]
 async fn wake_notifier_drains_submitted_run() {
     let store = Arc::new(InMemoryTurnStateStore::default());
     let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
@@ -557,6 +723,46 @@ async fn executor_error_records_recovery_required_instead_of_retrying() {
     })
     .await
     .expect("run did not move to recovery_required");
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn executor_panic_records_recovery_required() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(PanickingExecutor::default());
+    let scheduler =
+        TurnRunScheduler::new(Arc::clone(&transitions), executor.clone(), fast_config());
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let request = submit_turn_request("thread-panic", "idem-panic");
+    let scope = request.scope.clone();
+    let run_id = accepted_run_id(coordinator.submit_turn(request).await.unwrap());
+
+    executor.wait_for_started().await;
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let state = store
+                .get_run_state(ironclaw_turns::GetRunStateRequest {
+                    scope: scope.clone(),
+                    run_id,
+                })
+                .await
+                .unwrap();
+            if state.status == TurnStatus::RecoveryRequired {
+                assert_eq!(
+                    state.failure.as_ref().map(|failure| failure.category()),
+                    Some("scheduler_executor_panic")
+                );
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("run did not move to recovery_required after executor panic");
     handle.shutdown().await;
 }
 

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -23,9 +23,9 @@ use ironclaw_turns::{
     AcceptedMessageRef, CancelRunRequest, CancelRunResponse, DefaultTurnCoordinator,
     GetRunStateRequest, IdempotencyKey, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits,
     NoopTurnRunWakeNotifier, ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse,
-    RunProfileRequest, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnActor,
-    TurnCoordinator, TurnError, TurnRunState, TurnRunWake, TurnRunWakeNotifier, TurnScope,
-    TurnStateStore, TurnStatus,
+    RunProfileRequest, SanitizedCancelReason, SourceBindingRef, SubmitTurnRequest,
+    SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnRunState, TurnRunWake,
+    TurnRunWakeNotifier, TurnScope, TurnStateStore, TurnStatus,
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
         ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
@@ -591,6 +591,46 @@ async fn scheduler_heartbeats_long_running_executor_until_completion() {
     transitions.wait_for_heartbeats(2).await;
     gate.notify_waiters();
     wait_for_status(&store, scope, run_id, TurnStatus::Completed).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn canceled_hanging_executor_lease_expires_to_recovery_required() {
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            runner_lease_ttl: ChronoDuration::milliseconds(40),
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(HangingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        Arc::clone(&transitions),
+        executor.clone(),
+        fast_config()
+            .with_poll_interval(Duration::from_secs(60))
+            .with_runner_heartbeat_interval(Duration::from_millis(5)),
+    );
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let request = submit_turn_request("thread-cancel-recovery", "idem-cancel-recovery");
+    let scope = request.scope.clone();
+    let run_id = accepted_run_id(coordinator.submit_turn(request).await.unwrap());
+    executor.wait_for_started().await;
+    coordinator
+        .cancel_run(CancelRunRequest {
+            scope: scope.clone(),
+            actor: TurnActor::new(UserId::new("user1").unwrap()),
+            run_id,
+            reason: SanitizedCancelReason::UserRequested,
+            idempotency_key: IdempotencyKey::new("idem-cancel-request").unwrap(),
+        })
+        .await
+        .unwrap();
+
+    wait_for_status(&store, scope, run_id, TurnStatus::RecoveryRequired).await;
     handle.shutdown().await;
 }
 

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -13,8 +13,9 @@ use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_host_runtime::{
-    CapabilitySurfaceVersion, HostRuntimeServices, TurnRunExecutor, TurnRunExecutorError,
-    TurnRunScheduler, TurnRunSchedulerConfig,
+    CapabilitySurfaceVersion, HostRuntimeServices, ProductionWiringComponent,
+    ProductionWiringIssueKind, TurnRunExecutor, TurnRunExecutorError, TurnRunScheduler,
+    TurnRunSchedulerConfig,
 };
 use ironclaw_processes::ProcessServices;
 use ironclaw_resources::InMemoryResourceGovernor;
@@ -247,6 +248,94 @@ impl HangingExecutor {
     }
 }
 
+struct HeartbeatTrackingTransitions {
+    store: Arc<InMemoryTurnStateStore>,
+    heartbeats: AtomicUsize,
+    notify_heartbeat: Notify,
+}
+
+impl HeartbeatTrackingTransitions {
+    fn new(store: Arc<InMemoryTurnStateStore>) -> Self {
+        Self {
+            store,
+            heartbeats: AtomicUsize::new(0),
+            notify_heartbeat: Notify::new(),
+        }
+    }
+
+    async fn wait_for_heartbeats(&self, expected: usize) {
+        timeout(Duration::from_secs(2), async {
+            while self.heartbeats.load(Ordering::SeqCst) < expected {
+                self.notify_heartbeat.notified().await;
+            }
+        })
+        .await
+        .expect("scheduler did not heartbeat claimed run");
+    }
+}
+
+#[async_trait]
+impl TurnRunTransitionPort for HeartbeatTrackingTransitions {
+    async fn claim_next_run(
+        &self,
+        request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        self.store.claim_next_run(request).await
+    }
+
+    async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<ironclaw_turns::EventCursor, TurnError> {
+        let result = self.store.heartbeat(request).await;
+        if result.is_ok() {
+            self.heartbeats.fetch_add(1, Ordering::SeqCst);
+            self.notify_heartbeat.notify_waiters();
+        }
+        result
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        self.store.recover_expired_leases(request).await
+    }
+
+    async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.block_run(request).await
+    }
+
+    async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.complete_run(request).await
+    }
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.cancel_run(request).await
+    }
+
+    async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.fail_run(request).await
+    }
+
+    async fn record_recovery_required(
+        &self,
+        request: RecordRecoveryRequiredRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.record_recovery_required(request).await
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.apply_validated_loop_exit(request).await
+    }
+}
+
 #[test]
 fn production_services_build_scheduler_from_configured_transition_port_without_notifier() {
     let store = Arc::new(DurableTurnStoreStub);
@@ -264,6 +353,32 @@ fn production_services_build_scheduler_from_configured_transition_port_without_n
     let _scheduler = services
         .turn_scheduler_for_production(executor, fast_config())
         .expect("production turn scheduler should build from configured transition port");
+}
+
+#[test]
+fn production_services_reject_unverified_scheduler_transition_port() {
+    let turn_state = Arc::new(DurableTurnStoreStub);
+    let transition_port = Arc::new(DurableTurnStoreStub);
+    let services = HostRuntimeServices::new(
+        Arc::new(ExtensionRegistry::new()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_turn_state(turn_state)
+    .with_turn_run_transition_port(transition_port);
+    let executor: Arc<dyn TurnRunExecutor> = Arc::new(CompletingExecutor::default());
+
+    let result = services.turn_scheduler_for_production(executor, fast_config());
+    let Err(report) = result else {
+        panic!("production scheduler should reject unverified transition port");
+    };
+    assert!(report.contains(
+        ProductionWiringComponent::TurnState,
+        ProductionWiringIssueKind::UnverifiedProductionImplementation
+    ));
 }
 
 #[tokio::test]
@@ -446,6 +561,40 @@ async fn executor_error_records_recovery_required_instead_of_retrying() {
 }
 
 #[tokio::test]
+async fn scheduler_heartbeats_long_running_executor_until_completion() {
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            runner_lease_ttl: ChronoDuration::milliseconds(40),
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let transitions = Arc::new(HeartbeatTrackingTransitions::new(Arc::clone(&store)));
+    let transition_port: Arc<dyn TurnRunTransitionPort> = transitions.clone();
+    let gate = Arc::new(Notify::new());
+    let executor = Arc::new(CompletingExecutor::with_gate(Arc::clone(&gate)));
+    let scheduler = TurnRunScheduler::new(
+        transition_port,
+        executor.clone(),
+        fast_config()
+            .with_poll_interval(Duration::from_secs(60))
+            .with_runner_heartbeat_interval(Duration::from_millis(5)),
+    );
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let request = submit_turn_request("thread-heartbeat", "idem-heartbeat");
+    let scope = request.scope.clone();
+    let run_id = accepted_run_id(coordinator.submit_turn(request).await.unwrap());
+
+    executor.wait_for_started(1).await;
+    transitions.wait_for_heartbeats(2).await;
+    gate.notify_waiters();
+    wait_for_status(&store, scope, run_id, TurnStatus::Completed).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
 async fn expired_lease_reconciler_marks_running_run_recovery_required() {
     let store = Arc::new(InMemoryTurnStateStore::with_limits(
         InMemoryTurnStateStoreLimits {
@@ -503,6 +652,31 @@ fn fast_config() -> TurnRunSchedulerConfig {
         .with_lease_recovery_interval(Duration::from_millis(10))
         .with_claim_error_backoff(Duration::from_millis(10))
         .with_wake_channel_capacity(16)
+}
+
+async fn wait_for_status(
+    store: &InMemoryTurnStateStore,
+    scope: TurnScope,
+    run_id: ironclaw_turns::TurnRunId,
+    expected: TurnStatus,
+) {
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let state = store
+                .get_run_state(ironclaw_turns::GetRunStateRequest {
+                    scope: scope.clone(),
+                    run_id,
+                })
+                .await
+                .unwrap();
+            if state.status == expected {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("run did not reach expected status");
 }
 
 fn submit_turn_request(thread: &str, idempotency_key: &str) -> SubmitTurnRequest {

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -1,0 +1,548 @@
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use chrono::{Duration as ChronoDuration, Utc};
+use ironclaw_authorization::GrantAuthorizer;
+use ironclaw_extensions::ExtensionRegistry;
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_host_runtime::{
+    CapabilitySurfaceVersion, HostRuntimeServices, TurnRunExecutor, TurnRunExecutorError,
+    TurnRunScheduler, TurnRunSchedulerConfig,
+};
+use ironclaw_processes::ProcessServices;
+use ironclaw_resources::InMemoryResourceGovernor;
+use ironclaw_turns::{
+    AcceptedMessageRef, CancelRunRequest, CancelRunResponse, DefaultTurnCoordinator,
+    GetRunStateRequest, IdempotencyKey, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits,
+    NoopTurnRunWakeNotifier, ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse,
+    RunProfileRequest, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnActor,
+    TurnCoordinator, TurnError, TurnRunState, TurnRunWake, TurnRunWakeNotifier, TurnScope,
+    TurnStateStore, TurnStatus,
+    runner::{
+        ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
+        ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
+        RecordRecoveryRequiredRequest, RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse,
+        TurnRunTransitionPort,
+    },
+};
+use tokio::{sync::Notify, time::timeout};
+
+#[derive(Default)]
+struct CompletingExecutor {
+    started: AtomicUsize,
+    notify_started: Notify,
+    gate: Mutex<Option<Arc<Notify>>>,
+}
+
+impl CompletingExecutor {
+    fn with_gate(gate: Arc<Notify>) -> Self {
+        Self {
+            gate: Mutex::new(Some(gate)),
+            ..Self::default()
+        }
+    }
+
+    async fn wait_for_started(&self, expected: usize) {
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if self.started.load(Ordering::SeqCst) >= expected {
+                    return;
+                }
+                self.notify_started.notified().await;
+            }
+        })
+        .await
+        .expect("executor did not start expected runs");
+    }
+
+    fn started_count(&self) -> usize {
+        self.started.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TurnRunExecutor for CompletingExecutor {
+    async fn execute_claimed_run(
+        &self,
+        claimed: ClaimedTurnRun,
+        transitions: Arc<dyn TurnRunTransitionPort>,
+    ) -> Result<(), TurnRunExecutorError> {
+        let started = self.started.fetch_add(1, Ordering::SeqCst) + 1;
+        self.notify_started.notify_waiters();
+        let gate = self.gate.lock().unwrap().clone();
+        if started == 1
+            && let Some(gate) = gate
+        {
+            gate.notified().await;
+        }
+        transitions
+            .complete_run(CompleteRunRequest {
+                run_id: claimed.state.run_id,
+                runner_id: claimed.runner_id,
+                lease_token: claimed.lease_token,
+            })
+            .await
+            .unwrap();
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct FailingExecutor {
+    started: AtomicUsize,
+    notify_started: Notify,
+}
+
+#[derive(Debug)]
+struct DurableTurnStoreStub;
+
+#[derive(Default)]
+struct HangingExecutor {
+    started: AtomicUsize,
+    notify_started: Notify,
+}
+
+impl FailingExecutor {
+    async fn wait_for_started(&self) {
+        timeout(Duration::from_secs(2), async {
+            while self.started.load(Ordering::SeqCst) == 0 {
+                self.notify_started.notified().await;
+            }
+        })
+        .await
+        .expect("executor did not start");
+    }
+}
+
+#[async_trait]
+impl TurnRunExecutor for FailingExecutor {
+    async fn execute_claimed_run(
+        &self,
+        _claimed: ClaimedTurnRun,
+        _transitions: Arc<dyn TurnRunTransitionPort>,
+    ) -> Result<(), TurnRunExecutorError> {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        self.notify_started.notify_waiters();
+        Err(TurnRunExecutorError::new("scheduler_test_error").unwrap())
+    }
+}
+
+#[async_trait]
+impl TurnStateStore for DurableTurnStoreStub {
+    async fn submit_turn(
+        &self,
+        _request: SubmitTurnRequest,
+        _admission_policy: &dyn ironclaw_turns::TurnAdmissionPolicy,
+        _run_profile_resolver: &dyn ironclaw_turns::RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        panic!("store stub should not submit turns")
+    }
+
+    async fn resume_turn(
+        &self,
+        _request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        panic!("store stub should not resume turns")
+    }
+
+    async fn request_cancel(
+        &self,
+        _request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        panic!("store stub should not cancel turns")
+    }
+
+    async fn get_run_state(&self, _request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        panic!("store stub should not read turns")
+    }
+}
+
+#[async_trait]
+impl TurnRunTransitionPort for DurableTurnStoreStub {
+    async fn claim_next_run(
+        &self,
+        _request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        panic!("transition stub should not claim turns")
+    }
+
+    async fn heartbeat(
+        &self,
+        _request: HeartbeatRequest,
+    ) -> Result<ironclaw_turns::EventCursor, TurnError> {
+        panic!("transition stub should not heartbeat")
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        _request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        panic!("transition stub should not recover leases")
+    }
+
+    async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        panic!("transition stub should not block runs")
+    }
+
+    async fn complete_run(&self, _request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        panic!("transition stub should not complete runs")
+    }
+
+    async fn cancel_run(
+        &self,
+        _request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("transition stub should not cancel runs")
+    }
+
+    async fn fail_run(&self, _request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        panic!("transition stub should not fail runs")
+    }
+
+    async fn record_recovery_required(
+        &self,
+        _request: RecordRecoveryRequiredRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("transition stub should not record recovery")
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        _request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("transition stub should not apply loop exits")
+    }
+}
+
+#[async_trait]
+impl TurnRunExecutor for HangingExecutor {
+    async fn execute_claimed_run(
+        &self,
+        _claimed: ClaimedTurnRun,
+        _transitions: Arc<dyn TurnRunTransitionPort>,
+    ) -> Result<(), TurnRunExecutorError> {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        self.notify_started.notify_waiters();
+        std::future::pending::<()>().await;
+        Ok(())
+    }
+}
+
+impl HangingExecutor {
+    async fn wait_for_started(&self) {
+        timeout(Duration::from_secs(2), async {
+            while self.started.load(Ordering::SeqCst) == 0 {
+                self.notify_started.notified().await;
+            }
+        })
+        .await
+        .expect("hanging executor did not start");
+    }
+}
+
+#[test]
+fn production_services_build_scheduler_from_configured_transition_port_without_notifier() {
+    let store = Arc::new(DurableTurnStoreStub);
+    let services = HostRuntimeServices::new(
+        Arc::new(ExtensionRegistry::new()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_turn_state_and_transition_port(store);
+    let executor: Arc<dyn TurnRunExecutor> = Arc::new(CompletingExecutor::default());
+
+    let _scheduler = services
+        .turn_scheduler_for_production(executor, fast_config())
+        .expect("production turn scheduler should build from configured transition port");
+}
+
+#[tokio::test]
+async fn wake_notifier_drains_submitted_run() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        Arc::clone(&transitions),
+        executor.clone(),
+        fast_config().with_poll_interval(Duration::from_secs(60)),
+    );
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let request = submit_turn_request("thread-wake", "idem-wake");
+    let scope = request.scope.clone();
+    let run_id = accepted_run_id(coordinator.submit_turn(request).await.unwrap());
+
+    executor.wait_for_started(1).await;
+    assert_eq!(
+        store
+            .get_run_state(ironclaw_turns::GetRunStateRequest { scope, run_id })
+            .await
+            .unwrap()
+            .status,
+        TurnStatus::Completed
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn duplicate_wakes_claim_run_once() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let gate = Arc::new(Notify::new());
+    let executor = Arc::new(CompletingExecutor::with_gate(Arc::clone(&gate)));
+    let scheduler =
+        TurnRunScheduler::new(Arc::clone(&transitions), executor.clone(), fast_config());
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let request = submit_turn_request("thread-duplicate", "idem-duplicate");
+    let scope = request.scope.clone();
+    let response = coordinator.submit_turn(request).await.unwrap();
+    let wake = wake_from_response(scope, &response);
+    handle.wake_notifier().notify_queued_run(wake).unwrap();
+
+    executor.wait_for_started(1).await;
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert_eq!(executor.started_count(), 1);
+    gate.notify_waiters();
+    executor.wait_for_started(1).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn shutdown_aborts_in_flight_executor_tasks() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(HangingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        Arc::clone(&transitions),
+        executor.clone(),
+        fast_config().with_poll_interval(Duration::from_secs(60)),
+    );
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    coordinator
+        .submit_turn(submit_turn_request("thread-shutdown", "idem-shutdown"))
+        .await
+        .unwrap();
+    executor.wait_for_started().await;
+
+    timeout(Duration::from_secs(2), handle.shutdown())
+        .await
+        .expect("scheduler shutdown should not detach hanging executor tasks");
+}
+
+#[tokio::test]
+async fn poller_recovers_queued_run_after_missed_wake() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler =
+        TurnRunScheduler::new(Arc::clone(&transitions), executor.clone(), fast_config());
+    let handle = scheduler.start();
+    let coordinator = DefaultTurnCoordinator::new(store.clone())
+        .with_wake_notifier(Arc::new(NoopTurnRunWakeNotifier));
+
+    coordinator
+        .submit_turn(submit_turn_request("thread-poll", "idem-poll"))
+        .await
+        .unwrap();
+
+    executor.wait_for_started(1).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn executor_completion_rearms_drain_without_waiting_for_poll() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let gate = Arc::new(Notify::new());
+    let executor = Arc::new(CompletingExecutor::with_gate(Arc::clone(&gate)));
+    let scheduler = TurnRunScheduler::new(
+        Arc::clone(&transitions),
+        executor.clone(),
+        fast_config()
+            .with_max_concurrent_runs(1)
+            .with_poll_interval(Duration::from_secs(60)),
+    );
+    let handle = scheduler.start();
+    let coordinator = DefaultTurnCoordinator::new(store.clone())
+        .with_wake_notifier(Arc::new(NoopTurnRunWakeNotifier));
+
+    let first = coordinator
+        .submit_turn(submit_turn_request("thread-rearm-a", "idem-rearm-a"))
+        .await
+        .unwrap();
+    coordinator
+        .submit_turn(submit_turn_request("thread-rearm-b", "idem-rearm-b"))
+        .await
+        .unwrap();
+    handle
+        .wake_notifier()
+        .notify_queued_run(wake_from_response(scope("thread-rearm-a"), &first))
+        .unwrap();
+
+    executor.wait_for_started(1).await;
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert_eq!(executor.started_count(), 1);
+    gate.notify_waiters();
+    executor.wait_for_started(2).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn executor_error_records_recovery_required_instead_of_retrying() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(FailingExecutor::default());
+    let scheduler =
+        TurnRunScheduler::new(Arc::clone(&transitions), executor.clone(), fast_config());
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let request = submit_turn_request("thread-error", "idem-error");
+    let scope = request.scope.clone();
+    let run_id = accepted_run_id(coordinator.submit_turn(request).await.unwrap());
+
+    executor.wait_for_started().await;
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let state = store
+                .get_run_state(ironclaw_turns::GetRunStateRequest {
+                    scope: scope.clone(),
+                    run_id,
+                })
+                .await
+                .unwrap();
+            if state.status == TurnStatus::RecoveryRequired {
+                assert_eq!(
+                    state.failure.as_ref().map(|failure| failure.category()),
+                    Some("scheduler_test_error")
+                );
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("run did not move to recovery_required");
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn expired_lease_reconciler_marks_running_run_recovery_required() {
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            runner_lease_ttl: ChronoDuration::milliseconds(-1),
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        Arc::clone(&transitions),
+        executor,
+        fast_config().with_poll_interval(Duration::from_secs(60)),
+    );
+    let handle = scheduler.start();
+    let coordinator = DefaultTurnCoordinator::new(store.clone())
+        .with_wake_notifier(Arc::new(NoopTurnRunWakeNotifier));
+
+    let request = submit_turn_request("thread-expired", "idem-expired");
+    let scope = request.scope.clone();
+    let run_id = accepted_run_id(coordinator.submit_turn(request).await.unwrap());
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: ironclaw_turns::TurnRunnerId::new(),
+            lease_token: ironclaw_turns::TurnLeaseToken::new(),
+            scope_filter: Some(scope.clone()),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let state = store
+                .get_run_state(ironclaw_turns::GetRunStateRequest {
+                    scope: scope.clone(),
+                    run_id,
+                })
+                .await
+                .unwrap();
+            if state.status == TurnStatus::RecoveryRequired {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("expired lease was not reconciled");
+    handle.shutdown().await;
+}
+
+fn fast_config() -> TurnRunSchedulerConfig {
+    TurnRunSchedulerConfig::default()
+        .with_poll_interval(Duration::from_millis(10))
+        .with_lease_recovery_interval(Duration::from_millis(10))
+        .with_claim_error_backoff(Duration::from_millis(10))
+        .with_wake_channel_capacity(16)
+}
+
+fn submit_turn_request(thread: &str, idempotency_key: &str) -> SubmitTurnRequest {
+    SubmitTurnRequest {
+        scope: scope(thread),
+        actor: TurnActor::new(UserId::new("user1").unwrap()),
+        accepted_message_ref: AcceptedMessageRef::new(format!("message-{thread}")).unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
+        requested_run_profile: Some(RunProfileRequest::new("default").unwrap()),
+        idempotency_key: IdempotencyKey::new(idempotency_key).unwrap(),
+        received_at: Utc::now(),
+    }
+}
+
+fn scope(thread: &str) -> TurnScope {
+    TurnScope::new(
+        TenantId::new("tenant1").unwrap(),
+        Some(AgentId::new("agent1").unwrap()),
+        Some(ProjectId::new("project1").unwrap()),
+        ThreadId::new(thread).unwrap(),
+    )
+}
+
+fn accepted_run_id(response: SubmitTurnResponse) -> ironclaw_turns::TurnRunId {
+    let SubmitTurnResponse::Accepted { run_id, .. } = response;
+    run_id
+}
+
+fn wake_from_response(scope: TurnScope, response: &SubmitTurnResponse) -> TurnRunWake {
+    let SubmitTurnResponse::Accepted {
+        run_id,
+        status,
+        event_cursor,
+        ..
+    } = response;
+    TurnRunWake {
+        scope,
+        run_id: *run_id,
+        status: *status,
+        event_cursor: *event_cursor,
+    }
+}

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -25,7 +25,8 @@ use ironclaw_turns::{
     NoopTurnRunWakeNotifier, ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse,
     RunProfileRequest, SanitizedCancelReason, SourceBindingRef, SubmitTurnRequest,
     SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnRunState, TurnRunWake,
-    TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnScope, TurnStateStore, TurnStatus,
+    TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnRunnerId, TurnScope, TurnStateStore,
+    TurnStatus,
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
         ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
@@ -477,6 +478,11 @@ struct HeartbeatTrackingTransitions {
     notify_heartbeat: Notify,
 }
 
+struct ClaimRecordingTransitions {
+    store: Arc<InMemoryTurnStateStore>,
+    claim_runner_ids: Mutex<Vec<TurnRunnerId>>,
+}
+
 impl HeartbeatTrackingTransitions {
     fn new(store: Arc<InMemoryTurnStateStore>) -> Self {
         Self {
@@ -494,6 +500,19 @@ impl HeartbeatTrackingTransitions {
         })
         .await
         .expect("scheduler did not heartbeat claimed run");
+    }
+}
+
+impl ClaimRecordingTransitions {
+    fn new(store: Arc<InMemoryTurnStateStore>) -> Self {
+        Self {
+            store,
+            claim_runner_ids: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn claim_runner_ids(&self) -> Vec<TurnRunnerId> {
+        self.claim_runner_ids.lock().unwrap().clone()
     }
 }
 
@@ -559,6 +578,75 @@ impl TurnRunTransitionPort for HeartbeatTrackingTransitions {
     }
 }
 
+#[async_trait]
+impl TurnRunTransitionPort for ClaimRecordingTransitions {
+    async fn claim_next_run(
+        &self,
+        request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        self.claim_runner_ids
+            .lock()
+            .unwrap()
+            .push(request.runner_id);
+        self.store.claim_next_run(request).await
+    }
+
+    async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<ironclaw_turns::EventCursor, TurnError> {
+        self.store.heartbeat(request).await
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        self.store.recover_expired_leases(request).await
+    }
+
+    async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.block_run(request).await
+    }
+
+    async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.complete_run(request).await
+    }
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.cancel_run(request).await
+    }
+
+    async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        self.store.fail_run(request).await
+    }
+
+    async fn record_recovery_required(
+        &self,
+        request: RecordRecoveryRequiredRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.record_recovery_required(request).await
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.apply_validated_loop_exit(request).await
+    }
+}
+
+#[test]
+fn executor_error_exposes_typed_sanitized_failure() {
+    let error = TurnRunExecutorError::new("scheduler_test_error").unwrap();
+
+    assert_eq!(error.failure().category(), "scheduler_test_error");
+    assert_eq!(error.failure_category(), "scheduler_test_error");
+}
+
 #[test]
 fn production_services_build_scheduler_from_configured_transition_port_without_notifier() {
     let store = Arc::new(DurableTurnStoreStub);
@@ -602,6 +690,43 @@ fn production_services_reject_unverified_scheduler_transition_port() {
         ProductionWiringComponent::TurnState,
         ProductionWiringIssueKind::UnverifiedProductionImplementation
     ));
+}
+
+#[tokio::test]
+async fn scheduler_uses_stable_runner_id_across_claims() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions = Arc::new(ClaimRecordingTransitions::new(Arc::clone(&store)));
+    let transition_port: Arc<dyn TurnRunTransitionPort> = transitions.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        transition_port,
+        executor.clone(),
+        fast_config()
+            .with_max_concurrent_runs(2)
+            .with_poll_interval(Duration::from_secs(60)),
+    );
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let first = submit_turn_request("thread-runner-id-a", "idem-runner-id-a");
+    let second = submit_turn_request("thread-runner-id-b", "idem-runner-id-b");
+    coordinator.submit_turn(first).await.unwrap();
+    coordinator.submit_turn(second).await.unwrap();
+
+    executor.wait_for_started(2).await;
+    let runner_ids = transitions.claim_runner_ids();
+    assert!(
+        runner_ids.len() >= 2,
+        "scheduler should record at least two claim attempts"
+    );
+    assert!(
+        runner_ids
+            .iter()
+            .all(|runner_id| *runner_id == runner_ids[0]),
+        "one scheduler instance should use one stable TurnRunnerId across claims"
+    );
+    handle.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -25,7 +25,7 @@ use ironclaw_turns::{
     NoopTurnRunWakeNotifier, ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse,
     RunProfileRequest, SanitizedCancelReason, SourceBindingRef, SubmitTurnRequest,
     SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnRunState, TurnRunWake,
-    TurnRunWakeNotifier, TurnScope, TurnStateStore, TurnStatus,
+    TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnScope, TurnStateStore, TurnStatus,
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
         ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
@@ -111,6 +111,10 @@ struct PanickingExecutor {
 struct FailingClaimTransitions {
     claim_attempts: AtomicUsize,
     notify_claim: Notify,
+}
+
+struct DurableLikeTurnStore {
+    inner: InMemoryTurnStateStore,
 }
 
 #[derive(Debug)]
@@ -254,6 +258,103 @@ impl TurnRunTransitionPort for FailingClaimTransitions {
         _request: ApplyValidatedLoopExitRequest,
     ) -> Result<TurnRunState, TurnError> {
         panic!("failing claim transitions should not apply loop exits")
+    }
+}
+
+impl Default for DurableLikeTurnStore {
+    fn default() -> Self {
+        Self {
+            inner: InMemoryTurnStateStore::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl TurnStateStore for DurableLikeTurnStore {
+    async fn submit_turn(
+        &self,
+        request: SubmitTurnRequest,
+        admission_policy: &dyn ironclaw_turns::TurnAdmissionPolicy,
+        run_profile_resolver: &dyn ironclaw_turns::RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        self.inner
+            .submit_turn(request, admission_policy, run_profile_resolver)
+            .await
+    }
+
+    async fn resume_turn(
+        &self,
+        request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        self.inner.resume_turn(request).await
+    }
+
+    async fn request_cancel(
+        &self,
+        request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        self.inner.request_cancel(request).await
+    }
+
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        self.inner.get_run_state(request).await
+    }
+}
+
+#[async_trait]
+impl TurnRunTransitionPort for DurableLikeTurnStore {
+    async fn claim_next_run(
+        &self,
+        request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        self.inner.claim_next_run(request).await
+    }
+
+    async fn heartbeat(
+        &self,
+        request: HeartbeatRequest,
+    ) -> Result<ironclaw_turns::EventCursor, TurnError> {
+        self.inner.heartbeat(request).await
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        self.inner.recover_expired_leases(request).await
+    }
+
+    async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        self.inner.block_run(request).await
+    }
+
+    async fn complete_run(&self, request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        self.inner.complete_run(request).await
+    }
+
+    async fn cancel_run(
+        &self,
+        request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.inner.cancel_run(request).await
+    }
+
+    async fn fail_run(&self, request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        self.inner.fail_run(request).await
+    }
+
+    async fn record_recovery_required(
+        &self,
+        request: RecordRecoveryRequiredRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.inner.record_recovery_required(request).await
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.inner.apply_validated_loop_exit(request).await
     }
 }
 
@@ -501,6 +602,147 @@ fn production_services_reject_unverified_scheduler_transition_port() {
         ProductionWiringComponent::TurnState,
         ProductionWiringIssueKind::UnverifiedProductionImplementation
     ));
+}
+
+#[tokio::test]
+async fn production_services_scheduler_and_coordinator_execute_turn_end_to_end() {
+    let store = Arc::new(DurableLikeTurnStore::default());
+    let services = HostRuntimeServices::new(
+        Arc::new(ExtensionRegistry::new()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_turn_state_and_transition_port(Arc::clone(&store));
+    let executor = Arc::new(CompletingExecutor::default());
+    let executor_port: Arc<dyn TurnRunExecutor> = executor.clone();
+    let scheduler = services
+        .turn_scheduler_for_production(
+            executor_port,
+            fast_config().with_poll_interval(Duration::from_secs(60)),
+        )
+        .expect("production scheduler should build from verified turn store");
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let request = submit_turn_request("thread-production-e2e", "idem-production-e2e");
+    let scope = request.scope.clone();
+    let run_id = accepted_run_id(coordinator.submit_turn(request).await.unwrap());
+
+    executor.wait_for_started(1).await;
+    wait_for_status(store.as_ref(), scope, run_id, TurnStatus::Completed).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn scheduler_completes_multiple_submitted_threads_end_to_end() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        Arc::clone(&transitions),
+        executor.clone(),
+        fast_config()
+            .with_max_concurrent_runs(2)
+            .with_poll_interval(Duration::from_secs(60)),
+    );
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let first = submit_turn_request("thread-multi-a", "idem-multi-a");
+    let first_scope = first.scope.clone();
+    let first_run = accepted_run_id(coordinator.submit_turn(first).await.unwrap());
+    let second = submit_turn_request("thread-multi-b", "idem-multi-b");
+    let second_scope = second.scope.clone();
+    let second_run = accepted_run_id(coordinator.submit_turn(second).await.unwrap());
+
+    executor.wait_for_started(2).await;
+    wait_for_status(&*store, first_scope, first_run, TurnStatus::Completed).await;
+    wait_for_status(&*store, second_scope, second_run, TurnStatus::Completed).await;
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn fake_wake_without_queued_run_does_not_execute() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        Arc::clone(&transitions),
+        executor.clone(),
+        fast_config().with_poll_interval(Duration::from_secs(60)),
+    );
+    let handle = scheduler.start();
+
+    handle
+        .wake_notifier()
+        .notify_queued_run(fake_wake("thread-fake-wake"))
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert_eq!(
+        executor.started_count(),
+        0,
+        "scheduler must not execute directly from wake payload without a claimed queued run"
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn stale_wake_after_completion_does_not_reexecute_run() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(
+        Arc::clone(&transitions),
+        executor.clone(),
+        fast_config().with_poll_interval(Duration::from_secs(60)),
+    );
+    let handle = scheduler.start();
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(handle.wake_notifier());
+
+    let request = submit_turn_request("thread-stale-wake", "idem-stale-wake");
+    let scope = request.scope.clone();
+    let response = coordinator.submit_turn(request).await.unwrap();
+    let run_id = accepted_run_id(response.clone());
+    let stale_wake = wake_from_response(scope.clone(), &response);
+
+    executor.wait_for_started(1).await;
+    wait_for_status(&*store, scope, run_id, TurnStatus::Completed).await;
+    handle
+        .wake_notifier()
+        .notify_queued_run(stale_wake)
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert_eq!(
+        executor.started_count(),
+        1,
+        "stale wake for completed run must not re-execute work"
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn wake_notifier_reports_delivery_unavailable_after_scheduler_shutdown() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let transitions: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let executor = Arc::new(CompletingExecutor::default());
+    let scheduler = TurnRunScheduler::new(Arc::clone(&transitions), executor, fast_config());
+    let handle = scheduler.start();
+    let notifier = handle.wake_notifier();
+
+    handle.shutdown().await;
+
+    assert_eq!(
+        notifier.notify_queued_run(fake_wake("thread-after-shutdown")),
+        Err(TurnRunWakeNotifyError::DeliveryUnavailable)
+    );
 }
 
 #[tokio::test]
@@ -796,7 +1038,7 @@ async fn scheduler_heartbeats_long_running_executor_until_completion() {
     executor.wait_for_started(1).await;
     transitions.wait_for_heartbeats(2).await;
     gate.notify_waiters();
-    wait_for_status(&store, scope, run_id, TurnStatus::Completed).await;
+    wait_for_status(&*store, scope, run_id, TurnStatus::Completed).await;
     handle.shutdown().await;
 }
 
@@ -836,7 +1078,7 @@ async fn canceled_hanging_executor_lease_expires_to_recovery_required() {
         .await
         .unwrap();
 
-    wait_for_status(&store, scope, run_id, TurnStatus::RecoveryRequired).await;
+    wait_for_status(&*store, scope, run_id, TurnStatus::RecoveryRequired).await;
     handle.shutdown().await;
 }
 
@@ -900,12 +1142,14 @@ fn fast_config() -> TurnRunSchedulerConfig {
         .with_wake_channel_capacity(16)
 }
 
-async fn wait_for_status(
-    store: &InMemoryTurnStateStore,
+async fn wait_for_status<S>(
+    store: &S,
     scope: TurnScope,
     run_id: ironclaw_turns::TurnRunId,
     expected: TurnStatus,
-) {
+) where
+    S: TurnStateStore + ?Sized,
+{
     timeout(Duration::from_secs(2), async {
         loop {
             let state = store
@@ -950,6 +1194,15 @@ fn scope(thread: &str) -> TurnScope {
 fn accepted_run_id(response: SubmitTurnResponse) -> ironclaw_turns::TurnRunId {
     let SubmitTurnResponse::Accepted { run_id, .. } = response;
     run_id
+}
+
+fn fake_wake(thread: &str) -> TurnRunWake {
+    TurnRunWake {
+        scope: scope(thread),
+        run_id: ironclaw_turns::TurnRunId::new(),
+        status: TurnStatus::Queued,
+        event_cursor: ironclaw_turns::EventCursor::default(),
+    }
 }
 
 fn wake_from_response(scope: TurnScope, response: &SubmitTurnResponse) -> TurnRunWake {

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -562,6 +562,12 @@ impl TurnRunTransitionPort for InMemoryTurnStateStore {
         let result = (|| {
             let now = Utc::now();
             ensure_active_lease(&record, request.runner_id, request.lease_token, now)?;
+            if record.status != TurnStatus::Running {
+                return Err(TurnError::InvalidTransition {
+                    from: record.status,
+                    to: TurnStatus::Running,
+                });
+            }
             record.last_heartbeat_at = Some(now);
             record.lease_expires_at = Some(inner.next_lease_expiry(now));
             record.event_cursor = inner.next_cursor();

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -2332,6 +2332,67 @@ async fn runner_claims_queued_run_with_lease_and_heartbeat_requires_matching_lea
 }
 
 #[tokio::test]
+async fn cancel_requested_runner_heartbeat_does_not_extend_lease() {
+    let limits = InMemoryTurnStateStoreLimits {
+        runner_lease_ttl: ChronoDuration::milliseconds(40),
+        ..InMemoryTurnStateStoreLimits::default()
+    };
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(limits));
+    let coordinator = DefaultTurnCoordinator::new(store.clone());
+    let request = submit_request("thread-cancel-heartbeat", "idem-submit-cancel-heartbeat");
+    let scope = request.scope.clone();
+    let run_id = accepted_run_id(&coordinator.submit_turn(request).await.unwrap());
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: Some(scope.clone()),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    coordinator
+        .cancel_run(CancelRunRequest {
+            scope,
+            actor: TurnActor::new(UserId::new("user1").unwrap()),
+            run_id,
+            reason: SanitizedCancelReason::UserRequested,
+            idempotency_key: IdempotencyKey::new("idem-cancel-heartbeat").unwrap(),
+        })
+        .await
+        .unwrap();
+
+    let heartbeat = store
+        .heartbeat(HeartbeatRequest {
+            run_id,
+            runner_id,
+            lease_token,
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(
+        heartbeat,
+        TurnError::InvalidTransition {
+            from: TurnStatus::CancelRequested,
+            to: TurnStatus::Running,
+        }
+    );
+
+    std::thread::sleep(Duration::from_millis(60));
+    let recovered = store
+        .recover_expired_leases(RecoverExpiredLeasesRequest {
+            now: Utc::now(),
+            scope_filter: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(recovered.recovered.len(), 1);
+    assert_eq!(recovered.recovered[0].status, TurnStatus::RecoveryRequired);
+}
+
+#[tokio::test]
 async fn expired_runner_lease_rejects_heartbeat_and_terminal_completion_before_recovery_sweep() {
     let limits = InMemoryTurnStateStoreLimits {
         runner_lease_ttl: ChronoDuration::milliseconds(-1),

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -56,4 +56,4 @@ Agent-loop drivers return `LoopExit` claims. `TurnRunner` validates those claims
 
 ## 6. Deferred work
 
-The current `ironclaw_turns` slices define the core lease/recovery state machine, initial PostgreSQL/libSQL persistence adapters, pure `LoopExit` validation/mapping types, and runner-side `apply_loop_exit` transition application. AgentLoopHost/AgentLoopDriver integration, durable exit-id replay storage, transcript draft validation, side-effect boundary checkpoint cadence inside the loop, production service-graph wiring, and safe explicit retry/fork UX remain follow-up slices.
+The current slices define the core lease/recovery state machine, initial PostgreSQL/libSQL persistence adapters, pure `LoopExit` validation/mapping types, runner-side `apply_loop_exit` transition application, and host-runtime production scheduler wiring. AgentLoopHost/AgentLoopDriver integration, durable exit-id replay storage, transcript draft validation, side-effect boundary checkpoint cadence inside the loop, concrete runner-worker startup, and safe explicit retry/fork UX remain follow-up slices.

--- a/docs/reborn/contracts/turn-runner.md
+++ b/docs/reborn/contracts/turn-runner.md
@@ -19,7 +19,7 @@ Product adapters must continue to use `TurnCoordinator`. Runner transition APIs 
 - `submit_turn` creates a queued `TurnRunId` and active-thread lock, but no model/tool side effects may run before a runner claim succeeds.
 - `claim_next_run` atomically moves one matching `Queued` run to `Running`.
 - A successful claim stores `runner_id`, `lease_token`, `last_heartbeat_at`, `lease_expires_at`, increments `claim_count`, updates the active lock, and emits `RunnerClaimed`.
-- `heartbeat` requires the matching `runner_id` and `lease_token` and rejects leases whose `lease_expires_at` has already passed; on success it refreshes `last_heartbeat_at`, extends `lease_expires_at`, touches the active lock, and emits `RunnerHeartbeat`.
+- `heartbeat` requires the matching `runner_id` and `lease_token`, only refreshes actively `Running` work, and rejects leases whose `lease_expires_at` has already passed. Once cancellation is requested, heartbeats no longer extend the lease; the runner must complete cancellation before the existing lease expires or the reconciler moves the run to recovery. On success, heartbeat refreshes `last_heartbeat_at`, extends `lease_expires_at`, touches the active lock, and emits `RunnerHeartbeat`.
 - Pull-based claims are authoritative. Wake notifications are optimization hints only.
 - After `TurnCoordinator` durably accepts a submitted run or requeues a resumed run, it may emit a redacted queued-run wake hint containing only the canonical scope, `TurnRunId`, queued status, and event cursor. Wake delivery is best-effort, is not a source of truth, must not fail the durable adapter call, and duplicate hints must be harmless.
 


### PR DESCRIPTION
## Summary

Closes #3435.

Adds the generic Reborn turn-run scheduler infrastructure in `ironclaw_host_runtime`:

- `TurnRunScheduler` with in-process wake nudges plus bounded polling
- `SchedulerTurnRunWakeNotifier` for coordinator submit/resume wake hints
- `TurnRunExecutor` port so product loop strategy stays above host-runtime
- scoped wake drain first, global drain fallback
- bounded local concurrency via semaphore
- executor error/panic best-effort `record_recovery_required`
- periodic `recover_expired_leases`
- shutdown tracking/aborting executor tasks through `JoinSet`
- `HostRuntimeServices::turn_scheduler_for_production`
- libSQL/Postgres turn store builders now retain `TurnRunTransitionPort`

## Tests

- `CARGO_TARGET_DIR=/tmp/ironclaw-target-scheduler cargo test -p ironclaw_host_runtime --test turn_scheduler_contract --no-default-features --quiet`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-scheduler cargo test -p ironclaw_host_runtime --no-default-features --quiet`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-scheduler cargo check -p ironclaw_host_runtime --features libsql --quiet`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-scheduler cargo check -p ironclaw_host_runtime --features postgres --quiet`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-scheduler cargo test -p ironclaw_architecture --quiet`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-scheduler cargo clippy -p ironclaw_host_runtime --no-default-features --all-targets -- -D warnings`

## Review

- Internal reviewer pass found no remaining Critical/High/Medium issues after fixes.
