### PR TITLE
feat(hooks): production gate-ref factory (successor to #3573)

### DIFF
--- a/crates/ironclaw_hooks/docs/successors/01-prod-gate-ref-factory.md
+++ b/crates/ironclaw_hooks/docs/successors/01-prod-gate-ref-factory.md
@@ -100,3 +100,40 @@ installed:
 
 Medium. Most of the complexity is in the cross-crate seam to the
 approval gateway, not in the factory itself.
+
+## Codex review addenda (2026-05-14)
+
+Codex flagged two scope-shaping issues during the design review pass:
+
+### Critical: actor/session binding
+
+The original scope binds reservations to `(run, thread, tenant)` but
+not to the *resolving user/session*. In a multi-user / multi-session
+deployment that's a same-tenant approval-bypass vector: user B inside
+tenant α can resolve a gate-ref issued for user A's pending action.
+
+**Mitigation**: the gateway reservation must carry the actor
+identity (or session id) that originated the suspension, and the
+gateway's resolution check must compare the resolving actor against
+the reservation. The implementation PR will:
+
+- Bind `LoopRunContext.scope.{tenant_id, actor_id, session_id?}`
+  (or the channel-equivalent) into the reservation.
+- Add a caller-level negative test: ext-A's gate-ref issued in
+  user-A's session is rejected when user-B resolves it.
+
+### Recommendation: capability + arguments digest in reservation
+
+The original scope binds `reason` (free-form text). The gateway can
+show better context — and reject more replay vectors — if the
+reservation includes the *exact* capability id + arguments digest
+the hook intended to gate. That way:
+
+- The user-facing approval UI displays "approve calling
+  `polymarket.place_order` with args digest XXXX", not a free-form
+  string.
+- A future call that doesn't match the reserved digest cannot
+  consume the gate-ref even if it shares the same capability id.
+
+The implementation PR will include both fields in the reservation
+payload alongside `reason`.

--- a/crates/ironclaw_hooks/docs/successors/01-prod-gate-ref-factory.md
+++ b/crates/ironclaw_hooks/docs/successors/01-prod-gate-ref-factory.md
@@ -1,0 +1,102 @@
+# Successor PR: production hook gate-ref factory
+
+> Successor work from PR #3573. Until this lands, hook `PauseApproval` /
+> `PauseAuth` decisions surface as `Denied` in production because the
+> default factory is `FailClosedHookGateRefFactory`.
+
+## Scope
+
+Implement a `HookGateRefFactory` that mints refs the host's existing
+approval/auth router can resolve. The current `UuidHookGateRefFactory`
+mints v4 UUIDs — locally unique but router-unregistered, so the loop
+parks on a ref the gateway has never heard of. That's why the middleware
+default is fail-closed (henrypark133 Critical #3).
+
+## What this factory must do
+
+1. **Reserve a gate.** On `mint_approval_ref(reason)`, register a new
+   pending approval with the host's approval gateway. The returned
+   `LoopGateRef` is the gateway's chosen identifier — not synthesized
+   in the factory.
+2. **Bind to `LoopRunContext`.** The factory carries the current
+   `LoopRunContext` so the reservation is keyed against the right
+   run / thread / tenant. Resolution events route back to the correct
+   loop.
+3. **Carry one-shot + TTL semantics.** Reservations expire after a
+   configurable window (operator policy). The gateway enforces
+   one-shot consumption — once a user approval lands, the ref is
+   marked consumed and a replay attempt is rejected.
+4. **Symmetric `mint_auth_ref`** behavior for auth flows.
+
+## Likely surface
+
+```rust
+// in ironclaw_reborn (or a new crate if approval lives elsewhere)
+pub struct RouterBackedHookGateRefFactory {
+    run_context: LoopRunContext,
+    approval_gateway: Arc<dyn ApprovalGateway>,
+    auth_gateway: Arc<dyn AuthGateway>,
+    reservation_ttl: Duration,
+}
+
+#[async_trait]
+impl HookGateRefFactory for RouterBackedHookGateRefFactory {
+    async fn mint_approval_ref(&self, reason: &str) -> Result<LoopGateRef, AgentLoopHostError> {
+        // 1. Call approval_gateway.reserve(...) with run_context + reason + ttl
+        // 2. Map gateway result to LoopGateRef
+        // 3. Fail closed if gateway is unavailable
+    }
+    // ...
+}
+```
+
+Wired into `RebornLoopDriverHostFactory::with_hook_gate_ref_factory(...)`
+per-build (so `LoopRunContext` is the current run's).
+
+## Threat model considerations
+
+- **Forgery resistance.** Already pinned at the factory side (122-bit v4
+  UUIDs or gateway-issued opaque tokens). The router-backed impl should
+  use the gateway's existing reservation-id format if it's
+  unguessable, otherwise wrap a v4 UUID inside.
+- **Replay resistance.** Comes from gateway's one-shot consumption,
+  not from the factory. Test: consume a ref twice → second consumption
+  rejected with `gate_already_consumed`.
+- **TTL bypass.** Operator policy. Test: mint, wait > TTL, attempt
+  resolution → rejected with `gate_expired`.
+- **Cross-run consumption.** Resolution of run A's gate ref from run B
+  must be rejected. Test: mint under run A, attempt consumption under
+  run B's context → rejected.
+
+## Required tests (caller level)
+
+All through `RebornLoopDriverHostFactory` with the production factory
+installed:
+
+1. **Happy path**: `PauseApproval` hook → outcome is `ApprovalRequired
+   { gate_ref }`; user resolves via gateway; loop receives `Resolved`
+   event; loop unblocks.
+2. **TTL expiry**: mint, wait past TTL, attempt resolution → gateway
+   rejects; loop receives `Expired` event.
+3. **One-shot**: consume twice → second attempt rejected.
+4. **Cross-run**: gate-ref from run A is unconsumable from run B.
+5. **Gateway unavailable**: mint fails → middleware surfaces
+   `Denied { reason_kind: hook_gate_ref_unavailable }`.
+
+## What this PR does NOT do
+
+- Change the middleware default (stays `FailClosedHookGateRefFactory`).
+- Provide a UI for the operator to configure TTL — that's the host's
+  config concern.
+- Touch the existing `UuidHookGateRefFactory` (kept for tests + dev).
+
+## Risk
+
+- Cross-crate dependency on the approval/auth gateway. May require a
+  trait extraction if the gateway lives downstream of `ironclaw_hooks`.
+- Coordination with the channel-to-user path (#3564 area).
+
+## Effort
+
+Medium. Most of the complexity is in the cross-crate seam to the
+approval gateway, not in the factory itself.

--- a/crates/ironclaw_reborn/src/hook_gate_refs.rs
+++ b/crates/ironclaw_reborn/src/hook_gate_refs.rs
@@ -152,6 +152,16 @@ pub struct HookGateReservation {
 }
 
 /// Request to consume a previously issued hook gate ref.
+///
+/// **No timestamp field.** Resolution time and consumption time are
+/// authoritatively owned by the router via its own clock — see
+/// [`HookGateResolution::resolved_at`] for the router-supplied value
+/// returned on successful consumption. An earlier revision of this struct
+/// exposed a caller-supplied `resolved_at`; that was a trust-boundary bug
+/// (serrrfirat HIGH on PR #3633) because any adapter or buggy caller could
+/// backdate it and bypass TTL enforcement. The field is gone; expiry and
+/// `consumed_at` are now computed inside `resolve_gate` from the router's
+/// own wall clock.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HookGateResolutionRequest {
     pub gate_ref: LoopGateRef,
@@ -160,7 +170,6 @@ pub struct HookGateResolutionRequest {
     pub run_context: LoopRunContext,
     pub capability_id: CapabilityId,
     pub arguments_digest: String,
-    pub resolved_at: DateTime<Utc>,
 }
 
 impl HookGateResolutionRequest {
@@ -194,7 +203,6 @@ impl HookGateResolutionRequest {
             run_context,
             capability_id: metadata.capability_id,
             arguments_digest: metadata.arguments_digest,
-            resolved_at: Utc::now(),
         })
     }
 }

--- a/crates/ironclaw_reborn/src/hook_gate_refs.rs
+++ b/crates/ironclaw_reborn/src/hook_gate_refs.rs
@@ -1,0 +1,683 @@
+//! Router-backed hook gate refs for Reborn host composition.
+//!
+//! `ironclaw_hooks` owns the hook middleware contract, but it deliberately
+//! does not know how to reserve host approval/auth gates. This module is the
+//! Reborn-side adapter: it binds hook-emitted pause decisions to the current
+//! run, actor, capability, arguments digest, and router-enforced lease window
+//! before returning a `LoopGateRef` to the middleware.
+
+use std::{
+    collections::HashMap,
+    error::Error,
+    fmt,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use ironclaw_hooks::middleware::HookGateRefFactory;
+use ironclaw_host_api::{ApprovalRequestId, CapabilityId, UserId, sha256_digest_token};
+use ironclaw_turns::{
+    LoopGateRef,
+    run_profile::{
+        AgentLoopHostError, AgentLoopHostErrorKind, CapabilityBatchInvocation,
+        CapabilityBatchOutcome, CapabilityInvocation, CapabilityOutcome, LoopCapabilityPort,
+        LoopRunContext, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    },
+};
+
+tokio::task_local! {
+    static HOOK_GATE_INVOCATION: HookGateInvocationMetadata;
+}
+
+/// The gateway lane a hook pause decision reserved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookGateKind {
+    Approval,
+    Auth,
+}
+
+impl HookGateKind {
+    fn gate_ref_prefix(self) -> &'static str {
+        match self {
+            Self::Approval => "hook-approval",
+            Self::Auth => "hook-auth",
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Approval => "approval",
+            Self::Auth => "auth",
+        }
+    }
+}
+
+/// Actor/session identity bound into a hook gate reservation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookGateActorBinding {
+    pub actor_id: UserId,
+    pub session_id: Option<String>,
+}
+
+impl HookGateActorBinding {
+    pub fn new(actor_id: UserId) -> Self {
+        Self {
+            actor_id,
+            session_id: None,
+        }
+    }
+
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Result<Self, HookGateError> {
+        let session_id = validate_token(session_id.into(), "session id", 128)?;
+        self.session_id = Some(session_id);
+        Ok(self)
+    }
+}
+
+/// Per-invocation metadata captured outside `ironclaw_hooks` and consumed by
+/// [`RouterBackedHookGateRefFactory`] when the hook middleware asks for a ref.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookGateInvocationMetadata {
+    pub capability_id: CapabilityId,
+    pub arguments_digest: String,
+}
+
+impl HookGateInvocationMetadata {
+    pub fn for_invocation(invocation: &CapabilityInvocation) -> Result<Self, HookGateError> {
+        let arguments_digest = hook_gate_arguments_digest(invocation);
+        validate_digest(&arguments_digest)?;
+        Ok(Self {
+            capability_id: invocation.capability_id.clone(),
+            arguments_digest,
+        })
+    }
+}
+
+/// Stable digest token for the capability invocation arguments visible to the
+/// hook gate path. The digest includes the cited capability id and opaque input
+/// ref so a later resolution can verify it is consuming the same gated call
+/// without exposing raw arguments to the approval surface.
+pub fn hook_gate_arguments_digest(invocation: &CapabilityInvocation) -> String {
+    let payload = format!(
+        "hook-gate-arguments-v1\nsurface={}\ncapability={}\ninput={}",
+        invocation.surface_version.as_str(),
+        invocation.capability_id.as_str(),
+        invocation.input_ref.as_str()
+    );
+    sha256_digest_token(payload.as_bytes())
+}
+
+/// Request handed to the host approval/auth router when a hook pauses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookGateReservationRequest {
+    pub kind: HookGateKind,
+    pub run_context: LoopRunContext,
+    pub actor: HookGateActorBinding,
+    pub capability_id: CapabilityId,
+    pub arguments_digest: String,
+    pub reason: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Router-owned reservation returned for an issued hook gate ref.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookGateReservation {
+    pub gate_ref: LoopGateRef,
+    pub kind: HookGateKind,
+    pub run_context: LoopRunContext,
+    pub actor: HookGateActorBinding,
+    pub capability_id: CapabilityId,
+    pub arguments_digest: String,
+    pub reason: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Request to consume a previously issued hook gate ref.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookGateResolutionRequest {
+    pub gate_ref: LoopGateRef,
+    pub expected_kind: Option<HookGateKind>,
+    pub actor: HookGateActorBinding,
+    pub run_context: LoopRunContext,
+    pub capability_id: CapabilityId,
+    pub arguments_digest: String,
+    pub resolved_at: DateTime<Utc>,
+}
+
+impl HookGateResolutionRequest {
+    pub fn for_invocation(
+        gate_ref: LoopGateRef,
+        actor: HookGateActorBinding,
+        run_context: LoopRunContext,
+        invocation: &CapabilityInvocation,
+    ) -> Result<Self, HookGateError> {
+        Self::for_kind(
+            gate_ref,
+            HookGateKind::Approval,
+            actor,
+            run_context,
+            invocation,
+        )
+    }
+
+    pub fn for_kind(
+        gate_ref: LoopGateRef,
+        expected_kind: HookGateKind,
+        actor: HookGateActorBinding,
+        run_context: LoopRunContext,
+        invocation: &CapabilityInvocation,
+    ) -> Result<Self, HookGateError> {
+        let metadata = HookGateInvocationMetadata::for_invocation(invocation)?;
+        Ok(Self {
+            gate_ref,
+            expected_kind: Some(expected_kind),
+            actor,
+            run_context,
+            capability_id: metadata.capability_id,
+            arguments_digest: metadata.arguments_digest,
+            resolved_at: Utc::now(),
+        })
+    }
+}
+
+/// Successful one-shot consumption of a hook gate ref.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookGateResolution {
+    pub gate_ref: LoopGateRef,
+    pub kind: HookGateKind,
+    pub run_context: LoopRunContext,
+    pub actor: HookGateActorBinding,
+    pub capability_id: CapabilityId,
+    pub arguments_digest: String,
+    pub resolved_at: DateTime<Utc>,
+}
+
+/// Minimal host-router seam used by the Reborn hook gate-ref factory.
+///
+/// Existing approval resolution in `ironclaw_approvals::ApprovalResolver`
+/// resolves already persisted approval requests into capability leases; it
+/// does not expose a hook-facing reservation API with actor/session binding,
+/// argument digest matching, TTL, and one-shot consumption. Production hosts
+/// should implement this trait over their approval/auth router and durable
+/// stores, while tests may use [`InMemoryHookGateRouter`].
+#[async_trait]
+pub trait HookGateRouter: Send + Sync {
+    async fn reserve_gate(
+        &self,
+        request: HookGateReservationRequest,
+    ) -> Result<LoopGateRef, HookGateError>;
+
+    async fn resolve_gate(
+        &self,
+        request: HookGateResolutionRequest,
+    ) -> Result<HookGateResolution, HookGateError>;
+}
+
+/// Production `HookGateRefFactory` adapter backed by a host approval/auth
+/// router.
+pub struct RouterBackedHookGateRefFactory {
+    run_context: LoopRunContext,
+    actor: HookGateActorBinding,
+    router: Arc<dyn HookGateRouter>,
+    reservation_ttl: Duration,
+}
+
+impl fmt::Debug for RouterBackedHookGateRefFactory {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RouterBackedHookGateRefFactory")
+            .field("run_context", &self.run_context)
+            .field("actor", &self.actor)
+            .field("reservation_ttl", &self.reservation_ttl)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RouterBackedHookGateRefFactory {
+    pub fn try_new(
+        run_context: LoopRunContext,
+        actor: HookGateActorBinding,
+        router: Arc<dyn HookGateRouter>,
+        reservation_ttl: Duration,
+    ) -> Result<Self, HookGateError> {
+        if reservation_ttl <= Duration::zero() {
+            return Err(HookGateError::InvalidTtl);
+        }
+        Ok(Self {
+            run_context,
+            actor,
+            router,
+            reservation_ttl,
+        })
+    }
+
+    async fn mint(
+        &self,
+        kind: HookGateKind,
+        reason: &str,
+    ) -> Result<LoopGateRef, AgentLoopHostError> {
+        let metadata =
+            current_hook_gate_invocation().ok_or(HookGateError::MissingInvocationMetadata)?;
+        let now = Utc::now();
+        let expires_at = now
+            .checked_add_signed(self.reservation_ttl)
+            .ok_or(HookGateError::InvalidTtl)?;
+        let request = HookGateReservationRequest {
+            kind,
+            run_context: self.run_context.clone(),
+            actor: self.actor.clone(),
+            capability_id: metadata.capability_id,
+            arguments_digest: metadata.arguments_digest,
+            reason: reason.to_string(),
+            created_at: now,
+            expires_at,
+        };
+        self.router
+            .reserve_gate(request)
+            .await
+            .map_err(AgentLoopHostError::from)
+    }
+}
+
+#[async_trait]
+impl HookGateRefFactory for RouterBackedHookGateRefFactory {
+    async fn mint_approval_ref(&self, reason: &str) -> Result<LoopGateRef, AgentLoopHostError> {
+        self.mint(HookGateKind::Approval, reason).await
+    }
+
+    async fn mint_auth_ref(&self, reason: &str) -> Result<LoopGateRef, AgentLoopHostError> {
+        self.mint(HookGateKind::Auth, reason).await
+    }
+}
+
+/// Outer capability-port adapter that scopes the current invocation metadata
+/// for router-backed hook gate factories without changing `ironclaw_hooks`.
+pub struct HookGateInvocationScopePort {
+    inner: Arc<dyn LoopCapabilityPort>,
+}
+
+impl HookGateInvocationScopePort {
+    pub fn new(inner: Arc<dyn LoopCapabilityPort>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityPort for HookGateInvocationScopePort {
+    async fn visible_capabilities(
+        &self,
+        request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        self.inner.visible_capabilities(request).await
+    }
+
+    async fn invoke_capability(
+        &self,
+        request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        let metadata = HookGateInvocationMetadata::for_invocation(&request)
+            .map_err(AgentLoopHostError::from)?;
+        HOOK_GATE_INVOCATION
+            .scope(metadata, self.inner.invoke_capability(request))
+            .await
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        let CapabilityBatchInvocation {
+            invocations,
+            stop_on_first_suspension,
+        } = request;
+        let mut outcomes = Vec::with_capacity(invocations.len());
+        let mut stopped_on_suspension = false;
+        for invocation in invocations {
+            if stopped_on_suspension {
+                break;
+            }
+            let outcome = self.invoke_capability(invocation).await?;
+            if outcome.is_suspension() && stop_on_first_suspension {
+                stopped_on_suspension = true;
+            }
+            outcomes.push(outcome);
+        }
+        Ok(CapabilityBatchOutcome {
+            outcomes,
+            stopped_on_suspension,
+        })
+    }
+}
+
+fn current_hook_gate_invocation() -> Option<HookGateInvocationMetadata> {
+    HOOK_GATE_INVOCATION.try_with(Clone::clone).ok()
+}
+
+/// In-memory router implementation for caller-level tests and local harnesses.
+#[derive(Debug, Default)]
+pub struct InMemoryHookGateRouter {
+    reservations: Mutex<HashMap<String, InMemoryReservation>>,
+}
+
+impl InMemoryHookGateRouter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn reserve(
+        &self,
+        request: HookGateReservationRequest,
+    ) -> Result<LoopGateRef, HookGateError> {
+        self.reserve_gate(request).await
+    }
+
+    pub async fn resolve(
+        &self,
+        request: HookGateResolutionRequest,
+    ) -> Result<HookGateResolution, HookGateError> {
+        self.resolve_gate(request).await
+    }
+
+    fn reservations_guard(
+        &self,
+    ) -> Result<MutexGuard<'_, HashMap<String, InMemoryReservation>>, HookGateError> {
+        self.reservations
+            .lock()
+            .map_err(|_| HookGateError::Backend("hook gate router mutex poisoned".to_string()))
+    }
+}
+
+#[async_trait]
+impl HookGateRouter for InMemoryHookGateRouter {
+    async fn reserve_gate(
+        &self,
+        request: HookGateReservationRequest,
+    ) -> Result<LoopGateRef, HookGateError> {
+        validate_digest(&request.arguments_digest)?;
+        if request.expires_at <= request.created_at {
+            return Err(HookGateError::InvalidTtl);
+        }
+        let gate_ref = LoopGateRef::new(format!(
+            "gate:{}-{}",
+            request.kind.gate_ref_prefix(),
+            ApprovalRequestId::new()
+        ))
+        .map_err(|error| HookGateError::InvalidGateRef(error.to_string()))?;
+        let reservation = HookGateReservation {
+            gate_ref: gate_ref.clone(),
+            kind: request.kind,
+            run_context: request.run_context,
+            actor: request.actor,
+            capability_id: request.capability_id,
+            arguments_digest: request.arguments_digest,
+            reason: request.reason,
+            created_at: request.created_at,
+            expires_at: request.expires_at,
+        };
+        let mut reservations = self.reservations_guard()?;
+        reservations.insert(
+            gate_ref.as_str().to_string(),
+            InMemoryReservation {
+                reservation,
+                consumed_at: None,
+            },
+        );
+        Ok(gate_ref)
+    }
+
+    async fn resolve_gate(
+        &self,
+        request: HookGateResolutionRequest,
+    ) -> Result<HookGateResolution, HookGateError> {
+        let mut reservations = self.reservations_guard()?;
+        let state = reservations
+            .get_mut(request.gate_ref.as_str())
+            .ok_or_else(|| HookGateError::UnknownGate {
+                gate_ref: request.gate_ref.clone(),
+            })?;
+        if let Some(consumed_at) = state.consumed_at {
+            return Err(HookGateError::AlreadyConsumed {
+                gate_ref: state.reservation.gate_ref.clone(),
+                consumed_at,
+            });
+        }
+        if request.resolved_at >= state.reservation.expires_at {
+            return Err(HookGateError::Expired {
+                gate_ref: state.reservation.gate_ref.clone(),
+                expires_at: state.reservation.expires_at,
+            });
+        }
+        if let Some(expected_kind) = request.expected_kind
+            && expected_kind != state.reservation.kind
+        {
+            return Err(HookGateError::KindMismatch {
+                gate_ref: state.reservation.gate_ref.clone(),
+                expected: expected_kind,
+                actual: state.reservation.kind,
+            });
+        }
+        if !same_run_context(&request.run_context, &state.reservation.run_context) {
+            return Err(HookGateError::RunMismatch {
+                gate_ref: state.reservation.gate_ref.clone(),
+            });
+        }
+        if request.actor != state.reservation.actor {
+            return Err(HookGateError::ActorMismatch {
+                gate_ref: state.reservation.gate_ref.clone(),
+            });
+        }
+        if request.capability_id != state.reservation.capability_id {
+            return Err(HookGateError::CapabilityMismatch {
+                gate_ref: state.reservation.gate_ref.clone(),
+                expected: state.reservation.capability_id.clone(),
+                actual: request.capability_id,
+            });
+        }
+        if request.arguments_digest != state.reservation.arguments_digest {
+            return Err(HookGateError::ArgumentsDigestMismatch {
+                gate_ref: state.reservation.gate_ref.clone(),
+            });
+        }
+        state.consumed_at = Some(request.resolved_at);
+        Ok(HookGateResolution {
+            gate_ref: state.reservation.gate_ref.clone(),
+            kind: state.reservation.kind,
+            run_context: state.reservation.run_context.clone(),
+            actor: state.reservation.actor.clone(),
+            capability_id: state.reservation.capability_id.clone(),
+            arguments_digest: state.reservation.arguments_digest.clone(),
+            resolved_at: request.resolved_at,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct InMemoryReservation {
+    reservation: HookGateReservation,
+    consumed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookGateError {
+    InvalidTtl,
+    MissingInvocationMetadata,
+    InvalidDigest(String),
+    InvalidGateRef(String),
+    UnknownGate {
+        gate_ref: LoopGateRef,
+    },
+    AlreadyConsumed {
+        gate_ref: LoopGateRef,
+        consumed_at: DateTime<Utc>,
+    },
+    Expired {
+        gate_ref: LoopGateRef,
+        expires_at: DateTime<Utc>,
+    },
+    KindMismatch {
+        gate_ref: LoopGateRef,
+        expected: HookGateKind,
+        actual: HookGateKind,
+    },
+    RunMismatch {
+        gate_ref: LoopGateRef,
+    },
+    ActorMismatch {
+        gate_ref: LoopGateRef,
+    },
+    CapabilityMismatch {
+        gate_ref: LoopGateRef,
+        expected: CapabilityId,
+        actual: CapabilityId,
+    },
+    ArgumentsDigestMismatch {
+        gate_ref: LoopGateRef,
+    },
+    Backend(String),
+}
+
+impl HookGateError {
+    pub fn is_already_consumed(&self) -> bool {
+        matches!(self, Self::AlreadyConsumed { .. })
+    }
+
+    pub fn is_actor_mismatch(&self) -> bool {
+        matches!(self, Self::ActorMismatch { .. })
+    }
+
+    pub fn is_expired(&self) -> bool {
+        matches!(self, Self::Expired { .. })
+    }
+}
+
+impl fmt::Display for HookGateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidTtl => formatter.write_str("hook gate ttl must be positive and bounded"),
+            Self::MissingInvocationMetadata => {
+                formatter.write_str("hook gate reservation missing invocation metadata")
+            }
+            Self::InvalidDigest(reason) => write!(formatter, "invalid hook gate digest: {reason}"),
+            Self::InvalidGateRef(reason) => {
+                write!(formatter, "invalid router-issued hook gate ref: {reason}")
+            }
+            Self::UnknownGate { gate_ref } => {
+                write!(formatter, "hook gate ref {} is unknown", gate_ref.as_str())
+            }
+            Self::AlreadyConsumed { gate_ref, .. } => {
+                write!(
+                    formatter,
+                    "hook gate ref {} was already consumed",
+                    gate_ref.as_str()
+                )
+            }
+            Self::Expired {
+                gate_ref,
+                expires_at,
+            } => write!(
+                formatter,
+                "hook gate ref {} expired at {expires_at}",
+                gate_ref.as_str()
+            ),
+            Self::KindMismatch {
+                gate_ref,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "hook gate ref {} expected {} gate, got {}",
+                gate_ref.as_str(),
+                expected.as_str(),
+                actual.as_str()
+            ),
+            Self::RunMismatch { gate_ref } => {
+                write!(
+                    formatter,
+                    "hook gate ref {} belongs to another run",
+                    gate_ref.as_str()
+                )
+            }
+            Self::ActorMismatch { gate_ref } => write!(
+                formatter,
+                "hook gate ref {} belongs to another actor/session",
+                gate_ref.as_str()
+            ),
+            Self::CapabilityMismatch {
+                gate_ref,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "hook gate ref {} expected capability {}, got {}",
+                gate_ref.as_str(),
+                expected.as_str(),
+                actual.as_str()
+            ),
+            Self::ArgumentsDigestMismatch { gate_ref } => write!(
+                formatter,
+                "hook gate ref {} arguments digest did not match",
+                gate_ref.as_str()
+            ),
+            Self::Backend(reason) => write!(formatter, "hook gate router backend error: {reason}"),
+        }
+    }
+}
+
+impl Error for HookGateError {}
+
+impl From<HookGateError> for AgentLoopHostError {
+    fn from(error: HookGateError) -> Self {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Unavailable,
+            format!("hook gate router unavailable: {error}"),
+        )
+    }
+}
+
+fn validate_digest(value: &str) -> Result<(), HookGateError> {
+    if value.starts_with("sha256:")
+        && value.len() == "sha256:".len() + 64
+        && value["sha256:".len()..]
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        Ok(())
+    } else {
+        Err(HookGateError::InvalidDigest(
+            "expected sha256:<64 hex characters>".to_string(),
+        ))
+    }
+}
+
+fn validate_token(
+    value: String,
+    label: &'static str,
+    max_bytes: usize,
+) -> Result<String, HookGateError> {
+    if value.is_empty() {
+        return Err(HookGateError::InvalidDigest(format!(
+            "{label} must not be empty"
+        )));
+    }
+    if value.len() > max_bytes {
+        return Err(HookGateError::InvalidDigest(format!(
+            "{label} must be at most {max_bytes} bytes"
+        )));
+    }
+    if value.chars().any(|character| character.is_control()) {
+        return Err(HookGateError::InvalidDigest(format!(
+            "{label} must not contain control characters"
+        )));
+    }
+    Ok(value)
+}
+
+fn same_run_context(left: &LoopRunContext, right: &LoopRunContext) -> bool {
+    left.scope == right.scope
+        && left.thread_id == right.thread_id
+        && left.turn_id == right.turn_id
+        && left.run_id == right.run_id
+}

--- a/crates/ironclaw_reborn/src/hook_gate_refs.rs
+++ b/crates/ironclaw_reborn/src/hook_gate_refs.rs
@@ -75,6 +75,22 @@ impl HookGateActorBinding {
     }
 }
 
+/// Run and actor identity resolved when minting a hook gate reservation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookGateReservationContext {
+    pub run_context: LoopRunContext,
+    pub actor: HookGateActorBinding,
+}
+
+impl HookGateReservationContext {
+    pub fn new(run_context: LoopRunContext, actor: HookGateActorBinding) -> Self {
+        Self { run_context, actor }
+    }
+}
+
+type HookGateReservationContextSource =
+    Arc<dyn Fn() -> HookGateReservationContext + Send + Sync + 'static>;
+
 /// Per-invocation metadata captured outside `ironclaw_hooks` and consumed by
 /// [`RouterBackedHookGateRefFactory`] when the hook middleware asks for a ref.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -219,8 +235,7 @@ pub trait HookGateRouter: Send + Sync {
 /// Production `HookGateRefFactory` adapter backed by a host approval/auth
 /// router.
 pub struct RouterBackedHookGateRefFactory {
-    run_context: LoopRunContext,
-    actor: HookGateActorBinding,
+    context_source: HookGateReservationContextSource,
     router: Arc<dyn HookGateRouter>,
     reservation_ttl: Duration,
 }
@@ -229,26 +244,25 @@ impl fmt::Debug for RouterBackedHookGateRefFactory {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("RouterBackedHookGateRefFactory")
-            .field("run_context", &self.run_context)
-            .field("actor", &self.actor)
             .field("reservation_ttl", &self.reservation_ttl)
             .finish_non_exhaustive()
     }
 }
 
 impl RouterBackedHookGateRefFactory {
-    pub fn try_new(
-        run_context: LoopRunContext,
-        actor: HookGateActorBinding,
+    pub fn try_new<F>(
         router: Arc<dyn HookGateRouter>,
         reservation_ttl: Duration,
-    ) -> Result<Self, HookGateError> {
+        context_source: F,
+    ) -> Result<Self, HookGateError>
+    where
+        F: Fn() -> HookGateReservationContext + Send + Sync + 'static,
+    {
         if reservation_ttl <= Duration::zero() {
             return Err(HookGateError::InvalidTtl);
         }
         Ok(Self {
-            run_context,
-            actor,
+            context_source: Arc::new(context_source),
             router,
             reservation_ttl,
         })
@@ -265,10 +279,11 @@ impl RouterBackedHookGateRefFactory {
         let expires_at = now
             .checked_add_signed(self.reservation_ttl)
             .ok_or(HookGateError::InvalidTtl)?;
+        let context = (self.context_source)();
         let request = HookGateReservationRequest {
             kind,
-            run_context: self.run_context.clone(),
-            actor: self.actor.clone(),
+            run_context: context.run_context,
+            actor: context.actor,
             capability_id: metadata.capability_id,
             arguments_digest: metadata.arguments_digest,
             reason: reason.to_string(),
@@ -432,6 +447,7 @@ impl HookGateRouter for InMemoryHookGateRouter {
         &self,
         request: HookGateResolutionRequest,
     ) -> Result<HookGateResolution, HookGateError> {
+        let resolved_at = Utc::now();
         let mut reservations = self.reservations_guard()?;
         let state = reservations
             .get_mut(request.gate_ref.as_str())
@@ -444,7 +460,7 @@ impl HookGateRouter for InMemoryHookGateRouter {
                 consumed_at,
             });
         }
-        if request.resolved_at >= state.reservation.expires_at {
+        if resolved_at >= state.reservation.expires_at {
             return Err(HookGateError::Expired {
                 gate_ref: state.reservation.gate_ref.clone(),
                 expires_at: state.reservation.expires_at,
@@ -481,7 +497,7 @@ impl HookGateRouter for InMemoryHookGateRouter {
                 gate_ref: state.reservation.gate_ref.clone(),
             });
         }
-        state.consumed_at = Some(request.resolved_at);
+        state.consumed_at = Some(resolved_at);
         Ok(HookGateResolution {
             gate_ref: state.reservation.gate_ref.clone(),
             kind: state.reservation.kind,
@@ -489,7 +505,7 @@ impl HookGateRouter for InMemoryHookGateRouter {
             actor: state.reservation.actor.clone(),
             capability_id: state.reservation.capability_id.clone(),
             arguments_digest: state.reservation.arguments_digest.clone(),
-            resolved_at: request.resolved_at,
+            resolved_at,
         })
     }
 }

--- a/crates/ironclaw_reborn/src/hook_gate_refs.rs
+++ b/crates/ironclaw_reborn/src/hook_gate_refs.rs
@@ -91,6 +91,21 @@ impl HookGateReservationContext {
 type HookGateReservationContextSource =
     Arc<dyn Fn() -> HookGateReservationContext + Send + Sync + 'static>;
 
+/// Upper bound on a configured reservation TTL. Reservations that never
+/// resolve accumulate in router state for the full TTL; an operator
+/// misconfiguring a year-long TTL would create a long-tail memory leak
+/// in `InMemoryHookGateRouter` and an unbounded grant window in durable
+/// backends. 24 hours is plenty for human-in-the-loop approval flows.
+/// henrypark133 must-fix #1 on PR #3633.
+const MAX_RESERVATION_TTL_HOURS: i64 = 24;
+
+/// Upper bound on the free-form reason text accompanying a gate-ref
+/// reservation. Without a cap, a buggy or malicious caller could push
+/// arbitrarily large strings through the approval store. 4 KiB is
+/// generous for human-facing approval reasons. henrypark133 must-fix #2
+/// on PR #3633.
+const MAX_REASON_BYTES: usize = 4096;
+
 /// Per-invocation metadata captured outside `ironclaw_hooks` and consumed by
 /// [`RouterBackedHookGateRefFactory`] when the hook middleware asks for a ref.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -269,6 +284,12 @@ impl RouterBackedHookGateRefFactory {
         if reservation_ttl <= Duration::zero() {
             return Err(HookGateError::InvalidTtl);
         }
+        // henrypark133 must-fix #1: cap to keep unresolved reservations
+        // from accumulating in router state for impractical durations.
+        let max_ttl = Duration::hours(MAX_RESERVATION_TTL_HOURS);
+        if reservation_ttl > max_ttl {
+            return Err(HookGateError::InvalidTtl);
+        }
         Ok(Self {
             context_source: Arc::new(context_source),
             router,
@@ -281,6 +302,19 @@ impl RouterBackedHookGateRefFactory {
         kind: HookGateKind,
         reason: &str,
     ) -> Result<LoopGateRef, AgentLoopHostError> {
+        // henrypark133 must-fix #2: cap reason text before it crosses
+        // into router state. The reason is operator-facing and may be
+        // persisted; an unbounded string is a memory + display surface
+        // problem.
+        if reason.len() > MAX_REASON_BYTES {
+            return Err(AgentLoopHostError::from(HookGateError::InvalidToken {
+                field: "reason",
+                reason: format!(
+                    "must be at most {MAX_REASON_BYTES} bytes; got {}",
+                    reason.len()
+                ),
+            }));
+        }
         let metadata =
             current_hook_gate_invocation().ok_or(HookGateError::MissingInvocationMetadata)?;
         let now = Utc::now();
@@ -528,7 +562,17 @@ struct InMemoryReservation {
 pub enum HookGateError {
     InvalidTtl,
     MissingInvocationMetadata,
+    /// Argument digest didn't satisfy the `sha256:<64-hex>` shape. Distinct
+    /// from [`Self::InvalidToken`] (which covers non-digest opaque tokens
+    /// like actor/session ids) — henrypark133 must-fix #3 on PR #3633.
     InvalidDigest(String),
+    /// A non-digest opaque token (actor id, session id, etc.) failed
+    /// validation. `field` names the rejected token type; `reason`
+    /// describes the failure (empty, over-limit, control characters).
+    InvalidToken {
+        field: &'static str,
+        reason: String,
+    },
     InvalidGateRef(String),
     UnknownGate {
         gate_ref: LoopGateRef,
@@ -585,6 +629,9 @@ impl fmt::Display for HookGateError {
                 formatter.write_str("hook gate reservation missing invocation metadata")
             }
             Self::InvalidDigest(reason) => write!(formatter, "invalid hook gate digest: {reason}"),
+            Self::InvalidToken { field, reason } => {
+                write!(formatter, "invalid hook gate {field}: {reason}")
+            }
             Self::InvalidGateRef(reason) => {
                 write!(formatter, "invalid router-issued hook gate ref: {reason}")
             }
@@ -654,10 +701,41 @@ impl Error for HookGateError {}
 
 impl From<HookGateError> for AgentLoopHostError {
     fn from(error: HookGateError) -> Self {
-        AgentLoopHostError::new(
-            AgentLoopHostErrorKind::Unavailable,
-            format!("hook gate router unavailable: {error}"),
-        )
+        // henrypark133 must-fix #5 on PR #3633: collapse consumption-
+        // failure variants to an opaque public surface. Distinguishing
+        // "this gate ref doesn't exist" from "this gate ref belongs to
+        // another run/actor/capability" is an oracle that lets a probing
+        // caller learn which gate refs are live. Internally the variants
+        // are still distinct (for routing + assertion ergonomics in tests
+        // + operator-visible logs); the public `AgentLoopHostError` says
+        // only "consumption denied".
+        //
+        // Also: a `tracing::warn!` here gives operators an observable
+        // signal that distinguishes security rejections (consumption
+        // failures) from availability failures (router unreachable).
+        // henrypark133 non-blocking #9.
+        tracing::warn!(
+            error = %error,
+            "hook gate router rejected request; mapping to opaque AgentLoopHostError"
+        );
+        let safe_summary: String = match &error {
+            // Consumption-failure family: collapse oracle.
+            HookGateError::UnknownGate { .. }
+            | HookGateError::AlreadyConsumed { .. }
+            | HookGateError::Expired { .. }
+            | HookGateError::KindMismatch { .. }
+            | HookGateError::RunMismatch { .. }
+            | HookGateError::ActorMismatch { .. }
+            | HookGateError::CapabilityMismatch { .. }
+            | HookGateError::ArgumentsDigestMismatch { .. } => {
+                "hook gate consumption denied".to_string()
+            }
+            // Misuse / availability failures: surface the variant detail
+            // (these are not oracles — they signal configuration / wiring
+            // bugs and need to be operator-visible).
+            _ => format!("hook gate router unavailable: {error}"),
+        };
+        AgentLoopHostError::new(AgentLoopHostErrorKind::Unavailable, safe_summary)
     }
 }
 
@@ -681,20 +759,26 @@ fn validate_token(
     label: &'static str,
     max_bytes: usize,
 ) -> Result<String, HookGateError> {
+    // henrypark133 must-fix #3 on PR #3633: route through `InvalidToken`
+    // rather than `InvalidDigest` so the error name matches what's being
+    // validated (actor / session id, not a sha256 digest).
     if value.is_empty() {
-        return Err(HookGateError::InvalidDigest(format!(
-            "{label} must not be empty"
-        )));
+        return Err(HookGateError::InvalidToken {
+            field: label,
+            reason: "must not be empty".to_string(),
+        });
     }
     if value.len() > max_bytes {
-        return Err(HookGateError::InvalidDigest(format!(
-            "{label} must be at most {max_bytes} bytes"
-        )));
+        return Err(HookGateError::InvalidToken {
+            field: label,
+            reason: format!("must be at most {max_bytes} bytes"),
+        });
     }
     if value.chars().any(|character| character.is_control()) {
-        return Err(HookGateError::InvalidDigest(format!(
-            "{label} must not contain control characters"
-        )));
+        return Err(HookGateError::InvalidToken {
+            field: label,
+            reason: "must not contain control characters".to_string(),
+        });
     }
     Ok(value)
 }

--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod app_loop_family;
 pub mod driver_registry;
+pub mod hook_gate_refs;
 pub mod loop_driver_host;
 pub mod loop_exit_applier;
 pub mod milestone_events;

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -25,6 +25,7 @@ use ironclaw_loop_support::{
 use ironclaw_threads::{SessionThreadService, ThreadScope};
 
 use crate::driver_registry::{DriverRequirements, LoopDriverRegistryKey, RequirementLevel};
+use crate::hook_gate_refs::HookGateInvocationScopePort;
 use crate::model_routes::{ModelRouteError, ModelRouteResolver, ModelSlot};
 use crate::text_loop_driver::{TEXT_ONLY_DRIVER_ID, TEXT_ONLY_DRIVER_VERSION};
 
@@ -790,7 +791,12 @@ where
                     ));
                 hooked = hooked.with_resolver(adapter);
             }
-            capabilities = Arc::new(hooked);
+            let hooked: Arc<dyn LoopCapabilityPort> = Arc::new(hooked);
+            capabilities = if self.hook_gate_ref_factory.is_some() {
+                Arc::new(HookGateInvocationScopePort::new(hooked))
+            } else {
+                hooked
+            };
         }
         capabilities
             .visible_capabilities(VisibleCapabilityRequest)

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -428,12 +428,29 @@ where
     /// install `UuidHookGateRefFactory` to exercise the affirmative path.
     /// See [`Self::with_hook_gate_ref_factory`].
     hook_gate_ref_factory: Option<Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory>>,
+    /// Per-build hook-gate-factory builder. See
+    /// [`Self::with_hook_gate_ref_factory_builder`].
+    hook_gate_ref_factory_builder: Option<HookGateRefFactoryBuilder>,
     safety_context: Option<InstructionSafetyContext>,
     identity_context_source: Option<Arc<dyn HostIdentityContextSource>>,
     input_queue: Option<Arc<dyn HostInputQueue>>,
     profiled_capabilities: Option<ProfiledCapabilityHostRuntime>,
     driver_requirements: HashMap<LoopDriverRegistryKey, DriverRequirements>,
 }
+
+/// Per-host-build callback that produces a fresh hook-gate factory bound
+/// to the active run. Preferred over a shared `Arc<dyn HookGateRefFactory>`
+/// because it eliminates the stale-`LoopRunContext` capture risk
+/// serrrfirat MEDIUM (5-15 review on PR #3633) flagged: a single shared
+/// factory carries whatever run context it was constructed against, and
+/// the host reuses the same `Arc` across every host it produces — so a
+/// second host build could mint gate refs against the first build's run
+/// context.
+pub type HookGateRefFactoryBuilder = Arc<
+    dyn Fn(&LoopRunContext) -> Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory>
+        + Send
+        + Sync,
+>;
 
 impl<S, G> RebornLoopDriverHostFactory<S, G>
 where
@@ -471,6 +488,7 @@ where
             hook_dispatcher_builder_factory: None,
             capability_input_resolver: None,
             hook_gate_ref_factory: None,
+            hook_gate_ref_factory_builder: None,
             safety_context: None,
             identity_context_source: None,
             input_queue: None,
@@ -567,11 +585,46 @@ where
     /// the affirmative `ApprovalRequired { gate_ref }` shape (the refs are
     /// locally unique but not router-registered — production must not use
     /// this).
+    /// **Deprecated for production use.** A single shared factory captures
+    /// its `LoopRunContext` (typically through the `Fn() ->
+    /// HookGateReservationContext` closure passed to
+    /// `RouterBackedHookGateRefFactory::try_new`) at construction time
+    /// and reuses it for every host build. The host factory itself
+    /// produces many hosts with different run contexts, so a later
+    /// build can mint a gate ref against a stale run — exactly the
+    /// integration footgun serrrfirat MEDIUM on PR #3633 (5-15 review)
+    /// flagged. Use [`Self::with_hook_gate_ref_factory_builder`]
+    /// instead, which receives the current `LoopRunContext` per build
+    /// so the factory can carry the right run identity by construction.
+    #[deprecated(
+        since = "0.1.0",
+        note = "shared factory captures stale LoopRunContext across host \
+                builds. Use `with_hook_gate_ref_factory_builder(|run_ctx| ...)` \
+                so the factory is constructed fresh per host with the right \
+                run context."
+    )]
     pub fn with_hook_gate_ref_factory(
         mut self,
         factory: Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory>,
     ) -> Self {
         self.hook_gate_ref_factory = Some(factory);
+        self
+    }
+
+    /// Install a per-build hook-gate-factory builder. The closure is
+    /// invoked once per `build_text_only_host*` call with the current
+    /// `LoopRunContext`; the returned factory is wired into that host's
+    /// `HookedLoopCapabilityPort`. This is the preferred path for
+    /// router-backed factories that need to bind the active run/actor
+    /// at mint time (serrrfirat MEDIUM on PR #3633 5-15 review).
+    pub fn with_hook_gate_ref_factory_builder<F>(mut self, factory_builder: F) -> Self
+    where
+        F: Fn(&LoopRunContext) -> Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.hook_gate_ref_factory_builder = Some(Arc::new(factory_builder));
         self
     }
 
@@ -780,8 +833,19 @@ where
                 run_context.scope.tenant_id.clone(),
             )
             .with_provider_resolver(provider_resolver);
-            if let Some(factory) = self.hook_gate_ref_factory.as_ref() {
-                hooked = hooked.with_gate_ref_factory(Arc::clone(factory));
+            // Prefer the per-build builder (serrrfirat MEDIUM on PR
+            // #3633 5-15 review): each host build invokes the closure
+            // with its own `LoopRunContext`, so the resulting factory
+            // can't capture stale run/actor identity. Fall back to the
+            // deprecated shared factory if only the older API is wired.
+            let per_build_gate_factory = self
+                .hook_gate_ref_factory_builder
+                .as_ref()
+                .map(|builder| builder(&run_context))
+                .or_else(|| self.hook_gate_ref_factory.clone());
+            let has_gate_factory = per_build_gate_factory.is_some();
+            if let Some(factory) = per_build_gate_factory {
+                hooked = hooked.with_gate_ref_factory(factory);
             }
             if let Some(input_resolver) = self.capability_input_resolver.as_ref() {
                 let adapter: Arc<dyn HookCapabilityInputResolver> =
@@ -792,7 +856,7 @@ where
                 hooked = hooked.with_resolver(adapter);
             }
             let hooked: Arc<dyn LoopCapabilityPort> = Arc::new(hooked);
-            capabilities = if self.hook_gate_ref_factory.is_some() {
+            capabilities = if has_gate_factory {
                 Arc::new(HookGateInvocationScopePort::new(hooked))
             } else {
                 hooked

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -976,7 +976,10 @@ async fn pause_approval_hook_surfaces_as_approval_required_with_real_gate_ref() 
     let host = fixture
         .factory()
         .with_hook_dispatcher(pause_approval_dispatcher())
-        .with_hook_gate_ref_factory(Arc::new(factory))
+        .with_hook_gate_ref_factory_builder({
+            let f: Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory> = Arc::new(factory);
+            move |_| Arc::clone(&f)
+        })
         .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
         .await
         .expect("host builds with hook dispatcher installed");
@@ -1048,7 +1051,10 @@ async fn router_backed_pause_approval_gate_ref_rejects_cross_actor_resolution() 
     let host = fixture
         .factory()
         .with_hook_dispatcher(pause_approval_dispatcher())
-        .with_hook_gate_ref_factory(Arc::new(factory))
+        .with_hook_gate_ref_factory_builder({
+            let f: Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory> = Arc::new(factory);
+            move |_| Arc::clone(&f)
+        })
         .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
         .await
         .expect("host builds with hook dispatcher installed");
@@ -1124,7 +1130,11 @@ async fn router_backed_gate_ref_factory_sources_context_per_mint_when_reused() {
     let host_factory = fixture
         .factory()
         .with_hook_dispatcher(pause_approval_dispatcher())
-        .with_hook_gate_ref_factory(Arc::new(gate_ref_factory));
+        .with_hook_gate_ref_factory_builder({
+            let f: Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory> =
+                Arc::new(gate_ref_factory);
+            move |_| Arc::clone(&f)
+        });
 
     let inner_a = Arc::new(RecordingCapabilityPort::new());
     let request_a = fixture.request();
@@ -1239,7 +1249,10 @@ async fn router_backed_pause_approval_gate_ref_expires_after_ttl() {
     let host = fixture
         .factory()
         .with_hook_dispatcher(pause_approval_dispatcher())
-        .with_hook_gate_ref_factory(Arc::new(factory))
+        .with_hook_gate_ref_factory_builder({
+            let f: Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory> = Arc::new(factory);
+            move |_| Arc::clone(&f)
+        })
         .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
         .await
         .expect("host builds with hook dispatcher installed");
@@ -1295,7 +1308,10 @@ async fn router_backed_pause_approval_gate_ref_rejects_backdated_resolution_afte
     let host = fixture
         .factory()
         .with_hook_dispatcher(pause_approval_dispatcher())
-        .with_hook_gate_ref_factory(Arc::new(factory))
+        .with_hook_gate_ref_factory_builder({
+            let f: Arc<dyn ironclaw_hooks::middleware::HookGateRefFactory> = Arc::new(factory);
+            move |_| Arc::clone(&f)
+        })
         .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
         .await
         .expect("host builds with hook dispatcher installed");

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -1308,20 +1308,25 @@ async fn router_backed_pause_approval_gate_ref_rejects_backdated_resolution_afte
     let CapabilityOutcome::ApprovalRequired { gate_ref, .. } = outcome else {
         panic!("expected ApprovalRequired, got {outcome:?}");
     };
+    // serrrfirat HIGH regression: `HookGateResolutionRequest` no longer
+    // exposes a caller-controllable `resolved_at`. Time authority lives on
+    // the router's own wall clock — see `InMemoryHookGateRouter::resolve_gate`
+    // where `Utc::now()` is read directly. The TTL was 1ms above and we
+    // slept 5ms past reservation, so the router will compute "now is past
+    // expires_at" using its own clock; no caller value can override it.
     tokio::time::sleep(StdDuration::from_millis(5)).await;
-    let mut resolution_request = HookGateResolutionRequest::for_invocation(
+    let resolution_request = HookGateResolutionRequest::for_invocation(
         gate_ref,
         HookGateActorBinding::new(fixture.actor_id.clone()),
         fixture.context.clone(),
         &request,
     )
     .expect("resolution request can be derived from invocation");
-    resolution_request.resolved_at = Utc::now() - chrono::Duration::seconds(30);
 
     let err = router
         .resolve(resolution_request)
         .await
-        .expect_err("backdating resolved_at must not bypass router TTL enforcement");
+        .expect_err("router-owned clock must enforce TTL regardless of caller intent");
     assert!(err.is_expired(), "expected expired error, got {err:?}");
     assert!(
         inner.invocations().is_empty(),

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -55,8 +55,8 @@ use ironclaw_loop_support::{
     HostManagedModelResponse, LoopCapabilityInputResolver,
 };
 use ironclaw_reborn::hook_gate_refs::{
-    HookGateActorBinding, HookGateResolutionRequest, HookGateRouter, InMemoryHookGateRouter,
-    RouterBackedHookGateRefFactory, hook_gate_arguments_digest,
+    HookGateActorBinding, HookGateReservationContext, HookGateResolutionRequest, HookGateRouter,
+    InMemoryHookGateRouter, RouterBackedHookGateRefFactory, hook_gate_arguments_digest,
 };
 use ironclaw_reborn::loop_driver_host::{
     RebornLoopDriverHostFactory, RebornLoopDriverHostRequest, TextOnlyLoopHostConfig,
@@ -595,12 +595,12 @@ fn router_backed_factory(
     fixture: &Fixture,
     router: Arc<InMemoryHookGateRouter>,
 ) -> RouterBackedHookGateRefFactory {
-    RouterBackedHookGateRefFactory::try_new(
-        fixture.context.clone(),
-        HookGateActorBinding::new(fixture.actor_id.clone()),
-        router,
-        chrono::Duration::seconds(30),
-    )
+    let run_context = fixture.context.clone();
+    let actor = HookGateActorBinding::new(fixture.actor_id.clone());
+    let router: Arc<dyn HookGateRouter> = router;
+    RouterBackedHookGateRefFactory::try_new(router, chrono::Duration::seconds(30), move || {
+        HookGateReservationContext::new(run_context.clone(), actor.clone())
+    })
     .expect("router-backed hook gate-ref factory accepts positive ttl")
 }
 
@@ -1093,17 +1093,145 @@ async fn router_backed_pause_approval_gate_ref_rejects_cross_actor_resolution() 
 }
 
 #[tokio::test]
+async fn router_backed_gate_ref_factory_sources_context_per_mint_when_reused() {
+    let fixture = Fixture::new().await;
+    let router = Arc::new(InMemoryHookGateRouter::new());
+    let surface_version = fixture.surface_version.clone();
+
+    let actor_a = HookGateActorBinding::new(
+        UserId::new("ext-a-hooks-user").expect("actor A id literal is valid"),
+    );
+    let actor_b = HookGateActorBinding::new(
+        UserId::new("ext-b-hooks-user").expect("actor B id literal is valid"),
+    );
+    let live_context = Arc::new(Mutex::new(HookGateReservationContext::new(
+        fixture.context.clone(),
+        actor_a.clone(),
+    )));
+    let context_source = Arc::clone(&live_context);
+    let router_for_factory: Arc<dyn HookGateRouter> = router.clone();
+    let gate_ref_factory = RouterBackedHookGateRefFactory::try_new(
+        router_for_factory,
+        chrono::Duration::seconds(30),
+        move || {
+            context_source
+                .lock()
+                .expect("live hook gate context mutex not poisoned")
+                .clone()
+        },
+    )
+    .expect("router-backed hook gate-ref factory accepts positive ttl");
+    let host_factory = fixture
+        .factory()
+        .with_hook_dispatcher(pause_approval_dispatcher())
+        .with_hook_gate_ref_factory(Arc::new(gate_ref_factory));
+
+    let inner_a = Arc::new(RecordingCapabilityPort::new());
+    let request_a = fixture.request();
+    let context_a = request_a.loop_run_context.clone();
+    let host_a = host_factory
+        .build_text_only_host_with_capabilities(request_a, inner_a.clone())
+        .await
+        .expect("first host builds");
+    let invocation_a = invocation(&surface_version, "cap.blocked");
+    let outcome_a = host_a
+        .invoke_capability(invocation_a.clone())
+        .await
+        .expect("first invoke returns outcome");
+    let CapabilityOutcome::ApprovalRequired {
+        gate_ref: gate_ref_a,
+        ..
+    } = outcome_a
+    else {
+        panic!("expected first build ApprovalRequired, got {outcome_a:?}");
+    };
+    router
+        .resolve(
+            HookGateResolutionRequest::for_invocation(
+                gate_ref_a,
+                actor_a.clone(),
+                context_a.clone(),
+                &invocation_a,
+            )
+            .expect("first resolution request can be derived from invocation"),
+        )
+        .await
+        .expect("first build gate resolves with actor A/context A");
+
+    let mut request_b = fixture.request();
+    let turn_id_b = ironclaw_turns::TurnId::new();
+    let run_id_b = TurnRunId::new();
+    request_b.loop_run_context = LoopRunContext::new(
+        request_b.loop_run_context.scope.clone(),
+        turn_id_b,
+        run_id_b,
+        request_b.loop_run_context.resolved_run_profile.clone(),
+    );
+    request_b.claimed_run.state.turn_id = turn_id_b;
+    request_b.claimed_run.state.run_id = run_id_b;
+    let context_b = request_b.loop_run_context.clone();
+    *live_context
+        .lock()
+        .expect("live hook gate context mutex not poisoned") =
+        HookGateReservationContext::new(context_b.clone(), actor_b.clone());
+
+    let inner_b = Arc::new(RecordingCapabilityPort::new());
+    let host_b = host_factory
+        .build_text_only_host_with_capabilities(request_b, inner_b.clone())
+        .await
+        .expect("second host builds");
+    let invocation_b = invocation(&surface_version, "cap.blocked");
+    let outcome_b = host_b
+        .invoke_capability(invocation_b.clone())
+        .await
+        .expect("second invoke returns outcome");
+    let CapabilityOutcome::ApprovalRequired {
+        gate_ref: gate_ref_b,
+        ..
+    } = outcome_b
+    else {
+        panic!("expected second build ApprovalRequired, got {outcome_b:?}");
+    };
+
+    router
+        .resolve(
+            HookGateResolutionRequest::for_invocation(
+                gate_ref_b.clone(),
+                actor_a,
+                context_a,
+                &invocation_b,
+            )
+            .expect("stale resolution request can be derived from invocation"),
+        )
+        .await
+        .expect_err("second build gate must not resolve with actor/context from build A");
+    router
+        .resolve(
+            HookGateResolutionRequest::for_invocation(
+                gate_ref_b,
+                actor_b,
+                context_b,
+                &invocation_b,
+            )
+            .expect("second resolution request can be derived from invocation"),
+        )
+        .await
+        .expect("second build gate resolves with actor B/context B");
+}
+
+#[tokio::test]
 async fn router_backed_pause_approval_gate_ref_expires_after_ttl() {
     let fixture = Fixture::new().await;
     let inner = Arc::new(RecordingCapabilityPort::new());
     let surface_version = fixture.surface_version.clone();
     let router = Arc::new(InMemoryHookGateRouter::new());
     let router_for_factory: Arc<dyn HookGateRouter> = router.clone();
+    let run_context = fixture.context.clone();
+    let actor = HookGateActorBinding::new(fixture.actor_id.clone());
     let factory = RouterBackedHookGateRefFactory::try_new(
-        fixture.context.clone(),
-        HookGateActorBinding::new(fixture.actor_id.clone()),
         router_for_factory,
         chrono::Duration::milliseconds(1),
+        move || HookGateReservationContext::new(run_context.clone(), actor.clone()),
     )
     .expect("positive ttl is accepted");
     let request = invocation(&surface_version, "cap.blocked");
@@ -1140,6 +1268,61 @@ async fn router_backed_pause_approval_gate_ref_expires_after_ttl() {
         }
         other => panic!("expected ApprovalRequired, got {other:?}"),
     }
+    assert!(
+        inner.invocations().is_empty(),
+        "inner port must NOT be invoked when a hook pauses; got {:?}",
+        inner.invocations()
+    );
+}
+
+#[tokio::test]
+async fn router_backed_pause_approval_gate_ref_rejects_backdated_resolution_after_ttl() {
+    let fixture = Fixture::new().await;
+    let inner = Arc::new(RecordingCapabilityPort::new());
+    let surface_version = fixture.surface_version.clone();
+    let router = Arc::new(InMemoryHookGateRouter::new());
+    let router_for_factory: Arc<dyn HookGateRouter> = router.clone();
+    let run_context = fixture.context.clone();
+    let actor = HookGateActorBinding::new(fixture.actor_id.clone());
+    let factory = RouterBackedHookGateRefFactory::try_new(
+        router_for_factory,
+        chrono::Duration::milliseconds(1),
+        move || HookGateReservationContext::new(run_context.clone(), actor.clone()),
+    )
+    .expect("positive ttl is accepted");
+    let request = invocation(&surface_version, "cap.blocked");
+
+    let host = fixture
+        .factory()
+        .with_hook_dispatcher(pause_approval_dispatcher())
+        .with_hook_gate_ref_factory(Arc::new(factory))
+        .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
+        .await
+        .expect("host builds with hook dispatcher installed");
+
+    let outcome = host
+        .invoke_capability(request.clone())
+        .await
+        .expect("invoke_capability returns a (suspended) outcome, not an error");
+
+    let CapabilityOutcome::ApprovalRequired { gate_ref, .. } = outcome else {
+        panic!("expected ApprovalRequired, got {outcome:?}");
+    };
+    tokio::time::sleep(StdDuration::from_millis(5)).await;
+    let mut resolution_request = HookGateResolutionRequest::for_invocation(
+        gate_ref,
+        HookGateActorBinding::new(fixture.actor_id.clone()),
+        fixture.context.clone(),
+        &request,
+    )
+    .expect("resolution request can be derived from invocation");
+    resolution_request.resolved_at = Utc::now() - chrono::Duration::seconds(30);
+
+    let err = router
+        .resolve(resolution_request)
+        .await
+        .expect_err("backdating resolved_at must not bypass router TTL enforcement");
+    assert!(err.is_expired(), "expected expired error, got {err:?}");
     assert!(
         inner.invocations().is_empty(),
         "inner port must NOT be invoked when a hook pauses; got {:?}",

--- a/crates/ironclaw_reborn/tests/hooks_integration.rs
+++ b/crates/ironclaw_reborn/tests/hooks_integration.rs
@@ -27,7 +27,10 @@
 //! added to prove non-matching predicate invocations also reach the inner
 //! port.
 
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration as StdDuration,
+};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -50,6 +53,10 @@ use ironclaw_host_api::{AgentId, CapabilityId, ProjectId, TenantId, ThreadId, Us
 use ironclaw_loop_support::{
     HostManagedModelError, HostManagedModelGateway, HostManagedModelRequest,
     HostManagedModelResponse, LoopCapabilityInputResolver,
+};
+use ironclaw_reborn::hook_gate_refs::{
+    HookGateActorBinding, HookGateResolutionRequest, HookGateRouter, InMemoryHookGateRouter,
+    RouterBackedHookGateRefFactory, hook_gate_arguments_digest,
 };
 use ironclaw_reborn::loop_driver_host::{
     RebornLoopDriverHostFactory, RebornLoopDriverHostRequest, TextOnlyLoopHostConfig,
@@ -452,6 +459,7 @@ struct Fixture {
     milestone_sink: Arc<InMemoryLoopHostMilestoneSink>,
     gateway: Arc<UnusedGateway>,
     thread_scope: ThreadScope,
+    actor_id: UserId,
     claimed: ClaimedTurnRun,
     context: LoopRunContext,
     surface_version: CapabilitySurfaceVersion,
@@ -551,6 +559,7 @@ impl Fixture {
             milestone_sink,
             gateway,
             thread_scope,
+            actor_id: user_id,
             claimed,
             context,
             surface_version: CapabilitySurfaceVersion::new("hooks-integration:v1")
@@ -580,6 +589,19 @@ impl Fixture {
             loop_run_context: self.context.clone(),
         }
     }
+}
+
+fn router_backed_factory(
+    fixture: &Fixture,
+    router: Arc<InMemoryHookGateRouter>,
+) -> RouterBackedHookGateRefFactory {
+    RouterBackedHookGateRefFactory::try_new(
+        fixture.context.clone(),
+        HookGateActorBinding::new(fixture.actor_id.clone()),
+        router,
+        chrono::Duration::seconds(30),
+    )
+    .expect("router-backed hook gate-ref factory accepts positive ttl")
 }
 
 fn invocation(
@@ -944,29 +966,27 @@ async fn legacy_with_hook_dispatcher_shares_state_across_builds() {
 
 #[tokio::test]
 async fn pause_approval_hook_surfaces_as_approval_required_with_real_gate_ref() {
-    // Proves that PauseApproval decisions can surface as `ApprovalRequired`
-    // when a gate-ref factory is wired. The factory's default is fail-
-    // closed (henrypark133 Critical #3 — refuse to mint a syntactically-
-    // valid but router-unregistered ref); tests must opt into the dev-only
-    // `UuidHookGateRefFactory` to exercise the affirmative path.
     let fixture = Fixture::new().await;
     let inner = Arc::new(RecordingCapabilityPort::new());
     let surface_version = fixture.surface_version.clone();
+    let router = Arc::new(InMemoryHookGateRouter::new());
+    let factory = router_backed_factory(&fixture, Arc::clone(&router));
+    let request = invocation(&surface_version, "cap.blocked");
 
     let host = fixture
         .factory()
         .with_hook_dispatcher(pause_approval_dispatcher())
-        .with_hook_gate_ref_factory(Arc::new(ironclaw_hooks::middleware::UuidHookGateRefFactory))
+        .with_hook_gate_ref_factory(Arc::new(factory))
         .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
         .await
         .expect("host builds with hook dispatcher installed");
 
     let outcome = host
-        .invoke_capability(invocation(&surface_version, "cap.blocked"))
+        .invoke_capability(request.clone())
         .await
         .expect("invoke_capability returns a (suspended) outcome, not an error");
 
-    match outcome {
+    let gate_ref = match outcome {
         CapabilityOutcome::ApprovalRequired {
             gate_ref,
             safe_summary,
@@ -977,6 +997,146 @@ async fn pause_approval_hook_surfaces_as_approval_required_with_real_gate_ref() 
                 gate_ref.as_str()
             );
             assert_eq!(safe_summary, "integration-test pause approval");
+            gate_ref
+        }
+        other => panic!("expected ApprovalRequired, got {other:?}"),
+    };
+    assert!(
+        inner.invocations().is_empty(),
+        "inner port must NOT be invoked when a hook pauses; got {:?}",
+        inner.invocations()
+    );
+
+    let resolution_request = HookGateResolutionRequest::for_invocation(
+        gate_ref.clone(),
+        HookGateActorBinding::new(fixture.actor_id.clone()),
+        fixture.context.clone(),
+        &request,
+    )
+    .expect("resolution request can be derived from invocation");
+    let resolution = router
+        .resolve(resolution_request.clone())
+        .await
+        .expect("gateway consumes issued hook approval ref");
+    assert_eq!(resolution.gate_ref, gate_ref);
+    assert_eq!(resolution.capability_id.as_str(), "cap.blocked");
+    assert_eq!(
+        resolution.arguments_digest,
+        hook_gate_arguments_digest(&request),
+        "gateway reservation must carry the exact gated invocation digest"
+    );
+
+    let replay = router
+        .resolve(resolution_request)
+        .await
+        .expect_err("gate refs are one-shot");
+    assert!(
+        replay.is_already_consumed(),
+        "replay must be rejected as consumed, got {replay:?}"
+    );
+}
+
+#[tokio::test]
+async fn router_backed_pause_approval_gate_ref_rejects_cross_actor_resolution() {
+    let fixture = Fixture::new().await;
+    let inner = Arc::new(RecordingCapabilityPort::new());
+    let surface_version = fixture.surface_version.clone();
+    let router = Arc::new(InMemoryHookGateRouter::new());
+    let factory = router_backed_factory(&fixture, Arc::clone(&router));
+    let request = invocation(&surface_version, "cap.blocked");
+
+    let host = fixture
+        .factory()
+        .with_hook_dispatcher(pause_approval_dispatcher())
+        .with_hook_gate_ref_factory(Arc::new(factory))
+        .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
+        .await
+        .expect("host builds with hook dispatcher installed");
+
+    let outcome = host
+        .invoke_capability(request.clone())
+        .await
+        .expect("invoke_capability returns a (suspended) outcome, not an error");
+
+    let CapabilityOutcome::ApprovalRequired { gate_ref, .. } = outcome else {
+        panic!("expected ApprovalRequired, got {outcome:?}");
+    };
+
+    let wrong_actor = UserId::new("other-hooks-user").expect("user id literal is valid");
+    let cross_actor = HookGateResolutionRequest::for_invocation(
+        gate_ref.clone(),
+        HookGateActorBinding::new(wrong_actor),
+        fixture.context.clone(),
+        &request,
+    )
+    .expect("resolution request can be derived from invocation");
+    let err = router
+        .resolve(cross_actor)
+        .await
+        .expect_err("wrong actor must not consume another actor's gate ref");
+    assert!(
+        err.is_actor_mismatch(),
+        "wrong actor must be rejected before consumption, got {err:?}"
+    );
+
+    let right_actor = HookGateResolutionRequest::for_invocation(
+        gate_ref,
+        HookGateActorBinding::new(fixture.actor_id.clone()),
+        fixture.context.clone(),
+        &request,
+    )
+    .expect("resolution request can be derived from invocation");
+    router
+        .resolve(right_actor)
+        .await
+        .expect("cross-actor rejection must not consume the ref");
+}
+
+#[tokio::test]
+async fn router_backed_pause_approval_gate_ref_expires_after_ttl() {
+    let fixture = Fixture::new().await;
+    let inner = Arc::new(RecordingCapabilityPort::new());
+    let surface_version = fixture.surface_version.clone();
+    let router = Arc::new(InMemoryHookGateRouter::new());
+    let router_for_factory: Arc<dyn HookGateRouter> = router.clone();
+    let factory = RouterBackedHookGateRefFactory::try_new(
+        fixture.context.clone(),
+        HookGateActorBinding::new(fixture.actor_id.clone()),
+        router_for_factory,
+        chrono::Duration::milliseconds(1),
+    )
+    .expect("positive ttl is accepted");
+    let request = invocation(&surface_version, "cap.blocked");
+
+    let host = fixture
+        .factory()
+        .with_hook_dispatcher(pause_approval_dispatcher())
+        .with_hook_gate_ref_factory(Arc::new(factory))
+        .build_text_only_host_with_capabilities(fixture.request(), inner.clone())
+        .await
+        .expect("host builds with hook dispatcher installed");
+
+    let outcome = host
+        .invoke_capability(request.clone())
+        .await
+        .expect("invoke_capability returns a (suspended) outcome, not an error");
+
+    match outcome {
+        CapabilityOutcome::ApprovalRequired { gate_ref, .. } => {
+            tokio::time::sleep(StdDuration::from_millis(5)).await;
+            let err = router
+                .resolve(
+                    HookGateResolutionRequest::for_invocation(
+                        gate_ref,
+                        HookGateActorBinding::new(fixture.actor_id.clone()),
+                        fixture.context.clone(),
+                        &request,
+                    )
+                    .expect("resolution request can be derived from invocation"),
+                )
+                .await
+                .expect_err("expired gate ref must be rejected");
+            assert!(err.is_expired(), "expected expired error, got {err:?}");
         }
         other => panic!("expected ApprovalRequired, got {other:?}"),
     }


### PR DESCRIPTION
Successor PR from #3573. **Draft** — scope doc only, no implementation yet.

## Problem
Hook \`PauseApproval\` / \`PauseAuth\` decisions currently fail-closed in production because the middleware default is \`FailClosedHookGateRefFactory\`. The dev-only \`UuidHookGateRefFactory\` mints syntactically-valid but router-unregistered refs — the loop would park on a ref the approval gateway has never heard of.

## Scope
Implement a \`HookGateRefFactory\` that mints refs the host's existing approval/auth router can resolve, with TTL + one-shot consumption + cross-run isolation.

## Design doc
[\`crates/ironclaw_hooks/docs/successors/01-prod-gate-ref-factory.md\`](https://github.com/nearai/ironclaw/blob/hooks-fu-prod-gate-ref-factory/crates/ironclaw_hooks/docs/successors/01-prod-gate-ref-factory.md)

## Status
Draft for design review. Promote to ready when the cross-crate seam to the approval gateway is agreed.