### PR TITLE
arch(ws-4): planner facade - AgentLoopPlanner and DefaultPlanner

### DIFF
--- a/crates/ironclaw_agent_loop/src/default_planner.rs
+++ b/crates/ironclaw_agent_loop/src/default_planner.rs
@@ -1,0 +1,372 @@
+//! `DefaultPlanner` — the reference composition of the nine strategies.
+//!
+//! Construction is crate-private. Public callers get a sealed
+//! `AgentLoopPlanner` through `families::*` and `LoopFamilyRegistry`; they
+//! cannot instantiate or mutate planner strategy slots.
+
+use std::sync::Arc;
+
+use crate::families::DEFAULT_FAMILY_DIGEST;
+use crate::family::{ComponentIdentity, LoopFamilyId};
+use crate::planner::{AgentLoopPlanner, AgentLoopPlannerInternal};
+use crate::strategies::{
+    BatchPolicyStrategy, BudgetStrategy, CapabilityStrategy, ContextStrategy,
+    DefaultBatchPolicyStrategy, DefaultBudgetStrategy, DefaultCapabilityStrategy,
+    DefaultContextStrategy, DefaultGateHandlingStrategy, DefaultInputDrainStrategy,
+    DefaultModelStrategy, DefaultRecoveryStrategy, DefaultStopConditionStrategy,
+    GateHandlingStrategy, InputDrainStrategy, ModelStrategy, RecoveryStrategy,
+    StopConditionStrategy,
+};
+
+/// The reference planner: a concrete, Builtin-only composition of nine
+/// strategies.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(crate) struct DefaultPlanner {
+    id: LoopFamilyId,
+    version: ComponentIdentity,
+    context: Arc<dyn ContextStrategy>,
+    capability: Arc<dyn CapabilityStrategy>,
+    model: Arc<dyn ModelStrategy>,
+    batch: Arc<dyn BatchPolicyStrategy>,
+    gate: Arc<dyn GateHandlingStrategy>,
+    recovery: Arc<dyn RecoveryStrategy>,
+    stop: Arc<dyn StopConditionStrategy>,
+    drain: Arc<dyn InputDrainStrategy>,
+    budget: Arc<dyn BudgetStrategy>,
+}
+
+#[allow(dead_code)]
+impl DefaultPlanner {
+    /// Crate-private constructor for the all-default strategy composition.
+    pub(crate) fn compose_default() -> Self {
+        Self::compose(
+            LoopFamilyId::DEFAULT,
+            ComponentIdentity::from_static("default", DEFAULT_FAMILY_DIGEST),
+            DefaultStrategySlots::default(),
+        )
+    }
+
+    /// Crate-private constructor used by future family factories that need to
+    /// provide an already-selected strategy set.
+    pub(crate) fn compose(
+        id: LoopFamilyId,
+        version: ComponentIdentity,
+        slots: DefaultStrategySlots,
+    ) -> Self {
+        Self {
+            id,
+            version,
+            context: slots.context,
+            capability: slots.capability,
+            model: slots.model,
+            batch: slots.batch,
+            gate: slots.gate,
+            recovery: slots.recovery,
+            stop: slots.stop,
+            drain: slots.drain,
+            budget: slots.budget,
+        }
+    }
+
+    pub(crate) fn with_id(mut self, id: LoopFamilyId) -> Self {
+        self.id = id;
+        self
+    }
+
+    pub(crate) fn with_version(mut self, version: ComponentIdentity) -> Self {
+        self.version = version;
+        self
+    }
+
+    pub(crate) fn with_context(mut self, strategy: Arc<dyn ContextStrategy>) -> Self {
+        self.context = strategy;
+        self
+    }
+
+    pub(crate) fn with_capability(mut self, strategy: Arc<dyn CapabilityStrategy>) -> Self {
+        self.capability = strategy;
+        self
+    }
+
+    pub(crate) fn with_model(mut self, strategy: Arc<dyn ModelStrategy>) -> Self {
+        self.model = strategy;
+        self
+    }
+
+    pub(crate) fn with_batch(mut self, strategy: Arc<dyn BatchPolicyStrategy>) -> Self {
+        self.batch = strategy;
+        self
+    }
+
+    pub(crate) fn with_gate(mut self, strategy: Arc<dyn GateHandlingStrategy>) -> Self {
+        self.gate = strategy;
+        self
+    }
+
+    pub(crate) fn with_recovery(mut self, strategy: Arc<dyn RecoveryStrategy>) -> Self {
+        self.recovery = strategy;
+        self
+    }
+
+    pub(crate) fn with_stop(mut self, strategy: Arc<dyn StopConditionStrategy>) -> Self {
+        self.stop = strategy;
+        self
+    }
+
+    pub(crate) fn with_drain(mut self, strategy: Arc<dyn InputDrainStrategy>) -> Self {
+        self.drain = strategy;
+        self
+    }
+
+    pub(crate) fn with_budget(mut self, strategy: Arc<dyn BudgetStrategy>) -> Self {
+        self.budget = strategy;
+        self
+    }
+}
+
+impl AgentLoopPlanner for DefaultPlanner {
+    fn id(&self) -> &LoopFamilyId {
+        &self.id
+    }
+
+    fn version(&self) -> &ComponentIdentity {
+        &self.version
+    }
+}
+
+impl AgentLoopPlannerInternal for DefaultPlanner {
+    fn context(&self) -> &dyn ContextStrategy {
+        &*self.context
+    }
+
+    fn capability(&self) -> &dyn CapabilityStrategy {
+        &*self.capability
+    }
+
+    fn model(&self) -> &dyn ModelStrategy {
+        &*self.model
+    }
+
+    fn batch(&self) -> &dyn BatchPolicyStrategy {
+        &*self.batch
+    }
+
+    fn gate(&self) -> &dyn GateHandlingStrategy {
+        &*self.gate
+    }
+
+    fn recovery(&self) -> &dyn RecoveryStrategy {
+        &*self.recovery
+    }
+
+    fn stop(&self) -> &dyn StopConditionStrategy {
+        &*self.stop
+    }
+
+    fn drain(&self) -> &dyn InputDrainStrategy {
+        &*self.drain
+    }
+
+    fn budget(&self) -> &dyn BudgetStrategy {
+        &*self.budget
+    }
+}
+
+/// Strategy slots accepted by `DefaultPlanner::compose`.
+///
+/// The type is crate-private so future family factories can compose slot sets
+/// without making strategy traits constructible outside this crate.
+pub(crate) struct DefaultStrategySlots {
+    context: Arc<dyn ContextStrategy>,
+    capability: Arc<dyn CapabilityStrategy>,
+    model: Arc<dyn ModelStrategy>,
+    batch: Arc<dyn BatchPolicyStrategy>,
+    gate: Arc<dyn GateHandlingStrategy>,
+    recovery: Arc<dyn RecoveryStrategy>,
+    stop: Arc<dyn StopConditionStrategy>,
+    drain: Arc<dyn InputDrainStrategy>,
+    budget: Arc<dyn BudgetStrategy>,
+}
+
+impl Default for DefaultStrategySlots {
+    fn default() -> Self {
+        Self {
+            context: Arc::new(DefaultContextStrategy::default()),
+            capability: Arc::new(DefaultCapabilityStrategy),
+            model: Arc::new(DefaultModelStrategy),
+            batch: Arc::new(DefaultBatchPolicyStrategy),
+            gate: Arc::new(DefaultGateHandlingStrategy),
+            recovery: Arc::new(DefaultRecoveryStrategy::default()),
+            stop: Arc::new(DefaultStopConditionStrategy::default()),
+            drain: Arc::new(DefaultInputDrainStrategy),
+            budget: Arc::new(DefaultBudgetStrategy::default()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use ironclaw_host_api::{TenantId, ThreadId};
+    use ironclaw_turns::{
+        AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId, TurnScope,
+        run_profile::{
+            CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
+            ConcurrencyClass, ContextProfileId, LoopDriverId, LoopPromptBundleRequest,
+            LoopRunContext, ModelProfileId, PromptMode, RedactedRunProfileProvenance,
+            ResolvedRunProfile, ResourceBudgetPolicy, ResourceBudgetTier, RunClassId,
+            RunProfileFingerprint, RuntimeProfileConstraints, SchedulingClass, SteeringPolicy,
+        },
+    };
+
+    use crate::family::{ComponentDigest, LoopFamilyId};
+    use crate::state::LoopExecutionState;
+    use crate::strategies::{BatchPolicy, CapabilityFilter, ContextStrategy};
+
+    use super::*;
+
+    fn assert_send_sync<T: Send + Sync>() {}
+    fn assert_clone<T: Clone>() {}
+
+    #[allow(dead_code)]
+    fn _check(_: &dyn AgentLoopPlanner) {}
+
+    #[test]
+    fn default_planner_is_send_sync_and_clone() {
+        assert_send_sync::<DefaultPlanner>();
+        assert_clone::<DefaultPlanner>();
+    }
+
+    #[test]
+    fn compose_default_uses_default_family_identity() {
+        let planner = DefaultPlanner::compose_default();
+
+        assert_eq!(planner.id(), &LoopFamilyId::DEFAULT);
+        assert_eq!(planner.version().id, "default");
+        assert_eq!(planner.version().digest, DEFAULT_FAMILY_DIGEST);
+    }
+
+    #[tokio::test]
+    async fn builder_chain_overrides_identity_and_context() {
+        #[derive(Default)]
+        struct CustomContext;
+
+        #[async_trait]
+        impl ContextStrategy for CustomContext {
+            async fn plan_context_request(
+                &self,
+                _state: &LoopExecutionState,
+            ) -> LoopPromptBundleRequest {
+                LoopPromptBundleRequest {
+                    mode: PromptMode::TextOnly,
+                    context_cursor: None,
+                    surface_version: None,
+                    checkpoint_state_ref: None,
+                    max_messages: Some(7),
+                    inline_messages: Vec::new(),
+                }
+            }
+        }
+
+        let id = LoopFamilyId::new("custom").expect("valid custom family id");
+        let version = ComponentIdentity::from_static("custom", ComponentDigest([1; 32]));
+        let planner = DefaultPlanner::compose_default()
+            .with_id(id.clone())
+            .with_version(version.clone())
+            .with_context(Arc::new(CustomContext));
+
+        assert_eq!(planner.id(), &id);
+        assert_eq!(planner.version(), &version);
+
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+        let request = planner.context().plan_context_request(&state).await;
+        assert_eq!(request.max_messages, Some(7));
+    }
+
+    #[tokio::test]
+    async fn crate_private_internal_accessors_are_wired() {
+        let planner = DefaultPlanner::compose_default();
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+
+        assert_eq!(planner.budget().iteration_limit(&state), 32);
+        assert_eq!(planner.batch().policy(&state, &[]), BatchPolicy::Parallel);
+
+        let filter = planner.capability().filter(&state).await;
+        assert_eq!(filter, CapabilityFilter::All);
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn test_run_context() -> LoopRunContext {
+        let scope = TurnScope::new(
+            TenantId::new("tenant-default-planner").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-default-planner").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("default_planner_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("default_planner_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("default_planner_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("default_planner_test_model").expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "default_planner_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("default_planner_test_context")
+                .expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("default_planner_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new("default-planner-test-fingerprint")
+                .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+    }
+}

--- a/crates/ironclaw_agent_loop/src/families/mod.rs
+++ b/crates/ironclaw_agent_loop/src/families/mod.rs
@@ -1,38 +1,51 @@
 use std::sync::Arc;
 
-use crate::family::{
-    ComponentDigest, ComponentIdentity, LoopFamily, LoopFamilyId, LoopFamilyPlanner,
-};
-
-struct DefaultLoopFamilyPlanner;
-
-impl LoopFamilyPlanner for DefaultLoopFamilyPlanner {}
+use crate::default_planner::DefaultPlanner;
+use crate::family::{ComponentDigest, LoopFamily};
+use crate::planner::AgentLoopPlanner;
 
 #[cfg(test)]
-const DEFAULT_FAMILY_FINGERPRINT: &[u8] =
-    b"ironclaw_agent_loop.default_family.v1:planner=DefaultLoopFamilyPlanner;schema=component_identity_v1;family_id=default";
+const DEFAULT_FAMILY_FINGERPRINT: &[u8] = concat!(
+    "ironclaw_agent_loop.default_family.v1:",
+    "family_id=default;",
+    "identity=component_identity_v1;",
+    "planner=DefaultPlanner;",
+    "strategies=",
+    "context:DefaultContextStrategy(max_messages=16),",
+    "capability:DefaultCapabilityStrategy(all),",
+    "model:DefaultModelStrategy(primary_or_fallback_index),",
+    "batch:DefaultBatchPolicyStrategy(exclusive_sequential),",
+    "gate:DefaultGateHandlingStrategy(block),",
+    "recovery:DefaultRecoveryStrategy(max_attempts_per_class=2),",
+    "stop:DefaultStopConditionStrategy(window=5,repeat=3,failure_run=3),",
+    "drain:DefaultInputDrainStrategy(steering=true,followup=true),",
+    "budget:DefaultBudgetStrategy(iteration_limit=32,wall_clock_limit=none)"
+)
+.as_bytes();
 
 /// Stable digest: BLAKE3-256 of `DEFAULT_FAMILY_FINGERPRINT`.
 ///
 /// Update this digest when the default family composition, planner behavior, or
 /// identity schema changes in a replay-relevant way.
 pub const DEFAULT_FAMILY_DIGEST: ComponentDigest = ComponentDigest([
-    0x40, 0xe2, 0xeb, 0x31, 0x69, 0x81, 0x22, 0x31, 0x39, 0x76, 0x00, 0x25, 0x49, 0x4a, 0x0e, 0x14,
-    0xb5, 0xa1, 0x7a, 0x0a, 0x57, 0x59, 0x7d, 0xcd, 0xa7, 0x48, 0xae, 0x38, 0x11, 0x75, 0xf8, 0x0f,
+    0x65, 0x5e, 0xde, 0x7b, 0xff, 0x4c, 0x2d, 0x95, 0x70, 0xb5, 0xa2, 0xf7, 0x6f, 0x9c, 0x32, 0x53,
+    0x59, 0x19, 0xbe, 0x95, 0xbe, 0xcc, 0x1d, 0xc5, 0x77, 0x47, 0x5f, 0xd1, 0x78, 0xec, 0xbd, 0x93,
 ]);
 
 /// The default loop family: the text-tool-use baseline once the planner and
 /// executor workstreams land.
 pub fn default() -> LoopFamily {
-    LoopFamily::new(
-        LoopFamilyId::DEFAULT,
-        ComponentIdentity::from_static("default", DEFAULT_FAMILY_DIGEST),
-        Arc::new(DefaultLoopFamilyPlanner),
-    )
+    let planner = DefaultPlanner::compose_default();
+    let id = planner.id().clone();
+    let version = planner.version().clone();
+
+    LoopFamily::new(id, version, Arc::new(planner))
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::family::LoopFamilyId;
+
     use super::*;
 
     #[test]

--- a/crates/ironclaw_agent_loop/src/family.rs
+++ b/crates/ironclaw_agent_loop/src/family.rs
@@ -2,6 +2,8 @@ use std::{borrow::Cow, collections::HashMap, fmt, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
+use crate::planner::AgentLoopPlannerInternal;
+
 /// Identity for a Builtin loop family.
 ///
 /// Profile JSON serializes as a flat string. The registry is the authority on
@@ -102,8 +104,6 @@ impl ComponentIdentity {
     }
 }
 
-pub(crate) trait LoopFamilyPlanner: Send + Sync {}
-
 /// A Builtin loop family, opaque outside `ironclaw_agent_loop`.
 ///
 /// Family factories are the only production constructors. Downstream crates can
@@ -111,19 +111,20 @@ pub(crate) trait LoopFamilyPlanner: Send + Sync {}
 pub struct LoopFamily {
     id: LoopFamilyId,
     version: ComponentIdentity,
-    _planner: Arc<dyn LoopFamilyPlanner>,
+    #[allow(dead_code)]
+    planner: Arc<dyn AgentLoopPlannerInternal>,
 }
 
 impl LoopFamily {
     pub(crate) fn new(
         id: LoopFamilyId,
         version: ComponentIdentity,
-        planner: Arc<dyn LoopFamilyPlanner>,
+        planner: Arc<dyn AgentLoopPlannerInternal>,
     ) -> Self {
         Self {
             id,
             version,
-            _planner: planner,
+            planner,
         }
     }
 
@@ -133,6 +134,11 @@ impl LoopFamily {
 
     pub fn version(&self) -> &ComponentIdentity {
         &self.version
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn planner(&self) -> &dyn AgentLoopPlannerInternal {
+        self.planner.as_ref()
     }
 }
 
@@ -175,11 +181,9 @@ impl LoopFamilyRegistry {
 mod tests {
     use std::sync::Arc;
 
+    use crate::default_planner::DefaultPlanner;
+
     use super::*;
-
-    struct TestPlanner;
-
-    impl LoopFamilyPlanner for TestPlanner {}
 
     #[test]
     fn loop_family_id_default_is_flat_string() {
@@ -232,7 +236,7 @@ mod tests {
         let family = Arc::new(LoopFamily::new(
             LoopFamilyId::DEFAULT,
             ComponentIdentity::from_static("default", ComponentDigest([0; 32])),
-            Arc::new(TestPlanner),
+            Arc::new(DefaultPlanner::compose_default()),
         ));
         let registry = LoopFamilyRegistry::with_families(vec![family]).expect("valid registry");
 
@@ -250,12 +254,12 @@ mod tests {
         let family_a = Arc::new(LoopFamily::new(
             LoopFamilyId::DEFAULT,
             ComponentIdentity::from_static("default", ComponentDigest([1; 32])),
-            Arc::new(TestPlanner),
+            Arc::new(DefaultPlanner::compose_default()),
         ));
         let family_b = Arc::new(LoopFamily::new(
             LoopFamilyId::DEFAULT,
             ComponentIdentity::from_static("default", ComponentDigest([2; 32])),
-            Arc::new(TestPlanner),
+            Arc::new(DefaultPlanner::compose_default()),
         ));
 
         let error = match LoopFamilyRegistry::with_families(vec![family_a, family_b]) {

--- a/crates/ironclaw_agent_loop/src/lib.rs
+++ b/crates/ironclaw_agent_loop/src/lib.rs
@@ -4,7 +4,11 @@
 //! architecture is `docs/reborn/agent-loop-skeleton.md`; workstream briefs live
 //! under `docs/reborn/agent-loop-briefs/`.
 
+mod default_planner;
 pub mod families;
 pub mod family;
+pub mod planner;
 pub mod state;
 pub(crate) mod strategies;
+
+pub use planner::AgentLoopPlanner;

--- a/crates/ironclaw_agent_loop/src/planner.rs
+++ b/crates/ironclaw_agent_loop/src/planner.rs
@@ -1,0 +1,74 @@
+//! Planner facade for loop-family strategy composition.
+//!
+//! The public trait is intentionally identity-only. The canonical executor
+//! consults strategies through the crate-private `AgentLoopPlannerInternal`
+//! extension trait so downstream crates can hold a planner object without
+//! reaching into its Builtin strategy slots.
+
+use crate::family::{ComponentIdentity, LoopFamilyId};
+use crate::strategies::{
+    BatchPolicyStrategy, BudgetStrategy, CapabilityStrategy, ContextStrategy, GateHandlingStrategy,
+    InputDrainStrategy, ModelStrategy, RecoveryStrategy, StopConditionStrategy,
+};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+impl sealed::Sealed for crate::default_planner::DefaultPlanner {}
+
+/// A planner is a Builtin composition of the nine loop strategies.
+///
+/// The planner has no `run()` or `tick()` method; loop mechanics live in the
+/// executor. Public callers can only observe the family id and content identity
+/// used for profile resolution and replay validation.
+pub trait AgentLoopPlanner: sealed::Sealed + Send + Sync {
+    /// The loop family this planner composes for.
+    fn id(&self) -> &LoopFamilyId;
+
+    /// Content-addressed identity for this planner composition.
+    fn version(&self) -> &ComponentIdentity;
+}
+
+/// Crate-private executor-facing strategy access.
+#[allow(dead_code)]
+pub(crate) trait AgentLoopPlannerInternal: AgentLoopPlanner {
+    fn context(&self) -> &dyn ContextStrategy;
+    fn capability(&self) -> &dyn CapabilityStrategy;
+    fn model(&self) -> &dyn ModelStrategy;
+    fn batch(&self) -> &dyn BatchPolicyStrategy;
+    fn gate(&self) -> &dyn GateHandlingStrategy;
+    fn recovery(&self) -> &dyn RecoveryStrategy;
+    fn stop(&self) -> &dyn StopConditionStrategy;
+    fn drain(&self) -> &dyn InputDrainStrategy;
+    fn budget(&self) -> &dyn BudgetStrategy;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::default_planner::DefaultPlanner;
+    use crate::family::LoopFamilyId;
+
+    use super::*;
+
+    #[allow(dead_code)]
+    fn _check_object_safe(_: &dyn AgentLoopPlanner) {}
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn default_planner_is_object_safe_as_public_trait() {
+        let planner = DefaultPlanner::compose_default();
+        let object: &dyn AgentLoopPlanner = &planner;
+
+        assert_eq!(object.id(), &LoopFamilyId::DEFAULT);
+        assert_eq!(object.version().id, "default");
+    }
+
+    #[test]
+    fn arc_dyn_agent_loop_planner_is_send_sync() {
+        assert_send_sync::<Arc<dyn AgentLoopPlanner>>();
+    }
+}


### PR DESCRIPTION
## Context

WS4 adds the planner facade layer for the Reborn agent loop. It composes the nine strategy slots behind a sealed planner API and wires the default built-in loop family to the planner composition point.

Master spec: `docs/reborn/agent-loop-skeleton.md`
Workstream brief: `docs/reborn/agent-loop-briefs/planner-facade.md`
Current base: `reborn-integration`

## What Landed

- `AgentLoopPlanner`, a public identity-only planner facade.
- `AgentLoopPlannerInternal`, a crate-private executor-facing extension trait for strategy slot access.
- `DefaultPlanner`, a crate-private built-in composition for the default loop family.
- Default family wiring through `families::default()` and `LoopFamily`.
- A non-zero BLAKE3-backed `DEFAULT_FAMILY_DIGEST` tied to the declared default planner/strategy composition.
- Duplicate loop-family ID rejection preserved in `LoopFamilyRegistry`.

## Boundary Notes

- `DefaultPlanner` is intentionally `pub(crate)` and is not re-exported from the crate root.
- Public callers can observe only planner/family identity through `AgentLoopPlanner`.
- Concrete default strategy behavior remains owned by WS5; this branch only consumes the WS5 default strategy types in the planner slots.
- Executor tick mechanics remain deferred to WS6a.

## Reviewer Focus

- The public planner API should expose identity/composition only, not raw mutable strategy internals.
- Strategy access must remain available to the executor/families while staying closed to external crates.
- The planner should compose families; it should not become a runtime service locator.
- The default family digest should change when replay-relevant planner composition changes.

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo test -p ironclaw_agent_loop`
- `cargo clippy -p ironclaw_agent_loop -p ironclaw_reborn --all-targets --all-features -- -D warnings`
- `git merge-tree origin/reborn-integration HEAD`

## Stack Position

WS1, WS2, WS3, WS3.5, and WS5 have been squash-merged into `reborn-integration`. This PR is now a standalone WS4 planner-facade branch retargeted to `reborn-integration`.
