### PR TITLE
Architectural improvements: preserve typed dispatch failure kinds

### DIFF
--- a/crates/ironclaw_capabilities/src/error.rs
+++ b/crates/ironclaw_capabilities/src/error.rs
@@ -1,5 +1,7 @@
 use ironclaw_authorization::CapabilityLeaseError;
-use ironclaw_host_api::{CapabilityId, DenyReason, DispatchError, HostApiError, Obligation};
+use ironclaw_host_api::{
+    CapabilityId, DenyReason, DispatchError, DispatchFailureKind, HostApiError, Obligation,
+};
 use ironclaw_processes::ProcessError;
 
 use crate::CapabilityObligationFailureKind;
@@ -84,12 +86,11 @@ pub enum CapabilityInvocationError {
     Process(Box<ProcessError>),
     /// Runtime dispatch failure surfaced through the neutral host API port.
     ///
-    /// `kind` is a stable, redacted identifier produced by
-    /// [`dispatch_error_kind`]. The mapping is part of the public contract:
-    /// upstream callers may depend on these strings for routing, metrics, or
-    /// audit grouping. The mapping is pinned by unit tests in this crate.
+    /// `kind` is a stable, redacted category. Its display string remains part
+    /// of the public contract for routing, metrics, and audit grouping, but
+    /// callers that stay in-process can keep typed failure identity.
     #[error("dispatch failed: {kind}")]
-    Dispatch { kind: String },
+    Dispatch { kind: DispatchFailureKind },
 }
 
 impl From<RunStateError> for CapabilityInvocationError {
@@ -112,18 +113,8 @@ impl From<DispatchError> for CapabilityInvocationError {
     }
 }
 
-fn dispatch_error_kind(error: &DispatchError) -> String {
-    match error {
-        DispatchError::UnknownCapability { .. } => "UnknownCapability".to_string(),
-        DispatchError::UnknownProvider { .. } => "UnknownProvider".to_string(),
-        DispatchError::RuntimeMismatch { .. } => "RuntimeMismatch".to_string(),
-        DispatchError::MissingRuntimeBackend { .. } => "MissingRuntimeBackend".to_string(),
-        DispatchError::UnsupportedRuntime { .. } => "UnsupportedRuntime".to_string(),
-        DispatchError::Mcp { kind }
-        | DispatchError::Script { kind }
-        | DispatchError::Wasm { kind }
-        | DispatchError::FirstParty { kind } => kind.as_str().to_string(),
-    }
+fn dispatch_error_kind(error: &DispatchError) -> DispatchFailureKind {
+    error.failure_kind()
 }
 
 #[cfg(test)]
@@ -142,7 +133,7 @@ mod tests {
     #[test]
     fn dispatch_error_kind_maps_unknown_capability_to_stable_literal() {
         let kind = dispatch_error_kind(&DispatchError::UnknownCapability { capability: cap() });
-        assert_eq!(kind, "UnknownCapability");
+        assert_eq!(kind.as_str(), "UnknownCapability");
     }
 
     #[test]
@@ -151,7 +142,7 @@ mod tests {
             capability: cap(),
             provider: ext(),
         });
-        assert_eq!(kind, "UnknownProvider");
+        assert_eq!(kind.as_str(), "UnknownProvider");
     }
 
     #[test]
@@ -161,7 +152,7 @@ mod tests {
             descriptor_runtime: RuntimeKind::Wasm,
             package_runtime: RuntimeKind::Mcp,
         });
-        assert_eq!(kind, "RuntimeMismatch");
+        assert_eq!(kind.as_str(), "RuntimeMismatch");
     }
 
     #[test]
@@ -169,7 +160,7 @@ mod tests {
         let kind = dispatch_error_kind(&DispatchError::MissingRuntimeBackend {
             runtime: RuntimeKind::Wasm,
         });
-        assert_eq!(kind, "MissingRuntimeBackend");
+        assert_eq!(kind.as_str(), "MissingRuntimeBackend");
     }
 
     #[test]
@@ -178,7 +169,7 @@ mod tests {
             capability: cap(),
             runtime: RuntimeKind::Wasm,
         });
-        assert_eq!(kind, "UnsupportedRuntime");
+        assert_eq!(kind.as_str(), "UnsupportedRuntime");
     }
 
     #[test]
@@ -186,7 +177,7 @@ mod tests {
         let kind = dispatch_error_kind(&DispatchError::Mcp {
             kind: RuntimeDispatchErrorKind::Backend,
         });
-        assert_eq!(kind, "Backend");
+        assert_eq!(kind.as_str(), "Backend");
     }
 
     #[test]
@@ -194,7 +185,7 @@ mod tests {
         let kind = dispatch_error_kind(&DispatchError::Script {
             kind: RuntimeDispatchErrorKind::OutputTooLarge,
         });
-        assert_eq!(kind, "OutputTooLarge");
+        assert_eq!(kind.as_str(), "OutputTooLarge");
     }
 
     #[test]
@@ -202,7 +193,7 @@ mod tests {
         let kind = dispatch_error_kind(&DispatchError::Wasm {
             kind: RuntimeDispatchErrorKind::Memory,
         });
-        assert_eq!(kind, "Memory");
+        assert_eq!(kind.as_str(), "Memory");
     }
 
     #[test]
@@ -210,26 +201,33 @@ mod tests {
         let kind = dispatch_error_kind(&DispatchError::FirstParty {
             kind: RuntimeDispatchErrorKind::UndeclaredCapability,
         });
-        assert_eq!(kind, "UndeclaredCapability");
+        assert_eq!(kind.as_str(), "UndeclaredCapability");
     }
 
     #[test]
-    fn from_dispatch_error_flattens_via_dispatch_error_kind() {
+    fn from_dispatch_error_preserves_top_level_dispatch_kind() {
         let err =
             CapabilityInvocationError::from(DispatchError::UnknownCapability { capability: cap() });
         match err {
-            CapabilityInvocationError::Dispatch { kind } => assert_eq!(kind, "UnknownCapability"),
+            CapabilityInvocationError::Dispatch { kind } => {
+                assert_eq!(kind, DispatchFailureKind::UnknownCapability)
+            }
             other => panic!("expected Dispatch variant, got {other:?}"),
         }
     }
 
     #[test]
-    fn from_dispatch_error_flattens_redacted_runtime_kind() {
+    fn from_dispatch_error_preserves_redacted_runtime_kind() {
         let err = CapabilityInvocationError::from(DispatchError::Wasm {
             kind: RuntimeDispatchErrorKind::Guest,
         });
         match err {
-            CapabilityInvocationError::Dispatch { kind } => assert_eq!(kind, "Guest"),
+            CapabilityInvocationError::Dispatch { kind } => {
+                assert_eq!(
+                    kind,
+                    DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Guest)
+                )
+            }
             other => panic!("expected Dispatch variant, got {other:?}"),
         }
     }

--- a/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
+++ b/crates/ironclaw_capabilities/tests/capability_host_run_state_contract.rs
@@ -856,7 +856,9 @@ async fn capability_host_revokes_claimed_lease_when_dispatch_fails_after_resume(
 
     assert!(matches!(
         err,
-        CapabilityInvocationError::Dispatch { ref kind } if kind == "Backend"
+        CapabilityInvocationError::Dispatch {
+            kind: DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend)
+        }
     ));
     let run = run_state.get(&scope, invocation_id).await.unwrap().unwrap();
     assert_eq!(run.status, RunStatus::Failed);

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -116,6 +116,36 @@ impl std::fmt::Display for RuntimeDispatchErrorKind {
     }
 }
 
+/// Stable, redacted dispatch failure categories surfaced above the neutral dispatch port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchFailureKind {
+    UnknownCapability,
+    UnknownProvider,
+    RuntimeMismatch,
+    MissingRuntimeBackend,
+    UnsupportedRuntime,
+    Runtime(RuntimeDispatchErrorKind),
+}
+
+impl DispatchFailureKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UnknownCapability => "UnknownCapability",
+            Self::UnknownProvider => "UnknownProvider",
+            Self::RuntimeMismatch => "RuntimeMismatch",
+            Self::MissingRuntimeBackend => "MissingRuntimeBackend",
+            Self::UnsupportedRuntime => "UnsupportedRuntime",
+            Self::Runtime(kind) => kind.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Display for DispatchFailureKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
 /// Runtime dispatch failures surfaced through the neutral host API port.
 #[derive(Debug, Error)]
 pub enum DispatchError {
@@ -151,6 +181,22 @@ pub enum DispatchError {
     Wasm { kind: RuntimeDispatchErrorKind },
     #[error("first-party dispatch failed: {kind}")]
     FirstParty { kind: RuntimeDispatchErrorKind },
+}
+
+impl DispatchError {
+    pub const fn failure_kind(&self) -> DispatchFailureKind {
+        match self {
+            Self::UnknownCapability { .. } => DispatchFailureKind::UnknownCapability,
+            Self::UnknownProvider { .. } => DispatchFailureKind::UnknownProvider,
+            Self::RuntimeMismatch { .. } => DispatchFailureKind::RuntimeMismatch,
+            Self::MissingRuntimeBackend { .. } => DispatchFailureKind::MissingRuntimeBackend,
+            Self::UnsupportedRuntime { .. } => DispatchFailureKind::UnsupportedRuntime,
+            Self::Mcp { kind }
+            | Self::Script { kind }
+            | Self::Wasm { kind }
+            | Self::FirstParty { kind } => DispatchFailureKind::Runtime(*kind),
+        }
+    }
 }
 
 /// Interface for already-authorized runtime dispatch.

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -102,6 +102,91 @@ fn local_default_resource_scope_uses_default_agent_and_bootstrap_project() {
 }
 
 #[test]
+fn dispatch_errors_preserve_typed_failure_kind() {
+    let capability = CapabilityId::new("test.cap").unwrap();
+    let provider = ExtensionId::new("test").unwrap();
+
+    assert_eq!(
+        DispatchError::UnknownCapability {
+            capability: capability.clone(),
+        }
+        .failure_kind(),
+        DispatchFailureKind::UnknownCapability
+    );
+    assert_eq!(
+        DispatchError::UnknownProvider {
+            capability: capability.clone(),
+            provider,
+        }
+        .failure_kind(),
+        DispatchFailureKind::UnknownProvider
+    );
+    assert_eq!(
+        DispatchError::RuntimeMismatch {
+            capability: capability.clone(),
+            descriptor_runtime: RuntimeKind::Wasm,
+            package_runtime: RuntimeKind::Mcp,
+        }
+        .failure_kind(),
+        DispatchFailureKind::RuntimeMismatch
+    );
+    assert_eq!(
+        DispatchError::MissingRuntimeBackend {
+            runtime: RuntimeKind::Script,
+        }
+        .failure_kind(),
+        DispatchFailureKind::MissingRuntimeBackend
+    );
+    assert_eq!(
+        DispatchError::UnsupportedRuntime {
+            capability,
+            runtime: RuntimeKind::Wasm,
+        }
+        .failure_kind(),
+        DispatchFailureKind::UnsupportedRuntime
+    );
+    assert_eq!(
+        DispatchError::Wasm {
+            kind: RuntimeDispatchErrorKind::Guest,
+        }
+        .failure_kind(),
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Guest)
+    );
+}
+
+#[test]
+fn dispatch_failure_kind_display_preserves_stable_literals() {
+    assert_eq!(
+        DispatchFailureKind::UnknownCapability.as_str(),
+        "UnknownCapability"
+    );
+    assert_eq!(
+        DispatchFailureKind::UnknownProvider.as_str(),
+        "UnknownProvider"
+    );
+    assert_eq!(
+        DispatchFailureKind::RuntimeMismatch.as_str(),
+        "RuntimeMismatch"
+    );
+    assert_eq!(
+        DispatchFailureKind::MissingRuntimeBackend.as_str(),
+        "MissingRuntimeBackend"
+    );
+    assert_eq!(
+        DispatchFailureKind::UnsupportedRuntime.as_str(),
+        "UnsupportedRuntime"
+    );
+    assert_eq!(
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::NetworkDenied).as_str(),
+        "NetworkDenied"
+    );
+    assert_eq!(
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::NetworkDenied).to_string(),
+        "NetworkDenied"
+    );
+}
+
+#[test]
 fn runtime_dispatch_error_kinds_have_safe_event_tokens() {
     for (kind, token) in [
         (RuntimeDispatchErrorKind::Backend, "backend"),

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -23,8 +23,8 @@ use ironclaw_capabilities::{
 };
 use ironclaw_extensions::{ExtensionPackage, ExtensionRegistry};
 use ironclaw_host_api::{
-    ApprovalRequestId, CapabilityDispatcher, CapabilityId, InvocationId, PackageSource,
-    ResourceScope, RuntimeKind,
+    ApprovalRequestId, CapabilityDispatcher, CapabilityId, DispatchFailureKind, InvocationId,
+    PackageSource, ResourceScope, RuntimeDispatchErrorKind, RuntimeKind,
 };
 use ironclaw_processes::{
     ProcessCancellationRegistry, ProcessError, ProcessHost, ProcessManager, ProcessResultStore,
@@ -1009,33 +1009,54 @@ pub(crate) fn failure_kind_from(error: &CapabilityInvocationError) -> RuntimeFai
         CapabilityInvocationError::Lease(_)
         | CapabilityInvocationError::RunState(_)
         | CapabilityInvocationError::Process(_) => RuntimeFailureKind::Backend,
-        CapabilityInvocationError::Dispatch { kind } => dispatch_kind_to_failure(kind),
+        CapabilityInvocationError::Dispatch { kind } => dispatch_kind_to_failure(*kind),
     }
 }
 
-fn dispatch_kind_to_failure(kind: &str) -> RuntimeFailureKind {
+fn dispatch_kind_to_failure(kind: DispatchFailureKind) -> RuntimeFailureKind {
     match kind {
-        "UnknownCapability"
-        | "UnknownProvider"
-        | "MissingRuntimeBackend"
-        | "UnsupportedRuntime"
-        | "ExtensionRuntimeMismatch" => RuntimeFailureKind::MissingRuntime,
-        "RuntimeMismatch" => RuntimeFailureKind::Backend,
-        "Memory" | "Resource" => RuntimeFailureKind::Resource,
-        "NetworkDenied" => RuntimeFailureKind::Network,
-        "OutputTooLarge" => RuntimeFailureKind::OutputTooLarge,
-        "FilesystemDenied" => RuntimeFailureKind::Authorization,
-        "ExitFailure" => RuntimeFailureKind::Process,
-        "InputEncode" | "OutputDecode" | "InvalidResult" => RuntimeFailureKind::InvalidInput,
-        "Backend"
-        | "Client"
-        | "Executor"
-        | "Guest"
-        | "Manifest"
-        | "MethodMissing"
-        | "UndeclaredCapability"
-        | "UnsupportedRunner" => RuntimeFailureKind::Backend,
-        _ => RuntimeFailureKind::Unknown,
+        DispatchFailureKind::UnknownCapability
+        | DispatchFailureKind::UnknownProvider
+        | DispatchFailureKind::MissingRuntimeBackend
+        | DispatchFailureKind::UnsupportedRuntime => RuntimeFailureKind::MissingRuntime,
+        DispatchFailureKind::RuntimeMismatch => RuntimeFailureKind::Backend,
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExtensionRuntimeMismatch) => {
+            RuntimeFailureKind::MissingRuntime
+        }
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Memory)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Resource) => {
+            RuntimeFailureKind::Resource
+        }
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::NetworkDenied) => {
+            RuntimeFailureKind::Network
+        }
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OutputTooLarge) => {
+            RuntimeFailureKind::OutputTooLarge
+        }
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::FilesystemDenied) => {
+            RuntimeFailureKind::Authorization
+        }
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::ExitFailure) => {
+            RuntimeFailureKind::Process
+        }
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::InputEncode)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::OutputDecode)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::InvalidResult) => {
+            RuntimeFailureKind::InvalidInput
+        }
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Backend)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Client)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Executor)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Guest)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Manifest)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::MethodMissing)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UndeclaredCapability)
+        | DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::UnsupportedRunner) => {
+            RuntimeFailureKind::Backend
+        }
+        DispatchFailureKind::Runtime(RuntimeDispatchErrorKind::Unknown) => {
+            RuntimeFailureKind::Unknown
+        }
     }
 }
 
@@ -1044,25 +1065,21 @@ mod tests {
     //! Pinning tests for the host-runtime failure-kind and sanitized-message
     //! mappings.
     //!
-    //! The dispatch-kind strings come from
-    //! [`ironclaw_host_api::RuntimeDispatchErrorKind::as_str`] and from
-    //! [`ironclaw_capabilities::error::dispatch_error_kind`]. Both are
-    //! treated as part of the public contract surface; if an upstream rename
-    //! drops a string, this module fails closed instead of silently
-    //! degrading to [`RuntimeFailureKind::Unknown`].
+    //! The dispatch failure kinds come from typed
+    //! [`ironclaw_host_api::DispatchFailureKind`] values. Their display
+    //! strings remain part of the public observability contract, but runtime
+    //! failure mapping stays type-directed instead of reparsing strings.
 
     use super::*;
     use ironclaw_capabilities::CapabilityInvocationError;
-    use ironclaw_host_api::{CapabilityId, RuntimeDispatchErrorKind};
+    use ironclaw_host_api::{CapabilityId, DispatchFailureKind, RuntimeDispatchErrorKind};
 
     fn cap() -> CapabilityId {
         CapabilityId::new("test.cap").unwrap()
     }
 
-    fn dispatch(kind: &str) -> CapabilityInvocationError {
-        CapabilityInvocationError::Dispatch {
-            kind: kind.to_string(),
-        }
+    fn dispatch(kind: DispatchFailureKind) -> CapabilityInvocationError {
+        CapabilityInvocationError::Dispatch { kind }
     }
 
     #[test]
@@ -1145,7 +1162,7 @@ mod tests {
             ),
         ];
         for (variant, expected) in cases {
-            let kind = variant.as_str();
+            let kind = DispatchFailureKind::Runtime(*variant);
             let actual = dispatch_kind_to_failure(kind);
             assert_eq!(
                 actual, *expected,
@@ -1155,43 +1172,32 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_kind_to_failure_pins_dispatch_error_top_level_strings() {
-        // These strings come from `dispatch_error_kind` for non-runtime
-        // DispatchError variants (UnknownCapability, UnknownProvider, ...).
+    fn dispatch_kind_to_failure_pins_dispatch_error_top_level_kinds() {
         assert_eq!(
-            dispatch_kind_to_failure("UnknownCapability"),
+            dispatch_kind_to_failure(DispatchFailureKind::UnknownCapability),
             RuntimeFailureKind::MissingRuntime
         );
         assert_eq!(
-            dispatch_kind_to_failure("UnknownProvider"),
+            dispatch_kind_to_failure(DispatchFailureKind::UnknownProvider),
             RuntimeFailureKind::MissingRuntime
         );
         assert_eq!(
-            dispatch_kind_to_failure("MissingRuntimeBackend"),
+            dispatch_kind_to_failure(DispatchFailureKind::MissingRuntimeBackend),
             RuntimeFailureKind::MissingRuntime
         );
         assert_eq!(
-            dispatch_kind_to_failure("UnsupportedRuntime"),
+            dispatch_kind_to_failure(DispatchFailureKind::UnsupportedRuntime),
             RuntimeFailureKind::MissingRuntime
         );
         assert_eq!(
-            dispatch_kind_to_failure("RuntimeMismatch"),
+            dispatch_kind_to_failure(DispatchFailureKind::RuntimeMismatch),
             RuntimeFailureKind::Backend
         );
     }
 
     #[test]
-    fn dispatch_kind_to_failure_unknown_strings_fall_back_to_unknown() {
-        assert_eq!(
-            dispatch_kind_to_failure("some_future_kind_name"),
-            RuntimeFailureKind::Unknown
-        );
-        assert_eq!(dispatch_kind_to_failure(""), RuntimeFailureKind::Unknown);
-    }
-
-    #[test]
     fn failure_kind_from_dispatch_unknown_capability_maps_to_missing_runtime() {
-        let error = dispatch("UnknownCapability");
+        let error = dispatch(DispatchFailureKind::UnknownCapability);
         assert_eq!(
             failure_kind_from(&error),
             RuntimeFailureKind::MissingRuntime
@@ -1209,7 +1215,9 @@ mod tests {
 
     #[test]
     fn sanitized_failure_message_redacts_dispatch_kind_to_stable_form() {
-        let error = dispatch("NetworkDenied");
+        let error = dispatch(DispatchFailureKind::Runtime(
+            RuntimeDispatchErrorKind::NetworkDenied,
+        ));
         let message = sanitized_failure_message(&error).expect("dispatch produces a message");
         // Stable form: relies only on the redacted kind token, never on raw
         // backend strings.


### PR DESCRIPTION
## Summary
- add a typed `DispatchFailureKind` above the neutral dispatch port
- preserve typed dispatch failure identity through `CapabilityInvocationError::Dispatch`
- convert host-runtime failure classification from string reparsing to typed matching

## Architectural improvements
This is the first architectural improvements PR from the Reborn crates architecture review. It deepens the dispatch-failure Module by keeping failure identity typed across the host API → capability host → host runtime seam, while preserving the existing stable display strings for metrics/audit routing.

## Verification
- `cargo test -p ironclaw_host_api --locked`
- `cargo test -p ironclaw_capabilities --locked`
- `cargo test -p ironclaw_host_runtime --no-default-features --locked`
- `cargo clippy -p ironclaw_host_api -p ironclaw_capabilities -p ironclaw_host_runtime --no-default-features --tests --locked -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
