### PR TITLE
feat(reborn-cli): add profile list command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,6 +4554,7 @@ dependencies = [
  "clap_complete",
  "ironclaw_reborn",
  "ironclaw_reborn_config",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.5.0"
 ironclaw_reborn = { path = "../ironclaw_reborn", version = "0.1.0" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
+serde_json = "1"
 
 [[bin]]
 name = "ironclaw-reborn"

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ use clap::Subcommand;
 
 pub(crate) mod completion;
 pub(crate) mod doctor;
+pub(crate) mod profile;
 pub(crate) mod run;
 
 #[derive(Debug, Subcommand)]
@@ -10,6 +11,8 @@ pub(crate) enum Command {
     Completion(completion::CompletionCommand),
     /// Check Reborn binary configuration without creating state.
     Doctor(doctor::DoctorCommand),
+    /// Inspect supported Reborn boot profiles.
+    Profile(profile::ProfileCommand),
     /// Initialize the minimal Reborn runtime shell and exit.
     Run(run::RunCommand),
 }
@@ -21,6 +24,7 @@ impl Command {
             Self::Doctor(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }
+            Self::Profile(command) => command.execute(),
             Self::Run(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }

--- a/crates/ironclaw_reborn_cli/src/commands/profile.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/profile.rs
@@ -30,29 +30,26 @@ impl ProfileCommand {
 
 impl ProfileListCommand {
     fn execute(self) -> anyhow::Result<()> {
-        let profiles = [
-            RebornProfile::LocalDev,
-            RebornProfile::Production,
-            RebornProfile::MigrationDryRun,
-        ];
+        let profiles = RebornProfile::all();
 
         if self.json {
-            print!("{{\"profiles\":[");
-            for (index, profile) in profiles.iter().enumerate() {
-                if index > 0 {
-                    print!(",");
-                }
-                print!(
-                    "{{\"name\":\"{}\",\"default\":{}}}",
-                    profile,
-                    *profile == RebornProfile::default()
-                );
-            }
-            println!("],\"selector\":\"{}\"}}", REBORN_PROFILE_ENV);
+            let profiles = profiles.iter().map(|profile| {
+                serde_json::json!({
+                    "name": profile.as_str(),
+                    "default": *profile == RebornProfile::default(),
+                })
+            });
+            println!(
+                "{}",
+                serde_json::json!({
+                    "profiles": profiles.collect::<Vec<_>>(),
+                    "selector": REBORN_PROFILE_ENV,
+                })
+            );
         } else {
             println!("IronClaw Reborn profiles");
             for profile in profiles {
-                if profile == RebornProfile::default() {
+                if *profile == RebornProfile::default() {
                     println!("- {} (default)", profile);
                 } else {
                     println!("- {}", profile);

--- a/crates/ironclaw_reborn_cli/src/commands/profile.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/profile.rs
@@ -1,0 +1,66 @@
+use clap::{Args, Subcommand};
+use ironclaw_reborn_config::{REBORN_PROFILE_ENV, RebornProfile};
+
+#[derive(Debug, Args)]
+pub(crate) struct ProfileCommand {
+    #[command(subcommand)]
+    command: ProfileSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ProfileSubcommand {
+    /// List supported Reborn boot profiles.
+    List(ProfileListCommand),
+}
+
+#[derive(Debug, Args)]
+struct ProfileListCommand {
+    /// Output profiles as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl ProfileCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            ProfileSubcommand::List(command) => command.execute(),
+        }
+    }
+}
+
+impl ProfileListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        let profiles = [
+            RebornProfile::LocalDev,
+            RebornProfile::Production,
+            RebornProfile::MigrationDryRun,
+        ];
+
+        if self.json {
+            print!("{{\"profiles\":[");
+            for (index, profile) in profiles.iter().enumerate() {
+                if index > 0 {
+                    print!(",");
+                }
+                print!(
+                    "{{\"name\":\"{}\",\"default\":{}}}",
+                    profile,
+                    *profile == RebornProfile::default()
+                );
+            }
+            println!("],\"selector\":\"{}\"}}", REBORN_PROFILE_ENV);
+        } else {
+            println!("IronClaw Reborn profiles");
+            for profile in profiles {
+                if profile == RebornProfile::default() {
+                    println!("- {} (default)", profile);
+                } else {
+                    println!("- {}", profile);
+                }
+            }
+            println!("Select with {}=<profile>", REBORN_PROFILE_ENV);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -73,7 +73,7 @@ fn profile_list_json_is_stable_and_does_not_resolve_reborn_home() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert_eq!(
         stdout.trim(),
-        r#"{"profiles":[{"name":"local-dev","default":true},{"name":"production","default":false},{"name":"migration-dry-run","default":false}],"selector":"IRONCLAW_REBORN_PROFILE"}"#
+        r#"{"profiles":[{"default":true,"name":"local-dev"},{"default":false,"name":"production"},{"default":false,"name":"migration-dry-run"}],"selector":"IRONCLAW_REBORN_PROFILE"}"#
     );
 }
 

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -23,7 +23,58 @@ fn help_mentions_reborn_commands() {
     );
     assert!(stdout.contains("completion"), "stdout: {stdout}");
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
+    assert!(stdout.contains("profile"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+}
+
+#[test]
+fn profile_list_shows_supported_profiles_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("profile")
+        .arg("list")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn profile list should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn profiles"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("local-dev (default)"), "stdout: {stdout}");
+    assert!(stdout.contains("production"), "stdout: {stdout}");
+    assert!(stdout.contains("migration-dry-run"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("IRONCLAW_REBORN_PROFILE"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn profile_list_json_is_stable_and_does_not_resolve_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("profile")
+        .arg("list")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn profile list --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        r#"{"profiles":[{"name":"local-dev","default":true},{"name":"production","default":false},{"name":"migration-dry-run","default":false}],"selector":"IRONCLAW_REBORN_PROFILE"}"#
+    );
 }
 
 #[test]

--- a/crates/ironclaw_reborn_config/src/profile.rs
+++ b/crates/ironclaw_reborn_config/src/profile.rs
@@ -21,6 +21,12 @@ pub enum RebornProfile {
 }
 
 impl RebornProfile {
+    const ALL: [Self; 3] = [Self::LocalDev, Self::Production, Self::MigrationDryRun];
+
+    pub fn all() -> &'static [Self] {
+        &Self::ALL
+    }
+
     pub fn from_env_value(value: Option<OsString>) -> Result<Self, RebornConfigError> {
         let Some(value) = value else {
             return Ok(Self::default());

--- a/crates/ironclaw_reborn_config/tests/profile_contract.rs
+++ b/crates/ironclaw_reborn_config/tests/profile_contract.rs
@@ -12,6 +12,18 @@ fn profile_wire_values_are_stable() {
 }
 
 #[test]
+fn all_profiles_are_exposed_in_display_order() {
+    assert_eq!(
+        RebornProfile::all(),
+        &[
+            RebornProfile::LocalDev,
+            RebornProfile::Production,
+            RebornProfile::MigrationDryRun,
+        ]
+    );
+}
+
+#[test]
 fn profile_parsing_accepts_expected_values() {
     assert_eq!(
         RebornProfile::from_str("local-dev"),

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -15,6 +15,8 @@ ironclaw-reborn --help
 ironclaw-reborn completion --shell bash
 ironclaw-reborn completion --shell zsh
 ironclaw-reborn doctor
+ironclaw-reborn profile list
+ironclaw-reborn profile list --json
 ironclaw-reborn run
 ```
 
@@ -55,6 +57,23 @@ Expected fields include:
 - `profile`
 - `v1_state: not-used`
 - `driver_registry: initialized`
+
+### `profile list`
+
+Lists the supported Reborn boot profiles without resolving Reborn home, reading v1 state, or creating directories.
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- profile list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- profile list --json
+```
+
+Supported profiles:
+
+- `local-dev` (default)
+- `production`
+- `migration-dry-run`
+
+Select a profile with `IRONCLAW_REBORN_PROFILE=<profile>`.
 
 ### `run`
 
@@ -116,6 +135,7 @@ cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- profile list
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
 ```


### PR DESCRIPTION
## Summary
- Add `ironclaw-reborn profile list` as a pure read-only command.
- Add `--json` output for scripting.
- Document the new command in `docs/reborn-binary.md`.

## Safety / Reborn boundaries
- Does not resolve Reborn home.
- Does not read or create v1 state.
- Does not add v1 runtime imports.

## Tests
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_architecture reborn`
- `TMPDIR=$PWD/.tmp-cargo cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `TMPDIR=$PWD/.tmp-cargo cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- profile list`

Note: `TMPDIR` points at the NVME worktree because the macOS system volume `/var` has only ~117MiB free and rustc temp writes fail there with `No space left on device`.
