### PR TITLE
test(hooks): pin invocation_arguments_digest with snapshot (successor to #3573)

### DIFF
--- a/crates/ironclaw_hooks/docs/successors/10-digest-snapshot-pin.md
+++ b/crates/ironclaw_hooks/docs/successors/10-digest-snapshot-pin.md
@@ -1,0 +1,79 @@
+# Successor PR: `invocation_arguments_digest` snapshot pin
+
+> Successor work from PR #3573 — addressing serrrfirat's #3 follow-up
+> (the partial fix). Adds an explicit snapshot test pinning the digest
+> for a known input so a future change to the hashing path or input-ref
+> format is loud.
+
+## Problem
+
+`invocation_arguments_digest` (in `middleware/capability_port.rs`) was
+moved from `format!("{:?}", input_ref)` (Debug-unstable) to
+`input_ref.as_str()` in PR #3573. That fix removed the immediate
+stability risk, but the digest itself is now *implicitly* pinned by L3
+milestone snapshots and behavioral tests — not *explicitly* pinned by
+a fixture.
+
+Implicit pinning means: a future change to `LoopCapabilityInputRef` or
+to the digest's hashing structure (length prefixing order, blake3
+version, etc.) can shift the digest silently for repetition-detection
+hooks that key on it. The L3 snapshots would catch *some* shifts but
+they're not the right tool — they pin the milestone shape, not the
+digest value.
+
+## Scope
+
+A single test in `capability_port.rs::tests` (or a snapshot file) that
+pins the digest for one canonical `(capability_id, input_ref)` pair:
+
+```rust
+#[test]
+fn invocation_arguments_digest_is_stable_for_known_inputs() {
+    let invocation = CapabilityInvocation {
+        surface_version: CapabilitySurfaceVersion::new("snapshot:v1").unwrap(),
+        capability_id: CapabilityId::new("cap.snapshot").unwrap(),
+        input_ref: CapabilityInputRef::new("input:snapshot:fixed").unwrap(),
+    };
+    let digest = invocation_arguments_digest(&invocation);
+    let hex = hex::encode(digest);
+    assert_eq!(
+        hex,
+        // captured one-time; if you find yourself updating this, ask
+        // whether the digest change is intentional, and document it
+        // in the digest stability contract.
+        "INSERT_CAPTURED_HEX_HERE"
+    );
+}
+```
+
+Plus rustdoc on `invocation_arguments_digest` calling out the
+stability contract:
+
+> This digest is part of the **public hook contract**. Repetition-
+> detection hooks key on `arguments_digest` across invocations; a
+> shifted digest silently breaks them. Changing the hashing structure
+> (length-prefix ordering, hasher choice, input field selection)
+> requires:
+> 1. Updating this contract test with the new fixture.
+> 2. Surfacing the change in the cross-crate wire-format contract
+>    section of `identity.rs`.
+> 3. Bumping the hook framework's contract version if downstream
+>    consumers exist.
+
+## What this PR does NOT do
+
+- Switch to a content-addressed *full* arguments digest (i.e., hashing
+  the resolved JSON). That's a separate design: the current digest
+  hashes only the input *ref*, not the resolved content. Hook authors
+  who want content-keyed repetition detection should look at the
+  arguments resolver, not this digest.
+- Move the digest into the `BeforeCapabilityHookContext` constructor.
+  It's already there (`arguments_digest: [u8; 32]`).
+
+## Risk
+
+Tiny. Single test + rustdoc.
+
+## Effort
+
+Small. ~10 minutes including digest capture.

--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -132,7 +132,7 @@ impl HookedLoopCapabilityPort {
         self
     }
 
-    async fn hook_context(
+    pub(crate) async fn hook_context(
         &self,
         invocation: &CapabilityInvocation,
         provider: Option<ironclaw_host_api::ExtensionId>,
@@ -813,6 +813,70 @@ mod tests {
             "invocation_arguments_digest shifted for a fixed input — \
              this is a wire-contract break. See the stability-contract \
              rustdoc on `invocation_arguments_digest`."
+        );
+    }
+
+    /// serrrfirat #3637 regression: pin the digest at the boundary that
+    /// hook authors actually observe — `BeforeCapabilityHookContext.arguments_digest`
+    /// produced by `HookedLoopCapabilityPort::hook_context`. If caller-side
+    /// wiring drifts (wrong field set, transform inserted, default value
+    /// leaked, or an alternate path bypassing the helper), this assertion
+    /// catches it while the helper-only snapshot would stay green.
+    #[tokio::test]
+    async fn hook_context_arguments_digest_is_stable_at_middleware_boundary() {
+        use ironclaw_host_api::TenantId;
+        use std::sync::Arc as StdArc;
+        struct NoopInner;
+        #[async_trait]
+        impl LoopCapabilityPort for NoopInner {
+            async fn visible_capabilities(
+                &self,
+                _request: VisibleCapabilityRequest,
+            ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+                unreachable!("snapshot test never calls visible_capabilities")
+            }
+            async fn invoke_capability(
+                &self,
+                _request: CapabilityInvocation,
+            ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+                unreachable!("snapshot test never invokes through inner port")
+            }
+            async fn invoke_capability_batch(
+                &self,
+                _request: CapabilityBatchInvocation,
+            ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+                unreachable!("snapshot test never invokes through inner port")
+            }
+        }
+
+        let port = HookedLoopCapabilityPort::new(
+            StdArc::new(NoopInner),
+            StdArc::new(HookDispatcher::new(HookRegistry::new())),
+            TenantId::new("alpha").expect("ok"),
+        );
+        let invocation = CapabilityInvocation {
+            surface_version: ironclaw_turns::run_profile::CapabilitySurfaceVersion::new(
+                "snapshot:v1",
+            )
+            .expect("surface version literal is valid"),
+            capability_id: CapabilityId::new("cap.snapshot.fixture")
+                .expect("capability id literal is valid"),
+            input_ref: ironclaw_turns::run_profile::CapabilityInputRef::new(
+                "input:cap.snapshot.fixture",
+            )
+            .expect("input ref literal is valid"),
+        };
+        let ctx = port.hook_context(&invocation, None).await;
+        let hex: String = ctx
+            .arguments_digest
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        assert_eq!(
+            hex, "4d0ab78e009b32615c2766bd1c26921bd59ef81b5741a75387707f82f0344315",
+            "BeforeCapabilityHookContext.arguments_digest shifted at the \
+             middleware boundary; this is a hook-visible wire-contract \
+             break, not just a helper-output drift."
         );
     }
 

--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -551,6 +551,31 @@ fn serialized_len(value: &serde_json::Value) -> Result<u64, serde_json::Error> {
 /// hashes the input-ref's underlying value so two invocations with identical
 /// arguments produce the same digest, enabling repetition / rate-cap logic
 /// without exposing raw arguments to hook code.
+///
+/// # Stability contract
+///
+/// This digest is part of the **public hook contract**. Repetition-detection
+/// hooks key on `BeforeCapabilityHookContext.arguments_digest` across
+/// invocations; a shifted digest silently breaks them. Changing the hashing
+/// structure (length-prefix ordering, hasher choice, which fields contribute)
+/// requires:
+///
+/// 1. Updating the fixture in
+///    `tests::invocation_arguments_digest_is_stable_for_known_inputs` with
+///    the new captured hex.
+/// 2. Surfacing the change in the cross-crate wire-format contract section
+///    of `crate::identity` (the same section that pins `HookId::to_hex()`).
+/// 3. Bumping the hook framework's contract version if downstream
+///    consumers exist.
+///
+/// What this digest is NOT:
+///
+/// - **Not** a content digest of the resolved capability arguments. Hooks
+///   that want to key on resolved content should use
+///   `CapabilityInputResolver` + `SanitizedArguments`, not this digest.
+/// - **Not** suitable as a primary key for cross-process deduplication —
+///   two distinct invocations with the same `input_ref` (rare but legal)
+///   produce the same digest.
 fn invocation_arguments_digest(invocation: &CapabilityInvocation) -> [u8; 32] {
     let mut hasher = blake3::Hasher::new();
     let cap = invocation.capability_id.to_string();
@@ -760,6 +785,58 @@ mod tests {
                 "no router",
             ))
         }
+    }
+
+    /// Snapshot regression: pins `invocation_arguments_digest` for a known
+    /// `(capability_id, input_ref)` pair. If this assertion fails, the
+    /// digest's hashing structure changed — see the stability contract on
+    /// `invocation_arguments_digest`. **Do not update the expected hex
+    /// without auditing every caller that keys on `arguments_digest`.**
+    #[test]
+    fn invocation_arguments_digest_is_stable_for_known_inputs() {
+        let invocation = CapabilityInvocation {
+            surface_version: ironclaw_turns::run_profile::CapabilitySurfaceVersion::new(
+                "snapshot:v1",
+            )
+            .expect("surface version literal is valid"),
+            capability_id: CapabilityId::new("cap.snapshot.fixture")
+                .expect("capability id literal is valid"),
+            input_ref: ironclaw_turns::run_profile::CapabilityInputRef::new(
+                "input:cap.snapshot.fixture",
+            )
+            .expect("input ref literal is valid"),
+        };
+        let digest = invocation_arguments_digest(&invocation);
+        let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(
+            hex, "4d0ab78e009b32615c2766bd1c26921bd59ef81b5741a75387707f82f0344315",
+            "invocation_arguments_digest shifted for a fixed input — \
+             this is a wire-contract break. See the stability-contract \
+             rustdoc on `invocation_arguments_digest`."
+        );
+    }
+
+    /// Distinct inputs must produce distinct digests (sanity check; the
+    /// snapshot test pins one specific point in input space, this widens
+    /// coverage to the structural property).
+    #[test]
+    fn invocation_arguments_digest_differs_for_different_input_refs() {
+        let cap_id = CapabilityId::new("cap.x").expect("ok");
+        let surface = ironclaw_turns::run_profile::CapabilitySurfaceVersion::new("v").expect("ok");
+        let a = CapabilityInvocation {
+            surface_version: surface.clone(),
+            capability_id: cap_id.clone(),
+            input_ref: ironclaw_turns::run_profile::CapabilityInputRef::new("input:a").expect("ok"),
+        };
+        let b = CapabilityInvocation {
+            surface_version: surface,
+            capability_id: cap_id,
+            input_ref: ironclaw_turns::run_profile::CapabilityInputRef::new("input:b").expect("ok"),
+        };
+        assert_ne!(
+            invocation_arguments_digest(&a),
+            invocation_arguments_digest(&b)
+        );
     }
 
     fn invocation(capability: &str) -> CapabilityInvocation {

--- a/crates/ironclaw_hooks/src/middleware/capability_port.rs
+++ b/crates/ironclaw_hooks/src/middleware/capability_port.rs
@@ -547,10 +547,15 @@ fn serialized_len(value: &serde_json::Value) -> Result<u64, serde_json::Error> {
     Ok(writer.0)
 }
 
-/// Stable digest of capability arguments for hook context. The middleware
-/// hashes the input-ref's underlying value so two invocations with identical
-/// arguments produce the same digest, enabling repetition / rate-cap logic
-/// without exposing raw arguments to hook code.
+/// Stable digest of capability invocation identity for hook context. The
+/// middleware hashes the `(capability_id, input_ref)` pair so two
+/// invocations with the same capability id and the same input ref produce
+/// the same digest, enabling repetition / rate-cap logic without exposing
+/// raw arguments to hook code. The digest is over input-ref identity, not
+/// over the resolved argument content the input-ref points at — two
+/// distinct refs that happen to resolve to identical JSON will NOT share a
+/// digest, and the same ref representing changed underlying content will
+/// keep the same digest.
 ///
 /// # Stability contract
 ///


### PR DESCRIPTION
Successor PR from #3573 — addresses serrrfirat's #3 follow-up. **Draft** — scope doc only, implementation is one test + rustdoc.

## Scope
Single test pinning \`invocation_arguments_digest\` for a known \`(capability_id, input_ref)\` pair, plus rustdoc on the function calling out its stability contract.

## Design doc
[\`crates/ironclaw_hooks/docs/successors/10-digest-snapshot-pin.md\`](https://github.com/nearai/ironclaw/blob/hooks-fu-digest-snapshot-pin/crates/ironclaw_hooks/docs/successors/10-digest-snapshot-pin.md)

## Background
PR #3573 moved the digest from \`format!(\"{:?}\", input_ref)\` (Debug-unstable) to \`input_ref.as_str()\` per Firat's #3 finding. That removed the immediate stability risk, but the digest is only *implicitly* pinned now. This PR makes the pin explicit.

## Status
Draft. Smallest of the successor PRs; ready to promote after design ack.