### PR TITLE
feat(extensions): add Extension Manifest v2 types and parser (slice 2a)

### DIFF
--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -318,7 +318,8 @@ pub mod v2;
 
 pub use v2::{
     CapabilityDeclV2, CapabilityVisibility, ExtensionManifestV2, ExtensionRuntimeV2,
-    MANIFEST_SCHEMA_VERSION, ManifestSource, ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX,
+    MANIFEST_SCHEMA_VERSION, MAX_MANIFEST_BYTES, ManifestSource, ManifestV2Error,
+    RESERVED_HOST_BUNDLED_ID_PREFIX,
 };
 
 pub use lifecycle::{

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -314,6 +314,12 @@ impl ExtensionPackage {
 
 mod lifecycle;
 mod registry;
+pub mod v2;
+
+pub use v2::{
+    CapabilityDeclV2, CapabilityVisibility, ExtensionManifestV2, ExtensionRuntimeV2,
+    MANIFEST_SCHEMA_VERSION, ManifestSource, ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX,
+};
 
 pub use lifecycle::{
     ExtensionLifecycleEvent, ExtensionLifecycleEventSink, ExtensionLifecycleService,

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -18,8 +18,24 @@
 //!
 //! This module does **not** dispatch capabilities, load WASM modules, evaluate
 //! trust policy, or grant authority. It is contract vocabulary only.
+//!
+//! ## Whitespace and field shape
+//!
+//! `name`, `version`, and `description` are rejected when empty or
+//! whitespace-only, but the *exact* bytes from the TOML are preserved on the
+//! validated manifest (no `trim`). `version` is treated as opaque,
+//! registry-defined vocabulary — v2 does **not** require semver; downstream
+//! consumers that need ordered comparison must parse it themselves.
+//!
+//! ## Serialization
+//!
+//! v2 deliberately ships `Deserialize`-only types. `ExtensionManifestV2` has
+//! no `Serialize` impl: this module is a parser/validator contract, not a
+//! registry write path. If a future diagnostic / registry tool needs round
+//! tripping it should add a deliberate serialization layer with its own
+//! schema.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 
 use ironclaw_host_api::{
     CapabilityId, CapabilityProfileId, CapabilityProfileSchemaRef, EffectKind, ExtensionId,
@@ -34,6 +50,13 @@ pub const MANIFEST_SCHEMA_VERSION: &str = "reborn.extension_manifest.v2";
 
 /// Reserved extension-ID prefix for host-bundled extensions.
 pub const RESERVED_HOST_BUNDLED_ID_PREFIX: &str = "ironclaw.";
+
+/// Upper bound on raw manifest TOML input size.
+///
+/// Loaders feed installed manifests of ≤ a few KB; this cap exists to fail
+/// closed before `toml::from_str` parses and allocates a pathological input.
+/// Tune cautiously — raising this also raises peak loader memory.
+pub const MAX_MANIFEST_BYTES: usize = 256 * 1024;
 
 /// Loader-supplied source for a manifest. Never read from TOML.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -142,8 +165,22 @@ pub struct ExtensionManifestV2 {
     pub version: String,
     pub description: String,
     pub source: ManifestSource,
+    /// Raw, loader-supplied trust *request*. Untrusted vocabulary.
     pub requested_trust: RequestedTrustClass,
-    pub trust: TrustClass,
+    /// Default `TrustClass` that downstream code may use **only when no host
+    /// trust policy has run yet**.
+    ///
+    /// Mapping:
+    /// - `ThirdParty` → `UserTrusted`
+    /// - `Untrusted` / `FirstPartyRequested` / `SystemRequested` → `Sandbox`
+    ///
+    /// FirstParty/System requests intentionally map to `Sandbox` here even
+    /// for `ManifestSource::HostBundled`: this field is a safe pre-policy
+    /// default, **not** the effective trust class. Effective privileged trust
+    /// only ever comes from `ironclaw_trust::TrustPolicy::evaluate` on a
+    /// `TrustPolicyInput`. Consumers that need effective trust **must** run
+    /// the policy; they must not read this field as authoritative.
+    pub descriptor_trust_default: TrustClass,
     pub runtime: ExtensionRuntimeV2,
     pub capabilities: Vec<CapabilityDeclV2>,
 }
@@ -195,6 +232,19 @@ pub enum ManifestV2Error {
         id: CapabilityId,
         expected: ExtensionId,
     },
+    #[error("manifest exceeds maximum size: {bytes} > {max} bytes")]
+    ManifestTooLarge { bytes: usize, max: usize },
+    #[error("capability {capability} declares duplicate effect {effect:?}")]
+    DuplicateEffect {
+        capability: CapabilityId,
+        effect: EffectKind,
+    },
+    #[error("capability {capability} field '{field}' is invalid: {reason}")]
+    InvalidSchemaRef {
+        capability: CapabilityId,
+        field: &'static str,
+        reason: String,
+    },
     #[error("capability {capability} declares duplicate required host port '{port}'")]
     DuplicateRequiredHostPort {
         capability: CapabilityId,
@@ -220,6 +270,14 @@ impl ExtensionManifestV2 {
         source: ManifestSource,
         host_port_catalog: &HostPortCatalog,
     ) -> Result<Self, ManifestV2Error> {
+        // Fail closed on pathological inputs *before* invoking the TOML parser.
+        // `toml::from_str` will otherwise read and allocate the full input.
+        if input.len() > MAX_MANIFEST_BYTES {
+            return Err(ManifestV2Error::ManifestTooLarge {
+                bytes: input.len(),
+                max: MAX_MANIFEST_BYTES,
+            });
+        }
         let raw: RawManifestV2 = toml::from_str(input).map_err(|error| ManifestV2Error::Parse {
             reason: error.to_string(),
         })?;
@@ -239,15 +297,9 @@ impl ExtensionManifestV2 {
             });
         }
 
-        let id = ExtensionId::new(raw.id)?;
-        if !source.allows_first_party() && id.as_str().starts_with(RESERVED_HOST_BUNDLED_ID_PREFIX)
-        {
-            return Err(ManifestV2Error::ReservedIdForInstalledSource {
-                id,
-                prefix: RESERVED_HOST_BUNDLED_ID_PREFIX,
-            });
-        }
-
+        // Cheap empty-string checks first — surface them before the more
+        // structured id / runtime / capability errors so hand-edited manifests
+        // get the most actionable message.
         if raw.name.trim().is_empty() {
             return Err(ManifestV2Error::Invalid {
                 reason: "name must not be empty".to_string(),
@@ -269,6 +321,15 @@ impl ExtensionManifestV2 {
             });
         }
 
+        let id = ExtensionId::new(raw.id)?;
+        if !source.allows_first_party() && id.as_str().starts_with(RESERVED_HOST_BUNDLED_ID_PREFIX)
+        {
+            return Err(ManifestV2Error::ReservedIdForInstalledSource {
+                id,
+                prefix: RESERVED_HOST_BUNDLED_ID_PREFIX,
+            });
+        }
+
         let requested_trust = raw.trust;
         if !source.allows_first_party()
             && matches!(
@@ -281,7 +342,7 @@ impl ExtensionManifestV2 {
                 requested: requested_trust,
             });
         }
-        let trust = requested_trust_to_descriptor_trust(requested_trust);
+        let descriptor_trust_default = requested_trust_to_descriptor_trust(requested_trust);
 
         let runtime = raw.runtime.into_runtime()?;
         if !source.allows_first_party() && !runtime.installed_allows() {
@@ -309,7 +370,7 @@ impl ExtensionManifestV2 {
             description: raw.description,
             source,
             requested_trust,
-            trust,
+            descriptor_trust_default,
             runtime,
             capabilities,
         })
@@ -343,6 +404,20 @@ impl CapabilityDeclV2 {
             });
         }
 
+        // Reject duplicate effects — declaring the same `EffectKind` twice in
+        // one capability is always a manifest bug, never load-bearing, and
+        // letting it through would defeat consistency with the dedup applied
+        // to `implements` and `required_host_ports`.
+        let mut effects_seen: HashSet<EffectKind> = HashSet::new();
+        for effect in &raw.effects {
+            if !effects_seen.insert(*effect) {
+                return Err(ManifestV2Error::DuplicateEffect {
+                    capability: id,
+                    effect: *effect,
+                });
+            }
+        }
+
         let mut implements_seen = BTreeSet::new();
         let mut implements = Vec::with_capacity(raw.implements.len());
         for profile in raw.implements {
@@ -356,11 +431,33 @@ impl CapabilityDeclV2 {
             implements.push(profile);
         }
 
-        let input_schema_ref = CapabilityProfileSchemaRef::new(raw.input_schema_ref)?;
-        let output_schema_ref = CapabilityProfileSchemaRef::new(raw.output_schema_ref)?;
+        let input_schema_ref =
+            CapabilityProfileSchemaRef::new(raw.input_schema_ref).map_err(|err| {
+                ManifestV2Error::InvalidSchemaRef {
+                    capability: id.clone(),
+                    field: "input_schema_ref",
+                    reason: err.to_string(),
+                }
+            })?;
+        let output_schema_ref =
+            CapabilityProfileSchemaRef::new(raw.output_schema_ref).map_err(|err| {
+                ManifestV2Error::InvalidSchemaRef {
+                    capability: id.clone(),
+                    field: "output_schema_ref",
+                    reason: err.to_string(),
+                }
+            })?;
         let prompt_doc_ref = raw
             .prompt_doc_ref
-            .map(CapabilityProfileSchemaRef::new)
+            .map(|value| {
+                CapabilityProfileSchemaRef::new(value).map_err(|err| {
+                    ManifestV2Error::InvalidSchemaRef {
+                        capability: id.clone(),
+                        field: "prompt_doc_ref",
+                        reason: err.to_string(),
+                    }
+                })
+            })
             .transpose()?;
 
         if matches!(raw.visibility, CapabilityVisibility::Model) && prompt_doc_ref.is_none() {
@@ -522,7 +619,7 @@ fn requested_trust_to_descriptor_trust(requested: RequestedTrustClass) -> TrustC
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct RawManifestV2 {
+struct RawManifestV2 {
     schema_version: String,
     id: String,
     name: String,
@@ -663,7 +760,7 @@ impl RawRuntimeV2 {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct RawCapabilityV2 {
+struct RawCapabilityV2 {
     id: String,
     #[serde(default)]
     implements: Vec<String>,

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -1,0 +1,544 @@
+//! Extension Manifest v2.
+//!
+//! v2 is the manifest shape consumed by Reborn. It is intentionally additive in
+//! this slice: this module ships alongside the v1 parser so downstream crates
+//! can migrate one at a time. The v1 parser is deleted in the follow-up slice
+//! once every caller is on v2.
+//!
+//! Key contract changes from v1:
+//! - manifests carry a loader-supplied [`ManifestSource`]; first-party / system
+//!   trust and runtime are only ever effective for [`ManifestSource::HostBundled`];
+//! - extension IDs starting with `ironclaw.` are reserved for HostBundled;
+//! - installed manifests must use `wasm` / `mcp` / `script` runtimes only;
+//! - every capability declares `visibility`, relative
+//!   [`CapabilityProfileSchemaRef`] input/output schema refs, optional
+//!   `prompt_doc_ref` (required when visibility is `model`), and the set of
+//!   host ports it needs;
+//! - host port names validate against a host-defined [`HostPortCatalog`].
+//!
+//! This module does **not** dispatch capabilities, load WASM modules, evaluate
+//! trust policy, or grant authority. It is contract vocabulary only.
+
+use std::collections::BTreeSet;
+
+use ironclaw_host_api::{
+    CapabilityId, CapabilityProfileId, CapabilityProfileSchemaRef, EffectKind, ExtensionId,
+    HostApiError, HostPortCatalog, HostPortId, PermissionMode, RequestedTrustClass,
+    ResourceProfile, RuntimeKind, TrustClass,
+};
+use serde::{Deserialize, Deserializer};
+use thiserror::Error;
+
+/// Required value of the `schema_version` field for v2 manifests.
+pub const MANIFEST_SCHEMA_VERSION: &str = "reborn.extension_manifest.v2";
+
+/// Reserved extension-ID prefix for host-bundled extensions.
+pub const RESERVED_HOST_BUNDLED_ID_PREFIX: &str = "ironclaw.";
+
+/// Loader-supplied source for a manifest. Never read from TOML.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ManifestSource {
+    /// Compiled or bundled with the host binary. Only source eligible for
+    /// effective FirstParty/System trust and runtime.
+    HostBundled,
+    /// Locally installed extension under `/system/extensions/`. Never eligible
+    /// for effective FirstParty/System.
+    InstalledLocal,
+    /// Installed from registry/catalog with digest/signature metadata. Never
+    /// eligible for effective FirstParty/System in v2.
+    RegistryInstalled,
+}
+
+impl ManifestSource {
+    /// True if the source is allowed to assert FirstParty/System trust/runtime.
+    pub fn allows_first_party(self) -> bool {
+        matches!(self, Self::HostBundled)
+    }
+}
+
+/// Per-capability surface visibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityVisibility {
+    /// Visible to the model through the Hot Capability Surface.
+    Model,
+    /// Used by host-internal flows (memory injection, audit) only.
+    HostInternal,
+    /// Reachable through the gateway/API surface only.
+    Api,
+}
+
+/// Validated v2 capability declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityDeclV2 {
+    pub id: CapabilityId,
+    pub implements: Vec<CapabilityProfileId>,
+    pub description: String,
+    pub effects: Vec<EffectKind>,
+    pub default_permission: PermissionMode,
+    pub visibility: CapabilityVisibility,
+    pub input_schema_ref: CapabilityProfileSchemaRef,
+    pub output_schema_ref: CapabilityProfileSchemaRef,
+    pub prompt_doc_ref: Option<CapabilityProfileSchemaRef>,
+    pub required_host_ports: Vec<HostPortId>,
+    pub resource_profile: Option<ResourceProfile>,
+}
+
+/// v2 runtime declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExtensionRuntimeV2 {
+    Wasm {
+        module: String,
+    },
+    Script {
+        runner: String,
+        image: Option<String>,
+        command: String,
+        args: Vec<String>,
+    },
+    Mcp {
+        transport: String,
+        command: Option<String>,
+        args: Vec<String>,
+        url: Option<String>,
+    },
+    FirstParty {
+        service: String,
+    },
+    System {
+        service: String,
+    },
+}
+
+impl ExtensionRuntimeV2 {
+    pub fn kind(&self) -> RuntimeKind {
+        match self {
+            Self::Wasm { .. } => RuntimeKind::Wasm,
+            Self::Script { .. } => RuntimeKind::Script,
+            Self::Mcp { .. } => RuntimeKind::Mcp,
+            Self::FirstParty { .. } => RuntimeKind::FirstParty,
+            Self::System { .. } => RuntimeKind::System,
+        }
+    }
+
+    /// Runtimes that an installed (non-bundled) manifest may declare.
+    fn installed_allows(&self) -> bool {
+        matches!(
+            self,
+            Self::Wasm { .. } | Self::Mcp { .. } | Self::Script { .. }
+        )
+    }
+}
+
+/// Validated v2 manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionManifestV2 {
+    pub schema_version: String,
+    pub id: ExtensionId,
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub source: ManifestSource,
+    pub requested_trust: RequestedTrustClass,
+    pub trust: TrustClass,
+    pub runtime: ExtensionRuntimeV2,
+    pub capabilities: Vec<CapabilityDeclV2>,
+}
+
+/// v2 manifest parser/validator errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ManifestV2Error {
+    #[error(transparent)]
+    Contract(#[from] HostApiError),
+    #[error("failed to parse extension manifest: {reason}")]
+    Parse { reason: String },
+    #[error("invalid extension manifest: {reason}")]
+    Invalid { reason: String },
+    #[error("schema_version must be '{expected}', got '{actual}'")]
+    SchemaVersion {
+        expected: &'static str,
+        actual: String,
+    },
+    #[error("manifest source {manifest_source:?} is not allowed to assert trust '{requested:?}'")]
+    TrustForbiddenForSource {
+        manifest_source: ManifestSource,
+        requested: RequestedTrustClass,
+    },
+    #[error(
+        "manifest source {manifest_source:?} is not allowed to declare runtime kind '{kind:?}'"
+    )]
+    RuntimeForbiddenForSource {
+        manifest_source: ManifestSource,
+        kind: RuntimeKind,
+    },
+    #[error("extension id '{id}' uses the reserved '{prefix}' prefix, which is host-bundled only")]
+    ReservedIdForInstalledSource {
+        id: ExtensionId,
+        prefix: &'static str,
+    },
+    #[error(
+        "capability {capability} declares unknown host port '{port}' (not in host-defined catalog)"
+    )]
+    UnknownHostPort {
+        capability: CapabilityId,
+        port: HostPortId,
+    },
+    #[error("capability {capability} is model-visible but has no prompt_doc_ref")]
+    MissingPromptDocRef { capability: CapabilityId },
+    #[error("duplicate capability id {id}")]
+    DuplicateCapability { id: CapabilityId },
+    #[error("capability id {id} must be provider-prefixed with '{expected}.' (extension id)")]
+    CapabilityIdNotPrefixed {
+        id: CapabilityId,
+        expected: ExtensionId,
+    },
+}
+
+impl ExtensionManifestV2 {
+    /// Parse a v2 manifest TOML body and validate it against `host_port_catalog`.
+    ///
+    /// `source` is supplied by the loader/install path, never read from TOML.
+    pub fn parse(
+        input: &str,
+        source: ManifestSource,
+        host_port_catalog: &HostPortCatalog,
+    ) -> Result<Self, ManifestV2Error> {
+        let raw: RawManifestV2 = toml::from_str(input).map_err(|error| ManifestV2Error::Parse {
+            reason: error.to_string(),
+        })?;
+        Self::from_raw(raw, source, host_port_catalog)
+    }
+
+    /// Construct a manifest from an already-deserialized raw representation.
+    pub fn from_raw(
+        raw: RawManifestV2,
+        source: ManifestSource,
+        host_port_catalog: &HostPortCatalog,
+    ) -> Result<Self, ManifestV2Error> {
+        if raw.schema_version != MANIFEST_SCHEMA_VERSION {
+            return Err(ManifestV2Error::SchemaVersion {
+                expected: MANIFEST_SCHEMA_VERSION,
+                actual: raw.schema_version,
+            });
+        }
+
+        let id = ExtensionId::new(raw.id)?;
+        if !source.allows_first_party() && id.as_str().starts_with(RESERVED_HOST_BUNDLED_ID_PREFIX)
+        {
+            return Err(ManifestV2Error::ReservedIdForInstalledSource {
+                id,
+                prefix: RESERVED_HOST_BUNDLED_ID_PREFIX,
+            });
+        }
+
+        if raw.name.trim().is_empty() {
+            return Err(ManifestV2Error::Invalid {
+                reason: "name must not be empty".to_string(),
+            });
+        }
+        if raw.version.trim().is_empty() {
+            return Err(ManifestV2Error::Invalid {
+                reason: "version must not be empty".to_string(),
+            });
+        }
+        if raw.capabilities.is_empty() {
+            return Err(ManifestV2Error::Invalid {
+                reason: "at least one capability is required".to_string(),
+            });
+        }
+
+        let requested_trust = raw.trust;
+        if !source.allows_first_party()
+            && matches!(
+                requested_trust,
+                RequestedTrustClass::FirstPartyRequested | RequestedTrustClass::SystemRequested
+            )
+        {
+            return Err(ManifestV2Error::TrustForbiddenForSource {
+                manifest_source: source,
+                requested: requested_trust,
+            });
+        }
+        let trust = requested_trust_to_descriptor_trust(requested_trust);
+
+        let runtime = raw.runtime.into_runtime()?;
+        if !source.allows_first_party() && !runtime.installed_allows() {
+            return Err(ManifestV2Error::RuntimeForbiddenForSource {
+                manifest_source: source,
+                kind: runtime.kind(),
+            });
+        }
+
+        let mut seen_capabilities = BTreeSet::new();
+        let mut capabilities = Vec::with_capacity(raw.capabilities.len());
+        for raw_cap in raw.capabilities {
+            let cap = CapabilityDeclV2::from_raw(raw_cap, &id, host_port_catalog)?;
+            if !seen_capabilities.insert(cap.id.clone()) {
+                return Err(ManifestV2Error::DuplicateCapability { id: cap.id });
+            }
+            capabilities.push(cap);
+        }
+
+        Ok(Self {
+            schema_version: raw.schema_version,
+            id,
+            name: raw.name,
+            version: raw.version,
+            description: raw.description,
+            source,
+            requested_trust,
+            trust,
+            runtime,
+            capabilities,
+        })
+    }
+}
+
+impl CapabilityDeclV2 {
+    fn from_raw(
+        raw: RawCapabilityV2,
+        extension_id: &ExtensionId,
+        host_port_catalog: &HostPortCatalog,
+    ) -> Result<Self, ManifestV2Error> {
+        let id = CapabilityId::new(raw.id)?;
+        let expected_prefix = format!("{}.", extension_id.as_str());
+        if !id.as_str().starts_with(&expected_prefix) {
+            return Err(ManifestV2Error::CapabilityIdNotPrefixed {
+                id,
+                expected: extension_id.clone(),
+            });
+        }
+
+        if raw.description.trim().is_empty() {
+            return Err(ManifestV2Error::Invalid {
+                reason: format!("capability {id} description must not be empty"),
+            });
+        }
+
+        let implements = raw
+            .implements
+            .into_iter()
+            .map(CapabilityProfileId::new)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let input_schema_ref = CapabilityProfileSchemaRef::new(raw.input_schema_ref)?;
+        let output_schema_ref = CapabilityProfileSchemaRef::new(raw.output_schema_ref)?;
+        let prompt_doc_ref = raw
+            .prompt_doc_ref
+            .map(CapabilityProfileSchemaRef::new)
+            .transpose()?;
+
+        if matches!(raw.visibility, CapabilityVisibility::Model) && prompt_doc_ref.is_none() {
+            return Err(ManifestV2Error::MissingPromptDocRef { capability: id });
+        }
+
+        let required_host_ports = raw
+            .required_host_ports
+            .into_iter()
+            .map(HostPortId::new)
+            .collect::<Result<Vec<_>, _>>()?;
+        for port in &required_host_ports {
+            if !host_port_catalog.contains(port) {
+                return Err(ManifestV2Error::UnknownHostPort {
+                    capability: id.clone(),
+                    port: port.clone(),
+                });
+            }
+        }
+
+        Ok(Self {
+            id,
+            implements,
+            description: raw.description,
+            effects: raw.effects,
+            default_permission: raw.default_permission,
+            visibility: raw.visibility,
+            input_schema_ref,
+            output_schema_ref,
+            prompt_doc_ref,
+            required_host_ports,
+            resource_profile: raw.resource_profile,
+        })
+    }
+}
+
+fn requested_trust_to_descriptor_trust(requested: RequestedTrustClass) -> TrustClass {
+    match requested {
+        RequestedTrustClass::ThirdParty => TrustClass::UserTrusted,
+        RequestedTrustClass::Untrusted
+        | RequestedTrustClass::FirstPartyRequested
+        | RequestedTrustClass::SystemRequested => TrustClass::Sandbox,
+    }
+}
+
+// ---- Raw deserialization shapes --------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawManifestV2 {
+    schema_version: String,
+    id: String,
+    name: String,
+    version: String,
+    description: String,
+    #[serde(
+        default = "default_requested_trust",
+        deserialize_with = "deserialize_requested_trust"
+    )]
+    trust: RequestedTrustClass,
+    runtime: RawRuntimeV2,
+    #[serde(default)]
+    capabilities: Vec<RawCapabilityV2>,
+}
+
+fn default_requested_trust() -> RequestedTrustClass {
+    RequestedTrustClass::Untrusted
+}
+
+fn deserialize_requested_trust<'de, D>(deserializer: D) -> Result<RequestedTrustClass, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    match value.as_str() {
+        "untrusted" => Ok(RequestedTrustClass::Untrusted),
+        "third_party" => Ok(RequestedTrustClass::ThirdParty),
+        "first_party_requested" => Ok(RequestedTrustClass::FirstPartyRequested),
+        "system_requested" => Ok(RequestedTrustClass::SystemRequested),
+        other => Err(serde::de::Error::custom(format!(
+            "unsupported trust value {other:?}; expected one of untrusted, third_party, first_party_requested, system_requested"
+        ))),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum RawRuntimeV2 {
+    Wasm {
+        module: String,
+    },
+    Script {
+        runner: String,
+        #[serde(default)]
+        image: Option<String>,
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+    Mcp {
+        transport: String,
+        #[serde(default)]
+        command: Option<String>,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default)]
+        url: Option<String>,
+    },
+    FirstParty {
+        service: String,
+    },
+    System {
+        service: String,
+    },
+}
+
+impl RawRuntimeV2 {
+    fn into_runtime(self) -> Result<ExtensionRuntimeV2, ManifestV2Error> {
+        match self {
+            Self::Wasm { module } => {
+                if module.trim().is_empty() {
+                    return Err(ManifestV2Error::Invalid {
+                        reason: "wasm runtime module must not be empty".to_string(),
+                    });
+                }
+                Ok(ExtensionRuntimeV2::Wasm { module })
+            }
+            Self::Script {
+                runner,
+                image,
+                command,
+                args,
+            } => {
+                if runner.trim().is_empty() {
+                    return Err(ManifestV2Error::Invalid {
+                        reason: "script runner must not be empty".to_string(),
+                    });
+                }
+                if command.trim().is_empty() {
+                    return Err(ManifestV2Error::Invalid {
+                        reason: "script command must not be empty".to_string(),
+                    });
+                }
+                if runner == "docker" {
+                    let image_str = image.as_deref().unwrap_or_default();
+                    if image_str.trim().is_empty() {
+                        return Err(ManifestV2Error::Invalid {
+                            reason: "script image is required for docker runner".to_string(),
+                        });
+                    }
+                }
+                Ok(ExtensionRuntimeV2::Script {
+                    runner,
+                    image,
+                    command,
+                    args,
+                })
+            }
+            Self::Mcp {
+                transport,
+                command,
+                args,
+                url,
+            } => {
+                if transport.trim().is_empty() {
+                    return Err(ManifestV2Error::Invalid {
+                        reason: "mcp transport must not be empty".to_string(),
+                    });
+                }
+                Ok(ExtensionRuntimeV2::Mcp {
+                    transport,
+                    command,
+                    args,
+                    url,
+                })
+            }
+            Self::FirstParty { service } => {
+                if service.trim().is_empty() {
+                    return Err(ManifestV2Error::Invalid {
+                        reason: "first-party service must not be empty".to_string(),
+                    });
+                }
+                Ok(ExtensionRuntimeV2::FirstParty { service })
+            }
+            Self::System { service } => {
+                if service.trim().is_empty() {
+                    return Err(ManifestV2Error::Invalid {
+                        reason: "system service must not be empty".to_string(),
+                    });
+                }
+                Ok(ExtensionRuntimeV2::System { service })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawCapabilityV2 {
+    id: String,
+    #[serde(default)]
+    implements: Vec<String>,
+    description: String,
+    #[serde(default)]
+    effects: Vec<EffectKind>,
+    default_permission: PermissionMode,
+    visibility: CapabilityVisibility,
+    input_schema_ref: String,
+    output_schema_ref: String,
+    #[serde(default)]
+    prompt_doc_ref: Option<String>,
+    #[serde(default)]
+    required_host_ports: Vec<String>,
+    #[serde(default)]
+    resource_profile: Option<ResourceProfile>,
+}

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -122,11 +122,14 @@ impl ExtensionRuntimeV2 {
     }
 
     /// Runtimes that an installed (non-bundled) manifest may declare.
+    ///
+    /// Exhaustive match — adding a new `ExtensionRuntimeV2` variant must force
+    /// an explicit decision here rather than silently defaulting to `false`.
     fn installed_allows(&self) -> bool {
-        matches!(
-            self,
-            Self::Wasm { .. } | Self::Mcp { .. } | Self::Script { .. }
-        )
+        match self {
+            Self::Wasm { .. } | Self::Mcp { .. } | Self::Script { .. } => true,
+            Self::FirstParty { .. } | Self::System { .. } => false,
+        }
     }
 }
 
@@ -320,8 +323,14 @@ impl CapabilityDeclV2 {
         host_port_catalog: &HostPortCatalog,
     ) -> Result<Self, ManifestV2Error> {
         let id = CapabilityId::new(raw.id)?;
-        let expected_prefix = format!("{}.", extension_id.as_str());
-        if !id.as_str().starts_with(&expected_prefix) {
+        // Provider-prefix check without an intermediate `format!` allocation:
+        // capability id must be `<extension_id>.<...>` (the dot is required so
+        // `foo.bar` cannot squat `foo`'s namespace via `foobar.baz`).
+        let prefixed = id
+            .as_str()
+            .strip_prefix(extension_id.as_str())
+            .is_some_and(|rest| rest.starts_with('.'));
+        if !prefixed {
             return Err(ManifestV2Error::CapabilityIdNotPrefixed {
                 id,
                 expected: extension_id.clone(),

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -192,6 +192,20 @@ pub enum ManifestV2Error {
         id: CapabilityId,
         expected: ExtensionId,
     },
+    #[error("capability {capability} declares duplicate required host port '{port}'")]
+    DuplicateRequiredHostPort {
+        capability: CapabilityId,
+        port: HostPortId,
+    },
+    #[error("capability {capability} implements profile '{profile}' more than once")]
+    DuplicateImplementedProfile {
+        capability: CapabilityId,
+        profile: CapabilityProfileId,
+    },
+    #[error("invalid wasm module ref '{value}': {reason}")]
+    InvalidWasmModuleRef { value: String, reason: String },
+    #[error("invalid mcp runtime: {reason}")]
+    InvalidMcpRuntime { reason: String },
 }
 
 impl ExtensionManifestV2 {
@@ -210,7 +224,7 @@ impl ExtensionManifestV2 {
     }
 
     /// Construct a manifest from an already-deserialized raw representation.
-    pub fn from_raw(
+    fn from_raw(
         raw: RawManifestV2,
         source: ManifestSource,
         host_port_catalog: &HostPortCatalog,
@@ -239,6 +253,11 @@ impl ExtensionManifestV2 {
         if raw.version.trim().is_empty() {
             return Err(ManifestV2Error::Invalid {
                 reason: "version must not be empty".to_string(),
+            });
+        }
+        if raw.description.trim().is_empty() {
+            return Err(ManifestV2Error::Invalid {
+                reason: "description must not be empty".to_string(),
             });
         }
         if raw.capabilities.is_empty() {
@@ -315,11 +334,18 @@ impl CapabilityDeclV2 {
             });
         }
 
-        let implements = raw
-            .implements
-            .into_iter()
-            .map(CapabilityProfileId::new)
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut implements_seen = BTreeSet::new();
+        let mut implements = Vec::with_capacity(raw.implements.len());
+        for profile in raw.implements {
+            let profile = CapabilityProfileId::new(profile)?;
+            if !implements_seen.insert(profile.clone()) {
+                return Err(ManifestV2Error::DuplicateImplementedProfile {
+                    capability: id,
+                    profile,
+                });
+            }
+            implements.push(profile);
+        }
 
         let input_schema_ref = CapabilityProfileSchemaRef::new(raw.input_schema_ref)?;
         let output_schema_ref = CapabilityProfileSchemaRef::new(raw.output_schema_ref)?;
@@ -332,18 +358,23 @@ impl CapabilityDeclV2 {
             return Err(ManifestV2Error::MissingPromptDocRef { capability: id });
         }
 
-        let required_host_ports = raw
-            .required_host_ports
-            .into_iter()
-            .map(HostPortId::new)
-            .collect::<Result<Vec<_>, _>>()?;
-        for port in &required_host_ports {
-            if !host_port_catalog.contains(port) {
-                return Err(ManifestV2Error::UnknownHostPort {
+        let mut required_host_ports_seen = BTreeSet::new();
+        let mut required_host_ports = Vec::with_capacity(raw.required_host_ports.len());
+        for port in raw.required_host_ports {
+            let port = HostPortId::new(port)?;
+            if !required_host_ports_seen.insert(port.clone()) {
+                return Err(ManifestV2Error::DuplicateRequiredHostPort {
                     capability: id.clone(),
-                    port: port.clone(),
+                    port,
                 });
             }
+            if !host_port_catalog.contains(&port) {
+                return Err(ManifestV2Error::UnknownHostPort {
+                    capability: id.clone(),
+                    port,
+                });
+            }
+            required_host_ports.push(port);
         }
 
         Ok(Self {
@@ -360,6 +391,113 @@ impl CapabilityDeclV2 {
             resource_profile: raw.resource_profile,
         })
     }
+}
+
+fn validate_wasm_module_ref(value: &str) -> Result<(), ManifestV2Error> {
+    let raise = |reason: &str| ManifestV2Error::InvalidWasmModuleRef {
+        value: value.to_string(),
+        reason: reason.to_string(),
+    };
+    if value.is_empty() {
+        return Err(raise("must not be empty"));
+    }
+    if value.chars().any(|ch| ch == ' ' || ch.is_control()) {
+        return Err(raise("NUL/control characters and spaces are not allowed"));
+    }
+    if value.contains("://") {
+        return Err(raise("URLs are not extension asset paths"));
+    }
+    if value.starts_with('/') {
+        return Err(raise("must be relative"));
+    }
+    if value.contains('\\') {
+        return Err(raise("host path separators are not allowed"));
+    }
+    let bytes = value.as_bytes();
+    let looks_windows = (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+        || (bytes.len() >= 3 && bytes[1] == b':' && (bytes[2] == b'\\' || bytes[2] == b'/'));
+    if looks_windows {
+        return Err(raise("host path separators are not allowed"));
+    }
+    for segment in value.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return Err(raise("empty or dot path segments are not allowed"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_mcp_runtime_shape(
+    transport: &str,
+    command: Option<&str>,
+    url: Option<&str>,
+) -> Result<(), ManifestV2Error> {
+    if transport.trim().is_empty() {
+        return Err(ManifestV2Error::InvalidMcpRuntime {
+            reason: "transport must not be empty".to_string(),
+        });
+    }
+    if let Some(command) = command
+        && command.trim().is_empty()
+    {
+        return Err(ManifestV2Error::InvalidMcpRuntime {
+            reason: "command must not be empty".to_string(),
+        });
+    }
+    if let Some(url) = url
+        && url.trim().is_empty()
+    {
+        return Err(ManifestV2Error::InvalidMcpRuntime {
+            reason: "url must not be empty".to_string(),
+        });
+    }
+    match transport {
+        "stdio" => {
+            if url.is_some() {
+                return Err(ManifestV2Error::InvalidMcpRuntime {
+                    reason: "stdio transport must not specify url".to_string(),
+                });
+            }
+            if command.is_none() {
+                return Err(ManifestV2Error::InvalidMcpRuntime {
+                    reason: "stdio transport requires command".to_string(),
+                });
+            }
+        }
+        "http" | "sse" => {
+            if command.is_some() {
+                return Err(ManifestV2Error::InvalidMcpRuntime {
+                    reason: format!("{transport} transport must not specify command"),
+                });
+            }
+            let Some(url) = url else {
+                return Err(ManifestV2Error::InvalidMcpRuntime {
+                    reason: format!("{transport} transport requires url"),
+                });
+            };
+            validate_mcp_http_url(transport, url)?;
+        }
+        other => {
+            return Err(ManifestV2Error::InvalidMcpRuntime {
+                reason: format!(
+                    "transport '{other}' is not supported; expected stdio, http, or sse"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_mcp_http_url(transport: &str, value: &str) -> Result<(), ManifestV2Error> {
+    let parsed = url::Url::parse(value).map_err(|_| ManifestV2Error::InvalidMcpRuntime {
+        reason: format!("{transport} transport url must be an absolute http(s) URL"),
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(ManifestV2Error::InvalidMcpRuntime {
+            reason: format!("{transport} transport url must use http or https"),
+        });
+    }
+    Ok(())
 }
 
 fn requested_trust_to_descriptor_trust(requested: RequestedTrustClass) -> TrustClass {
@@ -446,11 +584,7 @@ impl RawRuntimeV2 {
     fn into_runtime(self) -> Result<ExtensionRuntimeV2, ManifestV2Error> {
         match self {
             Self::Wasm { module } => {
-                if module.trim().is_empty() {
-                    return Err(ManifestV2Error::Invalid {
-                        reason: "wasm runtime module must not be empty".to_string(),
-                    });
-                }
+                validate_wasm_module_ref(&module)?;
                 Ok(ExtensionRuntimeV2::Wasm { module })
             }
             Self::Script {
@@ -490,11 +624,7 @@ impl RawRuntimeV2 {
                 args,
                 url,
             } => {
-                if transport.trim().is_empty() {
-                    return Err(ManifestV2Error::Invalid {
-                        reason: "mcp transport must not be empty".to_string(),
-                    });
-                }
+                validate_mcp_runtime_shape(&transport, command.as_deref(), url.as_deref())?;
                 Ok(ExtensionRuntimeV2::Mcp {
                     transport,
                     command,

--- a/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
+++ b/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
@@ -61,7 +61,7 @@ fn parses_minimum_valid_v2_manifest_for_installed_third_party_extension() {
     assert_eq!(manifest.id, ExtensionId::new("acme-tools").unwrap());
     assert_eq!(manifest.source, ManifestSource::InstalledLocal);
     assert_eq!(manifest.requested_trust, RequestedTrustClass::ThirdParty);
-    assert_eq!(manifest.trust, TrustClass::UserTrusted);
+    assert_eq!(manifest.descriptor_trust_default, TrustClass::UserTrusted);
     assert_eq!(manifest.runtime.kind(), RuntimeKind::Wasm);
     assert_eq!(manifest.capabilities.len(), 1);
     let cap = &manifest.capabilities[0];
@@ -212,6 +212,11 @@ required_host_ports = [
         manifest.requested_trust,
         RequestedTrustClass::FirstPartyRequested
     );
+    // Lock in the v2 contract: `descriptor_trust_default` is a safe
+    // pre-policy default. Privileged requests *intentionally* surface as
+    // Sandbox here even for HostBundled — effective trust must come from a
+    // host trust-policy evaluation, never from this field.
+    assert_eq!(manifest.descriptor_trust_default, TrustClass::Sandbox);
     assert!(matches!(
         manifest.runtime,
         ExtensionRuntimeV2::FirstParty { .. }
@@ -348,8 +353,14 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
         let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
             .unwrap_err();
         assert!(
-            matches!(err, ManifestV2Error::Contract(_)),
-            "{bad_ref:?} should be rejected via contract error, got {err:?}"
+            matches!(
+                err,
+                ManifestV2Error::InvalidSchemaRef {
+                    field: "input_schema_ref",
+                    ..
+                }
+            ),
+            "{bad_ref:?} should be rejected via InvalidSchemaRef, got {err:?}"
         );
     }
 }
@@ -411,7 +422,7 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
     let manifest =
         ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
     assert_eq!(manifest.requested_trust, RequestedTrustClass::Untrusted);
-    assert_eq!(manifest.trust, TrustClass::Sandbox);
+    assert_eq!(manifest.descriptor_trust_default, TrustClass::Sandbox);
 }
 
 #[test]
@@ -692,4 +703,163 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
         matches!(err, ManifestV2Error::DuplicateCapability { .. }),
         "{err:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Issue-driven coverage (zmanian review, slice 2a).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn host_bundled_accepts_non_reserved_id() {
+    // Spec: the `ironclaw.` prefix is reserved *for* HostBundled. It is not
+    // *required* of HostBundled. A host-bundled extension may legitimately
+    // ship under any id; lock that in so the reserved-prefix rule does not
+    // accidentally become a "must use" rule downstream.
+    let toml = third_party_wasm_manifest("memory-native", "memory-native.echo");
+    let manifest =
+        ExtensionManifestV2::parse(&toml, ManifestSource::HostBundled, &catalog()).unwrap();
+    assert_eq!(manifest.source, ManifestSource::HostBundled);
+    assert_eq!(manifest.id, ExtensionId::new("memory-native").unwrap());
+}
+
+#[test]
+fn parses_multi_capability_manifest_with_distinct_implements() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "Acme"
+version = "0.1.0"
+description = "two capabilities"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/acme.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+implements = ["acme.echo.v1"]
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+
+[[capabilities]]
+id = "acme-tools.reverse"
+implements = ["acme.reverse.v1", "acme.string_ops.v1"]
+description = "reverse a string"
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/acme/reverse.input.v1.json"
+output_schema_ref = "schemas/acme/reverse.output.v1.json"
+prompt_doc_ref = "prompt/acme/reverse.md"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let manifest =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    assert_eq!(manifest.capabilities.len(), 2);
+    assert_eq!(
+        manifest.capabilities[0].implements,
+        vec![CapabilityProfileId::new("acme.echo.v1").unwrap()]
+    );
+    assert_eq!(
+        manifest.capabilities[1].implements,
+        vec![
+            CapabilityProfileId::new("acme.reverse.v1").unwrap(),
+            CapabilityProfileId::new("acme.string_ops.v1").unwrap(),
+        ]
+    );
+}
+
+#[test]
+fn rejects_manifest_exceeding_max_size() {
+    use ironclaw_extensions::{MAX_MANIFEST_BYTES, ManifestV2Error};
+    // Construct an input strictly larger than MAX_MANIFEST_BYTES *before*
+    // reaching the TOML parser. The check must fail closed without parsing.
+    let mut huge = String::with_capacity(MAX_MANIFEST_BYTES + 1024);
+    huge.push_str("# pad\n");
+    while huge.len() <= MAX_MANIFEST_BYTES {
+        huge.push_str("# filler line to defeat short-circuit eval\n");
+    }
+    let err =
+        ExtensionManifestV2::parse(&huge, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::ManifestTooLarge { bytes, max } if bytes == huge.len() && max == MAX_MANIFEST_BYTES),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn rejects_duplicate_effect_in_capability() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "Acme"
+version = "0.1.0"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/acme.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+effects = ["read_filesystem", "read_filesystem"]
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::DuplicateEffect { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn schema_ref_errors_carry_field_context() {
+    // Absolute schema refs are rejected by CapabilityProfileSchemaRef::new.
+    // The parser must wrap the underlying error with the offending field name
+    // so hand-edited manifests get an actionable error.
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "Acme"
+version = "0.1.0"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/acme.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "/abs/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    match err {
+        ManifestV2Error::InvalidSchemaRef { field, .. } => {
+            assert_eq!(field, "input_schema_ref");
+        }
+        other => panic!("expected InvalidSchemaRef, got {other:?}"),
+    }
 }

--- a/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
+++ b/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
@@ -385,6 +385,275 @@ output_schema_ref = "schemas/acme/echo.output.v1.json"
 }
 
 #[test]
+fn default_trust_is_untrusted_when_field_is_omitted() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let manifest =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+    assert_eq!(manifest.requested_trust, RequestedTrustClass::Untrusted);
+    assert_eq!(manifest.trust, TrustClass::Sandbox);
+}
+
+#[test]
+fn rejects_empty_top_level_name_version_or_description() {
+    for (field, value) in [("name", ""), ("version", ""), ("description", "")] {
+        let toml = format!(
+            r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "{name}"
+version = "{version}"
+description = "{description}"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+            schema = MANIFEST_SCHEMA_VERSION,
+            name = if field == "name" { value } else { "x" },
+            version = if field == "version" { value } else { "0.1" },
+            description = if field == "description" { value } else { "x" },
+        );
+        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
+            .unwrap_err();
+        assert!(
+            matches!(err, ManifestV2Error::Invalid { .. }),
+            "{field}={value:?} should be rejected, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn rejects_wasm_module_with_host_or_url_or_traversal_paths() {
+    for bad in [
+        "",
+        " ",
+        "/abs/path.wasm",
+        "../escape.wasm",
+        "foo/../bar.wasm",
+        "https://evil.example.com/x.wasm",
+        "file:///tmp/x.wasm",
+        "C:\\windows.wasm",
+        "c:/win.wasm",
+        "has space.wasm",
+        "wasm/./echo.wasm",
+    ] {
+        let toml = format!(
+            r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "{bad}"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+            schema = MANIFEST_SCHEMA_VERSION,
+            bad = bad.replace('\\', "\\\\"),
+        );
+        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
+            .unwrap_err();
+        assert!(
+            matches!(err, ManifestV2Error::InvalidWasmModuleRef { .. }),
+            "wasm module {bad:?} should be rejected, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn mcp_runtime_enforces_transport_and_shape() {
+    let cap_block = r#"
+[[capabilities]]
+id = "acme-mcp.search"
+description = "search"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/search.input.v1.json"
+output_schema_ref = "schemas/acme/search.output.v1.json"
+"#;
+    let header = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-mcp"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+
+    // accepts: stdio with command, http with absolute https url
+    for runtime in [
+        "[runtime]\nkind = \"mcp\"\ntransport = \"stdio\"\ncommand = \"server\"\n",
+        "[runtime]\nkind = \"mcp\"\ntransport = \"http\"\nurl = \"https://example.com/mcp\"\n",
+        "[runtime]\nkind = \"mcp\"\ntransport = \"sse\"\nurl = \"https://example.com/mcp\"\n",
+    ] {
+        let toml = format!("{header}\n{runtime}\n{cap_block}");
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
+            .unwrap_or_else(|err| panic!("valid mcp runtime rejected: {err:?}\n{runtime}"));
+    }
+
+    // rejects: stdio with url; http without url; http with command; unknown transport; ftp url.
+    for runtime in [
+        "[runtime]\nkind = \"mcp\"\ntransport = \"stdio\"\nurl = \"https://x.com\"\n",
+        "[runtime]\nkind = \"mcp\"\ntransport = \"stdio\"\n",
+        "[runtime]\nkind = \"mcp\"\ntransport = \"http\"\n",
+        "[runtime]\nkind = \"mcp\"\ntransport = \"http\"\ncommand = \"x\"\nurl = \"https://x.com\"\n",
+        "[runtime]\nkind = \"mcp\"\ntransport = \"telnet\"\nurl = \"telnet://x.com\"\n",
+        "[runtime]\nkind = \"mcp\"\ntransport = \"http\"\nurl = \"ftp://example.com\"\n",
+        "[runtime]\nkind = \"mcp\"\ntransport = \"\"\n",
+    ] {
+        let toml = format!("{header}\n{runtime}\n{cap_block}");
+        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
+            .unwrap_err();
+        assert!(
+            matches!(err, ManifestV2Error::InvalidMcpRuntime { .. }),
+            "runtime should be rejected:\n{runtime}\n got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn rejects_duplicate_required_host_ports_in_one_capability() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+required_host_ports = ["host.events.audit", "host.events.audit"]
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::DuplicateRequiredHostPort { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn rejects_duplicate_implements_in_one_capability() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+implements = ["memory.context_retrieval.v1", "memory.context_retrieval.v1"]
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::DuplicateImplementedProfile { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn capability_rejects_unknown_fields_on_deserialize() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+sneaky = true
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(matches!(err, ManifestV2Error::Parse { .. }), "{err:?}");
+}
+
+#[test]
 fn rejects_duplicate_capability_ids() {
     let toml = format!(
         r#"

--- a/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
+++ b/crates/ironclaw_extensions/tests/manifest_v2_contract.rs
@@ -1,0 +1,426 @@
+//! Extension Manifest v2 contract tests.
+
+use ironclaw_extensions::{
+    CapabilityVisibility, ExtensionManifestV2, ExtensionRuntimeV2, MANIFEST_SCHEMA_VERSION,
+    ManifestSource, ManifestV2Error,
+};
+use ironclaw_host_api::{
+    CapabilityProfileId, ExtensionId, HostPortCatalog, HostPortCatalogEntry, HostPortId,
+    PermissionMode, RequestedTrustClass, RuntimeKind, TrustClass,
+};
+
+const TELEGRAM_TOKEN_PORT: &str = "host.secrets.telegram_bot_token";
+const AUDIT_PORT: &str = "host.events.audit";
+const SQL_TX_PORT: &str = "host.storage.sql_transaction.first_party";
+
+fn catalog() -> HostPortCatalog {
+    HostPortCatalog::new(vec![
+        HostPortCatalogEntry::new(HostPortId::new(AUDIT_PORT).unwrap()),
+        HostPortCatalogEntry::new(HostPortId::new(SQL_TX_PORT).unwrap()),
+        HostPortCatalogEntry::new(HostPortId::new(TELEGRAM_TOKEN_PORT).unwrap()),
+    ])
+    .unwrap()
+}
+
+fn third_party_wasm_manifest(extension_id: &str, capability_id: &str) -> String {
+    format!(
+        r#"
+schema_version = "{schema}"
+id = "{ext}"
+name = "Example Extension"
+version = "0.1.0"
+description = "test"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/example.wasm"
+
+[[capabilities]]
+id = "{cap}"
+description = "Echoes input"
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/example/echo.input.v1.json"
+output_schema_ref = "schemas/example/echo.output.v1.json"
+prompt_doc_ref = "prompt/example/echo.md"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+        ext = extension_id,
+        cap = capability_id,
+    )
+}
+
+#[test]
+fn parses_minimum_valid_v2_manifest_for_installed_third_party_extension() {
+    let toml = third_party_wasm_manifest("acme-tools", "acme-tools.echo");
+    let manifest =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap();
+
+    assert_eq!(manifest.schema_version, MANIFEST_SCHEMA_VERSION);
+    assert_eq!(manifest.id, ExtensionId::new("acme-tools").unwrap());
+    assert_eq!(manifest.source, ManifestSource::InstalledLocal);
+    assert_eq!(manifest.requested_trust, RequestedTrustClass::ThirdParty);
+    assert_eq!(manifest.trust, TrustClass::UserTrusted);
+    assert_eq!(manifest.runtime.kind(), RuntimeKind::Wasm);
+    assert_eq!(manifest.capabilities.len(), 1);
+    let cap = &manifest.capabilities[0];
+    assert_eq!(cap.visibility, CapabilityVisibility::Model);
+    assert_eq!(cap.default_permission, PermissionMode::Allow);
+    assert!(cap.prompt_doc_ref.is_some());
+}
+
+#[test]
+fn rejects_unknown_top_level_fields() {
+    let toml = r#"
+schema_version = "reborn.extension_manifest.v2"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+oops = true
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#;
+    let err =
+        ExtensionManifestV2::parse(toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(matches!(err, ManifestV2Error::Parse { .. }), "{err:?}");
+}
+
+#[test]
+fn rejects_first_party_trust_for_installed_source() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "first_party_requested"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ManifestV2Error::TrustForbiddenForSource {
+                manifest_source: ManifestSource::InstalledLocal,
+                requested: RequestedTrustClass::FirstPartyRequested,
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn rejects_first_party_runtime_for_installed_source() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "first_party"
+service = "native_memory_provider"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ManifestV2Error::RuntimeForbiddenForSource {
+                manifest_source: ManifestSource::InstalledLocal,
+                kind: RuntimeKind::FirstParty,
+            }
+        ),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn host_bundled_source_may_assert_first_party_and_reserved_id() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "ironclaw.memory.native"
+name = "Reborn Native Memory"
+version = "0.1.0"
+description = "host-bundled"
+trust = "first_party_requested"
+
+[runtime]
+kind = "first_party"
+service = "native_memory_provider"
+
+[[capabilities]]
+id = "ironclaw.memory.native.context.retrieve"
+implements = ["memory.context_retrieval.v1"]
+description = "Retrieve bounded provider-neutral memory context."
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/memory/context-retrieve.input.v1.json"
+output_schema_ref = "schemas/memory/context-retrieve.output.v1.json"
+required_host_ports = [
+  "host.storage.sql_transaction.first_party",
+  "host.events.audit",
+]
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let manifest =
+        ExtensionManifestV2::parse(&toml, ManifestSource::HostBundled, &catalog()).unwrap();
+    assert_eq!(
+        manifest.requested_trust,
+        RequestedTrustClass::FirstPartyRequested
+    );
+    assert!(matches!(
+        manifest.runtime,
+        ExtensionRuntimeV2::FirstParty { .. }
+    ));
+    let cap = &manifest.capabilities[0];
+    assert_eq!(
+        cap.implements,
+        vec![CapabilityProfileId::new("memory.context_retrieval.v1").unwrap()]
+    );
+    assert_eq!(cap.required_host_ports.len(), 2);
+}
+
+#[test]
+fn rejects_reserved_id_prefix_for_installed_source() {
+    let toml = third_party_wasm_manifest("ironclaw.fake", "ironclaw.fake.echo");
+    let err = ExtensionManifestV2::parse(&toml, ManifestSource::RegistryInstalled, &catalog())
+        .unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::ReservedIdForInstalledSource { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn rejects_capability_id_without_provider_prefix() {
+    let toml = third_party_wasm_manifest("acme-tools", "other.echo");
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::CapabilityIdNotPrefixed { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn rejects_unknown_host_ports() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+required_host_ports = ["host.does.not.exist"]
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::UnknownHostPort { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn rejects_model_visible_capability_without_prompt_doc_ref() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::MissingPromptDocRef { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn rejects_schema_ref_with_absolute_or_url_or_traversal_paths() {
+    for bad_ref in [
+        "/schemas/abs.json",
+        "../escape.json",
+        "https://example.com/schema.json",
+        "schemas/with:colon.json",
+    ] {
+        let toml = format!(
+            r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "{bad}"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+            schema = MANIFEST_SCHEMA_VERSION,
+            bad = bad_ref,
+        );
+        let err = ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog())
+            .unwrap_err();
+        assert!(
+            matches!(err, ManifestV2Error::Contract(_)),
+            "{bad_ref:?} should be rejected via contract error, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn rejects_wrong_schema_version() {
+    let toml = r#"
+schema_version = "reborn.extension_manifest.v1"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#;
+    let err =
+        ExtensionManifestV2::parse(toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::SchemaVersion { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn rejects_duplicate_capability_ids() {
+    let toml = format!(
+        r#"
+schema_version = "{schema}"
+id = "acme-tools"
+name = "x"
+version = "0.1"
+description = "x"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/echo.wasm"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+
+[[capabilities]]
+id = "acme-tools.echo"
+description = "echo (dup)"
+default_permission = "allow"
+visibility = "host_internal"
+input_schema_ref = "schemas/acme/echo.input.v1.json"
+output_schema_ref = "schemas/acme/echo.output.v1.json"
+"#,
+        schema = MANIFEST_SCHEMA_VERSION,
+    );
+    let err =
+        ExtensionManifestV2::parse(&toml, ManifestSource::InstalledLocal, &catalog()).unwrap_err();
+    assert!(
+        matches!(err, ManifestV2Error::DuplicateCapability { .. }),
+        "{err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the v2 manifest module (`ironclaw_extensions::v2`) alongside the existing v1 parser. v1 is left untouched so the workspace keeps compiling; the follow-up PR (slice 2b) migrates the 44 downstream callers and deletes v1.

## Contract changes vs v1

- `ManifestSource` is supplied by the loader (`HostBundled` / `InstalledLocal` / `RegistryInstalled`); never read from TOML.
- `HostBundled` is the only source that may assert FirstParty/System trust or runtime.
- Installed manifests may declare only `wasm` / `mcp` / `script` runtimes.
- The `ironclaw.` extension-id prefix is reserved for HostBundled.
- Every capability declares `visibility` (`model` / `host_internal` / `api`), relative `input_schema_ref` and `output_schema_ref`, optional `prompt_doc_ref` (required when `visibility = "model"`), and the set of required host ports.
- Host-port names validate against a host-defined `HostPortCatalog` (from #3568).
- Per-capability `implements` lists `CapabilityProfileId`s.
- `#[serde(deny_unknown_fields)]` on every new struct.

## Tests

12 contract tests in `crates/ironclaw_extensions/tests/manifest_v2_contract.rs`:

- minimum valid installed manifest
- reject unknown top-level field
- reject FirstParty/System trust for installed source
- reject FirstParty runtime for installed source
- HostBundled accepts reserved id and first-party runtime
- reject reserved id for installed source
- reject capability id without provider prefix
- reject unknown host ports (catalog miss)
- reject model-visible capability without `prompt_doc_ref`
- reject absolute / URL / traversal / colon-bearing schema refs
- reject wrong `schema_version`
- reject duplicate capability ids

## Scope

This PR is **slice 2a**. Part of issue #3537.

- ✅ v2 types + parser + validation
- ✅ Tests inside `ironclaw_extensions`
- ⬜ slice 2b: migrate 44 downstream callers and delete v1 parser (separate PR)
- ⬜ slice 2c (issue #3537 slice 3+): runtime dispatch wiring, host-port view threading, hot capability surface

## Stacking

Based on `reborn/issue-3537-extension-v2-prep` (PR #3568). Merge order:

```
#3568 → #3587 → this PR (slice 2a) → slice 2b → slice 3
```

## Verification

```bash
cargo fmt --all --check
cargo test -p ironclaw_extensions             # 47 passed
cargo clippy -p ironclaw_extensions --tests --all-features -- -D warnings
cargo test -p ironclaw_architecture           # 8 passed
```
