### PR TITLE
[Reborn] Add deterministic instruction bundle builder

### DIFF
--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -32,11 +32,12 @@ use ironclaw_turns::{
         AgentLoopHostError, AgentLoopHostErrorKind, AssistantReply, BeginAssistantDraft,
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDenied,
         CapabilityDeniedReasonKind, CapabilityInvocation, CapabilityOutcome,
-        CapabilitySurfaceVersion, FinalizeAssistantMessage, LoopContextBundle, LoopContextMessage,
-        LoopContextPort, LoopContextRequest, LoopHostMilestoneEmitter, LoopHostMilestoneSink,
-        LoopInputCursor, LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelResponse,
-        LoopRunContext, LoopRunInfoPort, LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput,
-        UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
+        CapabilitySurfaceVersion, FinalizeAssistantMessage, InstructionMaterializationStore,
+        LoopContextBundle, LoopContextMessage, LoopContextPort, LoopContextRequest,
+        LoopHostMilestoneEmitter, LoopHostMilestoneSink, LoopInputCursor, LoopModelMessage,
+        LoopModelPort, LoopModelRequest, LoopModelResponse, LoopRunContext, LoopRunInfoPort,
+        LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, UpdateAssistantDraft,
+        VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -457,6 +458,7 @@ where
     max_messages: usize,
     milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
     skill_context_source: Option<Arc<dyn HostSkillContextSource>>,
+    instruction_materialization_store: Option<Arc<dyn InstructionMaterializationStore>>,
 }
 
 impl<S, G> ThreadBackedLoopModelPort<S, G>
@@ -479,6 +481,7 @@ where
             max_messages,
             milestone_sink: None,
             skill_context_source: None,
+            instruction_materialization_store: None,
         }
     }
 
@@ -498,11 +501,20 @@ where
             max_messages,
             milestone_sink: Some(milestone_sink),
             skill_context_source: None,
+            instruction_materialization_store: None,
         }
     }
 
     pub fn with_skill_context_source(mut self, source: Arc<dyn HostSkillContextSource>) -> Self {
         self.skill_context_source = Some(source);
+        self
+    }
+
+    pub fn with_instruction_materialization_store(
+        mut self,
+        store: Arc<dyn InstructionMaterializationStore>,
+    ) -> Self {
+        self.instruction_materialization_store = Some(store);
         self
     }
 }
@@ -649,9 +661,21 @@ where
         }
 
         let mut messages_by_ref = context_messages_by_ref(context.messages);
-        let needs_history_lookup = requested_messages
-            .iter()
-            .any(|message| !messages_by_ref.contains_key(message.content_ref.as_str()));
+        let mut needs_history_lookup = false;
+        for message in &requested_messages {
+            if messages_by_ref.contains_key(message.content_ref.as_str()) {
+                continue;
+            }
+            if let Some(materialization_store) = self.instruction_materialization_store.as_ref()
+                && materialization_store
+                    .get_materialized_message(&self.run_context, &message.content_ref)?
+                    .is_some()
+            {
+                continue;
+            }
+            needs_history_lookup = true;
+            break;
+        }
         let snippet_messages_by_ref = if requested_messages
             .iter()
             .any(|message| skill_context::is_snippet_model_message_ref(&message.content_ref))
@@ -675,6 +699,26 @@ where
         let mut resolved = Vec::with_capacity(requested_messages.len());
         for message in requested_messages {
             let requested_role = HostManagedModelMessageRole::from_loop_role(&message.role)?;
+            if let Some(materialization_store) = self.instruction_materialization_store.as_ref()
+                && let Some(materialized) = materialization_store
+                    .get_materialized_message(&self.run_context, &message.content_ref)?
+            {
+                let materialized_role =
+                    HostManagedModelMessageRole::from_loop_role(&materialized.role)?;
+                if requested_role != materialized_role {
+                    return Err(AgentLoopHostError::new(
+                        AgentLoopHostErrorKind::InvalidInvocation,
+                        "model message role does not match materialized instruction context",
+                    ));
+                }
+                resolved.push(HostManagedModelMessage {
+                    role: materialized_role,
+                    content: materialized.safe_content,
+                    content_ref: message.content_ref,
+                });
+                continue;
+            }
+
             if let Some(snippet_message) = snippet_messages_by_ref.get(message.content_ref.as_str())
             {
                 if requested_role != snippet_message.role {

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -28,12 +28,14 @@ use ironclaw_turns::{
     run_profile::{
         AgentLoopHostErrorKind, AssistantReply, BeginAssistantDraft, CapabilityDeniedReasonKind,
         CapabilityInputRef, CapabilityInvocation, CapabilityOutcome, CapabilitySurfaceVersion,
-        FinalizeAssistantMessage, HostManagedLoopPromptPort, InMemoryLoopHostMilestoneSink,
-        InMemoryRunProfileResolver, LoopCapabilityPort, LoopContextPort, LoopContextRequest,
-        LoopHostMilestoneKind, LoopInputCursor, LoopInputCursorToken, LoopModelMessage,
-        LoopModelPort, LoopModelRequest, LoopModelRouteSnapshot, LoopPromptPort, LoopRunContext,
-        LoopTranscriptPort, ParentLoopOutput, PromptSkillContextMetadata, SkillVisibility,
-        UpdateAssistantDraft, VisibleCapabilityRequest,
+        FinalizeAssistantMessage, HostManagedLoopPromptPort,
+        InMemoryInstructionMaterializationStore, InMemoryLoopHostMilestoneSink,
+        InMemoryRunProfileResolver, LoopCapabilityPort, LoopContextBundle, LoopContextMessage,
+        LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopHostMilestoneKind,
+        LoopInputCursor, LoopInputCursorToken, LoopModelMessage, LoopModelPort, LoopModelRequest,
+        LoopModelRouteSnapshot, LoopPromptPort, LoopRunContext, LoopTranscriptPort,
+        ParentLoopOutput, PromptSkillContextMetadata, SkillVisibility, UpdateAssistantDraft,
+        VisibleCapabilityRequest,
     },
 };
 use tracing_test::traced_test;
@@ -421,6 +423,87 @@ async fn prompt_and_model_ports_send_selected_skill_context_to_gateway() {
     );
     assert_eq!(calls[0].messages[1].role, HostManagedModelMessageRole::User);
     assert_eq!(calls[0].messages[1].content, "hello reborn");
+}
+
+#[tokio::test]
+async fn prompt_and_model_ports_resolve_instruction_memory_and_identity_refs() {
+    let fixture = ThreadFixture::new().await;
+    let materialization_store = Arc::new(InMemoryInstructionMaterializationStore::default());
+    let context_port = Arc::new(StaticLoopContextPort {
+        bundle: LoopContextBundle {
+            identity_messages: vec![LoopContextMessage {
+                message_ref: LoopMessageRef::new("msg:identity-policy").unwrap(),
+                role: "system".to_string(),
+                safe_summary: "identity policy summary".to_string(),
+            }],
+            messages: vec![LoopContextMessage {
+                message_ref: LoopMessageRef::new(format!("msg:{}", fixture.user_message_id))
+                    .unwrap(),
+                role: "user".to_string(),
+                safe_summary: "user message available".to_string(),
+            }],
+            instruction_snippets: vec![LoopContextSnippet {
+                snippet_ref: "instruction:project".to_string(),
+                safe_summary: "project instruction summary".to_string(),
+                metadata: None,
+            }],
+            memory_snippets: vec![LoopContextSnippet {
+                snippet_ref: "memory:project-summary".to_string(),
+                safe_summary: "project memory summary".to_string(),
+                metadata: None,
+            }],
+        },
+    });
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let prompt_port =
+        HostManagedLoopPromptPort::new(fixture.run_context.clone(), context_port, milestones)
+            .with_instruction_materialization_store(materialization_store.clone());
+    let prompt_bundle = prompt_port
+        .build_prompt_bundle(ironclaw_turns::run_profile::LoopPromptBundleRequest {
+            mode: ironclaw_turns::run_profile::PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(prompt_bundle.messages.len(), 4);
+
+    let gateway = Arc::new(RecordingGateway::reply("model says hi"));
+    let model_port = ThreadBackedLoopModelPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway.clone(),
+        16,
+    )
+    .with_instruction_materialization_store(materialization_store);
+
+    model_port
+        .stream_model(LoopModelRequest {
+            messages: prompt_bundle.messages,
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap();
+
+    let calls = gateway.calls.lock().unwrap();
+    let contents = calls[0]
+        .messages
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        contents,
+        vec![
+            "identity policy summary",
+            "project instruction summary",
+            "project memory summary",
+            "hello reborn",
+        ]
+    );
 }
 
 #[tokio::test]
@@ -1549,6 +1632,20 @@ async fn model_port_surfaces_fail_closed_gateway_policy_errors_without_raw_detai
 }
 
 #[derive(Clone)]
+struct StaticLoopContextPort {
+    bundle: LoopContextBundle,
+}
+
+#[async_trait]
+impl LoopContextPort for StaticLoopContextPort {
+    async fn load_loop_context(
+        &self,
+        _request: LoopContextRequest,
+    ) -> Result<LoopContextBundle, ironclaw_turns::run_profile::AgentLoopHostError> {
+        Ok(self.bundle.clone())
+    }
+}
+
 struct StaticSkillContextSource {
     candidates: Vec<HostSkillContextCandidate>,
 }

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -1307,6 +1307,45 @@ async fn model_port_resolves_explicit_refs_that_fall_outside_context_window() {
 }
 
 #[tokio::test]
+async fn prompt_port_builds_bundle_with_tool_result_reference_context() {
+    let fixture = ThreadFixture::new().await;
+    let tool_result_ref = LoopMessageRef::new("msg:11111111-1111-1111-1111-111111111111").unwrap();
+    let thread_service = Arc::new(StaticContextThreadService::new(ContextMessage {
+        message_id: Some(ThreadMessageId::parse("11111111-1111-1111-1111-111111111111").unwrap()),
+        summary_id: None,
+        sequence: 1,
+        kind: MessageKind::ToolResultReference,
+        content: "tool result content".to_string(),
+    }));
+    let context_port = Arc::new(ThreadBackedLoopContextPort::new(
+        thread_service,
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        16,
+    ));
+    let prompt_port = HostManagedLoopPromptPort::new(
+        fixture.run_context.clone(),
+        context_port,
+        Arc::new(InMemoryLoopHostMilestoneSink::default()),
+    );
+
+    let prompt_bundle = prompt_port
+        .build_prompt_bundle(ironclaw_turns::run_profile::LoopPromptBundleRequest {
+            mode: ironclaw_turns::run_profile::PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(prompt_bundle.messages.len(), 1);
+    assert_eq!(prompt_bundle.messages[0].role, "tool_result_reference");
+    assert_eq!(prompt_bundle.messages[0].content_ref, tool_result_ref);
+}
+
+#[tokio::test]
 async fn model_port_round_trips_tool_result_reference_context_as_system_model_input() {
     let fixture = ThreadFixture::new().await;
     let tool_result_ref = LoopMessageRef::new("msg:11111111-1111-1111-1111-111111111111").unwrap();

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -30,12 +30,12 @@ use ironclaw_turns::{
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDenied,
         CapabilityDeniedReasonKind, CapabilityDescriptorView, CapabilityFailure,
         CapabilityInvocation, CapabilityOutcome, CapabilityResultMessage, FinalizeAssistantMessage,
-        HostManagedLoopPromptPort,
-        InMemoryInstructionMaterializationStore, InstructionMaterializationStore,
-        LoopCapabilityPort, LoopCheckpointPort, LoopCheckpointRequest, LoopContextBundle,
-        LoopContextPort, LoopContextRequest, LoopHostMilestoneEmitter, LoopHostMilestoneSink,
-        LoopInputBatch, LoopInputCursor, LoopInputPort, LoopModelPort, LoopModelRequest,
-        LoopModelResponse, LoopProcessRef, LoopProgressEvent, LoopProgressPort, LoopPromptBundle,
+        HostManagedLoopPromptPort, InMemoryInstructionMaterializationStore,
+        InstructionMaterializationStore, InstructionSafetyContext, LoopCapabilityPort,
+        LoopCheckpointPort, LoopCheckpointRequest, LoopContextBundle, LoopContextPort,
+        LoopContextRequest, LoopHostMilestoneEmitter, LoopHostMilestoneSink, LoopInputBatch,
+        LoopInputCursor, LoopInputPort, LoopModelPort, LoopModelRequest, LoopModelResponse,
+        LoopProcessRef, LoopProgressEvent, LoopProgressPort, LoopPromptBundle,
         LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
         LoopTranscriptPort, ProcessHandleSummary, UpdateAssistantDraft, VisibleCapabilityRequest,
         VisibleCapabilitySurface,
@@ -928,6 +928,7 @@ where
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     config: TextOnlyLoopHostConfig,
     skill_context_source: Option<Arc<dyn HostSkillContextSource>>,
+    safety_context: Option<InstructionSafetyContext>,
 }
 
 impl<S, G> RebornLoopDriverHostFactory<S, G>
@@ -954,11 +955,17 @@ where
             milestone_sink,
             config,
             skill_context_source: None,
+            safety_context: None,
         }
     }
 
     pub fn with_skill_context_source(mut self, source: Arc<dyn HostSkillContextSource>) -> Self {
         self.skill_context_source = Some(source);
+        self
+    }
+
+    pub fn with_safety_context(mut self, safety_context: InstructionSafetyContext) -> Self {
+        self.safety_context = Some(safety_context);
         self
     }
 
@@ -1012,16 +1019,18 @@ where
                 reason: error.safe_summary,
             })?;
         let surface_state_for_prompt = Arc::clone(&surface_state);
-        let prompt: Arc<dyn LoopPromptPort> = Arc::new(
-            HostManagedLoopPromptPort::new(
-                run_context.clone(),
-                Arc::clone(&context),
-                Arc::clone(&self.milestone_sink),
-            )
-            .with_default_message_limit(max_messages)
-            .with_current_surface_lookup(move || surface_state_for_prompt.current())
-            .with_instruction_materialization_store(Arc::clone(&instruction_materialization_store)),
-        );
+        let mut prompt_port = HostManagedLoopPromptPort::new(
+            run_context.clone(),
+            Arc::clone(&context),
+            Arc::clone(&self.milestone_sink),
+        )
+        .with_default_message_limit(max_messages)
+        .with_current_surface_lookup(move || surface_state_for_prompt.current())
+        .with_instruction_materialization_store(Arc::clone(&instruction_materialization_store));
+        if let Some(safety_context) = self.safety_context.clone() {
+            prompt_port = prompt_port.with_safety_context(safety_context);
+        }
+        let prompt: Arc<dyn LoopPromptPort> = Arc::new(prompt_port);
         let input: Arc<dyn LoopInputPort> =
             Arc::new(NoExtraLoopInputPort::new(run_context.clone()));
         let mut model_adapter = ThreadBackedLoopModelPort::with_milestone_sink(

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -29,12 +29,13 @@ use ironclaw_turns::{
         AgentLoopHostError, AgentLoopHostErrorKind, AppendCapabilityResultRef, BeginAssistantDraft,
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityDenied,
         CapabilityDeniedReasonKind, CapabilityDescriptorView, CapabilityFailure,
-        CapabilityInvocation, CapabilityOutcome, CapabilityResultMessage, CapabilitySurfaceVersion,
-        FinalizeAssistantMessage, HostManagedLoopPromptPort, LoopCapabilityPort,
-        LoopCheckpointPort, LoopCheckpointRequest, LoopContextBundle, LoopContextPort,
-        LoopContextRequest, LoopHostMilestoneEmitter, LoopHostMilestoneSink, LoopInputBatch,
-        LoopInputCursor, LoopInputPort, LoopModelPort, LoopModelRequest, LoopModelResponse,
-        LoopProcessRef, LoopProgressEvent, LoopProgressPort, LoopPromptBundle,
+        CapabilityInvocation, CapabilityOutcome, CapabilityResultMessage, FinalizeAssistantMessage,
+        HostManagedLoopPromptPort,
+        InMemoryInstructionMaterializationStore, InstructionMaterializationStore,
+        LoopCapabilityPort, LoopCheckpointPort, LoopCheckpointRequest, LoopContextBundle,
+        LoopContextPort, LoopContextRequest, LoopHostMilestoneEmitter, LoopHostMilestoneSink,
+        LoopInputBatch, LoopInputCursor, LoopInputPort, LoopModelPort, LoopModelRequest,
+        LoopModelResponse, LoopProcessRef, LoopProgressEvent, LoopProgressPort, LoopPromptBundle,
         LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
         LoopTranscriptPort, ProcessHandleSummary, UpdateAssistantDraft, VisibleCapabilityRequest,
         VisibleCapabilitySurface,
@@ -87,22 +88,22 @@ pub struct RebornLoopDriverHostRequest {
 
 #[derive(Default)]
 struct CapabilitySurfaceState {
-    current: Mutex<Option<CapabilitySurfaceVersion>>,
+    current: Mutex<Option<VisibleCapabilitySurface>>,
 }
 
 impl CapabilitySurfaceState {
-    fn set_current(&self, version: CapabilitySurfaceVersion) -> Result<(), AgentLoopHostError> {
+    fn set_current(&self, surface: VisibleCapabilitySurface) -> Result<(), AgentLoopHostError> {
         let mut current = self.current.lock().map_err(|_| {
             AgentLoopHostError::new(
                 AgentLoopHostErrorKind::Unavailable,
                 "capability surface state is unavailable",
             )
         })?;
-        *current = Some(version);
+        *current = Some(surface);
         Ok(())
     }
 
-    fn current(&self) -> Result<Option<CapabilitySurfaceVersion>, AgentLoopHostError> {
+    fn current(&self) -> Result<Option<VisibleCapabilitySurface>, AgentLoopHostError> {
         self.current
             .lock()
             .map(|current| current.clone())
@@ -136,7 +137,7 @@ impl LoopCapabilityPort for SurfaceTrackingLoopCapabilityPort {
         request: VisibleCapabilityRequest,
     ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
         let surface = self.inner.visible_capabilities(request).await?;
-        self.surface_state.set_current(surface.version.clone())?;
+        self.surface_state.set_current(surface.clone())?;
         Ok(surface)
     }
 
@@ -998,6 +999,8 @@ where
             context_adapter = context_adapter.with_skill_context_source(source.clone());
         }
         let context: Arc<dyn LoopContextPort> = Arc::new(context_adapter);
+        let instruction_materialization_store: Arc<dyn InstructionMaterializationStore> =
+            Arc::new(InMemoryInstructionMaterializationStore::default());
         let surface_state = Arc::new(CapabilitySurfaceState::default());
         let capabilities: Arc<dyn LoopCapabilityPort> = Arc::new(
             SurfaceTrackingLoopCapabilityPort::new(capabilities, Arc::clone(&surface_state)),
@@ -1016,7 +1019,8 @@ where
                 Arc::clone(&self.milestone_sink),
             )
             .with_default_message_limit(max_messages)
-            .with_current_surface_version_lookup(move || surface_state_for_prompt.current()),
+            .with_current_surface_lookup(move || surface_state_for_prompt.current())
+            .with_instruction_materialization_store(Arc::clone(&instruction_materialization_store)),
         );
         let input: Arc<dyn LoopInputPort> =
             Arc::new(NoExtraLoopInputPort::new(run_context.clone()));
@@ -1031,6 +1035,8 @@ where
         if let Some(source) = self.skill_context_source.as_ref() {
             model_adapter = model_adapter.with_skill_context_source(source.clone());
         }
+        model_adapter =
+            model_adapter.with_instruction_materialization_store(instruction_materialization_store);
         let model: Arc<dyn LoopModelPort> = Arc::new(model_adapter);
         let checkpoint: Arc<dyn LoopCheckpointPort> = Arc::new(HostManagedLoopCheckpointPort::new(
             run_context.clone(),

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -70,9 +70,10 @@ use ironclaw_turns::{
         CapabilitySurfaceVersion, FinalizeAssistantMessage, InMemoryLoopHostMilestoneSink,
         LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort, LoopCheckpointRequest,
         LoopCheckpointStateRef, LoopContextRequest, LoopDriverId, LoopDriverNoteKind,
-        LoopHostMilestone, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelRequest,
-        LoopModelRouteSnapshot, LoopProgressEvent, LoopPromptBundleRequest, LoopPromptPort,
-        LoopRunContext, ParentLoopOutput, PromptMode, SkillVisibility, VisibleCapabilityRequest,
+        LoopHostMilestone, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelPort,
+        LoopModelRequest, LoopModelRouteSnapshot, LoopProgressEvent, LoopPromptBundleRequest,
+        LoopPromptPort, LoopRunContext, ParentLoopOutput, PromptMode, SkillVisibility,
+        VisibleCapabilityRequest,
     },
     runner::ClaimedTurnRun,
 };
@@ -119,6 +120,7 @@ async fn text_only_host_factory_builds_complete_agent_loop_driver_host() {
         .await
         .unwrap();
     assert_eq!(prompt_bundle.messages.len(), 1);
+    assert!(prompt_bundle.instruction_fingerprint.is_some());
 
     let model_response = host_dyn
         .stream_model(LoopModelRequest {
@@ -1530,6 +1532,60 @@ async fn text_only_host_skill_context_does_not_expand_capability_surface() {
         outcome.outcomes.as_slice(),
         [CapabilityOutcome::Denied(denied)] if denied.reason_kind == CapabilityDeniedReasonKind::EmptySurface
     ));
+}
+
+#[tokio::test]
+async fn text_only_host_prompt_bundle_includes_surface_metadata_and_still_streams_model() {
+    let fixture = HostFixture::new("thread-host-surface-prompt", "hello").await;
+    let capability_id = CapabilityId::new("demo.echo").unwrap();
+    let runtime = Arc::new(RecordingHostRuntime::with_surface(host_runtime_surface([
+        capability_descriptor(capability_id.as_str()),
+    ])));
+    let capability_port = HostRuntimeLoopCapabilityPort::new(
+        runtime,
+        fixture.context.clone(),
+        host_runtime_visible_request(&fixture, ["demo"]),
+        Arc::new(InMemoryCapabilityIo::default()),
+        Arc::new(InMemoryCapabilityIo::default()),
+    );
+    let host = fixture
+        .factory()
+        .build_text_only_host_with_capabilities(
+            RebornLoopDriverHostRequest {
+                claimed_run: fixture.claimed.clone(),
+                loop_run_context: fixture.context.clone(),
+            },
+            Arc::new(capability_port),
+        )
+        .await
+        .unwrap();
+
+    let surface = host
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+    let prompt_bundle = host
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(surface.version.clone()),
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+        })
+        .await
+        .unwrap();
+
+    assert!(prompt_bundle.instruction_fingerprint.is_some());
+    assert_eq!(prompt_bundle.surface_version, Some(surface.version.clone()));
+    assert_eq!(prompt_bundle.messages.len(), 2);
+
+    host.stream_model(LoopModelRequest {
+        messages: prompt_bundle.messages,
+        surface_version: Some(surface.version),
+        model_preference: None,
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -68,12 +68,12 @@ use ironclaw_turns::{
         AgentLoopDriverHost, AgentLoopHostError, AgentLoopHostErrorKind,
         CapabilityDeniedReasonKind, CapabilityInputRef, CapabilityInvocation, CapabilityOutcome,
         CapabilitySurfaceVersion, FinalizeAssistantMessage, InMemoryLoopHostMilestoneSink,
-        LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort, LoopCheckpointRequest,
-        LoopCheckpointStateRef, LoopContextRequest, LoopDriverId, LoopDriverNoteKind,
-        LoopHostMilestone, LoopInputCursor, LoopInputCursorToken, LoopInputPort, LoopModelPort,
-        LoopModelRequest, LoopModelRouteSnapshot, LoopProgressEvent, LoopPromptBundleRequest,
-        LoopPromptPort, LoopRunContext, ParentLoopOutput, PromptMode, SkillVisibility,
-        VisibleCapabilityRequest,
+        InstructionSafetyContext, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
+        LoopCheckpointRequest, LoopCheckpointStateRef, LoopContextRequest, LoopDriverId,
+        LoopDriverNoteKind, LoopHostMilestone, LoopInputCursor, LoopInputCursorToken,
+        LoopInputPort, LoopModelPort, LoopModelRequest, LoopModelRouteSnapshot, LoopProgressEvent,
+        LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, ParentLoopOutput, PromptMode,
+        SkillVisibility, VisibleCapabilityRequest,
     },
     runner::ClaimedTurnRun,
 };
@@ -334,6 +334,52 @@ async fn text_only_model_reply_driver_rejects_profiles_not_assigned_to_driver() 
     assert!(fixture.gateway.requests().is_empty());
     assert!(fixture.milestones().is_empty());
     assert_driver_error_hides_raw_payloads(&error);
+}
+
+#[tokio::test]
+async fn text_only_host_factory_includes_safety_context_in_prompt_bundle() {
+    let fixture = HostFixture::new("thread-host-safety-context", "hello safety").await;
+    let host = fixture
+        .factory()
+        .with_safety_context(
+            InstructionSafetyContext::new("safety:prompt-write", "prompt write safety enforced")
+                .unwrap(),
+        )
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: fixture.claimed.clone(),
+            loop_run_context: fixture.context.clone(),
+        })
+        .await
+        .unwrap();
+    let host_dyn: &(dyn AgentLoopDriverHost + Send + Sync) = &host;
+
+    let prompt_bundle = host_dyn
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+        })
+        .await
+        .unwrap();
+    host_dyn
+        .stream_model(LoopModelRequest {
+            messages: prompt_bundle.messages,
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap();
+
+    let requests = fixture.gateway.requests();
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0]
+            .messages
+            .iter()
+            .any(|message| message.content == "prompt write safety enforced")
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 use super::{
+    instruction_bundle::InstructionBundleFingerprint,
     refs::{CheckpointSchemaId, LoopDriverId, ModelProfileId},
     snapshot::ResolvedRunProfile,
 };
@@ -801,6 +802,8 @@ pub struct LoopPromptBundle {
     pub bundle_ref: LoopPromptBundleRef,
     pub messages: Vec<LoopModelMessage>,
     pub surface_version: Option<CapabilitySurfaceVersion>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instruction_fingerprint: Option<InstructionBundleFingerprint>,
 }
 
 /// Host boundary for building prompt bundles before model invocation.

--- a/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
+++ b/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
@@ -198,6 +198,7 @@ impl InstructionBundleBuilder {
         let mut materialized_messages = Vec::new();
         let mut skill_context = Vec::new();
         let mut requires_materialization_store = false;
+        let mut synthetic_refs = SyntheticMessageRefRegistry::default();
         let mut fingerprint = Sha256::new();
 
         feed_field(
@@ -260,7 +261,12 @@ impl InstructionBundleBuilder {
                 skill_ordinal += 1;
             } else {
                 requires_materialization_store = true;
-                let content_ref = snippet_message_ref("instruction", &snippet, messages.len())?;
+                let content_ref = snippet_message_ref(
+                    "instruction",
+                    &snippet,
+                    messages.len(),
+                    &mut synthetic_refs,
+                )?;
                 push_snippet_message(
                     &mut messages,
                     &mut materialized_messages,
@@ -278,7 +284,8 @@ impl InstructionBundleBuilder {
         }
         memory_snippets.sort_by(compare_snippet_refs);
         for (ordinal, snippet) in memory_snippets.into_iter().enumerate() {
-            let content_ref = snippet_message_ref("memory", &snippet, ordinal)?;
+            let content_ref =
+                snippet_message_ref("memory", &snippet, ordinal, &mut synthetic_refs)?;
             push_snippet_message(
                 &mut messages,
                 &mut materialized_messages,
@@ -296,6 +303,7 @@ impl InstructionBundleBuilder {
                 &mut materialized_messages,
                 &mut fingerprint,
                 safety_context,
+                &mut synthetic_refs,
             )?;
         }
 
@@ -309,6 +317,7 @@ impl InstructionBundleBuilder {
                 &mut materialized_messages,
                 &mut fingerprint,
                 surface,
+                &mut synthetic_refs,
             )?;
         }
 
@@ -401,12 +410,14 @@ fn push_safety_context(
     materialized_messages: &mut Vec<InstructionBundleMaterializedMessage>,
     fingerprint: &mut Sha256,
     safety_context: InstructionSafetyContext,
+    synthetic_refs: &mut SyntheticMessageRefRegistry,
 ) -> Result<(), AgentLoopHostError> {
     let content_ref = synthetic_message_ref(
         "safety",
         &safety_context.policy_ref,
         &safety_context.safe_summary,
         0,
+        synthetic_refs,
     )?;
     feed_field(fingerprint, b"section", b"safety");
     feed_field(fingerprint, b"ref", content_ref.as_str().as_bytes());
@@ -433,6 +444,7 @@ fn push_visible_surface(
     materialized_messages: &mut Vec<InstructionBundleMaterializedMessage>,
     fingerprint: &mut Sha256,
     mut surface: VisibleCapabilitySurface,
+    synthetic_refs: &mut SyntheticMessageRefRegistry,
 ) -> Result<(), AgentLoopHostError> {
     surface
         .descriptors
@@ -447,7 +459,13 @@ fn push_visible_surface(
         summary.push('|');
         summary.push_str(&descriptor.safe_description);
     }
-    let content_ref = synthetic_message_ref("surface", surface.version.as_str(), &summary, 0)?;
+    let content_ref = synthetic_message_ref(
+        "surface",
+        surface.version.as_str(),
+        &summary,
+        0,
+        synthetic_refs,
+    )?;
     feed_field(fingerprint, b"section", b"surface");
     feed_field(fingerprint, b"ref", content_ref.as_str().as_bytes());
     feed_field(fingerprint, b"version", surface.version.as_str().as_bytes());
@@ -491,12 +509,14 @@ fn snippet_message_ref(
     section: &'static str,
     snippet: &LoopContextSnippet,
     ordinal: usize,
+    synthetic_refs: &mut SyntheticMessageRefRegistry,
 ) -> Result<LoopMessageRef, AgentLoopHostError> {
     synthetic_message_ref(
         section,
         &snippet.snippet_ref,
         &snippet.safe_summary,
         ordinal,
+        synthetic_refs,
     )
 }
 
@@ -505,15 +525,78 @@ fn synthetic_message_ref(
     source_ref: &str,
     safe_summary: &str,
     ordinal: usize,
+    synthetic_refs: &mut SyntheticMessageRefRegistry,
 ) -> Result<LoopMessageRef, AgentLoopHostError> {
     let slug = sanitize_ref_suffix(source_ref);
     let hash = stable_ref_hash(section, source_ref, safe_summary, ordinal);
-    LoopMessageRef::new(format!("msg:{section}.{slug}.{ordinal}.{hash:016x}")).map_err(|_| {
-        AgentLoopHostError::new(
-            AgentLoopHostErrorKind::Internal,
-            "instruction bundle message reference could not be represented",
-        )
-    })
+    let content_ref = LoopMessageRef::new(format!("msg:{section}.{slug}.{ordinal}.{hash:016x}"))
+        .map_err(|_| {
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::Internal,
+                "instruction bundle message reference could not be represented",
+            )
+        })?;
+    synthetic_refs.record(
+        content_ref,
+        SyntheticMessageRefInput::new(section, source_ref, safe_summary, ordinal),
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SyntheticMessageRefInput {
+    section: &'static str,
+    source_ref: String,
+    safe_summary: String,
+    ordinal: usize,
+}
+
+impl SyntheticMessageRefInput {
+    fn new(
+        section: &'static str,
+        source_ref: impl Into<String>,
+        safe_summary: impl Into<String>,
+        ordinal: usize,
+    ) -> Self {
+        Self {
+            section,
+            source_ref: source_ref.into(),
+            safe_summary: safe_summary.into(),
+            ordinal,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SyntheticMessageRefRegistry {
+    inputs_by_ref: HashMap<String, SyntheticMessageRefInput>,
+}
+
+impl SyntheticMessageRefRegistry {
+    fn record(
+        &mut self,
+        content_ref: LoopMessageRef,
+        input: SyntheticMessageRefInput,
+    ) -> Result<LoopMessageRef, AgentLoopHostError> {
+        let key = content_ref.as_str().to_string();
+        if let Some(existing) = self.inputs_by_ref.get(&key) {
+            if existing != &input {
+                tracing::debug!(
+                    content_ref = %content_ref.as_str(),
+                    existing_section = existing.section,
+                    new_section = input.section,
+                    new_ordinal = input.ordinal,
+                    "instruction bundle synthetic message ref collision detected"
+                );
+                return Err(AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Internal,
+                    "instruction bundle message reference collision detected",
+                ));
+            }
+        } else {
+            self.inputs_by_ref.insert(key, input);
+        }
+        Ok(content_ref)
+    }
 }
 
 fn compare_instruction_snippets(
@@ -548,7 +631,10 @@ fn instruction_rank(snippet_ref: &str) -> u8 {
 }
 
 fn validate_model_role(role: &str) -> Result<(), AgentLoopHostError> {
-    if matches!(role, "system" | "user" | "assistant" | "tool") {
+    if matches!(
+        role,
+        "system" | "user" | "assistant" | "tool" | "tool_result_reference"
+    ) {
         return Ok(());
     }
     Err(AgentLoopHostError::new(
@@ -577,7 +663,7 @@ fn validate_model_safe_text(
     value: String,
     label: &'static str,
 ) -> Result<String, AgentLoopHostError> {
-    if value.is_empty() || value.len() > 4096 || value.chars().any(|ch| ch == '\0') {
+    if value.is_empty() || value.len() > 4096 {
         return Err(AgentLoopHostError::new(
             AgentLoopHostErrorKind::PolicyDenied,
             format!("{label} is not model-safe"),
@@ -598,23 +684,39 @@ fn validate_model_safe_text(
 
 fn reject_sensitive_text(value: &str, label: &'static str) -> Result<(), AgentLoopHostError> {
     let lower = value.to_ascii_lowercase();
-    for forbidden in [
+    for forbidden_path in [
         "/users/",
         "/home/",
         "/private/",
-        "/tmp/",
+        "/tmp/", // safety: model-safety denylist literal, not a filesystem temp path.
         "/var/",
         "/etc/",
+    ] {
+        if lower.contains(forbidden_path) {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::PolicyDenied,
+                format!("{label} contains non-model-safe content"),
+            ));
+        }
+    }
+    for forbidden_phrase in [
         "access token",
         "api key",
         "api_key",
+        "api secret",
         "authorization",
-        "bearer ",
+        "bearer",
+        "client secret",
         "invalid api key",
         "password",
         "passwd",
+        "secret key",
+        "secret-key",
+        "secret token",
+        "secret_token",
+        "shared secret",
     ] {
-        if lower.contains(forbidden) {
+        if contains_token_phrase(&lower, forbidden_phrase) {
             return Err(AgentLoopHostError::new(
                 AgentLoopHostErrorKind::PolicyDenied,
                 format!("{label} contains non-model-safe content"),
@@ -631,6 +733,35 @@ fn reject_sensitive_text(value: &str, label: &'static str) -> Result<(), AgentLo
         ));
     }
     Ok(())
+}
+
+fn contains_token_phrase(value: &str, phrase: &str) -> bool {
+    value.match_indices(phrase).any(|(start, matched)| {
+        let end = start + matched.len();
+        is_token_boundary(char_before(value, start)) && is_token_boundary(char_at(value, end))
+    })
+}
+
+fn char_before(value: &str, byte_index: usize) -> Option<char> {
+    value
+        .char_indices()
+        .take_while(|(index, _)| *index < byte_index)
+        .last()
+        .map(|(_, character)| character)
+}
+
+fn char_at(value: &str, byte_index: usize) -> Option<char> {
+    value
+        .char_indices()
+        .find(|(index, _)| *index == byte_index)
+        .map(|(_, character)| character)
+}
+
+fn is_token_boundary(character: Option<char>) -> bool {
+    match character {
+        Some(character) => !character.is_ascii_alphanumeric() && character != '_',
+        None => true,
+    }
 }
 
 fn sanitize_ref_suffix(value: &str) -> String {
@@ -679,4 +810,30 @@ fn feed_field(digest: &mut Sha256, label: &[u8], value: &[u8]) {
     digest.update(label);
     digest.update((value.len() as u64).to_le_bytes());
     digest.update(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthetic_ref_registry_rejects_mismatched_duplicate_refs() {
+        let mut registry = SyntheticMessageRefRegistry::default();
+        let content_ref = LoopMessageRef::new("msg:instruction.source.0.deadbeefdeadbeef").unwrap();
+
+        registry
+            .record(
+                content_ref.clone(),
+                SyntheticMessageRefInput::new("instruction", "source-a", "summary-a", 0),
+            )
+            .unwrap();
+        let error = registry
+            .record(
+                content_ref,
+                SyntheticMessageRefInput::new("instruction", "source-b", "summary-b", 0),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.kind, AgentLoopHostErrorKind::Internal);
+    }
 }

--- a/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
+++ b/crates/ironclaw_turns/src/run_profile/instruction_bundle.rs
@@ -1,0 +1,682 @@
+//! Deterministic instruction/context bundle assembly for loop prompt ports.
+//!
+//! This module owns the host-side assembly step between a scoped loop context
+//! snapshot and model-message refs. It does not fetch memory, skills, secrets,
+//! capabilities, or provider data directly; callers pass already host-approved
+//! context/services output in [`InstructionBundleRequest`].
+
+use std::{collections::HashMap, sync::Mutex};
+
+use sha2::{Digest, Sha256};
+
+use crate::LoopMessageRef;
+
+use super::{
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilityDescriptorView, LoopContextBundle,
+    LoopContextMessage, LoopContextSnippet, LoopModelMessage, LoopRunContext,
+    PromptSkillContextMetadata, VisibleCapabilitySurface, skill_snippet_model_message_ref,
+};
+
+/// Stable fingerprint for an instruction bundle rebuild.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InstructionBundleFingerprint(String);
+
+impl InstructionBundleFingerprint {
+    pub fn new(value: impl Into<String>) -> Result<Self, String> {
+        let value = value.into();
+        let Some(hex) = value.strip_prefix("sha256:") else {
+            return Err("instruction bundle fingerprint must start with sha256:".to_string());
+        };
+        if hex.len() != 64 || !hex.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            return Err(
+                "instruction bundle fingerprint must contain a SHA-256 hex digest".to_string(),
+            );
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for InstructionBundleFingerprint {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl serde::Serialize for InstructionBundleFingerprint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for InstructionBundleFingerprint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Model-safe safety policy context to include in prompt construction.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InstructionSafetyContext {
+    pub policy_ref: String,
+    pub safe_summary: String,
+}
+
+impl InstructionSafetyContext {
+    pub fn new(
+        policy_ref: impl Into<String>,
+        safe_summary: impl Into<String>,
+    ) -> Result<Self, AgentLoopHostError> {
+        let policy_ref = validate_context_ref(policy_ref.into(), "safety policy ref")?;
+        let safe_summary = validate_model_safe_text(safe_summary.into(), "safety policy summary")?;
+        Ok(Self {
+            policy_ref,
+            safe_summary,
+        })
+    }
+}
+
+/// Inputs for a deterministic instruction bundle build.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InstructionBundleRequest {
+    pub context_bundle: LoopContextBundle,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visible_surface: Option<VisibleCapabilitySurface>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub safety_context: Option<InstructionSafetyContext>,
+}
+
+/// Host-built instruction bundle materialized in memory for model-port resolution.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InstructionBundleMaterializedMessage {
+    pub role: String,
+    pub content_ref: LoopMessageRef,
+    pub safe_content: String,
+}
+
+/// Scoped store for host-owned prompt refs that are not durable transcript refs.
+pub trait InstructionMaterializationStore: Send + Sync {
+    fn put_materialized_messages(
+        &self,
+        context: &LoopRunContext,
+        messages: Vec<InstructionBundleMaterializedMessage>,
+    ) -> Result<(), AgentLoopHostError>;
+
+    fn get_materialized_message(
+        &self,
+        context: &LoopRunContext,
+        content_ref: &LoopMessageRef,
+    ) -> Result<Option<InstructionBundleMaterializedMessage>, AgentLoopHostError>;
+}
+
+/// In-memory, per-process materialization store for model-visible safe context.
+#[derive(Default)]
+pub struct InMemoryInstructionMaterializationStore {
+    messages: Mutex<HashMap<String, InstructionBundleMaterializedMessage>>,
+}
+
+impl InMemoryInstructionMaterializationStore {
+    fn key(context: &LoopRunContext, content_ref: &LoopMessageRef) -> String {
+        format!("{}:{}", context.run_id, content_ref.as_str())
+    }
+}
+
+impl InstructionMaterializationStore for InMemoryInstructionMaterializationStore {
+    fn put_materialized_messages(
+        &self,
+        context: &LoopRunContext,
+        messages: Vec<InstructionBundleMaterializedMessage>,
+    ) -> Result<(), AgentLoopHostError> {
+        let mut stored = self.messages.lock().map_err(|_| {
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::Unavailable,
+                "instruction materialization store is unavailable",
+            )
+        })?;
+        for message in messages {
+            stored.insert(Self::key(context, &message.content_ref), message);
+        }
+        Ok(())
+    }
+
+    fn get_materialized_message(
+        &self,
+        context: &LoopRunContext,
+        content_ref: &LoopMessageRef,
+    ) -> Result<Option<InstructionBundleMaterializedMessage>, AgentLoopHostError> {
+        self.messages
+            .lock()
+            .map(|messages| messages.get(&Self::key(context, content_ref)).cloned())
+            .map_err(|_| {
+                AgentLoopHostError::new(
+                    AgentLoopHostErrorKind::Unavailable,
+                    "instruction materialization store is unavailable",
+                )
+            })
+    }
+}
+
+/// Host-built instruction bundle suitable for model invocation.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InstructionBundle {
+    pub fingerprint: InstructionBundleFingerprint,
+    pub messages: Vec<LoopModelMessage>,
+    #[serde(default, skip)]
+    pub materialized_messages: Vec<InstructionBundleMaterializedMessage>,
+    #[serde(default, skip)]
+    pub requires_materialization_store: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skill_context: Vec<PromptSkillContextMetadata>,
+}
+
+/// Deterministic host-owned instruction bundle builder.
+#[derive(Debug, Clone)]
+pub struct InstructionBundleBuilder {
+    context: LoopRunContext,
+}
+
+impl InstructionBundleBuilder {
+    pub fn new(context: LoopRunContext) -> Self {
+        Self { context }
+    }
+
+    pub fn build(
+        &self,
+        request: InstructionBundleRequest,
+    ) -> Result<InstructionBundle, AgentLoopHostError> {
+        let mut messages = Vec::new();
+        let mut materialized_messages = Vec::new();
+        let mut skill_context = Vec::new();
+        let mut requires_materialization_store = false;
+        let mut fingerprint = Sha256::new();
+
+        feed_field(
+            &mut fingerprint,
+            b"run",
+            self.context.run_id.to_string().as_bytes(),
+        );
+        feed_field(
+            &mut fingerprint,
+            b"profile",
+            self.context
+                .resolved_run_profile
+                .profile_id
+                .as_str()
+                .as_bytes(),
+        );
+
+        if !request.context_bundle.identity_messages.is_empty() {
+            requires_materialization_store = true;
+        }
+        for message in request.context_bundle.identity_messages {
+            push_context_message(
+                &mut messages,
+                &mut materialized_messages,
+                &mut fingerprint,
+                "identity",
+                message,
+            )?;
+        }
+
+        let mut instruction_snippets = request.context_bundle.instruction_snippets;
+        instruction_snippets.sort_by(compare_instruction_snippets);
+        let mut skill_ordinal = 0usize;
+        for snippet in instruction_snippets {
+            if snippet.snippet_ref.starts_with("skill:") {
+                let content_ref = skill_snippet_model_message_ref(
+                    &snippet.snippet_ref,
+                    &snippet.safe_summary,
+                    skill_ordinal,
+                )?;
+                let Some(metadata) = snippet.metadata.as_ref() else {
+                    return Err(AgentLoopHostError::new(
+                        AgentLoopHostErrorKind::Internal,
+                        "skill instruction snippet metadata is missing",
+                    ));
+                };
+                push_snippet_message(
+                    &mut messages,
+                    &mut materialized_messages,
+                    &mut fingerprint,
+                    "skill",
+                    content_ref,
+                    &snippet,
+                )?;
+                skill_context.push(PromptSkillContextMetadata {
+                    ordinal: skill_ordinal,
+                    source_name: metadata.source_name.clone(),
+                    trust_level: metadata.trust_level.clone(),
+                });
+                skill_ordinal += 1;
+            } else {
+                requires_materialization_store = true;
+                let content_ref = snippet_message_ref("instruction", &snippet, messages.len())?;
+                push_snippet_message(
+                    &mut messages,
+                    &mut materialized_messages,
+                    &mut fingerprint,
+                    "instruction",
+                    content_ref,
+                    &snippet,
+                )?;
+            }
+        }
+
+        let mut memory_snippets = request.context_bundle.memory_snippets;
+        if !memory_snippets.is_empty() {
+            requires_materialization_store = true;
+        }
+        memory_snippets.sort_by(compare_snippet_refs);
+        for (ordinal, snippet) in memory_snippets.into_iter().enumerate() {
+            let content_ref = snippet_message_ref("memory", &snippet, ordinal)?;
+            push_snippet_message(
+                &mut messages,
+                &mut materialized_messages,
+                &mut fingerprint,
+                "memory",
+                content_ref,
+                &snippet,
+            )?;
+        }
+
+        if let Some(safety_context) = request.safety_context {
+            requires_materialization_store = true;
+            push_safety_context(
+                &mut messages,
+                &mut materialized_messages,
+                &mut fingerprint,
+                safety_context,
+            )?;
+        }
+
+        if let Some(surface) = request
+            .visible_surface
+            .filter(|surface| !surface.descriptors.is_empty())
+        {
+            requires_materialization_store = true;
+            push_visible_surface(
+                &mut messages,
+                &mut materialized_messages,
+                &mut fingerprint,
+                surface,
+            )?;
+        }
+
+        for message in request.context_bundle.messages {
+            push_context_message(
+                &mut messages,
+                &mut materialized_messages,
+                &mut fingerprint,
+                "thread",
+                message,
+            )?;
+        }
+
+        let fingerprint = InstructionBundleFingerprint::new(format!(
+            "sha256:{}",
+            hex::encode(fingerprint.finalize())
+        ))
+        .map_err(|_| {
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::Internal,
+                "instruction bundle fingerprint could not be represented",
+            )
+        })?;
+
+        Ok(InstructionBundle {
+            fingerprint,
+            messages,
+            materialized_messages,
+            requires_materialization_store,
+            skill_context,
+        })
+    }
+}
+
+fn push_context_message(
+    messages: &mut Vec<LoopModelMessage>,
+    materialized_messages: &mut Vec<InstructionBundleMaterializedMessage>,
+    fingerprint: &mut Sha256,
+    section: &'static str,
+    message: LoopContextMessage,
+) -> Result<(), AgentLoopHostError> {
+    let safe_summary = validate_model_safe_text(message.safe_summary, "context message summary")?;
+    validate_model_role(&message.role)?;
+    feed_field(fingerprint, b"section", section.as_bytes());
+    feed_field(fingerprint, b"role", message.role.as_bytes());
+    feed_field(fingerprint, b"ref", message.message_ref.as_str().as_bytes());
+    if section == "identity" {
+        materialized_messages.push(InstructionBundleMaterializedMessage {
+            role: message.role.clone(),
+            content_ref: message.message_ref.clone(),
+            safe_content: safe_summary,
+        });
+    }
+    messages.push(LoopModelMessage {
+        role: message.role,
+        content_ref: message.message_ref,
+    });
+    Ok(())
+}
+
+fn push_snippet_message(
+    messages: &mut Vec<LoopModelMessage>,
+    materialized_messages: &mut Vec<InstructionBundleMaterializedMessage>,
+    fingerprint: &mut Sha256,
+    section: &'static str,
+    content_ref: LoopMessageRef,
+    snippet: &LoopContextSnippet,
+) -> Result<(), AgentLoopHostError> {
+    validate_context_ref(snippet.snippet_ref.clone(), "context snippet ref")?;
+    let safe_summary =
+        validate_model_safe_text(snippet.safe_summary.clone(), "context snippet summary")?;
+    feed_field(fingerprint, b"section", section.as_bytes());
+    feed_field(fingerprint, b"ref", content_ref.as_str().as_bytes());
+    feed_field(fingerprint, b"source", snippet.snippet_ref.as_bytes());
+    feed_field(fingerprint, b"summary", snippet.safe_summary.as_bytes());
+    materialized_messages.push(InstructionBundleMaterializedMessage {
+        role: "system".to_string(),
+        content_ref: content_ref.clone(),
+        safe_content: safe_summary,
+    });
+    messages.push(LoopModelMessage {
+        role: "system".to_string(),
+        content_ref,
+    });
+    Ok(())
+}
+
+fn push_safety_context(
+    messages: &mut Vec<LoopModelMessage>,
+    materialized_messages: &mut Vec<InstructionBundleMaterializedMessage>,
+    fingerprint: &mut Sha256,
+    safety_context: InstructionSafetyContext,
+) -> Result<(), AgentLoopHostError> {
+    let content_ref = synthetic_message_ref(
+        "safety",
+        &safety_context.policy_ref,
+        &safety_context.safe_summary,
+        0,
+    )?;
+    feed_field(fingerprint, b"section", b"safety");
+    feed_field(fingerprint, b"ref", content_ref.as_str().as_bytes());
+    feed_field(fingerprint, b"source", safety_context.policy_ref.as_bytes());
+    feed_field(
+        fingerprint,
+        b"summary",
+        safety_context.safe_summary.as_bytes(),
+    );
+    materialized_messages.push(InstructionBundleMaterializedMessage {
+        role: "system".to_string(),
+        content_ref: content_ref.clone(),
+        safe_content: safety_context.safe_summary,
+    });
+    messages.push(LoopModelMessage {
+        role: "system".to_string(),
+        content_ref,
+    });
+    Ok(())
+}
+
+fn push_visible_surface(
+    messages: &mut Vec<LoopModelMessage>,
+    materialized_messages: &mut Vec<InstructionBundleMaterializedMessage>,
+    fingerprint: &mut Sha256,
+    mut surface: VisibleCapabilitySurface,
+) -> Result<(), AgentLoopHostError> {
+    surface
+        .descriptors
+        .sort_by(|a, b| a.capability_id.cmp(&b.capability_id));
+    let mut summary = format!("surface {}", surface.version.as_str());
+    for descriptor in &surface.descriptors {
+        validate_surface_descriptor(descriptor)?;
+        summary.push('|');
+        summary.push_str(descriptor.capability_id.as_str());
+        summary.push('|');
+        summary.push_str(&descriptor.safe_name);
+        summary.push('|');
+        summary.push_str(&descriptor.safe_description);
+    }
+    let content_ref = synthetic_message_ref("surface", surface.version.as_str(), &summary, 0)?;
+    feed_field(fingerprint, b"section", b"surface");
+    feed_field(fingerprint, b"ref", content_ref.as_str().as_bytes());
+    feed_field(fingerprint, b"version", surface.version.as_str().as_bytes());
+    for descriptor in &surface.descriptors {
+        feed_field(
+            fingerprint,
+            b"capability",
+            descriptor.capability_id.as_str().as_bytes(),
+        );
+        feed_field(fingerprint, b"name", descriptor.safe_name.as_bytes());
+        feed_field(
+            fingerprint,
+            b"description",
+            descriptor.safe_description.as_bytes(),
+        );
+    }
+    materialized_messages.push(InstructionBundleMaterializedMessage {
+        role: "system".to_string(),
+        content_ref: content_ref.clone(),
+        safe_content: summary,
+    });
+    messages.push(LoopModelMessage {
+        role: "system".to_string(),
+        content_ref,
+    });
+    Ok(())
+}
+
+fn validate_surface_descriptor(
+    descriptor: &CapabilityDescriptorView,
+) -> Result<(), AgentLoopHostError> {
+    validate_model_safe_text(descriptor.safe_name.clone(), "capability safe name")?;
+    validate_model_safe_text(
+        descriptor.safe_description.clone(),
+        "capability safe description",
+    )?;
+    Ok(())
+}
+
+fn snippet_message_ref(
+    section: &'static str,
+    snippet: &LoopContextSnippet,
+    ordinal: usize,
+) -> Result<LoopMessageRef, AgentLoopHostError> {
+    synthetic_message_ref(
+        section,
+        &snippet.snippet_ref,
+        &snippet.safe_summary,
+        ordinal,
+    )
+}
+
+fn synthetic_message_ref(
+    section: &'static str,
+    source_ref: &str,
+    safe_summary: &str,
+    ordinal: usize,
+) -> Result<LoopMessageRef, AgentLoopHostError> {
+    let slug = sanitize_ref_suffix(source_ref);
+    let hash = stable_ref_hash(section, source_ref, safe_summary, ordinal);
+    LoopMessageRef::new(format!("msg:{section}.{slug}.{ordinal}.{hash:016x}")).map_err(|_| {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Internal,
+            "instruction bundle message reference could not be represented",
+        )
+    })
+}
+
+fn compare_instruction_snippets(
+    a: &LoopContextSnippet,
+    b: &LoopContextSnippet,
+) -> std::cmp::Ordering {
+    instruction_rank(&a.snippet_ref)
+        .cmp(&instruction_rank(&b.snippet_ref))
+        .then_with(|| compare_snippet_refs(a, b))
+}
+
+fn compare_snippet_refs(a: &LoopContextSnippet, b: &LoopContextSnippet) -> std::cmp::Ordering {
+    a.snippet_ref
+        .cmp(&b.snippet_ref)
+        .then_with(|| a.safe_summary.cmp(&b.safe_summary))
+}
+
+fn instruction_rank(snippet_ref: &str) -> u8 {
+    if snippet_ref.starts_with("instruction:system") {
+        0
+    } else if snippet_ref.starts_with("instruction:user") {
+        1
+    } else if snippet_ref.starts_with("instruction:agent") {
+        2
+    } else if snippet_ref.starts_with("instruction:project") {
+        3
+    } else if snippet_ref.starts_with("skill:") {
+        4
+    } else {
+        5
+    }
+}
+
+fn validate_model_role(role: &str) -> Result<(), AgentLoopHostError> {
+    if matches!(role, "system" | "user" | "assistant" | "tool") {
+        return Ok(());
+    }
+    Err(AgentLoopHostError::new(
+        AgentLoopHostErrorKind::PolicyDenied,
+        "context message role is not model-safe",
+    ))
+}
+
+fn validate_context_ref(value: String, label: &'static str) -> Result<String, AgentLoopHostError> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, ':' | '_' | '-' | '.'))
+    {
+        return Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::PolicyDenied,
+            format!("{label} is not model-safe"),
+        ));
+    }
+    reject_sensitive_text(&value, label)?;
+    Ok(value)
+}
+
+fn validate_model_safe_text(
+    value: String,
+    label: &'static str,
+) -> Result<String, AgentLoopHostError> {
+    if value.is_empty() || value.len() > 4096 || value.chars().any(|ch| ch == '\0') {
+        return Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::PolicyDenied,
+            format!("{label} is not model-safe"),
+        ));
+    }
+    if value
+        .chars()
+        .any(|ch| ch.is_control() && !matches!(ch, '\n' | '\r' | '\t'))
+    {
+        return Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::PolicyDenied,
+            format!("{label} contains control characters"),
+        ));
+    }
+    reject_sensitive_text(&value, label)?;
+    Ok(value)
+}
+
+fn reject_sensitive_text(value: &str, label: &'static str) -> Result<(), AgentLoopHostError> {
+    let lower = value.to_ascii_lowercase();
+    for forbidden in [
+        "/users/",
+        "/home/",
+        "/private/",
+        "/tmp/",
+        "/var/",
+        "/etc/",
+        "access token",
+        "api key",
+        "api_key",
+        "authorization",
+        "bearer ",
+        "invalid api key",
+        "password",
+        "passwd",
+    ] {
+        if lower.contains(forbidden) {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::PolicyDenied,
+                format!("{label} contains non-model-safe content"),
+            ));
+        }
+    }
+    if lower
+        .split(|character: char| !character.is_ascii_alphanumeric() && character != '-')
+        .any(|token| token.starts_with("sk-"))
+    {
+        return Err(AgentLoopHostError::new(
+            AgentLoopHostErrorKind::PolicyDenied,
+            format!("{label} contains non-model-safe content"),
+        ));
+    }
+    Ok(())
+}
+
+fn sanitize_ref_suffix(value: &str) -> String {
+    let mut suffix = String::with_capacity(value.len().min(96));
+    for character in value.chars() {
+        if character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.') {
+            suffix.push(character);
+        } else {
+            suffix.push('.');
+        }
+        if suffix.len() >= 96 {
+            break;
+        }
+    }
+    let suffix = suffix.trim_matches('.');
+    if suffix.is_empty() {
+        "context".to_string()
+    } else {
+        suffix.to_string()
+    }
+}
+
+fn stable_ref_hash(section: &str, source_ref: &str, safe_summary: &str, ordinal: usize) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x00000100000001B3;
+    let mut hash = FNV_OFFSET;
+    for bytes in [
+        section.as_bytes(),
+        &[0xFF],
+        source_ref.as_bytes(),
+        &[0xFF],
+        safe_summary.as_bytes(),
+        &[0xFF],
+        ordinal.to_string().as_bytes(),
+    ] {
+        for &byte in bytes {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+    }
+    hash
+}
+
+fn feed_field(digest: &mut Sha256, label: &[u8], value: &[u8]) {
+    digest.update((label.len() as u64).to_le_bytes());
+    digest.update(label);
+    digest.update((value.len() as u64).to_le_bytes());
+    digest.update(value);
+}

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -10,6 +10,7 @@
 
 mod driver;
 mod host;
+mod instruction_bundle;
 mod memory_context;
 mod milestones;
 mod model;
@@ -41,6 +42,11 @@ pub use host::{
     LoopPromptPort, LoopRunContext, LoopRunInfoPort, LoopSafeSummary, LoopTranscriptPort,
     ModelStreamChunk, ParentLoopOutput, ProcessHandleSummary, PromptMode, UpdateAssistantDraft,
     VisibleCapabilityRequest, VisibleCapabilitySurface, validate_model_route_component_value,
+};
+pub use instruction_bundle::{
+    InMemoryInstructionMaterializationStore, InstructionBundle, InstructionBundleBuilder,
+    InstructionBundleFingerprint, InstructionBundleMaterializedMessage, InstructionBundleRequest,
+    InstructionMaterializationStore, InstructionSafetyContext,
 };
 pub use memory_context::{
     EmptyMemoryPromptContextService, MemoryPromptContextRequest, MemoryPromptContextService,

--- a/crates/ironclaw_turns/src/run_profile/prompt.rs
+++ b/crates/ironclaw_turns/src/run_profile/prompt.rs
@@ -3,20 +3,24 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use super::host::{
-    AgentLoopHostError, AgentLoopHostErrorKind, CapabilitySurfaceVersion, LoopContextBundle,
-    LoopContextMessage, LoopContextPort, LoopContextRequest, LoopModelMessage, LoopPromptBundle,
-    LoopPromptBundleRef, LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, PromptMode,
+    AgentLoopHostError, AgentLoopHostErrorKind, CapabilitySurfaceVersion, LoopContextPort,
+    LoopContextRequest, LoopPromptBundle, LoopPromptBundleRef, LoopPromptBundleRequest,
+    LoopPromptPort, LoopRunContext, PromptMode, VisibleCapabilitySurface,
 };
-use super::milestones::{
-    LoopHostMilestoneEmitter, LoopHostMilestoneSink, PromptSkillContextMetadata,
+use super::instruction_bundle::{
+    InstructionBundleBuilder, InstructionBundleRequest, InstructionMaterializationStore,
+    InstructionSafetyContext,
 };
-use super::skill_context::skill_snippet_model_message_ref;
+use super::milestones::LoopHostMilestoneEmitter;
+use super::milestones::LoopHostMilestoneSink;
 
 const DEFAULT_TEXT_ONLY_MESSAGE_LIMIT: usize = 32;
 const MAX_TEXT_ONLY_MESSAGE_LIMIT: usize = 128;
 
 type CurrentSurfaceVersionLookup =
     dyn Fn() -> Result<Option<CapabilitySurfaceVersion>, AgentLoopHostError> + Send + Sync;
+type CurrentSurfaceLookup =
+    dyn Fn() -> Result<Option<VisibleCapabilitySurface>, AgentLoopHostError> + Send + Sync;
 
 /// Text-only host-managed prompt bundle port.
 ///
@@ -24,9 +28,9 @@ type CurrentSurfaceVersionLookup =
 /// [`LoopRunContext`], loads bounded transcript context through a
 /// [`LoopContextPort`], returns model-message references, and emits a
 /// `prompt_bundle_built` milestone containing only metadata. It currently
-/// supports [`PromptMode::TextOnly`] only; checkpoint-backed prompt state and
-/// memory snippet materialization fail closed until dedicated host stores are
-/// wired. Instruction snippets are surfaced as host-owned system message refs.
+/// supports [`PromptMode::TextOnly`] only; checkpoint-backed prompt state fails
+/// closed until dedicated host stores are wired. Instruction and memory snippets
+/// are surfaced as host-owned system message refs.
 #[derive(Clone)]
 pub struct HostManagedLoopPromptPort<C, S>
 where
@@ -38,6 +42,9 @@ where
     milestones: LoopHostMilestoneEmitter<S>,
     default_message_limit: usize,
     current_surface_version: Option<Arc<CurrentSurfaceVersionLookup>>,
+    current_surface: Option<Arc<CurrentSurfaceLookup>>,
+    safety_context: Option<InstructionSafetyContext>,
+    instruction_materialization_store: Option<Arc<dyn InstructionMaterializationStore>>,
 }
 
 impl<C, S> HostManagedLoopPromptPort<C, S>
@@ -52,6 +59,9 @@ where
             milestones: LoopHostMilestoneEmitter::new(context, milestone_sink),
             default_message_limit: DEFAULT_TEXT_ONLY_MESSAGE_LIMIT,
             current_surface_version: None,
+            current_surface: None,
+            safety_context: None,
+            instruction_materialization_store: None,
         }
     }
 
@@ -75,6 +85,44 @@ where
             + 'static,
     {
         self.current_surface_version = Some(Arc::new(lookup));
+        self
+    }
+
+    pub fn with_current_surface(mut self, current_surface: VisibleCapabilitySurface) -> Self {
+        let current_surface_for_version = current_surface.clone();
+        self.current_surface_version = Some(Arc::new(move || {
+            Ok(Some(current_surface_for_version.version.clone()))
+        }));
+        self.current_surface = Some(Arc::new(move || Ok(Some(current_surface.clone()))));
+        self
+    }
+
+    pub fn with_current_surface_lookup<F>(mut self, lookup: F) -> Self
+    where
+        F: Fn() -> Result<Option<VisibleCapabilitySurface>, AgentLoopHostError>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let lookup = Arc::new(lookup);
+        let lookup_for_version = Arc::clone(&lookup);
+        self.current_surface_version = Some(Arc::new(move || {
+            Ok(lookup_for_version()?.map(|surface| surface.version))
+        }));
+        self.current_surface = Some(lookup);
+        self
+    }
+
+    pub fn with_safety_context(mut self, safety_context: InstructionSafetyContext) -> Self {
+        self.safety_context = Some(safety_context);
+        self
+    }
+
+    pub fn with_instruction_materialization_store(
+        mut self,
+        store: Arc<dyn InstructionMaterializationStore>,
+    ) -> Self {
+        self.instruction_materialization_store = Some(store);
         self
     }
 
@@ -159,16 +207,8 @@ where
             .clamp(1, MAX_TEXT_ONLY_MESSAGE_LIMIT)
     }
 
-    fn ensure_supported_context_shape(
-        context: &LoopContextBundle,
-    ) -> Result<(), AgentLoopHostError> {
-        if !context.memory_snippets.is_empty() {
-            return Err(AgentLoopHostError::new(
-                AgentLoopHostErrorKind::PolicyDenied,
-                "text-only prompt port cannot materialize memory snippets",
-            ));
-        }
-        Ok(())
+    fn instruction_builder(&self) -> InstructionBundleBuilder {
+        InstructionBundleBuilder::new(self.context.clone())
     }
 }
 
@@ -190,55 +230,35 @@ where
                 limit: self.message_limit(&request),
             })
             .await?;
-        Self::ensure_supported_context_shape(&context)?;
-        let mut messages = Vec::with_capacity(
-            context.identity_messages.len()
-                + context.instruction_snippets.len()
-                + context.messages.len(),
-        );
-        messages.extend(
-            context
-                .identity_messages
-                .into_iter()
-                .map(context_message_to_model_message),
-        );
-
-        let mut skill_context = Vec::with_capacity(context.instruction_snippets.len());
-        for (ordinal, snippet) in context.instruction_snippets.into_iter().enumerate() {
-            let content_ref = skill_snippet_model_message_ref(
-                &snippet.snippet_ref,
-                &snippet.safe_summary,
-                ordinal,
-            )?;
-            match snippet.metadata.as_ref() {
-                Some(metadata) => skill_context.push(PromptSkillContextMetadata {
-                    ordinal,
-                    source_name: metadata.source_name.clone(),
-                    trust_level: metadata.trust_level.clone(),
-                }),
-                None if snippet.snippet_ref.starts_with("skill:") => {
-                    return Err(AgentLoopHostError::new(
-                        AgentLoopHostErrorKind::Internal,
-                        "skill instruction snippet metadata is missing",
-                    ));
-                }
-                None => {}
+        let visible_surface = if request.surface_version.is_some() {
+            match self.current_surface.as_ref() {
+                Some(current_surface) => current_surface()?,
+                None => None,
             }
-            messages.push(LoopModelMessage {
-                role: "system".to_string(),
-                content_ref,
-            });
+        } else {
+            None
+        };
+        let instruction_bundle = self.instruction_builder().build(InstructionBundleRequest {
+            context_bundle: context,
+            visible_surface,
+            safety_context: self.safety_context.clone(),
+        })?;
+        if let Some(store) = self.instruction_materialization_store.as_ref() {
+            store.put_materialized_messages(
+                &self.context,
+                instruction_bundle.materialized_messages.clone(),
+            )?;
+        } else if instruction_bundle.requires_materialization_store {
+            return Err(AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "instruction materialization store is required for this prompt bundle",
+            ));
         }
-        messages.extend(
-            context
-                .messages
-                .into_iter()
-                .map(context_message_to_model_message),
-        );
         let bundle = LoopPromptBundle {
             bundle_ref: LoopPromptBundleRef::fresh_for_run(&self.context),
-            messages,
+            messages: instruction_bundle.messages,
             surface_version: request.surface_version.clone(),
+            instruction_fingerprint: Some(instruction_bundle.fingerprint),
         };
         self.milestones
             .prompt_bundle_built(
@@ -246,16 +266,9 @@ where
                 request.mode,
                 bundle.surface_version.clone(),
                 bundle.messages.len(),
-                skill_context,
+                instruction_bundle.skill_context,
             )
             .await?;
         Ok(bundle)
-    }
-}
-
-fn context_message_to_model_message(message: LoopContextMessage) -> LoopModelMessage {
-    LoopModelMessage {
-        role: message.role,
-        content_ref: message.message_ref,
     }
 }

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -456,6 +456,86 @@ async fn instruction_bundle_builder_allows_safe_domain_terms_in_summaries() {
 }
 
 #[tokio::test]
+async fn instruction_bundle_builder_allows_terms_inside_larger_words() {
+    let context = claimed_run_context().await;
+    let builder = InstructionBundleBuilder::new(context);
+
+    builder
+        .build(InstructionBundleRequest {
+            context_bundle: LoopContextBundle {
+                identity_messages: Vec::new(),
+                messages: Vec::new(),
+                instruction_snippets: vec![LoopContextSnippet {
+                    snippet_ref: "instruction:system".to_string(),
+                    safe_summary: "Explain preauthorization sync behavior".to_string(),
+                    metadata: None,
+                }],
+                memory_snippets: Vec::new(),
+            },
+            visible_surface: None,
+            safety_context: None,
+        })
+        .unwrap();
+}
+
+#[tokio::test]
+async fn instruction_bundle_builder_rejects_secret_credential_phrases() {
+    let context = claimed_run_context().await;
+    let builder = InstructionBundleBuilder::new(context);
+
+    let error = builder
+        .build(InstructionBundleRequest {
+            context_bundle: LoopContextBundle {
+                identity_messages: Vec::new(),
+                messages: Vec::new(),
+                instruction_snippets: vec![LoopContextSnippet {
+                    snippet_ref: "instruction:system".to_string(),
+                    safe_summary: "client secret should not appear in prompt context".to_string(),
+                    metadata: None,
+                }],
+                memory_snippets: Vec::new(),
+            },
+            visible_surface: None,
+            safety_context: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+}
+
+#[tokio::test]
+async fn instruction_bundle_builder_allows_tool_result_reference_context_messages() {
+    let host = Arc::new(
+        RecordingAgentLoopHost::new(claimed_run_context().await).with_context_tail_message(
+            "tool_result_reference",
+            "msg:tool-result-reference",
+            "tool result reference safe summary",
+        ),
+    );
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    );
+
+    let bundle = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+        })
+        .await
+        .unwrap();
+
+    assert!(bundle.messages.iter().any(|message| {
+        message.role == "tool_result_reference"
+            && message.content_ref.as_str() == "msg:tool-result-reference"
+    }));
+}
+
+#[tokio::test]
 async fn instruction_bundle_serialization_hides_materialized_content() {
     let context = claimed_run_context().await;
     let bundle = InstructionBundleBuilder::new(context)

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -19,7 +19,9 @@ use ironclaw_turns::{
         CapabilityDeniedReasonKind, CapabilityDescriptorView, CapabilityInputRef,
         CapabilityInvocation, CapabilityOutcome, CapabilitySurfaceVersion,
         FinalizeAssistantMessage, HostManagedLoopModelPort, HostManagedLoopPromptPort,
-        InMemoryLoopHostMilestoneSink, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
+        InMemoryInstructionMaterializationStore, InMemoryLoopHostMilestoneSink,
+        InstructionBundleBuilder, InstructionBundleFingerprint, InstructionBundleRequest,
+        InstructionSafetyContext, LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort,
         LoopCheckpointRequest, LoopCheckpointStateRef, LoopContextBundle, LoopContextMessage,
         LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopContextSnippetMetadata,
         LoopDriverId, LoopDriverNoteKind, LoopHostMilestone, LoopHostMilestoneEmitter,
@@ -271,6 +273,245 @@ async fn host_managed_model_port_sanitizes_gateway_errors() {
 }
 
 #[tokio::test]
+async fn instruction_bundle_builder_orders_sections_and_rebuilds_deterministically() {
+    let context = claimed_run_context().await;
+    let surface = VisibleCapabilitySurface {
+        version: CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        descriptors: vec![CapabilityDescriptorView {
+            capability_id: CapabilityId::new("demo.echo").unwrap(),
+            provider: None,
+            runtime: RuntimeKind::FirstParty,
+            safe_name: "Echo".to_string(),
+            safe_description: "Echo safe input".to_string(),
+        }],
+    };
+    let request = InstructionBundleRequest {
+        context_bundle: LoopContextBundle {
+            identity_messages: vec![LoopContextMessage {
+                message_ref: LoopMessageRef::new("msg:identity").unwrap(),
+                role: "system".to_string(),
+                safe_summary: "identity safe".to_string(),
+            }],
+            messages: vec![LoopContextMessage {
+                message_ref: LoopMessageRef::new("msg:user-message").unwrap(),
+                role: "user".to_string(),
+                safe_summary: "user safe".to_string(),
+            }],
+            instruction_snippets: vec![
+                LoopContextSnippet {
+                    snippet_ref: "instruction:project".to_string(),
+                    safe_summary: "project rule".to_string(),
+                    metadata: None,
+                },
+                LoopContextSnippet {
+                    snippet_ref: "skill:alpha".to_string(),
+                    safe_summary: "alpha skill".to_string(),
+                    metadata: Some(LoopContextSnippetMetadata {
+                        source_name: "alpha".to_string(),
+                        trust_level: "trusted".to_string(),
+                    }),
+                },
+                LoopContextSnippet {
+                    snippet_ref: "instruction:system".to_string(),
+                    safe_summary: "system rule".to_string(),
+                    metadata: None,
+                },
+                LoopContextSnippet {
+                    snippet_ref: "instruction:user".to_string(),
+                    safe_summary: "user rule".to_string(),
+                    metadata: None,
+                },
+                LoopContextSnippet {
+                    snippet_ref: "instruction:agent".to_string(),
+                    safe_summary: "agent rule".to_string(),
+                    metadata: None,
+                },
+            ],
+            memory_snippets: vec![LoopContextSnippet {
+                snippet_ref: "memory:project-summary".to_string(),
+                safe_summary: "project memory".to_string(),
+                metadata: None,
+            }],
+        },
+        visible_surface: Some(surface),
+        safety_context: Some(
+            InstructionSafetyContext::new("safety:prompt-write", "prompt write safety enforced")
+                .unwrap(),
+        ),
+    };
+
+    let builder = InstructionBundleBuilder::new(context);
+    let first = builder.build(request.clone()).unwrap();
+    let second = builder.build(request).unwrap();
+
+    assert_eq!(first.fingerprint, second.fingerprint);
+    assert_eq!(first.messages, second.messages);
+    assert_eq!(
+        first
+            .messages
+            .iter()
+            .map(|message| message.content_ref.as_str().to_string())
+            .collect::<Vec<_>>(),
+        vec![
+            "msg:identity".to_string(),
+            first.messages[1].content_ref.as_str().to_string(),
+            first.messages[2].content_ref.as_str().to_string(),
+            first.messages[3].content_ref.as_str().to_string(),
+            first.messages[4].content_ref.as_str().to_string(),
+            first.messages[5].content_ref.as_str().to_string(),
+            first.messages[6].content_ref.as_str().to_string(),
+            first.messages[7].content_ref.as_str().to_string(),
+            first.messages[8].content_ref.as_str().to_string(),
+            "msg:user-message".to_string(),
+        ]
+    );
+    assert!(
+        first.messages[1]
+            .content_ref
+            .as_str()
+            .starts_with("msg:instruction.instruction.system.")
+    );
+    assert!(
+        first.messages[2]
+            .content_ref
+            .as_str()
+            .starts_with("msg:instruction.instruction.user.")
+    );
+    assert!(
+        first.messages[3]
+            .content_ref
+            .as_str()
+            .starts_with("msg:instruction.instruction.agent.")
+    );
+    assert!(
+        first.messages[4]
+            .content_ref
+            .as_str()
+            .starts_with("msg:instruction.instruction.project.")
+    );
+    assert!(
+        first.messages[5]
+            .content_ref
+            .as_str()
+            .starts_with("msg:snippet.skill.alpha.")
+    );
+    assert!(
+        first.messages[6]
+            .content_ref
+            .as_str()
+            .starts_with("msg:memory.memory.project-summary.")
+    );
+    assert!(
+        first.messages[7]
+            .content_ref
+            .as_str()
+            .starts_with("msg:safety.safety.prompt-write.")
+    );
+    assert!(
+        first.messages[8]
+            .content_ref
+            .as_str()
+            .starts_with("msg:surface.surface-v1.")
+    );
+    assert_eq!(first.skill_context.len(), 1);
+    assert_eq!(first.skill_context[0].source_name, "alpha");
+}
+
+#[test]
+fn instruction_bundle_fingerprint_deserialize_rejects_invalid_values() {
+    let error = serde_json::from_value::<InstructionBundleFingerprint>(serde_json::json!(
+        "not-a-sha256-fingerprint"
+    ))
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("instruction bundle fingerprint must start with sha256:")
+    );
+}
+
+#[tokio::test]
+async fn instruction_bundle_builder_allows_safe_domain_terms_in_summaries() {
+    let context = claimed_run_context().await;
+    let builder = InstructionBundleBuilder::new(context);
+
+    builder
+        .build(InstructionBundleRequest {
+            context_bundle: LoopContextBundle {
+                identity_messages: Vec::new(),
+                messages: Vec::new(),
+                instruction_snippets: vec![LoopContextSnippet {
+                    snippet_ref: "instruction:system".to_string(),
+                    safe_summary: "Explain how to rotate a secret without exposing values"
+                        .to_string(),
+                    metadata: None,
+                }],
+                memory_snippets: Vec::new(),
+            },
+            visible_surface: None,
+            safety_context: None,
+        })
+        .unwrap();
+}
+
+#[tokio::test]
+async fn instruction_bundle_serialization_hides_materialized_content() {
+    let context = claimed_run_context().await;
+    let bundle = InstructionBundleBuilder::new(context)
+        .build(InstructionBundleRequest {
+            context_bundle: LoopContextBundle {
+                identity_messages: Vec::new(),
+                messages: Vec::new(),
+                instruction_snippets: vec![LoopContextSnippet {
+                    snippet_ref: "instruction:system".to_string(),
+                    safe_summary: "RAW_MATERIALIZED_PROMPT_SENTINEL".to_string(),
+                    metadata: None,
+                }],
+                memory_snippets: Vec::new(),
+            },
+            visible_surface: None,
+            safety_context: None,
+        })
+        .unwrap();
+
+    assert!(
+        bundle
+            .materialized_messages
+            .iter()
+            .any(|message| message.safe_content == "RAW_MATERIALIZED_PROMPT_SENTINEL")
+    );
+    let wire = serde_json::to_string(&bundle).unwrap();
+    assert!(!wire.contains("RAW_MATERIALIZED_PROMPT_SENTINEL"));
+    assert!(!wire.contains("materialized_messages"));
+}
+
+#[tokio::test]
+async fn instruction_bundle_builder_rejects_unsafe_instruction_context() {
+    let context = claimed_run_context().await;
+    let builder = InstructionBundleBuilder::new(context);
+
+    let error = builder
+        .build(InstructionBundleRequest {
+            context_bundle: LoopContextBundle {
+                identity_messages: Vec::new(),
+                messages: Vec::new(),
+                instruction_snippets: vec![LoopContextSnippet {
+                    snippet_ref: "instruction:system".to_string(),
+                    safe_summary: "leaks /Users/alice/.ssh/id_rsa path".to_string(),
+                    metadata: None,
+                }],
+                memory_snippets: Vec::new(),
+            },
+            visible_surface: None,
+            safety_context: None,
+        })
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+}
+
+#[tokio::test]
 async fn loop_prompt_port_builds_text_only_bundle_from_context_refs() {
     let host = Arc::new(RecordingAgentLoopHost::new(claimed_run_context().await));
     let surface_version = CapabilitySurfaceVersion::new("surface-v1").unwrap();
@@ -444,7 +685,10 @@ async fn loop_prompt_port_keeps_identity_before_skill_snippets_and_records_skill
         host.context.clone(),
         host.clone(),
         host.milestone_sink.clone(),
-    );
+    )
+    .with_instruction_materialization_store(Arc::new(
+        InMemoryInstructionMaterializationStore::default(),
+    ));
 
     let bundle = port
         .build_prompt_bundle(LoopPromptBundleRequest {
@@ -699,11 +943,10 @@ async fn loop_prompt_port_rejects_stale_surface_version() {
 }
 
 #[tokio::test]
-async fn loop_prompt_port_rejects_memory_snippets_it_cannot_materialize() {
+async fn loop_prompt_port_rejects_unstored_synthetic_instruction_refs() {
     let host = Arc::new(
         RecordingAgentLoopHost::new(claimed_run_context().await)
-            .with_context_instruction_snippet("instruction:system", "system instruction available")
-            .with_context_memory_snippet("memory:project", "project memory available"),
+            .with_context_instruction_snippet("instruction:system", "system instruction available"),
     );
     let port = HostManagedLoopPromptPort::new(
         host.context.clone(),
@@ -722,9 +965,72 @@ async fn loop_prompt_port_rejects_memory_snippets_it_cannot_materialize() {
         .await
         .unwrap_err();
 
-    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    assert_eq!(error.kind, AgentLoopHostErrorKind::InvalidInvocation);
+}
+
+#[tokio::test]
+async fn loop_prompt_port_materializes_memory_surface_and_safety_as_host_owned_refs() {
+    let host = Arc::new(
+        RecordingAgentLoopHost::new(claimed_run_context().await)
+            .with_context_instruction_snippet("instruction:system", "system instruction available")
+            .with_context_memory_snippet("memory:project", "project memory available"),
+    );
+    let surface = VisibleCapabilitySurface {
+        version: CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+        descriptors: vec![CapabilityDescriptorView {
+            capability_id: CapabilityId::new("demo.echo").unwrap(),
+            provider: None,
+            runtime: RuntimeKind::FirstParty,
+            safe_name: "Echo".to_string(),
+            safe_description: "Echo safe input".to_string(),
+        }],
+    };
+    let port = HostManagedLoopPromptPort::new(
+        host.context.clone(),
+        host.clone(),
+        host.milestone_sink.clone(),
+    )
+    .with_instruction_materialization_store(Arc::new(
+        InMemoryInstructionMaterializationStore::default(),
+    ))
+    .with_current_surface(surface.clone())
+    .with_safety_context(
+        InstructionSafetyContext::new("safety:prompt-write", "prompt write safety enforced")
+            .unwrap(),
+    );
+
+    let bundle = port
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: Some(surface.version),
+            checkpoint_state_ref: None,
+            max_messages: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(bundle.messages.iter().any(|message| {
+        message
+            .content_ref
+            .as_str()
+            .starts_with("msg:memory.memory.project.")
+    }));
+    assert!(bundle.messages.iter().any(|message| {
+        message
+            .content_ref
+            .as_str()
+            .starts_with("msg:safety.safety.prompt-write.")
+    }));
+    assert!(bundle.messages.iter().any(|message| {
+        message
+            .content_ref
+            .as_str()
+            .starts_with("msg:surface.surface-v1.")
+    }));
+    assert!(bundle.instruction_fingerprint.is_some());
     assert_eq!(host.effects(), vec!["context"]);
-    assert!(host.milestones().is_empty());
+    assert_eq!(host.milestone_kind_names(), vec!["prompt_bundle_built"]);
 }
 
 #[tokio::test]
@@ -828,7 +1134,7 @@ fn capability_surface_versions_are_public_safe_tokens() {
 async fn loop_prompt_bundle_public_serialization_hides_raw_content() {
     let host = Arc::new(
         RecordingAgentLoopHost::new(claimed_run_context().await)
-            .with_context_message_safe_summary("RAW_PROMPT_SENTINEL /host/path secret"),
+            .with_context_message_safe_summary("safe prompt summary"),
     );
     let port = HostManagedLoopPromptPort::new(
         host.context.clone(),
@@ -1537,6 +1843,7 @@ impl LoopPromptPort for RecordingAgentLoopHost {
                 })
                 .collect(),
             surface_version: request.surface_version,
+            instruction_fingerprint: None,
         };
         self.milestone_emitter()
             .prompt_bundle_built(


### PR DESCRIPTION
## Summary
- add `InstructionBundleBuilder` with deterministic section ordering and `InstructionBundleFingerprint`
- wire prompt bundle construction through host-owned instruction materialization refs
- add Reborn host/model-port integration so synthetic instruction, memory, safety, and surface refs resolve safely
- add regression tests for deterministic rebuilds, redaction/serialization, fingerprint validation, and Reborn production path

Fixes #3434

## Verification
- `cargo test -p ironclaw_turns`
- `cargo test -p ironclaw_loop_support`
- `cargo test -p ironclaw_reborn`
- `cargo fmt --check`
- `cargo clippy -p ironclaw_turns -p ironclaw_loop_support -p ironclaw_reborn --tests -- -D warnings`