### PR TITLE
fix(channels): strip model-generated channel/reasoning tags from responses

### DIFF
--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -301,11 +301,44 @@ pub struct OutgoingResponse {
     pub metadata: serde_json::Value,
 }
 
+/// Strip model-generated channel/reasoning tags from response text.
+/// Some models emit internal tags like `<|channel>thought\n<channel|>`
+/// that should never reach the user.
+fn strip_channel_tags(s: &str) -> String {
+    let mut result = s.to_string();
+    // Remove combined thought+close tag patterns (with real newline)
+    result = result.replace("<|channel>thought\n<channel|>", "");
+    result = result.replace("<|channel>response\n<channel|>", "");
+    // Without newline (rare but possible)
+    result = result.replace("<|channel>thought<channel|>", "");
+    result = result.replace("<|channel>response<channel|>", "");
+    // Standalone opening tag with newline
+    result = result.replace("<|channel>thought\n", "");
+    result = result.replace("<|channel>response\n", "");
+    // Standalone tags
+    result = result.replace("<|channel>thought", "");
+    result = result.replace("<|channel>response", "");
+    result = result.replace("<channel|>", "");
+    result = result.replace("<|channel>", "");
+    // Also handle tool_call closing tag (rare leak)
+    result = result.replace("<tool_call|>", "");
+    let cleaned = result.trim().to_string();
+    let final_result = cleaned.replace("\n\n\n", "\n\n");
+    if final_result.len() != s.len() {
+        tracing::warn!(
+            original_len = s.len(),
+            cleaned_len = final_result.len(),
+            "strip_channel_tags: removed channel tags from response"
+        );
+    }
+    final_result
+}
+
 impl OutgoingResponse {
     /// Create a simple text response.
     pub fn text(content: impl Into<String>) -> Self {
         Self {
-            content: content.into(),
+            content: strip_channel_tags(&content.into()),
             thread_id: None,
             attachments: Vec::new(),
             inline_attachments: Vec::new(),


### PR DESCRIPTION
## Problem

Some models (notably Gemma-4) emit internal control tags as part of their chat template when thinking/reasoning mode is disabled. These tags—such as `<|channel>thought\n<channel|>` and `<|channel>response\n<channel|>`—are meant as internal markers for the model's reasoning/response channels and should never be shown to end users.

Currently, these tags leak through to Telegram, Slack, and other channel outputs, resulting in visible artifacts like:

```
<|channel>thought
<channel|>The actual response text here...
```

## Solution

Add a `strip_channel_tags()` function in `src/channels/channel.rs` that removes these tags from the response content in `OutgoingResponse::text()` before it reaches the outgoing channel.

The function handles all known variants:
- Combined tags with newline: `<|channel>thought\n<channel|>`
- Combined tags without newline: `<|channel>thought<channel|>`
- Standalone opening tags: `<|channel>thought\n`
- Standalone closing tags: `<channel|>`
- The `<|channel>` prefix itself
- Also strips `<tool_call|>` tags that may occasionally leak

A `tracing::warn!` log is emitted when tags are actually removed, making it easy to diagnose models that produce these artifacts.

## Testing

- Built and tested on a local deployment with Gemma-4 via vLLM
- Confirmed tags are stripped from Telegram channel output
- Binary includes the strip patterns verified via `strings`

## Notes

The root cause is in the Gemma-4 chat template (`chat_template.jinja`), which injects `<|channel>thought\n<channel|>` as a generation prefix when `enable_thinking` is false. While a custom chat template could avoid this, the strip approach is more robust—it handles any model that emits similar control tags.