### PR TITLE
feat(reborn): add concrete TurnRunner worker composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4526,6 +4526,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -8787,6 +8789,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -24,6 +24,9 @@ ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 secrecy = { version = "0.10", optional = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = "0.1"
 
 [dev-dependencies]
 chrono = "0.4"
@@ -31,7 +34,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 rust_decimal = "1"
 serde_json = "1"
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 
 [[test]]
 name = "llm_gateway"

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -17,6 +17,7 @@ libsql-secrets = ["dep:ironclaw_secrets", "ironclaw_secrets/libsql", "dep:libsql
 
 [dependencies]
 async-trait = "0.1"
+chrono = "0.4"
 ironclaw_llm = { path = "../ironclaw_llm", version = "0.1.0", optional = true, default-features = false }
 ironclaw_loop_support = { path = "../ironclaw_loop_support", version = "0.1.0" }
 ironclaw_secrets = { path = "../ironclaw_secrets", version = "0.1.0", optional = true }
@@ -29,7 +30,6 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 
 [dev-dependencies]
-chrono = "0.4"
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 rust_decimal = "1"
 serde_json = "1"

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -6,6 +6,8 @@
 
 pub mod driver_registry;
 pub mod loop_driver_host;
+pub mod loop_exit_applier;
+pub mod turn_runner;
 
 #[cfg(feature = "root-llm-provider")]
 pub mod model_gateway;

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -19,6 +19,9 @@ pub use loop_driver_host::{
     RebornLoopDriverHost, RebornLoopDriverHostError, RebornLoopDriverHostFactory,
     RebornLoopDriverHostRequest, TextOnlyLoopHostConfig,
 };
+pub use loop_exit_applier::{
+    FailClosedLoopExitEvidencePort, LoopExitApplier, LoopExitEvidencePort,
+};
 #[cfg(feature = "root-llm-provider")]
 pub use model_gateway::{
     LlmModelProfilePolicy, LlmProviderModelGateway, ThreadBackedLoopModelGateway,

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -541,6 +541,38 @@ fn validate_claimed_run_context(
     Ok(())
 }
 
+#[async_trait]
+impl<S, G> crate::turn_runner::HostFactory for RebornLoopDriverHostFactory<S, G>
+where
+    S: SessionThreadService + ?Sized + Send + Sync + 'static,
+    G: HostManagedModelGateway + ?Sized + Send + Sync + 'static,
+{
+    async fn create_host(
+        &self,
+        claimed: &ClaimedTurnRun,
+    ) -> Result<
+        Box<dyn ironclaw_turns::run_profile::AgentLoopDriverHost + Send + Sync>,
+        crate::turn_runner::HostFactoryError,
+    > {
+        let loop_run_context = LoopRunContext::new(
+            claimed.state.scope.clone(),
+            claimed.state.turn_id,
+            claimed.state.run_id,
+            claimed.resolved_run_profile.clone(),
+        );
+        self.build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: claimed.clone(),
+            loop_run_context,
+        })
+        .await
+        .map(|host| {
+            Box::new(host)
+                as Box<dyn ironclaw_turns::run_profile::AgentLoopDriverHost + Send + Sync>
+        })
+        .map_err(|error| crate::turn_runner::HostFactoryError::new(error.to_string()))
+    }
+}
+
 fn persisted_profile_id(profile_id: &RunProfileId) -> RunProfileId {
     if profile_id.is_interactive_default() {
         RunProfileId::default_profile()

--- a/crates/ironclaw_reborn/src/loop_exit_applier.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier.rs
@@ -1,0 +1,274 @@
+//! Trusted `LoopExit` applier for the Reborn turn-runner composition.
+//!
+//! `LoopExit` is a driver claim — the driver declares *what happened* but does
+//! not set evidence booleans. `LoopExitApplier` sits between the driver's
+//! `LoopExit` and the `TurnRunTransitionPort` state transition, deriving
+//! evidence from durable stores (checkpoint state, transcript refs,
+//! cancellation signals), computing the `LoopExitValidationPolicy`, and
+//! delegating to the existing `LoopExit::validate()` +
+//! `apply_validated_loop_exit()` path. Drivers never set evidence booleans.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use ironclaw_turns::{
+    LoopExit, LoopExitInvalidHandling, LoopExitValidationPolicy, LoopGateRef, LoopMessageRef,
+    LoopResultRef, ResolvedRunProfile, TurnCheckpointId, TurnError, TurnLeaseToken, TurnRunId,
+    TurnRunState, TurnRunnerId, TurnScope,
+    runner::{ApplyValidatedLoopExitRequest, TurnRunTransitionPort},
+};
+
+/// Port for verifying durable evidence backing a driver's `LoopExit` claim.
+///
+/// Each method checks whether the corresponding evidence exists durably —
+/// i.e. has been persisted to a store that survives process restarts. The
+/// applier calls these methods to derive `LoopExitValidationPolicy` booleans
+/// before delegating to `LoopExit::validate()`.
+///
+/// Implementations should be side-effect-free: they only read stores, never
+/// mutate state.
+#[async_trait]
+pub trait LoopExitEvidencePort: Send + Sync {
+    /// Verify that completion references (reply messages and/or results) exist
+    /// durably, belong to the given scope/run, and are finalized (not draft).
+    async fn verify_completion_refs(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        reply_refs: &[LoopMessageRef],
+        result_refs: &[LoopResultRef],
+    ) -> Result<bool, TurnError>;
+
+    /// Verify that blocked evidence exists durably: the checkpoint belongs to
+    /// the run, has the correct kind (e.g. `BeforeBlock`), and the gate/process
+    /// ref exists and is pending.
+    async fn verify_blocked_evidence(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        checkpoint_id: &TurnCheckpointId,
+        gate_ref: &LoopGateRef,
+    ) -> Result<bool, TurnError>;
+
+    /// Verify that failure diagnostic evidence exists durably if required
+    /// by the profile.
+    async fn verify_failure_evidence(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> Result<bool, TurnError>;
+
+    /// Check whether a host cancellation signal was received for this run.
+    async fn is_cancellation_observed(&self, run_id: TurnRunId) -> Result<bool, TurnError>;
+}
+
+/// Trusted loop-exit applier that derives evidence from durable stores.
+///
+/// Constructed once per worker and reused across all runs. The applier is
+/// parameterised on injectable ports for both evidence verification and
+/// state transitions, making it fully testable without I/O.
+pub struct LoopExitApplier {
+    transition_port: Arc<dyn TurnRunTransitionPort>,
+    evidence_port: Arc<dyn LoopExitEvidencePort>,
+}
+
+impl LoopExitApplier {
+    /// Create a new applier with the given transition and evidence ports.
+    pub fn new(
+        transition_port: Arc<dyn TurnRunTransitionPort>,
+        evidence_port: Arc<dyn LoopExitEvidencePort>,
+    ) -> Self {
+        Self {
+            transition_port,
+            evidence_port,
+        }
+    }
+
+    /// Derive evidence-backed `LoopExitValidationPolicy`, validate the
+    /// driver's `LoopExit` claim, and apply the resulting mapping through
+    /// the transition port.
+    ///
+    /// This is the primary entry point called by `TurnRunnerWorker::apply_exit`.
+    pub async fn apply(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        runner_id: TurnRunnerId,
+        lease_token: TurnLeaseToken,
+        exit: LoopExit,
+        profile: &ResolvedRunProfile,
+    ) -> Result<TurnRunState, TurnError> {
+        let policy = self.derive_policy(scope, run_id, &exit, profile).await?;
+        let decision = exit.validate(policy);
+
+        self.transition_port
+            .apply_validated_loop_exit(ApplyValidatedLoopExitRequest {
+                run_id,
+                runner_id,
+                lease_token,
+                mapping: decision.mapping,
+            })
+            .await
+    }
+
+    /// Derive a `LoopExitValidationPolicy` by querying evidence ports.
+    async fn derive_policy(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        exit: &LoopExit,
+        profile: &ResolvedRunProfile,
+    ) -> Result<LoopExitValidationPolicy, TurnError> {
+        let mut policy = LoopExitValidationPolicy {
+            require_final_checkpoint: false,
+            host_cancellation_observed: false,
+            invalid_handling: LoopExitInvalidHandling::RecoveryRequired,
+            completion_refs_verified: false,
+            blocked_evidence_verified: false,
+            failure_evidence_verified: false,
+        };
+
+        match exit {
+            LoopExit::Completed(completed) => {
+                policy.require_final_checkpoint =
+                    profile.checkpoint_policy.require_final_checkpoint;
+                policy.completion_refs_verified = self
+                    .evidence_port
+                    .verify_completion_refs(
+                        scope,
+                        run_id,
+                        &completed.reply_message_refs,
+                        &completed.result_refs,
+                    )
+                    .await?;
+            }
+            LoopExit::Blocked(blocked) => {
+                policy.blocked_evidence_verified = self
+                    .evidence_port
+                    .verify_blocked_evidence(
+                        scope,
+                        run_id,
+                        &blocked.checkpoint_id,
+                        &blocked.gate_ref,
+                    )
+                    .await?;
+            }
+            LoopExit::Cancelled(_) => {
+                policy.host_cancellation_observed =
+                    self.evidence_port.is_cancellation_observed(run_id).await?;
+            }
+            LoopExit::Failed(_) => {
+                policy.require_final_checkpoint =
+                    profile.checkpoint_policy.require_final_checkpoint;
+                policy.failure_evidence_verified = self
+                    .evidence_port
+                    .verify_failure_evidence(scope, run_id)
+                    .await?;
+            }
+        }
+
+        Ok(policy)
+    }
+}
+
+/// In-memory evidence port for tests.
+///
+/// All evidence verification returns `Ok(false)` by default (most restrictive /
+/// untrusted). Use builder methods to override individual responses.
+pub struct InMemoryLoopExitEvidencePort {
+    completion_refs_verified: bool,
+    blocked_evidence_verified: bool,
+    failure_evidence_verified: bool,
+    cancellation_observed: bool,
+}
+
+impl InMemoryLoopExitEvidencePort {
+    /// Create a new in-memory evidence port with all evidence unverified.
+    pub fn new() -> Self {
+        Self {
+            completion_refs_verified: false,
+            blocked_evidence_verified: false,
+            failure_evidence_verified: false,
+            cancellation_observed: false,
+        }
+    }
+
+    /// Set whether completion refs verification succeeds.
+    pub fn with_completion_refs_verified(mut self, verified: bool) -> Self {
+        self.completion_refs_verified = verified;
+        self
+    }
+
+    /// Set whether blocked evidence verification succeeds.
+    pub fn with_blocked_evidence_verified(mut self, verified: bool) -> Self {
+        self.blocked_evidence_verified = verified;
+        self
+    }
+
+    /// Set whether failure evidence verification succeeds.
+    pub fn with_failure_evidence_verified(mut self, verified: bool) -> Self {
+        self.failure_evidence_verified = verified;
+        self
+    }
+
+    /// Set whether host cancellation was observed.
+    pub fn with_cancellation_observed(mut self, observed: bool) -> Self {
+        self.cancellation_observed = observed;
+        self
+    }
+
+    /// Create a fully-trusted evidence port (all evidence verified).
+    pub fn all_verified() -> Self {
+        Self {
+            completion_refs_verified: true,
+            blocked_evidence_verified: true,
+            failure_evidence_verified: true,
+            cancellation_observed: true,
+        }
+    }
+}
+
+impl Default for InMemoryLoopExitEvidencePort {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl LoopExitEvidencePort for InMemoryLoopExitEvidencePort {
+    async fn verify_completion_refs(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+        _reply_refs: &[LoopMessageRef],
+        _result_refs: &[LoopResultRef],
+    ) -> Result<bool, TurnError> {
+        Ok(self.completion_refs_verified)
+    }
+
+    async fn verify_blocked_evidence(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+        _checkpoint_id: &TurnCheckpointId,
+        _gate_ref: &LoopGateRef,
+    ) -> Result<bool, TurnError> {
+        Ok(self.blocked_evidence_verified)
+    }
+
+    async fn verify_failure_evidence(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+    ) -> Result<bool, TurnError> {
+        Ok(self.failure_evidence_verified)
+    }
+
+    async fn is_cancellation_observed(&self, _run_id: TurnRunId) -> Result<bool, TurnError> {
+        Ok(self.cancellation_observed)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ironclaw_reborn/src/loop_exit_applier.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier.rs
@@ -172,10 +172,54 @@ impl LoopExitApplier {
     }
 }
 
+/// Production-safe evidence port that never trusts driver-supplied evidence.
+///
+/// Use this as the fallback until a composition root wires durable transcript,
+/// checkpoint, gate, failure-diagnostic, and cancellation stores. It fails
+/// closed by mapping evidence-required exits to recovery instead of accepting
+/// unverifiable driver claims.
+pub struct FailClosedLoopExitEvidencePort;
+
+#[async_trait]
+impl LoopExitEvidencePort for FailClosedLoopExitEvidencePort {
+    async fn verify_completion_refs(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+        _reply_refs: &[LoopMessageRef],
+        _result_refs: &[LoopResultRef],
+    ) -> Result<bool, TurnError> {
+        Ok(false)
+    }
+
+    async fn verify_blocked_evidence(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+        _checkpoint_id: &TurnCheckpointId,
+        _gate_ref: &LoopGateRef,
+    ) -> Result<bool, TurnError> {
+        Ok(false)
+    }
+
+    async fn verify_failure_evidence(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+    ) -> Result<bool, TurnError> {
+        Ok(false)
+    }
+
+    async fn is_cancellation_observed(&self, _run_id: TurnRunId) -> Result<bool, TurnError> {
+        Ok(false)
+    }
+}
+
 /// In-memory evidence port for tests.
 ///
 /// All evidence verification returns `Ok(false)` by default (most restrictive /
 /// untrusted). Use builder methods to override individual responses.
+#[cfg(test)]
 pub struct InMemoryLoopExitEvidencePort {
     completion_refs_verified: bool,
     blocked_evidence_verified: bool,
@@ -183,6 +227,7 @@ pub struct InMemoryLoopExitEvidencePort {
     cancellation_observed: bool,
 }
 
+#[cfg(test)]
 impl InMemoryLoopExitEvidencePort {
     /// Create a new in-memory evidence port with all evidence unverified.
     pub fn new() -> Self {
@@ -229,12 +274,14 @@ impl InMemoryLoopExitEvidencePort {
     }
 }
 
+#[cfg(test)]
 impl Default for InMemoryLoopExitEvidencePort {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl LoopExitEvidencePort for InMemoryLoopExitEvidencePort {
     async fn verify_completion_refs(

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests.rs
@@ -402,10 +402,10 @@ async fn blocked_approval_verified_trusted() {
 }
 
 #[tokio::test]
-async fn blocked_process_verified_trusted() {
+async fn blocked_process_maps_to_recovery_even_when_evidence_is_verified() {
     let s = setup(
         InMemoryLoopExitEvidencePort::new().with_blocked_evidence_verified(true),
-        TurnStatus::BlockedProcess,
+        TurnStatus::RecoveryRequired,
     );
     let profile = test_profile(false);
 
@@ -413,13 +413,7 @@ async fn blocked_process_verified_trusted() {
         .await
         .expect("should succeed");
 
-    let mapping = s.captured_mapping();
-    match &mapping {
-        LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Blocked { reason, .. }) => {
-            assert!(matches!(reason, BlockedReason::Process { .. }));
-        }
-        other => panic!("expected Blocked outcome, got {other:?}"),
-    }
+    assert!(is_recovery_mapping(&s.captured_mapping()));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests.rs
@@ -1,0 +1,531 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use ironclaw_host_api::{TenantId, ThreadId};
+use ironclaw_turns::{
+    AcceptedMessageRef, BlockedReason, EventCursor, LoopBlocked, LoopBlockedKind, LoopCancelled,
+    LoopCancelledReasonKind, LoopCompleted, LoopCompletionKind, LoopExit, LoopExitId,
+    LoopExitMapping, LoopFailed, LoopFailureKind, LoopGateRef, LoopMessageRef,
+    ReplyTargetBindingRef, RunProfileId, RunProfileVersion, SourceBindingRef, TurnCheckpointId,
+    TurnError, TurnId, TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope,
+    TurnStatus,
+    run_profile::*,
+    runner::{
+        ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
+        ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
+        RecordRecoveryRequiredRequest, RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse,
+        TurnRunTransitionPort, TurnRunnerOutcome,
+    },
+};
+
+use super::{InMemoryLoopExitEvidencePort, LoopExitApplier};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn test_scope() -> TurnScope {
+    TurnScope::new(
+        TenantId::new("test-tenant").expect("valid"),
+        None,
+        None,
+        ThreadId::new("test-thread").expect("valid"),
+    )
+}
+
+fn test_run_state(status: TurnStatus) -> TurnRunState {
+    TurnRunState {
+        scope: test_scope(),
+        turn_id: TurnId::new(),
+        run_id: TurnRunId::new(),
+        status,
+        accepted_message_ref: AcceptedMessageRef::new("test-msg").expect("valid"),
+        source_binding_ref: SourceBindingRef::new("test-source").expect("valid"),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("test-reply").expect("valid"),
+        resolved_run_profile_id: RunProfileId::default_profile(),
+        resolved_run_profile_version: RunProfileVersion::new(1),
+        received_at: chrono::Utc::now(),
+        checkpoint_id: None,
+        gate_ref: None,
+        failure: None,
+        event_cursor: EventCursor(0),
+    }
+}
+
+fn test_profile(require_final_checkpoint: bool) -> ResolvedRunProfile {
+    ResolvedRunProfile {
+        run_class_id: RunClassId::new("test_class").expect("valid"),
+        profile_id: RunProfileId::default_profile(),
+        profile_version: RunProfileVersion::new(1),
+        loop_driver: AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("test_loop").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(CheckpointSchemaId::new("test_cp").expect("valid")),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        },
+        checkpoint_schema_id: CheckpointSchemaId::new("test_cp").expect("valid"),
+        checkpoint_schema_version: RunProfileVersion::new(1),
+        model_profile_id: ModelProfileId::new("test_model").expect("valid"),
+        capability_surface_profile_id: CapabilitySurfaceProfileId::new("test_caps").expect("valid"),
+        context_profile_id: ContextProfileId::new("test_ctx").expect("valid"),
+        steering_policy: SteeringPolicy {
+            allow_steering: false,
+            allow_interrupt: true,
+            allow_driver_specific_nudges: false,
+        },
+        cancellation_policy: CancellationPolicy {
+            allow_cancel: true,
+            require_checkpoint_before_cancel: false,
+        },
+        checkpoint_policy: CheckpointPolicy {
+            require_before_model: false,
+            require_before_side_effect: false,
+            require_before_block: true,
+            max_checkpoint_bytes: 64 * 1024,
+            require_final_checkpoint,
+        },
+        resource_budget_policy: ResourceBudgetPolicy {
+            tier: ResourceBudgetTier::new("test_tier").expect("valid"),
+            max_model_calls: 32,
+            max_capability_invocations: 64,
+        },
+        runtime_constraints: RuntimeProfileConstraints {
+            allow_raw_runtime_backend_selection: false,
+            allow_broad_capability_surface: false,
+        },
+        runner_pool_id: None,
+        scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+        concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+        resolution_fingerprint: RunProfileFingerprint::new("test-fp-v1").expect("valid"),
+        provenance: RedactedRunProfileProvenance {
+            sources: vec![],
+            effective_privileges: vec![],
+        },
+    }
+}
+
+// ─── Mock transition port ───────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct CapturingTransitionPort {
+    captured_requests: Mutex<Vec<ApplyValidatedLoopExitRequest>>,
+    result_status: TurnStatus,
+}
+
+impl CapturingTransitionPort {
+    fn new(result_status: TurnStatus) -> Self {
+        Self {
+            captured_requests: Mutex::new(Vec::new()),
+            result_status,
+        }
+    }
+
+    fn captured(&self) -> Vec<ApplyValidatedLoopExitRequest> {
+        self.captured_requests.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl TurnRunTransitionPort for CapturingTransitionPort {
+    async fn claim_next_run(
+        &self,
+        _request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        Ok(None)
+    }
+
+    async fn heartbeat(&self, _request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
+        Ok(EventCursor(0))
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        _request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        Ok(RecoverExpiredLeasesResponse {
+            recovered: Vec::new(),
+        })
+    }
+
+    async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(TurnStatus::BlockedApproval))
+    }
+
+    async fn complete_run(&self, _request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(TurnStatus::Completed))
+    }
+
+    async fn cancel_run(
+        &self,
+        _request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(TurnStatus::Cancelled))
+    }
+
+    async fn fail_run(&self, _request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(TurnStatus::Failed))
+    }
+
+    async fn record_recovery_required(
+        &self,
+        _request: RecordRecoveryRequiredRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(TurnStatus::RecoveryRequired))
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.captured_requests.lock().expect("lock").push(request);
+        Ok(test_run_state(self.result_status))
+    }
+}
+
+// ─── Test setup ─────────────────────────────────────────────────────────────
+
+struct TestSetup {
+    applier: LoopExitApplier,
+    port: Arc<CapturingTransitionPort>,
+    scope: TurnScope,
+    run_id: TurnRunId,
+    runner_id: TurnRunnerId,
+    lease_token: TurnLeaseToken,
+}
+
+fn setup(evidence: InMemoryLoopExitEvidencePort, result_status: TurnStatus) -> TestSetup {
+    let port = Arc::new(CapturingTransitionPort::new(result_status));
+    let applier = LoopExitApplier::new(port.clone(), Arc::new(evidence));
+    TestSetup {
+        applier,
+        port,
+        scope: test_scope(),
+        run_id: TurnRunId::new(),
+        runner_id: TurnRunnerId::new(),
+        lease_token: TurnLeaseToken::new(),
+    }
+}
+
+impl TestSetup {
+    async fn apply(
+        &self,
+        exit: LoopExit,
+        profile: &ResolvedRunProfile,
+    ) -> Result<TurnRunState, TurnError> {
+        self.applier
+            .apply(
+                &self.scope,
+                self.run_id,
+                self.runner_id,
+                self.lease_token,
+                exit,
+                profile,
+            )
+            .await
+    }
+
+    fn captured_mapping(&self) -> LoopExitMapping {
+        let captured = self.port.captured();
+        assert_eq!(captured.len(), 1, "expected exactly one apply call");
+        captured[0].mapping.clone()
+    }
+}
+
+fn completed_exit_with_refs() -> LoopExit {
+    LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::FinalReply,
+        reply_message_refs: vec![LoopMessageRef::new("msg:test-1").expect("valid")],
+        result_refs: vec![],
+        final_checkpoint_id: Some(TurnCheckpointId::new()),
+        usage_summary_ref: None,
+        exit_id: LoopExitId::new("exit:completed-1").expect("valid"),
+    })
+}
+
+fn completed_exit_no_reply() -> LoopExit {
+    LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::NoReply,
+        reply_message_refs: vec![],
+        result_refs: vec![],
+        final_checkpoint_id: None,
+        usage_summary_ref: None,
+        exit_id: LoopExitId::new("exit:noreply-1").expect("valid"),
+    })
+}
+
+fn completed_exit_no_checkpoint() -> LoopExit {
+    LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::FinalReply,
+        reply_message_refs: vec![LoopMessageRef::new("msg:test-1").expect("valid")],
+        result_refs: vec![],
+        final_checkpoint_id: None,
+        usage_summary_ref: None,
+        exit_id: LoopExitId::new("exit:nocp-1").expect("valid"),
+    })
+}
+
+fn blocked_exit(kind: LoopBlockedKind) -> LoopExit {
+    LoopExit::Blocked(LoopBlocked {
+        kind,
+        gate_ref: LoopGateRef::new("gate:test-1").expect("valid"),
+        checkpoint_id: TurnCheckpointId::new(),
+        exit_id: LoopExitId::new("exit:blocked-1").expect("valid"),
+    })
+}
+
+fn cancelled_exit() -> LoopExit {
+    LoopExit::Cancelled(LoopCancelled {
+        reason_kind: LoopCancelledReasonKind::HostCancellation,
+        checkpoint_id: None,
+        interrupted_message_refs: vec![],
+        exit_id: LoopExitId::new("exit:cancelled-1").expect("valid"),
+    })
+}
+
+fn failed_exit() -> LoopExit {
+    LoopExit::Failed(LoopFailed {
+        reason_kind: LoopFailureKind::ModelError,
+        checkpoint_id: None,
+        usage_summary_ref: None,
+        diagnostic_ref: None,
+        exit_id: LoopExitId::new("exit:failed-1").expect("valid"),
+    })
+}
+
+fn is_recovery_mapping(mapping: &LoopExitMapping) -> bool {
+    matches!(mapping, LoopExitMapping::RecoveryRequired { .. })
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn completed_final_reply_verified_refs_trusted() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_completion_refs_verified(true),
+        TurnStatus::Completed,
+    );
+    let profile = test_profile(false);
+
+    s.apply(completed_exit_with_refs(), &profile)
+        .await
+        .expect("should succeed");
+
+    let mapping = s.captured_mapping();
+    assert_eq!(
+        mapping,
+        LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Completed)
+    );
+}
+
+#[tokio::test]
+async fn completed_final_reply_unverified_refs_recovery() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_completion_refs_verified(false),
+        TurnStatus::RecoveryRequired,
+    );
+    let profile = test_profile(false);
+
+    s.apply(completed_exit_with_refs(), &profile)
+        .await
+        .expect("should succeed");
+
+    assert!(is_recovery_mapping(&s.captured_mapping()));
+}
+
+#[tokio::test]
+async fn completed_no_reply_empty_refs_violation() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::all_verified(),
+        TurnStatus::RecoveryRequired,
+    );
+    let profile = test_profile(false);
+
+    s.apply(completed_exit_no_reply(), &profile)
+        .await
+        .expect("should succeed");
+
+    // NoReply with empty refs → MissingCompletionReference via validate()
+    assert!(is_recovery_mapping(&s.captured_mapping()));
+}
+
+#[tokio::test]
+async fn completed_missing_checkpoint_when_required_violation() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_completion_refs_verified(true),
+        TurnStatus::RecoveryRequired,
+    );
+    let profile = test_profile(true); // require_final_checkpoint = true
+
+    s.apply(completed_exit_no_checkpoint(), &profile)
+        .await
+        .expect("should succeed");
+
+    assert!(is_recovery_mapping(&s.captured_mapping()));
+}
+
+#[tokio::test]
+async fn completed_missing_checkpoint_when_not_required_trusted() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_completion_refs_verified(true),
+        TurnStatus::Completed,
+    );
+    let profile = test_profile(false); // require_final_checkpoint = false
+
+    s.apply(completed_exit_no_checkpoint(), &profile)
+        .await
+        .expect("should succeed");
+
+    assert_eq!(
+        s.captured_mapping(),
+        LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Completed)
+    );
+}
+
+#[tokio::test]
+async fn blocked_approval_verified_trusted() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_blocked_evidence_verified(true),
+        TurnStatus::BlockedApproval,
+    );
+    let profile = test_profile(false);
+
+    s.apply(blocked_exit(LoopBlockedKind::Approval), &profile)
+        .await
+        .expect("should succeed");
+
+    let mapping = s.captured_mapping();
+    match &mapping {
+        LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Blocked { reason, .. }) => {
+            assert!(matches!(reason, BlockedReason::Approval { .. }));
+        }
+        other => panic!("expected Blocked outcome, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn blocked_process_verified_trusted() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_blocked_evidence_verified(true),
+        TurnStatus::BlockedProcess,
+    );
+    let profile = test_profile(false);
+
+    s.apply(blocked_exit(LoopBlockedKind::Process), &profile)
+        .await
+        .expect("should succeed");
+
+    let mapping = s.captured_mapping();
+    match &mapping {
+        LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Blocked { reason, .. }) => {
+            assert!(matches!(reason, BlockedReason::Process { .. }));
+        }
+        other => panic!("expected Blocked outcome, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn blocked_unverified_evidence_violation() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_blocked_evidence_verified(false),
+        TurnStatus::RecoveryRequired,
+    );
+    let profile = test_profile(false);
+
+    s.apply(blocked_exit(LoopBlockedKind::Approval), &profile)
+        .await
+        .expect("should succeed");
+
+    assert!(is_recovery_mapping(&s.captured_mapping()));
+}
+
+#[tokio::test]
+async fn cancelled_observed_trusted() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_cancellation_observed(true),
+        TurnStatus::Cancelled,
+    );
+    let profile = test_profile(false);
+
+    s.apply(cancelled_exit(), &profile)
+        .await
+        .expect("should succeed");
+
+    assert_eq!(
+        s.captured_mapping(),
+        LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Cancelled)
+    );
+}
+
+#[tokio::test]
+async fn cancelled_not_observed_violation() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_cancellation_observed(false),
+        TurnStatus::RecoveryRequired,
+    );
+    let profile = test_profile(false);
+
+    s.apply(cancelled_exit(), &profile)
+        .await
+        .expect("should succeed");
+
+    assert!(is_recovery_mapping(&s.captured_mapping()));
+}
+
+#[tokio::test]
+async fn failed_verified_trusted() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_failure_evidence_verified(true),
+        TurnStatus::Failed,
+    );
+    let profile = test_profile(false);
+
+    s.apply(failed_exit(), &profile)
+        .await
+        .expect("should succeed");
+
+    let mapping = s.captured_mapping();
+    match &mapping {
+        LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Failed { failure }) => {
+            assert_eq!(failure.category(), "model_error");
+        }
+        other => panic!("expected Failed outcome, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn failed_unverified_violation() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_failure_evidence_verified(false),
+        TurnStatus::RecoveryRequired,
+    );
+    let profile = test_profile(false);
+
+    s.apply(failed_exit(), &profile)
+        .await
+        .expect("should succeed");
+
+    assert!(is_recovery_mapping(&s.captured_mapping()));
+}
+
+#[tokio::test]
+async fn applier_passes_correct_request_fields_to_port() {
+    let s = setup(
+        InMemoryLoopExitEvidencePort::new().with_completion_refs_verified(true),
+        TurnStatus::Completed,
+    );
+    let profile = test_profile(false);
+
+    s.apply(completed_exit_with_refs(), &profile)
+        .await
+        .expect("should succeed");
+
+    let captured = s.port.captured();
+    assert_eq!(captured.len(), 1);
+    let req = &captured[0];
+    assert_eq!(req.run_id, s.run_id);
+    assert_eq!(req.runner_id, s.runner_id);
+    assert_eq!(req.lease_token, s.lease_token);
+    assert_eq!(
+        req.mapping,
+        LoopExitMapping::RunnerOutcome(TurnRunnerOutcome::Completed)
+    );
+}

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -1,0 +1,618 @@
+//! Concrete Reborn turn-runner worker composition.
+//!
+//! This module owns the worker lifecycle that claims queued/resumed turn runs,
+//! heartbeats the runner lease, selects a registered loop driver, constructs a
+//! per-run `AgentLoopDriverHost`, invokes the driver, and applies the returned
+//! `LoopExit` through trusted transition ports.
+//!
+//! # Architecture boundary
+//!
+//! `ironclaw_turns` owns `TurnRunTransitionPort`, claim/heartbeat/transition
+//! DTOs, state-machine invariants, and the `apply_loop_exit` helper.
+//!
+//! This module owns the concrete worker loop, driver registry lookup, host
+//! factory, readiness/config, and worker lifecycle.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+use ironclaw_turns::{
+    AgentLoopDriverError, AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, LoopExit,
+    ResolvedRunProfile, SanitizedFailure, TurnError, TurnLeaseToken, TurnRunId, TurnRunnerId,
+    TurnScope,
+    runner::{
+        ClaimRunRequest, ClaimedTurnRun, HeartbeatRequest, RecordRecoveryRequiredRequest,
+        TurnRunTransitionPort,
+    },
+};
+
+use crate::loop_exit_applier::LoopExitApplier;
+
+use crate::driver_registry::{DriverRegistry, LoopDriverRegistryKey};
+
+/// Create a `SanitizedFailure` from a known-valid static category.
+///
+/// All categories used here are lowercase ASCII with underscores, satisfying
+/// validation invariants. Returning `Result` keeps production code panic-free if
+/// a future static category violates that invariant.
+fn sanitized_failure(category: &'static str) -> Result<SanitizedFailure, String> {
+    SanitizedFailure::new(category)
+}
+
+/// Configuration for the turn-runner worker.
+#[derive(Debug, Clone)]
+pub struct TurnRunnerWorkerConfig {
+    /// How often to send heartbeats for an active run lease.
+    pub heartbeat_interval: Duration,
+
+    /// Fallback poll interval when no wake signal arrives.
+    pub poll_interval: Duration,
+
+    /// Optional scope filter to restrict which runs this worker claims.
+    pub scope_filter: Option<TurnScope>,
+}
+
+impl Default for TurnRunnerWorkerConfig {
+    fn default() -> Self {
+        Self {
+            heartbeat_interval: Duration::from_secs(10),
+            poll_interval: Duration::from_secs(5),
+            scope_filter: None,
+        }
+    }
+}
+
+/// Factory trait for constructing a per-run `AgentLoopDriverHost`.
+///
+/// The host is created once per claimed run and provides the driver with access
+/// to model, transcript, checkpoint, input, capabilities, and progress services.
+#[async_trait]
+pub trait HostFactory: Send + Sync {
+    /// Construct a host for the given claimed run.
+    ///
+    /// The returned host must be valid for the entire duration of the driver
+    /// invocation. Errors here result in `RecoveryRequired` for the run.
+    async fn create_host(
+        &self,
+        claimed: &ClaimedTurnRun,
+    ) -> Result<
+        Box<dyn ironclaw_turns::run_profile::AgentLoopDriverHost + Send + Sync>,
+        HostFactoryError,
+    >;
+}
+
+/// Error returned when host construction fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostFactoryError {
+    pub reason: String,
+}
+
+impl HostFactoryError {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for HostFactoryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "host factory error: {}", self.reason)
+    }
+}
+
+impl std::error::Error for HostFactoryError {}
+
+/// Wake signal receiver for the turn-runner worker.
+///
+/// The worker uses wake-driven execution with fallback polling. Wake delivery
+/// is best-effort: safe to duplicate or miss.
+#[derive(Debug, Clone)]
+pub struct TurnRunnerWakeReceiver {
+    notify: Arc<Notify>,
+}
+
+impl TurnRunnerWakeReceiver {
+    pub fn new() -> (TurnRunnerWakeSender, Self) {
+        let notify = Arc::new(Notify::new());
+        (
+            TurnRunnerWakeSender {
+                notify: Arc::clone(&notify),
+            },
+            Self { notify },
+        )
+    }
+
+    /// Wait for a wake signal or timeout.
+    async fn wait_or_timeout(&self, timeout: Duration) {
+        tokio::select! {
+            () = self.notify.notified() => {}
+            () = tokio::time::sleep(timeout) => {}
+        }
+    }
+}
+
+impl Default for TurnRunnerWakeReceiver {
+    fn default() -> Self {
+        Self::new().1
+    }
+}
+
+/// Sender half for wake signals.
+///
+/// This can be integrated with `TurnRunWakeNotifier` to forward queued-run
+/// wakes into the worker.
+#[derive(Debug, Clone)]
+pub struct TurnRunnerWakeSender {
+    notify: Arc<Notify>,
+}
+
+impl TurnRunnerWakeSender {
+    /// Signal the worker that there may be new work available.
+    pub fn wake(&self) {
+        self.notify.notify_one();
+    }
+}
+
+/// The concrete Reborn turn-runner worker.
+///
+/// Claims one run at a time, heartbeats the lease, invokes the matched driver,
+/// and applies the returned `LoopExit` through the trusted transition port.
+pub struct TurnRunnerWorker {
+    runner_id: TurnRunnerId,
+    config: TurnRunnerWorkerConfig,
+    transition_port: Arc<dyn TurnRunTransitionPort>,
+    driver_registry: Arc<DriverRegistry>,
+    host_factory: Arc<dyn HostFactory>,
+    wake_receiver: TurnRunnerWakeReceiver,
+    loop_exit_applier: Arc<LoopExitApplier>,
+}
+
+impl TurnRunnerWorker {
+    pub fn new(
+        config: TurnRunnerWorkerConfig,
+        transition_port: Arc<dyn TurnRunTransitionPort>,
+        driver_registry: Arc<DriverRegistry>,
+        host_factory: Arc<dyn HostFactory>,
+        wake_receiver: TurnRunnerWakeReceiver,
+        loop_exit_applier: Arc<LoopExitApplier>,
+    ) -> Self {
+        let runner_id = TurnRunnerId::new();
+        info!(runner_id = ?runner_id, "turn runner worker created");
+        Self {
+            runner_id,
+            config,
+            transition_port,
+            driver_registry,
+            host_factory,
+            wake_receiver,
+            loop_exit_applier,
+        }
+    }
+
+    /// Returns the stable runner identity for this worker instance.
+    pub fn runner_id(&self) -> TurnRunnerId {
+        self.runner_id
+    }
+
+    /// Run the worker claim loop until the cancellation token fires.
+    ///
+    /// This is the main entry point. It loops:
+    /// 1. Wait for a wake signal or fallback poll tick
+    /// 2. Claim the next available run
+    /// 3. If none claimed, continue
+    /// 4. Run the claimed run to `LoopExit` / application
+    /// 5. Repeat
+    pub async fn run(&self, cancel: CancellationToken) {
+        info!(runner_id = ?self.runner_id, "turn runner worker started");
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    info!(runner_id = ?self.runner_id, "turn runner worker shutting down");
+                    break;
+                }
+                () = self.wake_receiver.wait_or_timeout(self.config.poll_interval) => {}
+            }
+
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            if let Err(err) = self.try_claim_and_run().await {
+                warn!(
+                    runner_id = ?self.runner_id,
+                    error = %err,
+                    "claim-and-run cycle failed"
+                );
+            }
+        }
+
+        info!(runner_id = ?self.runner_id, "turn runner worker stopped");
+    }
+
+    /// Attempt one claim-and-run cycle.
+    async fn try_claim_and_run(&self) -> Result<(), TurnRunnerError> {
+        let lease_token = TurnLeaseToken::new();
+        let request = ClaimRunRequest {
+            runner_id: self.runner_id,
+            lease_token,
+            scope_filter: self.config.scope_filter.clone(),
+        };
+
+        let claimed = self
+            .transition_port
+            .claim_next_run(request)
+            .await
+            .map_err(TurnRunnerError::ClaimFailed)?;
+
+        let Some(claimed) = claimed else {
+            debug!(runner_id = ?self.runner_id, "no runs available to claim");
+            return Ok(());
+        };
+
+        let run_id = claimed.state.run_id;
+        let status = claimed.state.status;
+
+        info!(
+            runner_id = ?self.runner_id,
+            run_id = ?run_id,
+            status = ?status,
+            "claimed turn run"
+        );
+
+        self.execute_claimed_run(claimed).await;
+        Ok(())
+    }
+
+    /// Execute a claimed run: heartbeat, invoke driver, apply exit.
+    async fn execute_claimed_run(&self, claimed: ClaimedTurnRun) {
+        let run_id = claimed.state.run_id;
+        let runner_id = claimed.runner_id;
+        let lease_token = claimed.lease_token;
+        let scope = claimed.state.scope.clone();
+        let profile = claimed.resolved_run_profile.clone();
+
+        let heartbeat_cancel = CancellationToken::new();
+        let mut heartbeat_handle = {
+            let port = Arc::clone(&self.transition_port);
+            let interval = self.config.heartbeat_interval;
+            let cancel = heartbeat_cancel.clone();
+            tokio::spawn(heartbeat_loop(
+                port,
+                run_id,
+                runner_id,
+                lease_token,
+                interval,
+                cancel,
+            ))
+        };
+        let mut driver_handle = tokio::spawn(invoke_driver(
+            Arc::clone(&self.driver_registry),
+            Arc::clone(&self.host_factory),
+            claimed,
+        ));
+
+        let exit_result = tokio::select! {
+            joined = &mut driver_handle => {
+                heartbeat_cancel.cancel();
+                let _ = heartbeat_handle.await;
+                match joined {
+                    Ok(result) => result,
+                    Err(err) => Err(DriverInvocationError::DriverPanic {
+                        reason: join_error_summary(err),
+                    }),
+                }
+            }
+            heartbeat_joined = &mut heartbeat_handle => {
+                driver_handle.abort();
+                let _ = driver_handle.await;
+                match heartbeat_joined {
+                    Ok(Ok(())) => Err(DriverInvocationError::HeartbeatFailed {
+                        reason: "heartbeat stopped before driver completed".to_string(),
+                    }),
+                    Ok(Err(err)) => Err(DriverInvocationError::HeartbeatFailed {
+                        reason: err.to_string(),
+                    }),
+                    Err(err) => Err(DriverInvocationError::HeartbeatTaskFailed {
+                        reason: join_error_summary(err),
+                    }),
+                }
+            }
+        };
+
+        match exit_result {
+            Ok(exit) => {
+                self.apply_exit(&scope, run_id, runner_id, lease_token, exit, &profile)
+                    .await;
+            }
+            Err(err) => {
+                warn!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    error = %err,
+                    "driver invocation failed, recording recovery required"
+                );
+                self.record_recovery(run_id, runner_id, lease_token, &err)
+                    .await;
+            }
+        }
+    }
+
+    /// Apply a `LoopExit` through the trusted `LoopExitApplier`.
+    ///
+    /// The applier derives evidence from durable stores, computes
+    /// `LoopExitValidationPolicy`, and delegates to the existing
+    /// `LoopExit::validate()` + `apply_validated_loop_exit()` path.
+    async fn apply_exit(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        runner_id: TurnRunnerId,
+        lease_token: TurnLeaseToken,
+        exit: LoopExit,
+        profile: &ResolvedRunProfile,
+    ) {
+        match self
+            .loop_exit_applier
+            .apply(scope, run_id, runner_id, lease_token, exit, profile)
+            .await
+        {
+            Ok(state) => {
+                info!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    status = ?state.status,
+                    "loop exit applied successfully"
+                );
+            }
+            Err(err) => {
+                error!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    error = %err,
+                    "failed to apply loop exit"
+                );
+                // If exit application fails, try recording recovery.
+                let Ok(failure) = sanitized_failure("exit_application_failed") else {
+                    error!(
+                        runner_id = ?runner_id,
+                        run_id = ?run_id,
+                        "invalid static failure category for exit application failure"
+                    );
+                    return;
+                };
+                let recovery_request = RecordRecoveryRequiredRequest {
+                    run_id,
+                    runner_id,
+                    lease_token,
+                    failure,
+                };
+                if let Err(recovery_err) = self
+                    .transition_port
+                    .record_recovery_required(recovery_request)
+                    .await
+                {
+                    error!(
+                        runner_id = ?runner_id,
+                        run_id = ?run_id,
+                        error = %recovery_err,
+                        "failed to record recovery after exit application failure"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Record recovery required for a failed driver invocation.
+    async fn record_recovery(
+        &self,
+        run_id: TurnRunId,
+        runner_id: TurnRunnerId,
+        lease_token: TurnLeaseToken,
+        error: &DriverInvocationError,
+    ) {
+        let category = match error {
+            DriverInvocationError::DriverNotFound { .. } => "driver_not_found",
+            DriverInvocationError::HostCreationFailed { .. } => "host_creation_failed",
+            DriverInvocationError::DriverError(AgentLoopDriverError::InvalidRequest { .. }) => {
+                "driver_invalid_request"
+            }
+            DriverInvocationError::DriverError(AgentLoopDriverError::Unavailable { .. }) => {
+                "driver_unavailable"
+            }
+            DriverInvocationError::DriverError(AgentLoopDriverError::Failed { .. }) => {
+                "driver_failed"
+            }
+            DriverInvocationError::DriverPanic { .. } => "driver_panic",
+            DriverInvocationError::HeartbeatFailed { .. }
+            | DriverInvocationError::HeartbeatTaskFailed { .. } => "heartbeat_failed",
+        };
+
+        let Ok(failure) = sanitized_failure(category) else {
+            error!(
+                runner_id = ?runner_id,
+                run_id = ?run_id,
+                category,
+                "invalid static failure category for recovery"
+            );
+            return;
+        };
+        let request = RecordRecoveryRequiredRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            failure,
+        };
+
+        if let Err(err) = self.transition_port.record_recovery_required(request).await {
+            error!(
+                runner_id = ?runner_id,
+                run_id = ?run_id,
+                error = %err,
+                "failed to record recovery required"
+            );
+        }
+    }
+}
+
+/// Resolve driver from registry and invoke it.
+async fn invoke_driver(
+    driver_registry: Arc<DriverRegistry>,
+    host_factory: Arc<dyn HostFactory>,
+    claimed: ClaimedTurnRun,
+) -> Result<LoopExit, DriverInvocationError> {
+    let descriptor = &claimed.resolved_run_profile.loop_driver;
+    let registry_key = LoopDriverRegistryKey::from_descriptor(descriptor).map_err(|reason| {
+        DriverInvocationError::DriverNotFound {
+            reason: format!("invalid descriptor: {reason}"),
+        }
+    })?;
+
+    let registered = driver_registry.get(&registry_key).ok_or_else(|| {
+        DriverInvocationError::DriverNotFound {
+            reason: format!("no registered driver for {registry_key}"),
+        }
+    })?;
+
+    let driver = registered.driver();
+    let host = host_factory
+        .create_host(&claimed)
+        .await
+        .map_err(|err| DriverInvocationError::HostCreationFailed { reason: err.reason })?;
+
+    let turn_id = claimed.state.turn_id;
+    let run_id = claimed.state.run_id;
+    let resolved_run_profile = claimed.resolved_run_profile.clone();
+
+    if let Some(checkpoint_id) = claimed.state.checkpoint_id {
+        let request = AgentLoopDriverResumeRequest {
+            turn_id,
+            run_id,
+            checkpoint_id,
+            resolved_run_profile,
+        };
+        driver
+            .resume(request, host.as_ref())
+            .await
+            .map_err(DriverInvocationError::DriverError)
+    } else {
+        let request = AgentLoopDriverRunRequest {
+            turn_id,
+            run_id,
+            resolved_run_profile,
+        };
+        driver
+            .run(request, host.as_ref())
+            .await
+            .map_err(DriverInvocationError::DriverError)
+    }
+}
+
+fn join_error_summary(err: tokio::task::JoinError) -> String {
+    if err.is_panic() {
+        "task panicked".to_string()
+    } else if err.is_cancelled() {
+        "task cancelled".to_string()
+    } else {
+        err.to_string()
+    }
+}
+
+/// Heartbeat loop that runs in a spawned task for the duration of a driver run.
+async fn heartbeat_loop(
+    port: Arc<dyn TurnRunTransitionPort>,
+    run_id: TurnRunId,
+    runner_id: TurnRunnerId,
+    lease_token: TurnLeaseToken,
+    interval: Duration,
+    cancel: CancellationToken,
+) -> Result<(), TurnError> {
+    let mut tick = tokio::time::interval(interval);
+    // Skip the first immediate tick
+    tick.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                debug!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    "heartbeat loop stopped"
+                );
+                return Ok(());
+            }
+            _ = tick.tick() => {
+                let request = HeartbeatRequest {
+                    run_id,
+                    runner_id,
+                    lease_token,
+                };
+                match port.heartbeat(request).await {
+                    Ok(_cursor) => {
+                        debug!(
+                            runner_id = ?runner_id,
+                            run_id = ?run_id,
+                            "heartbeat sent"
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            runner_id = ?runner_id,
+                            run_id = ?run_id,
+                            error = %err,
+                            "heartbeat failed"
+                        );
+                        return Err(err);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Internal error type for a single claim-and-run cycle.
+#[derive(Debug)]
+enum TurnRunnerError {
+    ClaimFailed(TurnError),
+}
+
+impl std::fmt::Display for TurnRunnerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClaimFailed(err) => write!(f, "claim failed: {err}"),
+        }
+    }
+}
+
+/// Error during driver invocation (before `LoopExit` is returned).
+#[derive(Debug)]
+enum DriverInvocationError {
+    DriverNotFound { reason: String },
+    HostCreationFailed { reason: String },
+    DriverError(AgentLoopDriverError),
+    DriverPanic { reason: String },
+    HeartbeatFailed { reason: String },
+    HeartbeatTaskFailed { reason: String },
+}
+
+impl std::fmt::Display for DriverInvocationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DriverNotFound { reason } => write!(f, "driver not found: {reason}"),
+            Self::HostCreationFailed { reason } => write!(f, "host creation failed: {reason}"),
+            Self::DriverError(err) => write!(f, "driver error: {err}"),
+            Self::DriverPanic { reason } => write!(f, "driver panic: {reason}"),
+            Self::HeartbeatFailed { reason } => write!(f, "heartbeat failed: {reason}"),
+            Self::HeartbeatTaskFailed { reason } => write!(f, "heartbeat task failed: {reason}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -336,6 +336,15 @@ impl TurnRunnerWorker {
                 self.apply_exit(&scope, run_id, runner_id, lease_token, exit, &profile)
                     .await;
             }
+            Err(err) if err.is_heartbeat_failure() => {
+                warn!(
+                    runner_id = ?runner_id,
+                    run_id = ?run_id,
+                    error = %err,
+                    "heartbeat failed, stopping driver and asking transition port to recover expired leases"
+                );
+                self.recover_after_heartbeat_failure(&scope, &err).await;
+            }
             Err(err) => {
                 warn!(
                     runner_id = ?runner_id,
@@ -343,15 +352,32 @@ impl TurnRunnerWorker {
                     error = %err,
                     "driver invocation failed, recording recovery required"
                 );
-                self.record_recovery_or_recover_expired_lease(
-                    &scope,
-                    run_id,
-                    runner_id,
-                    lease_token,
-                    &err,
-                )
-                .await;
+                self.record_recovery(run_id, runner_id, lease_token, &err)
+                    .await;
             }
+        }
+    }
+
+    async fn recover_after_heartbeat_failure(
+        &self,
+        scope: &TurnScope,
+        error: &DriverInvocationError,
+    ) {
+        if let Err(err) = self
+            .transition_port
+            .recover_expired_leases(RecoverExpiredLeasesRequest {
+                now: chrono::Utc::now(),
+                scope_filter: Some(scope.clone()),
+            })
+            .await
+        {
+            error!(
+                runner_id = ?self.runner_id,
+                scope = ?scope,
+                heartbeat_error = %error,
+                error = %err,
+                "failed to recover expired leases after heartbeat failure"
+            );
         }
     }
 
@@ -418,65 +444,6 @@ impl TurnRunnerWorker {
                 }
             }
         }
-    }
-
-    /// Record recovery required for a failed driver invocation, or run the
-    /// lease-expiry recovery sweep when the active lease is already expired.
-    async fn record_recovery_or_recover_expired_lease(
-        &self,
-        scope: &TurnScope,
-        run_id: TurnRunId,
-        runner_id: TurnRunnerId,
-        lease_token: TurnLeaseToken,
-        error: &DriverInvocationError,
-    ) {
-        if matches!(
-            error,
-            DriverInvocationError::HeartbeatFailed {
-                error: TurnError::Conflict { .. }
-            }
-        ) {
-            match self
-                .transition_port
-                .recover_expired_leases(RecoverExpiredLeasesRequest {
-                    now: chrono::Utc::now(),
-                    scope_filter: Some(scope.clone()),
-                })
-                .await
-            {
-                Ok(response)
-                    if response
-                        .recovered
-                        .iter()
-                        .any(|state| state.run_id == run_id) =>
-                {
-                    info!(
-                        runner_id = ?runner_id,
-                        run_id = ?run_id,
-                        "expired runner lease recovered"
-                    );
-                }
-                Ok(_) => {
-                    warn!(
-                        runner_id = ?runner_id,
-                        run_id = ?run_id,
-                        "heartbeat reported expired lease but recovery sweep did not recover run"
-                    );
-                }
-                Err(err) => {
-                    error!(
-                        runner_id = ?runner_id,
-                        run_id = ?run_id,
-                        error = %err,
-                        "failed to recover expired runner lease"
-                    );
-                }
-            }
-            return;
-        }
-
-        self.record_recovery(run_id, runner_id, lease_token, error)
-            .await;
     }
 
     /// Record recovery required for a failed driver invocation while the
@@ -688,6 +655,15 @@ impl std::fmt::Display for DriverInvocationError {
             Self::HeartbeatTaskFailed { reason } => write!(f, "heartbeat task failed: {reason}"),
             Self::WorkerCancelled => write!(f, "worker cancelled active driver"),
         }
+    }
+}
+
+impl DriverInvocationError {
+    fn is_heartbeat_failure(&self) -> bool {
+        matches!(
+            self,
+            Self::HeartbeatFailed { .. } | Self::HeartbeatTaskFailed { .. }
+        )
     }
 }
 

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -27,7 +27,7 @@ use ironclaw_turns::{
     TurnScope,
     runner::{
         ClaimRunRequest, ClaimedTurnRun, HeartbeatRequest, RecordRecoveryRequiredRequest,
-        TurnRunTransitionPort,
+        RecoverExpiredLeasesRequest, TurnRunTransitionPort,
     },
 };
 
@@ -224,7 +224,7 @@ impl TurnRunnerWorker {
                 break;
             }
 
-            if let Err(err) = self.try_claim_and_run().await {
+            if let Err(err) = self.try_claim_and_run(&cancel).await {
                 warn!(
                     runner_id = ?self.runner_id,
                     error = %err,
@@ -237,7 +237,7 @@ impl TurnRunnerWorker {
     }
 
     /// Attempt one claim-and-run cycle.
-    async fn try_claim_and_run(&self) -> Result<(), TurnRunnerError> {
+    async fn try_claim_and_run(&self, cancel: &CancellationToken) -> Result<(), TurnRunnerError> {
         let lease_token = TurnLeaseToken::new();
         let request = ClaimRunRequest {
             runner_id: self.runner_id,
@@ -266,12 +266,12 @@ impl TurnRunnerWorker {
             "claimed turn run"
         );
 
-        self.execute_claimed_run(claimed).await;
+        self.execute_claimed_run(claimed, cancel).await;
         Ok(())
     }
 
     /// Execute a claimed run: heartbeat, invoke driver, apply exit.
-    async fn execute_claimed_run(&self, claimed: ClaimedTurnRun) {
+    async fn execute_claimed_run(&self, claimed: ClaimedTurnRun, cancel: &CancellationToken) {
         let run_id = claimed.state.run_id;
         let runner_id = claimed.runner_id;
         let lease_token = claimed.lease_token;
@@ -299,6 +299,8 @@ impl TurnRunnerWorker {
         ));
 
         let exit_result = tokio::select! {
+            biased;
+
             joined = &mut driver_handle => {
                 heartbeat_cancel.cancel();
                 let _ = heartbeat_handle.await;
@@ -313,16 +315,19 @@ impl TurnRunnerWorker {
                 driver_handle.abort();
                 let _ = driver_handle.await;
                 match heartbeat_joined {
-                    Ok(Ok(())) => Err(DriverInvocationError::HeartbeatFailed {
-                        reason: "heartbeat stopped before driver completed".to_string(),
-                    }),
-                    Ok(Err(err)) => Err(DriverInvocationError::HeartbeatFailed {
-                        reason: err.to_string(),
-                    }),
+                    Ok(Ok(())) => Err(DriverInvocationError::HeartbeatStopped),
+                    Ok(Err(error)) => Err(DriverInvocationError::HeartbeatFailed { error }),
                     Err(err) => Err(DriverInvocationError::HeartbeatTaskFailed {
                         reason: join_error_summary(err),
                     }),
                 }
+            }
+            () = cancel.cancelled() => {
+                heartbeat_cancel.cancel();
+                driver_handle.abort();
+                let _ = driver_handle.await;
+                let _ = heartbeat_handle.await;
+                Err(DriverInvocationError::WorkerCancelled)
             }
         };
 
@@ -338,8 +343,14 @@ impl TurnRunnerWorker {
                     error = %err,
                     "driver invocation failed, recording recovery required"
                 );
-                self.record_recovery(run_id, runner_id, lease_token, &err)
-                    .await;
+                self.record_recovery_or_recover_expired_lease(
+                    &scope,
+                    run_id,
+                    runner_id,
+                    lease_token,
+                    &err,
+                )
+                .await;
             }
         }
     }
@@ -409,7 +420,67 @@ impl TurnRunnerWorker {
         }
     }
 
-    /// Record recovery required for a failed driver invocation.
+    /// Record recovery required for a failed driver invocation, or run the
+    /// lease-expiry recovery sweep when the active lease is already expired.
+    async fn record_recovery_or_recover_expired_lease(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        runner_id: TurnRunnerId,
+        lease_token: TurnLeaseToken,
+        error: &DriverInvocationError,
+    ) {
+        if matches!(
+            error,
+            DriverInvocationError::HeartbeatFailed {
+                error: TurnError::Conflict { .. }
+            }
+        ) {
+            match self
+                .transition_port
+                .recover_expired_leases(RecoverExpiredLeasesRequest {
+                    now: chrono::Utc::now(),
+                    scope_filter: Some(scope.clone()),
+                })
+                .await
+            {
+                Ok(response)
+                    if response
+                        .recovered
+                        .iter()
+                        .any(|state| state.run_id == run_id) =>
+                {
+                    info!(
+                        runner_id = ?runner_id,
+                        run_id = ?run_id,
+                        "expired runner lease recovered"
+                    );
+                }
+                Ok(_) => {
+                    warn!(
+                        runner_id = ?runner_id,
+                        run_id = ?run_id,
+                        "heartbeat reported expired lease but recovery sweep did not recover run"
+                    );
+                }
+                Err(err) => {
+                    error!(
+                        runner_id = ?runner_id,
+                        run_id = ?run_id,
+                        error = %err,
+                        "failed to recover expired runner lease"
+                    );
+                }
+            }
+            return;
+        }
+
+        self.record_recovery(run_id, runner_id, lease_token, error)
+            .await;
+    }
+
+    /// Record recovery required for a failed driver invocation while the
+    /// worker still owns the active lease.
     async fn record_recovery(
         &self,
         run_id: TurnRunId,
@@ -430,8 +501,10 @@ impl TurnRunnerWorker {
                 "driver_failed"
             }
             DriverInvocationError::DriverPanic { .. } => "driver_panic",
-            DriverInvocationError::HeartbeatFailed { .. }
+            DriverInvocationError::HeartbeatStopped
+            | DriverInvocationError::HeartbeatFailed { .. }
             | DriverInvocationError::HeartbeatTaskFailed { .. } => "heartbeat_failed",
+            DriverInvocationError::WorkerCancelled => "worker_cancelled",
         };
 
         let Ok(failure) = sanitized_failure(category) else {
@@ -597,8 +670,10 @@ enum DriverInvocationError {
     HostCreationFailed { reason: String },
     DriverError(AgentLoopDriverError),
     DriverPanic { reason: String },
-    HeartbeatFailed { reason: String },
+    HeartbeatStopped,
+    HeartbeatFailed { error: TurnError },
     HeartbeatTaskFailed { reason: String },
+    WorkerCancelled,
 }
 
 impl std::fmt::Display for DriverInvocationError {
@@ -608,8 +683,10 @@ impl std::fmt::Display for DriverInvocationError {
             Self::HostCreationFailed { reason } => write!(f, "host creation failed: {reason}"),
             Self::DriverError(err) => write!(f, "driver error: {err}"),
             Self::DriverPanic { reason } => write!(f, "driver panic: {reason}"),
-            Self::HeartbeatFailed { reason } => write!(f, "heartbeat failed: {reason}"),
+            Self::HeartbeatStopped => write!(f, "heartbeat stopped before driver completed"),
+            Self::HeartbeatFailed { error } => write!(f, "heartbeat failed: {error}"),
             Self::HeartbeatTaskFailed { reason } => write!(f, "heartbeat task failed: {reason}"),
+            Self::WorkerCancelled => write!(f, "worker cancelled active driver"),
         }
     }
 }

--- a/crates/ironclaw_reborn/src/turn_runner.rs
+++ b/crates/ironclaw_reborn/src/turn_runner.rs
@@ -341,8 +341,10 @@ impl TurnRunnerWorker {
                     runner_id = ?runner_id,
                     run_id = ?run_id,
                     error = %err,
-                    "heartbeat failed, stopping driver and asking transition port to recover expired leases"
+                    "heartbeat failed, stopping driver and recording recovery before lease sweep"
                 );
+                self.record_recovery(run_id, runner_id, lease_token, &err)
+                    .await;
                 self.recover_after_heartbeat_failure(&scope, &err).await;
             }
             Err(err) => {

--- a/crates/ironclaw_reborn/src/turn_runner/tests.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests.rs
@@ -1,0 +1,914 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+use ironclaw_host_api::{TenantId, ThreadId};
+use ironclaw_turns::{
+    AcceptedMessageRef, AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError,
+    AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, EventCursor, LoopCompleted,
+    LoopCompletionKind, LoopExit, LoopExitId, LoopMessageRef, ReplyTargetBindingRef,
+    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken,
+    TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
+    run_profile::{AgentLoopDriverHost, AgentLoopHostError, CheckpointSchemaId, LoopDriverId},
+    runner::{
+        ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
+        ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
+        RecordRecoveryRequiredRequest, RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse,
+        TurnRunTransitionPort,
+    },
+};
+
+use crate::driver_registry::{DriverKind, DriverRegistry, DriverRequirements};
+use crate::loop_exit_applier::{InMemoryLoopExitEvidencePort, LoopExitApplier};
+
+use super::*;
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+fn test_scope() -> TurnScope {
+    TurnScope::new(
+        TenantId::new("test-tenant").expect("valid"),
+        None,
+        None,
+        ThreadId::new("test-thread").expect("valid"),
+    )
+}
+
+fn test_descriptor() -> AgentLoopDriverDescriptor {
+    AgentLoopDriverDescriptor {
+        id: LoopDriverId::new("test_loop").expect("valid"),
+        version: RunProfileVersion::new(1),
+        checkpoint_schema_id: Some(CheckpointSchemaId::new("test_checkpoint").expect("valid")),
+        checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+    }
+}
+
+fn test_resolved_profile_with_driver(
+    desc: &AgentLoopDriverDescriptor,
+) -> ironclaw_turns::ResolvedRunProfile {
+    use ironclaw_turns::run_profile::*;
+    use ironclaw_turns::*;
+
+    ResolvedRunProfile {
+        run_class_id: RunClassId::new("test_class").expect("valid"),
+        profile_id: RunProfileId::default_profile(),
+        profile_version: RunProfileVersion::new(1),
+        loop_driver: desc.clone(),
+        checkpoint_schema_id: desc
+            .checkpoint_schema_id
+            .clone()
+            .unwrap_or_else(|| CheckpointSchemaId::new("fallback_checkpoint").expect("valid")),
+        checkpoint_schema_version: desc
+            .checkpoint_schema_version
+            .unwrap_or_else(|| RunProfileVersion::new(1)),
+        model_profile_id: ModelProfileId::new("test_model").expect("valid"),
+        capability_surface_profile_id: CapabilitySurfaceProfileId::new("test_capabilities")
+            .expect("valid"),
+        context_profile_id: ContextProfileId::new("test_context").expect("valid"),
+        steering_policy: SteeringPolicy {
+            allow_steering: false,
+            allow_interrupt: true,
+            allow_driver_specific_nudges: false,
+        },
+        cancellation_policy: CancellationPolicy {
+            allow_cancel: true,
+            require_checkpoint_before_cancel: false,
+        },
+        checkpoint_policy: CheckpointPolicy {
+            require_before_model: false,
+            require_before_side_effect: false,
+            require_before_block: true,
+            max_checkpoint_bytes: 64 * 1024,
+            require_final_checkpoint: false,
+        },
+        resource_budget_policy: ResourceBudgetPolicy {
+            tier: ResourceBudgetTier::new("test_tier").expect("valid"),
+            max_model_calls: 32,
+            max_capability_invocations: 64,
+        },
+        runtime_constraints: RuntimeProfileConstraints {
+            allow_raw_runtime_backend_selection: false,
+            allow_broad_capability_surface: false,
+        },
+        runner_pool_id: None,
+        scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+        concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+        resolution_fingerprint: RunProfileFingerprint::new("test-fingerprint-v1").expect("valid"),
+        provenance: RedactedRunProfileProvenance {
+            sources: vec![],
+            effective_privileges: vec![],
+        },
+    }
+}
+
+fn test_run_state(scope: TurnScope, status: TurnStatus) -> TurnRunState {
+    TurnRunState {
+        scope,
+        turn_id: TurnId::new(),
+        run_id: TurnRunId::new(),
+        status,
+        accepted_message_ref: AcceptedMessageRef::new("test-msg").expect("valid"),
+        source_binding_ref: SourceBindingRef::new("test-source").expect("valid"),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("test-reply").expect("valid"),
+        resolved_run_profile_id: ironclaw_turns::RunProfileId::default_profile(),
+        resolved_run_profile_version: RunProfileVersion::new(1),
+        received_at: chrono::Utc::now(),
+        checkpoint_id: None,
+        gate_ref: None,
+        failure: None,
+        event_cursor: EventCursor(0),
+    }
+}
+
+fn test_completed_exit() -> LoopExit {
+    LoopExit::Completed(LoopCompleted {
+        completion_kind: LoopCompletionKind::FinalReply,
+        reply_message_refs: vec![LoopMessageRef::new("msg:test-1").expect("valid")],
+        result_refs: vec![],
+        final_checkpoint_id: None,
+        usage_summary_ref: None,
+        exit_id: LoopExitId::new("exit:test-1").expect("valid"),
+    })
+}
+
+// ─── Mock transition port ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TransitionCall {
+    Claim,
+    Heartbeat,
+    ApplyValidatedLoopExit,
+    RecordRecoveryRequired,
+}
+
+struct MockTransitionPort {
+    claim_results: Mutex<Vec<Result<Option<ClaimedTurnRun>, TurnError>>>,
+    heartbeat_result: Mutex<Result<EventCursor, TurnError>>,
+    apply_exit_result: Mutex<Result<TurnRunState, TurnError>>,
+    recovery_result: Mutex<Result<TurnRunState, TurnError>>,
+    calls: Mutex<Vec<TransitionCall>>,
+}
+
+impl MockTransitionPort {
+    fn new() -> Self {
+        Self {
+            claim_results: Mutex::new(Vec::new()),
+            heartbeat_result: Mutex::new(Ok(EventCursor(1))),
+            apply_exit_result: Mutex::new(Ok(test_run_state(test_scope(), TurnStatus::Completed))),
+            recovery_result: Mutex::new(Ok(test_run_state(
+                test_scope(),
+                TurnStatus::RecoveryRequired,
+            ))),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn with_claim_result(self, result: Result<Option<ClaimedTurnRun>, TurnError>) -> Self {
+        self.claim_results.lock().expect("lock").push(result);
+        self
+    }
+
+    fn with_heartbeat_result(self, result: Result<EventCursor, TurnError>) -> Self {
+        *self.heartbeat_result.lock().expect("lock") = result;
+        self
+    }
+
+    fn calls(&self) -> Vec<TransitionCall> {
+        self.calls.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl TurnRunTransitionPort for MockTransitionPort {
+    async fn claim_next_run(
+        &self,
+        _request: ClaimRunRequest,
+    ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        self.calls.lock().expect("lock").push(TransitionCall::Claim);
+        let mut results = self.claim_results.lock().expect("lock");
+        if results.is_empty() {
+            Ok(None)
+        } else {
+            results.remove(0)
+        }
+    }
+
+    async fn heartbeat(&self, _request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
+        self.calls
+            .lock()
+            .expect("lock")
+            .push(TransitionCall::Heartbeat);
+        self.heartbeat_result.lock().expect("lock").clone()
+    }
+
+    async fn recover_expired_leases(
+        &self,
+        _request: RecoverExpiredLeasesRequest,
+    ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        Ok(RecoverExpiredLeasesResponse {
+            recovered: Vec::new(),
+        })
+    }
+
+    async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(test_scope(), TurnStatus::BlockedApproval))
+    }
+
+    async fn complete_run(&self, _request: CompleteRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(test_scope(), TurnStatus::Completed))
+    }
+
+    async fn cancel_run(
+        &self,
+        _request: CancelRunCompletionRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(test_scope(), TurnStatus::Cancelled))
+    }
+
+    async fn fail_run(&self, _request: FailRunRequest) -> Result<TurnRunState, TurnError> {
+        Ok(test_run_state(test_scope(), TurnStatus::Failed))
+    }
+
+    async fn record_recovery_required(
+        &self,
+        _request: RecordRecoveryRequiredRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.calls
+            .lock()
+            .expect("lock")
+            .push(TransitionCall::RecordRecoveryRequired);
+        self.recovery_result.lock().expect("lock").clone()
+    }
+
+    async fn apply_validated_loop_exit(
+        &self,
+        _request: ApplyValidatedLoopExitRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.calls
+            .lock()
+            .expect("lock")
+            .push(TransitionCall::ApplyValidatedLoopExit);
+        self.apply_exit_result.lock().expect("lock").clone()
+    }
+}
+
+// ─── Mock driver ────────────────────────────────────────────────────────────
+
+struct MockDriver {
+    descriptor: AgentLoopDriverDescriptor,
+    run_result: Mutex<Result<LoopExit, AgentLoopDriverError>>,
+    run_delay: Duration,
+}
+
+struct PanickingDriver {
+    descriptor: AgentLoopDriverDescriptor,
+}
+
+impl MockDriver {
+    fn completing(descriptor: AgentLoopDriverDescriptor) -> Self {
+        Self {
+            descriptor,
+            run_result: Mutex::new(Ok(test_completed_exit())),
+            run_delay: Duration::ZERO,
+        }
+    }
+
+    fn failing(descriptor: AgentLoopDriverDescriptor, error: AgentLoopDriverError) -> Self {
+        Self {
+            descriptor,
+            run_result: Mutex::new(Err(error)),
+            run_delay: Duration::ZERO,
+        }
+    }
+
+    fn with_delay(mut self, delay: Duration) -> Self {
+        self.run_delay = delay;
+        self
+    }
+}
+
+#[async_trait]
+impl AgentLoopDriver for MockDriver {
+    fn descriptor(&self) -> AgentLoopDriverDescriptor {
+        self.descriptor.clone()
+    }
+
+    async fn run(
+        &self,
+        _request: AgentLoopDriverRunRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        if !self.run_delay.is_zero() {
+            tokio::time::sleep(self.run_delay).await;
+        }
+        self.run_result.lock().expect("lock").clone()
+    }
+
+    async fn resume(
+        &self,
+        _request: AgentLoopDriverResumeRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        if !self.run_delay.is_zero() {
+            tokio::time::sleep(self.run_delay).await;
+        }
+        self.run_result.lock().expect("lock").clone()
+    }
+}
+
+#[async_trait]
+impl AgentLoopDriver for PanickingDriver {
+    fn descriptor(&self) -> AgentLoopDriverDescriptor {
+        self.descriptor.clone()
+    }
+
+    async fn run(
+        &self,
+        _request: AgentLoopDriverRunRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        panic!("driver panic for test")
+    }
+
+    async fn resume(
+        &self,
+        _request: AgentLoopDriverResumeRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        panic!("driver panic for test")
+    }
+}
+
+// ─── Stub host (mock driver never calls host methods) ───────────────────────
+
+struct StubHost;
+
+impl ironclaw_turns::run_profile::LoopRunInfoPort for StubHost {
+    fn run_context(&self) -> &ironclaw_turns::run_profile::LoopRunContext {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopContextPort for StubHost {
+    async fn load_loop_context(
+        &self,
+        _request: ironclaw_turns::run_profile::LoopContextRequest,
+    ) -> Result<ironclaw_turns::run_profile::LoopContextBundle, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopPromptPort for StubHost {
+    async fn build_prompt_bundle(
+        &self,
+        _request: ironclaw_turns::run_profile::LoopPromptBundleRequest,
+    ) -> Result<ironclaw_turns::run_profile::LoopPromptBundle, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopInputPort for StubHost {
+    async fn poll_inputs(
+        &self,
+        _after: ironclaw_turns::run_profile::LoopInputCursor,
+        _limit: usize,
+    ) -> Result<ironclaw_turns::run_profile::LoopInputBatch, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+
+    async fn ack_inputs(
+        &self,
+        _cursor: ironclaw_turns::run_profile::LoopInputCursor,
+    ) -> Result<(), AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopModelPort for StubHost {
+    async fn stream_model(
+        &self,
+        _request: ironclaw_turns::run_profile::LoopModelRequest,
+    ) -> Result<ironclaw_turns::run_profile::LoopModelResponse, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopCapabilityPort for StubHost {
+    async fn visible_capabilities(
+        &self,
+        _request: ironclaw_turns::run_profile::VisibleCapabilityRequest,
+    ) -> Result<ironclaw_turns::run_profile::VisibleCapabilitySurface, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+
+    async fn invoke_capability(
+        &self,
+        _request: ironclaw_turns::run_profile::CapabilityInvocation,
+    ) -> Result<ironclaw_turns::run_profile::CapabilityOutcome, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        _request: ironclaw_turns::run_profile::CapabilityBatchInvocation,
+    ) -> Result<ironclaw_turns::run_profile::CapabilityBatchOutcome, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopTranscriptPort for StubHost {
+    async fn finalize_assistant_message(
+        &self,
+        _request: ironclaw_turns::run_profile::FinalizeAssistantMessage,
+    ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopCheckpointPort for StubHost {
+    async fn checkpoint(
+        &self,
+        _request: ironclaw_turns::run_profile::LoopCheckpointRequest,
+    ) -> Result<TurnCheckpointId, AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+#[async_trait]
+impl ironclaw_turns::run_profile::LoopProgressPort for StubHost {
+    async fn emit_loop_progress(
+        &self,
+        _event: ironclaw_turns::run_profile::LoopProgressEvent,
+    ) -> Result<(), AgentLoopHostError> {
+        unimplemented!("stub host: never called by mock driver")
+    }
+}
+
+// ─── Mock host factory ──────────────────────────────────────────────────────
+
+struct MockHostFactory;
+
+#[async_trait]
+impl HostFactory for MockHostFactory {
+    async fn create_host(
+        &self,
+        _claimed: &ClaimedTurnRun,
+    ) -> Result<Box<dyn AgentLoopDriverHost + Send + Sync>, HostFactoryError> {
+        Ok(Box::new(StubHost))
+    }
+}
+
+struct FailingHostFactory {
+    reason: String,
+}
+
+#[async_trait]
+impl HostFactory for FailingHostFactory {
+    async fn create_host(
+        &self,
+        _claimed: &ClaimedTurnRun,
+    ) -> Result<Box<dyn AgentLoopDriverHost + Send + Sync>, HostFactoryError> {
+        Err(HostFactoryError::new(self.reason.clone()))
+    }
+}
+
+// ─── Test setup ─────────────────────────────────────────────────────────────
+
+fn make_claimed_run(
+    descriptor: &AgentLoopDriverDescriptor,
+    scope: TurnScope,
+    status: TurnStatus,
+) -> ClaimedTurnRun {
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    let profile = test_resolved_profile_with_driver(descriptor);
+    let mut state = test_run_state(scope, status);
+    state.resolved_run_profile_id = profile.profile_id.clone();
+    state.resolved_run_profile_version = profile.profile_version;
+    ClaimedTurnRun {
+        state,
+        resolved_run_profile: profile,
+        runner_id,
+        lease_token,
+    }
+}
+
+fn make_applier(port: Arc<dyn TurnRunTransitionPort>) -> Arc<LoopExitApplier> {
+    let evidence = Arc::new(InMemoryLoopExitEvidencePort::all_verified());
+    Arc::new(LoopExitApplier::new(port, evidence))
+}
+
+fn setup_registry(driver: Arc<dyn AgentLoopDriver>) -> DriverRegistry {
+    let mut registry = DriverRegistry::new();
+    registry
+        .register_driver(
+            driver,
+            DriverRequirements::all_optional(),
+            DriverKind::Production,
+        )
+        .expect("registration should succeed");
+    registry
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn worker_claims_and_completes_run() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let calls = port.calls();
+    assert!(calls.contains(&TransitionCall::Claim));
+    assert!(calls.contains(&TransitionCall::ApplyValidatedLoopExit));
+}
+
+#[tokio::test]
+async fn worker_records_recovery_on_driver_error() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::failing(
+        desc.clone(),
+        AgentLoopDriverError::Failed {
+            reason_kind: "test_failure".to_string(),
+        },
+    ));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn worker_records_recovery_on_host_factory_error() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let host_factory = Arc::new(FailingHostFactory {
+        reason: "test host creation failure".to_string(),
+    });
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        host_factory,
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn worker_records_recovery_when_driver_not_found() {
+    let registered_desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(registered_desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+
+    let mut claimed_desc = test_descriptor();
+    claimed_desc.id = LoopDriverId::new("missing_driver").expect("valid");
+    let claimed = make_claimed_run(&claimed_desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(
+        port.calls()
+            .contains(&TransitionCall::RecordRecoveryRequired)
+    );
+}
+
+#[tokio::test]
+async fn worker_continues_when_no_runs_available() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let port = Arc::new(MockTransitionPort::new());
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let claim_count = port
+        .calls()
+        .iter()
+        .filter(|c| **c == TransitionCall::Claim)
+        .count();
+    assert!(
+        claim_count >= 1,
+        "should have attempted claims, got {claim_count}"
+    );
+}
+
+#[tokio::test]
+async fn wake_signal_triggers_claim_attempt() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let port = Arc::new(MockTransitionPort::new());
+
+    let (wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_secs(60), // very long so wake is the trigger
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    wake_sender.wake();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    assert!(port.calls().contains(&TransitionCall::Claim));
+}
+
+#[tokio::test]
+async fn heartbeat_runs_during_driver_execution() {
+    let desc = test_descriptor();
+    let driver =
+        Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_millis(300)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_millis(50), // fast heartbeats
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let heartbeat_count = port
+        .calls()
+        .iter()
+        .filter(|c| **c == TransitionCall::Heartbeat)
+        .count();
+    assert!(
+        heartbeat_count >= 2,
+        "should have sent multiple heartbeats, got {heartbeat_count}"
+    );
+}
+
+#[tokio::test]
+async fn worker_generates_stable_runner_id() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let port = Arc::new(MockTransitionPort::new());
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+
+    let applier = make_applier(port.clone());
+    let worker = TurnRunnerWorker::new(
+        TurnRunnerWorkerConfig::default(),
+        port,
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        applier,
+    );
+
+    let id1 = worker.runner_id();
+    let id2 = worker.runner_id();
+    assert_eq!(id1, id2, "runner_id should be stable across calls");
+}
+
+#[tokio::test]
+async fn worker_records_recovery_when_driver_panics() {
+    let desc = test_descriptor();
+    let driver = Arc::new(PanickingDriver {
+        descriptor: desc.clone(),
+    });
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle
+        .await
+        .expect("worker task should survive driver panic");
+
+    let calls = port.calls();
+    assert!(calls.contains(&TransitionCall::RecordRecoveryRequired));
+    assert!(!calls.contains(&TransitionCall::ApplyValidatedLoopExit));
+}
+
+#[tokio::test]
+async fn worker_records_recovery_when_heartbeat_ownership_is_lost() {
+    let desc = test_descriptor();
+    let driver =
+        Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_millis(300)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(
+        MockTransitionPort::new()
+            .with_claim_result(Ok(Some(claimed)))
+            .with_heartbeat_result(Err(TurnError::LeaseMismatch)),
+    );
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_millis(25),
+        poll_interval: Duration::from_millis(50),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let calls = port.calls();
+    assert!(calls.contains(&TransitionCall::Heartbeat));
+    assert!(calls.contains(&TransitionCall::RecordRecoveryRequired));
+    assert!(!calls.contains(&TransitionCall::ApplyValidatedLoopExit));
+}

--- a/crates/ironclaw_reborn/src/turn_runner/tests.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests.rs
@@ -235,6 +235,7 @@ async fn submit_test_turn(
 enum TransitionCall {
     Claim,
     Heartbeat,
+    RecoverExpiredLeases,
     ApplyValidatedLoopExit,
     RecordRecoveryRequired,
 }
@@ -245,6 +246,10 @@ struct MockTransitionPort {
     apply_exit_result: Mutex<Result<TurnRunState, TurnError>>,
     recovery_result: Mutex<Result<TurnRunState, TurnError>>,
     calls: Mutex<Vec<TransitionCall>>,
+    claim_requests: Mutex<Vec<ClaimRunRequest>>,
+    heartbeat_requests: Mutex<Vec<HeartbeatRequest>>,
+    apply_exit_requests: Mutex<Vec<ApplyValidatedLoopExitRequest>>,
+    recovery_requests: Mutex<Vec<RecordRecoveryRequiredRequest>>,
 }
 
 impl MockTransitionPort {
@@ -258,6 +263,10 @@ impl MockTransitionPort {
                 TurnStatus::RecoveryRequired,
             ))),
             calls: Mutex::new(Vec::new()),
+            claim_requests: Mutex::new(Vec::new()),
+            heartbeat_requests: Mutex::new(Vec::new()),
+            apply_exit_requests: Mutex::new(Vec::new()),
+            recovery_requests: Mutex::new(Vec::new()),
         }
     }
 
@@ -280,18 +289,30 @@ impl MockTransitionPort {
 impl TurnRunTransitionPort for MockTransitionPort {
     async fn claim_next_run(
         &self,
-        _request: ClaimRunRequest,
+        request: ClaimRunRequest,
     ) -> Result<Option<ClaimedTurnRun>, TurnError> {
+        self.claim_requests
+            .lock()
+            .expect("lock")
+            .push(request.clone());
         self.calls.lock().expect("lock").push(TransitionCall::Claim);
         let mut results = self.claim_results.lock().expect("lock");
         if results.is_empty() {
             Ok(None)
         } else {
-            results.remove(0)
+            match results.remove(0) {
+                Ok(Some(mut claimed)) => {
+                    claimed.runner_id = request.runner_id;
+                    claimed.lease_token = request.lease_token;
+                    Ok(Some(claimed))
+                }
+                other => other,
+            }
         }
     }
 
-    async fn heartbeat(&self, _request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
+    async fn heartbeat(&self, request: HeartbeatRequest) -> Result<EventCursor, TurnError> {
+        self.heartbeat_requests.lock().expect("lock").push(request);
         self.calls
             .lock()
             .expect("lock")
@@ -303,6 +324,10 @@ impl TurnRunTransitionPort for MockTransitionPort {
         &self,
         _request: RecoverExpiredLeasesRequest,
     ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
+        self.calls
+            .lock()
+            .expect("lock")
+            .push(TransitionCall::RecoverExpiredLeases);
         Ok(RecoverExpiredLeasesResponse {
             recovered: Vec::new(),
         })
@@ -329,8 +354,9 @@ impl TurnRunTransitionPort for MockTransitionPort {
 
     async fn record_recovery_required(
         &self,
-        _request: RecordRecoveryRequiredRequest,
+        request: RecordRecoveryRequiredRequest,
     ) -> Result<TurnRunState, TurnError> {
+        self.recovery_requests.lock().expect("lock").push(request);
         self.calls
             .lock()
             .expect("lock")
@@ -340,8 +366,9 @@ impl TurnRunTransitionPort for MockTransitionPort {
 
     async fn apply_validated_loop_exit(
         &self,
-        _request: ApplyValidatedLoopExitRequest,
+        request: ApplyValidatedLoopExitRequest,
     ) -> Result<TurnRunState, TurnError> {
+        self.apply_exit_requests.lock().expect("lock").push(request);
         self.calls
             .lock()
             .expect("lock")
@@ -673,6 +700,60 @@ async fn worker_claims_and_completes_run() {
 }
 
 #[tokio::test]
+async fn worker_uses_fresh_claim_lease_for_heartbeat_and_exit_apply() {
+    let desc = test_descriptor();
+    let driver =
+        Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_millis(120)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_millis(25),
+        poll_interval: Duration::from_millis(10),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let claim_requests = port.claim_requests.lock().expect("lock").clone();
+    assert!(
+        !claim_requests.is_empty(),
+        "worker should claim at least once"
+    );
+    let claimed_lease = claim_requests[0].lease_token;
+    let claimed_runner = claim_requests[0].runner_id;
+    let heartbeat_requests = port.heartbeat_requests.lock().expect("lock").clone();
+    assert!(
+        heartbeat_requests
+            .iter()
+            .any(|request| request.lease_token == claimed_lease
+                && request.runner_id == claimed_runner),
+        "heartbeat should reuse active claim identity"
+    );
+    let apply_requests = port.apply_exit_requests.lock().expect("lock").clone();
+    assert_eq!(apply_requests.len(), 1);
+    assert_eq!(apply_requests[0].lease_token, claimed_lease);
+    assert_eq!(apply_requests[0].runner_id, claimed_runner);
+}
+
+#[tokio::test]
 async fn worker_records_recovery_on_driver_error() {
     let desc = test_descriptor();
     let driver = Arc::new(MockDriver::failing(
@@ -841,6 +922,45 @@ async fn worker_continues_when_no_runs_available() {
 }
 
 #[tokio::test]
+async fn worker_generates_fresh_lease_token_per_claim_attempt() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()));
+    let registry = Arc::new(setup_registry(driver));
+    let port = Arc::new(MockTransitionPort::new());
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(10),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let claim_requests = port.claim_requests.lock().expect("lock").clone();
+    assert!(
+        claim_requests.len() >= 2,
+        "expected repeated fallback claims"
+    );
+    assert_ne!(claim_requests[0].lease_token, claim_requests[1].lease_token);
+}
+
+#[tokio::test]
 async fn wake_signal_triggers_claim_attempt() {
     let desc = test_descriptor();
     let driver = Arc::new(MockDriver::completing(desc.clone()));
@@ -917,6 +1037,50 @@ async fn heartbeat_runs_during_driver_execution() {
     assert!(
         heartbeat_count >= 2,
         "should have sent multiple heartbeats, got {heartbeat_count}"
+    );
+}
+
+#[tokio::test]
+async fn worker_cancels_active_driver_when_worker_shutdown_is_requested() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_secs(10)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_millis(25),
+        poll_interval: Duration::from_millis(1),
+        scope_filter: None,
+    };
+
+    let worker = TurnRunnerWorker::new(
+        config,
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(75)).await;
+    assert!(port.calls().contains(&TransitionCall::Claim));
+    cancel.cancel();
+
+    tokio::time::timeout(Duration::from_millis(500), handle)
+        .await
+        .expect("worker should stop promptly after cancellation")
+        .expect("worker task should complete");
+
+    assert!(
+        !port
+            .calls()
+            .contains(&TransitionCall::ApplyValidatedLoopExit)
     );
 }
 
@@ -1023,7 +1187,8 @@ async fn worker_records_recovery_when_heartbeat_ownership_is_lost() {
 
     let calls = port.calls();
     assert!(calls.contains(&TransitionCall::Heartbeat));
-    assert!(calls.contains(&TransitionCall::RecordRecoveryRequired));
+    assert!(calls.contains(&TransitionCall::RecoverExpiredLeases));
+    assert!(!calls.contains(&TransitionCall::RecordRecoveryRequired));
     assert!(!calls.contains(&TransitionCall::ApplyValidatedLoopExit));
 }
 

--- a/crates/ironclaw_reborn/src/turn_runner/tests.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests.rs
@@ -4,13 +4,16 @@ use std::time::Duration;
 use async_trait::async_trait;
 use tokio_util::sync::CancellationToken;
 
-use ironclaw_host_api::{TenantId, ThreadId};
+use ironclaw_host_api::{TenantId, ThreadId, UserId};
 use ironclaw_turns::{
     AcceptedMessageRef, AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError,
-    AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, EventCursor, LoopCompleted,
-    LoopCompletionKind, LoopExit, LoopExitId, LoopMessageRef, ReplyTargetBindingRef,
-    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken,
-    TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
+    AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, AllowAllTurnAdmissionPolicy,
+    EventCursor, GetRunStateRequest, IdempotencyKey, InMemoryTurnStateStore,
+    InMemoryTurnStateStoreLimits, LoopCompleted, LoopCompletionKind, LoopExit, LoopExitId,
+    LoopGateRef, LoopMessageRef, LoopResultRef, ReplyTargetBindingRef, RunProfileResolutionError,
+    RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion, SourceBindingRef,
+    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCheckpointId, TurnError, TurnId,
+    TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
     run_profile::{AgentLoopDriverHost, AgentLoopHostError, CheckpointSchemaId, LoopDriverId},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -21,7 +24,9 @@ use ironclaw_turns::{
 };
 
 use crate::driver_registry::{DriverKind, DriverRegistry, DriverRequirements};
-use crate::loop_exit_applier::{InMemoryLoopExitEvidencePort, LoopExitApplier};
+use crate::loop_exit_applier::{
+    InMemoryLoopExitEvidencePort, LoopExitApplier, LoopExitEvidencePort,
+};
 
 use super::*;
 
@@ -131,6 +136,97 @@ fn test_completed_exit() -> LoopExit {
         usage_summary_ref: None,
         exit_id: LoopExitId::new("exit:test-1").expect("valid"),
     })
+}
+
+#[derive(Clone)]
+struct FixedRunProfileResolver {
+    profile: ironclaw_turns::ResolvedRunProfile,
+}
+
+struct CompletionEvidencePort {
+    expected_scope: TurnScope,
+    expected_run_id: TurnRunId,
+    expected_reply_ref: LoopMessageRef,
+}
+
+#[async_trait]
+impl RunProfileResolver for FixedRunProfileResolver {
+    async fn resolve_run_profile(
+        &self,
+        _request: RunProfileResolutionRequest,
+    ) -> Result<ironclaw_turns::ResolvedRunProfile, RunProfileResolutionError> {
+        Ok(self.profile.clone())
+    }
+}
+
+#[async_trait]
+impl LoopExitEvidencePort for CompletionEvidencePort {
+    async fn verify_completion_refs(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+        reply_refs: &[LoopMessageRef],
+        result_refs: &[LoopResultRef],
+    ) -> Result<bool, TurnError> {
+        Ok(scope == &self.expected_scope
+            && run_id == self.expected_run_id
+            && reply_refs == [self.expected_reply_ref.clone()]
+            && result_refs.is_empty())
+    }
+
+    async fn verify_blocked_evidence(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+        _checkpoint_id: &TurnCheckpointId,
+        _gate_ref: &LoopGateRef,
+    ) -> Result<bool, TurnError> {
+        Ok(false)
+    }
+
+    async fn verify_failure_evidence(
+        &self,
+        _scope: &TurnScope,
+        _run_id: TurnRunId,
+    ) -> Result<bool, TurnError> {
+        Ok(false)
+    }
+
+    async fn is_cancellation_observed(&self, _run_id: TurnRunId) -> Result<bool, TurnError> {
+        Ok(false)
+    }
+}
+
+async fn submit_test_turn(
+    store: &InMemoryTurnStateStore,
+    profile: ironclaw_turns::ResolvedRunProfile,
+) -> (TurnScope, TurnRunId) {
+    let scope = test_scope();
+    let response = store
+        .submit_turn(
+            SubmitTurnRequest {
+                scope: scope.clone(),
+                actor: TurnActor::new(UserId::new("test-user").expect("valid")),
+                accepted_message_ref: AcceptedMessageRef::new(format!(
+                    "accepted-{}",
+                    TurnRunId::new()
+                ))
+                .expect("valid"),
+                source_binding_ref: SourceBindingRef::new("source-real-store").expect("valid"),
+                reply_target_binding_ref: ReplyTargetBindingRef::new("reply-real-store")
+                    .expect("valid"),
+                requested_run_profile: None,
+                idempotency_key: IdempotencyKey::new(format!("idem-{}", TurnRunId::new()))
+                    .expect("valid"),
+                received_at: chrono::Utc::now(),
+            },
+            &AllowAllTurnAdmissionPolicy,
+            &FixedRunProfileResolver { profile },
+        )
+        .await
+        .expect("submit should succeed");
+    let SubmitTurnResponse::Accepted { run_id, .. } = response;
+    (scope, run_id)
 }
 
 // ─── Mock transition port ───────────────────────────────────────────────────
@@ -271,6 +367,24 @@ impl MockDriver {
         Self {
             descriptor,
             run_result: Mutex::new(Ok(test_completed_exit())),
+            run_delay: Duration::ZERO,
+        }
+    }
+
+    fn completing_with_reply(
+        descriptor: AgentLoopDriverDescriptor,
+        reply_ref: LoopMessageRef,
+    ) -> Self {
+        Self {
+            descriptor,
+            run_result: Mutex::new(Ok(LoopExit::Completed(LoopCompleted {
+                completion_kind: LoopCompletionKind::FinalReply,
+                reply_message_refs: vec![reply_ref],
+                result_refs: vec![],
+                final_checkpoint_id: None,
+                usage_summary_ref: None,
+                exit_id: LoopExitId::new("exit:real-store-complete").expect("valid"),
+            }))),
             run_delay: Duration::ZERO,
         }
     }
@@ -909,6 +1023,140 @@ async fn worker_records_recovery_when_heartbeat_ownership_is_lost() {
 
     let calls = port.calls();
     assert!(calls.contains(&TransitionCall::Heartbeat));
+    assert!(calls.contains(&TransitionCall::RecordRecoveryRequired));
+    assert!(!calls.contains(&TransitionCall::ApplyValidatedLoopExit));
+}
+
+#[tokio::test]
+async fn worker_completes_queued_run_through_real_transition_store() {
+    let desc = test_descriptor();
+    let profile = test_resolved_profile_with_driver(&desc);
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let (scope, run_id) = submit_test_turn(store.as_ref(), profile).await;
+    let reply_ref = LoopMessageRef::new("msg:real-store-reply").expect("valid");
+
+    let driver = Arc::new(MockDriver::completing_with_reply(
+        desc.clone(),
+        reply_ref.clone(),
+    ));
+    let registry = Arc::new(setup_registry(driver));
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_secs(60),
+        poll_interval: Duration::from_millis(10),
+        scope_filter: None,
+    };
+    let transition_port: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let evidence = Arc::new(CompletionEvidencePort {
+        expected_scope: scope.clone(),
+        expected_run_id: run_id,
+        expected_reply_ref: reply_ref,
+    });
+    let applier = Arc::new(LoopExitApplier::new(transition_port.clone(), evidence));
+    let worker = TurnRunnerWorker::new(
+        config,
+        transition_port,
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        applier,
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let state = store
+        .get_run_state(GetRunStateRequest { scope, run_id })
+        .await
+        .expect("run state should still exist");
+    assert_eq!(state.status, TurnStatus::Completed);
+}
+
+#[tokio::test]
+async fn worker_recovers_expired_heartbeat_lease_with_real_store() {
+    let desc = test_descriptor();
+    let profile = test_resolved_profile_with_driver(&desc);
+    let store = Arc::new(InMemoryTurnStateStore::with_limits(
+        InMemoryTurnStateStoreLimits {
+            runner_lease_ttl: chrono::Duration::milliseconds(10),
+            ..InMemoryTurnStateStoreLimits::default()
+        },
+    ));
+    let (scope, run_id) = submit_test_turn(store.as_ref(), profile).await;
+
+    let driver =
+        Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_millis(300)));
+    let registry = Arc::new(setup_registry(driver));
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let config = TurnRunnerWorkerConfig {
+        heartbeat_interval: Duration::from_millis(50),
+        poll_interval: Duration::from_millis(10),
+        scope_filter: None,
+    };
+    let transition_port: Arc<dyn TurnRunTransitionPort> = store.clone();
+    let worker = TurnRunnerWorker::new(
+        config,
+        transition_port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(transition_port),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    cancel.cancel();
+    handle.await.expect("worker task should complete");
+
+    let state = store
+        .get_run_state(GetRunStateRequest { scope, run_id })
+        .await
+        .expect("run state should still exist");
+    assert_eq!(state.status, TurnStatus::RecoveryRequired);
+}
+
+#[tokio::test]
+async fn worker_cancel_aborts_active_driver_and_records_recovery() {
+    let desc = test_descriptor();
+    let driver = Arc::new(MockDriver::completing(desc.clone()).with_delay(Duration::from_secs(60)));
+    let registry = Arc::new(setup_registry(driver));
+    let claimed = make_claimed_run(&desc, test_scope(), TurnStatus::Queued);
+    let port = Arc::new(MockTransitionPort::new().with_claim_result(Ok(Some(claimed))));
+
+    let (_ws, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let worker = TurnRunnerWorker::new(
+        TurnRunnerWorkerConfig {
+            heartbeat_interval: Duration::from_secs(60),
+            poll_interval: Duration::from_millis(10),
+            scope_filter: None,
+        },
+        port.clone(),
+        registry,
+        Arc::new(MockHostFactory),
+        wake_receiver,
+        make_applier(port.clone()),
+    );
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_millis(500), handle)
+        .await
+        .expect("worker should stop promptly after cancellation")
+        .expect("worker task should complete");
+
+    let calls = port.calls();
     assert!(calls.contains(&TransitionCall::RecordRecoveryRequired));
     assert!(!calls.contains(&TransitionCall::ApplyValidatedLoopExit));
 }

--- a/crates/ironclaw_reborn/src/turn_runner/tests.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests.rs
@@ -1187,8 +1187,8 @@ async fn worker_records_recovery_when_heartbeat_ownership_is_lost() {
 
     let calls = port.calls();
     assert!(calls.contains(&TransitionCall::Heartbeat));
+    assert!(calls.contains(&TransitionCall::RecordRecoveryRequired));
     assert!(calls.contains(&TransitionCall::RecoverExpiredLeases));
-    assert!(!calls.contains(&TransitionCall::RecordRecoveryRequired));
     assert!(!calls.contains(&TransitionCall::ApplyValidatedLoopExit));
 }
 

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -9,6 +9,7 @@ use ironclaw_loop_support::{
 };
 use ironclaw_reborn::{
     RebornLoopDriverHostFactory, RebornLoopDriverHostRequest, TextOnlyLoopHostConfig,
+    turn_runner::HostFactory,
 };
 use ironclaw_threads::{
     AcceptInboundMessageRequest, EnsureThreadRequest, InMemorySessionThreadService, MessageContent,
@@ -152,6 +153,24 @@ async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
         ]
     );
     assert_public_milestones_hide_raw_payloads(&fixture.milestones());
+}
+
+#[tokio::test]
+async fn text_only_host_factory_implements_turn_runner_host_factory() {
+    let fixture = HostFixture::new("thread-host-turn-runner-factory", "hello runner").await;
+    let factory = fixture.factory();
+
+    let host = factory.create_host(&fixture.claimed).await.unwrap();
+
+    assert_eq!(host.run_context().run_id, fixture.context.run_id);
+    let context = host
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 8,
+        })
+        .await
+        .unwrap();
+    assert_eq!(context.messages.len(), 1);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/src/loop_exit.rs
+++ b/crates/ironclaw_turns/src/loop_exit.rs
@@ -52,6 +52,15 @@ impl LoopExit {
                 LoopExitViolationKind::UnverifiedBlockedEvidence,
                 policy.invalid_handling,
             ),
+            Self::Cancelled(exit)
+                if policy.require_final_checkpoint && exit.checkpoint_id.is_none() =>
+            {
+                invalid_exit_decision(
+                    exit_id,
+                    LoopExitViolationKind::MissingFinalCheckpoint,
+                    policy.invalid_handling,
+                )
+            }
             Self::Cancelled(_exit) if policy.host_cancellation_observed => {
                 LoopExitValidationDecision::trusted(exit_id, TurnRunnerOutcome::Cancelled)
             }
@@ -60,6 +69,15 @@ impl LoopExit {
                 LoopExitViolationKind::CancellationNotObserved,
                 policy.invalid_handling,
             ),
+            Self::Failed(exit)
+                if policy.require_final_checkpoint && exit.checkpoint_id.is_none() =>
+            {
+                invalid_exit_decision(
+                    exit_id,
+                    LoopExitViolationKind::MissingFinalCheckpoint,
+                    policy.invalid_handling,
+                )
+            }
             Self::Failed(exit) if policy.failure_evidence_verified => {
                 LoopExitValidationDecision::trusted(
                     exit_id,
@@ -139,19 +157,21 @@ pub enum LoopBlockedKind {
     Approval,
     Auth,
     Resource,
-    /// Spawned process suspension — maps to `BlockedReason::Process`.
+    /// Spawned process suspension is parsed for forward compatibility but is
+    /// not trusted by the MVP `LoopExit` applicator because process completion
+    /// uses a separate host-owned transition.
     Process,
 }
 
 impl LoopBlockedKind {
     fn to_blocked_reason(self, gate_ref: LoopGateRef) -> Result<BlockedReason, ()> {
         let gate_ref = GateRef::new(gate_ref.as_str()).map_err(|_| ())?;
-        Ok(match self {
-            Self::Approval => BlockedReason::Approval { gate_ref },
-            Self::Auth => BlockedReason::Auth { gate_ref },
-            Self::Resource => BlockedReason::Resource { gate_ref },
-            Self::Process => BlockedReason::Process { gate_ref },
-        })
+        match self {
+            Self::Approval => Ok(BlockedReason::Approval { gate_ref }),
+            Self::Auth => Ok(BlockedReason::Auth { gate_ref }),
+            Self::Resource => Ok(BlockedReason::Resource { gate_ref }),
+            Self::Process => Err(()),
+        }
     }
 }
 

--- a/crates/ironclaw_turns/src/loop_exit.rs
+++ b/crates/ironclaw_turns/src/loop_exit.rs
@@ -139,6 +139,8 @@ pub enum LoopBlockedKind {
     Approval,
     Auth,
     Resource,
+    /// Spawned process suspension — maps to `BlockedReason::Process`.
+    Process,
 }
 
 impl LoopBlockedKind {
@@ -148,6 +150,7 @@ impl LoopBlockedKind {
             Self::Approval => BlockedReason::Approval { gate_ref },
             Self::Auth => BlockedReason::Auth { gate_ref },
             Self::Resource => BlockedReason::Resource { gate_ref },
+            Self::Process => BlockedReason::Process { gate_ref },
         })
     }
 }

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -1172,6 +1172,8 @@ impl Inner {
             if record.scope != request.scope {
                 return Err(TurnError::ScopeNotFound);
             }
+            // BlockedProcess is not resumable via gate resolution — process
+            // blocks resume through a separate process-completion mechanism.
             if !matches!(
                 record.status,
                 TurnStatus::BlockedApproval | TurnStatus::BlockedAuth | TurnStatus::BlockedResource
@@ -1228,6 +1230,7 @@ impl Inner {
                 | TurnStatus::BlockedApproval
                 | TurnStatus::BlockedAuth
                 | TurnStatus::BlockedResource
+                | TurnStatus::BlockedProcess
                 | TurnStatus::RecoveryRequired => (TurnStatus::Cancelled, TurnEventKind::Cancelled),
                 TurnStatus::Running | TurnStatus::CancelRequested => {
                     (TurnStatus::CancelRequested, TurnEventKind::CancelRequested)

--- a/crates/ironclaw_turns/src/run_profile/policy.rs
+++ b/crates/ironclaw_turns/src/run_profile/policy.rs
@@ -22,6 +22,11 @@ pub struct CheckpointPolicy {
     pub require_before_side_effect: bool,
     pub require_before_block: bool,
     pub max_checkpoint_bytes: u64,
+    /// When true, terminal exits (Completed, Cancelled, Failed) require a
+    /// final_checkpoint_id. Production profiles set this; local/test profiles
+    /// may relax it.
+    #[serde(default)]
+    pub require_final_checkpoint: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_turns/src/run_profile/resolver.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolver.rs
@@ -413,6 +413,10 @@ fn fingerprint_for(
             .max_checkpoint_bytes
             .to_string(),
     );
+    update_bool(
+        definition.checkpoint_policy.require_final_checkpoint,
+        &mut update,
+    );
     update(resource_budget_policy.tier.as_str());
     update(&resource_budget_policy.max_model_calls.to_string());
     update(
@@ -450,4 +454,32 @@ fn fingerprint_for(
         update(&source.summary);
     }
     RunProfileFingerprint::from_trusted_string(format!("fp:{hash:016x}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_changes_when_final_checkpoint_requirement_changes() {
+        let relaxed = interactive_profile();
+        let mut strict = relaxed.clone();
+        strict.checkpoint_policy.require_final_checkpoint = true;
+
+        let relaxed_provenance = provenance_for(
+            &relaxed,
+            &RunProfileResolutionRequest::interactive_default(),
+        );
+        let strict_provenance =
+            provenance_for(&strict, &RunProfileResolutionRequest::interactive_default());
+
+        assert_ne!(
+            fingerprint_for(
+                &relaxed,
+                &relaxed.resource_budget_policy,
+                &relaxed_provenance
+            ),
+            fingerprint_for(&strict, &strict.resource_budget_policy, &strict_provenance),
+        );
+    }
 }

--- a/crates/ironclaw_turns/src/run_profile/resolver.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolver.rs
@@ -237,6 +237,7 @@ fn interactive_profile() -> RunProfileDefinition {
             require_before_side_effect: true,
             require_before_block: true,
             max_checkpoint_bytes: 64 * 1024,
+            require_final_checkpoint: false,
         },
         resource_budget_policy: ResourceBudgetPolicy {
             tier: ResourceBudgetTier::from_trusted_static("interactive_standard"),
@@ -288,6 +289,7 @@ fn long_running_mission_profile() -> RunProfileDefinition {
             require_before_side_effect: true,
             require_before_block: true,
             max_checkpoint_bytes: 256 * 1024,
+            require_final_checkpoint: false,
         },
         resource_budget_policy: ResourceBudgetPolicy {
             tier: ResourceBudgetTier::from_trusted_static("mission_high"),

--- a/crates/ironclaw_turns/src/run_profile/snapshot.rs
+++ b/crates/ironclaw_turns/src/run_profile/snapshot.rs
@@ -78,6 +78,7 @@ impl ResolvedRunProfile {
                 require_before_side_effect: true,
                 require_before_block: true,
                 max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
             },
             resource_budget_policy: ResourceBudgetPolicy {
                 tier: ResourceBudgetTier::from_trusted_static("interactive_standard"),

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -14,6 +14,8 @@ pub enum TurnStatus {
     BlockedApproval,
     BlockedAuth,
     BlockedResource,
+    /// Blocked waiting for a spawned process to complete.
+    BlockedProcess,
     CancelRequested,
     Cancelled,
     Completed,
@@ -101,9 +103,19 @@ fn compatibility_profile_id(resolved: &ResolvedRunProfile) -> RunProfileId {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BlockedReason {
-    Approval { gate_ref: GateRef },
-    Auth { gate_ref: GateRef },
-    Resource { gate_ref: GateRef },
+    Approval {
+        gate_ref: GateRef,
+    },
+    Auth {
+        gate_ref: GateRef,
+    },
+    Resource {
+        gate_ref: GateRef,
+    },
+    /// Blocked waiting for a spawned process — maps to `TurnStatus::BlockedProcess`.
+    Process {
+        gate_ref: GateRef,
+    },
 }
 
 impl BlockedReason {
@@ -112,14 +124,16 @@ impl BlockedReason {
             Self::Approval { .. } => TurnStatus::BlockedApproval,
             Self::Auth { .. } => TurnStatus::BlockedAuth,
             Self::Resource { .. } => TurnStatus::BlockedResource,
+            Self::Process { .. } => TurnStatus::BlockedProcess,
         }
     }
 
     pub fn gate_ref(&self) -> &GateRef {
         match self {
-            Self::Approval { gate_ref } | Self::Auth { gate_ref } | Self::Resource { gate_ref } => {
-                gate_ref
-            }
+            Self::Approval { gate_ref }
+            | Self::Auth { gate_ref }
+            | Self::Resource { gate_ref }
+            | Self::Process { gate_ref } => gate_ref,
         }
     }
 }

--- a/crates/ironclaw_turns/tests/loop_exit_contract.rs
+++ b/crates/ironclaw_turns/tests/loop_exit_contract.rs
@@ -112,34 +112,49 @@ fn completed_exit_requires_host_verified_completion_refs_before_trusted_mapping(
 
 #[test]
 fn final_checkpoint_policy_rejects_terminal_exit_without_checkpoint() {
-    let decision = LoopExit::Completed(LoopCompleted {
-        completion_kind: LoopCompletionKind::FinalReply,
-        reply_message_refs: vec![message_ref("msg:assistant-final")],
-        result_refs: vec![],
-        final_checkpoint_id: None,
-        usage_summary_ref: None,
-        exit_id: exit_id("exit:no-final-checkpoint"),
-    })
-    .validate(LoopExitValidationPolicy {
-        require_final_checkpoint: true,
-        host_cancellation_observed: false,
-        invalid_handling: LoopExitInvalidHandling::FailTerminal,
-        completion_refs_verified: true,
-        blocked_evidence_verified: false,
-        failure_evidence_verified: false,
-    });
+    let cases = [
+        LoopExit::Completed(LoopCompleted {
+            completion_kind: LoopCompletionKind::FinalReply,
+            reply_message_refs: vec![message_ref("msg:assistant-final")],
+            result_refs: vec![],
+            final_checkpoint_id: None,
+            usage_summary_ref: None,
+            exit_id: exit_id("exit:no-final-checkpoint-completed"),
+        }),
+        LoopExit::Cancelled(LoopCancelled {
+            reason_kind: LoopCancelledReasonKind::HostCancellation,
+            checkpoint_id: None,
+            interrupted_message_refs: vec![],
+            exit_id: exit_id("exit:no-final-checkpoint-cancelled"),
+        }),
+        LoopExit::failed(
+            LoopFailureKind::DriverBug,
+            exit_id("exit:no-final-checkpoint-failed"),
+        ),
+    ];
 
-    assert_eq!(
-        decision.violation.unwrap().category(),
-        "missing_final_checkpoint"
-    );
-    assert_eq!(
-        decision.mapping,
-        TurnRunnerOutcome::Failed {
-            failure: SanitizedFailure::new("driver_protocol_violation").unwrap(),
-        }
-        .into()
-    );
+    for exit in cases {
+        let decision = exit.validate(LoopExitValidationPolicy {
+            require_final_checkpoint: true,
+            host_cancellation_observed: true,
+            invalid_handling: LoopExitInvalidHandling::FailTerminal,
+            completion_refs_verified: true,
+            blocked_evidence_verified: false,
+            failure_evidence_verified: true,
+        });
+
+        assert_eq!(
+            decision.violation.unwrap().category(),
+            "missing_final_checkpoint"
+        );
+        assert_eq!(
+            decision.mapping,
+            TurnRunnerOutcome::Failed {
+                failure: SanitizedFailure::new("driver_protocol_violation").unwrap(),
+            }
+            .into()
+        );
+    }
 }
 
 #[test]
@@ -489,6 +504,7 @@ fn blocked_variants_map_to_correct_blocked_reason() {
             LoopBlockedKind::Approval => BlockedReason::Approval { gate_ref },
             LoopBlockedKind::Auth => BlockedReason::Auth { gate_ref },
             LoopBlockedKind::Resource => BlockedReason::Resource { gate_ref },
+            LoopBlockedKind::Process => unreachable!("process is tested separately as untrusted"),
         };
 
         assert_eq!(decision.violation, None);
@@ -501,6 +517,29 @@ fn blocked_variants_map_to_correct_blocked_reason() {
             .into()
         );
     }
+}
+
+#[test]
+fn blocked_process_exit_maps_to_recovery_even_with_verified_evidence() {
+    let decision = LoopExit::Blocked(LoopBlocked {
+        kind: LoopBlockedKind::Process,
+        gate_ref: loop_gate_ref("gate:process-gate"),
+        checkpoint_id: TurnCheckpointId::new(),
+        exit_id: exit_id("exit:process-blocked"),
+    })
+    .validate(LoopExitValidationPolicy {
+        blocked_evidence_verified: true,
+        ..LoopExitValidationPolicy::default()
+    });
+
+    assert_eq!(
+        decision.violation.unwrap().category(),
+        "unverified_blocked_evidence"
+    );
+    assert!(matches!(
+        decision.mapping,
+        ironclaw_turns::LoopExitMapping::RecoveryRequired { .. }
+    ));
 }
 
 #[test]
@@ -594,6 +633,7 @@ fn terminal_statuses_release_lock_and_non_terminal_keep_it() {
         TurnStatus::BlockedApproval,
         TurnStatus::BlockedAuth,
         TurnStatus::BlockedResource,
+        TurnStatus::BlockedProcess,
         TurnStatus::CancelRequested,
         TurnStatus::Cancelled,
         TurnStatus::Completed,
@@ -606,6 +646,7 @@ fn terminal_statuses_release_lock_and_non_terminal_keep_it() {
             TurnStatus::BlockedApproval => (false, true),
             TurnStatus::BlockedAuth => (false, true),
             TurnStatus::BlockedResource => (false, true),
+            TurnStatus::BlockedProcess => (false, true),
             TurnStatus::CancelRequested => (false, true),
             TurnStatus::Cancelled => (true, false),
             TurnStatus::Completed => (true, false),

--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -207,15 +207,16 @@ def line_test_contexts(lines: list[str]) -> list[bool]:
 
 
 def is_test_only_path(path: str) -> bool:
-    """Return True for files that live inside a test-only directory.
+    """Return True for files that live in Rust test-only locations.
 
-    Files under ``src/**/tests/*.rs`` are Rust test sub-modules, typically
-    included behind ``#[cfg(test)]`` and never compiled in production.
-    Top-level ``tests/*.rs`` integration test files are already outside
-    ``src/`` / ``crates/`` and therefore never checked.
+    Files under ``src/**/tests/*.rs`` and ``src/**/tests.rs`` are Rust test
+    sub-modules, typically included behind ``#[cfg(test)]`` and never compiled
+    in production. Top-level ``tests/*.rs`` integration test files are already
+    outside ``src/`` / ``crates/`` and therefore never checked.
     """
-    parts = pathlib.PurePosixPath(path).parts
-    return "tests" in parts
+    posix_path = pathlib.PurePosixPath(path)
+    parts = posix_path.parts
+    return "tests" in parts or posix_path.name == "tests.rs"
 
 
 def changed_rust_files(base: str, head: str) -> list[pathlib.Path]:
@@ -379,6 +380,8 @@ class CheckNoPanicsTests(unittest.TestCase):
     def test_test_only_path_detection(self) -> None:
         self.assertTrue(is_test_only_path("src/channels/web/tests/multi_tenant.rs"))
         self.assertTrue(is_test_only_path("crates/foo/src/tests/helpers.rs"))
+        self.assertTrue(is_test_only_path("crates/foo/src/tests.rs"))
+        self.assertTrue(is_test_only_path("crates/foo/src/nested/tests.rs"))
         self.assertFalse(is_test_only_path("src/channels/web/mod.rs"))
         self.assertFalse(is_test_only_path("src/channels/web/test_helpers.rs"))
         self.assertFalse(is_test_only_path("crates/foo/src/lib.rs"))


### PR DESCRIPTION
## Summary
- add concrete Reborn `TurnRunnerWorker` composition on a clean branch from `origin/reborn-integration`
- claim one run at a time with stable worker `TurnRunnerId` and fresh per-claim `TurnLeaseToken`
- run wake-driven claim draining plus fallback polling, worker-owned heartbeats, registry driver lookup, per-run host construction, and trusted `LoopExit` application
- add evidence-backed `LoopExitApplier` and recovery mapping for missing drivers, host failures, driver errors/panics, heartbeat lease loss, cancellation, and exit-application failures
- wire the text-only `RebornLoopDriverHostFactory` into the runner `HostFactory` seam

Closes #3404

Supersedes #3446 with a clean branch directly from `reborn-integration`.

## Tests
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3404-clean cargo test -p ironclaw_reborn`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3404-clean cargo clippy -p ironclaw_reborn --all-targets --all-features -- -D warnings`
