### PR TITLE
[Reborn] Require model route snapshot transition ports

### DIFF
--- a/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/turn_scheduler_contract.rs
@@ -30,8 +30,8 @@ use ironclaw_turns::{
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
         ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
-        RecordRecoveryRequiredRequest, RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse,
-        TurnRunTransitionPort,
+        RecordModelRouteSnapshotRequest, RecordRecoveryRequiredRequest,
+        RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse, TurnRunTransitionPort,
     },
 };
 use tokio::{sync::Notify, time::timeout};
@@ -229,6 +229,13 @@ impl TurnRunTransitionPort for FailingClaimTransitions {
         Ok(RecoverExpiredLeasesResponse { recovered: vec![] })
     }
 
+    async fn record_model_route_snapshot(
+        &self,
+        _request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("failing claim transitions should not record model route snapshots")
+    }
+
     async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
         panic!("failing claim transitions should not block runs")
     }
@@ -318,6 +325,13 @@ impl TurnRunTransitionPort for DurableLikeTurnStore {
         self.inner.recover_expired_leases(request).await
     }
 
+    async fn record_model_route_snapshot(
+        &self,
+        request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.inner.record_model_route_snapshot(request).await
+    }
+
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
         self.inner.block_run(request).await
     }
@@ -403,6 +417,13 @@ impl TurnRunTransitionPort for DurableTurnStoreStub {
         _request: RecoverExpiredLeasesRequest,
     ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
         panic!("transition stub should not recover leases")
+    }
+
+    async fn record_model_route_snapshot(
+        &self,
+        _request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("transition stub should not record model route snapshots")
     }
 
     async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
@@ -537,6 +558,13 @@ impl TurnRunTransitionPort for HeartbeatTrackingTransitions {
         self.store.recover_expired_leases(request).await
     }
 
+    async fn record_model_route_snapshot(
+        &self,
+        request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.record_model_route_snapshot(request).await
+    }
+
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
         self.store.block_run(request).await
     }
@@ -596,6 +624,13 @@ impl TurnRunTransitionPort for ClaimRecordingTransitions {
         request: RecoverExpiredLeasesRequest,
     ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
         self.store.recover_expired_leases(request).await
+    }
+
+    async fn record_model_route_snapshot(
+        &self,
+        request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        self.store.record_model_route_snapshot(request).await
     }
 
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -14,8 +14,8 @@ use ironclaw_turns::{
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
         ClaimRunRequest, ClaimedTurnRun, CompleteRunRequest, FailRunRequest, HeartbeatRequest,
-        RecordRecoveryRequiredRequest, RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse,
-        TurnRunTransitionPort,
+        RecordModelRouteSnapshotRequest, RecordRecoveryRequiredRequest,
+        RecoverExpiredLeasesRequest, RecoverExpiredLeasesResponse, TurnRunTransitionPort,
     },
 };
 
@@ -535,6 +535,13 @@ impl TurnRunTransitionPort for RecordingTransitionPort {
         _request: RecoverExpiredLeasesRequest,
     ) -> Result<RecoverExpiredLeasesResponse, TurnError> {
         Ok(RecoverExpiredLeasesResponse { recovered: vec![] })
+    }
+
+    async fn record_model_route_snapshot(
+        &self,
+        _request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("loop-exit applier tests should not record model route snapshots")
     }
 
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError> {

--- a/crates/ironclaw_turns/src/runner.rs
+++ b/crates/ironclaw_turns/src/runner.rs
@@ -127,12 +127,8 @@ pub trait TurnRunTransitionPort: Send + Sync {
 
     async fn record_model_route_snapshot(
         &self,
-        _request: RecordModelRouteSnapshotRequest,
-    ) -> Result<TurnRunState, TurnError> {
-        Err(TurnError::Unavailable {
-            reason: "model route snapshot persistence is unsupported".to_string(),
-        })
-    }
+        request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError>;
 
     async fn block_run(&self, request: BlockRunRequest) -> Result<TurnRunState, TurnError>;
 

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -3866,6 +3866,13 @@ impl TurnRunTransitionPort for AtomicLoopExitPort {
         panic!("cancelled loop-exit application must not recover leases")
     }
 
+    async fn record_model_route_snapshot(
+        &self,
+        _request: RecordModelRouteSnapshotRequest,
+    ) -> Result<TurnRunState, TurnError> {
+        panic!("cancelled loop-exit application must not record model route snapshots")
+    }
+
     async fn block_run(&self, _request: BlockRunRequest) -> Result<TurnRunState, TurnError> {
         panic!("cancelled loop-exit application must not block runs")
     }


### PR DESCRIPTION
## Summary
- make `TurnRunTransitionPort::record_model_route_snapshot` a required method instead of a default `Unavailable` implementation
- update all in-tree test transition-port implementations to either delegate or fail loudly

## Issue #3492 scope
Addresses one item from nearai/ironclaw#3492 comment: #3462 route snapshot persistence must not silently regress when new transition adapters are added.

## Verification
- `cargo test -p ironclaw_turns -p ironclaw_host_runtime -p ironclaw_reborn`
- `cargo test -p ironclaw_architecture`

Does not close #3492.