### PR TITLE
test(reborn): cover libsql restart transcript flow

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -59,7 +59,7 @@ jobs:
             echo "has_boundary_check=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/ironclaw_reborn_cli/|crates/ironclaw_reborn_config/|crates/ironclaw_architecture/tests/reborn_dependency_boundaries\.rs$|Cargo\.toml$|Cargo\.lock$|\.github/workflows/code_style\.yml$)'; then
+          if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(crates/ironclaw_reborn/|crates/ironclaw_reborn_cli/|crates/ironclaw_reborn_config/|crates/ironclaw_architecture/tests/reborn_dependency_boundaries\.rs$|Cargo\.toml$|Cargo\.lock$|\.github/workflows/code_style\.yml$)'; then
             echo "has_reborn_cli=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_reborn_cli=false" >> "$GITHUB_OUTPUT"
@@ -203,6 +203,13 @@ jobs:
         run: cargo test -p ironclaw_reborn_config
       - name: Test Reborn CLI binary crate
         run: cargo test -p ironclaw_reborn_cli
+      - name: Test Reborn libSQL restart integration
+        run: |
+          cargo test -p ironclaw_reborn \
+            --features libsql-restart-tests \
+            --test loop_driver_host \
+            turn_runner_worker_completes_after_libsql_turn_and_thread_services_reopen \
+            -- --nocapture
       - name: Test Reborn architecture boundaries
         run: cargo test -p ironclaw_architecture reborn
 

--- a/crates/ironclaw_reborn/Cargo.toml
+++ b/crates/ironclaw_reborn/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 default = []
 root-llm-provider = ["dep:ironclaw_llm"]
 libsql-secrets = ["dep:ironclaw_secrets", "ironclaw_secrets/libsql", "dep:libsql", "dep:secrecy"]
+libsql-restart-tests = ["dep:libsql", "ironclaw_threads/libsql", "ironclaw_turns/libsql"]
 
 [dependencies]
 async-trait = "0.1"

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -304,6 +304,218 @@ async fn turn_runner_worker_completes_queued_run_after_turn_store_reopen() {
     }));
 }
 
+#[cfg(feature = "libsql-restart-tests")]
+#[tokio::test]
+async fn turn_runner_worker_completes_after_libsql_turn_and_thread_services_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let thread_db_path = dir.path().join("threads.db");
+    let turn_db_path = dir.path().join("turns.db");
+    let tenant_id = TenantId::new("tenant-libsql-restart").unwrap();
+    let agent_id = AgentId::new("agent-libsql-restart").unwrap();
+    let project_id = ProjectId::new("project-libsql-restart").unwrap();
+    let user_id = UserId::new("user-libsql-restart").unwrap();
+    let thread_id = ThreadId::new("thread-libsql-restart").unwrap();
+    let thread_scope = ThreadScope {
+        tenant_id: tenant_id.clone(),
+        agent_id: agent_id.clone(),
+        project_id: Some(project_id.clone()),
+        owner_user_id: None,
+        mission_id: None,
+    };
+    let turn_scope = TurnScope::new(
+        tenant_id,
+        Some(agent_id),
+        Some(project_id),
+        thread_id.clone(),
+    );
+    let resolver = InMemoryRunProfileResolver::default();
+    let resolved = resolver
+        .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+        .await
+        .unwrap();
+    let descriptor = resolved.loop_driver.clone();
+
+    let run_id = {
+        let thread_db = Arc::new(
+            libsql::Builder::new_local(&thread_db_path)
+                .build()
+                .await
+                .unwrap(),
+        );
+        let turn_db = Arc::new(
+            libsql::Builder::new_local(&turn_db_path)
+                .build()
+                .await
+                .unwrap(),
+        );
+        let thread_service = ironclaw_threads::LibSqlSessionThreadService::new(thread_db);
+        thread_service.run_migrations().await.unwrap();
+        let turn_store = ironclaw_turns::LibSqlTurnStateStore::new(turn_db);
+        turn_store.run_migrations().await.unwrap();
+        thread_service
+            .ensure_thread(EnsureThreadRequest {
+                scope: thread_scope.clone(),
+                thread_id: Some(thread_id.clone()),
+                created_by_actor_id: user_id.to_string(),
+                title: None,
+                metadata_json: None,
+            })
+            .await
+            .unwrap();
+        let accepted = thread_service
+            .accept_inbound_message(AcceptInboundMessageRequest {
+                scope: thread_scope.clone(),
+                thread_id: thread_id.clone(),
+                actor_id: user_id.to_string(),
+                source_binding_id: Some("source-web".to_string()),
+                reply_target_binding_id: Some("reply-web".to_string()),
+                external_event_id: Some("event-libsql-restart".to_string()),
+                content: MessageContent::text("hello after libsql restart"),
+            })
+            .await
+            .unwrap();
+        let submit = turn_store
+            .submit_turn(
+                SubmitTurnRequest {
+                    scope: turn_scope.clone(),
+                    actor: TurnActor::new(user_id),
+                    accepted_message_ref: AcceptedMessageRef::new("accepted-libsql-restart")
+                        .unwrap(),
+                    source_binding_ref: SourceBindingRef::new("source-web").unwrap(),
+                    reply_target_binding_ref: ReplyTargetBindingRef::new("reply-web").unwrap(),
+                    requested_run_profile: None,
+                    idempotency_key: IdempotencyKey::new("idem-libsql-restart").unwrap(),
+                    received_at: Utc::now(),
+                },
+                &ironclaw_turns::AllowAllTurnAdmissionPolicy,
+                &resolver,
+            )
+            .await
+            .unwrap();
+        let SubmitTurnResponse::Accepted {
+            turn_id,
+            run_id,
+            status,
+            ..
+        } = submit;
+        assert_eq!(status, TurnStatus::Queued);
+        thread_service
+            .mark_message_submitted(
+                &thread_scope,
+                &thread_id,
+                accepted.message_id,
+                turn_id.to_string(),
+                run_id.to_string(),
+            )
+            .await
+            .unwrap();
+        run_id
+    };
+
+    let thread_db = Arc::new(
+        libsql::Builder::new_local(&thread_db_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    let turn_db = Arc::new(
+        libsql::Builder::new_local(&turn_db_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    let thread_service = Arc::new(ironclaw_threads::LibSqlSessionThreadService::new(thread_db));
+    thread_service.run_migrations().await.unwrap();
+    let turn_store = Arc::new(ironclaw_turns::LibSqlTurnStateStore::new(turn_db));
+    turn_store.run_migrations().await.unwrap();
+    let loop_checkpoint_store: Arc<dyn LoopCheckpointStore> = turn_store.clone();
+    let transition_port: Arc<dyn ironclaw_turns::runner::TurnRunTransitionPort> =
+        turn_store.clone();
+    let evidence: Arc<dyn LoopExitEvidencePort> =
+        Arc::new(ThreadCheckpointLoopExitEvidencePort::new(
+            thread_service.clone(),
+            loop_checkpoint_store.clone(),
+        ));
+    let applier = Arc::new(LoopExitApplier::new(transition_port, evidence));
+    let gateway = Arc::new(RecordingGateway::reply("model says hi"));
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let factory = RebornLoopDriverHostFactory::new(
+        thread_service.clone(),
+        thread_scope.clone(),
+        gateway.clone(),
+        Arc::new(InMemoryCheckpointStateStore::default()),
+        loop_checkpoint_store,
+        milestone_sink,
+        TextOnlyLoopHostConfig {
+            max_messages: 8,
+            require_model_route_snapshot: false,
+        },
+    );
+    let mut registry = DriverRegistry::new();
+    registry
+        .register_driver(
+            Arc::new(TextOnlyFinalReplyDriver { descriptor }),
+            DriverRequirements::all_required(),
+            DriverKind::Reference,
+        )
+        .unwrap();
+    let (_wake_sender, wake_receiver) = TurnRunnerWakeReceiver::new();
+    let worker = TurnRunnerWorker::new(
+        TurnRunnerWorkerConfig {
+            heartbeat_interval: std::time::Duration::from_millis(20),
+            poll_interval: std::time::Duration::from_millis(10),
+            scope_filter: Some(turn_scope.clone()),
+        },
+        turn_store.clone(),
+        applier,
+        Arc::new(registry),
+        Arc::new(factory),
+        wake_receiver,
+    );
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let handle = tokio::spawn(async move { worker.run(cancel_clone).await });
+    let completed_state = wait_for_run_status(
+        turn_store.as_ref(),
+        &turn_scope,
+        run_id,
+        TurnStatus::Completed,
+        "reopened libSQL turn/thread services should complete queued run",
+    )
+    .await;
+    cancel.cancel();
+    handle.await.unwrap();
+
+    assert_eq!(completed_state.run_id, run_id);
+    assert!(completed_state.failure.is_none());
+    let requests = gateway.requests();
+    assert_eq!(
+        requests.len(),
+        1,
+        "restarted worker must not duplicate model calls"
+    );
+    assert_eq!(requests[0].run_id, run_id);
+    assert_eq!(
+        requests[0].messages[0].content,
+        "hello after libsql restart"
+    );
+    let history = thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: thread_scope,
+            thread_id,
+        })
+        .await
+        .unwrap();
+    let expected_run_id = run_id.to_string();
+    assert!(history.messages.iter().any(|message| {
+        message.kind == MessageKind::Assistant
+            && message.status == MessageStatus::Finalized
+            && message.content.as_deref() == Some("model says hi")
+            && message.turn_run_id.as_deref() == Some(expected_run_id.as_str())
+    }));
+}
+
 #[tokio::test]
 async fn turn_runner_worker_drives_full_text_only_model_transcript_completion_after_missed_wake() {
     let fixture = HostFixture::new_unsubmitted("thread-runner-e2e", "hello full runner").await;
@@ -3590,7 +3802,7 @@ impl LoopExitEvidencePort for AlwaysVerifiedLoopExitEvidence {
 }
 
 async fn wait_for_run_status(
-    store: &InMemoryTurnStateStore,
+    store: &dyn TurnStateStore,
     scope: &TurnScope,
     run_id: TurnRunId,
     expected: TurnStatus,
@@ -3908,7 +4120,7 @@ fn loop_exit_applier_for_fixture(
 
 async fn queue_fixture_turn(
     fixture: &HostFixture,
-    turn_store: &InMemoryTurnStateStore,
+    turn_store: &dyn TurnStateStore,
     resolver: &dyn RunProfileResolver,
     idempotency_key: &str,
 ) -> TurnRunId {


### PR DESCRIPTION
## Summary
- add libSQL-backed restart integration coverage for Reborn runner/host factory
- create queued turn + inbound transcript using `LibSqlTurnStateStore` and `LibSqlSessionThreadService`
- reopen both services from disk, rebuild `TurnRunnerWorker` + `RebornLoopDriverHostFactory`, and verify the same run completes with one model call and finalized assistant transcript
- add explicit Code Style CI step so this feature-gated restart test runs, not only compiles under all-features clippy

## Stacked PR
- Stacked on #3516 (`reborn/e2e-integration-coverage-20260512`).
- Retarget to `reborn-integration` after #3516 merges.

## Verification
- `cargo test -p ironclaw_reborn --features libsql-restart-tests --test loop_driver_host turn_runner_worker_completes_after_libsql_turn_and_thread_services_reopen -- --nocapture`
- `cargo test -p ironclaw_reborn --test loop_driver_host`
- `cargo test -p ironclaw_reborn --all-features --test loop_driver_host`
- `git diff --check`
- `cargo clippy -p ironclaw_reborn --all-targets --all-features -- -D warnings`
- parsed `.github/workflows/code_style.yml` with Python YAML loader

## Remaining gap
- Gateway/product E2E still awaits a real Reborn user-facing entrypoint; this PR avoids fake/legacy gateway coverage.
