### PR TITLE
arch(ws-3): strategy traits gamma - stop, drain, budget

### DIFF
--- a/crates/ironclaw_agent_loop/src/strategies/budget.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/budget.rs
@@ -1,0 +1,141 @@
+//! Budget strategy contract.
+
+use std::time::Duration;
+
+use crate::state::LoopExecutionState;
+
+/// Hard caps on loop execution.
+///
+/// This is sync, read-only policy. The executor owns enforcement.
+pub trait BudgetStrategy: Send + Sync {
+    /// Maximum number of iterations before the loop is forcibly failed.
+    fn iteration_limit(&self, state: &LoopExecutionState) -> u32;
+
+    /// Optional wall-clock cap. `None` means no time limit.
+    fn wall_clock_limit(&self, state: &LoopExecutionState) -> Option<Duration>;
+}
+
+/// No wall-clock cap and a 32-iteration limit.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UnlimitedBudget;
+
+impl BudgetStrategy for UnlimitedBudget {
+    fn iteration_limit(&self, _: &LoopExecutionState) -> u32 {
+        32
+    }
+
+    fn wall_clock_limit(&self, _: &LoopExecutionState) -> Option<Duration> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{TenantId, ThreadId};
+    use ironclaw_turns::{
+        AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId, TurnScope,
+        run_profile::{
+            CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
+            ConcurrencyClass, ContextProfileId, LoopDriverId, LoopRunContext, ModelProfileId,
+            RedactedRunProfileProvenance, ResolvedRunProfile, ResourceBudgetPolicy,
+            ResourceBudgetTier, RunClassId, RunProfileFingerprint, RuntimeProfileConstraints,
+            SchedulingClass, SteeringPolicy,
+        },
+    };
+
+    use super::*;
+
+    #[test]
+    fn budget_strategy_is_object_safe() {
+        fn _check(_: &dyn BudgetStrategy) {}
+
+        _check(&UnlimitedBudget);
+    }
+
+    #[test]
+    fn unlimited_budget_exercises_trait_surface() {
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+        let strategy: &dyn BudgetStrategy = &UnlimitedBudget;
+
+        assert_eq!(
+            (
+                strategy.iteration_limit(&state),
+                strategy.wall_clock_limit(&state)
+            ),
+            (32, None)
+        );
+    }
+
+    fn test_run_context() -> LoopRunContext {
+        let scope = TurnScope::new(
+            TenantId::new("tenant-budget-strategy").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-budget-strategy").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("budget_strategy_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("budget_strategy_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("budget_strategy_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("budget_strategy_test_model").expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "budget_strategy_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("budget_strategy_test_context")
+                .expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("budget_strategy_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new("budget-strategy-test-fingerprint")
+                .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/budget.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/budget.rs
@@ -4,9 +4,13 @@ use std::time::Duration;
 
 use crate::state::LoopExecutionState;
 
-/// Hard caps on loop execution.
+/// Hard caps on loop execution iterations and elapsed wall-clock time.
 ///
-/// This is sync, read-only policy. The executor owns enforcement.
+/// Model-call and capability-call caps belong to
+/// `ResolvedRunProfile.resource_budget_policy` / `ResourceBudgetPolicy`, not
+/// this strategy. This stays sync because it is pure read-only policy with no
+/// host consult; tenant/profile-backed budget logic should be resolved into
+/// the run profile, or added later behind an explicit async contract change.
 pub(crate) trait BudgetStrategy: Send + Sync {
     /// Maximum number of iterations before the loop is forcibly failed.
     fn iteration_limit(&self, state: &LoopExecutionState) -> u32;
@@ -14,6 +18,9 @@ pub(crate) trait BudgetStrategy: Send + Sync {
     /// Optional wall-clock cap. `None` means no time limit.
     fn wall_clock_limit(&self, state: &LoopExecutionState) -> Option<Duration>;
 }
+
+#[allow(dead_code)]
+fn assert_budget_strategy_object_safe(_: &dyn BudgetStrategy) {}
 
 #[cfg(test)]
 mod tests {
@@ -33,9 +40,7 @@ mod tests {
 
     #[test]
     fn budget_strategy_is_object_safe() {
-        fn _check(_: &dyn BudgetStrategy) {}
-
-        _check(&FixedBudget);
+        assert_budget_strategy_object_safe(&FixedBudget);
     }
 
     #[test]

--- a/crates/ironclaw_agent_loop/src/strategies/budget.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/budget.rs
@@ -7,26 +7,12 @@ use crate::state::LoopExecutionState;
 /// Hard caps on loop execution.
 ///
 /// This is sync, read-only policy. The executor owns enforcement.
-pub trait BudgetStrategy: Send + Sync {
+pub(crate) trait BudgetStrategy: Send + Sync {
     /// Maximum number of iterations before the loop is forcibly failed.
     fn iteration_limit(&self, state: &LoopExecutionState) -> u32;
 
     /// Optional wall-clock cap. `None` means no time limit.
     fn wall_clock_limit(&self, state: &LoopExecutionState) -> Option<Duration>;
-}
-
-/// No wall-clock cap and a 32-iteration limit.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct UnlimitedBudget;
-
-impl BudgetStrategy for UnlimitedBudget {
-    fn iteration_limit(&self, _: &LoopExecutionState) -> u32 {
-        32
-    }
-
-    fn wall_clock_limit(&self, _: &LoopExecutionState) -> Option<Duration> {
-        None
-    }
 }
 
 #[cfg(test)]
@@ -49,13 +35,13 @@ mod tests {
     fn budget_strategy_is_object_safe() {
         fn _check(_: &dyn BudgetStrategy) {}
 
-        _check(&UnlimitedBudget);
+        _check(&FixedBudget);
     }
 
     #[test]
-    fn unlimited_budget_exercises_trait_surface() {
+    fn fixed_budget_exercises_trait_surface() {
         let state = LoopExecutionState::initial_for_run(&test_run_context());
-        let strategy: &dyn BudgetStrategy = &UnlimitedBudget;
+        let strategy: &dyn BudgetStrategy = &FixedBudget;
 
         assert_eq!(
             (
@@ -64,6 +50,18 @@ mod tests {
             ),
             (32, None)
         );
+    }
+
+    struct FixedBudget;
+
+    impl BudgetStrategy for FixedBudget {
+        fn iteration_limit(&self, _: &LoopExecutionState) -> u32 {
+            32
+        }
+
+        fn wall_clock_limit(&self, _: &LoopExecutionState) -> Option<Duration> {
+            None
+        }
     }
 
     fn test_run_context() -> LoopRunContext {

--- a/crates/ironclaw_agent_loop/src/strategies/drain.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/drain.rs
@@ -9,7 +9,7 @@ use crate::state::LoopExecutionState;
 /// This is pure policy: implementations do not mutate strategy state. Async
 /// leaves room for future host-backed queue hints or priority checks.
 #[async_trait]
-pub trait InputDrainStrategy: Send + Sync {
+pub(crate) trait InputDrainStrategy: Send + Sync {
     /// Called at the start of each tick before prompt construction.
     async fn drain_steering(&self, state: &LoopExecutionState) -> bool;
 
@@ -21,7 +21,7 @@ pub trait InputDrainStrategy: Send + Sync {
 mod tests {
     use async_trait::async_trait;
 
-    use crate::strategies::stop::{TurnEndKind, TurnSummary};
+    use crate::strategies::{TurnEndKind, TurnSummary};
     use ironclaw_turns::{LoopMessageRef, LoopResultRef};
 
     use super::*;

--- a/crates/ironclaw_agent_loop/src/strategies/drain.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/drain.rs
@@ -1,0 +1,65 @@
+//! Input-drain strategy contract.
+
+use async_trait::async_trait;
+
+use crate::state::LoopExecutionState;
+
+/// Decides when to drain the host's steering and followup queues.
+///
+/// This is pure policy: implementations do not mutate strategy state. Async
+/// leaves room for future host-backed queue hints or priority checks.
+#[async_trait]
+pub trait InputDrainStrategy: Send + Sync {
+    /// Called at the start of each tick before prompt construction.
+    async fn drain_steering(&self, state: &LoopExecutionState) -> bool;
+
+    /// Called after the loop would otherwise stop, before returning completed.
+    async fn drain_followup(&self, state: &LoopExecutionState) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use crate::strategies::stop::{TurnEndKind, TurnSummary};
+    use ironclaw_turns::{LoopMessageRef, LoopResultRef};
+
+    use super::*;
+
+    #[test]
+    fn drain_strategy_is_object_safe() {
+        fn _check(_: &dyn InputDrainStrategy) {}
+
+        struct NeverDrain;
+
+        #[async_trait]
+        impl InputDrainStrategy for NeverDrain {
+            async fn drain_steering(&self, _: &LoopExecutionState) -> bool {
+                false
+            }
+
+            async fn drain_followup(&self, _: &LoopExecutionState) -> bool {
+                false
+            }
+        }
+
+        _check(&NeverDrain);
+    }
+
+    #[test]
+    fn turn_summary_round_trips_through_json() {
+        let summary = TurnSummary {
+            kind: TurnEndKind::AfterCapabilityBatch,
+            assistant_message_ref: Some(LoopMessageRef::new("msg:assistant-1").unwrap()),
+            batch_result_refs: vec![
+                LoopResultRef::new("result:call-1").unwrap(),
+                LoopResultRef::new("result:call-2").unwrap(),
+            ],
+        };
+
+        let serialized = serde_json::to_string(&summary).unwrap();
+        let deserialized = serde_json::from_str::<TurnSummary>(&serialized).unwrap();
+
+        assert_eq!(deserialized, summary);
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/drain.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/drain.rs
@@ -17,19 +17,17 @@ pub(crate) trait InputDrainStrategy: Send + Sync {
     async fn drain_followup(&self, state: &LoopExecutionState) -> bool;
 }
 
+#[allow(dead_code)]
+fn assert_input_drain_strategy_object_safe(_: &dyn InputDrainStrategy) {}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-
-    use crate::strategies::{TurnEndKind, TurnSummary};
-    use ironclaw_turns::{LoopMessageRef, LoopResultRef};
 
     use super::*;
 
     #[test]
     fn drain_strategy_is_object_safe() {
-        fn _check(_: &dyn InputDrainStrategy) {}
-
         struct NeverDrain;
 
         #[async_trait]
@@ -43,23 +41,6 @@ mod tests {
             }
         }
 
-        _check(&NeverDrain);
-    }
-
-    #[test]
-    fn turn_summary_round_trips_through_json() {
-        let summary = TurnSummary {
-            kind: TurnEndKind::AfterCapabilityBatch,
-            assistant_message_ref: Some(LoopMessageRef::new("msg:assistant-1").unwrap()),
-            batch_result_refs: vec![
-                LoopResultRef::new("result:call-1").unwrap(),
-                LoopResultRef::new("result:call-2").unwrap(),
-            ],
-        };
-
-        let serialized = serde_json::to_string(&summary).unwrap();
-        let deserialized = serde_json::from_str::<TurnSummary>(&serialized).unwrap();
-
-        assert_eq!(deserialized, summary);
+        assert_input_drain_strategy_object_safe(&NeverDrain);
     }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -18,19 +18,19 @@
 //! state such as grant history, auth flow status, route health, or
 //! circuit-breaker counters.
 
-// WS-1/2/3 land crate-internal contracts before WS-4/5/6 compose and execute
-// them. Keep the unused lint local to these forward-declared contracts.
+// WS-1/2/3 land crate-private strategy contracts before WS-4/5/6 compose and
+// execute them. Keep the unused lint local to these forward-declared contracts.
 #![allow(dead_code, unused_imports)]
 
 pub(crate) mod batch;
-pub(crate) mod budget;
+mod budget;
 mod capability;
 mod context;
-pub(crate) mod drain;
+mod drain;
 pub(crate) mod gate;
 mod model;
 pub(crate) mod recovery;
-pub(crate) mod stop;
+mod stop;
 
 pub(crate) use batch::{BatchPolicy, BatchPolicyStrategy, CapabilityCallSummary};
 pub(crate) use budget::BudgetStrategy;

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -5,9 +5,9 @@
 //! into the next whole state. See `docs/reborn/agent-loop-skeleton.md` §6
 //! ("Strategy decomposition") and §8 ("Outcome enums").
 //!
-//! WS-2 lands the trait stubs and outcome enums for the batch / gate /
-//! recovery axis. `Default*` impls land in WS-5; the executor body that
-//! consumes these outcomes lands in WS-6.
+//! WS-1/2/3 land the alpha, beta, and gamma trait stubs and outcome enums.
+//! `Default*` impls land in WS-5; the executor body that consumes these
+//! outcomes lands in WS-6.
 //!
 //! Checkpoint/observability wire enums are `#[non_exhaustive]`; later
 //! workstreams should extend them without forcing consumers to assume the
@@ -18,20 +18,25 @@
 //! state such as grant history, auth flow status, route health, or
 //! circuit-breaker counters.
 
-// WS-1/2 land crate-internal contracts before WS-4/5/6 compose and execute
+// WS-1/2/3 land crate-internal contracts before WS-4/5/6 compose and execute
 // them. Keep the unused lint local to these forward-declared contracts.
 #![allow(dead_code, unused_imports)]
 
 pub(crate) mod batch;
+pub(crate) mod budget;
 mod capability;
 mod context;
+pub(crate) mod drain;
 pub(crate) mod gate;
 mod model;
 pub(crate) mod recovery;
+pub(crate) mod stop;
 
 pub(crate) use batch::{BatchPolicy, BatchPolicyStrategy, CapabilityCallSummary};
+pub(crate) use budget::BudgetStrategy;
 pub(crate) use capability::{CapabilityFilter, CapabilityStrategy};
 pub(crate) use context::ContextStrategy;
+pub(crate) use drain::InputDrainStrategy;
 pub(crate) use gate::{GateHandlingStrategy, GateKind, GateOutcome, GateSummary};
 pub(crate) use ironclaw_turns::run_profile::ConcurrencyHint;
 pub(crate) use model::{ModelPreference, ModelStrategy};
@@ -40,3 +45,4 @@ pub(crate) use recovery::{
     ModelErrorSummary, RecoveryOutcome, RecoveryStrategy, RetryAlteration, RetryScope,
     SanitizedStrategySummary,
 };
+pub(crate) use stop::{StopConditionStrategy, StopKind, StopOutcome, TurnEndKind, TurnSummary};

--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -159,11 +159,16 @@ mod tests {
     }
 
     #[test]
-    fn aborted_stop_kind_preserves_policy_denied_variant_tag() {
-        let kind = StopKind::Aborted(LoopFailureKind::PolicyDenied);
-        let value = serde_json::to_value(kind).unwrap();
+    fn aborted_stop_kind_preserves_failure_variant_tags() {
+        for (failure_kind, wire_tag) in [
+            (LoopFailureKind::PolicyDenied, "policy_denied"),
+            (LoopFailureKind::ModelError, "model_error"),
+        ] {
+            let kind = StopKind::Aborted(failure_kind);
+            let value = serde_json::to_value(kind).unwrap();
 
-        assert_eq!(value, json!({ "aborted": "policy_denied" }));
-        assert_eq!(serde_json::from_value::<StopKind>(value).unwrap(), kind);
+            assert_eq!(value, json!({ "aborted": wire_tag }));
+            assert_eq!(serde_json::from_value::<StopKind>(value).unwrap(), kind);
+        }
     }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -3,14 +3,14 @@
 use async_trait::async_trait;
 use ironclaw_turns::{LoopFailureKind, LoopMessageRef, LoopResultRef};
 
-use crate::state::{ControlStrategyState, LoopExecutionState};
+use crate::state::{LoopExecutionState, StopStrategyState};
 
 /// Decides whether the loop should stop after the current turn finishes.
 ///
-/// Implementations return a new `control_state` slot value. Async because
+/// Implementations return a new `stop_state` slot value. Async because
 /// future strategies may consult host state for milestone tracking.
 #[async_trait]
-pub trait StopConditionStrategy: Send + Sync {
+pub(crate) trait StopConditionStrategy: Send + Sync {
     /// Called after a turn completes.
     async fn should_stop_after_turn(
         &self,
@@ -24,7 +24,7 @@ pub trait StopConditionStrategy: Send + Sync {
 /// This carries refs only. Strategies that need content must read it through
 /// host ports so host-side redaction and scope policy remain authoritative.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct TurnSummary {
+pub(crate) struct TurnSummary {
     pub kind: TurnEndKind,
     pub assistant_message_ref: Option<LoopMessageRef>,
     pub batch_result_refs: Vec<LoopResultRef>,
@@ -32,7 +32,7 @@ pub struct TurnSummary {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum TurnEndKind {
+pub(crate) enum TurnEndKind {
     /// The model returned a reply and no capability batch executed this turn.
     ReplyOnly,
     /// The model returned capability calls and the listed refs are the
@@ -40,22 +40,22 @@ pub enum TurnEndKind {
     AfterCapabilityBatch,
 }
 
-/// Strategy decision plus the new `control_state` slot value.
+/// Strategy decision plus the new `stop_state` slot value.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum StopOutcome {
+pub(crate) enum StopOutcome {
     Continue {
-        control: ControlStrategyState,
+        stop: StopStrategyState,
     },
     Stop {
-        control: ControlStrategyState,
+        stop: StopStrategyState,
         kind: StopKind,
     },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum StopKind {
+pub(crate) enum StopKind {
     /// Strategy is satisfied; the executor maps this to graceful completion.
     GracefulStop,
     /// Safety-net escape for repeated calls or repeated failures.
@@ -85,7 +85,7 @@ mod tests {
                 _: &TurnSummary,
             ) -> StopOutcome {
                 StopOutcome::Continue {
-                    control: ControlStrategyState::default(),
+                    stop: StopStrategyState::default(),
                 }
             }
         }
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn stop_outcome_round_trips_through_json() {
         let outcome = StopOutcome::Stop {
-            control: ControlStrategyState {
+            stop: StopStrategyState {
                 turns_completed: 3,
                 terminate_hints_in_last_batch: 1,
                 last_batch_total: 2,
@@ -119,7 +119,7 @@ mod tests {
         assert_eq!(deserialized, outcome);
 
         let continue_outcome = StopOutcome::Continue {
-            control: ControlStrategyState::default(),
+            stop: StopStrategyState::default(),
         };
         let continue_value = serde_json::to_value(&continue_outcome).unwrap();
         assert!(
@@ -133,11 +133,11 @@ mod tests {
     }
 
     #[test]
-    fn aborted_stop_kind_preserves_failure_variant_tag() {
-        let kind = StopKind::Aborted(LoopFailureKind::ModelError);
+    fn aborted_stop_kind_preserves_policy_denied_variant_tag() {
+        let kind = StopKind::Aborted(LoopFailureKind::PolicyDenied);
         let value = serde_json::to_value(kind).unwrap();
 
-        assert_eq!(value, json!({ "aborted": "model_error" }));
+        assert_eq!(value, json!({ "aborted": "policy_denied" }));
         assert_eq!(serde_json::from_value::<StopKind>(value).unwrap(), kind);
     }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -1,0 +1,143 @@
+//! Stop-condition strategy contract.
+
+use async_trait::async_trait;
+use ironclaw_turns::{LoopFailureKind, LoopMessageRef, LoopResultRef};
+
+use crate::state::{ControlStrategyState, LoopExecutionState};
+
+/// Decides whether the loop should stop after the current turn finishes.
+///
+/// Implementations return a new `control_state` slot value. Async because
+/// future strategies may consult host state for milestone tracking.
+#[async_trait]
+pub trait StopConditionStrategy: Send + Sync {
+    /// Called after a turn completes.
+    async fn should_stop_after_turn(
+        &self,
+        state: &LoopExecutionState,
+        just_completed: &TurnSummary,
+    ) -> StopOutcome;
+}
+
+/// Loop-side projection of what just happened in the completed turn.
+///
+/// This carries refs only. Strategies that need content must read it through
+/// host ports so host-side redaction and scope policy remain authoritative.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct TurnSummary {
+    pub kind: TurnEndKind,
+    pub assistant_message_ref: Option<LoopMessageRef>,
+    pub batch_result_refs: Vec<LoopResultRef>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnEndKind {
+    /// The model returned a reply and no capability batch executed this turn.
+    ReplyOnly,
+    /// The model returned capability calls and the listed refs are the
+    /// finalized batch outcomes for this turn.
+    AfterCapabilityBatch,
+}
+
+/// Strategy decision plus the new `control_state` slot value.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopOutcome {
+    Continue {
+        control: ControlStrategyState,
+    },
+    Stop {
+        control: ControlStrategyState,
+        kind: StopKind,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopKind {
+    /// Strategy is satisfied; the executor maps this to graceful completion.
+    GracefulStop,
+    /// Safety-net escape for repeated calls or repeated failures.
+    NoProgressDetected,
+    /// Strategy aborts with an explicit failure kind.
+    Aborted(LoopFailureKind),
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn stop_condition_strategy_is_object_safe() {
+        fn _check(_: &dyn StopConditionStrategy) {}
+
+        struct AlwaysContinue;
+
+        #[async_trait]
+        impl StopConditionStrategy for AlwaysContinue {
+            async fn should_stop_after_turn(
+                &self,
+                _: &LoopExecutionState,
+                _: &TurnSummary,
+            ) -> StopOutcome {
+                StopOutcome::Continue {
+                    control: ControlStrategyState::default(),
+                }
+            }
+        }
+
+        _check(&AlwaysContinue);
+    }
+
+    #[test]
+    fn stop_outcome_round_trips_through_json() {
+        let outcome = StopOutcome::Stop {
+            control: ControlStrategyState {
+                turns_completed: 3,
+                terminate_hints_in_last_batch: 1,
+                last_batch_total: 2,
+            },
+            kind: StopKind::NoProgressDetected,
+        };
+
+        let value = serde_json::to_value(&outcome).unwrap();
+        // Variant tag must be snake_case on the wire, matching sibling enums.
+        assert!(
+            value.get("stop").is_some(),
+            "expected snake_case `stop` key, got {value}"
+        );
+        assert!(
+            value.get("Stop").is_none(),
+            "PascalCase `Stop` key leaked into wire form: {value}"
+        );
+
+        let deserialized = serde_json::from_value::<StopOutcome>(value).unwrap();
+        assert_eq!(deserialized, outcome);
+
+        let continue_outcome = StopOutcome::Continue {
+            control: ControlStrategyState::default(),
+        };
+        let continue_value = serde_json::to_value(&continue_outcome).unwrap();
+        assert!(
+            continue_value.get("continue").is_some(),
+            "expected snake_case `continue` key, got {continue_value}"
+        );
+        assert_eq!(
+            serde_json::from_value::<StopOutcome>(continue_value).unwrap(),
+            continue_outcome
+        );
+    }
+
+    #[test]
+    fn aborted_stop_kind_preserves_failure_variant_tag() {
+        let kind = StopKind::Aborted(LoopFailureKind::ModelError);
+        let value = serde_json::to_value(kind).unwrap();
+
+        assert_eq!(value, json!({ "aborted": "model_error" }));
+        assert_eq!(serde_json::from_value::<StopKind>(value).unwrap(), kind);
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -19,6 +19,9 @@ pub(crate) trait StopConditionStrategy: Send + Sync {
     ) -> StopOutcome;
 }
 
+#[allow(dead_code)]
+fn assert_stop_condition_strategy_object_safe(_: &dyn StopConditionStrategy) {}
+
 /// Loop-side projection of what just happened in the completed turn.
 ///
 /// This carries refs only. Strategies that need content must read it through
@@ -31,6 +34,7 @@ pub(crate) struct TurnSummary {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum TurnEndKind {
     /// The model returned a reply and no capability batch executed this turn.
@@ -42,11 +46,14 @@ pub(crate) enum TurnEndKind {
 
 /// Strategy decision plus the new `stop_state` slot value.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum StopOutcome {
     Continue {
         stop: StopStrategyState,
     },
+    /// Carries the final stop slot for checkpoint, observability, and final
+    /// state assembly even though no later strategy consumes it after exit.
     Stop {
         stop: StopStrategyState,
         kind: StopKind,
@@ -54,11 +61,14 @@ pub(crate) enum StopOutcome {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum StopKind {
     /// Strategy is satisfied; the executor maps this to graceful completion.
     GracefulStop,
-    /// Safety-net escape for repeated calls or repeated failures.
+    /// Safety-net escape for repeated calls or repeated failures; default
+    /// logic should read `state.recent_call_signatures` and
+    /// `state.recent_failure_kinds`.
     NoProgressDetected,
     /// Strategy aborts with an explicit failure kind.
     Aborted(LoopFailureKind),
@@ -67,14 +77,13 @@ pub(crate) enum StopKind {
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
+    use ironclaw_turns::{LoopMessageRef, LoopResultRef};
     use serde_json::json;
 
     use super::*;
 
     #[test]
     fn stop_condition_strategy_is_object_safe() {
-        fn _check(_: &dyn StopConditionStrategy) {}
-
         struct AlwaysContinue;
 
         #[async_trait]
@@ -90,7 +99,24 @@ mod tests {
             }
         }
 
-        _check(&AlwaysContinue);
+        assert_stop_condition_strategy_object_safe(&AlwaysContinue);
+    }
+
+    #[test]
+    fn turn_summary_round_trips_through_json() {
+        let summary = TurnSummary {
+            kind: TurnEndKind::AfterCapabilityBatch,
+            assistant_message_ref: Some(LoopMessageRef::new("msg:assistant-1").unwrap()),
+            batch_result_refs: vec![
+                LoopResultRef::new("result:call-1").unwrap(),
+                LoopResultRef::new("result:call-2").unwrap(),
+            ],
+        };
+
+        let serialized = serde_json::to_string(&summary).unwrap();
+        let deserialized = serde_json::from_str::<TurnSummary>(&serialized).unwrap();
+
+        assert_eq!(deserialized, summary);
     }
 
     #[test]


### PR DESCRIPTION
## Context

Third strategy-trait slice. It owns loop termination, input-drain timing, and iteration/wall-clock budget decisions.

Master spec: `docs/reborn/agent-loop-skeleton.md`
Workstream brief: `docs/reborn/agent-loop-briefs/strategy-traits-gamma.md`
Stack base: `arch/ws-0`

Latest stack maintenance on 2026-05-14:
- Rebased this branch onto its current stack base after the WS0 prompt-authority fix and the follow-up WS8/WS14-parent/WS16/WS17 conflict resolutions.
- Pushed the updated branch with force-with-lease where the remote already existed, or published it as a new branch where it did not.
- Verified the final ancestry chain from `origin/reborn-integration` through WS17 before publishing the PR descriptions.

## What landed

- `StopConditionStrategy` and stop outcomes for terminate hints, assistant completion, no-progress detection, and continuing the loop.
- `InputDrainStrategy` for steering/follow-up drain timing without giving strategies direct queue access.
- `BudgetStrategy` and iteration-limit values for executor enforcement.
- Default gamma strategies that mirror the pi-mono loop baseline and consume the WS0 observed rings.
- Strategy module wiring aligned with the sealed built-in-only model.

## Reviewer focus

- Stop decisions should be derived from immutable state and observed refs, not from direct host mutation.
- No-progress detection should consume `recent_call_signatures` and `recent_failure_kinds` without retaining raw prompts or tool args.
- Input drain decisions should remain timing hints; WS11 owns the actual host input port.

## Non-goals / deferred work

- Family registry and profile selection are WS3.5/WS14.
- Executor enforcement of stop/drain/budget decisions is WS6a.
- Cancellation observation is WS13.

## Validation

- [x] Branch rebased onto the current WS0 after conflict resolution in the strategy module.
- [x] Included in `arch/level1-merged` validation: `cargo check -p ironclaw_agent_loop -p ironclaw_reborn`.
- [x] Included in the final stack ancestry verification.

## Stack position

```
[#3550 ws-0] state/checkpoint foundation -> reborn-integration
   |-- #3551 ws-1 strategy alpha -> ws-0
   |-- #3552 ws-2 strategy beta -> ws-0
   |-- #3553 ws-3 strategy gamma -> ws-0
   |-- #3643 ws-3.5 loop family registry -> ws-0
   '-- #3554 level1-merged -> ws-0
         |-- #3555 ws-4 planner facade -> level1
         |-- #3556 ws-5 default strategies -> level1
         '-- #3557 level2-merged -> level1
               '-- #3596 ws-6a canonical executor -> level2
                     '-- #3597 ws-7 PlannedDriver adapter -> ws-6a
                           '-- #3598 ws-8 integration/test support -> ws-7
                                 |-- #3644 ws-9 capability host wiring -> ws-8
                                 |-- #3645 ws-10 checkpoint load/resume -> ws-8
                                 |-- #3646 ws-11 input port -> ws-8
                                 |-- #3647 ws-12 progress port -> ws-8
                                 |-- #3648 ws-13 cancellation accessor -> ws-8
                                 |-- #3649 ws-15 prompt/identity context -> ws-8
                                 '-- #3650 ws-14-parent integrated host ports -> ws-8
                                       '-- #3651 ws-14 planned default registration -> ws-14-parent
                                             '-- #3652 ws-16 live runtime wiring -> ws-14
                                                   '-- #3653 ws-17 product live cutover -> ws-16
```
