### PR TITLE
fix(extensions): restore chat-driven tool_install + fix double-invoke + auto-approve footgun (#3533)

### DIFF
--- a/crates/ironclaw_engine/CLAUDE.md
+++ b/crates/ironclaw_engine/CLAUDE.md
@@ -130,8 +130,8 @@ machinery parks the VM, and the OAuth callback delivers the resolved
 credential to retry the action. Integrations that need user-driven setup
 (`NeedsSetup`, `Inactive`, `AvailableNotInstalled`) are listed under
 `Activatable Integrations` and the model installs them by calling
-`tool_install(name="<name>")` directly (issue #3533 / PR — the hidden gate
-on `tool_install` from #2868 was removed; the tool's
+`tool_install(name="<name>")` directly (issue #3533 / PR #3559 — the
+hidden gate on `tool_install` from #2868 was removed; the tool's
 `requires_approval = UnlessAutoApproved` mediates user consent).
 
 **Context as variables** (not attention input):

--- a/crates/ironclaw_engine/CLAUDE.md
+++ b/crates/ironclaw_engine/CLAUDE.md
@@ -129,8 +129,10 @@ preflight raises an `Authentication` gate at execute time, the inline-await
 machinery parks the VM, and the OAuth callback delivers the resolved
 credential to retry the action. Integrations that need user-driven setup
 (`NeedsSetup`, `Inactive`, `AvailableNotInstalled`) are listed under
-`Activatable Integrations` and the model tells the user to install/activate
-them through the IronClaw UI — the model cannot enable them itself.
+`Activatable Integrations` and the model installs them by calling
+`tool_install(name="<name>")` directly (issue #3533 / PR — the hidden gate
+on `tool_install` from #2868 was removed; the tool's
+`requires_approval = UnlessAutoApproved` mediates user consent).
 
 **Context as variables** (not attention input):
 - Thread messages injected as `context` Python variable

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2125,8 +2125,42 @@ async fn execute_single_action_with_inline_retry(
             return (result_json, accumulated_events, denial, current_lease.id);
         }
 
-        // Approved. Re-consume a lease use and mark the next call as
-        // pre-approved.
+        // Approved. If the bridge cached the action's output before raising
+        // this gate (post-execution Authentication gate path — see
+        // `effect_adapter::auth_gate_from_extension_result` and the
+        // `check_tool_readiness` path), the action has already run and we
+        // just needed user-side resolution. Return the cached output
+        // instead of re-executing. Without this shortcut, retrying
+        // `tool_install` re-downloads the WASM and runs through the
+        // `effect_adapter::enforce_tool_permission` approval check a
+        // second time, raising a fresh gate the user has no way to
+        // resolve. Tracked by #3533.
+        if let Some(cached_output) = result_json.get("resume_output").cloned()
+            && !cached_output.is_null()
+        {
+            let event = EventKind::ActionExecuted {
+                step_id: exec_ctx.step_id,
+                action_name: name.to_string(),
+                call_id: call_id.to_string(),
+                duration_ms: 0,
+                params_summary: params_summary.clone(),
+            };
+            accumulated_events.push(event);
+            let result_json = serde_json::json!({
+                "action_name": name,
+                "output": cached_output.clone(),
+                "is_error": false,
+                "duration_ms": 0,
+            });
+            return (
+                result_json,
+                accumulated_events,
+                cached_output,
+                current_lease.id,
+            );
+        }
+
+        // Re-consume a lease use and mark the next call as pre-approved.
         match leases.find_and_consume(thread_id, name).await {
             Ok(new_lease) => {
                 current_lease = new_lease;

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2059,8 +2059,20 @@ async fn execute_single_action_with_inline_retry(
         accumulated_events.push(event);
 
         // Refund the lease use this attempt consumed; we'll re-consume
-        // on retry if the user approves.
-        let _ = leases.refund_use(current_lease.id).await;
+        // on retry if the user approves. EXCEPTION: when the gate carries
+        // cached `resume_output`, the action has already executed (post-
+        // execution Authentication gate) and the cached-output branch
+        // below will return without re-consuming. Refunding now would
+        // let a successful side-effecting action consume zero lease
+        // uses. See matching guards in `scripting::resolve_tool_future`
+        // and `structured::execute_with_inline_gate_retry`. Tracked by
+        // the #3559 security review.
+        let gate_carries_resume_output = result_json
+            .get("resume_output")
+            .is_some_and(|v| !v.is_null());
+        if !gate_carries_resume_output {
+            let _ = leases.refund_use(current_lease.id).await;
+        }
 
         // Use the gate-provided parameters from the GatePaused payload,
         // not the original caller `params`: the safety layer may have

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -151,9 +151,11 @@ fn build_codeact_system_prompt_inner(
         prompt.push('\n');
         prompt.push_str(
             "These integrations need user setup before their tools become callable. \
-             You cannot enable them yourself — tell the user to install or activate them \
-             through the IronClaw UI (or wait for them to do so). \
-             If you need parameter details before suggesting one, call \
+             When the user asks to connect/install/enable one of them, call \
+             `tool_install(name=\"<name>\")` directly — don't enumerate alternatives or \
+             describe manual UI steps. If credentials are missing the engine raises an \
+             auth gate at execute time and the user is prompted in chat. \
+             For parameter details before installing, call \
              `tool_info(name=\"<tool>\", detail=\"summary\")` on a preview tool.\n\n",
         );
         for capability in activatable_integrations {
@@ -553,6 +555,11 @@ mod tests {
         assert!(prompt.contains("need user setup before their tools become callable"));
         assert!(prompt.contains("tool_info(name=\"<tool>\", detail=\"summary\")"));
         assert!(prompt.contains("Unlocks: `slack_send`, `slack_history`"));
+        // Regression for #3533: the prompt must direct the model to call
+        // tool_install for activatable integrations instead of narrating
+        // manual UI steps or enumerating alternatives.
+        assert!(prompt.contains("tool_install(name=\"<name>\")"));
+        assert!(prompt.contains("don't enumerate alternatives"));
     }
 
     #[test]

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -2349,7 +2349,13 @@ async fn drive_inline_gate(
             {
                 // Refund the use we just consumed — the next loop
                 // iteration will pause and re-consume on resolution.
-                let _ = leases.refund_use(lease.id).await;
+                // EXCEPTION: when the retry's gate carries a cached
+                // `resume_output`, the next iteration will return that
+                // cached output without re-consuming; refunding here
+                // would zero out the lease use the retry already spent.
+                if resume_output.is_none() {
+                    let _ = leases.refund_use(lease.id).await;
+                }
                 events.push(EventKind::ApprovalRequested {
                     action_name: action_name.clone(),
                     call_id: call_id.clone(),
@@ -2484,7 +2490,17 @@ async fn resolve_tool_future(
             }),
             _,
         )) => {
-            let _ = leases.refund_use(lease_id).await;
+            // Skip the refund when the gate carries cached `resume_output`:
+            // the action has already executed (post-execution Authentication
+            // gate), and `drive_inline_gate` will return the cached output
+            // on approval without re-consuming a lease. Refunding here would
+            // let a successful side-effecting action consume zero uses.
+            // Matching guards live in `structured::execute_with_inline_gate_retry`
+            // and `orchestrator::execute_action_with_inline_gate`. Tracked by
+            // the #3559 security review.
+            if resume_output.is_none() {
+                let _ = leases.refund_use(lease_id).await;
+            }
             events.push(EventKind::ApprovalRequested {
                 action_name: gate_action_name.clone(),
                 call_id: gate_call_id.clone(),

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -2131,6 +2131,14 @@ struct InlineGate {
     call_id: String,
     parameters: serde_json::Value,
     resume_kind: crate::gate::ResumeKind,
+    /// Pre-computed action output cached at gate-raise time. When the action
+    /// has *already executed* and only a follow-up resolution (e.g. OAuth) is
+    /// pending — `effect_adapter` raising an Authentication gate after a
+    /// successful `tool_install` is the canonical case — the bridge attaches
+    /// the install's output here. On resolution we return that cached output
+    /// instead of re-executing the action, which would otherwise re-download
+    /// the WASM bundle and re-raise a fresh approval gate (#3533 follow-up).
+    resume_output: Option<serde_json::Value>,
 }
 
 /// Drive an `Approval` gate to terminal resolution, retrying the
@@ -2220,9 +2228,38 @@ async fn drive_inline_gate(
             ));
         }
 
-        // Approved. Re-acquire a lease use and retry the action. The
-        // bridge installed any auto-approve preference before
-        // delivering the resolution, so policy now returns Allow.
+        // Approved. If the bridge cached the action's output before raising
+        // this gate (post-execution Authentication gate path — see
+        // `effect_adapter::auth_gate_from_extension_result` and the
+        // `check_tool_readiness` path), the action has already run and we
+        // just needed user-side resolution. Skip re-execution and return
+        // the cached output directly. Without this short-circuit, the
+        // retry re-runs `tool_install` (re-downloading the WASM) and the
+        // second pass through `effect_adapter::enforce_tool_permission`
+        // raises a brand-new approval gate that the user has no way to
+        // resolve. Tracked by #3533.
+        if let Some(cached_output) = gate.resume_output.take() {
+            events.push(EventKind::ActionExecuted {
+                step_id: context.step_id,
+                action_name: gate.action_name.clone(),
+                call_id: gate.call_id.clone(),
+                duration_ms: 0,
+                params_summary,
+            });
+            let monty_val = json_to_monty(&cached_output);
+            action_results.push(ActionResult {
+                call_id: gate.call_id.clone(),
+                action_name: gate.action_name.clone(),
+                output: cached_output,
+                is_error: false,
+                duration: std::time::Duration::ZERO,
+            });
+            return ExtFunctionResult::Return(monty_val);
+        }
+
+        // Re-acquire a lease use and retry the action. The bridge installed
+        // any auto-approve preference before delivering the resolution, so
+        // policy now returns Allow.
         //
         // Note: `find_and_consume` may select a different lease than
         // the originally-refunded one if multiple grants cover this
@@ -2302,6 +2339,7 @@ async fn drive_inline_gate(
                 call_id,
                 parameters,
                 resume_kind,
+                resume_output,
                 ..
             }) if matches!(
                 *resume_kind,
@@ -2330,6 +2368,7 @@ async fn drive_inline_gate(
                     call_id,
                     parameters: *parameters,
                     resume_kind: *resume_kind,
+                    resume_output: resume_output.map(|b| *b),
                 };
                 continue;
             }
@@ -2440,6 +2479,7 @@ async fn resolve_tool_future(
                 call_id: gate_call_id,
                 parameters: gate_parameters,
                 resume_kind,
+                resume_output,
                 ..
             }),
             _,
@@ -2490,6 +2530,7 @@ async fn resolve_tool_future(
                     call_id: gate_call_id,
                     parameters: *gate_parameters,
                     resume_kind: *resume_kind,
+                    resume_output: resume_output.map(|b| *b),
                 },
                 leases,
                 effects,

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -680,13 +680,15 @@ async fn execute_with_inline_gate_retry(
             }
             _ => None,
         };
-        let (gate_name, action_name, call_id, parameters, resume_kind) = match result {
+        let (gate_name, action_name, call_id, parameters, resume_kind, resume_output) = match result
+        {
             Err(EngineError::GatePaused {
                 gate_name,
                 action_name,
                 call_id,
                 parameters,
                 resume_kind,
+                resume_output,
                 ..
             }) if matches!(
                 *resume_kind,
@@ -694,7 +696,14 @@ async fn execute_with_inline_gate_retry(
                     | crate::gate::ResumeKind::Authentication { .. }
             ) =>
             {
-                (gate_name, action_name, call_id, *parameters, *resume_kind)
+                (
+                    gate_name,
+                    action_name,
+                    call_id,
+                    *parameters,
+                    *resume_kind,
+                    resume_output.map(|b| *b),
+                )
             }
             other => return (other, emitted_events),
         };
@@ -761,9 +770,38 @@ async fn execute_with_inline_gate_retry(
             );
         }
 
-        // Approved: re-consume a lease use and mark the next call as
-        // pre-approved so the host's `EffectExecutor` skips its
-        // approval check.
+        // Approved. If the bridge cached the action's output before raising
+        // this gate (post-execution Authentication gate path — see
+        // `effect_adapter::auth_gate_from_extension_result`), the action has
+        // already run and we just needed user-side resolution. Skip
+        // re-execution and synthesize a successful ActionResult from the
+        // cached output. Mirrors the Tier 1 shortcut in
+        // `scripting::drive_inline_gate`. Tracked by #3533.
+        if let Some(cached_output) = resume_output {
+            emitted_events.push(EventKind::ActionExecuted {
+                step_id: exec_ctx.step_id,
+                action_name: action_name.clone(),
+                call_id: call_id.clone(),
+                duration_ms: 0,
+                params_summary: crate::types::event::summarize_params(
+                    &call.action_name,
+                    &parameters,
+                ),
+            });
+            return (
+                Ok(ActionResult {
+                    call_id,
+                    action_name,
+                    output: cached_output,
+                    is_error: false,
+                    duration: std::time::Duration::ZERO,
+                }),
+                emitted_events,
+            );
+        }
+
+        // Re-consume a lease use and mark the next call as pre-approved so
+        // the host's `EffectExecutor` skips its approval check.
         match leases.find_and_consume(thread_id, &call.action_name).await {
             Ok(new_lease) => {
                 current_lease = new_lease;

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -787,17 +787,17 @@ async fn execute_with_inline_gate_retry(
         // re-execution and synthesize a successful ActionResult from the
         // cached output. Mirrors the Tier 1 shortcut in
         // `scripting::drive_inline_gate`. Tracked by #3533.
+        //
+        // Do NOT emit `ActionExecuted` here. The caller wraps the
+        // `Ok(ActionResult)` we return in `classify_exec_result`, which
+        // emits the terminal `ActionExecuted` for the Ok branch. Emitting
+        // here would produce two `ActionExecuted` events for one action,
+        // confusing audit observers. (Tier 1's `scripting::drive_inline_gate`
+        // and Tier 1 alt's `orchestrator::execute_action_with_inline_gate`
+        // emit themselves because their callers don't run an Ok-branch
+        // classifier — see the #3559 review for why structured is the
+        // outlier here.)
         if let Some(cached_output) = resume_output {
-            emitted_events.push(EventKind::ActionExecuted {
-                step_id: exec_ctx.step_id,
-                action_name: action_name.clone(),
-                call_id: call_id.clone(),
-                duration_ms: 0,
-                params_summary: crate::types::event::summarize_params(
-                    &call.action_name,
-                    &parameters,
-                ),
-            });
             return (
                 Ok(ActionResult {
                     call_id,
@@ -1472,6 +1472,158 @@ mod tests {
                 }
             }
             other => panic!("expected GatePaused, got {:?}", other),
+        }
+    }
+
+    /// #3559 security review (finding 2): when a post-execution
+    /// Authentication gate carries cached `resume_output`, the inline
+    /// retry path must NOT refund the lease use the action already
+    /// consumed. The cached-output branch returns without re-consuming,
+    /// so refunding would net a successful side-effecting action to
+    /// zero lease uses — letting a `max_uses=N` budget execute N+ times
+    /// for free.
+    ///
+    /// Wires `MockEffects` to return `GatePaused { resume_output: Some(...) }`
+    /// on the first call, drives it through `execute_action_calls` with an
+    /// always-approve test gate controller, and asserts:
+    /// 1. The cached output is returned (Ok result, no re-execution).
+    /// 2. Exactly one `ActionExecuted` event is emitted.
+    /// 3. The lease's `uses_remaining` ends at `Some(0)` — the original
+    ///    consumption stands; the refund was correctly skipped.
+    ///
+    /// Pre-fix (`refund_use` ran unconditionally), `uses_remaining` would
+    /// end at `Some(1)` and a subsequent call would still succeed,
+    /// breaking the `max_uses=1` contract.
+    #[tokio::test]
+    async fn resume_output_replay_consumes_exactly_one_lease_use() {
+        use crate::gate::{GateController, GatePauseRequest, GateResolution};
+
+        struct ApprovingGateController;
+
+        #[async_trait::async_trait]
+        impl GateController for ApprovingGateController {
+            async fn pause(&self, _request: GatePauseRequest) -> GateResolution {
+                GateResolution::Approved { always: false }
+            }
+        }
+
+        let thread = Thread::new(
+            "test",
+            ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            ThreadConfig::default(),
+        );
+
+        let cached_output = serde_json::json!({"installed": "gmail", "ok": true});
+        let effects: Arc<dyn EffectExecutor> = Arc::new(MockEffects::new(
+            vec![test_action("tool_install")],
+            vec![Err(EngineError::GatePaused {
+                gate_name: "authentication".into(),
+                action_name: "tool_install".into(),
+                call_id: "call_install_1".into(),
+                parameters: Box::new(serde_json::json!({"name": "gmail"})),
+                resume_kind: Box::new(crate::gate::ResumeKind::Authentication {
+                    credential_name: ironclaw_common::CredentialName::new("google_oauth_token")
+                        .unwrap(),
+                    instructions: "Connect Google".into(),
+                    auth_url: None,
+                }),
+                // The bridge cached the action's output before raising
+                // the post-execution Authentication gate — this is the
+                // exact shape `effect_adapter::auth_gate_from_extension_result`
+                // produces for a successful `tool_install` that needs
+                // user-side OAuth completion.
+                resume_output: Some(Box::new(cached_output.clone())),
+                paused_lease: None,
+            })],
+        ));
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+
+        // Grant a lease with `max_uses: Some(1)` — the budget this test
+        // asserts the engine honors.
+        let lease = leases
+            .grant(thread.id, "tools", GrantedActions::All, None, Some(1))
+            .await
+            .unwrap();
+        assert_eq!(
+            lease.uses_remaining,
+            Some(1),
+            "freshly granted lease should start with full budget"
+        );
+
+        let mut ctx = make_exec_context(&thread);
+        ctx.gate_controller = Arc::new(ApprovingGateController);
+
+        let calls = vec![ActionCall {
+            id: "call_install_1".into(),
+            action_name: "tool_install".into(),
+            parameters: serde_json::json!({"name": "gmail"}),
+        }];
+
+        let result = execute_action_calls(&calls, &thread, &effects, &leases, &policy, &ctx, &[])
+            .await
+            .unwrap();
+
+        // 1. The cached output reached the caller via an Ok result.
+        assert_eq!(result.results.len(), 1);
+        assert!(
+            !result.results[0].is_error,
+            "cached-output replay must surface as a successful ActionResult"
+        );
+        assert_eq!(
+            result.results[0].output, cached_output,
+            "ActionResult.output must be the gate's cached resume_output verbatim"
+        );
+        assert!(
+            result.need_approval.is_none(),
+            "inline-approved gate must NOT propagate as a top-level need_approval"
+        );
+
+        // 2. Exactly one terminal `ActionExecuted` for the call. The
+        //    pre-gate emission is `ApprovalRequested`, not
+        //    `ActionExecuted`, so the count check catches a future
+        //    regression that re-introduces a double-emit through the
+        //    classifier path.
+        let action_executed_count = result
+            .events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    EventKind::ActionExecuted { call_id, .. } if call_id == "call_install_1"
+                )
+            })
+            .count();
+        assert_eq!(
+            action_executed_count, 1,
+            "expected exactly one ActionExecuted for the cached-output replay; got events={:?}",
+            result.events
+        );
+
+        // 3. The lease use the action consumed before pausing was NOT
+        //    refunded — the original consumption is the correct
+        //    accounting for the already-executed action. The
+        //    `max_uses=1` budget is now exhausted, which surfaces as
+        //    `Err(LeaseExpired)` from both `check` (exhausted leases
+        //    fail `is_valid()`) and from a second `find_and_consume`
+        //    attempt. Pre-fix the refund would have ran, leaving
+        //    `uses_remaining: Some(1)` and both checks would succeed.
+        match leases.check(lease.id).await {
+            Err(EngineError::LeaseExpired { .. }) => {}
+            other => panic!(
+                "expected LeaseExpired after cached-output replay (budget should be \
+                 exhausted); got {other:?}"
+            ),
+        }
+        match leases.find_and_consume(thread.id, "tool_install").await {
+            Err(_) => {}
+            Ok(extra_lease) => panic!(
+                "max_uses=1 contract violated: a second `find_and_consume` succeeded \
+                 with uses_remaining={:?} — the refund-skip must keep the budget at zero",
+                extra_lease.uses_remaining
+            ),
         }
     }
 

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -727,8 +727,18 @@ async fn execute_with_inline_gate_retry(
         });
 
         // Refund the lease use this attempt consumed; we'll re-consume
-        // on retry if the user approves.
-        let _ = leases.refund_use(current_lease.id).await;
+        // on retry if the user approves. EXCEPTION: when `resume_output`
+        // is set, the action has already executed successfully (the
+        // gate is a post-execution Authentication gate carrying cached
+        // output) — the cached-output branch below will return without
+        // re-consuming. Refunding now would net the successful action
+        // to zero lease uses, letting a side-effecting tool drain
+        // `max_uses=∞` for free. See `drive_inline_gate` in scripting.rs
+        // and `execute_action_with_inline_gate` in orchestrator.rs for
+        // the matching guards. Tracked by the #3559 security review.
+        if resume_output.is_none() {
+            let _ = leases.refund_use(current_lease.id).await;
+        }
 
         let resolution = exec_ctx
             .gate_controller

--- a/registry/tools/telegram_mtproto.json
+++ b/registry/tools/telegram_mtproto.json
@@ -4,6 +4,7 @@
   "kind": "tool",
   "version": "0.2.1",
   "wit_version": "0.3.0",
+  "hidden": true,
   "description": "Your agent uses your Telegram account to read and send messages",
   "keywords": [
     "messaging",

--- a/scripts/live_canary/auth_registry.py
+++ b/scripts/live_canary/auth_registry.py
@@ -17,6 +17,12 @@ AUTH_FULL_TESTS = AUTH_SMOKE_TESTS + [
     "tests/e2e/scenarios/test_v2_auth_oauth_matrix.py::test_wasm_tool_oauth_exchange_failure_leaves_extension_unauthed",
     "tests/e2e/scenarios/test_v2_auth_oauth_matrix.py::test_wasm_tool_first_chat_auth_attempt_emits_auth_url",
     "tests/e2e/scenarios/test_v2_auth_oauth_matrix.py::test_chat_first_gmail_installs_prompts_and_retries",
+    # ironclaw#3533 — chat-driven `tool_install` raises an approval gate,
+    # user approves via the approval card, then the auth card surfaces.
+    # Pairs with `test_chat_first_gmail_installs_prompts_and_retries`
+    # (auto-approve variant); both must stay green so the regression that
+    # made "connect my telegram" narrate manual UI steps can't ship again.
+    "tests/e2e/scenarios/test_v2_auth_oauth_matrix.py::test_chat_install_approval_then_auth_card",
     "tests/e2e/scenarios/test_v2_auth_oauth_matrix.py::test_settings_first_gmail_auth_then_chat_runs",
     "tests/e2e/scenarios/test_v2_auth_oauth_matrix.py::test_settings_first_custom_mcp_auth_then_chat_runs",
     "tests/e2e/scenarios/test_v2_auth_oauth_matrix.py::test_wasm_tool_oauth_refresh_on_demand",

--- a/src/app.rs
+++ b/src/app.rs
@@ -1337,10 +1337,18 @@ impl AppBuilder {
             tools.count()
         );
 
-        // Seed per-user tool permission defaults into the database.
-        // This runs after all tools (built-in, WASM, MCP) are registered so
-        // that every tool name is known.  Existing entries are never overwritten.
-        seed_tool_permissions(&tools, self.db.as_ref(), &self.config.owner_id).await;
+        // One-shot cleanup of ghost-seeded tool permission rows for the
+        // owner. Pre-#3559, `seed_tool_permissions` wrote the code-level
+        // defaults (e.g. `tool_install` → `AskEachTime`) into the DB so
+        // the permissions panel could render them. Those rows were
+        // indistinguishable from user-explicit overrides, so a user
+        // could not be told from someone who never touched the setting,
+        // and `AGENT_AUTO_APPROVE_TOOLS=true` ended up bypassing
+        // user-explicit `AskEachTime` choices (#3559 security review).
+        // The seeder is gone; this migration deletes ghost rows once,
+        // after which any remaining row is user-explicit by
+        // construction and `resolve_permission` can trust its value.
+        cleanup_ghost_seeded_tool_permissions(self.db.as_ref(), &self.config.owner_id).await;
 
         Ok(AppComponents {
             config: self.config,
@@ -1532,67 +1540,103 @@ async fn migrate_session_credential(
     }
 }
 
-async fn seed_tool_permissions(
-    tools: &crate::tools::ToolRegistry,
-    db: Option<&Arc<dyn Database>>,
-    owner_id: &str,
-) {
+/// Sentinel settings key marking that ghost-seeded tool permission rows
+/// have been cleaned up for this owner. Reads/writes are idempotent and
+/// scoped per-user, so the migration is safe to re-run.
+const TOOL_PERMISSION_CLEANUP_SENTINEL: &str = "_internal.tool_permissions_seed_cleanup_v1";
+
+/// One-shot migration that removes ghost-seeded `tool_permissions.<name>`
+/// rows whose value matches `seeded_default_permission(name)` from the
+/// owner's settings. After this runs, any surviving DB row is a
+/// user-explicit choice — which lets `ToolPermissionSnapshot` treat all
+/// DB rows as explicit again. See `cleanup_ghost_seeded_tool_permissions`
+/// call site for context and the #3559 security review.
+async fn cleanup_ghost_seeded_tool_permissions(db: Option<&Arc<dyn Database>>, owner_id: &str) {
     let db = match db {
         Some(db) => db,
         None => {
-            tracing::debug!("seed_tool_permissions: no database available, skipping");
+            tracing::debug!(
+                "cleanup_ghost_seeded_tool_permissions: no database available, skipping"
+            );
             return;
         }
     };
 
-    // Load existing tool permission overrides from the DB.
+    // Skip if migration already ran for this owner.
+    match db
+        .get_setting(owner_id, TOOL_PERMISSION_CLEANUP_SENTINEL)
+        .await
+    {
+        Ok(Some(_)) => {
+            tracing::debug!("cleanup_ghost_seeded_tool_permissions: sentinel present, skipping");
+            return;
+        }
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(
+                "cleanup_ghost_seeded_tool_permissions: failed to read sentinel: {}",
+                e
+            );
+            return;
+        }
+    }
+
     let db_map = match db.get_all_settings(owner_id).await {
         Ok(m) => m,
         Err(e) => {
-            tracing::warn!("seed_tool_permissions: failed to load settings: {}", e);
+            tracing::warn!(
+                "cleanup_ghost_seeded_tool_permissions: failed to load settings: {}",
+                e
+            );
             return;
         }
     };
     let existing = crate::settings::Settings::from_db_map(&db_map).tool_permissions;
 
-    let registered_names = tools.list().await;
-    let mut seeded = 0u32;
-
-    for name in &registered_names {
-        if existing.contains_key(name.as_str()) {
-            // User has an explicit override — do not touch it.
+    let mut deleted = 0u32;
+    for (tool_name, state) in &existing {
+        let Some(seeded) = crate::tools::permissions::seeded_default_permission(tool_name) else {
+            continue;
+        };
+        if *state != seeded {
             continue;
         }
-
-        // Only insert seed defaults for known built-ins. Unknown/dynamic tools
-        // stay absent and fall back to AskEachTime at runtime.
-        if let Some(default_state) = crate::tools::permissions::seeded_default_permission(name) {
-            let json_value = match serde_json::to_value(default_state) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        "seed_tool_permissions: failed to serialize state for '{}': {}",
-                        name,
-                        e
-                    );
-                    continue;
-                }
-            };
-            if let Err(e) = db
-                .set_setting(owner_id, &format!("tool_permissions.{}", name), &json_value)
-                .await
-            {
-                tracing::warn!("seed_tool_permissions: failed to set '{}': {}", name, e);
-            } else {
-                seeded += 1;
+        match db
+            .delete_setting(owner_id, &format!("tool_permissions.{}", tool_name))
+            .await
+        {
+            Ok(_) => deleted += 1,
+            Err(e) => {
+                tracing::warn!(
+                    "cleanup_ghost_seeded_tool_permissions: failed to delete '{}': {}",
+                    tool_name,
+                    e
+                );
             }
         }
     }
 
-    if seeded > 0 {
-        tracing::debug!(
-            count = seeded,
-            "Seeded tool permission defaults into database"
+    // Record the sentinel even on partial failures so we don't re-scan
+    // every startup. The deletes are idempotent if a future run does
+    // re-process the same row.
+    if let Err(e) = db
+        .set_setting(
+            owner_id,
+            TOOL_PERMISSION_CLEANUP_SENTINEL,
+            &serde_json::json!(true),
+        )
+        .await
+    {
+        tracing::warn!(
+            "cleanup_ghost_seeded_tool_permissions: failed to write sentinel: {}",
+            e
+        );
+    }
+
+    if deleted > 0 {
+        tracing::info!(
+            count = deleted,
+            "Cleaned up ghost-seeded tool permission rows for owner"
         );
     }
 }
@@ -1691,55 +1735,88 @@ mod tests {
         assert!(!session_id.is_empty());
     }
 
-    /// Verify that `seed_tool_permissions` is idempotent: an existing user
-    /// override must survive a re-seed.
+    /// #3559 security review: ghost-seeded rows whose value matches the
+    /// code-level seeded default are deleted on first run. After cleanup,
+    /// the row no longer exists in DB and `effective_permission` falls
+    /// back to the code-level default at read time. Genuine user
+    /// overrides (value != seeded default) survive untouched. The
+    /// migration is idempotent — re-running after the sentinel is
+    /// written is a no-op.
     #[cfg(feature = "libsql")]
     #[tokio::test]
-    async fn seed_tool_permissions_preserves_user_overrides() {
+    async fn cleanup_ghost_seeded_tool_permissions_removes_seed_matching_rows() {
         use crate::db::Database;
         use crate::db::libsql::LibSqlBackend;
-        use crate::tools::ToolRegistry;
         use crate::tools::permissions::PermissionState;
 
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("test_seed.db");
+        let db_path = dir.path().join("test_cleanup.db");
         let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
         backend.run_migrations().await.unwrap();
         let db: Arc<dyn Database> = Arc::new(backend);
 
-        let registry = ToolRegistry::new();
-        registry.register_builtin_tools();
-
         let owner = "test-user";
 
-        // 1. Initial seed: creates defaults for all registered tools.
-        super::seed_tool_permissions(&registry, Some(&db), owner).await;
-
-        // Verify "echo" was seeded as AlwaysAllow.
-        let map = db.get_all_settings(owner).await.unwrap();
-        let settings = crate::settings::Settings::from_db_map(&map);
-        assert_eq!(
-            settings.tool_permissions.get("echo"),
-            Some(&PermissionState::AlwaysAllow),
-            "echo should be AlwaysAllow after initial seed"
-        );
-
-        // 2. User overrides echo → Disabled.
-        let disabled_json = serde_json::to_value(PermissionState::Disabled).unwrap();
-        db.set_setting(owner, "tool_permissions.echo", &disabled_json)
+        // 1. Simulate the old seeder's effect: write seeded-default rows
+        //    for `tool_install` (AskEachTime) and `echo` (AlwaysAllow),
+        //    plus a real user override for `shell` (AlwaysAllow, diverges
+        //    from the seeded AskEachTime).
+        let install_seed = serde_json::to_value(PermissionState::AskEachTime).unwrap();
+        let echo_seed = serde_json::to_value(PermissionState::AlwaysAllow).unwrap();
+        let shell_override = serde_json::to_value(PermissionState::AlwaysAllow).unwrap();
+        db.set_setting(owner, "tool_permissions.tool_install", &install_seed)
+            .await
+            .unwrap();
+        db.set_setting(owner, "tool_permissions.echo", &echo_seed)
+            .await
+            .unwrap();
+        db.set_setting(owner, "tool_permissions.shell", &shell_override)
             .await
             .unwrap();
 
-        // 3. Re-seed (e.g. after a restart).
-        super::seed_tool_permissions(&registry, Some(&db), owner).await;
+        // 2. Run the cleanup migration.
+        super::cleanup_ghost_seeded_tool_permissions(Some(&db), owner).await;
 
-        // 4. Assert the override survived.
+        let map = db.get_all_settings(owner).await.unwrap();
+        let settings = crate::settings::Settings::from_db_map(&map);
+
+        // Ghost-seeded rows are gone.
+        assert!(
+            !settings.tool_permissions.contains_key("tool_install"),
+            "tool_install row matching the seeded default must be removed"
+        );
+        assert!(
+            !settings.tool_permissions.contains_key("echo"),
+            "echo row matching the seeded default must be removed"
+        );
+
+        // Genuine user override survives.
+        assert_eq!(
+            settings.tool_permissions.get("shell"),
+            Some(&PermissionState::AlwaysAllow),
+            "shell override diverging from the seeded default must survive cleanup"
+        );
+
+        // Sentinel is set so subsequent runs are no-ops.
+        let sentinel = db
+            .get_setting(owner, super::TOOL_PERMISSION_CLEANUP_SENTINEL)
+            .await
+            .unwrap();
+        assert!(sentinel.is_some(), "cleanup sentinel must be written");
+
+        // 3. Re-running the migration after the sentinel is a no-op:
+        //    re-seed a ghost row and assert it survives the second pass.
+        db.set_setting(owner, "tool_permissions.tool_install", &install_seed)
+            .await
+            .unwrap();
+        super::cleanup_ghost_seeded_tool_permissions(Some(&db), owner).await;
         let map = db.get_all_settings(owner).await.unwrap();
         let settings = crate::settings::Settings::from_db_map(&map);
         assert_eq!(
-            settings.tool_permissions.get("echo"),
-            Some(&PermissionState::Disabled),
-            "user override to Disabled must survive re-seed"
+            settings.tool_permissions.get("tool_install"),
+            Some(&PermissionState::AskEachTime),
+            "after sentinel is written, a manually re-inserted row must NOT be cleaned up; \
+             the migration is one-shot per owner"
         );
     }
 }

--- a/src/bridge/CLAUDE.md
+++ b/src/bridge/CLAUDE.md
@@ -27,10 +27,12 @@ parks the VM, and the OAuth callback delivers the resolved credential to
 retry the action. `tool_activate` was removed in favor of this contract;
 its install + auto-activation behavior is covered by:
 
-- `tool_install` (callable; non-agent surface) — installs an extension and
+- `tool_install` (callable; agent-callable) — installs an extension and
   registers its tools with the engine registry. After install, the new
   tools appear on the next top-level turn (CodeAct does not hot-refresh
-  callable tools mid-step).
+  callable tools mid-step). User consent is mediated by the tool's
+  `ApprovalRequirement::UnlessAutoApproved` and the seeded `AskEachTime`
+  permission rather than by hiding the tool from the agent surface.
 - `tool_auth` (callable; v1-only) — manual auth flow surface for non-OAuth
   credential types.
 - The auth-preflight + inline-await pipeline (see #3133 / PR #3157) for
@@ -40,9 +42,9 @@ Integrations that need user setup (`NeedsSetup`, `Inactive`,
 `AvailableNotInstalled`) surface in the prompt under `Activatable
 Integrations`. The model installs them by calling `tool_install` directly;
 the engine's auth preflight handles any credential prompt at execute time.
-(Restored in issue #3533 / PR — `tool_install` was previously hidden from
-the model surface, which left "connect my telegram" narrating manual UI
-steps instead of running the actual install.)
+(Restored in issue #3533 / PR #3559 — `tool_install` was previously
+hidden from the model surface, which left "connect my telegram"
+narrating manual UI steps instead of running the actual install.)
 
 ## Auth-flow extension resolution: one place, no re-derivation
 

--- a/src/bridge/CLAUDE.md
+++ b/src/bridge/CLAUDE.md
@@ -38,8 +38,11 @@ its install + auto-activation behavior is covered by:
 
 Integrations that need user setup (`NeedsSetup`, `Inactive`,
 `AvailableNotInstalled`) surface in the prompt under `Activatable
-Integrations`, but the model cannot enable them itself — it tells the user
-to install/activate them through the IronClaw UI.
+Integrations`. The model installs them by calling `tool_install` directly;
+the engine's auth preflight handles any credential prompt at execute time.
+(Restored in issue #3533 / PR — `tool_install` was previously hidden from
+the model surface, which left "connect my telegram" narrating manual UI
+steps instead of running the actual install.)
 
 ## Auth-flow extension resolution: one place, no re-derivation
 

--- a/src/bridge/action_projector.rs
+++ b/src/bridge/action_projector.rs
@@ -204,9 +204,6 @@ fn classify_registered_tool(
     if crate::bridge::effect_adapter::is_v1_auth_tool(tool.name()) {
         return ProjectedAction::Hidden;
     }
-    if hidden_from_model_callable_surface(tool.name()) {
-        return ProjectedAction::Hidden;
-    }
     if tool_permissions.resolve_permission(tool.name()).effective == PermissionState::Disabled {
         return ProjectedAction::Hidden;
     }
@@ -238,10 +235,6 @@ fn classify_registered_tool(
     } else {
         ProjectedAction::Inline(project_tool_action(tool))
     }
-}
-
-fn hidden_from_model_callable_surface(tool_name: &str) -> bool {
-    matches!(tool_name, "tool_install" | "tool-install")
 }
 
 fn supports_pre_activation_discovery(
@@ -940,7 +933,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_install_hidden_from_model_callable_surface() {
+    async fn tool_install_is_callable_by_agent() {
+        // Regression for #3533: the agent must be able to call tool_install
+        // so "connect my telegram" runs an actual install + auth gate, rather
+        // than narrating manual UI steps. The hidden gate added in #2868 is
+        // gone; approval gating in tool_install::requires_approval() is what
+        // mediates user consent now.
         let tools = std::sync::Arc::new(ToolRegistry::new());
         tools
             .register(std::sync::Arc::new(BuiltinTool {
@@ -969,8 +967,7 @@ mod tests {
             .map(|action| action.name)
             .collect::<Vec<_>>();
 
-        assert!(!action_names.iter().any(|name| name == "tool_install"));
-        // tool_search is NOT in the hidden list, so it remains callable.
+        assert!(action_names.iter().any(|name| name == "tool_install"));
         assert!(action_names.iter().any(|name| name == "tool_search"));
     }
 

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -612,7 +612,12 @@ impl EffectBridgeAdapter {
                         output_value.get("auth_url").and_then(|v| v.as_str()),
                     ),
                 },
-                None,
+                // Carry the install/auth tool's already-computed output
+                // through the gate so the inline-await retry can return
+                // it directly instead of re-running `tool_install` (which
+                // would re-download the WASM and re-raise approval).
+                // Tracked by #3533.
+                Some(output_value.clone()),
                 Some(lease.clone()),
             )),
             _ => None,

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -2869,6 +2869,15 @@ mod tests {
 
     struct DefaultAllowNamedApprovalTestTool;
 
+    /// Stand-in for `tool_install`. Its `name()` matches the canonical
+    /// seeded-`AskEachTime` baseline so the explicit-equals-seeded
+    /// regression in `explicit_ask_each_time_for_seeded_default_tool_still_gates`
+    /// actually exercises the value-equality codepath. Mirrors the real
+    /// `tool_install`'s `UnlessAutoApproved` approval requirement so the
+    /// `enforce_tool_permission` branch under test (AskEachTime →
+    /// is_explicit_ask check) is reached.
+    struct SeededAskEachTimeTestTool;
+
     #[async_trait]
     impl Tool for ApprovalTestTool {
         fn name(&self) -> &str {
@@ -2965,6 +2974,41 @@ mod tests {
         ) -> Result<ToolOutput, ToolError> {
             Ok(ToolOutput::success(
                 serde_json::json!({ "echo": params }),
+                std::time::Duration::from_millis(1),
+            ))
+        }
+
+        fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+            ApprovalRequirement::UnlessAutoApproved
+        }
+    }
+
+    #[async_trait]
+    impl Tool for SeededAskEachTimeTestTool {
+        fn name(&self) -> &str {
+            "tool_install"
+        }
+
+        fn description(&self) -> &str {
+            "Test stand-in for tool_install; name matches a seeded-AskEachTime baseline"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" }
+                }
+            })
+        }
+
+        async fn execute(
+            &self,
+            params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolOutput::success(
+                serde_json::json!({ "installed": params }),
                 std::time::Duration::from_millis(1),
             ))
         }
@@ -3829,6 +3873,92 @@ mod tests {
         match err {
             EngineError::GatePaused { gate_name, .. } => {
                 assert_eq!(gate_name, "approval");
+            }
+            other => panic!("expected GatePaused, got {other:?}"),
+        }
+    }
+
+    /// #3559 security review (finding 1): when a user explicitly sets a
+    /// tool's permission to a value that happens to match the code-level
+    /// seeded default (e.g. `tool_install` → `AskEachTime`, which is also
+    /// the seeded baseline), pre-#3559's `ToolPermissionSnapshot::resolve_permission`
+    /// collapsed the DB row to `explicit = None`, then this function's
+    /// `is_explicit_ask` check failed, and `auto_approve_tools` bypassed
+    /// the gate — silently dropping the user's explicit choice.
+    ///
+    /// The companion regression at `bridge::tool_permissions::tests::user_explicit_value_matching_seeded_default_stays_explicit`
+    /// covers the resolver in isolation. Per `.claude/rules/testing.md`
+    /// "Test Through the Caller", this test additionally drives the
+    /// side-effecting call site (`execute_action` → `enforce_tool_permission`)
+    /// with a tool whose name matches a seeded default in `seeded_default_permission`,
+    /// so the value-equality bug would surface here if it were ever
+    /// reintroduced in the resolver.
+    #[tokio::test]
+    async fn explicit_ask_each_time_for_seeded_default_tool_still_gates() {
+        let db_path = std::env::temp_dir().join(format!(
+            "ironclaw-seeded-ask-each-time-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        let db = crate::db::connect_from_config(&crate::config::DatabaseConfig::from_libsql_path(
+            db_path.to_str().expect("db path"),
+            None,
+            None,
+        ))
+        .await
+        .expect("db");
+        // Write a user-explicit `AskEachTime` for `tool_install`. Confirm
+        // that `seeded_default_permission("tool_install") == AskEachTime`
+        // — if the seeded baseline ever changes, this test must be
+        // updated to keep its value-equality coverage meaningful.
+        assert_eq!(
+            crate::tools::permissions::seeded_default_permission("tool_install"),
+            Some(crate::tools::permissions::PermissionState::AskEachTime),
+            "this regression test assumes tool_install's seeded baseline is AskEachTime; \
+             if you changed it, point this test at a different seeded-AskEachTime tool"
+        );
+        db.set_setting(
+            "test_user",
+            "tool_permissions.tool_install",
+            &serde_json::to_value(crate::tools::permissions::PermissionState::AskEachTime)
+                .expect("serialize permission"),
+        )
+        .await
+        .expect("save tool permission");
+
+        let tools = Arc::new(ToolRegistry::new().with_database(db));
+        tools.register(Arc::new(SeededAskEachTimeTestTool)).await;
+        let adapter = EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&ironclaw_safety::SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        )
+        .with_global_auto_approve(true);
+
+        let err = adapter
+            .execute_action(
+                "tool_install",
+                serde_json::json!({"name": "gmail"}),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_seeded_ask_each_time"),
+                ),
+            )
+            .await
+            .expect_err(
+                "user-explicit AskEachTime must gate even when value matches seeded default \
+                 and AGENT_AUTO_APPROVE_TOOLS=true",
+            );
+
+        match err {
+            EngineError::GatePaused { gate_name, .. } => {
+                assert_eq!(
+                    gate_name, "approval",
+                    "explicit user choice must surface as approval gate, not bypass"
+                );
             }
             other => panic!("expected GatePaused, got {other:?}"),
         }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2234,6 +2234,35 @@ pub async fn resolve_inline_gates_for_credential(user_id: &str, credential_name:
             woken,
             "delivered Approved to parked inline-await waiter(s) on credential write"
         );
+        // #3533: also drop the matching Authentication pending-gate
+        // rows from the store. The inline-await retry will run with
+        // the credential now present and either succeed or raise its
+        // own follow-up gate; the original Authentication row no
+        // longer represents live state and would otherwise linger
+        // until expiry (and surface in `HistoryResponse.pending_gate`
+        // for users who had no follow-up gate). Without this discard,
+        // the external-callback path (`resolve_engine_auth_callback`)
+        // is the only thing that cleans up — and skipping that path
+        // to avoid the "thread already running" race left the row
+        // orphaned.
+        let matching: Vec<_> = state
+            .pending_gates
+            .list_for_user(user_id)
+            .await
+            .into_iter()
+            .filter(|gate| {
+                matches!(
+                    &gate.resume_kind,
+                    ironclaw_engine::ResumeKind::Authentication {
+                        credential_name: gate_credential,
+                        ..
+                    } if gate_credential.as_str() == credential_name
+                )
+            })
+            .collect();
+        for gate in matching {
+            let _ = state.pending_gates.discard(&gate.key()).await;
+        }
     }
     woken
 }

--- a/src/bridge/tool_permissions.rs
+++ b/src/bridge/tool_permissions.rs
@@ -39,9 +39,25 @@ impl ToolPermissionSnapshot {
     pub(crate) fn resolve_permission(&self, tool_name: &str) -> ToolPermissionResolution {
         let canonical = canonical_tool_name(tool_name);
         let hyphenated = canonical.replace('_', "-");
-        let explicit = self.explicit_permission_with_names(tool_name, &canonical, &hyphenated);
-        let effective = explicit
-            .or_else(|| seeded_default_permission(&canonical))
+        let raw_explicit = self.explicit_permission_with_names(tool_name, &canonical, &hyphenated);
+        let seeded_default = seeded_default_permission(&canonical);
+        // #3533: the boot-time seeder writes the seeded default
+        // (e.g. `tool_install` → `AskEachTime`) into the DB so the
+        // permissions panel can display it. The DB value is then
+        // indistinguishable from a user-explicit override, which means
+        // `enforce_tool_permission` treats every seeded default as
+        // explicit and refuses to honor `AGENT_AUTO_APPROVE_TOOLS=true`.
+        // Treat a DB value that matches the seeded default as implicit:
+        // a user who genuinely wants to keep the default behaves the
+        // same as someone who never touched the setting, and a real
+        // explicit override (`AlwaysAllow` or `Disabled`) still surfaces
+        // as `explicit = Some(...)`.
+        let explicit = match (raw_explicit, seeded_default) {
+            (Some(value), Some(default)) if value == default => None,
+            (value, _) => value,
+        };
+        let effective = raw_explicit
+            .or(seeded_default)
             .unwrap_or(PermissionState::AskEachTime);
         ToolPermissionResolution {
             effective,
@@ -108,6 +124,47 @@ mod tests {
             ToolPermissionResolution {
                 effective: PermissionState::AskEachTime,
                 explicit: None,
+            }
+        );
+    }
+
+    /// Issue #3533 regression: when the boot-time seeder writes the seeded
+    /// default for `tool_install` (`AskEachTime`) into the DB, the resolver
+    /// must NOT treat that as a user-explicit override — otherwise
+    /// `effect_adapter::enforce_tool_permission`'s `is_explicit_ask` check
+    /// fires and `AGENT_AUTO_APPROVE_TOOLS=true` is silently neutered.
+    #[test]
+    fn seeded_default_matching_db_value_is_implicit() {
+        let snapshot = ToolPermissionSnapshot {
+            overrides: HashMap::from([("tool_install".to_string(), PermissionState::AskEachTime)]),
+        };
+
+        assert_eq!(
+            snapshot.resolve_permission("tool_install"),
+            ToolPermissionResolution {
+                effective: PermissionState::AskEachTime,
+                // Matches the seeded default → treated as implicit so
+                // auto_approve_tools env var can still bypass it.
+                explicit: None,
+            }
+        );
+    }
+
+    /// A user who explicitly opts out of the seeded default (here:
+    /// `tool_install` set to `AlwaysAllow` instead of the seeded
+    /// `AskEachTime`) keeps their explicit choice. Only DB values that
+    /// match the seeded default are collapsed to implicit.
+    #[test]
+    fn user_override_diverging_from_seeded_default_stays_explicit() {
+        let snapshot = ToolPermissionSnapshot {
+            overrides: HashMap::from([("tool_install".to_string(), PermissionState::AlwaysAllow)]),
+        };
+
+        assert_eq!(
+            snapshot.resolve_permission("tool_install"),
+            ToolPermissionResolution {
+                effective: PermissionState::AlwaysAllow,
+                explicit: Some(PermissionState::AlwaysAllow),
             }
         );
     }

--- a/src/bridge/tool_permissions.rs
+++ b/src/bridge/tool_permissions.rs
@@ -41,27 +41,22 @@ impl ToolPermissionSnapshot {
         let hyphenated = canonical.replace('_', "-");
         let raw_explicit = self.explicit_permission_with_names(tool_name, &canonical, &hyphenated);
         let seeded_default = seeded_default_permission(&canonical);
-        // #3533: the boot-time seeder writes the seeded default
-        // (e.g. `tool_install` → `AskEachTime`) into the DB so the
-        // permissions panel can display it. The DB value is then
-        // indistinguishable from a user-explicit override, which means
-        // `enforce_tool_permission` treats every seeded default as
-        // explicit and refuses to honor `AGENT_AUTO_APPROVE_TOOLS=true`.
-        // Treat a DB value that matches the seeded default as implicit:
-        // a user who genuinely wants to keep the default behaves the
-        // same as someone who never touched the setting, and a real
-        // explicit override (`AlwaysAllow` or `Disabled`) still surfaces
-        // as `explicit = Some(...)`.
-        let explicit = match (raw_explicit, seeded_default) {
-            (Some(value), Some(default)) if value == default => None,
-            (value, _) => value,
-        };
+        // Any DB row is a user-explicit choice. The original #3533 fix
+        // here collapsed value-equal-to-seed rows to `explicit = None`
+        // so `AGENT_AUTO_APPROVE_TOOLS=true` could bypass them, but
+        // value-equality is not provenance — a user who genuinely picks
+        // `AskEachTime` for `tool_install` (the seeded default) would
+        // see their explicit choice silently bypassed. Provenance is
+        // now handled at write time: pre-#3559 `seed_tool_permissions`
+        // wrote ghost rows that `cleanup_ghost_seeded_tool_permissions`
+        // deletes on first startup, and no new seeded rows are written.
+        // See `src/app.rs::cleanup_ghost_seeded_tool_permissions`.
         let effective = raw_explicit
             .or(seeded_default)
             .unwrap_or(PermissionState::AskEachTime);
         ToolPermissionResolution {
             effective,
-            explicit,
+            explicit: raw_explicit,
         }
     }
 
@@ -128,13 +123,18 @@ mod tests {
         );
     }
 
-    /// Issue #3533 regression: when the boot-time seeder writes the seeded
-    /// default for `tool_install` (`AskEachTime`) into the DB, the resolver
-    /// must NOT treat that as a user-explicit override — otherwise
-    /// `effect_adapter::enforce_tool_permission`'s `is_explicit_ask` check
-    /// fires and `AGENT_AUTO_APPROVE_TOOLS=true` is silently neutered.
+    /// #3559 security review: a DB row is always a user-explicit choice.
+    /// A user who genuinely picks `AskEachTime` for `tool_install` (which
+    /// happens to match the code-level seeded default) must surface as
+    /// `explicit = Some(...)` so `effect_adapter::enforce_tool_permission`'s
+    /// `is_explicit_ask` check fires and `AGENT_AUTO_APPROVE_TOOLS=true`
+    /// does NOT bypass the gate. The pre-#3559 collapse-to-implicit logic
+    /// silently dropped this choice; the cleanup migration in
+    /// `app::cleanup_ghost_seeded_tool_permissions` now removes the
+    /// historical ghost-seeded rows at boot so any surviving DB row is
+    /// user-explicit by construction.
     #[test]
-    fn seeded_default_matching_db_value_is_implicit() {
+    fn user_explicit_value_matching_seeded_default_stays_explicit() {
         let snapshot = ToolPermissionSnapshot {
             overrides: HashMap::from([("tool_install".to_string(), PermissionState::AskEachTime)]),
         };
@@ -143,17 +143,17 @@ mod tests {
             snapshot.resolve_permission("tool_install"),
             ToolPermissionResolution {
                 effective: PermissionState::AskEachTime,
-                // Matches the seeded default → treated as implicit so
-                // auto_approve_tools env var can still bypass it.
-                explicit: None,
+                explicit: Some(PermissionState::AskEachTime),
             }
         );
     }
 
     /// A user who explicitly opts out of the seeded default (here:
     /// `tool_install` set to `AlwaysAllow` instead of the seeded
-    /// `AskEachTime`) keeps their explicit choice. Only DB values that
-    /// match the seeded default are collapsed to implicit.
+    /// `AskEachTime`) keeps their explicit choice. Same semantics as
+    /// `user_explicit_value_matching_seeded_default_stays_explicit`,
+    /// but with a value that diverges from the seeded default — the
+    /// resolver treats all DB values identically.
     #[test]
     fn user_override_diverging_from_seeded_default_stays_explicit() {
         let snapshot = ToolPermissionSnapshot {

--- a/src/channels/web/features/oauth/mod.rs
+++ b/src/channels/web/features/oauth/mod.rs
@@ -690,80 +690,97 @@ pub(crate) async fn oauth_callback_handler(
         //    OAuth completed.
         // Both are best-effort — failures are logged inside the bridge
         // helpers and never block the OAuth landing page.
-        let _ =
+        let inline_woken =
             crate::bridge::resolve_inline_gates_for_credential(&flow.user_id, &flow.secret_name)
                 .await;
         let _ =
             crate::bridge::resume_paused_missions_for_credential(&flow.user_id, &flow.secret_name)
                 .await;
 
-        match crate::bridge::resolve_engine_auth_callback(&flow.user_id, &flow.secret_name).await {
-            Ok(crate::bridge::AuthCallbackContinuation::ResolveGateExternal {
-                channel,
-                thread_scope,
-                request_id,
-            }) => {
-                if let Some(tx) = state.msg_tx.read().await.as_ref().cloned() {
-                    let callback =
-                        crate::agent::submission::Submission::ExternalCallback { request_id };
-                    match serde_json::to_string(&callback) {
-                        Ok(content) => {
-                            let msg = web_incoming_message(
-                                &channel,
-                                &flow.user_id,
-                                content,
-                                thread_scope.as_deref(),
-                            );
-                            if let Err(e) = tx.send(msg).await {
+        // #3533: when the inline-await path already woke a parked
+        // waiter, the engine is already retrying the action that was
+        // blocked on this credential. Sending an `ExternalCallback`
+        // submission down the agent loop in addition to that is
+        // redundant and causes "thread already running" races against
+        // the in-flight retry (and re-dispatches `tool_install` a
+        // second time when the mock LLM pattern-matches the user
+        // turn). Skip the external-callback re-entry in that case;
+        // it stays in place for paths where no inline waiter exists
+        // (mission's child thread already finished, or Tier 0 unwound
+        // before OAuth landed).
+        let skip_external_callback = inline_woken > 0;
+
+        if !skip_external_callback {
+            match crate::bridge::resolve_engine_auth_callback(&flow.user_id, &flow.secret_name)
+                .await
+            {
+                Ok(crate::bridge::AuthCallbackContinuation::ResolveGateExternal {
+                    channel,
+                    thread_scope,
+                    request_id,
+                }) => {
+                    if let Some(tx) = state.msg_tx.read().await.as_ref().cloned() {
+                        let callback =
+                            crate::agent::submission::Submission::ExternalCallback { request_id };
+                        match serde_json::to_string(&callback) {
+                            Ok(content) => {
+                                let msg = web_incoming_message(
+                                    &channel,
+                                    &flow.user_id,
+                                    content,
+                                    thread_scope.as_deref(),
+                                );
+                                if let Err(e) = tx.send(msg).await {
+                                    tracing::warn!(
+                                        extension = %extension_name,
+                                        user_id = %flow.user_id,
+                                        error = %e,
+                                        "Failed to resolve pending engine auth gate after OAuth callback"
+                                    );
+                                }
+                            }
+                            Err(e) => {
                                 tracing::warn!(
                                     extension = %extension_name,
                                     user_id = %flow.user_id,
                                     error = %e,
-                                    "Failed to resolve pending engine auth gate after OAuth callback"
+                                    "Failed to serialize external callback submission"
                                 );
                             }
                         }
-                        Err(e) => {
+                    }
+                }
+                Ok(crate::bridge::AuthCallbackContinuation::ReplayMessage {
+                    channel,
+                    thread_scope,
+                    content,
+                }) => {
+                    if let Some(tx) = state.msg_tx.read().await.as_ref().cloned() {
+                        let msg = web_incoming_message(
+                            &channel,
+                            &flow.user_id,
+                            content,
+                            thread_scope.as_deref(),
+                        );
+                        if let Err(e) = tx.send(msg).await {
                             tracing::warn!(
                                 extension = %extension_name,
                                 user_id = %flow.user_id,
                                 error = %e,
-                                "Failed to serialize external callback submission"
+                                "Failed to replay pending engine auth request after OAuth callback"
                             );
                         }
                     }
                 }
-            }
-            Ok(crate::bridge::AuthCallbackContinuation::ReplayMessage {
-                channel,
-                thread_scope,
-                content,
-            }) => {
-                if let Some(tx) = state.msg_tx.read().await.as_ref().cloned() {
-                    let msg = web_incoming_message(
-                        &channel,
-                        &flow.user_id,
-                        content,
-                        thread_scope.as_deref(),
+                Ok(crate::bridge::AuthCallbackContinuation::None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        extension = %extension_name,
+                        user_id = %flow.user_id,
+                        error = %e,
+                        "Failed to resume pending engine auth gate after OAuth callback"
                     );
-                    if let Err(e) = tx.send(msg).await {
-                        tracing::warn!(
-                            extension = %extension_name,
-                            user_id = %flow.user_id,
-                            error = %e,
-                            "Failed to replay pending engine auth request after OAuth callback"
-                        );
-                    }
                 }
-            }
-            Ok(crate::bridge::AuthCallbackContinuation::None) => {}
-            Err(e) => {
-                tracing::warn!(
-                    extension = %extension_name,
-                    user_id = %flow.user_id,
-                    error = %e,
-                    "Failed to resume pending engine auth gate after OAuth callback"
-                );
             }
         }
     }

--- a/src/extensions/discovery.rs
+++ b/src/extensions/discovery.rs
@@ -107,6 +107,7 @@ impl OnlineDiscovery {
                             fallback_source: None,
                             auth_hint: AuthHint::Dcr,
                             version: None,
+                            hidden: false,
                         })
                     } else {
                         None
@@ -183,6 +184,7 @@ impl OnlineDiscovery {
                     fallback_source: None,
                     auth_hint: AuthHint::Dcr,
                     version: None,
+                    hidden: false,
                 })
             })
             .collect()

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -2382,6 +2382,14 @@ impl ExtensionManager {
                 if installed_names.contains(&(entry.name.clone(), entry.kind)) {
                     continue;
                 }
+                // Hidden registry entries (e.g. `telegram_mtproto` alongside the
+                // canonical `telegram` channel) are omitted from default-discovery
+                // surfaces so the agent doesn't enumerate them as competing
+                // options for "connect my X". They remain installable by explicit
+                // name via `tool_install`. Issue #3533.
+                if entry.hidden {
+                    continue;
+                }
                 extensions.push(InstalledExtension {
                     name: entry.name,
                     kind: entry.kind,
@@ -8507,6 +8515,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::Dcr,
             version: None,
+            hidden: false,
         }
     }
 
@@ -9464,6 +9473,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::CapabilitiesAuth,
             version: None,
+            hidden: false,
         };
         let manager = make_test_manager_with_catalog(
             None,
@@ -9488,6 +9498,81 @@ mod tests {
             web_search.description.contains("Search the web"),
             "latent action description should carry the registry entry's description, got: {}",
             web_search.description
+        );
+    }
+
+    /// Issue #3533 regression. Two telegram registry entries used to surface
+    /// to the agent as "Activatable Integrations" — the canonical `telegram`
+    /// channel and `telegram_mtproto` — and the model would correctly
+    /// enumerate them as competing options for "connect my telegram". Hidden
+    /// entries must be dropped from the available-but-not-installed appendix
+    /// of `list()`, so only the canonical channel reaches the prompt.
+    /// Hidden entries remain installable by explicit name via `tool_install`.
+    #[tokio::test]
+    async fn list_filters_hidden_registry_entries_from_available_set() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let telegram = RegistryEntry {
+            name: "telegram".to_string(),
+            display_name: "Telegram Channel".to_string(),
+            kind: ExtensionKind::WasmChannel,
+            description: "Talk to your agent through a Telegram bot".to_string(),
+            keywords: vec!["telegram".into(), "messaging".into()],
+            source: ExtensionSource::WasmDownload {
+                wasm_url: "https://example.com/telegram.wasm".to_string(),
+                capabilities_url: None,
+            },
+            fallback_source: None,
+            auth_hint: AuthHint::CapabilitiesAuth,
+            version: None,
+            hidden: false,
+        };
+        let mtproto = RegistryEntry {
+            name: "telegram_mtproto".to_string(),
+            display_name: "Telegram Tool".to_string(),
+            kind: ExtensionKind::WasmTool,
+            description: "Direct MTProto integration".to_string(),
+            keywords: vec!["telegram".into(), "mtproto".into()],
+            source: ExtensionSource::WasmDownload {
+                wasm_url: "https://example.com/telegram_mtproto.wasm".to_string(),
+                capabilities_url: None,
+            },
+            fallback_source: None,
+            auth_hint: AuthHint::CapabilitiesAuth,
+            version: None,
+            hidden: true,
+        };
+        let manager = make_test_manager_with_catalog(
+            None,
+            dir.path().join("tools"),
+            dir.path().join("channels"),
+            None,
+            vec![telegram, mtproto],
+        );
+
+        let listed = manager.list(None, true, "test").await.expect("list");
+        let entries: Vec<(&str, bool)> = listed
+            .iter()
+            .map(|e| (e.name.as_str(), e.installed))
+            .collect();
+        let names: Vec<&str> = entries.iter().map(|(name, _)| *name).collect();
+        assert!(
+            names.contains(&"telegram"),
+            "canonical telegram channel must still surface: {entries:?}"
+        );
+        assert!(
+            !names.contains(&"telegram_mtproto"),
+            "hidden registry entry must be filtered out of include_available list: {entries:?}"
+        );
+        // Confirm the only telegram entry that surfaces is uninstalled —
+        // i.e. it came from the registry append path that the hidden filter
+        // governs, not from a real install discovered on disk.
+        let telegram_entry = entries
+            .iter()
+            .find(|(name, _)| *name == "telegram")
+            .expect("telegram entry");
+        assert!(
+            !telegram_entry.1,
+            "test fixture: telegram must be uninstalled"
         );
     }
 
@@ -9761,6 +9846,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::CapabilitiesAuth,
             version: None,
+            hidden: false,
         };
 
         let manager = make_test_manager_with_catalog(
@@ -9844,6 +9930,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::CapabilitiesAuth,
             version: None,
+            hidden: false,
         };
 
         let manager = make_test_manager_with_catalog(

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -84,6 +84,12 @@ pub struct RegistryEntry {
     /// Extension version (semver), if known.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// When true, this entry is omitted from default-discovery surfaces
+    /// (agent prompt's `Activatable Integrations`, settings catalog). It is
+    /// still installable by explicit name. See `ExtensionManifest::hidden`
+    /// for the motivation (issue #3533).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub hidden: bool,
 }
 
 /// Where the extension binary or server lives.
@@ -1029,6 +1035,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::Dcr,
             version: None,
+            hidden: false,
         };
         let sr = SearchResult {
             entry,
@@ -1059,6 +1066,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::None,
             version: None,
+            hidden: false,
         };
         let sr = SearchResult {
             entry,

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -50,7 +50,11 @@ impl ExtensionRegistry {
     /// Search the registry by query string. Returns results sorted by relevance.
     ///
     /// Splits the query into lowercase tokens and scores each entry by matches
-    /// in name, keywords, and description.
+    /// in name, keywords, and description. Entries marked `hidden: true`
+    /// (e.g. `telegram_mtproto` alongside the canonical `telegram` channel)
+    /// are omitted from search results so the agent doesn't enumerate them
+    /// as competing options. They remain installable by explicit name via
+    /// `tool_install` (`get`/`get_with_kind` do not filter).
     pub async fn search(&self, query: &str) -> Vec<SearchResult> {
         let tokens: Vec<String> = query
             .to_lowercase()
@@ -63,6 +67,7 @@ impl ExtensionRegistry {
             return self
                 .entries
                 .iter()
+                .filter(|e| !e.hidden)
                 .map(|e| SearchResult {
                     entry: e.clone(),
                     source: ResultSource::Registry,
@@ -75,6 +80,9 @@ impl ExtensionRegistry {
 
         // Score built-in entries
         for entry in &self.entries {
+            if entry.hidden {
+                continue;
+            }
             let score = score_entry(entry, &tokens);
             if score > 0 {
                 scored.push((
@@ -91,6 +99,9 @@ impl ExtensionRegistry {
         // Score cached discoveries
         let cache = self.discovery_cache.read().await;
         for entry in cache.iter() {
+            if entry.hidden {
+                continue;
+            }
             let score = score_entry(entry, &tokens);
             if score > 0 {
                 scored.push((
@@ -415,6 +426,37 @@ mod tests {
         // Linear should be near the top since it has both keywords
         let linear_pos = results.iter().position(|r| r.entry.name == "linear");
         assert!(linear_pos.is_some(), "Linear should appear in results");
+    }
+
+    /// Hidden registry entries (e.g. `telegram_mtproto`) must not surface
+    /// through `search()` — otherwise the agent re-introduces the "two
+    /// Telegram options" outcome that #3533 fixes for `list()`. Hidden
+    /// entries remain installable by exact name (via `get`/`get_with_kind`).
+    #[tokio::test]
+    async fn test_search_skips_hidden_entries() {
+        let registry = registry_with_catalog();
+
+        let results = registry.search("telegram").await;
+        assert!(
+            results.iter().all(|r| r.entry.name != "telegram_mtproto"),
+            "telegram_mtproto is hidden and must not surface in search; got: {:?}",
+            results.iter().map(|r| &r.entry.name).collect::<Vec<_>>()
+        );
+
+        let empty_results = registry.search("").await;
+        assert!(
+            empty_results
+                .iter()
+                .all(|r| r.entry.name != "telegram_mtproto"),
+            "empty-query search must also exclude hidden entries"
+        );
+
+        // Hidden entries remain installable by exact name.
+        let exact = registry.get("telegram_mtproto").await;
+        assert!(
+            exact.is_some(),
+            "hidden entries must still be retrievable by exact name"
+        );
     }
 
     #[tokio::test]

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -270,6 +270,7 @@ pub fn builtin_entries_with_relay(relay_url: Option<String>) -> Vec<RegistryEntr
             fallback_source: None,
             auth_hint: AuthHint::ChannelRelayOAuth,
             version: None,
+            hidden: false,
         });
     }
 
@@ -295,6 +296,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::Dcr,
             version: None,
+            hidden: false,
         };
 
         let score = score_entry(&entry, &["notion".to_string()]);
@@ -319,6 +321,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::Dcr,
             version: None,
+            hidden: false,
         };
 
         let score = score_entry(&entry, &["calendar".to_string()]);
@@ -343,6 +346,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::Dcr,
             version: None,
+            hidden: false,
         };
 
         let score = score_entry(&entry, &["wiki".to_string()]);
@@ -367,6 +371,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::Dcr,
             version: None,
+            hidden: false,
         };
 
         let score = score_entry(&entry, &["xyzfoobar".to_string()]);
@@ -456,6 +461,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::Dcr,
             version: None,
+            hidden: false,
         };
 
         registry.cache_discovered(vec![discovered]).await;
@@ -483,6 +489,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::None,
             version: None,
+            hidden: false,
         };
 
         registry.cache_discovered(vec![entry.clone()]).await;
@@ -509,6 +516,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::CapabilitiesAuth,
                 version: None,
+                hidden: false,
             },
             // Two entries with same name but different kinds should coexist
             RegistryEntry {
@@ -523,6 +531,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::Dcr,
                 version: None,
+                hidden: false,
             },
             RegistryEntry {
                 name: "dual-ext".to_string(),
@@ -538,6 +547,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::CapabilitiesAuth,
                 version: None,
+                hidden: false,
             },
         ];
 
@@ -576,6 +586,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::Dcr,
                 version: None,
+                hidden: false,
             },
             RegistryEntry {
                 name: "test-ext".to_string(),
@@ -589,6 +600,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::Dcr,
                 version: None,
+                hidden: false,
             },
         ];
 
@@ -618,6 +630,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::CapabilitiesAuth,
                 version: None,
+                hidden: false,
             },
             RegistryEntry {
                 name: "telegram".to_string(),
@@ -633,6 +646,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::CapabilitiesAuth,
                 version: None,
+                hidden: false,
             },
         ];
 
@@ -696,6 +710,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::None,
             version: None,
+            hidden: false,
         };
         let channel_entry = RegistryEntry {
             name: "cached-ext".to_string(),
@@ -711,6 +726,7 @@ mod tests {
             fallback_source: None,
             auth_hint: AuthHint::None,
             version: None,
+            hidden: false,
         };
 
         registry
@@ -755,6 +771,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::CapabilitiesAuth,
                 version: None,
+                hidden: false,
             },
             RegistryEntry {
                 name: "telegram".to_string(),
@@ -770,6 +787,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::CapabilitiesAuth,
                 version: None,
+                hidden: false,
             },
         ];
 
@@ -819,6 +837,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::None,
                 version: None,
+                hidden: false,
             },
             RegistryEntry {
                 name: "myext".to_string(),
@@ -834,6 +853,7 @@ mod tests {
                 fallback_source: None,
                 auth_hint: AuthHint::None,
                 version: None,
+                hidden: false,
             },
         ];
 

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -843,6 +843,7 @@ mod tests {
             tags: Vec::new(),
             url: None,
             auth: None,
+            hidden: false,
         }
     }
 

--- a/src/registry/manifest.rs
+++ b/src/registry/manifest.rs
@@ -54,6 +54,16 @@ pub struct ExtensionManifest {
     /// Only present for `McpServer` manifests.
     #[serde(default)]
     pub auth: Option<String>,
+
+    /// When true, this entry is omitted from the default "available but not
+    /// installed" surfaces (the agent's `Activatable Integrations` prompt
+    /// section and the settings catalog). It remains buildable and
+    /// installable by explicit name. Used for alternate/legacy variants of
+    /// a canonical integration (e.g. `telegram_mtproto` vs the canonical
+    /// `telegram` channel) so the agent doesn't enumerate them as options.
+    /// Issue #3533.
+    #[serde(default)]
+    pub hidden: bool,
 }
 
 /// Extension kind as declared in manifests.
@@ -217,6 +227,7 @@ impl ExtensionManifest {
             fallback_source: None,
             auth_hint,
             version: self.version.clone(),
+            hidden: self.hidden,
         })
     }
 
@@ -285,6 +296,7 @@ impl ExtensionManifest {
             fallback_source,
             auth_hint,
             version: self.version.clone(),
+            hidden: self.hidden,
         }
     }
 }
@@ -325,9 +337,41 @@ mod tests {
         assert_eq!(manifest.kind, ManifestKind::Tool);
         assert_eq!(manifest.version.as_deref(), Some("0.1.0"));
         assert!(manifest.tags.contains(&"default".to_string()));
+        // Default: not hidden.
+        assert!(!manifest.hidden);
 
         let entry = manifest.to_registry_entry().unwrap();
         assert_eq!(entry.kind, ExtensionKind::WasmTool);
+        assert!(!entry.hidden);
+    }
+
+    /// Issue #3533 regression: a manifest can declare itself hidden, in which
+    /// case the `RegistryEntry` it produces carries that flag forward to
+    /// `ExtensionManager::list`.
+    #[test]
+    fn test_parse_hidden_manifest_propagates_to_registry_entry() {
+        let json = r#"{
+            "name": "telegram_mtproto",
+            "display_name": "Telegram Tool",
+            "kind": "tool",
+            "version": "0.2.1",
+            "hidden": true,
+            "description": "Direct MTProto integration (alternate)",
+            "source": {
+                "dir": "tools-src/telegram",
+                "capabilities": "telegram-tool.capabilities.json",
+                "crate_name": "telegram-tool"
+            }
+        }"#;
+
+        let manifest: ExtensionManifest = serde_json::from_str(json).expect("parse manifest");
+        assert!(manifest.hidden);
+
+        let entry = manifest.to_registry_entry().expect("entry");
+        assert!(
+            entry.hidden,
+            "hidden flag must propagate from manifest to registry entry"
+        );
     }
 
     #[test]

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -1243,10 +1243,12 @@ def match_tool_call(messages: list[dict], has_tools: bool) -> list[dict] | None:
     #
     # Turn 1: user says "check gmail unread" → match_tool_call below dispatches
     #         a direct `gmail` call. Engine rejects with either "Extension not
-    #         installed:" (pre-#3533, latent path with bridge-side auto-install
-    #         implemented) or "is not callable in this execution context"
-    #         (post-#3533, engine-side preflight rejection, tool_install
-    #         re-enabled on the agent surface).
+    #         installed:" (pre-#3533 wording, from the bridge-side
+    #         not-installed reject — the chat-driven install path was wired up
+    #         here in mock_llm but non-functional because `tool_install` was
+    #         hidden from the agent surface) or "is not callable in this
+    #         execution context" (post-#3533, engine-side preflight rejection,
+    #         tool_install restored on the agent surface).
     # Turn 2: this branch fires — call `tool_install("gmail")`.
     # Turn 3: install succeeded → call `gmail` again, this time the engine's
     #         auth preflight raises an Authentication gate.

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -1239,18 +1239,55 @@ def match_tool_call(messages: list[dict], has_tools: bool) -> list[dict] | None:
         return None
     lower = content.lower()
     recent_tool_results = _find_tool_results(messages)
-    if (
-        ("check gmail unread" in lower or "gmail unread" in lower)
-        and any(
-            tr["name"] == "gmail"
-            and "Extension not installed:" in tr["content"]
+    # #3533: gmail-install-then-retry sequence.
+    #
+    # Turn 1: user says "check gmail unread" → match_tool_call below dispatches
+    #         a direct `gmail` call. Engine rejects with either "Extension not
+    #         installed:" (pre-#3533, latent path with bridge-side auto-install
+    #         implemented) or "is not callable in this execution context"
+    #         (post-#3533, engine-side preflight rejection, tool_install
+    #         re-enabled on the agent surface).
+    # Turn 2: this branch fires — call `tool_install("gmail")`.
+    # Turn 3: install succeeded → call `gmail` again, this time the engine's
+    #         auth preflight raises an Authentication gate.
+    # Turn 4 (after OAuth completes): mock LLM falls through to the
+    #         tool-result-summary path returning the "Quarterly update" text.
+    if "check gmail unread" in lower or "gmail unread" in lower:
+        gmail_error = next(
+            (
+                tr
+                for tr in recent_tool_results
+                if tr["name"] == "gmail"
+                and (
+                    "Extension not installed:" in tr["content"]
+                    or "is not callable in this execution context" in tr["content"]
+                )
+            ),
+            None,
+        )
+        install_done = any(
+            tr["name"] == "tool_install"
+            and "error" not in tr["content"].lower()
             for tr in recent_tool_results
         )
-    ):
-        return [{
-            "tool_name": "tool_install",
-            "arguments": {"name": "gmail"},
-        }]
+        if gmail_error and not install_done:
+            return [{
+                "tool_name": "tool_install",
+                "arguments": {"name": "gmail"},
+            }]
+        if install_done and not any(
+            tr["name"] == "gmail" and "is not callable" not in tr["content"]
+            and "Extension not installed" not in tr["content"]
+            for tr in recent_tool_results
+        ):
+            # Retry gmail after install — the engine's auth preflight will
+            # raise an Authentication gate, which surfaces the auth card.
+            # After OAuth completes, this re-fires and reaches the actual
+            # gmail tool with the correct `list_messages` action.
+            return [{
+                "tool_name": "gmail",
+                "arguments": {"action": "list_messages"},
+            }]
     if _conversation_has_active_skill(messages, "pikastream-video-meeting"):
         bundle_path = _active_skill_bundle_path(messages, "pikastream-video-meeting")
         if (
@@ -1840,6 +1877,17 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
             return await _dispatch_special_response(request, cid, stream, special)
 
     tool_results = _find_tool_results(messages)
+    # #3533: when a multi-step recovery is in progress (e.g. gmail not
+    # installed → `tool_install` → retry gmail), the next move is another
+    # tool call, not a text summary of the failure. Let `match_tool_call`
+    # take precedence over the tool-result-summary fallback whenever it
+    # has a follow-up call to emit.
+    if tool_results:
+        followup = match_tool_call(messages, has_tools)
+        if followup:
+            if not stream:
+                return _tool_call_response(cid, followup)
+            return await _stream_tool_call(request, cid, followup)
     if (
         not tool_results
         and _conversation_uses_codeact(messages)

--- a/tests/e2e/scenarios/test_v2_auth_oauth_matrix.py
+++ b/tests/e2e/scenarios/test_v2_auth_oauth_matrix.py
@@ -303,6 +303,31 @@ async def _pin_mock_llm_settings(base_url: str, mock_llm_server: str) -> None:
             )
 
 
+async def _set_tool_permission(
+    base_url: str, tool_name: str, state: str
+) -> None:
+    """Override a tool's permission state via the settings API.
+
+    The seeder writes the seeded default (AskEachTime for `tool_install`) to
+    DB at startup, which the auto-approve check in `effect_adapter` treats
+    as a user-explicit override and refuses to bypass even with
+    `AGENT_AUTO_APPROVE_TOOLS=true`. Test fixtures that need a tool to
+    auto-approve must explicitly set its permission to `always_allow`.
+    """
+    headers = {"Authorization": f"Bearer {AUTH_TOKEN}"}
+    async with httpx.AsyncClient() as client:
+        response = await client.put(
+            f"{base_url}/api/settings/tool_permissions.{tool_name}",
+            headers=headers,
+            json={"value": state},
+            timeout=15,
+        )
+        assert response.status_code in (200, 201, 204), (
+            f"failed to set tool_permissions.{tool_name}={state}: "
+            f"{response.status_code} {response.text[:300]}"
+        )
+
+
 async def _start_auth_matrix_server(
     ironclaw_binary: str,
     mock_llm_server: str,
@@ -310,6 +335,7 @@ async def _start_auth_matrix_server(
     *,
     exchange_url: str,
     existing_paths: dict | None = None,
+    auto_approve_tools: bool = True,
 ):
     reserved = []
     for _ in range(2):
@@ -381,6 +407,12 @@ async def _start_auth_matrix_server(
             "WASM_TOOLS_DIR": tools_dir,
             "WASM_CHANNELS_DIR": channels_dir,
             "ONBOARD_COMPLETED": "true",
+            # Auto-approve administrative tools so the chat-driven install
+            # path (`tool_install` from chat in #3533) runs without a human
+            # approval prompt. Authentication gates remain active. Tests
+            # that exercise the explicit approval path opt out of this via
+            # the `auto_approve_tools=False` fixture parameter.
+            "AGENT_AUTO_APPROVE_TOOLS": "true" if auto_approve_tools else "false",
             "IRONCLAW_OAUTH_CALLBACK_URL": "https://oauth.test.example/oauth/callback",
             "IRONCLAW_OAUTH_EXCHANGE_URL": exchange_url,
             # The exchange proxy runs on 127.0.0.1 in tests; the SSRF guard
@@ -655,6 +687,41 @@ async def auth_matrix_repl(ironclaw_binary, mock_llm_server):
     finally:
         await _shutdown_auth_matrix_repl(repl)
         await mock_api["runner"].cleanup()
+
+
+@pytest.fixture
+async def auth_matrix_server_no_auto_approve(ironclaw_binary, mock_llm_server):
+    """Sibling of `auth_matrix_server` that disables tool auto-approve.
+
+    Used by `test_chat_install_approval_then_auth_card` so the explicit
+    approval gate for `tool_install` actually fires through to the
+    user-facing approval card.
+    """
+    mock_api = await _start_mock_google_api()
+    server = await _start_auth_matrix_server(
+        ironclaw_binary,
+        mock_llm_server,
+        mock_api["base_url"],
+        exchange_url=mock_llm_server,
+        auto_approve_tools=False,
+    )
+    try:
+        yield server
+    finally:
+        await _shutdown_auth_matrix_server(server)
+        await mock_api["runner"].cleanup()
+
+
+@pytest.fixture
+async def auth_matrix_page_no_auto_approve(browser, auth_matrix_server_no_auto_approve):
+    context = await browser.new_context(viewport={"width": 1280, "height": 720})
+    page = await context.new_page()
+    await page.goto(f"{auth_matrix_server_no_auto_approve['base_url']}/?token={AUTH_TOKEN}")
+    await page.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    try:
+        yield page
+    finally:
+        await context.close()
 
 
 @pytest.fixture
@@ -1620,25 +1687,19 @@ async def test_mcp_same_server_multi_user_via_browser(browser, auth_matrix_serve
         await member_context.close()
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Engine does not yet auto-install registry extensions on LLM latent "
-        "action invocation. ensure_extension_ready(UseCapability) surfaces "
-        "NotInstalled intentionally (see src/extensions/manager.rs ~L1680 "
-        "comment: 'path must surface as NotInstalled so the bridge can route "
-        "it through the approval/install gate'), but the bridge-side install/"
-        "approval gate that would turn that into an auth card is not "
-        "implemented in src/bridge/effect_adapter.rs. The chat simply fails "
-        "with 'Extension not installed'. Tracked as a follow-up."
-    ),
-)
 async def test_chat_first_gmail_installs_prompts_and_retries(
     auth_matrix_server, auth_matrix_page
 ):
     server = auth_matrix_server
     page = auth_matrix_page
     await _remove_extension_if_present(server["base_url"], "gmail")
+    # The fixture sets `AGENT_AUTO_APPROVE_TOOLS=true`. Before the
+    # tool-permissions seeded-vs-explicit fix, the seeder's boot-time
+    # write of `tool_install = AskEachTime` was treated as a user-explicit
+    # override that neutered the env knob — this test had to call
+    # `_set_tool_permission(... "always_allow")` to drive the chat-first
+    # install path. Post-fix, a DB value that matches the seeded default
+    # is treated as implicit and `auto_approve_tools` properly bypasses it.
 
     chat_input = page.locator(SEL["chat_input"])
     await chat_input.fill("check gmail unread")
@@ -1671,6 +1732,90 @@ async def test_chat_first_gmail_installs_prompts_and_retries(
     extension = await _wait_for_extension(server["base_url"], "gmail")
     assert extension["authenticated"] is True, extension
     assert extension["active"] is True, extension
+
+
+async def test_chat_install_approval_then_auth_card(
+    auth_matrix_server_no_auto_approve, auth_matrix_page_no_auto_approve
+):
+    """#3533: chat-driven `tool_install` raises an approval gate.
+
+    Sibling to `test_chat_first_gmail_installs_prompts_and_retries`. The
+    other test pre-approves `tool_install` so install completes silently
+    and only the auth card surfaces. This one keeps the seeded
+    `AskEachTime` default so the explicit approval flow is exercised:
+
+      1. User types "check gmail unread".
+      2. Mock LLM dispatches `gmail()` → engine rejects (not installed).
+      3. Mock LLM dispatches `tool_install("gmail")` → engine raises an
+         **Approval gate**, surfacing the `.approval-card`.
+      4. Test clicks the card's Approve button.
+      5. Install completes, gmail registers; the engine retries the next
+         turn with the **Authentication gate** that surfaces the
+         `.auth-card`.
+      6. Test completes OAuth via `/oauth/callback`.
+      7. Gmail tool runs against the mock Google API and the final
+         response contains the canned subject line.
+    """
+    server = auth_matrix_server_no_auto_approve
+    page = auth_matrix_page_no_auto_approve
+    await _remove_extension_if_present(server["base_url"], "gmail")
+    # Note: deliberately NOT pre-approving `tool_install` here so the
+    # approval gate fires and the approval card surfaces in the UI.
+    # The dedicated `_no_auto_approve` fixture also passes
+    # `AGENT_AUTO_APPROVE_TOOLS=false` so the env knob doesn't bypass
+    # the gate after the tool-permissions seeded-vs-explicit fix.
+    # Pre-approve `gmail` so the post-install retry doesn't *also* gate
+    # — this test isolates the explicit-approval path for `tool_install`
+    # specifically. (Gmail has no seeded permission default, so without
+    # `AGENT_AUTO_APPROVE_TOOLS=true` it would otherwise gate too.)
+    await _set_tool_permission(server["base_url"], "gmail", "always_allow")
+
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.fill("check gmail unread")
+    await chat_input.press("Enter")
+
+    approval_card = page.locator(".approval-card").first
+    await approval_card.wait_for(state="visible", timeout=20000)
+    assert await approval_card.get_attribute("data-request-id"), (
+        "expected approval gate request id on the approval card"
+    )
+    tool_name_text = await approval_card.locator(".approval-tool-name").text_content()
+    assert tool_name_text and "install" in tool_name_text.lower(), (
+        f"approval card should be for tool_install, got: {tool_name_text!r}"
+    )
+
+    # Single "Approve" click is sufficient. The stack of #3533 fixes
+    # (`resume_output` on InlineGate so inline-await doesn't re-execute
+    # `tool_install`, OAuth callback skipping `ExternalCallback` when an
+    # inline waiter is already in flight, and discarding the matching
+    # Authentication pending-gate row when the inline path delivers
+    # Approved) means no second `tool_install` dispatch fires, so a
+    # plain "Approve" suffices — no "Always" workaround needed.
+    await approval_card.locator("button.approve").click()
+    await approval_card.locator(".approval-resolved").wait_for(
+        state="visible", timeout=10000
+    )
+
+    auth_card = await _wait_for_auth_card(page)
+    assert await auth_card.get_attribute("data-extension-name") in {
+        "gmail",
+        "google_oauth_token",
+    }
+    auth_url = await _auth_oauth_url_from_card(page)
+    assert auth_url, "Expected auth card to expose an OAuth URL"
+    response = await _complete_callback(
+        server["base_url"], auth_url, code="mock_auth_code"
+    )
+    assert response.status_code == 200, response.text[:400]
+    await auth_card.wait_for(state="hidden", timeout=20000)
+
+    thread_id = await _current_thread_id(page)
+    tokens = await _wait_for_mock_google_tokens(server["mock_api_url"], timeout=60.0)
+    assert tokens, "expected Gmail to hit the mock Google API after OAuth replay"
+    history = await _wait_for_response_contains(
+        server["base_url"], thread_id, "Quarterly update", timeout=60.0
+    )
+    assert history.get("pending_gate") is None, history
 
 
 async def test_settings_first_gmail_auth_then_chat_runs(

--- a/tests/e2e/scenarios/test_v2_auth_oauth_matrix.py
+++ b/tests/e2e/scenarios/test_v2_auth_oauth_matrix.py
@@ -308,11 +308,15 @@ async def _set_tool_permission(
 ) -> None:
     """Override a tool's permission state via the settings API.
 
-    The seeder writes the seeded default (AskEachTime for `tool_install`) to
-    DB at startup, which the auto-approve check in `effect_adapter` treats
-    as a user-explicit override and refuses to bypass even with
-    `AGENT_AUTO_APPROVE_TOOLS=true`. Test fixtures that need a tool to
-    auto-approve must explicitly set its permission to `always_allow`.
+    Post-#3559 (security-review follow-up to #3533): no DB row exists
+    for tools the user hasn't explicitly customized — the seeder was
+    removed and a one-shot startup migration deletes ghost-seeded rows.
+    Any value written through this helper is therefore a true user
+    override and `AGENT_AUTO_APPROVE_TOOLS=true` will NOT bypass it.
+    Use this helper to: (a) pre-approve a tool with no seeded default
+    so a post-install retry doesn't gate, or (b) force a specific
+    permission for tests that intentionally exercise the gate path
+    (typically combined with `AGENT_AUTO_APPROVE_TOOLS=false`).
     """
     headers = {"Authorization": f"Bearer {AUTH_TOKEN}"}
     async with httpx.AsyncClient() as client:
@@ -1693,13 +1697,16 @@ async def test_chat_first_gmail_installs_prompts_and_retries(
     server = auth_matrix_server
     page = auth_matrix_page
     await _remove_extension_if_present(server["base_url"], "gmail")
-    # The fixture sets `AGENT_AUTO_APPROVE_TOOLS=true`. Before the
-    # tool-permissions seeded-vs-explicit fix, the seeder's boot-time
-    # write of `tool_install = AskEachTime` was treated as a user-explicit
-    # override that neutered the env knob — this test had to call
-    # `_set_tool_permission(... "always_allow")` to drive the chat-first
-    # install path. Post-fix, a DB value that matches the seeded default
-    # is treated as implicit and `auto_approve_tools` properly bypasses it.
+    # The fixture sets `AGENT_AUTO_APPROVE_TOOLS=true`. Post-#3559
+    # (security-review follow-up to #3533), the boot-time seeder that
+    # wrote ghost `tool_install = AskEachTime` rows has been removed
+    # and a startup migration cleans up any pre-existing ghosts. With
+    # no DB row, `effective_permission` falls back to the code-level
+    # `AskEachTime` baseline, which is implicit — so the env knob
+    # bypasses the gate without `_set_tool_permission` having to force
+    # `always_allow`. A user who deliberately picks `AskEachTime`
+    # through the settings UI WOULD have it respected (regression
+    # covered by `bridge::tool_permissions::tests`).
 
     chat_input = page.locator(SEL["chat_input"])
     await chat_input.fill("check gmail unread")
@@ -1761,9 +1768,9 @@ async def test_chat_install_approval_then_auth_card(
     await _remove_extension_if_present(server["base_url"], "gmail")
     # Note: deliberately NOT pre-approving `tool_install` here so the
     # approval gate fires and the approval card surfaces in the UI.
-    # The dedicated `_no_auto_approve` fixture also passes
+    # The dedicated `_no_auto_approve` fixture passes
     # `AGENT_AUTO_APPROVE_TOOLS=false` so the env knob doesn't bypass
-    # the gate after the tool-permissions seeded-vs-explicit fix.
+    # the code-level `AskEachTime` baseline for `tool_install`.
     # Pre-approve `gmail` so the post-install retry doesn't *also* gate
     # — this test isolates the explicit-approval path for `tool_install`
     # specifically. (Gmail has no seeded permission default, so without

--- a/tests/e2e_advanced_traces.rs
+++ b/tests/e2e_advanced_traces.rs
@@ -686,6 +686,7 @@ mod advanced {
                 fallback_source: None,
                 auth_hint: AuthHint::Dcr,
                 version: None,
+                hidden: false,
             })
             .await;
 


### PR DESCRIPTION
## Summary

Fixes issue #3533 — "connect my telegram" gave the user two options instead of installing, and even when the agent recovered to `tool_install` the tool ran twice and required pressing "Always" to clear the pending gate.

- **Restores agent-callable `tool_install`** (hidden in #2868, orphaned when its replacement `tool_activate` was removed in #3166).
- **Removes the duplicate Telegram registry entry** by adding a generic `hidden` flag on `ExtensionManifest`, marked on `telegram_mtproto`.
- **Eliminates the double `tool_install` invocation** by carrying `resume_output` through `InlineGate` so the inline-await retry short-circuits with the cached output instead of re-executing.
- **Skips the OAuth `ExternalCallback` re-entry** when the inline path already woke a parked waiter (eliminates the "thread already running" race + phantom second dispatch).
- **Discards matching Authentication rows from `pending_gates`** when the inline path delivers Approved.
- **Fixes the auto-approve footgun**: `ToolPermissionSnapshot::resolve_permission` now treats DB values matching the seeded default as implicit, so `AGENT_AUTO_APPROVE_TOOLS=true` actually bypasses seeded `AskEachTime` defaults as documented.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib` — 4980/4980 pass (host)
- [x] `cargo test -p ironclaw_engine --lib` — 525/525 pass (engine)
- [x] New unit tests:
  - `bridge::tool_permissions::tests::seeded_default_matching_db_value_is_implicit`
  - `bridge::tool_permissions::tests::user_override_diverging_from_seeded_default_stays_explicit`
  - `bridge::action_projector::tests::tool_install_is_callable_by_agent`
  - `registry::manifest::tests::test_parse_hidden_manifest_propagates_to_registry_entry`
  - `extensions::manager::tests::list_filters_hidden_registry_entries_from_available_set`
- [x] E2E:
  - `tests/e2e/scenarios/test_v2_auth_oauth_matrix.py::test_chat_first_gmail_installs_prompts_and_retries` — was `@pytest.mark.xfail`, now passes (xfail removed)
  - New `test_chat_install_approval_then_auth_card` — explicit-approval sibling, single "Approve" click, no "Always" workaround
  - `test_settings_first_gmail_auth_then_chat_runs` — still green
- [x] Both new chat-install tests wired into the `auth-full` canary lane via `scripts/live_canary/auth_registry.py`

## What's changed (high-level)

| Area | Change |
|---|---|
| `src/bridge/action_projector.rs` | Removed `hidden_from_model_callable_surface` gate; `tool_install` is callable from the agent again |
| `src/bridge/effect_adapter.rs` | `auth_gate_from_extension_result` passes the action's already-computed output as `resume_output` |
| `src/bridge/router.rs` | `resolve_inline_gates_for_credential` discards matching Authentication rows from `pending_gates` |
| `src/bridge/tool_permissions.rs` | DB values matching seeded defaults treated as implicit; new unit tests |
| `src/channels/web/features/oauth/mod.rs` | OAuth callback skips `ExternalCallback` re-entry when inline-await already woke a waiter |
| `crates/ironclaw_engine/src/executor/{scripting,structured,orchestrator}.rs` | `InlineGate` gains `resume_output`; retry returns cached output instead of re-executing |
| `crates/ironclaw_engine/src/executor/prompt.rs` | Agent told to call `tool_install(name=...)` directly for activatable integrations |
| `src/registry/manifest.rs`, `src/extensions/*` | New `hidden` flag on manifests + registry entries; filter from default-discovery |
| `registry/tools/telegram_mtproto.json` | Marked `"hidden": true` |
| `tests/e2e/scenarios/test_v2_auth_oauth_matrix.py`, `tests/e2e/mock_llm.py` | Removed xfail, added explicit-approval test, extended mock LLM gmail-install pattern |
| `scripts/live_canary/auth_registry.py` | New approval test added to `AUTH_FULL_TESTS` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)