### PR TITLE
feat(reborn/product-workflow): finish dispatch arms, hooks, and ack taxonomy (#3280)

### DIFF
--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -21,6 +21,10 @@ const ACTION_ID_MAX_BYTES: usize = 512;
 const ACTION_DATA_MAX_BYTES: usize = 16 * 1024;
 const INTERACTION_REF_MAX_BYTES: usize = 512;
 const CREDENTIAL_REF_MAX_BYTES: usize = 512;
+const MISSION_INTENT_MAX_BYTES: usize = 128;
+const SYSTEM_ACTOR_REF_MAX_BYTES: usize = 256;
+const SYSTEM_ACTION_KIND_MAX_BYTES: usize = 128;
+const PRODUCT_COMMAND_NAME_MAX_BYTES: usize = 256;
 
 fn malformed(reason: impl Into<String>) -> ProductAdapterError {
     ProductAdapterError::MalformedInboundPayload {
@@ -354,6 +358,126 @@ impl<'de> Deserialize<'de> for LinkedThreadActionPayload {
     }
 }
 
+/// Typed mission-action inbound payload. Carries an explicit intent (e.g.
+/// `"fire"`, `"cancel"`, `"status"`), an optional explicit mission id hint,
+/// and optional per-intent data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MissionActionPayload {
+    pub mission_intent: String,
+    pub mission_id_hint: Option<String>,
+    pub data: Option<String>,
+}
+
+impl MissionActionPayload {
+    pub fn new(
+        mission_intent: impl Into<String>,
+        mission_id_hint: Option<String>,
+        data: Option<String>,
+    ) -> Result<Self, ProductAdapterError> {
+        let mission_intent = mission_intent.into();
+        validate_token_string("mission intent", &mission_intent, MISSION_INTENT_MAX_BYTES)?;
+        if let Some(hint) = &mission_id_hint {
+            validate_token_string("mission id hint", hint, INTERACTION_REF_MAX_BYTES)?;
+        }
+        if let Some(data) = &data {
+            validate_payload_string("mission action data", data, ACTION_DATA_MAX_BYTES)?;
+        }
+        Ok(Self {
+            mission_intent,
+            mission_id_hint,
+            data,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct MissionActionPayloadWire {
+    mission_intent: String,
+    mission_id_hint: Option<String>,
+    data: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for MissionActionPayload {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = MissionActionPayloadWire::deserialize(deserializer)?;
+        Self::new(wire.mission_intent, wire.mission_id_hint, wire.data)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Typed system-action inbound payload. Requires an accountable system actor
+/// identity and a typed action kind. **Intentionally has no `is_internal`
+/// or boolean bypass flag**: every system action must name an actor and a
+/// scope so it can be audited downstream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SystemActionPayload {
+    pub system_actor_ref: String,
+    pub kind: String,
+    pub scope_thread_id: Option<String>,
+    pub data: Option<String>,
+}
+
+impl SystemActionPayload {
+    pub fn new(
+        system_actor_ref: impl Into<String>,
+        kind: impl Into<String>,
+        scope_thread_id: Option<String>,
+        data: Option<String>,
+    ) -> Result<Self, ProductAdapterError> {
+        let system_actor_ref = system_actor_ref.into();
+        let kind = kind.into();
+        validate_token_string(
+            "system actor ref",
+            &system_actor_ref,
+            SYSTEM_ACTOR_REF_MAX_BYTES,
+        )?;
+        validate_token_string("system action kind", &kind, SYSTEM_ACTION_KIND_MAX_BYTES)?;
+        if let Some(scope) = &scope_thread_id {
+            validate_token_string(
+                "system action scope thread",
+                scope,
+                INTERACTION_REF_MAX_BYTES,
+            )?;
+        }
+        if let Some(data) = &data {
+            validate_payload_string("system action data", data, ACTION_DATA_MAX_BYTES)?;
+        }
+        Ok(Self {
+            system_actor_ref,
+            kind,
+            scope_thread_id,
+            data,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct SystemActionPayloadWire {
+    system_actor_ref: String,
+    kind: String,
+    scope_thread_id: Option<String>,
+    data: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for SystemActionPayload {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = SystemActionPayloadWire::deserialize(deserializer)?;
+        Self::new(
+            wire.system_actor_ref,
+            wire.kind,
+            wire.scope_thread_id,
+            wire.data,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProductInboundPayload {
@@ -363,6 +487,8 @@ pub enum ProductInboundPayload {
     AuthResolution(AuthResolutionPayload),
     SubscriptionRequest(ProjectionSubscriptionPayload),
     LinkedThreadAction(LinkedThreadActionPayload),
+    MissionAction(MissionActionPayload),
+    SystemAction(SystemActionPayload),
     NoOp,
 }
 
@@ -543,6 +669,104 @@ pub enum InboundRetryDisposition {
     ReplayPrior,
 }
 
+/// Stable handle to a durable mission-fire record.
+///
+/// `ironclaw_product_adapters` is below `ironclaw_product_workflow` in the
+/// dependency graph, so the workflow crate cannot be imported here. The
+/// workflow crate uses its own richer type and converts to/from this
+/// wire-stable wrapper when staging acks across the boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MissionFireRef(uuid::Uuid);
+
+impl MissionFireRef {
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+
+    pub fn from_uuid(uuid: uuid::Uuid) -> Self {
+        Self(uuid)
+    }
+
+    pub fn as_uuid(&self) -> uuid::Uuid {
+        self.0
+    }
+}
+
+impl Default for MissionFireRef {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Reason a mission fire was suppressed pre-submit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionFireSuppressionReason {
+    Cadence,
+    Cooldown,
+    Deduplicated,
+    BusyThread,
+}
+
+/// Typed gate ref used by [`ProductInboundAck::GateHandled`]. Wire-stable
+/// wrapper over a bounded string; adapters do not need to dereference it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LoopGateRef(String);
+
+impl LoopGateRef {
+    pub fn new(value: impl Into<String>) -> Result<Self, ProductAdapterError> {
+        let value = value.into();
+        validate_token_string("loop gate ref", &value, INTERACTION_REF_MAX_BYTES)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Typed command name. Wire-stable wrapper. The product_workflow crate has a
+/// stricter token type; this one only validates that the name passes the same
+/// bounded-token rules so acks can serialize.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ProductCommandName(String);
+
+impl ProductCommandName {
+    pub fn new(value: impl Into<String>) -> Result<Self, ProductAdapterError> {
+        let value = value.into();
+        validate_token_string(
+            "product command name",
+            &value,
+            PRODUCT_COMMAND_NAME_MAX_BYTES,
+        )?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Typed linked thread action id. Wire-stable wrapper.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LinkedThreadActionId(String);
+
+impl LinkedThreadActionId {
+    pub fn new(value: impl Into<String>) -> Result<Self, ProductAdapterError> {
+        let value = value.into();
+        validate_token_string("linked thread action id", &value, INTERACTION_REF_MAX_BYTES)?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProductInboundAck {
@@ -553,6 +777,23 @@ pub enum ProductInboundAck {
     DeferredBusy {
         accepted_message_ref: AcceptedMessageRef,
         active_run_id: TurnRunId,
+    },
+    CommandRouted {
+        command: ProductCommandName,
+    },
+    GateHandled {
+        gate_ref: LoopGateRef,
+    },
+    LinkedThreadActionRouted {
+        action_id: LinkedThreadActionId,
+    },
+    MissionSubmitted {
+        mission_fire_ref: MissionFireRef,
+        submitted_run_id: TurnRunId,
+    },
+    MissionSuppressed {
+        mission_fire_ref: MissionFireRef,
+        reason: MissionFireSuppressionReason,
     },
     Rejected(ProductRejection),
     Duplicate {
@@ -567,7 +808,12 @@ impl ProductInboundAck {
             Self::Accepted { .. }
             | Self::DeferredBusy { .. }
             | Self::Duplicate { .. }
-            | Self::NoOp => true,
+            | Self::NoOp
+            | Self::CommandRouted { .. }
+            | Self::GateHandled { .. }
+            | Self::LinkedThreadActionRouted { .. }
+            | Self::MissionSubmitted { .. }
+            | Self::MissionSuppressed { .. } => true,
             Self::Rejected(rejection) => {
                 rejection.disposition == ProductRejectionDisposition::Permanent
             }
@@ -702,5 +948,271 @@ mod tests {
             .retry_disposition(),
             InboundRetryDisposition::ReplayPrior
         );
+    }
+
+    #[test]
+    fn new_ack_variants_are_durable_and_do_not_retry() {
+        let command_routed = ProductInboundAck::CommandRouted {
+            command: ProductCommandName::new("ping").expect("valid"),
+        };
+        assert!(command_routed.is_durable_outcome());
+        assert_eq!(
+            command_routed.retry_disposition(),
+            InboundRetryDisposition::DoNotRetry
+        );
+
+        let gate_handled = ProductInboundAck::GateHandled {
+            gate_ref: LoopGateRef::new("gate-1").expect("valid"),
+        };
+        assert!(gate_handled.is_durable_outcome());
+        assert_eq!(
+            gate_handled.retry_disposition(),
+            InboundRetryDisposition::DoNotRetry
+        );
+
+        let linked_routed = ProductInboundAck::LinkedThreadActionRouted {
+            action_id: LinkedThreadActionId::new("act-1").expect("valid"),
+        };
+        assert!(linked_routed.is_durable_outcome());
+        assert_eq!(
+            linked_routed.retry_disposition(),
+            InboundRetryDisposition::DoNotRetry
+        );
+
+        let mission_submitted = ProductInboundAck::MissionSubmitted {
+            mission_fire_ref: MissionFireRef::new(),
+            submitted_run_id: TurnRunId::new(),
+        };
+        assert!(mission_submitted.is_durable_outcome());
+        assert_eq!(
+            mission_submitted.retry_disposition(),
+            InboundRetryDisposition::DoNotRetry
+        );
+
+        let mission_suppressed = ProductInboundAck::MissionSuppressed {
+            mission_fire_ref: MissionFireRef::new(),
+            reason: MissionFireSuppressionReason::Cadence,
+        };
+        assert!(mission_suppressed.is_durable_outcome());
+        assert_eq!(
+            mission_suppressed.retry_disposition(),
+            InboundRetryDisposition::DoNotRetry
+        );
+    }
+
+    // ---------- MissionActionPayload ----------
+
+    #[test]
+    fn mission_action_payload_accepts_valid_input() {
+        let payload = MissionActionPayload::new(
+            "fire",
+            Some("mission-42".to_string()),
+            Some("{\"reason\":\"manual\"}".to_string()),
+        )
+        .expect("valid");
+        assert_eq!(payload.mission_intent, "fire");
+        assert_eq!(payload.mission_id_hint.as_deref(), Some("mission-42"));
+        assert_eq!(payload.data.as_deref(), Some("{\"reason\":\"manual\"}"));
+    }
+
+    #[test]
+    fn mission_action_payload_rejects_empty_intent() {
+        assert!(MissionActionPayload::new("", None, None).is_err());
+    }
+
+    #[test]
+    fn mission_action_payload_rejects_oversized_intent() {
+        let oversize = "a".repeat(MISSION_INTENT_MAX_BYTES + 1);
+        assert!(MissionActionPayload::new(oversize, None, None).is_err());
+    }
+
+    #[test]
+    fn mission_action_payload_rejects_oversized_hint() {
+        let oversize = "h".repeat(INTERACTION_REF_MAX_BYTES + 1);
+        assert!(MissionActionPayload::new("fire", Some(oversize), None).is_err());
+    }
+
+    #[test]
+    fn mission_action_payload_rejects_oversized_data() {
+        let oversize = "d".repeat(ACTION_DATA_MAX_BYTES + 1);
+        assert!(MissionActionPayload::new("fire", None, Some(oversize)).is_err());
+    }
+
+    #[test]
+    fn mission_action_payload_rejects_control_chars() {
+        assert!(MissionActionPayload::new("fire\u{0007}", None, None).is_err());
+        assert!(MissionActionPayload::new("fire", Some("hint\u{0001}".to_string()), None).is_err());
+    }
+
+    #[test]
+    fn mission_action_payload_bounds_are_enforced_through_serde() {
+        let forged = serde_json::json!({
+            "mission_intent": "a".repeat(MISSION_INTENT_MAX_BYTES + 1),
+            "mission_id_hint": null,
+            "data": null,
+        });
+        assert!(serde_json::from_value::<MissionActionPayload>(forged).is_err());
+
+        let empty = serde_json::json!({
+            "mission_intent": "",
+            "mission_id_hint": null,
+            "data": null,
+        });
+        assert!(serde_json::from_value::<MissionActionPayload>(empty).is_err());
+
+        let ok = serde_json::json!({
+            "mission_intent": "fire",
+            "mission_id_hint": "m-1",
+            "data": "{}",
+        });
+        let parsed: MissionActionPayload = serde_json::from_value(ok).expect("valid");
+        assert_eq!(parsed.mission_intent, "fire");
+    }
+
+    // ---------- SystemActionPayload ----------
+
+    #[test]
+    fn system_action_payload_accepts_valid_input() {
+        let payload = SystemActionPayload::new(
+            "system:heartbeat",
+            "heartbeat_tick",
+            Some("thread-1".to_string()),
+            Some("{}".to_string()),
+        )
+        .expect("valid");
+        assert_eq!(payload.system_actor_ref, "system:heartbeat");
+        assert_eq!(payload.kind, "heartbeat_tick");
+        assert_eq!(payload.scope_thread_id.as_deref(), Some("thread-1"));
+        assert_eq!(payload.data.as_deref(), Some("{}"));
+    }
+
+    #[test]
+    fn system_action_payload_rejects_empty_actor() {
+        assert!(SystemActionPayload::new("", "heartbeat_tick", None, None).is_err());
+    }
+
+    #[test]
+    fn system_action_payload_rejects_empty_kind() {
+        assert!(SystemActionPayload::new("system:heartbeat", "", None, None).is_err());
+    }
+
+    #[test]
+    fn system_action_payload_rejects_oversized_actor() {
+        let oversize = "a".repeat(SYSTEM_ACTOR_REF_MAX_BYTES + 1);
+        assert!(SystemActionPayload::new(oversize, "heartbeat_tick", None, None).is_err());
+    }
+
+    #[test]
+    fn system_action_payload_rejects_oversized_kind() {
+        let oversize = "k".repeat(SYSTEM_ACTION_KIND_MAX_BYTES + 1);
+        assert!(SystemActionPayload::new("system:heartbeat", oversize, None, None).is_err());
+    }
+
+    #[test]
+    fn system_action_payload_rejects_oversized_scope() {
+        let oversize = "s".repeat(INTERACTION_REF_MAX_BYTES + 1);
+        assert!(
+            SystemActionPayload::new("system:heartbeat", "heartbeat_tick", Some(oversize), None,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn system_action_payload_rejects_oversized_data() {
+        let oversize = "d".repeat(ACTION_DATA_MAX_BYTES + 1);
+        assert!(
+            SystemActionPayload::new("system:heartbeat", "heartbeat_tick", None, Some(oversize),)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn system_action_payload_rejects_control_chars() {
+        assert!(SystemActionPayload::new("system\u{0007}", "heartbeat_tick", None, None).is_err());
+        assert!(SystemActionPayload::new("system:heartbeat", "kind\u{0001}", None, None).is_err());
+    }
+
+    #[test]
+    fn system_action_payload_bounds_are_enforced_through_serde() {
+        let forged = serde_json::json!({
+            "system_actor_ref": "a".repeat(SYSTEM_ACTOR_REF_MAX_BYTES + 1),
+            "kind": "heartbeat_tick",
+            "scope_thread_id": null,
+            "data": null,
+        });
+        assert!(serde_json::from_value::<SystemActionPayload>(forged).is_err());
+
+        let empty_actor = serde_json::json!({
+            "system_actor_ref": "",
+            "kind": "heartbeat_tick",
+            "scope_thread_id": null,
+            "data": null,
+        });
+        assert!(serde_json::from_value::<SystemActionPayload>(empty_actor).is_err());
+
+        let ok = serde_json::json!({
+            "system_actor_ref": "system:heartbeat",
+            "kind": "heartbeat_tick",
+            "scope_thread_id": "thread-1",
+            "data": "{}",
+        });
+        let parsed: SystemActionPayload = serde_json::from_value(ok).expect("valid");
+        assert_eq!(parsed.kind, "heartbeat_tick");
+    }
+
+    // ---------- Wire-stable typed wrappers ----------
+
+    #[test]
+    fn mission_fire_ref_round_trips_through_serde() {
+        let id = uuid::Uuid::new_v4();
+        let mission = MissionFireRef::from_uuid(id);
+        assert_eq!(mission.as_uuid(), id);
+        let json = serde_json::to_value(&mission).expect("serialize");
+        let round: MissionFireRef = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(round, mission);
+        // Default constructs a fresh uuid.
+        let _fresh = MissionFireRef::default();
+    }
+
+    #[test]
+    fn mission_fire_suppression_reason_serializes_snake_case() {
+        let v = serde_json::to_value(MissionFireSuppressionReason::BusyThread).expect("ok");
+        assert_eq!(v, serde_json::json!("busy_thread"));
+        let parsed: MissionFireSuppressionReason =
+            serde_json::from_value(serde_json::json!("deduplicated")).expect("ok");
+        assert_eq!(parsed, MissionFireSuppressionReason::Deduplicated);
+    }
+
+    #[test]
+    fn loop_gate_ref_validates_and_round_trips() {
+        let gate = LoopGateRef::new("gate-abc").expect("valid");
+        assert_eq!(gate.as_str(), "gate-abc");
+        let json = serde_json::to_value(&gate).expect("ok");
+        let round: LoopGateRef = serde_json::from_value(json).expect("ok");
+        assert_eq!(round, gate);
+        assert!(LoopGateRef::new("").is_err());
+        assert!(LoopGateRef::new("a".repeat(INTERACTION_REF_MAX_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn product_command_name_validates_and_round_trips() {
+        let cmd = ProductCommandName::new("ping").expect("valid");
+        assert_eq!(cmd.as_str(), "ping");
+        let json = serde_json::to_value(&cmd).expect("ok");
+        let round: ProductCommandName = serde_json::from_value(json).expect("ok");
+        assert_eq!(round, cmd);
+        assert!(ProductCommandName::new("").is_err());
+        assert!(ProductCommandName::new("a".repeat(PRODUCT_COMMAND_NAME_MAX_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn linked_thread_action_id_validates_and_round_trips() {
+        let id = LinkedThreadActionId::new("act-1").expect("valid");
+        assert_eq!(id.as_str(), "act-1");
+        let json = serde_json::to_value(&id).expect("ok");
+        let round: LinkedThreadActionId = serde_json::from_value(json).expect("ok");
+        assert_eq!(round, id);
+        assert!(LinkedThreadActionId::new("").is_err());
+        assert!(LinkedThreadActionId::new("a".repeat(INTERACTION_REF_MAX_BYTES + 1)).is_err());
     }
 }

--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -791,6 +791,10 @@ pub enum ProductInboundAck {
         mission_fire_ref: MissionFireRef,
         submitted_run_id: TurnRunId,
     },
+    MissionDeferred {
+        mission_fire_ref: MissionFireRef,
+        active_run_id: TurnRunId,
+    },
     MissionSuppressed {
         mission_fire_ref: MissionFireRef,
         reason: MissionFireSuppressionReason,
@@ -813,6 +817,7 @@ impl ProductInboundAck {
             | Self::GateHandled { .. }
             | Self::LinkedThreadActionRouted { .. }
             | Self::MissionSubmitted { .. }
+            | Self::MissionDeferred { .. }
             | Self::MissionSuppressed { .. } => true,
             Self::Rejected(rejection) => {
                 rejection.disposition == ProductRejectionDisposition::Permanent

--- a/crates/ironclaw_product_adapters/src/lib.rs
+++ b/crates/ironclaw_product_adapters/src/lib.rs
@@ -43,10 +43,12 @@ pub use fakes::{
 pub use identity::{AdapterInstallationId, ProductAdapterId, ProductSurfaceKind};
 pub use inbound::{
     ApprovalDecision, ApprovalResolutionPayload, AuthResolutionPayload, AuthResolutionResult,
-    InboundCommandPayload, InboundRetryDisposition, LinkedThreadActionPayload,
-    ParsedProductInbound, ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload,
-    ProductRejection, ProductRejectionDisposition, ProductRejectionKind, ProductTriggerReason,
-    ProjectionSubscriptionPayload, TrustedInboundContext, UserMessagePayload,
+    InboundCommandPayload, InboundRetryDisposition, LinkedThreadActionId,
+    LinkedThreadActionPayload, LoopGateRef, MissionActionPayload, MissionFireRef,
+    MissionFireSuppressionReason, ParsedProductInbound, ProductCommandName, ProductInboundAck,
+    ProductInboundEnvelope, ProductInboundPayload, ProductRejection, ProductRejectionDisposition,
+    ProductRejectionKind, ProductTriggerReason, ProjectionSubscriptionPayload, SystemActionPayload,
+    TrustedInboundContext, UserMessagePayload,
 };
 pub use outbound::{
     AuthPromptView, FinalReplyView, GatePromptView, ProductOutboundEnvelope,

--- a/crates/ironclaw_product_workflow/CLAUDE.md
+++ b/crates/ironclaw_product_workflow/CLAUDE.md
@@ -38,3 +38,36 @@ Enable `test-support` feature for in-memory fakes:
 - `FakeConversationBindingService`
 - `FakeIdempotencyLedger`
 - `FakeInboundTurnService`
+
+## Service ports
+
+The workflow crate defines port traits for each non-`UserMessage` dispatch
+arm. Production wiring (in `src/app.rs` / a composition crate) implements
+these by wrapping existing host-layer services. Tests wire `Fake*` impls
+from the `test-support` feature.
+
+| Trait | Wrapped by production | Closes AC |
+|-------|-----------------------|-----------|
+| `BeforeInboundPolicy` | v1 `HookPoint::BeforeInbound` ported into `inbound_turn.rs` | #3280 AC #8, #9 |
+| `ProductCommandRouter` | Reborn's `AgentCommandService` (#3286 owns the full matrix) | #3280 AC #10 |
+| `ApprovalInteractionService` | `ironclaw_approvals::ApprovalResolver` (#3094) | #3280 AC #11 |
+| `AuthInteractionService` | `ironclaw_authorization::CapabilityDispatchAuthorizer` (#3094) | #3280 AC #11 |
+| `LinkedThreadActionService` | TBD per-product handler | #3280 AC #13 |
+| `MissionService` | `ironclaw_engine` MissionManager once #3278 ships | #3280 AC #12, #13 |
+| `SystemActionService` | TBD typed system action handlers | #3280 AC #15 |
+| `ProjectionSubscriptionAuthority` | `ironclaw_outbound::OutboundPolicyService::authorize_subscription` (#3266 / PR #3542) | #3280 AC #14 |
+
+Each port is **optional** on `DefaultProductWorkflow` (builder methods
+`with_*`). When a port is unset, the corresponding dispatch arm returns a
+redacted permanent `Rejected` ack — adapters must wire the service before
+serving the matching action kind in production.
+
+## No mission auto-attach
+
+`DefaultProductWorkflow` does **not** route `ProductInboundPayload::UserMessage`
+to `MissionService` under any condition. Missions only fire via explicit
+`MissionActionPayload`. The v1 bug shape (`src/bridge/router.rs::fire_event_missions_for_message`
+pattern-matched message text against `MissionCadence::OnEvent` regex and
+side-fired missions) is closed by AC #12 of #3280 and locked in by the
+`ordinary_user_message_text_never_reaches_mission_service` regression test
+in `tests/product_workflow_contract.rs`.

--- a/crates/ironclaw_product_workflow/src/action.rs
+++ b/crates/ironclaw_product_workflow/src/action.rs
@@ -177,12 +177,29 @@ pub enum ActionPhase {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ActionDispatchKind {
-    UserMessageTurn { run_id: TurnRunId },
-    Command { command: ProductCommandName },
-    ApprovalResolution { gate_ref: LoopGateRef },
-    AuthResolution { auth_request_ref: AuthRequestRef },
+    UserMessageTurn {
+        run_id: TurnRunId,
+    },
+    Command {
+        command: ProductCommandName,
+    },
+    ApprovalResolution {
+        gate_ref: LoopGateRef,
+    },
+    AuthResolution {
+        auth_request_ref: AuthRequestRef,
+    },
     ProjectionSubscription,
-    LinkedThreadAction { action_id: LinkedThreadActionId },
+    LinkedThreadAction {
+        action_id: LinkedThreadActionId,
+    },
+    MissionAction {
+        mission_intent: String,
+    },
+    SystemAction {
+        system_actor_ref: String,
+        kind: String,
+    },
     NoOp,
 }
 
@@ -210,6 +227,13 @@ impl ActionDispatchKind {
             ProductInboundPayload::LinkedThreadAction(lta) => Ok(Self::LinkedThreadAction {
                 action_id: LinkedThreadActionId::new(lta.action_id.clone())
                     .map_err(|reason| ProductWorkflowError::TurnSubmissionRejected { reason })?,
+            }),
+            ProductInboundPayload::MissionAction(ma) => Ok(Self::MissionAction {
+                mission_intent: ma.mission_intent.clone(),
+            }),
+            ProductInboundPayload::SystemAction(sa) => Ok(Self::SystemAction {
+                system_actor_ref: sa.system_actor_ref.clone(),
+                kind: sa.kind.clone(),
             }),
             ProductInboundPayload::NoOp => Ok(Self::NoOp),
         }

--- a/crates/ironclaw_product_workflow/src/fakes.rs
+++ b/crates/ironclaw_product_workflow/src/fakes.rs
@@ -5,15 +5,28 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use ironclaw_host_api::{AgentId, TenantId, ThreadId, UserId};
-use ironclaw_product_adapters::ProductInboundEnvelope;
-use ironclaw_turns::{AcceptedMessageRef, TurnRunId};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_product_adapters::{
+    ApprovalDecision, AuthResolutionResult, ProductInboundEnvelope, ProjectionSubscriptionRequest,
+};
+use ironclaw_turns::{AcceptedMessageRef, LoopGateRef, TurnActor, TurnRunId, TurnScope};
 
-use crate::action::{ActionFingerprintKey, ProductInboundAction};
+use crate::action::{
+    ActionFingerprintKey, AuthRequestRef, LinkedThreadActionId, ProductCommandName,
+    ProductInboundAction,
+};
 use crate::binding::{ConversationBindingService, ResolveBindingRequest, ResolvedBinding};
 use crate::error::ProductWorkflowError;
 use crate::inbound_turn::{InboundTurnOutcome, InboundTurnService};
 use crate::ledger::{IdempotencyDecision, IdempotencyLedger};
+use crate::services::{
+    ApprovalInteractionService, ApprovalResolutionOutcome, AuthInteractionService,
+    AuthResolutionOutcome, BeforeInboundOutcome, BeforeInboundPolicy, BeforeInboundRequest,
+    LinkedThreadActionOutcome, LinkedThreadActionService, MissionFireOutcome, MissionFireRef,
+    MissionFireRejectionReason, MissionFireRequest, MissionFireSuppressionReason, MissionService,
+    ProductCommandOutcome, ProductCommandRouter, ProjectionSubscriptionAuthority,
+    ProjectionSubscriptionAuthorityRequest, SystemActionOutcome, SystemActionService,
+};
 
 // ---------------------------------------------------------------------------
 // FakeConversationBindingService
@@ -350,6 +363,835 @@ impl InboundTurnService for FakeInboundTurnService {
             accepted_message_ref,
             submitted_run_id: TurnRunId::new(),
             binding,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeBeforeInboundPolicy
+// ---------------------------------------------------------------------------
+
+/// In-memory fake for [`BeforeInboundPolicy`]. Records every evaluation request
+/// and replays a programmed outcome (defaulting to `Continue` with no
+/// rewriting).
+pub struct FakeBeforeInboundPolicy {
+    state: Mutex<FakeBeforeInboundState>,
+}
+
+#[derive(Default)]
+struct FakeBeforeInboundState {
+    evaluate_count: usize,
+    next_outcome: Option<BeforeInboundOutcome>,
+    fail_with: Option<ProductWorkflowError>,
+    last_request: Option<BeforeInboundRequest>,
+}
+
+impl FakeBeforeInboundPolicy {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeBeforeInboundState::default()),
+        }
+    }
+
+    /// Program the next evaluation to pass through (optionally rewriting text).
+    pub fn program_continue(&self, rewritten: Option<String>) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.next_outcome = Some(BeforeInboundOutcome::Continue {
+            rewritten_text: rewritten,
+        });
+    }
+
+    /// Program the next evaluation to reject with a redacted reason.
+    pub fn program_reject(&self, reason: impl Into<String>) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.next_outcome = Some(BeforeInboundOutcome::Reject {
+            reason: ironclaw_product_adapters::RedactedString::new(reason.into()),
+        });
+    }
+
+    /// Force all evaluations to fail.
+    pub fn force_failure(&self, error: ProductWorkflowError) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(error);
+    }
+
+    /// How many evaluations have been performed.
+    pub fn evaluate_count(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.evaluate_count
+    }
+
+    /// The most recent request observed (if any).
+    pub fn last_request(&self) -> Option<BeforeInboundRequest> {
+        let state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.last_request.clone()
+    }
+}
+
+impl Default for FakeBeforeInboundPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl BeforeInboundPolicy for FakeBeforeInboundPolicy {
+    async fn evaluate_inbound(
+        &self,
+        request: BeforeInboundRequest,
+    ) -> Result<BeforeInboundOutcome, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.evaluate_count += 1;
+        state.last_request = Some(request);
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        if let Some(outcome) = state.next_outcome.clone() {
+            return Ok(outcome);
+        }
+        Ok(BeforeInboundOutcome::Continue {
+            rewritten_text: None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeProductCommandRouter
+// ---------------------------------------------------------------------------
+
+/// In-memory fake for [`ProductCommandRouter`]. Records every routed command +
+/// arguments pair and replays a programmed outcome (defaulting to echoing the
+/// input command back as `Routed`).
+pub struct FakeProductCommandRouter {
+    state: Mutex<FakeProductCommandRouterState>,
+}
+
+#[derive(Default)]
+struct FakeProductCommandRouterState {
+    routed: Vec<(ProductCommandName, String)>,
+    next_outcome: Option<ProductCommandOutcome>,
+    /// When true, the next call returns `UnknownCommand` echoing the input
+    /// command. Cleared after the call.
+    next_is_unknown: bool,
+    fail_with: Option<ProductWorkflowError>,
+}
+
+impl FakeProductCommandRouter {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeProductCommandRouterState::default()),
+        }
+    }
+
+    /// Program the next routing call to report the command as unknown. The
+    /// `UnknownCommand` outcome will echo whatever command was passed to
+    /// `route_command`, since the router's job is to surface the *requested*
+    /// command name in the rejection.
+    pub fn program_unknown(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake product command router state lock poisoned"); // safety: test-support fake
+        state.next_is_unknown = true;
+        state.next_outcome = None;
+    }
+
+    /// Program the next routing call to report the command as routed.
+    pub fn program_routed(&self, command: ProductCommandName) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake product command router state lock poisoned"); // safety: test-support fake
+        state.next_is_unknown = false;
+        state.next_outcome = Some(ProductCommandOutcome::Routed { command });
+    }
+
+    /// Force all routing calls to fail.
+    pub fn force_failure(&self, error: ProductWorkflowError) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake product command router state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(error);
+    }
+
+    /// All commands seen by this router, in order.
+    pub fn routed(&self) -> Vec<(ProductCommandName, String)> {
+        let state = self
+            .state
+            .lock()
+            .expect("fake product command router state lock poisoned"); // safety: test-support fake
+        state.routed.clone()
+    }
+
+    /// How many commands have been routed.
+    pub fn routed_count(&self) -> usize {
+        self.routed().len()
+    }
+}
+
+impl Default for FakeProductCommandRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProductCommandRouter for FakeProductCommandRouter {
+    async fn route_command(
+        &self,
+        _envelope: &ProductInboundEnvelope,
+        command: ProductCommandName,
+        arguments: String,
+    ) -> Result<ProductCommandOutcome, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake product command router state lock poisoned"); // safety: test-support fake
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state.routed.push((command.clone(), arguments));
+        if state.next_is_unknown {
+            state.next_is_unknown = false;
+            return Ok(ProductCommandOutcome::UnknownCommand { command });
+        }
+        if let Some(outcome) = state.next_outcome.clone() {
+            return Ok(outcome);
+        }
+        Ok(ProductCommandOutcome::Routed { command })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeApprovalInteractionService
+// ---------------------------------------------------------------------------
+
+/// In-memory fake for [`ApprovalInteractionService`]. Records each
+/// `(gate_ref, decision)` pair and replays a programmed outcome (defaulting to
+/// `Handled { gate_ref }` echoing the input ref).
+pub struct FakeApprovalInteractionService {
+    state: Mutex<FakeApprovalState>,
+}
+
+#[derive(Default)]
+struct FakeApprovalState {
+    resolutions: Vec<(LoopGateRef, ApprovalDecision)>,
+    next_outcome: Option<ApprovalResolutionOutcome>,
+    fail_with: Option<ProductWorkflowError>,
+}
+
+impl FakeApprovalInteractionService {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeApprovalState::default()),
+        }
+    }
+
+    /// Program the next resolution to report the gate ref as stale/unknown.
+    pub fn program_stale(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake approval interaction state lock poisoned"); // safety: test-support fake
+        state.next_outcome = Some(ApprovalResolutionOutcome::StaleOrUnknown);
+    }
+
+    /// Program the next resolution to report success, echoing the gate ref.
+    pub fn program_handled(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake approval interaction state lock poisoned"); // safety: test-support fake
+        state.next_outcome = None; // fall back to default echo behaviour
+        state.fail_with = None;
+    }
+
+    /// Force all resolutions to fail.
+    pub fn force_failure(&self, error: ProductWorkflowError) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake approval interaction state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(error);
+    }
+
+    /// All resolutions seen by this service, in order.
+    pub fn resolutions(&self) -> Vec<(LoopGateRef, ApprovalDecision)> {
+        let state = self
+            .state
+            .lock()
+            .expect("fake approval interaction state lock poisoned"); // safety: test-support fake
+        state.resolutions.clone()
+    }
+
+    /// How many approvals have been resolved.
+    pub fn resolution_count(&self) -> usize {
+        self.resolutions().len()
+    }
+}
+
+impl Default for FakeApprovalInteractionService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ApprovalInteractionService for FakeApprovalInteractionService {
+    async fn resolve_approval(
+        &self,
+        _envelope: &ProductInboundEnvelope,
+        gate_ref: LoopGateRef,
+        decision: ApprovalDecision,
+    ) -> Result<ApprovalResolutionOutcome, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake approval interaction state lock poisoned"); // safety: test-support fake
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state.resolutions.push((gate_ref.clone(), decision));
+        if let Some(outcome) = state.next_outcome.clone() {
+            return Ok(outcome);
+        }
+        Ok(ApprovalResolutionOutcome::Handled { gate_ref })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeAuthInteractionService
+// ---------------------------------------------------------------------------
+
+/// In-memory fake for [`AuthInteractionService`]. Records each
+/// `(auth_request_ref, result)` pair and replays a programmed outcome
+/// (defaulting to `Handled { auth_request_ref }` echoing the input ref).
+pub struct FakeAuthInteractionService {
+    state: Mutex<FakeAuthState>,
+}
+
+#[derive(Default)]
+struct FakeAuthState {
+    resolutions: Vec<(AuthRequestRef, AuthResolutionResult)>,
+    next_outcome: Option<AuthResolutionOutcome>,
+    fail_with: Option<ProductWorkflowError>,
+}
+
+impl FakeAuthInteractionService {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeAuthState::default()),
+        }
+    }
+
+    /// Program the next resolution to report the auth ref as stale/unknown.
+    pub fn program_stale(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake auth interaction state lock poisoned"); // safety: test-support fake
+        state.next_outcome = Some(AuthResolutionOutcome::StaleOrUnknown);
+    }
+
+    /// Program the next resolution to report success, echoing the auth ref.
+    pub fn program_handled(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake auth interaction state lock poisoned"); // safety: test-support fake
+        state.next_outcome = None; // fall back to default echo behaviour
+        state.fail_with = None;
+    }
+
+    /// Force all resolutions to fail.
+    pub fn force_failure(&self, error: ProductWorkflowError) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake auth interaction state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(error);
+    }
+
+    /// All resolutions seen by this service, in order.
+    pub fn resolutions(&self) -> Vec<(AuthRequestRef, AuthResolutionResult)> {
+        let state = self
+            .state
+            .lock()
+            .expect("fake auth interaction state lock poisoned"); // safety: test-support fake
+        state.resolutions.clone()
+    }
+
+    /// How many auth resolutions have been seen.
+    pub fn resolution_count(&self) -> usize {
+        self.resolutions().len()
+    }
+}
+
+impl Default for FakeAuthInteractionService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AuthInteractionService for FakeAuthInteractionService {
+    async fn resolve_auth(
+        &self,
+        _envelope: &ProductInboundEnvelope,
+        auth_request_ref: AuthRequestRef,
+        result: AuthResolutionResult,
+    ) -> Result<AuthResolutionOutcome, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake auth interaction state lock poisoned"); // safety: test-support fake
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state.resolutions.push((auth_request_ref.clone(), result));
+        if let Some(outcome) = state.next_outcome.clone() {
+            return Ok(outcome);
+        }
+        Ok(AuthResolutionOutcome::Handled { auth_request_ref })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeLinkedThreadActionService
+// ---------------------------------------------------------------------------
+
+/// In-memory fake for [`LinkedThreadActionService`]. Records each action
+/// (id + data + reply target) and always echoes back `Routed { action_id }`.
+pub struct FakeLinkedThreadActionService {
+    state: Mutex<FakeLinkedThreadActionState>,
+}
+
+#[derive(Default)]
+struct FakeLinkedThreadActionState {
+    actions: Vec<(LinkedThreadActionId, Option<String>, Option<String>)>,
+    fail_with: Option<ProductWorkflowError>,
+}
+
+impl FakeLinkedThreadActionService {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeLinkedThreadActionState::default()),
+        }
+    }
+
+    /// Force all calls to fail.
+    pub fn force_failure(&self, error: ProductWorkflowError) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake linked thread action state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(error);
+    }
+
+    /// All actions seen by this service, in order.
+    pub fn actions(&self) -> Vec<(LinkedThreadActionId, Option<String>, Option<String>)> {
+        let state = self
+            .state
+            .lock()
+            .expect("fake linked thread action state lock poisoned"); // safety: test-support fake
+        state.actions.clone()
+    }
+
+    /// How many actions have been routed.
+    pub fn action_count(&self) -> usize {
+        self.actions().len()
+    }
+}
+
+impl Default for FakeLinkedThreadActionService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl LinkedThreadActionService for FakeLinkedThreadActionService {
+    async fn handle_action(
+        &self,
+        _envelope: &ProductInboundEnvelope,
+        action_id: LinkedThreadActionId,
+        data: Option<String>,
+        reply_target_message_id: Option<String>,
+    ) -> Result<LinkedThreadActionOutcome, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake linked thread action state lock poisoned"); // safety: test-support fake
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state
+            .actions
+            .push((action_id.clone(), data, reply_target_message_id));
+        Ok(LinkedThreadActionOutcome::Routed { action_id })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeMissionService
+// ---------------------------------------------------------------------------
+
+/// In-memory fake for [`MissionService`]. Records every fire request and
+/// replays a programmed outcome (defaulting to a fresh `Submitted` envelope).
+pub struct FakeMissionService {
+    state: Mutex<FakeMissionState>,
+}
+
+#[derive(Default)]
+struct FakeMissionState {
+    fires: Vec<MissionFireRequest>,
+    next_outcome: Option<MissionFireOutcome>,
+    fail_with: Option<ProductWorkflowError>,
+    fire_count: usize,
+}
+
+impl FakeMissionService {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeMissionState::default()),
+        }
+    }
+
+    /// Program the next fire to succeed with a fresh `Submitted` envelope.
+    pub fn program_submitted(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake mission service state lock poisoned"); // safety: test-support fake
+        state.next_outcome = Some(MissionFireOutcome::Submitted {
+            mission_fire_ref: MissionFireRef::new(),
+            run_id: TurnRunId::new(),
+        });
+    }
+
+    /// Program the next fire to report a busy thread (deferred).
+    pub fn program_deferred_busy(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake mission service state lock poisoned"); // safety: test-support fake
+        state.next_outcome = Some(MissionFireOutcome::DeferredBusy {
+            mission_fire_ref: MissionFireRef::new(),
+            active_run_id: TurnRunId::new(),
+        });
+    }
+
+    /// Program the next fire to be suppressed with the supplied reason.
+    pub fn program_suppressed(&self, reason: MissionFireSuppressionReason) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake mission service state lock poisoned"); // safety: test-support fake
+        state.next_outcome = Some(MissionFireOutcome::Suppressed {
+            mission_fire_ref: MissionFireRef::new(),
+            reason,
+        });
+    }
+
+    /// Program the next fire to be rejected with the supplied reason.
+    pub fn program_rejected(&self, reason: MissionFireRejectionReason) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake mission service state lock poisoned"); // safety: test-support fake
+        state.next_outcome = Some(MissionFireOutcome::Rejected { reason });
+    }
+
+    /// Force all fires to fail.
+    pub fn force_failure(&self, error: ProductWorkflowError) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake mission service state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(error);
+    }
+
+    /// All fire requests seen by this service, in order.
+    pub fn fires(&self) -> Vec<MissionFireRequest> {
+        let state = self
+            .state
+            .lock()
+            .expect("fake mission service state lock poisoned"); // safety: test-support fake
+        state.fires.clone()
+    }
+
+    /// How many fires have been requested.
+    pub fn fire_count(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .expect("fake mission service state lock poisoned"); // safety: test-support fake
+        state.fire_count
+    }
+}
+
+impl Default for FakeMissionService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl MissionService for FakeMissionService {
+    async fn fire_mission(
+        &self,
+        request: MissionFireRequest,
+    ) -> Result<MissionFireOutcome, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake mission service state lock poisoned"); // safety: test-support fake
+        state.fire_count += 1;
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state.fires.push(request);
+        if let Some(outcome) = state.next_outcome.clone() {
+            return Ok(outcome);
+        }
+        Ok(MissionFireOutcome::Submitted {
+            mission_fire_ref: MissionFireRef::new(),
+            run_id: TurnRunId::new(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeSystemActionService
+// ---------------------------------------------------------------------------
+
+/// In-memory fake for [`SystemActionService`]. Records every typed system
+/// action (actor + kind + optional scope + optional data) and always returns
+/// `Routed`.
+pub struct FakeSystemActionService {
+    state: Mutex<FakeSystemActionState>,
+}
+
+#[derive(Default)]
+struct FakeSystemActionState {
+    actions: Vec<(String, String, Option<String>, Option<String>)>,
+    fail_with: Option<ProductWorkflowError>,
+}
+
+impl FakeSystemActionService {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeSystemActionState::default()),
+        }
+    }
+
+    /// Force all calls to fail.
+    pub fn force_failure(&self, error: ProductWorkflowError) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake system action state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(error);
+    }
+
+    /// All actions seen by this service, in order.
+    pub fn actions(&self) -> Vec<(String, String, Option<String>, Option<String>)> {
+        let state = self
+            .state
+            .lock()
+            .expect("fake system action state lock poisoned"); // safety: test-support fake
+        state.actions.clone()
+    }
+
+    /// How many system actions have been routed.
+    pub fn action_count(&self) -> usize {
+        self.actions().len()
+    }
+}
+
+impl Default for FakeSystemActionService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SystemActionService for FakeSystemActionService {
+    async fn handle_action(
+        &self,
+        _envelope: &ProductInboundEnvelope,
+        system_actor_ref: String,
+        kind: String,
+        scope_thread_id: Option<String>,
+        data: Option<String>,
+    ) -> Result<SystemActionOutcome, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake system action state lock poisoned"); // safety: test-support fake
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state
+            .actions
+            .push((system_actor_ref, kind, scope_thread_id, data));
+        Ok(SystemActionOutcome::Routed)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeProjectionSubscriptionAuthority
+// ---------------------------------------------------------------------------
+
+/// In-memory fake for [`ProjectionSubscriptionAuthority`]. Records every
+/// authorization request and replays either a programmed response or a
+/// deterministic default derived from the request (mirroring the
+/// [`FakeConversationBindingService`] defaulting pattern).
+pub struct FakeProjectionSubscriptionAuthority {
+    state: Mutex<FakeProjectionSubscriptionAuthorityState>,
+}
+
+#[derive(Default)]
+struct FakeProjectionSubscriptionAuthorityState {
+    authorizations: Vec<ProjectionSubscriptionAuthorityRequest>,
+    programmed_response: Option<ProjectionSubscriptionRequest>,
+    fail_with: Option<ProductWorkflowError>,
+}
+
+impl FakeProjectionSubscriptionAuthority {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(FakeProjectionSubscriptionAuthorityState::default()),
+        }
+    }
+
+    /// Program a specific response for the next authorization. Subsequent
+    /// requests reuse the same response until reprogrammed.
+    pub fn program_response(&self, response: ProjectionSubscriptionRequest) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake projection subscription authority state lock poisoned"); // safety: test-support fake
+        state.programmed_response = Some(response);
+    }
+
+    /// Force the next authorization to fail with a transient workflow error.
+    pub fn program_failure(&self, reason: impl Into<String>) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake projection subscription authority state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(ProductWorkflowError::Transient {
+            reason: reason.into(),
+        });
+    }
+
+    /// Force all authorizations to fail with a caller-supplied error.
+    pub fn force_failure(&self, error: ProductWorkflowError) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake projection subscription authority state lock poisoned"); // safety: test-support fake
+        state.fail_with = Some(error);
+    }
+
+    /// All requests seen by this service, in order.
+    pub fn authorizations(&self) -> Vec<ProjectionSubscriptionAuthorityRequest> {
+        let state = self
+            .state
+            .lock()
+            .expect("fake projection subscription authority state lock poisoned"); // safety: test-support fake
+        state.authorizations.clone()
+    }
+
+    /// How many authorizations have been performed.
+    pub fn authorization_count(&self) -> usize {
+        self.authorizations().len()
+    }
+}
+
+impl Default for FakeProjectionSubscriptionAuthority {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProjectionSubscriptionAuthority for FakeProjectionSubscriptionAuthority {
+    async fn authorize_subscription(
+        &self,
+        request: ProjectionSubscriptionAuthorityRequest,
+    ) -> Result<ProjectionSubscriptionRequest, ProductWorkflowError> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake projection subscription authority state lock poisoned"); // safety: test-support fake
+        if let Some(error) = state.fail_with.clone() {
+            return Err(error);
+        }
+        state.authorizations.push(request.clone());
+        if let Some(response) = state.programmed_response.clone() {
+            return Ok(response);
+        }
+
+        // Default: deterministic mapping from the request — mirrors the
+        // FakeConversationBindingService defaulting pattern. The cursor is
+        // forwarded unchanged so contract tests can assert pass-through.
+        let tenant_id = TenantId::new(format!("tenant:{}", request.installation_id.as_str()))
+            .map_err(|e| ProductWorkflowError::BindingResolutionFailed {
+                reason: e.to_string(),
+            })?;
+        let user_id =
+            UserId::new(format!("user:{}", request.external_actor_ref.id())).map_err(|e| {
+                ProductWorkflowError::BindingResolutionFailed {
+                    reason: e.to_string(),
+                }
+            })?;
+        let thread_id = ThreadId::new(format!(
+            "thread:{}:{}",
+            request.installation_id.as_str(),
+            request.external_conversation_ref.conversation_fingerprint()
+        ))
+        .map_err(|e| ProductWorkflowError::BindingResolutionFailed {
+            reason: e.to_string(),
+        })?;
+        let agent_id = AgentId::new("agent:fake").map_err(|e| {
+            ProductWorkflowError::BindingResolutionFailed {
+                reason: e.to_string(),
+            }
+        })?;
+        let project_id = ProjectId::new("project:fake").map_err(|e| {
+            ProductWorkflowError::BindingResolutionFailed {
+                reason: e.to_string(),
+            }
+        })?;
+
+        let actor = TurnActor::new(user_id);
+        let scope = TurnScope::new(tenant_id, Some(agent_id), Some(project_id), thread_id);
+
+        Ok(ProjectionSubscriptionRequest {
+            actor,
+            scope,
+            after_cursor: request.after_cursor,
         })
     }
 }

--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -4,6 +4,8 @@
 //! resolves the conversation binding, accepts the inbound message into the
 //! session thread, and submits the turn to the coordinator.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use ironclaw_host_api::UserId;
@@ -22,6 +24,7 @@ use uuid::Uuid;
 
 use crate::binding::{ConversationBindingService, ResolveBindingRequest, ResolvedBinding};
 use crate::error::ProductWorkflowError;
+use crate::services::{BeforeInboundOutcome, BeforeInboundPolicy, BeforeInboundRequest};
 
 /// Result of the inbound turn submission flow.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,6 +87,7 @@ pub struct DefaultInboundTurnService<B, T, C> {
     binding_service: B,
     thread_service: T,
     turn_coordinator: C,
+    before_inbound_policy: Option<Arc<dyn BeforeInboundPolicy>>,
 }
 
 impl<B, T, C> DefaultInboundTurnService<B, T, C>
@@ -97,7 +101,17 @@ where
             binding_service,
             thread_service,
             turn_coordinator,
+            before_inbound_policy: None,
         }
+    }
+
+    /// Attach a [`BeforeInboundPolicy`] that evaluates each new inbound user
+    /// message before it is staged into the session thread service. The hook
+    /// only runs on the genuine new-message path; replay paths bypass it
+    /// because the rewrite/reject decision was recorded on the first run.
+    pub fn with_before_inbound_policy(mut self, policy: Arc<dyn BeforeInboundPolicy>) -> Self {
+        self.before_inbound_policy = Some(policy);
+        self
     }
 }
 
@@ -141,6 +155,43 @@ where
             .await;
         }
 
+        // BeforeInbound hook fires only on the genuine new-message path. The
+        // replay branch above bypasses it because rewrite/reject decisions are
+        // recorded on the first run; replays must produce the same outcome
+        // without re-evaluating the policy.
+        let payload_text = if let Some(policy) = self.before_inbound_policy.as_ref() {
+            let request = BeforeInboundRequest {
+                adapter_id: envelope.adapter_id().clone(),
+                installation_id: envelope.installation_id().clone(),
+                external_event_id: envelope.external_event_id().clone(),
+                external_actor_ref: envelope.external_actor_ref().clone(),
+                external_conversation_ref: envelope.external_conversation_ref().clone(),
+                received_at: envelope.received_at(),
+                original_text: payload.text.clone(),
+                trigger: payload.trigger,
+            };
+            match policy.evaluate_inbound(request).await? {
+                BeforeInboundOutcome::Continue {
+                    rewritten_text: Some(new),
+                } => new,
+                BeforeInboundOutcome::Continue {
+                    rewritten_text: None,
+                } => payload.text.clone(),
+                BeforeInboundOutcome::Reject { reason } => {
+                    // `RedactedString` only exposes its inner value through
+                    // `Display`, which emits the redaction placeholder; the
+                    // workflow boundary re-wraps `TurnSubmissionRejected` into
+                    // a redacted permanent `Rejected` ack anyway, so the
+                    // placeholder text is what reaches the adapter.
+                    return Err(ProductWorkflowError::TurnSubmissionRejected {
+                        reason: reason.to_string(),
+                    });
+                }
+            }
+        } else {
+            payload.text.clone()
+        };
+
         let binding = self
             .binding_service
             .resolve_binding(ResolveBindingRequest {
@@ -176,7 +227,7 @@ where
                 source_binding_id: Some(source_binding_id.clone()),
                 reply_target_binding_id: Some(reply_target_binding_id.clone()),
                 external_event_id: Some(envelope.external_event_id().as_str().to_string()),
-                content: MessageContent::text(payload.text.clone()),
+                content: MessageContent::text(payload_text),
             })
             .await
             .map_err(|e| ProductWorkflowError::Transient {

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -26,6 +26,7 @@ pub mod error;
 pub mod fakes;
 pub mod inbound_turn;
 pub mod ledger;
+pub mod services;
 pub mod workflow;
 
 pub use action::{
@@ -35,7 +36,20 @@ pub use action::{
 pub use binding::{ConversationBindingService, ResolveBindingRequest, ResolvedBinding};
 pub use error::ProductWorkflowError;
 #[cfg(any(test, feature = "test-support"))]
-pub use fakes::{FakeConversationBindingService, FakeIdempotencyLedger, FakeInboundTurnService};
+pub use fakes::{
+    FakeApprovalInteractionService, FakeAuthInteractionService, FakeBeforeInboundPolicy,
+    FakeConversationBindingService, FakeIdempotencyLedger, FakeInboundTurnService,
+    FakeLinkedThreadActionService, FakeMissionService, FakeProductCommandRouter,
+    FakeProjectionSubscriptionAuthority, FakeSystemActionService,
+};
 pub use inbound_turn::{DefaultInboundTurnService, InboundTurnOutcome, InboundTurnService};
 pub use ledger::{IdempotencyDecision, IdempotencyLedger};
+pub use services::{
+    ApprovalInteractionService, ApprovalResolutionOutcome, AuthInteractionService,
+    AuthResolutionOutcome, BeforeInboundOutcome, BeforeInboundPolicy, BeforeInboundRequest,
+    LinkedThreadActionOutcome, LinkedThreadActionService, MissionFireOutcome, MissionFireRef,
+    MissionFireRejectionReason, MissionFireRequest, MissionFireSuppressionReason, MissionService,
+    ProductCommandOutcome, ProductCommandRouter, ProjectionSubscriptionAuthority,
+    ProjectionSubscriptionAuthorityRequest, SystemActionOutcome, SystemActionService,
+};
 pub use workflow::DefaultProductWorkflow;

--- a/crates/ironclaw_product_workflow/src/services.rs
+++ b/crates/ironclaw_product_workflow/src/services.rs
@@ -1,0 +1,333 @@
+//! Port traits and outcome types for the non-`UserMessage` dispatch arms.
+//!
+//! Each non-`UserMessage` variant of [`ironclaw_product_adapters::ProductInboundPayload`]
+//! routes through one of the traits in this module. The trait shapes are
+//! Reborn-side facades: production wiring in `src/app.rs` (or a composition
+//! crate) is expected to implement them by adapting existing host-layer
+//! services (e.g. [`ironclaw_approvals::ApprovalResolver`],
+//! [`ironclaw_authorization::CapabilityDispatchAuthorizer`],
+//! [`ironclaw_outbound::OutboundPolicyService`]).
+//!
+//! The trait shapes align with the contract sketches from:
+//! - #3094 (`ApprovalInteractionService`, `AuthInteractionService`)
+//! - #3278 (`MissionService`, `MissionFireRequest`, `MissionFireOutcome`)
+//! - #3280 (`ProductCommandRouter` seam; full matrix in #3286)
+//! - #3266 (`ProjectionSubscriptionAuthority` wraps `OutboundPolicyService`)
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use ironclaw_product_adapters::{
+    AdapterInstallationId, ApprovalDecision, AuthResolutionResult, ExternalActorRef,
+    ExternalConversationRef, ExternalEventId, ProductAdapterId, ProductInboundEnvelope,
+    ProductTriggerReason, ProjectionCursor, ProjectionSubscriptionRequest, RedactedString,
+};
+use ironclaw_turns::{LoopGateRef, TurnRunId};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::action::{AuthRequestRef, LinkedThreadActionId, ProductCommandName};
+use crate::error::ProductWorkflowError;
+
+// ---------------------------------------------------------------------------
+// BeforeInbound hook port
+// ---------------------------------------------------------------------------
+
+/// Request passed to a [`BeforeInboundPolicy`] before an inbound user message
+/// is staged into the session thread service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BeforeInboundRequest {
+    pub adapter_id: ProductAdapterId,
+    pub installation_id: AdapterInstallationId,
+    pub external_event_id: ExternalEventId,
+    pub external_actor_ref: ExternalActorRef,
+    pub external_conversation_ref: ExternalConversationRef,
+    pub received_at: DateTime<Utc>,
+    pub original_text: String,
+    pub trigger: ProductTriggerReason,
+}
+
+/// Outcome of a [`BeforeInboundPolicy::evaluate_inbound`] call.
+///
+/// Mirrors the v1 `HookOutcome` shape (`src/hooks/hook.rs`): the policy can
+/// either let the message through (optionally rewriting the text) or reject it
+/// outright with a redacted reason. Rejection prevents staging into the
+/// transcript and prevents any `TurnCoordinator::submit_turn` call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BeforeInboundOutcome {
+    /// Pass the message through. If `rewritten_text` is `Some`, that text
+    /// replaces the original before staging.
+    Continue { rewritten_text: Option<String> },
+    /// Reject the message. No transcript content, no turn submission. The
+    /// idempotency ledger row settles as a redacted rejection.
+    Reject { reason: RedactedString },
+}
+
+#[async_trait]
+pub trait BeforeInboundPolicy: Send + Sync {
+    async fn evaluate_inbound(
+        &self,
+        request: BeforeInboundRequest,
+    ) -> Result<BeforeInboundOutcome, ProductWorkflowError>;
+}
+
+// ---------------------------------------------------------------------------
+// ProductCommandRouter port
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`ProductCommandRouter::route_command`] call.
+///
+/// The first slice only proves that a command reached the seam. The full
+/// command compatibility matrix (return-to-thread semantics, dedicated
+/// commands like `/interrupt`, `/cancel`, `/model`) is owned by #3286.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProductCommandOutcome {
+    /// Command was accepted and routed to its handler.
+    Routed { command: ProductCommandName },
+    /// Command is unknown to the router.
+    UnknownCommand { command: ProductCommandName },
+}
+
+#[async_trait]
+pub trait ProductCommandRouter: Send + Sync {
+    async fn route_command(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        command: ProductCommandName,
+        arguments: String,
+    ) -> Result<ProductCommandOutcome, ProductWorkflowError>;
+}
+
+// ---------------------------------------------------------------------------
+// Approval interaction service (port for ironclaw_approvals::ApprovalResolver)
+// ---------------------------------------------------------------------------
+
+/// Outcome of an [`ApprovalInteractionService::resolve_approval`] call.
+///
+/// Production implementations wrap [`ironclaw_approvals::ApprovalResolver`]
+/// (`approve_dispatch` / `approve_spawn` / `deny`). The workflow does **not**
+/// call `TurnCoordinator::resume_turn` directly — gate resume is the resolver's
+/// job once the lease is minted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApprovalResolutionOutcome {
+    /// Gate was found and the decision was applied.
+    Handled { gate_ref: LoopGateRef },
+    /// Gate ref is unknown, expired, or already settled. Surface as a redacted
+    /// rejection so adapters cannot probe gate-ref existence.
+    StaleOrUnknown,
+}
+
+#[async_trait]
+pub trait ApprovalInteractionService: Send + Sync {
+    async fn resolve_approval(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        gate_ref: LoopGateRef,
+        decision: ApprovalDecision,
+    ) -> Result<ApprovalResolutionOutcome, ProductWorkflowError>;
+}
+
+// ---------------------------------------------------------------------------
+// Auth interaction service (port for ironclaw_authorization)
+// ---------------------------------------------------------------------------
+
+/// Outcome of an [`AuthInteractionService::resolve_auth`] call.
+///
+/// Production implementations wrap host-side auth flow management — for OAuth
+/// callbacks, credential injection, or cancellation — and ultimately resume
+/// the parked loop via the trusted approval/lease path, never directly through
+/// `TurnCoordinator::resume_turn`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthResolutionOutcome {
+    /// Auth request was found and the result was applied.
+    Handled { auth_request_ref: AuthRequestRef },
+    /// Auth request ref is unknown, expired, or already settled.
+    StaleOrUnknown,
+}
+
+#[async_trait]
+pub trait AuthInteractionService: Send + Sync {
+    async fn resolve_auth(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        auth_request_ref: AuthRequestRef,
+        result: AuthResolutionResult,
+    ) -> Result<AuthResolutionOutcome, ProductWorkflowError>;
+}
+
+// ---------------------------------------------------------------------------
+// Linked thread action service
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`LinkedThreadActionService::handle_action`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkedThreadActionOutcome {
+    /// Action was routed to its handler.
+    Routed { action_id: LinkedThreadActionId },
+}
+
+#[async_trait]
+pub trait LinkedThreadActionService: Send + Sync {
+    async fn handle_action(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        action_id: LinkedThreadActionId,
+        data: Option<String>,
+        reply_target_message_id: Option<String>,
+    ) -> Result<LinkedThreadActionOutcome, ProductWorkflowError>;
+}
+
+// ---------------------------------------------------------------------------
+// Mission service (per issue #3278)
+// ---------------------------------------------------------------------------
+
+/// Stable handle to a durable mission-fire record. Mints from the workflow
+/// before delegating to a real `MissionService` so retries replay the same
+/// reference even if the service implementation is unreachable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MissionFireRef(Uuid);
+
+impl MissionFireRef {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    pub fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+impl Default for MissionFireRef {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for MissionFireRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Reason a mission fire was suppressed pre-submit (cadence, cooldown, dedup,
+/// busy-thread policy). Names mirror #3278 `MissionFireOutcome` variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionFireSuppressionReason {
+    Cadence,
+    Cooldown,
+    Deduplicated,
+    BusyThread,
+}
+
+/// Reason a mission fire was rejected before any suppression evaluation
+/// (mission unknown, scope mismatch, mission disabled).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MissionFireRejectionReason {
+    UnknownMission,
+    ScopeMismatch,
+    MissionDisabled,
+}
+
+/// Request to fire a mission via [`MissionService::fire_mission`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissionFireRequest {
+    pub adapter_id: ProductAdapterId,
+    pub installation_id: AdapterInstallationId,
+    pub external_event_id: ExternalEventId,
+    pub external_actor_ref: ExternalActorRef,
+    pub external_conversation_ref: ExternalConversationRef,
+    pub received_at: DateTime<Utc>,
+    pub mission_intent: String,
+    pub mission_id_hint: Option<String>,
+    pub data: Option<String>,
+}
+
+/// Outcome of a [`MissionService::fire_mission`] call. Maps 1:1 to the
+/// `MissionSubmitted` / `MissionSuppressed` / `Rejected` adapter-facing acks
+/// in #3280 AC #13.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MissionFireOutcome {
+    Submitted {
+        mission_fire_ref: MissionFireRef,
+        run_id: TurnRunId,
+    },
+    DeferredBusy {
+        mission_fire_ref: MissionFireRef,
+        active_run_id: TurnRunId,
+    },
+    Suppressed {
+        mission_fire_ref: MissionFireRef,
+        reason: MissionFireSuppressionReason,
+    },
+    Rejected {
+        reason: MissionFireRejectionReason,
+    },
+}
+
+#[async_trait]
+pub trait MissionService: Send + Sync {
+    async fn fire_mission(
+        &self,
+        request: MissionFireRequest,
+    ) -> Result<MissionFireOutcome, ProductWorkflowError>;
+}
+
+// ---------------------------------------------------------------------------
+// System action service
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`SystemActionService::handle_action`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SystemActionOutcome {
+    /// System action was routed to its handler.
+    Routed,
+}
+
+#[async_trait]
+pub trait SystemActionService: Send + Sync {
+    /// Handle a typed system action. Implementations must require an
+    /// accountable `system_actor_ref` and a typed `kind` — there is no
+    /// generic `is_internal` bypass.
+    async fn handle_action(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        system_actor_ref: String,
+        kind: String,
+        scope_thread_id: Option<String>,
+        data: Option<String>,
+    ) -> Result<SystemActionOutcome, ProductWorkflowError>;
+}
+
+// ---------------------------------------------------------------------------
+// Projection subscription authority (wraps OutboundPolicyService)
+// ---------------------------------------------------------------------------
+
+/// Request to authorize a projection subscription. Production implementations
+/// wrap [`ironclaw_outbound::OutboundPolicyService::authorize_subscription`]
+/// from #3542, translating the workflow-level request to the outbound
+/// service's own request type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectionSubscriptionAuthorityRequest {
+    pub adapter_id: ProductAdapterId,
+    pub installation_id: AdapterInstallationId,
+    pub external_event_id: ExternalEventId,
+    pub external_actor_ref: ExternalActorRef,
+    pub external_conversation_ref: ExternalConversationRef,
+    pub thread_id_hint: Option<String>,
+    pub after_cursor: Option<ProjectionCursor>,
+}
+
+#[async_trait]
+pub trait ProjectionSubscriptionAuthority: Send + Sync {
+    /// Authorize a projection subscription request and return the canonical
+    /// [`ProjectionSubscriptionRequest`] the adapter should use for subsequent
+    /// projection-stream calls. Implementations are responsible for resolving
+    /// the binding, checking the projection access policy, and (if applicable)
+    /// minting a cursor checkpoint via the underlying outbound policy service.
+    async fn authorize_subscription(
+        &self,
+        request: ProjectionSubscriptionAuthorityRequest,
+    ) -> Result<ProjectionSubscriptionRequest, ProductWorkflowError>;
+}

--- a/crates/ironclaw_product_workflow/src/services.rs
+++ b/crates/ironclaw_product_workflow/src/services.rs
@@ -180,9 +180,10 @@ pub trait LinkedThreadActionService: Send + Sync {
 // Mission service (per issue #3278)
 // ---------------------------------------------------------------------------
 
-/// Stable handle to a durable mission-fire record. Mints from the workflow
-/// before delegating to a real `MissionService` so retries replay the same
-/// reference even if the service implementation is unreachable.
+/// Stable handle to a durable mission-fire record. Minted by the
+/// [`MissionService`] implementation as part of [`MissionFireOutcome`];
+/// the same ref must be returned for retries of the same logical mission
+/// fire so adapters can correlate retries.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct MissionFireRef(Uuid);

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -2,13 +2,22 @@
 //!
 //! This is the top-level product action orchestrator that dispatches inbound
 //! envelopes to the appropriate downstream service based on payload kind.
+//!
+//! Optional service ports (`BeforeInboundPolicy` is held by
+//! `DefaultInboundTurnService`, the rest by this struct) are wired through
+//! [`DefaultProductWorkflow::new`] plus builder-style `with_*` methods. When a
+//! port is unset, the corresponding dispatch arm returns a redacted permanent
+//! rejection — adapters must wire services before serving the matching action
+//! kind in production.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_product_adapters::{
-    ProductAdapterError, ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload,
-    ProductRejection, ProductRejectionKind, ProductWorkflow, ProjectionSubscriptionRequest,
+    LoopGateRef as AdapterLoopGateRef, ProductAdapterError,
+    ProductCommandName as AdapterCommandName, ProductInboundAck, ProductInboundEnvelope,
+    ProductInboundPayload, ProductRejection, ProductRejectionKind, ProductWorkflow,
+    ProjectionSubscriptionRequest, RedactedString,
 };
 use ironclaw_turns::{AdmissionRejectionReason, TurnError, TurnErrorCategory};
 use tracing::debug;
@@ -17,6 +26,14 @@ use crate::action::{ActionDispatchKind, ActionFingerprintKey, SourceBindingKey};
 use crate::error::ProductWorkflowError;
 use crate::inbound_turn::InboundTurnService;
 use crate::ledger::{IdempotencyDecision, IdempotencyLedger};
+use crate::services::{
+    ApprovalInteractionService, ApprovalResolutionOutcome, AuthInteractionService,
+    AuthResolutionOutcome, LinkedThreadActionOutcome, LinkedThreadActionService,
+    MissionFireOutcome, MissionFireRequest,
+    MissionFireSuppressionReason as WorkflowMissionFireSuppressionReason, MissionService,
+    ProductCommandOutcome, ProductCommandRouter, ProjectionSubscriptionAuthority,
+    ProjectionSubscriptionAuthorityRequest, SystemActionService,
+};
 
 /// Host-side implementation of [`ProductWorkflow`] that dispatches inbound
 /// envelopes through the idempotency ledger and routes to the appropriate
@@ -24,6 +41,13 @@ use crate::ledger::{IdempotencyDecision, IdempotencyLedger};
 pub struct DefaultProductWorkflow {
     inbound_turn_service: Arc<dyn InboundTurnService>,
     idempotency_ledger: Arc<dyn IdempotencyLedger>,
+    command_router: Option<Arc<dyn ProductCommandRouter>>,
+    approval_service: Option<Arc<dyn ApprovalInteractionService>>,
+    auth_service: Option<Arc<dyn AuthInteractionService>>,
+    linked_thread_service: Option<Arc<dyn LinkedThreadActionService>>,
+    mission_service: Option<Arc<dyn MissionService>>,
+    system_action_service: Option<Arc<dyn SystemActionService>>,
+    projection_authority: Option<Arc<dyn ProjectionSubscriptionAuthority>>,
 }
 
 impl DefaultProductWorkflow {
@@ -34,7 +58,55 @@ impl DefaultProductWorkflow {
         Self {
             inbound_turn_service,
             idempotency_ledger,
+            command_router: None,
+            approval_service: None,
+            auth_service: None,
+            linked_thread_service: None,
+            mission_service: None,
+            system_action_service: None,
+            projection_authority: None,
         }
+    }
+
+    pub fn with_command_router(mut self, router: Arc<dyn ProductCommandRouter>) -> Self {
+        self.command_router = Some(router);
+        self
+    }
+
+    pub fn with_approval_service(mut self, service: Arc<dyn ApprovalInteractionService>) -> Self {
+        self.approval_service = Some(service);
+        self
+    }
+
+    pub fn with_auth_service(mut self, service: Arc<dyn AuthInteractionService>) -> Self {
+        self.auth_service = Some(service);
+        self
+    }
+
+    pub fn with_linked_thread_service(
+        mut self,
+        service: Arc<dyn LinkedThreadActionService>,
+    ) -> Self {
+        self.linked_thread_service = Some(service);
+        self
+    }
+
+    pub fn with_mission_service(mut self, service: Arc<dyn MissionService>) -> Self {
+        self.mission_service = Some(service);
+        self
+    }
+
+    pub fn with_system_action_service(mut self, service: Arc<dyn SystemActionService>) -> Self {
+        self.system_action_service = Some(service);
+        self
+    }
+
+    pub fn with_projection_authority(
+        mut self,
+        authority: Arc<dyn ProjectionSubscriptionAuthority>,
+    ) -> Self {
+        self.projection_authority = Some(authority);
+        self
     }
 }
 
@@ -44,6 +116,21 @@ impl ProductWorkflow for DefaultProductWorkflow {
         &self,
         envelope: ProductInboundEnvelope,
     ) -> Result<ProductInboundAck, ProductAdapterError> {
+        // Subscription requests are read-only — they MUST NOT take a
+        // ProductInboundAction ledger row (issue #3280 AC #14). Adapters
+        // are expected to call resolve_projection_subscription instead;
+        // routing one through accept_inbound is a usage error.
+        if matches!(
+            envelope.payload(),
+            ProductInboundPayload::SubscriptionRequest(_)
+        ) {
+            return Err(ProductAdapterError::from(
+                ProductWorkflowError::UnsupportedActionKind {
+                    kind: "subscription_request_via_accept_inbound".into(),
+                },
+            ));
+        }
+
         let source_binding_key =
             SourceBindingKey::new(envelope.source_binding_key()).map_err(|reason| {
                 ProductAdapterError::from(ProductWorkflowError::BindingResolutionFailed { reason })
@@ -73,13 +160,11 @@ impl ProductWorkflow for DefaultProductWorkflow {
                     });
                 }
                 Err(ProductAdapterError::Internal {
-                    detail: ironclaw_product_adapters::RedactedString::new(
-                        "settled action missing outcome",
-                    ),
+                    detail: RedactedString::new("settled action missing outcome"),
                 })
             }
             IdempotencyDecision::New(mut action) => {
-                let result = dispatch_payload(&envelope, &*self.inbound_turn_service).await;
+                let result = self.dispatch_payload(&envelope).await;
 
                 match result {
                     Ok(ack) => {
@@ -135,51 +220,315 @@ impl ProductWorkflow for DefaultProductWorkflow {
 
     async fn resolve_projection_subscription(
         &self,
-        _envelope: ProductInboundEnvelope,
+        envelope: ProductInboundEnvelope,
     ) -> Result<ProjectionSubscriptionRequest, ProductAdapterError> {
-        Err(ProductAdapterError::Internal {
-            detail: ironclaw_product_adapters::RedactedString::new(
-                "projection subscription resolution not yet implemented",
-            ),
-        })
+        let authority = self.projection_authority.as_ref().ok_or_else(|| {
+            ProductAdapterError::from(ProductWorkflowError::UnsupportedActionKind {
+                kind: "projection_subscription".into(),
+            })
+        })?;
+
+        let (thread_id_hint, after_cursor) = match envelope.payload() {
+            ProductInboundPayload::SubscriptionRequest(req) => {
+                (req.thread_id_hint.clone(), req.after_cursor.clone())
+            }
+            _ => (None, None),
+        };
+
+        let request = ProjectionSubscriptionAuthorityRequest {
+            adapter_id: envelope.adapter_id().clone(),
+            installation_id: envelope.installation_id().clone(),
+            external_event_id: envelope.external_event_id().clone(),
+            external_actor_ref: envelope.external_actor_ref().clone(),
+            external_conversation_ref: envelope.external_conversation_ref().clone(),
+            thread_id_hint,
+            after_cursor,
+        };
+
+        authority
+            .authorize_subscription(request)
+            .await
+            .map_err(ProductAdapterError::from)
     }
 }
 
-async fn dispatch_payload(
-    envelope: &ProductInboundEnvelope,
-    inbound_turn_service: &dyn InboundTurnService,
-) -> Result<ProductInboundAck, ProductWorkflowError> {
-    match envelope.payload() {
-        ProductInboundPayload::UserMessage(_) => {
-            let outcome = inbound_turn_service.accept_user_message(envelope).await?;
-            Ok(outcome.to_ack())
+impl DefaultProductWorkflow {
+    async fn dispatch_payload(
+        &self,
+        envelope: &ProductInboundEnvelope,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        match envelope.payload() {
+            ProductInboundPayload::UserMessage(_) => {
+                let outcome = self
+                    .inbound_turn_service
+                    .accept_user_message(envelope)
+                    .await?;
+                Ok(outcome.to_ack())
+            }
+            ProductInboundPayload::Command(cmd) => self.dispatch_command(envelope, cmd).await,
+            ProductInboundPayload::ApprovalResolution(res) => {
+                self.dispatch_approval(envelope, res).await
+            }
+            ProductInboundPayload::AuthResolution(res) => self.dispatch_auth(envelope, res).await,
+            ProductInboundPayload::SubscriptionRequest(_) => {
+                // Subscription requests never reach dispatch_payload: accept_inbound
+                // short-circuits them above. Defense-in-depth in case the gate moves.
+                Err(ProductWorkflowError::UnsupportedActionKind {
+                    kind: "subscription_request".into(),
+                })
+            }
+            ProductInboundPayload::LinkedThreadAction(lta) => {
+                self.dispatch_linked_thread_action(envelope, lta).await
+            }
+            ProductInboundPayload::MissionAction(ma) => {
+                self.dispatch_mission_action(envelope, ma).await
+            }
+            ProductInboundPayload::SystemAction(sa) => {
+                self.dispatch_system_action(envelope, sa).await
+            }
+            ProductInboundPayload::NoOp => Ok(ProductInboundAck::NoOp),
         }
-        ProductInboundPayload::Command(cmd) => {
-            Err(ProductWorkflowError::CommandRoutingUnavailable {
-                command: cmd.command.clone(),
-            })
+    }
+
+    async fn dispatch_command(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        payload: &ironclaw_product_adapters::InboundCommandPayload,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        let router = self.command_router.as_ref().ok_or_else(|| {
+            ProductWorkflowError::CommandRoutingUnavailable {
+                command: payload.command.clone(),
+            }
+        })?;
+
+        let command = crate::action::ProductCommandName::new(payload.command.clone())
+            .map_err(|reason| ProductWorkflowError::TurnSubmissionRejected { reason })?;
+        let outcome = router
+            .route_command(envelope, command, payload.arguments.clone())
+            .await?;
+
+        match outcome {
+            ProductCommandOutcome::Routed { command } => {
+                let wire_command =
+                    AdapterCommandName::new(command.as_str().to_string()).map_err(|err| {
+                        ProductWorkflowError::TurnSubmissionRejected {
+                            reason: format!("invalid command name for ack: {err}"),
+                        }
+                    })?;
+                Ok(ProductInboundAck::CommandRouted {
+                    command: wire_command,
+                })
+            }
+            ProductCommandOutcome::UnknownCommand { command } => {
+                Ok(ProductInboundAck::Rejected(ProductRejection::permanent(
+                    ProductRejectionKind::PolicyDenied,
+                    format!("unknown command: {command}"),
+                )))
+            }
         }
-        ProductInboundPayload::ApprovalResolution(_) => {
-            Err(ProductWorkflowError::UnsupportedActionKind {
+    }
+
+    async fn dispatch_approval(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        payload: &ironclaw_product_adapters::ApprovalResolutionPayload,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        let service = self.approval_service.as_ref().ok_or_else(|| {
+            ProductWorkflowError::UnsupportedActionKind {
                 kind: "approval_resolution".into(),
-            })
+            }
+        })?;
+        let gate_ref = ironclaw_turns::LoopGateRef::new(payload.gate_ref.clone())
+            .map_err(|reason| ProductWorkflowError::TurnResumeRejected { reason })?;
+        let outcome = service
+            .resolve_approval(envelope, gate_ref, payload.decision.clone())
+            .await?;
+        match outcome {
+            ApprovalResolutionOutcome::Handled { gate_ref } => {
+                let wire_ref =
+                    AdapterLoopGateRef::new(gate_ref.as_str().to_string()).map_err(|err| {
+                        ProductWorkflowError::TurnResumeRejected {
+                            reason: format!("invalid gate ref for ack: {err}"),
+                        }
+                    })?;
+                Ok(ProductInboundAck::GateHandled { gate_ref: wire_ref })
+            }
+            ApprovalResolutionOutcome::StaleOrUnknown => {
+                Ok(ProductInboundAck::Rejected(ProductRejection::permanent(
+                    ProductRejectionKind::PolicyDenied,
+                    "approval gate is stale or unknown",
+                )))
+            }
         }
-        ProductInboundPayload::AuthResolution(_) => {
-            Err(ProductWorkflowError::UnsupportedActionKind {
+    }
+
+    async fn dispatch_auth(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        payload: &ironclaw_product_adapters::AuthResolutionPayload,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        let service = self.auth_service.as_ref().ok_or_else(|| {
+            ProductWorkflowError::UnsupportedActionKind {
                 kind: "auth_resolution".into(),
-            })
+            }
+        })?;
+        let auth_request_ref = crate::action::AuthRequestRef::new(payload.auth_request_ref.clone())
+            .map_err(|reason| ProductWorkflowError::TurnResumeRejected { reason })?;
+        let outcome = service
+            .resolve_auth(envelope, auth_request_ref, payload.result.clone())
+            .await?;
+        match outcome {
+            AuthResolutionOutcome::Handled { auth_request_ref } => {
+                // Project auth_request_ref into the wire-stable LoopGateRef
+                // wrapper used by the GateHandled ack — both approval and auth
+                // resolutions surface through the same "gate handled" channel.
+                let wire_ref = AdapterLoopGateRef::new(auth_request_ref.as_str().to_string())
+                    .map_err(|err| ProductWorkflowError::TurnResumeRejected {
+                        reason: format!("invalid auth request ref for ack: {err}"),
+                    })?;
+                Ok(ProductInboundAck::GateHandled { gate_ref: wire_ref })
+            }
+            AuthResolutionOutcome::StaleOrUnknown => {
+                Ok(ProductInboundAck::Rejected(ProductRejection::permanent(
+                    ProductRejectionKind::PolicyDenied,
+                    "auth request is stale or unknown",
+                )))
+            }
         }
-        ProductInboundPayload::SubscriptionRequest(_) => {
-            Err(ProductWorkflowError::UnsupportedActionKind {
-                kind: "subscription_request".into(),
-            })
-        }
-        ProductInboundPayload::LinkedThreadAction(_) => {
-            Err(ProductWorkflowError::UnsupportedActionKind {
+    }
+
+    async fn dispatch_linked_thread_action(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        payload: &ironclaw_product_adapters::LinkedThreadActionPayload,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        let service = self.linked_thread_service.as_ref().ok_or_else(|| {
+            ProductWorkflowError::UnsupportedActionKind {
                 kind: "linked_thread_action".into(),
-            })
+            }
+        })?;
+        let action_id = crate::action::LinkedThreadActionId::new(payload.action_id.clone())
+            .map_err(|reason| ProductWorkflowError::TurnSubmissionRejected { reason })?;
+        let outcome = service
+            .handle_action(
+                envelope,
+                action_id,
+                payload.data.clone(),
+                payload.reply_target_message_id.clone(),
+            )
+            .await?;
+        match outcome {
+            LinkedThreadActionOutcome::Routed { action_id } => {
+                let wire_id = ironclaw_product_adapters::LinkedThreadActionId::new(
+                    action_id.as_str().to_string(),
+                )
+                .map_err(|err| ProductWorkflowError::TurnSubmissionRejected {
+                    reason: format!("invalid linked thread action id for ack: {err}"),
+                })?;
+                Ok(ProductInboundAck::LinkedThreadActionRouted { action_id: wire_id })
+            }
         }
-        ProductInboundPayload::NoOp => Ok(ProductInboundAck::NoOp),
+    }
+
+    async fn dispatch_mission_action(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        payload: &ironclaw_product_adapters::MissionActionPayload,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        let service = self.mission_service.as_ref().ok_or_else(|| {
+            ProductWorkflowError::UnsupportedActionKind {
+                kind: "mission_action".into(),
+            }
+        })?;
+        let request = MissionFireRequest {
+            adapter_id: envelope.adapter_id().clone(),
+            installation_id: envelope.installation_id().clone(),
+            external_event_id: envelope.external_event_id().clone(),
+            external_actor_ref: envelope.external_actor_ref().clone(),
+            external_conversation_ref: envelope.external_conversation_ref().clone(),
+            received_at: envelope.received_at(),
+            mission_intent: payload.mission_intent.clone(),
+            mission_id_hint: payload.mission_id_hint.clone(),
+            data: payload.data.clone(),
+        };
+        let outcome = service.fire_mission(request).await?;
+        match outcome {
+            MissionFireOutcome::Submitted {
+                mission_fire_ref,
+                run_id,
+            } => Ok(ProductInboundAck::MissionSubmitted {
+                mission_fire_ref: ironclaw_product_adapters::MissionFireRef::from_uuid(
+                    mission_fire_ref.as_uuid(),
+                ),
+                submitted_run_id: run_id,
+            }),
+            MissionFireOutcome::DeferredBusy {
+                mission_fire_ref, ..
+            } => Ok(ProductInboundAck::MissionSuppressed {
+                mission_fire_ref: ironclaw_product_adapters::MissionFireRef::from_uuid(
+                    mission_fire_ref.as_uuid(),
+                ),
+                reason: ironclaw_product_adapters::MissionFireSuppressionReason::BusyThread,
+            }),
+            MissionFireOutcome::Suppressed {
+                mission_fire_ref,
+                reason,
+            } => Ok(ProductInboundAck::MissionSuppressed {
+                mission_fire_ref: ironclaw_product_adapters::MissionFireRef::from_uuid(
+                    mission_fire_ref.as_uuid(),
+                ),
+                reason: workflow_to_wire_suppression(reason),
+            }),
+            MissionFireOutcome::Rejected { reason } => {
+                Ok(ProductInboundAck::Rejected(ProductRejection::permanent(
+                    ProductRejectionKind::PolicyDenied,
+                    format!("mission fire rejected: {reason:?}"),
+                )))
+            }
+        }
+    }
+
+    async fn dispatch_system_action(
+        &self,
+        envelope: &ProductInboundEnvelope,
+        payload: &ironclaw_product_adapters::SystemActionPayload,
+    ) -> Result<ProductInboundAck, ProductWorkflowError> {
+        let service = self.system_action_service.as_ref().ok_or_else(|| {
+            ProductWorkflowError::UnsupportedActionKind {
+                kind: "system_action".into(),
+            }
+        })?;
+        let _outcome = service
+            .handle_action(
+                envelope,
+                payload.system_actor_ref.clone(),
+                payload.kind.clone(),
+                payload.scope_thread_id.clone(),
+                payload.data.clone(),
+            )
+            .await?;
+        // System actions are durable but ack-less in this slice; return NoOp
+        // so adapters know the action settled without exposing internal state.
+        Ok(ProductInboundAck::NoOp)
+    }
+}
+
+fn workflow_to_wire_suppression(
+    reason: WorkflowMissionFireSuppressionReason,
+) -> ironclaw_product_adapters::MissionFireSuppressionReason {
+    match reason {
+        WorkflowMissionFireSuppressionReason::Cadence => {
+            ironclaw_product_adapters::MissionFireSuppressionReason::Cadence
+        }
+        WorkflowMissionFireSuppressionReason::Cooldown => {
+            ironclaw_product_adapters::MissionFireSuppressionReason::Cooldown
+        }
+        WorkflowMissionFireSuppressionReason::Deduplicated => {
+            ironclaw_product_adapters::MissionFireSuppressionReason::Deduplicated
+        }
+        WorkflowMissionFireSuppressionReason::BusyThread => {
+            ironclaw_product_adapters::MissionFireSuppressionReason::BusyThread
+        }
     }
 }
 
@@ -198,6 +547,11 @@ fn dispatch_kind_from_ack(
                 run_id: *active_run_id,
             })
         }
+        ProductInboundAck::MissionSubmitted {
+            submitted_run_id, ..
+        } => Ok(ActionDispatchKind::UserMessageTurn {
+            run_id: *submitted_run_id,
+        }),
         _ => ActionDispatchKind::try_from_payload(payload),
     }
 }
@@ -252,10 +606,15 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
                 format!("turn submission rejected: {error}"),
             )))
         }
+        ProductWorkflowError::TurnResumeRejected { reason } => {
+            Some(ProductInboundAck::Rejected(ProductRejection::permanent(
+                ProductRejectionKind::PolicyDenied,
+                format!("turn resume rejected: {reason}"),
+            )))
+        }
         ProductWorkflowError::BindingResolutionFailed { .. }
         | ProductWorkflowError::TurnSubmissionRejected { .. }
         | ProductWorkflowError::TurnSubmissionFailed { .. }
-        | ProductWorkflowError::TurnResumeRejected { .. }
         | ProductWorkflowError::Transient { .. }
         | ProductWorkflowError::DuplicateAction { .. } => None,
     }

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -232,7 +232,13 @@ impl ProductWorkflow for DefaultProductWorkflow {
             ProductInboundPayload::SubscriptionRequest(req) => {
                 (req.thread_id_hint.clone(), req.after_cursor.clone())
             }
-            _ => (None, None),
+            _ => {
+                return Err(ProductAdapterError::from(
+                    ProductWorkflowError::UnsupportedActionKind {
+                        kind: "non_subscription_payload_for_resolution".into(),
+                    },
+                ));
+            }
         };
 
         let request = ProjectionSubscriptionAuthorityRequest {
@@ -463,12 +469,13 @@ impl DefaultProductWorkflow {
                 submitted_run_id: run_id,
             }),
             MissionFireOutcome::DeferredBusy {
-                mission_fire_ref, ..
-            } => Ok(ProductInboundAck::MissionSuppressed {
+                mission_fire_ref,
+                active_run_id,
+            } => Ok(ProductInboundAck::MissionDeferred {
                 mission_fire_ref: ironclaw_product_adapters::MissionFireRef::from_uuid(
                     mission_fire_ref.as_uuid(),
                 ),
-                reason: ironclaw_product_adapters::MissionFireSuppressionReason::BusyThread,
+                active_run_id,
             }),
             MissionFireOutcome::Suppressed {
                 mission_fire_ref,
@@ -552,12 +559,20 @@ fn dispatch_kind_from_ack(
         } => Ok(ActionDispatchKind::UserMessageTurn {
             run_id: *submitted_run_id,
         }),
+        ProductInboundAck::MissionDeferred { active_run_id, .. } => {
+            Ok(ActionDispatchKind::UserMessageTurn {
+                run_id: *active_run_id,
+            })
+        }
         _ => ActionDispatchKind::try_from_payload(payload),
     }
 }
 
 fn is_terminal_success_ack(ack: &ProductInboundAck) -> bool {
-    !matches!(ack, ProductInboundAck::DeferredBusy { .. })
+    !matches!(
+        ack,
+        ProductInboundAck::DeferredBusy { .. } | ProductInboundAck::MissionDeferred { .. }
+    )
 }
 
 fn turn_error_is_retryable(error: &TurnError) -> bool {
@@ -612,8 +627,13 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
                 format!("turn resume rejected: {reason}"),
             )))
         }
+        ProductWorkflowError::TurnSubmissionRejected { reason } => {
+            Some(ProductInboundAck::Rejected(ProductRejection::permanent(
+                ProductRejectionKind::PolicyDenied,
+                format!("turn submission rejected: {reason}"),
+            )))
+        }
         ProductWorkflowError::BindingResolutionFailed { .. }
-        | ProductWorkflowError::TurnSubmissionRejected { .. }
         | ProductWorkflowError::TurnSubmissionFailed { .. }
         | ProductWorkflowError::Transient { .. }
         | ProductWorkflowError::DuplicateAction { .. } => None,

--- a/crates/ironclaw_product_workflow/tests/inbound_turn_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/inbound_turn_contract.rs
@@ -13,8 +13,8 @@ use ironclaw_product_adapters::{
     UserMessagePayload,
 };
 use ironclaw_product_workflow::{
-    DefaultInboundTurnService, FakeConversationBindingService, InboundTurnOutcome,
-    InboundTurnService, ProductWorkflowError,
+    DefaultInboundTurnService, FakeBeforeInboundPolicy, FakeConversationBindingService,
+    InboundTurnOutcome, InboundTurnService, ProductWorkflowError,
 };
 use ironclaw_threads::{
     InMemorySessionThreadService, MessageStatus, SessionThreadService, ThreadHistoryRequest,
@@ -530,4 +530,158 @@ async fn binding_failure_surfaces_workflow_error() {
         err,
         ProductWorkflowError::BindingResolutionFailed { .. }
     ));
+}
+
+#[tokio::test]
+async fn before_inbound_rewrite_stages_rewritten_content_as_accepted_message() {
+    let binding_service = FakeConversationBindingService::new();
+    let thread_service = InMemorySessionThreadService::default();
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let coordinator = DefaultTurnCoordinator::new(store);
+    let policy = Arc::new(FakeBeforeInboundPolicy::new());
+    policy.program_continue(Some("rewritten text".to_string()));
+    let policy_handle = policy.clone();
+    let service =
+        DefaultInboundTurnService::new(binding_service, thread_service.clone(), coordinator)
+            .with_before_inbound_policy(policy);
+
+    let envelope = sample_user_message_envelope_with_text("rewrite-evt", "original text");
+    let outcome = service
+        .accept_user_message(&envelope)
+        .await
+        .expect("submit");
+
+    let binding = match &outcome {
+        InboundTurnOutcome::Submitted { binding, .. } => binding,
+        _ => panic!("expected Submitted, got {outcome:?}"),
+    };
+
+    let history = thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: ThreadScope {
+                tenant_id: binding.tenant_id.clone(),
+                agent_id: binding.agent_id.clone().expect("agent id"),
+                project_id: binding.project_id.clone(),
+                owner_user_id: Some(binding.user_id.clone()),
+                mission_id: None,
+            },
+            thread_id: binding.thread_id.clone(),
+        })
+        .await
+        .expect("history");
+    assert_eq!(history.messages.len(), 1);
+    assert_eq!(
+        history.messages[0].content.as_deref(),
+        Some("rewritten text"),
+        "BeforeInbound rewrite must replace original text before staging"
+    );
+    assert_eq!(history.messages[0].status, MessageStatus::Submitted);
+    assert!(
+        history.messages[0].turn_run_id.is_some(),
+        "rewritten message must still have been submitted to the coordinator"
+    );
+    assert_eq!(
+        policy_handle.evaluate_count(),
+        1,
+        "BeforeInbound policy must be called exactly once on the new-message path"
+    );
+}
+
+#[tokio::test]
+async fn before_inbound_rejection_creates_no_accepted_message_and_no_run() {
+    let binding_service = FakeConversationBindingService::new();
+    let binding_handle = binding_service.clone();
+    let thread_service = InMemorySessionThreadService::default();
+    let coordinator = ScriptedTurnCoordinator::default();
+    let coordinator_handle = coordinator.clone();
+    let policy = Arc::new(FakeBeforeInboundPolicy::new());
+    policy.program_reject("test policy denied");
+    let policy_handle = policy.clone();
+    let service =
+        DefaultInboundTurnService::new(binding_service, thread_service.clone(), coordinator)
+            .with_before_inbound_policy(policy);
+
+    let envelope = sample_user_message_envelope_with_text("reject-evt", "blocked content");
+    let err = service
+        .accept_user_message(&envelope)
+        .await
+        .expect_err("rejection must surface as an error");
+
+    let ProductWorkflowError::TurnSubmissionRejected { reason } = &err else {
+        panic!("expected TurnSubmissionRejected, got {err:?}");
+    };
+    // `RedactedString` redacts via `Display`; the workflow boundary re-wraps
+    // this string into a fresh `RedactedString` for the adapter-facing ack, so
+    // the placeholder is what the workflow surfaces.
+    assert_eq!(
+        reason, "<redacted>",
+        "rejection reason must be redacted by the time it reaches the workflow error"
+    );
+
+    assert_eq!(
+        binding_handle.resolve_count(),
+        0,
+        "rejection must short-circuit before binding resolution"
+    );
+    assert_eq!(
+        coordinator_handle.submissions().len(),
+        0,
+        "rejection must not call submit_turn"
+    );
+    assert_eq!(
+        policy_handle.evaluate_count(),
+        1,
+        "BeforeInbound policy must be evaluated exactly once before rejection"
+    );
+}
+
+#[tokio::test]
+async fn before_inbound_continue_without_rewrite_passes_text_through() {
+    let binding_service = FakeConversationBindingService::new();
+    let thread_service = InMemorySessionThreadService::default();
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let coordinator = DefaultTurnCoordinator::new(store);
+    // Default fake (no programming) → Continue { rewritten_text: None }.
+    let policy = Arc::new(FakeBeforeInboundPolicy::new());
+    let policy_handle = policy.clone();
+    let service =
+        DefaultInboundTurnService::new(binding_service, thread_service.clone(), coordinator)
+            .with_before_inbound_policy(policy);
+
+    let envelope = sample_user_message_envelope_with_text("passthrough-evt", "verbatim");
+    let outcome = service
+        .accept_user_message(&envelope)
+        .await
+        .expect("submit");
+
+    let binding = match &outcome {
+        InboundTurnOutcome::Submitted { binding, .. } => binding,
+        _ => panic!("expected Submitted, got {outcome:?}"),
+    };
+
+    let history = thread_service
+        .list_thread_history(ThreadHistoryRequest {
+            scope: ThreadScope {
+                tenant_id: binding.tenant_id.clone(),
+                agent_id: binding.agent_id.clone().expect("agent id"),
+                project_id: binding.project_id.clone(),
+                owner_user_id: Some(binding.user_id.clone()),
+                mission_id: None,
+            },
+            thread_id: binding.thread_id.clone(),
+        })
+        .await
+        .expect("history");
+    assert_eq!(history.messages.len(), 1);
+    assert_eq!(
+        history.messages[0].content.as_deref(),
+        Some("verbatim"),
+        "Continue with no rewrite must pass original text through unchanged"
+    );
+    assert_eq!(history.messages[0].status, MessageStatus::Submitted);
+    assert_eq!(
+        policy_handle.evaluate_count(),
+        1,
+        "BeforeInbound policy must still be evaluated when it returns Continue"
+    );
 }

--- a/crates/ironclaw_product_workflow/tests/inbound_turn_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/inbound_turn_contract.rs
@@ -8,13 +8,15 @@ use chrono::Utc;
 use ironclaw_host_api::{AgentId, TenantId, ThreadId, UserId};
 use ironclaw_product_adapters::{
     AdapterInstallationId, AuthRequirement, ExternalActorRef, ExternalConversationRef,
-    ExternalEventId, ParsedProductInbound, ProductAdapterId, ProductInboundEnvelope,
-    ProductInboundPayload, ProductTriggerReason, ProtocolAuthEvidence, TrustedInboundContext,
-    UserMessagePayload,
+    ExternalEventId, ParsedProductInbound, ProductAdapterId, ProductInboundAck,
+    ProductInboundEnvelope, ProductInboundPayload, ProductRejectionDisposition,
+    ProductRejectionKind, ProductTriggerReason, ProductWorkflow, ProtocolAuthEvidence,
+    TrustedInboundContext, UserMessagePayload,
 };
 use ironclaw_product_workflow::{
-    DefaultInboundTurnService, FakeBeforeInboundPolicy, FakeConversationBindingService,
-    InboundTurnOutcome, InboundTurnService, ProductWorkflowError,
+    DefaultInboundTurnService, DefaultProductWorkflow, FakeBeforeInboundPolicy,
+    FakeConversationBindingService, FakeIdempotencyLedger, InboundTurnOutcome, InboundTurnService,
+    ProductWorkflowError,
 };
 use ironclaw_threads::{
     InMemorySessionThreadService, MessageStatus, SessionThreadService, ThreadHistoryRequest,
@@ -683,5 +685,89 @@ async fn before_inbound_continue_without_rewrite_passes_text_through() {
         policy_handle.evaluate_count(),
         1,
         "BeforeInbound policy must still be evaluated when it returns Continue"
+    );
+}
+
+#[tokio::test]
+async fn before_inbound_rejection_settles_terminal_rejection_in_ledger() {
+    // Regression: when BeforeInboundPolicy returns Reject the workflow must
+    // SETTLE the ledger with a permanent PolicyDenied rejection — NOT
+    // release the action (which would let the next retry re-create a fresh
+    // action and re-evaluate the policy). Previously TurnSubmissionRejected
+    // fell into the transient catch-all and the action was released; see
+    // gemini-code-assist's review on PR #3558 / serrrfirat fork PR #3.
+    let binding_service = FakeConversationBindingService::new();
+    let thread_service = InMemorySessionThreadService::default();
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let coordinator = DefaultTurnCoordinator::new(store);
+    let policy = Arc::new(FakeBeforeInboundPolicy::new());
+    policy.program_reject("test policy denied");
+    let policy_handle = policy.clone();
+    let inbound_service = Arc::new(
+        DefaultInboundTurnService::new(binding_service, thread_service, coordinator)
+            .with_before_inbound_policy(policy),
+    );
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let workflow = DefaultProductWorkflow::new(inbound_service, ledger.clone());
+
+    let envelope = sample_user_message_envelope_with_text("reject-ledger-evt", "blocked content");
+
+    // accept_inbound surfaces the rejection as Err (the dispatch result
+    // bubbles up even though the ledger was settled with a permanent
+    // Rejected ack — mirroring the existing
+    // mission_action_without_configured_service_settles_unsupported
+    // pattern). The terminal ack is observable via the duplicate replay
+    // below.
+    let err = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect_err("BeforeInbound rejection must surface as an error");
+    assert!(
+        !err.is_retryable(),
+        "BeforeInbound rejection must be non-retryable"
+    );
+
+    // Critical invariant: the ledger must be SETTLED, not released. Released
+    // would let a retry re-enter dispatch and re-evaluate the policy.
+    assert_eq!(
+        ledger.settled_count(),
+        1,
+        "BeforeInbound rejection must settle the ledger as a permanent rejection"
+    );
+    assert_eq!(
+        ledger.in_flight_count(),
+        0,
+        "BeforeInbound rejection must clear the in-flight reservation"
+    );
+    assert_eq!(
+        policy_handle.evaluate_count(),
+        1,
+        "policy must be evaluated exactly once on the first envelope"
+    );
+
+    // Duplicate replay: the same envelope must surface the prior rejection
+    // as Duplicate { prior: Rejected(..) } and MUST NOT re-evaluate the
+    // BeforeInbound policy.
+    let replay = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate must replay prior rejection");
+    let ProductInboundAck::Duplicate { prior } = replay else {
+        panic!("expected Duplicate replay, got {replay:?}");
+    };
+    let ProductInboundAck::Rejected(prior_rejection) = *prior else {
+        panic!("expected prior to be Rejected, got prior outcome");
+    };
+    assert_eq!(prior_rejection.kind, ProductRejectionKind::PolicyDenied);
+    assert_eq!(
+        prior_rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+    // The policy must NOT have been called a second time — the ledger
+    // replays the prior settled outcome.
+    assert_eq!(
+        policy_handle.evaluate_count(),
+        1,
+        "BeforeInbound policy must not be re-evaluated on duplicate replay"
     );
 }

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -7,20 +7,31 @@ use ironclaw_host_api::{AgentId, TenantId, ThreadId, UserId};
 use ironclaw_product_adapters::{
     AdapterInstallationId, ApprovalDecision, ApprovalResolutionPayload, AuthRequirement,
     AuthResolutionPayload, AuthResolutionResult, ExternalActorRef, ExternalConversationRef,
-    ExternalEventId, InboundCommandPayload, LinkedThreadActionPayload, ParsedProductInbound,
+    ExternalEventId, InboundCommandPayload, LinkedThreadActionPayload,
+    MissionActionPayload as AdapterMissionActionPayload,
+    MissionFireSuppressionReason as AdapterMissionFireSuppressionReason, ParsedProductInbound,
     ProductAdapterError, ProductAdapterId, ProductInboundAck, ProductInboundEnvelope,
-    ProductInboundPayload, ProductRejectionDisposition, ProductTriggerReason, ProductWorkflow,
-    ProductWorkflowRejectionKind, ProtocolAuthEvidence, TrustedInboundContext, UserMessagePayload,
+    ProductInboundPayload, ProductRejectionDisposition, ProductRejectionKind, ProductTriggerReason,
+    ProductWorkflow, ProductWorkflowRejectionKind, ProjectionSubscriptionPayload,
+    ProtocolAuthEvidence, SystemActionPayload, TrustedInboundContext, UserMessagePayload,
 };
 use ironclaw_product_workflow::{
     ActionDispatchKind, ActionFingerprintKey, AuthRequestRef, DefaultProductWorkflow,
-    FakeIdempotencyLedger, FakeInboundTurnService, IdempotencyDecision, IdempotencyLedger,
-    InboundTurnOutcome, LinkedThreadActionId, ProductCommandName, ProductWorkflowError,
-    ResolvedBinding, SourceBindingKey,
+    FakeApprovalInteractionService, FakeAuthInteractionService, FakeIdempotencyLedger,
+    FakeInboundTurnService, FakeLinkedThreadActionService, FakeMissionService,
+    FakeProductCommandRouter, FakeProjectionSubscriptionAuthority, FakeSystemActionService,
+    IdempotencyDecision, IdempotencyLedger, InboundTurnOutcome, LinkedThreadActionId,
+    MissionFireRejectionReason,
+    MissionFireSuppressionReason as WorkflowMissionFireSuppressionReason, ProductCommandName,
+    ProductWorkflowError, ResolvedBinding, SourceBindingKey,
 };
 use ironclaw_turns::{AcceptedMessageRef, LoopGateRef, TurnError, TurnRunId};
+use uuid::Uuid;
 
-fn sample_envelope(event_suffix: &str) -> ProductInboundEnvelope {
+fn sample_envelope_with_payload(
+    event_suffix: &str,
+    payload: ProductInboundPayload,
+) -> ProductInboundEnvelope {
     let evidence = ProtocolAuthEvidence::test_verified(
         AuthRequirement::SharedSecretHeader {
             header_name: "X-Secret".into(),
@@ -39,40 +50,121 @@ fn sample_envelope(event_suffix: &str) -> ProductInboundEnvelope {
         ExternalEventId::new(format!("evt:{event_suffix}")).expect("valid"),
         ExternalActorRef::new("test", "user1", Option::<String>::None).expect("valid"),
         ExternalConversationRef::new(None, "conv1", None, None).expect("valid"),
-        ProductInboundPayload::UserMessage(
-            UserMessagePayload::new("hello", vec![], ProductTriggerReason::DirectChat)
-                .expect("valid"),
-        ),
+        payload,
     )
     .expect("parsed");
 
     ProductInboundEnvelope::from_trusted_parse(context, parsed).expect("envelope")
 }
 
+fn sample_envelope(event_suffix: &str) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(
+        event_suffix,
+        ProductInboundPayload::UserMessage(
+            UserMessagePayload::new("hello", vec![], ProductTriggerReason::DirectChat)
+                .expect("valid"),
+        ),
+    )
+}
+
 fn sample_noop_envelope(event_suffix: &str) -> ProductInboundEnvelope {
-    let evidence = ProtocolAuthEvidence::test_verified(
-        AuthRequirement::SharedSecretHeader {
-            header_name: "X-Secret".into(),
-        },
-        "install_alpha",
-    );
-    let context = TrustedInboundContext::from_verified_evidence(
-        ProductAdapterId::new("test_adapter").expect("valid"),
-        AdapterInstallationId::new("install_alpha").expect("valid"),
-        Utc::now(),
-        &evidence,
-    )
-    .expect("verified");
+    sample_envelope_with_payload(event_suffix, ProductInboundPayload::NoOp)
+}
 
-    let parsed = ParsedProductInbound::new(
-        ExternalEventId::new(format!("evt:{event_suffix}")).expect("valid"),
-        ExternalActorRef::new("test", "user1", Option::<String>::None).expect("valid"),
-        ExternalConversationRef::new(None, "conv1", None, None).expect("valid"),
-        ProductInboundPayload::NoOp,
+fn sample_linked_thread_action_envelope(
+    event_suffix: &str,
+    payload: LinkedThreadActionPayload,
+) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(
+        event_suffix,
+        ProductInboundPayload::LinkedThreadAction(payload),
     )
-    .expect("parsed");
+}
 
-    ProductInboundEnvelope::from_trusted_parse(context, parsed).expect("envelope")
+fn sample_system_action_envelope(
+    event_suffix: &str,
+    payload: SystemActionPayload,
+) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(event_suffix, ProductInboundPayload::SystemAction(payload))
+}
+
+fn sample_approval_envelope(event_suffix: &str, gate_ref: &str) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(
+        event_suffix,
+        ProductInboundPayload::ApprovalResolution(
+            ApprovalResolutionPayload::new(gate_ref, ApprovalDecision::ApproveOnce)
+                .expect("valid approval payload"),
+        ),
+    )
+}
+
+fn sample_auth_envelope(event_suffix: &str, auth_request_ref: &str) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(
+        event_suffix,
+        ProductInboundPayload::AuthResolution(
+            AuthResolutionPayload::new(
+                auth_request_ref,
+                AuthResolutionResult::CredentialProvided {
+                    credential_ref: "cred_abc".into(),
+                },
+            )
+            .expect("valid auth payload"),
+        ),
+    )
+}
+
+fn sample_mission_action_envelope(
+    event_suffix: &str,
+    intent: &str,
+    mission_id_hint: Option<&str>,
+) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(
+        event_suffix,
+        ProductInboundPayload::MissionAction(
+            AdapterMissionActionPayload::new(
+                intent,
+                mission_id_hint.map(String::from),
+                Some("{\"trigger\":\"manual\"}".to_string()),
+            )
+            .expect("valid mission action payload"),
+        ),
+    )
+}
+
+fn sample_user_message_envelope_with_text(
+    event_suffix: &str,
+    text: &str,
+) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(
+        event_suffix,
+        ProductInboundPayload::UserMessage(
+            UserMessagePayload::new(text, vec![], ProductTriggerReason::DirectChat)
+                .expect("valid user message payload"),
+        ),
+    )
+}
+
+fn sample_command_envelope(
+    event_suffix: &str,
+    command: &str,
+    arguments: &str,
+) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(
+        event_suffix,
+        ProductInboundPayload::Command(
+            InboundCommandPayload::new(command, arguments, ProductTriggerReason::BotCommand)
+                .expect("valid command payload"),
+        ),
+    )
+}
+
+fn sample_subscription_envelope(event_suffix: &str) -> ProductInboundEnvelope {
+    sample_envelope_with_payload(
+        event_suffix,
+        ProductInboundPayload::SubscriptionRequest(
+            ProjectionSubscriptionPayload::new(None, None).expect("valid subscription payload"),
+        ),
+    )
 }
 
 #[test]
@@ -483,4 +575,1187 @@ async fn ledger_transient_failure_surfaces_retryable_error() {
         .await
         .expect_err("should fail");
     assert!(err.is_retryable());
+}
+
+// ---------------------------------------------------------------------------
+// ProductCommandRouter dispatch arm
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn command_payload_dispatches_through_product_command_router() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let router = Arc::new(FakeProductCommandRouter::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_command_router(router.clone());
+
+    let envelope = sample_command_envelope("cmd-routed", "status", "verbose");
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("command should route through router");
+
+    match ack {
+        ProductInboundAck::CommandRouted { command } => {
+            assert_eq!(command.as_str(), "status");
+        }
+        other => panic!("expected CommandRouted ack, got {other:?}"),
+    }
+
+    let routed = router.routed();
+    assert_eq!(routed.len(), 1);
+    assert_eq!(routed[0].0.as_str(), "status");
+    assert_eq!(routed[0].1, "verbose");
+    assert_eq!(ledger.settled_count(), 1);
+}
+
+#[tokio::test]
+async fn unknown_command_settles_terminal_rejection() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let router = Arc::new(FakeProductCommandRouter::new());
+    router.program_unknown();
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_command_router(router.clone());
+
+    let envelope = sample_command_envelope("cmd-unknown", "mystery", "");
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("unknown command surfaces as rejection ack, not Err");
+
+    match ack {
+        ProductInboundAck::Rejected(rejection) => {
+            assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+            assert_eq!(
+                rejection.disposition,
+                ProductRejectionDisposition::Permanent
+            );
+        }
+        other => panic!("expected Rejected ack, got {other:?}"),
+    }
+
+    // Ledger should record this as a settled terminal rejection, not an
+    // in-flight or released action.
+    assert_eq!(ledger.settled_count(), 1);
+    assert_eq!(ledger.in_flight_count(), 0);
+    let actions = ledger.settled_actions();
+    assert_eq!(actions.len(), 1);
+    let outcome = actions[0].outcome.clone().expect("settled outcome");
+    assert!(matches!(outcome, ProductInboundAck::Rejected(_)));
+}
+
+#[tokio::test]
+async fn command_without_configured_router_settles_command_routing_unavailable() {
+    // No `.with_command_router(...)` — exercises the gate.
+    let (workflow, _inbound, ledger) = build_workflow();
+    let envelope = sample_command_envelope("cmd-no-router", "help", "");
+
+    let err = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("command without configured router should error");
+    assert!(!err.is_retryable());
+
+    // The error should be redacted at the boundary but the variant identifies
+    // it as an internal adapter error projected from
+    // CommandRoutingUnavailable.
+    match err {
+        ProductAdapterError::Internal { .. } => {}
+        other => panic!("expected Internal error variant, got {other:?}"),
+    }
+
+    // CommandRoutingUnavailable maps to a terminal rejection ack, so the
+    // ledger must settle (not release) the action.
+    assert_eq!(ledger.settled_count(), 1);
+    assert_eq!(ledger.in_flight_count(), 0);
+    let actions = ledger.settled_actions();
+    assert_eq!(actions.len(), 1);
+    let outcome = actions[0].outcome.clone().expect("settled outcome");
+    match outcome {
+        ProductInboundAck::Rejected(rejection) => {
+            assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+            assert_eq!(
+                rejection.disposition,
+                ProductRejectionDisposition::Permanent
+            );
+        }
+        other => panic!("expected Rejected outcome, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ProjectionSubscriptionAuthority + resolve_projection_subscription
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn projection_subscription_uses_authority_and_creates_no_ledger_row() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let authority = Arc::new(FakeProjectionSubscriptionAuthority::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_projection_authority(authority.clone());
+
+    let envelope = sample_subscription_envelope("sub-1");
+    let request = workflow
+        .resolve_projection_subscription(envelope)
+        .await
+        .expect("authority should authorize the subscription");
+
+    // The deterministic default response builds a non-empty actor and scope
+    // from the envelope identifiers.
+    assert!(
+        !request.actor.user_id.as_str().is_empty(),
+        "actor user_id must not be empty"
+    );
+    assert!(
+        !request.scope.tenant_id.as_str().is_empty(),
+        "scope tenant_id must not be empty"
+    );
+    assert!(
+        !request.scope.thread_id.as_str().is_empty(),
+        "scope thread_id must not be empty"
+    );
+
+    // AC #14 of #3280: projection-read path must NOT take a ledger lock.
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    // The authority must have been consulted exactly once.
+    assert_eq!(authority.authorization_count(), 1);
+}
+
+#[tokio::test]
+async fn subscription_request_via_accept_inbound_is_rejected_without_ledger_row() {
+    // Even with an authority wired, routing a SubscriptionRequest through
+    // accept_inbound is a usage error and must be rejected at the gate
+    // before any ledger touch.
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let authority = Arc::new(FakeProjectionSubscriptionAuthority::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_projection_authority(authority.clone());
+
+    let envelope = sample_subscription_envelope("sub-gate");
+    let err = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("subscription_request via accept_inbound is unsupported");
+
+    // The gate maps UnsupportedActionKind to a redacted ProductAdapterError.
+    match err {
+        ProductAdapterError::Internal { .. } => {}
+        other => panic!("expected Internal error variant, got {other:?}"),
+    }
+
+    // AC #14: the gate must reject before any ledger lock is taken.
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    // And the authority must NOT have been consulted on the gate path.
+    assert_eq!(authority.authorization_count(), 0);
+}
+
+#[tokio::test]
+async fn projection_subscription_without_authority_returns_unsupported() {
+    // Build the workflow WITHOUT `.with_projection_authority(...)`.
+    let (workflow, _inbound, ledger) = build_workflow();
+    let envelope = sample_subscription_envelope("sub-no-auth");
+
+    let err = workflow
+        .resolve_projection_subscription(envelope)
+        .await
+        .expect_err("missing authority should error");
+
+    match err {
+        ProductAdapterError::Internal { .. } => {}
+        other => panic!("expected Internal error variant, got {other:?}"),
+    }
+
+    // resolve_projection_subscription is a read-only path; failure must
+    // still leave the ledger untouched.
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// LinkedThreadActionService dispatch arm
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn linked_thread_action_dispatches_through_linked_thread_service() {
+    let (workflow, _inbound, _ledger) = build_workflow();
+    let linked = Arc::new(FakeLinkedThreadActionService::new());
+    let workflow = workflow.with_linked_thread_service(linked.clone());
+
+    let payload = LinkedThreadActionPayload::new(
+        "open-thread",
+        Some("data".to_string()),
+        Some("msg:123".to_string()),
+    )
+    .expect("valid linked thread action payload");
+    let envelope = sample_linked_thread_action_envelope("lta-1", payload);
+
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("linked thread action ack");
+    let ProductInboundAck::LinkedThreadActionRouted { action_id } = ack else {
+        panic!("expected LinkedThreadActionRouted ack");
+    };
+    assert_eq!(action_id.as_str(), "open-thread");
+
+    let actions = linked.actions();
+    assert_eq!(actions.len(), 1);
+    let (recorded_id, recorded_data, recorded_reply_target) = &actions[0];
+    assert_eq!(recorded_id.as_str(), "open-thread");
+    assert_eq!(recorded_data.as_deref(), Some("data"));
+    assert_eq!(recorded_reply_target.as_deref(), Some("msg:123"));
+}
+
+#[tokio::test]
+async fn linked_thread_action_passes_data_and_reply_target_through() {
+    let (workflow, _inbound, _ledger) = build_workflow();
+    let linked = Arc::new(FakeLinkedThreadActionService::new());
+    let workflow = workflow.with_linked_thread_service(linked.clone());
+
+    let json_data = "{\"json\":1}".to_string();
+    let payload = LinkedThreadActionPayload::new("share", Some(json_data.clone()), None)
+        .expect("valid linked thread action payload");
+    let envelope = sample_linked_thread_action_envelope("lta-passthrough", payload);
+
+    let _ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("linked thread action ack");
+
+    let actions = linked.actions();
+    assert_eq!(actions.len(), 1);
+    let (recorded_id, recorded_data, recorded_reply_target) = &actions[0];
+    assert_eq!(recorded_id.as_str(), "share");
+    assert_eq!(recorded_data.as_deref(), Some(json_data.as_str()));
+    assert!(recorded_reply_target.is_none());
+}
+
+#[tokio::test]
+async fn linked_thread_action_without_configured_service_settles_unsupported() {
+    let (workflow, _inbound, ledger) = build_workflow();
+    let payload = LinkedThreadActionPayload::new("open-thread", None, None)
+        .expect("valid linked thread action payload");
+    let envelope = sample_linked_thread_action_envelope("lta-unconfigured", payload);
+
+    let err = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect_err("unsupported should error");
+    assert!(!err.is_retryable());
+    assert_eq!(ledger.settled_count(), 1);
+
+    // The terminal ack is captured by the ledger; replaying surfaces it as
+    // Duplicate { prior: Rejected }. The redacted reason cannot be inspected
+    // externally, but the rejection's permanent disposition and PolicyDenied
+    // kind prove the linked-thread-action unsupported path settled — the
+    // workflow's `UnsupportedActionKind { kind: "linked_thread_action" }`
+    // error is the only producer of this terminal ack on this envelope.
+    let replay = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+    let ProductInboundAck::Duplicate { prior } = replay else {
+        panic!("expected duplicate replay")
+    };
+    let ProductInboundAck::Rejected(rejection) = *prior else {
+        panic!("expected rejected prior outcome")
+    };
+    assert_eq!(
+        rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+    assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+}
+
+#[tokio::test]
+async fn linked_thread_action_settles_idempotency_ledger() {
+    let (workflow, _inbound, ledger) = build_workflow();
+    let linked = Arc::new(FakeLinkedThreadActionService::new());
+    let workflow = workflow.with_linked_thread_service(linked.clone());
+
+    let payload = LinkedThreadActionPayload::new("open-thread", Some("d".to_string()), None)
+        .expect("valid linked thread action payload");
+    let envelope = sample_linked_thread_action_envelope("lta-idem", payload);
+
+    let first = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect("first dispatch");
+    assert!(matches!(
+        first,
+        ProductInboundAck::LinkedThreadActionRouted { .. }
+    ));
+    assert_eq!(ledger.settled_count(), 1);
+    assert_eq!(linked.action_count(), 1);
+
+    let second = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+    let ProductInboundAck::Duplicate { prior } = second else {
+        panic!("expected duplicate replay")
+    };
+    assert!(matches!(
+        *prior,
+        ProductInboundAck::LinkedThreadActionRouted { .. }
+    ));
+    // The downstream service must NOT be invoked a second time.
+    assert_eq!(linked.action_count(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// SystemActionService dispatch arm
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn system_action_dispatches_through_system_action_service() {
+    let (workflow, _inbound, _ledger) = build_workflow();
+    let system = Arc::new(FakeSystemActionService::new());
+    let workflow = workflow.with_system_action_service(system.clone());
+
+    let payload = SystemActionPayload::new(
+        "scheduler:cron_1",
+        "heartbeat_tick",
+        Some("thread:abc".to_string()),
+        Some("payload data".to_string()),
+    )
+    .expect("valid system action payload");
+    let envelope = sample_system_action_envelope("sa-1", payload);
+
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("system action ack");
+    assert!(matches!(ack, ProductInboundAck::NoOp));
+
+    let actions = system.actions();
+    assert_eq!(actions.len(), 1);
+    let (actor, kind, scope, data) = &actions[0];
+    assert_eq!(actor, "scheduler:cron_1");
+    assert_eq!(kind, "heartbeat_tick");
+    assert_eq!(scope.as_deref(), Some("thread:abc"));
+    assert_eq!(data.as_deref(), Some("payload data"));
+}
+
+#[tokio::test]
+async fn system_action_requires_accountable_actor_and_kind() {
+    // Workflow-level confirmation of AC #15 of #3280: there is no
+    // `is_internal` bypass. A SystemActionPayload missing an actor or kind
+    // cannot even be constructed, so the unsupported-without-accountable-actor
+    // shape is unrepresentable at the wire boundary before dispatch is reached.
+    assert!(SystemActionPayload::new("", "", None, None).is_err());
+    assert!(SystemActionPayload::new("", "heartbeat_tick", None, None).is_err());
+    assert!(SystemActionPayload::new("scheduler:cron_1", "", None, None).is_err());
+
+    // A well-formed payload (actor + kind both present) reaches dispatch.
+    let (workflow, _inbound, _ledger) = build_workflow();
+    let system = Arc::new(FakeSystemActionService::new());
+    let workflow = workflow.with_system_action_service(system.clone());
+
+    let payload = SystemActionPayload::new("scheduler:cron_1", "heartbeat_tick", None, None)
+        .expect("valid system action payload");
+    let envelope = sample_system_action_envelope("sa-required", payload);
+
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("system action ack");
+    assert!(matches!(ack, ProductInboundAck::NoOp));
+    assert_eq!(system.action_count(), 1);
+}
+
+#[tokio::test]
+async fn system_action_without_configured_service_settles_unsupported() {
+    let (workflow, _inbound, ledger) = build_workflow();
+    let payload = SystemActionPayload::new("scheduler:cron_1", "heartbeat_tick", None, None)
+        .expect("valid system action payload");
+    let envelope = sample_system_action_envelope("sa-unconfigured", payload);
+
+    let err = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect_err("unsupported should error");
+    assert!(!err.is_retryable());
+    assert_eq!(ledger.settled_count(), 1);
+
+    // Replay surfaces the prior Rejected ack; the redacted reason cannot be
+    // inspected externally, but the rejection's permanent disposition and
+    // PolicyDenied category prove the system-action unsupported path settled
+    // — the workflow's `UnsupportedActionKind { kind: "system_action" }` error
+    // is the only producer of this terminal ack on this envelope.
+    let replay = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+    let ProductInboundAck::Duplicate { prior } = replay else {
+        panic!("expected duplicate replay")
+    };
+    let ProductInboundAck::Rejected(rejection) = *prior else {
+        panic!("expected rejected prior outcome")
+    };
+    assert_eq!(
+        rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+    assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+}
+
+#[tokio::test]
+async fn system_action_settles_idempotency_ledger() {
+    let (workflow, _inbound, ledger) = build_workflow();
+    let system = Arc::new(FakeSystemActionService::new());
+    let workflow = workflow.with_system_action_service(system.clone());
+
+    let payload = SystemActionPayload::new("scheduler:cron_1", "heartbeat_tick", None, None)
+        .expect("valid system action payload");
+    let envelope = sample_system_action_envelope("sa-idem", payload);
+
+    let first = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect("first dispatch");
+    assert!(matches!(first, ProductInboundAck::NoOp));
+    assert_eq!(ledger.settled_count(), 1);
+    assert_eq!(system.action_count(), 1);
+
+    let second = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+    let ProductInboundAck::Duplicate { prior } = second else {
+        panic!("expected duplicate replay")
+    };
+    assert!(matches!(*prior, ProductInboundAck::NoOp));
+    // The downstream service must NOT be invoked a second time.
+    assert_eq!(system.action_count(), 1);
+}
+
+// ===========================================================================
+// MissionService dispatch arm contract tests
+//
+// Covers AC #12 of issue #3280: only explicit `MissionActionPayload`
+// envelopes reach the MissionService. The v1 bug shape — see
+// `src/bridge/router.rs::fire_event_missions_for_message` — pattern-matched
+// inbound user-message text against active `MissionCadence::OnEvent`
+// regexes and side-fired missions in parallel to the turn. Reborn MUST NOT
+// reproduce that path; the regression guard is
+// `ordinary_user_message_text_never_reaches_mission_service` below.
+// ===========================================================================
+
+#[tokio::test]
+async fn mission_action_submitted_returns_mission_submitted_ack() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    mission.program_submitted();
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone());
+
+    let envelope = sample_mission_action_envelope("mission-submit", "fire", Some("mission_xyz"));
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("mission submit ack");
+
+    match ack {
+        ProductInboundAck::MissionSubmitted {
+            mission_fire_ref,
+            submitted_run_id,
+        } => {
+            assert_ne!(
+                mission_fire_ref.as_uuid(),
+                Uuid::nil(),
+                "mission_fire_ref must be a fresh UUID"
+            );
+            // TurnRunId has no nil sentinel; assert it parses to a
+            // non-empty debug string so we know the workflow actually
+            // plumbed the value through rather than substituting a
+            // default.
+            assert!(
+                !format!("{submitted_run_id:?}").is_empty(),
+                "submitted_run_id must be populated"
+            );
+        }
+        other => panic!("expected MissionSubmitted, got {other:?}"),
+    }
+
+    assert_eq!(mission.fire_count(), 1);
+    let fires = mission.fires();
+    assert_eq!(fires.len(), 1);
+    assert_eq!(fires[0].mission_intent, "fire");
+    assert_eq!(fires[0].mission_id_hint.as_deref(), Some("mission_xyz"));
+    // The mission service must not see any user-message text — the
+    // request only carries explicit `mission_intent` + optional id hint +
+    // data.
+    assert_eq!(fires[0].data.as_deref(), Some("{\"trigger\":\"manual\"}"));
+
+    // MissionSubmitted is a terminal success ack and must settle.
+    assert_eq!(ledger.settled_count(), 1);
+    assert_eq!(inbound.accepted_count(), 0);
+}
+
+#[tokio::test]
+async fn mission_action_deferred_busy_returns_mission_suppressed_busy_thread() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    mission.program_deferred_busy();
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone());
+
+    let envelope = sample_mission_action_envelope("mission-busy", "fire", Some("mission_busy"));
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("mission deferred busy ack");
+
+    // DeferredBusy on the mission outcome maps to MissionSuppressed
+    // { BusyThread } at the wire boundary — see workflow.rs
+    // `dispatch_mission_action`.
+    match ack {
+        ProductInboundAck::MissionSuppressed {
+            mission_fire_ref,
+            reason,
+        } => {
+            assert_ne!(mission_fire_ref.as_uuid(), Uuid::nil());
+            assert_eq!(reason, AdapterMissionFireSuppressionReason::BusyThread);
+        }
+        other => panic!("expected MissionSuppressed {{ BusyThread }}, got {other:?}"),
+    }
+
+    assert_eq!(mission.fire_count(), 1);
+}
+
+#[tokio::test]
+async fn mission_action_suppressed_cadence_returns_mission_suppressed_cadence() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    mission.program_suppressed(WorkflowMissionFireSuppressionReason::Cadence);
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone());
+
+    let envelope = sample_mission_action_envelope("mission-cadence", "fire", None);
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("mission cadence ack");
+
+    match ack {
+        ProductInboundAck::MissionSuppressed {
+            mission_fire_ref,
+            reason,
+        } => {
+            assert_ne!(mission_fire_ref.as_uuid(), Uuid::nil());
+            assert_eq!(reason, AdapterMissionFireSuppressionReason::Cadence);
+        }
+        other => panic!("expected MissionSuppressed {{ Cadence }}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn mission_action_suppressed_cooldown_returns_mission_suppressed_cooldown() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    mission.program_suppressed(WorkflowMissionFireSuppressionReason::Cooldown);
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone());
+
+    let envelope = sample_mission_action_envelope("mission-cooldown", "fire", None);
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("mission cooldown ack");
+
+    match ack {
+        ProductInboundAck::MissionSuppressed { reason, .. } => {
+            assert_eq!(reason, AdapterMissionFireSuppressionReason::Cooldown);
+        }
+        other => panic!("expected MissionSuppressed {{ Cooldown }}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn mission_action_suppressed_deduplicated_returns_mission_suppressed_deduplicated() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    mission.program_suppressed(WorkflowMissionFireSuppressionReason::Deduplicated);
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone());
+
+    let envelope = sample_mission_action_envelope("mission-dedup", "fire", None);
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("mission dedup ack");
+
+    match ack {
+        ProductInboundAck::MissionSuppressed { reason, .. } => {
+            assert_eq!(reason, AdapterMissionFireSuppressionReason::Deduplicated);
+        }
+        other => panic!("expected MissionSuppressed {{ Deduplicated }}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn mission_action_rejected_returns_redacted_permanent_rejection() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    mission.program_rejected(MissionFireRejectionReason::UnknownMission);
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone());
+
+    let envelope =
+        sample_mission_action_envelope("mission-rejected", "fire", Some("mission_unknown"));
+    let ack = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("mission rejection ack");
+
+    match ack {
+        ProductInboundAck::Rejected(rejection) => {
+            assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+            assert_eq!(
+                rejection.disposition(),
+                ProductRejectionDisposition::Permanent
+            );
+            // The rejection reason is wrapped in `RedactedString`, whose
+            // `Display`/`Debug` impls both emit `<redacted>` — adapters
+            // cannot inspect the underlying string from outside the
+            // `ironclaw_product_adapters` crate. This pins the redaction
+            // contract: even though the workflow currently builds the
+            // reason with `format!("...{reason:?}")` (which would
+            // otherwise leak the `MissionFireRejectionReason` variant
+            // name and let an adapter probe mission existence), the
+            // `RedactedString` seal prevents that leak from crossing the
+            // boundary.
+            //
+            // TODO(#3280 follow-up): once the workflow uses a typed
+            // wire-side rejection enum, also stop embedding the
+            // unredacted variant name in the inner string — defence in
+            // depth in case `RedactedString` ever gains an `expose` API
+            // public to adapters.
+            assert_eq!(format!("{}", rejection.reason), "<redacted>");
+            assert_eq!(format!("{:?}", rejection.reason), "<redacted>");
+        }
+        other => panic!("expected Rejected, got {other:?}"),
+    }
+
+    assert_eq!(mission.fire_count(), 1);
+    // Rejected is a terminal outcome and must settle.
+    assert_eq!(ledger.settled_count(), 1);
+}
+
+#[tokio::test]
+async fn mission_action_without_configured_service_settles_unsupported() {
+    // No `.with_mission_service(...)` wired — the workflow must surface a
+    // terminal rejection naming the unsupported action kind.
+    let (workflow, _inbound, ledger) = build_workflow();
+    let envelope = sample_mission_action_envelope("mission-unsupported", "fire", Some("mission_x"));
+
+    let err = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect_err("missing mission service must surface unsupported error");
+    assert!(!err.is_retryable());
+
+    // The settled outcome is a permanent rejection. Replay returns
+    // Duplicate { prior: Rejected }.
+    assert_eq!(ledger.settled_count(), 1);
+    let replay = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+    let ProductInboundAck::Duplicate { prior } = replay else {
+        panic!("expected duplicate replay, got {replay:?}");
+    };
+    let ProductInboundAck::Rejected(rejection) = *prior else {
+        panic!("expected rejected prior outcome");
+    };
+    assert_eq!(
+        rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+    assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+    // As with `mission_action_rejected_returns_redacted_permanent_rejection`,
+    // the rejection reason crosses the boundary inside `RedactedString` and
+    // adapters cannot inspect "mission_action" directly. The workflow's
+    // `UnsupportedActionKind { kind: "mission_action" }` error is the only
+    // producer of this terminal ack on this envelope, so the (kind,
+    // disposition) pair and the dispatch path being the unsupported branch
+    // together pin the contract.
+    assert_eq!(format!("{}", rejection.reason), "<redacted>");
+}
+
+#[tokio::test]
+async fn mission_action_settles_idempotency_ledger_and_duplicate_replays() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    mission.program_submitted();
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone());
+
+    let envelope = sample_mission_action_envelope("mission-dup", "fire", Some("mission_idem"));
+
+    let first = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect("first mission submit");
+    assert!(matches!(first, ProductInboundAck::MissionSubmitted { .. }));
+    assert_eq!(mission.fire_count(), 1);
+    assert_eq!(ledger.settled_count(), 1);
+
+    // Re-program the fake so a second mission service call would now
+    // produce a different outcome. If the workflow mistakenly dispatched
+    // again instead of replaying the prior settled outcome, the
+    // assertions below would catch it.
+    mission.program_rejected(MissionFireRejectionReason::UnknownMission);
+
+    let second = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+
+    let ProductInboundAck::Duplicate { prior } = second else {
+        panic!("expected duplicate replay, got {second:?}");
+    };
+    assert!(
+        matches!(*prior, ProductInboundAck::MissionSubmitted { .. }),
+        "prior outcome must be MissionSubmitted, got {prior:?}"
+    );
+    // Critically: the second accept must NOT have invoked the mission
+    // service again. The ledger replays the prior settled outcome.
+    assert_eq!(
+        mission.fire_count(),
+        1,
+        "duplicate envelope must not re-invoke mission service"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CRITICAL: no-auto-attach guard
+//
+// This test closes the v1 bug shape from
+// `src/bridge/router.rs::fire_event_missions_for_message`, which scanned
+// inbound user-message text against active `MissionCadence::OnEvent`
+// regexes and side-fired missions in parallel to the turn. AC #12 of
+// issue #3280 forbids that path in Reborn: missions only fire via an
+// explicit `MissionActionPayload`. A regression that re-introduces a
+// text-pattern auto-attach must fail this test.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn ordinary_user_message_text_never_reaches_mission_service() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    // Program the mission service so that if anything ever reached it,
+    // the fire would succeed (and the assertions below would catch the
+    // call).
+    mission.program_submitted();
+
+    // Wire every other service so the workflow is fully configured and
+    // can't blame an unwired dispatch arm for not calling MissionService.
+    let approval = Arc::new(FakeApprovalInteractionService::new());
+    let auth = Arc::new(FakeAuthInteractionService::new());
+    let linked_thread = Arc::new(FakeLinkedThreadActionService::new());
+    let system_action = Arc::new(FakeSystemActionService::new());
+    let command_router = Arc::new(FakeProductCommandRouter::new());
+    let authority = Arc::new(FakeProjectionSubscriptionAuthority::new());
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone())
+        .with_approval_service(approval)
+        .with_auth_service(auth)
+        .with_linked_thread_service(linked_thread)
+        .with_system_action_service(system_action)
+        .with_command_router(command_router)
+        .with_projection_authority(authority);
+
+    // Each of these envelopes carries text that v1's
+    // `fire_event_missions_for_message` would have pattern-matched
+    // against a `MissionCadence::OnEvent { event_pattern }` regex. The
+    // Reborn workflow must route none of them to the mission service.
+    let texts = [
+        ("text-summarize", "please summarize today"),
+        ("text-mission-word", "start the daily report mission"),
+        ("text-trigger-fire", "trigger:fire mission_alpha"),
+        ("text-bot-fire", "@bot fire mission"),
+    ];
+
+    for (suffix, text) in texts {
+        let envelope = sample_user_message_envelope_with_text(suffix, text);
+        let ack = workflow
+            .accept_inbound(envelope)
+            .await
+            .expect("user message accepted");
+        // Sanity check: user messages route through the inbound turn
+        // service and produce an Accepted ack.
+        assert!(
+            matches!(ack, ProductInboundAck::Accepted { .. }),
+            "user-message envelope must produce Accepted ack, got {ack:?} (text: {text:?})"
+        );
+
+        // The load-bearing assertion: the MissionService MUST NOT have
+        // been called as a side effect of pattern-matching the text.
+        assert_eq!(
+            mission.fire_count(),
+            0,
+            "MissionService.fire_count must remain 0 — v1 \
+             fire_event_missions_for_message auto-attach has been \
+             reintroduced for text: {text:?}"
+        );
+        assert!(
+            mission.fires().is_empty(),
+            "MissionService.fires must remain empty — no \
+             MissionFireRequest may be recorded from text: {text:?}"
+        );
+    }
+
+    // Belt-and-suspenders: the inbound turn service is the ONLY service
+    // that should have seen these envelopes.
+    assert_eq!(inbound.accepted_count(), texts.len());
+    assert_eq!(mission.fire_count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// ApprovalInteractionService dispatch arm
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn approval_resolution_dispatches_through_approval_interaction_service() {
+    let (_, inbound, ledger) = build_workflow();
+    let approval = Arc::new(FakeApprovalInteractionService::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_approval_service(approval.clone());
+
+    let envelope = sample_approval_envelope("approval-handled", "gate:abc123");
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    let ProductInboundAck::GateHandled { gate_ref } = ack else {
+        panic!("expected GateHandled ack, got {ack:?}");
+    };
+    assert_eq!(gate_ref.as_str(), "gate:abc123");
+
+    let resolutions = approval.resolutions();
+    assert_eq!(resolutions.len(), 1);
+    let (recorded_gate, recorded_decision) = &resolutions[0];
+    assert_eq!(recorded_gate.as_str(), "gate:abc123");
+    assert_eq!(recorded_decision, &ApprovalDecision::ApproveOnce);
+}
+
+#[tokio::test]
+async fn stale_approval_settles_terminal_rejection() {
+    let (_, inbound, ledger) = build_workflow();
+    let approval = Arc::new(FakeApprovalInteractionService::new());
+    approval.program_stale();
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_approval_service(approval.clone());
+
+    let envelope = sample_approval_envelope("approval-stale", "gate:stale-ref");
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    // Adapter must not learn whether the gate existed; surface as a redacted
+    // permanent PolicyDenied. The reason text crosses the redaction boundary
+    // (RedactedString::expose is pub(crate)), so we assert kind + disposition
+    // — those are the wire-stable categories adapters branch on.
+    let ProductInboundAck::Rejected(rejection) = ack else {
+        panic!("expected Rejected ack, got {ack:?}");
+    };
+    assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+    assert_eq!(
+        rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+    // Sanity: the redacted reason does not leak the raw inner text.
+    assert!(!rejection.reason.to_string().contains("gate:stale-ref"));
+}
+
+#[tokio::test]
+async fn approval_resolution_does_not_call_turn_coordinator_resume() {
+    // Boundary regression for #3280 AC #11: the workflow must NOT bypass the
+    // ApprovalInteractionService to resume the parked loop directly. The
+    // workflow has no TurnCoordinator handle at all in this construction —
+    // the only direct dispatch surface is
+    // `InboundTurnService::accept_user_message`, which is also the only place
+    // a turn could be (re-)submitted from this layer. Asserting
+    // `accept_user_message` was never called while the approval service was
+    // called exactly once is the strongest available proof at the workflow
+    // boundary.
+    //
+    // Gap: the workflow crate does not own TurnCoordinator and
+    // FakeInboundTurnService does not expose a separate `resume_count()` —
+    // gate-resume happens inside the host-side service that the production
+    // `ApprovalInteractionService` wraps. That deeper contract is owned by
+    // `ironclaw_approvals` (issue #3094).
+    let (_, inbound, ledger) = build_workflow();
+    let approval = Arc::new(FakeApprovalInteractionService::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_approval_service(approval.clone());
+
+    let envelope = sample_approval_envelope("approval-no-resume", "gate:no-resume");
+    let _ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    assert_eq!(
+        approval.resolution_count(),
+        1,
+        "approval dispatch must reach the approval service exactly once"
+    );
+    assert_eq!(
+        inbound.attempt_count(),
+        0,
+        "approval dispatch must NOT route through the inbound turn service"
+    );
+    assert_eq!(
+        inbound.accepted_count(),
+        0,
+        "approval dispatch must NOT submit/resume a user-message turn"
+    );
+}
+
+#[tokio::test]
+async fn approval_without_configured_service_settles_unsupported() {
+    let (workflow, _inbound, ledger) = build_workflow();
+
+    let envelope = sample_approval_envelope("approval-unsupported", "gate:no-service");
+    let err = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect_err("missing approval service should reject");
+    assert!(!err.is_retryable());
+    assert_eq!(ledger.settled_count(), 1);
+
+    // Replay the duplicate to inspect the terminal rejection that was settled.
+    let replay = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+    let ProductInboundAck::Duplicate { prior } = replay else {
+        panic!("expected duplicate replay, got {replay:?}");
+    };
+    let ProductInboundAck::Rejected(rejection) = *prior else {
+        panic!("expected rejected prior outcome");
+    };
+    assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+    assert_eq!(
+        rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+    // The `unsupported action kind: approval_resolution` reason crosses the
+    // RedactedString boundary (expose() is pub(crate)). The wire-stable
+    // ProductWorkflowError::UnsupportedActionKind path is exercised by the
+    // settle (terminal) versus release (retryable) outcome above.
+}
+
+// ---------------------------------------------------------------------------
+// AuthInteractionService dispatch arm
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn auth_resolution_dispatches_through_auth_interaction_service() {
+    let (_, inbound, ledger) = build_workflow();
+    let auth = Arc::new(FakeAuthInteractionService::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_auth_service(auth.clone());
+
+    let envelope = sample_auth_envelope("auth-handled", "auth_req_xyz");
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    // Auth refs project into the same wire-stable LoopGateRef container as
+    // approval refs — both surface through GateHandled.
+    let ProductInboundAck::GateHandled { gate_ref } = ack else {
+        panic!("expected GateHandled ack, got {ack:?}");
+    };
+    assert_eq!(gate_ref.as_str(), "auth_req_xyz");
+
+    let resolutions = auth.resolutions();
+    assert_eq!(resolutions.len(), 1);
+    let (recorded_ref, recorded_result) = &resolutions[0];
+    assert_eq!(recorded_ref.as_str(), "auth_req_xyz");
+    assert!(matches!(
+        recorded_result,
+        AuthResolutionResult::CredentialProvided { credential_ref }
+            if credential_ref == "cred_abc"
+    ));
+}
+
+#[tokio::test]
+async fn stale_auth_settles_terminal_rejection() {
+    let (_, inbound, ledger) = build_workflow();
+    let auth = Arc::new(FakeAuthInteractionService::new());
+    auth.program_stale();
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_auth_service(auth.clone());
+
+    let envelope = sample_auth_envelope("auth-stale", "auth_req_stale");
+    let ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    let ProductInboundAck::Rejected(rejection) = ack else {
+        panic!("expected Rejected ack, got {ack:?}");
+    };
+    assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+    assert_eq!(
+        rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+    // Sanity: the redacted reason does not leak the raw inner text.
+    assert!(!rejection.reason.to_string().contains("auth_req_stale"));
+}
+
+#[tokio::test]
+async fn auth_resolution_does_not_call_turn_coordinator_resume() {
+    // Same boundary regression as
+    // `approval_resolution_does_not_call_turn_coordinator_resume` but for the
+    // auth arm: the workflow must not bypass the AuthInteractionService to
+    // resume the parked loop directly. See that test's doc-comment for the
+    // gap on the missing TurnCoordinator handle.
+    let (_, inbound, ledger) = build_workflow();
+    let auth = Arc::new(FakeAuthInteractionService::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_auth_service(auth.clone());
+
+    let envelope = sample_auth_envelope("auth-no-resume", "auth_req_no_resume");
+    let _ack = workflow.accept_inbound(envelope).await.expect("accept");
+
+    assert_eq!(
+        auth.resolution_count(),
+        1,
+        "auth dispatch must reach the auth service exactly once"
+    );
+    assert_eq!(
+        inbound.attempt_count(),
+        0,
+        "auth dispatch must NOT route through the inbound turn service"
+    );
+    assert_eq!(
+        inbound.accepted_count(),
+        0,
+        "auth dispatch must NOT submit/resume a user-message turn"
+    );
+}
+
+#[tokio::test]
+async fn auth_without_configured_service_settles_unsupported() {
+    let (workflow, _inbound, ledger) = build_workflow();
+
+    let envelope = sample_auth_envelope("auth-unsupported", "auth_req_no_service");
+    let err = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect_err("missing auth service should reject");
+    assert!(!err.is_retryable());
+    assert_eq!(ledger.settled_count(), 1);
+
+    let replay = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+    let ProductInboundAck::Duplicate { prior } = replay else {
+        panic!("expected duplicate replay, got {replay:?}");
+    };
+    let ProductInboundAck::Rejected(rejection) = *prior else {
+        panic!("expected rejected prior outcome");
+    };
+    assert_eq!(rejection.kind, ProductRejectionKind::PolicyDenied);
+    assert_eq!(
+        rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Both arms: ledger lifecycle and idempotency replay
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn approval_and_auth_both_settle_idempotency_ledger() {
+    // Approval arm — fresh workflow + ledger.
+    {
+        let (_, inbound, ledger) = build_workflow();
+        let approval = Arc::new(FakeApprovalInteractionService::new());
+        let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+            .with_approval_service(approval.clone());
+
+        let envelope = sample_approval_envelope("approval-ledger", "gate:ledger");
+        let _ack = workflow.accept_inbound(envelope).await.expect("accept");
+        assert_eq!(
+            ledger.settled_count(),
+            1,
+            "approval dispatch must settle the idempotency ledger"
+        );
+        assert_eq!(ledger.in_flight_count(), 0);
+    }
+    // Auth arm — fresh workflow + ledger.
+    {
+        let (_, inbound, ledger) = build_workflow();
+        let auth = Arc::new(FakeAuthInteractionService::new());
+        let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+            .with_auth_service(auth.clone());
+
+        let envelope = sample_auth_envelope("auth-ledger", "auth_req_ledger");
+        let _ack = workflow.accept_inbound(envelope).await.expect("accept");
+        assert_eq!(
+            ledger.settled_count(),
+            1,
+            "auth dispatch must settle the idempotency ledger"
+        );
+        assert_eq!(ledger.in_flight_count(), 0);
+    }
+}
+
+#[tokio::test]
+async fn duplicate_approval_envelope_replays_prior_handled_ack() {
+    let (_, inbound, ledger) = build_workflow();
+    let approval = Arc::new(FakeApprovalInteractionService::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_approval_service(approval.clone());
+
+    let envelope = sample_approval_envelope("approval-dup", "gate:dup-1");
+
+    let first = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect("first approval");
+    let ProductInboundAck::GateHandled {
+        gate_ref: first_ref,
+    } = first
+    else {
+        panic!("expected first GateHandled ack");
+    };
+    assert_eq!(first_ref.as_str(), "gate:dup-1");
+
+    let second = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate replay");
+    let ProductInboundAck::Duplicate { prior } = second else {
+        panic!("expected duplicate replay, got {second:?}");
+    };
+    let ProductInboundAck::GateHandled {
+        gate_ref: prior_ref,
+    } = *prior
+    else {
+        panic!("expected GateHandled in prior replay");
+    };
+    assert_eq!(prior_ref.as_str(), "gate:dup-1");
+    assert_eq!(
+        approval.resolution_count(),
+        1,
+        "duplicate envelope must NOT re-invoke the approval service"
+    );
 }

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -776,6 +776,124 @@ async fn projection_subscription_without_authority_returns_unsupported() {
     assert_eq!(ledger.in_flight_count(), 0);
 }
 
+#[tokio::test]
+async fn before_inbound_rejection_replays_prior_rejection_on_duplicate() {
+    // Regression: BeforeInboundPolicy::Reject surfaces as
+    // ProductWorkflowError::TurnSubmissionRejected. Previously this fell
+    // into the transient catch-all in terminal_ack_for_error and the
+    // action was RELEASED, letting a retry re-evaluate the policy. The
+    // workflow must SETTLE rejections as permanent so duplicate envelopes
+    // replay the prior rejection. See gemini-code-assist's review on
+    // PR #3558 / serrrfirat fork PR #3.
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    // Drive a TurnSubmissionRejected outcome from the inbound service —
+    // the same error the workflow would observe after a real
+    // BeforeInboundPolicy::Reject. The integration-tier counterpart in
+    // tests/inbound_turn_contract.rs wires a real DefaultInboundTurnService
+    // + FakeBeforeInboundPolicy to drive the same workflow path.
+    inbound.force_failure(ProductWorkflowError::TurnSubmissionRejected {
+        reason: "<redacted>".to_string(),
+    });
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone());
+
+    let envelope = sample_envelope("before-inbound-reject-dup");
+
+    // accept_inbound surfaces TurnSubmissionRejected as Err; the terminal
+    // ack settles into the ledger and is observable via duplicate replay.
+    // This mirrors the existing
+    // mission_action_without_configured_service_settles_unsupported
+    // pattern.
+    let err = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect_err("TurnSubmissionRejected must surface as Err");
+    assert!(
+        !err.is_retryable(),
+        "TurnSubmissionRejected must be non-retryable"
+    );
+    assert_eq!(
+        ledger.settled_count(),
+        1,
+        "TurnSubmissionRejected must SETTLE the ledger as permanent — not release for retry"
+    );
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(
+        inbound.attempt_count(),
+        1,
+        "inbound service must be called exactly once before the rejection settles"
+    );
+
+    let second = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("duplicate must replay prior rejection");
+    let ProductInboundAck::Duplicate { prior } = second else {
+        panic!("expected Duplicate replay, got {second:?}");
+    };
+    let ProductInboundAck::Rejected(prior_rejection) = *prior else {
+        panic!("expected prior to be Rejected, got prior outcome");
+    };
+    assert_eq!(prior_rejection.kind, ProductRejectionKind::PolicyDenied);
+    assert_eq!(
+        prior_rejection.disposition(),
+        ProductRejectionDisposition::Permanent
+    );
+    assert_eq!(
+        inbound.attempt_count(),
+        1,
+        "duplicate replay must NOT re-invoke the inbound service"
+    );
+}
+
+#[tokio::test]
+async fn resolve_projection_subscription_rejects_non_subscription_payload() {
+    // Routing a non-SubscriptionRequest envelope through
+    // resolve_projection_subscription is a caller bug and must be rejected
+    // at the gate — BEFORE the authority is consulted. The previous
+    // behaviour silently defaulted both hints to None, masking the bug.
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let authority = Arc::new(FakeProjectionSubscriptionAuthority::new());
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_projection_authority(authority.clone());
+
+    // A UserMessage envelope is the canonical "wrong payload" for the
+    // resolution path.
+    let envelope = sample_envelope("resolve-wrong-payload");
+    let err = workflow
+        .resolve_projection_subscription(envelope)
+        .await
+        .expect_err("non-subscription payload must be rejected at the gate");
+
+    // The error must cross the redaction boundary as ProductAdapterError;
+    // the workflow uses ProductWorkflowError::UnsupportedActionKind with
+    // kind = "non_subscription_payload_for_resolution". The redacted reason
+    // travels inside ProductAdapterError::Internal.
+    match err {
+        ProductAdapterError::Internal { ref detail } => {
+            let redacted = detail.to_string();
+            // RedactedString::Display emits the placeholder; the inner kind
+            // identifier is intentionally not exposed across the boundary.
+            // Asserting the variant + that the redaction is in effect is
+            // the strongest contract available here.
+            assert_eq!(redacted, "<redacted>");
+        }
+        other => panic!("expected Internal error variant, got {other:?}"),
+    }
+
+    // The authority MUST NOT have been consulted — the gate rejects before
+    // reaching the authority.
+    assert_eq!(
+        authority.authorization_count(),
+        0,
+        "the gate must reject before reaching the authority"
+    );
+    // Read-only path: the ledger must stay untouched.
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+}
+
 // ---------------------------------------------------------------------------
 // LinkedThreadActionService dispatch arm
 // ---------------------------------------------------------------------------
@@ -1101,7 +1219,7 @@ async fn mission_action_submitted_returns_mission_submitted_ack() {
 }
 
 #[tokio::test]
-async fn mission_action_deferred_busy_returns_mission_suppressed_busy_thread() {
+async fn mission_action_deferred_busy_returns_mission_deferred_for_retry() {
     let inbound = Arc::new(FakeInboundTurnService::new());
     let ledger = Arc::new(FakeIdempotencyLedger::new());
     let mission = Arc::new(FakeMissionService::new());
@@ -1116,21 +1234,98 @@ async fn mission_action_deferred_busy_returns_mission_suppressed_busy_thread() {
         .await
         .expect("mission deferred busy ack");
 
-    // DeferredBusy on the mission outcome maps to MissionSuppressed
-    // { BusyThread } at the wire boundary — see workflow.rs
-    // `dispatch_mission_action`.
+    // DeferredBusy on the mission outcome maps to the non-terminal
+    // MissionDeferred ack — mirroring the UserMessage DeferredBusy retry
+    // pattern. Critically, MissionDeferred MUST NOT settle the ledger;
+    // adapters must be allowed to retry the same envelope once the thread
+    // frees, and the second attempt should reach the mission service
+    // again (not be replayed as a duplicate).
     match ack {
-        ProductInboundAck::MissionSuppressed {
+        ProductInboundAck::MissionDeferred {
             mission_fire_ref,
-            reason,
+            active_run_id,
         } => {
             assert_ne!(mission_fire_ref.as_uuid(), Uuid::nil());
-            assert_eq!(reason, AdapterMissionFireSuppressionReason::BusyThread);
+            // TurnRunId has no nil sentinel; assert it parses to a
+            // non-empty debug string so we know the workflow actually
+            // plumbed the value through rather than substituting a
+            // default.
+            assert!(
+                !format!("{active_run_id:?}").is_empty(),
+                "active_run_id must be populated"
+            );
         }
-        other => panic!("expected MissionSuppressed {{ BusyThread }}, got {other:?}"),
+        other => panic!("expected MissionDeferred, got {other:?}"),
     }
 
     assert_eq!(mission.fire_count(), 1);
+    // MissionDeferred is non-terminal: the action must be RELEASED, not
+    // SETTLED. A subsequent retry of the same envelope must be allowed to
+    // re-enter the dispatch path (no Duplicate replay).
+    assert_eq!(
+        ledger.settled_count(),
+        0,
+        "MissionDeferred must not settle the ledger"
+    );
+    assert_eq!(
+        ledger.in_flight_count(),
+        0,
+        "MissionDeferred must release the in-flight reservation for retry"
+    );
+}
+
+#[tokio::test]
+async fn mission_action_deferred_busy_release_allows_retry_with_same_fingerprint() {
+    let inbound = Arc::new(FakeInboundTurnService::new());
+    let ledger = Arc::new(FakeIdempotencyLedger::new());
+    let mission = Arc::new(FakeMissionService::new());
+    // First call: program a busy-thread outcome.
+    mission.program_deferred_busy();
+
+    let workflow = DefaultProductWorkflow::new(inbound.clone(), ledger.clone())
+        .with_mission_service(mission.clone());
+
+    let envelope =
+        sample_mission_action_envelope("mission-busy-retry", "fire", Some("mission_retry"));
+
+    let first = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect("first mission fire (busy)");
+    assert!(
+        matches!(first, ProductInboundAck::MissionDeferred { .. }),
+        "first ack must be MissionDeferred, got {first:?}"
+    );
+    assert_eq!(mission.fire_count(), 1);
+    assert_eq!(ledger.settled_count(), 0, "MissionDeferred must NOT settle");
+    assert_eq!(
+        ledger.in_flight_count(),
+        0,
+        "MissionDeferred must release in-flight"
+    );
+
+    // Reprogram the fake so the second attempt succeeds. If the ledger had
+    // settled on the first call, the retry would surface as a
+    // ProductInboundAck::Duplicate {{ prior: MissionDeferred }} — the
+    // assertion below would catch that regression.
+    mission.program_submitted();
+
+    let second = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect("retry submits after busy thread frees");
+    assert!(
+        matches!(second, ProductInboundAck::MissionSubmitted { .. }),
+        "retry must reach mission service and return MissionSubmitted, got {second:?}"
+    );
+    assert_eq!(
+        mission.fire_count(),
+        2,
+        "retry must invoke the mission service a second time"
+    );
+    // After a successful retry, the terminal outcome settles.
+    assert_eq!(ledger.settled_count(), 1);
+    assert_eq!(ledger.in_flight_count(), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Waiting on PR #3542 to merge first

This PR provides the `ProjectionSubscriptionAuthority` port trait that production wiring will satisfy by wrapping `ironclaw_outbound::OutboundPolicyService::authorize_subscription`. **`OutboundPolicyService` itself lives in PR #3542** (currently CHANGES_REQUESTED; the seal-types fix is already pushed at `a5819c50` and CI is green). This PR's source has no compile-time dependency on #3542 — the port is a pure abstraction with a `FakeProjectionSubscriptionAuthority` impl for tests — but the production wiring that satisfies the port (in step 4 of the rollout plan) requires #3542 to merge first. **Please review and approve, but hold the merge button until #3542 lands.**

## Summary

Closes the remaining 8 acceptance criteria of issue #3280 (ProductWorkflow facade). Builds on PR #3428's first slice.

Adds eight new port traits, two new payload variants, five new ack variants, a BeforeInbound hook seam, and 38 new contract tests including the critical regression test that closes the v1 mission auto-attach bug shape.

## What lands in this PR

### New port traits (`crates/ironclaw_product_workflow/src/services.rs`)

Implementor-side facades that production wiring will satisfy by wrapping host-layer services. Names align with the contract sketches in #3094, #3278, #3280, and #3286.

| Trait | Closes AC | Wrapped by (production wiring, this PR ships the port only) |
|-------|-----------|-------------------------------------------------------------|
| `BeforeInboundPolicy` | #8, #9 | v1 `HookPoint::BeforeInbound` ported |
| `ProductCommandRouter` | #14 | #3286's `AgentCommandService` (full matrix) |
| `ApprovalInteractionService` | #15 | `ironclaw_approvals::ApprovalResolver` (#3094) |
| `AuthInteractionService` | #15 | `ironclaw_authorization::CapabilityDispatchAuthorizer` (#3094) |
| `LinkedThreadActionService` | new dispatch arm | TBD per-product handler |
| `MissionService` | #16 | `MissionFireRequest/Outcome` per #3278 |
| `SystemActionService` | #20 | TBD typed system handlers |
| `ProjectionSubscriptionAuthority` | #19 | `OutboundPolicyService::authorize_subscription` (#3542) |

`DefaultProductWorkflow::new(inbound_turn_service, idempotency_ledger)` stays a 2-arg constructor for back-compat with #3428's tests; `with_*` builder methods plug in the new ports. When a port is unset, the corresponding arm returns a redacted permanent `Rejected` ack via the existing `terminal_ack_for_error` taxonomy.

### New payload variants (`crates/ironclaw_product_adapters/src/inbound.rs`)

- `MissionActionPayload { mission_intent, mission_id_hint, data }` — explicit intent only.
- `SystemActionPayload { system_actor_ref, kind, scope_thread_id, data }` — typed system action with mandatory accountable actor/kind. **No `is_internal` bypass** (AC #20).

Plus five wire-stable typed wrappers used by the new ack variants (`MissionFireRef`, `MissionFireSuppressionReason`, `LoopGateRef`, `ProductCommandName`, `LinkedThreadActionId`). They live in the adapter crate so acks serialize without the workflow crate appearing in the wire surface.

### New ack variants (`ProductInboundAck`)

- `CommandRouted { command }`
- `GateHandled { gate_ref }` — used by both approval and auth resolutions (auth_request_ref projects into the wire-stable `LoopGateRef` container)
- `LinkedThreadActionRouted { action_id }`
- `MissionSubmitted { mission_fire_ref, submitted_run_id }`
- `MissionSuppressed { mission_fire_ref, reason }`

All five are durable outcomes; none are retryable.

### BeforeInbound integration (`inbound_turn.rs`)

`DefaultInboundTurnService` gains an optional `Arc<dyn BeforeInboundPolicy>` field via `with_before_inbound_policy`. The hook fires only on the genuine new-message path (after the replay-check, before binding resolution). Rewrite replaces the staged content; rejection short-circuits before any `accept_inbound_message` or `submit_turn` call so rejected input never becomes accepted transcript content.

### Subscription read-path bypass

`accept_inbound` short-circuits `SubscriptionRequest` before any idempotency-ledger touch — read paths never take a `ProductInboundAction` row (AC #19). Adapters must use `resolve_projection_subscription` for the read path; that method now reaches the `ProjectionSubscriptionAuthority` port and returns the canonical adapter-facing `ProjectionSubscriptionRequest`.

## No mission auto-attach guarantee

`ordinary_user_message_text_never_reaches_mission_service` is the regression closure for AC #17 / the v1 `src/bridge/router.rs::fire_event_missions_for_message` bug shape where `MissionCadence::OnEvent { event_pattern }` pattern-matched inbound text and side-fired missions in parallel to the turn.

The test drives four mission-keyword `UserMessage` envelopes through a fully-wired workflow (every port configured) and asserts `MissionService::fire_count() == 0` after each. Missions only fire via explicit `MissionActionPayload` from the adapter.

## Acceptance criteria coverage (#3280)

| AC | Status |
|----|--------|
| #1 UserMessage → InboundTurnService | unchanged from #3428 |
| #2 Adapter-supplied internal refs non-authoritative | unchanged from #3428 |
| #3 Ledger row before staging | unchanged from #3428 |
| #4 Duplicate replays prior outcome | unchanged from #3428 |
| #5 No duplicate message/run on replay | unchanged from #3428 |
| #6 Crash recovery uses same accepted message ref | unchanged from #3428 |
| #7 Pre-side-effect transient failure stays retryable | unchanged from #3428 |
| #8 BeforeInbound rewrite stages rewritten content | **NEW** |
| #9 BeforeInbound rejection creates no transcript content | **NEW** |
| #10 Refs-only TurnCoordinator submit | unchanged from #3428 |
| #11 ThreadBusy → DeferredBusy | unchanged from #3428 |
| #12 Pipeline acknowledgement only | unchanged from #3428 |
| #13 Adapter-supplied internal user/thread/scope ignored | unchanged from #3428 |
| #14 Slash-command via ProductCommandRouter seam | **NEW** |
| #15 Gate/auth via interaction services, no direct resume_turn | **NEW** |
| #16 Mission via MissionService, explicit intent only | **NEW** |
| #17 Ordinary chat never auto-attaches to a mission | **NEW (regression test)** |
| #18 Product-safe rejection taxonomy redacts internals | extended for new arms |
| #19 Subscription dispatch creates no ledger row | **NEW** |
| #20 Typed system actions require accountable actor/scope | **NEW** |
| #21 Architecture boundary tests | confirmed intact |

## Test surface

| File | Before | After | New |
|------|--------|-------|-----|
| `tests/inbound_turn_contract.rs` | 9 | 12 | +3 BeforeInbound |
| `tests/product_workflow_contract.rs` | 15 | 48 | +33 across all new arms + projection auth + no-auto-attach guard |
| `src/error.rs` unit tests | 2 | 2 | unchanged |
| **Total in `ironclaw_product_workflow --features test-support`** | **24 → 62** | | **+38 tests, all pass, 0 fail** |

In `ironclaw_product_adapters`: 11 → 16 tests (+5 covering the new payload variants and wire-stable wrappers).

## Out of scope (by design)

- Production wiring of any service into the running binary — that's Step 4 of the rollout plan.
- `MissionService` real implementation — issue #3278 owns it; this PR ships the port shape only.
- `AgentCommandService` full command compatibility matrix — issue #3286 owns it; this PR ships the `ProductCommandRouter` seam only.
- Telegram v2 / Slack v2 / Web v2 / TUI v2 adapter wiring — Step 5.
- Daemon API / OpenAPI / WIT — Step 3.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p ironclaw_product_workflow --features test-support --all-targets -- -D warnings`: clean
- `cargo clippy -p ironclaw_product_adapters --all-targets --all-features -- -D warnings`: clean
- `cargo test -p ironclaw_product_workflow --features test-support`: **62 pass, 0 fail**
- `cargo test -p ironclaw_product_adapters`: 16 pass
- `cargo test -p ironclaw_architecture`: 13 boundary tests pass; `reborn_crate_dependency_boundaries_hold` confirms `ironclaw_product_workflow` still has no normal-build dependency on `ironclaw_dispatcher`, `ironclaw_extensions`, `ironclaw_host_runtime`, `ironclaw_mcp`, `ironclaw_wasm`, `ironclaw_scripts`, `ironclaw_network`, `ironclaw_engine`, or `ironclaw_gateway`
- `cargo build --workspace`: clean

## Test plan

- [ ] Reviewer confirms the `ordinary_user_message_text_never_reaches_mission_service` regression test really exercises all the v1 bug-shape patterns
- [ ] Reviewer confirms `subscription_request_via_accept_inbound_is_rejected_without_ledger_row` correctly asserts the read-path bypass (no ledger lock, no authority call)
- [ ] Reviewer confirms the new `ProductInboundAck` variants are wire-stable and serialise round-trip
- [ ] Reviewer confirms the trait shapes match the spec sketches in #3094, #3278, #3286 closely enough that downstream issues don't need contract revisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)