### PR TITLE
test(reborn): harden e2e backend failure sanitization (#3067)

### DIFF
--- a/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
+++ b/crates/ironclaw_host_runtime/tests/reborn_e2e_gate.rs
@@ -378,6 +378,85 @@ async fn reborn_e2e_gate_redacts_runtime_output_before_public_result() {
 }
 
 #[tokio::test]
+async fn reborn_e2e_gate_sanitizes_runtime_backend_failure_before_public_surfaces() {
+    let run_state = Arc::new(InMemoryRunStateStore::new());
+    let events = InMemoryEventSink::new();
+    let services = HostRuntimeServices::new(
+        Arc::new(registry_with_manifest(SCRIPT_MANIFEST)),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_trust_policy(Arc::new(local_manifest_trust_policy()))
+    .with_run_state(Arc::clone(&run_state))
+    .with_script_runtime(Arc::new(ScriptRuntime::new(
+        ScriptRuntimeConfig::for_testing(),
+        FailingScriptBackend,
+    )))
+    .with_event_sink(Arc::new(events.clone()));
+    let runtime = services.host_runtime_for_local_testing();
+    let context = execution_context_with_dispatch_grant();
+    let scope = context.resource_scope.clone();
+    let invocation_id = context.invocation_id;
+    let input_sentinel = "BACKEND_FAILURE_INPUT_SENTINEL_3067";
+    let backend_secret = "BACKEND_PROVIDER_ERROR_SECRET_3067 /private/tmp/backend-path sk-live";
+
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            script_capability_id(),
+            ResourceEstimate::default(),
+            json!({"message": input_sentinel}),
+            trust_decision_with_dispatch_authority(),
+        ))
+        .await
+        .unwrap();
+
+    match outcome {
+        RuntimeCapabilityOutcome::Failed(failure) => {
+            assert_eq!(failure.kind, RuntimeFailureKind::Backend);
+            let rendered = format!("{failure:?}");
+            for forbidden in [
+                input_sentinel,
+                backend_secret,
+                "/private/tmp/backend-path",
+                "sk-live",
+            ] {
+                assert!(
+                    !rendered.contains(forbidden),
+                    "public failure leaked backend sentinel {forbidden}: {rendered}"
+                );
+            }
+            assert!(failure.message.is_some());
+        }
+        other => panic!("expected sanitized backend failure, got {other:?}"),
+    }
+
+    let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
+    assert_eq!(run.status, RunStatus::Failed);
+    assert_eq!(run.error_kind.as_deref(), Some("Dispatch"));
+    let serialized_run = serde_json::to_string(&run).unwrap();
+    let serialized_events = serde_json::to_string(&events.events()).unwrap();
+    for forbidden in [
+        input_sentinel,
+        backend_secret,
+        "/private/tmp/backend-path",
+        "sk-live",
+    ] {
+        assert!(
+            !serialized_run.contains(forbidden),
+            "run-state leaked backend sentinel {forbidden}: {serialized_run}"
+        );
+        assert!(
+            !serialized_events.contains(forbidden),
+            "runtime events leaked backend sentinel {forbidden}: {serialized_events}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn reborn_e2e_gate_blocks_oversized_runtime_output_before_publication() {
     let run_state = Arc::new(InMemoryRunStateStore::new());
     let events = InMemoryEventSink::new();
@@ -688,6 +767,14 @@ impl TrustAwareCapabilityDispatchAuthorizer for ObligatingAuthorizer {
 }
 
 struct EchoScriptBackend;
+
+struct FailingScriptBackend;
+
+impl ScriptBackend for FailingScriptBackend {
+    fn execute(&self, _request: ScriptBackendRequest) -> Result<ScriptBackendOutput, String> {
+        Err("BACKEND_PROVIDER_ERROR_SECRET_3067 /private/tmp/backend-path sk-live".to_string())
+    }
+}
 
 impl ScriptBackend for EchoScriptBackend {
     fn execute(&self, request: ScriptBackendRequest) -> Result<ScriptBackendOutput, String> {


### PR DESCRIPTION
## Summary
- audit #3067 coverage after recent Reborn merges
- add a Reborn E2E gate test for runtime backend failure sanitization
- assert backend/provider error sentinels, host paths, secret-like values, and raw input do not leak through public failure output, run-state, or runtime events

## Tests
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3067-e2e cargo test -p ironclaw_host_runtime --test reborn_e2e_gate --no-default-features`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3067-e2e cargo clippy -p ironclaw_host_runtime --test reborn_e2e_gate --no-default-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/pre-commit-safety.sh`

Refs #3067.