### PR TITLE
feat(reborn): add first-party runtime adapter

### DIFF
--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -121,7 +121,8 @@ fn dispatch_error_kind(error: &DispatchError) -> String {
         DispatchError::UnsupportedRuntime { .. } => "UnsupportedRuntime".to_string(),
         DispatchError::Mcp { kind }
         | DispatchError::Script { kind }
-        | DispatchError::Wasm { kind } => kind.as_str().to_string(),
+        | DispatchError::Wasm { kind }
+        | DispatchError::FirstParty { kind } => kind.as_str().to_string(),
     }
 }
 
@@ -202,6 +203,14 @@ mod tests {
             kind: RuntimeDispatchErrorKind::Memory,
         });
         assert_eq!(kind, "Memory");
+    }
+
+    #[test]
+    fn dispatch_error_kind_forwards_first_party_runtime_kind_as_str() {
+        let kind = dispatch_error_kind(&DispatchError::FirstParty {
+            kind: RuntimeDispatchErrorKind::UndeclaredCapability,
+        });
+        assert_eq!(kind, "UndeclaredCapability");
     }
 
     #[test]

--- a/crates/ironclaw_dispatcher/src/lib.rs
+++ b/crates/ironclaw_dispatcher/src/lib.rs
@@ -369,6 +369,7 @@ fn dispatch_error_kind(error: &DispatchError) -> &'static str {
         DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime",
         DispatchError::Mcp { kind }
         | DispatchError::Script { kind }
-        | DispatchError::Wasm { kind } => kind.event_kind(),
+        | DispatchError::Wasm { kind }
+        | DispatchError::FirstParty { kind } => kind.event_kind(),
     }
 }

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -149,6 +149,8 @@ pub enum DispatchError {
     Script { kind: RuntimeDispatchErrorKind },
     #[error("WASM dispatch failed: {kind}")]
     Wasm { kind: RuntimeDispatchErrorKind },
+    #[error("first-party dispatch failed: {kind}")]
+    FirstParty { kind: RuntimeDispatchErrorKind },
 }
 
 /// Interface for already-authorized runtime dispatch.

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -1,0 +1,106 @@
+//! Host-owned FirstParty capability handler registry.
+//!
+//! First-party handlers are registered by host composition, not by extension
+//! manifests. They receive already-authorized, scoped dispatch input from the
+//! Reborn runtime adapter path and return normalized JSON output plus resource
+//! usage. Authority decisions remain in `CapabilityHost`/authorization and the
+//! runtime-policy/planning layers.
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    CapabilityId, MountView, ResourceEstimate, ResourceScope, ResourceUsage,
+    RuntimeDispatchErrorKind,
+};
+use serde_json::Value;
+
+/// Already-authorized first-party capability dispatch input.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct FirstPartyCapabilityRequest {
+    pub capability_id: CapabilityId,
+    pub scope: ResourceScope,
+    pub estimate: ResourceEstimate,
+    pub mounts: Option<MountView>,
+    pub input: Value,
+}
+
+/// Normalized first-party capability output before resource reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct FirstPartyCapabilityResult {
+    pub output: Value,
+    pub usage: ResourceUsage,
+}
+
+impl FirstPartyCapabilityResult {
+    pub fn new(output: Value, usage: ResourceUsage) -> Self {
+        Self { output, usage }
+    }
+}
+
+/// Stable redacted first-party handler failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("first-party capability dispatch failed: {kind}")]
+pub struct FirstPartyCapabilityError {
+    kind: RuntimeDispatchErrorKind,
+}
+
+impl FirstPartyCapabilityError {
+    pub fn new(kind: RuntimeDispatchErrorKind) -> Self {
+        Self { kind }
+    }
+
+    pub fn kind(&self) -> RuntimeDispatchErrorKind {
+        self.kind
+    }
+}
+
+/// Host-owned first-party capability implementation.
+#[async_trait]
+pub trait FirstPartyCapabilityHandler: Send + Sync {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError>;
+}
+
+/// Host-owned registry keyed by declared [`CapabilityId`].
+#[derive(Clone, Default)]
+pub struct FirstPartyCapabilityRegistry {
+    handlers: HashMap<CapabilityId, Arc<dyn FirstPartyCapabilityHandler>>,
+}
+
+impl FirstPartyCapabilityRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_handler<T>(mut self, capability_id: CapabilityId, handler: Arc<T>) -> Self
+    where
+        T: FirstPartyCapabilityHandler + 'static,
+    {
+        self.insert_handler(capability_id, handler);
+        self
+    }
+
+    pub fn insert_handler<T>(&mut self, capability_id: CapabilityId, handler: Arc<T>)
+    where
+        T: FirstPartyCapabilityHandler + 'static,
+    {
+        let handler: Arc<dyn FirstPartyCapabilityHandler> = handler;
+        self.handlers.insert(capability_id, handler);
+    }
+
+    pub fn get(
+        &self,
+        capability_id: &CapabilityId,
+    ) -> Option<Arc<dyn FirstPartyCapabilityHandler>> {
+        self.handlers.get(capability_id).cloned()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.handlers.is_empty()
+    }
+}

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -45,15 +45,25 @@ impl FirstPartyCapabilityResult {
 #[error("first-party capability dispatch failed: {kind}")]
 pub struct FirstPartyCapabilityError {
     kind: RuntimeDispatchErrorKind,
+    usage: Option<ResourceUsage>,
 }
 
 impl FirstPartyCapabilityError {
     pub fn new(kind: RuntimeDispatchErrorKind) -> Self {
-        Self { kind }
+        Self { kind, usage: None }
+    }
+
+    pub fn with_usage(mut self, usage: ResourceUsage) -> Self {
+        self.usage = Some(usage);
+        self
     }
 
     pub fn kind(&self) -> RuntimeDispatchErrorKind {
         self.kind
+    }
+
+    pub fn usage(&self) -> Option<&ResourceUsage> {
+        self.usage.as_ref()
     }
 }
 
@@ -98,6 +108,10 @@ impl FirstPartyCapabilityRegistry {
         capability_id: &CapabilityId,
     ) -> Option<Arc<dyn FirstPartyCapabilityHandler>> {
         self.handlers.get(capability_id).cloned()
+    }
+
+    pub fn contains_handler(&self, capability_id: &CapabilityId) -> bool {
+        self.handlers.contains_key(capability_id)
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -44,6 +44,7 @@ use serde_json::Value;
 use std::{collections::BTreeMap, fmt, sync::Arc};
 use thiserror::Error;
 
+mod first_party;
 mod obligations;
 mod planner;
 mod production;
@@ -51,6 +52,10 @@ mod services;
 mod surface;
 mod turn_scheduler;
 
+pub use first_party::{
+    FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
+    FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
+};
 pub use obligations::{
     BuiltinObligationHandler, BuiltinObligationServices, NetworkObligationPolicyStore,
     ProcessObligationLifecycleStore, RuntimeSecretInjectionStore, RuntimeSecretInjectionStoreError,

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -75,7 +75,8 @@ use ironclaw_wasm::{
 use thiserror::Error;
 
 use crate::{
-    BuiltinObligationHandler, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntimeError,
+    BuiltinObligationHandler, CapabilitySurfaceVersion, DefaultHostRuntime,
+    FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, HostRuntimeError,
     NetworkObligationPolicyStore, ProcessObligationLifecycleStore, RuntimeBackendHealth,
     RuntimeSecretInjectionStore, TurnRunExecutor, TurnRunScheduler, TurnRunSchedulerConfig,
 };
@@ -152,6 +153,7 @@ pub enum ProductionWiringComponent {
     ScriptRuntime,
     McpRuntime,
     WasmRuntime,
+    FirstPartyRuntime,
     TurnState,
     TurnRunWakeNotifier,
 }
@@ -176,6 +178,7 @@ impl ProductionWiringComponent {
             Self::ScriptRuntime => "script_runtime",
             Self::McpRuntime => "mcp_runtime",
             Self::WasmRuntime => "wasm_runtime",
+            Self::FirstPartyRuntime => "first_party_runtime",
             Self::TurnState => "turn_state",
             Self::TurnRunWakeNotifier => "turn_run_wake_notifier",
         }
@@ -256,6 +259,7 @@ struct ProductionComponentTypes {
     wasm_runtime_credential_provider_captured: bool,
     script_runtime: Option<&'static str>,
     mcp_runtime: Option<&'static str>,
+    first_party_runtime: Option<&'static str>,
     turn_state: Option<&'static str>,
     turn_run_transition_port: Option<&'static str>,
     turn_run_transition_port_verified: bool,
@@ -311,6 +315,7 @@ where
     runtime_health: Option<Arc<dyn RuntimeBackendHealth>>,
     script_runtime: Option<Arc<dyn ScriptExecutor>>,
     mcp_runtime: Option<Arc<dyn McpExecutor>>,
+    first_party_runtime: Option<Arc<FirstPartyCapabilityRegistry>>,
     wasm_runtime: Option<Arc<WasmRuntimeAdapter>>,
     turn_state: Option<Arc<dyn TurnStateStore>>,
     turn_run_transition_port: Option<Arc<dyn TurnRunTransitionPort>>,
@@ -365,6 +370,7 @@ where
             runtime_health: None,
             script_runtime: None,
             mcp_runtime: None,
+            first_party_runtime: None,
             wasm_runtime: None,
             turn_state: None,
             turn_run_transition_port: None,
@@ -389,6 +395,7 @@ where
                 wasm_runtime_credential_provider_captured: false,
                 script_runtime: None,
                 mcp_runtime: None,
+                first_party_runtime: None,
                 turn_state: None,
                 turn_run_transition_port: None,
                 turn_run_transition_port_verified: false,
@@ -426,6 +433,7 @@ where
             runtime_health,
             script_runtime,
             mcp_runtime,
+            first_party_runtime,
             wasm_runtime,
             turn_state,
             turn_run_transition_port,
@@ -457,6 +465,7 @@ where
             runtime_health,
             script_runtime,
             mcp_runtime,
+            first_party_runtime,
             wasm_runtime,
             turn_state,
             turn_run_transition_port,
@@ -510,6 +519,7 @@ where
             runtime_health,
             script_runtime,
             mcp_runtime,
+            first_party_runtime,
             wasm_runtime,
             turn_state,
             turn_run_transition_port,
@@ -551,6 +561,7 @@ where
             runtime_health,
             script_runtime,
             mcp_runtime,
+            first_party_runtime,
             wasm_runtime,
             turn_state,
             turn_run_transition_port,
@@ -926,6 +937,16 @@ where
         self
     }
 
+    pub fn with_first_party_capabilities(
+        mut self,
+        registry: Arc<FirstPartyCapabilityRegistry>,
+    ) -> Self {
+        self.component_types.first_party_runtime =
+            Some(type_name::<FirstPartyCapabilityRegistry>());
+        self.first_party_runtime = Some(registry);
+        self
+    }
+
     fn with_wasm_runtime(mut self, runtime: Arc<WasmRuntimeAdapter>) -> Self {
         self.component_types
             .wasm_runtime_credential_provider_captured = self.wasm_credential_provider.is_some();
@@ -1052,8 +1073,11 @@ where
         }
         for runtime in &config.required_runtime_backends {
             match runtime {
-                RuntimeKind::Script | RuntimeKind::Mcp | RuntimeKind::Wasm => {}
-                RuntimeKind::FirstParty | RuntimeKind::System => self.push_issue(
+                RuntimeKind::Script
+                | RuntimeKind::Mcp
+                | RuntimeKind::Wasm
+                | RuntimeKind::FirstParty => {}
+                RuntimeKind::System => self.push_issue(
                     &mut issues,
                     ProductionWiringComponent::RuntimeBackend,
                     ProductionWiringIssueKind::UnsupportedRequirement,
@@ -1080,6 +1104,13 @@ where
                 &mut issues,
                 ProductionWiringComponent::WasmRuntime,
                 self.wasm_runtime.is_some(),
+            );
+        }
+        if config.requires_runtime(RuntimeKind::FirstParty) {
+            self.push_missing(
+                &mut issues,
+                ProductionWiringComponent::FirstPartyRuntime,
+                self.first_party_runtime.is_some(),
             );
         }
 
@@ -1393,6 +1424,12 @@ where
                 Arc::new(McpRuntimeAdapter::from_executor(Arc::clone(runtime))),
             );
         }
+        if let Some(runtime) = &self.first_party_runtime {
+            dispatcher = dispatcher.with_runtime_adapter_arc(
+                RuntimeKind::FirstParty,
+                Arc::new(FirstPartyRuntimeAdapter::from_registry(Arc::clone(runtime))),
+            );
+        }
         if let Some(runtime) = &self.wasm_runtime {
             dispatcher =
                 dispatcher.with_runtime_adapter_arc(RuntimeKind::Wasm, Arc::clone(runtime));
@@ -1530,6 +1567,9 @@ where
         }
         if self.script_runtime.is_some() {
             backends.push(RuntimeKind::Script);
+        }
+        if self.first_party_runtime.is_some() {
+            backends.push(RuntimeKind::FirstParty);
         }
         backends
     }
@@ -1699,6 +1739,107 @@ where
             usage: execution.result.usage,
             receipt: execution.receipt,
             output_bytes: execution.result.output_bytes,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct FirstPartyRuntimeAdapter {
+    registry: Arc<FirstPartyCapabilityRegistry>,
+}
+
+impl FirstPartyRuntimeAdapter {
+    pub fn from_registry(registry: Arc<FirstPartyCapabilityRegistry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl<F, G> RuntimeAdapter<F, G> for FirstPartyRuntimeAdapter
+where
+    F: RootFilesystem,
+    G: ResourceGovernor,
+{
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, F, G>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        let Some(handler) = self.registry.get(request.capability_id) else {
+            if let Some(reservation) = request.resource_reservation
+                && let Err(error) = request.governor.release(reservation.id)
+            {
+                tracing::warn!(
+                    reservation_id = %reservation.id,
+                    error = %error,
+                    "failed to release prepared resource reservation after missing first-party handler"
+                );
+            }
+            return Err(DispatchError::FirstParty {
+                kind: RuntimeDispatchErrorKind::UndeclaredCapability,
+            });
+        };
+
+        let reservation = match request.resource_reservation {
+            Some(reservation) => reservation,
+            None => request
+                .governor
+                .reserve(request.scope.clone(), request.estimate.clone())
+                .map_err(|_| DispatchError::FirstParty {
+                    kind: RuntimeDispatchErrorKind::Resource,
+                })?,
+        };
+
+        let result = match handler
+            .dispatch(FirstPartyCapabilityRequest {
+                capability_id: request.capability_id.clone(),
+                scope: request.scope.clone(),
+                estimate: request.estimate,
+                mounts: request.mounts,
+                input: request.input,
+            })
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                if let Err(release_error) = request.governor.release(reservation.id) {
+                    tracing::warn!(
+                        reservation_id = %reservation.id,
+                        error = %release_error,
+                        "failed to release first-party resource reservation after handler failure"
+                    );
+                }
+                return Err(DispatchError::FirstParty { kind: error.kind() });
+            }
+        };
+
+        let output_bytes = serde_json::to_vec(&result.output)
+            .map(|bytes| bytes.len() as u64)
+            .map_err(|_| DispatchError::FirstParty {
+                kind: RuntimeDispatchErrorKind::OutputDecode,
+            })?;
+        let mut usage = result.usage;
+        usage.output_bytes = usage.output_bytes.max(output_bytes);
+        let receipt = match request.governor.reconcile(reservation.id, usage.clone()) {
+            Ok(receipt) => receipt,
+            Err(_) => {
+                if let Err(release_error) = request.governor.release(reservation.id) {
+                    tracing::warn!(
+                        reservation_id = %reservation.id,
+                        error = %release_error,
+                        "failed to release first-party resource reservation after reconcile failure"
+                    );
+                }
+                return Err(DispatchError::FirstParty {
+                    kind: RuntimeDispatchErrorKind::Resource,
+                });
+            }
+        };
+
+        Ok(RuntimeAdapterResult {
+            output: result.output,
+            usage,
+            receipt,
+            output_bytes,
         })
     }
 }
@@ -2094,7 +2235,8 @@ fn dispatch_error_kind(error: &DispatchError) -> &'static str {
         DispatchError::UnsupportedRuntime { .. } => "unsupported_runtime",
         DispatchError::Mcp { kind }
         | DispatchError::Script { kind }
-        | DispatchError::Wasm { kind } => kind.event_kind(),
+        | DispatchError::Wasm { kind }
+        | DispatchError::FirstParty { kind } => kind.event_kind(),
     }
 }
 

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -9,10 +9,12 @@
 use std::{
     any::type_name,
     collections::HashMap,
+    panic::AssertUnwindSafe,
     sync::{Arc, Mutex, MutexGuard},
 };
 
 use async_trait::async_trait;
+use futures_util::FutureExt;
 use ironclaw_approvals::ApprovalResolver;
 use ironclaw_authorization::{CapabilityLeaseStore, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_dispatcher::{
@@ -1110,7 +1112,7 @@ where
             self.push_missing(
                 &mut issues,
                 ProductionWiringComponent::FirstPartyRuntime,
-                self.first_party_runtime.is_some(),
+                self.first_party_runtime_covers_declared_capabilities(),
             );
         }
 
@@ -1568,10 +1570,25 @@ where
         if self.script_runtime.is_some() {
             backends.push(RuntimeKind::Script);
         }
-        if self.first_party_runtime.is_some() {
+        if self.first_party_runtime_covers_declared_capabilities() {
             backends.push(RuntimeKind::FirstParty);
         }
         backends
+    }
+
+    fn first_party_runtime_covers_declared_capabilities(&self) -> bool {
+        let Some(first_party_runtime) = &self.first_party_runtime else {
+            return false;
+        };
+        let mut declared = self
+            .registry
+            .capabilities()
+            .filter(|descriptor| descriptor.runtime == RuntimeKind::FirstParty)
+            .peekable();
+        if declared.peek().is_none() {
+            return false;
+        }
+        declared.all(|descriptor| first_party_runtime.contains_handler(&descriptor.id))
     }
 }
 
@@ -1789,26 +1806,30 @@ where
                 })?,
         };
 
-        let result = match handler
-            .dispatch(FirstPartyCapabilityRequest {
-                capability_id: request.capability_id.clone(),
-                scope: request.scope.clone(),
-                estimate: request.estimate,
-                mounts: request.mounts,
-                input: request.input,
-            })
-            .await
+        let result = match AssertUnwindSafe(handler.dispatch(FirstPartyCapabilityRequest {
+            capability_id: request.capability_id.clone(),
+            scope: request.scope.clone(),
+            estimate: request.estimate,
+            mounts: request.mounts,
+            input: request.input,
+        }))
+        .catch_unwind()
+        .await
         {
-            Ok(result) => result,
-            Err(error) => {
-                if let Err(release_error) = request.governor.release(reservation.id) {
-                    tracing::warn!(
-                        reservation_id = %reservation.id,
-                        error = %release_error,
-                        "failed to release first-party resource reservation after handler failure"
-                    );
-                }
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
+                account_or_release_failed_first_party_execution(
+                    request.governor,
+                    reservation.id,
+                    error.usage(),
+                )?;
                 return Err(DispatchError::FirstParty { kind: error.kind() });
+            }
+            Err(_) => {
+                release_first_party_reservation(request.governor, reservation.id);
+                return Err(DispatchError::FirstParty {
+                    kind: RuntimeDispatchErrorKind::Backend,
+                });
             }
         };
 
@@ -2127,6 +2148,40 @@ where
         usage: execution.usage,
         receipt,
     })
+}
+
+fn account_or_release_failed_first_party_execution<G>(
+    governor: &G,
+    reservation_id: ResourceReservationId,
+    usage: Option<&ResourceUsage>,
+) -> Result<(), DispatchError>
+where
+    G: ResourceGovernor + ?Sized,
+{
+    let Some(usage) = usage else {
+        release_first_party_reservation(governor, reservation_id);
+        return Ok(());
+    };
+    if !has_accountable_effects(usage) {
+        release_first_party_reservation(governor, reservation_id);
+        return Ok(());
+    }
+
+    if governor.reconcile(reservation_id, usage.clone()).is_err() {
+        release_first_party_reservation(governor, reservation_id);
+        return Err(DispatchError::FirstParty {
+            kind: RuntimeDispatchErrorKind::Resource,
+        });
+    }
+
+    Ok(())
+}
+
+fn release_first_party_reservation<G>(governor: &G, reservation_id: ResourceReservationId)
+where
+    G: ResourceGovernor + ?Sized,
+{
+    let _ = governor.release(reservation_id);
 }
 
 fn account_or_release_failed_wasm_execution<G>(

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -1,0 +1,303 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_authorization::GrantAuthorizer;
+use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
+use ironclaw_extensions::{
+    CapabilityManifest, ExtensionManifest, ExtensionPackage, ExtensionRegistry, ExtensionRuntime,
+};
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::*;
+use ironclaw_host_runtime::{
+    CapabilitySurfaceVersion, FirstPartyCapabilityError, FirstPartyCapabilityHandler,
+    FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
+    HostRuntime, HostRuntimeServices, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    RuntimeFailureKind,
+};
+use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount, ResourceTally};
+use ironclaw_run_state::{InMemoryRunStateStore, RunStateStore, RunStatus};
+use ironclaw_trust::{
+    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
+    HostTrustPolicy, TrustDecision, TrustProvenance,
+};
+use serde_json::{Value, json};
+
+#[tokio::test]
+async fn host_runtime_invokes_first_party_handler_through_capability_host() {
+    let handler = Arc::new(RecordingFirstPartyHandler::new(
+        json!({"via":"first-party"}),
+    ));
+    let first_party =
+        FirstPartyCapabilityRegistry::new().with_handler(capability_id(), Arc::clone(&handler));
+    let events = InMemoryEventSink::new();
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let runtime = HostRuntimeServices::new(
+        Arc::new(first_party_registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::clone(&governor),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(first_party))
+    .with_trust_policy(Arc::new(first_party_trust_policy()))
+    .with_run_state(Arc::clone(&run_state))
+    .with_event_sink(Arc::new(events.clone()))
+    .host_runtime_for_local_testing();
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant()],
+    });
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let estimate = ResourceEstimate {
+        output_bytes: Some(1024),
+        ..ResourceEstimate::default()
+    };
+    let input = json!({"message":"status"});
+
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            capability_id(),
+            estimate.clone(),
+            input.clone(),
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::Completed(completed) = outcome else {
+        panic!("expected completed first-party invocation, got {outcome:?}");
+    };
+    assert_eq!(completed.capability_id, capability_id());
+    assert_eq!(completed.output, json!({"via":"first-party"}));
+    assert!(completed.usage.output_bytes > 0);
+
+    let recorded = handler.take_request();
+    assert_eq!(recorded.capability_id, capability_id());
+    assert_eq!(recorded.scope, scope);
+    assert_eq!(recorded.estimate, estimate);
+    assert_eq!(recorded.mounts, None);
+    assert_eq!(recorded.input, input);
+
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Completed);
+    let tenant_account = ResourceAccount::tenant(scope.tenant_id.clone());
+    assert_eq!(
+        governor.reserved_for(&tenant_account),
+        ResourceTally::default()
+    );
+    assert!(governor.usage_for(&tenant_account).output_bytes > 0);
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchSucceeded,
+        ],
+    );
+}
+
+#[tokio::test]
+async fn first_party_missing_handler_fails_closed_without_side_effect_handler() {
+    let first_party = FirstPartyCapabilityRegistry::new();
+    let events = InMemoryEventSink::new();
+    let runtime = HostRuntimeServices::new(
+        Arc::new(first_party_registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(first_party))
+    .with_trust_policy(Arc::new(first_party_trust_policy()))
+    .with_event_sink(Arc::new(events.clone()))
+    .host_runtime_for_local_testing();
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant()],
+    });
+
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            capability_id(),
+            ResourceEstimate::default(),
+            json!({"message":"status"}),
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected missing first-party handler to fail closed, got {outcome:?}");
+    };
+    assert_eq!(failure.capability_id, capability_id());
+    assert_eq!(failure.kind, RuntimeFailureKind::Backend);
+    assert_eq!(
+        failure.message.as_deref(),
+        Some("dispatch failed: UndeclaredCapability")
+    );
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+}
+
+#[derive(Clone)]
+struct RecordedFirstPartyRequest {
+    capability_id: CapabilityId,
+    scope: ResourceScope,
+    estimate: ResourceEstimate,
+    mounts: Option<MountView>,
+    input: Value,
+}
+
+struct RecordingFirstPartyHandler {
+    output: Value,
+    requests: Mutex<Vec<RecordedFirstPartyRequest>>,
+}
+
+impl RecordingFirstPartyHandler {
+    fn new(output: Value) -> Self {
+        Self {
+            output,
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn take_request(&self) -> RecordedFirstPartyRequest {
+        self.requests.lock().unwrap().remove(0)
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for RecordingFirstPartyHandler {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        self.requests
+            .lock()
+            .unwrap()
+            .push(RecordedFirstPartyRequest {
+                capability_id: request.capability_id.clone(),
+                scope: request.scope.clone(),
+                estimate: request.estimate.clone(),
+                mounts: request.mounts.clone(),
+                input: request.input.clone(),
+            });
+        Ok(FirstPartyCapabilityResult::new(
+            self.output.clone(),
+            ResourceUsage::default(),
+        ))
+    }
+}
+
+fn first_party_registry() -> ExtensionRegistry {
+    let package = ExtensionPackage::from_manifest(
+        ExtensionManifest {
+            id: provider_id(),
+            name: "Host".to_string(),
+            version: "0.1.0".to_string(),
+            description: "Host-owned first-party capabilities".to_string(),
+            requested_trust: RequestedTrustClass::FirstPartyRequested,
+            trust: TrustClass::Sandbox,
+            runtime: ExtensionRuntime::FirstParty {
+                service: "host".to_string(),
+            },
+            capabilities: vec![CapabilityManifest {
+                id: capability_id(),
+                description: "Reports host status".to_string(),
+                effects: vec![EffectKind::DispatchCapability],
+                default_permission: PermissionMode::Allow,
+                parameters_schema: json!({"type":"object"}),
+                resource_profile: None,
+            }],
+        },
+        VirtualPath::new("/system/extensions/host").unwrap(),
+    )
+    .unwrap();
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package).unwrap();
+    registry
+}
+
+fn execution_context(grants: CapabilitySet) -> ExecutionContext {
+    ExecutionContext::local_default(
+        UserId::new("user").unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::FirstParty,
+        TrustClass::FirstParty,
+        grants,
+        MountView::default(),
+    )
+    .unwrap()
+}
+
+fn dispatch_grant() -> CapabilityGrant {
+    CapabilityGrant {
+        id: CapabilityGrantId::new(),
+        capability: capability_id(),
+        grantee: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        issued_by: Principal::HostRuntime,
+        constraints: GrantConstraints {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            mounts: MountView::default(),
+            network: NetworkPolicy::default(),
+            secrets: Vec::new(),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
+    }
+}
+
+fn first_party_trust_policy() -> HostTrustPolicy {
+    HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
+        AdminEntry::for_local_manifest(
+            PackageId::new("host").unwrap(),
+            "/system/extensions/host/manifest.toml".to_string(),
+            None,
+            HostTrustAssignment::first_party(),
+            vec![EffectKind::DispatchCapability],
+            None,
+        ),
+    ]))])
+    .unwrap()
+}
+
+fn trust_decision() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::user_trusted(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            max_resource_ceiling: None,
+        },
+        provenance: TrustProvenance::Default,
+        evaluated_at: Utc::now(),
+    }
+}
+
+fn provider_id() -> ExtensionId {
+    ExtensionId::new("host").unwrap()
+}
+
+fn capability_id() -> CapabilityId {
+    CapabilityId::new("host.status").unwrap()
+}
+
+fn assert_event_kinds(events: &InMemoryEventSink, expected: &[RuntimeEventKind]) {
+    let actual = events
+        .events()
+        .into_iter()
+        .map(|event| event.kind)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -1,7 +1,11 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    panic::AssertUnwindSafe,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use chrono::Utc;
+use futures_util::FutureExt;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
 use ironclaw_extensions::{
@@ -12,7 +16,8 @@ use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfaceVersion, FirstPartyCapabilityError, FirstPartyCapabilityHandler,
     FirstPartyCapabilityRegistry, FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
-    HostRuntime, HostRuntimeServices, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    HostRuntime, HostRuntimeServices, ProductionWiringComponent, ProductionWiringConfig,
+    ProductionWiringIssueKind, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
     RuntimeFailureKind,
 };
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount, ResourceTally};
@@ -101,6 +106,163 @@ async fn host_runtime_invokes_first_party_handler_through_capability_host() {
 }
 
 #[tokio::test]
+async fn production_wiring_rejects_first_party_registry_without_declared_handler() {
+    let services = HostRuntimeServices::new(
+        Arc::new(first_party_registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(FirstPartyCapabilityRegistry::new()));
+
+    let report = services
+        .validate_production_wiring(&ProductionWiringConfig::new([RuntimeKind::FirstParty]))
+        .expect_err("empty first-party registry must not satisfy declared first-party capability");
+
+    assert!(
+        report.contains(
+            ProductionWiringComponent::FirstPartyRuntime,
+            ProductionWiringIssueKind::Missing
+        ),
+        "missing first-party handler coverage should be reported: {report:?}"
+    );
+}
+
+#[tokio::test]
+async fn host_runtime_health_reports_missing_first_party_backend_for_empty_registry() {
+    let runtime = HostRuntimeServices::new(
+        Arc::new(first_party_registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(FirstPartyCapabilityRegistry::new()))
+    .host_runtime_for_local_testing();
+
+    let health = runtime.health().await.unwrap();
+
+    assert!(
+        !health.ready,
+        "first-party backend must be unready without handler coverage"
+    );
+    assert_eq!(
+        health.missing_runtime_backends,
+        vec![RuntimeKind::FirstParty]
+    );
+}
+
+#[tokio::test]
+async fn first_party_handler_error_reconciles_reported_usage_after_side_effect() {
+    let handler = Arc::new(FailingFirstPartyHandler::new(ResourceUsage {
+        network_egress_bytes: 77,
+        ..ResourceUsage::default()
+    }));
+    let first_party =
+        FirstPartyCapabilityRegistry::new().with_handler(capability_id(), Arc::clone(&handler));
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let runtime = HostRuntimeServices::new(
+        Arc::new(first_party_registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::clone(&governor),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(first_party))
+    .with_trust_policy(Arc::new(first_party_trust_policy()))
+    .host_runtime_for_local_testing();
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant()],
+    });
+    let account = ResourceAccount::tenant(context.resource_scope.tenant_id.clone());
+
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            capability_id(),
+            ResourceEstimate {
+                network_egress_bytes: Some(100),
+                ..ResourceEstimate::default()
+            },
+            json!({"message":"status"}),
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected failed first-party invocation, got {outcome:?}");
+    };
+    assert_eq!(failure.kind, RuntimeFailureKind::Backend);
+    assert_eq!(governor.usage_for(&account).network_egress_bytes, 77);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+}
+
+#[tokio::test]
+async fn first_party_handler_panic_fails_closed_and_releases_reservation() {
+    let handler = Arc::new(PanickingFirstPartyHandler);
+    let first_party =
+        FirstPartyCapabilityRegistry::new().with_handler(capability_id(), Arc::clone(&handler));
+    let events = InMemoryEventSink::new();
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let runtime = HostRuntimeServices::new(
+        Arc::new(first_party_registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::clone(&governor),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(first_party))
+    .with_trust_policy(Arc::new(first_party_trust_policy()))
+    .with_run_state(Arc::clone(&run_state))
+    .with_event_sink(Arc::new(events.clone()))
+    .host_runtime_for_local_testing();
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant()],
+    });
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    let outcome = AssertUnwindSafe(runtime.invoke_capability(RuntimeCapabilityRequest::new(
+        context,
+        capability_id(),
+        ResourceEstimate {
+            network_egress_bytes: Some(100),
+            ..ResourceEstimate::default()
+        },
+        json!({"message":"status"}),
+        trust_decision(),
+    )))
+    .catch_unwind()
+    .await
+    .expect("first-party handler panic must be translated into stable failed outcome")
+    .unwrap();
+
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected handler panic to fail closed, got {outcome:?}");
+    };
+    assert_eq!(failure.kind, RuntimeFailureKind::Backend);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_event_kinds(
+        &events,
+        &[
+            RuntimeEventKind::DispatchRequested,
+            RuntimeEventKind::RuntimeSelected,
+            RuntimeEventKind::DispatchFailed,
+        ],
+    );
+}
+
+#[tokio::test]
 async fn first_party_missing_handler_fails_closed_without_side_effect_handler() {
     let first_party = FirstPartyCapabilityRegistry::new();
     let events = InMemoryEventSink::new();
@@ -174,6 +336,41 @@ impl RecordingFirstPartyHandler {
 
     fn take_request(&self) -> RecordedFirstPartyRequest {
         self.requests.lock().unwrap().remove(0)
+    }
+}
+
+struct FailingFirstPartyHandler {
+    usage: ResourceUsage,
+}
+
+impl FailingFirstPartyHandler {
+    fn new(usage: ResourceUsage) -> Self {
+        Self { usage }
+    }
+}
+
+struct PanickingFirstPartyHandler;
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for FailingFirstPartyHandler {
+    async fn dispatch(
+        &self,
+        _request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        Err(
+            FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
+                .with_usage(self.usage.clone()),
+        )
+    }
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for PanickingFirstPartyHandler {
+    async fn dispatch(
+        &self,
+        _request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        panic!("first-party handler panic")
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/host_runtime_services_contract.rs
@@ -503,8 +503,8 @@ fn production_wiring_validation_rejects_unsupported_runtime_requirements() {
     );
 
     let report = services
-        .validate_production_wiring(&ProductionWiringConfig::new([RuntimeKind::FirstParty]))
-        .expect_err("first-party runtime requirements are not dispatcher backend requirements");
+        .validate_production_wiring(&ProductionWiringConfig::new([RuntimeKind::System]))
+        .expect_err("system runtime requirements are not dispatcher backend requirements");
 
     assert!(
         report.contains(

--- a/docs/reborn/2026-04-25-current-architecture-map.md
+++ b/docs/reborn/2026-04-25-current-architecture-map.md
@@ -127,7 +127,7 @@ Reborn has one host core with many adapters and runtime ports. It should not gro
 +--------------+ +---------------+ +---------------+ +------------------+
 | WASM adapter | | Script adapter| | MCP adapter   | | FirstParty/System|
 | -> runtime   | | -> runtime    | | -> runtime    | | runtime adapters |
-| [implemented slice]     | | [implemented slice]      | | [implemented slice]      | | [not implemented]   |
+| [implemented slice]     | | [implemented slice]      | | [implemented slice]      | | [FirstParty implemented; System deferred] |
 +--------------+ +---------------+ +---------------+ +------------------+
         ^                ^                 ^
         |                |                 |
@@ -276,7 +276,7 @@ These are explicit gaps, not architecture contradictions:
 | Durable leases | Async filesystem-backed exact-invocation lease persistence now covers issue, claim, consume, revoke, reload, tenant/user/invocation isolation, and fail-closed approval+lease coordination without nested async `block_on`; single-store ACID transactions, full audit retention policy, and reusable approval scopes are not complete. |
 | User-facing scoped event API | Runtime/process events, approval audit records, tenant/user/agent-scoped JSONL helpers, replay cursors, and JSONL/in-memory sinks exist as substrate, but scoped stream envelopes, replay-gap reporting, SSE/WebSocket/reconnect APIs, and projection reducers are not productized. |
 | Network execution boundary | Scoped network policy evaluation plus hardened runtime HTTP egress now cover DNS/private-address checks, redirect re-validation, pinned resolution, response-size bounds, WASM host-HTTP `ApplyNetworkPolicy` enforcement, host-runtime request/response leak scanning, and optional already-resolved credential injection; product proxying, secret lease consumption, trace recording, non-WASM enforcement, and network egress resource reservation are not complete. |
-| FirstParty/System runtime execution | `RuntimeKind::FirstParty` and `RuntimeKind::System` are recognized host API/runtime markers, but no host-policy-selected service adapters are registered yet. |
+| FirstParty/System runtime execution | `RuntimeKind::FirstParty` now has a host-composition-owned handler registry and `FirstPartyRuntimeAdapter` in `ironclaw_host_runtime`, so host-owned capabilities can execute through `HostRuntime -> CapabilityHost -> RuntimeDispatcher` without model/tool bypasses. `RuntimeKind::System` remains recognized but intentionally deferred until a stricter host-only adapter is designed. |
 | Full MCP server lifecycle | MCP is a current adapter lane, not yet a complete product lifecycle for server install/start/auth/restart/monitoring. |
 | Auth-blocked resume product path | `BlockedAuth` is reserved in run-state; full OAuth/token prompt, callback, and retry-after-auth workflow remains to be implemented. |
 | Obligation product gaps | Built-ins cover the V1 immediate dispatch/resume set, including direct `InjectSecretOnce`, post-dispatch redaction/output limits/audit-after, scoped mounts, and immediate resource handoff. Remaining gaps are `InjectCredentialOnce`, spawned/background post-output redaction/limits/audit-after, generic runtime environment injection, non-WASM network enforcement, and productized credential-account resolution. |

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -40,6 +40,20 @@ Supported built-in behavior:
 
 Surface versioning returns `sha256:<lower-hex>` over canonical JSON that includes the configured base version, `SurfaceKind`, visibility policy, visibility-affecting context fields, grants, relevant provider trust ceilings, visible capability ids/providers/runtimes/effects/schemas, selected resource estimates, and visible access status. Policy allow-lists and visible capability payloads are canonicalized before hashing, so semantically equivalent allow-list ordering or registry insertion ordering does not churn the version; returned capabilities still preserve filtered registry order for deterministic rendering. The hash is stable across process runs so upper loop services can checkpoint the visible tool surface. Direct invocation remains authoritative: a capability omitted from the visible surface must still fail closed through `CapabilityHost` authorization if a caller tries to invoke it directly.
 
+## FirstParty runtime adapter
+
+`HostRuntimeServices` can register host-owned first-party capability handlers through `FirstPartyCapabilityRegistry`. When a declared capability uses `RuntimeKind::FirstParty`, dispatch still follows the normal path:
+
+```text
+HostRuntime::invoke_capability
+  -> CapabilityHost authorization / approvals / obligations
+  -> RuntimeDispatcher
+  -> FirstPartyRuntimeAdapter
+  -> registered host-owned handler
+```
+
+First-party handlers are composition-owned and keyed by `CapabilityId`; user-installed manifests must not self-assign first-party/system authority. A missing handler fails closed as `UndeclaredCapability` before handler side effects. The adapter owns resource reservation/reconciliation, emits the same dispatcher runtime events as other runtime lanes, and surfaces only stable redacted dispatch categories. `RuntimeKind::System` remains deferred for a stricter host-only adapter.
+
 ## Runtime HTTP egress
 
 Runtime HTTP remains host-mediated through `RuntimeHttpEgress` and `HostHttpEgressService`. Runtime requests carry the full `ResourceScope` and `CapabilityId` so `HostHttpEgressService` can consume the matching one-shot policy from `NetworkObligationPolicyStore` immediately before outbound transport. The production constructor is fail-closed until a policy store is attached; request-embedded policy fallback is only available through an explicitly named test/legacy constructor. A missing scoped/capability policy fails before transport and any taken policy is not reusable after credential, request, network, or response failure. Runtime code must not perform ad-hoc DNS/private-IP checks or direct HTTP clients; `ironclaw_network` owns network policy enforcement and `ironclaw_secrets` owns secret lease/consume semantics.


### PR DESCRIPTION
Closes #3466

## Summary

- adds a host-owned `FirstPartyCapabilityRegistry` / handler API for composition-registered capabilities
- wires `RuntimeKind::FirstParty` through `HostRuntimeServices -> RuntimeDispatcher -> FirstPartyRuntimeAdapter`
- adds stable redacted `DispatchError::FirstParty` propagation and resource reservation/reconciliation behavior
- documents FirstParty adapter status and keeps `RuntimeKind::System` deferred

## Tests

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3466 cargo test -p ironclaw_host_api`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3466 cargo test -p ironclaw_dispatcher`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3466 cargo test -p ironclaw_capabilities`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3466 cargo test -p ironclaw_host_runtime`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3466 cargo test -p ironclaw_architecture`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3466 cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings`
