### PR TITLE
fix(resources): close durable governor review gaps

### DIFF
--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -494,7 +494,7 @@ where
             secret_store,
             network_policy_store,
             secret_injection_store,
-            process_lifecycle_store,
+            process_lifecycle_store: _,
             runtime_http_egress,
             wasm_credential_provider,
             runtime_health,
@@ -505,6 +505,16 @@ where
             turn_run_wake_notifier,
             mut component_types,
         } = self;
+        let lifecycle_governor: Arc<dyn ResourceGovernor> = governor.clone();
+        let process_lifecycle_store = Arc::new(ProcessObligationLifecycleStore::new(
+            process_services.process_store(),
+            Arc::clone(&network_policy_store),
+            Arc::clone(&secret_injection_store),
+            lifecycle_governor,
+        ));
+        if let Some(event_sink) = &event_sink {
+            process_lifecycle_store.set_event_sink(Arc::clone(event_sink));
+        }
         component_types.resource_governor = type_name::<T>();
         HostRuntimeServices {
             registry,

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -54,7 +54,7 @@ use ironclaw_reborn_event_store::{
 };
 use ironclaw_resources::{
     InMemoryResourceGovernor, JsonFileResourceGovernorStore, PersistentResourceGovernor,
-    ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
+    ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits, ResourceTally,
 };
 #[cfg(feature = "libsql")]
 use ironclaw_run_state::LibSqlRunStateApprovalStore;
@@ -269,6 +269,83 @@ async fn with_libsql_resource_governor_runs_migrations_before_first_reserve() {
         )
         .unwrap();
     governor.release(reservation.id).unwrap();
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn with_libsql_resource_governor_closes_process_reservations_on_cancel() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(
+        libsql::Builder::new_local(dir.path().join("resources.db"))
+            .build()
+            .await
+            .unwrap(),
+    );
+    let process_services = ProcessServices::new(
+        Arc::new(InMemoryProcessStore::new()),
+        Arc::new(InMemoryProcessResultStore::new()),
+    );
+    let process_store = process_services.process_store();
+
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        process_services,
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_libsql_resource_governor(Arc::clone(&db))
+    .await
+    .unwrap();
+    let governor = services.resource_governor();
+    let scope = sample_scope(InvocationId::new());
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let reservation_id = ResourceReservationId::new();
+    let estimate = ResourceEstimate {
+        concurrency_slots: Some(1),
+        ..ResourceEstimate::default()
+    };
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    governor
+        .reserve_with_id(scope.clone(), estimate.clone(), reservation_id)
+        .unwrap();
+    let process_id = ProcessId::new();
+    let mut start = process_start(process_id, scope.invocation_id, scope.clone());
+    start.estimated_resources = estimate;
+    start.resource_reservation_id = Some(reservation_id);
+    process_store.start(start).await.unwrap();
+
+    let runtime = services.host_runtime_for_local_testing();
+    let outcome = runtime
+        .cancel_work(CancelRuntimeWorkRequest::new(
+            scope.clone(),
+            CorrelationId::new(),
+            CancelReason::UserRequested,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.cancelled, vec![RuntimeWorkId::Process(process_id)]);
+    assert_eq!(
+        governor.reserved_for(&account).unwrap(),
+        ResourceTally::default()
+    );
+    assert!(matches!(
+        governor.release(reservation_id).unwrap_err(),
+        ResourceError::ReservationClosed {
+            status: ReservationStatus::Released,
+            ..
+        }
+    ));
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -265,7 +265,7 @@ pub enum ResourceError {
     },
     /// Durable storage or snapshot schema validation failed. Governors must
     /// fail closed when this is returned.
-    #[error("resource governor storage error: {reason}")]
+    #[error("resource governor storage error")]
     Storage { reason: String },
 }
 

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -47,6 +47,18 @@ fn persistent_trait_set_limit_surfaces_storage_errors() {
 }
 
 #[test]
+fn storage_errors_display_sanitized_message_without_backend_details() {
+    let error = ResourceError::Storage {
+        reason: "postgres://user:secret@localhost/db failed under /tmp/private".to_string(),
+    };
+    let rendered = error.to_string();
+
+    assert_eq!(rendered, "resource governor storage error");
+    assert!(!rendered.contains("secret"));
+    assert!(!rendered.contains("/tmp/private"));
+}
+
+#[test]
 fn reserve_succeeds_when_budget_is_available() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));


### PR DESCRIPTION
## Summary
- rebuild host-runtime process lifecycle store when replacing resource governor so process cleanup closes durable reservations against the active governor
- sanitize ResourceError::Storage display output while keeping the reason field available for internal matching
- add regression coverage for libSQL process-cancel cleanup and storage-error display redaction

## Verification
- CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3427-fix cargo fmt --all --check
- CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3427-fix cargo test -p ironclaw_resources
- CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3427-fix cargo test -p ironclaw_resources --features libsql
- CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3427-fix cargo test -p ironclaw_host_runtime --features libsql with_libsql_resource_governor_closes_process_reservations_on_cancel -- --nocapture
- CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3427-fix cargo check -p ironclaw_host_runtime --all-features
- CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3427-fix cargo clippy -p ironclaw_resources --all-targets --all-features -- -D warnings
- CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3427-fix cargo clippy -p ironclaw_host_runtime --all-targets --all-features -- -D warnings
- git diff --check

Follow-up to #3427.