### PR TITLE
Add Reborn CLI completion command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4539,6 +4539,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "ironclaw_reborn",
  "ironclaw_reborn_config",
  "tempfile",

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -99,6 +99,7 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
     let command_module_paths = [
         "crates/ironclaw_reborn_cli/AGENTS.md",
         "crates/ironclaw_reborn_cli/src/commands/mod.rs",
+        "crates/ironclaw_reborn_cli/src/commands/completion.rs",
         "crates/ironclaw_reborn_cli/src/commands/doctor.rs",
         "crates/ironclaw_reborn_cli/src/commands/run.rs",
         "crates/ironclaw_reborn_cli/src/context.rs",

--- a/crates/ironclaw_reborn_cli/AGENTS.md
+++ b/crates/ironclaw_reborn_cli/AGENTS.md
@@ -11,7 +11,7 @@ This crate owns the standalone `ironclaw-reborn` command surface. Keep it small,
 
 ## Boundaries
 
-- Use the provided RebornCliContext to access Reborn boot config instead of reading env in each command.
+- Commands that need Reborn boot config must receive `RebornCliContext` from dispatch instead of reading env directly. Pure commands that do not need boot config (for example, shell completion generation) must not force Reborn home resolution.
 - Keep commands side-effect free unless the command name and issue explicitly require mutation.
 - Use `IRONCLAW_REBORN_HOME` / `~/.ironclaw/reborn`; do not write current v1 state.
 - no v1 runtime imports: do not depend on root `ironclaw`, `src/agent`, channels, worker, DB, setup, service, sandbox, or `ironclaw_engine`.
@@ -19,11 +19,13 @@ This crate owns the standalone `ironclaw-reborn` command surface. Keep it small,
 
 ## Adding a command
 
-1. Add `src/commands/<name>.rs` with a clap `Args` type and `execute(self, context: RebornCliContext) -> anyhow::Result<()>`.
+1. Add `src/commands/<name>.rs` with a clap `Args` type and an `execute` method.
 2. Add a variant to `commands::Command`.
-3. Add a binary smoke test in `tests/smoke.rs` that invokes `env!("CARGO_BIN_EXE_ironclaw-reborn")`.
-4. If the command can touch state, assert it uses Reborn home only and does not create/read v1 DB/settings/secrets.
-5. Run:
+3. If the command needs boot config, resolve `RebornCliContext` in `commands::Command::execute` and pass it into the command handler.
+4. If the command is pure, do not resolve `RebornCliContext` just to run it.
+5. Add a binary smoke test in `tests/smoke.rs` that invokes `env!("CARGO_BIN_EXE_ironclaw-reborn")`.
+6. If the command can touch state, assert it uses Reborn home only and does not create/read v1 DB/settings/secrets.
+7. Run:
    - `cargo test -p ironclaw_reborn_cli`
    - `cargo test -p ironclaw_architecture reborn`
    - `cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -18,6 +18,7 @@ dist = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4.5.0"
 ironclaw_reborn = { path = "../ironclaw_reborn", version = "0.1.0" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
 

--- a/crates/ironclaw_reborn_cli/src/cli.rs
+++ b/crates/ironclaw_reborn_cli/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 
 use crate::commands::Command;
 
@@ -13,8 +13,10 @@ struct Cli {
     command: Command,
 }
 
+pub(crate) fn command() -> clap::Command {
+    Cli::command()
+}
+
 pub(crate) fn run() -> anyhow::Result<()> {
-    let cli = Cli::parse();
-    let context = crate::context::RebornCliContext::resolve_from_env()?;
-    cli.command.execute(context)
+    Cli::parse().command.execute()
 }

--- a/crates/ironclaw_reborn_cli/src/commands/completion.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/completion.rs
@@ -1,0 +1,32 @@
+use std::io::{self, Write};
+
+use clap::Args;
+use clap_complete::{Shell, generate};
+
+#[derive(Debug, Args)]
+pub(crate) struct CompletionCommand {
+    /// The shell to generate completions for.
+    #[arg(value_enum, long)]
+    shell: Shell,
+}
+
+impl CompletionCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        let mut command = crate::cli::command();
+        let bin_name = command.get_name().to_string();
+
+        if self.shell == Shell::Zsh {
+            let mut buffer = Vec::new();
+            generate(self.shell, &mut command, bin_name.clone(), &mut buffer);
+            let script = String::from_utf8(buffer)?;
+
+            let bare = format!("compdef _{0} {0}", bin_name);
+            let guarded = format!("(( $+functions[compdef] )) && compdef _{0} {0}", bin_name);
+            io::stdout().write_all(script.replace(&bare, &guarded).as_bytes())?;
+        } else {
+            generate(self.shell, &mut command, bin_name, &mut io::stdout());
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/completion.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/completion.rs
@@ -15,16 +15,19 @@ impl CompletionCommand {
         let mut command = crate::cli::command();
         let bin_name = command.get_name().to_string();
 
-        if self.shell == Shell::Zsh {
-            let mut buffer = Vec::new();
-            generate(self.shell, &mut command, bin_name.clone(), &mut buffer);
-            let script = String::from_utf8(buffer)?;
+        match self.shell {
+            Shell::Zsh => {
+                let mut buffer = Vec::new();
+                generate(self.shell, &mut command, bin_name.clone(), &mut buffer);
+                let script = String::from_utf8(buffer)?;
 
-            let bare = format!("compdef _{0} {0}", bin_name);
-            let guarded = format!("(( $+functions[compdef] )) && compdef _{0} {0}", bin_name);
-            io::stdout().write_all(script.replace(&bare, &guarded).as_bytes())?;
-        } else {
-            generate(self.shell, &mut command, bin_name, &mut io::stdout());
+                let bare = format!("compdef _{0} {0}", bin_name);
+                let guarded = format!("(( $+functions[compdef] )) && compdef _{0} {0}", bin_name);
+                io::stdout().write_all(script.replace(&bare, &guarded).as_bytes())?;
+            }
+            shell => {
+                generate(shell, &mut command, bin_name, &mut io::stdout());
+            }
         }
 
         Ok(())

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -1,10 +1,13 @@
 use clap::Subcommand;
 
+pub(crate) mod completion;
 pub(crate) mod doctor;
 pub(crate) mod run;
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum Command {
+    /// Generate shell completion scripts.
+    Completion(completion::CompletionCommand),
     /// Check Reborn binary configuration without creating state.
     Doctor(doctor::DoctorCommand),
     /// Initialize the minimal Reborn runtime shell and exit.
@@ -12,10 +15,15 @@ pub(crate) enum Command {
 }
 
 impl Command {
-    pub(crate) fn execute(self, context: crate::context::RebornCliContext) -> anyhow::Result<()> {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
         match self {
-            Self::Doctor(command) => command.execute(context),
-            Self::Run(command) => command.execute(context),
+            Self::Completion(command) => command.execute(),
+            Self::Doctor(command) => {
+                command.execute(crate::context::RebornCliContext::resolve_from_env()?)
+            }
+            Self::Run(command) => {
+                command.execute(crate::context::RebornCliContext::resolve_from_env()?)
+            }
         }
     }
 }

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -21,8 +21,36 @@ fn help_mentions_reborn_commands() {
         stdout.contains("Standalone IronClaw Reborn runtime"),
         "stdout: {stdout}"
     );
+    assert!(stdout.contains("completion"), "stdout: {stdout}");
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+}
+
+#[test]
+fn completion_generates_zsh_script_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("completion")
+        .arg("--shell")
+        .arg("zsh")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn completion should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef ironclaw-reborn"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("_ironclaw-reborn"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("$+functions[compdef]"),
+        "zsh completion should guard compdef: {stdout}"
+    );
 }
 
 #[test]

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -12,6 +12,8 @@ It currently supports:
 
 ```bash
 ironclaw-reborn --help
+ironclaw-reborn completion --shell bash
+ironclaw-reborn completion --shell zsh
 ironclaw-reborn doctor
 ironclaw-reborn run
 ```
@@ -26,6 +28,17 @@ It intentionally does not yet support:
 - long-lived Reborn runtime services.
 
 ## Commands
+
+### `completion`
+
+Generates shell completion scripts without resolving Reborn home, reading v1 state, or creating directories.
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh > ironclaw-reborn.zsh
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell bash > ironclaw-reborn.bash
+```
+
+The zsh output keeps the v1 CLI guard around `compdef` so the generated script is safe when zsh completion functions are not loaded yet.
 
 ### `doctor`
 
@@ -102,6 +115,7 @@ cargo test -p ironclaw_reborn_config
 cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
 ```
@@ -118,9 +132,10 @@ Short version:
 
 1. add one command module under `crates/ironclaw_reborn_cli/src/commands/`;
 2. register it in `commands::Command`;
-3. receive the already-resolved `RebornCliContext` from dispatch;
-4. add a binary smoke test through `env!("CARGO_BIN_EXE_ironclaw-reborn")`;
-5. avoid v1 runtime imports and v1 state mutation unless explicitly scoped and guarded.
+3. resolve and pass `RebornCliContext` from dispatch only when the command needs boot config;
+4. keep pure commands independent from Reborn home resolution;
+5. add a binary smoke test through `env!("CARGO_BIN_EXE_ironclaw-reborn")`;
+6. avoid v1 runtime imports and v1 state mutation unless explicitly scoped and guarded.
 
 Do not port the current `src/cli/*` command tree wholesale. Port commands one at a time, starting with Reborn-owned or read-only surfaces.
 


### PR DESCRIPTION
## Summary
- add `ironclaw-reborn completion --shell <shell>` using `clap_complete`
- keep completion generation independent from Reborn home/env resolution
- preserve the zsh `compdef` guard from the v1 CLI completion behavior
- document the command and update the Reborn CLI agent contract for pure commands

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_cli`
- `cargo test -p ironclaw_reborn_config`
- `cargo test -p ironclaw_architecture reborn`
- `cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- code-quality reviewer pass: only blocker was untracked new command file; fixed before commit

Refs #3069.
