### PR TITLE
[Reborn] Make runtime blocked reason matching exhaustive

### DIFF
--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -507,7 +507,6 @@ impl RuntimeCapabilityOutcome {
 
 /// Stable reasons for capability suspension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[non_exhaustive]
 pub enum RuntimeBlockedReason {
     ApprovalRequired,
     AuthRequired,

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -897,7 +897,6 @@ fn blocked_summary(reason: RuntimeBlockedReason) -> &'static str {
         RuntimeBlockedReason::AuthRequired => "capability requires authentication",
         RuntimeBlockedReason::ResourceLimit => "capability is blocked by resource limits",
         RuntimeBlockedReason::ResourceUnavailable => "capability resources are unavailable",
-        _ => "capability is blocked",
     }
 }
 


### PR DESCRIPTION
## Summary
- remove `#[non_exhaustive]` from `RuntimeBlockedReason`
- remove wildcard fallback from `blocked_summary` so new blocked reasons require an explicit audit

## Issue #3492 scope
Addresses one item from nearai/ironclaw#3492 comment: #3454 still had wildcard classification over `RuntimeBlockedReason`.

## Verification
- `cargo test -p ironclaw_host_runtime -p ironclaw_reborn`
- `cargo test -p ironclaw_architecture`

Does not close #3492.