### PR TITLE
[Reborn] Enforce installed-skill tool ceiling at dispatch

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -24,6 +24,7 @@ use crate::generated_images::GeneratedImageSentinel;
 use crate::tools::permissions::{PermissionState, effective_permission};
 use crate::tools::redact_params;
 use ironclaw_llm::{ChatMessage, Reasoning, ReasoningContext, TokenUsage};
+use ironclaw_skills::SkillTrust;
 
 fn selected_model_override(value: &serde_json::Value) -> Option<String> {
     ironclaw_llm::normalized_model_override(value.as_str()).map(str::to_string)
@@ -433,6 +434,10 @@ impl ChatDelegate<'_> {
                 f(&mut turn_usage)
             }
         }
+    }
+
+    fn active_skill_trust_ceiling(&self) -> Option<SkillTrust> {
+        self.active_skills.iter().map(|skill| skill.trust).min()
     }
 }
 
@@ -905,6 +910,27 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 
         for (idx, original_tc) in tool_calls.iter().enumerate() {
             let mut tc = original_tc.clone();
+
+            if self.active_skill_trust_ceiling() == Some(SkillTrust::Installed) {
+                let resolved_name = self
+                    .agent
+                    .tools()
+                    .resolve_name(&tc.name)
+                    .await
+                    .unwrap_or_else(|| tc.name.clone());
+                if let Err(error) = crate::skills::attenuation::enforce_installed_skill_tool_ceiling(
+                    &resolved_name,
+                    &mut tc.arguments,
+                ) {
+                    preflight.push((
+                        tc,
+                        PreflightOutcome::Rejected(format!(
+                            "Tool call blocked by installed skill trust ceiling: {error}"
+                        )),
+                    ));
+                    continue;
+                }
+            }
 
             let tool_opt = self.agent.tools().get(&tc.name).await;
             let sensitive = tool_opt

--- a/src/skills/attenuation.rs
+++ b/src/skills/attenuation.rs
@@ -40,6 +40,11 @@ const READ_ONLY_TOOLS: &[&str] = &[
     "skill_search",
 ];
 
+/// Return whether a tool is permitted under an Installed-skill read-only ceiling.
+pub fn is_read_only_tool(tool_name: &str) -> bool {
+    READ_ONLY_TOOLS.contains(&tool_name)
+}
+
 /// Result of tool attenuation, including transparency information.
 #[derive(Debug, Clone)]
 pub struct AttenuationResult {
@@ -96,7 +101,7 @@ pub fn attenuate_tools(
             let mut removed = Vec::new();
 
             for tool in tools {
-                if READ_ONLY_TOOLS.contains(&tool.name.as_str()) {
+                if is_read_only_tool(&tool.name) {
                     kept.push(tool.clone());
                 } else {
                     removed.push(tool.name.clone());

--- a/src/skills/attenuation.rs
+++ b/src/skills/attenuation.rs
@@ -45,6 +45,47 @@ pub fn is_read_only_tool(tool_name: &str) -> bool {
     READ_ONLY_TOOLS.contains(&tool_name)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstalledSkillToolCeilingError {
+    MutatingTool { tool_name: String },
+}
+
+impl std::fmt::Display for InstalledSkillToolCeilingError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MutatingTool { tool_name } => write!(
+                formatter,
+                "installed skills may only dispatch read-only tools; `{tool_name}` is not allowed"
+            ),
+        }
+    }
+}
+
+/// Enforce Installed-skill action-time tool ceilings.
+///
+/// This is the dispatch-time companion to prompt-time tool attenuation. It
+/// fails closed for tools outside the read-only allowlist and normalizes
+/// `memory_search.reasoning` to `false` so the read-only ceiling cannot trigger
+/// an LLM/network synthesis call through a read-only-looking tool.
+pub fn enforce_installed_skill_tool_ceiling(
+    tool_name: &str,
+    params: &mut serde_json::Value,
+) -> Result<(), InstalledSkillToolCeilingError> {
+    if !is_read_only_tool(tool_name) {
+        return Err(InstalledSkillToolCeilingError::MutatingTool {
+            tool_name: tool_name.to_string(),
+        });
+    }
+
+    if tool_name == "memory_search"
+        && let Some(object) = params.as_object_mut()
+    {
+        object.insert("reasoning".to_string(), serde_json::Value::Bool(false));
+    }
+
+    Ok(())
+}
+
 /// Result of tool attenuation, including transparency information.
 #[derive(Debug, Clone)]
 pub struct AttenuationResult {
@@ -234,5 +275,37 @@ mod tests {
         assert!(!result.explanation.is_empty());
         assert!(result.removed_tools.contains(&"shell".to_string()));
         assert!(!result.removed_tools.contains(&"time".to_string()));
+    }
+
+    #[test]
+    fn installed_skill_ceiling_denies_mutating_tools() {
+        let mut params = serde_json::json!({});
+        let error = enforce_installed_skill_tool_ceiling("memory_write", &mut params).unwrap_err();
+        assert_eq!(
+            error,
+            InstalledSkillToolCeilingError::MutatingTool {
+                tool_name: "memory_write".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn installed_skill_ceiling_forces_memory_search_reasoning_off() {
+        let mut params = serde_json::json!({ "query": "project", "reasoning": true });
+        enforce_installed_skill_tool_ceiling("memory_search", &mut params).unwrap();
+        assert_eq!(
+            params.get("reasoning").and_then(|value| value.as_bool()),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn installed_skill_ceiling_adds_memory_search_reasoning_false_when_missing() {
+        let mut params = serde_json::json!({ "query": "project" });
+        enforce_installed_skill_tool_ceiling("memory_search", &mut params).unwrap();
+        assert_eq!(
+            params.get("reasoning").and_then(|value| value.as_bool()),
+            Some(false)
+        );
     }
 }

--- a/src/tools/dispatch.rs
+++ b/src/tools/dispatch.rs
@@ -22,10 +22,12 @@ use uuid::Uuid;
 
 use crate::context::{ActionRecord, JobContext};
 use crate::db::Database;
+use crate::skills::attenuation::is_read_only_tool;
 use crate::tools::registry::ToolRegistry;
 use crate::tools::tool::{ToolError, ToolOutput};
 use crate::tools::{prepare_tool_params, redact_params};
 use ironclaw_safety::SafetyLayer;
+use ironclaw_skills::SkillTrust;
 
 /// Identifies where a tool dispatch originated.
 ///
@@ -41,6 +43,11 @@ pub enum DispatchSource {
     Channel(String),
     /// A routine engine operation.
     Routine { routine_id: Uuid },
+    /// A skill-originated operation with host-approved trust metadata.
+    Skill {
+        skill_name: String,
+        trust: SkillTrust,
+    },
     /// An internal system operation.
     System,
 }
@@ -50,6 +57,7 @@ impl std::fmt::Display for DispatchSource {
         match self {
             Self::Channel(name) => write!(f, "channel:{name}"),
             Self::Routine { routine_id } => write!(f, "routine:{routine_id}"),
+            Self::Skill { skill_name, trust } => write!(f, "skill:{skill_name}:{trust}"),
             Self::System => write!(f, "system"),
         }
     }
@@ -124,6 +132,17 @@ impl ToolDispatcher {
             self.registry.get_resolved(tool_name).await.ok_or_else(|| {
                 ToolError::ExecutionFailed(format!("tool not found: {tool_name}"))
             })?;
+
+        if let DispatchSource::Skill {
+            skill_name,
+            trust: SkillTrust::Installed,
+        } = &source
+            && !is_read_only_tool(&resolved_name)
+        {
+            return Err(ToolError::NotAuthorized(format!(
+                "installed skill `{skill_name}` may only dispatch read-only tools; `{resolved_name}` is not allowed"
+            )));
+        }
 
         // 1. Normalize parameters (coerce types, fill defaults).
         let normalized_params = prepare_tool_params(tool.as_ref(), &params);
@@ -253,6 +272,14 @@ mod tests {
         assert_eq!(
             DispatchSource::Routine { routine_id: id }.to_string(),
             format!("routine:{id}")
+        );
+        assert_eq!(
+            DispatchSource::Skill {
+                skill_name: "alpha".to_string(),
+                trust: SkillTrust::Installed,
+            }
+            .to_string(),
+            "skill:alpha:installed"
         );
         assert_eq!(DispatchSource::System.to_string(), "system");
     }
@@ -529,6 +556,41 @@ mod integration_tests {
         assert!(
             action.output_sanitized.is_some(),
             "output_sanitized should be populated on the audit row"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_installed_skill_source_blocks_mutating_tool() {
+        let (dispatcher, _backend, _db, registry, _dir) = test_dispatcher().await;
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        registry
+            .register(Arc::new(RecordingTool {
+                captured: Arc::clone(&captured),
+            }))
+            .await;
+
+        let result = dispatcher
+            .dispatch(
+                "recording_stub",
+                serde_json::json!({ "message": "blocked" }),
+                "tester",
+                DispatchSource::Skill {
+                    skill_name: "installed-skill".to_string(),
+                    trust: ironclaw_skills::SkillTrust::Installed,
+                },
+            )
+            .await;
+
+        match result {
+            Err(ToolError::NotAuthorized(message)) => {
+                assert!(message.contains("installed skill"));
+                assert!(message.contains("read-only"));
+            }
+            other => panic!("expected installed-skill dispatch denial, got {other:?}"),
+        }
+        assert!(
+            captured.lock().expect("captured lock").is_none(),
+            "tool must not execute after installed-skill ceiling denies dispatch"
         );
     }
 

--- a/src/tools/dispatch.rs
+++ b/src/tools/dispatch.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 use crate::context::{ActionRecord, JobContext};
 use crate::db::Database;
-use crate::skills::attenuation::is_read_only_tool;
+use crate::skills::attenuation::enforce_installed_skill_tool_ceiling;
 use crate::tools::registry::ToolRegistry;
 use crate::tools::tool::{ToolError, ToolOutput};
 use crate::tools::{prepare_tool_params, redact_params};
@@ -124,7 +124,7 @@ impl ToolDispatcher {
     pub async fn dispatch(
         &self,
         tool_name: &str,
-        params: serde_json::Value,
+        mut params: serde_json::Value,
         user_id: &str,
         source: DispatchSource,
     ) -> Result<ToolOutput, ToolError> {
@@ -133,15 +133,24 @@ impl ToolDispatcher {
                 ToolError::ExecutionFailed(format!("tool not found: {tool_name}"))
             })?;
 
-        if let DispatchSource::Skill {
-            skill_name,
-            trust: SkillTrust::Installed,
-        } = &source
-            && !is_read_only_tool(&resolved_name)
-        {
-            return Err(ToolError::NotAuthorized(format!(
-                "installed skill `{skill_name}` may only dispatch read-only tools; `{resolved_name}` is not allowed"
-            )));
+        match &source {
+            DispatchSource::Skill {
+                skill_name,
+                trust: SkillTrust::Installed,
+            } => enforce_installed_skill_tool_ceiling(&resolved_name, &mut params).map_err(
+                |err| {
+                    ToolError::NotAuthorized(format!(
+                        "installed skill `{skill_name}` denied: {err}"
+                    ))
+                },
+            )?,
+            DispatchSource::Skill {
+                trust: SkillTrust::Trusted,
+                ..
+            }
+            | DispatchSource::Channel(_)
+            | DispatchSource::Routine { .. }
+            | DispatchSource::System => {}
         }
 
         // 1. Normalize parameters (coerce types, fill defaults).
@@ -357,6 +366,34 @@ mod integration_tests {
                 }),
                 Duration::from_millis(1),
             ))
+        }
+    }
+
+    struct ReadOnlyEchoTool {
+        captured: Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+    }
+
+    #[async_trait]
+    impl Tool for ReadOnlyEchoTool {
+        fn name(&self) -> &str {
+            "echo"
+        }
+
+        fn description(&self) -> &str {
+            "Read-only echo test stub."
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object" })
+        }
+
+        async fn execute(
+            &self,
+            params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            *self.captured.lock().expect("captured lock") = Some(params.clone());
+            Ok(ToolOutput::success(params, Duration::from_millis(1)))
         }
     }
 
@@ -592,6 +629,89 @@ mod integration_tests {
             captured.lock().expect("captured lock").is_none(),
             "tool must not execute after installed-skill ceiling denies dispatch"
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_installed_skill_source_allows_read_only_tool() {
+        let (dispatcher, _backend, _db, registry, _dir) = test_dispatcher().await;
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        registry
+            .register(Arc::new(ReadOnlyEchoTool {
+                captured: Arc::clone(&captured),
+            }))
+            .await;
+
+        dispatcher
+            .dispatch(
+                "echo",
+                serde_json::json!({ "message": "allowed" }),
+                "tester",
+                DispatchSource::Skill {
+                    skill_name: "installed-skill".to_string(),
+                    trust: ironclaw_skills::SkillTrust::Installed,
+                },
+            )
+            .await
+            .expect("installed skills may dispatch read-only tools");
+
+        assert_eq!(
+            captured
+                .lock()
+                .expect("captured lock")
+                .as_ref()
+                .and_then(|params| params.get("message"))
+                .and_then(|value| value.as_str()),
+            Some("allowed")
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_trusted_skill_source_allows_mutating_tool() {
+        let (dispatcher, _backend, _db, registry, _dir) = test_dispatcher().await;
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        registry
+            .register(Arc::new(RecordingTool {
+                captured: Arc::clone(&captured),
+            }))
+            .await;
+
+        dispatcher
+            .dispatch(
+                "recording_stub",
+                serde_json::json!({ "message": "trusted" }),
+                "tester",
+                DispatchSource::Skill {
+                    skill_name: "trusted-skill".to_string(),
+                    trust: ironclaw_skills::SkillTrust::Trusted,
+                },
+            )
+            .await
+            .expect("trusted skills may dispatch mutating tools");
+
+        assert!(captured.lock().expect("captured lock").is_some());
+    }
+
+    #[tokio::test]
+    async fn dispatch_channel_source_ignores_skill_ceiling() {
+        let (dispatcher, _backend, _db, registry, _dir) = test_dispatcher().await;
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        registry
+            .register(Arc::new(RecordingTool {
+                captured: Arc::clone(&captured),
+            }))
+            .await;
+
+        dispatcher
+            .dispatch(
+                "recording_stub",
+                serde_json::json!({ "message": "channel" }),
+                "tester",
+                DispatchSource::Channel("gateway".to_string()),
+            )
+            .await
+            .expect("channel dispatch is not restricted by skill ceiling");
+
+        assert!(captured.lock().expect("captured lock").is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add a skill-originated dispatch source carrying host-approved `SkillTrust`
- enforce the Installed-skill read-only tool ceiling inside `ToolDispatcher::dispatch` before param normalization or execution
- share the read-only tool predicate with existing prompt-side attenuation tests

## Scope
Follow-up to #3476. Addresses the #3492 comment item: `SkillTrust::Installed` must gate actual tool dispatch, not prompt visibility only.

## Verification
- `CARGO_TARGET_DIR=/Users/firatsertgoz/Documents/ironclaw/target cargo check -p ironclaw --tests`
- `CARGO_TARGET_DIR=/Users/firatsertgoz/Documents/ironclaw/target cargo test -p ironclaw dispatch_installed_skill_source_blocks_mutating_tool`
- `CARGO_TARGET_DIR=/Users/firatsertgoz/Documents/ironclaw/target cargo test -p ironclaw dispatch_source_display`
- `CARGO_TARGET_DIR=/Users/firatsertgoz/Documents/ironclaw/target cargo test -p ironclaw skills::attenuation`
- `CARGO_TARGET_DIR=/Users/firatsertgoz/Documents/ironclaw/target cargo test -p ironclaw_architecture`

Does not close #3492.