### PR TITLE
feat(reborn-cli): add models status commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,6 +4573,7 @@ dependencies = [
  "clap_complete",
  "ironclaw_reborn",
  "ironclaw_reborn_config",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/ironclaw_reborn/src/model_routes.rs
+++ b/crates/ironclaw_reborn/src/model_routes.rs
@@ -19,6 +19,12 @@ pub enum ModelSlot {
 }
 
 impl ModelSlot {
+    const ALL: [Self; 2] = [Self::Default, Self::Mission];
+
+    pub fn all() -> &'static [Self] {
+        &Self::ALL
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Default => "default",

--- a/crates/ironclaw_reborn/tests/model_routes.rs
+++ b/crates/ironclaw_reborn/tests/model_routes.rs
@@ -29,6 +29,11 @@ fn llm_config_resolves_to_default_model_route_settings() {
 }
 
 #[test]
+fn model_slots_are_exposed_in_cli_display_order() {
+    assert_eq!(ModelSlot::all(), &[ModelSlot::Default, ModelSlot::Mission]);
+}
+
+#[test]
 fn model_slots_cover_builtin_interactive_and_mission_profiles() {
     let interactive_model =
         ironclaw_turns::run_profile::ModelProfileId::new("interactive_model").unwrap();

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.5.0"
 ironclaw_reborn = { path = "../ironclaw_reborn", version = "0.1.0" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
+serde_json = "1"
 
 [[bin]]
 name = "ironclaw-reborn"

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ use clap::Subcommand;
 
 pub(crate) mod completion;
 pub(crate) mod doctor;
+pub(crate) mod models;
 pub(crate) mod run;
 
 #[derive(Debug, Subcommand)]
@@ -10,6 +11,8 @@ pub(crate) enum Command {
     Completion(completion::CompletionCommand),
     /// Check Reborn binary configuration without creating state.
     Doctor(doctor::DoctorCommand),
+    /// Inspect Reborn model slots and route status.
+    Models(models::ModelsCommand),
     /// Initialize the minimal Reborn runtime shell and exit.
     Run(run::RunCommand),
 }
@@ -21,6 +24,7 @@ impl Command {
             Self::Doctor(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }
+            Self::Models(command) => command.execute(),
             Self::Run(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -1,0 +1,102 @@
+use clap::{Args, Subcommand};
+use ironclaw_reborn::ModelSlot;
+
+#[derive(Debug, Args)]
+pub(crate) struct ModelsCommand {
+    #[command(subcommand)]
+    command: ModelsSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ModelsSubcommand {
+    /// List Reborn model purpose slots.
+    List(ModelsListCommand),
+    /// Show Reborn model route status.
+    Status(ModelsStatusCommand),
+}
+
+#[derive(Debug, Args)]
+struct ModelsListCommand {
+    /// Output model slots as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct ModelsStatusCommand {
+    /// Output model status as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl ModelsCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            ModelsSubcommand::List(command) => command.execute(),
+            ModelsSubcommand::Status(command) => command.execute(),
+        }
+    }
+}
+
+impl ModelsListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        let slots = ModelSlot::all();
+
+        if self.json {
+            let slots = slots
+                .iter()
+                .map(|slot| serde_json::json!({ "slot": slot.as_str() }))
+                .collect::<Vec<_>>();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "slots": slots,
+                    "routes": "not-configured",
+                    "v1_state": "not-used",
+                })
+            );
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn model slots");
+        for slot in slots {
+            println!("- {}", slot);
+        }
+        println!("routes: not-configured");
+        println!("v1_state: not-used");
+        Ok(())
+    }
+}
+
+impl ModelsStatusCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        let slots = ModelSlot::all();
+
+        if self.json {
+            let mut slot_status = serde_json::Map::new();
+            for slot in slots {
+                slot_status.insert(
+                    slot.as_str().to_string(),
+                    serde_json::Value::String("not-configured".to_string()),
+                );
+            }
+            println!(
+                "{}",
+                serde_json::json!({
+                    "routes": "not-configured",
+                    "slots": slot_status,
+                    "v1_state": "not-used",
+                })
+            );
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn model status");
+        println!("routes: not-configured");
+        for slot in slots {
+            println!("{}: not-configured", slot);
+        }
+        println!("v1_state: not-used");
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -23,7 +23,118 @@ fn help_mentions_reborn_commands() {
     );
     assert!(stdout.contains("completion"), "stdout: {stdout}");
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
+    assert!(stdout.contains("models"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+}
+
+#[test]
+fn models_list_reports_reborn_slots_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("list")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn models list should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn model slots"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("- default"), "stdout: {stdout}");
+    assert!(stdout.contains("- mission"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("routes: not-configured"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+}
+
+#[test]
+fn models_list_json_reports_reborn_slots_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("list")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn models list --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let slots = json["slots"].as_array().expect("slots array");
+    assert_eq!(slots.len(), 2);
+    assert!(slots.iter().any(|slot| slot["slot"] == "default"));
+    assert!(slots.iter().any(|slot| slot["slot"] == "mission"));
+    assert_eq!(json["routes"], "not-configured");
+    assert_eq!(json["v1_state"], "not-used");
+}
+
+#[test]
+fn models_status_reports_routes_not_configured() {
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("status")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn models status should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn model status"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("routes: not-configured"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("default: not-configured"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("mission: not-configured"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+}
+
+#[test]
+fn models_status_json_reports_routes_not_configured() {
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("status")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn models status --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["routes"], "not-configured");
+    assert_eq!(json["slots"]["default"], "not-configured");
+    assert_eq!(json["slots"]["mission"], "not-configured");
+    assert_eq!(json["v1_state"], "not-used");
 }
 
 #[test]

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -15,6 +15,10 @@ ironclaw-reborn --help
 ironclaw-reborn completion --shell bash
 ironclaw-reborn completion --shell zsh
 ironclaw-reborn doctor
+ironclaw-reborn models list
+ironclaw-reborn models list --json
+ironclaw-reborn models status
+ironclaw-reborn models status --json
 ironclaw-reborn run
 ```
 
@@ -55,6 +59,26 @@ Expected fields include:
 - `profile`
 - `v1_state: not-used`
 - `driver_registry: initialized`
+
+### `models list` / `models status`
+
+Shows Reborn model purpose slots and route status without resolving Reborn home, reading v1 provider settings, or creating directories.
+
+Routes are not configurable through Reborn CLI yet, so the command currently reports `not-configured` routes for built-in slots:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models list --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status --json
+```
+
+Expected fields include:
+
+- `default`
+- `mission`
+- `routes: not-configured`
+- `v1_state: not-used`
 
 ### `run`
 
@@ -116,6 +140,7 @@ cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
 ```


### PR DESCRIPTION
## Summary
- Add `ironclaw-reborn models list` and `ironclaw-reborn models status` as pure read-only commands.
- Support JSON output for both commands.
- Expose Reborn model purpose slots (`default`, `mission`) through `ModelSlot::all()`.
- Report route status as `not-configured` until Reborn model route config is writable through the CLI.
- Document the commands in `docs/reborn-binary.md`.

## Safety / Reborn boundaries
- Does not resolve Reborn home.
- Does not read v1 provider/model settings.
- Does not create Reborn or v1 state directories.
- Does not add v1 runtime imports.

## Tests
- Red first: `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli models_ -- --nocapture` failed before command implementation.
- Red first: `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn model_slots_are_exposed_in_cli_display_order -- --nocapture` failed before `ModelSlot::all()`.
- `TMPDIR=$PWD/.tmp-cargo cargo fmt --all -- --check`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn model_slots_are_exposed_in_cli_display_order`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_architecture reborn`
- `TMPDIR=$PWD/.tmp-cargo cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `TMPDIR=$PWD/.tmp-cargo cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status`

Note: `TMPDIR` points at the NVME worktree because the macOS system volume `/var` has very little free space and rustc temp writes can fail there with `No space left on device`.
