### PR TITLE
feat(gateway): add logs download button

### DIFF
--- a/crates/ironclaw_gateway/src/assets.rs
+++ b/crates/ironclaw_gateway/src/assets.rs
@@ -172,3 +172,23 @@ pub const ADMIN_CSS: &str = include_str!("../static/admin/admin.css");
 
 /// Admin panel JavaScript.
 pub const ADMIN_JS: &str = include_str!("../static/admin/admin.js");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logs_toolbar_exposes_download_button() {
+        assert!(INDEX_HTML.contains("id=\"logs-download-btn\""));
+        assert!(INDEX_HTML.contains("data-i18n=\"logs.download\""));
+    }
+
+    #[test]
+    fn logs_surface_can_export_buffer_as_jsonl() {
+        assert!(APP_JS.contains("downloadLogsJsonl"));
+        assert!(APP_JS.contains("serializeLogEntriesAsJsonl"));
+        assert!(APP_JS.contains("ironclaw-logs-"));
+        assert!(APP_JS.contains("logs-download-btn').addEventListener('click'"));
+        assert!(APP_JS.contains("setTimeout(() => URL.revokeObjectURL(url)"));
+    }
+}

--- a/crates/ironclaw_gateway/static/i18n/en.js
+++ b/crates/ironclaw_gateway/static/i18n/en.js
@@ -217,6 +217,7 @@ I18n.register('en', {
   'logs.clientLevel': 'Client Log Level',
   'logs.pause': 'Pause',
   'logs.resume': 'Resume',
+  'logs.download': 'Download',
   'logs.clear': 'Clear',
   'logs.autoScroll': 'Auto-scroll',
   'logs.filter': 'Filter logs...',

--- a/crates/ironclaw_gateway/static/i18n/ko.js
+++ b/crates/ironclaw_gateway/static/i18n/ko.js
@@ -215,6 +215,7 @@ I18n.register('ko', {
   'logs.clientLevel': '클라이언트 로그 레벨',
   'logs.pause': '일시정지',
   'logs.resume': '재개',
+  'logs.download': '다운로드',
   'logs.clear': '지우기',
   'logs.autoScroll': '자동 스크롤',
   'logs.filter': '로그 필터링...',

--- a/crates/ironclaw_gateway/static/i18n/zh-CN.js
+++ b/crates/ironclaw_gateway/static/i18n/zh-CN.js
@@ -217,6 +217,7 @@ I18n.register('zh-CN', {
   'logs.clientLevel': '客户端日志级别',
   'logs.pause': '暂停',
   'logs.resume': '继续',
+  'logs.download': '下载',
   'logs.clear': '清空',
   'logs.autoScroll': '自动滚动',
   'logs.filter': '筛选日志...',

--- a/crates/ironclaw_gateway/static/index.html
+++ b/crates/ironclaw_gateway/static/index.html
@@ -339,6 +339,7 @@
           <input type="text" id="logs-target-filter" placeholder="Filter by target...">
           <label class="logs-checkbox"><input type="checkbox" id="logs-autoscroll" checked> <span data-i18n="logs.autoScroll">Auto-scroll</span></label>
           <button id="logs-pause-btn" data-i18n="logs.pause">Pause</button>
+          <button id="logs-download-btn" data-i18n="logs.download">Download</button>
           <button id="logs-clear-btn" data-i18n="logs.clear">Clear</button>
         </div>
         <div class="logs-output" id="logs-output"></div>

--- a/crates/ironclaw_gateway/static/js/core/ui-helpers.js
+++ b/crates/ironclaw_gateway/static/js/core/ui-helpers.js
@@ -260,6 +260,7 @@ document.getElementById('memory-save-btn').addEventListener('click', () => saveM
 document.getElementById('memory-cancel-btn').addEventListener('click', () => cancelMemoryEdit());
 document.getElementById('logs-server-level').addEventListener('change', (e) => setServerLogLevel(e.target.value));
 document.getElementById('logs-pause-btn').addEventListener('click', () => toggleLogsPause());
+document.getElementById('logs-download-btn').addEventListener('click', () => downloadLogsJsonl());
 document.getElementById('logs-clear-btn').addEventListener('click', () => clearLogs());
 document.getElementById('wasm-install-btn').addEventListener('click', () => installWasmExtension());
 document.getElementById('mcp-add-btn').addEventListener('click', () => addMcpServer());

--- a/crates/ironclaw_gateway/static/js/surfaces/logs.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/logs.js
@@ -1,6 +1,7 @@
 const LOG_MAX_ENTRIES = 2000;
 let logsPaused = false;
 let logBuffer = []; // buffer while paused
+let downloadLogEntries = []; // entries available for JSONL download
 
 function connectLogSSE() {
   if (logEventSource) logEventSource.close();
@@ -12,6 +13,7 @@ function connectLogSSE() {
 
   logEventSource.addEventListener('log', (e) => {
     const entry = JSON.parse(e.data);
+    rememberLogEntryForDownload(entry);
     if (logsPaused) {
       logBuffer.push(entry);
       return;
@@ -22,6 +24,41 @@ function connectLogSSE() {
   logEventSource.onerror = () => {
     // Silent reconnect
   };
+}
+
+function rememberLogEntryForDownload(entry) {
+  downloadLogEntries.push(entry);
+  while (downloadLogEntries.length > LOG_MAX_ENTRIES) {
+    downloadLogEntries.shift();
+  }
+}
+
+function serializeLogEntriesAsJsonl(entries) {
+  return entries.map(entry => JSON.stringify(entry)).join('\n') + (entries.length ? '\n' : '');
+}
+
+function logsDownloadFilename() {
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z')
+    .replace('T', '-');
+  return 'ironclaw-logs-' + stamp + '.jsonl';
+}
+
+function downloadLogsJsonl() {
+  const blob = new Blob([serializeLogEntriesAsJsonl(downloadLogEntries)], {
+    type: 'application/x-ndjson;charset=utf-8',
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = logsDownloadFilename();
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 function prependLogEntry(entry) {
@@ -96,6 +133,7 @@ function clearLogs() {
   if (!confirm(I18n.t('logs.confirmClear'))) return;
   document.getElementById('logs-output').innerHTML = '';
   logBuffer = [];
+  downloadLogEntries = [];
 }
 
 // Re-apply filters when level or target changes


### PR DESCRIPTION
## Summary
- Add a Download button to the Logs tab
- Export logs already received by the browser from `/api/logs/events` as JSONL
- Keep implementation frontend-only: no new gateway route, no core/tool-registry change
- Add asset tests for button wiring and JSONL export support

## PR LoC churn
- 7 files changed
- +63 / -0

## Verification
- `cargo test -p ironclaw_gateway` (63 passed)
- `git diff --check`

Closes #3534