### PR TITLE
[Reborn] Centralize snippet display hashing

### DIFF
--- a/crates/ironclaw_host_runtime/src/memory_context.rs
+++ b/crates/ironclaw_host_runtime/src/memory_context.rs
@@ -16,6 +16,7 @@ use ironclaw_memory::{
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, ContextProfileId, LoopContextSnippet,
     LoopSafeSummary, MemoryPromptContextRequest, MemoryPromptContextService,
+    stable_snippet_display_hash,
 };
 
 /// Maximum byte length for a snippet safe summary, matching `LoopSafeSummary`
@@ -251,25 +252,14 @@ fn map_search_result_to_snippet(result: MemorySearchResult) -> Option<LoopContex
 }
 
 fn snippet_ref_for_path(path: &MemoryDocumentPath) -> String {
-    // FNV-1a keeps refs deterministic and opaque for model display only. It is
-    // unkeyed and not collision-resistant, so callers must never use
-    // `snippet_ref` for authorization, tenancy checks, or backend lookup.
-    let mut hash = 0xcbf29ce484222325_u64;
-    update_hash(&mut hash, path.tenant_id());
-    update_hash(&mut hash, path.user_id());
-    update_hash(&mut hash, path.agent_id().unwrap_or(""));
-    update_hash(&mut hash, path.project_id().unwrap_or(""));
-    update_hash(&mut hash, path.relative_path());
+    let hash = stable_snippet_display_hash([
+        path.tenant_id(),
+        path.user_id(),
+        path.agent_id().unwrap_or(""),
+        path.project_id().unwrap_or(""),
+        path.relative_path(),
+    ]);
     format!("memory-snippet:{hash:016x}")
-}
-
-fn update_hash(hash: &mut u64, value: &str) {
-    for byte in value.as_bytes() {
-        *hash ^= u64::from(*byte);
-        *hash = hash.wrapping_mul(0x100000001b3);
-    }
-    *hash ^= 0xff;
-    *hash = hash.wrapping_mul(0x100000001b3);
 }
 
 /// Sanitize a raw snippet string into a model-safe summary.

--- a/crates/ironclaw_host_runtime/src/memory_context.rs
+++ b/crates/ironclaw_host_runtime/src/memory_context.rs
@@ -16,7 +16,7 @@ use ironclaw_memory::{
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, ContextProfileId, LoopContextSnippet,
     LoopSafeSummary, MemoryPromptContextRequest, MemoryPromptContextService,
-    stable_snippet_display_hash,
+    memory_snippet_display_ref,
 };
 
 /// Maximum byte length for a snippet safe summary, matching `LoopSafeSummary`
@@ -252,14 +252,13 @@ fn map_search_result_to_snippet(result: MemorySearchResult) -> Option<LoopContex
 }
 
 fn snippet_ref_for_path(path: &MemoryDocumentPath) -> String {
-    let hash = stable_snippet_display_hash([
+    memory_snippet_display_ref([
         path.tenant_id(),
         path.user_id(),
         path.agent_id().unwrap_or(""),
         path.project_id().unwrap_or(""),
         path.relative_path(),
-    ]);
-    format!("memory-snippet:{hash:016x}")
+    ])
 }
 
 /// Sanitize a raw snippet string into a model-safe summary.

--- a/crates/ironclaw_host_runtime/tests/memory_prompt_context.rs
+++ b/crates/ironclaw_host_runtime/tests/memory_prompt_context.rs
@@ -524,7 +524,7 @@ async fn safe_summary_length_is_bounded() {
 }
 
 #[tokio::test]
-async fn snippet_ref_is_opaque_and_does_not_expose_memory_path() {
+async fn snippet_ref_does_not_expose_raw_memory_path_and_preserves_hash() {
     let results = vec![make_result(
         "t",
         "u",
@@ -543,9 +543,32 @@ async fn snippet_ref_is_opaque_and_does_not_expose_memory_path() {
     let snippet_ref = &snippets[0].snippet_ref;
     assert!(
         snippet_ref.starts_with("memory-snippet:"),
-        "snippet_ref must use opaque memory-snippet prefix"
+        "snippet_ref must use memory-snippet display prefix"
     );
+    assert_eq!(snippet_ref, "memory-snippet:78c92ad79c11620d");
     assert!(!snippet_ref.contains("secrets"));
     assert!(!snippet_ref.contains("api-key"));
     assert!(!snippet_ref.contains("note.md"));
+}
+
+#[tokio::test]
+async fn snippet_ref_preserves_agent_project_hash_fields() {
+    let results = vec![make_result_with_agent(
+        "t",
+        "u",
+        Some("agent"),
+        Some("project"),
+        "note.md",
+        1.0,
+        "some content",
+    )];
+    let service = make_service(MockMemoryBackend::with_results(results));
+
+    let snippets = service
+        .load_memory_snippets(test_request("t", "u", Some("agent"), Some("project"), 10))
+        .await
+        .unwrap();
+
+    assert_eq!(snippets.len(), 1);
+    assert_eq!(snippets[0].snippet_ref, "memory-snippet:940957a16cb30048");
 }

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -379,11 +379,9 @@ async fn prompt_and_model_ports_send_selected_skill_context_to_gateway() {
         .unwrap();
     assert_eq!(prompt_bundle.messages.len(), 2);
     assert_eq!(prompt_bundle.messages[0].role, "system");
-    assert!(
-        prompt_bundle.messages[0]
-            .content_ref
-            .as_str()
-            .starts_with("msg:snippet.skill.alpha.")
+    assert_eq!(
+        prompt_bundle.messages[0].content_ref,
+        LoopMessageRef::new("msg:snippet.skill.alpha.0.5241b0c7358325ab").unwrap()
     );
 
     let gateway = Arc::new(RecordingGateway::reply("model says hi"));

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -19,6 +19,7 @@ mod refs;
 mod resolver;
 mod skill_context;
 mod snapshot;
+mod snippet_ref;
 
 pub use driver::{
     AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverResumeRequest,
@@ -74,3 +75,4 @@ pub use skill_context::{
     skill_snippet_model_message_ref,
 };
 pub use snapshot::ResolvedRunProfile;
+pub use snippet_ref::stable_snippet_display_hash;

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -75,4 +75,4 @@ pub use skill_context::{
     skill_snippet_model_message_ref,
 };
 pub use snapshot::ResolvedRunProfile;
-pub use snippet_ref::{stable_skill_snippet_display_hash, stable_snippet_display_hash};
+pub use snippet_ref::memory_snippet_display_ref;

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -75,4 +75,4 @@ pub use skill_context::{
     skill_snippet_model_message_ref,
 };
 pub use snapshot::ResolvedRunProfile;
-pub use snippet_ref::stable_snippet_display_hash;
+pub use snippet_ref::{stable_skill_snippet_display_hash, stable_snippet_display_hash};

--- a/crates/ironclaw_turns/src/run_profile/skill_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/skill_context.rs
@@ -38,9 +38,9 @@ use thiserror::Error;
 
 use crate::LoopMessageRef;
 
+use super::snippet_ref::stable_skill_snippet_display_hash;
 use super::{
     AgentLoopHostError, AgentLoopHostErrorKind, LoopContextSnippet, LoopContextSnippetMetadata,
-    stable_skill_snippet_display_hash,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/ironclaw_turns/src/run_profile/skill_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/skill_context.rs
@@ -40,6 +40,7 @@ use crate::LoopMessageRef;
 
 use super::{
     AgentLoopHostError, AgentLoopHostErrorKind, LoopContextSnippet, LoopContextSnippetMetadata,
+    stable_snippet_display_hash,
 };
 
 // ---------------------------------------------------------------------------
@@ -130,8 +131,6 @@ impl SkillTrustLevel {
 const EMPTY_SNAPSHOT_VERSION: &str = "empty";
 const DEFAULT_MAX_SKILL_SNIPPET_BYTES: usize = 8 * 1024;
 const DEFAULT_MAX_SKILL_CONTEXT_BYTES: usize = 32 * 1024;
-const FNV_OFFSET: u64 = 0xcbf29ce484222325;
-const FNV_PRIME: u64 = 0x00000100000001B3;
 
 /// Byte budgets for model-visible skill context produced by [`SkillContextService`].
 ///
@@ -407,7 +406,8 @@ pub fn skill_snippet_model_message_ref(
     ordinal: usize,
 ) -> Result<LoopMessageRef, AgentLoopHostError> {
     let slug = sanitize_ref_suffix(snippet_ref);
-    let hash = stable_snippet_ref_hash(snippet_ref, safe_summary, ordinal);
+    let ordinal = ordinal.to_string();
+    let hash = stable_snippet_display_hash([snippet_ref, safe_summary, &ordinal]);
     LoopMessageRef::new(format!("msg:snippet.{slug}.{ordinal}.{hash:016x}")).map_err(|_| {
         AgentLoopHostError::new(
             AgentLoopHostErrorKind::Internal,
@@ -437,23 +437,6 @@ fn sanitize_ref_suffix(value: &str) -> String {
         "context".to_string()
     } else {
         suffix.to_string()
-    }
-}
-
-fn stable_snippet_ref_hash(snippet_ref: &str, safe_summary: &str, ordinal: usize) -> u64 {
-    let mut hash = FNV_OFFSET;
-    feed_hash(&mut hash, snippet_ref.as_bytes());
-    feed_hash(&mut hash, &[0xFF]);
-    feed_hash(&mut hash, safe_summary.as_bytes());
-    feed_hash(&mut hash, &[0xFF]);
-    feed_hash(&mut hash, ordinal.to_string().as_bytes());
-    hash
-}
-
-fn feed_hash(hash: &mut u64, bytes: &[u8]) {
-    for &byte in bytes {
-        *hash ^= u64::from(byte);
-        *hash = hash.wrapping_mul(FNV_PRIME);
     }
 }
 

--- a/crates/ironclaw_turns/src/run_profile/skill_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/skill_context.rs
@@ -40,7 +40,7 @@ use crate::LoopMessageRef;
 
 use super::{
     AgentLoopHostError, AgentLoopHostErrorKind, LoopContextSnippet, LoopContextSnippetMetadata,
-    stable_snippet_display_hash,
+    stable_skill_snippet_display_hash,
 };
 
 // ---------------------------------------------------------------------------
@@ -407,7 +407,7 @@ pub fn skill_snippet_model_message_ref(
 ) -> Result<LoopMessageRef, AgentLoopHostError> {
     let slug = sanitize_ref_suffix(snippet_ref);
     let ordinal = ordinal.to_string();
-    let hash = stable_snippet_display_hash([snippet_ref, safe_summary, &ordinal]);
+    let hash = stable_skill_snippet_display_hash([snippet_ref, safe_summary, &ordinal]);
     LoopMessageRef::new(format!("msg:snippet.{slug}.{ordinal}.{hash:016x}")).map_err(|_| {
         AgentLoopHostError::new(
             AgentLoopHostErrorKind::Internal,
@@ -418,6 +418,21 @@ pub fn skill_snippet_model_message_ref(
 
 pub fn is_skill_snippet_model_message_ref(content_ref: &LoopMessageRef) -> bool {
     content_ref.as_str().starts_with("msg:snippet.")
+}
+
+#[cfg(test)]
+mod snippet_ref_tests {
+    use super::*;
+
+    #[test]
+    fn skill_snippet_model_message_ref_preserves_existing_hash() {
+        let content_ref =
+            skill_snippet_model_message_ref("skill:alpha", "summary", 0).expect("valid ref");
+        assert_eq!(
+            content_ref.as_str(),
+            "msg:snippet.skill.alpha.0.6e54cb74d742607c"
+        );
+    }
 }
 
 fn sanitize_ref_suffix(value: &str) -> String {

--- a/crates/ironclaw_turns/src/run_profile/snippet_ref.rs
+++ b/crates/ironclaw_turns/src/run_profile/snippet_ref.rs
@@ -1,19 +1,25 @@
 //! Shared helpers for opaque, model-visible snippet references.
 //!
-//! These hashes are deterministic display identifiers only. They are unkeyed and
-//! not collision-resistant; callers must never use them for authorization,
-//! tenancy checks, or backend lookup.
+//! These hashes are deterministic display identifiers only. They are unkeyed,
+//! not collision-resistant, and not a secrecy boundary; callers must never use
+//! them for authorization, tenancy checks, or backend lookup.
 
 const FNV_OFFSET: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 const FIELD_SEPARATOR: u8 = 0xFF;
 
-/// Compute a stable opaque display hash over ordered string fields.
+/// Build a stable opaque memory-snippet display reference over ordered string fields.
 ///
 /// This intentionally uses FNV-1a for short deterministic model-facing refs,
 /// not security. Field separators prevent simple concatenation drift between
-/// independent call sites.
-pub fn stable_snippet_display_hash<'a>(fields: impl IntoIterator<Item = &'a str>) -> u64 {
+/// independent call sites. It preserves the legacy memory-ref layout, which
+/// appends a separator after every field.
+pub fn memory_snippet_display_ref<'a>(fields: impl IntoIterator<Item = &'a str>) -> String {
+    let hash = stable_memory_snippet_display_hash(fields);
+    format!("memory-snippet:{hash:016x}")
+}
+
+fn stable_memory_snippet_display_hash<'a>(fields: impl IntoIterator<Item = &'a str>) -> u64 {
     stable_snippet_display_hash_with_layout(fields, SeparatorLayout::Trailing)
 }
 
@@ -21,8 +27,11 @@ pub fn stable_snippet_display_hash<'a>(fields: impl IntoIterator<Item = &'a str>
 ///
 /// Skill refs existed before the shared helper. Their field separator appeared
 /// only between fields, so centralization must preserve those model-visible
-/// refs instead of rotating them.
-pub fn stable_skill_snippet_display_hash<'a>(fields: impl IntoIterator<Item = &'a str>) -> u64 {
+/// refs instead of rotating them. Keep crate-private so external callers cannot
+/// select the wrong legacy layout for new refs.
+pub(crate) fn stable_skill_snippet_display_hash<'a>(
+    fields: impl IntoIterator<Item = &'a str>,
+) -> u64 {
     stable_snippet_display_hash_with_layout(fields, SeparatorLayout::BetweenFields)
 }
 
@@ -64,9 +73,9 @@ mod tests {
 
     #[test]
     fn display_hash_is_deterministic_and_field_ordered() {
-        let first = stable_snippet_display_hash(["skill:alpha", "summary", "0"]);
-        let second = stable_snippet_display_hash(["skill:alpha", "summary", "0"]);
-        let different = stable_snippet_display_hash(["skill:alpha", "0", "summary"]);
+        let first = stable_memory_snippet_display_hash(["skill:alpha", "summary", "0"]);
+        let second = stable_memory_snippet_display_hash(["skill:alpha", "summary", "0"]);
+        let different = stable_memory_snippet_display_hash(["skill:alpha", "0", "summary"]);
 
         assert_eq!(first, second);
         assert_ne!(first, different);
@@ -75,8 +84,8 @@ mod tests {
     #[test]
     fn display_hash_separates_fields() {
         assert_ne!(
-            stable_snippet_display_hash(["ab", "c"]),
-            stable_snippet_display_hash(["a", "bc"]),
+            stable_memory_snippet_display_hash(["ab", "c"]),
+            stable_memory_snippet_display_hash(["a", "bc"]),
         );
     }
 
@@ -89,10 +98,10 @@ mod tests {
     }
 
     #[test]
-    fn memory_display_hash_preserves_trailing_separator_layout() {
+    fn memory_display_ref_preserves_trailing_separator_layout() {
         assert_eq!(
-            stable_snippet_display_hash(["skill:alpha", "summary", "0"]),
-            0xbc763a89c5c9fe99
+            memory_snippet_display_ref(["skill:alpha", "summary", "0"]),
+            "memory-snippet:bc763a89c5c9fe99"
         );
     }
 }

--- a/crates/ironclaw_turns/src/run_profile/snippet_ref.rs
+++ b/crates/ironclaw_turns/src/run_profile/snippet_ref.rs
@@ -14,10 +14,39 @@ const FIELD_SEPARATOR: u8 = 0xFF;
 /// not security. Field separators prevent simple concatenation drift between
 /// independent call sites.
 pub fn stable_snippet_display_hash<'a>(fields: impl IntoIterator<Item = &'a str>) -> u64 {
+    stable_snippet_display_hash_with_layout(fields, SeparatorLayout::Trailing)
+}
+
+/// Compute legacy skill-snippet display hash semantics.
+///
+/// Skill refs existed before the shared helper. Their field separator appeared
+/// only between fields, so centralization must preserve those model-visible
+/// refs instead of rotating them.
+pub fn stable_skill_snippet_display_hash<'a>(fields: impl IntoIterator<Item = &'a str>) -> u64 {
+    stable_snippet_display_hash_with_layout(fields, SeparatorLayout::BetweenFields)
+}
+
+#[derive(Clone, Copy)]
+enum SeparatorLayout {
+    Trailing,
+    BetweenFields,
+}
+
+fn stable_snippet_display_hash_with_layout<'a>(
+    fields: impl IntoIterator<Item = &'a str>,
+    layout: SeparatorLayout,
+) -> u64 {
+    let fields: Vec<&str> = fields.into_iter().collect();
     let mut hash = FNV_OFFSET;
-    for field in fields {
+    for (index, field) in fields.iter().enumerate() {
         feed_hash(&mut hash, field.as_bytes());
-        feed_hash(&mut hash, &[FIELD_SEPARATOR]);
+        let should_append_separator = match layout {
+            SeparatorLayout::Trailing => true,
+            SeparatorLayout::BetweenFields => index + 1 < fields.len(),
+        };
+        if should_append_separator {
+            feed_hash(&mut hash, &[FIELD_SEPARATOR]);
+        }
     }
     hash
 }
@@ -48,6 +77,22 @@ mod tests {
         assert_ne!(
             stable_snippet_display_hash(["ab", "c"]),
             stable_snippet_display_hash(["a", "bc"]),
+        );
+    }
+
+    #[test]
+    fn skill_display_hash_preserves_existing_model_visible_refs() {
+        assert_eq!(
+            stable_skill_snippet_display_hash(["skill:alpha", "summary", "0"]),
+            0x6e54cb74d742607c
+        );
+    }
+
+    #[test]
+    fn memory_display_hash_preserves_trailing_separator_layout() {
+        assert_eq!(
+            stable_snippet_display_hash(["skill:alpha", "summary", "0"]),
+            0xbc763a89c5c9fe99
         );
     }
 }

--- a/crates/ironclaw_turns/src/run_profile/snippet_ref.rs
+++ b/crates/ironclaw_turns/src/run_profile/snippet_ref.rs
@@ -1,0 +1,53 @@
+//! Shared helpers for opaque, model-visible snippet references.
+//!
+//! These hashes are deterministic display identifiers only. They are unkeyed and
+//! not collision-resistant; callers must never use them for authorization,
+//! tenancy checks, or backend lookup.
+
+const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x00000100000001B3;
+const FIELD_SEPARATOR: u8 = 0xFF;
+
+/// Compute a stable opaque display hash over ordered string fields.
+///
+/// This intentionally uses FNV-1a for short deterministic model-facing refs,
+/// not security. Field separators prevent simple concatenation drift between
+/// independent call sites.
+pub fn stable_snippet_display_hash<'a>(fields: impl IntoIterator<Item = &'a str>) -> u64 {
+    let mut hash = FNV_OFFSET;
+    for field in fields {
+        feed_hash(&mut hash, field.as_bytes());
+        feed_hash(&mut hash, &[FIELD_SEPARATOR]);
+    }
+    hash
+}
+
+fn feed_hash(hash: &mut u64, bytes: &[u8]) {
+    for &byte in bytes {
+        *hash ^= u64::from(byte);
+        *hash = hash.wrapping_mul(FNV_PRIME);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_hash_is_deterministic_and_field_ordered() {
+        let first = stable_snippet_display_hash(["skill:alpha", "summary", "0"]);
+        let second = stable_snippet_display_hash(["skill:alpha", "summary", "0"]);
+        let different = stable_snippet_display_hash(["skill:alpha", "0", "summary"]);
+
+        assert_eq!(first, second);
+        assert_ne!(first, different);
+    }
+
+    #[test]
+    fn display_hash_separates_fields() {
+        assert_ne!(
+            stable_snippet_display_hash(["ab", "c"]),
+            stable_snippet_display_hash(["a", "bc"]),
+        );
+    }
+}

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -293,11 +293,9 @@ async fn loop_prompt_port_materializes_instruction_snippets_as_system_refs() {
 
     assert_eq!(bundle.messages.len(), 2);
     assert_eq!(bundle.messages[0].role, "system");
-    assert!(
-        bundle.messages[0]
-            .content_ref
-            .as_str()
-            .starts_with("msg:snippet.skill.alpha.")
+    assert_eq!(
+        bundle.messages[0].content_ref,
+        LoopMessageRef::new("msg:snippet.skill.alpha.0.25eba50bef20ee35").unwrap()
     );
     assert_eq!(bundle.messages[1].role, "user");
     assert_eq!(host.effects(), vec!["context"]);
@@ -330,11 +328,9 @@ async fn loop_prompt_port_preserves_mid_conversation_system_message_order() {
 
     assert_eq!(bundle.messages.len(), 3);
     assert_eq!(bundle.messages[0].role, "system");
-    assert!(
-        bundle.messages[0]
-            .content_ref
-            .as_str()
-            .starts_with("msg:snippet.skill.alpha.")
+    assert_eq!(
+        bundle.messages[0].content_ref,
+        LoopMessageRef::new("msg:snippet.skill.alpha.0.25eba50bef20ee35").unwrap()
     );
     assert_eq!(bundle.messages[1].role, "user");
     assert_eq!(
@@ -379,11 +375,9 @@ async fn loop_prompt_port_keeps_identity_before_skill_snippets_and_records_skill
         LoopMessageRef::new("msg:identity").unwrap()
     );
     assert_eq!(bundle.messages[1].role, "system");
-    assert!(
-        bundle.messages[1]
-            .content_ref
-            .as_str()
-            .starts_with("msg:snippet.skill.alpha.")
+    assert_eq!(
+        bundle.messages[1].content_ref,
+        LoopMessageRef::new("msg:snippet.skill.alpha.0.25eba50bef20ee35").unwrap()
     );
     assert_eq!(bundle.messages[2].role, "user");
 


### PR DESCRIPTION
## Summary
- add a shared run-profile helper for opaque model-visible snippet display hashes
- use it for skill snippet model-message refs and memory snippet refs
- remove duplicated FNV-1a hash loops from call sites

## Scope
Follow-up to #3476/#3470. Addresses the #3492 comment item: snippet-ref hash derivation should not be duplicated across prompt/context paths.

## Verification
- `CARGO_TARGET_DIR=/Users/firatsertgoz/Documents/ironclaw/target cargo test -p ironclaw_turns -p ironclaw_host_runtime`
- `CARGO_TARGET_DIR=/Users/firatsertgoz/Documents/ironclaw/target cargo test -p ironclaw_architecture`

Does not close #3492.