### PR TITLE
feat(product-workflow): add WebUI inbound DTO contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4542,6 +4542,7 @@ dependencies = [
  "ironclaw_threads",
  "ironclaw_turns",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -32,4 +32,5 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 [dev-dependencies]
 ironclaw_product_workflow = { path = ".", features = ["test-support"] }
 ironclaw_product_adapters = { path = "../ironclaw_product_adapters", features = ["test-support", "host-auth-mint"] }
+serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -26,6 +26,7 @@ pub mod error;
 pub mod fakes;
 pub mod inbound_turn;
 pub mod ledger;
+pub mod webui_inbound;
 pub mod workflow;
 
 pub use action::{
@@ -38,4 +39,9 @@ pub use error::ProductWorkflowError;
 pub use fakes::{FakeConversationBindingService, FakeIdempotencyLedger, FakeInboundTurnService};
 pub use inbound_turn::{DefaultInboundTurnService, InboundTurnOutcome, InboundTurnService};
 pub use ledger::{IdempotencyDecision, IdempotencyLedger};
+pub use webui_inbound::{
+    WebUiAuthenticatedCaller, WebUiCancelReason, WebUiCancelRunRequest, WebUiCreateThreadRequest,
+    WebUiGateResolution, WebUiInboundCommand, WebUiInboundValidationCode,
+    WebUiInboundValidationError, WebUiResolveGateRequest, WebUiSendMessageRequest,
+};
 pub use workflow::DefaultProductWorkflow;

--- a/crates/ironclaw_product_workflow/src/webui_inbound.rs
+++ b/crates/ironclaw_product_workflow/src/webui_inbound.rs
@@ -1,0 +1,434 @@
+//! Route-independent WebUI inbound DTO contract.
+//!
+//! These DTOs normalize authenticated WebUI callers plus browser request bodies
+//! into canonical Reborn commands without depending on WebUI route handlers,
+//! product adapters, protocol auth evidence, WASM, or adapter registries.
+
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_turns::{
+    CancelRunRequest, GateRef, IdempotencyKey, SanitizedCancelReason, TurnActor, TurnRunId,
+    TurnScope,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const CLIENT_ACTION_ID_MAX_BYTES: usize = 256;
+const USER_MESSAGE_TEXT_MAX_BYTES: usize = 64 * 1024;
+const GATE_REF_MAX_BYTES: usize = 256;
+const CREDENTIAL_REF_MAX_BYTES: usize = 512;
+
+/// Authenticated WebUI caller after route auth has already completed.
+///
+/// This is authority-bearing input supplied by the host/router layer, not by
+/// the browser body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebUiAuthenticatedCaller {
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<AgentId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<ProjectId>,
+}
+
+impl WebUiAuthenticatedCaller {
+    pub fn new(
+        tenant_id: TenantId,
+        user_id: UserId,
+        agent_id: Option<AgentId>,
+        project_id: Option<ProjectId>,
+    ) -> Self {
+        Self {
+            tenant_id,
+            user_id,
+            agent_id,
+            project_id,
+        }
+    }
+
+    pub fn actor(&self) -> TurnActor {
+        TurnActor::new(self.user_id.clone())
+    }
+
+    pub fn turn_scope(&self, thread_id: ThreadId) -> TurnScope {
+        TurnScope::new(
+            self.tenant_id.clone(),
+            self.agent_id.clone(),
+            self.project_id.clone(),
+            thread_id,
+        )
+    }
+}
+
+/// Browser body for WebUI create-thread mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebUiCreateThreadRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_thread_id: Option<String>,
+}
+
+/// Browser body for WebUI send-message mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebUiSendMessageRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+/// Browser body for WebUI cancel-run mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebUiCancelRunRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Browser body for WebUI gate-resolution mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct WebUiResolveGateRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gate_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub always: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebUiCancelReason {
+    UserRequested,
+    Superseded,
+    Timeout,
+    OperatorRequested,
+    Policy,
+}
+
+impl From<WebUiCancelReason> for SanitizedCancelReason {
+    fn from(value: WebUiCancelReason) -> Self {
+        match value {
+            WebUiCancelReason::UserRequested => Self::UserRequested,
+            WebUiCancelReason::Superseded => Self::Superseded,
+            WebUiCancelReason::Timeout => Self::Timeout,
+            WebUiCancelReason::OperatorRequested => Self::OperatorRequested,
+            WebUiCancelReason::Policy => Self::Policy,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "resolution", rename_all = "snake_case")]
+pub enum WebUiGateResolution {
+    Approved {
+        #[serde(default)]
+        always: bool,
+    },
+    Denied,
+    /// A host-stored credential reference, not a raw secret/token.
+    CredentialProvided {
+        credential_ref: String,
+    },
+    Cancelled,
+}
+
+/// Canonical route-independent WebUI command produced after validation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum WebUiInboundCommand {
+    CreateThread {
+        caller: WebUiAuthenticatedCaller,
+        client_action_id: IdempotencyKey,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        requested_thread_id: Option<ThreadId>,
+    },
+    SendMessage {
+        scope: TurnScope,
+        actor: TurnActor,
+        client_action_id: IdempotencyKey,
+        content: String,
+    },
+    CancelRun {
+        request: CancelRunRequest,
+    },
+    ResolveGate {
+        scope: TurnScope,
+        actor: TurnActor,
+        run_id: TurnRunId,
+        gate_ref: GateRef,
+        client_action_id: IdempotencyKey,
+        resolution: WebUiGateResolution,
+    },
+}
+
+impl WebUiCreateThreadRequest {
+    pub fn into_command(
+        self,
+        caller: WebUiAuthenticatedCaller,
+    ) -> Result<WebUiInboundCommand, WebUiInboundValidationError> {
+        let client_action_id = parse_client_action_id(self.client_action_id)?;
+        let requested_thread_id = self
+            .requested_thread_id
+            .map(|value| parse_thread_id_value("requested_thread_id", value))
+            .transpose()?;
+
+        Ok(WebUiInboundCommand::CreateThread {
+            caller,
+            client_action_id,
+            requested_thread_id,
+        })
+    }
+}
+
+impl WebUiSendMessageRequest {
+    pub fn into_command(
+        self,
+        caller: WebUiAuthenticatedCaller,
+    ) -> Result<WebUiInboundCommand, WebUiInboundValidationError> {
+        let client_action_id = parse_client_action_id(self.client_action_id)?;
+        let thread_id = parse_thread_id(self.thread_id)?;
+        let content = required_text(
+            "content",
+            self.content,
+            USER_MESSAGE_TEXT_MAX_BYTES,
+            TextMode::MessageContent,
+        )?;
+
+        Ok(WebUiInboundCommand::SendMessage {
+            scope: caller.turn_scope(thread_id),
+            actor: caller.actor(),
+            client_action_id,
+            content,
+        })
+    }
+}
+
+impl WebUiCancelRunRequest {
+    pub fn into_command(
+        self,
+        caller: WebUiAuthenticatedCaller,
+    ) -> Result<WebUiInboundCommand, WebUiInboundValidationError> {
+        let client_action_id = parse_client_action_id(self.client_action_id)?;
+        let thread_id = parse_thread_id(self.thread_id)?;
+        let run_id = parse_run_id(self.run_id)?;
+        let reason = parse_cancel_reason(self.reason)?;
+
+        Ok(WebUiInboundCommand::CancelRun {
+            request: CancelRunRequest {
+                scope: caller.turn_scope(thread_id),
+                actor: caller.actor(),
+                run_id,
+                reason,
+                idempotency_key: client_action_id,
+            },
+        })
+    }
+}
+
+impl WebUiResolveGateRequest {
+    pub fn into_command(
+        self,
+        caller: WebUiAuthenticatedCaller,
+    ) -> Result<WebUiInboundCommand, WebUiInboundValidationError> {
+        let client_action_id = parse_client_action_id(self.client_action_id)?;
+        let thread_id = parse_thread_id(self.thread_id)?;
+        let run_id = parse_run_id(self.run_id)?;
+        let gate_ref = parse_gate_ref(self.gate_ref)?;
+        let resolution = parse_gate_resolution(self.resolution, self.always, self.credential_ref)?;
+
+        Ok(WebUiInboundCommand::ResolveGate {
+            scope: caller.turn_scope(thread_id),
+            actor: caller.actor(),
+            run_id,
+            gate_ref,
+            client_action_id,
+            resolution,
+        })
+    }
+}
+
+/// Stable validation error code for WebUI inbound DTOs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebUiInboundValidationCode {
+    MissingField,
+    Blank,
+    TooLong,
+    InvalidControlCharacter,
+    InvalidId,
+    InvalidValue,
+}
+
+/// Stable validation error shape for WebUI clients and facade tests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("invalid WebUI inbound field {field}: {code:?}")]
+pub struct WebUiInboundValidationError {
+    pub field: String,
+    pub code: WebUiInboundValidationCode,
+}
+
+impl WebUiInboundValidationError {
+    pub fn new(field: &'static str, code: WebUiInboundValidationCode) -> Self {
+        Self {
+            field: field.to_string(),
+            code,
+        }
+    }
+}
+
+fn parse_client_action_id(
+    value: Option<String>,
+) -> Result<IdempotencyKey, WebUiInboundValidationError> {
+    let value = required_text(
+        "client_action_id",
+        value,
+        CLIENT_ACTION_ID_MAX_BYTES,
+        TextMode::Token,
+    )?;
+    IdempotencyKey::new(value).map_err(|_| {
+        WebUiInboundValidationError::new("client_action_id", WebUiInboundValidationCode::InvalidId)
+    })
+}
+
+fn parse_thread_id(value: Option<String>) -> Result<ThreadId, WebUiInboundValidationError> {
+    let value = required_text("thread_id", value, 256, TextMode::Token)?;
+    parse_thread_id_value("thread_id", value)
+}
+
+fn parse_thread_id_value(
+    field: &'static str,
+    value: String,
+) -> Result<ThreadId, WebUiInboundValidationError> {
+    ThreadId::new(value)
+        .map_err(|_| WebUiInboundValidationError::new(field, WebUiInboundValidationCode::InvalidId))
+}
+
+fn parse_run_id(value: Option<String>) -> Result<TurnRunId, WebUiInboundValidationError> {
+    let value = required_text("run_id", value, 64, TextMode::Token)?;
+    Uuid::parse_str(&value)
+        .map(TurnRunId::from_uuid)
+        .map_err(|_| {
+            WebUiInboundValidationError::new("run_id", WebUiInboundValidationCode::InvalidId)
+        })
+}
+
+fn parse_gate_ref(value: Option<String>) -> Result<GateRef, WebUiInboundValidationError> {
+    let value = required_text("gate_ref", value, GATE_REF_MAX_BYTES, TextMode::Token)?;
+    GateRef::new(value).map_err(|_| {
+        WebUiInboundValidationError::new("gate_ref", WebUiInboundValidationCode::InvalidId)
+    })
+}
+
+fn parse_cancel_reason(
+    value: Option<String>,
+) -> Result<SanitizedCancelReason, WebUiInboundValidationError> {
+    let Some(value) = value else {
+        return Ok(SanitizedCancelReason::UserRequested);
+    };
+    validate_text_value("reason", &value, 64, TextMode::Token)?;
+    match value.as_str() {
+        "user_requested" => Ok(SanitizedCancelReason::UserRequested),
+        "superseded" => Ok(SanitizedCancelReason::Superseded),
+        "timeout" => Ok(SanitizedCancelReason::Timeout),
+        "operator_requested" => Ok(SanitizedCancelReason::OperatorRequested),
+        "policy" => Ok(SanitizedCancelReason::Policy),
+        _ => Err(WebUiInboundValidationError::new(
+            "reason",
+            WebUiInboundValidationCode::InvalidValue,
+        )),
+    }
+}
+
+fn parse_gate_resolution(
+    resolution: Option<String>,
+    always: Option<bool>,
+    credential_ref: Option<String>,
+) -> Result<WebUiGateResolution, WebUiInboundValidationError> {
+    let resolution = required_text("resolution", resolution, 64, TextMode::Token)?;
+    match resolution.as_str() {
+        "approved" => Ok(WebUiGateResolution::Approved {
+            always: always.unwrap_or(false),
+        }),
+        "denied" => Ok(WebUiGateResolution::Denied),
+        "credential_provided" => Ok(WebUiGateResolution::CredentialProvided {
+            credential_ref: required_text(
+                "credential_ref",
+                credential_ref,
+                CREDENTIAL_REF_MAX_BYTES,
+                TextMode::Token,
+            )?,
+        }),
+        "cancelled" => Ok(WebUiGateResolution::Cancelled),
+        _ => Err(WebUiInboundValidationError::new(
+            "resolution",
+            WebUiInboundValidationCode::InvalidValue,
+        )),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextMode {
+    Token,
+    MessageContent,
+}
+
+fn required_text(
+    field: &'static str,
+    value: Option<String>,
+    max_bytes: usize,
+    mode: TextMode,
+) -> Result<String, WebUiInboundValidationError> {
+    let value = value.ok_or_else(|| {
+        WebUiInboundValidationError::new(field, WebUiInboundValidationCode::MissingField)
+    })?;
+    validate_text_value(field, &value, max_bytes, mode)?;
+    Ok(value)
+}
+
+fn validate_text_value(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+    mode: TextMode,
+) -> Result<(), WebUiInboundValidationError> {
+    if value.trim().is_empty() {
+        return Err(WebUiInboundValidationError::new(
+            field,
+            WebUiInboundValidationCode::Blank,
+        ));
+    }
+    if value.len() > max_bytes {
+        return Err(WebUiInboundValidationError::new(
+            field,
+            WebUiInboundValidationCode::TooLong,
+        ));
+    }
+    let has_invalid_control = value.chars().any(|c| match mode {
+        TextMode::Token => c == '\0' || c.is_control(),
+        TextMode::MessageContent => c == '\0' || (c.is_control() && c != '\n' && c != '\t'),
+    });
+    if has_invalid_control {
+        return Err(WebUiInboundValidationError::new(
+            field,
+            WebUiInboundValidationCode::InvalidControlCharacter,
+        ));
+    }
+    Ok(())
+}

--- a/crates/ironclaw_product_workflow/tests/webui_inbound_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/webui_inbound_contract.rs
@@ -1,0 +1,355 @@
+//! Contract tests for route-independent WebUI inbound DTOs.
+
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
+use ironclaw_product_workflow::{
+    WebUiAuthenticatedCaller, WebUiCancelReason, WebUiCancelRunRequest, WebUiCreateThreadRequest,
+    WebUiGateResolution, WebUiInboundCommand, WebUiInboundValidationCode, WebUiResolveGateRequest,
+    WebUiSendMessageRequest,
+};
+use ironclaw_turns::SanitizedCancelReason;
+use serde_json::json;
+use uuid::Uuid;
+
+fn caller() -> WebUiAuthenticatedCaller {
+    WebUiAuthenticatedCaller::new(
+        TenantId::new("tenant-alpha").expect("valid tenant"),
+        UserId::new("user-alpha").expect("valid user"),
+        Some(AgentId::new("agent-alpha").expect("valid agent")),
+        Some(ProjectId::new("project-alpha").expect("valid project")),
+    )
+}
+
+fn run_id() -> String {
+    "3d54a1f0-0a7f-4b9c-a350-4258f2fa3e18".to_string()
+}
+
+#[test]
+fn create_thread_maps_authenticated_caller_to_canonical_command() {
+    let request: WebUiCreateThreadRequest = serde_json::from_value(json!({
+        "client_action_id": "create-1",
+        "requested_thread_id": "thread-alpha"
+    }))
+    .expect("request json");
+
+    let command = request.into_command(caller()).expect("valid command");
+
+    let WebUiInboundCommand::CreateThread {
+        caller,
+        client_action_id,
+        requested_thread_id,
+    } = command
+    else {
+        panic!("expected create-thread command");
+    };
+    assert_eq!(caller.user_id.as_str(), "user-alpha");
+    assert_eq!(client_action_id.as_str(), "create-1");
+    assert_eq!(
+        requested_thread_id,
+        Some(ThreadId::new("thread-alpha").expect("valid thread"))
+    );
+}
+
+#[test]
+fn send_message_maps_body_to_turn_scope_actor_and_content() {
+    let request: WebUiSendMessageRequest = serde_json::from_value(json!({
+        "client_action_id": "send-1",
+        "thread_id": "thread-alpha",
+        "content": "hello\nworld"
+    }))
+    .expect("request json");
+
+    let command = request.into_command(caller()).expect("valid command");
+
+    let WebUiInboundCommand::SendMessage {
+        scope,
+        actor,
+        client_action_id,
+        content,
+    } = command
+    else {
+        panic!("expected send-message command");
+    };
+    assert_eq!(scope.tenant_id.as_str(), "tenant-alpha");
+    assert_eq!(scope.agent_id.expect("agent").as_str(), "agent-alpha");
+    assert_eq!(scope.project_id.expect("project").as_str(), "project-alpha");
+    assert_eq!(scope.thread_id.as_str(), "thread-alpha");
+    assert_eq!(actor.user_id.as_str(), "user-alpha");
+    assert_eq!(client_action_id.as_str(), "send-1");
+    assert_eq!(content, "hello\nworld");
+}
+
+#[test]
+fn cancel_run_maps_to_canonical_cancel_request() {
+    let request: WebUiCancelRunRequest = serde_json::from_value(json!({
+        "client_action_id": "cancel-1",
+        "thread_id": "thread-alpha",
+        "run_id": run_id(),
+        "reason": "operator_requested"
+    }))
+    .expect("request json");
+
+    let command = request.into_command(caller()).expect("valid command");
+
+    let WebUiInboundCommand::CancelRun { request } = command else {
+        panic!("expected cancel-run command");
+    };
+    assert_eq!(request.scope.thread_id.as_str(), "thread-alpha");
+    assert_eq!(request.actor.user_id.as_str(), "user-alpha");
+    assert_eq!(request.idempotency_key.as_str(), "cancel-1");
+    assert_eq!(request.reason, SanitizedCancelReason::OperatorRequested);
+}
+
+#[test]
+fn resolve_gate_maps_to_canonical_gate_command_without_raw_secret() {
+    let request: WebUiResolveGateRequest = serde_json::from_value(json!({
+        "client_action_id": "gate-1",
+        "thread_id": "thread-alpha",
+        "run_id": run_id(),
+        "gate_ref": "gate-alpha",
+        "resolution": "credential_provided",
+        "credential_ref": "credential-alpha"
+    }))
+    .expect("request json");
+
+    let command = request.into_command(caller()).expect("valid command");
+
+    let WebUiInboundCommand::ResolveGate {
+        scope,
+        actor,
+        run_id: parsed_run_id,
+        gate_ref,
+        client_action_id,
+        resolution,
+    } = command
+    else {
+        panic!("expected resolve-gate command");
+    };
+    assert_eq!(scope.thread_id.as_str(), "thread-alpha");
+    assert_eq!(actor.user_id.as_str(), "user-alpha");
+    assert_eq!(
+        parsed_run_id.as_uuid(),
+        Uuid::parse_str(&run_id()).expect("uuid")
+    );
+    assert_eq!(gate_ref.as_str(), "gate-alpha");
+    assert_eq!(client_action_id.as_str(), "gate-1");
+    assert_eq!(
+        resolution,
+        WebUiGateResolution::CredentialProvided {
+            credential_ref: "credential-alpha".to_string()
+        }
+    );
+}
+
+#[test]
+fn missing_content_returns_stable_validation_error() {
+    let request: WebUiSendMessageRequest = serde_json::from_value(json!({
+        "client_action_id": "send-1",
+        "thread_id": "thread-alpha"
+    }))
+    .expect("request json");
+
+    let err = request.into_command(caller()).expect_err("missing content");
+
+    assert_eq!(err.field, "content");
+    assert_eq!(err.code, WebUiInboundValidationCode::MissingField);
+    assert_eq!(
+        serde_json::to_value(&err).expect("error json"),
+        json!({"field":"content","code":"missing_field"})
+    );
+}
+
+#[test]
+fn blank_client_action_id_returns_stable_validation_error() {
+    let request: WebUiSendMessageRequest = serde_json::from_value(json!({
+        "client_action_id": "   ",
+        "thread_id": "thread-alpha",
+        "content": "hello"
+    }))
+    .expect("request json");
+
+    let err = request.into_command(caller()).expect_err("blank action id");
+
+    assert_eq!(err.field, "client_action_id");
+    assert_eq!(err.code, WebUiInboundValidationCode::Blank);
+}
+
+#[test]
+fn invalid_thread_id_returns_stable_validation_error() {
+    let request: WebUiSendMessageRequest = serde_json::from_value(json!({
+        "client_action_id": "send-1",
+        "thread_id": "../other-thread",
+        "content": "hello"
+    }))
+    .expect("request json");
+
+    let err = request
+        .into_command(caller())
+        .expect_err("invalid thread id");
+
+    assert_eq!(err.field, "thread_id");
+    assert_eq!(err.code, WebUiInboundValidationCode::InvalidId);
+}
+
+#[test]
+fn missing_run_id_returns_stable_validation_error_for_cancel() {
+    let request: WebUiCancelRunRequest = serde_json::from_value(json!({
+        "client_action_id": "cancel-1",
+        "thread_id": "thread-alpha"
+    }))
+    .expect("request json");
+
+    let err = request.into_command(caller()).expect_err("missing run id");
+
+    assert_eq!(err.field, "run_id");
+    assert_eq!(err.code, WebUiInboundValidationCode::MissingField);
+}
+
+#[test]
+fn invalid_run_id_returns_stable_validation_error_for_gate_resolution() {
+    let request: WebUiResolveGateRequest = serde_json::from_value(json!({
+        "client_action_id": "gate-1",
+        "thread_id": "thread-alpha",
+        "run_id": "not-a-uuid",
+        "gate_ref": "gate-alpha",
+        "resolution": "approved"
+    }))
+    .expect("request json");
+
+    let err = request.into_command(caller()).expect_err("invalid run id");
+
+    assert_eq!(err.field, "run_id");
+    assert_eq!(err.code, WebUiInboundValidationCode::InvalidId);
+}
+
+#[test]
+fn missing_gate_ref_returns_stable_validation_error() {
+    let request: WebUiResolveGateRequest = serde_json::from_value(json!({
+        "client_action_id": "gate-1",
+        "thread_id": "thread-alpha",
+        "run_id": run_id(),
+        "resolution": "denied"
+    }))
+    .expect("request json");
+
+    let err = request
+        .into_command(caller())
+        .expect_err("missing gate ref");
+
+    assert_eq!(err.field, "gate_ref");
+    assert_eq!(err.code, WebUiInboundValidationCode::MissingField);
+}
+
+#[test]
+fn blank_credential_ref_returns_stable_validation_error() {
+    let request: WebUiResolveGateRequest = serde_json::from_value(json!({
+        "client_action_id": "gate-1",
+        "thread_id": "thread-alpha",
+        "run_id": run_id(),
+        "gate_ref": "gate-alpha",
+        "resolution": "credential_provided",
+        "credential_ref": ""
+    }))
+    .expect("request json");
+
+    let err = request
+        .into_command(caller())
+        .expect_err("blank credential ref");
+
+    assert_eq!(err.field, "credential_ref");
+    assert_eq!(err.code, WebUiInboundValidationCode::Blank);
+}
+
+#[test]
+fn command_serializes_with_stable_command_tag() {
+    let request = WebUiSendMessageRequest {
+        client_action_id: Some("send-1".to_string()),
+        thread_id: Some("thread-alpha".to_string()),
+        content: Some("hello".to_string()),
+    };
+    let command = request.into_command(caller()).expect("valid command");
+
+    let value = serde_json::to_value(command).expect("command json");
+
+    assert_eq!(value["command"], "send_message");
+    assert_eq!(value["scope"]["thread_id"], "thread-alpha");
+    assert_eq!(value["actor"]["user_id"], "user-alpha");
+}
+
+#[test]
+fn token_fields_reject_control_characters() {
+    let request = WebUiSendMessageRequest {
+        client_action_id: Some("send\n1".to_string()),
+        thread_id: Some("thread-alpha".to_string()),
+        content: Some("hello".to_string()),
+    };
+
+    let err = request.into_command(caller()).expect_err("control char");
+
+    assert_eq!(err.field, "client_action_id");
+    assert_eq!(
+        err.code,
+        WebUiInboundValidationCode::InvalidControlCharacter
+    );
+}
+
+#[test]
+fn invalid_cancel_reason_returns_stable_validation_error() {
+    let request = WebUiCancelRunRequest {
+        client_action_id: Some("cancel-1".to_string()),
+        thread_id: Some("thread-alpha".to_string()),
+        run_id: Some(run_id()),
+        reason: Some("not_a_reason".to_string()),
+    };
+
+    let err = request.into_command(caller()).expect_err("invalid reason");
+
+    assert_eq!(err.field, "reason");
+    assert_eq!(err.code, WebUiInboundValidationCode::InvalidValue);
+}
+
+#[test]
+fn invalid_gate_resolution_returns_stable_validation_error() {
+    let request = WebUiResolveGateRequest {
+        client_action_id: Some("gate-1".to_string()),
+        thread_id: Some("thread-alpha".to_string()),
+        run_id: Some(run_id()),
+        gate_ref: Some("gate-alpha".to_string()),
+        resolution: Some("not_a_resolution".to_string()),
+        always: None,
+        credential_ref: None,
+    };
+
+    let err = request
+        .into_command(caller())
+        .expect_err("invalid resolution");
+
+    assert_eq!(err.field, "resolution");
+    assert_eq!(err.code, WebUiInboundValidationCode::InvalidValue);
+}
+
+#[test]
+fn cancel_reason_defaults_to_user_requested() {
+    let request = WebUiCancelRunRequest {
+        client_action_id: Some("cancel-1".to_string()),
+        thread_id: Some("thread-alpha".to_string()),
+        run_id: Some(run_id()),
+        reason: None,
+    };
+
+    let WebUiInboundCommand::CancelRun { request } = request
+        .into_command(caller())
+        .expect("valid cancel command")
+    else {
+        panic!("expected cancel-run command");
+    };
+
+    assert_eq!(request.reason, SanitizedCancelReason::UserRequested);
+}
+
+#[test]
+fn cancel_reason_serializes_as_snake_case() {
+    assert_eq!(
+        serde_json::to_value(WebUiCancelReason::Policy).expect("reason json"),
+        json!("policy")
+    );
+}


### PR DESCRIPTION
## Summary
- Add route-independent WebUI inbound DTOs for create-thread, send-message, cancel-run, and resolve-gate beta mutations.
- Normalize authenticated WebUI caller + request body into canonical Reborn commands using `TurnScope`, `TurnActor`, `TurnRunId`, `GateRef`, and `IdempotencyKey`.
- Add stable validation error codes for missing, blank, too-long, invalid-control-character, invalid-id, and invalid-value client fields.
- Keep slice independent of WebUI route/facade/runtime wiring; no `ProductAdapter`, `ExternalActorRef`, protocol auth evidence, WASM, or adapter registry dependency.

Closes #3624

## Verification
- `cargo fmt --check -p ironclaw_product_workflow`
- `cargo test -p ironclaw_product_workflow`
- `cargo clippy -p ironclaw_product_workflow --all-targets -- -D warnings`
- `git diff --check -- Cargo.lock crates/ironclaw_product_workflow/Cargo.toml crates/ironclaw_product_workflow/src/lib.rs crates/ironclaw_product_workflow/src/webui_inbound.rs crates/ironclaw_product_workflow/tests/webui_inbound_contract.rs`
