### PR TITLE
test(KB-060): verify checkpoint state store acceptance criteria & strengthen edge-case coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4713,6 +4713,7 @@ dependencies = [
  "libsql",
  "serde",
  "serde_json",
+ "static_assertions",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/ironclaw_turns/Cargo.toml
+++ b/crates/ironclaw_turns/Cargo.toml
@@ -30,5 +30,6 @@ tokio-postgres = { version = "0.7", optional = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
+static_assertions = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -252,6 +252,140 @@ fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
     }
 }
 
+#[tokio::test]
+async fn checkpoint_state_store_round_trips_empty_payload() {
+    let store = InMemoryCheckpointStateStore::default();
+    let scope = turn_scope("thread-checkpoint-empty");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+
+    let record = store
+        .put_checkpoint_state(PutCheckpointStateRequest::new(
+            scope.clone(),
+            turn_id,
+            run_id,
+            CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            RunProfileVersion::new(1),
+            LoopCheckpointKind::BeforeModel,
+            Vec::<u8>::new(),
+        ))
+        .await
+        .unwrap();
+
+    assert!(record.payload.is_empty());
+    assert_eq!(record.payload.len(), 0);
+
+    let loaded = store
+        .get_checkpoint_state(get_request(&record, scope, turn_id, run_id))
+        .await
+        .unwrap()
+        .expect("empty payload should round-trip");
+
+    assert_eq!(loaded.payload.as_bytes(), &[] as &[u8]);
+}
+
+#[tokio::test]
+async fn checkpoint_state_store_accepts_exact_max_size_payload() {
+    let store = InMemoryCheckpointStateStore::default();
+    let scope = turn_scope("thread-checkpoint-max-size");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let payload = vec![b'A'; MAX_CHECKPOINT_STATE_PAYLOAD_BYTES];
+
+    let record = store
+        .put_checkpoint_state(PutCheckpointStateRequest::new(
+            scope.clone(),
+            turn_id,
+            run_id,
+            CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            RunProfileVersion::new(1),
+            LoopCheckpointKind::BeforeSideEffect,
+            payload.clone(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(record.payload.len(), MAX_CHECKPOINT_STATE_PAYLOAD_BYTES);
+
+    let loaded = store
+        .get_checkpoint_state(get_request(&record, scope, turn_id, run_id))
+        .await
+        .unwrap()
+        .expect("exact max-size payload should round-trip");
+
+    assert_eq!(loaded.payload.as_bytes(), payload.as_slice());
+}
+
+#[tokio::test]
+async fn checkpoint_state_store_multiple_puts_produce_distinct_refs() {
+    let store = InMemoryCheckpointStateStore::default();
+    let scope = turn_scope("thread-checkpoint-multi");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+
+    let record_a = store
+        .put_checkpoint_state(PutCheckpointStateRequest::new(
+            scope.clone(),
+            turn_id,
+            run_id,
+            CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            RunProfileVersion::new(1),
+            LoopCheckpointKind::BeforeModel,
+            b"payload-a".to_vec(),
+        ))
+        .await
+        .unwrap();
+
+    let record_b = store
+        .put_checkpoint_state(PutCheckpointStateRequest::new(
+            scope.clone(),
+            turn_id,
+            run_id,
+            CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
+            RunProfileVersion::new(1),
+            LoopCheckpointKind::BeforeModel,
+            b"payload-b".to_vec(),
+        ))
+        .await
+        .unwrap();
+
+    assert_ne!(record_a.state_ref, record_b.state_ref, "each put must produce a unique state_ref");
+
+    let loaded_a = store
+        .get_checkpoint_state(get_request(&record_a, scope.clone(), turn_id, run_id))
+        .await
+        .unwrap()
+        .expect("first record should be independently retrievable");
+    assert_eq!(loaded_a.payload.as_bytes(), b"payload-a");
+
+    let loaded_b = store
+        .get_checkpoint_state(get_request(&record_b, scope, turn_id, run_id))
+        .await
+        .unwrap()
+        .expect("second record should be independently retrievable");
+    assert_eq!(loaded_b.payload.as_bytes(), b"payload-b");
+}
+
+#[tokio::test]
+async fn checkpoint_state_store_rejects_cross_turn_id_ref() {
+    let store = InMemoryCheckpointStateStore::default();
+    let scope = turn_scope("thread-checkpoint-cross-turn");
+    let turn_id = TurnId::new();
+    let run_id = TurnRunId::new();
+    let record = put_test_state(&store, scope.clone(), turn_id, run_id).await;
+
+    let different_turn_id = TurnId::new();
+    let loaded = store
+        .get_checkpoint_state(get_request(&record, scope, different_turn_id, run_id))
+        .await
+        .unwrap();
+
+    assert!(
+        loaded.is_none(),
+        "checkpoint state must not be returned for a different turn_id"
+    );
+}
+
 fn get_request(
     record: &CheckpointStateRecord,
     scope: TurnScope,

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -187,6 +187,13 @@ fn checkpoint_state_record_debug_redacts_payload() {
 }
 
 #[test]
+fn redacted_checkpoint_payload_is_not_serializable() {
+    static_assertions::assert_not_impl_any!(
+        RedactedCheckpointPayload: serde::Serialize, serde::de::DeserializeOwned
+    );
+}
+
+#[test]
 fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
     let payload = b"RAW_CHECKPOINT_PAYLOAD sk-secret /host/path tool_input".to_vec();
     let payload = RedactedCheckpointPayload::new(payload).unwrap();
@@ -273,7 +280,6 @@ async fn checkpoint_state_store_round_trips_empty_payload() {
         .unwrap();
 
     assert!(record.payload.is_empty());
-    assert_eq!(record.payload.len(), 0);
 
     let loaded = store
         .get_checkpoint_state(get_request(&record, scope, turn_id, run_id))
@@ -323,6 +329,8 @@ async fn checkpoint_state_store_multiple_puts_produce_distinct_refs() {
     let turn_id = TurnId::new();
     let run_id = TurnRunId::new();
 
+    let payload = b"same".to_vec();
+
     let record_a = store
         .put_checkpoint_state(PutCheckpointStateRequest::new(
             scope.clone(),
@@ -331,7 +339,7 @@ async fn checkpoint_state_store_multiple_puts_produce_distinct_refs() {
             CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
             RunProfileVersion::new(1),
             LoopCheckpointKind::BeforeModel,
-            b"payload-a".to_vec(),
+            payload.clone(),
         ))
         .await
         .unwrap();
@@ -344,26 +352,29 @@ async fn checkpoint_state_store_multiple_puts_produce_distinct_refs() {
             CheckpointSchemaId::new("interactive_checkpoint_v1").unwrap(),
             RunProfileVersion::new(1),
             LoopCheckpointKind::BeforeModel,
-            b"payload-b".to_vec(),
+            payload.clone(),
         ))
         .await
         .unwrap();
 
-    assert_ne!(record_a.state_ref, record_b.state_ref, "each put must produce a unique state_ref");
+    assert_ne!(
+        record_a.state_ref, record_b.state_ref,
+        "each put must produce a unique state_ref"
+    );
 
     let loaded_a = store
         .get_checkpoint_state(get_request(&record_a, scope.clone(), turn_id, run_id))
         .await
         .unwrap()
         .expect("first record should be independently retrievable");
-    assert_eq!(loaded_a.payload.as_bytes(), b"payload-a");
+    assert_eq!(loaded_a.payload.as_bytes(), payload.as_slice());
 
     let loaded_b = store
         .get_checkpoint_state(get_request(&record_b, scope, turn_id, run_id))
         .await
         .unwrap()
         .expect("second record should be independently retrievable");
-    assert_eq!(loaded_b.payload.as_bytes(), b"payload-b");
+    assert_eq!(loaded_b.payload.as_bytes(), payload.as_slice());
 }
 
 #[tokio::test]
@@ -383,6 +394,21 @@ async fn checkpoint_state_store_rejects_cross_turn_id_ref() {
     assert!(
         loaded.is_none(),
         "checkpoint state must not be returned for a different turn_id"
+    );
+
+    let loaded = store
+        .get_checkpoint_state(get_request(
+            &record,
+            turn_scope("thread-checkpoint-cross-all"),
+            TurnId::new(),
+            TurnRunId::new(),
+        ))
+        .await
+        .unwrap();
+
+    assert!(
+        loaded.is_none(),
+        "checkpoint state must not be returned when scope, turn_id, and run_id differ"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #3406 — verifies all acceptance criteria for the checkpoint state staging store (merged in commit b1b7d7f10) and adds edge-case contract tests.

## Acceptance Criteria Verification

All 9 ACs verified against merged code:

- **AC1** ✅ `CheckpointStateStore` trait with `put_checkpoint_state`/`get_checkpoint_state` in `src/checkpoint_state.rs`
- **AC2** ✅ `InMemoryCheckpointStateStore` is `Default`-constructible
- **AC3** ✅ `checkpoint_state_store_round_trips_scoped_state_ref` covers put/get by scope/run/ref
- **AC4** ✅ `rejects_cross_scope_ref` and `rejects_cross_run_ref` cover isolation
- **AC5** ✅ `rejects_oversized_payload` covers max payload size rejection
- **AC6** ✅ `rejects_schema_version_or_kind_mismatch` covers schema/version/kind preservation
- **AC7** ✅ Debug redaction tests verify no sentinel strings leak
- **AC8** ✅ `RedactedCheckpointPayload` has custom `Debug` with `<redacted>`, not `Serialize`/`Deserialize`
- **AC9** ✅ `LoopCheckpointStateRef` bounded ref (`checkpoint:` prefix, max 256 bytes), generated by store

## New Edge-Case Tests

4 new contract tests added to `checkpoint_state_store_contract.rs`:

1. **Empty payload round-trip** — zero-length payload stores and retrieves correctly
2. **Exact max-size payload** — payload of exactly `MAX_CHECKPOINT_STATE_PAYLOAD_BYTES` stores successfully
3. **Multiple puts produce distinct refs** — two puts yield different `LoopCheckpointStateRef` values, both independently retrievable
4. **Cross-turn-id isolation** — valid `state_ref` returns `None` when queried with a different `turn_id`

## No Gaps Found

All acceptance criteria satisfied by the existing implementation. No out-of-scope work discovered.