### PR TITLE
arch(ws-5): default strategies - Default* impls for all nine traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,6 +4084,7 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/ironclaw_agent_loop/Cargo.toml
+++ b/crates/ironclaw_agent_loop/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_jcs = "0.2"
 thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_agent_loop/src/state.rs
+++ b/crates/ironclaw_agent_loop/src/state.rs
@@ -13,7 +13,7 @@ pub use ironclaw_turns::LoopFailureKind;
 pub use signature::{ArgsHash, CapabilityCallSignature, CapabilityCallSignatureError};
 pub use slots::{
     CapabilityStrategyState, ContextStrategyState, GateStrategyState, ModelStrategyState,
-    RecoveryStrategyState, StopStrategyState,
+    RecoveryAttemptClass, RecoveryStrategyState, StopStrategyState,
 };
 
 use ironclaw_turns::{

--- a/crates/ironclaw_agent_loop/src/state/slots.rs
+++ b/crates/ironclaw_agent_loop/src/state/slots.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ContextStrategyState {}
 
@@ -9,16 +11,62 @@ pub struct ModelStrategyState {
     pub fallback_index: u32,
 }
 
-/// Per-error-class attempt counter for the recovery strategy.
+/// Per-error-class attempt counters for the recovery strategy.
 ///
 /// Semantics: the retry budget is *not* durable across resume — on rehydration
-/// from a `BeforeSideEffect` checkpoint, `attempts` resets to 0 so a fresh
+/// from a `BeforeSideEffect` checkpoint, counters reset to 0 so a fresh
 /// retry budget is granted post-resume. See master doc §10 for the
-/// retry-budget durability note. WS-2 may grow this into a
-/// `HashMap<LoopFailureKind, u32>` when `DefaultRecoveryStrategy` needs it.
+/// retry-budget durability note.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RecoveryStrategyState {
-    pub attempts: u32,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub attempts_by_class: BTreeMap<RecoveryAttemptClass, u32>,
+}
+
+impl RecoveryStrategyState {
+    /// Returns the attempt count already consumed for `class`.
+    pub fn attempts_for(&self, class: RecoveryAttemptClass) -> u32 {
+        self.attempts_by_class.get(&class).copied().unwrap_or(0)
+    }
+
+    /// Returns a new slot value with the attempt count for `class`
+    /// incremented by one (saturating at `u32::MAX`).
+    ///
+    /// Used by `DefaultRecoveryStrategy` when classifying a fresh error so
+    /// the next retry/abort decision sees the updated attempt count. See
+    /// `docs/reborn/agent-loop-skeleton.md` §6 ("RecoveryStrategy") and §10
+    /// ("Production-safe escape" — per-error retry budget).
+    pub fn with_incremented_attempts_for(&self, class: RecoveryAttemptClass) -> Self {
+        let mut attempts_by_class = self.attempts_by_class.clone();
+        attempts_by_class.insert(class, self.attempts_for(class).saturating_add(1));
+        Self { attempts_by_class }
+    }
+
+    pub fn with_attempts_for(class: RecoveryAttemptClass, attempts: u32) -> Self {
+        let mut attempts_by_class = BTreeMap::new();
+        attempts_by_class.insert(class, attempts);
+        Self { attempts_by_class }
+    }
+
+    /// Clears retry accounting after a terminal or non-retry decision so it
+    /// cannot poison an unrelated later retryable error.
+    pub fn cleared_attempts(&self) -> Self {
+        Self::default()
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryAttemptClass {
+    CapabilityTransient,
+    CapabilityUnavailable,
+    CapabilityInternal,
+    ModelTransient,
+    ModelContextOverflow,
+    ModelUnavailable,
+    ModelInternal,
 }
 
 /// Persistent state owned by `StopConditionStrategy`. Split from a previously

--- a/crates/ironclaw_agent_loop/src/strategies/batch.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/batch.rs
@@ -30,6 +30,31 @@ pub(crate) trait BatchPolicyStrategy: Send + Sync {
 #[allow(dead_code)]
 fn _batch_policy_strategy_object_safe(_: &dyn BatchPolicyStrategy) {}
 
+/// Reference baseline `BatchPolicyStrategy`: run parallel unless any call in
+/// the batch carries an `Exclusive` concurrency hint.
+///
+/// An empty batch returns `Parallel`. The default is a no-op for a zero-call
+/// batch (the executor never invokes the strategy in that case in practice),
+/// but a stable answer keeps the strategy total.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `BatchPolicyStrategy`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultBatchPolicyStrategy;
+
+impl BatchPolicyStrategy for DefaultBatchPolicyStrategy {
+    fn policy(&self, _state: &LoopExecutionState, calls: &[CapabilityCallSummary]) -> BatchPolicy {
+        if calls
+            .iter()
+            .any(|call| matches!(call.concurrency_hint, ConcurrencyHint::Exclusive))
+        {
+            BatchPolicy::Sequential
+        } else {
+            BatchPolicy::Parallel
+        }
+    }
+}
+
 /// Batch-level execution mode. Wire-stable: serialized into checkpoints and
 /// emitted on observability events, so the snake_case names are part of the
 /// public contract.
@@ -53,9 +78,132 @@ pub(crate) struct CapabilityCallSummary {
 
 #[cfg(test)]
 mod tests {
+    use ironclaw_host_api::{TenantId, ThreadId};
+    use ironclaw_turns::{
+        AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId, TurnScope,
+        run_profile::{
+            CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
+            ConcurrencyClass, ContextProfileId, LoopDriverId, LoopRunContext, ModelProfileId,
+            RedactedRunProfileProvenance, ResolvedRunProfile, ResourceBudgetPolicy,
+            ResourceBudgetTier, RunClassId, RunProfileFingerprint, RuntimeProfileConstraints,
+            SchedulingClass, SteeringPolicy,
+        },
+    };
     use serde_json::json;
 
     use super::*;
+    use crate::state::LoopExecutionState;
+
+    fn test_run_context() -> LoopRunContext {
+        let scope = TurnScope::new(
+            TenantId::new("tenant-default-batch").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-default-batch").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("default_batch_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("default_batch_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("default_batch_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("default_batch_test_model").expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "default_batch_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("default_batch_test_context").expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("default_batch_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new("default-batch-test-fingerprint")
+                .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+    }
+
+    fn call(name: &str, hint: ConcurrencyHint) -> CapabilityCallSummary {
+        CapabilityCallSummary {
+            name: ironclaw_host_api::CapabilityId::new(name).expect("valid"),
+            concurrency_hint: hint,
+        }
+    }
+
+    #[test]
+    fn default_batch_policy_returns_parallel_for_empty_batch() {
+        let strategy = DefaultBatchPolicyStrategy;
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+
+        assert_eq!(strategy.policy(&state, &[]), BatchPolicy::Parallel);
+    }
+
+    #[test]
+    fn default_batch_policy_returns_parallel_when_all_safe() {
+        let strategy = DefaultBatchPolicyStrategy;
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+        let calls = [
+            call("demo.echo", ConcurrencyHint::SafeForParallel),
+            call("demo.read", ConcurrencyHint::SafeForParallel),
+        ];
+
+        assert_eq!(strategy.policy(&state, &calls), BatchPolicy::Parallel);
+    }
+
+    #[test]
+    fn default_batch_policy_returns_sequential_when_any_exclusive() {
+        let strategy = DefaultBatchPolicyStrategy;
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+        let calls = [
+            call("demo.read", ConcurrencyHint::SafeForParallel),
+            call("demo.write", ConcurrencyHint::Exclusive),
+        ];
+
+        assert_eq!(strategy.policy(&state, &calls), BatchPolicy::Sequential);
+    }
 
     #[test]
     fn batch_policy_round_trips_snake_case() {

--- a/crates/ironclaw_agent_loop/src/strategies/budget.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/budget.rs
@@ -22,6 +22,42 @@ pub(crate) trait BudgetStrategy: Send + Sync {
 #[allow(dead_code)]
 fn assert_budget_strategy_object_safe(_: &dyn BudgetStrategy) {}
 
+/// Reference baseline `BudgetStrategy`: 32-iteration cap with no wall-clock
+/// limit.
+///
+/// Per master spec §10 ("Production-safe escape" — iteration cap), the
+/// 32-iteration ceiling is the first safety net. Loop families that need
+/// shorter or longer budgets construct this struct directly.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `BudgetStrategy`) and §10 ("Production-safe escape").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DefaultBudgetStrategy {
+    /// Hard ceiling on iteration count. Default `32`.
+    pub iteration_limit: u32,
+    /// Optional wall-clock cap. Default `None` (no limit).
+    pub wall_clock_limit: Option<Duration>,
+}
+
+impl Default for DefaultBudgetStrategy {
+    fn default() -> Self {
+        Self {
+            iteration_limit: 32,
+            wall_clock_limit: None,
+        }
+    }
+}
+
+impl BudgetStrategy for DefaultBudgetStrategy {
+    fn iteration_limit(&self, _: &LoopExecutionState) -> u32 {
+        self.iteration_limit
+    }
+
+    fn wall_clock_limit(&self, _: &LoopExecutionState) -> Option<Duration> {
+        self.wall_clock_limit
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ironclaw_host_api::{TenantId, ThreadId};
@@ -40,13 +76,13 @@ mod tests {
 
     #[test]
     fn budget_strategy_is_object_safe() {
-        assert_budget_strategy_object_safe(&FixedBudget);
+        assert_budget_strategy_object_safe(&DefaultBudgetStrategy::default());
     }
 
     #[test]
     fn fixed_budget_exercises_trait_surface() {
         let state = LoopExecutionState::initial_for_run(&test_run_context());
-        let strategy: &dyn BudgetStrategy = &FixedBudget;
+        let strategy: &dyn BudgetStrategy = &DefaultBudgetStrategy::default();
 
         assert_eq!(
             (
@@ -57,16 +93,13 @@ mod tests {
         );
     }
 
-    struct FixedBudget;
+    #[test]
+    fn default_budget_strategy_returns_32_iterations_no_wall_clock() {
+        let strategy = DefaultBudgetStrategy::default();
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
 
-    impl BudgetStrategy for FixedBudget {
-        fn iteration_limit(&self, _: &LoopExecutionState) -> u32 {
-            32
-        }
-
-        fn wall_clock_limit(&self, _: &LoopExecutionState) -> Option<Duration> {
-            None
-        }
+        assert_eq!(strategy.iteration_limit(&state), 32);
+        assert_eq!(strategy.wall_clock_limit(&state), None);
     }
 
     fn test_run_context() -> LoopRunContext {

--- a/crates/ironclaw_agent_loop/src/strategies/capability.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/capability.rs
@@ -21,6 +21,24 @@ pub(crate) trait CapabilityStrategy: Send + Sync {
 #[allow(dead_code)]
 fn _assert_object_safe(_: &dyn CapabilityStrategy) {}
 
+/// Reference baseline `CapabilityStrategy`: never narrow the host surface.
+///
+/// The host applies its own scope/grant/auth filters on top — this default
+/// strategy declines to filter further, leaving capability visibility entirely
+/// to the host's authoritative policy.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `CapabilityStrategy`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultCapabilityStrategy;
+
+#[async_trait]
+impl CapabilityStrategy for DefaultCapabilityStrategy {
+    async fn filter(&self, _state: &LoopExecutionState) -> CapabilityFilter {
+        CapabilityFilter::All
+    }
+}
+
 /// Strategy-side narrowing of the visible capability surface.
 ///
 /// Variants are mutually exclusive. The host always applies its own
@@ -39,9 +57,103 @@ pub(crate) enum CapabilityFilter {
 
 #[cfg(test)]
 mod tests {
-    use ironclaw_host_api::CapabilityId;
+    use ironclaw_host_api::{CapabilityId, TenantId, ThreadId};
+    use ironclaw_turns::{
+        AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId, TurnScope,
+        run_profile::{
+            CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
+            ConcurrencyClass, ContextProfileId, LoopDriverId, LoopRunContext, ModelProfileId,
+            RedactedRunProfileProvenance, ResolvedRunProfile, ResourceBudgetPolicy,
+            ResourceBudgetTier, RunClassId, RunProfileFingerprint, RuntimeProfileConstraints,
+            SchedulingClass, SteeringPolicy,
+        },
+    };
 
-    use super::CapabilityFilter;
+    use super::{CapabilityFilter, CapabilityStrategy, DefaultCapabilityStrategy};
+    use crate::state::LoopExecutionState;
+
+    #[allow(dead_code)]
+    fn _check(_: &dyn CapabilityStrategy) {}
+
+    fn test_run_context() -> LoopRunContext {
+        let scope = TurnScope::new(
+            TenantId::new("tenant-default-cap").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-default-cap").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("default_cap_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("default_cap_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("default_cap_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("default_cap_test_model").expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "default_cap_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("default_cap_test_context").expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("default_cap_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new("default-cap-test-fingerprint")
+                .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+    }
+
+    #[tokio::test]
+    async fn default_capability_strategy_returns_all() {
+        let strategy = DefaultCapabilityStrategy;
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+
+        assert_eq!(strategy.filter(&state).await, CapabilityFilter::All);
+    }
 
     #[test]
     fn default_filter_allows_all() {

--- a/crates/ironclaw_agent_loop/src/strategies/context.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/context.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use ironclaw_turns::run_profile::LoopPromptBundleRequest;
+use ironclaw_turns::run_profile::{LoopPromptBundleRequest, PromptMode};
 
 use crate::state::LoopExecutionState;
 
@@ -21,3 +21,173 @@ pub(crate) trait ContextStrategy: Send + Sync {
 
 #[allow(dead_code)]
 fn _assert_object_safe(_: &dyn ContextStrategy) {}
+
+/// Reference baseline `ContextStrategy` implementation.
+///
+/// Requests `PromptMode::TextOnly` with at most [`Self::DEFAULT_MAX_MESSAGES`]
+/// transcript messages and no inline nudges. Loop families that want
+/// CodeAct-shaped prompts or want to inject nudges swap this strategy
+/// rather than mutating state.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `ContextStrategy`).
+#[derive(Debug, Clone, Copy)]
+pub struct DefaultContextStrategy {
+    /// Max messages to ask the host to include in the bundle. Default
+    /// [`Self::DEFAULT_MAX_MESSAGES`].
+    pub max_messages: u32,
+}
+
+impl DefaultContextStrategy {
+    /// Default ceiling on transcript messages requested per turn.
+    pub const DEFAULT_MAX_MESSAGES: u32 = 16;
+}
+
+impl Default for DefaultContextStrategy {
+    fn default() -> Self {
+        Self {
+            max_messages: Self::DEFAULT_MAX_MESSAGES,
+        }
+    }
+}
+
+#[async_trait]
+impl ContextStrategy for DefaultContextStrategy {
+    async fn plan_context_request(&self, _state: &LoopExecutionState) -> LoopPromptBundleRequest {
+        // `max(1)` keeps the host's "zero is rejected" invariant from
+        // `LoopPromptBundleRequest` even if a loop family overrides
+        // `max_messages` to zero by accident.
+        LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(self.max_messages.max(1)),
+            inline_messages: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{TenantId, ThreadId};
+    use ironclaw_turns::{
+        AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId, TurnScope,
+        run_profile::{
+            CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
+            ConcurrencyClass, ContextProfileId, LoopDriverId, LoopRunContext, ModelProfileId,
+            PromptMode, RedactedRunProfileProvenance, ResolvedRunProfile, ResourceBudgetPolicy,
+            ResourceBudgetTier, RunClassId, RunProfileFingerprint, RuntimeProfileConstraints,
+            SchedulingClass, SteeringPolicy,
+        },
+    };
+
+    use super::{ContextStrategy, DefaultContextStrategy};
+    use crate::state::LoopExecutionState;
+
+    #[allow(dead_code)]
+    fn _check(_: &dyn ContextStrategy) {}
+
+    fn test_run_context() -> LoopRunContext {
+        let scope = TurnScope::new(
+            TenantId::new("tenant-default-context").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-default-context").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("default_context_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("default_context_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("default_context_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("default_context_test_model").expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "default_context_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("default_context_test_context")
+                .expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("default_context_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new("default-context-test-fingerprint")
+                .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+    }
+
+    #[test]
+    fn default_max_messages_is_sixteen() {
+        assert_eq!(DefaultContextStrategy::default().max_messages, 16);
+    }
+
+    #[tokio::test]
+    async fn plan_context_request_returns_text_only_bundle() {
+        let strategy = DefaultContextStrategy::default();
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+
+        let request = strategy.plan_context_request(&state).await;
+
+        assert_eq!(request.mode, PromptMode::TextOnly);
+        assert_eq!(request.max_messages, Some(16));
+        assert!(request.inline_messages.is_empty());
+        assert!(request.context_cursor.is_none());
+        assert!(request.surface_version.is_none());
+        assert!(request.checkpoint_state_ref.is_none());
+    }
+
+    #[tokio::test]
+    async fn plan_context_request_clamps_zero_to_one() {
+        let strategy = DefaultContextStrategy { max_messages: 0 };
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+
+        let request = strategy.plan_context_request(&state).await;
+
+        assert_eq!(request.max_messages, Some(1));
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/drain.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/drain.rs
@@ -20,11 +20,36 @@ pub(crate) trait InputDrainStrategy: Send + Sync {
 #[allow(dead_code)]
 fn assert_input_drain_strategy_object_safe(_: &dyn InputDrainStrategy) {}
 
+/// Reference baseline `InputDrainStrategy`: drain both queues every time the
+/// executor asks.
+///
+/// Returns `(drain_steering: true, drain_followup: true)` from the two hook
+/// points: steering before each model call, followup before otherwise
+/// stopping.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `InputDrainStrategy`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultInputDrainStrategy;
+
+#[async_trait]
+impl InputDrainStrategy for DefaultInputDrainStrategy {
+    async fn drain_steering(&self, _state: &LoopExecutionState) -> bool {
+        true
+    }
+
+    async fn drain_followup(&self, _state: &LoopExecutionState) -> bool {
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
+    use ironclaw_turns::{LoopMessageRef, LoopResultRef};
 
     use super::*;
+    use crate::strategies::{TurnEndKind, TurnSummary};
 
     #[test]
     fn drain_strategy_is_object_safe() {
@@ -42,5 +67,114 @@ mod tests {
         }
 
         assert_input_drain_strategy_object_safe(&NeverDrain);
+    }
+
+    #[tokio::test]
+    async fn default_input_drain_strategy_returns_true_for_both_hooks() {
+        use ironclaw_host_api::{TenantId, ThreadId};
+        use ironclaw_turns::{
+            AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId,
+            TurnScope,
+            run_profile::{
+                CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy,
+                CheckpointSchemaId, ConcurrencyClass, ContextProfileId, LoopDriverId,
+                LoopRunContext, ModelProfileId, RedactedRunProfileProvenance, ResolvedRunProfile,
+                ResourceBudgetPolicy, ResourceBudgetTier, RunClassId, RunProfileFingerprint,
+                RuntimeProfileConstraints, SchedulingClass, SteeringPolicy,
+            },
+        };
+
+        let scope = TurnScope::new(
+            TenantId::new("tenant-default-drain").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-default-drain").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("default_drain_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("default_drain_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("default_drain_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("default_drain_test_model").expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "default_drain_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("default_drain_test_context").expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("default_drain_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new("default-drain-test-fingerprint")
+                .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        let context =
+            LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile);
+        let state = crate::state::LoopExecutionState::initial_for_run(&context);
+        let strategy = super::DefaultInputDrainStrategy;
+
+        assert!(strategy.drain_steering(&state).await);
+        assert!(strategy.drain_followup(&state).await);
+    }
+
+    #[test]
+    fn turn_summary_round_trips_through_json() {
+        let summary = TurnSummary {
+            kind: TurnEndKind::AfterCapabilityBatch,
+            assistant_message_ref: Some(LoopMessageRef::new("msg:assistant-1").unwrap()),
+            batch_result_refs: vec![
+                LoopResultRef::new("result:call-1").unwrap(),
+                LoopResultRef::new("result:call-2").unwrap(),
+            ],
+        };
+
+        let serialized = serde_json::to_string(&summary).unwrap();
+        let deserialized = serde_json::from_str::<TurnSummary>(&serialized).unwrap();
+
+        assert_eq!(deserialized, summary);
     }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/gate.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/gate.rs
@@ -30,6 +30,26 @@ pub(crate) trait GateHandlingStrategy: Send + Sync {
 #[allow(dead_code)]
 fn _gate_handling_strategy_object_safe(_: &dyn GateHandlingStrategy) {}
 
+/// Reference baseline `GateHandlingStrategy`: always `Block`.
+///
+/// The executor checkpoints (`BeforeBlock`) and returns
+/// `LoopExit::Blocked`. Loop families that want skip-and-continue or abort
+/// semantics swap this strategy.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `GateHandlingStrategy`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultGateHandlingStrategy;
+
+#[async_trait]
+impl GateHandlingStrategy for DefaultGateHandlingStrategy {
+    async fn handle(&self, state: &LoopExecutionState, _gate: &GateSummary) -> GateOutcome {
+        GateOutcome::Block {
+            gate: state.gate_state.clone(),
+        }
+    }
+}
+
 /// Loop-side projection of a host capability gate — kind + opaque ref only.
 /// The strategy never sees raw input, secrets, or auth state (per
 /// `contracts/turns-agent-loop.md` §6 + `contracts/lightweight-agent-loop.md`
@@ -91,10 +111,95 @@ impl GateOutcome {
 
 #[cfg(test)]
 mod tests {
+    use ironclaw_host_api::{TenantId, ThreadId};
+    use ironclaw_turns::{
+        AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId, TurnScope,
+        run_profile::{
+            CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
+            ConcurrencyClass, ContextProfileId, LoopDriverId, LoopRunContext, ModelProfileId,
+            RedactedRunProfileProvenance, ResolvedRunProfile, ResourceBudgetPolicy,
+            ResourceBudgetTier, RunClassId, RunProfileFingerprint, RuntimeProfileConstraints,
+            SchedulingClass, SteeringPolicy,
+        },
+    };
+
     use super::*;
+    use crate::state::LoopExecutionState;
 
     fn sample_gate() -> GateStrategyState {
         GateStrategyState::default()
+    }
+
+    fn test_run_context() -> LoopRunContext {
+        let scope = TurnScope::new(
+            TenantId::new("tenant-default-gate").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-default-gate").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("default_gate_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("default_gate_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("default_gate_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("default_gate_test_model").expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "default_gate_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("default_gate_test_context").expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("default_gate_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new("default-gate-test-fingerprint")
+                .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
     }
 
     #[test]
@@ -190,5 +295,23 @@ mod tests {
         };
         assert_eq!(outcome.validate_for_gate_kind(GateKind::Auth), Ok(()));
         assert_eq!(outcome.validate_for_gate_kind(GateKind::Resource), Ok(()));
+    }
+
+    #[tokio::test]
+    async fn default_gate_handling_strategy_blocks_for_every_kind() {
+        let strategy = DefaultGateHandlingStrategy;
+        let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+        state.gate_state = sample_gate();
+
+        for kind in [GateKind::Approval, GateKind::Auth, GateKind::Resource] {
+            let summary = GateSummary {
+                kind,
+                gate_ref: LoopGateRef::new("gate:default-test").expect("valid"),
+            };
+            match strategy.handle(&state, &summary).await {
+                GateOutcome::Block { gate } => assert_eq!(gate, sample_gate()),
+                other => panic!("expected Block for {kind:?}, got {other:?}"),
+            }
+        }
     }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -32,17 +32,184 @@ mod model;
 pub(crate) mod recovery;
 mod stop;
 
-pub(crate) use batch::{BatchPolicy, BatchPolicyStrategy, CapabilityCallSummary};
-pub(crate) use budget::BudgetStrategy;
-pub(crate) use capability::{CapabilityFilter, CapabilityStrategy};
-pub(crate) use context::ContextStrategy;
-pub(crate) use drain::InputDrainStrategy;
-pub(crate) use gate::{GateHandlingStrategy, GateKind, GateOutcome, GateSummary};
-pub(crate) use ironclaw_turns::run_profile::ConcurrencyHint;
-pub(crate) use model::{ModelPreference, ModelStrategy};
-pub(crate) use recovery::{
-    BackoffDelayMs, CapabilityErrorClass, CapabilityErrorSummary, ModelErrorClass,
-    ModelErrorSummary, RecoveryOutcome, RecoveryStrategy, RetryAlteration, RetryScope,
-    SanitizedStrategySummary,
+pub(crate) use batch::{
+    BatchPolicy, BatchPolicyStrategy, CapabilityCallSummary, DefaultBatchPolicyStrategy,
 };
-pub(crate) use stop::{StopConditionStrategy, StopKind, StopOutcome, TurnEndKind, TurnSummary};
+pub(crate) use budget::{BudgetStrategy, DefaultBudgetStrategy};
+pub(crate) use capability::{CapabilityFilter, CapabilityStrategy, DefaultCapabilityStrategy};
+pub(crate) use context::{ContextStrategy, DefaultContextStrategy};
+pub(crate) use drain::{DefaultInputDrainStrategy, InputDrainStrategy};
+pub(crate) use gate::{
+    DefaultGateHandlingStrategy, GateHandlingStrategy, GateKind, GateOutcome, GateSummary,
+};
+pub(crate) use model::{DefaultModelStrategy, ModelPreference, ModelStrategy};
+pub(crate) use recovery::{
+    BackoffDelayMs, CapabilityErrorClass, CapabilityErrorSummary, DefaultRecoveryStrategy,
+    ModelErrorClass, ModelErrorSummary, RecoveryOutcome, RecoveryStrategy, RetryAlteration,
+    RetryScope, SanitizedStrategySummary,
+};
+pub(crate) use stop::{
+    DefaultStopConditionStrategy, StopConditionStrategy, StopKind, StopOutcome, TurnEndKind,
+    TurnSummary,
+};
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_host_api::{TenantId, ThreadId};
+    use ironclaw_turns::{
+        AgentLoopDriverDescriptor, LoopFailureKind, RunProfileId, RunProfileVersion, TurnId,
+        TurnRunId, TurnScope,
+        run_profile::{
+            CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
+            ConcurrencyClass, ContextProfileId, LoopDriverId, LoopRunContext, ModelProfileId,
+            RedactedRunProfileProvenance, ResolvedRunProfile, ResourceBudgetPolicy,
+            ResourceBudgetTier, RunClassId, RunProfileFingerprint, RuntimeProfileConstraints,
+            SchedulingClass, SteeringPolicy,
+        },
+    };
+
+    use super::*;
+    use crate::state::{
+        GateStrategyState, LoopExecutionState, RecoveryStrategyState, StopStrategyState,
+    };
+
+    #[test]
+    fn strategy_outcomes_compose_through_loop_state_slots() {
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+
+        let gate_outcome = GateOutcome::Block {
+            gate: GateStrategyState::default(),
+        };
+        let recovery_outcome = RecoveryOutcome::Retry {
+            recovery: RecoveryStrategyState::with_attempts_for(
+                crate::state::RecoveryAttemptClass::ModelTransient,
+                2,
+            ),
+            scope: RetryScope::Call,
+            alter: Some(RetryAlteration::ShrinkContext { drop_messages: 1 }),
+        };
+        let stop_outcome = StopOutcome::Stop {
+            stop: StopStrategyState {
+                turns_completed: 1,
+                terminate_hints_in_last_batch: 1,
+                last_batch_total: 1,
+            },
+            kind: StopKind::NoProgressDetected,
+        };
+
+        let mut next_state = state.clone();
+        if let GateOutcome::Block { gate } = gate_outcome {
+            next_state.gate_state = gate;
+        }
+        if let RecoveryOutcome::Retry { recovery, .. } = recovery_outcome {
+            next_state.recovery_state = recovery;
+        }
+        if let StopOutcome::Stop { stop, kind } = stop_outcome {
+            assert_eq!(kind, StopKind::NoProgressDetected);
+            next_state.stop_state = stop;
+        }
+
+        let value = serde_json::to_value(&next_state).expect("serialize loop state");
+        assert_eq!(
+            value["recovery_state"]["attempts_by_class"]["model_transient"],
+            2
+        );
+        assert_eq!(value["stop_state"]["turns_completed"], 1);
+        assert_eq!(value["gate_state"], serde_json::json!({}));
+
+        let restored: LoopExecutionState =
+            serde_json::from_value(value).expect("deserialize loop state");
+        assert_eq!(
+            restored.recovery_state,
+            RecoveryStrategyState::with_attempts_for(
+                crate::state::RecoveryAttemptClass::ModelTransient,
+                2,
+            )
+        );
+        assert_eq!(
+            restored.stop_state,
+            StopStrategyState {
+                turns_completed: 1,
+                terminate_hints_in_last_batch: 1,
+                last_batch_total: 1,
+            }
+        );
+        assert_eq!(restored.gate_state, GateStrategyState::default());
+    }
+
+    fn test_run_context() -> LoopRunContext {
+        let scope = TurnScope::new(
+            TenantId::new("tenant-strategy-composition").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-strategy-composition").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("strategy_composition_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("strategy_composition_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("strategy_composition_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("strategy_composition_test_model")
+                .expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "strategy_composition_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("strategy_composition_test_context")
+                .expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("strategy_composition_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new(
+                "strategy-composition-test-fingerprint",
+            )
+            .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+    }
+}

--- a/crates/ironclaw_agent_loop/src/strategies/model.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/model.rs
@@ -21,6 +21,28 @@ pub(crate) trait ModelStrategy: Send + Sync {
 #[allow(dead_code)]
 fn _assert_object_safe(_: &dyn ModelStrategy) {}
 
+/// Reference baseline `ModelStrategy`: track the executor-managed fallback
+/// index in `state.model_state.fallback_index`.
+///
+/// In the skeleton the executor never advances `fallback_index`, so this
+/// always returns `Primary`. The `Fallback` arm is wired through for the
+/// deferred `ModelRouteChain` follow-up (master doc §9).
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `ModelStrategy`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultModelStrategy;
+
+#[async_trait]
+impl ModelStrategy for DefaultModelStrategy {
+    async fn preference(&self, state: &LoopExecutionState) -> ModelPreference {
+        match state.model_state.fallback_index {
+            0 => ModelPreference::Primary,
+            index => ModelPreference::Fallback { index },
+        }
+    }
+}
+
 /// Strategy hint to the host about which already-resolved route to use.
 ///
 /// In the skeleton, `Primary` is the only value strategies produce. `Fallback`
@@ -41,11 +63,119 @@ pub(crate) enum ModelPreference {
 
 #[cfg(test)]
 mod tests {
-    use super::ModelPreference;
+    use ironclaw_host_api::{TenantId, ThreadId};
+    use ironclaw_turns::{
+        AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId, TurnScope,
+        run_profile::{
+            CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy, CheckpointSchemaId,
+            ConcurrencyClass, ContextProfileId, LoopDriverId, LoopRunContext, ModelProfileId,
+            RedactedRunProfileProvenance, ResolvedRunProfile, ResourceBudgetPolicy,
+            ResourceBudgetTier, RunClassId, RunProfileFingerprint, RuntimeProfileConstraints,
+            SchedulingClass, SteeringPolicy,
+        },
+    };
+
+    use super::{DefaultModelStrategy, ModelPreference, ModelStrategy};
+    use crate::state::LoopExecutionState;
+
+    #[allow(dead_code)]
+    fn _check(_: &dyn ModelStrategy) {}
+
+    fn test_run_context() -> LoopRunContext {
+        let scope = TurnScope::new(
+            TenantId::new("tenant-default-model").expect("valid"),
+            None,
+            None,
+            ThreadId::new("thread-default-model").expect("valid"),
+        );
+        let descriptor = AgentLoopDriverDescriptor {
+            id: LoopDriverId::new("default_model_test_driver").expect("valid"),
+            version: RunProfileVersion::new(1),
+            checkpoint_schema_id: Some(
+                CheckpointSchemaId::new("default_model_test_checkpoint").expect("valid"),
+            ),
+            checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+        };
+        let resolved_run_profile = ResolvedRunProfile {
+            run_class_id: RunClassId::new("default_model_test_class").expect("valid"),
+            profile_id: RunProfileId::default_profile(),
+            profile_version: RunProfileVersion::new(1),
+            loop_driver: descriptor.clone(),
+            checkpoint_schema_id: descriptor
+                .checkpoint_schema_id
+                .clone()
+                .expect("descriptor checkpoint id"),
+            checkpoint_schema_version: descriptor
+                .checkpoint_schema_version
+                .expect("descriptor checkpoint version"),
+            model_profile_id: ModelProfileId::new("default_model_test_model").expect("valid"),
+            capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                "default_model_test_capabilities",
+            )
+            .expect("valid"),
+            context_profile_id: ContextProfileId::new("default_model_test_context").expect("valid"),
+            steering_policy: SteeringPolicy {
+                allow_steering: false,
+                allow_interrupt: true,
+                allow_driver_specific_nudges: false,
+            },
+            cancellation_policy: CancellationPolicy {
+                allow_cancel: true,
+                require_checkpoint_before_cancel: false,
+            },
+            checkpoint_policy: CheckpointPolicy {
+                require_before_model: false,
+                require_before_side_effect: false,
+                require_before_block: true,
+                max_checkpoint_bytes: 64 * 1024,
+                require_final_checkpoint: false,
+                allow_no_reply_completion: false,
+            },
+            resource_budget_policy: ResourceBudgetPolicy {
+                tier: ResourceBudgetTier::new("default_model_test_tier").expect("valid"),
+                max_model_calls: 32,
+                max_capability_invocations: 64,
+            },
+            runtime_constraints: RuntimeProfileConstraints {
+                allow_raw_runtime_backend_selection: false,
+                allow_broad_capability_surface: false,
+            },
+            runner_pool_id: None,
+            scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+            concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+            resolution_fingerprint: RunProfileFingerprint::new("default-model-test-fingerprint")
+                .expect("valid"),
+            provenance: RedactedRunProfileProvenance {
+                sources: vec![],
+                effective_privileges: vec![],
+            },
+        };
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+    }
 
     #[test]
     fn default_preference_is_primary() {
         assert_eq!(ModelPreference::default(), ModelPreference::Primary);
+    }
+
+    #[tokio::test]
+    async fn default_model_strategy_returns_primary_at_index_zero() {
+        let strategy = DefaultModelStrategy;
+        let state = LoopExecutionState::initial_for_run(&test_run_context());
+
+        assert_eq!(strategy.preference(&state).await, ModelPreference::Primary);
+    }
+
+    #[tokio::test]
+    async fn default_model_strategy_returns_fallback_when_index_nonzero() {
+        let strategy = DefaultModelStrategy;
+        let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+        state.model_state.fallback_index = 2;
+
+        assert_eq!(
+            strategy.preference(&state).await,
+            ModelPreference::Fallback { index: 2 }
+        );
     }
 
     #[test]

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -13,7 +13,7 @@
 use async_trait::async_trait;
 use ironclaw_turns::{LoopDiagnosticRef, LoopFailureKind, run_profile::LoopSafeSummary};
 
-use crate::state::{LoopExecutionState, RecoveryStrategyState};
+use crate::state::{LoopExecutionState, RecoveryAttemptClass, RecoveryStrategyState};
 
 /// Decides what to do when a capability call OR a model call fails with a
 /// (sanitized) error summary.
@@ -168,6 +168,211 @@ pub(crate) enum RetryScope {
     Iteration,
 }
 
+/// Reference baseline `RecoveryStrategy`: bounded retry per error class with
+/// exponential backoff.
+///
+/// Per master spec §10 ("Production-safe escape" — per-error retry budget),
+/// this strategy:
+/// - Skips `PolicyDenied` so the model can try another authorized tool without
+///   consuming retry budget.
+/// - Aborts immediately on `Permanent`, `InputInvalid`, and `ContentFiltered`.
+/// - Retries capability/model transient, unavailable, and internal errors up
+///   to [`Self::max_attempts_per_class`] times with `Backoff`.
+/// - Retries `ContextOverflow` at iteration scope with `ShrinkContext`.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `RecoveryStrategy`) and §10 ("Production-safe escape").
+#[derive(Debug, Clone, Copy)]
+pub struct DefaultRecoveryStrategy {
+    /// Max retries per error class before giving up. Default `2`.
+    pub max_attempts_per_class: u32,
+}
+
+impl Default for DefaultRecoveryStrategy {
+    fn default() -> Self {
+        Self {
+            max_attempts_per_class: 2,
+        }
+    }
+}
+
+#[async_trait]
+impl RecoveryStrategy for DefaultRecoveryStrategy {
+    async fn on_capability_error(
+        &self,
+        state: &LoopExecutionState,
+        err: &CapabilityErrorSummary,
+    ) -> RecoveryOutcome {
+        let kind = capability_error_to_failure_kind(err.class);
+        match err.class {
+            CapabilityErrorClass::PolicyDenied => RecoveryOutcome::SkipResult {
+                recovery: state.recovery_state.cleared_attempts(),
+            },
+            CapabilityErrorClass::Permanent | CapabilityErrorClass::InputInvalid => {
+                RecoveryOutcome::Abort {
+                    recovery: state.recovery_state.cleared_attempts(),
+                    failure_kind: kind,
+                }
+            }
+            CapabilityErrorClass::Transient
+            | CapabilityErrorClass::Unavailable
+            | CapabilityErrorClass::Internal => {
+                let Some(attempt_class) = capability_retry_attempt_class(err.class) else {
+                    return RecoveryOutcome::Abort {
+                        recovery: state.recovery_state.cleared_attempts(),
+                        failure_kind: LoopFailureKind::DriverBug,
+                    };
+                };
+                retry_or_abort(
+                    state,
+                    attempt_class,
+                    self.max_attempts_per_class,
+                    kind,
+                    RetryScope::Call,
+                    |attempts| {
+                        Some(RetryAlteration::Backoff {
+                            delay_ms: backoff_for(attempts),
+                        })
+                    },
+                )
+            }
+        }
+    }
+
+    async fn on_model_error(
+        &self,
+        state: &LoopExecutionState,
+        err: &ModelErrorSummary,
+    ) -> RecoveryOutcome {
+        let kind = model_error_to_failure_kind(err.class);
+        match err.class {
+            ModelErrorClass::ContentFiltered => RecoveryOutcome::Abort {
+                recovery: state.recovery_state.cleared_attempts(),
+                failure_kind: kind,
+            },
+            ModelErrorClass::ContextOverflow => {
+                let Some(attempt_class) = model_retry_attempt_class(err.class) else {
+                    return RecoveryOutcome::Abort {
+                        recovery: state.recovery_state.cleared_attempts(),
+                        failure_kind: LoopFailureKind::DriverBug,
+                    };
+                };
+                retry_or_abort(
+                    state,
+                    attempt_class,
+                    self.max_attempts_per_class,
+                    kind,
+                    RetryScope::Iteration,
+                    |_| Some(RetryAlteration::ShrinkContext { drop_messages: 4 }),
+                )
+            }
+            ModelErrorClass::Transient
+            | ModelErrorClass::Unavailable
+            | ModelErrorClass::Internal => {
+                let Some(attempt_class) = model_retry_attempt_class(err.class) else {
+                    return RecoveryOutcome::Abort {
+                        recovery: state.recovery_state.cleared_attempts(),
+                        failure_kind: LoopFailureKind::DriverBug,
+                    };
+                };
+                retry_or_abort(
+                    state,
+                    attempt_class,
+                    self.max_attempts_per_class,
+                    kind,
+                    RetryScope::Call,
+                    |attempts| {
+                        Some(RetryAlteration::Backoff {
+                            delay_ms: backoff_for(attempts),
+                        })
+                    },
+                )
+            }
+        }
+    }
+}
+
+fn retry_or_abort(
+    state: &LoopExecutionState,
+    attempt_class: RecoveryAttemptClass,
+    max_attempts_per_class: u32,
+    failure_kind: LoopFailureKind,
+    scope: RetryScope,
+    alteration: impl FnOnce(u32) -> Option<RetryAlteration>,
+) -> RecoveryOutcome {
+    let attempts = state.recovery_state.attempts_for(attempt_class);
+    let next = state
+        .recovery_state
+        .with_incremented_attempts_for(attempt_class);
+    if attempts >= max_attempts_per_class {
+        RecoveryOutcome::Abort {
+            recovery: next,
+            failure_kind,
+        }
+    } else {
+        RecoveryOutcome::Retry {
+            recovery: next,
+            scope,
+            alter: alteration(attempts),
+        }
+    }
+}
+
+fn capability_retry_attempt_class(class: CapabilityErrorClass) -> Option<RecoveryAttemptClass> {
+    match class {
+        CapabilityErrorClass::Transient => Some(RecoveryAttemptClass::CapabilityTransient),
+        CapabilityErrorClass::Unavailable => Some(RecoveryAttemptClass::CapabilityUnavailable),
+        CapabilityErrorClass::Internal => Some(RecoveryAttemptClass::CapabilityInternal),
+        CapabilityErrorClass::Permanent
+        | CapabilityErrorClass::InputInvalid
+        | CapabilityErrorClass::PolicyDenied => None,
+    }
+}
+
+fn model_retry_attempt_class(class: ModelErrorClass) -> Option<RecoveryAttemptClass> {
+    match class {
+        ModelErrorClass::Transient => Some(RecoveryAttemptClass::ModelTransient),
+        ModelErrorClass::ContextOverflow => Some(RecoveryAttemptClass::ModelContextOverflow),
+        ModelErrorClass::Unavailable => Some(RecoveryAttemptClass::ModelUnavailable),
+        ModelErrorClass::Internal => Some(RecoveryAttemptClass::ModelInternal),
+        ModelErrorClass::ContentFiltered => None,
+    }
+}
+
+/// Maps a sanitized capability error class to the loop-level failure kind that
+/// the executor surfaces in `LoopExit::Failed { reason_kind }`.
+fn capability_error_to_failure_kind(class: CapabilityErrorClass) -> LoopFailureKind {
+    match class {
+        CapabilityErrorClass::PolicyDenied => LoopFailureKind::PolicyDenied,
+        CapabilityErrorClass::Transient
+        | CapabilityErrorClass::Permanent
+        | CapabilityErrorClass::InputInvalid
+        | CapabilityErrorClass::Unavailable
+        | CapabilityErrorClass::Internal => LoopFailureKind::CapabilityProtocolError,
+    }
+}
+
+/// Maps a sanitized model error class to the loop-level failure kind.
+fn model_error_to_failure_kind(class: ModelErrorClass) -> LoopFailureKind {
+    match class {
+        ModelErrorClass::Transient
+        | ModelErrorClass::ContextOverflow
+        | ModelErrorClass::ContentFiltered
+        | ModelErrorClass::Unavailable
+        | ModelErrorClass::Internal => LoopFailureKind::ModelError,
+    }
+}
+
+/// Exponential backoff for retry attempts: `250ms x 2^attempt`, capped at 5s.
+///
+/// Strictly monotonic in `attempt` until the 5s cap kicks in. The executor
+/// honors this as a sleep before re-issuing the call.
+fn backoff_for(attempt: u32) -> BackoffDelayMs {
+    let shift = attempt.min(5);
+    let ms = 250u64.saturating_mul(1u64 << shift);
+    BackoffDelayMs(ms.min(5_000))
+}
+
 /// Strategy hint about WHAT to alter on retry. Skeleton supports prompt-shape
 /// alterations only; model-route swap is reserved for the deferred
 /// `ModelRouteChain` follow-up (master doc §9).
@@ -232,7 +437,7 @@ mod tests {
     use super::*;
 
     fn sample_recovery() -> RecoveryStrategyState {
-        RecoveryStrategyState { attempts: 2 }
+        RecoveryStrategyState::with_attempts_for(RecoveryAttemptClass::ModelTransient, 2)
     }
 
     #[test]
@@ -471,6 +676,370 @@ mod tests {
                 assert_eq!(failure_kind, LoopFailureKind::NoProgressDetected);
             }
             other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    mod default_recovery_strategy {
+        use ironclaw_host_api::{TenantId, ThreadId};
+        use ironclaw_turns::{
+            AgentLoopDriverDescriptor, RunProfileId, RunProfileVersion, TurnId, TurnRunId,
+            TurnScope,
+            run_profile::{
+                CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy,
+                CheckpointSchemaId, ConcurrencyClass, ContextProfileId, LoopDriverId,
+                LoopRunContext, ModelProfileId, RedactedRunProfileProvenance, ResolvedRunProfile,
+                ResourceBudgetPolicy, ResourceBudgetTier, RunClassId, RunProfileFingerprint,
+                RuntimeProfileConstraints, SchedulingClass, SteeringPolicy,
+            },
+        };
+
+        use super::super::{
+            CapabilityErrorClass, CapabilityErrorSummary, DefaultRecoveryStrategy, ModelErrorClass,
+            ModelErrorSummary, RecoveryOutcome, RecoveryStrategy, RetryAlteration, RetryScope,
+            SanitizedStrategySummary, backoff_for,
+        };
+        use crate::state::{LoopExecutionState, RecoveryAttemptClass, RecoveryStrategyState};
+        use ironclaw_turns::LoopFailureKind;
+
+        fn test_run_context() -> LoopRunContext {
+            let scope = TurnScope::new(
+                TenantId::new("tenant-default-recovery").expect("valid"),
+                None,
+                None,
+                ThreadId::new("thread-default-recovery").expect("valid"),
+            );
+            let descriptor = AgentLoopDriverDescriptor {
+                id: LoopDriverId::new("default_recovery_test_driver").expect("valid"),
+                version: RunProfileVersion::new(1),
+                checkpoint_schema_id: Some(
+                    CheckpointSchemaId::new("default_recovery_test_checkpoint").expect("valid"),
+                ),
+                checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+            };
+            let resolved_run_profile = ResolvedRunProfile {
+                run_class_id: RunClassId::new("default_recovery_test_class").expect("valid"),
+                profile_id: RunProfileId::default_profile(),
+                profile_version: RunProfileVersion::new(1),
+                loop_driver: descriptor.clone(),
+                checkpoint_schema_id: descriptor
+                    .checkpoint_schema_id
+                    .clone()
+                    .expect("descriptor checkpoint id"),
+                checkpoint_schema_version: descriptor
+                    .checkpoint_schema_version
+                    .expect("descriptor checkpoint version"),
+                model_profile_id: ModelProfileId::new("default_recovery_test_model")
+                    .expect("valid"),
+                capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                    "default_recovery_test_capabilities",
+                )
+                .expect("valid"),
+                context_profile_id: ContextProfileId::new("default_recovery_test_context")
+                    .expect("valid"),
+                steering_policy: SteeringPolicy {
+                    allow_steering: false,
+                    allow_interrupt: true,
+                    allow_driver_specific_nudges: false,
+                },
+                cancellation_policy: CancellationPolicy {
+                    allow_cancel: true,
+                    require_checkpoint_before_cancel: false,
+                },
+                checkpoint_policy: CheckpointPolicy {
+                    require_before_model: false,
+                    require_before_side_effect: false,
+                    require_before_block: true,
+                    max_checkpoint_bytes: 64 * 1024,
+                    require_final_checkpoint: false,
+                    allow_no_reply_completion: false,
+                },
+                resource_budget_policy: ResourceBudgetPolicy {
+                    tier: ResourceBudgetTier::new("default_recovery_test_tier").expect("valid"),
+                    max_model_calls: 32,
+                    max_capability_invocations: 64,
+                },
+                runtime_constraints: RuntimeProfileConstraints {
+                    allow_raw_runtime_backend_selection: false,
+                    allow_broad_capability_surface: false,
+                },
+                runner_pool_id: None,
+                scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+                concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+                resolution_fingerprint: RunProfileFingerprint::new(
+                    "default-recovery-test-fingerprint",
+                )
+                .expect("valid"),
+                provenance: RedactedRunProfileProvenance {
+                    sources: vec![],
+                    effective_privileges: vec![],
+                },
+            };
+            LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+        }
+
+        fn state_with_no_attempts() -> LoopExecutionState {
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            state.recovery_state = RecoveryStrategyState::default();
+            state
+        }
+
+        fn state_with_attempts_for(
+            attempts: u32,
+            attempt_class: RecoveryAttemptClass,
+        ) -> LoopExecutionState {
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            state.recovery_state =
+                RecoveryStrategyState::with_attempts_for(attempt_class, attempts);
+            state
+        }
+
+        fn cap_err(class: CapabilityErrorClass) -> CapabilityErrorSummary {
+            CapabilityErrorSummary {
+                class,
+                safe_summary: SanitizedStrategySummary::from_trusted_static("test"),
+                diagnostic_ref: None,
+            }
+        }
+
+        fn model_err(class: ModelErrorClass) -> ModelErrorSummary {
+            ModelErrorSummary {
+                class,
+                safe_summary: SanitizedStrategySummary::from_trusted_static("test"),
+                diagnostic_ref: None,
+            }
+        }
+
+        #[test]
+        fn default_max_attempts_is_two() {
+            assert_eq!(DefaultRecoveryStrategy::default().max_attempts_per_class, 2);
+        }
+
+        #[tokio::test]
+        async fn capability_permanent_aborts_immediately() {
+            let strategy = DefaultRecoveryStrategy::default();
+            let state = state_with_no_attempts();
+
+            let outcome = strategy
+                .on_capability_error(&state, &cap_err(CapabilityErrorClass::Permanent))
+                .await;
+
+            assert!(matches!(
+                outcome,
+                RecoveryOutcome::Abort {
+                    failure_kind: LoopFailureKind::CapabilityProtocolError,
+                    ..
+                }
+            ));
+        }
+
+        #[tokio::test]
+        async fn capability_input_invalid_aborts_immediately() {
+            let strategy = DefaultRecoveryStrategy::default();
+            let state = state_with_no_attempts();
+
+            let outcome = strategy
+                .on_capability_error(&state, &cap_err(CapabilityErrorClass::InputInvalid))
+                .await;
+
+            assert!(matches!(outcome, RecoveryOutcome::Abort { .. }));
+        }
+
+        #[tokio::test]
+        async fn capability_policy_denied_skips_result() {
+            let strategy = DefaultRecoveryStrategy::default();
+            let state = state_with_no_attempts();
+
+            let outcome = strategy
+                .on_capability_error(&state, &cap_err(CapabilityErrorClass::PolicyDenied))
+                .await;
+
+            match outcome {
+                RecoveryOutcome::SkipResult { recovery } => {
+                    assert_eq!(recovery, RecoveryStrategyState::default());
+                }
+                other => panic!("expected SkipResult, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn capability_transient_retries_then_aborts_at_budget() {
+            let strategy = DefaultRecoveryStrategy::default();
+
+            for attempts in 0..2 {
+                let state =
+                    state_with_attempts_for(attempts, RecoveryAttemptClass::CapabilityTransient);
+                let outcome = strategy
+                    .on_capability_error(&state, &cap_err(CapabilityErrorClass::Transient))
+                    .await;
+                assert!(
+                    matches!(
+                        outcome,
+                        RecoveryOutcome::Retry {
+                            alter: Some(RetryAlteration::Backoff { .. }),
+                            ..
+                        }
+                    ),
+                    "expected retry at attempts={attempts}, got {outcome:?}"
+                );
+            }
+
+            let state = state_with_attempts_for(2, RecoveryAttemptClass::CapabilityTransient);
+            let outcome = strategy
+                .on_capability_error(&state, &cap_err(CapabilityErrorClass::Transient))
+                .await;
+            assert!(matches!(
+                outcome,
+                RecoveryOutcome::Abort {
+                    failure_kind: LoopFailureKind::CapabilityProtocolError,
+                    ..
+                }
+            ));
+        }
+
+        #[tokio::test]
+        async fn model_context_overflow_retries_with_context_shrink_then_aborts_at_budget() {
+            let strategy = DefaultRecoveryStrategy::default();
+            let state = state_with_no_attempts();
+
+            let outcome = strategy
+                .on_model_error(&state, &model_err(ModelErrorClass::ContextOverflow))
+                .await;
+
+            match outcome {
+                RecoveryOutcome::Retry {
+                    recovery,
+                    scope,
+                    alter,
+                } => {
+                    assert_eq!(
+                        recovery.attempts_for(RecoveryAttemptClass::ModelContextOverflow),
+                        1
+                    );
+                    assert_eq!(scope, RetryScope::Iteration);
+                    assert_eq!(
+                        alter,
+                        Some(RetryAlteration::ShrinkContext { drop_messages: 4 })
+                    );
+                }
+                other => panic!("expected context overflow retry, got {other:?}"),
+            }
+
+            let state = state_with_attempts_for(2, RecoveryAttemptClass::ModelContextOverflow);
+            let outcome = strategy
+                .on_model_error(&state, &model_err(ModelErrorClass::ContextOverflow))
+                .await;
+            assert!(matches!(
+                outcome,
+                RecoveryOutcome::Abort {
+                    failure_kind: LoopFailureKind::ModelError,
+                    ..
+                }
+            ));
+        }
+
+        #[tokio::test]
+        async fn model_transient_retries_then_aborts_at_budget() {
+            let strategy = DefaultRecoveryStrategy::default();
+
+            let state = state_with_no_attempts();
+            let outcome = strategy
+                .on_model_error(&state, &model_err(ModelErrorClass::Transient))
+                .await;
+            assert!(matches!(
+                outcome,
+                RecoveryOutcome::Retry {
+                    alter: Some(RetryAlteration::Backoff { .. }),
+                    ..
+                }
+            ));
+
+            let state = state_with_attempts_for(2, RecoveryAttemptClass::ModelTransient);
+            let outcome = strategy
+                .on_model_error(&state, &model_err(ModelErrorClass::Transient))
+                .await;
+            assert!(matches!(outcome, RecoveryOutcome::Abort { .. }));
+        }
+
+        #[tokio::test]
+        async fn retry_budget_tracks_each_error_class_independently() {
+            let strategy = DefaultRecoveryStrategy::default();
+            let mut state = state_with_attempts_for(2, RecoveryAttemptClass::CapabilityTransient);
+            state.recovery_state = state
+                .recovery_state
+                .with_incremented_attempts_for(RecoveryAttemptClass::CapabilityUnavailable);
+
+            let outcome = strategy
+                .on_capability_error(&state, &cap_err(CapabilityErrorClass::Transient))
+                .await;
+
+            assert!(matches!(outcome, RecoveryOutcome::Abort { .. }));
+        }
+
+        #[tokio::test]
+        async fn changed_error_class_keeps_prior_attempt_budget() {
+            let strategy = DefaultRecoveryStrategy::default();
+            let state = state_with_attempts_for(2, RecoveryAttemptClass::CapabilityTransient);
+
+            let outcome = strategy
+                .on_capability_error(&state, &cap_err(CapabilityErrorClass::Unavailable))
+                .await;
+
+            match outcome {
+                RecoveryOutcome::Retry { recovery, .. } => {
+                    assert_eq!(
+                        recovery.attempts_for(RecoveryAttemptClass::CapabilityTransient),
+                        2
+                    );
+                    assert_eq!(
+                        recovery.attempts_for(RecoveryAttemptClass::CapabilityUnavailable),
+                        1
+                    );
+                }
+                other => panic!("expected changed class retry, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn non_retry_paths_do_not_poison_later_retry_budget() {
+            let strategy = DefaultRecoveryStrategy::default();
+            let state = state_with_attempts_for(2, RecoveryAttemptClass::CapabilityTransient);
+
+            let outcome = strategy
+                .on_capability_error(&state, &cap_err(CapabilityErrorClass::PolicyDenied))
+                .await;
+            let RecoveryOutcome::SkipResult { recovery } = outcome else {
+                panic!("expected policy denied skip");
+            };
+
+            let mut next = LoopExecutionState::initial_for_run(&test_run_context());
+            next.recovery_state = recovery;
+            let outcome = strategy
+                .on_model_error(&next, &model_err(ModelErrorClass::Transient))
+                .await;
+
+            assert!(matches!(
+                outcome,
+                RecoveryOutcome::Retry { recovery, .. }
+                    if recovery.attempts_for(RecoveryAttemptClass::ModelTransient) == 1
+            ));
+        }
+
+        #[test]
+        fn backoff_increases_with_attempt_until_cap() {
+            let zero = backoff_for(0);
+            let one = backoff_for(1);
+            let two = backoff_for(2);
+            assert!(
+                one.as_u64() > zero.as_u64(),
+                "expected backoff(1) > backoff(0)"
+            );
+            assert!(
+                two.as_u64() > one.as_u64(),
+                "expected backoff(2) > backoff(1)"
+            );
+
+            assert!(backoff_for(10).as_u64() <= 5_000);
+            assert!(backoff_for(99).as_u64() <= 5_000);
         }
     }
 }

--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -74,6 +74,95 @@ pub(crate) enum StopKind {
     Aborted(LoopFailureKind),
 }
 
+/// Reference baseline `StopConditionStrategy` — owns the safety-net escape
+/// trio per master spec §10 ("Production-safe escape" — repetition /
+/// no-progress detection):
+///
+/// 1. **Graceful terminate-hint**: every result in the just-completed batch
+///    asked to terminate → `Stop { GracefulStop }`.
+/// 2. **Repetition escape**: the same `CapabilityCallSignature` is observed
+///    in `repetition_threshold` (default 3) of the last `repetition_window`
+///    (default 5) iterations → `Stop { NoProgressDetected }`.
+/// 3. **Failure-run escape**: the same `LoopFailureKind` appears
+///    `failure_run_threshold` (default 3) times in a row →
+///    `Stop { NoProgressDetected }`.
+///
+/// On no signal, returns `Continue` with `turns_completed += 1`.
+///
+/// See `docs/reborn/agent-loop-skeleton.md` §6 ("The nine strategies" →
+/// `StopConditionStrategy`) and §10 ("Production-safe escape").
+#[derive(Debug, Clone, Copy)]
+pub struct DefaultStopConditionStrategy {
+    /// Window size for the "same call signature ≥ N times" check.
+    pub repetition_window: usize,
+    /// Min repeated count within the window to trigger `NoProgressDetected`.
+    pub repetition_threshold: usize,
+    /// Min trailing run length of identical failure kinds to trigger
+    /// `NoProgressDetected`.
+    pub failure_run_threshold: usize,
+}
+
+impl Default for DefaultStopConditionStrategy {
+    fn default() -> Self {
+        Self {
+            repetition_window: 5,
+            repetition_threshold: 3,
+            failure_run_threshold: 3,
+        }
+    }
+}
+
+#[async_trait]
+impl StopConditionStrategy for DefaultStopConditionStrategy {
+    async fn should_stop_after_turn(
+        &self,
+        state: &LoopExecutionState,
+        just_completed: &TurnSummary,
+    ) -> StopOutcome {
+        // Bump `turns_completed` regardless of stop/continue — every
+        // completed turn counts.
+        let next = StopStrategyState {
+            turns_completed: state.stop_state.turns_completed.saturating_add(1),
+            ..state.stop_state.clone()
+        };
+
+        // (a) graceful terminate-hint: every result in the just-completed
+        // batch said terminate.
+        if just_completed.kind == TurnEndKind::AfterCapabilityBatch
+            && state.stop_state.last_batch_total > 0
+            && state.stop_state.terminate_hints_in_last_batch == state.stop_state.last_batch_total
+        {
+            return StopOutcome::Stop {
+                stop: next,
+                kind: StopKind::GracefulStop,
+            };
+        }
+
+        // (b) repetition escape — same call signature observed in
+        // `repetition_threshold` of the last `repetition_window` iterations.
+        if state
+            .recent_call_signatures
+            .most_common_count_in(self.repetition_window)
+            >= self.repetition_threshold
+        {
+            return StopOutcome::Stop {
+                stop: next,
+                kind: StopKind::NoProgressDetected,
+            };
+        }
+
+        // (c) failure-run escape — same failure kind ≥ threshold in a row.
+        if state.recent_failure_kinds.same_run_length() >= self.failure_run_threshold {
+            return StopOutcome::Stop {
+                stop: next,
+                kind: StopKind::NoProgressDetected,
+            };
+        }
+
+        StopOutcome::Continue { stop: next }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
@@ -169,6 +258,237 @@ mod tests {
 
             assert_eq!(value, json!({ "aborted": wire_tag }));
             assert_eq!(serde_json::from_value::<StopKind>(value).unwrap(), kind);
+        }
+    }
+
+    mod default_stop_condition_strategy {
+        use ironclaw_host_api::{CapabilityId, TenantId, ThreadId};
+        use ironclaw_turns::{
+            AgentLoopDriverDescriptor, LoopFailureKind, LoopMessageRef, RunProfileId,
+            RunProfileVersion, TurnId, TurnRunId, TurnScope,
+            run_profile::{
+                CancellationPolicy, CapabilitySurfaceProfileId, CheckpointPolicy,
+                CheckpointSchemaId, ConcurrencyClass, ContextProfileId, LoopDriverId,
+                LoopRunContext, ModelProfileId, RedactedRunProfileProvenance, ResolvedRunProfile,
+                ResourceBudgetPolicy, ResourceBudgetTier, RunClassId, RunProfileFingerprint,
+                RuntimeProfileConstraints, SchedulingClass, SteeringPolicy,
+            },
+        };
+        use serde_json::json;
+
+        use super::super::{
+            DefaultStopConditionStrategy, StopConditionStrategy, StopKind, StopOutcome,
+            TurnEndKind, TurnSummary,
+        };
+        use crate::state::{CapabilityCallSignature, LoopExecutionState, StopStrategyState};
+
+        fn test_run_context() -> LoopRunContext {
+            let scope = TurnScope::new(
+                TenantId::new("tenant-default-stop").expect("valid"),
+                None,
+                None,
+                ThreadId::new("thread-default-stop").expect("valid"),
+            );
+            let descriptor = AgentLoopDriverDescriptor {
+                id: LoopDriverId::new("default_stop_test_driver").expect("valid"),
+                version: RunProfileVersion::new(1),
+                checkpoint_schema_id: Some(
+                    CheckpointSchemaId::new("default_stop_test_checkpoint").expect("valid"),
+                ),
+                checkpoint_schema_version: Some(RunProfileVersion::new(1)),
+            };
+            let resolved_run_profile = ResolvedRunProfile {
+                run_class_id: RunClassId::new("default_stop_test_class").expect("valid"),
+                profile_id: RunProfileId::default_profile(),
+                profile_version: RunProfileVersion::new(1),
+                loop_driver: descriptor.clone(),
+                checkpoint_schema_id: descriptor
+                    .checkpoint_schema_id
+                    .clone()
+                    .expect("descriptor checkpoint id"),
+                checkpoint_schema_version: descriptor
+                    .checkpoint_schema_version
+                    .expect("descriptor checkpoint version"),
+                model_profile_id: ModelProfileId::new("default_stop_test_model").expect("valid"),
+                capability_surface_profile_id: CapabilitySurfaceProfileId::new(
+                    "default_stop_test_capabilities",
+                )
+                .expect("valid"),
+                context_profile_id: ContextProfileId::new("default_stop_test_context")
+                    .expect("valid"),
+                steering_policy: SteeringPolicy {
+                    allow_steering: false,
+                    allow_interrupt: true,
+                    allow_driver_specific_nudges: false,
+                },
+                cancellation_policy: CancellationPolicy {
+                    allow_cancel: true,
+                    require_checkpoint_before_cancel: false,
+                },
+                checkpoint_policy: CheckpointPolicy {
+                    require_before_model: false,
+                    require_before_side_effect: false,
+                    require_before_block: true,
+                    max_checkpoint_bytes: 64 * 1024,
+                    require_final_checkpoint: false,
+                    allow_no_reply_completion: false,
+                },
+                resource_budget_policy: ResourceBudgetPolicy {
+                    tier: ResourceBudgetTier::new("default_stop_test_tier").expect("valid"),
+                    max_model_calls: 32,
+                    max_capability_invocations: 64,
+                },
+                runtime_constraints: RuntimeProfileConstraints {
+                    allow_raw_runtime_backend_selection: false,
+                    allow_broad_capability_surface: false,
+                },
+                runner_pool_id: None,
+                scheduling_class: SchedulingClass::new("interactive").expect("valid"),
+                concurrency_class: ConcurrencyClass::new("thread_serial").expect("valid"),
+                resolution_fingerprint: RunProfileFingerprint::new("default-stop-test-fingerprint")
+                    .expect("valid"),
+                provenance: RedactedRunProfileProvenance {
+                    sources: vec![],
+                    effective_privileges: vec![],
+                },
+            };
+            LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved_run_profile)
+        }
+
+        fn after_batch() -> TurnSummary {
+            TurnSummary {
+                kind: TurnEndKind::AfterCapabilityBatch,
+                assistant_message_ref: Some(
+                    LoopMessageRef::new("msg:default-stop").expect("valid"),
+                ),
+                batch_result_refs: Vec::new(),
+            }
+        }
+
+        #[test]
+        fn defaults_match_master_spec() {
+            let strategy = DefaultStopConditionStrategy::default();
+            assert_eq!(strategy.repetition_window, 5);
+            assert_eq!(strategy.repetition_threshold, 3);
+            assert_eq!(strategy.failure_run_threshold, 3);
+        }
+
+        #[tokio::test]
+        async fn no_signal_continues_with_turns_completed_incremented() {
+            let strategy = DefaultStopConditionStrategy::default();
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            state.stop_state = StopStrategyState {
+                turns_completed: 4,
+                terminate_hints_in_last_batch: 0,
+                last_batch_total: 0,
+            };
+
+            let outcome = strategy
+                .should_stop_after_turn(&state, &after_batch())
+                .await;
+
+            match outcome {
+                StopOutcome::Continue { stop } => {
+                    assert_eq!(stop.turns_completed, 5);
+                }
+                other => panic!("expected Continue, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn all_results_terminate_hint_returns_graceful_stop() {
+            let strategy = DefaultStopConditionStrategy::default();
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            state.stop_state = StopStrategyState {
+                turns_completed: 1,
+                terminate_hints_in_last_batch: 3,
+                last_batch_total: 3,
+            };
+
+            let outcome = strategy
+                .should_stop_after_turn(&state, &after_batch())
+                .await;
+
+            match outcome {
+                StopOutcome::Stop { stop, kind } => {
+                    assert_eq!(stop.turns_completed, 2);
+                    assert_eq!(kind, StopKind::GracefulStop);
+                }
+                other => panic!("expected Stop GracefulStop, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn terminate_hint_ignored_when_batch_was_empty() {
+            let strategy = DefaultStopConditionStrategy::default();
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            // last_batch_total == 0: no batch this turn — strategy must not
+            // graceful-stop on a vacuous "all-terminated" check.
+            state.stop_state = StopStrategyState {
+                turns_completed: 0,
+                terminate_hints_in_last_batch: 0,
+                last_batch_total: 0,
+            };
+
+            let outcome = strategy
+                .should_stop_after_turn(
+                    &state,
+                    &TurnSummary {
+                        kind: TurnEndKind::ReplyOnly,
+                        assistant_message_ref: None,
+                        batch_result_refs: Vec::new(),
+                    },
+                )
+                .await;
+
+            assert!(matches!(outcome, StopOutcome::Continue { .. }));
+        }
+
+        #[tokio::test]
+        async fn same_signature_three_times_triggers_no_progress() {
+            let strategy = DefaultStopConditionStrategy::default();
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            let signature = CapabilityCallSignature::from_call(
+                CapabilityId::new("demo.echo").expect("valid"),
+                &json!({"x": 1}),
+            )
+            .expect("valid call signature");
+            for _ in 0..3 {
+                state.recent_call_signatures.push(signature.clone());
+            }
+
+            let outcome = strategy
+                .should_stop_after_turn(&state, &after_batch())
+                .await;
+
+            assert!(matches!(
+                outcome,
+                StopOutcome::Stop {
+                    kind: StopKind::NoProgressDetected,
+                    ..
+                }
+            ));
+        }
+
+        #[tokio::test]
+        async fn same_failure_kind_three_times_triggers_no_progress() {
+            let strategy = DefaultStopConditionStrategy::default();
+            let mut state = LoopExecutionState::initial_for_run(&test_run_context());
+            for _ in 0..3 {
+                state.recent_failure_kinds.push(LoopFailureKind::ModelError);
+            }
+
+            let outcome = strategy
+                .should_stop_after_turn(&state, &after_batch())
+                .await;
+
+            assert!(matches!(
+                outcome,
+                StopOutcome::Stop {
+                    kind: StopKind::NoProgressDetected,
+                    ..
+                }
+            ));
         }
     }
 }


### PR DESCRIPTION
## Context

Default strategy implementation layer. It fills the strategy slots with the baseline behavior the canonical executor can run.

Master spec: `docs/reborn/agent-loop-skeleton.md`
Workstream brief: `docs/reborn/agent-loop-briefs/default-strategies.md`
Stack base: `arch/level1-merged`

Latest stack maintenance on 2026-05-14:
- Rebased this branch onto its current stack base after the WS0 prompt-authority fix and the follow-up WS8/WS14-parent/WS16/WS17 conflict resolutions.
- Pushed the updated branch with force-with-lease where the remote already existed, or published it as a new branch where it did not.
- Verified the final ancestry chain from `origin/reborn-integration` through WS17 before publishing the PR descriptions.

## What landed

- Default implementations for context, capability, model, batch, gate, recovery, stop, drain, and budget strategies.
- Stop/recovery/gate behavior wired to the WS0 state slots without direct durable mutation.
- Default prompt request and capability filter behavior that mirrors the text-first Reborn baseline.
- No-progress/retry defaults built on observed state rather than raw transcript/tool data.
- Tests for default strategy outputs and state transitions.

## Reviewer focus

- Default behavior should be boring and explicit; avoid hidden product-specific branches in the shared loop framework.
- The defaults should return decisions, not perform side effects.
- Stop/gate/recovery state should stay slot-local and serializable.

## Non-goals / deferred work

- Actual loop execution is WS6a.
- Real host capability/checkpoint/input/progress/cancellation/identity ports land in WS9 through WS15.
- Product-live runtime selection is WS17.

## Validation

- [x] Branch rebased onto the current level1 integration branch.
- [x] Included in `arch/level2-merged` validation: `cargo check -p ironclaw_agent_loop -p ironclaw_reborn`.
- [x] Included in the final stack ancestry verification.

## Stack position

```
[#3550 ws-0] state/checkpoint foundation -> reborn-integration
   |-- #3551 ws-1 strategy alpha -> ws-0
   |-- #3552 ws-2 strategy beta -> ws-0
   |-- #3553 ws-3 strategy gamma -> ws-0
   |-- #3643 ws-3.5 loop family registry -> ws-0
   '-- #3554 level1-merged -> ws-0
         |-- #3555 ws-4 planner facade -> level1
         |-- #3556 ws-5 default strategies -> level1
         '-- #3557 level2-merged -> level1
               '-- #3596 ws-6a canonical executor -> level2
                     '-- #3597 ws-7 PlannedDriver adapter -> ws-6a
                           '-- #3598 ws-8 integration/test support -> ws-7
                                 |-- #3644 ws-9 capability host wiring -> ws-8
                                 |-- #3645 ws-10 checkpoint load/resume -> ws-8
                                 |-- #3646 ws-11 input port -> ws-8
                                 |-- #3647 ws-12 progress port -> ws-8
                                 |-- #3648 ws-13 cancellation accessor -> ws-8
                                 |-- #3649 ws-15 prompt/identity context -> ws-8
                                 '-- #3650 ws-14-parent integrated host ports -> ws-8
                                       '-- #3651 ws-14 planned default registration -> ws-14-parent
                                             '-- #3652 ws-16 live runtime wiring -> ws-14
                                                   '-- #3653 ws-17 product live cutover -> ws-16
```
