### PR TITLE
feat(reborn): add text-only loop driver host factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4512,6 +4512,7 @@ name = "ironclaw_reborn"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "ironclaw_host_api",
  "ironclaw_llm",
  "ironclaw_loop_support",
@@ -4521,6 +4522,7 @@ dependencies = [
  "libsql",
  "rust_decimal",
  "secrecy",
+ "serde_json",
  "tempfile",
  "tokio",
 ]

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -26,8 +26,10 @@ libsql = { version = "0.6", optional = true, default-features = false, features 
 secrecy = { version = "0.10", optional = true }
 
 [dev-dependencies]
+chrono = "0.4"
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 rust_decimal = "1"
+serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }
 

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -5,12 +5,18 @@
 //! free of Reborn loop-support wiring.
 
 pub mod driver_registry;
+pub mod loop_driver_host;
 
 #[cfg(feature = "root-llm-provider")]
 pub mod model_gateway;
 #[cfg(feature = "libsql-secrets")]
 pub mod secrets;
 
+pub use loop_driver_host::{
+    HostManagedLoopCheckpointPort, HostManagedLoopProgressPort, NoExtraLoopInputPort,
+    RebornLoopDriverHost, RebornLoopDriverHostError, RebornLoopDriverHostFactory,
+    RebornLoopDriverHostRequest, TextOnlyLoopHostConfig,
+};
 #[cfg(feature = "root-llm-provider")]
 pub use model_gateway::{
     LlmModelProfilePolicy, LlmProviderModelGateway, ThreadBackedLoopModelGateway,

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -115,13 +115,21 @@ where
             run_context.clone(),
             max_messages,
         ));
+        let current_surface_version = EmptyLoopCapabilityPort
+            .visible_capabilities(VisibleCapabilityRequest)
+            .await
+            .map_err(|error| RebornLoopDriverHostError::InvalidRequest {
+                reason: error.safe_summary,
+            })?
+            .version;
         let prompt: Arc<dyn LoopPromptPort> = Arc::new(
             HostManagedLoopPromptPort::new(
                 run_context.clone(),
                 Arc::clone(&context),
                 Arc::clone(&self.milestone_sink),
             )
-            .with_default_message_limit(max_messages),
+            .with_default_message_limit(max_messages)
+            .with_current_surface_version(current_surface_version),
         );
         let input: Arc<dyn LoopInputPort> =
             Arc::new(NoExtraLoopInputPort::new(run_context.clone()));

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -542,7 +542,7 @@ fn validate_claimed_run_context(
 }
 
 fn persisted_profile_id(profile_id: &RunProfileId) -> RunProfileId {
-    if profile_id.as_str() == "interactive_default" {
+    if profile_id.is_interactive_default() {
         RunProfileId::default_profile()
     } else {
         profile_id.clone()
@@ -553,8 +553,16 @@ fn validate_thread_scope(
     thread_scope: &ThreadScope,
     run_context: &LoopRunContext,
 ) -> Result<(), RebornLoopDriverHostError> {
+    // Reborn text-only hosts currently wrap `ironclaw_threads::ThreadScope`,
+    // whose production transcript boundary is agent-scoped. Agentless turn
+    // scopes are rejected here until that lower thread boundary grows an
+    // explicit agentless thread scope.
+    if run_context.scope.agent_id.as_ref() != Some(&thread_scope.agent_id) {
+        return Err(RebornLoopDriverHostError::ScopeMismatch {
+            reason: "text-only loop host requires a matching agent-scoped thread".to_string(),
+        });
+    }
     if thread_scope.tenant_id != run_context.scope.tenant_id
-        || Some(thread_scope.agent_id.clone()) != run_context.scope.agent_id
         || thread_scope.project_id != run_context.scope.project_id
     {
         return Err(RebornLoopDriverHostError::ScopeMismatch {
@@ -578,12 +586,21 @@ fn turn_error_to_host_error(error: TurnError) -> AgentLoopHostError {
             AgentLoopHostErrorKind::Unavailable,
             "checkpoint state store is unavailable",
         ),
-        TurnError::ScopeNotFound
-        | TurnError::Conflict { .. }
-        | TurnError::InvalidTransition { .. }
-        | TurnError::LeaseMismatch => AgentLoopHostError::new(
+        TurnError::ScopeNotFound => AgentLoopHostError::new(
             AgentLoopHostErrorKind::CheckpointRejected,
-            "checkpoint state ref is unavailable for this loop run",
+            "checkpoint state scope was not found for this loop run",
+        ),
+        TurnError::Conflict { .. } => AgentLoopHostError::new(
+            AgentLoopHostErrorKind::CheckpointRejected,
+            "checkpoint state write conflicted with current turn state",
+        ),
+        TurnError::InvalidTransition { .. } => AgentLoopHostError::new(
+            AgentLoopHostErrorKind::CheckpointRejected,
+            "checkpoint state write was invalid for current turn state",
+        ),
+        TurnError::LeaseMismatch => AgentLoopHostError::new(
+            AgentLoopHostErrorKind::CheckpointRejected,
+            "checkpoint state write lease no longer matches current run",
         ),
         TurnError::ThreadBusy(_) | TurnError::AdmissionRejected(_) => AgentLoopHostError::new(
             AgentLoopHostErrorKind::Unavailable,

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -1,0 +1,585 @@
+use std::{error::Error, fmt, sync::Arc};
+
+use async_trait::async_trait;
+use ironclaw_loop_support::{
+    EmptyLoopCapabilityPort, HostManagedModelGateway, ThreadBackedLoopContextPort,
+    ThreadBackedLoopModelPort, ThreadBackedLoopTranscriptPort,
+};
+use ironclaw_threads::{SessionThreadService, ThreadScope};
+use ironclaw_turns::{
+    CheckpointStateStore, GetCheckpointStateRequest, LoopCheckpointStore, PutLoopCheckpointRequest,
+    RunProfileId, TurnCheckpointId, TurnError, TurnStatus,
+    run_profile::{
+        AgentLoopHostError, AgentLoopHostErrorKind, AppendCapabilityResultRef, BeginAssistantDraft,
+        CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityInvocation, CapabilityOutcome,
+        FinalizeAssistantMessage, HostManagedLoopPromptPort, LoopCapabilityPort,
+        LoopCheckpointPort, LoopCheckpointRequest, LoopContextBundle, LoopContextPort,
+        LoopContextRequest, LoopHostMilestoneEmitter, LoopHostMilestoneSink, LoopInputBatch,
+        LoopInputCursor, LoopInputPort, LoopModelPort, LoopModelRequest, LoopModelResponse,
+        LoopProgressEvent, LoopProgressPort, LoopPromptBundle, LoopPromptBundleRequest,
+        LoopPromptPort, LoopRunContext, LoopRunInfoPort, LoopTranscriptPort, UpdateAssistantDraft,
+        VisibleCapabilityRequest, VisibleCapabilitySurface,
+    },
+    runner::ClaimedTurnRun,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextOnlyLoopHostConfig {
+    pub max_messages: usize,
+}
+
+impl Default for TextOnlyLoopHostConfig {
+    fn default() -> Self {
+        Self { max_messages: 16 }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RebornLoopDriverHostError {
+    ScopeMismatch { reason: String },
+    InvalidRequest { reason: String },
+}
+
+impl fmt::Display for RebornLoopDriverHostError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ScopeMismatch { reason } => {
+                write!(formatter, "loop driver host scope mismatch: {reason}")
+            }
+            Self::InvalidRequest { reason } => {
+                write!(formatter, "invalid loop driver host request: {reason}")
+            }
+        }
+    }
+}
+
+impl Error for RebornLoopDriverHostError {}
+
+#[derive(Debug, Clone)]
+pub struct RebornLoopDriverHostRequest {
+    pub claimed_run: ClaimedTurnRun,
+    pub loop_run_context: LoopRunContext,
+}
+
+pub struct RebornLoopDriverHostFactory<S, G>
+where
+    S: SessionThreadService + ?Sized,
+    G: HostManagedModelGateway + ?Sized,
+{
+    thread_service: Arc<S>,
+    thread_scope: ThreadScope,
+    model_gateway: Arc<G>,
+    checkpoint_state_store: Arc<dyn CheckpointStateStore>,
+    loop_checkpoint_store: Arc<dyn LoopCheckpointStore>,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+    config: TextOnlyLoopHostConfig,
+}
+
+impl<S, G> RebornLoopDriverHostFactory<S, G>
+where
+    S: SessionThreadService + ?Sized + Send + Sync + 'static,
+    G: HostManagedModelGateway + ?Sized + Send + Sync + 'static,
+{
+    pub fn new(
+        thread_service: Arc<S>,
+        thread_scope: ThreadScope,
+        model_gateway: Arc<G>,
+        checkpoint_state_store: Arc<dyn CheckpointStateStore>,
+        loop_checkpoint_store: Arc<dyn LoopCheckpointStore>,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+        config: TextOnlyLoopHostConfig,
+    ) -> Self {
+        Self {
+            thread_service,
+            thread_scope,
+            model_gateway,
+            checkpoint_state_store,
+            loop_checkpoint_store,
+            milestone_sink,
+            config,
+        }
+    }
+
+    pub async fn build_text_only_host(
+        &self,
+        request: RebornLoopDriverHostRequest,
+    ) -> Result<RebornLoopDriverHost, RebornLoopDriverHostError> {
+        validate_claimed_run_context(&request.claimed_run, &request.loop_run_context)?;
+        validate_thread_scope(&self.thread_scope, &request.loop_run_context)?;
+
+        let max_messages = self.config.max_messages.max(1);
+        let run_context = request.loop_run_context;
+        let context: Arc<dyn LoopContextPort> = Arc::new(ThreadBackedLoopContextPort::new(
+            Arc::clone(&self.thread_service),
+            self.thread_scope.clone(),
+            run_context.clone(),
+            max_messages,
+        ));
+        let prompt: Arc<dyn LoopPromptPort> = Arc::new(
+            HostManagedLoopPromptPort::new(
+                run_context.clone(),
+                Arc::clone(&context),
+                Arc::clone(&self.milestone_sink),
+            )
+            .with_default_message_limit(max_messages),
+        );
+        let input: Arc<dyn LoopInputPort> =
+            Arc::new(NoExtraLoopInputPort::new(run_context.clone()));
+        let model: Arc<dyn LoopModelPort> =
+            Arc::new(ThreadBackedLoopModelPort::with_milestone_sink(
+                Arc::clone(&self.thread_service),
+                self.thread_scope.clone(),
+                run_context.clone(),
+                Arc::clone(&self.model_gateway),
+                max_messages,
+                Arc::clone(&self.milestone_sink),
+            ));
+        let checkpoint: Arc<dyn LoopCheckpointPort> = Arc::new(HostManagedLoopCheckpointPort::new(
+            run_context.clone(),
+            Arc::clone(&self.checkpoint_state_store),
+            Arc::clone(&self.loop_checkpoint_store),
+            Arc::clone(&self.milestone_sink),
+        ));
+        let capabilities: Arc<dyn LoopCapabilityPort> = Arc::new(EmptyLoopCapabilityPort);
+        let transcript: Arc<dyn LoopTranscriptPort> =
+            Arc::new(ThreadBackedLoopTranscriptPort::with_milestone_sink(
+                Arc::clone(&self.thread_service),
+                self.thread_scope.clone(),
+                run_context.clone(),
+                Arc::clone(&self.milestone_sink),
+            ));
+        let progress: Arc<dyn LoopProgressPort> = Arc::new(HostManagedLoopProgressPort::new(
+            run_context.clone(),
+            Arc::clone(&self.milestone_sink),
+        ));
+
+        Ok(RebornLoopDriverHost {
+            run_context,
+            context,
+            prompt,
+            input,
+            model,
+            checkpoint,
+            capabilities,
+            transcript,
+            progress,
+        })
+    }
+}
+
+pub struct RebornLoopDriverHost {
+    run_context: LoopRunContext,
+    context: Arc<dyn LoopContextPort>,
+    prompt: Arc<dyn LoopPromptPort>,
+    input: Arc<dyn LoopInputPort>,
+    model: Arc<dyn LoopModelPort>,
+    checkpoint: Arc<dyn LoopCheckpointPort>,
+    capabilities: Arc<dyn LoopCapabilityPort>,
+    transcript: Arc<dyn LoopTranscriptPort>,
+    progress: Arc<dyn LoopProgressPort>,
+}
+
+impl fmt::Debug for RebornLoopDriverHost {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RebornLoopDriverHost")
+            .field("scope", &self.run_context.scope)
+            .field("turn_id", &self.run_context.turn_id)
+            .field("run_id", &self.run_context.run_id)
+            .field("loop_driver_id", &self.run_context.loop_driver_id)
+            .finish()
+    }
+}
+
+impl LoopRunInfoPort for RebornLoopDriverHost {
+    fn run_context(&self) -> &LoopRunContext {
+        &self.run_context
+    }
+}
+
+#[async_trait]
+impl LoopContextPort for RebornLoopDriverHost {
+    async fn load_loop_context(
+        &self,
+        request: LoopContextRequest,
+    ) -> Result<LoopContextBundle, AgentLoopHostError> {
+        self.context.load_loop_context(request).await
+    }
+}
+
+#[async_trait]
+impl LoopPromptPort for RebornLoopDriverHost {
+    async fn build_prompt_bundle(
+        &self,
+        request: LoopPromptBundleRequest,
+    ) -> Result<LoopPromptBundle, AgentLoopHostError> {
+        self.prompt.build_prompt_bundle(request).await
+    }
+}
+
+#[async_trait]
+impl LoopInputPort for RebornLoopDriverHost {
+    async fn poll_inputs(
+        &self,
+        after: LoopInputCursor,
+        limit: usize,
+    ) -> Result<LoopInputBatch, AgentLoopHostError> {
+        self.input.poll_inputs(after, limit).await
+    }
+
+    async fn ack_inputs(&self, cursor: LoopInputCursor) -> Result<(), AgentLoopHostError> {
+        self.input.ack_inputs(cursor).await
+    }
+}
+
+#[async_trait]
+impl LoopModelPort for RebornLoopDriverHost {
+    async fn stream_model(
+        &self,
+        request: LoopModelRequest,
+    ) -> Result<LoopModelResponse, AgentLoopHostError> {
+        self.model.stream_model(request).await
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityPort for RebornLoopDriverHost {
+    async fn visible_capabilities(
+        &self,
+        request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        self.capabilities.visible_capabilities(request).await
+    }
+
+    async fn invoke_capability(
+        &self,
+        request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        self.capabilities.invoke_capability(request).await
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        self.capabilities.invoke_capability_batch(request).await
+    }
+}
+
+#[async_trait]
+impl LoopTranscriptPort for RebornLoopDriverHost {
+    async fn begin_assistant_draft(
+        &self,
+        request: BeginAssistantDraft,
+    ) -> Result<ironclaw_turns::LoopMessageRef, AgentLoopHostError> {
+        self.transcript.begin_assistant_draft(request).await
+    }
+
+    async fn update_assistant_draft(
+        &self,
+        request: UpdateAssistantDraft,
+    ) -> Result<(), AgentLoopHostError> {
+        self.transcript.update_assistant_draft(request).await
+    }
+
+    async fn finalize_assistant_message(
+        &self,
+        request: FinalizeAssistantMessage,
+    ) -> Result<ironclaw_turns::LoopMessageRef, AgentLoopHostError> {
+        self.transcript.finalize_assistant_message(request).await
+    }
+
+    async fn append_capability_result_ref(
+        &self,
+        request: AppendCapabilityResultRef,
+    ) -> Result<ironclaw_turns::LoopMessageRef, AgentLoopHostError> {
+        self.transcript.append_capability_result_ref(request).await
+    }
+}
+
+#[async_trait]
+impl LoopCheckpointPort for RebornLoopDriverHost {
+    async fn checkpoint(
+        &self,
+        request: LoopCheckpointRequest,
+    ) -> Result<TurnCheckpointId, AgentLoopHostError> {
+        self.checkpoint.checkpoint(request).await
+    }
+}
+
+#[async_trait]
+impl LoopProgressPort for RebornLoopDriverHost {
+    async fn emit_loop_progress(&self, event: LoopProgressEvent) -> Result<(), AgentLoopHostError> {
+        self.progress.emit_loop_progress(event).await
+    }
+}
+
+#[derive(Clone)]
+pub struct NoExtraLoopInputPort {
+    run_context: LoopRunContext,
+}
+
+impl NoExtraLoopInputPort {
+    pub fn new(run_context: LoopRunContext) -> Self {
+        Self { run_context }
+    }
+
+    fn validate_cursor(&self, cursor: &LoopInputCursor) -> Result<(), AgentLoopHostError> {
+        if cursor.is_for_run(&self.run_context) {
+            Ok(())
+        } else {
+            Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::ScopeMismatch,
+                "input cursor is not scoped to this loop run",
+            ))
+        }
+    }
+}
+
+impl LoopRunInfoPort for NoExtraLoopInputPort {
+    fn run_context(&self) -> &LoopRunContext {
+        &self.run_context
+    }
+}
+
+#[async_trait]
+impl LoopInputPort for NoExtraLoopInputPort {
+    async fn poll_inputs(
+        &self,
+        after: LoopInputCursor,
+        _limit: usize,
+    ) -> Result<LoopInputBatch, AgentLoopHostError> {
+        self.validate_cursor(&after)?;
+        Ok(LoopInputBatch {
+            inputs: Vec::new(),
+            next_cursor: after,
+        })
+    }
+
+    async fn ack_inputs(&self, cursor: LoopInputCursor) -> Result<(), AgentLoopHostError> {
+        self.validate_cursor(&cursor)
+    }
+}
+
+#[derive(Clone)]
+pub struct HostManagedLoopCheckpointPort {
+    run_context: LoopRunContext,
+    checkpoint_state_store: Arc<dyn CheckpointStateStore>,
+    loop_checkpoint_store: Arc<dyn LoopCheckpointStore>,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+}
+
+impl HostManagedLoopCheckpointPort {
+    pub fn new(
+        run_context: LoopRunContext,
+        checkpoint_state_store: Arc<dyn CheckpointStateStore>,
+        loop_checkpoint_store: Arc<dyn LoopCheckpointStore>,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+    ) -> Self {
+        Self {
+            run_context,
+            checkpoint_state_store,
+            loop_checkpoint_store,
+            milestone_sink,
+        }
+    }
+}
+
+impl LoopRunInfoPort for HostManagedLoopCheckpointPort {
+    fn run_context(&self) -> &LoopRunContext {
+        &self.run_context
+    }
+}
+
+#[async_trait]
+impl LoopCheckpointPort for HostManagedLoopCheckpointPort {
+    async fn checkpoint(
+        &self,
+        request: LoopCheckpointRequest,
+    ) -> Result<TurnCheckpointId, AgentLoopHostError> {
+        let loaded = self
+            .checkpoint_state_store
+            .get_checkpoint_state(GetCheckpointStateRequest {
+                scope: self.run_context.scope.clone(),
+                turn_id: self.run_context.turn_id,
+                run_id: self.run_context.run_id,
+                state_ref: request.state_ref.clone(),
+                schema_id: self.run_context.checkpoint_schema_id.clone(),
+                schema_version: self.run_context.checkpoint_schema_version,
+                kind: request.kind,
+            })
+            .await
+            .map_err(turn_error_to_host_error)?;
+        if loaded.is_none() {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::CheckpointRejected,
+                "checkpoint state ref is unavailable for this loop run",
+            ));
+        }
+
+        let checkpoint = self
+            .loop_checkpoint_store
+            .put_loop_checkpoint(PutLoopCheckpointRequest {
+                scope: self.run_context.scope.clone(),
+                turn_id: self.run_context.turn_id,
+                run_id: self.run_context.run_id,
+                state_ref: request.state_ref,
+                schema_id: self.run_context.checkpoint_schema_id.clone(),
+                schema_version: self.run_context.checkpoint_schema_version,
+                kind: request.kind,
+            })
+            .await
+            .map_err(turn_error_to_host_error)?;
+        LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(&self.milestone_sink))
+            .checkpoint_created(checkpoint.checkpoint_id, request.kind)
+            .await?;
+        Ok(checkpoint.checkpoint_id)
+    }
+}
+
+#[derive(Clone)]
+pub struct HostManagedLoopProgressPort {
+    run_context: LoopRunContext,
+    milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+}
+
+impl HostManagedLoopProgressPort {
+    pub fn new(
+        run_context: LoopRunContext,
+        milestone_sink: Arc<dyn LoopHostMilestoneSink>,
+    ) -> Self {
+        Self {
+            run_context,
+            milestone_sink,
+        }
+    }
+}
+
+impl LoopRunInfoPort for HostManagedLoopProgressPort {
+    fn run_context(&self) -> &LoopRunContext {
+        &self.run_context
+    }
+}
+
+#[async_trait]
+impl LoopProgressPort for HostManagedLoopProgressPort {
+    async fn emit_loop_progress(&self, event: LoopProgressEvent) -> Result<(), AgentLoopHostError> {
+        match event {
+            LoopProgressEvent::DriverNote { kind, safe_summary } => {
+                LoopHostMilestoneEmitter::new(
+                    self.run_context.clone(),
+                    Arc::clone(&self.milestone_sink),
+                )
+                .driver_note(kind, safe_summary)
+                .await
+            }
+        }
+    }
+}
+
+fn validate_claimed_run_context(
+    claimed_run: &ClaimedTurnRun,
+    run_context: &LoopRunContext,
+) -> Result<(), RebornLoopDriverHostError> {
+    if claimed_run.state.status != TurnStatus::Running {
+        return Err(RebornLoopDriverHostError::InvalidRequest {
+            reason: "claimed run must be running".to_string(),
+        });
+    }
+    if claimed_run.state.scope != run_context.scope
+        || claimed_run.state.turn_id != run_context.turn_id
+        || claimed_run.state.run_id != run_context.run_id
+    {
+        return Err(RebornLoopDriverHostError::ScopeMismatch {
+            reason: "claimed run state does not match loop run context".to_string(),
+        });
+    }
+    if claimed_run.resolved_run_profile != run_context.resolved_run_profile {
+        return Err(RebornLoopDriverHostError::ScopeMismatch {
+            reason: "claimed run profile does not match loop run context".to_string(),
+        });
+    }
+    let expected_profile_id = persisted_profile_id(&run_context.resolved_run_profile.profile_id);
+    if claimed_run.state.resolved_run_profile_id != expected_profile_id
+        || claimed_run.state.resolved_run_profile_version
+            != run_context.resolved_run_profile.profile_version
+    {
+        return Err(RebornLoopDriverHostError::ScopeMismatch {
+            reason: "claimed run persisted profile identity does not match loop run context"
+                .to_string(),
+        });
+    }
+    if run_context.loop_driver_id != run_context.resolved_run_profile.loop_driver.id
+        || run_context.loop_driver_version != run_context.resolved_run_profile.loop_driver.version
+    {
+        return Err(RebornLoopDriverHostError::ScopeMismatch {
+            reason: "loop driver identity does not match resolved profile".to_string(),
+        });
+    }
+    if run_context.thread_id != run_context.scope.thread_id {
+        return Err(RebornLoopDriverHostError::ScopeMismatch {
+            reason: "loop run context thread does not match scope thread".to_string(),
+        });
+    }
+    if run_context.checkpoint_schema_id != run_context.resolved_run_profile.checkpoint_schema_id
+        || run_context.checkpoint_schema_version
+            != run_context.resolved_run_profile.checkpoint_schema_version
+    {
+        return Err(RebornLoopDriverHostError::ScopeMismatch {
+            reason: "loop run context checkpoint identity does not match resolved profile"
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn persisted_profile_id(profile_id: &RunProfileId) -> RunProfileId {
+    if profile_id.as_str() == "interactive_default" {
+        RunProfileId::default_profile()
+    } else {
+        profile_id.clone()
+    }
+}
+
+fn validate_thread_scope(
+    thread_scope: &ThreadScope,
+    run_context: &LoopRunContext,
+) -> Result<(), RebornLoopDriverHostError> {
+    if thread_scope.tenant_id != run_context.scope.tenant_id
+        || Some(thread_scope.agent_id.clone()) != run_context.scope.agent_id
+        || thread_scope.project_id != run_context.scope.project_id
+    {
+        return Err(RebornLoopDriverHostError::ScopeMismatch {
+            reason: "thread scope does not match loop run scope".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn turn_error_to_host_error(error: TurnError) -> AgentLoopHostError {
+    match error {
+        TurnError::Unauthorized => AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Unauthorized,
+            "checkpoint state access was unauthorized",
+        ),
+        TurnError::InvalidRequest { .. } => AgentLoopHostError::new(
+            AgentLoopHostErrorKind::InvalidInvocation,
+            "checkpoint state request is invalid",
+        ),
+        TurnError::Unavailable { .. } => AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Unavailable,
+            "checkpoint state store is unavailable",
+        ),
+        TurnError::ScopeNotFound
+        | TurnError::Conflict { .. }
+        | TurnError::InvalidTransition { .. }
+        | TurnError::LeaseMismatch => AgentLoopHostError::new(
+            AgentLoopHostErrorKind::CheckpointRejected,
+            "checkpoint state ref is unavailable for this loop run",
+        ),
+        TurnError::ThreadBusy(_) | TurnError::AdmissionRejected(_) => AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Unavailable,
+            "checkpoint state store returned unsupported turn admission status",
+        ),
+    }
+}

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -18,9 +18,10 @@ use ironclaw_turns::{
     AcceptedMessageRef, CheckpointStateStore, EventCursor, GetCheckpointStateRequest,
     GetLoopCheckpointRequest, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
     InMemoryRunProfileResolver, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits,
-    LoopCheckpointStore, PutCheckpointStateRequest, ReplyTargetBindingRef, RunProfileId,
-    RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion, SourceBindingRef,
-    TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope, TurnStatus,
+    LoopCheckpointRecord, LoopCheckpointStore, PutCheckpointStateRequest, PutLoopCheckpointRequest,
+    ReplyTargetBindingRef, RunProfileId, RunProfileResolutionRequest, RunProfileResolver,
+    RunProfileVersion, SourceBindingRef, TurnError, TurnLeaseToken, TurnRunId, TurnRunnerId,
+    TurnScope, TurnStatus,
     run_profile::{
         AgentLoopDriverHost, AgentLoopHostErrorKind, CapabilityInputRef, CapabilityInvocation,
         CapabilityOutcome, CapabilitySurfaceVersion, FinalizeAssistantMessage,
@@ -394,6 +395,26 @@ async fn text_only_host_factory_rejects_thread_scope_mismatch() {
 }
 
 #[tokio::test]
+async fn text_only_host_factory_rejects_agentless_turn_scope() {
+    let fixture = HostFixture::new("thread-host-agentless-scope", "hello").await;
+    let mut context = fixture.context.clone();
+    context.scope.agent_id = None;
+    let mut claimed = fixture.claimed.clone();
+    claimed.state.scope = context.scope.clone();
+
+    let error = fixture
+        .factory()
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: claimed,
+            loop_run_context: context,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("agent-scoped thread"));
+}
+
+#[tokio::test]
 async fn text_only_host_factory_rejects_persisted_profile_identity_mismatch() {
     let fixture = HostFixture::new("thread-host-profile-mismatch", "hello").await;
     let mut claimed = fixture.claimed.clone();
@@ -578,6 +599,32 @@ async fn text_only_host_checkpoint_port_rejects_kind_mismatch() {
         .unwrap_err();
 
     assert_eq!(error.kind, AgentLoopHostErrorKind::CheckpointRejected);
+}
+
+#[tokio::test]
+async fn text_only_host_checkpoint_port_maps_store_failures_to_unavailable() {
+    let fixture = HostFixture::new("thread-host-checkpoint-store-error", "hello").await;
+    let factory = fixture.factory_with_loop_checkpoint_store(Arc::new(FailingLoopCheckpointStore));
+    let host = factory
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: fixture.claimed.clone(),
+            loop_run_context: fixture.context.clone(),
+        })
+        .await
+        .unwrap();
+    let state = fixture
+        .stage_checkpoint_state(LoopCheckpointKind::BeforeBlock, b"state before store error")
+        .await;
+
+    let error = host
+        .checkpoint(LoopCheckpointRequest {
+            kind: LoopCheckpointKind::BeforeBlock,
+            state_ref: state.state_ref,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::Unavailable);
 }
 
 #[tokio::test]
@@ -804,6 +851,10 @@ fn thread_scope_from_turn(scope: &TurnScope) -> ThreadScope {
 }
 
 fn assert_public_milestones_hide_raw_payloads(milestones: &[LoopHostMilestone]) {
+    // Milestones are public progress metadata: they may carry durable refs and
+    // safe summaries, never raw model text, checkpoint bytes, tool input,
+    // secrets, or host paths. Drivers must rehydrate content through scoped
+    // stores instead of learning it from milestone JSON.
     let wire = serde_json::to_string(milestones).unwrap();
     for forbidden in [
         "RAW_CHECKPOINT_PAYLOAD",
@@ -813,6 +864,29 @@ fn assert_public_milestones_hide_raw_payloads(milestones: &[LoopHostMilestone]) 
         "model says hi",
     ] {
         assert!(!wire.contains(forbidden), "milestone leaked {forbidden}");
+    }
+}
+
+struct FailingLoopCheckpointStore;
+
+#[async_trait]
+impl LoopCheckpointStore for FailingLoopCheckpointStore {
+    async fn put_loop_checkpoint(
+        &self,
+        _request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError> {
+        Err(TurnError::Unavailable {
+            reason: "loop checkpoint store offline".to_string(),
+        })
+    }
+
+    async fn get_loop_checkpoint(
+        &self,
+        _request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        Err(TurnError::Unavailable {
+            reason: "loop checkpoint store offline".to_string(),
+        })
     }
 }
 

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -27,8 +27,8 @@ use ironclaw_turns::{
         InMemoryLoopHostMilestoneSink, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
         LoopCheckpointRequest, LoopContextRequest, LoopDriverId, LoopDriverNoteKind,
         LoopHostMilestone, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelRequest,
-        LoopProgressEvent, LoopPromptBundleRequest, LoopRunContext, ParentLoopOutput, PromptMode,
-        VisibleCapabilityRequest,
+        LoopProgressEvent, LoopPromptBundleRequest, LoopPromptPort, LoopRunContext,
+        ParentLoopOutput, PromptMode, VisibleCapabilityRequest,
     },
     runner::ClaimedTurnRun,
 };
@@ -151,6 +151,29 @@ async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
         ]
     );
     assert_public_milestones_hide_raw_payloads(&fixture.milestones());
+}
+
+#[tokio::test]
+async fn text_only_host_prompt_accepts_empty_surface_version() {
+    let fixture = HostFixture::new("thread-host-prompt-surface", "hello reborn").await;
+    let host = fixture.build_host().await;
+    let surface = host
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+
+    let prompt_bundle = host
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(surface.version),
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(prompt_bundle.messages.len(), 1);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -17,10 +17,10 @@ use ironclaw_threads::{
 use ironclaw_turns::{
     AcceptedMessageRef, CheckpointStateStore, EventCursor, GetCheckpointStateRequest,
     GetLoopCheckpointRequest, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
-    InMemoryRunProfileResolver, LoopCheckpointStore, PutCheckpointStateRequest,
-    ReplyTargetBindingRef, RunProfileId, RunProfileResolutionRequest, RunProfileResolver,
-    RunProfileVersion, SourceBindingRef, TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope,
-    TurnStatus,
+    InMemoryRunProfileResolver, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits,
+    LoopCheckpointStore, PutCheckpointStateRequest, ReplyTargetBindingRef, RunProfileId,
+    RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion, SourceBindingRef,
+    TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope, TurnStatus,
     run_profile::{
         AgentLoopDriverHost, AgentLoopHostErrorKind, CapabilityInputRef, CapabilityInvocation,
         CapabilityOutcome, CapabilitySurfaceVersion, FinalizeAssistantMessage,
@@ -154,6 +154,110 @@ async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
 }
 
 #[tokio::test]
+async fn text_only_host_e2e_flow_persists_checkpoint_mapping_in_turn_state_store() {
+    let fixture = HostFixture::new("thread-host-turn-state-e2e", "hello durable host").await;
+    let turn_state_store = Arc::new(InMemoryTurnStateStore::default());
+    let host = fixture
+        .factory_with_loop_checkpoint_store(turn_state_store.clone())
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: fixture.claimed.clone(),
+            loop_run_context: fixture.context.clone(),
+        })
+        .await
+        .unwrap();
+    let host_dyn: &(dyn AgentLoopDriverHost + Send + Sync) = &host;
+
+    let surface = host_dyn
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+    let surface_version = surface.version.clone();
+    let prompt_bundle = host_dyn
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(surface_version.clone()),
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+        })
+        .await
+        .unwrap();
+    let model_response = host_dyn
+        .stream_model(LoopModelRequest {
+            messages: prompt_bundle.messages,
+            surface_version: Some(surface_version.clone()),
+            model_preference: None,
+        })
+        .await
+        .unwrap();
+    let ParentLoopOutput::AssistantReply(reply) = model_response.output else {
+        panic!("expected assistant reply");
+    };
+    host_dyn
+        .finalize_assistant_message(FinalizeAssistantMessage { reply })
+        .await
+        .unwrap();
+    let gateway_requests = fixture.gateway.requests();
+    assert_eq!(gateway_requests.len(), 1);
+    assert_eq!(
+        gateway_requests[0].run_id,
+        fixture.context.run_id.to_string()
+    );
+    assert_eq!(
+        gateway_requests[0].turn_id,
+        fixture.context.turn_id.to_string()
+    );
+    assert_eq!(
+        gateway_requests[0].surface_version.as_ref(),
+        Some(&surface_version)
+    );
+
+    let checkpoint_state = fixture
+        .stage_checkpoint_state(LoopCheckpointKind::BeforeBlock, b"durable resume bytes")
+        .await;
+    let checkpoint_id = host_dyn
+        .checkpoint(LoopCheckpointRequest {
+            kind: LoopCheckpointKind::BeforeBlock,
+            state_ref: checkpoint_state.state_ref.clone(),
+        })
+        .await
+        .unwrap();
+
+    let snapshot = turn_state_store.persistence_snapshot();
+    assert_eq!(snapshot.loop_checkpoints.len(), 1);
+    let reopened = InMemoryTurnStateStore::from_persistence_snapshot(
+        snapshot,
+        InMemoryTurnStateStoreLimits::default(),
+    )
+    .unwrap();
+    let checkpoint_record = reopened
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope: fixture.context.scope.clone(),
+            turn_id: fixture.context.turn_id,
+            run_id: fixture.context.run_id,
+            checkpoint_id,
+        })
+        .await
+        .unwrap()
+        .expect("checkpoint id should survive turn-state reload");
+    assert_eq!(checkpoint_record.state_ref, checkpoint_state.state_ref);
+
+    let history = fixture
+        .thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: fixture.thread_scope.clone(),
+            thread_id: fixture.thread_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(history.messages.iter().any(|message| {
+        message.kind == MessageKind::Assistant
+            && message.status == MessageStatus::Finalized
+            && message.content.as_deref() == Some("model says hi")
+    }));
+}
+
+#[tokio::test]
 async fn text_only_host_prompt_accepts_empty_surface_version() {
     let fixture = HostFixture::new("thread-host-prompt-surface", "hello reborn").await;
     let host = fixture.build_host().await;
@@ -177,6 +281,55 @@ async fn text_only_host_prompt_accepts_empty_surface_version() {
 }
 
 #[tokio::test]
+async fn text_only_host_prompt_rejects_stale_surface_version() {
+    let fixture = HostFixture::new("thread-host-prompt-stale", "hello reborn").await;
+    let host = fixture.build_host().await;
+
+    let error = host
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(CapabilitySurfaceVersion::new("stale:v1").unwrap()),
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::StaleSurface);
+}
+
+#[tokio::test]
+async fn text_only_host_prompt_rejects_codeact_mode_and_zero_budget() {
+    let fixture = HostFixture::new("thread-host-prompt-mode", "hello reborn").await;
+    let host = fixture.build_host().await;
+
+    let codeact = host
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::CodeAct,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(codeact.kind, AgentLoopHostErrorKind::PolicyDenied);
+
+    let zero_budget = host
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(0),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(zero_budget.kind, AgentLoopHostErrorKind::BudgetExceeded);
+}
+
+#[tokio::test]
 async fn text_only_host_factory_rejects_scope_mismatch() {
     let fixture = HostFixture::new("thread-host-scope", "hello").await;
     let mut wrong_context = fixture.context.clone();
@@ -192,6 +345,52 @@ async fn text_only_host_factory_rejects_scope_mismatch() {
         .unwrap_err();
 
     assert!(error.to_string().contains("claimed run"));
+}
+
+#[tokio::test]
+async fn text_only_host_factory_rejects_non_running_claimed_run() {
+    let fixture = HostFixture::new("thread-host-non-running", "hello").await;
+    let mut claimed = fixture.claimed.clone();
+    claimed.state.status = TurnStatus::Queued;
+
+    let error = fixture
+        .factory()
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: claimed,
+            loop_run_context: fixture.context.clone(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("must be running"));
+}
+
+#[tokio::test]
+async fn text_only_host_factory_rejects_thread_scope_mismatch() {
+    let fixture = HostFixture::new("thread-host-thread-scope-mismatch", "hello").await;
+    let wrong_scope = ThreadScope {
+        tenant_id: TenantId::new("tenant-other").unwrap(),
+        ..fixture.thread_scope.clone()
+    };
+    let factory = RebornLoopDriverHostFactory::new(
+        Arc::clone(&fixture.thread_service),
+        wrong_scope,
+        Arc::clone(&fixture.gateway),
+        fixture.checkpoint_state_store.clone(),
+        fixture.loop_checkpoint_store.clone(),
+        fixture.milestone_sink.clone(),
+        TextOnlyLoopHostConfig { max_messages: 8 },
+    );
+
+    let error = factory
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: fixture.claimed.clone(),
+            loop_run_context: fixture.context.clone(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("thread scope"));
 }
 
 #[tokio::test]
@@ -249,6 +448,28 @@ async fn no_extra_loop_input_port_rejects_foreign_cursor() {
             ),
             8,
         )
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
+}
+
+#[tokio::test]
+async fn no_extra_loop_input_port_ack_rejects_foreign_cursor() {
+    let fixture = HostFixture::new("thread-host-input-ack", "hello").await;
+    let host = fixture.build_host().await;
+    let other_context = LoopRunContext::new(
+        fixture.context.scope.clone(),
+        fixture.context.turn_id,
+        TurnRunId::new(),
+        fixture.context.resolved_run_profile.clone(),
+    );
+
+    let error = host
+        .ack_inputs(LoopInputCursor::from_host_token(
+            &other_context,
+            LoopInputCursorToken::new("input-cursor:foreign-ack").unwrap(),
+        ))
         .await
         .unwrap_err();
 
@@ -333,6 +554,25 @@ async fn text_only_host_checkpoint_port_rejects_foreign_state_ref() {
         .checkpoint(LoopCheckpointRequest {
             kind: LoopCheckpointKind::BeforeModel,
             state_ref: foreign_state.state_ref,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::CheckpointRejected);
+}
+
+#[tokio::test]
+async fn text_only_host_checkpoint_port_rejects_kind_mismatch() {
+    let fixture = HostFixture::new("thread-host-checkpoint-kind", "hello").await;
+    let host = fixture.build_host().await;
+    let state = fixture
+        .stage_checkpoint_state(LoopCheckpointKind::BeforeModel, b"model checkpoint")
+        .await;
+
+    let error = host
+        .checkpoint(LoopCheckpointRequest {
+            kind: LoopCheckpointKind::BeforeSideEffect,
+            state_ref: state.state_ref,
         })
         .await
         .unwrap_err();
@@ -494,12 +734,19 @@ impl HostFixture {
     fn factory(
         &self,
     ) -> RebornLoopDriverHostFactory<InMemorySessionThreadService, RecordingGateway> {
+        self.factory_with_loop_checkpoint_store(self.loop_checkpoint_store.clone())
+    }
+
+    fn factory_with_loop_checkpoint_store(
+        &self,
+        loop_checkpoint_store: Arc<dyn LoopCheckpointStore>,
+    ) -> RebornLoopDriverHostFactory<InMemorySessionThreadService, RecordingGateway> {
         RebornLoopDriverHostFactory::new(
             Arc::clone(&self.thread_service),
             self.thread_scope.clone(),
             Arc::clone(&self.gateway),
             self.checkpoint_state_store.clone(),
-            self.loop_checkpoint_store.clone(),
+            loop_checkpoint_store,
             self.milestone_sink.clone(),
             TextOnlyLoopHostConfig { max_messages: 8 },
         )

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -1,0 +1,576 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_host_api::{AgentId, CapabilityId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_loop_support::{
+    HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
+    HostManagedModelResponse,
+};
+use ironclaw_reborn::{
+    RebornLoopDriverHostFactory, RebornLoopDriverHostRequest, TextOnlyLoopHostConfig,
+};
+use ironclaw_threads::{
+    AcceptInboundMessageRequest, EnsureThreadRequest, InMemorySessionThreadService, MessageContent,
+    MessageKind, MessageStatus, SessionThreadService, ThreadHistoryRequest, ThreadScope,
+};
+use ironclaw_turns::{
+    AcceptedMessageRef, CheckpointStateStore, EventCursor, GetCheckpointStateRequest,
+    GetLoopCheckpointRequest, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
+    InMemoryRunProfileResolver, LoopCheckpointStore, PutCheckpointStateRequest,
+    ReplyTargetBindingRef, RunProfileId, RunProfileResolutionRequest, RunProfileResolver,
+    RunProfileVersion, SourceBindingRef, TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope,
+    TurnStatus,
+    run_profile::{
+        AgentLoopDriverHost, AgentLoopHostErrorKind, CapabilityInputRef, CapabilityInvocation,
+        CapabilityOutcome, CapabilitySurfaceVersion, FinalizeAssistantMessage,
+        InMemoryLoopHostMilestoneSink, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
+        LoopCheckpointRequest, LoopContextRequest, LoopDriverId, LoopDriverNoteKind,
+        LoopHostMilestone, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelRequest,
+        LoopProgressEvent, LoopPromptBundleRequest, LoopRunContext, ParentLoopOutput, PromptMode,
+        VisibleCapabilityRequest,
+    },
+    runner::ClaimedTurnRun,
+};
+
+#[tokio::test]
+async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
+    let fixture = HostFixture::new("thread-host-complete", "hello reborn").await;
+    let host = fixture.build_host().await;
+    let host_dyn: &(dyn AgentLoopDriverHost + Send + Sync) = &host;
+
+    assert_eq!(host_dyn.run_context().run_id, fixture.context.run_id);
+
+    let context = host_dyn
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 8,
+        })
+        .await
+        .unwrap();
+    assert_eq!(context.messages.len(), 1);
+
+    let input = host_dyn
+        .poll_inputs(LoopInputCursor::origin_for_run(&fixture.context), 8)
+        .await
+        .unwrap();
+    assert!(input.inputs.is_empty());
+    host_dyn.ack_inputs(input.next_cursor).await.unwrap();
+
+    let surface = host_dyn
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+    assert!(surface.descriptors.is_empty());
+
+    let prompt_bundle = host_dyn
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+        })
+        .await
+        .unwrap();
+    assert_eq!(prompt_bundle.messages.len(), 1);
+
+    let model_response = host_dyn
+        .stream_model(LoopModelRequest {
+            messages: prompt_bundle.messages,
+            surface_version: Some(surface.version.clone()),
+            model_preference: None,
+        })
+        .await
+        .unwrap();
+    let ParentLoopOutput::AssistantReply(reply) = model_response.output else {
+        panic!("expected assistant reply");
+    };
+
+    let reply_ref = host_dyn
+        .finalize_assistant_message(FinalizeAssistantMessage { reply })
+        .await
+        .unwrap();
+    assert!(reply_ref.as_str().starts_with("msg:"));
+
+    let checkpoint_state = fixture
+        .stage_checkpoint_state(
+            LoopCheckpointKind::BeforeModel,
+            b"RAW_CHECKPOINT_PAYLOAD sk-secret",
+        )
+        .await;
+    let checkpoint_id = host_dyn
+        .checkpoint(LoopCheckpointRequest {
+            kind: LoopCheckpointKind::BeforeModel,
+            state_ref: checkpoint_state.state_ref.clone(),
+        })
+        .await
+        .unwrap();
+    let _ = checkpoint_id;
+
+    host_dyn
+        .emit_loop_progress(
+            LoopProgressEvent::driver_note(LoopDriverNoteKind::Planning, "safe driver note")
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let history = fixture
+        .thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: fixture.thread_scope.clone(),
+            thread_id: fixture.thread_id.clone(),
+        })
+        .await
+        .unwrap();
+    let assistant = history
+        .messages
+        .iter()
+        .find(|message| message.kind == MessageKind::Assistant)
+        .expect("assistant reply should be persisted");
+    assert_eq!(assistant.status, MessageStatus::Finalized);
+    assert_eq!(assistant.content.as_deref(), Some("model says hi"));
+
+    assert_eq!(fixture.gateway.requests().len(), 1);
+    assert_eq!(
+        fixture.gateway.requests()[0].messages[0].content,
+        "hello reborn"
+    );
+
+    let milestone_names = fixture.milestone_names();
+    assert_eq!(
+        milestone_names,
+        vec![
+            "prompt_bundle_built",
+            "model_started",
+            "model_completed",
+            "assistant_reply_finalized",
+            "checkpoint_created",
+            "driver_note",
+        ]
+    );
+    assert_public_milestones_hide_raw_payloads(&fixture.milestones());
+}
+
+#[tokio::test]
+async fn text_only_host_factory_rejects_scope_mismatch() {
+    let fixture = HostFixture::new("thread-host-scope", "hello").await;
+    let mut wrong_context = fixture.context.clone();
+    wrong_context.run_id = TurnRunId::new();
+
+    let error = fixture
+        .factory()
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: fixture.claimed.clone(),
+            loop_run_context: wrong_context,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("claimed run"));
+}
+
+#[tokio::test]
+async fn text_only_host_factory_rejects_persisted_profile_identity_mismatch() {
+    let fixture = HostFixture::new("thread-host-profile-mismatch", "hello").await;
+    let mut claimed = fixture.claimed.clone();
+    claimed.state.resolved_run_profile_version = RunProfileVersion::new(999);
+
+    let error = fixture
+        .factory()
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: claimed,
+            loop_run_context: fixture.context.clone(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("profile identity"));
+}
+
+#[tokio::test]
+async fn text_only_host_factory_rejects_loop_driver_identity_mismatch() {
+    let fixture = HostFixture::new("thread-host-driver-mismatch", "hello").await;
+    let mut wrong_context = fixture.context.clone();
+    wrong_context.loop_driver_id = LoopDriverId::new("other_loop_driver").unwrap();
+
+    let error = fixture
+        .factory()
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: fixture.claimed.clone(),
+            loop_run_context: wrong_context,
+        })
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("driver identity"));
+}
+
+#[tokio::test]
+async fn no_extra_loop_input_port_rejects_foreign_cursor() {
+    let fixture = HostFixture::new("thread-host-input", "hello").await;
+    let host = fixture.build_host().await;
+    let other_context = LoopRunContext::new(
+        fixture.context.scope.clone(),
+        fixture.context.turn_id,
+        TurnRunId::new(),
+        fixture.context.resolved_run_profile.clone(),
+    );
+
+    let error = host
+        .poll_inputs(
+            LoopInputCursor::from_host_token(
+                &other_context,
+                LoopInputCursorToken::new("input-cursor:foreign").unwrap(),
+            ),
+            8,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::ScopeMismatch);
+}
+
+#[tokio::test]
+async fn text_only_host_checkpoint_port_persists_ref_without_public_payload() {
+    let fixture = HostFixture::new("thread-host-checkpoint", "hello").await;
+    let host = fixture.build_host().await;
+    let checkpoint_state = fixture
+        .stage_checkpoint_state(
+            LoopCheckpointKind::BeforeSideEffect,
+            b"RAW_CHECKPOINT_PAYLOAD sk-secret /host/path tool_input",
+        )
+        .await;
+
+    let checkpoint_id = host
+        .checkpoint(LoopCheckpointRequest {
+            kind: LoopCheckpointKind::BeforeSideEffect,
+            state_ref: checkpoint_state.state_ref.clone(),
+        })
+        .await
+        .unwrap();
+    let checkpoint_record = fixture
+        .loop_checkpoint_store
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope: fixture.context.scope.clone(),
+            turn_id: fixture.context.turn_id,
+            run_id: fixture.context.run_id,
+            checkpoint_id,
+        })
+        .await
+        .unwrap()
+        .expect("returned checkpoint id should resolve to staged state ref");
+    assert_eq!(checkpoint_record.state_ref, checkpoint_state.state_ref);
+    assert!(
+        fixture
+            .checkpoint_state_store
+            .get_checkpoint_state(GetCheckpointStateRequest {
+                scope: fixture.context.scope.clone(),
+                turn_id: fixture.context.turn_id,
+                run_id: fixture.context.run_id,
+                state_ref: checkpoint_record.state_ref,
+                schema_id: fixture.context.checkpoint_schema_id.clone(),
+                schema_version: fixture.context.checkpoint_schema_version,
+                kind: LoopCheckpointKind::BeforeSideEffect,
+            })
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    let wire = format!(
+        "{}{}",
+        serde_json::to_string(&checkpoint_id).unwrap(),
+        serde_json::to_string(&fixture.milestones()).unwrap()
+    );
+    for forbidden in [
+        "RAW_CHECKPOINT_PAYLOAD",
+        "sk-secret",
+        "/host/path",
+        "tool_input",
+    ] {
+        assert!(
+            !wire.contains(forbidden),
+            "public checkpoint wire leaked {forbidden}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn text_only_host_checkpoint_port_rejects_foreign_state_ref() {
+    let fixture = HostFixture::new("thread-host-checkpoint-foreign", "hello").await;
+    let host = fixture.build_host().await;
+    let foreign = HostFixture::new("thread-host-checkpoint-other", "hello").await;
+    let foreign_state = foreign
+        .stage_checkpoint_state(LoopCheckpointKind::BeforeModel, b"foreign state")
+        .await;
+
+    let error = host
+        .checkpoint(LoopCheckpointRequest {
+            kind: LoopCheckpointKind::BeforeModel,
+            state_ref: foreign_state.state_ref,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::CheckpointRejected);
+}
+
+#[tokio::test]
+async fn text_only_host_empty_capability_surface_denies_invocation() {
+    let fixture = HostFixture::new("thread-host-capability", "hello").await;
+    let host = fixture.build_host().await;
+    let surface = host
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+
+    let outcome = host
+        .invoke_capability_batch(ironclaw_turns::run_profile::CapabilityBatchInvocation {
+            invocations: vec![CapabilityInvocation {
+                surface_version: surface.version.clone(),
+                capability_id: CapabilityId::new("demo.echo").unwrap(),
+                input_ref: CapabilityInputRef::new("input:opaque-tool-input").unwrap(),
+            }],
+            stop_on_first_suspension: true,
+        })
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        outcome.outcomes.as_slice(),
+        [CapabilityOutcome::Denied(denied)] if denied.reason_kind == "empty_surface"
+    ));
+
+    let stale = host
+        .invoke_capability(CapabilityInvocation {
+            surface_version: CapabilitySurfaceVersion::new("other:v1").unwrap(),
+            capability_id: CapabilityId::new("demo.echo").unwrap(),
+            input_ref: CapabilityInputRef::new("input:opaque-tool-input").unwrap(),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(stale.kind, AgentLoopHostErrorKind::StaleSurface);
+}
+
+struct HostFixture {
+    thread_service: Arc<InMemorySessionThreadService>,
+    checkpoint_state_store: Arc<InMemoryCheckpointStateStore>,
+    loop_checkpoint_store: Arc<InMemoryLoopCheckpointStore>,
+    gateway: Arc<RecordingGateway>,
+    milestone_sink: Arc<InMemoryLoopHostMilestoneSink>,
+    thread_scope: ThreadScope,
+    thread_id: ThreadId,
+    claimed: ClaimedTurnRun,
+    context: LoopRunContext,
+}
+
+impl HostFixture {
+    async fn new(thread_name: &str, user_content: &str) -> Self {
+        let thread_service = Arc::new(InMemorySessionThreadService::default());
+        let checkpoint_state_store = Arc::new(InMemoryCheckpointStateStore::default());
+        let loop_checkpoint_store = Arc::new(InMemoryLoopCheckpointStore::default());
+        let gateway = Arc::new(RecordingGateway::reply("model says hi"));
+        let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+        let tenant_id = TenantId::new("tenant-text-host").unwrap();
+        let agent_id = AgentId::new("agent-text-host").unwrap();
+        let project_id = ProjectId::new("project-text-host").unwrap();
+        let user_id = UserId::new("user-text-host").unwrap();
+        let thread_id = ThreadId::new(thread_name).unwrap();
+        let thread_scope = ThreadScope {
+            tenant_id: tenant_id.clone(),
+            agent_id: agent_id.clone(),
+            project_id: Some(project_id.clone()),
+            owner_user_id: Some(user_id.clone()),
+            mission_id: None,
+        };
+        thread_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: thread_scope.clone(),
+                thread_id: Some(thread_id.clone()),
+                created_by_actor_id: user_id.to_string(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        let accepted = thread_service
+            .accept_inbound_message(AcceptInboundMessageRequest {
+                scope: thread_scope.clone(),
+                thread_id: thread_id.clone(),
+                actor_id: user_id.to_string(),
+                source_binding_id: Some("source-web".to_string()),
+                reply_target_binding_id: Some("reply-web".to_string()),
+                external_event_id: Some(format!("event-{thread_name}")),
+                content: MessageContent::text(user_content),
+            })
+            .await
+            .unwrap();
+
+        let turn_scope = TurnScope::new(
+            tenant_id,
+            Some(agent_id),
+            Some(project_id),
+            thread_id.clone(),
+        );
+        let resolved = InMemoryRunProfileResolver::default()
+            .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+            .await
+            .unwrap();
+        let turn_id = ironclaw_turns::TurnId::new();
+        let run_id = TurnRunId::new();
+        let state = ironclaw_turns::TurnRunState {
+            scope: turn_scope.clone(),
+            turn_id,
+            run_id,
+            status: TurnStatus::Running,
+            accepted_message_ref: AcceptedMessageRef::new(format!("accepted-{thread_name}"))
+                .unwrap(),
+            source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
+            resolved_run_profile_id: RunProfileId::default_profile(),
+            resolved_run_profile_version: RunProfileVersion::new(1),
+            received_at: Utc::now(),
+            checkpoint_id: None,
+            gate_ref: None,
+            failure: None,
+            event_cursor: EventCursor(1),
+        };
+        let claimed = ClaimedTurnRun {
+            state,
+            resolved_run_profile: resolved.clone(),
+            runner_id: TurnRunnerId::new(),
+            lease_token: TurnLeaseToken::new(),
+        };
+        let context = LoopRunContext::new(turn_scope, turn_id, run_id, resolved);
+        thread_service
+            .mark_message_submitted(
+                &thread_scope_from_turn(&context.scope),
+                &thread_id,
+                accepted.message_id,
+                turn_id.to_string(),
+                run_id.to_string(),
+            )
+            .await
+            .unwrap();
+
+        Self {
+            thread_service,
+            checkpoint_state_store,
+            loop_checkpoint_store,
+            gateway,
+            milestone_sink,
+            thread_scope,
+            thread_id,
+            claimed,
+            context,
+        }
+    }
+
+    fn factory(
+        &self,
+    ) -> RebornLoopDriverHostFactory<InMemorySessionThreadService, RecordingGateway> {
+        RebornLoopDriverHostFactory::new(
+            Arc::clone(&self.thread_service),
+            self.thread_scope.clone(),
+            Arc::clone(&self.gateway),
+            self.checkpoint_state_store.clone(),
+            self.loop_checkpoint_store.clone(),
+            self.milestone_sink.clone(),
+            TextOnlyLoopHostConfig { max_messages: 8 },
+        )
+    }
+
+    async fn build_host(&self) -> ironclaw_reborn::RebornLoopDriverHost {
+        self.factory()
+            .build_text_only_host(RebornLoopDriverHostRequest {
+                claimed_run: self.claimed.clone(),
+                loop_run_context: self.context.clone(),
+            })
+            .await
+            .unwrap()
+    }
+
+    async fn stage_checkpoint_state(
+        &self,
+        kind: LoopCheckpointKind,
+        payload: &[u8],
+    ) -> ironclaw_turns::CheckpointStateRecord {
+        self.checkpoint_state_store
+            .put_checkpoint_state(PutCheckpointStateRequest::new(
+                self.context.scope.clone(),
+                self.context.turn_id,
+                self.context.run_id,
+                self.context.checkpoint_schema_id.clone(),
+                self.context.checkpoint_schema_version,
+                kind,
+                payload.to_vec(),
+            ))
+            .await
+            .unwrap()
+    }
+
+    fn milestones(&self) -> Vec<LoopHostMilestone> {
+        self.milestone_sink.milestones()
+    }
+
+    fn milestone_names(&self) -> Vec<&'static str> {
+        self.milestones()
+            .iter()
+            .map(|milestone| milestone.kind.kind_name())
+            .collect()
+    }
+}
+
+fn thread_scope_from_turn(scope: &TurnScope) -> ThreadScope {
+    ThreadScope {
+        tenant_id: scope.tenant_id.clone(),
+        agent_id: scope.agent_id.clone().unwrap(),
+        project_id: scope.project_id.clone(),
+        owner_user_id: Some(UserId::new("user-text-host").unwrap()),
+        mission_id: None,
+    }
+}
+
+fn assert_public_milestones_hide_raw_payloads(milestones: &[LoopHostMilestone]) {
+    let wire = serde_json::to_string(milestones).unwrap();
+    for forbidden in [
+        "RAW_CHECKPOINT_PAYLOAD",
+        "sk-secret",
+        "/host/path",
+        "tool_input",
+        "model says hi",
+    ] {
+        assert!(!wire.contains(forbidden), "milestone leaked {forbidden}");
+    }
+}
+
+struct RecordingGateway {
+    requests: Mutex<Vec<HostManagedModelRequest>>,
+    response: HostManagedModelResponse,
+}
+
+impl RecordingGateway {
+    fn reply(content: impl Into<String>) -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            response: HostManagedModelResponse::assistant_reply(content),
+        }
+    }
+
+    fn requests(&self) -> Vec<HostManagedModelRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl HostManagedModelGateway for RecordingGateway {
+    async fn stream_model(
+        &self,
+        request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        self.requests.lock().unwrap().push(request);
+        Ok(self.response.clone())
+    }
+}

--- a/crates/ironclaw_turns/src/checkpoint_state.rs
+++ b/crates/ironclaw_turns/src/checkpoint_state.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fmt, sync::Mutex};
 
 use async_trait::async_trait;
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
@@ -148,7 +149,7 @@ pub trait CheckpointStateStore: Send + Sync {
     ) -> Result<Option<CheckpointStateRecord>, TurnError>;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopCheckpointRecord {
     pub checkpoint_id: TurnCheckpointId,
     pub scope: TurnScope,

--- a/crates/ironclaw_turns/src/checkpoint_state.rs
+++ b/crates/ironclaw_turns/src/checkpoint_state.rs
@@ -5,8 +5,8 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use crate::{
-    CheckpointSchemaId, LoopCheckpointKind, LoopCheckpointStateRef, RunProfileVersion, TurnError,
-    TurnId, TurnRunId, TurnScope, TurnTimestamp,
+    CheckpointSchemaId, LoopCheckpointKind, LoopCheckpointStateRef, RunProfileVersion,
+    TurnCheckpointId, TurnError, TurnId, TurnRunId, TurnScope, TurnTimestamp,
 };
 
 pub const MAX_CHECKPOINT_STATE_PAYLOAD_BYTES: usize = 64 * 1024;
@@ -148,9 +148,59 @@ pub trait CheckpointStateStore: Send + Sync {
     ) -> Result<Option<CheckpointStateRecord>, TurnError>;
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoopCheckpointRecord {
+    pub checkpoint_id: TurnCheckpointId,
+    pub scope: TurnScope,
+    pub turn_id: TurnId,
+    pub run_id: TurnRunId,
+    pub state_ref: LoopCheckpointStateRef,
+    pub schema_id: CheckpointSchemaId,
+    pub schema_version: RunProfileVersion,
+    pub kind: LoopCheckpointKind,
+    pub created_at: TurnTimestamp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PutLoopCheckpointRequest {
+    pub scope: TurnScope,
+    pub turn_id: TurnId,
+    pub run_id: TurnRunId,
+    pub state_ref: LoopCheckpointStateRef,
+    pub schema_id: CheckpointSchemaId,
+    pub schema_version: RunProfileVersion,
+    pub kind: LoopCheckpointKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetLoopCheckpointRequest {
+    pub scope: TurnScope,
+    pub turn_id: TurnId,
+    pub run_id: TurnRunId,
+    pub checkpoint_id: TurnCheckpointId,
+}
+
+#[async_trait]
+pub trait LoopCheckpointStore: Send + Sync {
+    async fn put_loop_checkpoint(
+        &self,
+        request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError>;
+
+    async fn get_loop_checkpoint(
+        &self,
+        request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError>;
+}
+
 #[derive(Default)]
 pub struct InMemoryCheckpointStateStore {
     records: Mutex<HashMap<LoopCheckpointStateRef, CheckpointStateRecord>>,
+}
+
+#[derive(Default)]
+pub struct InMemoryLoopCheckpointStore {
+    records: Mutex<HashMap<TurnCheckpointId, LoopCheckpointRecord>>,
 }
 
 #[async_trait]
@@ -193,7 +243,7 @@ impl CheckpointStateStore for InMemoryCheckpointStateStore {
         let Some(record) = records.get(&request.state_ref) else {
             return Ok(None);
         };
-        if record_matches_request(record, &request) {
+        if checkpoint_state_record_matches_request(record, &request) {
             Ok(Some(record.clone()))
         } else {
             Ok(None)
@@ -201,7 +251,50 @@ impl CheckpointStateStore for InMemoryCheckpointStateStore {
     }
 }
 
-fn record_matches_request(
+#[async_trait]
+impl LoopCheckpointStore for InMemoryLoopCheckpointStore {
+    async fn put_loop_checkpoint(
+        &self,
+        request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError> {
+        let checkpoint_id = TurnCheckpointId::new();
+        let record = LoopCheckpointRecord {
+            checkpoint_id,
+            scope: request.scope,
+            turn_id: request.turn_id,
+            run_id: request.run_id,
+            state_ref: request.state_ref,
+            schema_id: request.schema_id,
+            schema_version: request.schema_version,
+            kind: request.kind,
+            created_at: Utc::now(),
+        };
+        let mut records = self.records.lock().map_err(|_| TurnError::Unavailable {
+            reason: "loop checkpoint store lock poisoned".to_string(),
+        })?;
+        records.insert(checkpoint_id, record.clone());
+        Ok(record)
+    }
+
+    async fn get_loop_checkpoint(
+        &self,
+        request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        let records = self.records.lock().map_err(|_| TurnError::Unavailable {
+            reason: "loop checkpoint store lock poisoned".to_string(),
+        })?;
+        let Some(record) = records.get(&request.checkpoint_id) else {
+            return Ok(None);
+        };
+        if loop_checkpoint_record_matches_request(record, &request) {
+            Ok(Some(record.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn checkpoint_state_record_matches_request(
     record: &CheckpointStateRecord,
     request: &GetCheckpointStateRequest,
 ) -> bool {
@@ -211,6 +304,16 @@ fn record_matches_request(
         && record.schema_id == request.schema_id
         && record.schema_version == request.schema_version
         && record.kind == request.kind
+}
+
+fn loop_checkpoint_record_matches_request(
+    record: &LoopCheckpointRecord,
+    request: &GetLoopCheckpointRequest,
+) -> bool {
+    record.scope == request.scope
+        && record.turn_id == request.turn_id
+        && record.run_id == request.run_id
+        && record.checkpoint_id == request.checkpoint_id
 }
 
 fn new_state_ref() -> Result<LoopCheckpointStateRef, TurnError> {

--- a/crates/ironclaw_turns/src/db.rs
+++ b/crates/ironclaw_turns/src/db.rs
@@ -3,13 +3,15 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use crate::{
-    AllowAllTurnAdmissionLimitProvider, CancelRunRequest, CancelRunResponse, GetRunStateRequest,
-    InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, ResolvedRunProfile, ResumeTurnRequest,
-    ResumeTurnResponse, RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver,
-    SubmitTurnRequest, SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionLimitProvider,
-    TurnAdmissionPolicy, TurnAdmissionReservationRecord, TurnCheckpointRecord, TurnError,
-    TurnIdempotencyRecord, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord,
-    TurnRunState, TurnScope, TurnStateStore,
+    AllowAllTurnAdmissionLimitProvider, CancelRunRequest, CancelRunResponse,
+    GetLoopCheckpointRequest, GetRunStateRequest, InMemoryTurnStateStore,
+    InMemoryTurnStateStoreLimits, LoopCheckpointRecord, LoopCheckpointStore,
+    PutLoopCheckpointRequest, ResolvedRunProfile, ResumeTurnRequest, ResumeTurnResponse,
+    RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver, SubmitTurnRequest,
+    SubmitTurnResponse, TurnActiveLockRecord, TurnAdmissionLimitProvider, TurnAdmissionPolicy,
+    TurnAdmissionReservationRecord, TurnCheckpointRecord, TurnError, TurnIdempotencyRecord,
+    TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRecord, TurnRunRecord, TurnRunState,
+    TurnScope, TurnStateStore,
     events::{EventCursor, TurnEventPage, TurnEventProjectionSource, project_turn_events},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -87,6 +89,16 @@ CREATE TABLE IF NOT EXISTS turn_checkpoints (
 );
 CREATE INDEX IF NOT EXISTS idx_turn_checkpoints_run ON turn_checkpoints(run_id, sequence);
 
+CREATE TABLE IF NOT EXISTS turn_loop_checkpoints (
+    checkpoint_id TEXT PRIMARY KEY,
+    scope_key TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_loop_checkpoints_run ON turn_loop_checkpoints(scope_key, turn_id, run_id);
+
 CREATE TABLE IF NOT EXISTS turn_idempotency_records (
     record_key TEXT PRIMARY KEY,
     scope_key TEXT NOT NULL,
@@ -156,6 +168,16 @@ CREATE TABLE IF NOT EXISTS turn_checkpoints (
     payload JSONB NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_turn_checkpoints_run ON turn_checkpoints(run_id, sequence);
+
+CREATE TABLE IF NOT EXISTS turn_loop_checkpoints (
+    checkpoint_id TEXT PRIMARY KEY,
+    scope_key TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    payload JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turn_loop_checkpoints_run ON turn_loop_checkpoints(scope_key, turn_id, run_id);
 
 CREATE TABLE IF NOT EXISTS turn_idempotency_records (
     record_key TEXT PRIMARY KEY,
@@ -351,6 +373,38 @@ impl TurnEventProjectionSource for LibSqlTurnStateStore {
             limit,
             snapshot.event_retention_floor,
         ))
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl LoopCheckpointStore for LibSqlTurnStateStore {
+    async fn put_loop_checkpoint(
+        &self,
+        request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError> {
+        let conn = self.begin_immediate().await?;
+        let result = async {
+            let store = self.load_store_from_conn(&conn).await?;
+            let result = store.put_loop_checkpoint(request).await;
+            libsql_replace_snapshot(&conn, &store.persistence_snapshot()).await?;
+            Ok(result)
+        }
+        .await;
+        finish_libsql_transaction(&conn, result).await?
+    }
+
+    async fn get_loop_checkpoint(
+        &self,
+        request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        self.load_snapshot()
+            .await
+            .and_then(|snapshot| {
+                InMemoryTurnStateStore::from_persistence_snapshot(snapshot, self.limits)
+            })?
+            .get_loop_checkpoint(request)
+            .await
     }
 }
 
@@ -637,6 +691,37 @@ impl TurnEventProjectionSource for PostgresTurnStateStore {
 
 #[cfg(feature = "postgres")]
 #[async_trait]
+impl LoopCheckpointStore for PostgresTurnStateStore {
+    async fn put_loop_checkpoint(
+        &self,
+        request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError> {
+        let mut client = self.client().await?;
+        let txn = client.transaction().await.map_err(db_error)?;
+        lock_postgres_turn_tables(&txn, "SHARE ROW EXCLUSIVE MODE").await?;
+        let store = self.load_store_from_txn(&txn).await?;
+        let result = store.put_loop_checkpoint(request).await;
+        postgres_replace_snapshot(&txn, &store.persistence_snapshot()).await?;
+        txn.commit().await.map_err(db_error)?;
+        result
+    }
+
+    async fn get_loop_checkpoint(
+        &self,
+        request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        self.load_snapshot()
+            .await
+            .and_then(|snapshot| {
+                InMemoryTurnStateStore::from_persistence_snapshot(snapshot, self.limits)
+            })?
+            .get_loop_checkpoint(request)
+            .await
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait]
 impl TurnRunTransitionPort for PostgresTurnStateStore {
     async fn claim_next_run(
         &self,
@@ -812,6 +897,11 @@ async fn libsql_load_snapshot(
         "SELECT payload FROM turn_checkpoints ORDER BY run_id, sequence",
     )
     .await?;
+    let loop_checkpoints = libsql_load_payloads::<LoopCheckpointRecord>(
+        conn,
+        "SELECT payload FROM turn_loop_checkpoints ORDER BY created_at, checkpoint_id",
+    )
+    .await?;
     let idempotency_records = libsql_load_payloads::<TurnIdempotencyRecord>(
         conn,
         "SELECT payload FROM turn_idempotency_records ORDER BY created_at, record_key",
@@ -833,6 +923,7 @@ async fn libsql_load_snapshot(
         runs,
         active_locks,
         checkpoints,
+        loop_checkpoints,
         idempotency_records,
         events,
         event_retention_floor,
@@ -867,6 +958,7 @@ async fn libsql_replace_snapshot(
         "turn_lifecycle_events",
         "turn_admission_reservations",
         "turn_idempotency_records",
+        "turn_loop_checkpoints",
         "turn_checkpoints",
         "turn_active_locks",
         "turn_run_records",
@@ -924,6 +1016,21 @@ async fn libsql_replace_snapshot(
                 record.checkpoint_id.as_uuid().to_string(),
                 record.run_id.to_string(),
                 record.sequence as i64,
+                to_json(record)?,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.loop_checkpoints {
+        conn.execute(
+            "INSERT INTO turn_loop_checkpoints (checkpoint_id, scope_key, turn_id, run_id, created_at, payload) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            libsql::params![
+                record.checkpoint_id.as_uuid().to_string(),
+                scope_key(&record.scope)?,
+                record.turn_id.to_string(),
+                record.run_id.to_string(),
+                record.created_at.to_rfc3339(),
                 to_json(record)?,
             ],
         )
@@ -988,7 +1095,7 @@ async fn lock_postgres_turn_tables(
     mode: &str,
 ) -> Result<(), TurnError> {
     let statement = format!(
-        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_idempotency_records, turn_lifecycle_events, turn_store_metadata, turn_admission_reservations IN {mode}"
+        "LOCK TABLE turn_records, turn_run_records, turn_active_locks, turn_checkpoints, turn_loop_checkpoints, turn_idempotency_records, turn_lifecycle_events, turn_store_metadata, turn_admission_reservations IN {mode}"
     );
     client.batch_execute(&statement).await.map_err(db_error)
 }
@@ -1052,6 +1159,11 @@ async fn postgres_load_snapshot(
         "SELECT payload::text FROM turn_checkpoints ORDER BY run_id, sequence",
     )
     .await?;
+    let loop_checkpoints = postgres_load_payloads::<LoopCheckpointRecord>(
+        client,
+        "SELECT payload::text FROM turn_loop_checkpoints ORDER BY created_at, checkpoint_id",
+    )
+    .await?;
     let idempotency_records = postgres_load_payloads::<TurnIdempotencyRecord>(
         client,
         "SELECT payload::text FROM turn_idempotency_records ORDER BY created_at, record_key",
@@ -1073,6 +1185,7 @@ async fn postgres_load_snapshot(
         runs,
         active_locks,
         checkpoints,
+        loop_checkpoints,
         idempotency_records,
         events,
         event_retention_floor,
@@ -1090,6 +1203,7 @@ async fn postgres_replace_snapshot(
         "turn_lifecycle_events",
         "turn_admission_reservations",
         "turn_idempotency_records",
+        "turn_loop_checkpoints",
         "turn_checkpoints",
         "turn_active_locks",
         "turn_run_records",
@@ -1151,6 +1265,22 @@ async fn postgres_replace_snapshot(
                 &record.checkpoint_id.as_uuid().to_string(),
                 &record.run_id.to_string(),
                 &(record.sequence as i64),
+                &payload,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    }
+    for record in &snapshot.loop_checkpoints {
+        let payload = to_json(record)?;
+        txn.execute(
+            "INSERT INTO turn_loop_checkpoints (checkpoint_id, scope_key, turn_id, run_id, created_at, payload) VALUES ($1, $2, $3, $4, $5::timestamptz, $6::jsonb)",
+            &[
+                &record.checkpoint_id.as_uuid().to_string(),
+                &scope_key(&record.scope)?,
+                &record.turn_id.to_string(),
+                &record.run_id.to_string(),
+                &record.created_at.to_rfc3339(),
                 &payload,
             ],
         )

--- a/crates/ironclaw_turns/src/ids.rs
+++ b/crates/ironclaw_turns/src/ids.rs
@@ -205,7 +205,19 @@ loop_ref!(LoopDiagnosticRef, "loop_diagnostic_ref", "diag:");
 
 impl RunProfileId {
     pub fn default_profile() -> Self {
-        Self("default".to_string())
+        Self::from_trusted_static("default")
+    }
+
+    pub fn interactive_default() -> Self {
+        Self::from_trusted_static("interactive_default")
+    }
+
+    pub fn long_running_mission() -> Self {
+        Self::from_trusted_static("long_running_mission")
+    }
+
+    pub fn is_interactive_default(&self) -> bool {
+        self == &Self::interactive_default()
     }
 
     pub(crate) fn from_trusted_static(value: &'static str) -> Self {

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -30,8 +30,9 @@ pub use admission::{
 };
 pub use checkpoint_state::{
     CheckpointStateRecord, CheckpointStateStore, GetCheckpointStateRequest,
-    InMemoryCheckpointStateStore, MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, PutCheckpointStateRequest,
-    RedactedCheckpointPayload,
+    GetLoopCheckpointRequest, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
+    LoopCheckpointRecord, LoopCheckpointStore, MAX_CHECKPOINT_STATE_PAYLOAD_BYTES,
+    PutCheckpointStateRequest, PutLoopCheckpointRequest, RedactedCheckpointPayload,
 };
 pub use coordinator::{
     AllowAllTurnAdmissionPolicy, DefaultTurnCoordinator, NoopTurnRunWakeNotifier,

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -10,10 +10,11 @@ use chrono::{Duration as ChronoDuration, Utc};
 use crate::{
     AcceptedMessageRef, AdmissionRejection, AdmissionRejectionReason,
     AllowAllTurnAdmissionLimitProvider, BlockedReason, CancelRunRequest, CancelRunResponse,
-    GetRunStateRequest, IdempotencyKey, LoopExitMapping, ReplyTargetBindingRef, ResumeTurnRequest,
-    ResumeTurnResponse, RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver,
-    SanitizedFailure, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy,
-    TurnActiveLockKey, TurnActiveLockRecord, TurnActor, TurnAdmissionClass,
+    GetLoopCheckpointRequest, GetRunStateRequest, IdempotencyKey, LoopCheckpointRecord,
+    LoopCheckpointStore, LoopExitMapping, PutLoopCheckpointRequest, ReplyTargetBindingRef,
+    ResumeTurnRequest, ResumeTurnResponse, RunProfileResolutionError, RunProfileResolutionRequest,
+    RunProfileResolver, SanitizedFailure, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse,
+    ThreadBusy, TurnActiveLockKey, TurnActiveLockRecord, TurnActor, TurnAdmissionClass,
     TurnAdmissionLimitProvider, TurnAdmissionPolicy, TurnAdmissionReservationRecord,
     TurnCheckpointId, TurnCheckpointRecord, TurnError, TurnEventKind, TurnIdempotencyErrorReplay,
     TurnIdempotencyOperationKind, TurnIdempotencyOutcomeKind, TurnIdempotencyRecord,
@@ -75,6 +76,7 @@ struct Inner {
     terminal_runs: VecDeque<TurnRunId>,
     active_locks: HashMap<TurnActiveLockKey, TurnActiveLockRecord>,
     checkpoints: Vec<TurnCheckpointRecord>,
+    loop_checkpoints: HashMap<TurnCheckpointId, LoopCheckpointRecord>,
     submit_idempotency: HashMap<SubmitIdempotencyKey, Result<SubmitTurnResponse, TurnError>>,
     submit_idempotency_in_flight: HashSet<SubmitIdempotencyKey>,
     resume_idempotency: HashMap<RunIdempotencyKey, Result<ResumeTurnResponse, TurnError>>,
@@ -297,6 +299,49 @@ impl TurnEventProjectionSource for InMemoryTurnStateStore {
             limit,
             inner.event_retention_floor,
         ))
+    }
+}
+
+#[async_trait]
+impl LoopCheckpointStore for InMemoryTurnStateStore {
+    async fn put_loop_checkpoint(
+        &self,
+        request: PutLoopCheckpointRequest,
+    ) -> Result<LoopCheckpointRecord, TurnError> {
+        let checkpoint_id = TurnCheckpointId::new();
+        let record = LoopCheckpointRecord {
+            checkpoint_id,
+            scope: request.scope,
+            turn_id: request.turn_id,
+            run_id: request.run_id,
+            state_ref: request.state_ref,
+            schema_id: request.schema_id,
+            schema_version: request.schema_version,
+            kind: request.kind,
+            created_at: Utc::now(),
+        };
+        let mut inner = self.lock_inner()?;
+        inner.loop_checkpoints.insert(checkpoint_id, record.clone());
+        Ok(record)
+    }
+
+    async fn get_loop_checkpoint(
+        &self,
+        request: GetLoopCheckpointRequest,
+    ) -> Result<Option<LoopCheckpointRecord>, TurnError> {
+        let inner = self.lock_inner()?;
+        let Some(record) = inner.loop_checkpoints.get(&request.checkpoint_id) else {
+            return Ok(None);
+        };
+        if record.scope == request.scope
+            && record.turn_id == request.turn_id
+            && record.run_id == request.run_id
+            && record.checkpoint_id == request.checkpoint_id
+        {
+            Ok(Some(record.clone()))
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -783,6 +828,12 @@ impl Inner {
             }
         }
 
+        let loop_checkpoints = snapshot
+            .loop_checkpoints
+            .into_iter()
+            .map(|record| (record.checkpoint_id, record))
+            .collect::<HashMap<_, _>>();
+
         let events = snapshot.events;
         cursor = cursor.max(events.iter().map(|event| event.cursor.0).max().unwrap_or(0));
         cursor = cursor.max(snapshot.event_retention_floor.0);
@@ -829,6 +880,7 @@ impl Inner {
             terminal_runs,
             active_locks,
             checkpoints: snapshot.checkpoints,
+            loop_checkpoints,
             submit_idempotency,
             submit_idempotency_in_flight: HashSet::new(),
             resume_idempotency,
@@ -895,6 +947,12 @@ impl Inner {
                 .cmp(&b.created_at)
                 .then_with(|| a.sequence.cmp(&b.sequence))
         });
+        let mut loop_checkpoints = self.loop_checkpoints.values().cloned().collect::<Vec<_>>();
+        loop_checkpoints.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.checkpoint_id.as_uuid().cmp(&b.checkpoint_id.as_uuid()))
+        });
         let mut idempotency_records = self
             .idempotency_records
             .values()
@@ -912,6 +970,7 @@ impl Inner {
             runs,
             active_locks,
             checkpoints,
+            loop_checkpoints,
             idempotency_records,
             events: self.events.clone(),
             event_retention_floor: self.event_retention_floor,

--- a/crates/ironclaw_turns/src/run_profile/resolver.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolver.rs
@@ -207,7 +207,7 @@ fn interactive_profile() -> RunProfileDefinition {
     let checkpoint_schema_id = CheckpointSchemaId::from_trusted_static("interactive_checkpoint_v1");
     let checkpoint_schema_version = RunProfileVersion::new(1);
     RunProfileDefinition {
-        profile_id: RunProfileId::from_trusted_static("interactive_default"),
+        profile_id: RunProfileId::interactive_default(),
         profile_version: RunProfileVersion::new(1),
         run_class_id: RunClassId::from_trusted_static("interactive_coding"),
         loop_driver: AgentLoopDriverDescriptor {
@@ -258,7 +258,7 @@ fn long_running_mission_profile() -> RunProfileDefinition {
     let checkpoint_schema_id = CheckpointSchemaId::from_trusted_static("durable_mission_v1");
     let checkpoint_schema_version = RunProfileVersion::new(1);
     RunProfileDefinition {
-        profile_id: RunProfileId::from_trusted_static("long_running_mission"),
+        profile_id: RunProfileId::long_running_mission(),
         profile_version: RunProfileVersion::new(1),
         run_class_id: RunClassId::from_trusted_static("long_running_mission"),
         loop_driver: AgentLoopDriverDescriptor {
@@ -321,16 +321,20 @@ fn provenance_for(
     RedactedRunProfileProvenance {
         sources: vec![RedactedRunProfileSource {
             layer: RunProfileSourceLayer::from_trusted_static("system_default"),
-            source_ref: RunProfileSourceRef::from_trusted_static(
-                match definition.profile_id.as_str() {
-                    "interactive_default" => "builtin:interactive_default:v1",
-                    "long_running_mission" => "builtin:long_running_mission:v1",
-                    _ => "builtin:unknown:v1",
-                },
-            ),
+            source_ref: source_ref_for(definition),
             summary: summary.to_string(),
         }],
         effective_privileges: definition.required_privileges.clone(),
+    }
+}
+
+fn source_ref_for(definition: &RunProfileDefinition) -> RunProfileSourceRef {
+    if definition.profile_id == RunProfileId::interactive_default() {
+        RunProfileSourceRef::from_trusted_static("builtin:interactive_default:v1")
+    } else if definition.profile_id == RunProfileId::long_running_mission() {
+        RunProfileSourceRef::from_trusted_static("builtin:long_running_mission:v1")
+    } else {
+        RunProfileSourceRef::from_trusted_static("builtin:unknown:v1")
     }
 }
 

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for TurnRunProfile {
 }
 
 fn compatibility_profile_id(resolved: &ResolvedRunProfile) -> RunProfileId {
-    if resolved.profile_id.as_str() == "interactive_default" {
+    if resolved.profile_id.is_interactive_default() {
         RunProfileId::default_profile()
     } else {
         resolved.profile_id.clone()

--- a/crates/ironclaw_turns/src/store.rs
+++ b/crates/ironclaw_turns/src/store.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AcceptedMessageRef, AdmissionRejection, CancelRunRequest, CancelRunResponse, GateRef,
-    GetRunStateRequest, IdempotencyKey, ReplyTargetBindingRef, ResumeTurnRequest,
-    ResumeTurnResponse, RunProfileResolver, SourceBindingRef, SubmitTurnRequest,
+    GetRunStateRequest, IdempotencyKey, LoopCheckpointRecord, ReplyTargetBindingRef,
+    ResumeTurnRequest, ResumeTurnResponse, RunProfileResolver, SourceBindingRef, SubmitTurnRequest,
     SubmitTurnResponse, ThreadBusy, TurnActor, TurnAdmissionPolicy, TurnAdmissionReservationRecord,
     TurnCheckpointId, TurnError, TurnErrorCategory, TurnId, TurnLeaseToken, TurnLifecycleEvent,
     TurnRunId, TurnRunProfile, TurnRunState, TurnRunnerId, TurnScope, TurnStatus, TurnTimestamp,
@@ -275,6 +275,8 @@ pub struct TurnPersistenceSnapshot {
     pub runs: Vec<TurnRunRecord>,
     pub active_locks: Vec<TurnActiveLockRecord>,
     pub checkpoints: Vec<TurnCheckpointRecord>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub loop_checkpoints: Vec<LoopCheckpointRecord>,
     pub idempotency_records: Vec<TurnIdempotencyRecord>,
     #[serde(default)]
     pub events: Vec<TurnLifecycleEvent>,

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -139,6 +139,45 @@ async fn turn_state_loop_checkpoint_store_survives_persistence_snapshot() {
 }
 
 #[tokio::test]
+async fn turn_state_loop_checkpoint_store_rejects_cross_scope_after_snapshot_reload() {
+    let state_store = InMemoryCheckpointStateStore::default();
+    let checkpoint_store = InMemoryTurnStateStore::default();
+    let scope = turn_scope("thread-loop-checkpoint-snapshot-scope-a");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let state_record = put_test_state(&state_store, scope.clone(), turn_id, run_id).await;
+    let checkpoint = checkpoint_store
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: state_record.state_ref,
+            schema_id: state_record.schema_id,
+            schema_version: state_record.schema_version,
+            kind: state_record.kind,
+        })
+        .await
+        .unwrap();
+
+    let reopened = InMemoryTurnStateStore::from_persistence_snapshot(
+        checkpoint_store.persistence_snapshot(),
+        InMemoryTurnStateStoreLimits::default(),
+    )
+    .unwrap();
+    let loaded = reopened
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope: turn_scope("thread-loop-checkpoint-snapshot-scope-b"),
+            turn_id,
+            run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap();
+
+    assert!(loaded.is_none());
+}
+
+#[tokio::test]
 async fn loop_checkpoint_store_rejects_cross_run_checkpoint_id() {
     let state_store = InMemoryCheckpointStateStore::default();
     let checkpoint_store = InMemoryLoopCheckpointStore::default();

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -2,12 +2,13 @@ use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
 use ironclaw_turns::{
     AcceptedMessageRef, CheckpointSchemaId, CheckpointStateRecord, CheckpointStateStore,
     EventCursor, GateRef, GetCheckpointStateRequest, GetLoopCheckpointRequest,
-    InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore, LoopCheckpointStateRef,
-    LoopCheckpointStore, MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, PutCheckpointStateRequest,
-    PutLoopCheckpointRequest, RedactedCheckpointPayload, ReplyTargetBindingRef, RunProfileId,
-    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnCheckpointRecord, TurnEventKind,
-    TurnId, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRunId, TurnRunState, TurnScope,
-    TurnStatus, TurnTimestamp, run_profile::LoopCheckpointKind,
+    InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore, InMemoryTurnStateStore,
+    InMemoryTurnStateStoreLimits, LoopCheckpointStateRef, LoopCheckpointStore,
+    MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, PutCheckpointStateRequest, PutLoopCheckpointRequest,
+    RedactedCheckpointPayload, ReplyTargetBindingRef, RunProfileId, RunProfileVersion,
+    SourceBindingRef, TurnCheckpointId, TurnCheckpointRecord, TurnEventKind, TurnId,
+    TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRunId, TurnRunState, TurnScope, TurnStatus,
+    TurnTimestamp, run_profile::LoopCheckpointKind,
 };
 
 #[tokio::test]
@@ -89,6 +90,50 @@ async fn loop_checkpoint_store_maps_checkpoint_ids_to_staged_state_refs() {
         .await
         .unwrap()
         .expect("checkpoint id should resolve to state ref");
+
+    assert_eq!(loaded, checkpoint);
+}
+
+#[tokio::test]
+async fn turn_state_loop_checkpoint_store_survives_persistence_snapshot() {
+    let state_store = InMemoryCheckpointStateStore::default();
+    let checkpoint_store = InMemoryTurnStateStore::default();
+    let scope = turn_scope("thread-loop-checkpoint-snapshot");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let state_record = put_test_state(&state_store, scope.clone(), turn_id, run_id).await;
+
+    let checkpoint = checkpoint_store
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: state_record.state_ref.clone(),
+            schema_id: state_record.schema_id.clone(),
+            schema_version: state_record.schema_version,
+            kind: state_record.kind,
+        })
+        .await
+        .unwrap();
+
+    let snapshot = checkpoint_store.persistence_snapshot();
+    assert_eq!(snapshot.loop_checkpoints.len(), 1);
+
+    let reopened = InMemoryTurnStateStore::from_persistence_snapshot(
+        snapshot,
+        InMemoryTurnStateStoreLimits::default(),
+    )
+    .unwrap();
+    let loaded = reopened
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope,
+            turn_id,
+            run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap()
+        .expect("turn-state-backed checkpoint id should survive snapshot reload");
 
     assert_eq!(loaded, checkpoint);
 }

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
 use ironclaw_turns::{
     AcceptedMessageRef, CheckpointSchemaId, CheckpointStateRecord, CheckpointStateStore,
@@ -92,6 +94,61 @@ async fn loop_checkpoint_store_maps_checkpoint_ids_to_staged_state_refs() {
         .expect("checkpoint id should resolve to state ref");
 
     assert_eq!(loaded, checkpoint);
+}
+
+#[tokio::test]
+async fn loop_checkpoint_store_handles_parallel_puts() {
+    let state_store = Arc::new(InMemoryCheckpointStateStore::default());
+    let checkpoint_store = Arc::new(InMemoryLoopCheckpointStore::default());
+    let scope = turn_scope("thread-loop-checkpoint-parallel");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let write = |suffix: &'static str| {
+        let state_store = Arc::clone(&state_store);
+        let checkpoint_store = Arc::clone(&checkpoint_store);
+        let scope = scope.clone();
+        async move {
+            let state_record = put_test_state(&state_store, scope.clone(), turn_id, run_id).await;
+            checkpoint_store
+                .put_loop_checkpoint(PutLoopCheckpointRequest {
+                    scope,
+                    turn_id,
+                    run_id,
+                    state_ref: state_record.state_ref,
+                    schema_id: state_record.schema_id,
+                    schema_version: state_record.schema_version,
+                    kind: state_record.kind,
+                })
+                .await
+                .unwrap_or_else(|error| panic!("{suffix} checkpoint put failed: {error}"))
+        }
+    };
+
+    let (first, second, third, fourth) = tokio::join!(
+        write("first"),
+        write("second"),
+        write("third"),
+        write("fourth")
+    );
+
+    let checkpoint_ids = [
+        first.checkpoint_id,
+        second.checkpoint_id,
+        third.checkpoint_id,
+        fourth.checkpoint_id,
+    ];
+    for checkpoint_id in checkpoint_ids {
+        let loaded = checkpoint_store
+            .get_loop_checkpoint(GetLoopCheckpointRequest {
+                scope: scope.clone(),
+                turn_id,
+                run_id,
+                checkpoint_id,
+            })
+            .await
+            .unwrap();
+        assert!(loaded.is_some());
+    }
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -1,12 +1,13 @@
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
 use ironclaw_turns::{
     AcceptedMessageRef, CheckpointSchemaId, CheckpointStateRecord, CheckpointStateStore,
-    EventCursor, GateRef, GetCheckpointStateRequest, InMemoryCheckpointStateStore,
-    LoopCheckpointStateRef, MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, PutCheckpointStateRequest,
-    RedactedCheckpointPayload, ReplyTargetBindingRef, RunProfileId, RunProfileVersion,
-    SourceBindingRef, TurnCheckpointId, TurnCheckpointRecord, TurnEventKind, TurnId,
-    TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRunId, TurnRunState, TurnScope, TurnStatus,
-    TurnTimestamp, run_profile::LoopCheckpointKind,
+    EventCursor, GateRef, GetCheckpointStateRequest, GetLoopCheckpointRequest,
+    InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore, LoopCheckpointStateRef,
+    LoopCheckpointStore, MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, PutCheckpointStateRequest,
+    PutLoopCheckpointRequest, RedactedCheckpointPayload, ReplyTargetBindingRef, RunProfileId,
+    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnCheckpointRecord, TurnEventKind,
+    TurnId, TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRunId, TurnRunState, TurnScope,
+    TurnStatus, TurnTimestamp, run_profile::LoopCheckpointKind,
 };
 
 #[tokio::test]
@@ -50,6 +51,80 @@ async fn checkpoint_state_store_round_trips_scoped_state_ref() {
         .expect("stored checkpoint state should be returned for matching scope/run");
 
     assert_eq!(loaded, record);
+}
+
+#[tokio::test]
+async fn loop_checkpoint_store_maps_checkpoint_ids_to_staged_state_refs() {
+    let state_store = InMemoryCheckpointStateStore::default();
+    let checkpoint_store = InMemoryLoopCheckpointStore::default();
+    let scope = turn_scope("thread-loop-checkpoint-roundtrip");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let state_record = put_test_state(&state_store, scope.clone(), turn_id, run_id).await;
+
+    let checkpoint = checkpoint_store
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: state_record.state_ref.clone(),
+            schema_id: state_record.schema_id.clone(),
+            schema_version: state_record.schema_version,
+            kind: state_record.kind,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(checkpoint.state_ref, state_record.state_ref);
+    assert_eq!(checkpoint.schema_id, state_record.schema_id);
+    assert_eq!(checkpoint.kind, state_record.kind);
+
+    let loaded = checkpoint_store
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope,
+            turn_id,
+            run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap()
+        .expect("checkpoint id should resolve to state ref");
+
+    assert_eq!(loaded, checkpoint);
+}
+
+#[tokio::test]
+async fn loop_checkpoint_store_rejects_cross_run_checkpoint_id() {
+    let state_store = InMemoryCheckpointStateStore::default();
+    let checkpoint_store = InMemoryLoopCheckpointStore::default();
+    let scope = turn_scope("thread-loop-checkpoint-cross-run");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let state_record = put_test_state(&state_store, scope.clone(), turn_id, run_id).await;
+    let checkpoint = checkpoint_store
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: state_record.state_ref,
+            schema_id: state_record.schema_id,
+            schema_version: state_record.schema_version,
+            kind: state_record.kind,
+        })
+        .await
+        .unwrap();
+
+    let loaded = checkpoint_store
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope,
+            turn_id,
+            run_id: TurnRunId::new(),
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap();
+
+    assert!(loaded.is_none());
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
@@ -258,6 +258,42 @@ async fn libsql_loop_checkpoint_store_persists_mapping_across_instances() {
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn libsql_loop_checkpoint_store_rejects_cross_scope_after_reopen() {
+    let (db, _dir) = libsql_db().await;
+    let store = LibSqlTurnStateStore::new(db.clone());
+    store.run_migrations().await.unwrap();
+    let checkpoint_scope = scope("thread-loop-checkpoint-db-scope-a");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let checkpoint = store
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: checkpoint_scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: LoopCheckpointStateRef::new("checkpoint:db-loop-state-scope").unwrap(),
+            schema_id: CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            schema_version: RunProfileVersion::new(3),
+            kind: ironclaw_turns::run_profile::LoopCheckpointKind::BeforeBlock,
+        })
+        .await
+        .unwrap();
+
+    let reopened = LibSqlTurnStateStore::new(db);
+    let loaded = reopened
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope: scope("thread-loop-checkpoint-db-scope-b"),
+            turn_id,
+            run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap();
+
+    assert!(loaded.is_none());
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn libsql_turn_state_store_persists_admission_reservations_across_instances() {
     let (db, _dir) = libsql_db().await;
     let limits = Arc::new(
@@ -729,6 +765,48 @@ async fn postgres_loop_checkpoint_store_persists_mapping_across_instances_when_c
         .expect("Postgres checkpoint id mapping should survive store reopen");
 
     assert_eq!(loaded, checkpoint);
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_loop_checkpoint_store_rejects_cross_scope_after_reopen_when_configured() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let store = PostgresTurnStateStore::new(pool.clone());
+    store.run_migrations().await.unwrap();
+    let checkpoint_scope = scope(&format!("thread-loop-checkpoint-postgres-scope-a-{suffix}"));
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let checkpoint = store
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: checkpoint_scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: LoopCheckpointStateRef::new(format!(
+                "checkpoint:pg-loop-state-scope:{suffix}"
+            ))
+            .unwrap(),
+            schema_id: CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            schema_version: RunProfileVersion::new(3),
+            kind: ironclaw_turns::run_profile::LoopCheckpointKind::BeforeBlock,
+        })
+        .await
+        .unwrap();
+
+    let reopened = PostgresTurnStateStore::new(pool);
+    let loaded = reopened
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope: scope(&format!("thread-loop-checkpoint-postgres-scope-b-{suffix}")),
+            turn_id,
+            run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap();
+
+    assert!(loaded.is_none());
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/db_turn_state_store_contract.rs
@@ -12,16 +12,18 @@ use std::{
 use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
 use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
-    AcceptedMessageRef, CancelRunRequest, DefaultTurnCoordinator, IdempotencyKey,
-    InMemoryRunProfileResolver, InMemoryTurnStateStoreLimits, LoopCompleted, LoopCompletionKind,
-    LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy, LoopMessageRef,
-    ReplyTargetBindingRef, ResolvedRunProfile, RunProfileRequest, RunProfileResolutionError,
-    RunProfileResolutionRequest, RunProfileResolver, SanitizedCancelReason, SanitizedFailure,
-    SourceBindingRef, StaticTurnAdmissionLimitProvider, SubmitTurnRequest, SubmitTurnResponse,
-    ThreadBusy, TurnActor, TurnAdmissionAxisKind, TurnAdmissionCapacityDenial, TurnCoordinator,
-    TurnError, TurnEventKind, TurnEventProjectionCursor, TurnEventProjectionError,
-    TurnEventProjectionRequest, TurnEventProjectionService, TurnLeaseToken, TurnRunId,
-    TurnRunnerId, TurnScope, TurnStatus,
+    AcceptedMessageRef, CancelRunRequest, CheckpointSchemaId, DefaultTurnCoordinator,
+    GetLoopCheckpointRequest, IdempotencyKey, InMemoryRunProfileResolver,
+    InMemoryTurnStateStoreLimits, LoopCheckpointStateRef, LoopCheckpointStore, LoopCompleted,
+    LoopCompletionKind, LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy,
+    LoopMessageRef, PutLoopCheckpointRequest, ReplyTargetBindingRef, ResolvedRunProfile,
+    RunProfileRequest, RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver,
+    RunProfileVersion, SanitizedCancelReason, SanitizedFailure, SourceBindingRef,
+    StaticTurnAdmissionLimitProvider, SubmitTurnRequest, SubmitTurnResponse, ThreadBusy, TurnActor,
+    TurnAdmissionAxisKind, TurnAdmissionCapacityDenial, TurnCoordinator, TurnError, TurnEventKind,
+    TurnEventProjectionCursor, TurnEventProjectionError, TurnEventProjectionRequest,
+    TurnEventProjectionService, TurnId, TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope,
+    TurnStatus,
     events::EventCursor,
     runner::{
         ApplyLoopExitRequest, ClaimRunRequest, CompleteRunRequest, HeartbeatRequest,
@@ -211,6 +213,47 @@ async fn libsql_turn_state_store_persists_submit_and_busy_across_instances() {
         .await
         .unwrap();
     assert_eq!(duplicate, accepted);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_loop_checkpoint_store_persists_mapping_across_instances() {
+    let (db, _dir) = libsql_db().await;
+    let store = LibSqlTurnStateStore::new(db.clone());
+    store.run_migrations().await.unwrap();
+    let scope = scope("thread-loop-checkpoint-db");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let state_ref = LoopCheckpointStateRef::new("checkpoint:db-loop-state").unwrap();
+    let schema_id = CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap();
+    let schema_version = RunProfileVersion::new(3);
+
+    let checkpoint = store
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: state_ref.clone(),
+            schema_id: schema_id.clone(),
+            schema_version,
+            kind: ironclaw_turns::run_profile::LoopCheckpointKind::BeforeModel,
+        })
+        .await
+        .unwrap();
+
+    let reopened = LibSqlTurnStateStore::new(db);
+    let loaded = reopened
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope,
+            turn_id,
+            run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap()
+        .expect("libSQL checkpoint id mapping should survive store reopen");
+
+    assert_eq!(loaded, checkpoint);
 }
 
 #[cfg(feature = "libsql")]
@@ -645,6 +688,51 @@ async fn libsql_turn_state_store_persists_runner_recovery_and_cancel_flow() {
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
+async fn postgres_loop_checkpoint_store_persists_mapping_across_instances_when_configured() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let store = PostgresTurnStateStore::new(pool.clone());
+    store.run_migrations().await.unwrap();
+    let scope = scope(&format!("thread-loop-checkpoint-postgres-{suffix}"));
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let state_ref =
+        LoopCheckpointStateRef::new(format!("checkpoint:pg-loop-state:{suffix}")).unwrap();
+    let schema_id = CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap();
+    let schema_version = RunProfileVersion::new(3);
+
+    let checkpoint = store
+        .put_loop_checkpoint(PutLoopCheckpointRequest {
+            scope: scope.clone(),
+            turn_id,
+            run_id,
+            state_ref: state_ref.clone(),
+            schema_id: schema_id.clone(),
+            schema_version,
+            kind: ironclaw_turns::run_profile::LoopCheckpointKind::BeforeModel,
+        })
+        .await
+        .unwrap();
+
+    let reopened = PostgresTurnStateStore::new(pool);
+    let loaded = reopened
+        .get_loop_checkpoint(GetLoopCheckpointRequest {
+            scope,
+            turn_id,
+            run_id,
+            checkpoint_id: checkpoint.checkpoint_id,
+        })
+        .await
+        .unwrap()
+        .expect("Postgres checkpoint id mapping should survive store reopen");
+
+    assert_eq!(loaded, checkpoint);
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
 async fn postgres_turn_state_store_persists_submit_and_busy_across_instances_when_configured() {
     let Some(pool) = postgres_pool().await else {
         return;
@@ -983,8 +1071,10 @@ async fn postgres_turn_state_store_persists_cancelled_loop_exit_application_when
 fn postgres_turn_state_store_implements_turn_contract_traits() {
     fn assert_state_store<T: ironclaw_turns::TurnStateStore>() {}
     fn assert_runner_port<T: TurnRunTransitionPort>() {}
+    fn assert_loop_checkpoint_store<T: LoopCheckpointStore>() {}
     assert_state_store::<PostgresTurnStateStore>();
     assert_runner_port::<PostgresTurnStateStore>();
+    assert_loop_checkpoint_store::<PostgresTurnStateStore>();
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_turns/tests/run_profile_contract.rs
+++ b/crates/ironclaw_turns/tests/run_profile_contract.rs
@@ -1,7 +1,8 @@
 use ironclaw_turns::{
     AgentLoopDriverDescriptor, CapabilitySurfaceProfileId, InMemoryRunProfileResolver,
-    ModelProfileId, PrivilegedRunProfileDimension, RunProfileRequest, RunProfileRequestAuthority,
-    RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion,
+    ModelProfileId, PrivilegedRunProfileDimension, RunProfileId, RunProfileRequest,
+    RunProfileRequestAuthority, RunProfileResolutionError, RunProfileResolutionRequest,
+    RunProfileResolver, RunProfileVersion,
 };
 
 #[tokio::test]
@@ -13,6 +14,7 @@ async fn default_interactive_profile_resolves_stable_driver_and_redacted_snapsho
         .await
         .unwrap();
 
+    assert_eq!(RunProfileId::interactive_default(), snapshot.profile_id);
     assert_eq!(snapshot.profile_id.as_str(), "interactive_default");
     assert_eq!(snapshot.profile_version, RunProfileVersion::new(1));
     assert_eq!(snapshot.run_class_id.as_str(), "interactive_coding");


### PR DESCRIPTION
Closes #3407.

## Summary
- add Reborn text-only `AgentLoopDriverHost` factory with trait-object-backed ports
- compose context, prompt, input, model, capability, transcript, checkpoint, and progress ports
- add scoped no-extra input, checkpoint id -> state ref persistence, and progress milestone ports
- validate claimed run/profile/driver/thread scope before returning host
- address ilblackdragon review: typed default-profile normalization, agent-scoped host boundary docs/tests, checkpoint error summaries, redacted milestone contract comment

## Follow-ups
- #3451 — [Reborn] Add direct DB operations for loop checkpoint mappings
- #3452 — [Reborn] Replace stringly loop support identity/reason fields

## Risk
- medium: additive Reborn production host factory plus turn checkpoint persistence surface and DB-backed contracts

## Tests
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3439-review cargo test -p ironclaw_turns --test run_profile_contract --test checkpoint_state_store_contract`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3439-review cargo test -p ironclaw_reborn --test loop_driver_host`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3439-review cargo test -p ironclaw_turns --features postgres`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3439-review cargo test -p ironclaw_reborn --tests`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3439-review cargo test -p ironclaw_architecture --test reborn_dependency_boundaries -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3439-review cargo clippy -p ironclaw_turns -p ironclaw_reborn --all-targets -- -D warnings`
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`
