### PR TITLE
refactor(reborn): modularize CLI commands

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -95,6 +95,34 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
         manifest.contains("[[bin]]") && manifest.contains("name = \"ironclaw-reborn\""),
         "Reborn CLI crate must declare the ironclaw-reborn binary explicitly"
     );
+
+    let command_module_paths = [
+        "crates/ironclaw_reborn_cli/AGENTS.md",
+        "crates/ironclaw_reborn_cli/src/commands/mod.rs",
+        "crates/ironclaw_reborn_cli/src/commands/doctor.rs",
+        "crates/ironclaw_reborn_cli/src/commands/run.rs",
+        "crates/ironclaw_reborn_cli/src/context.rs",
+    ];
+    for path in command_module_paths {
+        assert!(
+            root.join(path).exists(),
+            "Reborn CLI commands should use an agent-friendly one-command-per-file layout; missing {path}"
+        );
+    }
+
+    let agent_contract = std::fs::read_to_string(root.join("crates/ironclaw_reborn_cli/AGENTS.md"))
+        .expect("Reborn CLI crate-local AGENTS.md must be readable");
+    for required_phrase in [
+        "one command per file",
+        "RebornCliContext",
+        "no v1 runtime imports",
+    ] {
+        assert!(
+            agent_contract.contains(required_phrase),
+            "Reborn CLI AGENTS.md should document `{required_phrase}` for future command agents"
+        );
+    }
+
     assert_workspace_deps_exactly(
         &dependencies,
         "ironclaw_reborn_cli",

--- a/crates/ironclaw_reborn_cli/AGENTS.md
+++ b/crates/ironclaw_reborn_cli/AGENTS.md
@@ -1,0 +1,29 @@
+# Reborn CLI Agent Contract
+
+This crate owns the standalone `ironclaw-reborn` command surface. Keep it small, explicit, and safe for agents to extend.
+
+## Command layout
+
+- Use one command per file under `src/commands/`.
+- Register each command in `src/commands/mod.rs` and dispatch through `Command::execute`.
+- Keep `src/cli.rs` as the clap root only: parse top-level CLI and hand off to command modules.
+- Put shared process/env boot state in `RebornCliContext` from `src/context.rs`.
+
+## Boundaries
+
+- Use `RebornCliContext` to resolve Reborn boot config instead of reading env in each command.
+- Keep commands side-effect free unless the command name and issue explicitly require mutation.
+- Use `IRONCLAW_REBORN_HOME` / `~/.ironclaw/reborn`; do not write current v1 state.
+- no v1 runtime imports: do not depend on root `ironclaw`, `src/agent`, channels, worker, DB, setup, service, sandbox, or `ironclaw_engine`.
+- Do not add workspace dependencies beyond `ironclaw_reborn` and `ironclaw_reborn_config` without an architecture test update and explicit PR rationale.
+
+## Adding a command
+
+1. Add `src/commands/<name>.rs` with a clap `Args` type and `execute(self) -> anyhow::Result<()>`.
+2. Add a variant to `commands::Command`.
+3. Add a binary smoke test in `tests/smoke.rs` that invokes `env!("CARGO_BIN_EXE_ironclaw-reborn")`.
+4. If the command can touch state, assert it uses Reborn home only and does not create/read v1 DB/settings/secrets.
+5. Run:
+   - `cargo test -p ironclaw_reborn_cli`
+   - `cargo test -p ironclaw_architecture reborn`
+   - `cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`

--- a/crates/ironclaw_reborn_cli/AGENTS.md
+++ b/crates/ironclaw_reborn_cli/AGENTS.md
@@ -11,7 +11,7 @@ This crate owns the standalone `ironclaw-reborn` command surface. Keep it small,
 
 ## Boundaries
 
-- Use `RebornCliContext` to resolve Reborn boot config instead of reading env in each command.
+- Use the provided RebornCliContext to access Reborn boot config instead of reading env in each command.
 - Keep commands side-effect free unless the command name and issue explicitly require mutation.
 - Use `IRONCLAW_REBORN_HOME` / `~/.ironclaw/reborn`; do not write current v1 state.
 - no v1 runtime imports: do not depend on root `ironclaw`, `src/agent`, channels, worker, DB, setup, service, sandbox, or `ironclaw_engine`.
@@ -19,7 +19,7 @@ This crate owns the standalone `ironclaw-reborn` command surface. Keep it small,
 
 ## Adding a command
 
-1. Add `src/commands/<name>.rs` with a clap `Args` type and `execute(self) -> anyhow::Result<()>`.
+1. Add `src/commands/<name>.rs` with a clap `Args` type and `execute(self, context: RebornCliContext) -> anyhow::Result<()>`.
 2. Add a variant to `commands::Command`.
 3. Add a binary smoke test in `tests/smoke.rs` that invokes `env!("CARGO_BIN_EXE_ironclaw-reborn")`.
 4. If the command can touch state, assert it uses Reborn home only and does not create/read v1 DB/settings/secrets.

--- a/crates/ironclaw_reborn_cli/src/cli.rs
+++ b/crates/ironclaw_reborn_cli/src/cli.rs
@@ -1,7 +1,6 @@
-use clap::{Parser, Subcommand};
-use ironclaw_reborn_config::{RebornBootConfig, RebornDoctorReport};
+use clap::Parser;
 
-use crate::runtime::RuntimeShellReport;
+use crate::commands::Command;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -14,36 +13,6 @@ struct Cli {
     command: Command,
 }
 
-#[derive(Debug, Subcommand)]
-enum Command {
-    /// Check Reborn binary configuration without creating state.
-    Doctor,
-    /// Initialize the minimal Reborn runtime shell and exit.
-    Run,
-}
-
 pub(crate) fn run() -> anyhow::Result<()> {
-    let cli = Cli::parse();
-    match cli.command {
-        Command::Doctor => run_doctor(),
-        Command::Run => run_runtime_shell(),
-    }
-}
-
-fn run_doctor() -> anyhow::Result<()> {
-    let report = RebornDoctorReport::from_config(RebornBootConfig::resolve_from_env()?);
-    let _registry = ironclaw_reborn::driver_registry::DriverRegistry::new();
-
-    println!("IronClaw Reborn doctor");
-    println!("reborn_home: {}", report.home_path().display());
-    println!("home_source: {}", report.home_source_label());
-    println!("profile: {}", report.profile());
-    println!("v1_state: {}", report.v1_state());
-    println!("driver_registry: initialized");
-    Ok(())
-}
-
-fn run_runtime_shell() -> anyhow::Result<()> {
-    RuntimeShellReport::initialize(RebornBootConfig::resolve_from_env()?).print();
-    Ok(())
+    Cli::parse().command.execute()
 }

--- a/crates/ironclaw_reborn_cli/src/cli.rs
+++ b/crates/ironclaw_reborn_cli/src/cli.rs
@@ -14,5 +14,7 @@ struct Cli {
 }
 
 pub(crate) fn run() -> anyhow::Result<()> {
-    Cli::parse().command.execute()
+    let cli = Cli::parse();
+    let context = crate::context::RebornCliContext::resolve_from_env()?;
+    cli.command.execute(context)
 }

--- a/crates/ironclaw_reborn_cli/src/commands/doctor.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/doctor.rs
@@ -1,0 +1,23 @@
+use clap::Args;
+use ironclaw_reborn_config::RebornDoctorReport;
+
+use crate::context::RebornCliContext;
+
+#[derive(Debug, Args)]
+pub(crate) struct DoctorCommand;
+
+impl DoctorCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        let context = RebornCliContext::resolve_from_env()?;
+        let report = RebornDoctorReport::from_config(context.boot_config().clone());
+        let _registry = ironclaw_reborn::driver_registry::DriverRegistry::new();
+
+        println!("IronClaw Reborn doctor");
+        println!("reborn_home: {}", report.home_path().display());
+        println!("home_source: {}", report.home_source_label());
+        println!("profile: {}", report.profile());
+        println!("v1_state: {}", report.v1_state());
+        println!("driver_registry: initialized");
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/doctor.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/doctor.rs
@@ -7,8 +7,7 @@ use crate::context::RebornCliContext;
 pub(crate) struct DoctorCommand;
 
 impl DoctorCommand {
-    pub(crate) fn execute(self) -> anyhow::Result<()> {
-        let context = RebornCliContext::resolve_from_env()?;
+    pub(crate) fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
         let report = RebornDoctorReport::from_config(context.boot_config().clone());
         let _registry = ironclaw_reborn::driver_registry::DriverRegistry::new();
 

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -1,0 +1,21 @@
+use clap::Subcommand;
+
+pub(crate) mod doctor;
+pub(crate) mod run;
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum Command {
+    /// Check Reborn binary configuration without creating state.
+    Doctor(doctor::DoctorCommand),
+    /// Initialize the minimal Reborn runtime shell and exit.
+    Run(run::RunCommand),
+}
+
+impl Command {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self {
+            Self::Doctor(command) => command.execute(),
+            Self::Run(command) => command.execute(),
+        }
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -12,10 +12,10 @@ pub(crate) enum Command {
 }
 
 impl Command {
-    pub(crate) fn execute(self) -> anyhow::Result<()> {
+    pub(crate) fn execute(self, context: crate::context::RebornCliContext) -> anyhow::Result<()> {
         match self {
-            Self::Doctor(command) => command.execute(),
-            Self::Run(command) => command.execute(),
+            Self::Doctor(command) => command.execute(context),
+            Self::Run(command) => command.execute(context),
         }
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/run.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/run.rs
@@ -1,22 +1,35 @@
+use clap::Args;
 use ironclaw_reborn_config::RebornBootConfig;
+
+use crate::context::RebornCliContext;
+
+#[derive(Debug, Args)]
+pub(crate) struct RunCommand;
+
+impl RunCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        RuntimeShellReport::initialize(RebornCliContext::resolve_from_env()?).print();
+        Ok(())
+    }
+}
 
 /// Side-effect-free runtime-shell snapshot for the standalone Reborn binary.
 #[derive(Debug, Clone)]
-pub(crate) struct RuntimeShellReport {
+struct RuntimeShellReport {
     config: RebornBootConfig,
     driver_registry_initialized: bool,
 }
 
 impl RuntimeShellReport {
-    pub(crate) fn initialize(config: RebornBootConfig) -> Self {
+    fn initialize(context: RebornCliContext) -> Self {
         let _registry = ironclaw_reborn::driver_registry::DriverRegistry::new();
         Self {
-            config,
+            config: context.boot_config().clone(),
             driver_registry_initialized: true,
         }
     }
 
-    pub(crate) fn print(&self) {
+    fn print(&self) {
         println!("IronClaw Reborn runtime shell");
         println!("binary: ironclaw-reborn");
         println!("version: {}", env!("CARGO_PKG_VERSION"));

--- a/crates/ironclaw_reborn_cli/src/commands/run.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/run.rs
@@ -7,8 +7,8 @@ use crate::context::RebornCliContext;
 pub(crate) struct RunCommand;
 
 impl RunCommand {
-    pub(crate) fn execute(self) -> anyhow::Result<()> {
-        RuntimeShellReport::initialize(RebornCliContext::resolve_from_env()?).print();
+    pub(crate) fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        RuntimeShellReport::initialize(context).print();
         Ok(())
     }
 }

--- a/crates/ironclaw_reborn_cli/src/context.rs
+++ b/crates/ironclaw_reborn_cli/src/context.rs
@@ -1,0 +1,19 @@
+use ironclaw_reborn_config::RebornBootConfig;
+
+/// Per-invocation context shared by Reborn CLI commands.
+#[derive(Debug, Clone)]
+pub(crate) struct RebornCliContext {
+    boot_config: RebornBootConfig,
+}
+
+impl RebornCliContext {
+    pub(crate) fn resolve_from_env() -> anyhow::Result<Self> {
+        Ok(Self {
+            boot_config: RebornBootConfig::resolve_from_env()?,
+        })
+    }
+
+    pub(crate) fn boot_config(&self) -> &RebornBootConfig {
+        &self.boot_config
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/main.rs
+++ b/crates/ironclaw_reborn_cli/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
-mod runtime;
+mod commands;
+mod context;
 
 fn main() -> anyhow::Result<()> {
     cli::run()


### PR DESCRIPTION
## Summary
- split `ironclaw-reborn` commands into `src/commands/{doctor,run}.rs`
- add `RebornCliContext` as the shared boot/config entrypoint for commands
- add crate-local `AGENTS.md` with the command-addition contract for future agents
- extend Reborn architecture guardrail to require the agent-friendly command layout

Refs #3069

## Scope notes
This is a structure-only follow-up after #3480. It does not port v1 commands or add new command behavior; existing `doctor` and `run` outputs stay covered by binary smoke tests.

## Verification
- TDD red: `cargo test -p ironclaw_architecture reborn_cli_binary_crate_stays_separate_from_v1_root` failed on missing `crates/ironclaw_reborn_cli/AGENTS.md`
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_cli`
- `cargo test -p ironclaw_architecture reborn`
- `cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help`
- `IRONCLAW_REBORN_HOME=$(mktemp -d)/reborn-home cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run`
- `git diff --check`
- local code-quality review: no Medium+ findings
