### PR TITLE
feat(reborn): add concrete TurnRunner worker composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4514,6 +4514,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "futures-util",
  "ironclaw_host_api",
  "ironclaw_llm",
  "ironclaw_loop_support",
@@ -4526,6 +4527,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -8787,6 +8790,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -17,6 +17,7 @@ libsql-secrets = ["dep:ironclaw_secrets", "ironclaw_secrets/libsql", "dep:libsql
 
 [dependencies]
 async-trait = "0.1"
+futures-util = { version = "0.3", default-features = false }
 ironclaw_llm = { path = "../ironclaw_llm", version = "0.1.0", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support", version = "0.1.0" }
 ironclaw_secrets = { path = "../ironclaw_secrets", version = "0.1.0", optional = true }
@@ -24,6 +25,9 @@ ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 secrecy = { version = "0.10", optional = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = "0.1"
 
 [dev-dependencies]
 chrono = "0.4"
@@ -31,7 +35,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 rust_decimal = "1"
 serde_json = "1"
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 
 [[test]]
 name = "llm_gateway"

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -17,6 +17,7 @@ libsql-secrets = ["dep:ironclaw_secrets", "ironclaw_secrets/libsql", "dep:libsql
 
 [dependencies]
 async-trait = "0.1"
+chrono = "0.4"
 futures-util = { version = "0.3", default-features = false }
 ironclaw_llm = { path = "../ironclaw_llm", version = "0.1.0", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support", version = "0.1.0" }

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod driver_registry;
 pub mod loop_driver_host;
+pub mod turn_runner;
 
 #[cfg(feature = "root-llm-provider")]
 pub mod model_gateway;

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -541,6 +541,38 @@ fn validate_claimed_run_context(
     Ok(())
 }
 
+#[async_trait]
+impl<S, G> crate::turn_runner::HostFactory for RebornLoopDriverHostFactory<S, G>
+where
+    S: SessionThreadService + ?Sized + Send + Sync + 'static,
+    G: HostManagedModelGateway + ?Sized + Send + Sync + 'static,
+{
+    async fn create_host(
+        &self,
+        claimed: &ClaimedTurnRun,
+    ) -> Result<
+        Box<dyn ironclaw_turns::run_profile::AgentLoopDriverHost + Send + Sync>,
+        crate::turn_runner::HostFactoryError,
+    > {
+        let loop_run_context = LoopRunContext::new(
+            claimed.state.scope.clone(),
+            claimed.state.turn_id,
+            claimed.state.run_id,
+            claimed.resolved_run_profile.clone(),
+        );
+        self.build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: claimed.clone(),
+            loop_run_context,
+        })
+        .await
+        .map(|host| {
+            Box::new(host)
+                as Box<dyn ironclaw_turns::run_profile::AgentLoopDriverHost + Send + Sync>
+        })
+        .map_err(|error| crate::turn_runner::HostFactoryError::new(error.to_string()))
+    }
+}
+
 fn persisted_profile_id(profile_id: &RunProfileId) -> RunProfileId {
     if profile_id.is_interactive_default() {
         RunProfileId::default_profile()

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -1,0 +1,601 @@
+//! Concrete Reborn turn-runner worker composition.
+//!
+//! This module owns the worker lifecycle that claims queued/resumed turn runs,
+//! heartbeats the runner lease, selects a registered loop driver, constructs a
+//! per-run `AgentLoopDriverHost`, invokes the driver, and applies the returned
+//! `LoopExit` through trusted transition ports.
+//!
+//! # Architecture boundary
+//!
+//! `ironclaw_turns` owns `TurnRunTransitionPort`, claim/heartbeat/transition
+//! DTOs, state-machine invariants, and the `apply_loop_exit` helper.
+//!
+//! This module owns the concrete worker loop, driver registry lookup, host
+//! factory, readiness/config, and worker lifecycle.
+
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures_util::FutureExt;
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+use ironclaw_turns::{
+    AgentLoopDriverError, AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, LoopExit,
+    LoopExitValidationPolicy, SanitizedFailure, TurnError, TurnLeaseToken, TurnRunId, TurnRunnerId,
+    TurnScope, TurnStatus,
+    runner::{
+        ApplyLoopExitRequest, ClaimRunRequest, ClaimedTurnRun, HeartbeatRequest,
+        RecordRecoveryRequiredRequest, TurnRunTransitionPort,
+    },
+};
+
+use crate::driver_registry::{DriverRegistry, LoopDriverRegistryKey};
+
+/// Create a `SanitizedFailure` from a known-valid static category.
+///
+/// All categories used here are lowercase ASCII with underscores, satisfying
+/// validation invariants. Returning `None` is only possible if a static literal
+/// is changed to an invalid category.
+fn sanitized_failure(category: &'static str) -> Option<SanitizedFailure> {
+    match SanitizedFailure::new(category) {
+        Ok(failure) => Some(failure),
+        Err(error) => {
+            error!(category, %error, "invalid static recovery failure category");
+            match SanitizedFailure::new("unknown_failure") {
+                Ok(fallback) => Some(fallback),
+                Err(fallback_error) => {
+                    error!(%fallback_error, "fallback recovery failure category invalid");
+                    None
+                }
+            }
+        }
+    }
+}
+
+/// Configuration for the turn-runner worker.
+#[derive(Debug, Clone)]
+pub struct TurnRunnerWorkerConfig {
+    /// How often to send heartbeats for an active run lease.
+    pub heartbeat_interval: Duration,
+
+    /// Fallback poll interval when no wake signal arrives.
+    pub poll_interval: Duration,
+
+    /// Optional scope filter to restrict which runs this worker claims.
+    pub scope_filter: Option<TurnScope>,
+}
+
+impl Default for TurnRunnerWorkerConfig {
+    fn default() -> Self {
+        Self {
+            heartbeat_interval: Duration::from_secs(10),
+            poll_interval: Duration::from_secs(5),
+            scope_filter: None,
+        }
+    }
+}
+
+/// Factory trait for constructing a per-run `AgentLoopDriverHost`.
+///
+/// The host is created once per claimed run and provides the driver with access
+/// to model, transcript, checkpoint, input, capabilities, and progress services.
+#[async_trait]
+pub trait HostFactory: Send + Sync {
+    /// Construct a host for the given claimed run.
+    ///
+    /// The returned host must be valid for the entire duration of the driver
+    /// invocation. Errors here result in `RecoveryRequired` for the run.
+    async fn create_host(
+        &self,
+        claimed: &ClaimedTurnRun,
+    ) -> Result<
+        Box<dyn ironclaw_turns::run_profile::AgentLoopDriverHost + Send + Sync>,
+        HostFactoryError,
+    >;
+}
+
+/// Error returned when host construction fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostFactoryError {
+    pub reason: String,
+}
+
+impl HostFactoryError {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for HostFactoryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "host factory error: {}", self.reason)
+    }
+}
+
+impl std::error::Error for HostFactoryError {}
+
+/// Wake signal receiver for the turn-runner worker.
+///
+/// The worker uses wake-driven execution with fallback polling. Wake delivery
+/// is best-effort: safe to duplicate or miss.
+#[derive(Debug, Clone)]
+pub struct TurnRunnerWakeReceiver {
+    notify: Arc<Notify>,
+}
+
+impl TurnRunnerWakeReceiver {
+    pub fn new() -> (TurnRunnerWakeSender, Self) {
+        let notify = Arc::new(Notify::new());
+        (
+            TurnRunnerWakeSender {
+                notify: Arc::clone(&notify),
+            },
+            Self { notify },
+        )
+    }
+
+    /// Wait for a wake signal or timeout.
+    async fn wait_or_timeout(&self, timeout: Duration) {
+        tokio::select! {
+            () = self.notify.notified() => {}
+            () = tokio::time::sleep(timeout) => {}
+        }
+    }
+}
+
+impl Default for TurnRunnerWakeReceiver {
+    fn default() -> Self {
+        Self::new().1
+    }
+}
+
+/// Sender half for wake signals.
+///
+/// This can be integrated with `TurnRunWakeNotifier` to forward queued-run
+/// wakes into the worker.
+#[derive(Debug, Clone)]
+pub struct TurnRunnerWakeSender {
+    notify: Arc<Notify>,
+}
+
+impl TurnRunnerWakeSender {
+    /// Signal the worker that there may be new work available.
+    pub fn wake(&self) {
+        self.notify.notify_one();
+    }
+}
+
+/// The concrete Reborn turn-runner worker.
+///
+/// Claims one run at a time, heartbeats the lease, invokes the matched driver,
+/// and applies the returned `LoopExit` through the trusted transition port.
+pub struct TurnRunnerWorker {
+    runner_id: TurnRunnerId,
+    config: TurnRunnerWorkerConfig,
+    transition_port: Arc<dyn TurnRunTransitionPort>,
+    driver_registry: Arc<DriverRegistry>,
+    host_factory: Arc<dyn HostFactory>,
+    wake_receiver: TurnRunnerWakeReceiver,
+}
+
+impl TurnRunnerWorker {
+    pub fn new(
+        config: TurnRunnerWorkerConfig,
+        transition_port: Arc<dyn TurnRunTransitionPort>,
+        driver_registry: Arc<DriverRegistry>,
+        host_factory: Arc<dyn HostFactory>,
+        wake_receiver: TurnRunnerWakeReceiver,
+    ) -> Self {
+        let runner_id = TurnRunnerId::new();
+        info!(runner_id = ?runner_id, "turn runner worker created");
+        Self {
+            runner_id,
+            config,
+            transition_port,
+            driver_registry,
+            host_factory,
+            wake_receiver,
+        }
+    }
+
+    /// Returns the stable runner identity for this worker instance.
+    pub fn runner_id(&self) -> TurnRunnerId {
+        self.runner_id
+    }
+
+    /// Run the worker claim loop until the cancellation token fires.
+    ///
+    /// This is the main entry point. It loops:
+    /// 1. Wait for a wake signal or fallback poll tick
+    /// 2. Claim the next available run
+    /// 3. If none claimed, continue
+    /// 4. Run the claimed run to `LoopExit` / application
+    /// 5. Repeat
+    pub async fn run(&self, cancel: CancellationToken) {
+        info!(runner_id = ?self.runner_id, "turn runner worker started");
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    info!(runner_id = ?self.runner_id, "turn runner worker shutting down");
+                    break;
+                }
+                () = self.wake_receiver.wait_or_timeout(self.config.poll_interval) => {}
+            }
+
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            if let Err(err) = self.try_claim_and_run().await {
+                warn!(
+                    runner_id = ?self.runner_id,
+                    error = %err,
+                    "claim-and-run cycle failed"
+                );
+            }
+        }
+
+        info!(runner_id = ?self.runner_id, "turn runner worker stopped");
+    }
+
+    /// Attempt one claim-and-run cycle.
+    async fn try_claim_and_run(&self) -> Result<(), TurnRunnerError> {
+        let lease_token = TurnLeaseToken::new();
+        let request = ClaimRunRequest {
+            runner_id: self.runner_id,
+            lease_token,
+            scope_filter: self.config.scope_filter.clone(),
+        };
+
+        let claimed = self
+            .transition_port
+            .claim_next_run(request)
+            .await
+            .map_err(TurnRunnerError::ClaimFailed)?;
+
+        let Some(claimed) = claimed else {
+            debug!(runner_id = ?self.runner_id, "no runs available to claim");
+            return Ok(());
+        };
+
+        let run_id = claimed.state.run_id;
+        let status = claimed.state.status;
+
+        info!(
+            runner_id = ?self.runner_id,
+            run_id = ?run_id,
+            status = ?status,
+            "claimed turn run"
+        );
+
+        self.execute_claimed_run(claimed).await;
+        Ok(())
+    }
+
+    /// Execute a claimed run: heartbeat, invoke driver, apply exit.
+    async fn execute_claimed_run(&self, claimed: ClaimedTurnRun) {
+        let run_id = claimed.state.run_id;
+        let runner_id = claimed.runner_id;
+        let lease_token = claimed.lease_token;
+
+        // Start heartbeat task
+        let heartbeat_cancel = CancellationToken::new();
+        let heartbeat_handle = {
+            let port = Arc::clone(&self.transition_port);
+            let interval = self.config.heartbeat_interval;
+            let cancel = heartbeat_cancel.clone();
+            tokio::spawn(heartbeat_loop(
+                port,
+                run_id,
+                runner_id,
+                lease_token,
+                interval,
+                cancel,
+            ))
+        };
+
+        // Resolve driver from registry and invoke it. Driver panics indicate
+        // unknown partial state, so convert them to RecoveryRequired.
+        let exit_result = match AssertUnwindSafe(self.invoke_driver(&claimed))
+            .catch_unwind()
+            .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(DriverInvocationError::DriverPanic),
+        };
+
+        // Stop heartbeat
+        heartbeat_cancel.cancel();
+        let _ = heartbeat_handle.await;
+
+        // Apply the exit or record recovery
+        match exit_result {
+            Ok(exit) => {
+                self.apply_exit(run_id, runner_id, lease_token, exit).await;
+            }
+            Err(err) => {
+                warn!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    error = %err,
+                    "driver invocation failed, recording recovery required"
+                );
+                self.record_recovery(run_id, runner_id, lease_token, &err)
+                    .await;
+            }
+        }
+    }
+
+    /// Resolve driver from registry and invoke it.
+    async fn invoke_driver(
+        &self,
+        claimed: &ClaimedTurnRun,
+    ) -> Result<LoopExit, DriverInvocationError> {
+        let descriptor = &claimed.resolved_run_profile.loop_driver;
+        let registry_key =
+            LoopDriverRegistryKey::from_descriptor(descriptor).map_err(|reason| {
+                DriverInvocationError::DriverNotFound {
+                    reason: format!("invalid descriptor: {reason}"),
+                }
+            })?;
+
+        let registered = self.driver_registry.get(&registry_key).ok_or_else(|| {
+            DriverInvocationError::DriverNotFound {
+                reason: format!("no registered driver for {registry_key}"),
+            }
+        })?;
+
+        let driver = registered.driver();
+
+        // Create host for this run
+        let host = self
+            .host_factory
+            .create_host(claimed)
+            .await
+            .map_err(|err| DriverInvocationError::HostCreationFailed { reason: err.reason })?;
+
+        let status = claimed.state.status;
+        let turn_id = claimed.state.turn_id;
+        let run_id = claimed.state.run_id;
+
+        match (status, claimed.state.checkpoint_id) {
+            (TurnStatus::Queued, _) => {
+                let request = AgentLoopDriverRunRequest {
+                    turn_id,
+                    run_id,
+                    resolved_run_profile: claimed.resolved_run_profile.clone(),
+                };
+                driver
+                    .run(request, host.as_ref())
+                    .await
+                    .map_err(DriverInvocationError::DriverError)
+            }
+            // Resumed runs have a checkpoint.
+            (_, Some(checkpoint_id)) => {
+                let request = AgentLoopDriverResumeRequest {
+                    turn_id,
+                    run_id,
+                    checkpoint_id,
+                    resolved_run_profile: claimed.resolved_run_profile.clone(),
+                };
+                driver
+                    .resume(request, host.as_ref())
+                    .await
+                    .map_err(DriverInvocationError::DriverError)
+            }
+            // Fallback: treat as new run
+            _ => {
+                let request = AgentLoopDriverRunRequest {
+                    turn_id,
+                    run_id,
+                    resolved_run_profile: claimed.resolved_run_profile.clone(),
+                };
+                driver
+                    .run(request, host.as_ref())
+                    .await
+                    .map_err(DriverInvocationError::DriverError)
+            }
+        }
+    }
+
+    /// Apply a `LoopExit` through the trusted transition port.
+    async fn apply_exit(
+        &self,
+        run_id: TurnRunId,
+        runner_id: TurnRunnerId,
+        lease_token: TurnLeaseToken,
+        exit: LoopExit,
+    ) {
+        let request = ApplyLoopExitRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            exit,
+            validation_policy: LoopExitValidationPolicy::default(),
+        };
+
+        match ironclaw_turns::runner::apply_loop_exit(self.transition_port.as_ref(), request).await
+        {
+            Ok(state) => {
+                info!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    status = ?state.status,
+                    "loop exit applied successfully"
+                );
+            }
+            Err(err) => {
+                error!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    error = %err,
+                    "failed to apply loop exit"
+                );
+                // If exit application fails, try recording recovery
+                let Some(failure) = sanitized_failure("exit_application_failed") else {
+                    return;
+                };
+                let recovery_request = RecordRecoveryRequiredRequest {
+                    run_id,
+                    runner_id,
+                    lease_token,
+                    failure,
+                };
+                if let Err(recovery_err) = self
+                    .transition_port
+                    .record_recovery_required(recovery_request)
+                    .await
+                {
+                    error!(
+                        runner_id = ?runner_id,
+                        run_id = ?run_id,
+                        error = %recovery_err,
+                        "failed to record recovery after exit application failure"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Record recovery required for a failed driver invocation.
+    async fn record_recovery(
+        &self,
+        run_id: TurnRunId,
+        runner_id: TurnRunnerId,
+        lease_token: TurnLeaseToken,
+        error: &DriverInvocationError,
+    ) {
+        let category = match error {
+            DriverInvocationError::DriverNotFound { .. } => "driver_not_found",
+            DriverInvocationError::HostCreationFailed { .. } => "host_creation_failed",
+            DriverInvocationError::DriverError(AgentLoopDriverError::InvalidRequest { .. }) => {
+                "driver_invalid_request"
+            }
+            DriverInvocationError::DriverError(AgentLoopDriverError::Unavailable { .. }) => {
+                "driver_unavailable"
+            }
+            DriverInvocationError::DriverError(AgentLoopDriverError::Failed { .. }) => {
+                "driver_failed"
+            }
+            DriverInvocationError::DriverPanic => "driver_panic",
+        };
+
+        let Some(failure) = sanitized_failure(category) else {
+            return;
+        };
+        let request = RecordRecoveryRequiredRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            failure,
+        };
+
+        if let Err(err) = self.transition_port.record_recovery_required(request).await {
+            error!(
+                runner_id = ?runner_id,
+                run_id = ?run_id,
+                error = %err,
+                "failed to record recovery required"
+            );
+        }
+    }
+}
+
+/// Heartbeat loop that runs in a spawned task for the duration of a driver run.
+async fn heartbeat_loop(
+    port: Arc<dyn TurnRunTransitionPort>,
+    run_id: TurnRunId,
+    runner_id: TurnRunnerId,
+    lease_token: TurnLeaseToken,
+    interval: Duration,
+    cancel: CancellationToken,
+) {
+    let mut tick = tokio::time::interval(interval);
+    // Skip the first immediate tick
+    tick.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                debug!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    "heartbeat loop stopped"
+                );
+                break;
+            }
+            _ = tick.tick() => {
+                let request = HeartbeatRequest {
+                    run_id,
+                    runner_id,
+                    lease_token,
+                };
+                match port.heartbeat(request).await {
+                    Ok(_cursor) => {
+                        debug!(
+                            runner_id = ?runner_id,
+                            run_id = ?run_id,
+                            "heartbeat sent"
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            runner_id = ?runner_id,
+                            run_id = ?run_id,
+                            error = %err,
+                            "heartbeat failed"
+                        );
+                        // Heartbeat failure is not fatal — the driver invocation
+                        // continues. If the lease actually expires, the store will
+                        // transition to RecoveryRequired on the next claim/recovery
+                        // sweep.
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Internal error type for a single claim-and-run cycle.
+#[derive(Debug)]
+enum TurnRunnerError {
+    ClaimFailed(TurnError),
+}
+
+impl std::fmt::Display for TurnRunnerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClaimFailed(err) => write!(f, "claim failed: {err}"),
+        }
+    }
+}
+
+/// Error during driver invocation (before `LoopExit` is returned).
+#[derive(Debug)]
+enum DriverInvocationError {
+    DriverNotFound { reason: String },
+    HostCreationFailed { reason: String },
+    DriverError(AgentLoopDriverError),
+    DriverPanic,
+}
+
+impl std::fmt::Display for DriverInvocationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DriverNotFound { reason } => write!(f, "driver not found: {reason}"),
+            Self::HostCreationFailed { reason } => write!(f, "host creation failed: {reason}"),
+            Self::DriverError(err) => write!(f, "driver error: {err}"),
+            Self::DriverPanic => write!(f, "driver panicked before returning loop exit"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use futures_util::FutureExt;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use ironclaw_turns::{
     AgentLoopDriverError, AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, LoopExit,
@@ -29,7 +29,7 @@ use ironclaw_turns::{
     TurnRunId, TurnRunnerId, TurnScope, TurnStatus,
     runner::{
         ApplyLoopExitRequest, ClaimRunRequest, ClaimedTurnRun, HeartbeatRequest,
-        RecordRecoveryRequiredRequest, TurnRunTransitionPort,
+        RecordRecoveryRequiredRequest, RecoverExpiredLeasesRequest, TurnRunTransitionPort,
     },
 };
 
@@ -82,7 +82,7 @@ impl Default for TurnRunnerWorkerConfig {
             heartbeat_interval: Duration::from_secs(10),
             poll_interval: Duration::from_secs(5),
             scope_filter: None,
-            exit_validation_policy: trusted_text_only_exit_validation_policy(),
+            exit_validation_policy: default_text_only_exit_validation_policy(),
         }
     }
 }
@@ -201,7 +201,7 @@ impl TurnRunnerWorker {
         wake_receiver: TurnRunnerWakeReceiver,
     ) -> Self {
         let runner_id = TurnRunnerId::new();
-        info!(runner_id = ?runner_id, "turn runner worker created");
+        debug!(runner_id = ?runner_id, "turn runner worker created");
         Self {
             runner_id,
             config,
@@ -220,41 +220,78 @@ impl TurnRunnerWorker {
     /// Run the worker claim loop until the cancellation token fires.
     ///
     /// This is the main entry point. It loops:
-    /// 1. Wait for a wake signal or fallback poll tick
-    /// 2. Claim the next available run
-    /// 3. If none claimed, continue
-    /// 4. Run the claimed run to `LoopExit` / application
-    /// 5. Repeat
+    /// 1. Sweep expired leases so crashed workers do not strand runs
+    /// 2. Claim and run queued work until the queue is empty
+    /// 3. Wait for a wake signal or fallback poll tick when no work remains
+    /// 4. Repeat until cancelled
     pub async fn run(&self, cancel: CancellationToken) {
-        info!(runner_id = ?self.runner_id, "turn runner worker started");
+        debug!(runner_id = ?self.runner_id, "turn runner worker started");
 
         loop {
+            if cancel.is_cancelled() {
+                debug!(runner_id = ?self.runner_id, "turn runner worker shutting down");
+                break;
+            }
+
+            if let Err(err) = self.recover_expired_leases().await {
+                warn!(
+                    runner_id = ?self.runner_id,
+                    error = %err,
+                    "expired lease recovery failed"
+                );
+            }
+
+            while !cancel.is_cancelled() {
+                match self.try_claim_and_run(&cancel).await {
+                    Ok(true) => continue,
+                    Ok(false) => break,
+                    Err(err) => {
+                        warn!(
+                            runner_id = ?self.runner_id,
+                            error = %err,
+                            "claim-and-run cycle failed"
+                        );
+                        break;
+                    }
+                }
+            }
+
+            if cancel.is_cancelled() {
+                continue;
+            }
+
             tokio::select! {
                 () = cancel.cancelled() => {
-                    info!(runner_id = ?self.runner_id, "turn runner worker shutting down");
+                    debug!(runner_id = ?self.runner_id, "turn runner worker shutting down");
                     break;
                 }
                 () = self.wake_receiver.wait_or_timeout(self.config.poll_interval) => {}
             }
-
-            if cancel.is_cancelled() {
-                break;
-            }
-
-            if let Err(err) = self.try_claim_and_run(&cancel).await {
-                warn!(
-                    runner_id = ?self.runner_id,
-                    error = %err,
-                    "claim-and-run cycle failed"
-                );
-            }
         }
 
-        info!(runner_id = ?self.runner_id, "turn runner worker stopped");
+        debug!(runner_id = ?self.runner_id, "turn runner worker stopped");
+    }
+
+    async fn recover_expired_leases(&self) -> Result<(), TurnError> {
+        let response = self
+            .transition_port
+            .recover_expired_leases(RecoverExpiredLeasesRequest {
+                now: chrono::Utc::now(),
+                scope_filter: self.config.scope_filter.clone(),
+            })
+            .await?;
+        if !response.recovered.is_empty() {
+            debug!(
+                runner_id = ?self.runner_id,
+                recovered = response.recovered.len(),
+                "expired turn-run leases recovered"
+            );
+        }
+        Ok(())
     }
 
     /// Attempt one claim-and-run cycle.
-    async fn try_claim_and_run(&self, cancel: &CancellationToken) -> Result<(), TurnRunnerError> {
+    async fn try_claim_and_run(&self, cancel: &CancellationToken) -> Result<bool, TurnRunnerError> {
         let lease_token = TurnLeaseToken::new();
         let request = ClaimRunRequest {
             runner_id: self.runner_id,
@@ -270,13 +307,13 @@ impl TurnRunnerWorker {
 
         let Some(claimed) = claimed else {
             debug!(runner_id = ?self.runner_id, "no runs available to claim");
-            return Ok(());
+            return Ok(false);
         };
 
         let run_id = claimed.state.run_id;
         let status = claimed.state.status;
 
-        info!(
+        debug!(
             runner_id = ?self.runner_id,
             run_id = ?run_id,
             status = ?status,
@@ -284,7 +321,7 @@ impl TurnRunnerWorker {
         );
 
         self.execute_claimed_run(claimed, cancel).await;
-        Ok(())
+        Ok(true)
     }
 
     /// Execute a claimed run: heartbeat, invoke driver, apply exit.
@@ -432,7 +469,7 @@ impl TurnRunnerWorker {
         match ironclaw_turns::runner::apply_loop_exit(self.transition_port.as_ref(), request).await
         {
             Ok(state) => {
-                info!(
+                debug!(
                     runner_id = ?runner_id,
                     run_id = ?run_id,
                     status = ?state.status,
@@ -461,11 +498,11 @@ impl TurnRunnerWorker {
                     .record_recovery_required(recovery_request)
                     .await
                 {
-                    error!(
-                        runner_id = ?runner_id,
-                        run_id = ?run_id,
-                        error = %recovery_err,
-                        "failed to record recovery after exit application failure"
+                    log_recovery_record_failure(
+                        runner_id,
+                        run_id,
+                        &recovery_err,
+                        "failed to record recovery after exit application failure",
                     );
                 }
             }
@@ -510,30 +547,77 @@ impl TurnRunnerWorker {
         };
 
         if let Err(err) = self.transition_port.record_recovery_required(request).await {
-            error!(
-                runner_id = ?runner_id,
-                run_id = ?run_id,
-                error = %err,
-                "failed to record recovery required"
+            log_recovery_record_failure(
+                runner_id,
+                run_id,
+                &err,
+                "failed to record recovery required",
             );
         }
     }
 }
 
-/// Temporary trusted text-only validation policy for this narrow worker slice.
+fn log_recovery_record_failure(
+    runner_id: TurnRunnerId,
+    run_id: TurnRunId,
+    error: &TurnError,
+    message: &'static str,
+) {
+    if recovery_record_rejection_is_expected(error) {
+        debug!(
+            runner_id = ?runner_id,
+            run_id = ?run_id,
+            error = %error,
+            message
+        );
+    } else {
+        error!(
+            runner_id = ?runner_id,
+            run_id = ?run_id,
+            error = %error,
+            message
+        );
+    }
+}
+
+fn recovery_record_rejection_is_expected(error: &TurnError) -> bool {
+    matches!(error, TurnError::LeaseMismatch)
+        || matches!(
+            error,
+            TurnError::InvalidTransition {
+                from: TurnStatus::Completed
+                    | TurnStatus::Cancelled
+                    | TurnStatus::Failed
+                    | TurnStatus::BlockedApproval
+                    | TurnStatus::BlockedAuth
+                    | TurnStatus::BlockedResource
+                    | TurnStatus::RecoveryRequired,
+                to: TurnStatus::RecoveryRequired,
+            }
+        )
+}
+
+/// Default text-only validation policy for this narrow worker slice.
 ///
-/// Completion refs are trusted because the only concrete host currently wired
-/// here finalizes assistant replies through the host-managed transcript port.
-/// Blocked, failed, and cancelled exits remain fail-closed until a durable
-/// evidence-backed applier is wired.
-fn trusted_text_only_exit_validation_policy() -> LoopExitValidationPolicy {
+/// Completion refs remain fail-closed until a durable host-issued completion
+/// evidence path is wired into this worker. Blocked, failed, and cancelled exits
+/// also remain fail-closed unless tests inject a narrower trusted policy.
+fn default_text_only_exit_validation_policy() -> LoopExitValidationPolicy {
     LoopExitValidationPolicy {
         require_final_checkpoint: false,
         host_cancellation_observed: false,
         invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
-        completion_refs_verified: true,
+        completion_refs_verified: false,
         blocked_evidence_verified: false,
         failure_evidence_verified: false,
+    }
+}
+
+#[cfg(test)]
+fn trusted_text_only_exit_validation_policy_for_tests() -> LoopExitValidationPolicy {
+    LoopExitValidationPolicy {
+        completion_refs_verified: true,
+        ..default_text_only_exit_validation_policy()
     }
 }
 

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -25,8 +25,8 @@ use tracing::{debug, error, info, warn};
 
 use ironclaw_turns::{
     AgentLoopDriverError, AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, LoopExit,
-    LoopExitValidationPolicy, SanitizedFailure, TurnError, TurnLeaseToken, TurnRunId, TurnRunnerId,
-    TurnScope, TurnStatus,
+    LoopExitInvalidHandling, LoopExitValidationPolicy, SanitizedFailure, TurnError, TurnLeaseToken,
+    TurnRunId, TurnRunnerId, TurnScope, TurnStatus,
     runner::{
         ApplyLoopExitRequest, ClaimRunRequest, ClaimedTurnRun, HeartbeatRequest,
         RecordRecoveryRequiredRequest, TurnRunTransitionPort,
@@ -67,6 +67,13 @@ pub struct TurnRunnerWorkerConfig {
 
     /// Optional scope filter to restrict which runs this worker claims.
     pub scope_filter: Option<TurnScope>,
+
+    /// Validation policy used when applying driver-returned loop exits.
+    ///
+    /// This is injected here so a durable evidence-backed applier can replace
+    /// the temporary trusted text-only policy without changing worker control
+    /// flow.
+    pub exit_validation_policy: LoopExitValidationPolicy,
 }
 
 impl Default for TurnRunnerWorkerConfig {
@@ -75,6 +82,7 @@ impl Default for TurnRunnerWorkerConfig {
             heartbeat_interval: Duration::from_secs(10),
             poll_interval: Duration::from_secs(5),
             scope_filter: None,
+            exit_validation_policy: trusted_text_only_exit_validation_policy(),
         }
     }
 }
@@ -233,7 +241,7 @@ impl TurnRunnerWorker {
                 break;
             }
 
-            if let Err(err) = self.try_claim_and_run().await {
+            if let Err(err) = self.try_claim_and_run(&cancel).await {
                 warn!(
                     runner_id = ?self.runner_id,
                     error = %err,
@@ -246,7 +254,7 @@ impl TurnRunnerWorker {
     }
 
     /// Attempt one claim-and-run cycle.
-    async fn try_claim_and_run(&self) -> Result<(), TurnRunnerError> {
+    async fn try_claim_and_run(&self, cancel: &CancellationToken) -> Result<(), TurnRunnerError> {
         let lease_token = TurnLeaseToken::new();
         let request = ClaimRunRequest {
             runner_id: self.runner_id,
@@ -275,45 +283,45 @@ impl TurnRunnerWorker {
             "claimed turn run"
         );
 
-        self.execute_claimed_run(claimed).await;
+        self.execute_claimed_run(claimed, cancel).await;
         Ok(())
     }
 
     /// Execute a claimed run: heartbeat, invoke driver, apply exit.
-    async fn execute_claimed_run(&self, claimed: ClaimedTurnRun) {
+    async fn execute_claimed_run(&self, claimed: ClaimedTurnRun, cancel: &CancellationToken) {
         let run_id = claimed.state.run_id;
         let runner_id = claimed.runner_id;
         let lease_token = claimed.lease_token;
 
-        // Start heartbeat task
         let heartbeat_cancel = CancellationToken::new();
-        let heartbeat_handle = {
-            let port = Arc::clone(&self.transition_port);
-            let interval = self.config.heartbeat_interval;
-            let cancel = heartbeat_cancel.clone();
-            tokio::spawn(heartbeat_loop(
-                port,
-                run_id,
-                runner_id,
-                lease_token,
-                interval,
-                cancel,
-            ))
-        };
+        let heartbeat = heartbeat_loop(
+            Arc::clone(&self.transition_port),
+            run_id,
+            runner_id,
+            lease_token,
+            self.config.heartbeat_interval,
+            heartbeat_cancel.clone(),
+        );
+        tokio::pin!(heartbeat);
 
         // Resolve driver from registry and invoke it. Driver panics indicate
         // unknown partial state, so convert them to RecoveryRequired.
-        let exit_result = match AssertUnwindSafe(self.invoke_driver(&claimed))
-            .catch_unwind()
-            .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(DriverInvocationError::DriverPanic),
+        let driver = AssertUnwindSafe(self.invoke_driver(&claimed)).catch_unwind();
+        tokio::pin!(driver);
+
+        let exit_result = tokio::select! {
+            result = &mut driver => match result {
+                Ok(result) => result,
+                Err(_) => Err(DriverInvocationError::DriverPanic),
+            },
+            heartbeat_result = &mut heartbeat => match heartbeat_result {
+                Ok(()) => Err(DriverInvocationError::HeartbeatStopped),
+                Err(err) => Err(DriverInvocationError::HeartbeatFailed(err)),
+            },
+            () = cancel.cancelled() => Err(DriverInvocationError::WorkerCancelled),
         };
 
-        // Stop heartbeat
         heartbeat_cancel.cancel();
-        let _ = heartbeat_handle.await;
 
         // Apply the exit or record recovery
         match exit_result {
@@ -418,7 +426,7 @@ impl TurnRunnerWorker {
             runner_id,
             lease_token,
             exit,
-            validation_policy: LoopExitValidationPolicy::default(),
+            validation_policy: self.config.exit_validation_policy,
         };
 
         match ironclaw_turns::runner::apply_loop_exit(self.transition_port.as_ref(), request).await
@@ -485,6 +493,10 @@ impl TurnRunnerWorker {
                 "driver_failed"
             }
             DriverInvocationError::DriverPanic => "driver_panic",
+            DriverInvocationError::HeartbeatFailed(_) | DriverInvocationError::HeartbeatStopped => {
+                "heartbeat_failed"
+            }
+            DriverInvocationError::WorkerCancelled => "worker_cancelled",
         };
 
         let Some(failure) = sanitized_failure(category) else {
@@ -508,7 +520,23 @@ impl TurnRunnerWorker {
     }
 }
 
-/// Heartbeat loop that runs in a spawned task for the duration of a driver run.
+/// Temporary trusted text-only validation policy for this narrow worker slice.
+///
+/// Completion refs are trusted because the only concrete host currently wired
+/// here finalizes assistant replies through the host-managed transcript port.
+/// Blocked, failed, and cancelled exits remain fail-closed until a durable
+/// evidence-backed applier is wired.
+fn trusted_text_only_exit_validation_policy() -> LoopExitValidationPolicy {
+    LoopExitValidationPolicy {
+        require_final_checkpoint: false,
+        host_cancellation_observed: false,
+        invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+        completion_refs_verified: true,
+        blocked_evidence_verified: false,
+        failure_evidence_verified: false,
+    }
+}
+
 async fn heartbeat_loop(
     port: Arc<dyn TurnRunTransitionPort>,
     run_id: TurnRunId,
@@ -516,7 +544,12 @@ async fn heartbeat_loop(
     lease_token: TurnLeaseToken,
     interval: Duration,
     cancel: CancellationToken,
-) {
+) -> Result<(), TurnError> {
+    let interval = if interval.is_zero() {
+        Duration::from_millis(1)
+    } else {
+        interval
+    };
     let mut tick = tokio::time::interval(interval);
     // Skip the first immediate tick
     tick.tick().await;
@@ -529,7 +562,7 @@ async fn heartbeat_loop(
                     run_id = ?run_id,
                     "heartbeat loop stopped"
                 );
-                break;
+                return Ok(());
             }
             _ = tick.tick() => {
                 let request = HeartbeatRequest {
@@ -552,10 +585,7 @@ async fn heartbeat_loop(
                             error = %err,
                             "heartbeat failed"
                         );
-                        // Heartbeat failure is not fatal — the driver invocation
-                        // continues. If the lease actually expires, the store will
-                        // transition to RecoveryRequired on the next claim/recovery
-                        // sweep.
+                        return Err(err);
                     }
                 }
             }
@@ -584,6 +614,9 @@ enum DriverInvocationError {
     HostCreationFailed { reason: String },
     DriverError(AgentLoopDriverError),
     DriverPanic,
+    HeartbeatFailed(TurnError),
+    HeartbeatStopped,
+    WorkerCancelled,
 }
 
 impl std::fmt::Display for DriverInvocationError {
@@ -593,6 +626,9 @@ impl std::fmt::Display for DriverInvocationError {
             Self::HostCreationFailed { reason } => write!(f, "host creation failed: {reason}"),
             Self::DriverError(err) => write!(f, "driver error: {err}"),
             Self::DriverPanic => write!(f, "driver panicked before returning loop exit"),
+            Self::HeartbeatFailed(err) => write!(f, "heartbeat failed: {err}"),
+            Self::HeartbeatStopped => write!(f, "heartbeat stopped before driver completed"),
+            Self::WorkerCancelled => write!(f, "worker cancelled before driver completed"),
         }
     }
 }

--- a/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
@@ -137,6 +137,7 @@ fn test_completed_exit() -> LoopExit {
 enum TransitionCall {
     Claim,
     Heartbeat,
+    RecoverExpiredLeases,
     ApplyValidatedLoopExit,
     RecordRecoveryRequired,
 }
@@ -144,10 +145,16 @@ enum TransitionCall {
 struct MockTransitionPort {
     claim_results: Mutex<Vec<Result<Option<ClaimedTurnRun>, TurnError>>>,
     heartbeat_result: Mutex<Result<EventCursor, TurnError>>,
+    recover_result: Mutex<Result<RecoverExpiredLeasesResponse, TurnError>>,
     apply_exit_result: Mutex<Result<TurnRunState, TurnError>>,
     recovery_result: Mutex<Result<TurnRunState, TurnError>>,
     applied_mappings: Mutex<Vec<LoopExitMapping>>,
     calls: Mutex<Vec<TransitionCall>>,
+    claim_requests: Mutex<Vec<ClaimRunRequest>>,
+    heartbeat_requests: Mutex<Vec<HeartbeatRequest>>,
+    recover_requests: Mutex<Vec<RecoverExpiredLeasesRequest>>,
+    apply_exit_requests: Mutex<Vec<ApplyValidatedLoopExitRequest>>,
+    recovery_requests: Mutex<Vec<RecordRecoveryRequiredRequest>>,
 }
 
 impl MockTransitionPort {
@@ -155,6 +162,9 @@ impl MockTransitionPort {
         Self {
             claim_results: Mutex::new(Vec::new()),
             heartbeat_result: Mutex::new(Ok(EventCursor(1))),
+            recover_result: Mutex::new(Ok(RecoverExpiredLeasesResponse {
+                recovered: Vec::new(),
+            })),
             apply_exit_result: Mutex::new(Ok(test_run_state(test_scope(), TurnStatus::Completed))),
             recovery_result: Mutex::new(Ok(test_run_state(
                 test_scope(),
@@ -162,6 +172,11 @@ impl MockTransitionPort {
             ))),
             applied_mappings: Mutex::new(Vec::new()),
             calls: Mutex::new(Vec::new()),
+            claim_requests: Mutex::new(Vec::new()),
+            heartbeat_requests: Mutex::new(Vec::new()),
+            recover_requests: Mutex::new(Vec::new()),
+            apply_exit_requests: Mutex::new(Vec::new()),
+            recovery_requests: Mutex::new(Vec::new()),
         }
     }
 
@@ -188,32 +203,46 @@ impl MockTransitionPort {
 impl TurnRunTransitionPort for MockTransitionPort {
     async fn claim_next_run(
         &self,
-        _request: ClaimRunRequest,
+        request: ClaimRunRequest,
     ) -> Result<Option<ClaimedTurnRun>, TurnError> {
         self.calls.lock().expect("lock").push(TransitionCall::Claim);
+        self.claim_requests
+            .lock()
+            .expect("lock")
+            .push(request.clone());
         let mut results = self.claim_results.lock().expect("lock");
         if results.is_empty() {
             Ok(None)
         } else {
-            results.remove(0)
+            results.remove(0).map(|maybe_claimed| {
+                maybe_claimed.map(|mut claimed| {
+                    claimed.runner_id = request.runner_id;
+                    claimed.lease_token = request.lease_token;
+                    claimed
+                })
+            })
         }
     }
 
-    async fn heartbeat(&self, _request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
+    async fn heartbeat(&self, request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
         self.calls
             .lock()
             .expect("lock")
             .push(TransitionCall::Heartbeat);
+        self.heartbeat_requests.lock().expect("lock").push(request);
         self.heartbeat_result.lock().expect("lock").clone()
     }
 
     async fn recover_expired_leases(
         &self,
-        _request: RecoverExpiredLeasesRequest,
+        request: RecoverExpiredLeasesRequest,
     ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
-        Ok(RecoverExpiredLeasesResponse {
-            recovered: Vec::new(),
-        })
+        self.calls
+            .lock()
+            .expect("lock")
+            .push(TransitionCall::RecoverExpiredLeases);
+        self.recover_requests.lock().expect("lock").push(request);
+        self.recover_result.lock().expect("lock").clone()
     }
 
     async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
@@ -237,12 +266,13 @@ impl TurnRunTransitionPort for MockTransitionPort {
 
     async fn record_recovery_required(
         &self,
-        _request: RecordRecoveryRequiredRequest,
+        request: RecordRecoveryRequiredRequest,
     ) -> Result<TurnRunState, TurnError> {
         self.calls
             .lock()
             .expect("lock")
             .push(TransitionCall::RecordRecoveryRequired);
+        self.recovery_requests.lock().expect("lock").push(request);
         self.recovery_result.lock().expect("lock").clone()
     }
 
@@ -257,7 +287,8 @@ impl TurnRunTransitionPort for MockTransitionPort {
         self.applied_mappings
             .lock()
             .expect("lock")
-            .push(request.mapping);
+            .push(request.mapping.clone());
+        self.apply_exit_requests.lock().expect("lock").push(request);
         self.apply_exit_result.lock().expect("lock").clone()
     }
 }
@@ -510,6 +541,20 @@ fn make_claimed_run(
     }
 }
 
+fn assert_first_recovery_matches_first_claim(port: &MockTransitionPort, run_id: TurnRunId) {
+    let claim_requests = port.claim_requests.lock().expect("lock");
+    let recovery_requests = port.recovery_requests.lock().expect("lock");
+    let claim = claim_requests
+        .first()
+        .expect("worker should issue a claim request before recovery");
+    let recovery = recovery_requests
+        .first()
+        .expect("worker should record recovery");
+    assert_eq!(recovery.run_id, run_id);
+    assert_eq!(recovery.runner_id, claim.runner_id);
+    assert_eq!(recovery.lease_token, claim.lease_token);
+}
+
 fn setup_registry(driver: Arc<dyn AgentLoopDriver>) -> DriverRegistry {
     let mut registry = DriverRegistry::new();
     registry
@@ -525,6 +570,143 @@ fn setup_registry(driver: Arc<dyn AgentLoopDriver>) -> DriverRegistry {
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 #[tokio::test]
+async fn worker_recovers_expired_leases_before_claiming() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_secs(60),
+        scope_filter: None,
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    wake_sender.wake();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let calls = port.calls();
+    let recover_pos = calls
+        .iter()
+        .position(|call| *call == TransitionCall::RecoverExpiredLeases)
+        .expect("worker should recover expired leases before claiming");
+    let claim_pos = calls
+        .iter()
+        .position(|call| *call == TransitionCall::Claim)
+        .expect("worker should claim after recovery sweep");
+    assert!(recover_pos < claim_pos);
+    assert!(!port.recover_requests.lock().expect("lock").is_empty());
+}
+
+#[tokio::test]
+async fn worker_reuses_claim_runner_and_lease_for_heartbeat_and_exit() {
+    let desc = test_descriptor();
+    let driver =
+        Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_millis(150)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let run_id = claimed.state.run_id;
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_millis(25),
+        poll_interval: Duration::from_secs(60),
+        scope_filter: None,
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+    let worker_runner_id = worker.runner_id();
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    wake_sender.wake();
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let claim_requests = port.claim_requests.lock().expect("lock").clone();
+    let first_claim = claim_requests
+        .first()
+        .expect("worker should issue a claim request");
+    assert_eq!(first_claim.runner_id, worker_runner_id);
+
+    let heartbeat_requests = port.heartbeat_requests.lock().expect("lock").clone();
+    assert!(
+        heartbeat_requests
+            .iter()
+            .any(|request| request.run_id == run_id
+                && request.runner_id == first_claim.runner_id
+                && request.lease_token == first_claim.lease_token),
+        "heartbeat must use the same runner and lease token as the claim"
+    );
+
+    let apply_requests = port.apply_exit_requests.lock().expect("lock").clone();
+    assert!(
+        apply_requests.iter().any(|request| request.run_id == run_id
+            && request.runner_id == first_claim.runner_id
+            && request.lease_token == first_claim.lease_token),
+        "exit application must use the same runner and lease token as the claim"
+    );
+}
+
+#[tokio::test]
+async fn default_worker_policy_rejects_fabricated_completion_refs() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let worker = TurnRunnerWorker::new(
+        TurnRunnerWorkerConfig::default(),
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    worker.try_claim_and_run(&cancel).await.unwrap();
+
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::ApplyValidatedLoopExit)
+    );
+    assert!(matches!(
+        port.applied_mappings().as_slice(),
+        [LoopExitMapping::RecoveryRequired { .. }]
+    ));
+}
+
+#[tokio::test]
 async fn worker_claims_and_completes_run() {
     let desc = test_descriptor();
     let driver = Arc::new(MockDriver::completing(desc.clone()));
@@ -537,7 +719,7 @@ async fn worker_claims_and_completes_run() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(
@@ -571,6 +753,7 @@ async fn worker_records_recovery_when_heartbeat_fails() {
     let driver = Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_secs(60)));
     let registry = Arc::new(setup_registry(driver));
     let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let run_id = claimed.state.run_id;
     let port = Arc::new(
         MockTransitionPort::new()
             .with_claim_result(Ok(Some(claimed)))
@@ -582,7 +765,7 @@ async fn worker_records_recovery_when_heartbeat_fails() {
         heartbeat_interval: Duration::from_millis(10),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(
@@ -609,6 +792,7 @@ async fn worker_records_recovery_when_heartbeat_fails() {
         port.calls()
             .contains(&TransitionCall::RecordRecoveryRequired)
     );
+    assert_first_recovery_matches_first_claim(&port, run_id);
 }
 
 #[tokio::test]
@@ -617,6 +801,7 @@ async fn worker_cancellation_stops_active_driver_promptly() {
     let driver = Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_secs(60)));
     let registry = Arc::new(setup_registry(driver));
     let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let run_id = claimed.state.run_id;
     let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
 
     let (_wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
@@ -624,7 +809,7 @@ async fn worker_cancellation_stops_active_driver_promptly() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(
@@ -651,6 +836,7 @@ async fn worker_cancellation_stops_active_driver_promptly() {
         port.calls()
             .contains(&TransitionCall::RecordRecoveryRequired)
     );
+    assert_first_recovery_matches_first_claim(&port, run_id);
 }
 
 #[tokio::test]
@@ -664,6 +850,7 @@ async fn worker_records_recovery_on_driver_error() {
     ));
     let registry = Arc::new(setup_registry(driver));
     let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let run_id = claimed.state.run_id;
     let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
 
     let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
@@ -671,7 +858,7 @@ async fn worker_records_recovery_on_driver_error() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(
@@ -694,6 +881,7 @@ async fn worker_records_recovery_on_driver_error() {
         port.calls()
             .contains(&TransitionCall::RecordRecoveryRequired)
     );
+    assert_first_recovery_matches_first_claim(&port, run_id);
 }
 
 #[tokio::test]
@@ -711,7 +899,7 @@ async fn worker_records_recovery_on_driver_panic() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(
@@ -742,6 +930,7 @@ async fn worker_records_recovery_on_host_factory_error() {
     let driver = Arc::new(MockDriver::completing(desc.clone()));
     let registry = Arc::new(setup_registry(driver));
     let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let run_id = claimed.state.run_id;
     let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
 
     let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
@@ -749,7 +938,7 @@ async fn worker_records_recovery_on_host_factory_error() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let host_factory = Arc::new(FailingHostFactory {
@@ -770,6 +959,7 @@ async fn worker_records_recovery_on_host_factory_error() {
         port.calls()
             .contains(&TransitionCall::RecordRecoveryRequired)
     );
+    assert_first_recovery_matches_first_claim(&port, run_id);
 }
 
 #[tokio::test]
@@ -781,6 +971,7 @@ async fn worker_records_recovery_when_driver_not_found() {
     let mut claimed_desc = test_descriptor();
     claimed_desc.id = LoopDriverId::new("missing_driver").expect("valid");
     let claimed = make_claimed_run(&claimed_desc, test_scope(), TurnStatus::Queued);
+    let run_id = claimed.state.run_id;
     let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
 
     let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
@@ -788,7 +979,7 @@ async fn worker_records_recovery_when_driver_not_found() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(
@@ -811,6 +1002,7 @@ async fn worker_records_recovery_when_driver_not_found() {
         port.calls()
             .contains(&TransitionCall::RecordRecoveryRequired)
     );
+    assert_first_recovery_matches_first_claim(&port, run_id);
 }
 
 #[tokio::test]
@@ -825,7 +1017,7 @@ async fn worker_continues_when_no_runs_available() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(
@@ -856,6 +1048,63 @@ async fn worker_continues_when_no_runs_available() {
 }
 
 #[tokio::test]
+async fn wake_signal_drains_available_runs_until_queue_empty() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let first = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let second = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(
+        MockTransitionPort::new()
+            .with_claim_result(Ok(Some(first)))
+            .with_claim_result(Ok(Some(second))),
+    );
+
+    let (wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_secs(60),
+        scope_filter: None,
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    wake_sender.wake();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let calls = port.calls();
+    let claim_count = calls
+        .iter()
+        .filter(|call| **call == TransitionCall::Claim)
+        .count();
+    let apply_count = calls
+        .iter()
+        .filter(|call| **call == TransitionCall::ApplyValidatedLoopExit)
+        .count();
+    assert!(
+        claim_count >= 3,
+        "drain should process queued runs and observe an empty claim"
+    );
+    assert_eq!(
+        apply_count, 2,
+        "single wake should process both queued runs"
+    );
+}
+
+#[tokio::test]
 async fn wake_signal_triggers_claim_attempt() {
     let desc = test_descriptor();
     let driver = Arc::new(MockDriver::completing(desc.clone()));
@@ -867,7 +1116,7 @@ async fn wake_signal_triggers_claim_attempt() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_secs(60), // very long so wake is the trigger
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(
@@ -905,7 +1154,7 @@ async fn heartbeat_runs_during_driver_execution() {
         heartbeat_interval: Duration::from_millis(50), // fast heartbeats
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
-        ..TurnRunnerWorkerConfig::default()
+        exit_validation_policy: trusted_text_only_exit_validation_policy_for_tests(),
     };
 
     let worker = TurnRunnerWorker::new(

--- a/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
@@ -8,15 +8,15 @@ use ironclaw_host_api::{TenantId, ThreadId};
 use ironclaw_turns::{
     AcceptedMessageRef, AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError,
     AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, EventCursor, LoopCompleted,
-    LoopCompletionKind, LoopExit, LoopExitId, LoopMessageRef, ReplyTargetBindingRef,
-    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken,
-    TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
+    LoopCompletionKind, LoopExit, LoopExitId, LoopExitMapping, LoopMessageRef,
+    ReplyTargetBindingRef, RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnError,
+    TurnId, TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
     run_profile::{AgentLoopDriverHost, AgentLoopHostError, CheckpointSchemaId, LoopDriverId},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
         ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
         RecordRecoveryRequiredRequest, RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse,
-        TurnRunTransitionPort,
+        TurnRunTransitionPort, TurnRunnerOutcome,
     },
 };
 
@@ -146,6 +146,7 @@ struct MockTransitionPort {
     heartbeat_result: Mutex<Result<EventCursor, TurnError>>,
     apply_exit_result: Mutex<Result<TurnRunState, TurnError>>,
     recovery_result: Mutex<Result<TurnRunState, TurnError>>,
+    applied_mappings: Mutex<Vec<LoopExitMapping>>,
     calls: Mutex<Vec<TransitionCall>>,
 }
 
@@ -159,6 +160,7 @@ impl MockTransitionPort {
                 test_scope(),
                 TurnStatus::RecoveryRequired,
             ))),
+            applied_mappings: Mutex::new(Vec::new()),
             calls: Mutex::new(Vec::new()),
         }
     }
@@ -168,8 +170,17 @@ impl MockTransitionPort {
         self
     }
 
+    fn with_heartbeat_result(self, result: Result<EventCursor, TurnError>) -> Self {
+        *self.heartbeat_result.lock().expect("lock") = result;
+        self
+    }
+
     fn calls(&self) -> Vec<TransitionCall> {
         self.calls.lock().expect("lock").clone()
+    }
+
+    fn applied_mappings(&self) -> Vec<LoopExitMapping> {
+        self.applied_mappings.lock().expect("lock").clone()
     }
 }
 
@@ -237,12 +248,16 @@ impl TurnRunTransitionPort for MockTransitionPort {
 
     async fn apply_validated_loop_exit(
         &self,
-        _request: ApplyValidatedLoopExitRequest,
+        request: ApplyValidatedLoopExitRequest,
     ) -> Result<TurnRunState, TurnError> {
         self.calls
             .lock()
             .expect("lock")
             .push(TransitionCall::ApplyValidatedLoopExit);
+        self.applied_mappings
+            .lock()
+            .expect("lock")
+            .push(request.mapping);
         self.apply_exit_result.lock().expect("lock").clone()
     }
 }
@@ -522,6 +537,7 @@ async fn worker_claims_and_completes_run() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
     };
 
     let worker = TurnRunnerWorker::new(
@@ -543,6 +559,98 @@ async fn worker_claims_and_completes_run() {
     let calls = port.calls();
     assert!(calls.contains(&TransitionCall::Claim));
     assert!(calls.contains(&TransitionCall::ApplyValidatedLoopExit));
+    assert!(matches!(
+        port.applied_mappings().as_slice(),
+        [LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Completed)]
+    ));
+}
+
+#[tokio::test]
+async fn worker_records_recovery_when_heartbeat_fails() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_secs(60)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(
+        MockTransitionPort::new()
+            .with_claim_result(Ok(Some(claimed)))
+            .with_heartbeat_result(Err(TurnError::LeaseMismatch)),
+    );
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_millis(10),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let result = tokio::time::timeout(
+        Duration::from_millis(300),
+        worker.try_claim_and_run(&cancel),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "heartbeat failure should stop active driver promptly"
+    );
+    result.unwrap().unwrap();
+    assert!(port.calls().contains(&TransitionCall::Heartbeat));
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn worker_cancellation_stops_active_driver_promptly() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_secs(60)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let mut handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    cancel.cancel();
+    let result = tokio::time::timeout(Duration::from_millis(300), &mut handle).await;
+    if result.is_err() {
+        handle.abort();
+        panic!("worker cancellation should stop active driver promptly");
+    }
+    result.unwrap().expect("worker task should complete");
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
 }
 
 #[tokio::test]
@@ -563,6 +671,7 @@ async fn worker_records_recovery_on_driver_error() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
     };
 
     let worker = TurnRunnerWorker::new(
@@ -602,6 +711,7 @@ async fn worker_records_recovery_on_driver_panic() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
     };
 
     let worker = TurnRunnerWorker::new(
@@ -639,6 +749,7 @@ async fn worker_records_recovery_on_host_factory_error() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
     };
 
     let host_factory = Arc::new(FailingHostFactory {
@@ -677,6 +788,7 @@ async fn worker_records_recovery_when_driver_not_found() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
     };
 
     let worker = TurnRunnerWorker::new(
@@ -713,6 +825,7 @@ async fn worker_continues_when_no_runs_available() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
     };
 
     let worker = TurnRunnerWorker::new(
@@ -754,6 +867,7 @@ async fn wake_signal_triggers_claim_attempt() {
         heartbeat_interval: Duration::from_secs(60),
         poll_interval: Duration::from_secs(60), // very long so wake is the trigger
         scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
     };
 
     let worker = TurnRunnerWorker::new(
@@ -791,6 +905,7 @@ async fn heartbeat_runs_during_driver_execution() {
         heartbeat_interval: Duration::from_millis(50), // fast heartbeats
         poll_interval: Duration::from_millis(50),
         scope_filter: None,
+        ..TurnRunnerWorkerConfig::default()
     };
 
     let worker = TurnRunnerWorker::new(

--- a/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
@@ -1,0 +1,842 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+use ironclaw_host_api::{TenantId, ThreadId};
+use ironclaw_turns::{
+    AcceptedMessageRef, AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError,
+    AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, EventCursor, LoopCompleted,
+    LoopCompletionKind, LoopExit, LoopExitId, LoopMessageRef, ReplyTargetBindingRef,
+    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken,
+    TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
+    run_profile::{AgentLoopDriverHost, AgentLoopHostError, CheckpointSchemaId, LoopDriverId},
+    runner::{
+        ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
+        ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
+        RecordRecoveryRequiredRequest, RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse,
+        TurnRunTransitionPort,
+    },
+};
+
+use crate::driver_registry::{DriverKind, DriverRegistry, DriverRequirements};
+
+use super::*;
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+fn test_scope() -> TurnScope {
+    TurnScope::new(
+        TenantId::new("test-tenant").expect("valid"),
+        None,
+        None,
+        ThreadId::new("test-thread").expect("valid"),
+    )
+}
+
+fn test_descriptor() -> AgentLoopDriverDescriptor {
+    AgentLoopDriverDescriptor {
+        id: LoopDriverId::new("test_loop").expect("valid"),
+        version: RunProfileVersion::new(1),
+        checkpoint_schema_id: Some(CheckpointSchemaId::new("test_checkpoint").expect("valid")),
+        checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+    }
+}
+
+fn test_resolved_profile_with_driver(
+    desc: &AgentLoopDriverDescriptor,
+) -> ironclaw_turns::ResolvedRunProfile {
+    use ironclaw_turns::run_profile::*;
+    use ironclaw_turns::*;
+
+    ResolvedRunProfile {
+        run_class_id: RunClassId::new("test_class").expect("valid"),
+        profile_id: RunProfileId::default_profile(),
+        profile_version: RunProfileVersion::new(1),
+        loop_driver: desc.clone(),
+        checkpoint_schema_id: desc
+            .checkpoint_schema_id
+            .clone()
+            .unwrap_or_else(|| CheckpointSchemaId::new("fallback_checkpoint").expect("valid")),
+        checkpoint_schema_version: desc
+            .checkpoint_schema_version
+            .unwrap_or_else(|| RunProfileVersion::new(1)),
+        model_profile_id: ModelProfileId::new("test_model").expect("valid"),
+        capability_surface_profile_id: CapabilitySurfaceProfileId::new("test_capabilities")
+            .expect("valid"),
+        context_profile_id: ContextProfileId::new("test_context").expect("valid"),
+        steering_policy: SteeringPolicy {
+            allow_steering: false,
+            allow_interrupt: true,
+            allow_driver_specific_nudges: false,
+        },
+        cancellation_policy: CancellationPolicy {
+            allow_cancel: true,
+            require_checkpoint_before_cancel: false,
+        },
+        checkpoint_policy: CheckpointPolicy {
+            require_before_model: false,
+            require_before_side_effect: false,
+            require_before_block: true,
+            max_checkpoint_bytes: 64 * 1024,
+        },
+        resource_budget_policy: ResourceBudgetPolicy {
+            tier: ResourceBudgetTier::new("test_tier").expect("valid"),
+            max_model_calls: 32,
+            max_capability_invocations: 64,
+        },
+        runtime_constraints: RuntimeProfileConstraints {
+            allow_raw_runtime_backend_selection: false,
+            allow_broad_capability_surface: false,
+        },
+        runner_pool_id: None,
+        scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+        concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+        resolution_fingerprint: RunProfileFingerprint::new("test-fingerprint-v1").expect("valid"),
+        provenance: RedactedRunProfileProvenance {
+            sources: vec![],
+            effective_privileges: vec![],
+        },
+    }
+}
+
+fn test_run_state(scope: TurnScope, status: TurnStatus) -> TurnRunState {
+    TurnRunState {
+        scope,
+        turn_id: TurnId::new(),
+        run_id: TurnRunId::new(),
+        status,
+        accepted_message_ref: AcceptedMessageRef::new("test-msg").expect("valid"),
+        source_binding_ref: SourceBindingRef::new("test-source").expect("valid"),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("test-reply").expect("valid"),
+        resolved_run_profile_id: ironclaw_turns::RunProfileId::default_profile(),
+        resolved_run_profile_version: RunProfileVersion::new(1),
+        received_at: chrono::Utc::now(),
+        checkpoint_id: None,
+        gate_ref: None,
+        failure: None,
+        event_cursor: EventCursor(0),
+    }
+}
+
+fn test_completed_exit() -> LoopExit {
+    LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::FinalReply,
+        reply_message_refs: vec![LoopMessageRef::new("msg:test-1").expect("valid")],
+        result_refs: vec![],
+        final_checkpoint_id: None,
+        usage_summary_ref: None,
+        exit_id: LoopExitId::new("exit:test-1").expect("valid"),
+    })
+}
+
+// ─── Mock transition port ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TransitionCall {
+    Claim,
+    Heartbeat,
+    ApplyValidatedLoopExit,
+    RecordRecoveryRequired,
+}
+
+struct MockTransitionPort {
+    claim_results: Mutex<Vec<Result<Option<ClaimedTurnRun>, TurnError>>>,
+    heartbeat_result: Mutex<Result<EventCursor, TurnError>>,
+    apply_exit_result: Mutex<Result<TurnRunState, TurnError>>,
+    recovery_result: Mutex<Result<TurnRunState, TurnError>>,
+    calls: Mutex<Vec<TransitionCall>>,
+}
+
+impl MockTransitionPort {
+    fn new() -> Self {
+        Self {
+            claim_results: Mutex::new(Vec::new()),
+            heartbeat_result: Mutex::new(Ok(EventCursor(1))),
+            apply_exit_result: Mutex::new(Ok(test_run_state(test_scope(), TurnStatus::Completed))),
+            recovery_result: Mutex::new(Ok(test_run_state(
+                test_scope(),
+                TurnStatus::RecoveryRequired,
+            ))),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn with_claim_result(self, result: Result<Option<ClaimedTurnRun>, TurnError>) -> Self {
+        self.claim_results.lock().expect("lock").push(result);
+        self
+    }
+
+    fn calls(&self) -> Vec<TransitionCall> {
+        self.calls.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl TurnRunTransitionPort for MockTransitionPort {
+    async fn claim_next_run(
+        &self,
+        _request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        self.calls.lock().expect("lock").push(TransitionCall::Claim);
+        let mut results = self.claim_results.lock().expect("lock");
+        if results.is_empty() {
+            Ok(None)
+        } else {
+            results.remove(0)
+        }
+    }
+
+    async fn heartbeat(&self, _request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
+        self.calls
+            .lock()
+            .expect("lock")
+            .push(TransitionCall::Heartbeat);
+        self.heartbeat_result.lock().expect("lock").clone()
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        _request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        Ok(RecoverExpiredLeasesResponse {
+            recovered: Vec::new(),
+        })
+    }
+
+    async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(test_scope(), TurnStatus::BlockedApproval))
+    }
+
+    async fn complete_run(&self, _request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(test_scope(), TurnStatus::Completed))
+    }
+
+    async fn cancel_run(
+        &self,
+        _request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(test_scope(), TurnStatus::Cancelled))
+    }
+
+    async fn fail_run(&self, _request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(test_scope(), TurnStatus::Failed))
+    }
+
+    async fn record_recovery_required(
+        &self,
+        _request: RecordRecoveryRequiredRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.calls
+            .lock()
+            .expect("lock")
+            .push(TransitionCall::RecordRecoveryRequired);
+        self.recovery_result.lock().expect("lock").clone()
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        _request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.calls
+            .lock()
+            .expect("lock")
+            .push(TransitionCall::ApplyValidatedLoopExit);
+        self.apply_exit_result.lock().expect("lock").clone()
+    }
+}
+
+// ─── Mock driver ────────────────────────────────────────────────────────────
+
+struct MockDriver {
+    descriptor: AgentLoopDriverDescriptor,
+    run_result: Mutex<Result<LoopExit, AgentLoopDriverError>>,
+    run_delay: Duration,
+}
+
+impl MockDriver {
+    fn completing(descriptor: AgentLoopDriverDescriptor) -> Self {
+        Self {
+            descriptor,
+            run_result: Mutex::new(Ok(test_completed_exit())),
+            run_delay: Duration::ZERO,
+        }
+    }
+
+    fn failing(descriptor: AgentLoopDriverDescriptor, error: AgentLoopDriverError) -> Self {
+        Self {
+            descriptor,
+            run_result: Mutex::new(Err(error)),
+            run_delay: Duration::ZERO,
+        }
+    }
+
+    fn with_delay(mut self, delay: Duration) -> Self {
+        self.run_delay = delay;
+        self
+    }
+}
+
+#[async_trait]
+impl AgentLoopDriver for MockDriver {
+    fn descriptor(&self) -> AgentLoopDriverDescriptor {
+        self.descriptor.clone()
+    }
+
+    async fn run(
+        &self,
+        _request: AgentLoopDriverRunRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        if !self.run_delay.is_zero() {
+            tokio::time::sleep(self.run_delay).await;
+        }
+        self.run_result.lock().expect("lock").clone()
+    }
+
+    async fn resume(
+        &self,
+        _request: AgentLoopDriverResumeRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        if !self.run_delay.is_zero() {
+            tokio::time::sleep(self.run_delay).await;
+        }
+        self.run_result.lock().expect("lock").clone()
+    }
+}
+
+struct PanickingDriver {
+    descriptor: AgentLoopDriverDescriptor,
+}
+
+#[async_trait]
+impl AgentLoopDriver for PanickingDriver {
+    fn descriptor(&self) -> AgentLoopDriverDescriptor {
+        self.descriptor.clone()
+    }
+
+    async fn run(
+        &self,
+        _request: AgentLoopDriverRunRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        panic!("simulated driver panic")
+    }
+
+    async fn resume(
+        &self,
+        _request: AgentLoopDriverResumeRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        panic!("simulated driver resume panic")
+    }
+}
+
+// ─── Stub host (mock driver never calls host methods) ───────────────────────
+
+struct StubHost;
+
+impl ironclaw_turns::run_profile::LoopRunInfoPort for StubHost {
+    fn run_context(&self) -> &ironclaw_turns::run_profile::LoopRunContext {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopContextPort for StubHost {
+    async fn load_loop_context(
+        &self,
+        _request: ironclaw_turns::run_profile::LoopContextRequest,
+    ) -> Result<ironclaw_turns::run_profile::LoopContextBundle, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopPromptPort for StubHost {
+    async fn build_prompt_bundle(
+        &self,
+        _request: ironclaw_turns::run_profile::LoopPromptBundleRequest,
+    ) -> Result<ironclaw_turns::run_profile::LoopPromptBundle, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopInputPort for StubHost {
+    async fn poll_inputs(
+        &self,
+        _after: ironclaw_turns::run_profile::LoopInputCursor,
+        _limit: usize,
+    ) -> Result<ironclaw_turns::run_profile::LoopInputBatch, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+
+    async fn ack_inputs(
+        &self,
+        _cursor: ironclaw_turns::run_profile::LoopInputCursor,
+    ) -> Result<(), AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopModelPort for StubHost {
+    async fn stream_model(
+        &self,
+        _request: ironclaw_turns::run_profile::LoopModelRequest,
+    ) -> Result<ironclaw_turns::run_profile::LoopModelResponse, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopCapabilityPort for StubHost {
+    async fn visible_capabilities(
+        &self,
+        _request: ironclaw_turns::run_profile::VisibleCapabilityRequest,
+    ) -> Result<ironclaw_turns::run_profile::VisibleCapabilitySurface, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+
+    async fn invoke_capability(
+        &self,
+        _request: ironclaw_turns::run_profile::CapabilityInvocation,
+    ) -> Result<ironclaw_turns::run_profile::CapabilityOutcome, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        _request: ironclaw_turns::run_profile::CapabilityBatchInvocation,
+    ) -> Result<ironclaw_turns::run_profile::CapabilityBatchOutcome, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopTranscriptPort for StubHost {
+    async fn finalize_assistant_message(
+        &self,
+        _request: ironclaw_turns::run_profile::FinalizeAssistantMessage,
+    ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopCheckpointPort for StubHost {
+    async fn checkpoint(
+        &self,
+        _request: ironclaw_turns::run_profile::LoopCheckpointRequest,
+    ) -> Result<TurnCheckpointId, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopProgressPort for StubHost {
+    async fn emit_loop_progress(
+        &self,
+        _event: ironclaw_turns::run_profile::LoopProgressEvent,
+    ) -> Result<(), AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+// ─── Mock host factory ──────────────────────────────────────────────────────
+
+struct MockHostFactory;
+
+#[async_trait]
+impl HostFactory for MockHostFactory {
+    async fn create_host(
+        &self,
+        _claimed: &ClaimedTurnRun,
+    ) -> Result<Box<dyn AgentLoopDriverHost + Send + Sync>, HostFactoryError> {
+        Ok(Box::new(StubHost))
+    }
+}
+
+struct FailingHostFactory {
+    reason: String,
+}
+
+#[async_trait]
+impl HostFactory for FailingHostFactory {
+    async fn create_host(
+        &self,
+        _claimed: &ClaimedTurnRun,
+    ) -> Result<Box<dyn AgentLoopDriverHost + Send + Sync>, HostFactoryError> {
+        Err(HostFactoryError::new(self.reason.clone()))
+    }
+}
+
+// ─── Test setup ─────────────────────────────────────────────────────────────
+
+fn make_claimed_run(
+    descriptor: &AgentLoopDriverDescriptor,
+    scope: TurnScope,
+    status: TurnStatus,
+) -> ClaimedTurnRun {
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    let profile = test_resolved_profile_with_driver(descriptor);
+    let mut state = test_run_state(scope, status);
+    state.resolved_run_profile_id = profile.profile_id.clone();
+    state.resolved_run_profile_version = profile.profile_version;
+    ClaimedTurnRun {
+        state,
+        resolved_run_profile: profile,
+        runner_id,
+        lease_token,
+    }
+}
+
+fn setup_registry(driver: Arc<dyn AgentLoopDriver>) -> DriverRegistry {
+    let mut registry = DriverRegistry::new();
+    registry
+        .register_driver(
+            driver,
+            DriverRequirements::all_optional(),
+            DriverKind::Production,
+        )
+        .expect("registration should succeed");
+    registry
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn worker_claims_and_completes_run() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let calls = port.calls();
+    assert!(calls.contains(&TransitionCall::Claim));
+    assert!(calls.contains(&TransitionCall::ApplyValidatedLoopExit));
+}
+
+#[tokio::test]
+async fn worker_records_recovery_on_driver_error() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::failing(
+        desc.clone(),
+        AgentLoopDriverError::Failed {
+            reason_kind: "test_failure".to_string(),
+        },
+    ));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn worker_records_recovery_on_driver_panic() {
+    let desc = test_descriptor();
+    let driver = Arc::new(PanickingDriver {
+        descriptor: desc.clone(),
+    });
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn worker_records_recovery_on_host_factory_error() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let host_factory = Arc::new(FailingHostFactory {
+        reason: "test host creation failure".to_string(),
+    });
+
+    let worker = TurnRunnerWorker::new(config, port.clone(), registry, host_factory, wake_receiver);
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn worker_records_recovery_when_driver_not_found() {
+    let registered_desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(registered_desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+
+    let mut claimed_desc = test_descriptor();
+    claimed_desc.id = LoopDriverId::new("missing_driver").expect("valid");
+    let claimed = make_claimed_run(&claimed_desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn worker_continues_when_no_runs_available() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let port = Arc::new(MockTransitionPort::new());
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let claim_count = port
+        .calls()
+        .iter()
+        .filter(|c| **c == TransitionCall::Claim)
+        .count();
+    assert!(
+        claim_count >= 1,
+        "should have attempted claims, got {claim_count}"
+    );
+}
+
+#[tokio::test]
+async fn wake_signal_triggers_claim_attempt() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let port = Arc::new(MockTransitionPort::new());
+
+    let (wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_secs(60), // very long so wake is the trigger
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    wake_sender.wake();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(port.calls().contains(&TransitionCall::Claim));
+}
+
+#[tokio::test]
+async fn heartbeat_runs_during_driver_execution() {
+    let desc = test_descriptor();
+    let driver =
+        Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_millis(300)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_millis(50), // fast heartbeats
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let heartbeat_count = port
+        .calls()
+        .iter()
+        .filter(|c| **c == TransitionCall::Heartbeat)
+        .count();
+    assert!(
+        heartbeat_count >= 2,
+        "should have sent multiple heartbeats, got {heartbeat_count}"
+    );
+}
+
+#[tokio::test]
+async fn worker_generates_stable_runner_id() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let port = Arc::new(MockTransitionPort::new());
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+
+    let worker = TurnRunnerWorker::new(
+        TurnRunnerWorkerConfig::default(),
+        port,
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+    );
+
+    let id1 = worker.runner_id();
+    let id2 = worker.runner_id();
+    assert_eq!(id1, id2, "runner_id should be stable across calls");
+}

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -9,6 +9,7 @@ use ironclaw_loop_support::{
 };
 use ironclaw_reborn::{
     RebornLoopDriverHostFactory, RebornLoopDriverHostRequest, TextOnlyLoopHostConfig,
+    turn_runner::HostFactory,
 };
 use ironclaw_threads::{
     AcceptInboundMessageRequest, EnsureThreadRequest, InMemorySessionThreadService, MessageContent,
@@ -152,6 +153,24 @@ async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
         ]
     );
     assert_public_milestones_hide_raw_payloads(&fixture.milestones());
+}
+
+#[tokio::test]
+async fn text_only_host_factory_implements_turn_runner_host_factory() {
+    let fixture = HostFixture::new("thread-host-turn-runner-factory", "hello runner").await;
+    let factory = fixture.factory();
+
+    let host = factory.create_host(&fixture.claimed).await.unwrap();
+
+    assert_eq!(host.run_context().run_id, fixture.context.run_id);
+    let context = host
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 8,
+        })
+        .await
+        .unwrap();
+    assert_eq!(context.messages.len(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add concrete Reborn `TurnRunnerWorker` composition that claims one run at a time, owns runner identity/lease tokens, heartbeats active runs, resolves drivers through the registry, invokes per-run hosts, and applies `LoopExit` through the existing transition port path
- add recovery mapping for missing drivers, host/driver errors, driver panics, heartbeat lease loss, cancellation, and exit-application failures
- wire `RebornLoopDriverHostFactory` into the runner `HostFactory` seam so the worker can build text-only `AgentLoopDriverHost` instances per claimed run

Closes #3404

## Tests
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3446-host cargo test -p ironclaw_reborn text_only_host_factory_implements_turn_runner_host_factory --no-default-features`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3446-host cargo test -p ironclaw_reborn turn_runner::tests --no-default-features --lib`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-pr3446-host cargo clippy -p ironclaw_reborn --all-targets --no-default-features -- -D warnings`
- `cargo fmt --all -- --check`
- `uv run --python 3.12 python scripts/check_no_panics.py --base origin/reborn-integration --head HEAD`

## Notes
- PR targets `reborn-integration`.
- #3424 (`LoopExitApplier`) is intentionally kept out of this PR and should land separately.
- No merge performed.
