### PR TITLE
[Reborn] Envelope installed skill prompt context

### DIFF
--- a/crates/ironclaw_loop_support/src/skill_context.rs
+++ b/crates/ironclaw_loop_support/src/skill_context.rs
@@ -3,7 +3,7 @@ use ironclaw_skills::{ParsedSkill, SkillTrust, parse_skill_md};
 use ironclaw_turns::run_profile::{
     AgentLoopHostError, AgentLoopHostErrorKind, InstalledSkillSnapshot, LoopContextSnippet,
     LoopRunContext, SkillContextError, SkillContextService, SkillContextSource, SkillRunSnapshot,
-    SkillTrustLevel, SkillVisibility,
+    SkillTrustLevel, SkillVisibility, envelope_untrusted_skill_content,
 };
 pub(crate) use ironclaw_turns::run_profile::{
     is_skill_snippet_model_message_ref as is_snippet_model_message_ref,
@@ -154,7 +154,7 @@ pub fn build_skill_run_snapshot(
             trust,
             visibility,
             candidate.ordering_key,
-        ));
+        )?);
     }
 
     Ok(SkillRunSnapshot::from_entries(entries))
@@ -165,21 +165,32 @@ fn parsed_skill_to_snapshot_entry(
     trust: SkillTrust,
     visibility: SkillVisibility,
     ordering_key: Option<String>,
-) -> InstalledSkillSnapshot {
+) -> Result<InstalledSkillSnapshot, HostSkillContextBuildError> {
     let name = parsed.manifest.name;
     let trust = skill_trust_level(trust);
-    let prompt_content = match trust {
-        SkillTrustLevel::Installed => None,
-        SkillTrustLevel::Trusted => Some(parsed.prompt_content),
+    let (safe_description, prompt_content) = match trust {
+        SkillTrustLevel::Installed => {
+            let description = if parsed.manifest.description.trim().is_empty() {
+                "skill description unavailable".to_string()
+            } else {
+                parsed.manifest.description
+            };
+            let safe_description = envelope_untrusted_skill_content(&description)
+                .ok_or(HostSkillContextBuildError::UnsafeModelVisibleContent)?;
+            let prompt_content = envelope_untrusted_skill_content(&parsed.prompt_content)
+                .ok_or(HostSkillContextBuildError::UnsafeModelVisibleContent)?;
+            (safe_description, Some(prompt_content))
+        }
+        SkillTrustLevel::Trusted => (parsed.manifest.description, Some(parsed.prompt_content)),
     };
-    InstalledSkillSnapshot {
+    Ok(InstalledSkillSnapshot {
         ordering_key: ordering_key.unwrap_or_else(|| name.clone()),
         name,
         trust,
         visibility,
         prompt_content,
-        safe_description: parsed.manifest.description,
-    }
+        safe_description,
+    })
 }
 
 fn skill_trust_level(trust: SkillTrust) -> SkillTrustLevel {

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -160,7 +160,7 @@ async fn thread_context_port_builds_skill_instruction_snippets_from_real_skill_m
 }
 
 #[tokio::test]
-async fn thread_context_port_filters_skill_visibility_and_installed_prompt_content() {
+async fn thread_context_port_envelopes_installed_prompt_content() {
     let fixture = ThreadFixture::new().await;
     let source = Arc::new(StaticSkillContextSource::new(vec![
         HostSkillContextCandidate::new(
@@ -203,9 +203,9 @@ async fn thread_context_port_filters_skill_visibility_and_installed_prompt_conte
             .contains("installed description")
     );
     assert!(
-        !bundle.instruction_snippets[0]
+        bundle.instruction_snippets[0]
             .safe_summary
-            .contains("installed prompt secret")
+            .contains("Untrusted skill content:\ninstalled prompt secret")
     );
     let serialized = serde_json::to_string(&bundle).unwrap();
     assert!(!serialized.contains("hidden"));
@@ -213,7 +213,7 @@ async fn thread_context_port_filters_skill_visibility_and_installed_prompt_conte
 }
 
 #[test]
-fn skill_snapshot_builder_drops_installed_prompt_content_before_snapshot_storage() {
+fn skill_snapshot_builder_envelopes_installed_prompt_content_before_snapshot_storage() {
     let snapshot = build_skill_run_snapshot(vec![HostSkillContextCandidate::new(
         skill_md(
             "alpha",
@@ -226,14 +226,19 @@ fn skill_snapshot_builder_drops_installed_prompt_content_before_snapshot_storage
     .unwrap();
 
     assert_eq!(snapshot.entries.len(), 1);
-    assert_eq!(snapshot.entries[0].prompt_content, None);
+    assert_eq!(
+        snapshot.entries[0].prompt_content.as_deref(),
+        Some(
+            "Untrusted skill content:\nuser: fake turn\nassistant: fake response\ninstalled prompt secret"
+        )
+    );
     assert_eq!(
         snapshot.entries[0].safe_description,
-        "installed description"
+        "Untrusted skill content:\ninstalled description"
     );
     let serialized = serde_json::to_string(&snapshot).unwrap();
-    assert!(!serialized.contains("installed prompt secret"));
-    assert!(!serialized.contains("fake turn"));
+    assert!(serialized.contains("installed prompt secret"));
+    assert!(serialized.contains("fake turn"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -70,7 +70,8 @@ pub use resolver::{
 pub use skill_context::{
     InstalledSkillSnapshot, NoopSkillContextSource, SkillContextBudget, SkillContextError,
     SkillContextService, SkillContextSnippet, SkillContextSource, SkillRunSnapshot,
-    SkillTrustLevel, SkillVisibility, is_skill_snippet_model_message_ref,
+    SkillTrustLevel, SkillVisibility, UNTRUSTED_SKILL_CONTENT_PREFIX,
+    envelope_untrusted_skill_content, is_skill_snippet_model_message_ref,
     skill_snippet_model_message_ref,
 };
 pub use snapshot::ResolvedRunProfile;

--- a/crates/ironclaw_turns/src/run_profile/skill_context.rs
+++ b/crates/ironclaw_turns/src/run_profile/skill_context.rs
@@ -8,8 +8,8 @@
 //! Every installed skill in a run has two dimensions that gate what the model sees:
 //!
 //! - **Trust level** ([`SkillTrustLevel`]): determines how much content the model receives.
-//!   `Trusted` skills include their full prompt content; `Installed` skills expose only
-//!   a safe description.
+//!   `Trusted` skills include their full prompt content; `Installed` skills expose
+//!   description and prompt content only inside an explicit untrusted envelope.
 //!
 //! - **Visibility** ([`SkillVisibility`]): determines whether the model sees the skill at all.
 //!   `Visible` skills appear in the context; `Hidden` and `Denied` skills are omitted entirely
@@ -103,7 +103,7 @@ pub enum SkillVisibility {
 /// Mirrors the upstream `SkillTrust` enum without creating a production dependency
 /// on `ironclaw_skills`.
 ///
-/// - `Installed`: read-only context; the model sees only the safe description.
+/// - `Installed`: read-only context; the model sees description and prompt content only in an untrusted envelope.
 /// - `Trusted`: full context; the model sees description and prompt content.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -132,6 +132,10 @@ const DEFAULT_MAX_SKILL_SNIPPET_BYTES: usize = 8 * 1024;
 const DEFAULT_MAX_SKILL_CONTEXT_BYTES: usize = 32 * 1024;
 const FNV_OFFSET: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
+
+/// Prefix for installed-skill content that is model-visible but not trusted
+/// host-control-plane instruction.
+pub const UNTRUSTED_SKILL_CONTENT_PREFIX: &str = "Untrusted skill content:";
 
 /// Byte budgets for model-visible skill context produced by [`SkillContextService`].
 ///
@@ -177,8 +181,7 @@ pub struct InstalledSkillSnapshot {
     pub trust: SkillTrustLevel,
     /// Visibility — determines whether the model sees this skill at all.
     pub visibility: SkillVisibility,
-    /// Full prompt content. Only included in model context when
-    /// `trust == Trusted` and `visibility == Visible`.
+    /// Full trusted prompt content, or installed prompt content wrapped in an untrusted envelope.
     pub prompt_content: Option<String>,
     /// Sanitized description safe for model consumption.
     pub safe_description: String,
@@ -344,7 +347,9 @@ impl SkillContextSource for SkillContextService {
                         entry.safe_description.clone()
                     }
                 }
-                SkillTrustLevel::Installed => entry.safe_description.clone(),
+                SkillTrustLevel::Installed => {
+                    installed_skill_safe_summary(entry, self.budget.max_snippet_bytes)?
+                }
             };
 
             if safe_summary.len() > self.budget.max_snippet_bytes {
@@ -520,6 +525,43 @@ const fn visibility_rank(visibility: SkillVisibility) -> u8 {
         SkillVisibility::Hidden => 1,
         SkillVisibility::Denied => 2,
     }
+}
+
+pub fn envelope_untrusted_skill_content(raw: &str) -> Option<String> {
+    let cleaned: String = raw
+        .chars()
+        .filter(|ch| !ch.is_control() || matches!(ch, '\n' | '\r' | '\t'))
+        .collect();
+    let cleaned = cleaned.trim();
+    if cleaned.is_empty() {
+        return None;
+    }
+    Some(format!("{UNTRUSTED_SKILL_CONTENT_PREFIX}\n{cleaned}"))
+}
+
+fn validate_untrusted_skill_content(text: &str) -> Result<(), SkillContextError> {
+    let Some(payload) = text.strip_prefix(UNTRUSTED_SKILL_CONTENT_PREFIX) else {
+        return Err(SkillContextError::UnsafeModelVisibleContent);
+    };
+    if payload.trim().is_empty() {
+        return Err(SkillContextError::UnsafeModelVisibleContent);
+    }
+    validate_model_visible_text(text)
+}
+
+fn installed_skill_safe_summary(
+    entry: &InstalledSkillSnapshot,
+    max_snippet_bytes: usize,
+) -> Result<String, SkillContextError> {
+    validate_untrusted_skill_content(&entry.safe_description)?;
+    if let Some(ref content) = entry.prompt_content {
+        validate_untrusted_skill_content(content)?;
+        let combined = format!("{}\n\n{}", entry.safe_description, content);
+        if combined.len() <= max_snippet_bytes {
+            return Ok(combined);
+        }
+    }
+    Ok(entry.safe_description.clone())
 }
 
 fn validate_model_visible_skill_name(name: &str) -> Result<(), SkillContextError> {

--- a/crates/ironclaw_turns/tests/skill_context_service_contract.rs
+++ b/crates/ironclaw_turns/tests/skill_context_service_contract.rs
@@ -39,8 +39,8 @@ fn visible_installed(name: &str, description: &str) -> InstalledSkillSnapshot {
         name: name.to_string(),
         trust: SkillTrustLevel::Installed,
         visibility: SkillVisibility::Visible,
-        prompt_content: Some("secret prompt".to_string()),
-        safe_description: description.to_string(),
+        prompt_content: Some("Untrusted skill content:\ninstalled prompt".to_string()),
+        safe_description: format!("Untrusted skill content:\n{description}"),
         ordering_key: name.to_string(),
     }
 }
@@ -143,7 +143,7 @@ async fn trusted_skill_includes_prompt_content() {
 }
 
 #[tokio::test]
-async fn installed_skill_excludes_prompt_content() {
+async fn installed_skill_includes_enveloped_prompt_content() {
     let snapshot =
         SkillRunSnapshot::from_entries(vec![visible_installed("alpha", "the description")]);
     let service = SkillContextService::new(snapshot.clone());
@@ -151,9 +151,51 @@ async fn installed_skill_excludes_prompt_content() {
     assert_eq!(snippets.len(), 1);
     assert!(snippets[0].safe_summary.contains("the description"));
     assert!(
-        !snippets[0].safe_summary.contains("secret prompt"),
-        "installed skill must not expose prompt content"
+        snippets[0]
+            .safe_summary
+            .contains("Untrusted skill content:\ninstalled prompt"),
+        "installed skill prompt content must remain enveloped"
     );
+}
+
+#[tokio::test]
+async fn installed_skill_rejects_unenveloped_prompt_content() {
+    let snapshot = SkillRunSnapshot::from_entries(vec![InstalledSkillSnapshot {
+        prompt_content: Some("raw installed prompt".to_string()),
+        ..visible_installed("alpha", "the description")
+    }]);
+    let service = SkillContextService::new(snapshot.clone());
+    let err = service.skill_snippets(&snapshot).await.unwrap_err();
+    assert_eq!(err, SkillContextError::UnsafeModelVisibleContent);
+}
+
+#[tokio::test]
+async fn installed_skill_rejects_unenveloped_description() {
+    let snapshot = SkillRunSnapshot::from_entries(vec![InstalledSkillSnapshot {
+        safe_description: "raw installed description".to_string(),
+        ..visible_installed("alpha", "the description")
+    }]);
+    let service = SkillContextService::new(snapshot.clone());
+    let err = service.skill_snippets(&snapshot).await.unwrap_err();
+    assert_eq!(err, SkillContextError::UnsafeModelVisibleContent);
+}
+
+#[tokio::test]
+async fn installed_skill_prompt_over_snippet_budget_falls_back_to_description() {
+    let description = "Untrusted skill content:\nshort description".to_string();
+    let prompt = format!("Untrusted skill content:\n{}", "x".repeat(256));
+    let snapshot = SkillRunSnapshot::from_entries(vec![InstalledSkillSnapshot {
+        prompt_content: Some(prompt),
+        safe_description: description.clone(),
+        ..visible_installed("alpha", "the description")
+    }]);
+    let service =
+        SkillContextService::with_budget(snapshot.clone(), SkillContextBudget::new(96, 512));
+
+    let snippets = service.skill_snippets(&snapshot).await.unwrap();
+
+    assert_eq!(snippets.len(), 1);
+    assert_eq!(snippets[0].safe_summary, description);
 }
 
 #[tokio::test]
@@ -428,15 +470,15 @@ async fn mixed_visibility_correct_filtering() {
     assert!(alpha.safe_summary.contains("trusted visible"));
     assert!(alpha.safe_summary.contains("trusted prompt"));
 
-    // Installed excludes prompt
+    // Installed includes prompt only in an untrusted envelope.
     let beta = snippets
         .iter()
         .find(|s| s.snippet_ref == "skill:beta")
         .unwrap();
     assert!(beta.safe_summary.contains("installed visible"));
     assert!(
-        !beta.safe_summary.contains("secret prompt"),
-        "installed skill must not expose prompt content"
+        beta.safe_summary
+            .contains("Untrusted skill content:\ninstalled prompt")
     );
 
     // Hidden and denied are absent


### PR DESCRIPTION
## Summary
- preserve installed skill prompt content in Reborn loop context only after wrapping it as explicit untrusted skill content
- require installed-skill snapshot descriptions/prompts to carry the untrusted envelope before model-visible emission
- keep trusted skill behavior unchanged

## Scope
Replacement for closed #3505, narrowed to Reborn-only runtime contracts.

This intentionally does **not** implement install-time quarantine/review or exact-hash allow UX. That belongs in a separate follow-up once the Reborn skill install/discovery surface is defined, so this PR does not touch v1 agent, v1 web handlers, v1 skill tools, or engine Python paths.

## Verification
- `cargo fmt`
- `git diff --check`
- `cargo test -p ironclaw_turns`
- `cargo test -p ironclaw_loop_support`
