### PR TITLE
arch(ws-7): wire planned loop driver

### DIFF
--- a/crates/ironclaw_agent_loop/src/state.rs
+++ b/crates/ironclaw_agent_loop/src/state.rs
@@ -28,6 +28,7 @@ use ironclaw_turns::{
 /// legacy `&'static str` form because the `ComponentIdentity` migration is
 /// deferred to follow-up PRs (#3470/#3524/#3462) per the brief.
 pub const CHECKPOINT_SCHEMA_ID: &str = "reborn:default-loop-v1";
+pub const CHECKPOINT_SCHEMA_VERSION: u64 = 1;
 
 /// Immutable execution state threaded through the loop.
 ///

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -11,6 +11,7 @@ pub mod loop_exit_applier;
 pub mod milestone_events;
 pub mod model_routes;
 pub mod production_readiness;
+pub mod planned_driver;
 pub mod text_loop_driver;
 pub mod turn_runner;
 
@@ -37,4 +38,5 @@ pub use model_routes::{
     ModelRouteResolver, ModelRouteSource, ModelSelectionMode, ModelSlot,
     ResolvedModelRouteSnapshot, StaticModelRouteResolver,
 };
+pub use planned_driver::PlannedDriver;
 pub use text_loop_driver::{TextOnlyModelReplyDriver, TextOnlyModelReplyDriverConfig};

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -10,8 +10,8 @@ pub mod loop_driver_host;
 pub mod loop_exit_applier;
 pub mod milestone_events;
 pub mod model_routes;
-pub mod production_readiness;
 pub mod planned_driver;
+pub mod production_readiness;
 pub mod text_loop_driver;
 pub mod turn_runner;
 

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -11,16 +11,17 @@ use async_trait::async_trait;
 use ironclaw_agent_loop::{
     executor::{AgentLoopExecutor, AgentLoopExecutorError, CanonicalAgentLoopExecutor, HostStage},
     family::{LoopFamily, LoopFamilyId, LoopFamilyRegistry},
-    state::{CHECKPOINT_SCHEMA_ID, CheckpointKind, LoopExecutionState},
+    state::{CHECKPOINT_SCHEMA_ID, CHECKPOINT_SCHEMA_VERSION, CheckpointKind, LoopExecutionState},
 };
 use ironclaw_turns::{
     LoopExit, RunProfileVersion,
     run_profile::{
         AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverHost,
-        AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest,
+        AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, LoopDriverId,
     },
 };
 
+pub const PLANNED_DRIVER_DEFAULT_ID: &str = "reborn:planned-default";
 const PLANNED_DRIVER_VERSION: u64 = 1;
 
 /// Non-generic adapter from one resolved loop family to `AgentLoopDriver`.
@@ -32,11 +33,12 @@ pub struct PlannedDriver {
 
 impl PlannedDriver {
     pub fn from_family(
+        driver_id: LoopDriverId,
         family: Arc<LoopFamily>,
         executor: Arc<CanonicalAgentLoopExecutor>,
         version: RunProfileVersion,
     ) -> Result<Self, AgentLoopDriverError> {
-        let descriptor = descriptor_for_family(family.id(), version)?;
+        let descriptor = descriptor_for_driver_id(driver_id, version)?;
         Ok(Self {
             descriptor,
             family,
@@ -45,6 +47,7 @@ impl PlannedDriver {
     }
 
     pub fn from_registry(
+        driver_id: LoopDriverId,
         registry: &LoopFamilyRegistry,
         id: &LoopFamilyId,
         executor: Arc<CanonicalAgentLoopExecutor>,
@@ -55,13 +58,14 @@ impl PlannedDriver {
             .ok_or_else(|| AgentLoopDriverError::InvalidRequest {
                 reason: format!("unknown loop family: {id}"),
             })?;
-        Self::from_family(family, executor, version)
+        Self::from_family(driver_id, family, executor, version)
     }
 
     pub fn default_from_registry(
         registry: &LoopFamilyRegistry,
     ) -> Result<Self, AgentLoopDriverError> {
         Self::from_registry(
+            planned_default_driver_id()?,
             registry,
             &LoopFamilyId::DEFAULT,
             Arc::new(CanonicalAgentLoopExecutor),
@@ -87,6 +91,7 @@ impl AgentLoopDriver for PlannedDriver {
             .execute_family(self.family.as_ref(), host, initial)
             .await
             .map_err(map_executor_error)
+            .and_then(reject_blocked_exit_until_resume_supported)
     }
 
     async fn resume(
@@ -95,20 +100,25 @@ impl AgentLoopDriver for PlannedDriver {
         _host: &(dyn AgentLoopDriverHost + Send + Sync),
     ) -> Result<LoopExit, AgentLoopDriverError> {
         validate_resume_request(&request, &self.descriptor)?;
-        Err(AgentLoopDriverError::InvalidRequest {
-            reason: "planned driver resume requires WS-10 checkpoint payload loading".to_string(),
-        })
+        Err(pending_resume_error())
     }
 }
 
-fn descriptor_for_family(
-    family_id: &LoopFamilyId,
+fn planned_default_driver_id() -> Result<LoopDriverId, AgentLoopDriverError> {
+    LoopDriverId::new(PLANNED_DRIVER_DEFAULT_ID)
+        .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })
+}
+
+fn descriptor_for_driver_id(
+    driver_id: LoopDriverId,
     version: RunProfileVersion,
 ) -> Result<AgentLoopDriverDescriptor, AgentLoopDriverError> {
-    let driver_id = format!("reborn:{family_id}-loop");
-    AgentLoopDriverDescriptor::new(driver_id, version)
+    AgentLoopDriverDescriptor::new(driver_id.as_str(), version)
         .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })?
-        .with_checkpoint_schema(CHECKPOINT_SCHEMA_ID, version)
+        .with_checkpoint_schema(
+            CHECKPOINT_SCHEMA_ID,
+            RunProfileVersion::new(CHECKPOINT_SCHEMA_VERSION),
+        )
         .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })
 }
 
@@ -150,8 +160,30 @@ fn validate_descriptor_assignment(
     Ok(())
 }
 
+fn pending_resume_error() -> AgentLoopDriverError {
+    AgentLoopDriverError::Unavailable {
+        reason: "planned driver resume requires WS-10 checkpoint payload loading".to_string(),
+    }
+}
+
+fn reject_blocked_exit_until_resume_supported(
+    exit: LoopExit,
+) -> Result<LoopExit, AgentLoopDriverError> {
+    if matches!(exit, LoopExit::Blocked(_)) {
+        return Err(AgentLoopDriverError::Unavailable {
+            reason: "planned driver blocked exits require WS-10 checkpoint payload loading"
+                .to_string(),
+        });
+    }
+    Ok(exit)
+}
+
 pub(crate) fn map_executor_error(error: AgentLoopExecutorError) -> AgentLoopDriverError {
-    tracing::warn!(?error, "planned driver executor returned sanitized error");
+    if matches!(error, AgentLoopExecutorError::Cancelled) {
+        tracing::debug!(?error, "planned driver executor cancelled");
+    } else {
+        tracing::warn!(?error, "planned driver executor returned sanitized error");
+    }
     match error {
         AgentLoopExecutorError::HostUnavailable { stage } => AgentLoopDriverError::Unavailable {
             reason: format!("{}: unavailable", host_stage_name(stage)),
@@ -193,21 +225,112 @@ fn checkpoint_kind_name(kind: CheckpointKind) -> &'static str {
 mod tests {
     use super::*;
     use crate::build_loop_family_registry;
-    use ironclaw_turns::run_profile::{CheckpointSchemaId, LoopDriverId};
+    use ironclaw_turns::{
+        LoopBlocked, LoopBlockedKind, LoopExitId, LoopGateRef, TurnCheckpointId,
+        run_profile::{CheckpointSchemaId, LoopCheckpointStateRef, LoopDriverId},
+    };
 
     #[test]
     fn default_planned_driver_descriptor_uses_default_family_identity() {
-        let registry = build_loop_family_registry();
+        let registry = build_loop_family_registry().expect("registry");
         let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
         let descriptor = driver.descriptor();
 
         assert_eq!(
             descriptor.id,
-            LoopDriverId::new("reborn:default-loop").expect("valid")
+            LoopDriverId::new(PLANNED_DRIVER_DEFAULT_ID).expect("valid")
         );
         assert_eq!(
             descriptor.checkpoint_schema_id,
             Some(CheckpointSchemaId::new(CHECKPOINT_SCHEMA_ID).expect("valid"))
+        );
+        assert_eq!(
+            descriptor.checkpoint_schema_version,
+            Some(RunProfileVersion::new(CHECKPOINT_SCHEMA_VERSION))
+        );
+    }
+
+    #[test]
+    fn descriptor_for_family_uses_independent_checkpoint_schema_version() {
+        let descriptor = descriptor_for_driver_id(
+            LoopDriverId::new("reborn:custom-planned").expect("valid"),
+            RunProfileVersion::new(PLANNED_DRIVER_VERSION + 1),
+        )
+        .expect("descriptor");
+
+        assert_eq!(
+            descriptor.version,
+            RunProfileVersion::new(PLANNED_DRIVER_VERSION + 1)
+        );
+        assert_eq!(
+            descriptor.checkpoint_schema_version,
+            Some(RunProfileVersion::new(CHECKPOINT_SCHEMA_VERSION))
+        );
+    }
+
+    #[test]
+    fn validate_descriptor_assignment_rejects_wrong_driver() {
+        let descriptor = descriptor_for_driver_id(
+            LoopDriverId::new(PLANNED_DRIVER_DEFAULT_ID).expect("valid"),
+            RunProfileVersion::new(1),
+        )
+        .expect("descriptor");
+        let wrong_descriptor =
+            AgentLoopDriverDescriptor::new("reborn:other-loop", RunProfileVersion::new(1))
+                .expect("wrong descriptor")
+                .with_checkpoint_schema(
+                    CHECKPOINT_SCHEMA_ID,
+                    RunProfileVersion::new(CHECKPOINT_SCHEMA_VERSION),
+                )
+                .expect("wrong checkpoint schema");
+
+        let err = validate_descriptor_assignment(&wrong_descriptor, &descriptor)
+            .expect_err("descriptor mismatch should be rejected");
+
+        assert_eq!(
+            err,
+            AgentLoopDriverError::InvalidRequest {
+                reason: "driver request profile is not assigned to this planned driver".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn planned_resume_pending_error_is_unavailable() {
+        let descriptor = descriptor_for_driver_id(
+            LoopDriverId::new(PLANNED_DRIVER_DEFAULT_ID).expect("valid"),
+            RunProfileVersion::new(1),
+        )
+        .expect("descriptor");
+        let request_descriptor = descriptor.clone();
+
+        validate_descriptor_assignment(&request_descriptor, &descriptor)
+            .expect("matching descriptor");
+        assert_eq!(
+            pending_resume_error(),
+            AgentLoopDriverError::Unavailable {
+                reason: "planned driver resume requires WS-10 checkpoint payload loading"
+                    .to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn blocked_exits_are_unavailable_until_resume_is_supported() {
+        let blocked = LoopExit::Blocked(LoopBlocked {
+            kind: LoopBlockedKind::Approval,
+            gate_ref: LoopGateRef::new("gate:approval").expect("valid"),
+            checkpoint_id: TurnCheckpointId::new(),
+            state_ref: LoopCheckpointStateRef::new("checkpoint:state").expect("valid"),
+            exit_id: LoopExitId::new("exit:blocked").expect("valid"),
+        });
+
+        assert_eq!(
+            reject_blocked_exit_until_resume_supported(blocked).expect_err("blocked pending WS10"),
+            AgentLoopDriverError::Unavailable {
+                reason: "planned driver blocked exits require WS-10 checkpoint payload loading"
+                    .to_string()
+            }
         );
     }
 

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -1,0 +1,225 @@
+//! Planned Reborn loop driver.
+//!
+//! This module is the bridge from the runner-facing `AgentLoopDriver` trait to
+//! the sealed `ironclaw_agent_loop` framework. It intentionally holds an opaque
+//! `LoopFamily` and the canonical executor; it does not expose planner slots to
+//! `ironclaw_reborn`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_agent_loop::{
+    executor::{AgentLoopExecutor, AgentLoopExecutorError, CanonicalAgentLoopExecutor, HostStage},
+    family::{LoopFamily, LoopFamilyId, LoopFamilyRegistry},
+    state::{CHECKPOINT_SCHEMA_ID, CheckpointKind, LoopExecutionState},
+};
+use ironclaw_turns::{
+    LoopExit, RunProfileVersion,
+    run_profile::{
+        AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, AgentLoopDriverHost,
+        AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest,
+    },
+};
+
+const PLANNED_DRIVER_VERSION: u64 = 1;
+
+/// Non-generic adapter from one resolved loop family to `AgentLoopDriver`.
+pub struct PlannedDriver {
+    descriptor: AgentLoopDriverDescriptor,
+    family: Arc<LoopFamily>,
+    executor: Arc<CanonicalAgentLoopExecutor>,
+}
+
+impl PlannedDriver {
+    pub fn from_family(
+        family: Arc<LoopFamily>,
+        executor: Arc<CanonicalAgentLoopExecutor>,
+        version: RunProfileVersion,
+    ) -> Result<Self, AgentLoopDriverError> {
+        let descriptor = descriptor_for_family(family.id(), version)?;
+        Ok(Self {
+            descriptor,
+            family,
+            executor,
+        })
+    }
+
+    pub fn from_registry(
+        registry: &LoopFamilyRegistry,
+        id: &LoopFamilyId,
+        executor: Arc<CanonicalAgentLoopExecutor>,
+        version: RunProfileVersion,
+    ) -> Result<Self, AgentLoopDriverError> {
+        let family = registry
+            .get(id)
+            .ok_or_else(|| AgentLoopDriverError::InvalidRequest {
+                reason: format!("unknown loop family: {id}"),
+            })?;
+        Self::from_family(family, executor, version)
+    }
+
+    pub fn default_from_registry(
+        registry: &LoopFamilyRegistry,
+    ) -> Result<Self, AgentLoopDriverError> {
+        Self::from_registry(
+            registry,
+            &LoopFamilyId::DEFAULT,
+            Arc::new(CanonicalAgentLoopExecutor),
+            RunProfileVersion::new(PLANNED_DRIVER_VERSION),
+        )
+    }
+}
+
+#[async_trait]
+impl AgentLoopDriver for PlannedDriver {
+    fn descriptor(&self) -> AgentLoopDriverDescriptor {
+        self.descriptor.clone()
+    }
+
+    async fn run(
+        &self,
+        request: AgentLoopDriverRunRequest,
+        host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        validate_run_request(&request, &self.descriptor)?;
+        let initial = LoopExecutionState::initial_for_run(host.run_context());
+        self.executor
+            .execute_family(self.family.as_ref(), host, initial)
+            .await
+            .map_err(map_executor_error)
+    }
+
+    async fn resume(
+        &self,
+        request: AgentLoopDriverResumeRequest,
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
+    ) -> Result<LoopExit, AgentLoopDriverError> {
+        validate_resume_request(&request, &self.descriptor)?;
+        Err(AgentLoopDriverError::InvalidRequest {
+            reason: "planned driver resume requires WS-10 checkpoint payload loading".to_string(),
+        })
+    }
+}
+
+fn descriptor_for_family(
+    family_id: &LoopFamilyId,
+    version: RunProfileVersion,
+) -> Result<AgentLoopDriverDescriptor, AgentLoopDriverError> {
+    let driver_id = format!("reborn:{family_id}-loop");
+    AgentLoopDriverDescriptor::new(driver_id, version)
+        .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })?
+        .with_checkpoint_schema(CHECKPOINT_SCHEMA_ID, version)
+        .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })
+}
+
+fn validate_run_request(
+    request: &AgentLoopDriverRunRequest,
+    descriptor: &AgentLoopDriverDescriptor,
+) -> Result<(), AgentLoopDriverError> {
+    validate_descriptor_assignment(&request.resolved_run_profile.loop_driver, descriptor)
+}
+
+fn validate_resume_request(
+    request: &AgentLoopDriverResumeRequest,
+    descriptor: &AgentLoopDriverDescriptor,
+) -> Result<(), AgentLoopDriverError> {
+    validate_descriptor_assignment(&request.resolved_run_profile.loop_driver, descriptor)?;
+    let want = descriptor.checkpoint_schema_id.as_ref();
+    let have = request
+        .resolved_run_profile
+        .loop_driver
+        .checkpoint_schema_id
+        .as_ref();
+    if want != have {
+        return Err(AgentLoopDriverError::InvalidRequest {
+            reason: "checkpoint schema id does not match driver descriptor".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_descriptor_assignment(
+    request_descriptor: &AgentLoopDriverDescriptor,
+    descriptor: &AgentLoopDriverDescriptor,
+) -> Result<(), AgentLoopDriverError> {
+    if request_descriptor != descriptor {
+        return Err(AgentLoopDriverError::InvalidRequest {
+            reason: "driver request profile is not assigned to this planned driver".to_string(),
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn map_executor_error(error: AgentLoopExecutorError) -> AgentLoopDriverError {
+    tracing::warn!(?error, "planned driver executor returned sanitized error");
+    match error {
+        AgentLoopExecutorError::HostUnavailable { stage } => AgentLoopDriverError::Unavailable {
+            reason: format!("{}: unavailable", host_stage_name(stage)),
+        },
+        AgentLoopExecutorError::PlannerContract { detail } => AgentLoopDriverError::Failed {
+            reason_kind: format!("driver_bug:{detail}"),
+        },
+        AgentLoopExecutorError::CheckpointFailed { stage } => AgentLoopDriverError::Failed {
+            reason_kind: format!("checkpoint_rejected:{}", checkpoint_kind_name(stage)),
+        },
+        AgentLoopExecutorError::Cancelled => AgentLoopDriverError::Failed {
+            reason_kind: "interrupted_unexpectedly".to_string(),
+        },
+    }
+}
+
+fn host_stage_name(stage: HostStage) -> &'static str {
+    match stage {
+        HostStage::Prompt => "Prompt",
+        HostStage::Model => "Model",
+        HostStage::Capability => "Capability",
+        HostStage::Transcript => "Transcript",
+        HostStage::Checkpoint => "Checkpoint",
+        HostStage::Progress => "Progress",
+        HostStage::Input => "Input",
+    }
+}
+
+fn checkpoint_kind_name(kind: CheckpointKind) -> &'static str {
+    match kind {
+        CheckpointKind::BeforeModel => "before_model",
+        CheckpointKind::BeforeSideEffect => "before_side_effect",
+        CheckpointKind::BeforeBlock => "before_block",
+        CheckpointKind::Final => "final",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build_loop_family_registry;
+    use ironclaw_turns::run_profile::{CheckpointSchemaId, LoopDriverId};
+
+    #[test]
+    fn default_planned_driver_descriptor_uses_default_family_identity() {
+        let registry = build_loop_family_registry();
+        let driver = PlannedDriver::default_from_registry(&registry).expect("driver");
+        let descriptor = driver.descriptor();
+
+        assert_eq!(
+            descriptor.id,
+            LoopDriverId::new("reborn:default-loop").expect("valid")
+        );
+        assert_eq!(
+            descriptor.checkpoint_schema_id,
+            Some(CheckpointSchemaId::new(CHECKPOINT_SCHEMA_ID).expect("valid"))
+        );
+    }
+
+    #[test]
+    fn executor_cancelled_error_maps_to_failed_not_unavailable() {
+        let mapped = map_executor_error(AgentLoopExecutorError::Cancelled);
+
+        assert_eq!(
+            mapped,
+            AgentLoopDriverError::Failed {
+                reason_kind: "interrupted_unexpectedly".to_string()
+            }
+        );
+    }
+}

--- a/docs/reborn/agent-loop-briefs/loop-family-registry.md
+++ b/docs/reborn/agent-loop-briefs/loop-family-registry.md
@@ -319,7 +319,12 @@ impl TurnRunner {
             .ok_or(Error::UnknownLoopFamily {
                 id: profile.loop_family_id.clone(),
             })?;
-        let driver = PlannedDriver::from_family(family, self.executor.clone());
+        let driver = PlannedDriver::from_family(
+            profile.loop_driver.id.clone(),
+            family,
+            self.executor.clone(),
+            profile.loop_driver.version,
+        );
         driver.run(self.host.clone(), /* request */).await
     }
 }

--- a/docs/reborn/agent-loop-briefs/planned-driver-adapter.md
+++ b/docs/reborn/agent-loop-briefs/planned-driver-adapter.md
@@ -12,16 +12,16 @@
 Bridge the framework crate (`ironclaw_agent_loop`) to the runner-facing `AgentLoopDriver` trait (`ironclaw_turns`). One small struct + one trait impl in `ironclaw_reborn`.
 
 - `PlannedDriver` struct — **non-generic**. Holds `Arc<LoopFamily>` (opaque to this crate; produced by WS-3.5's registry) and `Arc<CanonicalAgentLoopExecutor>`. No `<P, E>` type parameters.
-- `impl AgentLoopDriver for PlannedDriver` — wires `run` and `resume` through to the executor.
+- `impl AgentLoopDriver for PlannedDriver` — wires fresh `run` calls through to the executor. `resume` validates the request but returns `Unavailable` until WS-10 adds checkpoint payload loading.
 - Sanitized error mapping from `AgentLoopExecutorError` to `AgentLoopDriverError`.
 - Driver descriptor produced from the registry/profile `LoopDriverId`; the checkpoint payload separately records the family's `LoopFamilyId` and `ComponentIdentity` for resume compatibility (the framework's reserved checkpoint schema is `CHECKPOINT_SCHEMA_ID` from WS-0).
 - Constructor `PlannedDriver::from_family(driver_id, family, executor)` — the canonical path. `TurnRunner` resolves a family from `Arc<LoopFamilyRegistry>` (WS-3.5) then constructs the driver under the registry/profile driver id. No direct planner injection exists.
+- Blocked exits are rejected as `Unavailable` in WS-7, because emitting a resumable `LoopExit::Blocked` before WS-10 can reload checkpoint payloads would persist runs that cannot continue.
 
 ## 2. Files
 
 ### NEW
 - `crates/ironclaw_reborn/src/planned_driver.rs` — struct, impl, error mapping
-- `crates/ironclaw_reborn/CLAUDE.md` — crate guardrail (see §6 below). Today this crate has no top-level CLAUDE.md; WS-7 introduces one alongside `PlannedDriver` since this is the first non-trivial integration code landing here under the new framework.
 
 ### EXTEND (only if registry wiring is included)
 - `crates/ironclaw_reborn/src/driver_registry.rs` — register the planned driver under its descriptor
@@ -45,7 +45,7 @@ use ironclaw_agent_loop::{
     canonical_executor::CanonicalAgentLoopExecutor,
     executor::{AgentLoopExecutor, AgentLoopExecutorError, HostStage},
     family::{LoopFamily, LoopFamilyId, LoopFamilyRegistry},
-    state::{CHECKPOINT_SCHEMA_ID, LoopExecutionState},
+    state::{CHECKPOINT_SCHEMA_ID, CHECKPOINT_SCHEMA_VERSION, LoopExecutionState},
 };
 use ironclaw_turns::{
     LoopExit, RunProfileVersion,
@@ -95,7 +95,10 @@ impl PlannedDriver {
         // for resume compatibility.
         let descriptor = AgentLoopDriverDescriptor::new(driver_id.as_str(), version)
             .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })?
-            .with_checkpoint_schema(CHECKPOINT_SCHEMA_ID, version)
+            .with_checkpoint_schema(
+                CHECKPOINT_SCHEMA_ID,
+                RunProfileVersion::new(CHECKPOINT_SCHEMA_VERSION),
+            )
             .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })?;
 
         Ok(Self { descriptor, family, executor })
@@ -128,7 +131,7 @@ impl AgentLoopDriver for PlannedDriver {
         host: &(dyn AgentLoopDriverHost + Send + Sync),
     ) -> Result<LoopExit, AgentLoopDriverError> {
         validate_run_request(&request, &self.descriptor)?;
-        let initial = LoopExecutionState::initial(&request.run_context);
+        let initial = LoopExecutionState::initial_for_run(host.run_context());
         // The executor consumes `&LoopFamily` directly. The
         // `pub(crate) fn planner()` accessor on `LoopFamily` is invisible
         // outside `ironclaw_agent_loop`, so `PlannedDriver` cannot reach
@@ -137,40 +140,35 @@ impl AgentLoopDriver for PlannedDriver {
             .execute_family(self.family.as_ref(), host, initial)
             .await
             .map_err(map_executor_error)
+            .and_then(reject_blocked_exit_until_resume_supported)
     }
 
     async fn resume(
         &self,
         request: AgentLoopDriverResumeRequest,
-        host: &(dyn AgentLoopDriverHost + Send + Sync),
+        _host: &(dyn AgentLoopDriverHost + Send + Sync),
     ) -> Result<LoopExit, AgentLoopDriverError> {
         validate_resume_request(&request, &self.descriptor)?;
-        // Use the canonical WS-10 load-side request/response shape — see
-        // `checkpoint-store-and-resume.md` §3.1.
-        let loaded = host
-            .load_checkpoint_payload(LoadCheckpointPayloadRequest {
-                checkpoint_id: request.checkpoint_id,
-                expected_schema_id: request.resolved_run_profile.loop_driver
-                    .checkpoint_schema_id.clone(),
-                expected_schema_version: request.resolved_run_profile.loop_driver
-                    .checkpoint_schema_version,
-            })
-            .await
-            .map_err(|_| AgentLoopDriverError::Unavailable {
-                reason: "checkpoint:unavailable".to_string(),
-            })?;
-        let resumed = LoopExecutionState::from_checkpoint_payload(
-                loaded.payload.as_bytes(),
-                loaded.kind,
-            )
-            .map_err(|e| AgentLoopDriverError::Failed {
-                reason_kind: format!("checkpoint_rejected:{e}"),
-            })?;
-        self.executor
-            .execute_family(self.family.as_ref(), host, resumed)
-            .await
-            .map_err(map_executor_error)
+        Err(pending_resume_error())
     }
+}
+
+fn pending_resume_error() -> AgentLoopDriverError {
+    AgentLoopDriverError::Unavailable {
+        reason: "planned driver resume requires WS-10 checkpoint payload loading".to_string(),
+    }
+}
+
+fn reject_blocked_exit_until_resume_supported(
+    exit: LoopExit,
+) -> Result<LoopExit, AgentLoopDriverError> {
+    if matches!(exit, LoopExit::Blocked(_)) {
+        return Err(AgentLoopDriverError::Unavailable {
+            reason: "planned driver blocked exits require WS-10 checkpoint payload loading"
+                .to_string(),
+        });
+    }
+    Ok(exit)
 }
 ```
 
@@ -303,18 +301,20 @@ when there's a real use case (typically the first follow-up loop-family PR).
 - [ ] Trait conformance: `fn _check(_: &PlannedDriver) where PlannedDriver: AgentLoopDriver {}` (no generics)
 - [ ] Round-trip test: `PlannedDriver::from_registry(LoopDriverId::from_trusted_static("reborn:planned-default"), &registry, &LoopFamilyId::DEFAULT, executor, v1)` succeeds against `LoopFamilyRegistry::with_families(vec![Arc::new(families::default())])`; descriptor's `id` is `"reborn:planned-default"`; descriptor's `checkpoint_schema_id` is `CHECKPOINT_SCHEMA_ID`; checkpoint metadata separately records `LoopFamilyId::DEFAULT`
 - [ ] Resolution failure: `PlannedDriver::from_registry(LoopDriverId::from_trusted_static("reborn:planned-default"), &empty_registry, &LoopFamilyId("nope"), …)` returns `Err(InvalidRequest { reason: "unknown loop family: nope" })`
+- [ ] `resume` validates descriptor/schema assignment but returns `Unavailable { reason: "planned driver resume requires WS-10 checkpoint payload loading" }` until WS-10 lands the load path
+- [ ] `LoopExit::Blocked` from the executor is rejected as `Unavailable` until WS-10 can reload checkpoint payloads
 - [ ] Error-mapping tests:
   - `map_executor_error(HostUnavailable { stage: Model })` → `Unavailable { reason: "Model: unavailable" }`
   - `map_executor_error(CheckpointFailed { stage: BeforeModel })` → `Failed { reason_kind: "checkpoint_rejected:BeforeModel" }`
   - mapped `AgentLoopDriverError` debug output contains no raw provider names, no `/` paths, no secret-shaped strings (mirror the existing `text_loop_driver` test pattern)
-- [ ] Smoke test using a `MockAgentLoopDriverHost` that returns a Reply on first call:
-  - `PlannedDriver::run(req, &host)` returns `LoopExit::Completed` with assistant ref
-  - host recorder shows the four-checkpoint sequence (`BeforeModel`, `Final`)
-- [ ] Resume smoke test: load a checkpoint payload produced by serializing `LoopExecutionState`; assert `from_checkpoint_payload` accepts it; assert mismatched schema id is rejected with `Failed { reason_kind: "checkpoint_rejected:..." }`
+- [ ] Driver-side E2E smoke through `PlannedDriver::run` is tracked in WS-8 (`e2e-integration-tests.md`)
+- [ ] Full checkpoint load/resume smoke is tracked in WS-10 (`checkpoint-store-and-resume.md`)
 
 ## 5. Out of scope
 
 - A real `LoopCapabilityPort` (still `EmptyLoopCapabilityPort` until a tool-capable driver lands)
+- Checkpoint payload loading and true `resume` execution — WS-10 owns the load-side host port and resume path
+- Driver-side E2E proof through `PlannedDriver::run` — WS-8 owns the feature-gated test-support module and integration suite
 - Registry wiring — optional; recommended but not required for the skeleton
 - Migration of `TextOnlyModelReplyDriver` to a `TextOnlyPlanner` factory — explicitly deferred per master doc §11
 - `ModelRouteChain` migration of `LoopRunContext.resolved_model_route` — deferred per master doc §9


### PR DESCRIPTION
## Context

Runner adapter layer. It introduces the Reborn-side `PlannedDriver` that implements the runner-facing `AgentLoopDriver` trait while keeping framework execution in `ironclaw_agent_loop`.

Master spec: `docs/reborn/agent-loop-skeleton.md`
Workstream brief: `docs/reborn/agent-loop-briefs/planned-driver-adapter.md`
Stack base: `reborn-integration`

Latest stack maintenance on 2026-05-14:
- Rebased this branch onto its current stack base after the WS0 prompt-authority fix and the follow-up WS8/WS14-parent/WS16/WS17 conflict resolutions.
- Pushed the updated branch with force-with-lease where the remote already existed, or published it as a new branch where it did not.
- Verified the final ancestry chain from `origin/reborn-integration` through WS17 before publishing the PR descriptions.

Conflict refresh on 2026-05-15:
- Rebased WS7-only commits onto current `reborn-integration` after GitHub retargeted this PR off the old stack base.
- Force-pushed with lease after resolving the retarget conflict.

## What landed

- `PlannedDriver` in `ironclaw_reborn` as the non-generic adapter from `AgentLoopDriver` to `CanonicalAgentLoopExecutor`.
- Family lookup through the registry and execution through `execute_family`.
- Run/resume wiring shaped around runner-owned `LoopRunContext` and host ports.
- Error mapping from executor failures into runner-visible loop exits.
- Focused descriptor, resume-pending, and blocked-exit fail-closed tests for the WS7 adapter boundary.

## Reviewer focus

- The adapter should remain thin: lookup family, call executor, map result.
- It should not duplicate strategy logic or canonical tick mechanics.
- The branch should preserve `TextOnlyModelReplyDriver` behavior as an independent existing path.
- WS7 should not claim the WS8 driver E2E suite or the WS10 checkpoint-load resume path.

## Non-goals / deferred work

- Driver-side E2E through the real `PlannedDriver::run` boundary is WS8.
- Checkpoint payload loading and successful blocked-run resume are WS10.
- Driver registry default selection is WS14.
- Production host-runtime composition is WS16.
- Product no-profile cutover is WS17.

## Validation

- [x] `cargo test -p ironclaw_reborn planned_driver`
- [x] `cargo test -p ironclaw_reborn planned_driver --lib`
- [x] `git diff --check reborn-integration...arch/ws-7`
- [x] Final ancestry check verified `reborn-integration -> arch/ws-7`.

## Stack position

```
[#3550 ws-0] state/checkpoint foundation -> reborn-integration
   |-- #3551 ws-1 strategy alpha -> ws-0
   |-- #3552 ws-2 strategy beta -> ws-0
   |-- #3553 ws-3 strategy gamma -> ws-0
   |-- #3643 ws-3.5 loop family registry -> ws-0
   '-- #3554 level1-merged -> ws-0
         |-- #3555 ws-4 planner facade -> level1
         |-- #3556 ws-5 default strategies -> level1
         '-- #3557 level2-merged -> level1
               '-- #3596 ws-6a canonical executor -> level2
                     '-- #3597 ws-7 PlannedDriver adapter -> ws-6a
                           '-- #3598 ws-8 integration/test support -> ws-7
                                 |-- #3644 ws-9 capability host wiring -> ws-8
                                 |-- #3645 ws-10 checkpoint load/resume -> ws-8
                                 |-- #3646 ws-11 input port -> ws-8
                                 |-- #3647 ws-12 progress port -> ws-8
                                 |-- #3648 ws-13 cancellation accessor -> ws-8
                                 |-- #3649 ws-15 prompt/identity context -> ws-8
                                 '-- #3650 ws-14-parent integrated host ports -> ws-8
                                       '-- #3651 ws-14 planned default registration -> ws-14-parent
                                             '-- #3652 ws-16 live runtime wiring -> ws-14
                                                   '-- #3653 ws-17 product live cutover -> ws-16
```
