### PR TITLE
docs(reborn): document standalone binary release status

### DIFF
--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -10,8 +10,8 @@ homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
 publish = false
 
-# First PR establishes the binary boundary only. Release packaging is a
-# follow-up decision after `run`/docs land and `dist plan` is verified.
+# Keep disabled until #3483 resolves cargo-dist tag/versioning + Windows WiX
+# packaging for the standalone Reborn binary.
 [package.metadata.dist]
 dist = false
 

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -1,0 +1,142 @@
+# `ironclaw-reborn` standalone binary
+
+`ironclaw-reborn` is the standalone executable boundary for Reborn. It is separate from the current `ironclaw` binary so Reborn boot, config, state, and runtime composition can evolve without accidentally invoking v1 runtime paths.
+
+This binary is available as the workspace package `ironclaw_reborn_cli` and builds the executable named `ironclaw-reborn`.
+
+## Current status
+
+`ironclaw-reborn` is an early operator/testing surface, not the default IronClaw runtime.
+
+It currently supports:
+
+```bash
+ironclaw-reborn --help
+ironclaw-reborn doctor
+ironclaw-reborn run
+```
+
+It intentionally does not yet support:
+
+- replacing `ironclaw` behavior;
+- daemon/service installation;
+- web gateway/UI startup;
+- v1 config, DB, settings, or secrets migration;
+- production extension/tool execution;
+- long-lived Reborn runtime services.
+
+## Commands
+
+### `doctor`
+
+Validates and reports Reborn boot configuration without creating state directories or starting runtime services.
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- doctor
+```
+
+Expected fields include:
+
+- `reborn_home`
+- `home_source`
+- `profile`
+- `v1_state: not-used`
+- `driver_registry: initialized`
+
+### `run`
+
+Initializes the minimal Reborn runtime shell and exits successfully. This is a smokeable composition shell, not full agent execution.
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
+```
+
+Expected fields include:
+
+- `binary: ironclaw-reborn`
+- `version`
+- `reborn_home`
+- `home_source`
+- `profile`
+- `v1_state: not-used`
+- `driver_registry: initialized`
+- `runtime_shell: initialized`
+
+## State and config root
+
+Reborn must not use the current v1 IronClaw state root by default.
+
+Home resolution precedence:
+
+1. `IRONCLAW_REBORN_HOME`
+2. `~/.ironclaw/reborn`
+
+The resolver rejects unsafe or misleading homes, including empty paths, relative paths, filesystem root, parent-directory components, and known v1 state-root aliases such as `$HOME/.ironclaw` or `IRONCLAW_BASE_DIR`.
+
+## Profiles
+
+Use `IRONCLAW_REBORN_PROFILE` to select the boot profile.
+
+Supported values:
+
+- `local-dev` (default)
+- `production`
+- `migration-dry-run`
+
+Example:
+
+```bash
+IRONCLAW_REBORN_HOME="$PWD/.reborn-home" \
+IRONCLAW_REBORN_PROFILE=production \
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- doctor
+```
+
+## Local smoke checks
+
+Run these before changing Reborn CLI behavior:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p ironclaw_reborn_cli
+cargo test -p ironclaw_reborn_config
+cargo test -p ironclaw_architecture reborn
+cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
+IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
+  cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
+```
+
+## Adding commands
+
+Future commands should follow the crate-local agent contract in:
+
+```text
+crates/ironclaw_reborn_cli/AGENTS.md
+```
+
+Short version:
+
+1. add one command module under `crates/ironclaw_reborn_cli/src/commands/`;
+2. register it in `commands::Command`;
+3. receive the already-resolved `RebornCliContext` from dispatch;
+4. add a binary smoke test through `env!("CARGO_BIN_EXE_ironclaw-reborn")`;
+5. avoid v1 runtime imports and v1 state mutation unless explicitly scoped and guarded.
+
+Do not port the current `src/cli/*` command tree wholesale. Port commands one at a time, starting with Reborn-owned or read-only surfaces.
+
+## Release packaging decision
+
+`ironclaw-reborn` is **not yet included in cargo-dist release artifacts**.
+
+Current `dist plan --output-format=json` with `crates/ironclaw_reborn_cli` marked `dist = false` emits only the root `ironclaw` package artifacts. Removing `dist = false` alone is not enough to ship `ironclaw-reborn` in the existing `ironclaw-v*` release workflow because that workflow is shaped around the root `ironclaw` package tag. Enabling a standalone `ironclaw_reborn_cli` release also requires cargo-dist WiX metadata/template work and an explicit tag/versioning decision.
+
+Follow-up issue: #3483 tracks packaging `ironclaw-reborn` in release artifacts.
+
+Until #3483 is resolved, keep:
+
+```toml
+[package.metadata.dist]
+dist = false
+```
+
+in `crates/ironclaw_reborn_cli/Cargo.toml` so releases do not silently claim to ship an unverified Reborn binary package.

--- a/docs/reborn/README.md
+++ b/docs/reborn/README.md
@@ -10,6 +10,7 @@ The `reborn-integration` branch currently exposes Reborn structure primarily thr
 
 | Need | Start with |
 | --- | --- |
+| Standalone Reborn binary | `docs/reborn-binary.md` |
 | Host API vocabulary | `crates/ironclaw_host_api/` |
 | Host API local rules | `crates/ironclaw_host_api/CLAUDE.md` |
 | Host/runtime composition and shared runtime HTTP egress | `crates/ironclaw_host_runtime/` |


### PR DESCRIPTION
## Summary
- add operator-facing docs for the standalone `ironclaw-reborn` binary
- link the binary doc from the Reborn harness map
- keep `ironclaw_reborn_cli` out of cargo-dist release artifacts pending follow-up #3483
- document current `dist plan` evidence and the packaging blockers/decision still needed

Refs #3069
Follow-up: #3483

## Release packaging evidence
- `dist plan --output-format=json` currently emits only the root `ironclaw` release (`29` artifacts)
- removing `dist = false` alone does not add `ironclaw_reborn_cli` to the existing `ironclaw-v*` release plan
- enabling standalone `ironclaw_reborn_cli` distribution requires Windows WiX metadata/template work and an explicit tag/versioning workflow decision

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_cli`
- `cargo test -p ironclaw_reborn_config`
- `cargo test -p ironclaw_architecture reborn`
- `cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `dist plan --output-format=json`
- `git diff --check`
- local reviewer: no blocker/Medium+ docs or release-decision findings
