### PR TITLE
feat(reborn): add loop production readiness gate

### DIFF
--- a/crates/ironclaw_reborn/src/driver_registry.rs
+++ b/crates/ironclaw_reborn/src/driver_registry.rs
@@ -5,7 +5,7 @@
 //! descriptor metadata at startup, and validates that configured and persisted
 //! run identities can be served before traffic is accepted.
 
-use std::{collections::HashMap, error::Error, fmt, sync::Arc};
+use std::{borrow::Borrow, collections::HashMap, error::Error, fmt, sync::Arc};
 
 use ironclaw_turns::{
     AgentLoopDriver, AgentLoopDriverDescriptor, RunProfileVersion, TurnStatus,
@@ -207,19 +207,41 @@ impl DriverRegistry {
         mode: DriverReadinessMode,
         inputs: DriverReadinessInputs,
     ) -> DriverReadinessReport {
+        self.validate_readiness_from_iter(
+            mode,
+            inputs.host_graph,
+            inputs.configured_profiles,
+            inputs.persisted_runs,
+        )
+    }
+
+    pub fn validate_readiness_from_iter<C, P>(
+        &self,
+        mode: DriverReadinessMode,
+        host_graph: HostGraphReadiness,
+        configured_profiles: C,
+        persisted_runs: P,
+    ) -> DriverReadinessReport
+    where
+        C: IntoIterator,
+        C::Item: Borrow<ConfiguredRunProfile>,
+        P: IntoIterator,
+        P::Item: Borrow<PersistedRunDriverIdentity>,
+    {
         let mut diagnostics = Vec::new();
         let mut has_reference_driver = false;
 
-        for profile in inputs
-            .configured_profiles
-            .iter()
-            .filter(|profile| profile.enabled)
-        {
+        for profile in configured_profiles {
+            let profile = profile.borrow();
+            if !profile.enabled {
+                continue;
+            }
+
             match self.get(&profile.driver_identity) {
                 Some(entry) => {
                     validate_entry_readiness(
                         mode,
-                        &inputs.host_graph,
+                        &host_graph,
                         &profile.name,
                         &profile.driver_identity,
                         entry,
@@ -228,7 +250,7 @@ impl DriverRegistry {
                     );
                 }
                 None => diagnostics.push(DriverReadinessDiagnostic::new(
-                    "missing_configured_driver",
+                    DriverReadinessDiagnosticCode::MissingConfiguredDriver,
                     profile.name.clone(),
                     Some(profile.driver_identity.clone()),
                     "enabled run profile references an unregistered loop driver identity",
@@ -236,16 +258,17 @@ impl DriverRegistry {
             }
         }
 
-        for persisted_run in inputs
-            .persisted_runs
-            .iter()
-            .filter(|run| !run.status.is_terminal())
-        {
+        for persisted_run in persisted_runs {
+            let persisted_run = persisted_run.borrow();
+            if persisted_run.status.is_terminal() {
+                continue;
+            }
+
             match self.get(&persisted_run.driver_identity) {
                 Some(entry) => {
                     validate_entry_readiness(
                         mode,
-                        &inputs.host_graph,
+                        &host_graph,
                         &persisted_run.run_id,
                         &persisted_run.driver_identity,
                         entry,
@@ -254,7 +277,7 @@ impl DriverRegistry {
                     );
                 }
                 None => diagnostics.push(DriverReadinessDiagnostic::new(
-                    "missing_non_terminal_run_driver",
+                    DriverReadinessDiagnosticCode::MissingNonTerminalRunDriver,
                     persisted_run.run_id.clone(),
                     Some(persisted_run.driver_identity.clone()),
                     "non-terminal persisted run requires an unregistered loop driver identity",
@@ -384,9 +407,18 @@ pub struct DriverReadinessReport {
     pub diagnostics: Vec<DriverReadinessDiagnostic>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriverReadinessDiagnosticCode {
+    MissingConfiguredDriver,
+    MissingNonTerminalRunDriver,
+    ReferenceDriverNotProductionReady,
+    ReferenceDriverAllowedForLocalDev,
+    MissingRequiredDriverRequirement,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriverReadinessDiagnostic {
-    pub code: &'static str,
+    pub code: DriverReadinessDiagnosticCode,
     pub subject: String,
     pub driver_identity: Option<LoopDriverRegistryKey>,
     pub message: String,
@@ -395,7 +427,7 @@ pub struct DriverReadinessDiagnostic {
 
 impl DriverReadinessDiagnostic {
     fn new(
-        code: &'static str,
+        code: DriverReadinessDiagnosticCode,
         subject: String,
         driver_identity: Option<LoopDriverRegistryKey>,
         message: &'static str,
@@ -410,7 +442,7 @@ impl DriverReadinessDiagnostic {
     }
 
     fn non_blocking(
-        code: &'static str,
+        code: DriverReadinessDiagnosticCode,
         subject: String,
         driver_identity: Option<LoopDriverRegistryKey>,
         message: &'static str,
@@ -456,7 +488,7 @@ fn validate_entry_readiness(
     match (mode, entry.kind()) {
         (DriverReadinessMode::Production, DriverKind::Reference) => {
             diagnostics.push(DriverReadinessDiagnostic::new(
-                "reference_driver_not_production_ready",
+                DriverReadinessDiagnosticCode::ReferenceDriverNotProductionReady,
                 subject.to_string(),
                 Some(driver_identity.clone()),
                 "fake/reference loop driver cannot satisfy production readiness",
@@ -465,7 +497,7 @@ fn validate_entry_readiness(
         (DriverReadinessMode::LocalDevTest, DriverKind::Reference) => {
             *has_reference_driver = true;
             diagnostics.push(DriverReadinessDiagnostic::non_blocking(
-                "reference_driver_allowed_for_local_dev",
+                DriverReadinessDiagnosticCode::ReferenceDriverAllowedForLocalDev,
                 subject.to_string(),
                 Some(driver_identity.clone()),
                 "fake/reference loop driver allowed only for explicit local-dev/test readiness",
@@ -476,7 +508,7 @@ fn validate_entry_readiness(
 
     for requirement in missing_requirements(entry.requirements(), host_graph) {
         diagnostics.push(DriverReadinessDiagnostic::new(
-            "missing_required_driver_requirement",
+            DriverReadinessDiagnosticCode::MissingRequiredDriverRequirement,
             subject.to_string(),
             Some(driver_identity.clone()),
             requirement.message,

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -9,6 +9,7 @@ pub mod loop_driver_host;
 pub mod loop_exit_applier;
 pub mod milestone_events;
 pub mod model_routes;
+pub mod production_readiness;
 pub mod text_loop_driver;
 pub mod turn_runner;
 

--- a/crates/ironclaw_reborn/src/production_readiness.rs
+++ b/crates/ironclaw_reborn/src/production_readiness.rs
@@ -5,6 +5,12 @@
 //! upper Reborn loop graph: selected profile identities, registered loop
 //! drivers, host-loop ports, production safety class, and active-run drain
 //! protection.
+//!
+//! Startup composition is expected to construct `RebornLoopProductionInputs`,
+//! call `validate_reborn_loop_production_readiness`, gate production startup on
+//! `report.is_ready()`, and still surface `report.issues` / `has_warnings()` for
+//! operator diagnostics. The runtime gate is tracked separately from this pure
+//! reporting slice so readiness semantics can stabilize before startup wiring.
 
 use ironclaw_turns::{
     RunProfileId, RunProfileVersion, TurnStatus, run_profile::CheckpointSchemaId,
@@ -82,7 +88,7 @@ pub enum RebornComponentRequirement {
     Unsupported,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RebornLoopProductionComponent {
     RunProfile,
     LoopDriver,
@@ -100,7 +106,7 @@ pub enum RebornLoopProductionComponent {
     ProgressEvents,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RebornLoopProductionIssueKind {
     Missing,
     TestOnlyImplementation,
@@ -110,6 +116,7 @@ pub enum RebornLoopProductionIssueKind {
     UnsupportedRequirement,
     VersionMismatch,
     ActiveRunsRequireVersion,
+    ActiveRunDriverUnregistered,
     PolicyDenied,
 }
 
@@ -193,6 +200,10 @@ impl RebornLoopProductionReport {
 
     pub fn blocking_issues(&self) -> impl Iterator<Item = &RebornLoopProductionIssue> {
         self.issues.iter().filter(|issue| issue.blocks_ready)
+    }
+
+    pub fn has_warnings(&self) -> bool {
+        self.issues.iter().any(|issue| !issue.blocks_ready)
     }
 
     pub fn contains(
@@ -586,7 +597,13 @@ fn push_driver_readiness_issues(
         selected_profiles,
         persisted_runs,
     );
-    push_mapped_driver_issues(report, true, issues);
+    push_mapped_driver_issues(
+        report,
+        true,
+        &inputs.configured_profiles,
+        &inputs.active_runs,
+        issues,
+    );
 }
 
 fn push_optional_profile_issues(
@@ -605,12 +622,16 @@ fn push_optional_profile_issues(
         optional_profiles,
         std::iter::empty::<PersistedRunDriverIdentity>(),
     );
-    push_mapped_driver_issues(report, false, issues);
+    // Optional-profile validation never supplies persisted active runs, so
+    // MissingNonTerminalRunDriver is unreachable on this path.
+    push_mapped_driver_issues(report, false, &inputs.configured_profiles, &[], issues);
 }
 
 fn push_mapped_driver_issues(
     report: crate::driver_registry::DriverReadinessReport,
     keep_blocking: bool,
+    configured_profiles: &[RebornConfiguredRunProfile],
+    active_runs: &[RebornActiveRunIdentity],
     issues: &mut Vec<RebornLoopProductionIssue>,
 ) {
     for diagnostic in report.diagnostics {
@@ -621,7 +642,7 @@ fn push_mapped_driver_issues(
             ),
             DriverReadinessDiagnosticCode::MissingNonTerminalRunDriver => (
                 RebornLoopProductionComponent::LoopDriver,
-                RebornLoopProductionIssueKind::ActiveRunsRequireVersion,
+                RebornLoopProductionIssueKind::ActiveRunDriverUnregistered,
             ),
             DriverReadinessDiagnosticCode::ReferenceDriverNotProductionReady
             | DriverReadinessDiagnosticCode::ReferenceDriverAllowedForLocalDev => (
@@ -634,7 +655,7 @@ fn push_mapped_driver_issues(
             ),
         };
         let blocks_ready = keep_blocking && diagnostic.blocks_ready;
-        issues.push(RebornLoopProductionIssue {
+        let mut issue = RebornLoopProductionIssue {
             component,
             kind,
             subject: diagnostic.subject,
@@ -642,8 +663,35 @@ fn push_mapped_driver_issues(
             profile_version: None,
             driver_identity: diagnostic.driver_identity,
             blocks_ready,
-        });
+        };
+        if let Some(profile) = matching_configured_profile(&issue, configured_profiles) {
+            issue = issue.with_profile(profile);
+        } else if let Some(run) = matching_active_run(&issue, active_runs) {
+            issue = issue.with_active_run(run);
+        }
+        issues.push(issue);
     }
+}
+
+fn matching_configured_profile<'a>(
+    issue: &RebornLoopProductionIssue,
+    profiles: &'a [RebornConfiguredRunProfile],
+) -> Option<&'a RebornConfiguredRunProfile> {
+    profiles.iter().find(|profile| {
+        issue.subject == profile.profile_id.as_str()
+            && issue.driver_identity.as_ref() == Some(&profile.driver_identity)
+    })
+}
+
+fn matching_active_run<'a>(
+    issue: &RebornLoopProductionIssue,
+    active_runs: &'a [RebornActiveRunIdentity],
+) -> Option<&'a RebornActiveRunIdentity> {
+    issue.driver_identity.as_ref().and_then(|driver_identity| {
+        active_runs
+            .iter()
+            .find(|run| !run.status.is_terminal() && run.driver_identity == *driver_identity)
+    })
 }
 
 fn configured_driver_profile(profile: &RebornConfiguredRunProfile) -> ConfiguredRunProfile {
@@ -673,9 +721,9 @@ fn component_subject(component: RebornLoopProductionComponent) -> &'static str {
     }
 }
 
-/// Utility for text-only profiles: capability calls are supported by an
-/// explicit production-safe deny capability port, not by omitting the port.
-pub fn text_only_driver_requirements() -> DriverRequirements {
+/// Utility for profiles that need every host surface, including a real
+/// capability port.
+pub fn tool_capable_driver_requirements() -> DriverRequirements {
     DriverRequirements {
         model: RequirementLevel::Required,
         prompt: RequirementLevel::Required,
@@ -685,6 +733,12 @@ pub fn text_only_driver_requirements() -> DriverRequirements {
         capabilities: RequirementLevel::Required,
         progress_events: RequirementLevel::Required,
     }
+}
+
+/// Utility for text-only profiles: capability calls are supported by an
+/// explicit production-safe deny capability port, not by omitting the port.
+pub fn text_only_driver_requirements() -> DriverRequirements {
+    tool_capable_driver_requirements()
 }
 
 #[cfg(test)]
@@ -710,6 +764,8 @@ mod tests {
                 diagnostics: Vec::new(),
             },
             false,
+            &[],
+            &[],
             &mut issues,
         );
 

--- a/crates/ironclaw_reborn/src/production_readiness.rs
+++ b/crates/ironclaw_reborn/src/production_readiness.rs
@@ -11,9 +11,9 @@ use ironclaw_turns::{
 };
 
 use crate::driver_registry::{
-    ConfiguredRunProfile, DriverReadinessInputs, DriverReadinessMode, DriverReadinessStatus,
-    DriverRegistry, DriverRequirements, HostGraphReadiness, LoopDriverRegistryKey,
-    PersistedRunDriverIdentity, RequirementLevel,
+    ConfiguredRunProfile, DriverReadinessInputs, DriverReadinessMode, DriverRegistry,
+    DriverRequirements, HostGraphReadiness, LoopDriverRegistryKey, PersistedRunDriverIdentity,
+    RequirementLevel,
 };
 
 /// Readiness mode for the Reborn loop graph.
@@ -62,16 +62,14 @@ impl RebornComponentSafetyClass {
         self != Self::ProductionVerified
     }
 
-    fn issue_kind(self) -> RebornLoopProductionIssueKind {
+    fn issue_kind(self) -> Option<RebornLoopProductionIssueKind> {
         match self {
-            Self::ProductionVerified => {
-                RebornLoopProductionIssueKind::UnverifiedProductionImplementation
-            }
-            Self::TestOnly => RebornLoopProductionIssueKind::TestOnlyImplementation,
-            Self::NonDurable => RebornLoopProductionIssueKind::NonDurableImplementation,
-            Self::Noop => RebornLoopProductionIssueKind::NoopImplementation,
+            Self::ProductionVerified => None,
+            Self::TestOnly => Some(RebornLoopProductionIssueKind::TestOnlyImplementation),
+            Self::NonDurable => Some(RebornLoopProductionIssueKind::NonDurableImplementation),
+            Self::Noop => Some(RebornLoopProductionIssueKind::NoopImplementation),
             Self::UnverifiedProductionImplementation => {
-                RebornLoopProductionIssueKind::UnverifiedProductionImplementation
+                Some(RebornLoopProductionIssueKind::UnverifiedProductionImplementation)
             }
         }
     }
@@ -111,7 +109,6 @@ pub enum RebornLoopProductionIssueKind {
     UnverifiedProductionImplementation,
     UnsupportedRequirement,
     VersionMismatch,
-    ProfileUnavailable,
     ActiveRunsRequireVersion,
     PolicyDenied,
 }
@@ -486,18 +483,24 @@ fn push_component_issues(
                 RebornComponentRequirement::Required,
                 Some(safety),
             ) if safety.blocks_production() => {
+                let Some(issue_kind) = safety.issue_kind() else {
+                    continue;
+                };
                 issues.push(RebornLoopProductionIssue::blocking(
                     component,
-                    safety.issue_kind(),
+                    issue_kind,
                     component_subject(component),
                 ));
             }
             (RebornLoopReadinessMode::LocalDevTest, _, Some(safety))
                 if safety.degraded_in_local_dev() =>
             {
+                let Some(issue_kind) = safety.issue_kind() else {
+                    continue;
+                };
                 issues.push(RebornLoopProductionIssue::warning(
                     component,
-                    safety.issue_kind(),
+                    issue_kind,
                     component_subject(component),
                 ));
             }
@@ -610,8 +613,6 @@ fn push_mapped_driver_issues(
     keep_blocking: bool,
     issues: &mut Vec<RebornLoopProductionIssue>,
 ) {
-    let status = report.status;
-    let had_diagnostics = !report.diagnostics.is_empty();
     for diagnostic in report.diagnostics {
         let (component, kind) = match diagnostic.code {
             "missing_configured_driver" => (
@@ -650,14 +651,6 @@ fn push_mapped_driver_issues(
             blocks_ready,
         });
     }
-
-    if !keep_blocking && status == DriverReadinessStatus::NotReady && !had_diagnostics {
-        issues.push(RebornLoopProductionIssue::warning(
-            RebornLoopProductionComponent::RunProfile,
-            RebornLoopProductionIssueKind::ProfileUnavailable,
-            "optional_profile",
-        ));
-    }
 }
 
 fn configured_driver_profile(profile: &RebornConfiguredRunProfile) -> ConfiguredRunProfile {
@@ -694,5 +687,35 @@ pub fn text_only_driver_requirements() -> DriverRequirements {
         input_polling: RequirementLevel::Required,
         capabilities: RequirementLevel::Required,
         progress_events: RequirementLevel::Required,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver_registry::{DriverReadinessReport, DriverReadinessStatus};
+
+    #[test]
+    fn production_verified_safety_has_no_issue_kind() {
+        assert_eq!(
+            RebornComponentSafetyClass::ProductionVerified.issue_kind(),
+            None
+        );
+    }
+
+    #[test]
+    fn mapped_driver_issues_do_not_invent_unavailable_profiles_without_diagnostics() {
+        let mut issues = Vec::new();
+
+        push_mapped_driver_issues(
+            DriverReadinessReport {
+                status: DriverReadinessStatus::NotReady,
+                diagnostics: Vec::new(),
+            },
+            false,
+            &mut issues,
+        );
+
+        assert!(issues.is_empty());
     }
 }

--- a/crates/ironclaw_reborn/src/production_readiness.rs
+++ b/crates/ironclaw_reborn/src/production_readiness.rs
@@ -551,7 +551,7 @@ fn push_active_run_profile_issues(
                 RebornLoopProductionIssue::blocking(
                     RebornLoopProductionComponent::RunProfile,
                     RebornLoopProductionIssueKind::ActiveRunsRequireVersion,
-                    run.run_ref.clone(),
+                    active_run_subject(),
                 )
                 .with_active_run(run),
             );
@@ -574,7 +574,7 @@ fn push_driver_readiness_issues(
         .filter(|run| !run.status.is_terminal())
         .map(|run| {
             PersistedRunDriverIdentity::new(
-                run.run_ref.clone(),
+                active_run_subject(),
                 run.status,
                 run.driver_identity.clone(),
             )
@@ -648,6 +648,10 @@ fn push_mapped_driver_issues(
 
 fn configured_driver_profile(profile: &RebornConfiguredRunProfile) -> ConfiguredRunProfile {
     ConfiguredRunProfile::enabled(profile.profile_id.as_str(), profile.driver_identity.clone())
+}
+
+fn active_run_subject() -> &'static str {
+    "active_run"
 }
 
 fn component_subject(component: RebornLoopProductionComponent) -> &'static str {

--- a/crates/ironclaw_reborn/src/production_readiness.rs
+++ b/crates/ironclaw_reborn/src/production_readiness.rs
@@ -1,0 +1,698 @@
+//! Reborn loop production readiness validation.
+//!
+//! Host-runtime readiness stays substrate-scoped in
+//! `ironclaw_host_runtime::ProductionWiringReport`. This module validates the
+//! upper Reborn loop graph: selected profile identities, registered loop
+//! drivers, host-loop ports, production safety class, and active-run drain
+//! protection.
+
+use ironclaw_turns::{
+    RunProfileId, RunProfileVersion, TurnStatus, run_profile::CheckpointSchemaId,
+};
+
+use crate::driver_registry::{
+    ConfiguredRunProfile, DriverReadinessInputs, DriverReadinessMode, DriverReadinessStatus,
+    DriverRegistry, DriverRequirements, HostGraphReadiness, LoopDriverRegistryKey,
+    PersistedRunDriverIdentity, RequirementLevel,
+};
+
+/// Readiness mode for the Reborn loop graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebornLoopReadinessMode {
+    /// Explicit local/developer/test mode. Fake, non-durable, and no-op
+    /// implementations are allowed but reported as degraded warnings.
+    LocalDevTest,
+    /// Production mode. Components must be production-verified; local durable
+    /// implementations are valid, but fake/non-durable/no-op/unverified seams
+    /// fail closed.
+    Production,
+}
+
+impl From<RebornLoopReadinessMode> for DriverReadinessMode {
+    fn from(mode: RebornLoopReadinessMode) -> Self {
+        match mode {
+            RebornLoopReadinessMode::LocalDevTest => Self::LocalDevTest,
+            RebornLoopReadinessMode::Production => Self::Production,
+        }
+    }
+}
+
+/// Production safety class for a concrete component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebornComponentSafetyClass {
+    /// Verified for production invariants. The implementation may be local
+    /// durable (for standalone-local production) or remote/cloud-backed.
+    ProductionVerified,
+    /// Test/fake/reference implementation.
+    TestOnly,
+    /// State is not durable enough for production restart/recovery semantics.
+    NonDurable,
+    /// Explicit no-op/null implementation.
+    Noop,
+    /// Not proven safe for production traffic yet.
+    UnverifiedProductionImplementation,
+}
+
+impl RebornComponentSafetyClass {
+    fn blocks_production(self) -> bool {
+        self != Self::ProductionVerified
+    }
+
+    fn degraded_in_local_dev(self) -> bool {
+        self != Self::ProductionVerified
+    }
+
+    fn issue_kind(self) -> RebornLoopProductionIssueKind {
+        match self {
+            Self::ProductionVerified => {
+                RebornLoopProductionIssueKind::UnverifiedProductionImplementation
+            }
+            Self::TestOnly => RebornLoopProductionIssueKind::TestOnlyImplementation,
+            Self::NonDurable => RebornLoopProductionIssueKind::NonDurableImplementation,
+            Self::Noop => RebornLoopProductionIssueKind::NoopImplementation,
+            Self::UnverifiedProductionImplementation => {
+                RebornLoopProductionIssueKind::UnverifiedProductionImplementation
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebornComponentRequirement {
+    Required,
+    Optional,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebornLoopProductionComponent {
+    RunProfile,
+    LoopDriver,
+    CheckpointSchema,
+    HostFactory,
+    PromptPort,
+    ModelGateway,
+    TranscriptStore,
+    CapabilityPort,
+    CheckpointStateStore,
+    InputControl,
+    LoopExitApplier,
+    TurnStateStore,
+    WakeNotifier,
+    ProgressEvents,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebornLoopProductionIssueKind {
+    Missing,
+    TestOnlyImplementation,
+    NonDurableImplementation,
+    NoopImplementation,
+    UnverifiedProductionImplementation,
+    UnsupportedRequirement,
+    VersionMismatch,
+    ProfileUnavailable,
+    ActiveRunsRequireVersion,
+    PolicyDenied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebornLoopProductionIssue {
+    pub component: RebornLoopProductionComponent,
+    pub kind: RebornLoopProductionIssueKind,
+    pub subject: String,
+    pub profile_id: Option<RunProfileId>,
+    pub profile_version: Option<RunProfileVersion>,
+    pub driver_identity: Option<LoopDriverRegistryKey>,
+    pub blocks_ready: bool,
+}
+
+impl RebornLoopProductionIssue {
+    fn blocking(
+        component: RebornLoopProductionComponent,
+        kind: RebornLoopProductionIssueKind,
+        subject: impl Into<String>,
+    ) -> Self {
+        Self::new(component, kind, subject, true)
+    }
+
+    fn warning(
+        component: RebornLoopProductionComponent,
+        kind: RebornLoopProductionIssueKind,
+        subject: impl Into<String>,
+    ) -> Self {
+        Self::new(component, kind, subject, false)
+    }
+
+    fn new(
+        component: RebornLoopProductionComponent,
+        kind: RebornLoopProductionIssueKind,
+        subject: impl Into<String>,
+        blocks_ready: bool,
+    ) -> Self {
+        Self {
+            component,
+            kind,
+            subject: subject.into(),
+            profile_id: None,
+            profile_version: None,
+            driver_identity: None,
+            blocks_ready,
+        }
+    }
+
+    fn with_profile(mut self, profile: &RebornConfiguredRunProfile) -> Self {
+        self.profile_id = Some(profile.profile_id.clone());
+        self.profile_version = Some(profile.profile_version);
+        self.driver_identity = Some(profile.driver_identity.clone());
+        self
+    }
+
+    fn with_active_run(mut self, run: &RebornActiveRunIdentity) -> Self {
+        self.profile_id = Some(run.profile_id.clone());
+        self.profile_version = Some(run.profile_version);
+        self.driver_identity = Some(run.driver_identity.clone());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RebornLoopProductionStatus {
+    ProductionReady,
+    LocalDevDegraded,
+    NotReady,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebornLoopProductionReport {
+    pub status: RebornLoopProductionStatus,
+    pub issues: Vec<RebornLoopProductionIssue>,
+}
+
+impl RebornLoopProductionReport {
+    pub fn is_ready(&self) -> bool {
+        matches!(self.status, RebornLoopProductionStatus::ProductionReady)
+    }
+
+    pub fn blocking_issues(&self) -> impl Iterator<Item = &RebornLoopProductionIssue> {
+        self.issues.iter().filter(|issue| issue.blocks_ready)
+    }
+
+    pub fn contains(
+        &self,
+        component: RebornLoopProductionComponent,
+        kind: RebornLoopProductionIssueKind,
+    ) -> bool {
+        self.issues
+            .iter()
+            .any(|issue| issue.component == component && issue.kind == kind)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebornConfiguredRunProfile {
+    pub profile_id: RunProfileId,
+    pub profile_version: RunProfileVersion,
+    pub selected: bool,
+    pub driver_identity: LoopDriverRegistryKey,
+    pub checkpoint_schema_id: CheckpointSchemaId,
+    pub checkpoint_schema_version: RunProfileVersion,
+}
+
+impl RebornConfiguredRunProfile {
+    pub fn selected(
+        profile_id: RunProfileId,
+        profile_version: RunProfileVersion,
+        driver_identity: LoopDriverRegistryKey,
+        checkpoint_schema_id: CheckpointSchemaId,
+        checkpoint_schema_version: RunProfileVersion,
+    ) -> Self {
+        Self {
+            profile_id,
+            profile_version,
+            selected: true,
+            driver_identity,
+            checkpoint_schema_id,
+            checkpoint_schema_version,
+        }
+    }
+
+    pub fn optional(mut self) -> Self {
+        self.selected = false;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebornActiveRunIdentity {
+    pub run_ref: String,
+    pub status: TurnStatus,
+    pub profile_id: RunProfileId,
+    pub profile_version: RunProfileVersion,
+    pub driver_identity: LoopDriverRegistryKey,
+}
+
+impl RebornActiveRunIdentity {
+    pub fn new(
+        run_ref: impl Into<String>,
+        status: TurnStatus,
+        profile_id: RunProfileId,
+        profile_version: RunProfileVersion,
+        driver_identity: LoopDriverRegistryKey,
+    ) -> Self {
+        Self {
+            run_ref: run_ref.into(),
+            status,
+            profile_id,
+            profile_version,
+            driver_identity,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RebornComponentReadiness {
+    pub requirement: RebornComponentRequirement,
+    pub safety: Option<RebornComponentSafetyClass>,
+}
+
+impl RebornComponentReadiness {
+    pub fn production_verified(requirement: RebornComponentRequirement) -> Self {
+        Self {
+            requirement,
+            safety: Some(RebornComponentSafetyClass::ProductionVerified),
+        }
+    }
+
+    pub fn test_only(requirement: RebornComponentRequirement) -> Self {
+        Self {
+            requirement,
+            safety: Some(RebornComponentSafetyClass::TestOnly),
+        }
+    }
+
+    pub fn non_durable(requirement: RebornComponentRequirement) -> Self {
+        Self {
+            requirement,
+            safety: Some(RebornComponentSafetyClass::NonDurable),
+        }
+    }
+
+    pub fn noop(requirement: RebornComponentRequirement) -> Self {
+        Self {
+            requirement,
+            safety: Some(RebornComponentSafetyClass::Noop),
+        }
+    }
+
+    pub fn unverified(requirement: RebornComponentRequirement) -> Self {
+        Self {
+            requirement,
+            safety: Some(RebornComponentSafetyClass::UnverifiedProductionImplementation),
+        }
+    }
+
+    pub fn missing(requirement: RebornComponentRequirement) -> Self {
+        Self {
+            requirement,
+            safety: None,
+        }
+    }
+
+    fn present(self) -> bool {
+        self.safety.is_some()
+    }
+
+    fn available_for(self, mode: RebornLoopReadinessMode) -> bool {
+        match mode {
+            RebornLoopReadinessMode::LocalDevTest => self.present(),
+            RebornLoopReadinessMode::Production => {
+                self.safety == Some(RebornComponentSafetyClass::ProductionVerified)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebornLoopComponentGraphReadiness {
+    pub host_factory: RebornComponentReadiness,
+    pub prompt_port: RebornComponentReadiness,
+    pub model_gateway: RebornComponentReadiness,
+    pub transcript_store: RebornComponentReadiness,
+    pub capability_port: RebornComponentReadiness,
+    pub checkpoint_state_store: RebornComponentReadiness,
+    pub input_control: RebornComponentReadiness,
+    pub loop_exit_applier: RebornComponentReadiness,
+    pub turn_state_store: RebornComponentReadiness,
+    pub wake_notifier: RebornComponentReadiness,
+    pub progress_events: RebornComponentReadiness,
+}
+
+impl RebornLoopComponentGraphReadiness {
+    pub fn production_verified() -> Self {
+        let required = RebornComponentRequirement::Required;
+        Self {
+            host_factory: RebornComponentReadiness::production_verified(required),
+            prompt_port: RebornComponentReadiness::production_verified(required),
+            model_gateway: RebornComponentReadiness::production_verified(required),
+            transcript_store: RebornComponentReadiness::production_verified(required),
+            capability_port: RebornComponentReadiness::production_verified(required),
+            checkpoint_state_store: RebornComponentReadiness::production_verified(required),
+            input_control: RebornComponentReadiness::production_verified(required),
+            loop_exit_applier: RebornComponentReadiness::production_verified(required),
+            turn_state_store: RebornComponentReadiness::production_verified(required),
+            wake_notifier: RebornComponentReadiness::production_verified(required),
+            progress_events: RebornComponentReadiness::production_verified(required),
+        }
+    }
+
+    fn host_graph_for(&self, mode: RebornLoopReadinessMode) -> HostGraphReadiness {
+        HostGraphReadiness {
+            model: self.model_gateway.available_for(mode),
+            prompt: self.prompt_port.available_for(mode),
+            transcript: self.transcript_store.available_for(mode),
+            checkpoint: self.checkpoint_state_store.available_for(mode),
+            input_polling: self.input_control.available_for(mode),
+            capabilities: self.capability_port.available_for(mode),
+            progress_events: self.progress_events.available_for(mode),
+        }
+    }
+
+    fn components(&self) -> [(RebornLoopProductionComponent, RebornComponentReadiness); 11] {
+        [
+            (
+                RebornLoopProductionComponent::HostFactory,
+                self.host_factory,
+            ),
+            (RebornLoopProductionComponent::PromptPort, self.prompt_port),
+            (
+                RebornLoopProductionComponent::ModelGateway,
+                self.model_gateway,
+            ),
+            (
+                RebornLoopProductionComponent::TranscriptStore,
+                self.transcript_store,
+            ),
+            (
+                RebornLoopProductionComponent::CapabilityPort,
+                self.capability_port,
+            ),
+            (
+                RebornLoopProductionComponent::CheckpointStateStore,
+                self.checkpoint_state_store,
+            ),
+            (
+                RebornLoopProductionComponent::InputControl,
+                self.input_control,
+            ),
+            (
+                RebornLoopProductionComponent::LoopExitApplier,
+                self.loop_exit_applier,
+            ),
+            (
+                RebornLoopProductionComponent::TurnStateStore,
+                self.turn_state_store,
+            ),
+            (
+                RebornLoopProductionComponent::WakeNotifier,
+                self.wake_notifier,
+            ),
+            (
+                RebornLoopProductionComponent::ProgressEvents,
+                self.progress_events,
+            ),
+        ]
+    }
+}
+
+pub struct RebornLoopProductionInputs<'a> {
+    pub mode: RebornLoopReadinessMode,
+    pub driver_registry: &'a DriverRegistry,
+    pub component_graph: RebornLoopComponentGraphReadiness,
+    pub configured_profiles: Vec<RebornConfiguredRunProfile>,
+    pub active_runs: Vec<RebornActiveRunIdentity>,
+}
+
+pub fn validate_reborn_loop_production_readiness(
+    inputs: RebornLoopProductionInputs<'_>,
+) -> RebornLoopProductionReport {
+    let mut issues = Vec::new();
+    push_component_issues(inputs.mode, &inputs.component_graph, &mut issues);
+    push_profile_identity_issues(&inputs.configured_profiles, &mut issues);
+    push_active_run_profile_issues(
+        &inputs.configured_profiles,
+        &inputs.active_runs,
+        &mut issues,
+    );
+    push_driver_readiness_issues(&inputs, &mut issues);
+    push_optional_profile_issues(&inputs, &mut issues);
+
+    let status = if issues.iter().any(|issue| issue.blocks_ready) {
+        RebornLoopProductionStatus::NotReady
+    } else if inputs.mode == RebornLoopReadinessMode::LocalDevTest
+        && issues.iter().any(|issue| !issue.blocks_ready)
+    {
+        RebornLoopProductionStatus::LocalDevDegraded
+    } else {
+        RebornLoopProductionStatus::ProductionReady
+    };
+
+    RebornLoopProductionReport { status, issues }
+}
+
+fn push_component_issues(
+    mode: RebornLoopReadinessMode,
+    graph: &RebornLoopComponentGraphReadiness,
+    issues: &mut Vec<RebornLoopProductionIssue>,
+) {
+    for (component, readiness) in graph.components() {
+        match (mode, readiness.requirement, readiness.safety) {
+            (_, RebornComponentRequirement::Unsupported, Some(_)) => {
+                issues.push(RebornLoopProductionIssue::blocking(
+                    component,
+                    RebornLoopProductionIssueKind::UnsupportedRequirement,
+                    component_subject(component),
+                ))
+            }
+            (_, RebornComponentRequirement::Required, None) => {
+                issues.push(RebornLoopProductionIssue::blocking(
+                    component,
+                    RebornLoopProductionIssueKind::Missing,
+                    component_subject(component),
+                ))
+            }
+            (
+                RebornLoopReadinessMode::Production,
+                RebornComponentRequirement::Required,
+                Some(safety),
+            ) if safety.blocks_production() => {
+                issues.push(RebornLoopProductionIssue::blocking(
+                    component,
+                    safety.issue_kind(),
+                    component_subject(component),
+                ));
+            }
+            (RebornLoopReadinessMode::LocalDevTest, _, Some(safety))
+                if safety.degraded_in_local_dev() =>
+            {
+                issues.push(RebornLoopProductionIssue::warning(
+                    component,
+                    safety.issue_kind(),
+                    component_subject(component),
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn push_profile_identity_issues(
+    profiles: &[RebornConfiguredRunProfile],
+    issues: &mut Vec<RebornLoopProductionIssue>,
+) {
+    for profile in profiles.iter().filter(|profile| profile.selected) {
+        if profile.driver_identity.checkpoint_schema_id.as_ref()
+            != Some(&profile.checkpoint_schema_id)
+            || profile.driver_identity.checkpoint_schema_version
+                != Some(profile.checkpoint_schema_version)
+        {
+            issues.push(
+                RebornLoopProductionIssue::blocking(
+                    RebornLoopProductionComponent::CheckpointSchema,
+                    RebornLoopProductionIssueKind::VersionMismatch,
+                    profile.profile_id.as_str(),
+                )
+                .with_profile(profile),
+            );
+        }
+    }
+}
+
+fn push_active_run_profile_issues(
+    profiles: &[RebornConfiguredRunProfile],
+    active_runs: &[RebornActiveRunIdentity],
+    issues: &mut Vec<RebornLoopProductionIssue>,
+) {
+    for run in active_runs.iter().filter(|run| !run.status.is_terminal()) {
+        let keeps_profile_version = profiles.iter().any(|profile| {
+            profile.profile_id == run.profile_id && profile.profile_version == run.profile_version
+        });
+        if !keeps_profile_version {
+            issues.push(
+                RebornLoopProductionIssue::blocking(
+                    RebornLoopProductionComponent::RunProfile,
+                    RebornLoopProductionIssueKind::ActiveRunsRequireVersion,
+                    run.run_ref.clone(),
+                )
+                .with_active_run(run),
+            );
+        }
+    }
+}
+
+fn push_driver_readiness_issues(
+    inputs: &RebornLoopProductionInputs<'_>,
+    issues: &mut Vec<RebornLoopProductionIssue>,
+) {
+    let selected_profiles = inputs
+        .configured_profiles
+        .iter()
+        .filter(|profile| profile.selected)
+        .map(configured_driver_profile)
+        .collect();
+    let persisted_runs = inputs
+        .active_runs
+        .iter()
+        .filter(|run| !run.status.is_terminal())
+        .map(|run| {
+            PersistedRunDriverIdentity::new(
+                run.run_ref.clone(),
+                run.status,
+                run.driver_identity.clone(),
+            )
+        })
+        .collect();
+
+    let report = inputs.driver_registry.validate_readiness(
+        inputs.mode.into(),
+        DriverReadinessInputs {
+            host_graph: inputs.component_graph.host_graph_for(inputs.mode),
+            configured_profiles: selected_profiles,
+            persisted_runs,
+        },
+    );
+    push_mapped_driver_issues(report, true, issues);
+}
+
+fn push_optional_profile_issues(
+    inputs: &RebornLoopProductionInputs<'_>,
+    issues: &mut Vec<RebornLoopProductionIssue>,
+) {
+    for profile in inputs
+        .configured_profiles
+        .iter()
+        .filter(|profile| !profile.selected)
+    {
+        let report = inputs.driver_registry.validate_readiness(
+            inputs.mode.into(),
+            DriverReadinessInputs {
+                host_graph: inputs.component_graph.host_graph_for(inputs.mode),
+                configured_profiles: vec![configured_driver_profile(profile)],
+                persisted_runs: Vec::new(),
+            },
+        );
+        push_mapped_driver_issues(report, false, issues);
+    }
+}
+
+fn push_mapped_driver_issues(
+    report: crate::driver_registry::DriverReadinessReport,
+    keep_blocking: bool,
+    issues: &mut Vec<RebornLoopProductionIssue>,
+) {
+    let status = report.status;
+    let had_diagnostics = !report.diagnostics.is_empty();
+    for diagnostic in report.diagnostics {
+        let (component, kind) = match diagnostic.code {
+            "missing_configured_driver" => (
+                RebornLoopProductionComponent::LoopDriver,
+                RebornLoopProductionIssueKind::Missing,
+            ),
+            "missing_non_terminal_run_driver" => (
+                RebornLoopProductionComponent::LoopDriver,
+                RebornLoopProductionIssueKind::ActiveRunsRequireVersion,
+            ),
+            "reference_driver_not_production_ready" => (
+                RebornLoopProductionComponent::LoopDriver,
+                RebornLoopProductionIssueKind::TestOnlyImplementation,
+            ),
+            "reference_driver_allowed_for_local_dev" => (
+                RebornLoopProductionComponent::LoopDriver,
+                RebornLoopProductionIssueKind::TestOnlyImplementation,
+            ),
+            "missing_required_driver_requirement" => (
+                RebornLoopProductionComponent::RunProfile,
+                RebornLoopProductionIssueKind::Missing,
+            ),
+            _ => (
+                RebornLoopProductionComponent::RunProfile,
+                RebornLoopProductionIssueKind::PolicyDenied,
+            ),
+        };
+        let blocks_ready = keep_blocking && diagnostic.blocks_ready;
+        issues.push(RebornLoopProductionIssue {
+            component,
+            kind,
+            subject: diagnostic.subject,
+            profile_id: None,
+            profile_version: None,
+            driver_identity: diagnostic.driver_identity,
+            blocks_ready,
+        });
+    }
+
+    if !keep_blocking && status == DriverReadinessStatus::NotReady && !had_diagnostics {
+        issues.push(RebornLoopProductionIssue::warning(
+            RebornLoopProductionComponent::RunProfile,
+            RebornLoopProductionIssueKind::ProfileUnavailable,
+            "optional_profile",
+        ));
+    }
+}
+
+fn configured_driver_profile(profile: &RebornConfiguredRunProfile) -> ConfiguredRunProfile {
+    ConfiguredRunProfile::enabled(profile.profile_id.as_str(), profile.driver_identity.clone())
+}
+
+fn component_subject(component: RebornLoopProductionComponent) -> &'static str {
+    match component {
+        RebornLoopProductionComponent::RunProfile => "run_profile",
+        RebornLoopProductionComponent::LoopDriver => "loop_driver",
+        RebornLoopProductionComponent::CheckpointSchema => "checkpoint_schema",
+        RebornLoopProductionComponent::HostFactory => "host_factory",
+        RebornLoopProductionComponent::PromptPort => "prompt_port",
+        RebornLoopProductionComponent::ModelGateway => "model_gateway",
+        RebornLoopProductionComponent::TranscriptStore => "transcript_store",
+        RebornLoopProductionComponent::CapabilityPort => "capability_port",
+        RebornLoopProductionComponent::CheckpointStateStore => "checkpoint_state_store",
+        RebornLoopProductionComponent::InputControl => "input_control",
+        RebornLoopProductionComponent::LoopExitApplier => "loop_exit_applier",
+        RebornLoopProductionComponent::TurnStateStore => "turn_state_store",
+        RebornLoopProductionComponent::WakeNotifier => "wake_notifier",
+        RebornLoopProductionComponent::ProgressEvents => "progress_events",
+    }
+}
+
+/// Utility for text-only profiles: capability calls are supported by an
+/// explicit production-safe deny capability port, not by omitting the port.
+pub fn text_only_driver_requirements() -> DriverRequirements {
+    DriverRequirements {
+        model: RequirementLevel::Required,
+        prompt: RequirementLevel::Required,
+        transcript: RequirementLevel::Required,
+        checkpoint: RequirementLevel::Required,
+        input_polling: RequirementLevel::Required,
+        capabilities: RequirementLevel::Required,
+        progress_events: RequirementLevel::Required,
+    }
+}

--- a/crates/ironclaw_reborn/src/production_readiness.rs
+++ b/crates/ironclaw_reborn/src/production_readiness.rs
@@ -11,7 +11,7 @@ use ironclaw_turns::{
 };
 
 use crate::driver_registry::{
-    ConfiguredRunProfile, DriverReadinessInputs, DriverReadinessMode, DriverRegistry,
+    ConfiguredRunProfile, DriverReadinessDiagnosticCode, DriverReadinessMode, DriverRegistry,
     DriverRequirements, HostGraphReadiness, LoopDriverRegistryKey, PersistedRunDriverIdentity,
     RequirementLevel,
 };
@@ -375,7 +375,9 @@ impl RebornLoopComponentGraphReadiness {
         }
     }
 
-    fn components(&self) -> [(RebornLoopProductionComponent, RebornComponentReadiness); 11] {
+    fn components(
+        &self,
+    ) -> impl Iterator<Item = (RebornLoopProductionComponent, RebornComponentReadiness)> {
         [
             (
                 RebornLoopProductionComponent::HostFactory,
@@ -419,6 +421,7 @@ impl RebornLoopComponentGraphReadiness {
                 self.progress_events,
             ),
         ]
+        .into_iter()
     }
 }
 
@@ -538,7 +541,10 @@ fn push_active_run_profile_issues(
 ) {
     for run in active_runs.iter().filter(|run| !run.status.is_terminal()) {
         let keeps_profile_version = profiles.iter().any(|profile| {
-            profile.profile_id == run.profile_id && profile.profile_version == run.profile_version
+            profile.selected
+                && profile.profile_id == run.profile_id
+                && profile.profile_version == run.profile_version
+                && profile.driver_identity == run.driver_identity
         });
         if !keeps_profile_version {
             issues.push(
@@ -561,8 +567,7 @@ fn push_driver_readiness_issues(
         .configured_profiles
         .iter()
         .filter(|profile| profile.selected)
-        .map(configured_driver_profile)
-        .collect();
+        .map(configured_driver_profile);
     let persisted_runs = inputs
         .active_runs
         .iter()
@@ -573,16 +578,13 @@ fn push_driver_readiness_issues(
                 run.status,
                 run.driver_identity.clone(),
             )
-        })
-        .collect();
+        });
 
-    let report = inputs.driver_registry.validate_readiness(
+    let report = inputs.driver_registry.validate_readiness_from_iter(
         inputs.mode.into(),
-        DriverReadinessInputs {
-            host_graph: inputs.component_graph.host_graph_for(inputs.mode),
-            configured_profiles: selected_profiles,
-            persisted_runs,
-        },
+        inputs.component_graph.host_graph_for(inputs.mode),
+        selected_profiles,
+        persisted_runs,
     );
     push_mapped_driver_issues(report, true, issues);
 }
@@ -591,21 +593,19 @@ fn push_optional_profile_issues(
     inputs: &RebornLoopProductionInputs<'_>,
     issues: &mut Vec<RebornLoopProductionIssue>,
 ) {
-    for profile in inputs
+    let optional_profiles = inputs
         .configured_profiles
         .iter()
         .filter(|profile| !profile.selected)
-    {
-        let report = inputs.driver_registry.validate_readiness(
-            inputs.mode.into(),
-            DriverReadinessInputs {
-                host_graph: inputs.component_graph.host_graph_for(inputs.mode),
-                configured_profiles: vec![configured_driver_profile(profile)],
-                persisted_runs: Vec::new(),
-            },
-        );
-        push_mapped_driver_issues(report, false, issues);
-    }
+        .map(configured_driver_profile);
+
+    let report = inputs.driver_registry.validate_readiness_from_iter(
+        inputs.mode.into(),
+        inputs.component_graph.host_graph_for(inputs.mode),
+        optional_profiles,
+        std::iter::empty::<PersistedRunDriverIdentity>(),
+    );
+    push_mapped_driver_issues(report, false, issues);
 }
 
 fn push_mapped_driver_issues(
@@ -615,29 +615,22 @@ fn push_mapped_driver_issues(
 ) {
     for diagnostic in report.diagnostics {
         let (component, kind) = match diagnostic.code {
-            "missing_configured_driver" => (
+            DriverReadinessDiagnosticCode::MissingConfiguredDriver => (
                 RebornLoopProductionComponent::LoopDriver,
                 RebornLoopProductionIssueKind::Missing,
             ),
-            "missing_non_terminal_run_driver" => (
+            DriverReadinessDiagnosticCode::MissingNonTerminalRunDriver => (
                 RebornLoopProductionComponent::LoopDriver,
                 RebornLoopProductionIssueKind::ActiveRunsRequireVersion,
             ),
-            "reference_driver_not_production_ready" => (
+            DriverReadinessDiagnosticCode::ReferenceDriverNotProductionReady
+            | DriverReadinessDiagnosticCode::ReferenceDriverAllowedForLocalDev => (
                 RebornLoopProductionComponent::LoopDriver,
                 RebornLoopProductionIssueKind::TestOnlyImplementation,
             ),
-            "reference_driver_allowed_for_local_dev" => (
-                RebornLoopProductionComponent::LoopDriver,
-                RebornLoopProductionIssueKind::TestOnlyImplementation,
-            ),
-            "missing_required_driver_requirement" => (
+            DriverReadinessDiagnosticCode::MissingRequiredDriverRequirement => (
                 RebornLoopProductionComponent::RunProfile,
                 RebornLoopProductionIssueKind::Missing,
-            ),
-            _ => (
-                RebornLoopProductionComponent::RunProfile,
-                RebornLoopProductionIssueKind::PolicyDenied,
             ),
         };
         let blocks_ready = keep_blocking && diagnostic.blocks_ready;

--- a/crates/ironclaw_reborn/tests/driver_registry.rs
+++ b/crates/ironclaw_reborn/tests/driver_registry.rs
@@ -2,9 +2,10 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use ironclaw_reborn::driver_registry::{
-    ConfiguredRunProfile, DriverKind, DriverReadinessInputs, DriverReadinessMode,
-    DriverReadinessStatus, DriverRegistry, DriverRegistryError, DriverRequirements,
-    HostGraphReadiness, LoopDriverRegistryKey, PersistedRunDriverIdentity, RequirementLevel,
+    ConfiguredRunProfile, DriverKind, DriverReadinessDiagnosticCode, DriverReadinessInputs,
+    DriverReadinessMode, DriverReadinessStatus, DriverRegistry, DriverRegistryError,
+    DriverRequirements, HostGraphReadiness, LoopDriverRegistryKey, PersistedRunDriverIdentity,
+    RequirementLevel,
 };
 use ironclaw_turns::{
     AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverResumeRequest,
@@ -102,12 +103,9 @@ fn production_readiness_rejects_missing_configured_driver() {
     );
 
     assert_eq!(report.status, DriverReadinessStatus::NotReady);
-    assert!(
-        report
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.code == "missing_configured_driver")
-    );
+    assert!(report.diagnostics.iter().any(
+        |diagnostic| diagnostic.code == DriverReadinessDiagnosticCode::MissingConfiguredDriver
+    ));
 }
 
 #[test]
@@ -136,12 +134,8 @@ fn production_readiness_rejects_fake_driver() {
     );
 
     assert_eq!(report.status, DriverReadinessStatus::NotReady);
-    assert!(
-        report
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.code == "reference_driver_not_production_ready")
-    );
+    assert!(report.diagnostics.iter().any(|diagnostic| diagnostic.code
+        == DriverReadinessDiagnosticCode::ReferenceDriverNotProductionReady));
 }
 
 #[test]
@@ -173,12 +167,8 @@ fn local_dev_readiness_allows_fake_driver_with_degraded_status() {
         report.status,
         DriverReadinessStatus::LocalDevDegradedReference
     );
-    assert!(
-        report
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.code == "reference_driver_allowed_for_local_dev")
-    );
+    assert!(report.diagnostics.iter().any(|diagnostic| diagnostic.code
+        == DriverReadinessDiagnosticCode::ReferenceDriverAllowedForLocalDev));
 }
 
 #[test]
@@ -201,10 +191,8 @@ fn readiness_requires_driver_for_non_terminal_run_identity() {
 
     assert_eq!(report.status, DriverReadinessStatus::NotReady);
     assert!(
-        report
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.code == "missing_non_terminal_run_driver")
+        report.diagnostics.iter().any(|diagnostic| diagnostic.code
+            == DriverReadinessDiagnosticCode::MissingNonTerminalRunDriver)
     );
 }
 
@@ -298,12 +286,8 @@ fn production_readiness_rejects_missing_required_host_component() {
     );
 
     assert_eq!(report.status, DriverReadinessStatus::NotReady);
-    assert!(
-        report
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.code == "missing_required_driver_requirement")
-    );
+    assert!(report.diagnostics.iter().any(|diagnostic| diagnostic.code
+        == DriverReadinessDiagnosticCode::MissingRequiredDriverRequirement));
 }
 
 #[test]
@@ -344,7 +328,7 @@ fn production_readiness_enforces_required_prompt_port_availability() {
 
     assert_eq!(report.status, DriverReadinessStatus::NotReady);
     assert!(report.diagnostics.iter().any(|diagnostic| {
-        diagnostic.code == "missing_required_driver_requirement"
+        diagnostic.code == DriverReadinessDiagnosticCode::MissingRequiredDriverRequirement
             && diagnostic.message.contains("prompt bundle")
     }));
 

--- a/crates/ironclaw_reborn/tests/production_readiness.rs
+++ b/crates/ironclaw_reborn/tests/production_readiness.rs
@@ -8,7 +8,7 @@ use ironclaw_reborn::{
         RebornConfiguredRunProfile, RebornLoopComponentGraphReadiness,
         RebornLoopProductionComponent, RebornLoopProductionInputs, RebornLoopProductionIssueKind,
         RebornLoopProductionStatus, RebornLoopReadinessMode, text_only_driver_requirements,
-        validate_reborn_loop_production_readiness,
+        tool_capable_driver_requirements, validate_reborn_loop_production_readiness,
     },
 };
 use ironclaw_turns::{
@@ -165,7 +165,7 @@ fn production_readiness_rejects_tool_profile_without_surface_service() {
                 "tool_checkpoint",
                 1,
             ))),
-            text_only_driver_requirements(),
+            tool_capable_driver_requirements(),
             DriverKind::Production,
         )
         .expect("production tool driver registration succeeds");
@@ -361,7 +361,7 @@ fn optional_profile_unavailable_does_not_block_startup() {
         mode: RebornLoopReadinessMode::Production,
         driver_registry: &registry,
         component_graph: RebornLoopComponentGraphReadiness::production_verified(),
-        configured_profiles: vec![selected_profile(key), optional],
+        configured_profiles: vec![selected_profile(key), optional.clone()],
         active_runs: Vec::new(),
     });
 
@@ -371,6 +371,87 @@ fn optional_profile_unavailable_does_not_block_startup() {
         RebornLoopProductionComponent::LoopDriver,
         RebornLoopProductionIssueKind::Missing
     ));
+    assert!(report.has_warnings());
+    let issue = report
+        .issues
+        .iter()
+        .find(|issue| {
+            issue.component == RebornLoopProductionComponent::LoopDriver
+                && issue.kind == RebornLoopProductionIssueKind::Missing
+        })
+        .expect("optional missing driver issue is reported");
+    assert_eq!(issue.profile_id.as_ref(), Some(&optional.profile_id));
+    assert_eq!(issue.profile_version, Some(optional.profile_version));
+    assert_eq!(
+        issue.driver_identity.as_ref(),
+        Some(&optional.driver_identity)
+    );
+}
+
+#[test]
+fn selected_driver_readiness_issues_include_profile_context() {
+    let registry = DriverRegistry::new();
+    let profile = selected_profile(missing_key("text_loop", 1, "text_checkpoint", 1));
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![profile.clone()],
+        active_runs: Vec::new(),
+    });
+
+    let issue = report
+        .issues
+        .iter()
+        .find(|issue| {
+            issue.component == RebornLoopProductionComponent::LoopDriver
+                && issue.kind == RebornLoopProductionIssueKind::Missing
+        })
+        .expect("selected missing driver issue is reported");
+    assert_eq!(issue.profile_id.as_ref(), Some(&profile.profile_id));
+    assert_eq!(issue.profile_version, Some(profile.profile_version));
+    assert_eq!(
+        issue.driver_identity.as_ref(),
+        Some(&profile.driver_identity)
+    );
+}
+
+#[test]
+fn missing_active_run_driver_has_distinct_issue_kind_and_context() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let active_run = RebornActiveRunIdentity::new(
+        "run-active-1",
+        TurnStatus::Running,
+        RunProfileId::new("interactive_default").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        missing_key("missing_loop", 1, "text_checkpoint", 1),
+    );
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: vec![active_run.clone()],
+    });
+
+    let issue = report
+        .issues
+        .iter()
+        .find(|issue| {
+            issue.component == RebornLoopProductionComponent::LoopDriver
+                && issue.kind == RebornLoopProductionIssueKind::ActiveRunDriverUnregistered
+        })
+        .expect("active-run missing driver issue is reported");
+    assert_eq!(issue.subject, "active_run");
+    assert_eq!(issue.profile_id.as_ref(), Some(&active_run.profile_id));
+    assert_eq!(issue.profile_version, Some(active_run.profile_version));
+    assert_eq!(
+        issue.driver_identity.as_ref(),
+        Some(&active_run.driver_identity)
+    );
 }
 
 #[test]

--- a/crates/ironclaw_reborn/tests/production_readiness.rs
+++ b/crates/ironclaw_reborn/tests/production_readiness.rs
@@ -242,6 +242,34 @@ fn production_readiness_rejects_removed_profile_version_with_active_runs() {
 }
 
 #[test]
+fn production_readiness_rejects_active_run_driver_identity_mismatch() {
+    let mut registry = DriverRegistry::new();
+    let configured_key = register_driver(&mut registry, "text_loop_v2", DriverKind::Production);
+    let active_run_key = register_driver(&mut registry, "text_loop_v1", DriverKind::Production);
+    let active_run = RebornActiveRunIdentity::new(
+        "run-active-1",
+        TurnStatus::Running,
+        RunProfileId::new("interactive_default").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        active_run_key,
+    );
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![selected_profile(configured_key)],
+        active_runs: vec![active_run],
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::RunProfile,
+        RebornLoopProductionIssueKind::ActiveRunsRequireVersion
+    ));
+}
+
+#[test]
 fn optional_profile_unavailable_does_not_block_startup() {
     let mut registry = DriverRegistry::new();
     let key = register_driver(&mut registry, "text_loop", DriverKind::Production);

--- a/crates/ironclaw_reborn/tests/production_readiness.rs
+++ b/crates/ironclaw_reborn/tests/production_readiness.rs
@@ -1,0 +1,419 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_reborn::{
+    driver_registry::{DriverKind, DriverRegistry, DriverRequirements, LoopDriverRegistryKey},
+    production_readiness::{
+        RebornActiveRunIdentity, RebornComponentReadiness, RebornComponentRequirement,
+        RebornConfiguredRunProfile, RebornLoopComponentGraphReadiness,
+        RebornLoopProductionComponent, RebornLoopProductionInputs, RebornLoopProductionIssueKind,
+        RebornLoopProductionStatus, RebornLoopReadinessMode, text_only_driver_requirements,
+        validate_reborn_loop_production_readiness,
+    },
+};
+use ironclaw_turns::{
+    AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverResumeRequest,
+    AgentLoopDriverRunRequest, LoopExit, RunProfileId, RunProfileVersion, TurnStatus,
+    run_profile::{AgentLoopDriverHost, CheckpointSchemaId, LoopDriverId},
+};
+
+#[test]
+fn production_readiness_rejects_missing_selected_driver() {
+    let registry = DriverRegistry::new();
+    let profile = selected_profile(missing_key("text_loop", 1, "text_checkpoint", 1));
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![profile],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::LoopDriver,
+        RebornLoopProductionIssueKind::Missing
+    ));
+}
+
+#[test]
+fn production_readiness_rejects_reference_driver() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "reference_echo", DriverKind::Reference);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::LoopDriver,
+        RebornLoopProductionIssueKind::TestOnlyImplementation
+    ));
+}
+
+#[test]
+fn local_dev_allows_reference_driver_with_degraded_status() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "reference_echo", DriverKind::Reference);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::LocalDevTest,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::LocalDevDegraded);
+    assert_eq!(report.blocking_issues().count(), 0);
+    assert!(report.contains(
+        RebornLoopProductionComponent::LoopDriver,
+        RebornLoopProductionIssueKind::TestOnlyImplementation
+    ));
+}
+
+#[test]
+fn production_readiness_rejects_in_memory_checkpoint_store() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let mut graph = RebornLoopComponentGraphReadiness::production_verified();
+    graph.checkpoint_state_store =
+        RebornComponentReadiness::non_durable(RebornComponentRequirement::Required);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: graph,
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::CheckpointStateStore,
+        RebornLoopProductionIssueKind::NonDurableImplementation
+    ));
+}
+
+#[test]
+fn production_readiness_rejects_noop_wake_notifier() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let mut graph = RebornLoopComponentGraphReadiness::production_verified();
+    graph.wake_notifier = RebornComponentReadiness::noop(RebornComponentRequirement::Required);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: graph,
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::WakeNotifier,
+        RebornLoopProductionIssueKind::NoopImplementation
+    ));
+}
+
+#[test]
+fn production_readiness_allows_text_only_with_deny_capability_port() {
+    let mut registry = DriverRegistry::new();
+    let key = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "text_loop",
+                1,
+                "text_checkpoint",
+                1,
+            ))),
+            text_only_driver_requirements(),
+            DriverKind::Production,
+        )
+        .expect("production text driver registration succeeds");
+    let mut graph = RebornLoopComponentGraphReadiness::production_verified();
+    graph.capability_port =
+        RebornComponentReadiness::production_verified(RebornComponentRequirement::Required);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: graph,
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::ProductionReady);
+    assert!(report.issues.is_empty());
+}
+
+#[test]
+fn production_readiness_rejects_tool_profile_without_surface_service() {
+    let mut registry = DriverRegistry::new();
+    let key = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "tool_loop",
+                1,
+                "tool_checkpoint",
+                1,
+            ))),
+            text_only_driver_requirements(),
+            DriverKind::Production,
+        )
+        .expect("production tool driver registration succeeds");
+    let mut graph = RebornLoopComponentGraphReadiness::production_verified();
+    graph.capability_port = RebornComponentReadiness::missing(RebornComponentRequirement::Required);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: graph,
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::CapabilityPort,
+        RebornLoopProductionIssueKind::Missing
+    ));
+}
+
+#[test]
+fn production_readiness_rejects_checkpoint_version_mismatch() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let profile = RebornConfiguredRunProfile::selected(
+        RunProfileId::new("interactive_default").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        key,
+        CheckpointSchemaId::new("different_checkpoint").expect("valid schema id"),
+        RunProfileVersion::new(1),
+    );
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![profile],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::CheckpointSchema,
+        RebornLoopProductionIssueKind::VersionMismatch
+    ));
+}
+
+#[test]
+fn production_readiness_rejects_removed_profile_version_with_active_runs() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let active_run = RebornActiveRunIdentity::new(
+        "run-active-1",
+        TurnStatus::Running,
+        RunProfileId::new("old_interactive").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        key.clone(),
+    );
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: vec![active_run],
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::RunProfile,
+        RebornLoopProductionIssueKind::ActiveRunsRequireVersion
+    ));
+}
+
+#[test]
+fn optional_profile_unavailable_does_not_block_startup() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let optional = RebornConfiguredRunProfile::selected(
+        RunProfileId::new("optional_tool_profile").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        missing_key("tool_loop", 1, "tool_checkpoint", 1),
+        CheckpointSchemaId::new("tool_checkpoint").expect("valid checkpoint id"),
+        RunProfileVersion::new(1),
+    )
+    .optional();
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![selected_profile(key), optional],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::ProductionReady);
+    assert_eq!(report.blocking_issues().count(), 0);
+    assert!(report.contains(
+        RebornLoopProductionComponent::LoopDriver,
+        RebornLoopProductionIssueKind::Missing
+    ));
+}
+
+#[test]
+fn local_durable_components_are_not_rejected_by_name_or_locality() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(
+        &mut registry,
+        "standalone_local_text_loop",
+        DriverKind::Production,
+    );
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::ProductionReady);
+    assert!(report.issues.is_empty());
+}
+
+#[test]
+fn readiness_surface_stays_redaction_safe() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let mut graph = RebornLoopComponentGraphReadiness::production_verified();
+    graph.model_gateway =
+        RebornComponentReadiness::unverified(RebornComponentRequirement::Required);
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: graph,
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: Vec::new(),
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    for issue in report.issues {
+        assert!(!issue.subject.contains('/'));
+        assert!(!issue.subject.contains("sk-"));
+        assert!(!issue.subject.contains("provider"));
+        assert!(!issue.subject.contains("prompt"));
+    }
+}
+
+fn register_driver(
+    registry: &mut DriverRegistry,
+    driver_id: &str,
+    kind: DriverKind,
+) -> LoopDriverRegistryKey {
+    registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                driver_id,
+                1,
+                "text_checkpoint",
+                1,
+            ))),
+            DriverRequirements::all_required(),
+            kind,
+        )
+        .expect("driver registration succeeds")
+}
+
+fn selected_profile(driver_identity: LoopDriverRegistryKey) -> RebornConfiguredRunProfile {
+    RebornConfiguredRunProfile::selected(
+        RunProfileId::new("interactive_default").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        driver_identity,
+        CheckpointSchemaId::new("text_checkpoint").expect("valid checkpoint id"),
+        RunProfileVersion::new(1),
+    )
+}
+
+fn descriptor(
+    driver_id: &str,
+    driver_version: u64,
+    checkpoint_schema_id: &str,
+    checkpoint_schema_version: u64,
+) -> AgentLoopDriverDescriptor {
+    AgentLoopDriverDescriptor {
+        id: LoopDriverId::new(driver_id).expect("valid driver id"),
+        version: RunProfileVersion::new(driver_version),
+        checkpoint_schema_id: Some(
+            CheckpointSchemaId::new(checkpoint_schema_id).expect("valid checkpoint schema id"),
+        ),
+        checkpoint_schema_version: Some(RunProfileVersion::new(checkpoint_schema_version)),
+    }
+}
+
+fn missing_key(
+    driver_id: &str,
+    driver_version: u64,
+    checkpoint_schema_id: &str,
+    checkpoint_schema_version: u64,
+) -> LoopDriverRegistryKey {
+    LoopDriverRegistryKey::from_descriptor(&descriptor(
+        driver_id,
+        driver_version,
+        checkpoint_schema_id,
+        checkpoint_schema_version,
+    ))
+    .expect("valid missing key")
+}
+
+struct TestDriver {
+    descriptor: Mutex<AgentLoopDriverDescriptor>,
+}
+
+impl TestDriver {
+    fn new(descriptor: AgentLoopDriverDescriptor) -> Self {
+        Self {
+            descriptor: Mutex::new(descriptor),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentLoopDriver for TestDriver {
+    fn descriptor(&self) -> AgentLoopDriverDescriptor {
+        self.descriptor
+            .lock()
+            .expect("test descriptor lock")
+            .clone()
+    }
+
+    async fn run(
+        &self,
+        _request: AgentLoopDriverRunRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        Err(AgentLoopDriverError::Unavailable {
+            reason: "test driver does not execute".to_string(),
+        })
+    }
+
+    async fn resume(
+        &self,
+        _request: AgentLoopDriverResumeRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        Err(AgentLoopDriverError::Unavailable {
+            reason: "test driver does not execute".to_string(),
+        })
+    }
+}

--- a/crates/ironclaw_reborn/tests/production_readiness.rs
+++ b/crates/ironclaw_reborn/tests/production_readiness.rs
@@ -270,6 +270,81 @@ fn production_readiness_rejects_active_run_driver_identity_mismatch() {
 }
 
 #[test]
+fn production_readiness_rejects_active_run_checkpoint_schema_identity_mismatch() {
+    let mut registry = DriverRegistry::new();
+    let configured_key = registry
+        .register_driver(
+            Arc::new(TestDriver::new(descriptor(
+                "text_loop",
+                1,
+                "new_text_checkpoint",
+                1,
+            ))),
+            DriverRequirements::all_required(),
+            DriverKind::Production,
+        )
+        .expect("configured driver registration succeeds");
+    let active_run_key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let profile = RebornConfiguredRunProfile::selected(
+        RunProfileId::new("interactive_default").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        configured_key,
+        CheckpointSchemaId::new("new_text_checkpoint").expect("valid checkpoint id"),
+        RunProfileVersion::new(1),
+    );
+    let active_run = RebornActiveRunIdentity::new(
+        "run-active-1",
+        TurnStatus::Running,
+        RunProfileId::new("interactive_default").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        active_run_key,
+    );
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![profile],
+        active_runs: vec![active_run],
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    assert!(report.contains(
+        RebornLoopProductionComponent::RunProfile,
+        RebornLoopProductionIssueKind::ActiveRunsRequireVersion
+    ));
+}
+
+#[test]
+fn readiness_surface_redacts_active_run_subject() {
+    let mut registry = DriverRegistry::new();
+    let key = register_driver(&mut registry, "text_loop", DriverKind::Production);
+    let active_run = RebornActiveRunIdentity::new(
+        "provider/sk-secret/prompt",
+        TurnStatus::Running,
+        RunProfileId::new("old_interactive").expect("valid profile id"),
+        RunProfileVersion::new(1),
+        missing_key("missing_loop", 1, "text_checkpoint", 1),
+    );
+
+    let report = validate_reborn_loop_production_readiness(RebornLoopProductionInputs {
+        mode: RebornLoopReadinessMode::Production,
+        driver_registry: &registry,
+        component_graph: RebornLoopComponentGraphReadiness::production_verified(),
+        configured_profiles: vec![selected_profile(key)],
+        active_runs: vec![active_run],
+    });
+
+    assert_eq!(report.status, RebornLoopProductionStatus::NotReady);
+    for issue in report.issues {
+        assert!(!issue.subject.contains('/'));
+        assert!(!issue.subject.contains("sk-"));
+        assert!(!issue.subject.contains("provider"));
+        assert!(!issue.subject.contains("prompt"));
+    }
+}
+
+#[test]
 fn optional_profile_unavailable_does_not_block_startup() {
     let mut registry = DriverRegistry::new();
     let key = register_driver(&mut registry, "text_loop", DriverKind::Production);


### PR DESCRIPTION
Refs #3429

## Summary

- adds `ironclaw_reborn::production_readiness` with `RebornLoopProductionReport`
- validates selected profile/driver/checkpoint identities, component safety classes, optional profiles, and active-run drain protection
- separates production safety from locality: production rejects test-only/non-durable/noop/unverified seams, but does not reject durable local implementations just because they are local
- keeps host-runtime `ProductionWiringReport` separate and substrate-scoped

## Notes

This is the pure readiness/reporting slice. Startup composition can call this report once the production composition root is wired.

## Tests

- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3429 cargo test -p ironclaw_reborn production_readiness -- --nocapture`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3429 cargo test -p ironclaw_reborn`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-3429 cargo clippy -p ironclaw_reborn --all-targets -- -D warnings`
