### PR TITLE
arch(ws-1): strategy traits alpha - context, capability, model

### DIFF
--- a/crates/ironclaw_agent_loop/src/lib.rs
+++ b/crates/ironclaw_agent_loop/src/lib.rs
@@ -5,8 +5,4 @@
 //! under `docs/reborn/agent-loop-briefs/`.
 
 pub mod state;
-pub mod strategies;
-
-pub use strategies::{
-    CapabilityFilter, CapabilityStrategy, ContextStrategy, ModelPreference, ModelStrategy,
-};
+pub(crate) mod strategies;

--- a/crates/ironclaw_agent_loop/src/lib.rs
+++ b/crates/ironclaw_agent_loop/src/lib.rs
@@ -5,3 +5,8 @@
 //! under `docs/reborn/agent-loop-briefs/`.
 
 pub mod state;
+pub mod strategies;
+
+pub use strategies::{
+    CapabilityFilter, CapabilityStrategy, ContextStrategy, ModelPreference, ModelStrategy,
+};

--- a/crates/ironclaw_agent_loop/src/strategies/capability.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/capability.rs
@@ -14,7 +14,7 @@ use crate::state::LoopExecutionState;
 ///
 /// See `docs/reborn/agent-loop-skeleton.md` section 6.
 #[async_trait]
-pub trait CapabilityStrategy: Send + Sync {
+pub(crate) trait CapabilityStrategy: Send + Sync {
     async fn filter(&self, state: &LoopExecutionState) -> CapabilityFilter;
 }
 
@@ -24,7 +24,7 @@ pub trait CapabilityStrategy: Send + Sync {
 /// scope/grant/auth filters on top; this filter only narrows.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum CapabilityFilter {
+pub(crate) enum CapabilityFilter {
     /// Allow everything the host would otherwise expose.
     #[default]
     All,

--- a/crates/ironclaw_agent_loop/src/strategies/capability.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/capability.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use ironclaw_host_api::CapabilityId;
+
+use crate::state::LoopExecutionState;
+
+/// Decides which capabilities are visible to the model this iteration.
+///
+/// Pure policy: returns a filter the executor passes to the host when
+/// requesting the visible capability surface. Does NOT mutate state.
+///
+/// The host is the source of truth for the catalog and applies its own
+/// scope/grant/auth filters AFTER the strategy filter; the strategy can only
+/// narrow, never expand.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` section 6.
+#[async_trait]
+pub trait CapabilityStrategy: Send + Sync {
+    async fn filter(&self, state: &LoopExecutionState) -> CapabilityFilter;
+}
+
+/// Strategy-side narrowing of the visible capability surface.
+///
+/// Variants are mutually exclusive. The host always applies its own
+/// scope/grant/auth filters on top; this filter only narrows.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityFilter {
+    /// Allow everything the host would otherwise expose.
+    #[default]
+    All,
+    /// Only the capabilities whose IDs appear in the set.
+    AllowOnly(Vec<CapabilityId>),
+    /// Everything except the capabilities whose IDs appear in the set.
+    Deny(Vec<CapabilityId>),
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::CapabilityId;
+
+    use super::{CapabilityFilter, CapabilityStrategy};
+
+    #[allow(dead_code)]
+    fn _check(_: &dyn CapabilityStrategy) {}
+
+    #[test]
+    fn default_filter_allows_all() {
+        assert_eq!(CapabilityFilter::default(), CapabilityFilter::All);
+    }
+
+    #[test]
+    fn filter_round_trips_through_json() {
+        let capability_id = CapabilityId::new("test.echo").expect("valid capability id");
+        let filters = vec![
+            CapabilityFilter::All,
+            CapabilityFilter::AllowOnly(vec![capability_id.clone()]),
+            CapabilityFilter::Deny(vec![capability_id]),
+        ];
+
+        for filter in filters {
+            let encoded = serde_json::to_string(&filter).expect("serialize filter");
+            let decoded: CapabilityFilter =
+                serde_json::from_str(&encoded).expect("deserialize filter");
+            assert_eq!(decoded, filter);
+        }
+    }
+
+    #[test]
+    fn filter_serializes_with_snake_case_wire_form() {
+        let capability_id = CapabilityId::new("test.echo").expect("valid capability id");
+
+        assert_eq!(
+            serde_json::to_string(&CapabilityFilter::All).expect("serialize all"),
+            "\"all\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CapabilityFilter::AllowOnly(vec![capability_id.clone()]))
+                .expect("serialize allow_only"),
+            "{\"allow_only\":[\"test.echo\"]}"
+        );
+        assert_eq!(
+            serde_json::to_string(&CapabilityFilter::Deny(vec![capability_id]))
+                .expect("serialize deny"),
+            "{\"deny\":[\"test.echo\"]}"
+        );
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/capability.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/capability.rs
@@ -18,6 +18,9 @@ pub(crate) trait CapabilityStrategy: Send + Sync {
     async fn filter(&self, state: &LoopExecutionState) -> CapabilityFilter;
 }
 
+#[allow(dead_code)]
+fn _assert_object_safe(_: &dyn CapabilityStrategy) {}
+
 /// Strategy-side narrowing of the visible capability surface.
 ///
 /// Variants are mutually exclusive. The host always applies its own
@@ -38,10 +41,7 @@ pub(crate) enum CapabilityFilter {
 mod tests {
     use ironclaw_host_api::CapabilityId;
 
-    use super::{CapabilityFilter, CapabilityStrategy};
-
-    #[allow(dead_code)]
-    fn _check(_: &dyn CapabilityStrategy) {}
+    use super::CapabilityFilter;
 
     #[test]
     fn default_filter_allows_all() {

--- a/crates/ironclaw_agent_loop/src/strategies/context.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/context.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+use ironclaw_turns::run_profile::LoopPromptBundleRequest;
+
+use crate::state::LoopExecutionState;
+
+/// Decides what context the host should materialize for the next model call.
+///
+/// Pure policy: returns the request value the executor will pass to
+/// `LoopPromptPort::build_prompt_bundle`. Does NOT mutate state.
+///
+/// Inline messages flow through the `inline_messages` field of
+/// `LoopPromptBundleRequest`. There is no separate nudge strategy; loop
+/// families that need nudges extend their context strategy to populate this
+/// field from `state`.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` section 6.
+#[async_trait]
+pub trait ContextStrategy: Send + Sync {
+    async fn plan_context_request(&self, state: &LoopExecutionState) -> LoopPromptBundleRequest;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContextStrategy;
+
+    #[allow(dead_code)]
+    fn _check(_: &dyn ContextStrategy) {}
+}

--- a/crates/ironclaw_agent_loop/src/strategies/context.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/context.rs
@@ -15,7 +15,7 @@ use crate::state::LoopExecutionState;
 ///
 /// See `docs/reborn/agent-loop-skeleton.md` section 6.
 #[async_trait]
-pub trait ContextStrategy: Send + Sync {
+pub(crate) trait ContextStrategy: Send + Sync {
     async fn plan_context_request(&self, state: &LoopExecutionState) -> LoopPromptBundleRequest;
 }
 

--- a/crates/ironclaw_agent_loop/src/strategies/context.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/context.rs
@@ -19,10 +19,5 @@ pub(crate) trait ContextStrategy: Send + Sync {
     async fn plan_context_request(&self, state: &LoopExecutionState) -> LoopPromptBundleRequest;
 }
 
-#[cfg(test)]
-mod tests {
-    use super::ContextStrategy;
-
-    #[allow(dead_code)]
-    fn _check(_: &dyn ContextStrategy) {}
-}
+#[allow(dead_code)]
+fn _assert_object_safe(_: &dyn ContextStrategy) {}

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -1,9 +1,12 @@
-//! Strategy trait contracts for the Reborn agent-loop framework.
+//! Crate-internal strategy trait contracts for the Reborn agent-loop framework.
+
+// WS-1 lands these sealed contracts before WS-4/WS-6 consume them.
+#![allow(dead_code, unused_imports)]
 
 mod capability;
 mod context;
 mod model;
 
-pub use capability::{CapabilityFilter, CapabilityStrategy};
-pub use context::ContextStrategy;
-pub use model::{ModelPreference, ModelStrategy};
+pub(crate) use capability::{CapabilityFilter, CapabilityStrategy};
+pub(crate) use context::ContextStrategy;
+pub(crate) use model::{ModelPreference, ModelStrategy};

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -1,0 +1,9 @@
+//! Strategy trait contracts for the Reborn agent-loop framework.
+
+mod capability;
+mod context;
+mod model;
+
+pub use capability::{CapabilityFilter, CapabilityStrategy};
+pub use context::ContextStrategy;
+pub use model::{ModelPreference, ModelStrategy};

--- a/crates/ironclaw_agent_loop/src/strategies/model.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/model.rs
@@ -14,7 +14,7 @@ use crate::state::LoopExecutionState;
 ///
 /// See `docs/reborn/agent-loop-skeleton.md` section 6.
 #[async_trait]
-pub trait ModelStrategy: Send + Sync {
+pub(crate) trait ModelStrategy: Send + Sync {
     async fn preference(&self, state: &LoopExecutionState) -> ModelPreference;
 }
 
@@ -24,7 +24,7 @@ pub trait ModelStrategy: Send + Sync {
 /// through for the future `ModelRouteChain` follow-up.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ModelPreference {
+pub(crate) enum ModelPreference {
     #[default]
     Primary,
     Fallback {

--- a/crates/ironclaw_agent_loop/src/strategies/model.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/model.rs
@@ -18,26 +18,30 @@ pub(crate) trait ModelStrategy: Send + Sync {
     async fn preference(&self, state: &LoopExecutionState) -> ModelPreference;
 }
 
+#[allow(dead_code)]
+fn _assert_object_safe(_: &dyn ModelStrategy) {}
+
 /// Strategy hint to the host about which already-resolved route to use.
 ///
-/// In the skeleton, `Primary` is the only meaningful value. `Fallback` is wired
-/// through for the future `ModelRouteChain` follow-up.
+/// In the skeleton, `Primary` is the only value strategies produce. `Fallback`
+/// is reserved for the deferred `ModelRouteChain` follow-up.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum ModelPreference {
+    /// Route-chain index 0: the primary route.
     #[default]
     Primary,
     Fallback {
+        /// Deferred route-chain index from `ModelStrategyState::fallback_index`.
+        /// Valid fallback indexes are nonzero; `1` is the first fallback after
+        /// `Primary`.
         index: u32,
     },
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ModelPreference, ModelStrategy};
-
-    #[allow(dead_code)]
-    fn _check(_: &dyn ModelStrategy) {}
+    use super::ModelPreference;
 
     #[test]
     fn default_preference_is_primary() {

--- a/crates/ironclaw_agent_loop/src/strategies/model.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/model.rs
@@ -1,0 +1,62 @@
+use async_trait::async_trait;
+
+use crate::state::LoopExecutionState;
+
+/// Decides which model preference to pass on the next `stream_model` call.
+///
+/// Pure policy: returns a `ModelPreference` the executor includes in
+/// `LoopModelRequest`. Does NOT mutate state.
+///
+/// The actual model the host calls is bound by `LoopRunContext`'s resolved model
+/// route. The strategy's preference is a hint the host may interpret, such as
+/// choosing among already-resolved fallbacks. Strategies cannot introduce new
+/// routes mid-run.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` section 6.
+#[async_trait]
+pub trait ModelStrategy: Send + Sync {
+    async fn preference(&self, state: &LoopExecutionState) -> ModelPreference;
+}
+
+/// Strategy hint to the host about which already-resolved route to use.
+///
+/// In the skeleton, `Primary` is the only meaningful value. `Fallback` is wired
+/// through for the future `ModelRouteChain` follow-up.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelPreference {
+    #[default]
+    Primary,
+    Fallback {
+        index: u32,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ModelPreference, ModelStrategy};
+
+    #[allow(dead_code)]
+    fn _check(_: &dyn ModelStrategy) {}
+
+    #[test]
+    fn default_preference_is_primary() {
+        assert_eq!(ModelPreference::default(), ModelPreference::Primary);
+    }
+
+    #[test]
+    fn preference_round_trips_through_snake_case_json() {
+        let primary = serde_json::to_string(&ModelPreference::Primary).expect("serialize primary");
+        assert_eq!(primary, "\"primary\"");
+        let decoded_primary: ModelPreference =
+            serde_json::from_str(&primary).expect("deserialize primary");
+        assert_eq!(decoded_primary, ModelPreference::Primary);
+
+        let fallback =
+            serde_json::to_string(&ModelPreference::Fallback { index: 2 }).expect("serialize");
+        assert_eq!(fallback, "{\"fallback\":{\"index\":2}}");
+        let decoded_fallback: ModelPreference =
+            serde_json::from_str(&fallback).expect("deserialize fallback");
+        assert_eq!(decoded_fallback, ModelPreference::Fallback { index: 2 });
+    }
+}


### PR DESCRIPTION
## Context

First strategy-trait slice on top of WS0. It introduces the pure request-shaping strategies that decide prompt shape, visible capability filter, and model preference without executing any side effects.

Master spec: `docs/reborn/agent-loop-skeleton.md`
Workstream brief: `docs/reborn/agent-loop-briefs/strategy-traits-alpha.md`
Stack base: `arch/ws-0`

Latest stack maintenance on 2026-05-14:
- Rebased this branch onto its current stack base after the WS0 prompt-authority fix and the follow-up WS8/WS14-parent/WS16/WS17 conflict resolutions.
- Pushed the updated branch with force-with-lease where the remote already existed, or published it as a new branch where it did not.
- Verified the final ancestry chain from `origin/reborn-integration` through WS17 before publishing the PR descriptions.

## What landed

- `ContextStrategy` for producing a `LoopPromptBundleRequest` from immutable loop state.
- `CapabilityStrategy` and capability-filter value types for choosing the already-authorized surface projection the model may see.
- `ModelStrategy` for selecting model preference/route intent at the loop-framework layer.
- Default alpha strategy implementations that model the text-first baseline while keeping host-owned prompt/materialization work outside the strategy crate.
- Sealed/internal strategy access so external crates cannot implement or inject strategy slots.

## Reviewer focus

- The traits should remain policy-only; they should not read files, resolve tools, call models, or mutate durable state.
- Visibility should stay crate-local/internal where the skeleton spec requires built-in-only strategies.
- Context requests should carry selectors and inline-message intent, not materialized prompt text.

## Non-goals / deferred work

- Batching, gates, recovery, stopping, draining, and budget strategies are handled by WS2 and WS3.
- Default planner composition is WS4/WS5.
- Host-backed capability materialization is WS9.

## Validation

- [x] Branch rebased cleanly onto the current WS0.
- [x] Included in `arch/level1-merged` validation: `cargo check -p ironclaw_agent_loop -p ironclaw_reborn`.
- [x] Included in the final stack ancestry verification.

## Stack position

```
[#3550 ws-0] state/checkpoint foundation -> reborn-integration
   |-- #3551 ws-1 strategy alpha -> ws-0
   |-- #3552 ws-2 strategy beta -> ws-0
   |-- #3553 ws-3 strategy gamma -> ws-0
   |-- #3643 ws-3.5 loop family registry -> ws-0
   '-- #3554 level1-merged -> ws-0
         |-- #3555 ws-4 planner facade -> level1
         |-- #3556 ws-5 default strategies -> level1
         '-- #3557 level2-merged -> level1
               '-- #3596 ws-6a canonical executor -> level2
                     '-- #3597 ws-7 PlannedDriver adapter -> ws-6a
                           '-- #3598 ws-8 integration/test support -> ws-7
                                 |-- #3644 ws-9 capability host wiring -> ws-8
                                 |-- #3645 ws-10 checkpoint load/resume -> ws-8
                                 |-- #3646 ws-11 input port -> ws-8
                                 |-- #3647 ws-12 progress port -> ws-8
                                 |-- #3648 ws-13 cancellation accessor -> ws-8
                                 |-- #3649 ws-15 prompt/identity context -> ws-8
                                 '-- #3650 ws-14-parent integrated host ports -> ws-8
                                       '-- #3651 ws-14 planned default registration -> ws-14-parent
                                             '-- #3652 ws-16 live runtime wiring -> ws-14
                                                   '-- #3653 ws-17 product live cutover -> ws-16
```
