### PR TITLE
ci: extend nightly e2e timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
     name: E2E (${{ matrix.group }})
     needs: [matrix-config, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,94 +2,88 @@
 
 ## Purpose and Precedence
 
-- `AGENTS.md` is the quick-start contract for coding agents. It is not the full architecture spec.
-- Read the relevant subsystem spec before changing a complex area. When a repo spec exists, treat it as authoritative.
-Start with these deeper docs as needed:
-- `CLAUDE.md`
-- `src/agent/CLAUDE.md`
-- `src/channels/web/CLAUDE.md`
-- `src/db/CLAUDE.md`
-- `src/llm/CLAUDE.md`
-- `src/setup/README.md`
-- `src/tools/README.md`
-- `src/workspace/README.md`
-- `src/NETWORK_SECURITY.md`
-- `tests/e2e/CLAUDE.md`
+- `AGENTS.md` is the quick-start map for coding agents. It is not the full architecture spec.
+- Treat deeper subsystem docs as authoritative before changing complex areas:
+  - Root guide: `CLAUDE.md`
+  - Agent/runtime: `src/agent/CLAUDE.md`
+  - Web gateway/API/SSE/WebSocket: `src/channels/web/CLAUDE.md`
+  - Database backends: `src/db/CLAUDE.md`
+  - LLM providers/routing: `src/llm/CLAUDE.md`
+  - Setup/onboarding: `src/setup/README.md`
+  - Tools/extensions: `src/tools/README.md`
+  - Workspace/memory: `src/workspace/README.md`
+  - Network/security: `src/NETWORK_SECURITY.md`
+  - Browser E2E: `tests/e2e/CLAUDE.md`
+  - Internal crates: `crates/*/CLAUDE.md` when present
+- Prefer tracked files (`git ls-files`, `find`, `grep`) over local scratch dirs; ignore generated or operator-local output such as `target/`, `artifacts/`, `live-canary-*`, `worktrees/`, and `.kb/worktrees/`.
 
-## Architecture Mental Model
+## Repository Map
 
-- Channels normalize external input into `IncomingMessage`; `ChannelManager` merges all active channel streams.
-- `Agent` owns session/thread/turn handling, submission parsing, the LLM/tool loop, approvals, routines, and background runtime behavior.
-- `AppBuilder` is the composition root that wires database, secrets, LLMs, tools, workspace, extensions, skills, hooks, and cost controls before the agent starts.
-- The web gateway is a browser-facing API/UI layered on top of the same agent/session/tool systems, not a separate product path.
+- `src/` — root application, CLI, composition, agent loop, channels, DB, LLM, setup, tools, workspace, worker runtime.
+- `crates/` — internal Cargo workspace crates (`ironclaw_engine`, `ironclaw_gateway`, `ironclaw_tui`, host/runtime/capability/resource crates).
+- `channels-src/` — WASM channel extension crates (`discord`, `slack`, `telegram`, etc.), excluded from root workspace.
+- `tools-src/` — WASM tool extension crates plus `tools-src/TOOLS.md`, excluded from root workspace.
+- `tests/` — Rust integration tests, fixtures, snapshots, and Python/Playwright E2E in `tests/e2e/`.
+- `migrations/` and `src/db/` — PostgreSQL migrations plus libSQL schema/migration code.
+- `registry/`, `skills/`, `wit/` — bundled extension registries, skill definitions, and WIT interfaces.
+- `docs/`, `CONTRIBUTING.md`, `FEATURE_PARITY.md` — user/operator docs, contribution rules, and tracked feature status.
+- `scripts/`, `.github/workflows/`, `.config/nextest.toml` — local/CI validation, canaries, nextest timeout policy.
+- `profiles/`, `deploy/`, `docker/`, `infra/runner/` — runtime profiles, deployment, containers, and runner images.
 
-## Where to Work
+## Build, Test, and Run
 
-- Agent/runtime behavior: `src/agent/`
-- Web gateway/API/SSE/WebSocket: `src/channels/web/`
-- Persistence and DB abstractions: `src/db/`
-- Setup/onboarding/configuration flow: `src/setup/`
-- LLM providers and routing: `src/llm/`
-- Workspace, memory, embeddings, search: `src/workspace/`
-- Extensions, tools, channels, MCP, WASM: `src/extensions/`, `src/tools/`, `src/channels/`
+- Setup: `./scripts/dev-setup.sh`
+- Format: `cargo fmt`
+- Lint: `cargo clippy --all --benches --tests --examples --all-features`
+- Unit tests: `cargo test`
+- PostgreSQL/integration tests: `cargo test --features integration`
+- Run locally: `RUST_LOG=ironclaw=debug cargo run`
+- Pre-review gate from `CONTRIBUTING.md`:
+  - `cargo fmt --all -- --check`
+  - `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
+  - `cargo build`
+  - `cargo test`
+- Dependency changes: run `cargo deny check`.
+- libSQL checks: `cargo check --no-default-features --features libsql`; both DBs: `cargo check --all-features`.
+- Browser E2E: `cd tests/e2e && pip install -e . && playwright install chromium && pytest scenarios/ -v --timeout=120`.
+- WASM extension build shape: `cargo build --manifest-path tools-src/<name>/Cargo.toml --target wasm32-wasip2 --release` or same under `channels-src/<name>/`.
 
-## Ownership and Composition Rules
+## CI and Validation Signals
 
-- Keep `src/main.rs` and `src/app.rs` orchestration-focused. Do not move module-owned logic into entrypoints.
-- Module-specific initialization should live in the owning module behind a public factory/helper, not be reimplemented ad hoc.
-- Keep feature-flag branching inside the module that owns the abstraction whenever possible.
-- Prefer extending existing traits and registries over hardcoding one-off integration paths.
+- `.github/workflows/code_style.yml` runs formatting, `cargo deny`, clippy matrices, gateway JS syntax, and boundary checks.
+- `.github/workflows/test.yml` is the reusable core test workflow for PRs, merge queue, main, and nightly callers.
+- `.github/workflows/e2e.yml` builds `--no-default-features --features libsql` and runs Playwright groups with `timeout-minutes: 90`.
+- `.github/workflows/nightly-deep-ci.yml` reuses `test.yml` for deterministic deep checks and excludes Docker.
+- `.config/nextest.toml` owns cargo-nextest slow-timeout overrides; update it when a test legitimately needs more time.
 
-## Repo-Wide Coding Rules
+## Architecture Rules
 
-- Avoid `.unwrap()` and `.expect()` in production; prefer proper error handling. They are fine in tests, and in production only for truly infallible invariants (e.g., literals/regexes) with a safety comment.
-- Keep clippy clean with zero warnings.
-- Prefer `crate::` imports for cross-module references.
-- Use strong types and enums over stringly-typed control flow when the shape is known.
+- Keep `src/main.rs` and `src/app.rs` orchestration-focused. Put module-owned initialization behind public factories/helpers in the owning module.
+- Channels normalize external input into `IncomingMessage`; `ChannelManager` merges active streams.
+- `Agent` owns sessions, threads, turns, submission parsing, LLM/tool loop, approvals, routines, and background runtime behavior.
+- `AppBuilder` wires DB, secrets, LLMs, tools, workspace, extensions, skills, hooks, and cost controls before the agent starts.
+- The web gateway is a browser-facing layer over the same agent/session/tool systems, not a separate product path.
+- Prefer extending traits/registries over hardcoding one-off integration paths.
+- Use built-in Rust tools for core runtime capabilities, WASM tools/channels for sandboxed extensions, and MCP for external server integrations.
 
-## Database, Setup, and Config Rules
+## High-Risk Areas and Invariants
 
-- New persistence behavior must support both PostgreSQL and libSQL.
-- Add new DB operations to the shared DB trait first, then implement both backends.
-- Treat bootstrap config, DB-backed settings, and encrypted secrets as distinct layers; do not collapse them casually.
-- If onboarding or setup behavior changes, update `src/setup/README.md` in the same branch.
-- Do not break config precedence, bootstrap env loading, DB-backed config reload, or post-secrets LLM re-resolution.
-
-## Security and Runtime Invariants
-
-- Review any change touching listeners, routes, auth, secrets, sandboxing, approvals, or outbound HTTP with a security mindset.
-- Do not weaken bearer-token auth, webhook auth, CORS/origin checks, body limits, rate limits, allowlists, or secret-handling guarantees.
-- Treat Docker containers and external services as untrusted.
-- Session/thread/turn state matters. Submission parsing happens before normal chat handling.
-- Skills are selected deterministically. Tool approval and auth flows are special paths and must not be mixed into normal chat history carelessly.
-- Persistent memory is the workspace system, not just transcript storage; preserve file-like semantics, chunking/search behavior, and identity/system-prompt loading.
-
-## Tools, Channels, and Extensions
-
-- Use a built-in Rust tool for core internal capabilities tightly coupled to the runtime.
-- Use WASM tools or WASM channels for sandboxed extensions and plugin-style integrations.
-- Use MCP for external server integrations when the capability belongs outside the main binary.
-- Preserve extension lifecycle expectations: install, authenticate/configure, activate, remove.
+- Production code: avoid `.unwrap()`/`.expect()`; use typed errors (`thiserror`) and contextual `map_err`.
+- Prefer `crate::` imports for cross-module references; use strong types/enums over stringly control flow.
+- Persistence: add DB operations to the shared DB trait first, then implement PostgreSQL and libSQL. New persistence behavior must support both backends.
+- Migrations: base new versions on `origin/staging`/main state; do not reuse deployed migration numbers.
+- Setup/config: preserve bootstrap config, DB-backed settings, encrypted secrets, config precedence, env loading, and post-secrets LLM re-resolution.
+- Security-sensitive changes (listeners, routes, auth, secrets, sandboxing, approvals, outbound HTTP) must preserve bearer auth, webhook auth, CORS/origin checks, body limits, rate limits, allowlists, and secret-handling guarantees.
+- Web gateway: route composition lives in `src/channels/web/platform/router.rs`; other `platform/*` modules must stay handler-agnostic per `scripts/check_gateway_boundaries.py`.
+- Web identity: extension/setup routes use `ExtensionName`; do not expose `CredentialName` in web DTOs/handlers.
+- Session/thread/turn state is critical. Submission parsing happens before normal chat handling; auth and approval flows are special paths.
+- Workspace memory is file-like persistent storage with chunking/search semantics; do not treat it as transcript-only storage.
 
 ## Docs, Parity, and Testing
 
-- If behavior changes, update the relevant docs/specs in the same branch.
-- If you change implementation status for any feature tracked in `FEATURE_PARITY.md`, update that file in the same branch.
-- Do not open a PR that changes feature behavior without checking `FEATURE_PARITY.md` for needed status updates (`❌`, `🚧`, `✅`, notes, and priorities).
-- Add the narrowest tests that validate the change: unit tests for local logic, integration tests for runtime/DB/routing behavior, and E2E or trace coverage for gateway, approvals, extensions, or other user-visible flows.
-- **Test through the caller, not just the helper.** When a predicate/classifier/transform helper gates a side effect (HTTP, DB write, OAuth flow, UI mutation, tool execution) and has any wrapper or computed input between it and that side effect, a unit test on the helper alone is not sufficient regression coverage. Add a test that drives the actual call site (`*_handler`, `factory::create_*`, `manager::*`) at the integration tier or higher. Mocks of multi-arg runtime APIs must capture every argument the production caller passes. See `.claude/rules/testing.md` for the full rule and bug examples.
-
-## Risk and Change Discipline
-
-- Keep changes scoped; avoid broad refactors unless the task truly requires them.
-- Security, database schema, runtime, worker, CI, and secrets changes are high-risk. Call out rollback risks, compatibility concerns, and hidden side effects.
-- Preserve existing defaults unless the task explicitly changes them.
-- Avoid unrelated file churn and generated-file edits unless required.
-- Respect a dirty worktree and never revert user changes you did not make.
-
-## Before Finishing
-
-- Confirm whether behavior changes require updates to `FEATURE_PARITY.md`, specs, API docs, or `CHANGELOG.md`.
-- Run the most targeted tests/checks that cover the change.
-- Re-check security-sensitive paths when touching auth, secrets, network listeners, sandboxing, or approvals.
-- Keep the final diff scoped to the task.
+- If behavior changes, update relevant docs/specs and check `FEATURE_PARITY.md` in the same branch.
+- If onboarding/setup changes, update `src/setup/README.md`.
+- If channels, tools, or user-facing capabilities change, update matching docs under `docs/` and/or `tools-src/`/`channels-src/` READMEs.
+- Add the narrowest meaningful tests, but test through the caller when a helper gates side effects (HTTP, DB writes, OAuth, UI mutation, tool execution).
+- For E2E tests, use `tests/e2e/helpers.py` selectors/constants; raw SSE assertions belong in `aiohttp`, not Playwright.
+- Keep changes scoped; avoid unrelated churn and generated-file edits. Respect dirty worktrees and never revert user changes you did not make.


### PR DESCRIPTION
## Summary
- Extend the E2E workflow job timeout to 90 minutes.
- Refresh `AGENTS.md` with a compact, evidence-grounded repository map and validation guidance.
- Keep deeper subsystem details delegated to existing `CLAUDE.md`/README sources of truth.

## Test Plan
- `python3` path/line validation for `AGENTS.md` (89 lines; referenced paths exist)
- Code review agent: no findings on `AGENTS.md` diff
- Not run: full cargo/E2E suite (docs + CI timeout config change only)
