### PR TITLE
feat(hooks): DenyReasonCode closed-vocabulary enum (successor to #3573)

### DIFF
--- a/crates/ironclaw_hooks/docs/real-hooks-findings.md
+++ b/crates/ironclaw_hooks/docs/real-hooks-findings.md
@@ -243,7 +243,7 @@ deviate from `DEFAULT`. Optionally add named constants (`EARLY`,
 | ID | Severity | Status |
 |---|---|---|
 | F1 — Sealed `unresolved()` blocks external dispatch tests | High | **Fixed** — `pub fn unresolved()` |
-| F2 — Closed-vocabulary deny reason is undocumented | Med | **Fixed** — rustdoc on `OnExceededAction` and `GateDecisionView`. The `DenyReasonCode` enum is deferred (still worth doing but not blocking) |
+| F2 — Closed-vocabulary deny reason is undocumented | Med | **Fixed** — rustdoc on `OnExceededAction` and `GateDecisionView` in PR #3573; the `DenyReasonCode` + `PauseReasonCode` enums followed in successor PR #3636 (this branch) |
 | F3 — NumericSum can't be TDD'd outside Reborn | Med | **Fixed** — `SanitizedArguments::for_tests(value)` under `test-support` feature flag |
 | F4 — Trusted Rust before_prompt hooks (no friction) | — | — |
 | F5 — Two `ExtensionId` types are confusing | Low | **Fixed** — `From<&ironclaw_host_api::ExtensionId>` impl + cross-link rustdoc |

--- a/crates/ironclaw_hooks/docs/successors/06-deny-reason-code.md
+++ b/crates/ironclaw_hooks/docs/successors/06-deny-reason-code.md
@@ -1,0 +1,79 @@
+# Successor PR: `DenyReasonCode` closed-vocabulary enum
+
+> Successor work from PR #3573 — real-hooks ergonomics finding F2
+> (deferred). Adds a curated vocabulary of model-visible denial reasons
+> so hook authors can communicate *why* a deny happened without opening
+> a free-form prompt-injection channel.
+
+## Problem
+
+Today the model-visible `GateDecisionView::Deny { reason }` collapses
+every Installed-tier deny to the static label `hook_predicate_denied`
+(see `installed_hook.rs::evaluate`). The collapse is deliberate —
+manifest reason strings are author-controlled and would let a malicious
+extension smuggle prompt-injection content through the deny path.
+
+The cost: the agent can't tell *why* a hook denied. "Daily cap
+exceeded" vs "blocklisted capability" vs "amount over limit" are
+useful signals; one undifferentiated `hook_predicate_denied` is not.
+
+## Scope
+
+1. Introduce `DenyReasonCode` enum (closed vocabulary) in
+   `ironclaw_hooks::predicate`. Initial set (subject to design review):
+   - `Generic` (default, matches today's `hook_predicate_denied`)
+   - `RateLimit`
+   - `ValueCap`
+   - `Blocklist`
+   - `RequiresApproval` (when paired with PauseApproval — different
+     decision but same reason space)
+   - `OutOfPolicy`
+2. Extend `OnExceededAction` with a parallel `DenyWithCode` variant:
+   ```rust
+   pub enum OnExceededAction {
+       Deny { reason: String },                                    // existing
+       DenyWithCode { code: DenyReasonCode, reason: String },      // new
+       PauseApproval { reason: String },
+   }
+   ```
+3. `GateDecisionView::Deny` carries the code as a `&'static str` so
+   the model-visible label is stable + auditable. Free-form `reason`
+   still goes to audit, never to model.
+4. Same shape for `PauseApproval` (a separate `PauseReasonCode`).
+
+## Rejected designs
+
+- **Open string label** — defeats the purpose; restores the
+  prompt-injection vector.
+- **Numeric code only (no human label)** — harder to read in audit
+  logs and forces a separate code-table doc to interpret.
+
+## Required tests
+
+1. Manifest with `DenyWithCode { code: RateLimit, .. }` → outcome
+   carries the `rate_limit` label, not `hook_predicate_denied`.
+2. Existing `Deny { reason }` manifest still produces
+   `hook_predicate_denied` (back-compat).
+3. Serde round-trip on the enum.
+4. Threat-model regression: a hook author can NOT pass an arbitrary
+   `&str` through the new variant — only the enum vocabulary is
+   exposed model-side.
+
+## What this PR does NOT do
+
+- Extend the vocabulary to cover every conceivable policy denial. Keep
+  the initial enum small; add variants as use cases emerge.
+- Localize the labels. They're machine-readable identifiers; the UI
+  layer (not in scope) maps them to user-facing strings.
+
+## Risk
+
+Small. Single enum + small projection change. The threat-model risk is
+in the *initial vocabulary choice* — if a label is too descriptive
+(e.g., `daily_polymarket_cap_exceeded`), authors will gravitate toward
+encoding free-form content in label choice. Mitigation: keep the
+enum coarse-grained.
+
+## Effort
+
+Small. One enum, one projection change, ~3 tests.

--- a/crates/ironclaw_hooks/src/dispatch.rs
+++ b/crates/ironclaw_hooks/src/dispatch.rs
@@ -90,7 +90,15 @@ pub struct BeforeCapabilityDispatchOutcome {
 #[derive(Debug)]
 pub(crate) enum GateHookOutcome {
     Pass,
-    Decision(BeforeCapabilityHookDecision),
+    Decision {
+        decision: BeforeCapabilityHookDecision,
+        /// Free-form audit-only reason set by the hook via
+        /// [`crate::sink::PrivilegedGateSink::record_audit_reason`] /
+        /// [`crate::sink::RestrictedGateSink::record_audit_reason`]. The
+        /// model-visible reason inside `decision` is the closed-vocab
+        /// label; this carries the manifest-supplied context for audit/SSE.
+        audit_reason: Option<String>,
+    },
 }
 
 /// Per-hook record of misbehavior surfaced during a dispatch.
@@ -579,9 +587,13 @@ impl HookDispatcher {
                     self.emit_decision(&binding, HookDecisionSummary::Pass)
                         .await;
                 }
-                Ok(GateHookOutcome::Decision(decision)) => {
+                Ok(GateHookOutcome::Decision {
+                    decision,
+                    audit_reason,
+                }) => {
                     let summary = telemetry::gate_decision_summary(&decision);
-                    self.emit_decision(&binding, summary).await;
+                    self.emit_decision_with_audit(&binding, summary, audit_reason)
+                        .await;
                     composed = compose_gate_decision(composed, decision);
                     if !matches!(composed.inner(), GateDecisionInner::Allow) {
                         short_circuited = true;
@@ -791,7 +803,7 @@ impl HookDispatcher {
                         .catch_unwind()
                         .await
                         .map_err(|_| ())
-                        .map(|()| sink.state)
+                        .map(|()| (sink.state, sink.audit_reason))
                 }
                 BeforeCapabilityHookImpl::Restricted(h) => {
                     let mut sink = RecordingGateSink::new();
@@ -799,15 +811,20 @@ impl HookDispatcher {
                         .catch_unwind()
                         .await
                         .map_err(|_| ())
-                        .map(|()| sink.state)
+                        .map(|()| (sink.state, sink.audit_reason))
                 }
             }
         };
 
         match tokio::time::timeout(timeout, run).await {
-            Ok(Ok(GateSinkState::Decided(decision))) => Ok(GateHookOutcome::Decision(decision)),
-            Ok(Ok(GateSinkState::Passed)) => Ok(GateHookOutcome::Pass),
-            Ok(Ok(GateSinkState::Unset)) => {
+            Ok(Ok((GateSinkState::Decided(decision), audit_reason))) => {
+                Ok(GateHookOutcome::Decision {
+                    decision,
+                    audit_reason,
+                })
+            }
+            Ok(Ok((GateSinkState::Passed, _))) => Ok(GateHookOutcome::Pass),
+            Ok(Ok((GateSinkState::Unset, _))) => {
                 let failure = self.classify_failure(
                     binding,
                     FailureCategory::Malformed,
@@ -977,12 +994,22 @@ impl HookDispatcher {
     }
 
     async fn emit_decision(&self, binding: &HookBinding, decision: HookDecisionSummary) {
+        self.emit_decision_with_audit(binding, decision, None).await;
+    }
+
+    async fn emit_decision_with_audit(
+        &self,
+        binding: &HookBinding,
+        decision: HookDecisionSummary,
+        audit_reason: Option<String>,
+    ) {
         if self.milestone_sink.is_none() {
             return;
         }
         self.emit_milestone(LoopHostMilestoneKind::HookDecisionEmitted {
             hook_id: telemetry::hook_id_string(binding.hook_id),
             decision,
+            audit_reason,
         })
         .await;
     }

--- a/crates/ironclaw_hooks/src/evaluator.rs
+++ b/crates/ironclaw_hooks/src/evaluator.rs
@@ -56,11 +56,20 @@ use crate::predicate::{
 pub enum EvaluatorDecision {
     /// Predicate did not fire; capability invocation proceeds.
     Allow,
-    /// Predicate fired and requested a deny. Carries the reason string to
-    /// propagate to the sink.
-    Deny { reason: String },
-    /// Predicate fired and requested an approval pause.
-    PauseApproval { reason: String },
+    /// Predicate fired and requested a deny. `code` selects the model-
+    /// visible closed-vocabulary label; `reason` is the free-form
+    /// audit-only payload.
+    Deny {
+        code: crate::predicate::DenyReasonCode,
+        reason: String,
+    },
+    /// Predicate fired and requested an approval pause. `code` selects
+    /// the model-visible closed-vocabulary label; `reason` is the
+    /// free-form audit-only payload.
+    PauseApproval {
+        code: crate::predicate::PauseReasonCode,
+        reason: String,
+    },
 }
 
 /// In-process evaluator. One evaluator per dispatcher / run; sliding-window
@@ -120,6 +129,7 @@ impl PredicateEvaluator {
             HookPredicateSpec::DenyCapability { when, reason } => {
                 if predicate_matches(when, ctx) {
                     EvaluatorDecision::Deny {
+                        code: crate::predicate::DenyReasonCode::Generic,
                         reason: reason.clone(),
                     }
                 } else {
@@ -129,6 +139,7 @@ impl PredicateEvaluator {
             HookPredicateSpec::PauseApproval { when, reason } => {
                 if predicate_matches(when, ctx) {
                     EvaluatorDecision::PauseApproval {
+                        code: crate::predicate::PauseReasonCode::Generic,
                         reason: reason.clone(),
                     }
                 } else {
@@ -329,11 +340,23 @@ fn evict_lru_value(
 fn restrictive_action(action: &OnExceededAction) -> EvaluatorDecision {
     match action {
         OnExceededAction::Deny { reason } => EvaluatorDecision::Deny {
+            code: crate::predicate::DenyReasonCode::Generic,
+            reason: reason.clone(),
+        },
+        OnExceededAction::DenyWithCode { code, reason } => EvaluatorDecision::Deny {
+            code: *code,
             reason: reason.clone(),
         },
         OnExceededAction::PauseApproval { reason } => EvaluatorDecision::PauseApproval {
+            code: crate::predicate::PauseReasonCode::Generic,
             reason: reason.clone(),
         },
+        OnExceededAction::PauseApprovalWithCode { code, reason } => {
+            EvaluatorDecision::PauseApproval {
+                code: *code,
+                reason: reason.clone(),
+            }
+        }
     }
 }
 
@@ -445,6 +468,7 @@ mod tests {
         assert_eq!(
             denied,
             EvaluatorDecision::Deny {
+                code: crate::predicate::DenyReasonCode::Generic,
                 reason: "shell disabled".to_string()
             }
         );
@@ -514,6 +538,7 @@ mod tests {
         assert_eq!(
             blocked,
             EvaluatorDecision::Deny {
+                code: crate::predicate::DenyReasonCode::Generic,
                 reason: "rate cap".to_string()
             }
         );

--- a/crates/ironclaw_hooks/src/installed_hook.rs
+++ b/crates/ironclaw_hooks/src/installed_hook.rs
@@ -60,10 +60,17 @@ impl RestrictedBeforeCapabilityHook for PredicateBackedBeforeCapabilityHook {
                 // and continues composing without short-circuiting.
                 sink.pass();
             }
-            EvaluatorDecision::Deny { code, .. } => {
+            EvaluatorDecision::Deny { code, reason } => {
+                // serrrfirat #3636: model sees the closed-vocab label; audit/SSE
+                // gets the manifest's free-form reason via a separate channel.
+                // The two are intentionally split so a predicate author can name
+                // *why* (rich, operator-facing) without minting a model-visible
+                // label that could itself be a steering surface.
+                sink.record_audit_reason(reason);
                 sink.deny(code.as_label());
             }
-            EvaluatorDecision::PauseApproval { code, .. } => {
+            EvaluatorDecision::PauseApproval { code, reason } => {
+                sink.record_audit_reason(reason);
                 sink.pause_approval(code.as_label());
             }
         }
@@ -201,6 +208,58 @@ mod tests {
             }
             other => panic!("expected PauseApproval, got {other:?}"),
         }
+    }
+
+    /// serrrfirat #3636 regression: the manifest's free-form reason text
+    /// must reach the audit channel (the recording sink's `audit_reason`)
+    /// while the sink's decision reason stays on the closed-vocab label.
+    /// Model sees `hook_rate_limit`; audit sees the manifest text.
+    #[tokio::test]
+    async fn deny_with_code_records_audit_reason_separately_from_model_label() {
+        use crate::predicate::{DenyReasonCode, OnExceededAction, ValueOrRateBound};
+
+        let evaluator = Arc::new(PredicateEvaluator::new());
+        let spec = HookPredicateSpec::RateOrValueCap {
+            when: CapabilityPredicate::NameEquals {
+                name: "polymarket.place_order".to_string(),
+            },
+            bound: ValueOrRateBound::InvocationCount {
+                max: 0,
+                window: "1h".to_string(),
+            },
+            on_exceeded: OnExceededAction::DenyWithCode {
+                code: DenyReasonCode::RateLimit,
+                reason: "daily cap of $1000 exceeded at 14:32 UTC".to_string(),
+            },
+        };
+        let hook = PredicateBackedBeforeCapabilityHook::new(hook_id(), spec, evaluator);
+        let mut sink = RecordingGateSink::new();
+        let ctx = BeforeCapabilityHookContext::new_unresolved(
+            TenantId::new("alpha").expect("ok"),
+            "polymarket.place_order".to_string(),
+            [0u8; 32],
+        );
+
+        hook.evaluate(&ctx, &mut sink as &mut dyn RestrictedGateSink)
+            .await;
+        let decision = sink.decision().expect("hook emitted a decision");
+        match decision.view() {
+            crate::kinds::gate::GateDecisionView::Deny { reason } => {
+                assert_eq!(
+                    reason.as_str(),
+                    "hook_rate_limit",
+                    "model-visible reason must be the closed-vocab label, \
+                     never the manifest free-form text"
+                );
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+        assert_eq!(
+            sink.audit_reason.as_deref(),
+            Some("daily cap of $1000 exceeded at 14:32 UTC"),
+            "audit channel must receive the manifest's free-form reason \
+             intact for operator-facing SSE/audit consumers"
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_hooks/src/installed_hook.rs
+++ b/crates/ironclaw_hooks/src/installed_hook.rs
@@ -47,6 +47,12 @@ impl RestrictedBeforeCapabilityHook for PredicateBackedBeforeCapabilityHook {
         // (author-controlled) and are dynamic, so the evaluator's reason
         // string is leaked as a closed vocabulary of static labels here.
         // Richer reasons surface in audit, not in the model-visible decision.
+        //
+        // The `DenyReasonCode` / `PauseReasonCode` enums are themselves
+        // closed-vocabulary, and each variant's `as_label()` returns a
+        // `&'static str` — so we can surface a richer model-visible label
+        // (`hook_rate_limit`, `hook_value_cap`, ...) without opening a
+        // free-form text channel.
         match self.evaluator.evaluate(self.hook_id, &self.spec, ctx) {
             EvaluatorDecision::Allow => {
                 // The predicate did not match — the hook has no opinion. The
@@ -54,11 +60,11 @@ impl RestrictedBeforeCapabilityHook for PredicateBackedBeforeCapabilityHook {
                 // and continues composing without short-circuiting.
                 sink.pass();
             }
-            EvaluatorDecision::Deny { .. } => {
-                sink.deny("hook_predicate_denied");
+            EvaluatorDecision::Deny { code, .. } => {
+                sink.deny(code.as_label());
             }
-            EvaluatorDecision::PauseApproval { .. } => {
-                sink.pause_approval("hook_predicate_pause_requested");
+            EvaluatorDecision::PauseApproval { code, .. } => {
+                sink.pause_approval(code.as_label());
             }
         }
     }
@@ -102,6 +108,99 @@ mod tests {
             .await;
         let decision = sink.decision().expect("hook emitted a decision");
         assert!(!decision.permits());
+        // Legacy `DenyCapability` (no code) maps to the Generic label,
+        // preserving the existing `hook_predicate_denied` model-visible
+        // string. Back-compat property.
+        match decision.view() {
+            crate::kinds::gate::GateDecisionView::Deny { reason } => {
+                assert_eq!(reason.as_str(), "hook_predicate_denied");
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    /// `DenyWithCode` surfaces the code's label as the model-visible
+    /// reason, instead of the generic `hook_predicate_denied`. This is
+    /// the load-bearing affirmative-path test for the new variant.
+    #[tokio::test]
+    async fn rate_or_value_cap_with_deny_code_routes_to_code_label() {
+        use crate::predicate::{DenyReasonCode, OnExceededAction, ValueOrRateBound};
+
+        let evaluator = Arc::new(PredicateEvaluator::new());
+        let spec = HookPredicateSpec::RateOrValueCap {
+            when: CapabilityPredicate::NameEquals {
+                name: "polymarket.place_order".to_string(),
+            },
+            bound: ValueOrRateBound::InvocationCount {
+                max: 0,
+                window: "1h".to_string(),
+            },
+            on_exceeded: OnExceededAction::DenyWithCode {
+                code: DenyReasonCode::RateLimit,
+                reason: "audit-only: daily cap exceeded".to_string(),
+            },
+        };
+        let hook = PredicateBackedBeforeCapabilityHook::new(hook_id(), spec, evaluator);
+        let mut sink = RecordingGateSink::new();
+        let ctx = BeforeCapabilityHookContext::new_unresolved(
+            TenantId::new("alpha").expect("ok"),
+            "polymarket.place_order".to_string(),
+            [0u8; 32],
+        );
+
+        hook.evaluate(&ctx, &mut sink as &mut dyn RestrictedGateSink)
+            .await;
+        let decision = sink.decision().expect("hook emitted a decision");
+        match decision.view() {
+            crate::kinds::gate::GateDecisionView::Deny { reason } => {
+                assert_eq!(
+                    reason.as_str(),
+                    "hook_rate_limit",
+                    "DenyWithCode {{ code: RateLimit }} must surface the \
+                     code's label, not the legacy hook_predicate_denied"
+                );
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    /// `PauseApprovalWithCode` is the symmetric affirmative-path test
+    /// for the pause variant.
+    #[tokio::test]
+    async fn rate_or_value_cap_with_pause_code_routes_to_code_label() {
+        use crate::predicate::{OnExceededAction, PauseReasonCode, ValueOrRateBound};
+
+        let evaluator = Arc::new(PredicateEvaluator::new());
+        let spec = HookPredicateSpec::RateOrValueCap {
+            when: CapabilityPredicate::NameEquals {
+                name: "polymarket.place_order".to_string(),
+            },
+            bound: ValueOrRateBound::InvocationCount {
+                max: 0,
+                window: "1h".to_string(),
+            },
+            on_exceeded: OnExceededAction::PauseApprovalWithCode {
+                code: PauseReasonCode::OverThreshold,
+                reason: "audit-only: $1000/24h threshold".to_string(),
+            },
+        };
+        let hook = PredicateBackedBeforeCapabilityHook::new(hook_id(), spec, evaluator);
+        let mut sink = RecordingGateSink::new();
+        let ctx = BeforeCapabilityHookContext::new_unresolved(
+            TenantId::new("alpha").expect("ok"),
+            "polymarket.place_order".to_string(),
+            [0u8; 32],
+        );
+
+        hook.evaluate(&ctx, &mut sink as &mut dyn RestrictedGateSink)
+            .await;
+        let decision = sink.decision().expect("hook emitted a decision");
+        match decision.view() {
+            crate::kinds::gate::GateDecisionView::PauseApproval { reason } => {
+                assert_eq!(reason.as_str(), "hook_pause_over_threshold");
+            }
+            other => panic!("expected PauseApproval, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/ironclaw_hooks/src/predicate.rs
+++ b/crates/ironclaw_hooks/src/predicate.rs
@@ -97,8 +97,108 @@ pub enum ValueOrRateBound {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "decision", rename_all = "snake_case")]
 pub enum OnExceededAction {
+    /// Deny with a free-form `reason` (audit-only). Model-visible label
+    /// collapses to the static `hook_predicate_denied` — see the type-
+    /// level doc above.
     Deny { reason: String },
+    /// Deny with both a closed-vocabulary [`DenyReasonCode`] **and** a
+    /// free-form audit `reason`. The model-visible label becomes the
+    /// code's static string (e.g. `rate_limit`, `value_cap`) so the
+    /// agent can distinguish *why* a hook denied without opening a
+    /// prompt-injection channel through the free-form reason.
+    DenyWithCode {
+        code: DenyReasonCode,
+        reason: String,
+    },
+    /// Pause for human approval with a free-form audit `reason`.
     PauseApproval { reason: String },
+    /// Pause for human approval, with a closed-vocabulary
+    /// [`PauseReasonCode`] surfaced to the model alongside the audit-only
+    /// `reason`.
+    PauseApprovalWithCode {
+        code: PauseReasonCode,
+        reason: String,
+    },
+}
+
+/// Closed-vocabulary reason a hook denied a capability invocation.
+///
+/// Hook authors who want to communicate *why* a deny happened use
+/// [`OnExceededAction::DenyWithCode`]; the dispatcher surfaces the
+/// code's static string (via [`Self::as_label`]) as the model-visible
+/// label, replacing the generic `hook_predicate_denied`. The free-form
+/// `reason` payload still stays audit-only.
+///
+/// The vocabulary is intentionally coarse-grained. Labels are *machine-
+/// readable identifiers*, not localized strings — the UI layer maps them
+/// to user-facing text. Adding new variants is a back-compat
+/// consideration: downstream agents may pattern-match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DenyReasonCode {
+    /// Default; matches today's `hook_predicate_denied` label. Use this
+    /// when no more specific variant fits.
+    Generic,
+    /// Per-time-window rate limit tripped (e.g., `InvocationCount` cap).
+    RateLimit,
+    /// Per-time-window numeric-sum cap tripped (e.g., $-denominated
+    /// total).
+    ValueCap,
+    /// Capability is on a deny-list configured by the extension.
+    Blocklist,
+    /// Capability needs human approval before proceeding. Pair with
+    /// `PauseApprovalWithCode { code: PauseReasonCode::RequiresApproval }`
+    /// when the hook *requests* approval; use this variant when the hook
+    /// *denies* an invocation that would require approval the user
+    /// hasn't granted.
+    RequiresApproval,
+    /// Capability is outside the configured policy envelope (catch-all
+    /// for policy denials that don't fit the more specific variants).
+    OutOfPolicy,
+}
+
+impl DenyReasonCode {
+    /// Stable, model-visible string for this code. Stays in the closed
+    /// vocabulary the dispatcher's sink accepts (`&'static str`).
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Generic => "hook_predicate_denied",
+            Self::RateLimit => "hook_rate_limit",
+            Self::ValueCap => "hook_value_cap",
+            Self::Blocklist => "hook_blocklist",
+            Self::RequiresApproval => "hook_requires_approval",
+            Self::OutOfPolicy => "hook_out_of_policy",
+        }
+    }
+}
+
+/// Closed-vocabulary reason a hook is requesting a pause for human
+/// approval. Mirrors [`DenyReasonCode`]; see that type for the
+/// rationale on the closed-vocab design.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PauseReasonCode {
+    /// Default; matches today's `hook_predicate_pause_requested` label.
+    Generic,
+    /// The user must explicitly approve this capability before it runs.
+    RequiresApproval,
+    /// The action exceeds a policy threshold (rate or value) and needs
+    /// human review.
+    OverThreshold,
+    /// The action is sensitive enough that the extension wants explicit
+    /// user confirmation regardless of any threshold.
+    SensitiveAction,
+}
+
+impl PauseReasonCode {
+    pub const fn as_label(self) -> &'static str {
+        match self {
+            Self::Generic => "hook_predicate_pause_requested",
+            Self::RequiresApproval => "hook_pause_requires_approval",
+            Self::OverThreshold => "hook_pause_over_threshold",
+            Self::SensitiveAction => "hook_pause_sensitive_action",
+        }
+    }
 }
 
 #[cfg(test)]
@@ -162,5 +262,93 @@ mod tests {
         let json = serde_json::to_string(&spec).expect("ser");
         let back: HookPredicateSpec = serde_json::from_str(&json).expect("de");
         assert_eq!(spec, back);
+    }
+
+    /// Each `DenyReasonCode` variant must produce a stable, non-empty
+    /// model-visible label. Pins the vocabulary so a future enum-variant
+    /// rename or label rewrite is loud.
+    #[test]
+    fn deny_reason_code_labels_are_stable() {
+        let pairs: Vec<(DenyReasonCode, &'static str)> = vec![
+            (DenyReasonCode::Generic, "hook_predicate_denied"),
+            (DenyReasonCode::RateLimit, "hook_rate_limit"),
+            (DenyReasonCode::ValueCap, "hook_value_cap"),
+            (DenyReasonCode::Blocklist, "hook_blocklist"),
+            (DenyReasonCode::RequiresApproval, "hook_requires_approval"),
+            (DenyReasonCode::OutOfPolicy, "hook_out_of_policy"),
+        ];
+        for (code, expected) in pairs {
+            assert_eq!(
+                code.as_label(),
+                expected,
+                "label for {code:?} changed — this is a cross-crate \
+                 wire-format break for any consumer pattern-matching on \
+                 the model-visible deny label"
+            );
+        }
+    }
+
+    #[test]
+    fn pause_reason_code_labels_are_stable() {
+        let pairs: Vec<(PauseReasonCode, &'static str)> = vec![
+            (PauseReasonCode::Generic, "hook_predicate_pause_requested"),
+            (
+                PauseReasonCode::RequiresApproval,
+                "hook_pause_requires_approval",
+            ),
+            (PauseReasonCode::OverThreshold, "hook_pause_over_threshold"),
+            (
+                PauseReasonCode::SensitiveAction,
+                "hook_pause_sensitive_action",
+            ),
+        ];
+        for (code, expected) in pairs {
+            assert_eq!(code.as_label(), expected);
+        }
+    }
+
+    /// `OnExceededAction::DenyWithCode` round-trips through serde. The
+    /// closed-vocabulary code is serialized as a snake_case string;
+    /// downstream manifest authors can use the new variant alongside the
+    /// legacy `Deny { reason }` shape.
+    #[test]
+    fn deny_with_code_round_trips_through_json() {
+        let action = OnExceededAction::DenyWithCode {
+            code: DenyReasonCode::RateLimit,
+            reason: "polymarket daily cap exceeded".to_string(),
+        };
+        let json = serde_json::to_string(&action).expect("ser");
+        let back: OnExceededAction = serde_json::from_str(&json).expect("de");
+        assert_eq!(action, back);
+        // Defense against accidental enum-tag drift: the wire shape
+        // must serialize the code variant as snake_case.
+        assert!(json.contains("\"rate_limit\""), "wire form: {json}");
+    }
+
+    #[test]
+    fn pause_approval_with_code_round_trips_through_json() {
+        let action = OnExceededAction::PauseApprovalWithCode {
+            code: PauseReasonCode::OverThreshold,
+            reason: "$1000/24h threshold tripped".to_string(),
+        };
+        let json = serde_json::to_string(&action).expect("ser");
+        let back: OnExceededAction = serde_json::from_str(&json).expect("de");
+        assert_eq!(action, back);
+        assert!(json.contains("\"over_threshold\""), "wire form: {json}");
+    }
+
+    /// Threat-model regression: a hook author cannot smuggle arbitrary
+    /// text into the model-visible label via `DenyWithCode`. The `code`
+    /// field is typed as the enum — no `String` slot for the model-side
+    /// label exists on the closed-vocab path.
+    #[test]
+    fn deny_with_code_only_exposes_enum_variants_to_model() {
+        // This is a compile-time property; the test exists to document
+        // the intent and to fail if a future refactor turns `code` into
+        // a `String` field.
+        let _check: fn(OnExceededAction) -> Option<DenyReasonCode> = |action| match action {
+            OnExceededAction::DenyWithCode { code, .. } => Some(code),
+            _ => None,
+        };
     }
 }

--- a/crates/ironclaw_hooks/src/registrar.rs
+++ b/crates/ironclaw_hooks/src/registrar.rs
@@ -343,6 +343,70 @@ mod tests {
         assert!(matches!(err, HookError::RegistryConstruction(_)));
     }
 
+    /// End-to-end registrar test for `DenyWithCode`: a manifest carrying
+    /// `OnExceededAction::DenyWithCode { code, reason }` installs cleanly
+    /// AND dispatches with the code's static label as the model-visible
+    /// reason. Bridges the gap codex flagged: prior tests covered the
+    /// enum serde + direct hook evaluation; this one drives the full
+    /// install-then-dispatch path the registrar exposes.
+    #[tokio::test]
+    async fn install_deny_with_code_manifest_surfaces_code_label_on_dispatch() {
+        use crate::predicate::{DenyReasonCode, OnExceededAction, ValueOrRateBound};
+
+        let registrar = HookRegistrar::new(Arc::new(PredicateEvaluator::new()));
+        let builder = HookDispatcherBuilder::new(HookRegistry::new());
+        let entry = HookManifestEntry {
+            id: HookLocalId("rate-cap-with-code".to_string()),
+            kind: HookManifestKind::BeforeCapability,
+            scope: HookManifestScope::OwnCapabilities,
+            phase: HookPhase::Policy,
+            priority: HookPriority::DEFAULT,
+            description: None,
+            requires_grant: None,
+            body: HookManifestBody::Predicate {
+                spec: HookPredicateSpec::RateOrValueCap {
+                    when: CapabilityPredicate::NameEquals {
+                        name: "polymarket.place_order".to_string(),
+                    },
+                    bound: ValueOrRateBound::InvocationCount {
+                        max: 0,
+                        window: "1h".to_string(),
+                    },
+                    on_exceeded: OnExceededAction::DenyWithCode {
+                        code: DenyReasonCode::RateLimit,
+                        reason: "audit-only".to_string(),
+                    },
+                },
+            },
+        };
+        let (builder, ids) = registrar
+            .install(extension(), "0.4.2".to_string(), vec![entry], builder)
+            .expect("install ok");
+        assert_eq!(ids.len(), 1);
+        let dispatcher = builder.build_arc();
+
+        let tenant = ironclaw_host_api::TenantId::new("alpha").expect("tenant");
+        let ctx = BeforeCapabilityHookContext::new(
+            tenant,
+            "polymarket.place_order".to_string(),
+            [0u8; 32],
+            crate::points::SanitizedArguments::unresolved(),
+            Some(extension()),
+        );
+        let outcome = dispatcher.dispatch_before_capability(&ctx).await;
+        match outcome.decision.view() {
+            crate::kinds::gate::GateDecisionView::Deny { reason } => {
+                assert_eq!(
+                    reason.as_str(),
+                    "hook_rate_limit",
+                    "DenyWithCode manifest must surface the code's label \
+                     (hook_rate_limit) through the registrar→dispatcher path"
+                );
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn install_returns_hook_ids_in_input_order() {
         let registrar = HookRegistrar::new(Arc::new(PredicateEvaluator::new()));

--- a/crates/ironclaw_hooks/src/sink.rs
+++ b/crates/ironclaw_hooks/src/sink.rs
@@ -46,6 +46,14 @@ pub trait PrivilegedGateSink: Send {
     /// any sink method," which is treated as a protocol violation and
     /// fails closed.
     fn pass(&mut self);
+    /// Record a free-form audit-only reason that accompanies the model-
+    /// visible decision. The model never sees this text — it flows into the
+    /// hook decision milestone for SSE/audit consumers so operators can see
+    /// the manifest-supplied context behind a closed-vocab label like
+    /// `hook_rate_limit`. Implementations should overwrite any prior value;
+    /// if the hook calls this and then never mints a decision, the audit
+    /// reason is discarded along with the malformed-protocol failure.
+    fn record_audit_reason(&mut self, reason: String);
 }
 
 /// Gate sink surface for Installed hooks. Deliberately omits `allow`; an
@@ -57,6 +65,8 @@ pub trait RestrictedGateSink: Send {
     /// Record that the hook evaluated the context and has no opinion. See
     /// [`PrivilegedGateSink::pass`] for the full semantics.
     fn pass(&mut self);
+    /// See [`PrivilegedGateSink::record_audit_reason`].
+    fn record_audit_reason(&mut self, reason: String);
 }
 
 /// State recorded by [`RecordingGateSink`] as the hook calls sink methods.
@@ -77,12 +87,20 @@ pub(crate) enum GateSinkState {
 /// the hook.
 pub(crate) struct RecordingGateSink {
     pub(crate) state: GateSinkState,
+    /// Audit-only free-form reason set by [`PrivilegedGateSink::record_audit_reason`]
+    /// or [`RestrictedGateSink::record_audit_reason`]. The model-facing
+    /// decision in `state` carries the closed-vocab label; this field carries
+    /// the manifest-supplied context for audit/SSE consumers. `None` if the
+    /// hook never called `record_audit_reason` or did so before
+    /// `pass()`/Unset path.
+    pub(crate) audit_reason: Option<String>,
 }
 
 impl RecordingGateSink {
     pub(crate) fn new() -> Self {
         Self {
             state: GateSinkState::Unset,
+            audit_reason: None,
         }
     }
 
@@ -124,6 +142,10 @@ impl PrivilegedGateSink for RecordingGateSink {
     fn pass(&mut self) {
         self.state = GateSinkState::Passed;
     }
+
+    fn record_audit_reason(&mut self, reason: String) {
+        self.audit_reason = Some(reason);
+    }
 }
 
 impl RestrictedGateSink for RecordingGateSink {
@@ -147,6 +169,10 @@ impl RestrictedGateSink for RecordingGateSink {
 
     fn pass(&mut self) {
         self.state = GateSinkState::Passed;
+    }
+
+    fn record_audit_reason(&mut self, reason: String) {
+        self.audit_reason = Some(reason);
     }
 }
 

--- a/crates/ironclaw_reborn/src/milestone_events.rs
+++ b/crates/ironclaw_reborn/src/milestone_events.rs
@@ -213,14 +213,21 @@ impl DurableLoopHostMilestoneSink {
                 point.clone(),
                 trust_class.clone(),
             ),
-            LoopHostMilestoneKind::HookDecisionEmitted { hook_id, decision } => {
-                RuntimeEvent::hook_decision_emitted(
-                    scope,
-                    capability_id(HOOK_CAPABILITY_ID)?,
-                    hook_id.clone(),
-                    hook_decision_label(decision),
-                )
-            }
+            LoopHostMilestoneKind::HookDecisionEmitted {
+                hook_id,
+                decision,
+                // `audit_reason` is intentionally NOT projected into the
+                // durable event log: durable events are model-visible audit
+                // surface; the free-form manifest reason is operator-visible
+                // SSE/audit content delivered via the in-memory milestone
+                // sink, not the cross-process event channel.
+                audit_reason: _,
+            } => RuntimeEvent::hook_decision_emitted(
+                scope,
+                capability_id(HOOK_CAPABILITY_ID)?,
+                hook_id.clone(),
+                hook_decision_label(decision),
+            ),
             LoopHostMilestoneKind::HookFailed {
                 hook_id,
                 category,
@@ -371,6 +378,7 @@ mod tests {
                 decision: HookDecisionSummary::Deny {
                     reason: "policy-denied raw text".to_string(),
                 },
+                audit_reason: None,
             });
 
         let sink = projector_for(thread_id, run_id);

--- a/crates/ironclaw_turns/src/run_profile/milestones.rs
+++ b/crates/ironclaw_turns/src/run_profile/milestones.rs
@@ -115,6 +115,15 @@ pub enum LoopHostMilestoneKind {
     HookDecisionEmitted {
         hook_id: String,
         decision: HookDecisionSummary,
+        /// Audit-only free-form reason. Distinct from any reason embedded in
+        /// `decision` (which is the closed-vocab, model-visible label). This
+        /// field carries the manifest-supplied operator context behind a
+        /// closed-vocab label like `hook_rate_limit` and flows only to
+        /// audit/SSE consumers — never to the model. `None` for hooks that
+        /// did not record an audit reason (Builtin/Trusted gate hooks, or
+        /// any `Pass` outcome).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        audit_reason: Option<String>,
     },
     /// A hook misbehaved during dispatch. Captures the failure category and
     /// the dispatcher's disposition (fail-closed vs fail-isolated).
@@ -443,9 +452,14 @@ where
         &self,
         hook_id: String,
         decision: HookDecisionSummary,
+        audit_reason: Option<String>,
     ) -> Result<(), AgentLoopHostError> {
-        self.publish(LoopHostMilestoneKind::HookDecisionEmitted { hook_id, decision })
-            .await
+        self.publish(LoopHostMilestoneKind::HookDecisionEmitted {
+            hook_id,
+            decision,
+            audit_reason,
+        })
+        .await
     }
 
     pub async fn hook_failed(
@@ -515,6 +529,7 @@ mod hook_milestone_schema_snapshots {
         let value = LoopHostMilestoneKind::HookDecisionEmitted {
             hook_id: "abcdef0123456789".to_string(),
             decision: HookDecisionSummary::Allow,
+            audit_reason: None,
         };
         const EXPECTED: &str = r#"{
   "hook_decision_emitted": {
@@ -532,6 +547,7 @@ mod hook_milestone_schema_snapshots {
             decision: HookDecisionSummary::Deny {
                 reason: "blocked by policy".to_string(),
             },
+            audit_reason: None,
         };
         const EXPECTED: &str = r#"{
   "hook_decision_emitted": {
@@ -553,6 +569,7 @@ mod hook_milestone_schema_snapshots {
             decision: HookDecisionSummary::PauseApproval {
                 reason: "user approval required".to_string(),
             },
+            audit_reason: None,
         };
         const EXPECTED: &str = r#"{
   "hook_decision_emitted": {
@@ -574,6 +591,7 @@ mod hook_milestone_schema_snapshots {
             decision: HookDecisionSummary::PauseAuth {
                 reason: "re-authentication required".to_string(),
             },
+            audit_reason: None,
         };
         const EXPECTED: &str = r#"{
   "hook_decision_emitted": {
@@ -593,6 +611,7 @@ mod hook_milestone_schema_snapshots {
         let value = LoopHostMilestoneKind::HookDecisionEmitted {
             hook_id: "abcdef0123456789".to_string(),
             decision: HookDecisionSummary::Pass,
+            audit_reason: None,
         };
         const EXPECTED: &str = r#"{
   "hook_decision_emitted": {
@@ -608,6 +627,7 @@ mod hook_milestone_schema_snapshots {
         let value = LoopHostMilestoneKind::HookDecisionEmitted {
             hook_id: "abcdef0123456789".to_string(),
             decision: HookDecisionSummary::Patch,
+            audit_reason: None,
         };
         const EXPECTED: &str = r#"{
   "hook_decision_emitted": {


### PR DESCRIPTION
Successor PR from #3573. **Draft** — scope doc only, no implementation yet.

## Scope
Introduce \`DenyReasonCode\` enum with curated vocabulary (\`RateLimit\`, \`ValueCap\`, \`Blocklist\`, \`RequiresApproval\`, \`OutOfPolicy\`, \`Generic\`). Extends \`OnExceededAction\` with \`DenyWithCode { code, reason }\` so hook authors can communicate *why* a deny happened in the model-visible label without opening a free-form prompt-injection channel.

## Design doc
[\`crates/ironclaw_hooks/docs/successors/06-deny-reason-code.md\`](https://github.com/nearai/ironclaw/blob/hooks-fu-deny-reason-code/crates/ironclaw_hooks/docs/successors/06-deny-reason-code.md)

## Threat-model
Initial vocabulary kept coarse-grained — too descriptive labels would let authors smuggle content via label choice.

## Status
Draft for design review. Small + bounded; ~3 tests + back-compat path retained.