### PR TITLE
fix: upgrade base images to debian trixie, pin image and add to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,26 @@ updates:
           - "wasm-*"
           - "cargo-component*"
 
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: "/cargo"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns:
+          - "*"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,7 @@ updates:
           - "*"
 
   - package-ecosystem: docker
-    directory: "/cargo"
+    directory: "/crates"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #   docker run --env-file .env -p 3000:3000 ironclaw:latest
 
 # Stage 1: Install cargo-chef
-FROM rust:1.92-bookworm AS chef
+FROM rust:1.92-trixie@sha256:f58923369ba295ae1f60bc49d03f2c955a5c93a0b7d49acfb2b2a65bebaf350d AS chef
 
 RUN rustup target add wasm32-wasip2 \
     && cargo install --locked cargo-chef@0.1.77 wasm-tools@1.246.1
@@ -119,7 +119,7 @@ RUN set -eux; \
     [ "$count" -gt 0 ] || { echo "ERROR: No WASM extensions were built"; exit 1; }
 
 # Stage 5a: Shared runtime base
-FROM debian:bookworm-slim AS runtime-base
+FROM debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b AS runtime-base
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -9,7 +9,7 @@
 #   docker run --rm -p 3005:3003 ironclaw-test
 
 # Stage 1: Build (libsql only — no PostgreSQL dependency)
-FROM rust:1.92-slim-bookworm AS builder
+FROM rust:1.92-slim-trixie@sha256:bf3368a992915f128293ac76917ab6e561e4dda883273c8f5c9f6f8ea37a378e AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev cmake gcc g++ \
@@ -32,7 +32,7 @@ COPY wit/ wit/
 RUN cargo build --release --no-default-features --features libsql --bin ironclaw
 
 # Stage 2: Runtime
-FROM debian:bookworm-slim
+FROM debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libssl3 \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -9,7 +9,7 @@
 # The image includes common development tools so workers can build software,
 # run tests, and execute shell commands.
 
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.92-trixie@sha256:f58923369ba295ae1f60bc49d03f2c955a5c93a0b7d49acfb2b2a65bebaf350d AS builder
 
 WORKDIR /build
 COPY . .
@@ -19,7 +19,7 @@ RUN cargo build --release --bin ironclaw
 
 # ---
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
 
 # Install curl first (needed to fetch the GitHub CLI GPG key), then add the
 # gh CLI apt repository, then install all remaining dev tools in one layer.

--- a/crates/Dockerfile.sandbox
+++ b/crates/Dockerfile.sandbox
@@ -30,7 +30,7 @@
 # minor version keeps build-cache hit rates stable across reproducible
 # builds. Override at build time with `--build-arg RUST_VERSION=<v>`.
 ARG RUST_VERSION=1.92
-FROM rust:${RUST_VERSION}-slim-bookworm AS builder
+FROM rust:${RUST_VERSION}-slim-trixie AS builder
 
 WORKDIR /build
 
@@ -57,7 +57,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     && cp target/release/sandbox_daemon /sandbox_daemon
 
 # ── Stage 2: minimal runtime ─────────────────────────────────────────
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b AS runtime
 
 # tini reaps zombies (cargo/python often spawn helpers); the rest are the
 # common build/test toolchain that the LLM is likely to want for any

--- a/crates/Dockerfile.sandbox
+++ b/crates/Dockerfile.sandbox
@@ -26,11 +26,7 @@
 
 # ── Stage 1: build the sandbox_daemon binary ─────────────────────────
 #
-# We compile against the same Rust toolchain the host uses. Pinning to a
-# minor version keeps build-cache hit rates stable across reproducible
-# builds. Override at build time with `--build-arg RUST_VERSION=<v>`.
-ARG RUST_VERSION=1.92
-FROM rust:${RUST_VERSION}-slim-trixie AS builder
+FROM rust:1.92-slim-trixie@sha256:bf3368a992915f128293ac76917ab6e561e4dda883273c8f5c9f6f8ea37a378e AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary

- Update Docker images to use trixie as bookworm stopped receiving updates and security fixes after trixie was released in august 2025
- Pin docker images to follow best practise for reducing supply chain attack risks
- Pin docker images to make them reproducible


## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [X] Security
- [X] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [X] Manual testing: Tested docker build
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->
None

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->
None

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
