### PR TITLE
feat(reborn-cli): add config path command

### DIFF
--- a/crates/ironclaw_reborn_cli/src/commands/config.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/config.rs
@@ -1,0 +1,40 @@
+use clap::{Args, Subcommand};
+use ironclaw_reborn_config::RebornDoctorReport;
+
+use crate::context::RebornCliContext;
+
+#[derive(Debug, Args)]
+pub(crate) struct ConfigCommand {
+    #[command(subcommand)]
+    command: ConfigSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigSubcommand {
+    /// Show resolved Reborn configuration paths without creating state.
+    Path(ConfigPathCommand),
+}
+
+#[derive(Debug, Args)]
+struct ConfigPathCommand;
+
+impl ConfigCommand {
+    pub(crate) fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        match self.command {
+            ConfigSubcommand::Path(command) => command.execute(context),
+        }
+    }
+}
+
+impl ConfigPathCommand {
+    fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        let report = RebornDoctorReport::from_config(context.boot_config().clone());
+
+        println!("IronClaw Reborn config path");
+        println!("reborn_home: {}", report.home_path().display());
+        println!("home_source: {}", report.home_source_label());
+        println!("profile: {}", report.profile());
+        println!("v1_state: {}", report.v1_state());
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 use clap::Subcommand;
 
 pub(crate) mod completion;
+pub(crate) mod config;
 pub(crate) mod doctor;
 pub(crate) mod run;
 
@@ -8,6 +9,8 @@ pub(crate) mod run;
 pub(crate) enum Command {
     /// Generate shell completion scripts.
     Completion(completion::CompletionCommand),
+    /// Inspect Reborn configuration paths without creating state.
+    Config(config::ConfigCommand),
     /// Check Reborn binary configuration without creating state.
     Doctor(doctor::DoctorCommand),
     /// Initialize the minimal Reborn runtime shell and exit.
@@ -18,6 +21,9 @@ impl Command {
     pub(crate) fn execute(self) -> anyhow::Result<()> {
         match self {
             Self::Completion(command) => command.execute(),
+            Self::Config(command) => {
+                command.execute(crate::context::RebornCliContext::resolve_from_env()?)
+            }
             Self::Doctor(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -22,8 +22,87 @@ fn help_mentions_reborn_commands() {
         "stdout: {stdout}"
     );
     assert!(stdout.contains("completion"), "stdout: {stdout}");
+    assert!(stdout.contains("config"), "stdout: {stdout}");
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+}
+
+#[test]
+fn config_path_reports_reborn_home_without_touching_v1_state() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let v1_base_dir = temp.path().join("v1-state");
+
+    let output = Command::new(reborn_bin())
+        .arg("config")
+        .arg("path")
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("IRONCLAW_REBORN_PROFILE", "production")
+        .env("IRONCLAW_BASE_DIR", &v1_base_dir)
+        .output()
+        .expect("ironclaw-reborn config path should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn config path"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("reborn_home: {}", reborn_home.display())),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("home_source: IRONCLAW_REBORN_HOME"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("profile: production"), "stdout: {stdout}");
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+    assert!(
+        !reborn_home.exists(),
+        "config path should not create Reborn state directories"
+    );
+    assert!(
+        !v1_base_dir.exists(),
+        "config path should not create explicit v1 base directories"
+    );
+}
+
+#[test]
+fn config_path_reports_default_reborn_home_without_creating_directories() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join(".ironclaw").join("reborn");
+
+    let output = Command::new(reborn_bin())
+        .arg("config")
+        .arg("path")
+        .env_remove("IRONCLAW_REBORN_HOME")
+        .env("HOME", temp.path())
+        .env_remove("USERPROFILE")
+        .env_remove("IRONCLAW_REBORN_PROFILE")
+        .output()
+        .expect("ironclaw-reborn config path should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!("reborn_home: {}", reborn_home.display())),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("home_source: default"), "stdout: {stdout}");
+    assert!(stdout.contains("profile: local-dev"), "stdout: {stdout}");
+    assert!(
+        !temp.path().join(".ironclaw").exists(),
+        "config path should not create default Reborn or v1 state directories"
+    );
 }
 
 #[test]

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -14,6 +14,7 @@ It currently supports:
 ironclaw-reborn --help
 ironclaw-reborn completion --shell bash
 ironclaw-reborn completion --shell zsh
+ironclaw-reborn config path
 ironclaw-reborn doctor
 ironclaw-reborn run
 ```
@@ -39,6 +40,21 @@ cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell 
 ```
 
 The zsh output keeps the v1 CLI guard around `compdef` so the generated script is safe when zsh completion functions are not loaded yet.
+
+### `config path`
+
+Shows the resolved Reborn state root, its source, selected profile, and explicit v1-state status without creating directories.
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config path
+```
+
+Expected fields include:
+
+- `reborn_home`
+- `home_source`
+- `profile`
+- `v1_state: not-used`
 
 ### `doctor`
 
@@ -116,6 +132,8 @@ cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
+IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
+  cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config path
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
 ```


### PR DESCRIPTION
## Summary
- Add `ironclaw-reborn config path` as a read-only Reborn CLI command.
- Report resolved Reborn home, home source, selected profile, and explicit `v1_state: not-used`.
- Document the new command in `docs/reborn-binary.md`.

## Safety / Reborn boundaries
- Reads only Reborn boot config.
- Does not create Reborn state directories.
- Does not read or create v1 state.
- Does not add v1 runtime imports.

## Tests
- Red first: `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli config_path -- --nocapture` failed with `unrecognized subcommand 'config'` before implementation.
- `TMPDIR=$PWD/.tmp-cargo cargo fmt --all -- --check`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_architecture reborn`
- `TMPDIR=$PWD/.tmp-cargo cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `TMPDIR=$PWD/.tmp-cargo IRONCLAW_REBORN_HOME="$PWD/.reborn-home-check" cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config path`

Note: `TMPDIR` points at the NVME worktree because the macOS system volume `/var` has very little free space and rustc temp writes can fail there with `No space left on device`.
