### PR TITLE
feat(reborn-cli): add hooks list command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,6 +4573,7 @@ dependencies = [
  "clap_complete",
  "ironclaw_reborn",
  "ironclaw_reborn_config",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.5.0"
 ironclaw_reborn = { path = "../ironclaw_reborn", version = "0.1.0" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
+serde_json = "1"
 
 [[bin]]
 name = "ironclaw-reborn"

--- a/crates/ironclaw_reborn_cli/src/commands/hooks.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/hooks.rs
@@ -1,0 +1,60 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct HooksCommand {
+    #[command(subcommand)]
+    command: HooksSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum HooksSubcommand {
+    /// List configured Reborn hooks.
+    List(HooksListCommand),
+}
+
+#[derive(Debug, Args)]
+struct HooksListCommand {
+    /// Show extra status details.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Output hooks as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl HooksCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            HooksSubcommand::List(command) => command.execute(),
+        }
+    }
+}
+
+impl HooksListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        if self.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "hooks": [],
+                    "status": "not-wired",
+                    "v1_state": "not-used",
+                })
+            );
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn hooks");
+        println!("configured: 0");
+        println!("status: not-wired");
+        println!("v1_state: not-used");
+
+        if self.verbose {
+            println!("detail: Reborn hook registry is not wired yet");
+            println!("detail: v1 hook configuration is intentionally not read");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/hooks.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/hooks.rs
@@ -34,14 +34,19 @@ impl HooksCommand {
 impl HooksListCommand {
     fn execute(self) -> anyhow::Result<()> {
         if self.json {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "hooks": [],
-                    "status": "not-wired",
-                    "v1_state": "not-used",
-                })
-            );
+            let mut output = serde_json::json!({
+                "configured": 0,
+                "hooks": [],
+                "status": "not-wired",
+                "v1_state": "not-used",
+            });
+            if self.verbose {
+                output["details"] = serde_json::json!([
+                    "Reborn hook registry is not wired yet",
+                    "v1 hook configuration is intentionally not read"
+                ]);
+            }
+            println!("{}", output);
             return Ok(());
         }
 

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ use clap::Subcommand;
 
 pub(crate) mod completion;
 pub(crate) mod doctor;
+pub(crate) mod hooks;
 pub(crate) mod run;
 
 #[derive(Debug, Subcommand)]
@@ -10,6 +11,8 @@ pub(crate) enum Command {
     Completion(completion::CompletionCommand),
     /// Check Reborn binary configuration without creating state.
     Doctor(doctor::DoctorCommand),
+    /// Inspect configured Reborn hooks.
+    Hooks(hooks::HooksCommand),
     /// Initialize the minimal Reborn runtime shell and exit.
     Run(run::RunCommand),
 }
@@ -21,6 +24,7 @@ impl Command {
             Self::Doctor(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }
+            Self::Hooks(command) => command.execute(),
             Self::Run(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -64,9 +64,37 @@ fn hooks_list_json_reports_empty_surface_without_reborn_home() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(
-        stdout.trim(),
-        r#"{"hooks":[],"status":"not-wired","v1_state":"not-used"}"#
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["configured"], 0);
+    assert_eq!(json["hooks"].as_array().expect("hooks array").len(), 0);
+    assert_eq!(json["status"], "not-wired");
+    assert_eq!(json["v1_state"], "not-used");
+}
+
+#[test]
+fn hooks_list_json_verbose_includes_status_details() {
+    let output = Command::new(reborn_bin())
+        .arg("hooks")
+        .arg("list")
+        .arg("--json")
+        .arg("--verbose")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn hooks list --json --verbose should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let details = json["details"].as_array().expect("details array");
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail == "Reborn hook registry is not wired yet"),
+        "json: {json}"
     );
 }
 

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -23,7 +23,73 @@ fn help_mentions_reborn_commands() {
     );
     assert!(stdout.contains("completion"), "stdout: {stdout}");
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
+    assert!(stdout.contains("hooks"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+}
+
+#[test]
+fn hooks_list_reports_unwired_empty_surface_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("hooks")
+        .arg("list")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn hooks list should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("IronClaw Reborn hooks"), "stdout: {stdout}");
+    assert!(stdout.contains("configured: 0"), "stdout: {stdout}");
+    assert!(stdout.contains("status: not-wired"), "stdout: {stdout}");
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+}
+
+#[test]
+fn hooks_list_json_reports_empty_surface_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("hooks")
+        .arg("list")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn hooks list --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        r#"{"hooks":[],"status":"not-wired","v1_state":"not-used"}"#
+    );
+}
+
+#[test]
+fn hooks_list_verbose_explains_missing_reborn_registry() {
+    let output = Command::new(reborn_bin())
+        .arg("hooks")
+        .arg("list")
+        .arg("--verbose")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn hooks list --verbose should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Reborn hook registry is not wired yet"),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -15,6 +15,9 @@ ironclaw-reborn --help
 ironclaw-reborn completion --shell bash
 ironclaw-reborn completion --shell zsh
 ironclaw-reborn doctor
+ironclaw-reborn hooks list
+ironclaw-reborn hooks list --json
+ironclaw-reborn hooks list --verbose
 ironclaw-reborn run
 ```
 
@@ -55,6 +58,24 @@ Expected fields include:
 - `profile`
 - `v1_state: not-used`
 - `driver_registry: initialized`
+
+### `hooks list`
+
+Reports configured Reborn hooks without resolving Reborn home, reading v1 hook config, or creating directories.
+
+The Reborn hook registry is not wired yet, so the command currently reports an explicit empty surface:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list --verbose
+```
+
+Expected fields include:
+
+- `configured: 0`
+- `status: not-wired`
+- `v1_state: not-used`
 
 ### `run`
 
@@ -116,6 +137,7 @@ cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
 ```


### PR DESCRIPTION
## Summary
- Add `ironclaw-reborn hooks list` as a pure read-only command.
- Support `--json` and `--verbose` output.
- Report an explicit empty Reborn hook surface until a Reborn hook registry/config seam exists.
- Document the command in `docs/reborn-binary.md`.

## Safety / Reborn boundaries
- Does not resolve Reborn home.
- Does not read v1 hook configuration.
- Does not create Reborn or v1 state directories.
- Does not add v1 runtime imports.

## Tests
- Red first: `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli hooks_list -- --nocapture` failed with `unrecognized subcommand 'hooks'` before implementation.
- `TMPDIR=$PWD/.tmp-cargo cargo fmt --all -- --check`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_architecture reborn`
- `TMPDIR=$PWD/.tmp-cargo cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `TMPDIR=$PWD/.tmp-cargo cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list --verbose`

Note: `TMPDIR` points at the NVME worktree because the macOS system volume `/var` has very little free space and rustc temp writes can fail there with `No space left on device`.
