### PR TITLE
fix(web-ui): failed tool card history rendering

### DIFF
--- a/crates/ironclaw_gateway/static/js/core/tool-activity.js
+++ b/crates/ironclaw_gateway/static/js/core/tool-activity.js
@@ -17,10 +17,10 @@ function truncateToolActivityResult(text) {
 function buildToolFailureText(parameters, error) {
   let detail = '';
   if (parameters) {
-    detail += 'Input:\n' + parameters + '\n\n';
+    detail += 'Input:\n' + parameters;
   }
   if (error) {
-    detail += 'Error:\n' + error;
+    detail += (detail ? '\n\n' : '') + error;
   }
   return detail;
 }
@@ -514,4 +514,3 @@ function humanizeToolName(rawName) {
 function shouldShowChannelConnectedMessage(extensionName, success) {
   return false;
 }
-

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -426,6 +426,49 @@ pub fn tool_result_for_display(result: &serde_json::Value) -> Option<String> {
     Some(truncate_preview(&content, MAX_TOOL_RESULT_DISPLAY_BYTES))
 }
 
+fn displayed_tool_result_is_error(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    trimmed.starts_with("[ACTION FAILED]")
+        || (trimmed.starts_with("Tool '") && trimmed.contains("' failed:"))
+}
+
+fn displayed_tool_result_error_text(text: &str) -> Option<String> {
+    let trimmed = text.trim_start();
+
+    if let Some(rest) = trimmed.strip_prefix("[ACTION FAILED]") {
+        let rest = rest.trim_start();
+        for marker in [r#"{'error': "#, r#"{"error": "#] {
+            if let Some(idx) = rest.find(marker) {
+                let value = rest[idx + marker.len()..]
+                    .trim()
+                    .trim_end_matches('}')
+                    .trim()
+                    .trim_end_matches(',')
+                    .trim();
+                if let Some(unquoted) = value
+                    .strip_prefix('"')
+                    .and_then(|s| s.strip_suffix('"'))
+                    .or_else(|| value.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+                {
+                    return Some(unquoted.to_string());
+                }
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+        if !rest.is_empty() {
+            return Some(rest.to_string());
+        }
+    }
+
+    if trimmed.starts_with("Tool '") && trimmed.contains("' failed:") {
+        return Some(trimmed.to_string());
+    }
+
+    None
+}
+
 /// Parse tool call summary JSON objects into `ToolCallInfo` structs.
 fn parse_tool_call_infos(calls: &[serde_json::Value]) -> Vec<ToolCallInfo> {
     calls
@@ -433,11 +476,27 @@ fn parse_tool_call_infos(calls: &[serde_json::Value]) -> Vec<ToolCallInfo> {
         .map(|c| {
             let result_preview = c.get("result_preview").and_then(tool_result_for_display);
             let result = c.get("result").and_then(tool_result_for_display);
+            let error = c["error"]
+                .as_str()
+                .map(tool_error_for_display)
+                .or_else(|| {
+                    result_preview
+                        .as_deref()
+                        .and_then(displayed_tool_result_error_text)
+                })
+                .or_else(|| result.as_deref().and_then(displayed_tool_result_error_text));
+            let has_error = c.get("error").is_some_and(|v| !v.is_null())
+                || result_preview
+                    .as_deref()
+                    .is_some_and(displayed_tool_result_is_error)
+                || result
+                    .as_deref()
+                    .is_some_and(displayed_tool_result_is_error);
             ToolCallInfo {
                 name: c["name"].as_str().unwrap_or("unknown").to_string(),
                 has_result: c.get("result").is_some_and(|v| !v.is_null())
                     || c.get("result_preview").is_some_and(|v| !v.is_null()),
-                has_error: c.get("error").is_some_and(|v| !v.is_null()),
+                has_error,
                 call_id: c
                     .get("tool_call_id")
                     .or_else(|| c.get("call_id"))
@@ -445,7 +504,7 @@ fn parse_tool_call_infos(calls: &[serde_json::Value]) -> Vec<ToolCallInfo> {
                     .map(String::from),
                 result,
                 result_preview,
-                error: c["error"].as_str().map(tool_error_for_display),
+                error,
                 rationale: c["rationale"].as_str().map(String::from),
             }
         })
@@ -707,6 +766,36 @@ mod tests {
         assert_eq!(turns[0].tool_calls[1].name, "http");
         assert!(turns[0].tool_calls[1].has_error);
         assert_eq!(turns[0].response.as_deref(), Some("Done"));
+    }
+
+    #[test]
+    fn test_build_turns_marks_action_failed_result_as_error() {
+        let tc_json = serde_json::json!([{
+            "name": "http",
+            "result_preview": "[ACTION FAILED] http: {'error': \"Tool 'http' failed: invalid URL\"}",
+            "result": "[ACTION FAILED] http: {'error': \"Tool 'http' failed: invalid URL\"}"
+        }]);
+        let messages = vec![
+            make_msg("user", "Fetch a relative URL", 0),
+            make_msg("tool_calls", &tc_json.to_string(), 500),
+            make_msg("assistant", "The URL is invalid.", 1000),
+        ];
+
+        let turns = build_turns_from_db_messages(&messages);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        assert_eq!(turns[0].tool_calls[0].name, "http");
+        assert!(turns[0].tool_calls[0].has_result);
+        assert!(
+            turns[0].tool_calls[0].has_error,
+            "history must render action-failed result payloads as failed tool cards"
+        );
+        assert_eq!(
+            turns[0].tool_calls[0].error.as_deref(),
+            Some("Tool 'http' failed: invalid URL")
+        );
+        assert_eq!(turns[0].response.as_deref(), Some("The URL is invalid."));
     }
 
     #[test]

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -426,10 +426,64 @@ pub fn tool_result_for_display(result: &serde_json::Value) -> Option<String> {
     Some(truncate_preview(&content, MAX_TOOL_RESULT_DISPLAY_BYTES))
 }
 
-fn displayed_tool_result_is_error(text: &str) -> bool {
-    let trimmed = text.trim_start();
-    trimmed.starts_with("[ACTION FAILED]")
-        || (trimmed.starts_with("Tool '") && trimmed.contains("' failed:"))
+fn quoted_value_prefix(value: &str, quote: char) -> Option<&str> {
+    let mut escaped = false;
+    for (idx, ch) in value.char_indices().skip(1) {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == quote {
+            return Some(&value[..=idx]);
+        }
+    }
+    None
+}
+
+fn action_failed_error_value(rest: &str) -> Option<String> {
+    for key in [r#"'error'"#, r#""error""#] {
+        for (idx, _) in rest.match_indices(key) {
+            let after_key = rest[idx + key.len()..].trim_start();
+            let Some(value) = after_key.strip_prefix(':') else {
+                continue;
+            };
+            let value = value.trim_start();
+            let parsed = if let Some(quote) = value
+                .chars()
+                .next()
+                .filter(|quote| matches!(*quote, '"' | '\''))
+            {
+                let raw = quoted_value_prefix(value, quote).unwrap_or_else(|| {
+                    value
+                        .split_once(',')
+                        .map(|(value, _)| value)
+                        .unwrap_or(value)
+                        .trim_end_matches('}')
+                        .trim()
+                });
+                raw.trim_matches(quote).trim()
+            } else {
+                value
+                    .split_once(',')
+                    .map(|(value, _)| value)
+                    .unwrap_or(value)
+                    .trim_end_matches('}')
+                    .trim()
+                    .trim_matches(|c| c == '"' || c == '\'')
+                    .trim()
+            };
+
+            if !parsed.is_empty() {
+                return Some(parsed.to_string());
+            }
+        }
+    }
+
+    None
 }
 
 fn displayed_tool_result_error_text(text: &str) -> Option<String> {
@@ -437,25 +491,8 @@ fn displayed_tool_result_error_text(text: &str) -> Option<String> {
 
     if let Some(rest) = trimmed.strip_prefix("[ACTION FAILED]") {
         let rest = rest.trim_start();
-        for marker in [r#"{'error': "#, r#"{"error": "#] {
-            if let Some(idx) = rest.find(marker) {
-                let value = rest[idx + marker.len()..]
-                    .trim()
-                    .trim_end_matches('}')
-                    .trim()
-                    .trim_end_matches(',')
-                    .trim();
-                if let Some(unquoted) = value
-                    .strip_prefix('"')
-                    .and_then(|s| s.strip_suffix('"'))
-                    .or_else(|| value.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
-                {
-                    return Some(unquoted.to_string());
-                }
-                if !value.is_empty() {
-                    return Some(value.to_string());
-                }
-            }
+        if let Some(error) = action_failed_error_value(rest) {
+            return Some(error);
         }
         if !rest.is_empty() {
             return Some(rest.to_string());
@@ -469,6 +506,14 @@ fn displayed_tool_result_error_text(text: &str) -> Option<String> {
     None
 }
 
+fn tool_error_value_for_display(error: &serde_json::Value) -> Option<String> {
+    match error {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(error) => Some(tool_error_for_display(error)),
+        other => Some(tool_error_for_display(&other.to_string())),
+    }
+}
+
 /// Parse tool call summary JSON objects into `ToolCallInfo` structs.
 fn parse_tool_call_infos(calls: &[serde_json::Value]) -> Vec<ToolCallInfo> {
     calls
@@ -476,22 +521,16 @@ fn parse_tool_call_infos(calls: &[serde_json::Value]) -> Vec<ToolCallInfo> {
         .map(|c| {
             let result_preview = c.get("result_preview").and_then(tool_result_for_display);
             let result = c.get("result").and_then(tool_result_for_display);
-            let error = c["error"]
-                .as_str()
-                .map(tool_error_for_display)
+            let error = c
+                .get("error")
+                .and_then(tool_error_value_for_display)
                 .or_else(|| {
                     result_preview
                         .as_deref()
                         .and_then(displayed_tool_result_error_text)
                 })
                 .or_else(|| result.as_deref().and_then(displayed_tool_result_error_text));
-            let has_error = c.get("error").is_some_and(|v| !v.is_null())
-                || result_preview
-                    .as_deref()
-                    .is_some_and(displayed_tool_result_is_error)
-                || result
-                    .as_deref()
-                    .is_some_and(displayed_tool_result_is_error);
+            let has_error = error.is_some();
             ToolCallInfo {
                 name: c["name"].as_str().unwrap_or("unknown").to_string(),
                 has_result: c.get("result").is_some_and(|v| !v.is_null())
@@ -799,6 +838,29 @@ mod tests {
     }
 
     #[test]
+    fn test_build_turns_extracts_action_failed_error_with_extra_fields() {
+        let tc_json = serde_json::json!([{
+            "name": "http",
+            "result_preview": "[ACTION FAILED] http: {'error' :\"Tool 'http' failed: invalid URL\", 'code': 400}"
+        }]);
+        let messages = vec![
+            make_msg("user", "Fetch a relative URL", 0),
+            make_msg("tool_calls", &tc_json.to_string(), 500),
+            make_msg("assistant", "The URL is invalid.", 1000),
+        ];
+
+        let turns = build_turns_from_db_messages(&messages);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        assert!(turns[0].tool_calls[0].has_error);
+        assert_eq!(
+            turns[0].tool_calls[0].error.as_deref(),
+            Some("Tool 'http' failed: invalid URL")
+        );
+    }
+
+    #[test]
     fn test_build_turns_with_persisted_tool_result_for_display() {
         let tc_json = serde_json::json!([{
             "name": "memory_search",
@@ -863,6 +925,32 @@ mod tests {
             turns[0].tool_calls[0].error.as_deref(),
             Some("Tool 'http' failed: timeout")
         );
+    }
+
+    #[test]
+    fn test_build_turns_marks_non_string_tool_error_as_error() {
+        let tc_json = serde_json::json!([
+            {
+                "name": "mcp",
+                "error": {"code": -32000, "message": "Unauthorized"}
+            }
+        ]);
+        let messages = vec![
+            make_msg("user", "Call MCP", 0),
+            make_msg("tool_calls", &tc_json.to_string(), 500),
+        ];
+
+        let turns = build_turns_from_db_messages(&messages);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        assert!(turns[0].tool_calls[0].has_error);
+        let error = turns[0].tool_calls[0]
+            .error
+            .as_deref()
+            .expect("non-null error should be rendered");
+        assert!(error.contains(r#""code":-32000"#));
+        assert!(error.contains(r#""message":"Unauthorized""#));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixed chat history parsing so persisted failed tool calls no longer flip into successful cards after refresh.
- Normalized `[ACTION FAILED] ...` persisted payloads back into plain error text so history rendering matches live failure rendering.
- Removed the redundant `Error:` prefix from live failed tool cards to keep refresh and non-refresh states visually consistent.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Fixes #3464
Fixes #3729 

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test test_build_turns_marks_action_failed_result_as_error --lib`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: reproduced a failed tool call in Gateway, refreshed the page, and verified the tool card stayed failed with consistent error text before and after refresh.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None.

## Database Impact

None. No schema or migration changes.

## Blast Radius

Touches Gateway tool activity rendering and history parsing for persisted tool call records. Regressions would affect how failed tool calls appear in chat history after refresh.

## Rollback Plan

Revert this PR to restore the previous failed-tool-card parsing and rendering behavior.

## Review Follow-Through

This PR intentionally keeps the fix narrow to rendering/parsing consistency only. It does not change how failed tool call payloads are originally persisted.

---

**Review track**: B
