### PR TITLE
Fix Reborn memory error redaction and SQL replay cursors

### DIFF
--- a/crates/ironclaw_memory/src/backend.rs
+++ b/crates/ironclaw_memory/src/backend.rs
@@ -627,6 +627,27 @@ mod tests {
     use crate::embedding::EmbeddingError;
     use crate::repo::InMemoryMemoryDocumentRepository;
 
+    struct FailingEmbeddingProvider;
+
+    #[async_trait]
+    impl EmbeddingProvider for FailingEmbeddingProvider {
+        fn dimension(&self) -> usize {
+            3
+        }
+
+        fn model_name(&self) -> &str {
+            "failing"
+        }
+
+        async fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbeddingError> {
+            Err(EmbeddingError::ProviderUnavailable {
+                reason:
+                    "provider exploded at /tmp/HOST_PATH_SENTINEL with token RAW_TOKEN_SENTINEL"
+                        .to_string(),
+            })
+        }
+    }
+
     struct UnitEmbeddingProvider;
 
     #[async_trait]
@@ -808,6 +829,32 @@ mod tests {
         let request = MemorySearchRequest::new("query").unwrap();
         let err = backend.search(&alpha_context(), request).await.unwrap_err();
         assert!(err.to_string().contains("embedding generation"));
+    }
+
+    #[tokio::test]
+    async fn embedding_provider_error_is_sanitized_at_backend_boundary() {
+        let repo = Arc::new(InMemoryMemoryDocumentRepository::new());
+        let backend = RepositoryMemoryBackend::new(repo)
+            .without_prompt_write_safety_policy()
+            .with_embedding_provider(Arc::new(FailingEmbeddingProvider))
+            .with_capabilities(MemoryBackendCapabilities {
+                full_text_search: true,
+                vector_search: true,
+                embeddings: true,
+                ..MemoryBackendCapabilities::default()
+            });
+
+        let request = MemorySearchRequest::new("query").unwrap();
+        let err = backend.search(&alpha_context(), request).await.unwrap_err();
+        let displayed = err.to_string();
+
+        assert!(displayed.contains("embedding provider unavailable"));
+        assert!(
+            !displayed.contains("HOST_PATH_SENTINEL")
+                && !displayed.contains("RAW_TOKEN_SENTINEL")
+                && !displayed.contains("/tmp/"),
+            "public memory error leaked backend/provider details: {displayed}"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_memory/src/embedding.rs
+++ b/crates/ironclaw_memory/src/embedding.rs
@@ -73,7 +73,16 @@ pub(crate) fn embedding_filesystem_error(
     operation: FilesystemOperation,
     error: EmbeddingError,
 ) -> FilesystemError {
-    memory_error(path, operation, error.to_string())
+    let reason = match error {
+        EmbeddingError::ProviderUnavailable { .. } => "embedding provider unavailable".to_string(),
+        EmbeddingError::InvalidVector { expected, actual } => {
+            format!("embedding vector dimension mismatch: expected {expected}, got {actual}")
+        }
+        EmbeddingError::TextTooLong { length, max } => {
+            format!("embedding input too long: {length} > {max}")
+        }
+    };
+    memory_error(path, operation, reason)
 }
 
 pub(crate) async fn embed_text(

--- a/crates/ironclaw_memory/src/indexer.rs
+++ b/crates/ironclaw_memory/src/indexer.rs
@@ -537,9 +537,14 @@ mod tests {
         let indexer = ChunkingMemoryDocumentIndexer::new(repo.clone())
             .with_embedding_provider(Arc::new(RejectingEmbeddingProvider));
         let err = indexer.reindex_document(&doc_path()).await.unwrap_err();
+        let displayed = err.to_string();
         assert!(
-            err.to_string().contains("synthetic failure"),
-            "embedding error must still surface to callers for observability; got: {err}"
+            displayed.contains("embedding provider unavailable"),
+            "embedding error category must still surface to callers for observability; got: {err}"
+        );
+        assert!(
+            !displayed.contains("synthetic failure"),
+            "embedding backend details must not leak through public filesystem errors; got: {err}"
         );
         let calls = repo.calls.lock().unwrap();
         assert_eq!(calls.len(), 1, "expected exactly one indexer call");

--- a/crates/ironclaw_memory/src/path.rs
+++ b/crates/ironclaw_memory/src/path.rs
@@ -354,10 +354,42 @@ pub(crate) fn memory_error(
     operation: FilesystemOperation,
     reason: impl Into<String>,
 ) -> FilesystemError {
+    let reason = sanitize_memory_backend_reason(reason.into());
     FilesystemError::Backend {
         path,
         operation,
-        reason: reason.into(),
+        reason,
+    }
+}
+
+const MEMORY_BACKEND_DETAIL_MARKERS: &[&str] = &[
+    "no such table",
+    "drop table",
+    "sql",
+    "sqlite",
+    "libsql",
+    "postgres error",
+    "database error",
+    "connection refused",
+    "timeout",
+    "host=",
+    "port=",
+    "reborn_memory_",
+    "/tmp/",
+    "/var/folders/",
+    "/private/",
+    "\\appdata\\",
+];
+
+fn sanitize_memory_backend_reason(reason: String) -> String {
+    let lower = reason.to_ascii_lowercase();
+    if MEMORY_BACKEND_DETAIL_MARKERS
+        .iter()
+        .any(|marker| lower.as_str().contains(marker))
+    {
+        "memory backend operation failed".to_string()
+    } else {
+        reason
     }
 }
 

--- a/crates/ironclaw_memory/tests/reborn_native_libsql_repository_contract.rs
+++ b/crates/ironclaw_memory/tests/reborn_native_libsql_repository_contract.rs
@@ -37,6 +37,28 @@ async fn fresh_repository() -> Fixture {
 }
 
 #[tokio::test]
+async fn schema_failure_error_is_sanitized_at_public_boundary() {
+    let f = fresh_repository().await;
+    let conn = f.db.connect().expect("connect");
+    conn.execute("DROP TABLE reborn_memory_documents", ())
+        .await
+        .expect("drop table to force backend failure");
+
+    let path = MemoryDocumentPath::new("tenant-a", "alice", None, "sentinel.md").expect("path");
+    let err = f.repo.write_document(&path, b"body").await.unwrap_err();
+    let displayed = err.to_string();
+
+    assert!(displayed.contains("memory backend operation failed"));
+    assert!(
+        !displayed.contains("reborn_memory_documents")
+            && !displayed.contains("DROP TABLE")
+            && !displayed.contains("SQL")
+            && !displayed.contains("sqlite"),
+        "public memory error leaked backend details: {displayed}"
+    );
+}
+
+#[tokio::test]
 async fn round_trips_a_document_within_full_scope() {
     let f = fresh_repository().await;
     let path = MemoryDocumentPath::new("tenant-a", "alice", None, "MEMORY.md").expect("path");

--- a/crates/ironclaw_reborn_event_store/src/libsql_store.rs
+++ b/crates/ironclaw_reborn_event_store/src/libsql_store.rs
@@ -586,16 +586,21 @@ impl LibSqlStore {
                 });
             }
         }
-        // Track the highest cursor we scanned so callers can advance past
-        // records that were filtered out at the application layer. Without
-        // this, a filtered-out record at the head of the stream would be
-        // rescanned indefinitely on every replay.
+        // SQL query shape is `cursor > after AND <filter> ORDER BY cursor LIMIT limit`:
+        // filter predicates are pushed into SQL before the limit. Therefore a
+        // short page means the filtered replay reached the stream head, even if
+        // trailing records were filtered out and never appeared in `last_scanned`.
         let last_matched = entries.last().map(|entry| entry.cursor);
-        let next_cursor = match (last_matched, last_scanned) {
-            (Some(matched), Some(scanned)) if scanned.as_u64() > matched.as_u64() => scanned,
-            (Some(matched), _) => matched,
-            (None, Some(scanned)) => scanned,
-            (None, None) => EventCursor::new(next_cursor),
+        let stream_head_cursor = next_cursor;
+        let next_cursor = if entries.len() < limit {
+            EventCursor::new(stream_head_cursor)
+        } else {
+            match (last_matched, last_scanned) {
+                (Some(matched), Some(scanned)) if scanned.as_u64() > matched.as_u64() => scanned,
+                (Some(matched), _) => matched,
+                (None, Some(scanned)) => scanned,
+                (None, None) => EventCursor::new(stream_head_cursor),
+            }
         };
         Ok(EventReplay {
             entries,

--- a/crates/ironclaw_reborn_event_store/src/postgres_store.rs
+++ b/crates/ironclaw_reborn_event_store/src/postgres_store.rs
@@ -480,16 +480,21 @@ impl PostgresStore {
                 });
             }
         }
-        // Advance the cursor past records we scanned but filtered out, so the
-        // next call does not rescan them forever. When no entries matched at
-        // all, fall back to the stream head (`next_cursor` from the streams
-        // table is the cursor of the most recent append).
+        // SQL query shape is `cursor > after AND <filter> ORDER BY cursor LIMIT limit`:
+        // filter predicates are pushed into SQL before the limit. Therefore a
+        // short page means the filtered replay reached the stream head, even if
+        // trailing records were filtered out and never appeared in `last_scanned`.
         let last_matched = entries.last().map(|entry| entry.cursor);
-        let next_cursor = match (last_matched, last_scanned) {
-            (Some(matched), Some(scanned)) if scanned.as_u64() > matched.as_u64() => scanned,
-            (Some(matched), _) => matched,
-            (None, Some(scanned)) => scanned,
-            (None, None) => EventCursor::new(next_cursor),
+        let stream_head_cursor = next_cursor;
+        let next_cursor = if entries.len() < limit {
+            EventCursor::new(stream_head_cursor)
+        } else {
+            match (last_matched, last_scanned) {
+                (Some(matched), Some(scanned)) if scanned.as_u64() > matched.as_u64() => scanned,
+                (Some(matched), _) => matched,
+                (None, Some(scanned)) => scanned,
+                (None, None) => EventCursor::new(stream_head_cursor),
+            }
         };
         Ok(EventReplay {
             entries,

--- a/crates/ironclaw_reborn_event_store/tests/durable_event_store_contract.rs
+++ b/crates/ironclaw_reborn_event_store/tests/durable_event_store_contract.rs
@@ -68,6 +68,60 @@ fn audit_record(scope: &ResourceScope, status: &str) -> AuditEnvelope {
     }
 }
 
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_replay_advances_next_cursor_past_trailing_filtered_records() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let scope_a = scope_for("alice", "project-a");
+    let scope_b = scope_for("alice", "project-b");
+    let stream = EventStreamKey::from_scope(&scope_a);
+
+    let stores = build_reborn_event_stores(
+        RebornProfile::LocalDev,
+        RebornEventStoreConfig::Libsql {
+            path_or_url: temp.path().join("events.db").to_string_lossy().to_string(),
+            auth_token: None,
+        },
+    )
+    .await
+    .expect("libsql stores");
+
+    stores
+        .events
+        .append(RuntimeEvent::dispatch_requested(
+            scope_a.clone(),
+            capability_id(),
+        ))
+        .await
+        .expect("append project a");
+    stores
+        .events
+        .append(RuntimeEvent::dispatch_requested(
+            scope_b.clone(),
+            capability_id(),
+        ))
+        .await
+        .expect("append trailing project b");
+
+    let project_a = ReadScope {
+        project_id: scope_a.project_id.clone(),
+        ..ReadScope::default()
+    };
+    let replay = stores
+        .events
+        .read_after_cursor(&stream, &project_a, None, 10)
+        .await
+        .expect("replay project a");
+
+    assert_eq!(replay.entries.len(), 1);
+    assert_eq!(replay.entries[0].cursor, EventCursor::new(1));
+    assert_eq!(
+        replay.next_cursor,
+        EventCursor::new(2),
+        "filtered trailing records must advance SQL replay cursor"
+    );
+}
+
 #[tokio::test]
 async fn jsonl_runtime_log_survives_rebuild_and_preserves_filtered_cursor_semantics() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -361,6 +415,68 @@ async fn libsql_runtime_and_audit_logs_survive_rebuild_with_filtered_cursor_sema
             .unwrap()
             .status,
         Some("project-a".to_string())
+    );
+}
+
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn postgres_replay_advances_next_cursor_past_trailing_filtered_records() {
+    let Ok(url) = std::env::var("IRONCLAW_REBORN_EVENT_STORE_POSTGRES_URL") else {
+        eprintln!(
+            "skipping postgres event-store cursor contract: IRONCLAW_REBORN_EVENT_STORE_POSTGRES_URL not set"
+        );
+        return;
+    };
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let scope_a = scope_for(&format!("postgres-tail-alice-{suffix}"), "project-a");
+    let scope_b = scope_for(&format!("postgres-tail-alice-{suffix}"), "project-b");
+    let stream = EventStreamKey::from_scope(&scope_a);
+
+    let stores = build_reborn_event_stores(
+        RebornProfile::Production,
+        RebornEventStoreConfig::Postgres {
+            url: SecretString::new(url.into_boxed_str()),
+        },
+    )
+    .await
+    .expect("postgres stores");
+
+    stores
+        .events
+        .append(RuntimeEvent::dispatch_requested(
+            scope_a.clone(),
+            capability_id(),
+        ))
+        .await
+        .expect("append project a");
+    stores
+        .events
+        .append(RuntimeEvent::dispatch_requested(
+            scope_b.clone(),
+            capability_id(),
+        ))
+        .await
+        .expect("append trailing project b");
+
+    let project_a = ReadScope {
+        project_id: scope_a.project_id.clone(),
+        ..ReadScope::default()
+    };
+    let replay = stores
+        .events
+        .read_after_cursor(&stream, &project_a, None, 10)
+        .await
+        .expect("replay project a");
+
+    assert_eq!(replay.entries.len(), 1);
+    assert_eq!(replay.entries[0].cursor, EventCursor::new(1));
+    assert_eq!(
+        replay.next_cursor,
+        EventCursor::new(2),
+        "filtered trailing records must advance Postgres replay cursor"
     );
 }
 


### PR DESCRIPTION
## Summary
- sanitize public Reborn memory backend/provider filesystem errors so raw SQL/provider details do not leak
- keep embedding error category observable without exposing provider reason payloads
- make SQL event-store replay advance `next_cursor` past filtered tail records, matching JSONL semantics

## Tests
- `cargo fmt`
- `cargo test -p ironclaw_memory --features libsql -- --test-threads=1`
- `cargo test -p ironclaw_reborn_event_store --features libsql`
- `cargo check -p ironclaw_memory --features postgres`
- `cargo check -p ironclaw_reborn_event_store --features postgres`

Note: parallel `cargo test -p ironclaw_memory --features libsql` showed existing order-sensitive failures in schema/skip-versioning tests; serial run passed.