### PR TITLE
feat(reborn-cli): add channels list command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,6 +4573,7 @@ dependencies = [
  "clap_complete",
  "ironclaw_reborn",
  "ironclaw_reborn_config",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.5.0"
 ironclaw_reborn = { path = "../ironclaw_reborn", version = "0.1.0" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
+serde_json = "1"
 
 [[bin]]
 name = "ironclaw-reborn"

--- a/crates/ironclaw_reborn_cli/src/commands/channels.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/channels.rs
@@ -34,14 +34,19 @@ impl ChannelsCommand {
 impl ChannelsListCommand {
     fn execute(self) -> anyhow::Result<()> {
         if self.json {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "channels": [],
-                    "status": "not-wired",
-                    "v1_state": "not-used",
-                })
-            );
+            let mut output = serde_json::json!({
+                "configured": 0,
+                "channels": [],
+                "status": "not-wired",
+                "v1_state": "not-used",
+            });
+            if self.verbose {
+                output["details"] = serde_json::json!([
+                    "Reborn channel registry is not wired yet",
+                    "v1 channel configuration is intentionally not read"
+                ]);
+            }
+            println!("{}", output);
             return Ok(());
         }
 

--- a/crates/ironclaw_reborn_cli/src/commands/channels.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/channels.rs
@@ -1,0 +1,60 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct ChannelsCommand {
+    #[command(subcommand)]
+    command: ChannelsSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ChannelsSubcommand {
+    /// List configured Reborn channels.
+    List(ChannelsListCommand),
+}
+
+#[derive(Debug, Args)]
+struct ChannelsListCommand {
+    /// Show extra status details.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Output channels as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl ChannelsCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            ChannelsSubcommand::List(command) => command.execute(),
+        }
+    }
+}
+
+impl ChannelsListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        if self.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "channels": [],
+                    "status": "not-wired",
+                    "v1_state": "not-used",
+                })
+            );
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn channels");
+        println!("configured: 0");
+        println!("status: not-wired");
+        println!("v1_state: not-used");
+
+        if self.verbose {
+            println!("detail: Reborn channel registry is not wired yet");
+            println!("detail: v1 channel configuration is intentionally not read");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -1,11 +1,14 @@
 use clap::Subcommand;
 
+pub(crate) mod channels;
 pub(crate) mod completion;
 pub(crate) mod doctor;
 pub(crate) mod run;
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum Command {
+    /// Inspect configured Reborn channels.
+    Channels(channels::ChannelsCommand),
     /// Generate shell completion scripts.
     Completion(completion::CompletionCommand),
     /// Check Reborn binary configuration without creating state.
@@ -17,6 +20,7 @@ pub(crate) enum Command {
 impl Command {
     pub(crate) fn execute(self) -> anyhow::Result<()> {
         match self {
+            Self::Channels(command) => command.execute(),
             Self::Completion(command) => command.execute(),
             Self::Doctor(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -67,9 +67,40 @@ fn channels_list_json_reports_empty_surface_without_reborn_home() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["configured"], 0);
     assert_eq!(
-        stdout.trim(),
-        r#"{"channels":[],"status":"not-wired","v1_state":"not-used"}"#
+        json["channels"].as_array().expect("channels array").len(),
+        0
+    );
+    assert_eq!(json["status"], "not-wired");
+    assert_eq!(json["v1_state"], "not-used");
+}
+
+#[test]
+fn channels_list_json_verbose_includes_status_details() {
+    let output = Command::new(reborn_bin())
+        .arg("channels")
+        .arg("list")
+        .arg("--json")
+        .arg("--verbose")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn channels list --json --verbose should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let details = json["details"].as_array().expect("details array");
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail == "Reborn channel registry is not wired yet"),
+        "json: {json}"
     );
 }
 

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -21,9 +21,78 @@ fn help_mentions_reborn_commands() {
         stdout.contains("Standalone IronClaw Reborn runtime"),
         "stdout: {stdout}"
     );
+    assert!(stdout.contains("channels"), "stdout: {stdout}");
     assert!(stdout.contains("completion"), "stdout: {stdout}");
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+}
+
+#[test]
+fn channels_list_reports_unwired_empty_surface_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("channels")
+        .arg("list")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn channels list should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn channels"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("configured: 0"), "stdout: {stdout}");
+    assert!(stdout.contains("status: not-wired"), "stdout: {stdout}");
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+}
+
+#[test]
+fn channels_list_json_reports_empty_surface_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("channels")
+        .arg("list")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn channels list --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        r#"{"channels":[],"status":"not-wired","v1_state":"not-used"}"#
+    );
+}
+
+#[test]
+fn channels_list_verbose_explains_missing_reborn_registry() {
+    let output = Command::new(reborn_bin())
+        .arg("channels")
+        .arg("list")
+        .arg("--verbose")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn channels list --verbose should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Reborn channel registry is not wired yet"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -12,6 +12,9 @@ It currently supports:
 
 ```bash
 ironclaw-reborn --help
+ironclaw-reborn channels list
+ironclaw-reborn channels list --json
+ironclaw-reborn channels list --verbose
 ironclaw-reborn completion --shell bash
 ironclaw-reborn completion --shell zsh
 ironclaw-reborn doctor
@@ -28,6 +31,24 @@ It intentionally does not yet support:
 - long-lived Reborn runtime services.
 
 ## Commands
+
+### `channels list`
+
+Reports configured Reborn channels without resolving Reborn home, reading v1 channel config, or creating directories.
+
+The Reborn channel registry is not wired yet, so the command currently reports an explicit empty surface:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list --verbose
+```
+
+Expected fields include:
+
+- `configured: 0`
+- `status: not-wired`
+- `v1_state: not-used`
 
 ### `completion`
 
@@ -115,6 +136,7 @@ cargo test -p ironclaw_reborn_config
 cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run


### PR DESCRIPTION
## Summary
- Add `ironclaw-reborn channels list` as a pure read-only command.
- Support `--json` and `--verbose` output.
- Report an explicit empty Reborn channel surface until a Reborn channel registry/config seam exists.
- Document the command in `docs/reborn-binary.md`.

## Safety / Reborn boundaries
- Does not resolve Reborn home.
- Does not read v1 channel configuration.
- Does not create Reborn or v1 state directories.
- Does not add v1 runtime imports.

## Tests
- Red first: `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli channels_list -- --nocapture` failed with `unrecognized subcommand 'channels'` before implementation.
- `TMPDIR=$PWD/.tmp-cargo cargo fmt --all -- --check`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_architecture reborn`
- `TMPDIR=$PWD/.tmp-cargo cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `TMPDIR=$PWD/.tmp-cargo cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list --verbose`

Note: `TMPDIR` points at the NVME worktree because the macOS system volume `/var` has very little free space and rustc temp writes can fail there with `No space left on device`.
