### PR TITLE
fix(reborn): close architecture integrity gaps

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::PathBuf, process::Command};
+use std::{
+    collections::{BTreeSet, HashMap},
+    path::PathBuf,
+    process::Command,
+};
 
 use serde_json::Value;
 
@@ -35,6 +39,32 @@ fn reborn_boundary_rules_active_crates_are_workspace_members() {
             manifest.display()
         );
     }
+}
+
+#[test]
+fn reborn_virtual_roots_match_storage_placement_contract() {
+    let root = workspace_root();
+    let path_source = std::fs::read_to_string(root.join("crates/ironclaw_host_api/src/path.rs"))
+        .expect("host API path source must be readable");
+    let storage_contract =
+        std::fs::read_to_string(root.join("docs/reborn/contracts/storage-placement.md"))
+            .expect("storage placement contract must be readable");
+    let filesystem_contract =
+        std::fs::read_to_string(root.join("docs/reborn/contracts/filesystem.md"))
+            .expect("filesystem contract must be readable");
+
+    let implemented = extract_virtual_roots_const(&path_source);
+    let storage = extract_storage_placement_roots(&storage_contract);
+    let filesystem = extract_filesystem_namespace_roots(&filesystem_contract);
+
+    assert_eq!(
+        implemented, storage,
+        "ironclaw_host_api VIRTUAL_ROOTS must match storage-placement.md canonical roots"
+    );
+    assert_eq!(
+        filesystem, storage,
+        "filesystem.md namespace roots must match storage-placement.md canonical roots"
+    );
 }
 
 #[test]
@@ -1106,6 +1136,76 @@ fn workspace_root() -> PathBuf {
         .and_then(|path| path.parent())
         .expect("architecture crate must live under crates/ironclaw_architecture")
         .to_path_buf()
+}
+
+fn extract_virtual_roots_const(source: &str) -> BTreeSet<String> {
+    let const_body = source
+        .split("const VIRTUAL_ROOTS: &[&str] = &[")
+        .nth(1)
+        .and_then(|tail| tail.split("];").next())
+        .expect("VIRTUAL_ROOTS const array must be present");
+    extract_quoted_absolute_paths(const_body)
+}
+
+fn extract_storage_placement_roots(contract: &str) -> BTreeSet<String> {
+    contract
+        .lines()
+        .filter_map(|line| {
+            let root = line
+                .strip_prefix("| `")?
+                .split('`')
+                .next()
+                .expect("table cell must close code span");
+            let root = if root.starts_with("/engine/") {
+                "/engine"
+            } else {
+                root
+            };
+            Some(root.to_string())
+        })
+        .filter(|root| is_canonical_virtual_root(root))
+        .collect()
+}
+
+fn extract_filesystem_namespace_roots(contract: &str) -> BTreeSet<String> {
+    let roots_block = contract
+        .split("Frozen V1 canonical virtual roots")
+        .nth(1)
+        .and_then(|tail| tail.split("Recommended meaning:").next())
+        .expect("filesystem.md must list frozen V1 canonical virtual roots");
+    roots_block
+        .lines()
+        .map(str::trim)
+        .filter(|line| is_canonical_virtual_root(line))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn extract_quoted_absolute_paths(source: &str) -> BTreeSet<String> {
+    source
+        .lines()
+        .map(str::trim)
+        .filter_map(|line| line.strip_prefix('"')?.split('"').next())
+        .filter(|root| is_canonical_virtual_root(root))
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn is_canonical_virtual_root(value: &str) -> bool {
+    matches!(
+        value,
+        "/engine"
+            | "/system/settings"
+            | "/system/extensions"
+            | "/system/skills"
+            | "/users"
+            | "/projects"
+            | "/memory"
+            | "/artifacts"
+            | "/tmp"
+            | "/secrets"
+            | "/events"
+    )
 }
 
 fn package_dependencies(package: &Value) -> Option<(String, Vec<String>)> {

--- a/crates/ironclaw_host_api/src/path.rs
+++ b/crates/ironclaw_host_api/src/path.rs
@@ -63,10 +63,16 @@ impl fmt::Display for MountAlias {
 
 const VIRTUAL_ROOTS: &[&str] = &[
     "/engine",
+    "/system/settings",
     "/system/extensions",
+    "/system/skills",
     "/users",
     "/projects",
     "/memory",
+    "/artifacts",
+    "/tmp",
+    "/secrets",
+    "/events",
 ];
 
 /// Common raw host-path prefixes rejected before scoped-path normalization.
@@ -90,6 +96,8 @@ const RAW_HOST_PREFIXES: &[&str] = &[
     "/proc/",
     "/sys/",
 ];
+
+const REDACTED_PATH_VALUE: &str = "<redacted path>";
 
 impl Serialize for VirtualPath {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -179,11 +187,14 @@ impl ScopedPath {
     pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
         let raw = value.into();
         if looks_like_url(&raw) {
-            return Err(HostApiError::invalid_path(raw, "URLs are not scoped paths"));
+            return Err(HostApiError::invalid_path(
+                REDACTED_PATH_VALUE,
+                "URLs are not scoped paths",
+            ));
         }
         if looks_like_windows_path(&raw) {
             return Err(HostApiError::invalid_path(
-                raw,
+                REDACTED_PATH_VALUE,
                 "Windows host paths are not scoped paths",
             ));
         }
@@ -192,7 +203,7 @@ impl ScopedPath {
             .any(|prefix| raw.starts_with(prefix))
         {
             return Err(HostApiError::invalid_path(
-                raw,
+                REDACTED_PATH_VALUE,
                 "raw host paths are not scoped paths",
             ));
         }

--- a/crates/ironclaw_host_api/src/path.rs
+++ b/crates/ironclaw_host_api/src/path.rs
@@ -235,23 +235,30 @@ enum PathKind {
 }
 
 fn normalize_absolute_path(raw: String, kind: PathKind) -> Result<String, HostApiError> {
+    let invalid_value = invalid_path_error_value(&raw, kind);
     if raw.is_empty() {
-        return Err(HostApiError::invalid_path(raw, "path must not be empty"));
+        return Err(HostApiError::invalid_path(
+            invalid_value,
+            "path must not be empty",
+        ));
     }
     if raw.contains('\0') || raw.chars().any(char::is_control) {
         return Err(HostApiError::invalid_path(
-            raw,
+            invalid_value,
             "NUL/control characters are not allowed",
         ));
     }
     if raw.contains('\\') {
         return Err(HostApiError::invalid_path(
-            raw,
+            invalid_value,
             "backslashes are not allowed",
         ));
     }
     if !raw.starts_with('/') {
-        return Err(HostApiError::invalid_path(raw, "path must be absolute"));
+        return Err(HostApiError::invalid_path(
+            invalid_value,
+            "path must be absolute",
+        ));
     }
 
     let mut parts = Vec::new();
@@ -260,7 +267,7 @@ fn normalize_absolute_path(raw: String, kind: PathKind) -> Result<String, HostAp
             "" | "." => {}
             ".." => {
                 return Err(HostApiError::invalid_path(
-                    raw,
+                    invalid_value,
                     "`..` segments are not allowed",
                 ));
             }
@@ -270,7 +277,7 @@ fn normalize_absolute_path(raw: String, kind: PathKind) -> Result<String, HostAp
 
     if parts.is_empty() {
         return Err(HostApiError::invalid_path(
-            raw,
+            invalid_value,
             "root path is not valid here",
         ));
     }
@@ -283,6 +290,13 @@ fn normalize_absolute_path(raw: String, kind: PathKind) -> Result<String, HostAp
         ));
     }
     Ok(normalized)
+}
+
+fn invalid_path_error_value(raw: &str, kind: PathKind) -> String {
+    match kind {
+        PathKind::Scoped => REDACTED_PATH_VALUE.to_string(),
+        PathKind::Virtual | PathKind::MountAlias => raw.to_string(),
+    }
 }
 
 fn looks_like_url(value: &str) -> bool {

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -232,8 +232,14 @@ fn scoped_path_rejects_raw_host_paths_urls_and_traversal() {
 }
 
 #[test]
-fn scoped_path_redacts_host_looking_values_in_error_display() {
+fn scoped_path_redacts_all_rejected_values_in_error_display() {
     for invalid in [
+        "",
+        "relative/path",
+        "/workspace/../../secret",
+        "/workspace/has\0nul",
+        "\\server\\share\\private.txt",
+        "\\\\server\\share\\private.txt",
         "file:///etc/passwd",
         "https://example.com/private/file",
         "/Users/alice/project/private.txt",
@@ -244,7 +250,7 @@ fn scoped_path_redacts_host_looking_values_in_error_display() {
     ] {
         let message = ScopedPath::new(invalid).unwrap_err().to_string();
         assert!(
-            !message.contains(invalid),
+            invalid.is_empty() || !message.contains(invalid),
             "{invalid:?} must not be echoed in {message:?}"
         );
         assert!(
@@ -252,12 +258,6 @@ fn scoped_path_redacts_host_looking_values_in_error_display() {
             "{invalid:?} should use redacted placeholder in {message:?}"
         );
     }
-
-    let non_sensitive = ScopedPath::new("relative/path").unwrap_err().to_string();
-    assert!(
-        non_sensitive.contains("relative/path"),
-        "non-sensitive validation errors should still include useful value"
-    );
 }
 
 #[test]

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -232,6 +232,62 @@ fn scoped_path_rejects_raw_host_paths_urls_and_traversal() {
 }
 
 #[test]
+fn scoped_path_redacts_host_looking_values_in_error_display() {
+    for invalid in [
+        "file:///etc/passwd",
+        "https://example.com/private/file",
+        "/Users/alice/project/private.txt",
+        "/opt/ironclaw/project/private.txt",
+        "/tmp/ironclaw/project/private.txt",
+        "C:\\Users\\alice\\project\\private.txt",
+        "C:/Users/alice/project/private.txt",
+    ] {
+        let message = ScopedPath::new(invalid).unwrap_err().to_string();
+        assert!(
+            !message.contains(invalid),
+            "{invalid:?} must not be echoed in {message:?}"
+        );
+        assert!(
+            message.contains("<redacted path>"),
+            "{invalid:?} should use redacted placeholder in {message:?}"
+        );
+    }
+
+    let non_sensitive = ScopedPath::new("relative/path").unwrap_err().to_string();
+    assert!(
+        non_sensitive.contains("relative/path"),
+        "non-sensitive validation errors should still include useful value"
+    );
+}
+
+#[test]
+fn virtual_path_accepts_all_frozen_v1_roots() {
+    for root in [
+        "/engine",
+        "/system/settings",
+        "/system/extensions",
+        "/system/skills",
+        "/users",
+        "/projects",
+        "/memory",
+        "/artifacts",
+        "/tmp",
+        "/secrets",
+        "/events",
+    ] {
+        assert!(
+            VirtualPath::new(root).is_ok(),
+            "frozen V1 root {root:?} should be accepted"
+        );
+        let child = format!("{root}/child");
+        assert!(
+            VirtualPath::new(child).is_ok(),
+            "children of frozen V1 root {root:?} should be accepted"
+        );
+    }
+}
+
+#[test]
 fn virtual_path_requires_known_root_and_rejects_traversal() {
     assert!(VirtualPath::new("/projects/p1/threads/t1").is_ok());
     assert!(VirtualPath::new("/system/extensions/echo/state").is_ok());

--- a/crates/ironclaw_secrets/src/db.rs
+++ b/crates/ironclaw_secrets/src/db.rs
@@ -591,7 +591,7 @@ async fn libsql_upsert_session(
             key.mission_id,
             key.thread_id,
             key.invocation_id,
-            session.correlation_id().to_string(),
+            session.correlation_id().to_private_storage_string(),
             session.account_id().as_str(),
             session.expires_at().map(|value| value.to_rfc3339()),
             session.max_uses().map(|value| value as i64),
@@ -616,7 +616,7 @@ async fn libsql_get_session_record(
     let mut rows = conn
         .query(
             "SELECT account_id, expires_at, max_uses, uses, encrypted_payload, payload_key_salt FROM reborn_credential_sessions WHERE tenant_id = ?1 AND user_id = ?2 AND agent_id = ?3 AND project_id = ?4 AND mission_id = ?5 AND thread_id = ?6 AND invocation_id = ?7 AND session_id = ?8",
-            libsql::params![key.tenant_id, key.user_id, key.agent_id, key.project_id, key.mission_id, key.thread_id, key.invocation_id, session_id.to_string()],
+            libsql::params![key.tenant_id, key.user_id, key.agent_id, key.project_id, key.mission_id, key.thread_id, key.invocation_id, session_id.to_private_storage_string()],
         )
         .await
         .map_err(db_error)?;
@@ -661,7 +661,7 @@ async fn libsql_consume_session_record(
                 key.mission_id,
                 key.thread_id,
                 key.invocation_id,
-                session_id.to_string(),
+                session_id.to_private_storage_string(),
                 now.to_rfc3339(),
             ],
         )
@@ -768,7 +768,7 @@ async fn postgres_upsert_session(
     let key = DbScopeKey::from_full_scope(session.scope());
     let max_uses = session.max_uses().map(|value| value as i64);
     let payload = encrypt_session_payload(crypto, session)?;
-    client.execute("INSERT INTO reborn_credential_sessions (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id, account_id, expires_at, max_uses, uses, payload, encrypted_payload, payload_key_salt) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, '{}'::jsonb, $13, $14) ON CONFLICT(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id) DO UPDATE SET account_id = EXCLUDED.account_id, expires_at = EXCLUDED.expires_at, max_uses = EXCLUDED.max_uses, uses = EXCLUDED.uses, payload = '{}'::jsonb, encrypted_payload = EXCLUDED.encrypted_payload, payload_key_salt = EXCLUDED.payload_key_salt", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &key.mission_id, &key.thread_id, &key.invocation_id, &session.correlation_id().to_string(), &session.account_id().as_str(), &session.expires_at().map(|value| value.to_rfc3339()), &max_uses, &(uses as i64), &payload.encrypted_value, &payload.key_salt]).await.map_err(db_error)?;
+    client.execute("INSERT INTO reborn_credential_sessions (tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id, account_id, expires_at, max_uses, uses, payload, encrypted_payload, payload_key_salt) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, '{}'::jsonb, $13, $14) ON CONFLICT(tenant_id, user_id, agent_id, project_id, mission_id, thread_id, invocation_id, session_id) DO UPDATE SET account_id = EXCLUDED.account_id, expires_at = EXCLUDED.expires_at, max_uses = EXCLUDED.max_uses, uses = EXCLUDED.uses, payload = '{}'::jsonb, encrypted_payload = EXCLUDED.encrypted_payload, payload_key_salt = EXCLUDED.payload_key_salt", &[&key.tenant_id, &key.user_id, &key.agent_id, &key.project_id, &key.mission_id, &key.thread_id, &key.invocation_id, &session.correlation_id().to_private_storage_string(), &session.account_id().as_str(), &session.expires_at().map(|value| value.to_rfc3339()), &max_uses, &(uses as i64), &payload.encrypted_value, &payload.key_salt]).await.map_err(db_error)?;
     Ok(())
 }
 
@@ -791,7 +791,7 @@ async fn postgres_get_session_record(
                 &key.mission_id,
                 &key.thread_id,
                 &key.invocation_id,
-                &session_id.to_string(),
+                &session_id.to_private_storage_string(),
             ],
         )
         .await
@@ -837,7 +837,7 @@ async fn postgres_consume_session_record(
                 &key.mission_id,
                 &key.thread_id,
                 &key.invocation_id,
-                &session_id.to_string(),
+                &session_id.to_private_storage_string(),
                 &now.to_rfc3339(),
             ],
         )
@@ -1934,7 +1934,7 @@ impl From<&CredentialSession> for PersistedCredentialSession {
             allowed_targets: session.allowed_targets.clone(),
             expires_at: session.expires_at,
             max_uses: session.max_uses,
-            correlation_id: session.correlation_id.to_string(),
+            correlation_id: session.correlation_id.to_private_storage_string(),
         }
     }
 }

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -245,7 +245,9 @@ impl CredentialSessionId {
         Uuid::parse_str(value).map(Self)
     }
 
-    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    // Keep this helper feature-agnostic so private DTO conversion code does not
+    // depend on backend feature gates. It may be unused in featureless builds.
+    #[allow(dead_code)]
     pub(crate) fn to_private_storage_string(self) -> String {
         self.0.to_string()
     }

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -244,6 +244,11 @@ impl CredentialSessionId {
     pub fn parse(value: &str) -> Result<Self, uuid::Error> {
         Uuid::parse_str(value).map(Self)
     }
+
+    #[cfg(any(feature = "libsql", feature = "postgres"))]
+    pub(crate) fn to_private_storage_string(self) -> String {
+        self.0.to_string()
+    }
 }
 
 impl Default for CredentialSessionId {
@@ -260,7 +265,7 @@ impl fmt::Debug for CredentialSessionId {
 
 impl fmt::Display for CredentialSessionId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(formatter)
+        formatter.write_str("[REDACTED]")
     }
 }
 
@@ -1377,7 +1382,7 @@ mod tests {
 
     use crate::{
         CREDENTIAL_ID_MAX_LEN, CredentialAccount, CredentialAccountId, CredentialAccountStatus,
-        CredentialBrokerError, CredentialPathPolicy, CredentialSessionRequest,
+        CredentialBrokerError, CredentialPathPolicy, CredentialSessionId, CredentialSessionRequest,
         CredentialTargetPolicy, InMemoryCredentialBroker, InMemorySecretStore,
         InMemorySecretsStore, RedactedJson, ScopedSecretsStoreAdapter, SecretLeaseKey,
         SecretMaterial, SecretStore, SecretStoreError, SecretsCrypto, SecretsStore,
@@ -1487,6 +1492,43 @@ mod tests {
     }
 
     #[test]
+    fn credential_session_id_display_redacts_bearer_like_value() {
+        let raw_session_id = "3f2f4a08-f8ef-4d83-a8f6-624d77cf9181";
+        let session_id = CredentialSessionId::parse(raw_session_id).unwrap();
+        let display = session_id.to_string();
+
+        assert!(!display.contains(raw_session_id));
+        assert!(display.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn credential_broker_session_error_displays_redact_session_id() {
+        let raw_session_id = "3f2f4a08-f8ef-4d83-a8f6-624d77cf9181";
+        let session_id = CredentialSessionId::parse(raw_session_id).unwrap();
+
+        for (error, stable_reason) in [
+            (
+                CredentialBrokerError::UnknownSession { session_id },
+                "MissingCredential",
+            ),
+            (
+                CredentialBrokerError::SessionExpired { session_id },
+                "CredentialExpired",
+            ),
+            (
+                CredentialBrokerError::SessionUseLimitExceeded { session_id },
+                "CredentialExpired",
+            ),
+        ] {
+            let display = error.to_string();
+
+            assert!(!display.contains(raw_session_id), "{display}");
+            assert!(display.contains("[REDACTED]"), "{display}");
+            assert_eq!(error.stable_reason(), stable_reason);
+        }
+    }
+
+    #[test]
     fn stable_reason_tokens_are_locked() {
         let account_id = CredentialAccountId::new("openai_prod").unwrap();
         assert_eq!(
@@ -1546,7 +1588,7 @@ mod tests {
         let debug = format!("{session:?}");
         assert!(!debug.contains("sk-live-sentinel"));
         assert!(!debug.contains("token"));
-        assert!(!debug.contains(&session.correlation_id().to_string()));
+        assert!(debug.contains("CredentialSessionId([REDACTED])"));
     }
 
     #[test]

--- a/crates/ironclaw_wasm_product_adapters/src/runner.rs
+++ b/crates/ironclaw_wasm_product_adapters/src/runner.rs
@@ -99,11 +99,14 @@ impl WebhookAuth {
                     header_name,
                     timestamp_header_name: Some(timestamp_header_name),
                 },
-            ) => v.signature_header == *header_name && v.timestamp_header == *timestamp_header_name,
+            ) => {
+                header_name_matches(&v.signature_header, header_name)
+                    && header_name_matches(&v.timestamp_header, timestamp_header_name)
+            }
             (
                 WebhookAuth::SharedSecretHeader(v),
                 AuthRequirement::SharedSecretHeader { header_name },
-            ) => v.header_name == *header_name,
+            ) => header_name_matches(&v.header_name, header_name),
             _ => false,
         }
     }
@@ -136,6 +139,10 @@ pub fn evidence_from_session_subject(subject: impl Into<String>) -> ProtocolAuth
 
 pub fn evidence_from_bearer_subject(subject: impl Into<String>) -> ProtocolAuthEvidence {
     mark_bearer_token_verified(subject)
+}
+
+fn header_name_matches(configured: &str, required: &str) -> bool {
+    configured.eq_ignore_ascii_case(required)
 }
 
 pub const DEFAULT_WEBHOOK_WORKFLOW_TIMEOUT: Duration = Duration::from_secs(55);
@@ -653,6 +660,49 @@ mod tests {
                 .as_slice(),
             &[ProductInboundPayload::NoOp]
         );
+    }
+
+    #[tokio::test]
+    async fn process_webhook_accepts_case_insensitive_shared_secret_header_match() {
+        let adapter = StaticAdapter::new(sample_parsed()).with_auth_requirement(
+            AuthRequirement::SharedSecretHeader {
+                header_name: "x-test-secret".into(),
+            },
+        );
+        let runner = NativeProductAdapterRunner::with_config(
+            Arc::new(adapter),
+            Arc::new(AckWorkflow),
+            shared_secret_auth(),
+            test_config(1, Duration::from_secs(1)),
+        );
+
+        let outcome = runner
+            .process_webhook(&auth_headers(), b"{}")
+            .await
+            .expect("case-only header-name differences should not reject matching auth");
+
+        assert!(matches!(
+            outcome,
+            WebhookProcessOutcome::Acknowledged {
+                ack: ProductInboundAck::NoOp
+            }
+        ));
+    }
+
+    #[test]
+    fn webhook_auth_matches_hmac_requirement_header_names_case_insensitively() {
+        let auth = WebhookAuth::Hmac(HmacWebhookAuth::new(
+            "X-Signature",
+            "X-Timestamp",
+            b"topsecret".to_vec(),
+            "telegram_install_alpha",
+        ));
+        let requirement = AuthRequirement::RequestSignature {
+            header_name: "x-signature".into(),
+            timestamp_header_name: Some("x-timestamp".into()),
+        };
+
+        assert!(auth.matches_requirement(&requirement));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_wasm_product_adapters/src/runner.rs
+++ b/crates/ironclaw_wasm_product_adapters/src/runner.rs
@@ -25,9 +25,10 @@ use ironclaw_product_adapters::auth::{
     mark_bearer_token_verified, mark_request_signature_verified, mark_session_verified,
     mark_shared_secret_header_verified,
 };
+use ironclaw_product_adapters::redaction::RedactedString;
 use ironclaw_product_adapters::{
-    ProductAdapter, ProductAdapterError, ProductInboundAck, ProductInboundEnvelope,
-    ProductInboundPayload, ProductWorkflow, ProtocolAuthEvidence, ProtocolAuthFailure,
+    AuthRequirement, ProductAdapter, ProductAdapterError, ProductInboundAck,
+    ProductInboundEnvelope, ProductWorkflow, ProtocolAuthEvidence, ProtocolAuthFailure,
     TrustedInboundContext,
 };
 use thiserror::Error;
@@ -77,9 +78,9 @@ impl RunnerError {
 pub enum WebhookProcessOutcome {
     /// Auth succeeded, adapter parsed an envelope, workflow accepted it.
     Acknowledged { ack: ProductInboundAck },
-    /// Auth succeeded but the adapter chose to drop the message (group
-    /// ambient, edited message, unsupported event kind, ...). The protocol
-    /// layer should respond 200 OK no-op.
+    /// Reserved for host/protocol paths that acknowledge without a product
+    /// workflow envelope. Parsed `ProductInboundPayload::NoOp` events still
+    /// flow through `ProductWorkflow` and return `Acknowledged`.
     NoOp,
 }
 
@@ -90,6 +91,23 @@ pub enum WebhookAuth {
 }
 
 impl WebhookAuth {
+    pub fn matches_requirement(&self, requirement: &AuthRequirement) -> bool {
+        match (self, requirement) {
+            (
+                WebhookAuth::Hmac(v),
+                AuthRequirement::RequestSignature {
+                    header_name,
+                    timestamp_header_name: Some(timestamp_header_name),
+                },
+            ) => v.signature_header == *header_name && v.timestamp_header == *timestamp_header_name,
+            (
+                WebhookAuth::SharedSecretHeader(v),
+                AuthRequirement::SharedSecretHeader { header_name },
+            ) => v.header_name == *header_name,
+            _ => false,
+        }
+    }
+
     fn verify(&self, headers: &http::HeaderMap, body: &[u8]) -> VerificationOutcome {
         match self {
             WebhookAuth::Hmac(v) => v.verify(headers, body),
@@ -212,6 +230,18 @@ impl NativeProductAdapterRunner {
         headers: &http::HeaderMap,
         body: &[u8],
     ) -> Result<WebhookProcessOutcome, RunnerError> {
+        if !self
+            .auth
+            .matches_requirement(self.adapter.auth_requirement())
+        {
+            return Err(RunnerError::AuthenticationFailed {
+                failure: ProtocolAuthFailure::Other {
+                    detail: RedactedString::new(
+                        "configured webhook auth strategy does not match adapter auth requirement",
+                    ),
+                },
+            });
+        }
         let evidence = match self.auth.verify(headers, body) {
             VerificationOutcome::Verified { subject } => self.auth.mint_evidence(subject),
             VerificationOutcome::Failed { failure } => {
@@ -240,12 +270,6 @@ impl NativeProductAdapterRunner {
             &evidence,
         )?;
         let envelope = ProductInboundEnvelope::from_trusted_parse(context, parsed)?;
-        // Authenticated-but-ignored events surface as `NoOp` payloads, not as
-        // an out-of-band `None` parse result. The protocol layer still acks
-        // 200 OK so the upstream webhook does not retry.
-        if matches!(envelope.payload(), ProductInboundPayload::NoOp) {
-            return Ok(WebhookProcessOutcome::NoOp);
-        }
         let workflow = Arc::clone(&self.workflow);
         let mut workflow_task =
             tokio::spawn(async move { workflow.accept_inbound(envelope).await });
@@ -269,7 +293,8 @@ impl NativeProductAdapterRunner {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use async_trait::async_trait;
@@ -306,6 +331,7 @@ mod tests {
         capabilities: ProductAdapterCapabilities,
         auth_requirement: AuthRequirement,
         parsed: ParsedProductInbound,
+        parse_count: Option<Arc<AtomicUsize>>,
     }
 
     impl StaticAdapter {
@@ -316,7 +342,18 @@ mod tests {
                 capabilities: ProductAdapterCapabilities::empty(),
                 auth_requirement: stub_auth_requirement(),
                 parsed,
+                parse_count: None,
             }
+        }
+
+        fn with_auth_requirement(mut self, auth_requirement: AuthRequirement) -> Self {
+            self.auth_requirement = auth_requirement;
+            self
+        }
+
+        fn with_parse_count(mut self, parse_count: Arc<AtomicUsize>) -> Self {
+            self.parse_count = Some(parse_count);
+            self
         }
     }
 
@@ -347,6 +384,9 @@ mod tests {
             _raw_payload: &[u8],
             _auth_evidence: &ProtocolAuthEvidence,
         ) -> Result<ParsedProductInbound, ProductAdapterError> {
+            if let Some(parse_count) = &self.parse_count {
+                parse_count.fetch_add(1, Ordering::SeqCst);
+            }
             Ok(self.parsed.clone())
         }
 
@@ -449,6 +489,31 @@ mod tests {
         }
     }
 
+    struct RecordingWorkflow {
+        seen_payloads: Arc<Mutex<Vec<ProductInboundPayload>>>,
+    }
+
+    #[async_trait]
+    impl ProductWorkflow for RecordingWorkflow {
+        async fn accept_inbound(
+            &self,
+            envelope: ProductInboundEnvelope,
+        ) -> Result<ProductInboundAck, ProductAdapterError> {
+            self.seen_payloads
+                .lock()
+                .expect("seen payloads mutex should not be poisoned")
+                .push(envelope.payload().clone());
+            Ok(ProductInboundAck::NoOp)
+        }
+
+        async fn resolve_projection_subscription(
+            &self,
+            _envelope: ProductInboundEnvelope,
+        ) -> Result<ProjectionSubscriptionRequest, ProductAdapterError> {
+            Err(projection_subscription_unimplemented())
+        }
+    }
+
     struct PendingWorkflow;
 
     #[async_trait]
@@ -511,10 +576,7 @@ mod tests {
         }
     }
 
-    /// Sample `ParsedProductInbound` with a non-NoOp payload. The runner's
-    /// success-path tests need the workflow to actually be invoked, so the
-    /// payload must NOT be `ProductInboundPayload::NoOp` (which would short-
-    /// circuit before `accept_inbound`).
+    /// Sample `ParsedProductInbound` with a non-NoOp payload.
     fn sample_parsed() -> ParsedProductInbound {
         ParsedProductInbound::new(
             ExternalEventId::new("update:42").expect("valid"),
@@ -525,6 +587,17 @@ mod tests {
                 UserMessagePayload::new("hello", Vec::new(), ProductTriggerReason::DirectChat)
                     .expect("valid"),
             ),
+        )
+        .expect("valid parsed")
+    }
+
+    fn sample_noop_parsed() -> ParsedProductInbound {
+        ParsedProductInbound::new(
+            ExternalEventId::new("update:noop").expect("valid"),
+            ExternalActorRef::new("telegram_user", "777", None::<String>).expect("valid"),
+            ExternalConversationRef::new(None, "12345", Some("topic-7"), Some("msg-100"))
+                .expect("valid"),
+            ProductInboundPayload::NoOp,
         )
         .expect("valid parsed")
     }
@@ -548,6 +621,70 @@ mod tests {
             timeout,
             std::num::NonZeroUsize::new(max_in_flight).expect("nonzero"),
         )
+    }
+
+    #[tokio::test]
+    async fn process_webhook_routes_noop_payload_through_workflow() {
+        let seen_payloads = Arc::new(Mutex::new(Vec::new()));
+        let runner = NativeProductAdapterRunner::with_config(
+            Arc::new(StaticAdapter::new(sample_noop_parsed())),
+            Arc::new(RecordingWorkflow {
+                seen_payloads: Arc::clone(&seen_payloads),
+            }),
+            shared_secret_auth(),
+            test_config(1, Duration::from_secs(1)),
+        );
+
+        let outcome = runner
+            .process_webhook(&auth_headers(), b"{}")
+            .await
+            .expect("NoOp payload should still be acknowledged by workflow");
+
+        assert_eq!(
+            outcome,
+            WebhookProcessOutcome::Acknowledged {
+                ack: ProductInboundAck::NoOp
+            }
+        );
+        assert_eq!(
+            seen_payloads
+                .lock()
+                .expect("seen payloads mutex should not be poisoned")
+                .as_slice(),
+            &[ProductInboundPayload::NoOp]
+        );
+    }
+
+    #[tokio::test]
+    async fn process_webhook_rejects_auth_strategy_mismatch_before_parse() {
+        let parse_count = Arc::new(AtomicUsize::new(0));
+        let adapter = StaticAdapter::new(sample_parsed())
+            .with_auth_requirement(AuthRequirement::RequestSignature {
+                header_name: "X-Signature".into(),
+                timestamp_header_name: Some("X-Timestamp".into()),
+            })
+            .with_parse_count(Arc::clone(&parse_count));
+        let runner = NativeProductAdapterRunner::with_config(
+            Arc::new(adapter),
+            Arc::new(AckWorkflow),
+            shared_secret_auth(),
+            test_config(1, Duration::from_secs(1)),
+        );
+
+        let err = runner
+            .process_webhook(&auth_headers(), b"{}")
+            .await
+            .expect_err("auth strategy mismatch should fail closed");
+
+        assert!(err.is_auth_failure());
+        assert!(!err.is_retryable());
+        assert!(matches!(
+            err,
+            RunnerError::AuthenticationFailed {
+                failure: ProtocolAuthFailure::Other { .. }
+            }
+        ));
+        assert_eq!(parse_count.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_wasm_product_adapters/src/runner.rs
+++ b/crates/ironclaw_wasm_product_adapters/src/runner.rs
@@ -77,11 +77,9 @@ impl RunnerError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WebhookProcessOutcome {
     /// Auth succeeded, adapter parsed an envelope, workflow accepted it.
+    /// Parsed `ProductInboundPayload::NoOp` events still flow through
+    /// `ProductWorkflow` and return `Acknowledged` with a no-op ack.
     Acknowledged { ack: ProductInboundAck },
-    /// Reserved for host/protocol paths that acknowledge without a product
-    /// workflow envelope. Parsed `ProductInboundPayload::NoOp` events still
-    /// flow through `ProductWorkflow` and return `Acknowledged`.
-    NoOp,
 }
 
 /// Webhook auth strategy.
@@ -107,7 +105,23 @@ impl WebhookAuth {
                 WebhookAuth::SharedSecretHeader(v),
                 AuthRequirement::SharedSecretHeader { header_name },
             ) => header_name_matches(&v.header_name, header_name),
-            _ => false,
+            (
+                WebhookAuth::Hmac(_),
+                AuthRequirement::RequestSignature {
+                    timestamp_header_name: None,
+                    ..
+                },
+            ) => {
+                // Intentionally unsupported: current webhook callers must bind
+                // HMAC verification to both signature and timestamp headers.
+                false
+            }
+            (WebhookAuth::Hmac(_), AuthRequirement::SharedSecretHeader { .. })
+            | (WebhookAuth::Hmac(_), AuthRequirement::SessionCookie { .. })
+            | (WebhookAuth::Hmac(_), AuthRequirement::BearerToken)
+            | (WebhookAuth::SharedSecretHeader(_), AuthRequirement::RequestSignature { .. })
+            | (WebhookAuth::SharedSecretHeader(_), AuthRequirement::SessionCookie { .. })
+            | (WebhookAuth::SharedSecretHeader(_), AuthRequirement::BearerToken) => false,
         }
     }
 

--- a/docs/reborn/contracts/filesystem.md
+++ b/docs/reborn/contracts/filesystem.md
@@ -85,37 +85,46 @@ Use for:
 
 ## 4. Namespace roots
 
-V1 canonical virtual roots:
+Frozen V1 canonical virtual roots (aligned with `storage-placement.md`):
 
 ```text
 /engine
+/system/settings
 /system/extensions
+/system/skills
 /users
 /projects
 /memory
+/artifacts
+/tmp
+/secrets
+/events
 ```
 
 Recommended meaning:
 
 | Root | Purpose |
 |---|---|
-| `/engine` | host-owned engine config, schemas, migrations, and service metadata |
+| `/engine` | host-owned runtime state, schemas, migrations, and service metadata |
+| `/system/settings` | typed settings repository and optional settings projections |
 | `/system/extensions` | installed extension packages and extension-local config/state/cache roots |
+| `/system/skills` | skill manifests, registries, and installed skill state |
 | `/users` | user-owned durable profile/config areas |
-| `/projects` | project workspaces, missions, thread state, artifacts, and project-local config |
+| `/projects` | project workspaces, missions, thread state, and project-local config |
 | `/memory` | durable memory namespace, initially file-like even if backed by another store |
+| `/artifacts` | artifact/object storage for process output refs and durable generated files |
+| `/tmp` | process/invocation-local temporary data |
+| `/secrets` | encrypted secret records and redacted secret projections only |
+| `/events` | durable event/audit append log and projections |
 
-Extension-visible aliases should be scoped aliases such as:
+Extension-visible workspace-style names should be scoped aliases such as:
 
 ```text
 /workspace
 /project
-/memory
 /extension/config
 /extension/state
 /extension/cache
-/tmp
-/artifacts
 ```
 
 Aliases are resolved by `MountView`; they are not global virtual roots by themselves.

--- a/docs/reborn/contracts/storage-placement.md
+++ b/docs/reborn/contracts/storage-placement.md
@@ -129,6 +129,7 @@ not bypass domain invariants by mutating primitive storage rows directly.
 | Virtual area | Source of truth | Access surface | Indexed? | Notes |
 | --- | --- | --- | --- | --- |
 | `/memory` | `ironclaw_memory` DB repositories over `memory_documents`, `memory_chunks`, `memory_document_versions` | file-shaped memory docs + memory service APIs | backend-defined full-text/vector | Memory-specific path grammar lives in `ironclaw_memory`, not filesystem. |
+| `/users` | typed user/profile repositories + optional user config projection | user/profile APIs + optional file projection | no, unless projection says otherwise | User-owned durable profile and configuration areas. |
 | `/projects` | local/object/project file backend | filesystem | optional project indexer | Project source files and user-authored project artifacts. |
 | `/system/settings` | typed settings repository | typed API + optional file projection | no, unless projection says otherwise | Settings source of truth is not memory. |
 | `/system/extensions` | extension package/registry repositories | extension API + filesystem package reads/projections | no semantic memory indexing | Installed packages, manifests, registry state. |


### PR DESCRIPTION
## Summary
- add the frozen Reborn V1 virtual roots to `VirtualPath` and redact host-looking scoped-path validation errors
- redact bearer-like `CredentialSessionId` display/error surfaces while preserving private DB storage keys
- route native product-adapter `NoOp` payloads through `ProductWorkflow` and fail closed on webhook auth-strategy mismatch before parsing

## Architecture integrity audit
- Used the `architecture-integrity-review` rubric against `reborn-integration` docs/contracts and crate boundaries.
- Checked open PRs targeting `reborn-integration` first and avoided scopes already covered by active PRs (run-state approval stores, memory adapters, inbound product workflow, prompt bundle, host-runtime sealing, composition root, CLI, loop readiness, model gateway tests, etc.).
- Selected three non-overlapping fixes from the remaining findings: host API path contract drift, secret session-id redaction, and native product-adapter auth/NoOp boundary behavior.

## Verification
- `cargo test -p ironclaw_host_api --locked`
- `cargo test -p ironclaw_secrets --locked`
- `cargo test -p ironclaw_wasm_product_adapters --locked`
- `cargo test -p ironclaw_architecture --locked`
- `cargo clippy -p ironclaw_host_api --tests --locked -- -D warnings`
- `cargo clippy -p ironclaw_secrets --tests --locked -- -D warnings`
- `cargo clippy -p ironclaw_wasm_product_adapters --tests --locked -- -D warnings`
- `cargo check -p ironclaw_secrets --features libsql --locked`
- `cargo check -p ironclaw_secrets --features postgres --locked`
- `cargo fmt --check`
- `git diff --check`
