### PR TITLE
fix(setup): make local web UI discoverable during onboarding (#3500)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,27 +1783,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046d4b584c3bb9b5eb500c8f29549bec36be11000f1ba2a927cef3d1a9875691"
+checksum = "adc822414b18d1f5b1b33ce1441534e311e62fef86ebb5b9d382af857d0272c9"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b194a7870becb1490366fc0ae392ccd188065ff35f8391e77ac659db6fb977"
+checksum = "8c646808b06f4532478d8d6057d74f15c3322f10d995d9486e7dcea405bf521a"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6a4ab44c6b371e661846b97dab687387a60ac4e2f864e2d4257284aad9e889"
+checksum = "7b5996f01a686b2349cdb379083ec5ad3e8cb8767fb2d495d3a4f2ee4163a18d"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a44150c2f471a94023482bda1902710746e4bed9f9973d60c5a94319b06d"
+checksum = "523fea83273f6a985520f57788809a4de2165794d9ab00fb1254fceb4f5aa00c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b06598133b1dd76758b8b95f8d6747c124124aade50cea96a3d88b962da9fa"
+checksum = "d73d1e372730b5f64ed1a2bd9f01fe4686c8ec14a28034e3084e530c8d951878"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1850,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6190e2e7bcf0a678da2f715363d34ed530fedf7a2f0ab75edaefef72a70465ff"
+checksum = "b0319c18165e93dc1ebf78946a8da0b1c341c95b4a39729a69574671639bdb5f"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1863,24 +1863,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
+checksum = "9195cd8aeecb55e401aa96b2eaa55921636e8246c127ed7908f7ef7e0d40f270"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803159df35cc398ae54473c150b16d6c77e92ab2948be638488de126a3328fbc"
+checksum = "8976c2154b74136322befc74222ab5c7249edd7e2604f8cbef2b94975541ffb9"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e417257082d88087f5bcce677525bdaa8322b88dd7f175ed1a1fd41d546c"
+checksum = "6038b3147c7982f4951150d5f96c7c06c1e7214b99d4b4a98607aadf8ded89d1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db6b0e0e4994c581092df78d837be2072578f7cb2528f96a6cf895e56dee63"
+checksum = "4cbd294abe236e23cc3d907b0936226b6a8342db7636daa9c7c72be1e323420e"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1902,15 +1902,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
+checksum = "b5a90b6ed3aba84189352a87badeb93b2126d3724225a42dc67fdce53d1b139c"
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373ade56438e6232619d85678477d0a88a31b3581936e0503e61e96b546b0800"
+checksum = "c3ec0cc1a54e22925eacf4fc3dc815f907734d3b377899d19d52bec04863e853"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1919,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.1"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53619d3cd5c78fd998c6d9420547af26b72e6456f94c2a8a2334cb76b42baa"
+checksum = "948865622f87f30907bb46fbb081b235ae63c1896a99a83c26a003305c1fa82d"
 
 [[package]]
 name = "crc"
@@ -3570,7 +3570,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5799,9 +5799,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010dec3755eb61b2f1051ecb3611b718460b7a74c131e474de2af20a845938af"
+checksum = "7ec12fe19a9588315a49fe5704502a9c02d6a198303314b0c7c86123b06d29e5"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -5811,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad360c32e85ca4b083ac0e2b6856e8f11c3d5060dafa7d5dc57b370857fa3018"
+checksum = "36f7d5ef31ebf1b46cd7e722ffef934e670d7e462f49aa01cde07b9b76dca580"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5905,7 +5905,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5942,7 +5942,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8924,9 +8924,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
+checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -8977,9 +8977,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
+checksum = "4172382dcc785c31d0e862c6780a18f5dd437914d22c4691351f965ef751c821"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -9008,9 +9008,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
+checksum = "4ed398988226d7aa0505ac6bb576e09532ad722d702ec4e66365d78ed695c95f"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -9028,9 +9028,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d6914f34be2f9d78d8ee9f422e834dfc204e71ccce697205fae95fed87892"
+checksum = "ae5ec9fff073ff13b81732d56a9515d761c245750bcda09093827f84130ebc25"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -9043,15 +9043,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3751b0616b914fdd87fe1bf804694a078f321b000338e6476bc48a4d6e454f21"
+checksum = "935d9ab293ba27d1ec9aa7bc1b3a43993dbe961af2a8f23f90a11e1331b4c13f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
+checksum = "9a3820b174f477d2a7083209d1ad5353fcdb11eaea434b2137b8681029460dd3"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -9061,9 +9061,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3ca07b3e0bb3429674b173b5800577719d600774dd81bff58f775c0aaa64ee"
+checksum = "d1679d205caf9766c6aa309d45bb3e7c634d7725e3164404df33824b9f7c4fb7"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -9088,9 +9088,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c8b2c9704eb1f33ead025ec16038277ccb63d0a14c31e99d5b765d7c36da55"
+checksum = "f1e505254058be5b0df458d670ee42d9eafe2349d04c1296e9dc01071dc20a85"
 dependencies = [
  "cc",
  "cfg-if",
@@ -9103,9 +9103,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
+checksum = "1c2e05b345f1773e59c20e6ad7298fd6857cdea245023d88bb659c96d8f0ea72"
 dependencies = [
  "cc",
  "object",
@@ -9115,9 +9115,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3606662c156962d096be3127b8b8ae8ee2f8be3f896dad29259ff01ddb64abfd"
+checksum = "b86701b234a4643e3f111869aa792b3a05a06e02d486ee9cb6c04dae16b52dab"
 dependencies = [
  "cfg-if",
  "libc",
@@ -9127,9 +9127,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75eef0747e52dc545b075f64fd0e0cc237ae738e641266b1970e07e2d744bc32"
+checksum = "f63558d801beb83dde9b336eb4ae049019aee26627926edb32cd119d7e4c83cd"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -9140,9 +9140,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b0a5dab02a8fb527f547855ecc0e05f9fdc3d5bd57b8b080349408f9a6cece"
+checksum = "737c4d956fc3a848541a064afb683dd2771132a6b125be5baaf95c4379aa47df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9151,9 +9151,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
+checksum = "f599b79545e3bba0b7913406055ebede5bb0dabee9ba2015ef25a9f4c9f47807"
 dependencies = [
  "cranelift-codegen",
  "gimli",
@@ -9168,9 +9168,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7900c3e3c1d6e475bc225d73b02d6d5484815f260022e6964dca9558e50dd01a"
+checksum = "2192a77a00b9a67800c2b4e1c70fb6abca79d6b529e53a2ef9dcdcc36090330d"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -9181,9 +9181,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3e3ddcfad69e9eb025bd19bff70dad45bafe1d6eacd134c0ffdfc4c161d045"
+checksum = "00c7daf53ba2f64aa089f47d9a54bec654a45b7b1b55660efecfb09a2e6cfbcf"
 dependencies = [
  "async-trait",
  "bitflags 2.11.0",
@@ -9211,9 +9211,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca5dd3b9f04a851c422d05f333366722742da46bff9369ae0191f32cf83565a"
+checksum = "c2c9c6cd3daf62a4fb75ac4742c976fee1939686ffe461a366ce6446c58a58a0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9336,9 +9336,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1b1135efc8e5a008971897bea8d41ca56d8d501d4efb807842ae0a1c78f639"
+checksum = "9c8cfd3db2f05619c6f36f257d84327c11546e28d61e3a1c1220aaad553bc4b0"
 dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
@@ -9350,9 +9350,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bc2b0d50ec8773b44fbfe1da6cb5cc44a92deaf8483233dcf0831e6db33172"
+checksum = "4bd7a197903e5b4ff5e13aef9c891960d71e92073600ecf4c86c7e795ac1c803"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -9364,9 +9364,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6c7d44ea552e1fbfdcd7a2cd83f5c2d1e803d5b1a11e3462c06888b77f455f"
+checksum = "6410b86fcec207070d9372b215d3470bad67215e6bbac46981a16999c4abbc28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9407,9 +9407,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
+checksum = "52dbb0cf07b0dfe7b7a1ca8efb8f94ba98bd0fb144c411ea1665c78f0449e958"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/crates/ironclaw_tui/examples/dev.rs
+++ b/crates/ironclaw_tui/examples/dev.rs
@@ -161,6 +161,7 @@ fn main() {
             .unwrap_or_else(|_| "~/projects/ironclaw".into()),
         memory_count: 42,
         identity_files: vec!["AGENTS.md".into(), "SOUL.md".into(), "USER.md".into()],
+        tui_entry_prompt: None,
         available_models: vec![
             "gpt-4o".into(),
             "gpt-5.3-codex".into(),

--- a/crates/ironclaw_tui/src/app.rs
+++ b/crates/ironclaw_tui/src/app.rs
@@ -72,6 +72,13 @@ pub struct TuiAppConfig {
     pub memory_count: usize,
     /// Identity files loaded at startup (e.g. "AGENTS.md", "SOUL.md").
     pub identity_files: Vec<String>,
+    /// Optional TUI entry prompt shown before the TUI takes over the
+    /// terminal. When set, `run_tui()` prints it and blocks on a single
+    /// keypress before entering raw mode / the alternate screen. Acts as
+    /// a gate so the user can choose between an alternate chat surface
+    /// (e.g. the web gateway URL printed above) and pressing any key to
+    /// drop into the TUI.
+    pub tui_entry_prompt: Option<String>,
     /// Best-effort model list for the `/model` picker.
     pub available_models: Vec<String>,
 }
@@ -121,6 +128,15 @@ async fn run_tui(
     input_event_tx: mpsc::Sender<TuiEvent>,
     msg_tx: mpsc::Sender<TuiUserMessage>,
 ) -> io::Result<()> {
+    // TUI entry gate: when the host supplied a prompt, print it and wait
+    // for any keypress before claiming the terminal. Lets the user click
+    // a surfaced URL (e.g. the web gateway) and chat in a browser instead.
+    // Runs *before* enable_raw_mode so the prompt stays in scrollback
+    // and the user's keypress doesn't get swallowed by raw-mode echo.
+    if let Some(ref prompt) = config.tui_entry_prompt {
+        wait_for_any_key_with_prompt(prompt)?;
+    }
+
     // Terminal setup
     enable_raw_mode()?;
     let mut restore_guard = TerminalRestoreGuard::new();
@@ -1652,6 +1668,71 @@ fn terminal_area() -> Rect {
     ratatui::crossterm::terminal::size()
         .map(|(width, height)| Rect::new(0, 0, width, height))
         .unwrap_or_else(|_| Rect::new(0, 0, 80, 24))
+}
+
+/// RAII guard for crossterm raw mode.
+///
+/// Pairs `enable_raw_mode` / `disable_raw_mode` so the terminal is always
+/// restored — including on panic, early return, or `?` propagation. The
+/// closure-then-restore pattern would leak raw mode on panic.
+#[cfg(not(test))]
+struct RawModeGuard;
+
+#[cfg(not(test))]
+impl RawModeGuard {
+    fn enable() -> io::Result<Self> {
+        enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+#[cfg(not(test))]
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        // Best effort: Drop cannot propagate errors. If this fails, the
+        // user's terminal will look weird; `stty sane` recovers.
+        let _ = disable_raw_mode();
+    }
+}
+
+/// Print `prompt` and block until the user presses any key.
+///
+/// Briefly enables raw mode (via `RawModeGuard`) so we can detect a
+/// single keypress without requiring Enter. Raw mode is restored on
+/// every exit path, including panics.
+///
+/// Skips the wait when stdin isn't a terminal — piped or
+/// headless-CI invocations would otherwise block forever. The prompt
+/// still prints so logs capture any surfaced URL.
+#[cfg(not(test))]
+fn wait_for_any_key_with_prompt(prompt: &str) -> io::Result<()> {
+    use ratatui::crossterm::event::{Event, KeyEventKind, poll, read};
+    use std::io::IsTerminal;
+
+    println!("{prompt}");
+    io::Write::flush(&mut io::stdout())?;
+
+    if !io::stdin().is_terminal() {
+        return Ok(());
+    }
+
+    let _guard = RawModeGuard::enable()?;
+    loop {
+        if poll(std::time::Duration::from_secs(3600))?
+            && let Ok(Event::Key(key)) = read()
+            && key.kind == KeyEventKind::Press
+        {
+            return Ok(());
+        }
+    }
+}
+
+#[cfg(test)]
+fn wait_for_any_key_with_prompt(_prompt: &str) -> io::Result<()> {
+    // Tests must never block on a real terminal — this stub returns
+    // immediately. The behaviour under `cargo run` lives in the
+    // production `#[cfg(not(test))]` variant above.
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/ironclaw_tui/src/app.rs
+++ b/crates/ironclaw_tui/src/app.rs
@@ -1701,9 +1701,14 @@ impl Drop for RawModeGuard {
 /// single keypress without requiring Enter. Raw mode is restored on
 /// every exit path, including panics.
 ///
-/// Skips the wait when stdin isn't a terminal — piped or
-/// headless-CI invocations would otherwise block forever. The prompt
-/// still prints so logs capture any surfaced URL.
+/// Skips the wait when either stdin or stdout isn't a terminal:
+/// - **stdin not TTY** (piped, headless CI) would block forever waiting
+///   for input that can't arrive.
+/// - **stdout not TTY** (`ironclaw > out.txt`) means the prompt isn't
+///   visible to a human, so blocking on a keypress looks like a hang.
+///
+/// The prompt still prints in both cases so logs/redirected output
+/// capture any surfaced URL.
 #[cfg(not(test))]
 fn wait_for_any_key_with_prompt(prompt: &str) -> io::Result<()> {
     use ratatui::crossterm::event::{Event, KeyEventKind, poll, read};
@@ -1712,7 +1717,7 @@ fn wait_for_any_key_with_prompt(prompt: &str) -> io::Result<()> {
     println!("{prompt}");
     io::Write::flush(&mut io::stdout())?;
 
-    if !io::stdin().is_terminal() {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
         return Ok(());
     }
 

--- a/profiles/local.toml
+++ b/profiles/local.toml
@@ -1,8 +1,9 @@
 # IronClaw Profile: local
 #
-# Configuration for solo developers working locally.
-# Disables server-oriented gateway and Docker sandbox features while keeping
-# personal-assistant background tasks enabled.
+# Configuration for solo developers working locally on one machine.
+# Enables both the TUI and a loopback-bound web gateway so the browser UI
+# is discoverable on first run. Disables Docker sandbox to keep the
+# install dependency-free; personal-assistant background tasks stay on.
 #
 # Usage: set IRONCLAW_PROFILE=local in your environment or .env file.
 #
@@ -12,7 +13,11 @@
 database_backend = "libsql"
 
 [channels]
-gateway_enabled = false
+gateway_enabled = true
+# Bind the web gateway to loopback. The local profile is single-machine
+# by design; if you need LAN/remote access, use the `server` profile or
+# override `GATEWAY_HOST` explicitly.
+gateway_host = "127.0.0.1"
 cli_mode = "tui"
 
 [sandbox]

--- a/src/channels/tui.rs
+++ b/src/channels/tui.rs
@@ -209,6 +209,7 @@ pub struct TuiChannel {
     workspace_path: String,
     memory_count: usize,
     identity_files: Vec<String>,
+    tui_entry_prompt: Option<String>,
     available_models: Vec<String>,
 }
 
@@ -234,6 +235,7 @@ impl TuiChannel {
             workspace_path: String::new(),
             memory_count: 0,
             identity_files: Vec::new(),
+            tui_entry_prompt: None,
             available_models: Vec::new(),
         }
     }
@@ -286,6 +288,21 @@ impl TuiChannel {
         self
     }
 
+    /// Set a TUI entry prompt to print and pause on before the TUI takes
+    /// over the terminal.
+    ///
+    /// When set, [`Channel::start`] prints `prompt` to stdout (before any
+    /// alternate-screen / raw-mode switch), then blocks until the user
+    /// presses any key. Acts as a gate so the user can choose a parallel
+    /// chat surface (e.g. open the web gateway URL in a browser) rather
+    /// than dropping straight into the TUI.
+    ///
+    /// `None` (default) skips the gate and starts the TUI immediately.
+    pub fn with_tui_entry_prompt(mut self, prompt: Option<String>) -> Self {
+        self.tui_entry_prompt = prompt;
+        self
+    }
+
     /// Set the available models for the `/model` picker.
     pub fn with_available_models(mut self, models: Vec<String>) -> Self {
         self.available_models = models;
@@ -317,6 +334,7 @@ impl Channel for TuiChannel {
             workspace_path: self.workspace_path.clone(),
             memory_count: self.memory_count,
             identity_files: self.identity_files.clone(),
+            tui_entry_prompt: self.tui_entry_prompt.clone(),
             available_models: self.available_models.clone(),
         };
 

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -231,7 +231,10 @@ mod tests {
     }
 
     #[test]
-    fn local_profile_disables_gateway_and_sandbox() {
+    fn local_profile_enables_loopback_gateway_and_disables_sandbox() {
+        // Updated for #3500: the local profile now enables the web gateway
+        // bound to loopback so the browser UI is discoverable on first run.
+        // Sandbox stays off to keep the install dependency-free.
         let _guard = lock_env();
         unsafe { std::env::set_var("IRONCLAW_PROFILE", "local") };
 
@@ -240,13 +243,70 @@ mod tests {
 
         unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
 
-        assert!(!settings.channels.gateway_enabled);
+        assert!(
+            settings.channels.gateway_enabled,
+            "local profile must enable the web gateway (#3500)"
+        );
+        assert_eq!(
+            settings.channels.gateway_host.as_deref(),
+            Some("127.0.0.1"),
+            "local profile must pin gateway to loopback so quick onboarding can't accidentally expose it on the LAN"
+        );
         assert!(!settings.sandbox.enabled);
         assert!(settings.heartbeat.enabled);
         assert!(settings.routines.enabled);
         assert!(settings.hygiene.enabled);
         assert_eq!(settings.channels.cli_mode.as_deref(), Some("tui"));
         assert_eq!(settings.database_backend.as_deref(), Some("libsql"));
+    }
+
+    #[test]
+    fn local_profile_survives_admin_db_overlay_with_gateway_enabled() {
+        // Regression for #3500. Reproduces the runtime load order in
+        // `Config::load_db_backed_settings`:
+        //
+        //   1. Settings::default()
+        //   2. apply_profile("local")
+        //   3. merge_from(admin DB settings)
+        //
+        // The first iteration of #3500 wrote `gateway_enabled = true` to
+        // the DB but the profile *also* needed to leave the same value
+        // intact, because `merge_non_default` only overlays fields that
+        // differ from the hardcoded default. With `gateway_enabled`'s
+        // default being `true`, a DB-stored `true` couldn't restore a
+        // profile-set `false` on reload — meaning quick onboarding's
+        // intent was silently lost on the second startup. The profile
+        // change in `profiles/local.toml` makes the post-profile state
+        // already match user intent; this test pins that contract so a
+        // future profile edit can't quietly reintroduce the regression.
+        let _guard = lock_env();
+        unsafe { std::env::set_var("IRONCLAW_PROFILE", "local") };
+
+        let mut settings = Settings::default();
+        apply_profile(&mut settings).expect("local profile should load");
+
+        unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
+
+        // Simulate an admin-scope DB overlay containing only fields the
+        // user explicitly changed (the typical shape — `merge_from`
+        // ignores defaults). The overlay must NOT clobber gateway state.
+        let mut admin_overlay = Settings::default();
+        admin_overlay.channels.signal_enabled = true;
+        settings.merge_from(&admin_overlay);
+
+        assert!(
+            settings.channels.gateway_enabled,
+            "gateway must remain enabled after profile + admin-DB overlay (#3500 reload regression)"
+        );
+        assert_eq!(
+            settings.channels.gateway_host.as_deref(),
+            Some("127.0.0.1"),
+            "loopback host must survive the overlay"
+        );
+        assert!(
+            settings.channels.signal_enabled,
+            "admin overlay's non-default field must still apply"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -618,10 +618,9 @@ async fn async_main() -> anyhow::Result<()> {
 
             let to_persist = token.clone();
             tokio::spawn(async move {
-                if let Err(e) = ironclaw::bootstrap::upsert_bootstrap_var(
-                    "GATEWAY_AUTH_TOKEN",
-                    &to_persist,
-                ) {
+                if let Err(e) =
+                    ironclaw::bootstrap::upsert_bootstrap_var("GATEWAY_AUTH_TOKEN", &to_persist)
+                {
                     tracing::warn!("Failed to persist auto-generated gateway auth token: {e}");
                 } else {
                     tracing::debug!("Persisted auto-generated gateway auth token to bootstrap env");
@@ -638,9 +637,9 @@ async fn async_main() -> anyhow::Result<()> {
                         .delete_setting("default", "channels.gateway_auth_token")
                         .await
                     {
-                        Ok(true) => tracing::debug!(
-                            "Removed legacy gateway auth token from DB settings"
-                        ),
+                        Ok(true) => {
+                            tracing::debug!("Removed legacy gateway auth token from DB settings")
+                        }
                         Ok(false) => {}
                         Err(e) => tracing::warn!(
                             "Failed to remove legacy gateway auth token from DB settings: {e}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,7 +431,7 @@ async fn async_main() -> anyhow::Result<()> {
 
     // ── Tunnel setup ───────────────────────────────────────────────────
 
-    let (config, active_tunnel) = if enable_non_cli {
+    let (mut config, active_tunnel) = if enable_non_cli {
         ironclaw::tunnel::start_managed_tunnel(config).await
     } else {
         (config, None)
@@ -597,6 +597,76 @@ async fn async_main() -> anyhow::Result<()> {
             }
         };
 
+        // Resolve the gateway auth token now (rather than deferring to
+        // `GatewayChannel::new`), so the TUI startup gate can show the user
+        // a clickable URL that auto-authenticates. When the gateway is going
+        // to run and no token is configured, generate one and inject it
+        // into `config.channels.gateway.auth_token`; the gateway's own
+        // auto-gen branch then becomes a no-op. Persistence to
+        // `~/.ironclaw/.env` happens here (replaces the deferred persist
+        // that used to live alongside gateway startup).
+        if enable_non_cli
+            && let Some(gw_cfg) = config.channels.gateway.as_mut()
+            && gw_cfg.auth_token.is_none()
+        {
+            use rand::RngCore;
+            use rand::rngs::OsRng;
+            let mut bytes = [0u8; 32];
+            OsRng.fill_bytes(&mut bytes);
+            let token: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+            gw_cfg.auth_token = Some(token.clone());
+
+            let to_persist = token.clone();
+            tokio::spawn(async move {
+                if let Err(e) = ironclaw::bootstrap::upsert_bootstrap_var(
+                    "GATEWAY_AUTH_TOKEN",
+                    &to_persist,
+                ) {
+                    tracing::warn!("Failed to persist auto-generated gateway auth token: {e}");
+                } else {
+                    tracing::debug!("Persisted auto-generated gateway auth token to bootstrap env");
+                }
+            });
+
+            // Opportunistically remove any legacy DB-stored token. Gateway
+            // auth is env-only since #3217; this clears stale rows from
+            // pre-#3217 installs.
+            if let Some(ref db) = components.db {
+                let db = db.clone();
+                tokio::spawn(async move {
+                    match db
+                        .delete_setting("default", "channels.gateway_auth_token")
+                        .await
+                    {
+                        Ok(true) => tracing::debug!(
+                            "Removed legacy gateway auth token from DB settings"
+                        ),
+                        Ok(false) => {}
+                        Err(e) => tracing::warn!(
+                            "Failed to remove legacy gateway auth token from DB settings: {e}"
+                        ),
+                    }
+                });
+            }
+        }
+
+        // Build a TUI entry prompt when the web gateway is also running, so
+        // the user can pick where to chat: open the URL the boot screen
+        // already printed (browser), or press any key to drop into the
+        // terminal UI. Intentionally terse — the boot screen immediately
+        // above already shows the gateway URL with auth token.
+        let tui_entry_prompt: Option<String> = config.channels.gateway.as_ref().map(|_| {
+            use ironclaw::cli::fmt;
+            format!(
+                "\n  {}\u{25B6}{} Press any key to chat in this terminal{}, or open the {}Web UI link{} above.\n",
+                fmt::accent(),
+                fmt::reset(),
+                fmt::dim(),
+                fmt::bold_accent(),
+                fmt::reset(),
+            )
+        });
+
         let tui_channel = ironclaw::channels::TuiChannel::new(
             config.owner_id.clone(),
             env!("CARGO_PKG_VERSION"),
@@ -610,6 +680,7 @@ async fn async_main() -> anyhow::Result<()> {
         .with_workspace_path(workspace_path)
         .with_memory_count(memory_count)
         .with_identity_files(identity_files)
+        .with_tui_entry_prompt(tui_entry_prompt)
         .with_available_models(available_models);
 
         channels.add(Box::new(tui_channel)).await;
@@ -984,42 +1055,10 @@ async fn async_main() -> anyhow::Result<()> {
             }
         }
 
-        // Persist auto-generated auth token so it survives restarts.
-        // Gateway auth is env-only, so write to bootstrap `.env` rather than DB
-        // settings and opportunistically remove any legacy DB copy.
-        if gw_config.auth_token.is_none() {
-            let token_to_persist = gw.auth_token().to_string();
-            tokio::spawn(async move {
-                if let Err(e) = ironclaw::bootstrap::upsert_bootstrap_var(
-                    "GATEWAY_AUTH_TOKEN",
-                    &token_to_persist,
-                ) {
-                    tracing::warn!("Failed to persist auto-generated gateway auth token: {e}");
-                } else {
-                    tracing::debug!("Persisted auto-generated gateway auth token to bootstrap env");
-                }
-            });
-
-            if let Some(ref db) = components.db {
-                let db = db.clone();
-                tokio::spawn(async move {
-                    match db
-                        .delete_setting("default", "channels.gateway_auth_token")
-                        .await
-                    {
-                        Ok(true) => {
-                            tracing::debug!("Removed legacy gateway auth token from DB settings");
-                        }
-                        Ok(false) => {}
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to remove legacy gateway auth token from DB settings: {e}"
-                            );
-                        }
-                    }
-                });
-            }
-        }
+        // Auth-token persistence + legacy DB cleanup moved upstream so the
+        // TUI sidebar can display the same token the gateway accepts. By
+        // the time we reach this point, `gw_config.auth_token` is always
+        // `Some` (env-set, user-configured, or pre-generated above).
 
         gateway_url = Some(format!(
             "http://{}:{}/?token={}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -597,74 +597,24 @@ async fn async_main() -> anyhow::Result<()> {
             }
         };
 
-        // Resolve the gateway auth token now (rather than deferring to
-        // `GatewayChannel::new`), so the TUI startup gate can show the user
-        // a clickable URL that auto-authenticates. When the gateway is going
-        // to run and no token is configured, generate one and inject it
-        // into `config.channels.gateway.auth_token`; the gateway's own
-        // auto-gen branch then becomes a no-op. Persistence to
-        // `~/.ironclaw/.env` happens here (replaces the deferred persist
-        // that used to live alongside gateway startup).
-        if enable_non_cli
-            && let Some(gw_cfg) = config.channels.gateway.as_mut()
-            && gw_cfg.auth_token.is_none()
-        {
-            use rand::RngCore;
-            use rand::rngs::OsRng;
-            let mut bytes = [0u8; 32];
-            OsRng.fill_bytes(&mut bytes);
-            let token: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
-            gw_cfg.auth_token = Some(token.clone());
-
-            let to_persist = token.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    ironclaw::bootstrap::upsert_bootstrap_var("GATEWAY_AUTH_TOKEN", &to_persist)
-                {
-                    tracing::warn!("Failed to persist auto-generated gateway auth token: {e}");
-                } else {
-                    tracing::debug!("Persisted auto-generated gateway auth token to bootstrap env");
-                }
+        // Build a TUI entry prompt when the web gateway is also going to
+        // run. The boot screen prints the gateway URL with auth token; this
+        // prompt lets the user choose between opening that URL or dropping
+        // into the TUI. Only shown when both `enable_non_cli` (gateway
+        // start-gate) and a gateway is configured — otherwise the "Web UI
+        // link above" the prompt references wouldn't exist.
+        let tui_entry_prompt: Option<String> =
+            (enable_non_cli && config.channels.gateway.is_some()).then(|| {
+                use ironclaw::cli::fmt;
+                format!(
+                    "\n  {}\u{25B6}{} Press any key to chat in this terminal{}, or open the {}Web UI link{} above.\n",
+                    fmt::accent(),
+                    fmt::reset(),
+                    fmt::dim(),
+                    fmt::bold_accent(),
+                    fmt::reset(),
+                )
             });
-
-            // Opportunistically remove any legacy DB-stored token. Gateway
-            // auth is env-only since #3217; this clears stale rows from
-            // pre-#3217 installs.
-            if let Some(ref db) = components.db {
-                let db = db.clone();
-                tokio::spawn(async move {
-                    match db
-                        .delete_setting("default", "channels.gateway_auth_token")
-                        .await
-                    {
-                        Ok(true) => {
-                            tracing::debug!("Removed legacy gateway auth token from DB settings")
-                        }
-                        Ok(false) => {}
-                        Err(e) => tracing::warn!(
-                            "Failed to remove legacy gateway auth token from DB settings: {e}"
-                        ),
-                    }
-                });
-            }
-        }
-
-        // Build a TUI entry prompt when the web gateway is also running, so
-        // the user can pick where to chat: open the URL the boot screen
-        // already printed (browser), or press any key to drop into the
-        // terminal UI. Intentionally terse — the boot screen immediately
-        // above already shows the gateway URL with auth token.
-        let tui_entry_prompt: Option<String> = config.channels.gateway.as_ref().map(|_| {
-            use ironclaw::cli::fmt;
-            format!(
-                "\n  {}\u{25B6}{} Press any key to chat in this terminal{}, or open the {}Web UI link{} above.\n",
-                fmt::accent(),
-                fmt::reset(),
-                fmt::dim(),
-                fmt::bold_accent(),
-                fmt::reset(),
-            )
-        });
 
         let tui_channel = ironclaw::channels::TuiChannel::new(
             config.owner_id.clone(),
@@ -899,6 +849,54 @@ async fn async_main() -> anyhow::Result<()> {
 
     // ── Gateway channel ────────────────────────────────────────────────
 
+    // Pre-resolve the gateway auth token before constructing the channel.
+    // Done here (rather than inside `GatewayChannel::new`) so the boot
+    // screen and any TUI prompt can show a clickable URL that
+    // auto-authenticates. Runs for every gateway start — TUI, REPL, or
+    // headless — so a restart never invalidates a previously-issued URL.
+    // Persists to `~/.ironclaw/.env` and opportunistically clears any
+    // legacy DB-stored token (env-only since #3217).
+    if enable_non_cli
+        && let Some(gw_cfg) = config.channels.gateway.as_mut()
+        && gw_cfg.auth_token.is_none()
+    {
+        use rand::RngCore;
+        use rand::rngs::OsRng;
+        let mut bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut bytes);
+        let token: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+        gw_cfg.auth_token = Some(token.clone());
+
+        let to_persist = token.clone();
+        tokio::spawn(async move {
+            if let Err(e) =
+                ironclaw::bootstrap::upsert_bootstrap_var("GATEWAY_AUTH_TOKEN", &to_persist)
+            {
+                tracing::warn!("Failed to persist auto-generated gateway auth token: {e}");
+            } else {
+                tracing::debug!("Persisted auto-generated gateway auth token to bootstrap env");
+            }
+        });
+
+        if let Some(ref db) = components.db {
+            let db = db.clone();
+            tokio::spawn(async move {
+                match db
+                    .delete_setting("default", "channels.gateway_auth_token")
+                    .await
+                {
+                    Ok(true) => {
+                        tracing::debug!("Removed legacy gateway auth token from DB settings")
+                    }
+                    Ok(false) => {}
+                    Err(e) => tracing::warn!(
+                        "Failed to remove legacy gateway auth token from DB settings: {e}"
+                    ),
+                }
+            });
+        }
+    }
+
     let mut gateway_url: Option<String> = None;
     let mut sse_manager: Option<std::sync::Arc<ironclaw::channels::web::sse::SseManager>> = None;
     if enable_non_cli && let Some(ref gw_config) = config.channels.gateway {
@@ -1053,11 +1051,6 @@ async fn async_main() -> anyhow::Result<()> {
                 });
             }
         }
-
-        // Auth-token persistence + legacy DB cleanup moved upstream so the
-        // TUI sidebar can display the same token the gateway accepts. By
-        // the time we reach this point, `gw_config.auth_token` is always
-        // `Some` (env-set, user-configured, or pre-generated above).
 
         gateway_url = Some(format!(
             "http://{}:{}/?token={}",

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -346,9 +346,13 @@ key first, then falls back to the standard env var.
 
 **Channel index constants** (`wizard.rs`): the non-WASM options are at fixed
 positions `0..=3` — `CLI/TUI`, `Web Gateway`, `HTTP webhook`, `Signal` — tracked
-by `CHANNEL_INDEX_GATEWAY`, `CHANNEL_INDEX_HTTP`, `CHANNEL_INDEX_SIGNAL`. If
-you reorder these options, update the constants and the regression test
-`test_non_wasm_channel_labels_match_index_constants` together.
+by `CHANNEL_INDEX_CLI`, `CHANNEL_INDEX_GATEWAY`, `CHANNEL_INDEX_HTTP`,
+`CHANNEL_INDEX_SIGNAL`. The labels live in `NON_WASM_CHANNEL_LABELS` and the
+multi-select options are built by `non_wasm_channel_options()`. If you reorder
+options, update the constants, label array, and helper together — two
+regression tests guard the contract: `test_channel_index_constants_pinned`
+(numeric values) and `test_non_wasm_channel_options_positions` (drives the
+helper and asserts each position's label + enabled-bit wiring).
 
 **Channel sources** (priority order for installation):
 1. Already installed in `~/.ironclaw/channels/`

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -335,13 +335,20 @@ key first, then falls back to the standard env var.
 6a. Tunnel setup (if webhook channels needed)
 6b. Discover WASM channels from ~/.ironclaw/channels/
 6c. Build channel options: discovered + bundled + registry catalog
-6d. Multi-select: CLI/TUI, HTTP, all available channels
+6d. Multi-select: CLI/TUI, Web Gateway, HTTP, Signal, all available WASM channels
 6e. Install missing bundled channels (copy WASM binaries)
 6f. Install missing registry channels (download artifacts, fallback to source build)
 6g. Initialize SecretsContext (for token storage)
-6h. Setup HTTP webhook (if selected)
-6i. Setup each WASM channel (secrets, owner binding)
+6h. Setup Web Gateway flag (if selected — port/token use config defaults)
+6i. Setup HTTP webhook (if selected)
+6j. Setup each WASM channel (secrets, owner binding)
 ```
+
+**Channel index constants** (`wizard.rs`): the non-WASM options are at fixed
+positions `0..=3` — `CLI/TUI`, `Web Gateway`, `HTTP webhook`, `Signal` — tracked
+by `CHANNEL_INDEX_GATEWAY`, `CHANNEL_INDEX_HTTP`, `CHANNEL_INDEX_SIGNAL`. If
+you reorder these options, update the constants and the regression test
+`test_channel_index_positions_match_option_order` together.
 
 **Channel sources** (priority order for installation):
 1. Already installed in `~/.ironclaw/channels/`

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -348,7 +348,7 @@ key first, then falls back to the standard env var.
 positions `0..=3` — `CLI/TUI`, `Web Gateway`, `HTTP webhook`, `Signal` — tracked
 by `CHANNEL_INDEX_GATEWAY`, `CHANNEL_INDEX_HTTP`, `CHANNEL_INDEX_SIGNAL`. If
 you reorder these options, update the constants and the regression test
-`test_channel_index_positions_match_option_order` together.
+`test_non_wasm_channel_labels_match_index_constants` together.
 
 **Channel sources** (priority order for installation):
 1. Already installed in `~/.ironclaw/channels/`

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -1248,13 +1248,14 @@ impl SetupWizard {
         crate::config::profile::apply_profile(&mut self.settings)
             .map_err(|e| SetupError::Config(e.to_string()))?;
 
-        // Quick-mode override: the `local` profile sets
-        // `gateway_enabled = false`, which makes the web UI undiscoverable
-        // for first-run users. Re-enable it here so quick onboarding
-        // produces a working browser-or-TUI experience by default. Users
-        // who want a headless terminal-only install can disable the gateway
-        // via the full wizard's Step 6 or `GATEWAY_ENABLED=false`.
-        self.settings.channels.gateway_enabled = true;
+        // Note (#3500): we used to override `gateway_enabled = true` here
+        // because `profiles/local.toml` disabled the gateway. That override
+        // didn't survive a restart — on the next config load, the profile
+        // re-applied `gateway_enabled = false` and `merge_from` couldn't
+        // restore `true` from the DB because `true` equals the hardcoded
+        // default (see `merge_non_default` in `settings.rs`). The fix lives
+        // in `profiles/local.toml`: the profile itself now enables the
+        // gateway on loopback.
 
         self.selected_deployment_profile = Some(profile.to_string());
         Ok(())
@@ -4200,14 +4201,20 @@ mod tests {
             .apply_quick_local_profile(QUICK_PROFILE_LOCAL)
             .expect("apply_quick_local_profile should succeed");
 
-        // Quick-mode override: even though the `local` profile sets
-        // `gateway_enabled = false`, quick onboarding must re-enable the
-        // web UI so it's discoverable on first run (issue #3500).
-        // Regression guard — removing the override line in
-        // `apply_quick_local_profile` would silently revert the fix.
+        // Quick onboarding must leave the web UI discoverable on first
+        // run (#3500). The fix lives in `profiles/local.toml` rather
+        // than a wizard override (the override didn't survive config
+        // reload — see comment in `apply_quick_local_profile`). Pin
+        // both the enable flag and the loopback host so a regression
+        // in either trips this test.
         assert!(
             wizard.settings.channels.gateway_enabled,
-            "quick-mode override must leave gateway_enabled=true after applying the local profile"
+            "local profile must leave gateway_enabled=true so quick onboarding produces a working web UI on first run"
+        );
+        assert_eq!(
+            wizard.settings.channels.gateway_host.as_deref(),
+            Some("127.0.0.1"),
+            "local profile must pin gateway_host to loopback so quick onboarding doesn't expose the gateway on the LAN"
         );
 
         // Profile applies its own database_backend (libsql) which overwrites

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -42,8 +42,9 @@ use crate::setup::prompts::{
 
 // unused const, keep commented for clarity / future use
 // const CHANNEL_INDEX_CLI: usize = 0;
-const CHANNEL_INDEX_HTTP: usize = 1;
-const CHANNEL_INDEX_SIGNAL: usize = 2;
+const CHANNEL_INDEX_GATEWAY: usize = 1;
+const CHANNEL_INDEX_HTTP: usize = 2;
+const CHANNEL_INDEX_SIGNAL: usize = 3;
 const QUICK_PROFILE_LOCAL: &str = "local";
 const QUICK_PROFILE_LOCAL_SANDBOX: &str = "local-sandbox";
 
@@ -1206,6 +1207,14 @@ impl SetupWizard {
         crate::config::set_runtime_env("IRONCLAW_PROFILE", profile);
         crate::config::profile::apply_profile(&mut self.settings)
             .map_err(|e| SetupError::Config(e.to_string()))?;
+
+        // Quick-mode override: the `local` profile sets
+        // `gateway_enabled = false`, which makes the web UI undiscoverable
+        // for first-run users. Re-enable it here so quick onboarding
+        // produces a working browser-or-TUI experience by default. Users
+        // who want a headless terminal-only install can disable the gateway
+        // via the full wizard's Step 6 or `GATEWAY_ENABLED=false`.
+        self.settings.channels.gateway_enabled = true;
 
         self.selected_deployment_profile = Some(profile.to_string());
         Ok(())
@@ -2623,9 +2632,14 @@ impl SetupWizard {
         // Build channel list from registry (if available) + bundled + discovered
         let wasm_channel_names = build_channel_options(&discovered_channels);
 
-        // Build options list dynamically
+        // Build options list dynamically.
+        // Index order is fixed and tracked by CHANNEL_INDEX_* constants.
         let mut options: Vec<(String, bool)> = vec![
             ("CLI/TUI (always enabled)".to_string(), true),
+            (
+                "Web Gateway (browser UI)".to_string(),
+                self.settings.channels.gateway_enabled,
+            ),
             (
                 "HTTP webhook".to_string(),
                 self.settings.channels.http_enabled,
@@ -2718,6 +2732,19 @@ impl SetupWizard {
         } else {
             None
         };
+
+        // Web Gateway (browser UI).
+        // Port, host, and auth token use config defaults (3000, 127.0.0.1,
+        // auto-generated at startup) — only the enable flag is wizard-driven.
+        if selected.contains(&CHANNEL_INDEX_GATEWAY) {
+            self.settings.channels.gateway_enabled = true;
+            let port = self.settings.channels.gateway_port.unwrap_or(3000);
+            print_info(&format!(
+                "Web Gateway enabled on port {port} (auth token auto-generated at startup)"
+            ));
+        } else {
+            self.settings.channels.gateway_enabled = false;
+        }
 
         // HTTP channel
         if selected.contains(&CHANNEL_INDEX_HTTP) {
@@ -3986,6 +4013,19 @@ mod tests {
     }
 
     #[test]
+    fn test_channel_index_positions_match_option_order() {
+        // The channel multi-select uses fixed indices for the non-WASM options.
+        // If the option order in step_channels() changes, these indices must
+        // change too. This test pins the contract so a silent index drift
+        // (e.g. inserting a new option without updating constants) fails CI
+        // instead of silently turning the wrong setting on/off.
+        let labels = ["CLI/TUI", "Web Gateway", "HTTP webhook", "Signal"];
+        assert_eq!(labels[CHANNEL_INDEX_GATEWAY], "Web Gateway");
+        assert_eq!(labels[CHANNEL_INDEX_HTTP], "HTTP webhook");
+        assert_eq!(labels[CHANNEL_INDEX_SIGNAL], "Signal");
+    }
+
+    #[test]
     fn test_wizard_with_config() {
         let config = SetupConfig {
             skip_auth: true,
@@ -4084,6 +4124,16 @@ mod tests {
         wizard
             .apply_quick_local_profile(QUICK_PROFILE_LOCAL)
             .expect("apply_quick_local_profile should succeed");
+
+        // Quick-mode override: even though the `local` profile sets
+        // `gateway_enabled = false`, quick onboarding must re-enable the
+        // web UI so it's discoverable on first run (issue #3500).
+        // Regression guard — removing the override line in
+        // `apply_quick_local_profile` would silently revert the fix.
+        assert!(
+            wizard.settings.channels.gateway_enabled,
+            "quick-mode override must leave gateway_enabled=true after applying the local profile"
+        );
 
         // Profile applies its own database_backend (libsql) which overwrites
         // the wizard-chosen value.

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -48,16 +48,43 @@ const CHANNEL_INDEX_SIGNAL: usize = 3;
 /// Labels for the non-WASM channel options shown in Step 6's multi-select,
 /// in the order they appear. Indexed by `CHANNEL_INDEX_*` constants.
 ///
-/// Single source of truth: `step_channels` uses this to build the option
-/// list, and `test_non_wasm_channel_labels_match_index_constants` verifies
-/// the index→label mapping. Reorder both together (constant *and* array
-/// entry) or the test fails.
+/// Source of truth for option order: `non_wasm_channel_options()` builds
+/// the actual `(label, enabled)` pairs `step_channels` displays, and
+/// the regression tests below pin both the index constants and the
+/// helper's position-to-label-to-enabled-bit mapping.
 const NON_WASM_CHANNEL_LABELS: [&str; 4] = [
     "CLI/TUI (always enabled)",
     "Web Gateway (browser UI)",
     "HTTP webhook",
     "Signal",
 ];
+
+/// Build the non-WASM channel options for Step 6's multi-select.
+///
+/// Returns four `(label, enabled)` pairs in the order pinned by the
+/// `CHANNEL_INDEX_*` constants. The `step_channels` handler keys its
+/// post-select dispatch off those constants
+/// (`selected.contains(&CHANNEL_INDEX_GATEWAY)` etc.), so the vec
+/// position MUST stay aligned with the constant. Tests
+/// `test_non_wasm_channel_options_positions` and
+/// `test_channel_index_constants_pinned` enforce this contract.
+fn non_wasm_channel_options(channels: &crate::settings::ChannelSettings) -> Vec<(String, bool)> {
+    vec![
+        (NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_CLI].to_string(), true),
+        (
+            NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_GATEWAY].to_string(),
+            channels.gateway_enabled,
+        ),
+        (
+            NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_HTTP].to_string(),
+            channels.http_enabled,
+        ),
+        (
+            NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_SIGNAL].to_string(),
+            channels.signal_enabled,
+        ),
+    ]
+}
 const QUICK_PROFILE_LOCAL: &str = "local";
 const QUICK_PROFILE_LOCAL_SANDBOX: &str = "local-sandbox";
 
@@ -2645,24 +2672,11 @@ impl SetupWizard {
         // Build channel list from registry (if available) + bundled + discovered
         let wasm_channel_names = build_channel_options(&discovered_channels);
 
-        // Build options list dynamically. Labels and indices are pinned
-        // by `NON_WASM_CHANNEL_LABELS` and the `CHANNEL_INDEX_*` constants;
-        // reorder them together or the regression test fails.
-        let mut options: Vec<(String, bool)> = vec![
-            (NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_CLI].to_string(), true),
-            (
-                NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_GATEWAY].to_string(),
-                self.settings.channels.gateway_enabled,
-            ),
-            (
-                NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_HTTP].to_string(),
-                self.settings.channels.http_enabled,
-            ),
-            (
-                NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_SIGNAL].to_string(),
-                self.settings.channels.signal_enabled,
-            ),
-        ];
+        // Build options list dynamically. The non-WASM portion comes from
+        // `non_wasm_channel_options`, which pins label-and-enable-bit
+        // ordering against the `CHANNEL_INDEX_*` constants (see regression
+        // tests). WASM channels are appended after.
+        let mut options: Vec<(String, bool)> = non_wasm_channel_options(&self.settings.channels);
 
         let non_wasm_count = options.len();
 
@@ -4030,29 +4044,59 @@ mod tests {
     }
 
     #[test]
-    fn test_non_wasm_channel_labels_match_index_constants() {
-        // `step_channels` builds its non-WASM options list by indexing
-        // `NON_WASM_CHANNEL_LABELS` with the `CHANNEL_INDEX_*` constants.
-        // Reordering either the constants or the label array without
-        // updating the other would route enable/disable flags to the
-        // wrong channel — a silent and dangerous bug.
-        //
-        // This test pins the const-to-index contract that `step_channels`
-        // actually consumes. Reorder both together or this fails.
-        assert_eq!(
-            NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_CLI],
-            "CLI/TUI (always enabled)"
+    fn test_channel_index_constants_pinned() {
+        // The `CHANNEL_INDEX_*` constants are part of the wizard's
+        // selection-dispatch contract: after the multi-select returns
+        // a `Vec<usize>` of clicked positions, `step_channels` keys off
+        // these constants (`if selected.contains(&CHANNEL_INDEX_GATEWAY)
+        // { enable gateway }`). Changing any of these numbers without
+        // matching changes in `non_wasm_channel_options`'s order silently
+        // misroutes selections (clicking "HTTP" toggles "Signal", etc.).
+        // Pin the numeric values here so any drift fails CI.
+        assert_eq!(CHANNEL_INDEX_CLI, 0);
+        assert_eq!(CHANNEL_INDEX_GATEWAY, 1);
+        assert_eq!(CHANNEL_INDEX_HTTP, 2);
+        assert_eq!(CHANNEL_INDEX_SIGNAL, 3);
+    }
+
+    #[test]
+    fn test_non_wasm_channel_options_positions() {
+        // Drives the actual code path `step_channels` uses to build its
+        // options list. Asserts that the label and enabled-bit at each
+        // `CHANNEL_INDEX_*` position are wired to the right
+        // `ChannelSettings` field. A reorder of the `vec![...]` inside
+        // `non_wasm_channel_options` (without matching constant changes)
+        // would fail this — covering the gap the previous label-only test
+        // missed.
+        let channels = crate::settings::ChannelSettings {
+            gateway_enabled: true,
+            http_enabled: false,
+            signal_enabled: true,
+            ..Default::default()
+        };
+        let options = non_wasm_channel_options(&channels);
+
+        assert_eq!(options.len(), 4, "non-WASM option count");
+
+        assert_eq!(options[CHANNEL_INDEX_CLI].0, "CLI/TUI (always enabled)");
+        assert!(options[CHANNEL_INDEX_CLI].1, "CLI/TUI is always enabled");
+
+        assert_eq!(options[CHANNEL_INDEX_GATEWAY].0, "Web Gateway (browser UI)");
+        assert!(
+            options[CHANNEL_INDEX_GATEWAY].1,
+            "gateway position must reflect channels.gateway_enabled (was true)"
         );
-        assert_eq!(
-            NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_GATEWAY],
-            "Web Gateway (browser UI)"
+
+        assert_eq!(options[CHANNEL_INDEX_HTTP].0, "HTTP webhook");
+        assert!(
+            !options[CHANNEL_INDEX_HTTP].1,
+            "http position must reflect channels.http_enabled (was false)"
         );
-        assert_eq!(NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_HTTP], "HTTP webhook");
-        assert_eq!(NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_SIGNAL], "Signal");
-        assert_eq!(
-            NON_WASM_CHANNEL_LABELS.len(),
-            4,
-            "adding a new non-WASM channel option requires a new CHANNEL_INDEX_* constant and a new array entry"
+
+        assert_eq!(options[CHANNEL_INDEX_SIGNAL].0, "Signal");
+        assert!(
+            options[CHANNEL_INDEX_SIGNAL].1,
+            "signal position must reflect channels.signal_enabled (was true)"
         );
     }
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -40,11 +40,24 @@ use crate::setup::prompts::{
     print_step, print_success, secret_input, select_many, select_one,
 };
 
-// unused const, keep commented for clarity / future use
-// const CHANNEL_INDEX_CLI: usize = 0;
+const CHANNEL_INDEX_CLI: usize = 0;
 const CHANNEL_INDEX_GATEWAY: usize = 1;
 const CHANNEL_INDEX_HTTP: usize = 2;
 const CHANNEL_INDEX_SIGNAL: usize = 3;
+
+/// Labels for the non-WASM channel options shown in Step 6's multi-select,
+/// in the order they appear. Indexed by `CHANNEL_INDEX_*` constants.
+///
+/// Single source of truth: `step_channels` uses this to build the option
+/// list, and `test_non_wasm_channel_labels_match_index_constants` verifies
+/// the index→label mapping. Reorder both together (constant *and* array
+/// entry) or the test fails.
+const NON_WASM_CHANNEL_LABELS: [&str; 4] = [
+    "CLI/TUI (always enabled)",
+    "Web Gateway (browser UI)",
+    "HTTP webhook",
+    "Signal",
+];
 const QUICK_PROFILE_LOCAL: &str = "local";
 const QUICK_PROFILE_LOCAL_SANDBOX: &str = "local-sandbox";
 
@@ -2632,19 +2645,23 @@ impl SetupWizard {
         // Build channel list from registry (if available) + bundled + discovered
         let wasm_channel_names = build_channel_options(&discovered_channels);
 
-        // Build options list dynamically.
-        // Index order is fixed and tracked by CHANNEL_INDEX_* constants.
+        // Build options list dynamically. Labels and indices are pinned
+        // by `NON_WASM_CHANNEL_LABELS` and the `CHANNEL_INDEX_*` constants;
+        // reorder them together or the regression test fails.
         let mut options: Vec<(String, bool)> = vec![
-            ("CLI/TUI (always enabled)".to_string(), true),
+            (NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_CLI].to_string(), true),
             (
-                "Web Gateway (browser UI)".to_string(),
+                NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_GATEWAY].to_string(),
                 self.settings.channels.gateway_enabled,
             ),
             (
-                "HTTP webhook".to_string(),
+                NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_HTTP].to_string(),
                 self.settings.channels.http_enabled,
             ),
-            ("Signal".to_string(), self.settings.channels.signal_enabled),
+            (
+                NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_SIGNAL].to_string(),
+                self.settings.channels.signal_enabled,
+            ),
         ];
 
         let non_wasm_count = options.len();
@@ -4013,16 +4030,30 @@ mod tests {
     }
 
     #[test]
-    fn test_channel_index_positions_match_option_order() {
-        // The channel multi-select uses fixed indices for the non-WASM options.
-        // If the option order in step_channels() changes, these indices must
-        // change too. This test pins the contract so a silent index drift
-        // (e.g. inserting a new option without updating constants) fails CI
-        // instead of silently turning the wrong setting on/off.
-        let labels = ["CLI/TUI", "Web Gateway", "HTTP webhook", "Signal"];
-        assert_eq!(labels[CHANNEL_INDEX_GATEWAY], "Web Gateway");
-        assert_eq!(labels[CHANNEL_INDEX_HTTP], "HTTP webhook");
-        assert_eq!(labels[CHANNEL_INDEX_SIGNAL], "Signal");
+    fn test_non_wasm_channel_labels_match_index_constants() {
+        // `step_channels` builds its non-WASM options list by indexing
+        // `NON_WASM_CHANNEL_LABELS` with the `CHANNEL_INDEX_*` constants.
+        // Reordering either the constants or the label array without
+        // updating the other would route enable/disable flags to the
+        // wrong channel — a silent and dangerous bug.
+        //
+        // This test pins the const-to-index contract that `step_channels`
+        // actually consumes. Reorder both together or this fails.
+        assert_eq!(
+            NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_CLI],
+            "CLI/TUI (always enabled)"
+        );
+        assert_eq!(
+            NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_GATEWAY],
+            "Web Gateway (browser UI)"
+        );
+        assert_eq!(NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_HTTP], "HTTP webhook");
+        assert_eq!(NON_WASM_CHANNEL_LABELS[CHANNEL_INDEX_SIGNAL], "Signal");
+        assert_eq!(
+            NON_WASM_CHANNEL_LABELS.len(),
+            4,
+            "adding a new non-WASM channel option requires a new CHANNEL_INDEX_* constant and a new array entry"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #3500.

## Summary

A fresh local install would drop the user into the TUI with no signal that `http://localhost:3000` was available or how to turn it on. The `local` deployment profile disabled the gateway, quick onboarding applied it without reaching Step 6, the full wizard had no web-gateway option, and even when the gateway *was* enabled the boot-screen URL scrolled off as the TUI grabbed the terminal.

This PR closes all four gaps the issue lists:

- **Full wizard now offers "Web Gateway (browser UI)" in Step 6.** Sits at fixed index 1; existing HTTP/Signal indices shift to 2/3. A regression test pins the contract so a silent reorder fails CI.
- **Quick onboarding enables the gateway by default.** `apply_quick_local_profile` re-enables the gateway immediately after applying the `local` profile — no new prompt added to quickstart. A unit assertion guards the override.
- **Boot-screen URL matches what the server accepts.** Gateway auth token is now resolved before the boot screen prints; token persistence to `~/.ironclaw/.env` and legacy DB-row cleanup move with it.
- **TUI entry prompt keeps the URL legible.** When both surfaces run, `wait_for_any_key_with_prompt` blocks before `enable_raw_mode` so the user reads the URL on the boot screen and chooses: click for browser, press any key for TUI. A `RawModeGuard` RAII type restores the terminal on panic; an `IsTerminal` check skips the gate for piped/headless invocations.

## Out of scope (follow-ups)

- `db_first_bool` precedence semantics still shadow env vars when a profile writes a non-default bool. This PR sidesteps the shadow (the override happens to match the hardcoded default for `gateway_enabled`); the underlying audit across ~15 bool flags needs its own issue.
- `profiles/local.toml` unchanged — quick-mode override happens after profile application.
- `src/settings.rs` hardcoded default unchanged.

## Test plan

- [ ] `rm -rf /tmp/ic-fresh && IRONCLAW_BASE_DIR=/tmp/ic-fresh cargo run --bin ironclaw` — quick mode completes; boot screen prints `http://127.0.0.1:3000/?token=...` URL; "Press any key" prompt appears; pressing a key enters the TUI; pasting the URL into a browser logs in successfully.
- [ ] `rm -rf /tmp/ic-full && IRONCLAW_BASE_DIR=/tmp/ic-full cargo run --bin ironclaw -- onboard` — full wizard shows "Web Gateway (browser UI)" at index 1 in the channel multi-select; toggling it controls `gateway_enabled` in the resulting settings.
- [ ] Headless: piping stdin (`cargo run < /dev/null`) skips the press-any-key gate (IsTerminal check); the URL still prints to scrollback.
- [ ] Panic during TUI restores raw mode (RawModeGuard Drop fires).
- [ ] `cargo test --lib -p ironclaw test_apply_quick_local_profile` — new `gateway_enabled = true` assertion passes.
- [ ] `cargo test --lib -p ironclaw test_channel_index_positions_match_option_order` — index regression test passes.
- [ ] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)