### PR TITLE
feat(reborn): add first-party builtin tool capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4307,6 +4307,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "chrono-tz",
  "deadpool-postgres",
  "futures-util",
  "ironclaw_approvals",

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -12,6 +12,7 @@ libsql = ["dep:libsql", "ironclaw_filesystem/libsql", "ironclaw_resources/libsql
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono-tz = "0.10"
 deadpool-postgres = { version = "0.14", optional = true }
 futures-util = "0.3"
 ironclaw_approvals = { path = "../ironclaw_approvals" }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/echo.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/echo.rs
@@ -1,0 +1,34 @@
+use ironclaw_extensions::{CapabilityManifest, ExtensionError};
+use ironclaw_host_api::{CapabilityId, EffectKind, PermissionMode};
+use serde_json::{Value, json};
+
+use crate::FirstPartyCapabilityError;
+
+use super::{input_error, resource_profile};
+
+pub const ECHO_CAPABILITY_ID: &str = "builtin.echo";
+
+pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
+    Ok(CapabilityManifest {
+        id: CapabilityId::new(ECHO_CAPABILITY_ID)?,
+        description: "Echo a message".to_string(),
+        effects: vec![EffectKind::DispatchCapability],
+        default_permission: PermissionMode::Allow,
+        parameters_schema: json!({
+            "type": "object",
+            "properties": {
+                "message": { "type": "string", "description": "Message to echo" }
+            },
+            "required": ["message"]
+        }),
+        resource_profile: resource_profile(),
+    })
+}
+
+pub(super) fn dispatch(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
+    let message = input
+        .get("message")
+        .and_then(Value::as_str)
+        .ok_or_else(input_error)?;
+    Ok(Value::String(message.to_string()))
+}

--- a/crates/ironclaw_host_runtime/src/first_party_tools/json.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/json.rs
@@ -1,0 +1,98 @@
+use ironclaw_extensions::{CapabilityManifest, ExtensionError};
+use ironclaw_host_api::{CapabilityId, EffectKind, PermissionMode};
+use serde_json::{Value, json};
+
+use crate::FirstPartyCapabilityError;
+
+use super::{guest_error, input_error, resource_profile};
+
+pub const JSON_CAPABILITY_ID: &str = "builtin.json";
+
+pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
+    Ok(CapabilityManifest {
+        id: CapabilityId::new(JSON_CAPABILITY_ID)?,
+        description: "Parse, query, stringify, and validate JSON".to_string(),
+        effects: vec![EffectKind::DispatchCapability],
+        default_permission: PermissionMode::Allow,
+        parameters_schema: json!({
+            "type": "object",
+            "properties": {
+                "operation": { "type": "string", "enum": ["parse", "query", "stringify", "validate"] },
+                "data": {},
+                "path": { "type": "string" }
+            },
+            "required": ["operation"]
+        }),
+        resource_profile: resource_profile(),
+    })
+}
+
+pub(super) fn dispatch(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
+    if input.get("source_tool_call_id").is_some() {
+        return Err(input_error());
+    }
+    let operation = input
+        .get("operation")
+        .and_then(Value::as_str)
+        .ok_or_else(input_error)?;
+    match operation {
+        "parse" => {
+            let data = input.get("data").ok_or_else(input_error)?;
+            let text = data.as_str().ok_or_else(input_error)?;
+            serde_json::from_str::<Value>(text).map_err(|_| input_error())
+        }
+        "stringify" => {
+            let data = input.get("data").ok_or_else(input_error)?;
+            let value = if let Some(text) = data.as_str() {
+                serde_json::from_str::<Value>(text).map_err(|_| input_error())?
+            } else {
+                data.clone()
+            };
+            serde_json::to_string_pretty(&value)
+                .map(Value::String)
+                .map_err(|_| guest_error())
+        }
+        "query" => {
+            let data = input.get("data").ok_or_else(input_error)?;
+            let path = input
+                .get("path")
+                .and_then(Value::as_str)
+                .ok_or_else(input_error)?;
+            let value = if let Some(text) = data.as_str() {
+                serde_json::from_str::<Value>(text).map_err(|_| input_error())?
+            } else {
+                data.clone()
+            };
+            query_json(&value, path).cloned()
+        }
+        "validate" => {
+            let valid = input
+                .get("data")
+                .and_then(Value::as_str)
+                .map(|text| serde_json::from_str::<Value>(text).is_ok())
+                .unwrap_or(false);
+            Ok(json!({ "valid": valid }))
+        }
+        _ => Err(input_error()),
+    }
+}
+
+fn query_json<'a>(value: &'a Value, path: &str) -> Result<&'a Value, FirstPartyCapabilityError> {
+    let mut current = value;
+    for segment in path.split('.') {
+        if segment.is_empty() {
+            continue;
+        }
+        if let Some((field, rest)) = segment.split_once('[') {
+            if !field.is_empty() {
+                current = current.get(field).ok_or_else(input_error)?;
+            }
+            let index_text = rest.strip_suffix(']').ok_or_else(input_error)?;
+            let index = index_text.parse::<usize>().map_err(|_| input_error())?;
+            current = current.get(index).ok_or_else(input_error)?;
+        } else {
+            current = current.get(segment).ok_or_else(input_error)?;
+        }
+    }
+    Ok(current)
+}

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -1,0 +1,147 @@
+//! Built-in first-party capability handlers.
+//!
+//! These are host-owned capabilities, not extension-declared tools. They keep
+//! pure tool logic behind the Reborn capability path so callers still pass
+//! through `CapabilityHost`, trust policy, grants, resource accounting, and
+//! runtime dispatch before any handler runs.
+
+mod echo;
+mod json;
+mod time;
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+use ironclaw_extensions::{ExtensionError, ExtensionManifest, ExtensionPackage, ExtensionRuntime};
+use ironclaw_host_api::{
+    CapabilityId, ExtensionId, HostApiError, RequestedTrustClass, ResourceCeiling,
+    ResourceEstimate, ResourceProfile, ResourceUsage, RuntimeDispatchErrorKind, TrustClass,
+    VirtualPath,
+};
+
+use crate::{
+    FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
+    FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
+};
+
+pub use echo::ECHO_CAPABILITY_ID;
+pub use json::JSON_CAPABILITY_ID;
+pub use time::TIME_CAPABILITY_ID;
+
+pub const BUILTIN_FIRST_PARTY_PROVIDER: &str = "builtin";
+
+const MAX_FIRST_PARTY_INPUT_BYTES: usize = 1_048_576;
+const FIRST_PARTY_DEFAULT_OUTPUT_BYTES: u64 = 16 * 1024;
+const FIRST_PARTY_MAX_OUTPUT_BYTES: u64 = 1_048_576;
+const FIRST_PARTY_DEFAULT_WALL_CLOCK_MS: u64 = 100;
+const FIRST_PARTY_MAX_WALL_CLOCK_MS: u64 = 5_000;
+
+/// Create the host-assigned package that declares built-in first-party
+/// capabilities for the capability surface.
+pub fn builtin_first_party_package() -> Result<ExtensionPackage, ExtensionError> {
+    ExtensionPackage::from_manifest(
+        ExtensionManifest {
+            id: ExtensionId::new(BUILTIN_FIRST_PARTY_PROVIDER)?,
+            name: "Built-in first-party capabilities".to_string(),
+            version: "0.1.0".to_string(),
+            description: "Host-owned built-in Reborn capabilities".to_string(),
+            requested_trust: RequestedTrustClass::FirstPartyRequested,
+            // Effective first-party trust is assigned by host policy at
+            // invocation/surface time. Descriptor trust stays conservative.
+            trust: TrustClass::Sandbox,
+            runtime: ExtensionRuntime::FirstParty {
+                service: "builtin".to_string(),
+            },
+            capabilities: vec![echo::manifest()?, time::manifest()?, json::manifest()?],
+        },
+        VirtualPath::new("/system/extensions/builtin")?,
+    )
+}
+
+/// Create handlers for all built-in first-party capabilities.
+pub fn builtin_first_party_handlers() -> Result<FirstPartyCapabilityRegistry, HostApiError> {
+    let handler = std::sync::Arc::new(BuiltinFirstPartyTools);
+    Ok(FirstPartyCapabilityRegistry::new()
+        .with_handler(CapabilityId::new(ECHO_CAPABILITY_ID)?, handler.clone())
+        .with_handler(CapabilityId::new(TIME_CAPABILITY_ID)?, handler.clone())
+        .with_handler(CapabilityId::new(JSON_CAPABILITY_ID)?, handler))
+}
+
+#[derive(Debug, Default)]
+pub struct BuiltinFirstPartyTools;
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        bounded_input_size(&request.input)?;
+        let start = Instant::now();
+        let output = match request.capability_id.as_str() {
+            ECHO_CAPABILITY_ID => echo::dispatch(&request.input)?,
+            TIME_CAPABILITY_ID => time::dispatch(&request.input)?,
+            JSON_CAPABILITY_ID => json::dispatch(&request.input)?,
+            _ => {
+                return Err(FirstPartyCapabilityError::new(
+                    RuntimeDispatchErrorKind::UndeclaredCapability,
+                ));
+            }
+        };
+        let output_bytes = bounded_output_bytes(&output)?;
+        let usage = ResourceUsage {
+            wall_clock_ms: start.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+            output_bytes,
+            ..ResourceUsage::default()
+        };
+        Ok(FirstPartyCapabilityResult::new(output, usage))
+    }
+}
+
+fn bounded_input_size(input: &serde_json::Value) -> Result<(), FirstPartyCapabilityError> {
+    let bytes = serde_json::to_vec(input).map_err(|_| input_error())?;
+    if bytes.len() > MAX_FIRST_PARTY_INPUT_BYTES {
+        return Err(FirstPartyCapabilityError::new(
+            RuntimeDispatchErrorKind::Resource,
+        ));
+    }
+    Ok(())
+}
+
+fn bounded_output_bytes(output: &serde_json::Value) -> Result<u64, FirstPartyCapabilityError> {
+    let bytes = serde_json::to_vec(output).map_err(|_| input_error())?;
+    let bytes = u64::try_from(bytes.len())
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::OutputTooLarge))?;
+    if bytes > FIRST_PARTY_MAX_OUTPUT_BYTES {
+        return Err(FirstPartyCapabilityError::new(
+            RuntimeDispatchErrorKind::OutputTooLarge,
+        ));
+    }
+    Ok(bytes)
+}
+
+fn resource_profile() -> Option<ResourceProfile> {
+    Some(ResourceProfile {
+        default_estimate: ResourceEstimate {
+            wall_clock_ms: Some(FIRST_PARTY_DEFAULT_WALL_CLOCK_MS),
+            output_bytes: Some(FIRST_PARTY_DEFAULT_OUTPUT_BYTES),
+            ..ResourceEstimate::default()
+        },
+        hard_ceiling: Some(ResourceCeiling {
+            max_usd: None,
+            max_input_tokens: None,
+            max_output_tokens: None,
+            max_wall_clock_ms: Some(FIRST_PARTY_MAX_WALL_CLOCK_MS),
+            max_output_bytes: Some(FIRST_PARTY_MAX_OUTPUT_BYTES),
+            sandbox: None,
+        }),
+    })
+}
+
+fn input_error() -> FirstPartyCapabilityError {
+    FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InputEncode)
+}
+
+fn guest_error() -> FirstPartyCapabilityError {
+    FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Guest)
+}

--- a/crates/ironclaw_host_runtime/src/first_party_tools/time.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/time.rs
@@ -1,0 +1,210 @@
+use chrono::{DateTime, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use chrono_tz::Tz;
+use ironclaw_extensions::{CapabilityManifest, ExtensionError};
+use ironclaw_host_api::{CapabilityId, EffectKind, PermissionMode};
+use serde_json::{Value, json};
+
+use crate::FirstPartyCapabilityError;
+
+use super::{input_error, resource_profile};
+
+pub const TIME_CAPABILITY_ID: &str = "builtin.time";
+
+pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
+    Ok(CapabilityManifest {
+        id: CapabilityId::new(TIME_CAPABILITY_ID)?,
+        description: "Get, parse, format, convert, or diff timestamps".to_string(),
+        effects: vec![EffectKind::DispatchCapability],
+        default_permission: PermissionMode::Allow,
+        parameters_schema: json!({
+            "type": "object",
+            "properties": {
+                "operation": { "type": "string", "enum": ["now", "parse", "convert", "format", "diff"] },
+                "input": { "type": "string" },
+                "timestamp": { "type": "string" },
+                "timezone": { "type": "string" },
+                "from_timezone": { "type": "string" },
+                "to_timezone": { "type": "string" },
+                "format": { "type": "string" },
+                "format_string": { "type": "string" },
+                "timestamp2": { "type": "string" }
+            }
+        }),
+        resource_profile: resource_profile(),
+    })
+}
+
+pub(super) fn dispatch(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
+    let operation = input
+        .get("operation")
+        .and_then(Value::as_str)
+        .unwrap_or("now");
+    match operation {
+        "now" => time_now(input),
+        "parse" => time_parse(input),
+        "convert" => time_convert(input),
+        "format" => time_format(input),
+        "diff" => time_diff(input),
+        _ => Err(input_error()),
+    }
+}
+
+fn time_now(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
+    let now = Utc::now();
+    let mut output = json!({
+        "iso": now.to_rfc3339(),
+        "utc_iso": now.to_rfc3339(),
+        "unix": now.timestamp(),
+        "unix_millis": now.timestamp_millis()
+    });
+    if let Some((tz, name)) = optional_timezone(input, &["timezone"])? {
+        output["local_iso"] = Value::String(now.with_timezone(&tz).to_rfc3339());
+        output["timezone"] = Value::String(name);
+    }
+    Ok(output)
+}
+
+fn time_parse(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
+    let source = required_input(input)?;
+    let dt = parse_timestamp(
+        source,
+        optional_timezone(input, &["from_timezone", "timezone"])?
+            .map(|(tz, _)| tz)
+            .as_ref(),
+    )?;
+    Ok(json!({
+        "iso": dt.to_rfc3339(),
+        "unix": dt.timestamp(),
+        "unix_millis": dt.timestamp_millis()
+    }))
+}
+
+fn time_convert(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
+    let source = required_input(input)?;
+    let from_tz = optional_timezone(input, &["from_timezone", "timezone"])?.map(|(tz, _)| tz);
+    let dt = parse_timestamp(source, from_tz.as_ref())?;
+    let (target_tz, target_name) = required_timezone(input, "to_timezone")?;
+    Ok(json!({
+        "input": source,
+        "utc_iso": dt.to_rfc3339(),
+        "output": dt.with_timezone(&target_tz).to_rfc3339(),
+        "timezone": target_name
+    }))
+}
+
+fn time_format(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
+    let source = required_input(input)?;
+    let output_tz = optional_timezone(input, &["timezone"])?;
+    let from_tz = optional_timezone(input, &["from_timezone"])?.map(|(tz, _)| tz);
+    let fallback_tz = output_tz.as_ref().map(|(tz, _)| *tz);
+    let parse_tz = from_tz.as_ref().or(fallback_tz.as_ref());
+    let dt = parse_timestamp(source, parse_tz)?;
+    let fmt = input
+        .get("format_string")
+        .and_then(Value::as_str)
+        .or_else(|| input.get("format").and_then(Value::as_str))
+        .unwrap_or("%Y-%m-%d %H:%M:%S %Z");
+    let mut output = if let Some((tz, name)) = output_tz {
+        json!({
+            "formatted": dt.with_timezone(&tz).format(fmt).to_string(),
+            "timezone": name
+        })
+    } else {
+        json!({ "formatted": dt.format(fmt).to_string() })
+    };
+    output["utc_iso"] = Value::String(dt.to_rfc3339());
+    Ok(output)
+}
+
+fn time_diff(input: &Value) -> Result<Value, FirstPartyCapabilityError> {
+    let first = required_input(input)?;
+    let second = input
+        .get("timestamp2")
+        .and_then(Value::as_str)
+        .ok_or_else(input_error)?;
+    let tz = optional_timezone(input, &["from_timezone", "timezone"])?.map(|(tz, _)| tz);
+    let dt1 = parse_timestamp(first, tz.as_ref())?;
+    let dt2 = parse_timestamp(second, tz.as_ref())?;
+    let diff = dt2.signed_duration_since(dt1);
+    Ok(json!({
+        "seconds": diff.num_seconds(),
+        "minutes": diff.num_minutes(),
+        "hours": diff.num_hours(),
+        "days": diff.num_days()
+    }))
+}
+
+fn required_input(input: &Value) -> Result<&str, FirstPartyCapabilityError> {
+    input
+        .get("input")
+        .or_else(|| input.get("timestamp"))
+        .and_then(Value::as_str)
+        .ok_or_else(input_error)
+}
+
+fn required_timezone(
+    input: &Value,
+    field: &str,
+) -> Result<(Tz, String), FirstPartyCapabilityError> {
+    let name = input
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(input_error)?;
+    let tz = name.parse::<Tz>().map_err(|_| input_error())?;
+    Ok((tz, name.to_string()))
+}
+
+fn optional_timezone(
+    input: &Value,
+    fields: &[&str],
+) -> Result<Option<(Tz, String)>, FirstPartyCapabilityError> {
+    for field in fields {
+        if let Some(name) = input.get(*field).and_then(Value::as_str) {
+            let tz = name.parse::<Tz>().map_err(|_| input_error())?;
+            return Ok(Some((tz, name.to_string())));
+        }
+    }
+    Ok(None)
+}
+
+fn parse_timestamp(
+    input: &str,
+    timezone: Option<&Tz>,
+) -> Result<DateTime<Utc>, FirstPartyCapabilityError> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(input) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+    if let Some(naive) = parse_naive_datetime(input) {
+        let Some(timezone) = timezone else {
+            return Err(input_error());
+        };
+        return local_to_utc(naive, *timezone);
+    }
+    Err(input_error())
+}
+
+fn parse_naive_datetime(input: &str) -> Option<NaiveDateTime> {
+    const DATETIME_FORMATS: &[&str] = &[
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%dT%H:%M",
+    ];
+
+    for format in DATETIME_FORMATS {
+        if let Ok(value) = NaiveDateTime::parse_from_str(input, format) {
+            return Some(value);
+        }
+    }
+
+    NaiveDate::parse_from_str(input, "%Y-%m-%d")
+        .ok()
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+}
+
+fn local_to_utc(naive: NaiveDateTime, tz: Tz) -> Result<DateTime<Utc>, FirstPartyCapabilityError> {
+    match tz.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => Ok(dt.with_timezone(&Utc)),
+        LocalResult::Ambiguous(_, _) | LocalResult::None => Err(input_error()),
+    }
+}

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -45,6 +45,7 @@ use std::{collections::BTreeMap, fmt, sync::Arc};
 use thiserror::Error;
 
 mod first_party;
+mod first_party_tools;
 pub mod memory_context;
 mod obligations;
 mod planner;
@@ -56,6 +57,10 @@ mod turn_scheduler;
 pub use first_party::{
     FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
     FirstPartyCapabilityRequest, FirstPartyCapabilityResult,
+};
+pub use first_party_tools::{
+    BUILTIN_FIRST_PARTY_PROVIDER, BuiltinFirstPartyTools, ECHO_CAPABILITY_ID, JSON_CAPABILITY_ID,
+    TIME_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
 };
 pub use obligations::{
     BuiltinObligationHandler, BuiltinObligationServices, NetworkObligationPolicyStore,

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -1,0 +1,384 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use ironclaw_authorization::GrantAuthorizer;
+use ironclaw_extensions::ExtensionRegistry;
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::*;
+use ironclaw_host_runtime::{
+    CapabilitySurfacePolicy, CapabilitySurfaceVersion, ECHO_CAPABILITY_ID, HostRuntime,
+    HostRuntimeServices, JSON_CAPABILITY_ID, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    RuntimeFailureKind, SurfaceKind, TIME_CAPABILITY_ID, VisibleCapabilityAccess,
+    VisibleCapabilityRequest, builtin_first_party_handlers, builtin_first_party_package,
+};
+use ironclaw_resources::InMemoryResourceGovernor;
+use ironclaw_trust::{
+    AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
+    HostTrustPolicy, TrustDecision, TrustProvenance,
+};
+use serde_json::{Value, json};
+
+#[tokio::test]
+async fn builtin_first_party_package_declares_expected_capabilities() {
+    let package = builtin_first_party_package().unwrap();
+    assert_eq!(package.id, provider_id());
+    assert_eq!(package.manifest.runtime_kind(), RuntimeKind::FirstParty);
+
+    let ids = package
+        .capabilities
+        .iter()
+        .map(|descriptor| descriptor.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ids,
+        vec![ECHO_CAPABILITY_ID, TIME_CAPABILITY_ID, JSON_CAPABILITY_ID]
+    );
+
+    let handlers = builtin_first_party_handlers().unwrap();
+    for id in [ECHO_CAPABILITY_ID, TIME_CAPABILITY_ID, JSON_CAPABILITY_ID] {
+        assert!(handlers.contains_handler(&capability_id(id)));
+    }
+}
+
+#[tokio::test]
+async fn builtin_first_party_surface_lists_allowed_tools_in_registry_order() {
+    let runtime = runtime();
+    let request = VisibleCapabilityRequest::new(
+        execution_context([ECHO_CAPABILITY_ID, TIME_CAPABILITY_ID, JSON_CAPABILITY_ID]),
+        SurfaceKind::new("agent_loop").unwrap(),
+    )
+    .with_policy(CapabilitySurfacePolicy::allow_all())
+    .with_provider_trust(provider_trust());
+
+    let surface = runtime.visible_capabilities(request).await.unwrap();
+
+    let ids = surface
+        .capabilities
+        .iter()
+        .map(|capability| capability.descriptor.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ids,
+        vec![ECHO_CAPABILITY_ID, TIME_CAPABILITY_ID, JSON_CAPABILITY_ID]
+    );
+    assert!(
+        surface
+            .capabilities
+            .iter()
+            .all(|capability| capability.access == VisibleCapabilityAccess::Available)
+    );
+    assert!(
+        surface
+            .capabilities
+            .iter()
+            .all(|capability| capability.estimated_resources.output_bytes.is_some())
+    );
+}
+
+#[tokio::test]
+async fn builtin_rejects_oversized_inputs_before_dispatch() {
+    let outcome = runtime()
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context([JSON_CAPABILITY_ID]),
+            capability_id(JSON_CAPABILITY_ID),
+            ResourceEstimate::default(),
+            json!({"operation": "validate", "data": "x".repeat(1_048_577)}),
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected resource failure, got {outcome:?}");
+    };
+    assert_eq!(failure.kind, RuntimeFailureKind::Resource);
+}
+
+#[tokio::test]
+async fn builtin_rejects_oversized_outputs_before_return() {
+    let outcome = runtime()
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context([JSON_CAPABILITY_ID]),
+            capability_id(JSON_CAPABILITY_ID),
+            ResourceEstimate::default(),
+            json!({"operation": "stringify", "data": {"items": vec!["xxxxxxxx"; 80_000]}}),
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected output-too-large failure, got {outcome:?}");
+    };
+    assert_eq!(failure.kind, RuntimeFailureKind::OutputTooLarge);
+}
+
+#[tokio::test]
+async fn builtin_echo_invokes_through_host_runtime() {
+    let output = invoke(ECHO_CAPABILITY_ID, json!({"message": "hello reborn"}))
+        .await
+        .unwrap();
+    assert_eq!(output, Value::String("hello reborn".to_string()));
+}
+
+#[tokio::test]
+async fn builtin_time_parse_convert_and_diff_are_deterministic() {
+    let parsed = invoke(
+        TIME_CAPABILITY_ID,
+        json!({"operation": "parse", "input": "2026-05-12T13:00:00Z"}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(parsed["unix"], json!(1778590800));
+
+    let converted = invoke(
+        TIME_CAPABILITY_ID,
+        json!({
+            "operation": "convert",
+            "input": "2026-05-12T13:00:00Z",
+            "to_timezone": "America/New_York"
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(converted["output"], json!("2026-05-12T09:00:00-04:00"));
+
+    let diff = invoke(
+        TIME_CAPABILITY_ID,
+        json!({
+            "operation": "diff",
+            "input": "2026-05-12T13:00:00Z",
+            "timestamp2": "2026-05-12T15:30:00Z"
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(diff["minutes"], json!(150));
+}
+
+#[tokio::test]
+async fn builtin_time_rejects_naive_without_timezone_and_ambiguous_local_time() {
+    let missing_timezone = invoke(
+        TIME_CAPABILITY_ID,
+        json!({"operation": "parse", "input": "2026-05-12 13:00:00"}),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(missing_timezone, RuntimeFailureKind::InvalidInput);
+
+    let ambiguous = invoke(
+        TIME_CAPABILITY_ID,
+        json!({
+            "operation": "parse",
+            "input": "2026-11-01 01:30:00",
+            "timezone": "America/New_York"
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(ambiguous, RuntimeFailureKind::InvalidInput);
+}
+
+#[tokio::test]
+async fn builtin_json_parse_query_stringify_and_validate_work() {
+    let parsed = invoke(
+        JSON_CAPABILITY_ID,
+        json!({"operation": "parse", "data": "{\"items\":[{\"name\":\"alpha\"}]}"}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(parsed["items"][0]["name"], json!("alpha"));
+
+    let queried = invoke(
+        JSON_CAPABILITY_ID,
+        json!({
+            "operation": "query",
+            "data": {"items":[{"name":"alpha"}]},
+            "path": "items[0].name"
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(queried, json!("alpha"));
+
+    let valid = invoke(
+        JSON_CAPABILITY_ID,
+        json!({"operation": "validate", "data": "{\"ok\":true}"}),
+    )
+    .await
+    .unwrap();
+    assert_eq!(valid, json!({"valid": true}));
+
+    let stringified = invoke(
+        JSON_CAPABILITY_ID,
+        json!({"operation": "stringify", "data": {"ok": true}}),
+    )
+    .await
+    .unwrap();
+    assert!(stringified.as_str().unwrap().contains("\"ok\": true"));
+}
+
+#[tokio::test]
+async fn builtin_json_stringify_rejects_invalid_json_strings() {
+    let error = invoke(
+        JSON_CAPABILITY_ID,
+        json!({"operation": "stringify", "data": "not json"}),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error, RuntimeFailureKind::InvalidInput);
+}
+
+#[tokio::test]
+async fn builtin_json_rejects_v1_tool_output_stash_refs_without_leaking_input() {
+    let outcome = runtime()
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context([JSON_CAPABILITY_ID]),
+            capability_id(JSON_CAPABILITY_ID),
+            ResourceEstimate::default(),
+            json!({
+                "operation": "parse",
+                "source_tool_call_id": "call_RAW_SECRET_sk-provider-secret"
+            }),
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected sanitized failure, got {outcome:?}");
+    };
+    assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+    let debug = format!("{failure:?}");
+    assert!(!debug.contains("RAW_SECRET"));
+    assert!(!debug.contains("sk-provider-secret"));
+}
+
+#[tokio::test]
+async fn builtin_missing_grant_denies_before_handler_dispatch() {
+    let outcome = runtime()
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context([]),
+            capability_id(ECHO_CAPABILITY_ID),
+            ResourceEstimate::default(),
+            json!({"message":"must not run"}),
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected authorization failure, got {outcome:?}");
+    };
+    assert_eq!(failure.kind, RuntimeFailureKind::Authorization);
+}
+
+async fn invoke(capability: &str, input: Value) -> Result<Value, RuntimeFailureKind> {
+    let outcome = runtime()
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            execution_context([capability]),
+            capability_id(capability),
+            ResourceEstimate::default(),
+            input,
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+    match outcome {
+        RuntimeCapabilityOutcome::Completed(completed) => Ok(completed.output),
+        RuntimeCapabilityOutcome::Failed(failure) => Err(failure.kind),
+        other => panic!("unexpected capability outcome: {other:?}"),
+    }
+}
+
+fn runtime() -> impl HostRuntime {
+    HostRuntimeServices::new(
+        Arc::new(registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(builtin_first_party_handlers().unwrap()))
+    .with_trust_policy(Arc::new(trust_policy()))
+    .host_runtime_for_local_testing()
+}
+
+fn registry() -> ExtensionRegistry {
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(builtin_first_party_package().unwrap())
+        .unwrap();
+    registry
+}
+
+fn capability_id(value: &str) -> CapabilityId {
+    CapabilityId::new(value).unwrap()
+}
+
+fn provider_id() -> ExtensionId {
+    ExtensionId::new("builtin").unwrap()
+}
+
+fn execution_context<const N: usize>(grants: [&str; N]) -> ExecutionContext {
+    let capability_set = CapabilitySet {
+        grants: grants.into_iter().map(dispatch_grant).collect(),
+    };
+    ExecutionContext::local_default(
+        UserId::new("user").unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::FirstParty,
+        TrustClass::FirstParty,
+        capability_set,
+        MountView::default(),
+    )
+    .unwrap()
+}
+
+fn dispatch_grant(capability: &str) -> CapabilityGrant {
+    CapabilityGrant {
+        id: CapabilityGrantId::new(),
+        capability: capability_id(capability),
+        grantee: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        issued_by: Principal::HostRuntime,
+        constraints: GrantConstraints {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            mounts: MountView::default(),
+            network: NetworkPolicy::default(),
+            secrets: Vec::new(),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
+    }
+}
+
+fn trust_policy() -> HostTrustPolicy {
+    HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
+        AdminEntry::for_local_manifest(
+            PackageId::new("builtin").unwrap(),
+            "/system/extensions/builtin/manifest.toml".to_string(),
+            None,
+            HostTrustAssignment::first_party(),
+            vec![EffectKind::DispatchCapability],
+            None,
+        ),
+    ]))])
+    .unwrap()
+}
+
+fn provider_trust() -> BTreeMap<ExtensionId, TrustDecision> {
+    BTreeMap::from([(provider_id(), trust_decision())])
+}
+
+fn trust_decision() -> TrustDecision {
+    TrustDecision {
+        effective_trust: EffectiveTrustClass::user_trusted(),
+        authority_ceiling: AuthorityCeiling {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            max_resource_ceiling: None,
+        },
+        provenance: TrustProvenance::Default,
+        evaluated_at: chrono::Utc::now(),
+    }
+}


### PR DESCRIPTION
## Summary
- add host-assigned built-in first-party capabilities for echo, time, and json
- expose builtin package/handler helpers for Reborn composition
- cover surface visibility, invocation, missing-grant denial, and v1 stash-ref rejection

## Notes
- keeps filesystem tools for a follow-up slice; this PR ports pure compute tools only
- does not wire model-driven tool calls; capabilities are invokeable through HostRuntime/CapabilityHost substrate

## Tests
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/tmp/ic-first-party cargo test -p ironclaw_host_runtime --test first_party_builtin_tools
- CARGO_TARGET_DIR=/tmp/ic-first-party cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings
