### PR TITLE
fix(reborn): close secret store review gaps

### DIFF
--- a/crates/ironclaw_reborn/tests/secrets.rs
+++ b/crates/ironclaw_reborn/tests/secrets.rs
@@ -290,6 +290,44 @@ async fn reborn_secret_store_missing_secret_does_not_create_lease() {
 }
 
 #[tokio::test]
+async fn reborn_secret_store_active_lease_survives_secret_rotation() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("reborn-secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let store = build_libsql_reborn_secret_store(RebornLibSqlSecretStoreConfig {
+        database,
+        master_key: Some(SecretMaterial::from(
+            "0123456789abcdef0123456789abcdef".to_string(),
+        )),
+    })
+    .await
+    .unwrap();
+    let scope = sample_scope();
+    let handle = ironclaw_host_api::SecretHandle::new("openai_key").unwrap();
+
+    store
+        .put(
+            scope.clone(),
+            handle.clone(),
+            SecretMaterial::from("sk-live-before-rotation"),
+        )
+        .await
+        .unwrap();
+    let lease = store.lease_once(&scope, &handle).await.unwrap();
+    store
+        .put(
+            scope.clone(),
+            handle,
+            SecretMaterial::from("sk-live-after-rotation"),
+        )
+        .await
+        .unwrap();
+
+    let material = store.consume(&scope, lease.id).await.unwrap();
+    assert_eq!(material.expose_secret(), "sk-live-after-rotation");
+}
+
+#[tokio::test]
 async fn reborn_secret_store_persists_material_encrypted_and_exposes_only_through_secret_store() {
     let dir = tempfile::tempdir().unwrap().keep();
     let db_path = dir.join("reborn-secrets.db");

--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -1155,8 +1155,8 @@ impl LibSqlSecretsStore {
 
     /// Verifies the durable store key-check sentinel.
     ///
-    /// Stores that predate the sentinel are bootstrapped by decrypting one
-    /// deterministic existing secret row before installing the key-check record.
+    /// Stores that predate the sentinel are bootstrapped by decrypting all
+    /// existing secret rows before installing the key-check record.
     pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
         let conn = self.connect().await?;
         libsql_verify_or_bootstrap_secret_store_key_check(&conn, &self.crypto).await
@@ -1174,8 +1174,7 @@ impl SecretsStore for LibSqlSecretsStore {
         let conn = libsql_secret_begin_immediate(&self.db).await?;
         let result = async {
             let secret = build_encrypted_secret(user_id, params, &self.crypto)?;
-            libsql_upsert_secret(&conn, &secret).await?;
-            Ok(secret)
+            libsql_upsert_secret(&conn, &secret).await
         }
         .await;
         finish_libsql_secret_transaction(&conn, result).await
@@ -1314,8 +1313,8 @@ impl PostgresSecretsStore {
 
     /// Verifies the durable store key-check sentinel.
     ///
-    /// Stores that predate the sentinel are bootstrapped by decrypting one
-    /// deterministic existing secret row before installing the key-check record.
+    /// Stores that predate the sentinel are bootstrapped by decrypting all
+    /// existing secret rows before installing the key-check record.
     pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
         let client = self.pool.get().await.map_err(secret_db_error)?;
         postgres_verify_or_bootstrap_secret_store_key_check(&client, &self.crypto).await
@@ -1332,8 +1331,7 @@ impl SecretsStore for PostgresSecretsStore {
     ) -> Result<Secret, SecretError> {
         let client = self.pool.get().await.map_err(secret_db_error)?;
         let secret = build_encrypted_secret(user_id, params, &self.crypto)?;
-        postgres_upsert_secret(&client, &secret).await?;
-        Ok(secret)
+        postgres_upsert_secret(&client, &secret).await
     }
 
     async fn get(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
@@ -1505,10 +1503,9 @@ async fn libsql_verify_or_bootstrap_secret_store_key_check(
         return verify_secret_store_key_check(crypto, &encrypted_value, &key_salt);
     }
     // Legacy/bootstrap path for stores created before the key-check row existed:
-    // validate one deterministic existing row before installing the sentinel.
-    if let Some((encrypted_value, key_salt)) = libsql_first_secret_payload(conn).await? {
-        crypto.decrypt(&encrypted_value, &key_salt)?;
-    }
+    // validate every existing row before installing the sentinel. This is a
+    // one-time migration/readiness cost; steady-state checks use the sentinel.
+    libsql_verify_all_secret_payloads(conn, crypto).await?;
     libsql_insert_secret_store_key_check(conn, crypto).await?;
     let Some((encrypted_value, key_salt)) = libsql_secret_store_key_check(conn).await? else {
         return Err(SecretError::Database(
@@ -1539,23 +1536,23 @@ async fn libsql_secret_store_key_check(
 }
 
 #[cfg(feature = "libsql")]
-async fn libsql_first_secret_payload(
+async fn libsql_verify_all_secret_payloads(
     conn: &libsql::Connection,
-) -> Result<Option<(Vec<u8>, Vec<u8>)>, SecretError> {
+    crypto: &SecretsCrypto,
+) -> Result<(), SecretError> {
     let mut rows = conn
         .query(
-            "SELECT encrypted_value, key_salt FROM reborn_secret_records ORDER BY user_id, name LIMIT 1",
+            "SELECT encrypted_value, key_salt FROM reborn_secret_records ORDER BY user_id, name",
             (),
         )
         .await
         .map_err(secret_db_error)?;
-    let Some(row) = rows.next().await.map_err(secret_db_error)? else {
-        return Ok(None);
-    };
-    Ok(Some((
-        row.get(0).map_err(secret_db_error)?,
-        row.get(1).map_err(secret_db_error)?,
-    )))
+    while let Some(row) = rows.next().await.map_err(secret_db_error)? {
+        let encrypted_value: Vec<u8> = row.get(0).map_err(secret_db_error)?;
+        let key_salt: Vec<u8> = row.get(1).map_err(secret_db_error)?;
+        crypto.decrypt(&encrypted_value, &key_salt)?;
+    }
+    Ok(())
 }
 
 #[cfg(feature = "libsql")]
@@ -1579,9 +1576,9 @@ async fn libsql_insert_secret_store_key_check(
 async fn libsql_upsert_secret(
     conn: &libsql::Connection,
     secret: &Secret,
-) -> Result<(), SecretError> {
+) -> Result<Secret, SecretError> {
     conn.execute(
-        "INSERT INTO reborn_secret_records (user_id, name, id, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) ON CONFLICT(user_id, name) DO UPDATE SET id = EXCLUDED.id, encrypted_value = EXCLUDED.encrypted_value, key_salt = EXCLUDED.key_salt, provider = EXCLUDED.provider, expires_at = EXCLUDED.expires_at, last_used_at = NULL, usage_count = 0, created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at",
+        "INSERT INTO reborn_secret_records (user_id, name, id, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) ON CONFLICT(user_id, name) DO UPDATE SET encrypted_value = EXCLUDED.encrypted_value, key_salt = EXCLUDED.key_salt, provider = EXCLUDED.provider, expires_at = EXCLUDED.expires_at, updated_at = EXCLUDED.updated_at",
         libsql::params![
             secret.user_id.clone(),
             secret.name.clone(),
@@ -1598,7 +1595,11 @@ async fn libsql_upsert_secret(
     )
     .await
     .map_err(secret_db_error)?;
-    Ok(())
+    libsql_get_secret(conn, &secret.user_id, &secret.name)
+        .await?
+        .ok_or_else(|| {
+            SecretError::Database("secret upsert succeeded but row was not found".to_string())
+        })
 }
 
 #[cfg(feature = "libsql")]
@@ -1665,10 +1666,9 @@ async fn postgres_verify_or_bootstrap_secret_store_key_check(
         return verify_secret_store_key_check(crypto, &encrypted_value, &key_salt);
     }
     // Legacy/bootstrap path for stores created before the key-check row existed:
-    // validate one deterministic existing row before installing the sentinel.
-    if let Some((encrypted_value, key_salt)) = postgres_first_secret_payload(client).await? {
-        crypto.decrypt(&encrypted_value, &key_salt)?;
-    }
+    // validate every existing row before installing the sentinel. This is a
+    // one-time migration/readiness cost; steady-state checks use the sentinel.
+    postgres_verify_all_secret_payloads(client, crypto).await?;
     postgres_insert_secret_store_key_check(client, crypto).await?;
     let Some((encrypted_value, key_salt)) = postgres_secret_store_key_check(client).await? else {
         return Err(SecretError::Database(
@@ -1693,17 +1693,23 @@ async fn postgres_secret_store_key_check(
 }
 
 #[cfg(feature = "postgres")]
-async fn postgres_first_secret_payload(
+async fn postgres_verify_all_secret_payloads(
     client: &impl deadpool_postgres::GenericClient,
-) -> Result<Option<(Vec<u8>, Vec<u8>)>, SecretError> {
-    let row = client
-        .query_opt(
-            "SELECT encrypted_value, key_salt FROM reborn_secret_records ORDER BY user_id, name LIMIT 1",
+    crypto: &SecretsCrypto,
+) -> Result<(), SecretError> {
+    let rows = client
+        .query(
+            "SELECT encrypted_value, key_salt FROM reborn_secret_records ORDER BY user_id, name",
             &[],
         )
         .await
         .map_err(secret_db_error)?;
-    Ok(row.map(|row| (row.get(0), row.get(1))))
+    for row in rows {
+        let encrypted_value: Vec<u8> = row.get(0);
+        let key_salt: Vec<u8> = row.get(1);
+        crypto.decrypt(&encrypted_value, &key_salt)?;
+    }
+    Ok(())
 }
 
 #[cfg(feature = "postgres")]
@@ -1728,9 +1734,9 @@ async fn postgres_insert_secret_store_key_check(
 async fn postgres_upsert_secret(
     client: &impl deadpool_postgres::GenericClient,
     secret: &Secret,
-) -> Result<(), SecretError> {
-    client.execute("INSERT INTO reborn_secret_records (user_id, name, id, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) ON CONFLICT(user_id, name) DO UPDATE SET id = EXCLUDED.id, encrypted_value = EXCLUDED.encrypted_value, key_salt = EXCLUDED.key_salt, provider = EXCLUDED.provider, expires_at = EXCLUDED.expires_at, last_used_at = NULL, usage_count = 0, created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at", &[&secret.user_id, &secret.name, &secret.id.to_string(), &secret.encrypted_value, &secret.key_salt, &secret.provider, &secret.expires_at.map(|value| value.to_rfc3339()), &secret.last_used_at.map(|value| value.to_rfc3339()), &secret.usage_count, &secret.created_at.to_rfc3339(), &secret.updated_at.to_rfc3339()]).await.map_err(secret_db_error)?;
-    Ok(())
+) -> Result<Secret, SecretError> {
+    let row = client.query_one("INSERT INTO reborn_secret_records (user_id, name, id, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) ON CONFLICT(user_id, name) DO UPDATE SET encrypted_value = EXCLUDED.encrypted_value, key_salt = EXCLUDED.key_salt, provider = EXCLUDED.provider, expires_at = EXCLUDED.expires_at, updated_at = EXCLUDED.updated_at RETURNING id, user_id, name, encrypted_value, key_salt, provider, expires_at, last_used_at, usage_count, created_at, updated_at", &[&secret.user_id, &secret.name, &secret.id.to_string(), &secret.encrypted_value, &secret.key_salt, &secret.provider, &secret.expires_at.map(|value| value.to_rfc3339()), &secret.last_used_at.map(|value| value.to_rfc3339()), &secret.usage_count, &secret.created_at.to_rfc3339(), &secret.updated_at.to_rfc3339()]).await.map_err(secret_db_error)?;
+    postgres_secret_from_row(&row)
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
+++ b/crates/ironclaw_secrets/tests/db_secret_store_contract.rs
@@ -110,6 +110,44 @@ async fn libsql_secret_store_verify_can_decrypt_existing_secrets_rejects_wrong_k
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn libsql_secret_store_key_check_bootstrap_scans_all_existing_rows() {
+    let dir = tempfile::tempdir().unwrap().keep();
+    let db_path = dir.join("secrets.db");
+    let database = Arc::new(libsql::Builder::new_local(&db_path).build().await.unwrap());
+    let store = LibSqlSecretsStore::new(Arc::clone(&database), test_crypto());
+    store.run_migrations().await.unwrap();
+    store
+        .create(
+            "a-reborn-user",
+            CreateSecretParams::new("a_key", "sk-live-good-row"),
+        )
+        .await
+        .unwrap();
+    let conn = database.connect().unwrap();
+    insert_libsql_secret_record(
+        &conn,
+        "z-reborn-user",
+        "z_key",
+        wrong_crypto(),
+        "sk-live-wrong-row",
+    )
+    .await;
+
+    let error = store
+        .verify_can_decrypt_existing_secrets()
+        .await
+        .expect_err("pre-sentinel bootstrap must validate every existing row before installing the key check");
+    assert!(matches!(error, SecretError::DecryptionFailed(_)));
+    assert!(!format!("{error:?}").contains("sk-live-wrong-row"));
+    let mut rows = conn
+        .query("SELECT 1 FROM reborn_secret_store_key_check", ())
+        .await
+        .unwrap();
+    assert!(rows.next().await.unwrap().is_none());
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn libsql_secret_store_key_check_rejects_concurrent_conflict_winner_with_wrong_key() {
     let dir = tempfile::tempdir().unwrap().keep();
     let db_path = dir.join("secrets.db");
@@ -275,6 +313,68 @@ async fn postgres_secret_store_verify_can_decrypt_existing_secrets_rejects_wrong
 
 #[cfg(feature = "postgres")]
 #[tokio::test]
+async fn postgres_secret_store_key_check_bootstrap_scans_all_existing_rows() {
+    let Some(pool) = postgres_pool().await else {
+        return;
+    };
+    let suffix = unique_suffix();
+    let store = PostgresSecretsStore::new(pool.clone(), test_crypto());
+    store.run_migrations().await.unwrap();
+    let client = pool.get().await.unwrap();
+    client
+        .execute(
+            "DELETE FROM reborn_secret_store_key_check WHERE id = $1",
+            &[&"active"],
+        )
+        .await
+        .unwrap();
+    let good_user_id = format!("a-reborn-user-bootstrap-{suffix}");
+    let bad_user_id = format!("z-reborn-user-bootstrap-{suffix}");
+    let good_name = format!("a_key_{suffix}");
+    let bad_name = format!("z_key_{suffix}");
+    store
+        .create(
+            &good_user_id,
+            CreateSecretParams::new(&good_name, "sk-live-postgres-good-row"),
+        )
+        .await
+        .unwrap();
+    insert_postgres_secret_record(
+        &client,
+        &bad_user_id,
+        &bad_name,
+        wrong_crypto(),
+        "sk-live-postgres-wrong-row",
+    )
+    .await;
+
+    let error = store
+        .verify_can_decrypt_existing_secrets()
+        .await
+        .expect_err("pre-sentinel bootstrap must validate every existing row before installing the key check");
+    assert!(matches!(error, SecretError::DecryptionFailed(_)));
+    assert!(!format!("{error:?}").contains("sk-live-postgres-wrong-row"));
+    assert!(
+        client
+            .query_opt(
+                "SELECT 1 FROM reborn_secret_store_key_check WHERE id = $1",
+                &[&"active"],
+            )
+            .await
+            .unwrap()
+            .is_none()
+    );
+    client
+        .execute(
+            "DELETE FROM reborn_secret_records WHERE user_id = ANY($1)",
+            &[&vec![good_user_id, bad_user_id]],
+        )
+        .await
+        .unwrap();
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
 async fn postgres_secret_store_key_check_rejects_concurrent_conflict_winner_with_wrong_key() {
     let Some(pool) = postgres_pool().await else {
         return;
@@ -393,13 +493,17 @@ where
         )
         .await
         .unwrap();
-    assert_ne!(overwritten.id, created.id);
+    assert_eq!(overwritten.id, created.id);
     assert_eq!(overwritten.name, "beta_key");
+    assert_eq!(overwritten.created_at, created.created_at);
+    assert_eq!(overwritten.usage_count, 1);
+    assert!(overwritten.last_used_at.is_some());
 
     let after_overwrite = store.get(user_id, "beta_key").await.unwrap();
-    assert_eq!(after_overwrite.id, overwritten.id);
-    assert_eq!(after_overwrite.usage_count, 0);
-    assert!(after_overwrite.last_used_at.is_none());
+    assert_eq!(after_overwrite.id, created.id);
+    assert_eq!(after_overwrite.created_at, created.created_at);
+    assert_eq!(after_overwrite.usage_count, 1);
+    assert!(after_overwrite.last_used_at.is_some());
     assert_eq!(after_overwrite.provider.as_deref(), Some("anthropic"));
     let decrypted = store.get_decrypted(user_id, "beta_key").await.unwrap();
     assert_eq!(decrypted.expose(), "sk-live-second-value");
@@ -528,6 +632,24 @@ async fn insert_libsql_secret_store_key_check(
     .unwrap();
 }
 
+#[cfg(feature = "libsql")]
+async fn insert_libsql_secret_record(
+    conn: &libsql::Connection,
+    user_id: &str,
+    name: &str,
+    crypto: Arc<SecretsCrypto>,
+    plaintext: &str,
+) {
+    let (encrypted_value, key_salt) = crypto.encrypt(plaintext.as_bytes()).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO reborn_secret_records (user_id, name, id, encrypted_value, key_salt, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+        libsql::params![user_id, name, uuid::Uuid::new_v4().to_string(), encrypted_value, key_salt, now],
+    )
+    .await
+    .unwrap();
+}
+
 #[cfg(feature = "postgres")]
 async fn postgres_store() -> Option<PostgresSecretsStore> {
     postgres_store_with_crypto(test_crypto()).await
@@ -573,6 +695,25 @@ async fn insert_postgres_secret_store_key_check(
         .execute(
             "INSERT INTO reborn_secret_store_key_check (id, encrypted_value, key_salt, created_at, updated_at) VALUES ($1, $2, $3, $4, $4)",
             &[&"active", &encrypted_value, &key_salt, &now],
+        )
+        .await
+        .unwrap();
+}
+
+#[cfg(feature = "postgres")]
+async fn insert_postgres_secret_record(
+    client: &impl deadpool_postgres::GenericClient,
+    user_id: &str,
+    name: &str,
+    crypto: Arc<SecretsCrypto>,
+    plaintext: &str,
+) {
+    let (encrypted_value, key_salt) = crypto.encrypt(plaintext.as_bytes()).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    client
+        .execute(
+            "INSERT INTO reborn_secret_records (user_id, name, id, encrypted_value, key_salt, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $6)",
+            &[&user_id, &name, &uuid::Uuid::new_v4().to_string(), &encrypted_value, &key_salt, &now],
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

- preserve durable secret row identity/created_at/usage metadata when replacing secret material
- keep active Reborn secret leases consumable across trusted secret rotation
- make pre-sentinel secret-store readiness decrypt every existing row before installing the O(1) key-check sentinel

Follow-up to #3414.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p ironclaw_secrets --features "libsql postgres" --test db_secret_store_contract`
- `cargo test -p ironclaw_reborn --features libsql-secrets --test secrets`
- `cargo test -p ironclaw_reborn --all-features --test secrets`
- `cargo clippy -p ironclaw_secrets --features "libsql postgres" --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_reborn --all-features --all-targets -- -D warnings`