### PR TITLE
feat(reborn-cli): add skills list command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,6 +4573,7 @@ dependencies = [
  "clap_complete",
  "ironclaw_reborn",
  "ironclaw_reborn_config",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.5.0"
 ironclaw_reborn = { path = "../ironclaw_reborn", version = "0.1.0" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
+serde_json = "1"
 
 [[bin]]
 name = "ironclaw-reborn"

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ use clap::Subcommand;
 pub(crate) mod completion;
 pub(crate) mod doctor;
 pub(crate) mod run;
+pub(crate) mod skills;
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum Command {
@@ -12,6 +13,8 @@ pub(crate) enum Command {
     Doctor(doctor::DoctorCommand),
     /// Initialize the minimal Reborn runtime shell and exit.
     Run(run::RunCommand),
+    /// Inspect configured Reborn skills.
+    Skills(skills::SkillsCommand),
 }
 
 impl Command {
@@ -24,6 +27,7 @@ impl Command {
             Self::Run(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }
+            Self::Skills(command) => command.execute(),
         }
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/skills.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/skills.rs
@@ -1,0 +1,65 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct SkillsCommand {
+    #[command(subcommand)]
+    command: SkillsSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum SkillsSubcommand {
+    /// List configured Reborn skills.
+    List(SkillsListCommand),
+}
+
+#[derive(Debug, Args)]
+struct SkillsListCommand {
+    /// Show extra status details.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Output skills as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl SkillsCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            SkillsSubcommand::List(command) => command.execute(),
+        }
+    }
+}
+
+impl SkillsListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        if self.json {
+            let mut output = serde_json::json!({
+                "configured": 0,
+                "skills": [],
+                "status": "not-wired",
+                "v1_state": "not-used",
+            });
+            if self.verbose {
+                output["details"] = serde_json::json!([
+                    "Reborn skill catalog is not wired yet",
+                    "v1 skill discovery is intentionally not read"
+                ]);
+            }
+            println!("{}", output);
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn skills");
+        println!("configured: 0");
+        println!("status: not-wired");
+        println!("v1_state: not-used");
+
+        if self.verbose {
+            println!("detail: Reborn skill catalog is not wired yet");
+            println!("detail: v1 skill discovery is intentionally not read");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/skills.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/skills.rs
@@ -1,5 +1,12 @@
 use clap::{Args, Subcommand};
 
+const STATUS_NOT_WIRED: &str = "not-wired";
+const V1_STATE_NOT_USED: &str = "not-used";
+const DETAILS: [&str; 2] = [
+    "Reborn skill catalog is not wired yet",
+    "v1 skill discovery is intentionally not read",
+];
+
 #[derive(Debug, Args)]
 pub(crate) struct SkillsCommand {
     #[command(subcommand)]
@@ -33,18 +40,17 @@ impl SkillsCommand {
 
 impl SkillsListCommand {
     fn execute(self) -> anyhow::Result<()> {
+        let details = self.verbose.then_some(DETAILS.as_slice());
+
         if self.json {
             let mut output = serde_json::json!({
                 "configured": 0,
                 "skills": [],
-                "status": "not-wired",
-                "v1_state": "not-used",
+                "status": STATUS_NOT_WIRED,
+                "v1_state": V1_STATE_NOT_USED,
             });
-            if self.verbose {
-                output["details"] = serde_json::json!([
-                    "Reborn skill catalog is not wired yet",
-                    "v1 skill discovery is intentionally not read"
-                ]);
+            if let Some(details) = details {
+                output["details"] = serde_json::json!(details);
             }
             println!("{}", output);
             return Ok(());
@@ -52,12 +58,13 @@ impl SkillsListCommand {
 
         println!("IronClaw Reborn skills");
         println!("configured: 0");
-        println!("status: not-wired");
-        println!("v1_state: not-used");
+        println!("status: {STATUS_NOT_WIRED}");
+        println!("v1_state: {V1_STATE_NOT_USED}");
 
-        if self.verbose {
-            println!("detail: Reborn skill catalog is not wired yet");
-            println!("detail: v1 skill discovery is intentionally not read");
+        if let Some(details) = details {
+            for detail in details {
+                println!("detail: {detail}");
+            }
         }
 
         Ok(())

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -24,6 +24,103 @@ fn help_mentions_reborn_commands() {
     assert!(stdout.contains("completion"), "stdout: {stdout}");
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+    assert!(stdout.contains("skills"), "stdout: {stdout}");
+}
+
+#[test]
+fn skills_list_reports_unwired_empty_surface_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("skills")
+        .arg("list")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn skills list should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn skills"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("configured: 0"), "stdout: {stdout}");
+    assert!(stdout.contains("status: not-wired"), "stdout: {stdout}");
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+}
+
+#[test]
+fn skills_list_json_reports_empty_surface_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("skills")
+        .arg("list")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn skills list --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["configured"], 0);
+    assert_eq!(json["skills"].as_array().expect("skills array").len(), 0);
+    assert_eq!(json["status"], "not-wired");
+    assert_eq!(json["v1_state"], "not-used");
+}
+
+#[test]
+fn skills_list_verbose_explains_missing_reborn_catalog() {
+    let output = Command::new(reborn_bin())
+        .arg("skills")
+        .arg("list")
+        .arg("--verbose")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn skills list --verbose should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Reborn skill catalog is not wired yet"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn skills_list_json_verbose_includes_status_details() {
+    let output = Command::new(reborn_bin())
+        .arg("skills")
+        .arg("list")
+        .arg("--json")
+        .arg("--verbose")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn skills list --json --verbose should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let details = json["details"].as_array().expect("details array");
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail == "Reborn skill catalog is not wired yet"),
+        "json: {json}"
+    );
 }
 
 #[test]

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -16,6 +16,9 @@ ironclaw-reborn completion --shell bash
 ironclaw-reborn completion --shell zsh
 ironclaw-reborn doctor
 ironclaw-reborn run
+ironclaw-reborn skills list
+ironclaw-reborn skills list --json
+ironclaw-reborn skills list --verbose
 ```
 
 It intentionally does not yet support:
@@ -75,6 +78,24 @@ Expected fields include:
 - `driver_registry: initialized`
 - `runtime_shell: initialized`
 
+### `skills list`
+
+Reports configured Reborn skills without resolving Reborn home, reading v1 skill discovery paths, or creating directories.
+
+The Reborn skill catalog is not wired yet, so the command currently reports an explicit empty surface:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list --verbose
+```
+
+Expected fields include:
+
+- `configured: 0`
+- `status: not-wired`
+- `v1_state: not-used`
+
 ## State and config root
 
 Reborn must not use the current v1 IronClaw state root by default.
@@ -116,6 +137,7 @@ cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
 ```


### PR DESCRIPTION
## Summary
- Add `ironclaw-reborn skills list` as a pure read-only command.
- Support `--json` and `--verbose` output.
- Report an explicit empty Reborn skill surface until a Reborn skill catalog/snapshot seam exists.
- Document the command in `docs/reborn-binary.md`.

## Safety / Reborn boundaries
- Does not resolve Reborn home.
- Does not read v1 skill discovery paths.
- Does not create Reborn or v1 state directories.
- Does not add v1 runtime imports.

## Tests
- Red first: `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli skills_list -- --nocapture` failed with `unrecognized subcommand 'skills'` before implementation.
- `TMPDIR=$PWD/.tmp-cargo cargo fmt --all -- --check`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_architecture reborn`
- `TMPDIR=$PWD/.tmp-cargo cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`
- `TMPDIR=$PWD/.tmp-cargo cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list --verbose`

Note: `TMPDIR` points at the NVME worktree because the macOS system volume `/var` has very little free space and rustc temp writes can fail there with `No space left on device`.
