### PR TITLE
feat(reborn-cli): add inspection command surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,6 +4573,7 @@ dependencies = [
  "clap_complete",
  "ironclaw_reborn",
  "ironclaw_reborn_config",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/ironclaw_reborn/src/model_routes.rs
+++ b/crates/ironclaw_reborn/src/model_routes.rs
@@ -19,6 +19,12 @@ pub enum ModelSlot {
 }
 
 impl ModelSlot {
+    const ALL: [Self; 2] = [Self::Default, Self::Mission];
+
+    pub fn all() -> &'static [Self] {
+        &Self::ALL
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Default => "default",

--- a/crates/ironclaw_reborn/tests/model_routes.rs
+++ b/crates/ironclaw_reborn/tests/model_routes.rs
@@ -29,6 +29,11 @@ fn llm_config_resolves_to_default_model_route_settings() {
 }
 
 #[test]
+fn model_slots_are_exposed_in_cli_display_order() {
+    assert_eq!(ModelSlot::all(), &[ModelSlot::Default, ModelSlot::Mission]);
+}
+
+#[test]
 fn model_slots_cover_builtin_interactive_and_mission_profiles() {
     let interactive_model =
         ironclaw_turns::run_profile::ModelProfileId::new("interactive_model").unwrap();

--- a/crates/ironclaw_reborn_cli/Cargo.toml
+++ b/crates/ironclaw_reborn_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4.5.0"
 ironclaw_reborn = { path = "../ironclaw_reborn", version = "0.1.0" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config", version = "0.1.0" }
+serde_json = "1"
 
 [[bin]]
 name = "ironclaw-reborn"

--- a/crates/ironclaw_reborn_cli/src/commands/channels.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/channels.rs
@@ -1,0 +1,65 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct ChannelsCommand {
+    #[command(subcommand)]
+    command: ChannelsSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ChannelsSubcommand {
+    /// List configured Reborn channels.
+    List(ChannelsListCommand),
+}
+
+#[derive(Debug, Args)]
+struct ChannelsListCommand {
+    /// Show extra status details.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Output channels as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl ChannelsCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            ChannelsSubcommand::List(command) => command.execute(),
+        }
+    }
+}
+
+impl ChannelsListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        if self.json {
+            let mut output = serde_json::json!({
+                "configured": 0,
+                "channels": [],
+                "status": "not-wired",
+                "v1_state": "not-used",
+            });
+            if self.verbose {
+                output["details"] = serde_json::json!([
+                    "Reborn channel registry is not wired yet",
+                    "v1 channel configuration is intentionally not read"
+                ]);
+            }
+            println!("{}", output);
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn channels");
+        println!("configured: 0");
+        println!("status: not-wired");
+        println!("v1_state: not-used");
+
+        if self.verbose {
+            println!("detail: Reborn channel registry is not wired yet");
+            println!("detail: v1 channel configuration is intentionally not read");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/channels.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/channels.rs
@@ -1,5 +1,12 @@
 use clap::{Args, Subcommand};
 
+const STATUS_NOT_WIRED: &str = "not-wired";
+const V1_STATE_NOT_USED: &str = "not-used";
+const DETAILS: [&str; 2] = [
+    "Reborn channel registry is not wired yet",
+    "v1 channel configuration is intentionally not read",
+];
+
 #[derive(Debug, Args)]
 pub(crate) struct ChannelsCommand {
     #[command(subcommand)]
@@ -33,18 +40,17 @@ impl ChannelsCommand {
 
 impl ChannelsListCommand {
     fn execute(self) -> anyhow::Result<()> {
+        let details = self.verbose.then_some(DETAILS.as_slice());
+
         if self.json {
             let mut output = serde_json::json!({
                 "configured": 0,
                 "channels": [],
-                "status": "not-wired",
-                "v1_state": "not-used",
+                "status": STATUS_NOT_WIRED,
+                "v1_state": V1_STATE_NOT_USED,
             });
-            if self.verbose {
-                output["details"] = serde_json::json!([
-                    "Reborn channel registry is not wired yet",
-                    "v1 channel configuration is intentionally not read"
-                ]);
+            if let Some(details) = details {
+                output["details"] = serde_json::json!(details);
             }
             println!("{}", output);
             return Ok(());
@@ -52,12 +58,13 @@ impl ChannelsListCommand {
 
         println!("IronClaw Reborn channels");
         println!("configured: 0");
-        println!("status: not-wired");
-        println!("v1_state: not-used");
+        println!("status: {STATUS_NOT_WIRED}");
+        println!("v1_state: {V1_STATE_NOT_USED}");
 
-        if self.verbose {
-            println!("detail: Reborn channel registry is not wired yet");
-            println!("detail: v1 channel configuration is intentionally not read");
+        if let Some(details) = details {
+            for detail in details {
+                println!("detail: {detail}");
+            }
         }
 
         Ok(())

--- a/crates/ironclaw_reborn_cli/src/commands/hooks.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/hooks.rs
@@ -1,5 +1,12 @@
 use clap::{Args, Subcommand};
 
+const STATUS_NOT_WIRED: &str = "not-wired";
+const V1_STATE_NOT_USED: &str = "not-used";
+const DETAILS: [&str; 2] = [
+    "Reborn hook registry is not wired yet",
+    "v1 hook configuration is intentionally not read",
+];
+
 #[derive(Debug, Args)]
 pub(crate) struct HooksCommand {
     #[command(subcommand)]
@@ -33,18 +40,17 @@ impl HooksCommand {
 
 impl HooksListCommand {
     fn execute(self) -> anyhow::Result<()> {
+        let details = self.verbose.then_some(DETAILS.as_slice());
+
         if self.json {
             let mut output = serde_json::json!({
                 "configured": 0,
                 "hooks": [],
-                "status": "not-wired",
-                "v1_state": "not-used",
+                "status": STATUS_NOT_WIRED,
+                "v1_state": V1_STATE_NOT_USED,
             });
-            if self.verbose {
-                output["details"] = serde_json::json!([
-                    "Reborn hook registry is not wired yet",
-                    "v1 hook configuration is intentionally not read"
-                ]);
+            if let Some(details) = details {
+                output["details"] = serde_json::json!(details);
             }
             println!("{}", output);
             return Ok(());
@@ -52,12 +58,13 @@ impl HooksListCommand {
 
         println!("IronClaw Reborn hooks");
         println!("configured: 0");
-        println!("status: not-wired");
-        println!("v1_state: not-used");
+        println!("status: {STATUS_NOT_WIRED}");
+        println!("v1_state: {V1_STATE_NOT_USED}");
 
-        if self.verbose {
-            println!("detail: Reborn hook registry is not wired yet");
-            println!("detail: v1 hook configuration is intentionally not read");
+        if let Some(details) = details {
+            for detail in details {
+                println!("detail: {detail}");
+            }
         }
 
         Ok(())

--- a/crates/ironclaw_reborn_cli/src/commands/hooks.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/hooks.rs
@@ -1,0 +1,65 @@
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Args)]
+pub(crate) struct HooksCommand {
+    #[command(subcommand)]
+    command: HooksSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum HooksSubcommand {
+    /// List configured Reborn hooks.
+    List(HooksListCommand),
+}
+
+#[derive(Debug, Args)]
+struct HooksListCommand {
+    /// Show extra status details.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Output hooks as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl HooksCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            HooksSubcommand::List(command) => command.execute(),
+        }
+    }
+}
+
+impl HooksListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        if self.json {
+            let mut output = serde_json::json!({
+                "configured": 0,
+                "hooks": [],
+                "status": "not-wired",
+                "v1_state": "not-used",
+            });
+            if self.verbose {
+                output["details"] = serde_json::json!([
+                    "Reborn hook registry is not wired yet",
+                    "v1 hook configuration is intentionally not read"
+                ]);
+            }
+            println!("{}", output);
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn hooks");
+        println!("configured: 0");
+        println!("status: not-wired");
+        println!("v1_state: not-used");
+
+        if self.verbose {
+            println!("detail: Reborn hook registry is not wired yet");
+            println!("detail: v1 hook configuration is intentionally not read");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/logs.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/logs.rs
@@ -1,0 +1,45 @@
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub(crate) struct LogsCommand {
+    /// Show extra status details.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Output log status as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl LogsCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        if self.json {
+            let mut output = serde_json::json!({
+                "entries": 0,
+                "logs": [],
+                "status": "not-wired",
+                "v1_state": "not-used",
+            });
+            if self.verbose {
+                output["details"] = serde_json::json!([
+                    "Reborn log source is not wired yet",
+                    "v1 gateway logs are intentionally not read"
+                ]);
+            }
+            println!("{}", output);
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn logs");
+        println!("entries: 0");
+        println!("status: not-wired");
+        println!("v1_state: not-used");
+
+        if self.verbose {
+            println!("detail: Reborn log source is not wired yet");
+            println!("detail: v1 gateway logs are intentionally not read");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/logs.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/logs.rs
@@ -1,5 +1,12 @@
 use clap::Args;
 
+const STATUS_NOT_WIRED: &str = "not-wired";
+const V1_STATE_NOT_USED: &str = "not-used";
+const DETAILS: [&str; 2] = [
+    "Reborn log source is not wired yet",
+    "v1 gateway logs are intentionally not read",
+];
+
 #[derive(Debug, Args)]
 pub(crate) struct LogsCommand {
     /// Show extra status details.
@@ -13,18 +20,17 @@ pub(crate) struct LogsCommand {
 
 impl LogsCommand {
     pub(crate) fn execute(self) -> anyhow::Result<()> {
+        let details = self.verbose.then_some(DETAILS.as_slice());
+
         if self.json {
             let mut output = serde_json::json!({
                 "entries": 0,
                 "logs": [],
-                "status": "not-wired",
-                "v1_state": "not-used",
+                "status": STATUS_NOT_WIRED,
+                "v1_state": V1_STATE_NOT_USED,
             });
-            if self.verbose {
-                output["details"] = serde_json::json!([
-                    "Reborn log source is not wired yet",
-                    "v1 gateway logs are intentionally not read"
-                ]);
+            if let Some(details) = details {
+                output["details"] = serde_json::json!(details);
             }
             println!("{}", output);
             return Ok(());
@@ -32,12 +38,13 @@ impl LogsCommand {
 
         println!("IronClaw Reborn logs");
         println!("entries: 0");
-        println!("status: not-wired");
-        println!("v1_state: not-used");
+        println!("status: {STATUS_NOT_WIRED}");
+        println!("v1_state: {V1_STATE_NOT_USED}");
 
-        if self.verbose {
-            println!("detail: Reborn log source is not wired yet");
-            println!("detail: v1 gateway logs are intentionally not read");
+        if let Some(details) = details {
+            for detail in details {
+                println!("detail: {detail}");
+            }
         }
 
         Ok(())

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -1,25 +1,44 @@
 use clap::Subcommand;
 
+pub(crate) mod channels;
 pub(crate) mod completion;
 pub(crate) mod config;
 pub(crate) mod doctor;
+pub(crate) mod hooks;
+pub(crate) mod logs;
+pub(crate) mod models;
+pub(crate) mod profile;
 pub(crate) mod run;
+pub(crate) mod skills;
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum Command {
+    /// Inspect configured Reborn channels.
+    Channels(channels::ChannelsCommand),
     /// Generate shell completion scripts.
     Completion(completion::CompletionCommand),
     /// Inspect Reborn configuration paths without creating state.
     Config(config::ConfigCommand),
     /// Check Reborn binary configuration without creating state.
     Doctor(doctor::DoctorCommand),
+    /// Inspect configured Reborn hooks.
+    Hooks(hooks::HooksCommand),
+    /// Inspect Reborn logs.
+    Logs(logs::LogsCommand),
+    /// Inspect Reborn model slots and route status.
+    Models(models::ModelsCommand),
+    /// Inspect supported Reborn boot profiles.
+    Profile(profile::ProfileCommand),
     /// Initialize the minimal Reborn runtime shell and exit.
     Run(run::RunCommand),
+    /// Inspect configured Reborn skills.
+    Skills(skills::SkillsCommand),
 }
 
 impl Command {
     pub(crate) fn execute(self) -> anyhow::Result<()> {
         match self {
+            Self::Channels(command) => command.execute(),
             Self::Completion(command) => command.execute(),
             Self::Config(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
@@ -27,9 +46,14 @@ impl Command {
             Self::Doctor(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }
+            Self::Hooks(command) => command.execute(),
+            Self::Logs(command) => command.execute(),
+            Self::Models(command) => command.execute(),
+            Self::Profile(command) => command.execute(),
             Self::Run(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }
+            Self::Skills(command) => command.execute(),
         }
     }
 }

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -73,13 +73,15 @@ impl ModelsStatusCommand {
         let slots = ModelSlot::all();
 
         if self.json {
-            let mut slot_status = serde_json::Map::new();
-            for slot in slots {
-                slot_status.insert(
-                    slot.as_str().to_string(),
-                    serde_json::Value::String("not-configured".to_string()),
-                );
-            }
+            let slot_status: serde_json::Map<String, serde_json::Value> = slots
+                .iter()
+                .map(|slot| {
+                    (
+                        slot.as_str().to_string(),
+                        serde_json::Value::from("not-configured"),
+                    )
+                })
+                .collect();
             println!(
                 "{}",
                 serde_json::json!({

--- a/crates/ironclaw_reborn_cli/src/commands/models.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/models.rs
@@ -1,0 +1,102 @@
+use clap::{Args, Subcommand};
+use ironclaw_reborn::ModelSlot;
+
+#[derive(Debug, Args)]
+pub(crate) struct ModelsCommand {
+    #[command(subcommand)]
+    command: ModelsSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ModelsSubcommand {
+    /// List Reborn model purpose slots.
+    List(ModelsListCommand),
+    /// Show Reborn model route status.
+    Status(ModelsStatusCommand),
+}
+
+#[derive(Debug, Args)]
+struct ModelsListCommand {
+    /// Output model slots as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Args)]
+struct ModelsStatusCommand {
+    /// Output model status as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl ModelsCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            ModelsSubcommand::List(command) => command.execute(),
+            ModelsSubcommand::Status(command) => command.execute(),
+        }
+    }
+}
+
+impl ModelsListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        let slots = ModelSlot::all();
+
+        if self.json {
+            let slots = slots
+                .iter()
+                .map(|slot| serde_json::json!({ "slot": slot.as_str() }))
+                .collect::<Vec<_>>();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "slots": slots,
+                    "routes": "not-configured",
+                    "v1_state": "not-used",
+                })
+            );
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn model slots");
+        for slot in slots {
+            println!("- {}", slot);
+        }
+        println!("routes: not-configured");
+        println!("v1_state: not-used");
+        Ok(())
+    }
+}
+
+impl ModelsStatusCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        let slots = ModelSlot::all();
+
+        if self.json {
+            let mut slot_status = serde_json::Map::new();
+            for slot in slots {
+                slot_status.insert(
+                    slot.as_str().to_string(),
+                    serde_json::Value::String("not-configured".to_string()),
+                );
+            }
+            println!(
+                "{}",
+                serde_json::json!({
+                    "routes": "not-configured",
+                    "slots": slot_status,
+                    "v1_state": "not-used",
+                })
+            );
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn model status");
+        println!("routes: not-configured");
+        for slot in slots {
+            println!("{}: not-configured", slot);
+        }
+        println!("v1_state: not-used");
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/profile.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/profile.rs
@@ -1,0 +1,63 @@
+use clap::{Args, Subcommand};
+use ironclaw_reborn_config::{REBORN_PROFILE_ENV, RebornProfile};
+
+#[derive(Debug, Args)]
+pub(crate) struct ProfileCommand {
+    #[command(subcommand)]
+    command: ProfileSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum ProfileSubcommand {
+    /// List supported Reborn boot profiles.
+    List(ProfileListCommand),
+}
+
+#[derive(Debug, Args)]
+struct ProfileListCommand {
+    /// Output profiles as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl ProfileCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            ProfileSubcommand::List(command) => command.execute(),
+        }
+    }
+}
+
+impl ProfileListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        let profiles = RebornProfile::all();
+
+        if self.json {
+            let profiles = profiles.iter().map(|profile| {
+                serde_json::json!({
+                    "name": profile.as_str(),
+                    "default": *profile == RebornProfile::default(),
+                })
+            });
+            println!(
+                "{}",
+                serde_json::json!({
+                    "profiles": profiles.collect::<Vec<_>>(),
+                    "selector": REBORN_PROFILE_ENV,
+                })
+            );
+        } else {
+            println!("IronClaw Reborn profiles");
+            for profile in profiles {
+                if *profile == RebornProfile::default() {
+                    println!("- {} (default)", profile);
+                } else {
+                    println!("- {}", profile);
+                }
+            }
+            println!("Select with {}=<profile>", REBORN_PROFILE_ENV);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/skills.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/skills.rs
@@ -1,0 +1,72 @@
+use clap::{Args, Subcommand};
+
+const STATUS_NOT_WIRED: &str = "not-wired";
+const V1_STATE_NOT_USED: &str = "not-used";
+const DETAILS: [&str; 2] = [
+    "Reborn skill catalog is not wired yet",
+    "v1 skill discovery is intentionally not read",
+];
+
+#[derive(Debug, Args)]
+pub(crate) struct SkillsCommand {
+    #[command(subcommand)]
+    command: SkillsSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum SkillsSubcommand {
+    /// List configured Reborn skills.
+    List(SkillsListCommand),
+}
+
+#[derive(Debug, Args)]
+struct SkillsListCommand {
+    /// Show extra status details.
+    #[arg(short, long)]
+    verbose: bool,
+
+    /// Output skills as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl SkillsCommand {
+    pub(crate) fn execute(self) -> anyhow::Result<()> {
+        match self.command {
+            SkillsSubcommand::List(command) => command.execute(),
+        }
+    }
+}
+
+impl SkillsListCommand {
+    fn execute(self) -> anyhow::Result<()> {
+        let details = self.verbose.then_some(DETAILS.as_slice());
+
+        if self.json {
+            let mut output = serde_json::json!({
+                "configured": 0,
+                "skills": [],
+                "status": STATUS_NOT_WIRED,
+                "v1_state": V1_STATE_NOT_USED,
+            });
+            if let Some(details) = details {
+                output["details"] = serde_json::json!(details);
+            }
+            println!("{}", output);
+            return Ok(());
+        }
+
+        println!("IronClaw Reborn skills");
+        println!("configured: 0");
+        println!("status: {STATUS_NOT_WIRED}");
+        println!("v1_state: {V1_STATE_NOT_USED}");
+
+        if let Some(details) = details {
+            for detail in details {
+                println!("detail: {detail}");
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -21,10 +21,338 @@ fn help_mentions_reborn_commands() {
         stdout.contains("Standalone IronClaw Reborn runtime"),
         "stdout: {stdout}"
     );
+    assert!(stdout.contains("channels"), "stdout: {stdout}");
     assert!(stdout.contains("completion"), "stdout: {stdout}");
     assert!(stdout.contains("config"), "stdout: {stdout}");
     assert!(stdout.contains("doctor"), "stdout: {stdout}");
+    assert!(stdout.contains("hooks"), "stdout: {stdout}");
+    assert!(stdout.contains("logs"), "stdout: {stdout}");
+    assert!(stdout.contains("models"), "stdout: {stdout}");
+    assert!(stdout.contains("profile"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+    assert!(stdout.contains("skills"), "stdout: {stdout}");
+}
+
+#[test]
+fn profile_list_shows_supported_profiles_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("profile")
+        .arg("list")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn profile list should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn profiles"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("local-dev (default)"), "stdout: {stdout}");
+    assert!(stdout.contains("production"), "stdout: {stdout}");
+    assert!(stdout.contains("migration-dry-run"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("IRONCLAW_REBORN_PROFILE"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn profile_list_json_is_stable_and_does_not_resolve_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("profile")
+        .arg("list")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn profile list --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["selector"], "IRONCLAW_REBORN_PROFILE");
+    let profiles = json["profiles"].as_array().expect("profiles array");
+    assert_eq!(profiles.len(), 3);
+    assert!(
+        profiles
+            .iter()
+            .any(|profile| profile["name"] == "local-dev" && profile["default"] == true)
+    );
+    assert!(
+        profiles
+            .iter()
+            .any(|profile| profile["name"] == "production" && profile["default"] == false)
+    );
+    assert!(
+        profiles
+            .iter()
+            .any(|profile| profile["name"] == "migration-dry-run" && profile["default"] == false)
+    );
+}
+
+#[test]
+fn channels_list_reports_unwired_empty_surface_without_reborn_home() {
+    assert_empty_not_wired_surface(
+        &["channels", "list"],
+        "IronClaw Reborn channels",
+        "channels",
+        "configured",
+    );
+}
+
+#[test]
+fn channels_list_verbose_explains_missing_reborn_registry() {
+    assert_verbose_detail(
+        &["channels", "list", "--verbose"],
+        "Reborn channel registry is not wired yet",
+    );
+}
+
+#[test]
+fn channels_list_json_verbose_includes_status_details() {
+    assert_json_verbose_detail(
+        &["channels", "list", "--json", "--verbose"],
+        "channels",
+        "configured",
+        "Reborn channel registry is not wired yet",
+    );
+}
+
+#[test]
+fn hooks_list_reports_unwired_empty_surface_without_reborn_home() {
+    assert_empty_not_wired_surface(
+        &["hooks", "list"],
+        "IronClaw Reborn hooks",
+        "hooks",
+        "configured",
+    );
+}
+
+#[test]
+fn hooks_list_verbose_explains_missing_reborn_registry() {
+    assert_verbose_detail(
+        &["hooks", "list", "--verbose"],
+        "Reborn hook registry is not wired yet",
+    );
+}
+
+#[test]
+fn hooks_list_json_verbose_includes_status_details() {
+    assert_json_verbose_detail(
+        &["hooks", "list", "--json", "--verbose"],
+        "hooks",
+        "configured",
+        "Reborn hook registry is not wired yet",
+    );
+}
+
+#[test]
+fn skills_list_reports_unwired_empty_surface_without_reborn_home() {
+    assert_empty_not_wired_surface(
+        &["skills", "list"],
+        "IronClaw Reborn skills",
+        "skills",
+        "configured",
+    );
+}
+
+#[test]
+fn skills_list_verbose_explains_missing_reborn_catalog() {
+    assert_verbose_detail(
+        &["skills", "list", "--verbose"],
+        "Reborn skill catalog is not wired yet",
+    );
+}
+
+#[test]
+fn skills_list_json_verbose_includes_status_details() {
+    assert_json_verbose_detail(
+        &["skills", "list", "--json", "--verbose"],
+        "skills",
+        "configured",
+        "Reborn skill catalog is not wired yet",
+    );
+}
+
+#[test]
+fn logs_reports_unwired_surface_without_reborn_home() {
+    assert_empty_not_wired_surface(&["logs"], "IronClaw Reborn logs", "logs", "entries");
+}
+
+#[test]
+fn logs_verbose_explains_missing_reborn_log_source() {
+    assert_verbose_detail(&["logs", "--verbose"], "Reborn log source is not wired yet");
+}
+
+#[test]
+fn logs_json_verbose_includes_status_details() {
+    assert_json_verbose_detail(
+        &["logs", "--json", "--verbose"],
+        "logs",
+        "entries",
+        "Reborn log source is not wired yet",
+    );
+}
+
+#[test]
+fn models_list_reports_reborn_slots_without_reborn_home() {
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("list")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn models list should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn model slots"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("- default"), "stdout: {stdout}");
+    assert!(stdout.contains("- mission"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("routes: not-configured"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+}
+
+#[test]
+fn models_status_json_reports_routes_not_configured() {
+    let output = Command::new(reborn_bin())
+        .arg("models")
+        .arg("status")
+        .arg("--json")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn models status --json should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json["routes"], "not-configured");
+    assert_eq!(json["slots"]["default"], "not-configured");
+    assert_eq!(json["slots"]["mission"], "not-configured");
+    assert_eq!(json["v1_state"], "not-used");
+}
+
+fn assert_empty_not_wired_surface(
+    args: &[&str],
+    title: &str,
+    collection_key: &str,
+    count_key: &str,
+) {
+    let output = Command::new(reborn_bin())
+        .args(args)
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn command should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(title), "stdout: {stdout}");
+    assert!(
+        stdout.contains(&format!("{count_key}: 0")),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("status: not-wired"), "stdout: {stdout}");
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+
+    let mut json_args = args.to_vec();
+    json_args.push("--json");
+    let output = Command::new(reborn_bin())
+        .args(json_args)
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn JSON command should run");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json[count_key], 0);
+    assert_eq!(
+        json[collection_key]
+            .as_array()
+            .expect("collection array")
+            .len(),
+        0
+    );
+    assert_eq!(json["status"], "not-wired");
+    assert_eq!(json["v1_state"], "not-used");
+}
+
+fn assert_verbose_detail(args: &[&str], expected_detail: &str) {
+    let output = Command::new(reborn_bin())
+        .args(args)
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn verbose command should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(expected_detail), "stdout: {stdout}");
+}
+
+fn assert_json_verbose_detail(
+    args: &[&str],
+    collection_key: &str,
+    count_key: &str,
+    expected_detail: &str,
+) {
+    let output = Command::new(reborn_bin())
+        .args(args)
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn JSON verbose command should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(json[count_key], 0);
+    assert_eq!(
+        json[collection_key]
+            .as_array()
+            .expect("collection array")
+            .len(),
+        0
+    );
+    let details = json["details"].as_array().expect("details array");
+    assert!(
+        details.iter().any(|detail| detail == expected_detail),
+        "json: {json}"
+    );
 }
 
 #[test]

--- a/crates/ironclaw_reborn_config/src/profile.rs
+++ b/crates/ironclaw_reborn_config/src/profile.rs
@@ -21,6 +21,12 @@ pub enum RebornProfile {
 }
 
 impl RebornProfile {
+    const ALL: [Self; 3] = [Self::LocalDev, Self::Production, Self::MigrationDryRun];
+
+    pub fn all() -> &'static [Self] {
+        &Self::ALL
+    }
+
     pub fn from_env_value(value: Option<OsString>) -> Result<Self, RebornConfigError> {
         let Some(value) = value else {
             return Ok(Self::default());

--- a/crates/ironclaw_reborn_config/tests/profile_contract.rs
+++ b/crates/ironclaw_reborn_config/tests/profile_contract.rs
@@ -12,6 +12,18 @@ fn profile_wire_values_are_stable() {
 }
 
 #[test]
+fn all_profiles_are_exposed_in_display_order() {
+    assert_eq!(
+        RebornProfile::all(),
+        &[
+            RebornProfile::LocalDev,
+            RebornProfile::Production,
+            RebornProfile::MigrationDryRun,
+        ]
+    );
+}
+
+#[test]
 fn profile_parsing_accepts_expected_values() {
     assert_eq!(
         RebornProfile::from_str("local-dev"),

--- a/docs/reborn-binary.md
+++ b/docs/reborn-binary.md
@@ -12,11 +12,29 @@ It currently supports:
 
 ```bash
 ironclaw-reborn --help
+ironclaw-reborn channels list
+ironclaw-reborn channels list --json
+ironclaw-reborn channels list --verbose
 ironclaw-reborn completion --shell bash
 ironclaw-reborn completion --shell zsh
 ironclaw-reborn config path
 ironclaw-reborn doctor
+ironclaw-reborn hooks list
+ironclaw-reborn hooks list --json
+ironclaw-reborn hooks list --verbose
+ironclaw-reborn logs
+ironclaw-reborn logs --json
+ironclaw-reborn logs --verbose
+ironclaw-reborn models list
+ironclaw-reborn models list --json
+ironclaw-reborn models status
+ironclaw-reborn models status --json
+ironclaw-reborn profile list
+ironclaw-reborn profile list --json
 ironclaw-reborn run
+ironclaw-reborn skills list
+ironclaw-reborn skills list --json
+ironclaw-reborn skills list --verbose
 ```
 
 It intentionally does not yet support:
@@ -29,6 +47,24 @@ It intentionally does not yet support:
 - long-lived Reborn runtime services.
 
 ## Commands
+
+### `channels list`
+
+Reports configured Reborn channels without resolving Reborn home, reading v1 channel config, or creating directories.
+
+The Reborn channel registry is not wired yet, so the command currently reports an explicit empty surface:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list --verbose
+```
+
+Expected fields include:
+
+- `configured: 0`
+- `status: not-wired`
+- `v1_state: not-used`
 
 ### `completion`
 
@@ -72,6 +108,79 @@ Expected fields include:
 - `v1_state: not-used`
 - `driver_registry: initialized`
 
+### `hooks list`
+
+Reports configured Reborn hooks without resolving Reborn home, reading v1 hook config, or creating directories.
+
+The Reborn hook registry is not wired yet, so the command currently reports an explicit empty surface:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list --verbose
+```
+
+Expected fields include:
+
+- `configured: 0`
+- `status: not-wired`
+- `v1_state: not-used`
+
+### `logs`
+
+Reports Reborn log availability without resolving Reborn home, reading v1 gateway logs, or creating directories.
+
+The Reborn log source is not wired yet, so the command currently reports an explicit empty surface:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs --verbose
+```
+
+Expected fields include:
+
+- `entries: 0`
+- `status: not-wired`
+- `v1_state: not-used`
+
+### `models list` / `models status`
+
+Shows Reborn model purpose slots and route status without resolving Reborn home, reading v1 provider settings, or creating directories.
+
+Routes are not configurable through Reborn CLI yet, so the command currently reports `not-configured` routes for built-in slots:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models list --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status --json
+```
+
+Expected fields include:
+
+- `default`
+- `mission`
+- `routes: not-configured`
+- `v1_state: not-used`
+
+### `profile list`
+
+Lists the supported Reborn boot profiles without resolving Reborn home, reading v1 state, or creating directories.
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- profile list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- profile list --json
+```
+
+Supported profiles:
+
+- `local-dev` (default)
+- `production`
+- `migration-dry-run`
+
+Select a profile with `IRONCLAW_REBORN_PROFILE=<profile>`.
+
 ### `run`
 
 Initializes the minimal Reborn runtime shell and exits successfully. This is a smokeable composition shell, not full agent execution.
@@ -90,6 +199,24 @@ Expected fields include:
 - `v1_state: not-used`
 - `driver_registry: initialized`
 - `runtime_shell: initialized`
+
+### `skills list`
+
+Reports configured Reborn skills without resolving Reborn home, reading v1 skill discovery paths, or creating directories.
+
+The Reborn skill catalog is not wired yet, so the command currently reports an explicit empty surface:
+
+```bash
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list --json
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list --verbose
+```
+
+Expected fields include:
+
+- `configured: 0`
+- `status: not-wired`
+- `v1_state: not-used`
 
 ## State and config root
 
@@ -128,14 +255,21 @@ Run these before changing Reborn CLI behavior:
 cargo fmt --all -- --check
 cargo test -p ironclaw_reborn_cli
 cargo test -p ironclaw_reborn_config
+cargo test -p ironclaw_reborn model_slots_are_exposed_in_cli_display_order
 cargo test -p ironclaw_architecture reborn
 cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- --help
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- channels list
 cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- completion --shell zsh >/tmp/ironclaw-reborn.zsh
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- config path
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- hooks list
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- logs
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- models status
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- profile list
 IRONCLAW_REBORN_HOME="$(mktemp -d)/reborn-home" \
   cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- run
+cargo run -q -p ironclaw_reborn_cli --bin ironclaw-reborn -- skills list
 ```
 
 ## Adding commands


### PR DESCRIPTION
## Summary
- Consolidates the Reborn CLI inspection surfaces into one PR to avoid merge conflicts across shared CLI files.
- Adds read-only/pure inspection commands:
  - `profile list [--json]`
  - `channels list [--json] [--verbose]`
  - `hooks list [--json] [--verbose]`
  - `skills list [--json] [--verbose]`
  - `models list/status [--json]`
  - `logs [--json] [--verbose]`
- Keeps already-merged `config path` from #3518 as base behavior and updates docs/tests around the complete inspection surface.
- Adds small shared support seams: `RebornProfile::all()` and `ModelSlot::all()`.

## Supersedes / replaces
- Supersedes closed PRs #3517, #3520, #3522, #3525, #3526, #3527.
- Builds on merged PR #3518 (`config path`).

## Safety / Reborn boundaries
- Pure commands (`profile`, `channels`, `hooks`, `skills`, `models`, `logs`) do not resolve Reborn home.
- No v1 state reads/writes.
- No v1 runtime imports.
- Unwired Reborn surfaces report explicit `not-wired` / `not-configured` status instead of pretending to use v1 config.

## Tests
- `TMPDIR=$PWD/.tmp-cargo cargo fmt --all -- --check`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_cli`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn_config profile`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_reborn model_slots_are_exposed_in_cli_display_order`
- `TMPDIR=$PWD/.tmp-cargo cargo test -p ironclaw_architecture reborn`
- `TMPDIR=$PWD/.tmp-cargo cargo clippy -p ironclaw_reborn_cli --all-targets -- -D warnings`

Manual smoke:
- `profile list`
- `channels list --json`
- `hooks list --verbose`
- `models status`
- `logs --json`
- `skills list --verbose`

Note: `TMPDIR` points at the NVME worktree because the macOS system volume `/var` has very little free space and rustc temp writes can fail there with `No space left on device`.
