### PR TITLE
feat(reborn): add minimal runtime shell

### DIFF
--- a/crates/ironclaw_reborn_cli/src/cli.rs
+++ b/crates/ironclaw_reborn_cli/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 use ironclaw_reborn_config::{RebornBootConfig, RebornDoctorReport};
 
+use crate::runtime::RuntimeShellReport;
+
 #[derive(Debug, Parser)]
 #[command(
     name = "ironclaw-reborn",
@@ -16,12 +18,15 @@ struct Cli {
 enum Command {
     /// Check Reborn binary configuration without creating state.
     Doctor,
+    /// Initialize the minimal Reborn runtime shell and exit.
+    Run,
 }
 
 pub(crate) fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Doctor => run_doctor(),
+        Command::Run => run_runtime_shell(),
     }
 }
 
@@ -35,5 +40,10 @@ fn run_doctor() -> anyhow::Result<()> {
     println!("profile: {}", report.profile());
     println!("v1_state: {}", report.v1_state());
     println!("driver_registry: initialized");
+    Ok(())
+}
+
+fn run_runtime_shell() -> anyhow::Result<()> {
+    RuntimeShellReport::initialize(RebornBootConfig::resolve_from_env()?).print();
     Ok(())
 }

--- a/crates/ironclaw_reborn_cli/src/main.rs
+++ b/crates/ironclaw_reborn_cli/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod runtime;
 
 fn main() -> anyhow::Result<()> {
     cli::run()

--- a/crates/ironclaw_reborn_cli/src/runtime.rs
+++ b/crates/ironclaw_reborn_cli/src/runtime.rs
@@ -1,0 +1,37 @@
+use ironclaw_reborn_config::RebornBootConfig;
+
+/// Side-effect-free runtime-shell snapshot for the standalone Reborn binary.
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeShellReport {
+    config: RebornBootConfig,
+    driver_registry_initialized: bool,
+}
+
+impl RuntimeShellReport {
+    pub(crate) fn initialize(config: RebornBootConfig) -> Self {
+        let _registry = ironclaw_reborn::driver_registry::DriverRegistry::new();
+        Self {
+            config,
+            driver_registry_initialized: true,
+        }
+    }
+
+    pub(crate) fn print(&self) {
+        println!("IronClaw Reborn runtime shell");
+        println!("binary: ironclaw-reborn");
+        println!("version: {}", env!("CARGO_PKG_VERSION"));
+        println!("reborn_home: {}", self.config.home().path().display());
+        println!("home_source: {}", self.config.home().source_label());
+        println!("profile: {}", self.config.profile());
+        println!("v1_state: not-used");
+        println!("driver_registry: initialized");
+        println!(
+            "runtime_shell: {}",
+            if self.driver_registry_initialized {
+                "initialized"
+            } else {
+                "unavailable"
+            }
+        );
+    }
+}

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -22,6 +22,58 @@ fn help_mentions_reborn_commands() {
         "stdout: {stdout}"
     );
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
+    assert!(stdout.contains("run"), "stdout: {stdout}");
+}
+
+#[test]
+fn run_initializes_minimal_runtime_shell_without_touching_v1_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let home_dir = temp.path().join("home");
+    let v1_base_dir = temp.path().join("v1-state");
+
+    let output = Command::new(reborn_bin())
+        .arg("run")
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("HOME", &home_dir)
+        .env("IRONCLAW_BASE_DIR", &v1_base_dir)
+        .env_remove("USERPROFILE")
+        .env_remove("IRONCLAW_REBORN_PROFILE")
+        .output()
+        .expect("ironclaw-reborn run should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn runtime shell"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(reborn_home.to_str().expect("utf8 path")),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("profile: local-dev"), "stdout: {stdout}");
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("runtime_shell: initialized"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        !reborn_home.exists(),
+        "minimal runtime shell should not create Reborn state directories"
+    );
+    assert!(
+        !home_dir.join(".ironclaw").exists(),
+        "minimal runtime shell should not create default v1 state directories"
+    );
+    assert!(
+        !v1_base_dir.exists(),
+        "minimal runtime shell should not create explicit v1 base directories"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `ironclaw-reborn run` as a minimal Reborn runtime shell
- print binary/version, resolved Reborn home, profile, v1-state isolation, driver-registry status, and shell status
- cover `run` in the binary smoke test, including Reborn/v1 state dry-run assertions

Refs #3069

## Scope notes
This intentionally does **not** start long-lived services, wire v1 runtime paths, mutate Reborn state, or change release packaging/docs. It only lands Task 5 / the `run` smoke slice so docs + dist decision can follow.

## Verification
- TDD red: `cargo test -p ironclaw_reborn_cli run_initializes_minimal_runtime_shell_without_touching_v1_state` failed with `unrecognized subcommand 'run'`
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_cli`
- `cargo test -p ironclaw_architecture reborn`
- `cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `git diff --check`
- manual `IRONCLAW_REBORN_HOME=$(mktemp -d)/reborn-home cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run`
- local code-quality review: no remaining Medium+ findings
