### PR TITLE
arch(ws-2): strategy traits beta - batch, gate, recovery

### DIFF
--- a/crates/ironclaw_agent_loop/src/strategies/batch.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/batch.rs
@@ -1,0 +1,106 @@
+//! `BatchPolicyStrategy` — decides whether a capability batch executes
+//! sequentially or in parallel.
+//!
+//! Pure policy and synchronous: the strategy never consults the host and
+//! mutates nothing. Per-capability concurrency hints from descriptors are
+//! authoritative for "this specific call must run alone"; this strategy
+//! decides only the batch-level default.
+//!
+//! See `docs/reborn/agent-loop-skeleton.md` §6 ("Strategy decomposition"
+//! → batch policy) and `contracts/turns-agent-loop.md` §6 (the loop never
+//! sees raw tool input — only the sanitized projection).
+
+use ironclaw_host_api::CapabilityId;
+
+use crate::state::LoopExecutionState;
+
+/// Decides whether a capability batch executes sequentially or in parallel.
+///
+/// `&self` only — the strategy is value-immutable. The host's per-capability
+/// concurrency hints (from descriptors) override this batch-level default
+/// for any individual call that declares itself [`ConcurrencyHint::Exclusive`].
+pub trait BatchPolicyStrategy: Send + Sync {
+    fn policy(&self, state: &LoopExecutionState, calls: &[CapabilityCallSummary]) -> BatchPolicy;
+}
+
+/// Batch-level execution mode. Wire-stable: serialized into checkpoints and
+/// emitted on observability events, so the snake_case names are part of the
+/// public contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchPolicy {
+    Sequential,
+    Parallel,
+}
+
+/// Loop-side projection of one entry in a `CapabilityCalls` batch — name plus
+/// concurrency hint only. The strategy never sees raw args (per
+/// `contracts/turns-agent-loop.md` §6 — sanitization happens at the host port
+/// boundary).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CapabilityCallSummary {
+    pub name: CapabilityId,
+    pub concurrency_hint: ConcurrencyHint,
+}
+
+/// Per-call concurrency hint. The exact source (capability descriptor field,
+/// host call-time annotation, etc.) is the responsibility of the executor
+/// wiring in WS-6 — WS-2 only defines the loop-side projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConcurrencyHint {
+    /// Read-only or otherwise safe to run alongside others in this batch.
+    SafeForParallel,
+    /// Must run alone (filesystem write, shell, exclusive resource).
+    Exclusive,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    /// Compile-time object-safety check. `BatchPolicyStrategy` is pure-sync
+    /// policy, but we still want it usable behind a trait object so the
+    /// executor can hold a heterogeneous strategy stack.
+    #[allow(dead_code)]
+    fn _check(_: &dyn BatchPolicyStrategy) {}
+
+    #[test]
+    fn batch_policy_round_trips_snake_case() {
+        for (variant, wire) in [
+            (BatchPolicy::Sequential, "sequential"),
+            (BatchPolicy::Parallel, "parallel"),
+        ] {
+            let value = serde_json::to_value(variant).expect("serialize");
+            assert_eq!(value, json!(wire));
+            let restored: BatchPolicy = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(restored, variant);
+        }
+    }
+
+    #[test]
+    fn concurrency_hint_round_trips_snake_case() {
+        for (variant, wire) in [
+            (ConcurrencyHint::SafeForParallel, "safe_for_parallel"),
+            (ConcurrencyHint::Exclusive, "exclusive"),
+        ] {
+            let value = serde_json::to_value(variant).expect("serialize");
+            assert_eq!(value, json!(wire));
+            let restored: ConcurrencyHint = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(restored, variant);
+        }
+    }
+
+    #[test]
+    fn capability_call_summary_round_trips() {
+        let summary = CapabilityCallSummary {
+            name: CapabilityId::new("demo.echo").expect("valid"),
+            concurrency_hint: ConcurrencyHint::SafeForParallel,
+        };
+        let value = serde_json::to_value(&summary).expect("serialize");
+        let restored: CapabilityCallSummary = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, summary);
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/batch.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/batch.rs
@@ -24,9 +24,16 @@ pub(crate) trait BatchPolicyStrategy: Send + Sync {
     fn policy(&self, state: &LoopExecutionState, calls: &[CapabilityCallSummary]) -> BatchPolicy;
 }
 
+/// Compile-time object-safety check. `BatchPolicyStrategy` is pure-sync
+/// policy, but we still want it usable behind a trait object so the
+/// executor can hold a heterogeneous strategy stack.
+#[allow(dead_code)]
+fn _batch_policy_strategy_object_safe(_: &dyn BatchPolicyStrategy) {}
+
 /// Batch-level execution mode. Wire-stable: serialized into checkpoints and
 /// emitted on observability events, so the snake_case names are part of the
 /// public contract.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum BatchPolicy {
@@ -49,12 +56,6 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-
-    /// Compile-time object-safety check. `BatchPolicyStrategy` is pure-sync
-    /// policy, but we still want it usable behind a trait object so the
-    /// executor can hold a heterogeneous strategy stack.
-    #[allow(dead_code)]
-    fn _check(_: &dyn BatchPolicyStrategy) {}
 
     #[test]
     fn batch_policy_round_trips_snake_case() {

--- a/crates/ironclaw_agent_loop/src/strategies/batch.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/batch.rs
@@ -11,6 +11,7 @@
 //! sees raw tool input — only the sanitized projection).
 
 use ironclaw_host_api::CapabilityId;
+use ironclaw_turns::run_profile::ConcurrencyHint;
 
 use crate::state::LoopExecutionState;
 
@@ -19,7 +20,7 @@ use crate::state::LoopExecutionState;
 /// `&self` only — the strategy is value-immutable. The host's per-capability
 /// concurrency hints (from descriptors) override this batch-level default
 /// for any individual call that declares itself [`ConcurrencyHint::Exclusive`].
-pub trait BatchPolicyStrategy: Send + Sync {
+pub(crate) trait BatchPolicyStrategy: Send + Sync {
     fn policy(&self, state: &LoopExecutionState, calls: &[CapabilityCallSummary]) -> BatchPolicy;
 }
 
@@ -28,7 +29,7 @@ pub trait BatchPolicyStrategy: Send + Sync {
 /// public contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum BatchPolicy {
+pub(crate) enum BatchPolicy {
     Sequential,
     Parallel,
 }
@@ -38,21 +39,9 @@ pub enum BatchPolicy {
 /// `contracts/turns-agent-loop.md` §6 — sanitization happens at the host port
 /// boundary).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct CapabilityCallSummary {
-    pub name: CapabilityId,
-    pub concurrency_hint: ConcurrencyHint,
-}
-
-/// Per-call concurrency hint. The exact source (capability descriptor field,
-/// host call-time annotation, etc.) is the responsibility of the executor
-/// wiring in WS-6 — WS-2 only defines the loop-side projection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ConcurrencyHint {
-    /// Read-only or otherwise safe to run alongside others in this batch.
-    SafeForParallel,
-    /// Must run alone (filesystem write, shell, exclusive resource).
-    Exclusive,
+pub(crate) struct CapabilityCallSummary {
+    pub(crate) name: CapabilityId,
+    pub(crate) concurrency_hint: ConcurrencyHint,
 }
 
 #[cfg(test)]
@@ -76,19 +65,6 @@ mod tests {
             let value = serde_json::to_value(variant).expect("serialize");
             assert_eq!(value, json!(wire));
             let restored: BatchPolicy = serde_json::from_value(value).expect("deserialize");
-            assert_eq!(restored, variant);
-        }
-    }
-
-    #[test]
-    fn concurrency_hint_round_trips_snake_case() {
-        for (variant, wire) in [
-            (ConcurrencyHint::SafeForParallel, "safe_for_parallel"),
-            (ConcurrencyHint::Exclusive, "exclusive"),
-        ] {
-            let value = serde_json::to_value(variant).expect("serialize");
-            assert_eq!(value, json!(wire));
-            let restored: ConcurrencyHint = serde_json::from_value(value).expect("deserialize");
             assert_eq!(restored, variant);
         }
     }

--- a/crates/ironclaw_agent_loop/src/strategies/gate.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/gate.rs
@@ -1,7 +1,7 @@
 //! `GateHandlingStrategy` — decides what to do when a capability invocation
 //! returns a gate (Approval, Auth, or Resource).
 //!
-//! Mutates `control_state` (e.g. record gate fingerprints for resume).
+//! Mutates `gate_state` (e.g. record gate fingerprints for resume).
 //! Async because future strategies may consult host state for grant-history
 //! or auth-flow lookups.
 //!
@@ -14,15 +14,15 @@
 use async_trait::async_trait;
 use ironclaw_turns::{LoopFailureKind, LoopGateRef};
 
-use crate::state::{ControlStrategyState, LoopExecutionState};
+use crate::state::{GateStrategyState, LoopExecutionState};
 
 /// Decides what to do when a capability invocation comes back with a gate.
 ///
-/// `&self` only — strategies are value-immutable. The new `control_state`
+/// `&self` only — strategies are value-immutable. The new `gate_state`
 /// slot value is carried in the returned [`GateOutcome`]; the executor
 /// swaps it into the next whole state.
 #[async_trait]
-pub trait GateHandlingStrategy: Send + Sync {
+pub(crate) trait GateHandlingStrategy: Send + Sync {
     async fn handle(&self, state: &LoopExecutionState, gate: &GateSummary) -> GateOutcome;
 }
 
@@ -31,22 +31,22 @@ pub trait GateHandlingStrategy: Send + Sync {
 /// `contracts/turns-agent-loop.md` §6 + `contracts/lightweight-agent-loop.md`
 /// §8).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct GateSummary {
-    pub kind: GateKind,
-    pub gate_ref: LoopGateRef,
+pub(crate) struct GateSummary {
+    pub(crate) kind: GateKind,
+    pub(crate) gate_ref: LoopGateRef,
 }
 
 /// Wire-stable gate classification. Snake_case names are part of the public
 /// contract — they appear in checkpoints and observability events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum GateKind {
+pub(crate) enum GateKind {
     Approval,
     Auth,
     Resource,
 }
 
-/// Strategy decision for a gate, plus the new `control_state` slot value.
+/// Strategy decision for a gate, plus the new `gate_state` slot value.
 ///
 /// Variants:
 /// - `Block` — the executor checkpoints (`BeforeBlock`) and returns
@@ -57,15 +57,15 @@ pub enum GateKind {
 /// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "outcome")]
-pub enum GateOutcome {
+pub(crate) enum GateOutcome {
     Block {
-        control: ControlStrategyState,
+        gate: GateStrategyState,
     },
     SkipAndContinue {
-        control: ControlStrategyState,
+        gate: GateStrategyState,
     },
     Abort {
-        control: ControlStrategyState,
+        gate: GateStrategyState,
         failure_kind: LoopFailureKind,
     },
 }
@@ -78,12 +78,8 @@ mod tests {
     #[allow(dead_code)]
     fn _check(_: &dyn GateHandlingStrategy) {}
 
-    fn sample_control() -> ControlStrategyState {
-        ControlStrategyState {
-            turns_completed: 3,
-            terminate_hints_in_last_batch: 1,
-            last_batch_total: 4,
-        }
+    fn sample_gate() -> GateStrategyState {
+        GateStrategyState::default()
     }
 
     #[test]
@@ -112,52 +108,50 @@ mod tests {
     }
 
     #[test]
-    fn gate_outcome_block_carries_control_slot() {
+    fn gate_outcome_block_carries_gate_slot() {
         let outcome = GateOutcome::Block {
-            control: sample_control(),
+            gate: sample_gate(),
         };
         let value = serde_json::to_value(&outcome).expect("serialize");
+        assert_eq!(value["gate"], serde_json::json!({}));
         let restored: GateOutcome = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, outcome);
-        // Field is named `control` and is the strategy slot type.
+        // Field is named `gate` and is the strategy slot type.
         match restored {
-            GateOutcome::Block { control } => assert_eq!(control, sample_control()),
+            GateOutcome::Block { gate } => assert_eq!(gate, sample_gate()),
             other => panic!("unexpected variant: {other:?}"),
         }
     }
 
     #[test]
-    fn gate_outcome_skip_and_continue_carries_control_slot() {
+    fn gate_outcome_skip_and_continue_carries_gate_slot() {
         let outcome = GateOutcome::SkipAndContinue {
-            control: sample_control(),
+            gate: sample_gate(),
         };
         let value = serde_json::to_value(&outcome).expect("serialize");
+        assert_eq!(value["gate"], serde_json::json!({}));
         let restored: GateOutcome = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, outcome);
         match restored {
-            GateOutcome::SkipAndContinue { control } => {
-                assert_eq!(control, sample_control())
-            }
+            GateOutcome::SkipAndContinue { gate } => assert_eq!(gate, sample_gate()),
             other => panic!("unexpected variant: {other:?}"),
         }
     }
 
     #[test]
-    fn gate_outcome_abort_carries_control_slot_and_failure_kind() {
+    fn gate_outcome_abort_carries_gate_slot_and_failure_kind() {
         let outcome = GateOutcome::Abort {
-            control: sample_control(),
-            failure_kind: LoopFailureKind::DriverBug,
+            gate: sample_gate(),
+            failure_kind: LoopFailureKind::PolicyDenied,
         };
         let value = serde_json::to_value(&outcome).expect("serialize");
+        assert_eq!(value["gate"], serde_json::json!({}));
         let restored: GateOutcome = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, outcome);
         match restored {
-            GateOutcome::Abort {
-                control,
-                failure_kind,
-            } => {
-                assert_eq!(control, sample_control());
-                assert_eq!(failure_kind, LoopFailureKind::DriverBug);
+            GateOutcome::Abort { gate, failure_kind } => {
+                assert_eq!(gate, sample_gate());
+                assert_eq!(failure_kind, LoopFailureKind::PolicyDenied);
             }
             other => panic!("unexpected variant: {other:?}"),
         }

--- a/crates/ironclaw_agent_loop/src/strategies/gate.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/gate.rs
@@ -1,0 +1,165 @@
+//! `GateHandlingStrategy` — decides what to do when a capability invocation
+//! returns a gate (Approval, Auth, or Resource).
+//!
+//! Mutates `control_state` (e.g. record gate fingerprints for resume).
+//! Async because future strategies may consult host state for grant-history
+//! or auth-flow lookups.
+//!
+//! See `docs/reborn/agent-loop-skeleton.md` §6 ("Strategy decomposition" →
+//! gate handling) and §8 ("Outcome enums"). Sanitization at the host port
+//! boundary (per master doc §9 + `contracts/turns-agent-loop.md` §6 +
+//! `contracts/lightweight-agent-loop.md` §8) means strategies never see
+//! raw input, secrets, or auth state.
+
+use async_trait::async_trait;
+use ironclaw_turns::{LoopFailureKind, LoopGateRef};
+
+use crate::state::{ControlStrategyState, LoopExecutionState};
+
+/// Decides what to do when a capability invocation comes back with a gate.
+///
+/// `&self` only — strategies are value-immutable. The new `control_state`
+/// slot value is carried in the returned [`GateOutcome`]; the executor
+/// swaps it into the next whole state.
+#[async_trait]
+pub trait GateHandlingStrategy: Send + Sync {
+    async fn handle(&self, state: &LoopExecutionState, gate: &GateSummary) -> GateOutcome;
+}
+
+/// Loop-side projection of a host capability gate — kind + opaque ref only.
+/// The strategy never sees raw input, secrets, or auth state (per
+/// `contracts/turns-agent-loop.md` §6 + `contracts/lightweight-agent-loop.md`
+/// §8).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct GateSummary {
+    pub kind: GateKind,
+    pub gate_ref: LoopGateRef,
+}
+
+/// Wire-stable gate classification. Snake_case names are part of the public
+/// contract — they appear in checkpoints and observability events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GateKind {
+    Approval,
+    Auth,
+    Resource,
+}
+
+/// Strategy decision for a gate, plus the new `control_state` slot value.
+///
+/// Variants:
+/// - `Block` — the executor checkpoints (`BeforeBlock`) and returns
+///   `LoopExit::Blocked`. The standard production path.
+/// - `SkipAndContinue` — drop this call's result entirely and proceed with
+///   the rest of the batch. Use sparingly; intended for fire-and-forget
+///   tools where a missing approval is non-fatal.
+/// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "outcome")]
+pub enum GateOutcome {
+    Block {
+        control: ControlStrategyState,
+    },
+    SkipAndContinue {
+        control: ControlStrategyState,
+    },
+    Abort {
+        control: ControlStrategyState,
+        failure_kind: LoopFailureKind,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time object-safety check.
+    #[allow(dead_code)]
+    fn _check(_: &dyn GateHandlingStrategy) {}
+
+    fn sample_control() -> ControlStrategyState {
+        ControlStrategyState {
+            turns_completed: 3,
+            terminate_hints_in_last_batch: 1,
+            last_batch_total: 4,
+        }
+    }
+
+    #[test]
+    fn gate_kind_round_trips_snake_case() {
+        for (variant, wire) in [
+            (GateKind::Approval, "approval"),
+            (GateKind::Auth, "auth"),
+            (GateKind::Resource, "resource"),
+        ] {
+            let value = serde_json::to_value(variant).expect("serialize");
+            assert_eq!(value, serde_json::json!(wire));
+            let restored: GateKind = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(restored, variant);
+        }
+    }
+
+    #[test]
+    fn gate_summary_round_trips() {
+        let summary = GateSummary {
+            kind: GateKind::Approval,
+            gate_ref: LoopGateRef::new("gate:approval-demo").expect("valid"),
+        };
+        let value = serde_json::to_value(&summary).expect("serialize");
+        let restored: GateSummary = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, summary);
+    }
+
+    #[test]
+    fn gate_outcome_block_carries_control_slot() {
+        let outcome = GateOutcome::Block {
+            control: sample_control(),
+        };
+        let value = serde_json::to_value(&outcome).expect("serialize");
+        let restored: GateOutcome = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, outcome);
+        // Field is named `control` and is the strategy slot type.
+        match restored {
+            GateOutcome::Block { control } => assert_eq!(control, sample_control()),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gate_outcome_skip_and_continue_carries_control_slot() {
+        let outcome = GateOutcome::SkipAndContinue {
+            control: sample_control(),
+        };
+        let value = serde_json::to_value(&outcome).expect("serialize");
+        let restored: GateOutcome = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, outcome);
+        match restored {
+            GateOutcome::SkipAndContinue { control } => {
+                assert_eq!(control, sample_control())
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gate_outcome_abort_carries_control_slot_and_failure_kind() {
+        let outcome = GateOutcome::Abort {
+            control: sample_control(),
+            failure_kind: LoopFailureKind::DriverBug,
+        };
+        let value = serde_json::to_value(&outcome).expect("serialize");
+        let restored: GateOutcome = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, outcome);
+        match restored {
+            GateOutcome::Abort {
+                control,
+                failure_kind,
+            } => {
+                assert_eq!(control, sample_control());
+                assert_eq!(failure_kind, LoopFailureKind::DriverBug);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/gate.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/gate.rs
@@ -26,6 +26,10 @@ pub(crate) trait GateHandlingStrategy: Send + Sync {
     async fn handle(&self, state: &LoopExecutionState, gate: &GateSummary) -> GateOutcome;
 }
 
+/// Compile-time object-safety check.
+#[allow(dead_code)]
+fn _gate_handling_strategy_object_safe(_: &dyn GateHandlingStrategy) {}
+
 /// Loop-side projection of a host capability gate — kind + opaque ref only.
 /// The strategy never sees raw input, secrets, or auth state (per
 /// `contracts/turns-agent-loop.md` §6 + `contracts/lightweight-agent-loop.md`
@@ -38,6 +42,7 @@ pub(crate) struct GateSummary {
 
 /// Wire-stable gate classification. Snake_case names are part of the public
 /// contract — they appear in checkpoints and observability events.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum GateKind {
@@ -55,6 +60,7 @@ pub(crate) enum GateKind {
 ///   the rest of the batch. Use sparingly; intended for fire-and-forget
 ///   tools where a missing approval is non-fatal.
 /// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "outcome")]
 pub(crate) enum GateOutcome {
@@ -70,13 +76,22 @@ pub(crate) enum GateOutcome {
     },
 }
 
+impl GateOutcome {
+    /// Validate the outcome against the originating gate kind before an
+    /// executor honors it. WS-6 executor code must call this first.
+    pub(crate) fn validate_for_gate_kind(&self, kind: GateKind) -> Result<(), LoopFailureKind> {
+        match (kind, self) {
+            (GateKind::Approval, GateOutcome::SkipAndContinue { .. }) => {
+                Err(LoopFailureKind::DriverBug)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Compile-time object-safety check.
-    #[allow(dead_code)]
-    fn _check(_: &dyn GateHandlingStrategy) {}
 
     fn sample_gate() -> GateStrategyState {
         GateStrategyState::default()
@@ -155,5 +170,25 @@ mod tests {
             }
             other => panic!("unexpected variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn approval_gate_rejects_skip_and_continue_outcome() {
+        let outcome = GateOutcome::SkipAndContinue {
+            gate: sample_gate(),
+        };
+        assert_eq!(
+            outcome.validate_for_gate_kind(GateKind::Approval),
+            Err(LoopFailureKind::DriverBug)
+        );
+    }
+
+    #[test]
+    fn auth_and_resource_gates_allow_skip_and_continue_outcome() {
+        let outcome = GateOutcome::SkipAndContinue {
+            gate: sample_gate(),
+        };
+        assert_eq!(outcome.validate_for_gate_kind(GateKind::Auth), Ok(()));
+        assert_eq!(outcome.validate_for_gate_kind(GateKind::Resource), Ok(()));
     }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -36,6 +36,7 @@ pub(crate) use gate::{GateHandlingStrategy, GateKind, GateOutcome, GateSummary};
 pub(crate) use ironclaw_turns::run_profile::ConcurrencyHint;
 pub(crate) use model::{ModelPreference, ModelStrategy};
 pub(crate) use recovery::{
-    CapabilityErrorClass, CapabilityErrorSummary, ModelErrorClass, ModelErrorSummary,
-    RecoveryOutcome, RecoveryStrategy, RetryAlteration, SanitizedStrategySummary,
+    BackoffDelayMs, CapabilityErrorClass, CapabilityErrorSummary, ModelErrorClass,
+    ModelErrorSummary, RecoveryOutcome, RecoveryStrategy, RetryAlteration, RetryScope,
+    SanitizedStrategySummary,
 };

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -20,12 +20,13 @@ pub(crate) mod gate;
 mod model;
 pub(crate) mod recovery;
 
-pub use batch::{BatchPolicy, BatchPolicyStrategy, CapabilityCallSummary, ConcurrencyHint};
+pub(crate) use batch::{BatchPolicy, BatchPolicyStrategy, CapabilityCallSummary};
 pub(crate) use capability::{CapabilityFilter, CapabilityStrategy};
 pub(crate) use context::ContextStrategy;
-pub use gate::{GateHandlingStrategy, GateKind, GateOutcome, GateSummary};
+pub(crate) use gate::{GateHandlingStrategy, GateKind, GateOutcome, GateSummary};
+pub(crate) use ironclaw_turns::run_profile::ConcurrencyHint;
 pub(crate) use model::{ModelPreference, ModelStrategy};
-pub use recovery::{
+pub(crate) use recovery::{
     CapabilityErrorClass, CapabilityErrorSummary, ModelErrorClass, ModelErrorSummary,
     RecoveryOutcome, RecoveryStrategy, RetryAlteration,
 };

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -8,6 +8,15 @@
 //! WS-2 lands the trait stubs and outcome enums for the batch / gate /
 //! recovery axis. `Default*` impls land in WS-5; the executor body that
 //! consumes these outcomes lands in WS-6.
+//!
+//! Checkpoint/observability wire enums are `#[non_exhaustive]`; later
+//! workstreams should extend them without forcing consumers to assume the
+//! current variants are closed.
+//!
+//! Pure policy traits with no host or future host consult may stay sync.
+//! Gate and recovery traits are async because they can consult host/runtime
+//! state such as grant history, auth flow status, route health, or
+//! circuit-breaker counters.
 
 // WS-1/2 land crate-internal contracts before WS-4/5/6 compose and execute
 // them. Keep the unused lint local to these forward-declared contracts.
@@ -28,5 +37,5 @@ pub(crate) use ironclaw_turns::run_profile::ConcurrencyHint;
 pub(crate) use model::{ModelPreference, ModelStrategy};
 pub(crate) use recovery::{
     CapabilityErrorClass, CapabilityErrorSummary, ModelErrorClass, ModelErrorSummary,
-    RecoveryOutcome, RecoveryStrategy, RetryAlteration,
+    RecoveryOutcome, RecoveryStrategy, RetryAlteration, SanitizedStrategySummary,
 };

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -1,12 +1,31 @@
-//! Crate-internal strategy trait contracts for the Reborn agent-loop framework.
+//! Strategy trait contracts for the Reborn agent loop.
+//!
+//! Each strategy receives `&LoopExecutionState` and returns an outcome enum
+//! that carries the new value of its own slot. The executor swaps the slot
+//! into the next whole state. See `docs/reborn/agent-loop-skeleton.md` §6
+//! ("Strategy decomposition") and §8 ("Outcome enums").
+//!
+//! WS-2 lands the trait stubs and outcome enums for the batch / gate /
+//! recovery axis. `Default*` impls land in WS-5; the executor body that
+//! consumes these outcomes lands in WS-6.
 
-// WS-1 lands these sealed contracts before WS-4/WS-6 consume them.
+// WS-1/2 land crate-internal contracts before WS-4/5/6 compose and execute
+// them. Keep the unused lint local to these forward-declared contracts.
 #![allow(dead_code, unused_imports)]
 
+pub(crate) mod batch;
 mod capability;
 mod context;
+pub(crate) mod gate;
 mod model;
+pub(crate) mod recovery;
 
+pub use batch::{BatchPolicy, BatchPolicyStrategy, CapabilityCallSummary, ConcurrencyHint};
 pub(crate) use capability::{CapabilityFilter, CapabilityStrategy};
 pub(crate) use context::ContextStrategy;
+pub use gate::{GateHandlingStrategy, GateKind, GateOutcome, GateSummary};
 pub(crate) use model::{ModelPreference, ModelStrategy};
+pub use recovery::{
+    CapabilityErrorClass, CapabilityErrorSummary, ModelErrorClass, ModelErrorSummary,
+    RecoveryOutcome, RecoveryStrategy, RetryAlteration,
+};

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -36,6 +36,25 @@ pub(crate) trait RecoveryStrategy: Send + Sync {
     ) -> RecoveryOutcome;
 }
 
+/// Compile-time object-safety check.
+#[allow(dead_code)]
+fn _recovery_strategy_object_safe(_: &dyn RecoveryStrategy) {}
+
+/// Sanitized, strategy-visible error summary text.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub(crate) struct SanitizedStrategySummary(String);
+
+impl SanitizedStrategySummary {
+    pub(crate) fn from_trusted_static(summary: &'static str) -> Self {
+        Self(summary.to_string())
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Sanitized capability error — class + safe summary string + opaque
 /// diagnostic ref. Strategies never see raw provider errors, host paths,
 /// or secrets (sanitization happens at the host port boundary, per master
@@ -43,20 +62,27 @@ pub(crate) trait RecoveryStrategy: Send + Sync {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct CapabilityErrorSummary {
     pub(crate) class: CapabilityErrorClass,
-    pub(crate) safe_summary: String,
+    pub(crate) safe_summary: SanitizedStrategySummary,
     pub(crate) diagnostic_ref: Option<LoopDiagnosticRef>,
 }
 
 /// Wire-stable capability error classification. Snake_case names appear in
 /// checkpoints and observability events.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum CapabilityErrorClass {
+    /// Retryable capability-side failure such as timeout or temporary outage.
     Transient,
+    /// Non-retryable capability-side failure.
     Permanent,
+    /// Host rejected malformed capability input.
     InputInvalid,
+    /// Host policy denied the capability call.
     PolicyDenied,
+    /// Capability provider or backing service is unavailable.
     Unavailable,
+    /// Capability host failed internally without safe caller detail.
     Internal,
 }
 
@@ -64,18 +90,24 @@ pub(crate) enum CapabilityErrorClass {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ModelErrorSummary {
     pub(crate) class: ModelErrorClass,
-    pub(crate) safe_summary: String,
+    pub(crate) safe_summary: SanitizedStrategySummary,
     pub(crate) diagnostic_ref: Option<LoopDiagnosticRef>,
 }
 
 /// Wire-stable model error classification.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum ModelErrorClass {
+    /// Retryable model/provider failure such as timeout or temporary outage.
     Transient,
+    /// Prompt/context exceeded the selected model's limits.
     ContextOverflow,
+    /// Provider rejected or filtered the content.
     ContentFiltered,
+    /// Model route, credentials, or provider is unavailable.
     Unavailable,
+    /// Model gateway failed internally without safe caller detail.
     Internal,
 }
 
@@ -86,6 +118,7 @@ pub(crate) enum ModelErrorClass {
 ///   iteration-level retry; `alter` carries the strategy's hint).
 /// - `SkipResult` — drop this result and continue the batch.
 /// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "outcome")]
 pub(crate) enum RecoveryOutcome {
@@ -105,13 +138,14 @@ pub(crate) enum RecoveryOutcome {
 /// Strategy hint about WHAT to alter on retry. Skeleton supports prompt-shape
 /// alterations only; model-route swap is reserved for the deferred
 /// `ModelRouteChain` follow-up (master doc §9).
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "alteration")]
 pub(crate) enum RetryAlteration {
     /// Shrink context for the next attempt (e.g. on context-overflow).
     ShrinkContext { drop_messages: u32 },
     /// Backoff before retry (executor honors as a sleep).
-    Backoff { delay: std::time::Duration },
+    Backoff { delay_ms: u64 },
     /// Reserved for future `ModelRouteChain` landing. Skeleton executor MUST
     /// reject this alteration with `LoopFailureKind::DriverBug` until the
     /// chain mechanism lands.
@@ -120,16 +154,20 @@ pub(crate) enum RetryAlteration {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use super::*;
-
-    /// Compile-time object-safety check.
-    #[allow(dead_code)]
-    fn _check(_: &dyn RecoveryStrategy) {}
 
     fn sample_recovery() -> RecoveryStrategyState {
         RecoveryStrategyState { attempts: 2 }
+    }
+
+    #[test]
+    fn sanitized_strategy_summary_serializes_as_string() {
+        let summary = SanitizedStrategySummary::from_trusted_static("provider unavailable");
+        let value = serde_json::to_value(&summary).expect("serialize");
+        assert_eq!(value, serde_json::json!("provider unavailable"));
+        let restored: SanitizedStrategySummary =
+            serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored.as_str(), "provider unavailable");
     }
 
     #[test]
@@ -170,24 +208,34 @@ mod tests {
     fn capability_error_summary_round_trips() {
         let summary = CapabilityErrorSummary {
             class: CapabilityErrorClass::Transient,
-            safe_summary: "upstream timed out".to_string(),
+            safe_summary: SanitizedStrategySummary::from_trusted_static("upstream timed out"),
             diagnostic_ref: Some(LoopDiagnosticRef::new("diag:cap-1").expect("valid")),
         };
         let value = serde_json::to_value(&summary).expect("serialize");
+        assert_eq!(
+            value["safe_summary"],
+            serde_json::json!("upstream timed out")
+        );
         let restored: CapabilityErrorSummary = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, summary);
+        assert_eq!(restored.safe_summary.as_str(), "upstream timed out");
     }
 
     #[test]
     fn model_error_summary_round_trips() {
         let summary = ModelErrorSummary {
             class: ModelErrorClass::ContextOverflow,
-            safe_summary: "context window exceeded".to_string(),
+            safe_summary: SanitizedStrategySummary::from_trusted_static("context window exceeded"),
             diagnostic_ref: None,
         };
         let value = serde_json::to_value(&summary).expect("serialize");
+        assert_eq!(
+            value["safe_summary"],
+            serde_json::json!("context window exceeded")
+        );
         let restored: ModelErrorSummary = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, summary);
+        assert_eq!(restored.safe_summary.as_str(), "context window exceeded");
     }
 
     #[test]
@@ -206,15 +254,14 @@ mod tests {
 
     #[test]
     fn retry_alteration_backoff_round_trips() {
-        let alteration = RetryAlteration::Backoff {
-            delay: Duration::from_millis(250),
-        };
+        let alteration = RetryAlteration::Backoff { delay_ms: 250 };
         let value = serde_json::to_value(&alteration).expect("serialize");
+        assert_eq!(value["delay_ms"], serde_json::json!(250));
         let restored: RetryAlteration = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, alteration);
         match restored {
-            RetryAlteration::Backoff { delay } => {
-                assert_eq!(delay, Duration::from_millis(250))
+            RetryAlteration::Backoff { delay_ms } => {
+                assert_eq!(delay_ms, 250)
             }
             other => panic!("unexpected variant: {other:?}"),
         }

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -1,0 +1,288 @@
+//! `RecoveryStrategy` — decides what to do when a capability call OR a model
+//! call fails with a (sanitized) error summary.
+//!
+//! Mutates `recovery_state` (attempt counters, fallback advance bookkeeping).
+//! Async because future strategies may consult host state for circuit-breaker
+//! counters, route health, etc.
+//!
+//! See `docs/reborn/agent-loop-skeleton.md` §6 ("Strategy decomposition" →
+//! recovery) and §9 ("Sanitization at the host port boundary"). Strategies
+//! never see raw provider errors, host paths, or secrets — sanitization
+//! happens at the host port.
+
+use async_trait::async_trait;
+use ironclaw_turns::{LoopDiagnosticRef, LoopFailureKind};
+
+use crate::state::{LoopExecutionState, RecoveryStrategyState};
+
+/// Decides what to do when a capability call OR a model call fails with a
+/// (sanitized) error summary.
+///
+/// `&self` only — strategies are value-immutable. The new `recovery_state`
+/// slot value is carried in the returned [`RecoveryOutcome`]; the executor
+/// swaps it into the next whole state.
+#[async_trait]
+pub trait RecoveryStrategy: Send + Sync {
+    async fn on_capability_error(
+        &self,
+        state: &LoopExecutionState,
+        err: &CapabilityErrorSummary,
+    ) -> RecoveryOutcome;
+
+    async fn on_model_error(
+        &self,
+        state: &LoopExecutionState,
+        err: &ModelErrorSummary,
+    ) -> RecoveryOutcome;
+}
+
+/// Sanitized capability error — class + safe summary string + opaque
+/// diagnostic ref. Strategies never see raw provider errors, host paths,
+/// or secrets (sanitization happens at the host port boundary, per master
+/// doc §9).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CapabilityErrorSummary {
+    pub class: CapabilityErrorClass,
+    pub safe_summary: String,
+    pub diagnostic_ref: Option<LoopDiagnosticRef>,
+}
+
+/// Wire-stable capability error classification. Snake_case names appear in
+/// checkpoints and observability events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityErrorClass {
+    Transient,
+    Permanent,
+    InputInvalid,
+    PolicyDenied,
+    Unavailable,
+    Internal,
+}
+
+/// Sanitized model error — class + safe summary + opaque diagnostic ref.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ModelErrorSummary {
+    pub class: ModelErrorClass,
+    pub safe_summary: String,
+    pub diagnostic_ref: Option<LoopDiagnosticRef>,
+}
+
+/// Wire-stable model error classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelErrorClass {
+    Transient,
+    ContextOverflow,
+    ContentFiltered,
+    Unavailable,
+    Internal,
+}
+
+/// Strategy decision plus the new `recovery_state` slot value.
+///
+/// Variants:
+/// - `Retry` — re-issue (the executor decides whether call-level or
+///   iteration-level retry; `alter` carries the strategy's hint).
+/// - `SkipResult` — drop this result and continue the batch.
+/// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "outcome")]
+pub enum RecoveryOutcome {
+    Retry {
+        recovery: RecoveryStrategyState,
+        alter: Option<RetryAlteration>,
+    },
+    SkipResult {
+        recovery: RecoveryStrategyState,
+    },
+    Abort {
+        recovery: RecoveryStrategyState,
+        failure_kind: LoopFailureKind,
+    },
+}
+
+/// Strategy hint about WHAT to alter on retry. Skeleton supports prompt-shape
+/// alterations only; model-route swap is reserved for the deferred
+/// `ModelRouteChain` follow-up (master doc §9).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "alteration")]
+pub enum RetryAlteration {
+    /// Shrink context for the next attempt (e.g. on context-overflow).
+    ShrinkContext { drop_messages: u32 },
+    /// Backoff before retry (executor honors as a sleep).
+    Backoff { delay: std::time::Duration },
+    /// Reserved for future `ModelRouteChain` landing. Skeleton executor MUST
+    /// reject this alteration with `LoopFailureKind::DriverBug` until the
+    /// chain mechanism lands.
+    AdvanceFallback,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Compile-time object-safety check.
+    #[allow(dead_code)]
+    fn _check(_: &dyn RecoveryStrategy) {}
+
+    fn sample_recovery() -> RecoveryStrategyState {
+        RecoveryStrategyState { attempts: 2 }
+    }
+
+    #[test]
+    fn capability_error_class_round_trips_snake_case() {
+        for (variant, wire) in [
+            (CapabilityErrorClass::Transient, "transient"),
+            (CapabilityErrorClass::Permanent, "permanent"),
+            (CapabilityErrorClass::InputInvalid, "input_invalid"),
+            (CapabilityErrorClass::PolicyDenied, "policy_denied"),
+            (CapabilityErrorClass::Unavailable, "unavailable"),
+            (CapabilityErrorClass::Internal, "internal"),
+        ] {
+            let value = serde_json::to_value(variant).expect("serialize");
+            assert_eq!(value, serde_json::json!(wire));
+            let restored: CapabilityErrorClass =
+                serde_json::from_value(value).expect("deserialize");
+            assert_eq!(restored, variant);
+        }
+    }
+
+    #[test]
+    fn model_error_class_round_trips_snake_case() {
+        for (variant, wire) in [
+            (ModelErrorClass::Transient, "transient"),
+            (ModelErrorClass::ContextOverflow, "context_overflow"),
+            (ModelErrorClass::ContentFiltered, "content_filtered"),
+            (ModelErrorClass::Unavailable, "unavailable"),
+            (ModelErrorClass::Internal, "internal"),
+        ] {
+            let value = serde_json::to_value(variant).expect("serialize");
+            assert_eq!(value, serde_json::json!(wire));
+            let restored: ModelErrorClass = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(restored, variant);
+        }
+    }
+
+    #[test]
+    fn capability_error_summary_round_trips() {
+        let summary = CapabilityErrorSummary {
+            class: CapabilityErrorClass::Transient,
+            safe_summary: "upstream timed out".to_string(),
+            diagnostic_ref: Some(LoopDiagnosticRef::new("diag:cap-1").expect("valid")),
+        };
+        let value = serde_json::to_value(&summary).expect("serialize");
+        let restored: CapabilityErrorSummary = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, summary);
+    }
+
+    #[test]
+    fn model_error_summary_round_trips() {
+        let summary = ModelErrorSummary {
+            class: ModelErrorClass::ContextOverflow,
+            safe_summary: "context window exceeded".to_string(),
+            diagnostic_ref: None,
+        };
+        let value = serde_json::to_value(&summary).expect("serialize");
+        let restored: ModelErrorSummary = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, summary);
+    }
+
+    #[test]
+    fn retry_alteration_shrink_context_round_trips() {
+        let alteration = RetryAlteration::ShrinkContext { drop_messages: 4 };
+        let value = serde_json::to_value(&alteration).expect("serialize");
+        let restored: RetryAlteration = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, alteration);
+        match restored {
+            RetryAlteration::ShrinkContext { drop_messages } => {
+                assert_eq!(drop_messages, 4)
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retry_alteration_backoff_round_trips() {
+        let alteration = RetryAlteration::Backoff {
+            delay: Duration::from_millis(250),
+        };
+        let value = serde_json::to_value(&alteration).expect("serialize");
+        let restored: RetryAlteration = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, alteration);
+        match restored {
+            RetryAlteration::Backoff { delay } => {
+                assert_eq!(delay, Duration::from_millis(250))
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn retry_alteration_advance_fallback_round_trips() {
+        let alteration = RetryAlteration::AdvanceFallback;
+        let value = serde_json::to_value(&alteration).expect("serialize");
+        let restored: RetryAlteration = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, alteration);
+    }
+
+    #[test]
+    fn recovery_outcome_retry_carries_recovery_slot_and_optional_alteration() {
+        let outcome = RecoveryOutcome::Retry {
+            recovery: sample_recovery(),
+            alter: Some(RetryAlteration::ShrinkContext { drop_messages: 2 }),
+        };
+        let value = serde_json::to_value(&outcome).expect("serialize");
+        let restored: RecoveryOutcome = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, outcome);
+        match restored {
+            RecoveryOutcome::Retry { recovery, alter } => {
+                assert_eq!(recovery, sample_recovery());
+                assert_eq!(
+                    alter,
+                    Some(RetryAlteration::ShrinkContext { drop_messages: 2 })
+                );
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn recovery_outcome_skip_result_carries_recovery_slot() {
+        let outcome = RecoveryOutcome::SkipResult {
+            recovery: sample_recovery(),
+        };
+        let value = serde_json::to_value(&outcome).expect("serialize");
+        let restored: RecoveryOutcome = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, outcome);
+        match restored {
+            RecoveryOutcome::SkipResult { recovery } => {
+                assert_eq!(recovery, sample_recovery())
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn recovery_outcome_abort_carries_recovery_slot_and_failure_kind() {
+        let outcome = RecoveryOutcome::Abort {
+            recovery: sample_recovery(),
+            failure_kind: LoopFailureKind::NoProgressDetected,
+        };
+        let value = serde_json::to_value(&outcome).expect("serialize");
+        let restored: RecoveryOutcome = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, outcome);
+        match restored {
+            RecoveryOutcome::Abort {
+                recovery,
+                failure_kind,
+            } => {
+                assert_eq!(recovery, sample_recovery());
+                assert_eq!(failure_kind, LoopFailureKind::NoProgressDetected);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -11,7 +11,7 @@
 //! happens at the host port.
 
 use async_trait::async_trait;
-use ironclaw_turns::{LoopDiagnosticRef, LoopFailureKind};
+use ironclaw_turns::{LoopDiagnosticRef, LoopFailureKind, run_profile::LoopSafeSummary};
 
 use crate::state::{LoopExecutionState, RecoveryStrategyState};
 
@@ -41,17 +41,37 @@ pub(crate) trait RecoveryStrategy: Send + Sync {
 fn _recovery_strategy_object_safe(_: &dyn RecoveryStrategy) {}
 
 /// Sanitized, strategy-visible error summary text.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(transparent)]
 pub(crate) struct SanitizedStrategySummary(String);
 
 impl SanitizedStrategySummary {
+    pub(crate) fn new(summary: impl Into<String>) -> Result<Self, String> {
+        let summary = summary.into();
+        LoopSafeSummary::new(summary.clone()).map(|_| Self(summary))
+    }
+
     pub(crate) fn from_trusted_static(summary: &'static str) -> Self {
-        Self(summary.to_string())
+        // Invariant: callers pass reviewed hard-coded summaries, so failure
+        // here is a programming error in a literal rather than runtime input.
+        match Self::new(summary) {
+            Ok(summary) => summary,
+            Err(reason) => panic!("invalid trusted static strategy summary: {reason}"),
+        }
     }
 
     pub(crate) fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SanitizedStrategySummary {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let summary = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(summary).map_err(serde::de::Error::custom)
     }
 }
 
@@ -217,12 +237,39 @@ mod tests {
 
     #[test]
     fn sanitized_strategy_summary_serializes_as_string() {
-        let summary = SanitizedStrategySummary::from_trusted_static("provider unavailable");
+        let summary = SanitizedStrategySummary::new("provider unavailable").expect("valid");
         let value = serde_json::to_value(&summary).expect("serialize");
         assert_eq!(value, serde_json::json!("provider unavailable"));
         let restored: SanitizedStrategySummary =
             serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored.as_str(), "provider unavailable");
+    }
+
+    #[test]
+    fn sanitized_strategy_summary_rejects_unsafe_dynamic_values() {
+        assert!(SanitizedStrategySummary::new("").is_err());
+        assert!(SanitizedStrategySummary::new("/Users/alice/.ssh/id_rsa").is_err());
+        assert!(SanitizedStrategySummary::new("provider returned sk-live-secret").is_err());
+        assert!(SanitizedStrategySummary::new("a".repeat(513)).is_err());
+    }
+
+    #[test]
+    fn sanitized_strategy_summary_validates_during_deserialization() {
+        for unsafe_summary in [
+            "",
+            "/Users/alice/.ssh/id_rsa",
+            "provider returned sk-live-secret",
+        ] {
+            let result = serde_json::from_value::<SanitizedStrategySummary>(serde_json::json!(
+                unsafe_summary
+            ));
+            assert!(result.is_err(), "accepted unsafe summary: {unsafe_summary}");
+        }
+
+        let oversized = "a".repeat(513);
+        let result =
+            serde_json::from_value::<SanitizedStrategySummary>(serde_json::json!(oversized));
+        assert!(result.is_err(), "accepted oversized summary");
     }
 
     #[test]
@@ -263,7 +310,7 @@ mod tests {
     fn capability_error_summary_round_trips() {
         let summary = CapabilityErrorSummary {
             class: CapabilityErrorClass::Transient,
-            safe_summary: SanitizedStrategySummary::from_trusted_static("upstream timed out"),
+            safe_summary: SanitizedStrategySummary::new("upstream timed out").expect("valid"),
             diagnostic_ref: Some(LoopDiagnosticRef::new("diag:cap-1").expect("valid")),
         };
         let value = serde_json::to_value(&summary).expect("serialize");
@@ -280,7 +327,7 @@ mod tests {
     fn model_error_summary_round_trips() {
         let summary = ModelErrorSummary {
             class: ModelErrorClass::ContextOverflow,
-            safe_summary: SanitizedStrategySummary::from_trusted_static("context window exceeded"),
+            safe_summary: SanitizedStrategySummary::new("context window exceeded").expect("valid"),
             diagnostic_ref: None,
         };
         let value = serde_json::to_value(&summary).expect("serialize");

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -22,7 +22,7 @@ use crate::state::{LoopExecutionState, RecoveryStrategyState};
 /// slot value is carried in the returned [`RecoveryOutcome`]; the executor
 /// swaps it into the next whole state.
 #[async_trait]
-pub trait RecoveryStrategy: Send + Sync {
+pub(crate) trait RecoveryStrategy: Send + Sync {
     async fn on_capability_error(
         &self,
         state: &LoopExecutionState,
@@ -41,17 +41,17 @@ pub trait RecoveryStrategy: Send + Sync {
 /// or secrets (sanitization happens at the host port boundary, per master
 /// doc §9).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct CapabilityErrorSummary {
-    pub class: CapabilityErrorClass,
-    pub safe_summary: String,
-    pub diagnostic_ref: Option<LoopDiagnosticRef>,
+pub(crate) struct CapabilityErrorSummary {
+    pub(crate) class: CapabilityErrorClass,
+    pub(crate) safe_summary: String,
+    pub(crate) diagnostic_ref: Option<LoopDiagnosticRef>,
 }
 
 /// Wire-stable capability error classification. Snake_case names appear in
 /// checkpoints and observability events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum CapabilityErrorClass {
+pub(crate) enum CapabilityErrorClass {
     Transient,
     Permanent,
     InputInvalid,
@@ -62,16 +62,16 @@ pub enum CapabilityErrorClass {
 
 /// Sanitized model error — class + safe summary + opaque diagnostic ref.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct ModelErrorSummary {
-    pub class: ModelErrorClass,
-    pub safe_summary: String,
-    pub diagnostic_ref: Option<LoopDiagnosticRef>,
+pub(crate) struct ModelErrorSummary {
+    pub(crate) class: ModelErrorClass,
+    pub(crate) safe_summary: String,
+    pub(crate) diagnostic_ref: Option<LoopDiagnosticRef>,
 }
 
 /// Wire-stable model error classification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ModelErrorClass {
+pub(crate) enum ModelErrorClass {
     Transient,
     ContextOverflow,
     ContentFiltered,
@@ -88,7 +88,7 @@ pub enum ModelErrorClass {
 /// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "outcome")]
-pub enum RecoveryOutcome {
+pub(crate) enum RecoveryOutcome {
     Retry {
         recovery: RecoveryStrategyState,
         alter: Option<RetryAlteration>,
@@ -107,7 +107,7 @@ pub enum RecoveryOutcome {
 /// `ModelRouteChain` follow-up (master doc §9).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "alteration")]
-pub enum RetryAlteration {
+pub(crate) enum RetryAlteration {
     /// Shrink context for the next attempt (e.g. on context-overflow).
     ShrinkContext { drop_messages: u32 },
     /// Backoff before retry (executor honors as a sleep).

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -115,7 +115,8 @@ pub(crate) enum ModelErrorClass {
 ///
 /// Variants:
 /// - `Retry` — re-issue (the executor decides whether call-level or
-///   iteration-level retry; `alter` carries the strategy's hint).
+///   iteration-level retry from `scope`; `alter` carries the strategy's
+///   prompt/model hint).
 /// - `SkipResult` — drop this result and continue the batch.
 /// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
 #[non_exhaustive]
@@ -124,6 +125,7 @@ pub(crate) enum ModelErrorClass {
 pub(crate) enum RecoveryOutcome {
     Retry {
         recovery: RecoveryStrategyState,
+        scope: RetryScope,
         alter: Option<RetryAlteration>,
     },
     SkipResult {
@@ -133,6 +135,17 @@ pub(crate) enum RecoveryOutcome {
         recovery: RecoveryStrategyState,
         failure_kind: LoopFailureKind,
     },
+}
+
+/// Where the executor should apply a retry outcome.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RetryScope {
+    /// Retry only the capability call or model call that produced the error.
+    Call,
+    /// Re-run the current loop iteration after rebuilding iteration context.
+    Iteration,
 }
 
 /// Strategy hint about WHAT to alter on retry. Skeleton supports prompt-shape
@@ -145,11 +158,53 @@ pub(crate) enum RetryAlteration {
     /// Shrink context for the next attempt (e.g. on context-overflow).
     ShrinkContext { drop_messages: u32 },
     /// Backoff before retry (executor honors as a sleep).
-    Backoff { delay_ms: u64 },
+    Backoff { delay_ms: BackoffDelayMs },
     /// Reserved for future `ModelRouteChain` landing. Skeleton executor MUST
     /// reject this alteration with `LoopFailureKind::DriverBug` until the
     /// chain mechanism lands.
     AdvanceFallback,
+}
+
+/// Bounded retry backoff delay in milliseconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BackoffDelayMs(u64);
+
+impl BackoffDelayMs {
+    pub(crate) const MAX_DELAY_MS: u64 = 60_000;
+
+    pub(crate) fn new(delay_ms: u64) -> Result<Self, String> {
+        if delay_ms <= Self::MAX_DELAY_MS {
+            Ok(Self(delay_ms))
+        } else {
+            Err(format!(
+                "backoff delay {delay_ms}ms exceeds max {}ms",
+                Self::MAX_DELAY_MS
+            ))
+        }
+    }
+
+    pub(crate) fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl serde::Serialize for BackoffDelayMs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u64(self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for BackoffDelayMs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let delay_ms = <u64 as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(delay_ms).map_err(serde::de::Error::custom)
+    }
 }
 
 #[cfg(test)]
@@ -239,6 +294,37 @@ mod tests {
     }
 
     #[test]
+    fn retry_scope_round_trips_snake_case() {
+        for (variant, wire) in [
+            (RetryScope::Call, "call"),
+            (RetryScope::Iteration, "iteration"),
+        ] {
+            let value = serde_json::to_value(variant).expect("serialize");
+            assert_eq!(value, serde_json::json!(wire));
+            let restored: RetryScope = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(restored, variant);
+        }
+    }
+
+    #[test]
+    fn backoff_delay_ms_accepts_bounded_values_and_serializes_as_number() {
+        let delay = BackoffDelayMs::new(250).expect("valid");
+        assert_eq!(delay.as_u64(), 250);
+        let value = serde_json::to_value(delay).expect("serialize");
+        assert_eq!(value, serde_json::json!(250));
+        let restored: BackoffDelayMs = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(restored, delay);
+    }
+
+    #[test]
+    fn backoff_delay_ms_rejects_values_above_max() {
+        let too_large = BackoffDelayMs::MAX_DELAY_MS + 1;
+        assert!(BackoffDelayMs::new(too_large).is_err());
+        let result = serde_json::from_value::<BackoffDelayMs>(serde_json::json!(too_large));
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn retry_alteration_shrink_context_round_trips() {
         let alteration = RetryAlteration::ShrinkContext { drop_messages: 4 };
         let value = serde_json::to_value(&alteration).expect("serialize");
@@ -254,14 +340,16 @@ mod tests {
 
     #[test]
     fn retry_alteration_backoff_round_trips() {
-        let alteration = RetryAlteration::Backoff { delay_ms: 250 };
+        let alteration = RetryAlteration::Backoff {
+            delay_ms: BackoffDelayMs::new(250).expect("valid"),
+        };
         let value = serde_json::to_value(&alteration).expect("serialize");
         assert_eq!(value["delay_ms"], serde_json::json!(250));
         let restored: RetryAlteration = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, alteration);
         match restored {
             RetryAlteration::Backoff { delay_ms } => {
-                assert_eq!(delay_ms, 250)
+                assert_eq!(delay_ms.as_u64(), 250)
             }
             other => panic!("unexpected variant: {other:?}"),
         }
@@ -279,14 +367,20 @@ mod tests {
     fn recovery_outcome_retry_carries_recovery_slot_and_optional_alteration() {
         let outcome = RecoveryOutcome::Retry {
             recovery: sample_recovery(),
+            scope: RetryScope::Call,
             alter: Some(RetryAlteration::ShrinkContext { drop_messages: 2 }),
         };
         let value = serde_json::to_value(&outcome).expect("serialize");
         let restored: RecoveryOutcome = serde_json::from_value(value).expect("deserialize");
         assert_eq!(restored, outcome);
         match restored {
-            RecoveryOutcome::Retry { recovery, alter } => {
+            RecoveryOutcome::Retry {
+                recovery,
+                scope,
+                alter,
+            } => {
                 assert_eq!(recovery, sample_recovery());
+                assert_eq!(scope, RetryScope::Call);
                 assert_eq!(
                     alter,
                     Some(RetryAlteration::ShrinkContext { drop_messages: 2 })

--- a/docs/reborn/agent-loop-briefs/strategy-traits-beta.md
+++ b/docs/reborn/agent-loop-briefs/strategy-traits-beta.md
@@ -28,7 +28,7 @@ Trait stubs and outcome enums only. `Default*` impls land in WS-5.
 - `crates/ironclaw_agent_loop/src/strategies/recovery.rs`
 
 ### EXTEND
-- `crates/ironclaw_agent_loop/src/strategies/mod.rs` — add `pub mod` lines + re-exports
+- `crates/ironclaw_agent_loop/src/strategies/mod.rs` — add `pub(crate) mod` lines + crate-internal re-exports
 
 ## 3. Specification
 
@@ -46,13 +46,13 @@ use crate::state::LoopExecutionState;
 /// The host's per-capability concurrency hints (from descriptors) are
 /// authoritative for "this specific call must run alone"; this strategy
 /// decides the BATCH-level default.
-pub trait BatchPolicyStrategy: Send + Sync {
+pub(crate) trait BatchPolicyStrategy: Send + Sync {
     fn policy(&self, state: &LoopExecutionState, calls: &[CapabilityCallSummary]) -> BatchPolicy;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum BatchPolicy {
+pub(crate) enum BatchPolicy {
     Sequential,
     Parallel,
 }
@@ -61,13 +61,15 @@ pub enum BatchPolicy {
 /// + concurrency hint only. The strategy never sees raw args (per
 /// turns-agent-loop.md §6).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct CapabilityCallSummary {
-    pub name: ironclaw_turns::run_profile::CapabilityName,
-    pub concurrency_hint: ironclaw_turns::run_profile::ConcurrencyHint,
+pub(crate) struct CapabilityCallSummary {
+    pub(crate) name: ironclaw_host_api::CapabilityId,
+    pub(crate) concurrency_hint: ironclaw_turns::run_profile::ConcurrencyHint,
 }
 ```
 
 `ConcurrencyHint` is defined in **`ironclaw_turns::run_profile`** (in `host.rs` alongside the descriptor types) — NOT in this crate. `ironclaw_agent_loop` depends on `ironclaw_turns`, not the reverse, so a type that's read as a field on `CapabilityDescriptorView` (per WS-0) must live in `ironclaw_turns`. Variants: `SafeForParallel` and `Exclusive`. Derivation from `CapabilityDescriptor.effects` happens at the adapter boundary in WS-9 (see WS-9 §3.2a for the per-`EffectKind` mapping). WS-2 only consumes the type for the strategy projection.
+
+The capability identifier is the current host API `CapabilityId`; older references to `CapabilityName` are superseded.
 
 ### 3.2 `GateHandlingStrategy`
 
@@ -86,7 +88,7 @@ use crate::state::{GateStrategyState, LoopExecutionState};
 /// Async because future strategies may consult host state for grant-history
 /// or auth-flow lookups.
 #[async_trait]
-pub trait GateHandlingStrategy: Send + Sync {
+pub(crate) trait GateHandlingStrategy: Send + Sync {
     async fn handle(&self, state: &LoopExecutionState, gate: &GateSummary) -> GateOutcome;
 }
 
@@ -94,14 +96,14 @@ pub trait GateHandlingStrategy: Send + Sync {
 /// The strategy never sees raw input/secrets/auth state (per
 /// turns-agent-loop.md §6 + lightweight-agent-loop.md §8).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct GateSummary {
-    pub kind: GateKind,
-    pub gate_ref: ironclaw_turns::LoopGateRef,
+pub(crate) struct GateSummary {
+    pub(crate) kind: GateKind,
+    pub(crate) gate_ref: ironclaw_turns::LoopGateRef,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum GateKind {
+pub(crate) enum GateKind {
     Approval,
     Auth,
     Resource,
@@ -117,10 +119,23 @@ pub enum GateKind {
 ///   tools where a missing approval is non-fatal.
 /// - `Abort` — return `LoopExit::Failed { reason_kind: failure_kind }`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum GateOutcome {
+pub(crate) enum GateOutcome {
     Block { gate: GateStrategyState },
     SkipAndContinue { gate: GateStrategyState },
     Abort { gate: GateStrategyState, failure_kind: LoopFailureKind },
+}
+
+impl GateOutcome {
+    /// Executor-side contract check before honoring the outcome.
+    /// Approval gates must not be silently skipped.
+    pub(crate) fn validate_for_gate_kind(&self, kind: GateKind) -> Result<(), LoopFailureKind> {
+        match (kind, self) {
+            (GateKind::Approval, GateOutcome::SkipAndContinue { .. }) => {
+                Err(LoopFailureKind::DriverBug)
+            }
+            _ => Ok(()),
+        }
+    }
 }
 ```
 
@@ -130,7 +145,7 @@ pub enum GateOutcome {
 //! crates/ironclaw_agent_loop/src/strategies/recovery.rs
 
 use async_trait::async_trait;
-use ironclaw_turns::LoopFailureKind;
+use ironclaw_turns::{LoopDiagnosticRef, LoopFailureKind, run_profile::LoopSafeSummary};
 
 use crate::state::{LoopExecutionState, RecoveryStrategyState};
 
@@ -141,7 +156,7 @@ use crate::state::{LoopExecutionState, RecoveryStrategyState};
 /// Async because future strategies may consult host state for circuit-breaker
 /// counters, route health, etc.
 #[async_trait]
-pub trait RecoveryStrategy: Send + Sync {
+pub(crate) trait RecoveryStrategy: Send + Sync {
     async fn on_capability_error(
         &self,
         state: &LoopExecutionState,
@@ -158,16 +173,41 @@ pub trait RecoveryStrategy: Send + Sync {
 /// Sanitized capability error — class + safe summary string + opaque diagnostic
 /// ref. Strategies never see raw provider errors, host paths, or secrets
 /// (sanitization happens at the host port boundary, per master doc §9).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(transparent)]
+pub(crate) struct SanitizedStrategySummary(String);
+
+impl SanitizedStrategySummary {
+    pub(crate) fn new(summary: impl Into<String>) -> Result<Self, String> {
+        let summary = summary.into();
+        LoopSafeSummary::new(summary.clone()).map(|_| Self(summary))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SanitizedStrategySummary {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let summary = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(summary).map_err(serde::de::Error::custom)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct CapabilityErrorSummary {
-    pub class: CapabilityErrorClass,
-    pub safe_summary: String,
-    pub diagnostic_ref: Option<ironclaw_turns::LoopDiagnosticRef>,
+pub(crate) struct CapabilityErrorSummary {
+    pub(crate) class: CapabilityErrorClass,
+    pub(crate) safe_summary: SanitizedStrategySummary,
+    pub(crate) diagnostic_ref: Option<LoopDiagnosticRef>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum CapabilityErrorClass {
+pub(crate) enum CapabilityErrorClass {
     Transient,
     Permanent,
     InputInvalid,
@@ -178,15 +218,15 @@ pub enum CapabilityErrorClass {
 
 /// Sanitized model error — class + safe summary + opaque diagnostic ref.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct ModelErrorSummary {
-    pub class: ModelErrorClass,
-    pub safe_summary: String,
-    pub diagnostic_ref: Option<ironclaw_turns::LoopDiagnosticRef>,
+pub(crate) struct ModelErrorSummary {
+    pub(crate) class: ModelErrorClass,
+    pub(crate) safe_summary: SanitizedStrategySummary,
+    pub(crate) diagnostic_ref: Option<LoopDiagnosticRef>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ModelErrorClass {
+pub(crate) enum ModelErrorClass {
     Transient,
     ContextOverflow,
     ContentFiltered,
@@ -197,30 +237,64 @@ pub enum ModelErrorClass {
 /// Strategy decision plus the new recovery_state slot value.
 ///
 /// Variants:
-/// - `Retry` — re-issue (the executor decides whether call-level or
-///   iteration-level retry; alter carries the strategy's hint).
+/// - `Retry` — re-issue; `scope` states whether the executor should retry
+///   the failed call only or the current loop iteration, and `alter` carries
+///   the strategy's prompt/model hint.
 /// - `SkipResult` — drop this result and continue the batch.
 /// - `Abort` — return LoopExit::Failed.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum RecoveryOutcome {
-    Retry { recovery: RecoveryStrategyState, alter: Option<RetryAlteration> },
+pub(crate) enum RecoveryOutcome {
+    Retry {
+        recovery: RecoveryStrategyState,
+        scope: RetryScope,
+        alter: Option<RetryAlteration>,
+    },
     SkipResult { recovery: RecoveryStrategyState },
     Abort { recovery: RecoveryStrategyState, failure_kind: LoopFailureKind },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RetryScope {
+    Call,
+    Iteration,
 }
 
 /// Strategy hint about WHAT to alter on retry. Skeleton supports prompt-shape
 /// alterations only; model-route swap is reserved for the deferred
 /// ModelRouteChain follow-up (master doc §9).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum RetryAlteration {
+pub(crate) enum RetryAlteration {
     /// Shrink context for the next attempt (e.g. on context-overflow).
     ShrinkContext { drop_messages: u32 },
     /// Backoff before retry (executor honors as a sleep).
-    Backoff { delay: std::time::Duration },
+    Backoff { delay_ms: BackoffDelayMs },
     /// Reserved for future ModelRouteChain landing. Skeleton executor MUST
     /// reject this alteration with `LoopFailureKind::DriverBug` until the
     /// chain mechanism lands.
     AdvanceFallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BackoffDelayMs(u64);
+
+impl BackoffDelayMs {
+    pub(crate) const MAX_DELAY_MS: u64 = 60_000;
+
+    pub(crate) fn new(delay_ms: u64) -> Result<Self, String> {
+        if delay_ms <= Self::MAX_DELAY_MS {
+            Ok(Self(delay_ms))
+        } else {
+            Err(format!(
+                "backoff delay {delay_ms}ms exceeds max {}ms",
+                Self::MAX_DELAY_MS
+            ))
+        }
+    }
+
+    pub(crate) fn as_u64(self) -> u64 {
+        self.0
+    }
 }
 ```
 
@@ -230,8 +304,8 @@ pub enum RetryAlteration {
 - [ ] `cargo clippy --all --benches --tests --examples --all-features` zero warnings
 - [ ] Unit tests per file:
   - [ ] `batch.rs` — `BatchPolicy` round-trips through `serde_json` with snake_case; `ironclaw_turns::run_profile::ConcurrencyHint` round-trip test lives in `ironclaw_turns` (WS-0 owns it; this brief only consumes the type)
-  - [ ] `gate.rs` — `GateOutcome` round-trips; object-safety check `fn _check(_: &dyn GateHandlingStrategy) {}`
-  - [ ] `recovery.rs` — `RecoveryOutcome` round-trips; both `RetryAlteration::ShrinkContext` and `Backoff` round-trip; object-safety check
+  - [ ] `gate.rs` — `GateOutcome` round-trips; approval gates reject `SkipAndContinue` through `validate_for_gate_kind`; object-safety check `fn _check(_: &dyn GateHandlingStrategy) {}`
+  - [ ] `recovery.rs` — `RecoveryOutcome` round-trips; `RetryScope`, `SanitizedStrategySummary`, `BackoffDelayMs`, and both `RetryAlteration::ShrinkContext` and `Backoff` round-trip; object-safety check
   - [ ] one test per outcome enum confirms that `Retry`/`SkipResult`/`Abort` carry the new strategy slot value (the field is named correctly and is the right type)
 - [ ] Doc comments cite the master doc and the relevant contract section
 

--- a/docs/reborn/agent-loop-skeleton.md
+++ b/docs/reborn/agent-loop-skeleton.md
@@ -239,19 +239,19 @@ pub struct LoopExecutionState {
 - `most_common_count_in(window: usize) -> usize`
 - `same_run_length() -> usize`
 
-`CapabilityCallSignature` is `(CapabilityName, ArgsHash)` — a stable hash over the capability name plus canonicalized JSON args. Lets the executor cheaply detect "same call repeated" without retaining the args themselves (no raw tool input in state, per [`turns-agent-loop.md`](contracts/turns-agent-loop.md) §6).
+`CapabilityCallSignature` is `(CapabilityId, ArgsHash)` — a stable hash over the capability id plus canonicalized JSON args. Lets the executor cheaply detect "same call repeated" without retaining the args themselves (no raw tool input in state, per [`turns-agent-loop.md`](contracts/turns-agent-loop.md) §6).
 
 Strategy outcome shape (example for `RecoveryStrategy`):
 
 ```rust
 pub enum RecoveryOutcome {
-    Retry      { recovery: RecoveryStrategyState, alter: Option<RetryAlteration> },
+    Retry      { recovery: RecoveryStrategyState, scope: RetryScope, alter: Option<RetryAlteration> },
     SkipResult { recovery: RecoveryStrategyState },
     Abort      { recovery: RecoveryStrategyState, failure_kind: LoopFailureKind },
 }
 ```
 
-The strategy returns the new value of *its own slot only*. The executor builds the next whole state by swapping that slot. The compiler enforces that `RecoveryStrategy` cannot rewrite `BudgetStrategyState`.
+`RetryScope` is `Call` or `Iteration`, so the executor does not infer retry breadth from the alteration. Backoff alterations carry a bounded `BackoffDelayMs`, and recovery summaries use `SanitizedStrategySummary` rather than a raw `String`. The strategy returns the new value of *its own slot only*. The executor builds the next whole state by swapping that slot. The compiler enforces that `RecoveryStrategy` cannot rewrite `BudgetStrategyState`.
 
 ## 8. The canonical executor tick
 
@@ -309,7 +309,7 @@ loop:
       Err(err):
         recovery = planner.recovery().on_model_error(&state, &sanitize_model_error(&err))
         match recovery:
-          Retry { recovery, alter }: state.recovery_state = recovery; honor_alteration(alter); continue
+          Retry { recovery, scope, alter }: state.recovery_state = recovery; honor_retry(scope, alter); continue
           SkipResult { .. }: return PlannerContract { "SkipResult on model error" }
           Abort { recovery, fk }: state.recovery_state = recovery
                                    return LoopExit::Failed { reason_kind: fk, ... }
@@ -364,6 +364,8 @@ loop:
             state.append_result(result)
           ApprovalRequired(g) | AuthRequired(g) | ResourceBlocked(g):
             // Gate handling — Block/SkipAndContinue/Abort per planner.gate().
+            // validate_for_gate_kind() rejects approval SkipAndContinue before
+            // the executor honors the strategy outcome.
             // (See WS-6 §3.3 for full match.)
           Denied(reason):
             // EmptyLoopCapabilityPort returns Denied; capability policy can


### PR DESCRIPTION
## Context

Second strategy-trait slice. It covers decisions around capability batch execution, gate handling, and error recovery while still leaving concrete execution to the canonical executor and host ports.

Master spec: `docs/reborn/agent-loop-skeleton.md`
Workstream brief: `docs/reborn/agent-loop-briefs/strategy-traits-beta.md`
Stack base: `arch/ws-0`

Latest stack maintenance on 2026-05-14:
- Rebased this branch onto its current stack base after the WS0 prompt-authority fix and the follow-up WS8/WS14-parent/WS16/WS17 conflict resolutions.
- Pushed the updated branch with force-with-lease where the remote already existed, or published it as a new branch where it did not.
- Verified the final ancestry chain from `origin/reborn-integration` through WS17 before publishing the PR descriptions.

## What landed

- `BatchPolicyStrategy` plus sequential/parallel batch-policy values derived from the capability view.
- `GateHandlingStrategy` and gate outcomes that let the executor block, skip, or abort through the normal `LoopExit` path.
- `RecoveryStrategy` and recovery outcomes for transient model/capability failures.
- Default beta strategy implementations with bounded retry/block behavior and no direct mutation of runner state.
- Integration with WS0 state slots so gate/recovery updates remain value-immutable and strategy-owned.

## Reviewer focus

- Gate and recovery outcomes must return state transitions to the executor; they should not apply durable run-state changes directly.
- Batch-policy decisions should use `ConcurrencyHint` and visible descriptor metadata, not raw lower-layer capability internals.
- Policy-denied and no-progress failure kinds must flow through sanitized failure surfaces.

## Non-goals / deferred work

- Actual capability invocation is WS6a plus WS9.
- Checkpoint-on-block semantics are enforced in the executor, not here.
- Product runtime cutover is WS16/WS17.

## Validation

- [x] Branch rebased onto the current WS0 after conflict resolution in the strategy module.
- [x] Included in `arch/level1-merged` validation: `cargo check -p ironclaw_agent_loop -p ironclaw_reborn`.
- [x] Included in the final stack ancestry verification.

## Stack position

```
[#3550 ws-0] state/checkpoint foundation -> reborn-integration
   |-- #3551 ws-1 strategy alpha -> ws-0
   |-- #3552 ws-2 strategy beta -> ws-0
   |-- #3553 ws-3 strategy gamma -> ws-0
   |-- #3643 ws-3.5 loop family registry -> ws-0
   '-- #3554 level1-merged -> ws-0
         |-- #3555 ws-4 planner facade -> level1
         |-- #3556 ws-5 default strategies -> level1
         '-- #3557 level2-merged -> level1
               '-- #3596 ws-6a canonical executor -> level2
                     '-- #3597 ws-7 PlannedDriver adapter -> ws-6a
                           '-- #3598 ws-8 integration/test support -> ws-7
                                 |-- #3644 ws-9 capability host wiring -> ws-8
                                 |-- #3645 ws-10 checkpoint load/resume -> ws-8
                                 |-- #3646 ws-11 input port -> ws-8
                                 |-- #3647 ws-12 progress port -> ws-8
                                 |-- #3648 ws-13 cancellation accessor -> ws-8
                                 |-- #3649 ws-15 prompt/identity context -> ws-8
                                 '-- #3650 ws-14-parent integrated host ports -> ws-8
                                       '-- #3651 ws-14 planned default registration -> ws-14-parent
                                             '-- #3652 ws-16 live runtime wiring -> ws-14
                                                   '-- #3653 ws-17 product live cutover -> ws-16
```
