### PR TITLE
fix(trust): make default host policy explicitly fail closed

### DIFF
--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -34,23 +34,29 @@ fn valid_wasm_manifest_parses_and_extracts_capability_descriptor() {
 
 #[test]
 fn manifest_privileged_trust_request_is_metadata_and_descriptor_stays_sandboxed() {
-    let manifest = ExtensionManifest::parse(
-        &WASM_MANIFEST.replace("trust = \"untrusted\"", "trust = \"first_party_requested\""),
-    )
-    .unwrap();
+    for (manifest_value, requested_trust) in [
+        (
+            "first_party_requested",
+            RequestedTrustClass::FirstPartyRequested,
+        ),
+        ("system_requested", RequestedTrustClass::SystemRequested),
+    ] {
+        let manifest = ExtensionManifest::parse(&WASM_MANIFEST.replace(
+            "trust = \"untrusted\"",
+            &format!("trust = \"{manifest_value}\""),
+        ))
+        .unwrap();
 
-    assert_eq!(
-        manifest.requested_trust,
-        RequestedTrustClass::FirstPartyRequested
-    );
-    assert_eq!(manifest.trust, TrustClass::Sandbox);
+        assert_eq!(manifest.requested_trust, requested_trust);
+        assert_eq!(manifest.trust, TrustClass::Sandbox);
 
-    let package = ExtensionPackage::from_manifest(
-        manifest,
-        VirtualPath::new("/system/extensions/echo").unwrap(),
-    )
-    .unwrap();
-    assert_eq!(package.capabilities[0].trust_ceiling, TrustClass::Sandbox);
+        let package = ExtensionPackage::from_manifest(
+            manifest,
+            VirtualPath::new("/system/extensions/echo").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(package.capabilities[0].trust_ceiling, TrustClass::Sandbox);
+    }
 }
 
 #[test]

--- a/crates/ironclaw_host_runtime/src/production.rs
+++ b/crates/ironclaw_host_runtime/src/production.rs
@@ -10,8 +10,8 @@
 //! This layer evaluates the package's manifest-derived trust input immediately
 //! before invoking [`CapabilityHost`] so authorization consumes a host-owned
 //! [`TrustDecision`](ironclaw_trust::TrustDecision) instead of caller-supplied
-//! claims. The default empty policy fails closed until composition supplies a
-//! concrete host policy.
+//! claims. The default fail-closed policy denies authority until composition
+//! supplies a concrete host policy.
 
 use std::sync::Arc;
 
@@ -67,9 +67,9 @@ pub struct DefaultHostRuntime {
 impl DefaultHostRuntime {
     /// Constructs a default host runtime over the supplied kernel services.
     ///
-    /// The runtime starts with an empty host trust policy, so capability
-    /// dispatch fails closed until composition attaches a concrete policy with
-    /// [`Self::with_trust_policy`] or [`Self::with_trust_policy_dyn`].
+    /// The runtime starts with an explicit fail-closed host trust policy, so
+    /// capability dispatch is denied until composition attaches a concrete
+    /// policy with [`Self::with_trust_policy`] or [`Self::with_trust_policy_dyn`].
     ///
     /// Callers must additionally attach either a combined
     /// [`RunStateApprovalStore`] via
@@ -91,7 +91,7 @@ impl DefaultHostRuntime {
             registry,
             dispatcher,
             authorizer,
-            trust_policy: Arc::new(HostTrustPolicy::empty()),
+            trust_policy: Arc::new(HostTrustPolicy::fail_closed()),
             run_state: None,
             approval_requests: None,
             run_state_approval_store: None,

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -411,7 +411,7 @@ where
         ));
         Self {
             registry,
-            trust_policy: Arc::new(HostTrustPolicy::empty()),
+            trust_policy: Arc::new(HostTrustPolicy::fail_closed()),
             trust_policy_configured: false,
             filesystem,
             governor,
@@ -665,7 +665,7 @@ where
 
     /// Attaches the host-owned trust policy used by the produced
     /// [`DefaultHostRuntime`]. Without this, the service graph keeps the
-    /// default empty policy and capability dispatch fails closed.
+    /// default fail-closed policy and capability dispatch is denied.
     pub fn with_trust_policy<T>(mut self, trust_policy: Arc<T>) -> Self
     where
         T: TrustPolicy + 'static,

--- a/crates/ironclaw_reborn_composition/tests/libsql_substrate.rs
+++ b/crates/ironclaw_reborn_composition/tests/libsql_substrate.rs
@@ -31,7 +31,7 @@ async fn libsql_substrate_builder_wires_production_components_without_local_only
             auth_token: None,
         },
         secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
-        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::empty()),
+        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
         turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
         surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
     })
@@ -63,7 +63,7 @@ async fn libsql_substrate_builder_rejects_missing_secret_master_key() {
             auth_token: None,
         },
         secret_master_key: None,
-        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::empty()),
+        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
         turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
         surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
     })

--- a/crates/ironclaw_reborn_composition/tests/postgres_substrate.rs
+++ b/crates/ironclaw_reborn_composition/tests/postgres_substrate.rs
@@ -25,7 +25,7 @@ async fn postgres_substrate_builder_wires_production_components_without_local_on
                 url: SecretString::from(database_url),
             },
             secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
-            trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::empty()),
+            trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
             turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
             surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
         })
@@ -51,7 +51,7 @@ async fn postgres_substrate_builder_rejects_missing_secret_master_key() {
                 url: SecretString::from(database_url),
             },
             secret_master_key: None,
-            trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::empty()),
+            trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
             turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
             surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
         })

--- a/crates/ironclaw_trust/src/lib.rs
+++ b/crates/ironclaw_trust/src/lib.rs
@@ -69,9 +69,9 @@ mod tests {
     }
 
     #[test]
-    fn empty_policy_returns_default_for_local_manifest() {
+    fn fail_closed_policy_returns_default_for_local_manifest() {
         use ironclaw_host_api::{PackageId, PackageIdentity, PackageSource, RequestedTrustClass};
-        let policy = HostTrustPolicy::empty();
+        let policy = HostTrustPolicy::fail_closed();
         let identity = PackageIdentity::new(
             PackageId::new("any").unwrap(),
             PackageSource::LocalManifest {
@@ -88,7 +88,37 @@ mod tests {
             })
             .unwrap();
         assert!(!decision.effective_trust.is_privileged());
+        assert_eq!(
+            decision.effective_trust.class(),
+            ironclaw_host_api::TrustClass::Sandbox
+        );
+        assert!(decision.authority_ceiling.allowed_effects.is_empty());
         assert_eq!(decision.provenance, TrustProvenance::Default);
+    }
+
+    #[test]
+    fn empty_policy_alias_is_fail_closed() {
+        use ironclaw_host_api::{PackageId, PackageIdentity, PackageSource, RequestedTrustClass};
+        let identity = PackageIdentity::new(
+            PackageId::new("any").unwrap(),
+            PackageSource::Admin,
+            None,
+            None,
+        );
+        let input = TrustPolicyInput {
+            identity,
+            requested_trust: RequestedTrustClass::FirstPartyRequested,
+            requested_authority: std::collections::BTreeSet::new(),
+        };
+        let fail_closed = HostTrustPolicy::fail_closed().evaluate(&input).unwrap();
+        let empty_alias = HostTrustPolicy::empty().evaluate(&input).unwrap();
+
+        assert_eq!(
+            empty_alias.effective_trust.class(),
+            fail_closed.effective_trust.class()
+        );
+        assert_eq!(empty_alias.authority_ceiling, fail_closed.authority_ceiling);
+        assert_eq!(empty_alias.provenance, fail_closed.provenance);
     }
 }
 

--- a/crates/ironclaw_trust/src/policy.rs
+++ b/crates/ironclaw_trust/src/policy.rs
@@ -85,7 +85,8 @@ pub struct SourceMatch {
 }
 
 /// Default host-controlled policy. Composes layered sources in priority order;
-/// the first source returning `Some` wins. No source ⇒ non-privileged default.
+/// the first source returning `Some` wins. No source ⇒ fail-closed default
+/// (`Sandbox` + empty authority ceiling + `Default` provenance).
 ///
 /// The clock is injectable so policy evaluation is deterministic in tests
 /// and audit-replay harnesses; production wiring uses [`SystemClock`].
@@ -103,8 +104,23 @@ impl HostTrustPolicy {
         Self::with_clock(sources, Box::new(SystemClock))
     }
 
-    pub fn empty() -> Self {
+    /// Construct an explicit fail-closed policy with no host-controlled
+    /// sources. Every input falls through to `Sandbox` effective trust, an
+    /// empty authority ceiling, and `Default` provenance.
+    ///
+    /// Use this at composition boundaries only as a safe placeholder until a
+    /// real host policy is attached. It is never an allow-all policy.
+    pub fn fail_closed() -> Self {
         Self::from_parts_unchecked(Vec::new(), Box::new(SystemClock))
+    }
+
+    /// Compatibility alias for [`Self::fail_closed`].
+    ///
+    /// The name is historical; semantics are deny-by-default, not vacuous
+    /// success. New production composition should call [`Self::fail_closed`]
+    /// so the security posture is obvious at the call site.
+    pub fn empty() -> Self {
+        Self::fail_closed()
     }
 
     /// Construct with an explicit clock. Tests inject `FixedClock` here so

--- a/crates/ironclaw_trust/src/tests/policy_contract.rs
+++ b/crates/ironclaw_trust/src/tests/policy_contract.rs
@@ -1439,11 +1439,9 @@ fn t14i_trust_change_listener_can_reenter_evaluate_without_deadlock() {
 
 #[test]
 fn t15_default_decision_is_sandbox_for_every_unmatched_package_source() {
-    // Empty policy chain — every input falls through to `default_decision`.
-    let policy = policy(vec![
-        Box::new(BundledRegistry::new()),
-        Box::new(AdminConfig::new()),
-    ]);
+    // Explicit fail-closed policy — every input falls through to
+    // `default_decision` without consulting any host-controlled source.
+    let policy = HostTrustPolicy::fail_closed();
 
     let unmatched_origins = [
         // Already correct pre-fix; included so the test asserts the full
@@ -1481,6 +1479,10 @@ fn t15_default_decision_is_sandbox_for_every_unmatched_package_source() {
         assert!(
             decision.authority_ceiling.allowed_effects.is_empty(),
             "default decision must carry an empty authority ceiling"
+        );
+        assert!(
+            decision.authority_ceiling.max_resource_ceiling.is_none(),
+            "default decision must not carry a resource ceiling"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3604.

Makes the default Reborn host trust policy explicitly fail-closed instead of relying on the ambiguous `HostTrustPolicy::empty()` wording at production composition boundaries.

## What changed

- Add `HostTrustPolicy::fail_closed()` as the explicit no-source, deny-by-default constructor.
- Keep `HostTrustPolicy::empty()` as a compatibility alias to `fail_closed()`.
- Migrate host runtime production/service composition defaults to `fail_closed()`.
- Strengthen trust tests so privileged manifest requests remain metadata-only:
  - `first_party_requested`
  - `system_requested`
- Strengthen default policy tests to assert sandbox effective trust, empty allowed effects, and no resource ceiling.

## Contract boundaries

- `ironclaw_host_api`: vocabulary only.
- `ironclaw_extensions`: manifest requested trust remains metadata.
- `ironclaw_trust`: owns effective trust policy evaluation.
- `ironclaw_host_runtime`: evaluates host-owned policy before dispatch.

No manifest path can self-assign `FirstParty` or `System` effective trust.

## Verification

- `cargo test -p ironclaw_host_api`
- `cargo test -p ironclaw_extensions`
- `cargo test -p ironclaw_trust`
- `cargo test -p ironclaw_host_runtime --test production_trust_contract`
- `git diff --check`
- `rg "HostTrustPolicy::empty\\(" crates src tests -g '*.rs'` → only alias test remains
