### PR TITLE
fix: populate debug-panel cost + token stats end-to-end

### DIFF
--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -859,7 +859,8 @@ def run_loop(context, goal, actions, state, config):
         response = __llm_complete__(working_messages, actions, None)
         __emit_event__("step_completed", step=step,
                        input_tokens=response.get("usage", {}).get("input_tokens", 0),
-                       output_tokens=response.get("usage", {}).get("output_tokens", 0))
+                       output_tokens=response.get("usage", {}).get("output_tokens", 0),
+                       cost_usd=response.get("usage", {}).get("cost_usd", 0.0))
 
         # 5. Handle response based on type
         resp_type = response.get("type", "text")

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2272,6 +2272,15 @@ fn handle_emit_event(
         "step_completed" => {
             let input = extract_u64_kwarg(kwargs, "input_tokens").unwrap_or(0);
             let output = extract_u64_kwarg(kwargs, "output_tokens").unwrap_or(0);
+            // `cost_usd` is the per-step USD cost reported by the LLM
+            // adapter. Threading it through the event lets
+            // `bridge::router::thread_event_to_app_events` populate
+            // `AppEvent::TurnCost.cost_usd`, which drives the debug
+            // panel's session-cost card. Without this, the kwarg goes
+            // unread and the card stays at $0.00 even though the same
+            // value already updates `Thread::total_cost_usd` and the
+            // host CostGuard's daily aggregate.
+            let cost = extract_f64_kwarg(kwargs, "cost_usd").unwrap_or(0.0);
             // Increment step count (mirrors the old Rust loop's step_count += 1)
             thread.step_count += 1;
             // Track token usage
@@ -2281,6 +2290,7 @@ fn handle_emit_event(
                 tokens: TokenUsage {
                     input_tokens: input,
                     output_tokens: output,
+                    cost_usd: cost,
                     ..Default::default()
                 },
             }
@@ -3205,6 +3215,26 @@ fn extract_u64_kwarg(kwargs: &[(MontyObject, MontyObject)], name: &str) -> Optio
             && let MontyObject::Int(i) = v
         {
             return Some(*i as u64);
+        }
+    }
+    None
+}
+
+/// Extract an `f64` kwarg, accepting both `Float` and `Int` values
+/// because Python literals like `0` arrive as `Int` even when the
+/// caller intends a float (e.g. `cost_usd=0.0` collapses to `Int(0)`
+/// when the LLM adapter reports a zero cost on a subscription-billed
+/// provider).
+fn extract_f64_kwarg(kwargs: &[(MontyObject, MontyObject)], name: &str) -> Option<f64> {
+    for (k, v) in kwargs {
+        if let MontyObject::String(key) = k
+            && key == name
+        {
+            return match v {
+                MontyObject::Float(f) => Some(*f),
+                MontyObject::Int(i) => Some(*i as f64),
+                _ => None,
+            };
         }
     }
     None
@@ -5502,5 +5532,77 @@ FINAL(batch_error_count)
             action_failed,
             "expected ActionFailed event alongside CodeExecutionFailed"
         );
+    }
+
+    #[test]
+    fn handle_emit_event_step_completed_threads_cost_usd_into_token_usage() {
+        // Regression: the Python `__emit_event__("step_completed", ...)`
+        // call already had access to `response["usage"]["cost_usd"]` but
+        // never passed it through, and the Rust handler built
+        // `TokenUsage` with `..Default::default()`, which forced
+        // `cost_usd` to 0.0. The bridge then projected an
+        // `AppEvent::TurnCost` whose `cost_usd` field was always
+        // "$0.0000", leaving the debug-panel Session Cost card stuck at
+        // $0 even though daily_cost / per-model usage worked. This test
+        // drives `handle_emit_event` end-to-end and asserts the
+        // recorded `EventKind::StepCompleted` carries the kwarg cost.
+        let mut thread = Thread::new(
+            "step-completed cost regression",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let args = vec![MontyObject::String("step_completed".into())];
+        let kwargs = vec![
+            (
+                MontyObject::String("input_tokens".into()),
+                MontyObject::Int(1000),
+            ),
+            (
+                MontyObject::String("output_tokens".into()),
+                MontyObject::Int(500),
+            ),
+            (
+                MontyObject::String("cost_usd".into()),
+                MontyObject::Float(0.0105),
+            ),
+        ];
+
+        handle_emit_event(&args, &kwargs, &mut thread, None);
+
+        let step_completed = thread
+            .events
+            .iter()
+            .find_map(|e| match &e.kind {
+                EventKind::StepCompleted { tokens, .. } => Some(tokens),
+                _ => None,
+            })
+            .expect("step_completed event must be recorded on the thread");
+
+        assert_eq!(step_completed.input_tokens, 1000);
+        assert_eq!(step_completed.output_tokens, 500);
+        assert!(
+            (step_completed.cost_usd - 0.0105).abs() < 1e-9,
+            "cost_usd kwarg must thread through to TokenUsage.cost_usd; got {}",
+            step_completed.cost_usd
+        );
+    }
+
+    #[test]
+    fn extract_f64_kwarg_accepts_float_and_int() {
+        let kwargs = vec![
+            (MontyObject::String("a".into()), MontyObject::Float(0.0105)),
+            (MontyObject::String("b".into()), MontyObject::Int(7)),
+            (MontyObject::String("c".into()), MontyObject::None),
+        ];
+        assert_eq!(extract_f64_kwarg(&kwargs, "a"), Some(0.0105));
+        // `Int` is accepted so `cost_usd=0` (literal int from Python)
+        // doesn't silently fall back to 0.0 via the None branch.
+        assert_eq!(extract_f64_kwarg(&kwargs, "b"), Some(7.0));
+        assert_eq!(extract_f64_kwarg(&kwargs, "c"), None);
+        assert_eq!(extract_f64_kwarg(&kwargs, "missing"), None);
     }
 }

--- a/crates/ironclaw_gateway/static/debug-panel.js
+++ b/crates/ironclaw_gateway/static/debug-panel.js
@@ -354,7 +354,15 @@
       sessionStats.turns++;
       sessionStats.inputTokens += data.input_tokens || 0;
       sessionStats.outputTokens += data.output_tokens || 0;
-      var costVal = parseFloat(data.cost_usd);
+      // The backend ships `cost_usd` as a money-formatted string (e.g.
+      // "$0.0105"). The TUI consumer depends on the `$` prefix for its
+      // own rendering, so the wire format keeps it — strip the prefix
+      // here before `parseFloat`, otherwise the call returns NaN and the
+      // session-cost card never accumulates.
+      var rawCost = typeof data.cost_usd === 'string'
+        ? data.cost_usd.replace(/^\$/, '')
+        : data.cost_usd;
+      var costVal = parseFloat(rawCost);
       if (!isNaN(costVal)) sessionStats.cost += costVal;
 
       var costStr = (!isNaN(costVal) && costVal > 0) ? '$' + costVal.toFixed(4) : '';

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -73,6 +73,11 @@ pub struct LlmBridgeAdapter {
     provider: Arc<dyn LlmProvider>,
     /// Optional cheaper provider for sub-calls (depth > 0).
     cheap_provider: Option<Arc<dyn LlmProvider>>,
+    /// Optional CostGuard used to record each completion's spend so the
+    /// gateway's `/api/gateway/status` (daily_cost, model_usage) reflects
+    /// engine v2 activity. V1's dispatcher records here after every LLM
+    /// call; v2 must do the same or the dashboard reads 0.
+    cost_guard: Option<Arc<crate::agent::cost_guard::CostGuard>>,
 }
 
 impl LlmBridgeAdapter {
@@ -83,7 +88,13 @@ impl LlmBridgeAdapter {
         Self {
             provider,
             cheap_provider,
+            cost_guard: None,
         }
+    }
+
+    pub fn with_cost_guard(mut self, cost_guard: Arc<crate::agent::cost_guard::CostGuard>) -> Self {
+        self.cost_guard = Some(cost_guard);
+        self
     }
 
     fn provider_for_depth(&self, depth: u32) -> &Arc<dyn LlmProvider> {
@@ -92,6 +103,37 @@ impl LlmBridgeAdapter {
         } else {
             &self.provider
         }
+    }
+
+    /// Forward this completion's token usage to the host's `CostGuard` so
+    /// `daily_spend()` / `model_usage()` stay current. Mirrors the v1
+    /// dispatcher's post-call recording in `src/agent/dispatcher.rs`. A
+    /// no-op when no `CostGuard` was wired in (tests, bare engine v2).
+    async fn record_cost(
+        &self,
+        provider: &Arc<dyn LlmProvider>,
+        config: &LlmCallConfig,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_read_input_tokens: u32,
+        cache_creation_input_tokens: u32,
+    ) {
+        let Some(cost_guard) = self.cost_guard.as_ref() else {
+            return;
+        };
+        let model_name = provider.effective_model_name(config.model.as_deref());
+        cost_guard
+            .record_llm_call(
+                &model_name,
+                input_tokens,
+                output_tokens,
+                cache_read_input_tokens,
+                cache_creation_input_tokens,
+                provider.cache_read_discount(),
+                provider.cache_write_multiplier(),
+                Some(provider.cost_per_token()),
+            )
+            .await;
     }
 }
 
@@ -146,6 +188,16 @@ impl LlmBackend for LlmBridgeAdapter {
             // Check for code blocks in the response (CodeAct/RLM pattern)
             // after stripping provider-flattened internal markers from visible text.
             let llm_response = text_response_from_cleaned_text(cleaned_text);
+
+            self.record_cost(
+                provider,
+                config,
+                response.input_tokens,
+                response.output_tokens,
+                response.cache_read_input_tokens,
+                response.cache_creation_input_tokens,
+            )
+            .await;
 
             return Ok(LlmOutput {
                 response: llm_response,
@@ -241,6 +293,16 @@ impl LlmBackend for LlmBridgeAdapter {
                 text_response_from_cleaned_text(cleaned_text)
             }
         };
+
+        self.record_cost(
+            provider,
+            config,
+            response.input_tokens,
+            response.output_tokens,
+            response.cache_read_input_tokens,
+            response.cache_creation_input_tokens,
+        )
+        .await;
 
         Ok(LlmOutput {
             response: llm_response,
@@ -1740,6 +1802,54 @@ And also check the token price:\n\
             "expected cost_usd ≈ {EXPECTED_COST_USD}, got {}",
             output.usage.cost_usd
         );
+    }
+
+    #[tokio::test]
+    async fn complete_records_to_cost_guard_when_wired() {
+        // Regression: engine v2 used to skip `CostGuard::record_llm_call`
+        // entirely. `/api/gateway/status` reads `daily_spend()` and
+        // `model_usage()` from the same guard, so the debug panel's
+        // "今日费用" and "各模型用量" cards stayed empty after every LLM
+        // call. The bridge adapter now forwards each completion's usage
+        // to the host's CostGuard via `.with_cost_guard(...)`.
+        use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+
+        let cost_guard = Arc::new(CostGuard::new(CostGuardConfig::default()));
+        let provider: Arc<dyn LlmProvider> = Arc::new(PricedProvider);
+        let adapter =
+            LlmBridgeAdapter::new(provider, None).with_cost_guard(Arc::clone(&cost_guard));
+
+        // Drive both code paths — with-tools and no-tools — through the
+        // adapter; both must record.
+        adapter
+            .complete(
+                &[ThreadMessage::user("hi")],
+                &[test_action("noop")],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+        adapter
+            .complete(&[ThreadMessage::user("hi")], &[], &LlmCallConfig::default())
+            .await
+            .unwrap();
+
+        let daily = cost_guard.daily_spend().await;
+        let expected = rust_decimal_macros::dec!(0.0105) * rust_decimal_macros::dec!(2);
+        assert_eq!(
+            daily, expected,
+            "CostGuard.daily_spend() must reflect both adapter completions; got {daily}"
+        );
+
+        let model_usage = cost_guard.model_usage().await;
+        let entry = model_usage.get("priced-mock").unwrap_or_else(|| {
+            panic!(
+                "CostGuard.model_usage() must contain the provider's model name; got keys {:?}",
+                model_usage.keys().collect::<Vec<_>>()
+            )
+        });
+        assert_eq!(entry.input_tokens, 2000);
+        assert_eq!(entry.output_tokens, 1000);
     }
 
     #[tokio::test]

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1600,10 +1600,10 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
 
     debug!("engine v2: initializing engine state");
 
-    let llm_adapter = Arc::new(LlmBridgeAdapter::new(
-        agent.llm().clone(),
-        Some(agent.cheap_llm().clone()),
-    ));
+    let llm_adapter = Arc::new(
+        LlmBridgeAdapter::new(agent.llm().clone(), Some(agent.cheap_llm().clone()))
+            .with_cost_guard(Arc::clone(&agent.deps.cost_guard)),
+    );
 
     let effect_adapter = Arc::new(
         EffectBridgeAdapter::new(
@@ -6166,13 +6166,27 @@ fn thread_event_to_app_events(
                 },
             ]
         }
-        EventKind::StepCompleted { tokens, .. } => vec![AppEvent::Status {
-            message: format!(
-                "Step complete — {} in / {} out tokens",
-                tokens.input_tokens, tokens.output_tokens
-            ),
-            thread_id: Some(thread_id.into()),
-        }],
+        EventKind::StepCompleted { tokens, .. } => vec![
+            AppEvent::Status {
+                message: format!(
+                    "Step complete — {} in / {} out tokens",
+                    tokens.input_tokens, tokens.output_tokens
+                ),
+                thread_id: Some(thread_id.into()),
+            },
+            // Mirror v1's `StatusUpdate::TurnCost` so the debug panel's
+            // turn / token / session-cost cards populate. The frontend
+            // (`debug-panel.js` `on('turn_cost', ...)`) is the only
+            // listener that increments those counters; without this
+            // emission, engine v2 sessions show 0 across the board
+            // while still rendering tool counts.
+            AppEvent::TurnCost {
+                input_tokens: tokens.input_tokens,
+                output_tokens: tokens.output_tokens,
+                cost_usd: format!("${:.4}", tokens.cost_usd),
+                thread_id: Some(thread_id.into()),
+            },
+        ],
         EventKind::MessageAdded {
             role,
             content_preview,
@@ -8906,6 +8920,49 @@ mod tests {
                 && duration_ms == &Some(17)
                 && thread_id.as_deref() == Some("thread-123")
         ));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_projects_turn_cost_from_step_completed() {
+        // Regression: engine v2 used to project `EventKind::StepCompleted`
+        // only to a free-form `AppEvent::Status` text line, dropping the
+        // structured token + cost data. The debug panel's turn /
+        // input-token / output-token / session-cost cards (driven by the
+        // frontend's `on('turn_cost', ...)` listener) stayed at 0 across
+        // an entire session even though `tokens` was populated on every
+        // step.
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::StepCompleted {
+                step_id: ironclaw_engine::StepId::new(),
+                tokens: ironclaw_engine::TokenUsage {
+                    input_tokens: 1234,
+                    output_tokens: 567,
+                    cache_read_tokens: 0,
+                    cache_write_tokens: 0,
+                    cost_usd: 0.0105,
+                },
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-step");
+
+        let has_turn_cost = app_events.iter().any(|e| {
+            matches!(
+                e,
+                AppEvent::TurnCost {
+                    input_tokens: 1234,
+                    output_tokens: 567,
+                    cost_usd,
+                    thread_id,
+                } if cost_usd == "$0.0105" && thread_id.as_deref() == Some("thread-step")
+            )
+        });
+        assert!(
+            has_turn_cost,
+            "StepCompleted must project an AppEvent::TurnCost with tokens + cost so the \
+             debug panel's stats cards populate; got {app_events:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On `ENGINE_V2=true`, the Debug Inspector's Stats tab showed `0` for turns
/ total tokens / input tokens / output tokens / session cost / daily cost
/ per-model usage, while tool counts still worked. Four independent gaps
along the same data path produced the same symptom; this PR closes all
four and adds caller-level regression tests for each.

- Engine v2 now emits `AppEvent::TurnCost` from `EventKind::StepCompleted`
  (was: only `AppEvent::Status` text, so the frontend's `on('turn_cost')`
  listener never fired).
- `LlmBridgeAdapter` now records each completion to `CostGuard`, so
  `/api/gateway/status` returns non-zero `daily_cost` / `model_usage` on
  v2 — matching the v1 dispatcher's contract from `agent/CLAUDE.md`
  ("`record_llm_call()` must be called **after** every LLM call").
- The Python orchestrator (`default.py`) now passes `cost_usd` through
  `__emit_event__("step_completed", ...)` and the Rust handler extracts
  it; previously the kwarg was dropped on both sides and
  `TokenUsage.cost_usd` was always `0.0`.
- The debug-panel JS now strips a leading `$` before `parseFloat`. The
  wire ships `cost_usd` as `"$0.0105"` (the TUI's status bar compares
  against the `"$0.00"` literal, so the prefix has to stay on the wire),
  but `parseFloat("$0.0105")` returns `NaN` in JS, so the session-cost
  accumulator was a no-op on every event.

## Scope note

This PR's diff intentionally spans four files across the JS / Python /
engine / bridge boundaries — it's narrowly scoped to one user-visible
bug (debug panel reads 0) and each fix is load-bearing for the others.
No drive-by changes.

## Changes

| File | Change |
|------|--------|
| `src/bridge/router.rs` | `EventKind::StepCompleted` → emits both `AppEvent::Status` and `AppEvent::TurnCost`; wires `.with_cost_guard(...)` at engine v2 init. |
| `src/bridge/llm_adapter.rs` | New `cost_guard` field + `with_cost_guard()` builder + `record_cost()` helper called on both completion paths. |
| `crates/ironclaw_engine/orchestrator/default.py` | `__emit_event__("step_completed", ..., cost_usd=...)` passes the value through. |
| `crates/ironclaw_engine/src/executor/orchestrator.rs` | Handler reads `cost_usd` into `TokenUsage`; new `extract_f64_kwarg` helper (accepts `Float` and `Int`). |
| `crates/ironclaw_gateway/static/debug-panel.js` | Strip leading `$` before `parseFloat(data.cost_usd)`. |

<img width="782" height="1272" alt="fixed stats" src="https://github.com/user-attachments/assets/b1982579-2357-40bf-a6b2-0cfbcc02d7de" />


## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #3618 

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
