### PR TITLE
fix(reborn): strengthen host runtime publication gates

### DIFF
--- a/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/builtin_obligation_handler_contract.rs
@@ -549,7 +549,7 @@ async fn builtin_obligation_handler_fails_closed_when_redacted_object_keys_colli
         &capability_id,
         json!({
             leaked: "secret-key",
-            "[REDACTED].aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": "existing",
+            "[REDACTED]": "existing",
         }),
     );
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -54,7 +54,7 @@ use ironclaw_reborn_event_store::{
 };
 use ironclaw_resources::{
     InMemoryResourceGovernor, JsonFileResourceGovernorStore, PersistentResourceGovernor,
-    ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits, ResourceTally,
+    ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
 };
 #[cfg(feature = "libsql")]
 use ironclaw_run_state::LibSqlRunStateApprovalStore;
@@ -337,7 +337,7 @@ async fn with_libsql_resource_governor_closes_process_reservations_on_cancel() {
     assert_eq!(outcome.cancelled, vec![RuntimeWorkId::Process(process_id)]);
     assert_eq!(
         governor.reserved_for(&account).unwrap(),
-        ResourceTally::default()
+        ironclaw_resources::ResourceTally::default()
     );
     assert!(matches!(
         governor.release(reservation_id).unwrap_err(),

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -52,6 +52,8 @@ use ironclaw_processes::{
 use ironclaw_reborn_event_store::{
     RebornEventStoreConfig, RebornEventStoreError, RebornProfile, build_reborn_event_stores,
 };
+#[cfg(feature = "libsql")]
+use ironclaw_resources::ResourceTally;
 use ironclaw_resources::{
     InMemoryResourceGovernor, JsonFileResourceGovernorStore, PersistentResourceGovernor,
     ResourceAccount, ResourceError, ResourceGovernor, ResourceLimits,
@@ -337,7 +339,7 @@ async fn with_libsql_resource_governor_closes_process_reservations_on_cancel() {
     assert_eq!(outcome.cancelled, vec![RuntimeWorkId::Process(process_id)]);
     assert_eq!(
         governor.reserved_for(&account).unwrap(),
-        ironclaw_resources::ResourceTally::default()
+        ResourceTally::default()
     );
     assert!(matches!(
         governor.release(reservation_id).unwrap_err(),

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -413,6 +413,11 @@ async fn reborn_e2e_gate_blocks_oversized_runtime_output_before_publication() {
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::Failed);
     assert_eq!(run.error_kind.as_deref(), Some("ObligationFailed"));
+    let serialized_run = serde_json::to_string(&run).unwrap();
+    assert!(
+        !serialized_run.contains(forbidden),
+        "run-state record must not leak blocked output: {serialized_run}"
+    );
     let serialized_events = serde_json::to_string(&events.events()).unwrap();
     assert!(
         !serialized_events.contains(forbidden),

--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -257,7 +257,7 @@ async fn reborn_e2e_gate_fails_unsupported_obligations_before_runtime_events_or_
         Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
         Arc::new(LocalFilesystem::new()),
         Arc::clone(&governor),
-        Arc::new(ObligatingAuthorizer),
+        Arc::new(ObligatingAuthorizer::new(vec![Obligation::AuditBefore])),
         ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),
     )
@@ -297,6 +297,126 @@ async fn reborn_e2e_gate_fails_unsupported_obligations_before_runtime_events_or_
     assert_eq!(
         governor.usage_for(&tenant_account),
         ResourceTally::default()
+    );
+}
+
+#[tokio::test]
+async fn reborn_e2e_gate_redacts_runtime_output_before_public_result() {
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let events = InMemoryEventSink::new();
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ObligatingAuthorizer::new(vec![Obligation::RedactOutput])),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
+    .with_run_state(Arc::clone(&run_state))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )))
+    .with_event_sink(Arc::new(events.clone()));
+    let runtime = services.host_runtime_for_local_testing();
+    let context = execution_context_with_dispatch_grant();
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let leaked_header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+    let leaked_payload = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let leaked_signature = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let leaked = format!("Bearer {leaked_header}.{leaked_payload}.{leaked_signature}");
+
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            script_capability_id(),
+            ResourceEstimate::default(),
+            json!({"authorization": leaked, "message": "redact before public result"}),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Completed(completed) => {
+            let serialized = serde_json::to_string(&completed.output).unwrap();
+            assert_eq!(
+                completed.output,
+                json!({"authorization": "[REDACTED]", "message": "redact before public result"})
+            );
+            for forbidden in [leaked_header, leaked_payload, leaked_signature] {
+                assert!(
+                    !serialized.contains(forbidden),
+                    "redacted public result leaked token fragment {forbidden}: {serialized}"
+                );
+            }
+        }
+        other => panic!("expected completed redacted outcome, got {other:?}"),
+    }
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Completed);
+    let serialized_events = serde_json::to_string(&events.events()).unwrap();
+    assert!(
+        !serialized_events.contains(&leaked),
+        "runtime events must not leak raw output before redaction: {serialized_events}"
+    );
+}
+
+#[tokio::test]
+async fn reborn_e2e_gate_blocks_oversized_runtime_output_before_publication() {
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let events = InMemoryEventSink::new();
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(ObligatingAuthorizer::new(vec![
+            Obligation::EnforceOutputLimit { bytes: 8 },
+        ])),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
+    .with_run_state(Arc::clone(&run_state))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        EchoScriptBackend,
+    )))
+    .with_event_sink(Arc::new(events.clone()));
+    let runtime = services.host_runtime_for_local_testing();
+    let context = execution_context_with_dispatch_grant();
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let forbidden = "OUTPUT_LIMIT_SENTINEL_MUST_NOT_LEAK";
+
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            script_capability_id(),
+            ResourceEstimate::default(),
+            json!({"message": forbidden}),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.kind, RuntimeFailureKind::OutputTooLarge);
+            let rendered = format!("{failure:?}");
+            assert!(!rendered.contains(forbidden));
+        }
+        other => panic!("expected output-limit failure, got {other:?}"),
+    }
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(run.error_kind.as_deref(), Some("ObligationFailed"));
+    let serialized_events = serde_json::to_string(&events.events()).unwrap();
+    assert!(
+        !serialized_events.contains(forbidden),
+        "runtime events must not leak blocked output: {serialized_events}"
     );
 }
 
@@ -524,7 +644,15 @@ impl TrustAwareCapabilityDispatchAuthorizer for ApprovalThenGrantAuthorizer {
     }
 }
 
-struct ObligatingAuthorizer;
+struct ObligatingAuthorizer {
+    obligations: Vec<Obligation>,
+}
+
+impl ObligatingAuthorizer {
+    fn new(obligations: Vec<Obligation>) -> Self {
+        Self { obligations }
+    }
+}
 
 #[async_trait]
 impl TrustAwareCapabilityDispatchAuthorizer for ObligatingAuthorizer {
@@ -536,7 +664,7 @@ impl TrustAwareCapabilityDispatchAuthorizer for ObligatingAuthorizer {
         _trust_decision: &TrustDecision,
     ) -> Decision {
         Decision::Allow {
-            obligations: Obligations::new(vec![Obligation::AuditBefore]).unwrap(),
+            obligations: Obligations::new(self.obligations.clone()).unwrap(),
         }
     }
 }

--- a/crates/ironclaw_safety/src/leak_detector.rs
+++ b/crates/ironclaw_safety/src/leak_detector.rs
@@ -671,6 +671,39 @@ mod tests {
     }
 
     #[test]
+    fn test_redact_bearer_token_preserves_adjacent_sentence_boundary() {
+        let detector = LeakDetector::new();
+        let token = "abcdef1234567890123456";
+        let content = format!("prefix Bearer {token}. The next sentence.");
+
+        let redacted = detector.scan_and_clean(&content).unwrap();
+
+        assert_eq!(redacted, "prefix [REDACTED] The next sentence.");
+        assert!(!redacted.contains(token));
+        assert!(redacted.ends_with("The next sentence."));
+    }
+
+    #[test]
+    fn test_redact_dotted_opaque_bearer_token_without_fragment_leak() {
+        let detector = LeakDetector::new();
+        let prefix = "opaquePrefix1234567890";
+        let middle = "middle.segment.value";
+        let suffix = "opaqueSuffix0987654321";
+        let token = format!("{prefix}.{middle}.{suffix}");
+        let content = format!("token=Bearer {token}; after token");
+
+        let redacted = detector.scan_and_clean(&content).unwrap();
+
+        assert_eq!(redacted, "token=[REDACTED]; after token");
+        for forbidden in [prefix, middle, suffix] {
+            assert!(
+                !redacted.contains(forbidden),
+                "redacted dotted bearer token leaked fragment {forbidden}: {redacted}"
+            );
+        }
+    }
+
+    #[test]
     fn test_scan_and_clean_blocks() {
         let detector = LeakDetector::new();
         let content = "sk-proj-test1234567890abcdefghij";

--- a/crates/ironclaw_safety/src/leak_detector.rs
+++ b/crates/ironclaw_safety/src/leak_detector.rs
@@ -510,7 +510,7 @@ fn default_patterns() -> Vec<LeakPattern> {
         // Bearer tokens (redact instead of block, might be intentional)
         LeakPattern {
             name: "bearer_token".to_string(),
-            regex: Regex::new(r"Bearer\s+[a-zA-Z0-9_-]{20,}").unwrap(), // safety: hardcoded literal
+            regex: Regex::new(r"Bearer\s+[a-zA-Z0-9._-]{20,}").unwrap(), // safety: hardcoded literal
             severity: LeakSeverity::High,
             action: LeakAction::Redact,
         },
@@ -649,6 +649,25 @@ mod tests {
         let redacted = result.redacted_content.unwrap();
         assert!(redacted.contains("[REDACTED]"));
         assert!(!redacted.contains("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"));
+    }
+
+    #[test]
+    fn test_redact_bearer_jwt_token_without_tail_leak() {
+        let detector = LeakDetector::new();
+        let header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+        let payload = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let signature = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let content = format!("token: Bearer {header}.{payload}.{signature}");
+
+        let redacted = detector.scan_and_clean(&content).unwrap();
+
+        assert_eq!(redacted, "token: [REDACTED]");
+        for forbidden in [header, payload, signature] {
+            assert!(
+                !redacted.contains(forbidden),
+                "redacted bearer JWT leaked token fragment {forbidden}: {redacted}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds two #3067 Reborn E2E gate tests through `HostRuntimeServices -> DefaultHostRuntime -> ScriptRuntime`.
- Covers `RedactOutput` before public completed output is returned and verifies bearer/JWT fragments do not leak.
- Covers `EnforceOutputLimit` blocking oversized runtime output before public publication, with failed run-state and no sentinel leak in runtime events/failure output.
- Fixes bearer token redaction so dotted JWT-style bearer tokens redact as one token instead of leaving tail fragments.
- Keeps existing redacted-key collision coverage aligned with full-token redaction.
- Avoids a cfg-dependent `ResourceTally` import warning/error split between default and all-features clippy.

Refs #3067.

## Review follow-up

- Addressed reviewer finding: previous E2E assertion allowed `[REDACTED].<jwt-tail>` to pass. Tightened the E2E assertion and added a direct `ironclaw_safety` regression test; both failed before the regex fix and pass now.

## Tests

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3067-e2e cargo test -q -p ironclaw_safety leak_detector::tests::test_redact_bearer_jwt_token_without_tail_leak -- --exact`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3067-e2e cargo test -q -p ironclaw_host_runtime --tests --no-fail-fast`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3067-e2e cargo clippy -q -p ironclaw_host_runtime --tests --all-features -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3067-e2e cargo clippy -q -p ironclaw_safety -p ironclaw_host_runtime --tests -- -D warnings`
