### PR TITLE
arch(ws-14): register planned driver default path

### DIFF
--- a/crates/ironclaw_reborn/src/lib.rs
+++ b/crates/ironclaw_reborn/src/lib.rs
@@ -11,6 +11,7 @@ pub mod loop_exit_applier;
 mod milestone_events;
 mod model_routes;
 mod planned_driver;
+mod planned_driver_factory;
 pub mod production_readiness;
 mod text_loop_driver;
 pub mod turn_runner;
@@ -43,4 +44,14 @@ pub use model_routes::{
     ResolvedModelRouteSnapshot, StaticModelRouteResolver,
 };
 pub use planned_driver::PlannedDriver;
+pub use planned_driver_factory::{
+    DefaultPlannedDriverBuild, DefaultPlannedDriverRegistrationError, PLANNED_DEFAULT_PROFILE_ID,
+    PLANNED_DRIVER_CHECKPOINT_SCHEMA_ID, PLANNED_DRIVER_CHECKPOINT_SCHEMA_VERSION,
+    PLANNED_DRIVER_DEFAULT_ID, PLANNED_DRIVER_DEFAULT_VERSION, default_planned_driver,
+    default_planned_run_profile_resolver, planned_default_profile_id,
+    planned_driver_checkpoint_schema_id, planned_driver_checkpoint_schema_version,
+    planned_driver_default_id, planned_driver_default_version, planned_driver_descriptor,
+    register_default_planned_driver, register_default_planned_profile,
+    register_default_text_only_driver,
+};
 pub use text_loop_driver::{TextOnlyModelReplyDriver, TextOnlyModelReplyDriverConfig};

--- a/crates/ironclaw_reborn/src/planned_driver.rs
+++ b/crates/ironclaw_reborn/src/planned_driver.rs
@@ -36,6 +36,25 @@ pub struct PlannedDriver {
 }
 
 impl PlannedDriver {
+    pub fn from_family_with_descriptor(
+        family: Arc<LoopFamily>,
+        executor: Arc<CanonicalAgentLoopExecutor>,
+        descriptor: AgentLoopDriverDescriptor,
+    ) -> Result<Self, AgentLoopDriverError> {
+        if descriptor.checkpoint_schema_id.is_none()
+            || descriptor.checkpoint_schema_version.is_none()
+        {
+            return Err(AgentLoopDriverError::InvalidRequest {
+                reason: "planned driver descriptor must carry a checkpoint schema".to_string(),
+            });
+        }
+        Ok(Self {
+            descriptor,
+            family,
+            executor,
+        })
+    }
+
     pub fn from_family(
         driver_id: LoopDriverId,
         family: Arc<LoopFamily>,
@@ -314,7 +333,7 @@ mod tests {
         );
         assert_eq!(
             descriptor.checkpoint_schema_id,
-            Some(CheckpointSchemaId::new(CHECKPOINT_SCHEMA_ID).expect("valid"))
+            Some(CheckpointSchemaId::new(PLANNED_DRIVER_CHECKPOINT_SCHEMA_ID).expect("valid"))
         );
         assert_eq!(
             descriptor.checkpoint_schema_version,
@@ -675,6 +694,12 @@ mod tests {
     impl LoopRunInfoPort for ResumePayloadHost {
         fn run_context(&self) -> &LoopRunContext {
             self.inner.run_context()
+        }
+    }
+
+    impl LoopCancellationPort for ResumePayloadHost {
+        fn observe_cancellation(&self) -> Option<LoopCancellationSignal> {
+            self.inner.observe_cancellation()
         }
     }
 

--- a/crates/ironclaw_reborn/src/planned_driver_factory.rs
+++ b/crates/ironclaw_reborn/src/planned_driver_factory.rs
@@ -1,0 +1,319 @@
+//! Production registration helpers for the default planned Reborn loop.
+
+use std::{error::Error, fmt, sync::Arc};
+
+use ironclaw_agent_loop::{
+    executor::CanonicalAgentLoopExecutor,
+    family::{LoopFamilyId, LoopFamilyRegistry},
+    state::CHECKPOINT_SCHEMA_ID,
+};
+use ironclaw_turns::{
+    AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError, RunProfileId,
+    RunProfileVersion,
+    run_profile::{
+        CapabilitySurfaceProfileId, CheckpointSchemaId, InMemoryRunProfileRegistry,
+        InMemoryRunProfileResolver, RunProfileDefinition, RunProfileRegistryError,
+    },
+};
+
+use crate::{
+    driver_registry::{
+        DriverKind, DriverRegistry, DriverRegistryError, DriverRequirements, LoopDriverRegistryKey,
+        RequirementLevel,
+    },
+    planned_driver::PlannedDriver,
+    text_loop_driver::{TextOnlyModelReplyDriver, TextOnlyModelReplyDriverConfig},
+};
+
+pub const PLANNED_DRIVER_DEFAULT_ID: &str = "reborn:planned-default";
+pub const PLANNED_DRIVER_DEFAULT_VERSION: u64 = 1;
+pub const PLANNED_DRIVER_CHECKPOINT_SCHEMA_ID: &str = CHECKPOINT_SCHEMA_ID;
+pub const PLANNED_DRIVER_CHECKPOINT_SCHEMA_VERSION: u64 = 1;
+pub const PLANNED_DEFAULT_PROFILE_ID: &str = "reborn-planned-default";
+
+pub struct DefaultPlannedDriverBuild {
+    pub driver: Arc<dyn AgentLoopDriver>,
+    pub descriptor: AgentLoopDriverDescriptor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefaultPlannedDriverRegistrationError {
+    DriverBuild(AgentLoopDriverError),
+    Registry(DriverRegistryError),
+}
+
+impl fmt::Display for DefaultPlannedDriverRegistrationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DriverBuild(error) => {
+                write!(formatter, "default planned driver build failed: {error}")
+            }
+            Self::Registry(error) => write!(
+                formatter,
+                "default planned driver registration failed: {error}"
+            ),
+        }
+    }
+}
+
+impl Error for DefaultPlannedDriverRegistrationError {}
+
+impl From<AgentLoopDriverError> for DefaultPlannedDriverRegistrationError {
+    fn from(error: AgentLoopDriverError) -> Self {
+        Self::DriverBuild(error)
+    }
+}
+
+impl From<DriverRegistryError> for DefaultPlannedDriverRegistrationError {
+    fn from(error: DriverRegistryError) -> Self {
+        Self::Registry(error)
+    }
+}
+
+pub fn planned_driver_default_id() -> Result<ironclaw_turns::run_profile::LoopDriverId, String> {
+    ironclaw_turns::run_profile::LoopDriverId::new(PLANNED_DRIVER_DEFAULT_ID)
+}
+
+pub fn planned_driver_checkpoint_schema_id() -> Result<CheckpointSchemaId, String> {
+    CheckpointSchemaId::new(PLANNED_DRIVER_CHECKPOINT_SCHEMA_ID)
+}
+
+pub fn planned_default_profile_id() -> Result<RunProfileId, String> {
+    RunProfileId::new(PLANNED_DEFAULT_PROFILE_ID)
+}
+
+pub fn planned_driver_default_version() -> RunProfileVersion {
+    RunProfileVersion::new(PLANNED_DRIVER_DEFAULT_VERSION)
+}
+
+pub fn planned_driver_checkpoint_schema_version() -> RunProfileVersion {
+    RunProfileVersion::new(PLANNED_DRIVER_CHECKPOINT_SCHEMA_VERSION)
+}
+
+pub fn planned_driver_descriptor() -> Result<AgentLoopDriverDescriptor, String> {
+    AgentLoopDriverDescriptor::new(PLANNED_DRIVER_DEFAULT_ID, planned_driver_default_version())?
+        .with_checkpoint_schema(
+            PLANNED_DRIVER_CHECKPOINT_SCHEMA_ID,
+            planned_driver_checkpoint_schema_version(),
+        )
+}
+
+pub fn default_planned_driver(
+    family_registry: Arc<LoopFamilyRegistry>,
+) -> Result<DefaultPlannedDriverBuild, AgentLoopDriverError> {
+    let family = family_registry.get(&LoopFamilyId::DEFAULT).ok_or_else(|| {
+        AgentLoopDriverError::InvalidRequest {
+            reason: "default loop family is not registered".to_string(),
+        }
+    })?;
+    let descriptor = planned_driver_descriptor()
+        .map_err(|reason| AgentLoopDriverError::InvalidRequest { reason })?;
+    let executor = Arc::new(CanonicalAgentLoopExecutor);
+    let driver = PlannedDriver::from_family_with_descriptor(family, executor, descriptor.clone())?;
+    Ok(DefaultPlannedDriverBuild {
+        driver: Arc::new(driver),
+        descriptor,
+    })
+}
+
+pub fn planned_driver_requirements() -> DriverRequirements {
+    DriverRequirements {
+        model: RequirementLevel::Required,
+        prompt: RequirementLevel::Required,
+        transcript: RequirementLevel::Required,
+        checkpoint: RequirementLevel::Required,
+        input_polling: RequirementLevel::Required,
+        capabilities: RequirementLevel::Required,
+        progress_events: RequirementLevel::Required,
+    }
+}
+
+pub fn register_default_planned_driver(
+    registry: &mut DriverRegistry,
+    family_registry: Arc<LoopFamilyRegistry>,
+) -> Result<LoopDriverRegistryKey, DefaultPlannedDriverRegistrationError> {
+    let build = default_planned_driver(family_registry)?;
+    registry
+        .register_driver(
+            build.driver,
+            planned_driver_requirements(),
+            DriverKind::Production,
+        )
+        .map_err(Into::into)
+}
+
+pub fn register_default_text_only_driver(
+    registry: &mut DriverRegistry,
+    config: TextOnlyModelReplyDriverConfig,
+) -> Result<LoopDriverRegistryKey, DriverRegistryError> {
+    registry.register_driver(
+        Arc::new(TextOnlyModelReplyDriver::new(config)),
+        DriverRequirements::all_optional(),
+        DriverKind::Production,
+    )
+}
+
+pub fn planned_default_profile_definition() -> Result<RunProfileDefinition, RunProfileRegistryError>
+{
+    let descriptor = planned_driver_descriptor()
+        .map_err(|reason| RunProfileRegistryError::InvalidProfile { reason })?;
+    let profile_id = planned_default_profile_id()
+        .map_err(|reason| RunProfileRegistryError::InvalidProfile { reason })?;
+    let checkpoint_schema_id = planned_driver_checkpoint_schema_id()
+        .map_err(|reason| RunProfileRegistryError::InvalidProfile { reason })?;
+    let capability_surface_profile_id = CapabilitySurfaceProfileId::new("interactive_tools")
+        .map_err(|reason| RunProfileRegistryError::InvalidProfile { reason })?;
+    Ok(RunProfileDefinition::interactive_like(
+        profile_id,
+        descriptor,
+        checkpoint_schema_id,
+        planned_driver_checkpoint_schema_version(),
+        capability_surface_profile_id,
+    ))
+}
+
+pub fn register_default_planned_profile(
+    registry: &mut InMemoryRunProfileRegistry,
+) -> Result<(), RunProfileRegistryError> {
+    registry.register(planned_default_profile_definition()?)
+}
+
+pub fn default_planned_run_profile_resolver()
+-> Result<InMemoryRunProfileResolver, RunProfileRegistryError> {
+    let mut registry = InMemoryRunProfileRegistry::with_builtin_profiles();
+    register_default_planned_profile(&mut registry)?;
+    let implicit_default = planned_default_profile_id()
+        .map_err(|reason| RunProfileRegistryError::InvalidProfile { reason })?;
+    Ok(InMemoryRunProfileResolver::new_with_implicit_default(
+        registry,
+        implicit_default,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use ironclaw_turns::{
+        RunProfileRequest, RunProfileResolutionRequest, RunProfileResolver,
+        run_profile::LoopDriverId,
+    };
+
+    use super::*;
+    use crate::build_loop_family_registry;
+
+    #[test]
+    fn descriptor_carries_checkpoint_schema() {
+        let descriptor = planned_driver_descriptor().expect("static descriptor should validate");
+
+        assert_eq!(descriptor.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
+        assert_eq!(descriptor.version, planned_driver_default_version());
+        assert_eq!(
+            descriptor
+                .checkpoint_schema_id
+                .as_ref()
+                .map(|id| id.as_str()),
+            Some(PLANNED_DRIVER_CHECKPOINT_SCHEMA_ID)
+        );
+        assert_eq!(
+            descriptor.checkpoint_schema_version,
+            Some(planned_driver_checkpoint_schema_version())
+        );
+    }
+
+    #[test]
+    fn register_default_planned_driver_uses_v1_schema() {
+        let mut registry = DriverRegistry::new();
+        let key = register_default_planned_driver(
+            &mut registry,
+            build_loop_family_registry().expect("family registry should build"),
+        )
+        .expect("planned driver should register");
+
+        assert_eq!(key.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
+        assert_eq!(key.version, planned_driver_default_version());
+        assert_eq!(
+            key.checkpoint_schema_id.as_ref().map(|id| id.as_str()),
+            Some(PLANNED_DRIVER_CHECKPOINT_SCHEMA_ID)
+        );
+        assert_eq!(
+            key.checkpoint_schema_version,
+            Some(planned_driver_checkpoint_schema_version())
+        );
+    }
+
+    #[test]
+    fn key_collision_with_textonly_is_impossible() {
+        let mut registry = DriverRegistry::new();
+        let text_only_key = register_default_text_only_driver(
+            &mut registry,
+            TextOnlyModelReplyDriverConfig::default(),
+        )
+        .expect("text-only driver should register");
+        let planned_key = register_default_planned_driver(
+            &mut registry,
+            build_loop_family_registry().expect("family registry should build"),
+        )
+        .expect("planned driver should register");
+
+        assert_ne!(text_only_key, planned_key);
+        assert_eq!(text_only_key.id.as_str(), "reborn:text-only-model-reply");
+        assert_eq!(planned_key.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
+    }
+
+    #[tokio::test]
+    async fn profile_resolves_to_planned_driver() {
+        let mut registry = InMemoryRunProfileRegistry::with_builtin_profiles();
+        register_default_planned_profile(&mut registry).expect("profile should register");
+        let resolver = InMemoryRunProfileResolver::new(registry);
+        let snapshot = resolver
+            .resolve_run_profile(
+                RunProfileResolutionRequest::interactive_default().with_requested_run_profile(
+                    RunProfileRequest::new(PLANNED_DEFAULT_PROFILE_ID).unwrap(),
+                ),
+            )
+            .await
+            .expect("profile should resolve");
+
+        assert_eq!(snapshot.profile_id.as_str(), PLANNED_DEFAULT_PROFILE_ID);
+        assert_eq!(snapshot.loop_driver.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
+        assert_eq!(
+            snapshot
+                .loop_driver
+                .checkpoint_schema_id
+                .as_ref()
+                .map(|id| id.as_str()),
+            Some(PLANNED_DRIVER_CHECKPOINT_SCHEMA_ID)
+        );
+    }
+
+    #[tokio::test]
+    async fn implicit_default_resolves_to_planned_driver() {
+        let resolver =
+            default_planned_run_profile_resolver().expect("planned resolver should build");
+        let snapshot = resolver
+            .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+            .await
+            .expect("implicit default should resolve");
+
+        assert_eq!(snapshot.profile_id.as_str(), PLANNED_DEFAULT_PROFILE_ID);
+        assert_eq!(snapshot.loop_driver.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
+    }
+
+    #[tokio::test]
+    async fn explicit_text_only_profile_still_resolves_textonly() {
+        let resolver =
+            default_planned_run_profile_resolver().expect("planned resolver should build");
+        let snapshot = resolver
+            .resolve_run_profile(
+                RunProfileResolutionRequest::interactive_default().with_requested_run_profile(
+                    RunProfileRequest::new("interactive_default").unwrap(),
+                ),
+            )
+            .await
+            .expect("explicit text-only profile should resolve");
+
+        assert_eq!(
+            snapshot.loop_driver.id,
+            LoopDriverId::new("lightweight_loop").unwrap()
+        );
+    }
+}

--- a/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
+++ b/crates/ironclaw_reborn/tests/planned_driver_e2e.rs
@@ -6,9 +6,15 @@ use std::{
 use chrono::Utc;
 use ironclaw_agent_loop::{
     state::CheckpointKind,
-    test_support::{MockAgentLoopDriverHost, MockHostCall, ScenarioScript, ScriptedModelResponse},
+    test_support::{
+        MockAgentLoopDriverHost, MockHostCall, ScenarioScript, ScriptedModelResponse,
+        test_run_context,
+    },
 };
-use ironclaw_reborn::{PlannedDriver, build_loop_family_registry};
+use ironclaw_reborn::{
+    PLANNED_DEFAULT_PROFILE_ID, PLANNED_DRIVER_DEFAULT_ID, PlannedDriver,
+    build_loop_family_registry, default_planned_run_profile_resolver,
+};
 use ironclaw_turns::{
     AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, LoopCancelledReasonKind, LoopExit,
     LoopMessageRef, TurnCheckpointId,
@@ -22,8 +28,9 @@ use ironclaw_turns::{
         LoopContextRequest, LoopInput, LoopInputAckToken, LoopInputBatch, LoopInputCursor,
         LoopInputPort, LoopModelPort, LoopModelRequest, LoopModelResponse, LoopProgressEvent,
         LoopProgressPort, LoopPromptBundle, LoopPromptBundleRequest, LoopPromptPort,
-        LoopRunContext, LoopRunInfoPort, LoopTranscriptPort, StageCheckpointPayloadRequest,
-        UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
+        LoopRunContext, LoopRunInfoPort, LoopTranscriptPort, RunProfileResolver,
+        StageCheckpointPayloadRequest, UpdateAssistantDraft, VisibleCapabilityRequest,
+        VisibleCapabilitySurface,
     },
 };
 
@@ -95,7 +102,7 @@ async fn default_planned_driver_smoke() {
         .expect("planned driver run should succeed");
 
     assert!(matches!(exit, LoopExit::Completed(_)));
-    assert_eq!(driver.descriptor().id.as_str(), "reborn:planned-default");
+    assert_eq!(driver.descriptor().id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
 }
 
 #[tokio::test]
@@ -128,6 +135,40 @@ async fn planned_driver_cancellation_short_circuits_through_adapter() {
     }
     assert_eq!(host.model_call_count(), 0);
     checkpoints.assert_kinds(&[CheckpointKind::Final]);
+}
+
+#[tokio::test]
+async fn planned_driver_live_default_smoke() {
+    let resolver = default_planned_run_profile_resolver().expect("resolver should build");
+    let resolved = resolver
+        .resolve_run_profile(ironclaw_turns::RunProfileResolutionRequest::interactive_default())
+        .await
+        .expect("implicit profile should resolve");
+    assert_eq!(resolved.profile_id.as_str(), PLANNED_DEFAULT_PROFILE_ID);
+    assert_eq!(resolved.loop_driver.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
+
+    let registry = build_loop_family_registry().expect("registry should build");
+    let driver = PlannedDriver::default_from_registry(&registry).expect("driver should build");
+    let base_context = test_run_context("planned-live-default");
+    let context = LoopRunContext::new(
+        base_context.scope,
+        base_context.turn_id,
+        base_context.run_id,
+        resolved.clone(),
+    );
+    let (host, _) = MockAgentLoopDriverHost::builder()
+        .run_context(context)
+        .script(ScenarioScript::reply_only("hi"))
+        .build();
+    let request = run_request(&driver, &host);
+    assert_eq!(request.resolved_run_profile, resolved);
+
+    let exit = driver
+        .run(request, &host)
+        .await
+        .expect("planned live default should run");
+
+    assert!(matches!(exit, LoopExit::Completed(_)));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_turns/src/lib.rs
+++ b/crates/ironclaw_turns/src/lib.rs
@@ -74,9 +74,10 @@ pub use run_profile::{
     LoopCheckpointStateRef, LoopDriverId, MemoryPromptContextRequest, MemoryPromptContextService,
     ModelProfileId, PrivilegedRunProfileDimension, RedactedRunProfileProvenance,
     RedactedRunProfileSource, ResolvedRunProfile, ResourceBudgetPolicy, ResourceBudgetTier,
-    RunClassId, RunProfileFingerprint, RunProfileRequestAuthority, RunProfileResolutionError,
-    RunProfileResolutionRequest, RunProfileResolver, RunProfileSourceLayer, RunProfileSourceRef,
-    RunnerPoolId, RuntimeProfileConstraints, SchedulingClass, SteeringPolicy,
+    RunClassId, RunProfileFingerprint, RunProfileRegistryError, RunProfileRequestAuthority,
+    RunProfileResolutionError, RunProfileResolutionRequest, RunProfileResolver,
+    RunProfileSourceLayer, RunProfileSourceRef, RunnerPoolId, RuntimeProfileConstraints,
+    SchedulingClass, SteeringPolicy,
 };
 pub use scope::{TurnActor, TurnScope};
 pub use status::{

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -79,7 +79,7 @@ pub use refs::{
 };
 pub use resolver::{
     InMemoryRunProfileRegistry, InMemoryRunProfileResolver, RunProfileDefinition,
-    RunProfileResolutionRequest, RunProfileResolver,
+    RunProfileRegistryError, RunProfileResolutionRequest, RunProfileResolver,
 };
 pub use skill_context::{
     InstalledSkillSnapshot, NoopSkillContextSource, SkillContextBudget, SkillContextError,

--- a/crates/ironclaw_turns/src/run_profile/resolver.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolver.rs
@@ -1,3 +1,5 @@
+use std::{error::Error, fmt};
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -56,19 +58,34 @@ pub trait RunProfileResolver: Send + Sync {
 #[derive(Debug, Clone)]
 pub struct InMemoryRunProfileResolver {
     registry: InMemoryRunProfileRegistry,
+    implicit_default_profile_id: RunProfileId,
 }
 
 impl Default for InMemoryRunProfileResolver {
     fn default() -> Self {
         Self {
             registry: InMemoryRunProfileRegistry::with_builtin_profiles(),
+            implicit_default_profile_id: RunProfileId::interactive_default(),
         }
     }
 }
 
 impl InMemoryRunProfileResolver {
     pub fn new(registry: InMemoryRunProfileRegistry) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            implicit_default_profile_id: RunProfileId::interactive_default(),
+        }
+    }
+
+    pub fn new_with_implicit_default(
+        registry: InMemoryRunProfileRegistry,
+        implicit_default_profile_id: RunProfileId,
+    ) -> Self {
+        Self {
+            registry,
+            implicit_default_profile_id,
+        }
     }
 }
 
@@ -81,16 +98,14 @@ impl RunProfileResolver for InMemoryRunProfileResolver {
         let requested = request
             .requested_run_profile
             .as_ref()
-            .map(RunProfileRequest::as_str)
-            .unwrap_or("interactive_default");
-        let profile_key = if requested == "default" {
-            "interactive_default"
-        } else {
-            requested
+            .map(RunProfileRequest::as_str);
+        let profile_key = match requested {
+            Some("default") | None => self.implicit_default_profile_id.as_str(),
+            Some(requested) => requested,
         };
         let definition = self.registry.profile(profile_key).ok_or_else(|| {
             RunProfileResolutionError::ProfileUnavailable {
-                profile_id: requested.to_string(),
+                profile_id: requested.unwrap_or(profile_key).to_string(),
             }
         })?;
 
@@ -109,6 +124,29 @@ pub struct InMemoryRunProfileRegistry {
     profiles: Vec<RunProfileDefinition>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunProfileRegistryError {
+    InvalidProfile { reason: String },
+    DuplicateProfile { profile_id: RunProfileId },
+}
+
+impl fmt::Display for RunProfileRegistryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidProfile { reason } => write!(formatter, "invalid run profile: {reason}"),
+            Self::DuplicateProfile { profile_id } => {
+                write!(
+                    formatter,
+                    "duplicate run profile registration for {}",
+                    profile_id.as_str()
+                )
+            }
+        }
+    }
+}
+
+impl Error for RunProfileRegistryError {}
+
 impl InMemoryRunProfileRegistry {
     pub fn with_builtin_profiles() -> Self {
         Self {
@@ -120,6 +158,19 @@ impl InMemoryRunProfileRegistry {
         self.profiles
             .iter()
             .find(|definition| definition.profile_id.as_str() == profile_id)
+    }
+
+    pub fn register(
+        &mut self,
+        definition: RunProfileDefinition,
+    ) -> Result<(), RunProfileRegistryError> {
+        if self.profile(definition.profile_id.as_str()).is_some() {
+            return Err(RunProfileRegistryError::DuplicateProfile {
+                profile_id: definition.profile_id,
+            });
+        }
+        self.profiles.push(definition);
+        Ok(())
     }
 }
 
@@ -146,6 +197,23 @@ pub struct RunProfileDefinition {
 }
 
 impl RunProfileDefinition {
+    pub fn interactive_like(
+        profile_id: RunProfileId,
+        loop_driver: AgentLoopDriverDescriptor,
+        checkpoint_schema_id: CheckpointSchemaId,
+        checkpoint_schema_version: RunProfileVersion,
+        capability_surface_profile_id: CapabilitySurfaceProfileId,
+    ) -> Self {
+        let mut definition = interactive_profile();
+        definition.profile_id = profile_id;
+        definition.profile_version = loop_driver.version;
+        definition.loop_driver = loop_driver;
+        definition.checkpoint_schema_id = checkpoint_schema_id;
+        definition.checkpoint_schema_version = checkpoint_schema_version;
+        definition.capability_surface_profile_id = capability_surface_profile_id;
+        definition
+    }
+
     fn resolve(&self, request: &RunProfileResolutionRequest) -> ResolvedRunProfile {
         let mut provenance = provenance_for(self, request);
         let resource_budget_policy = self.resolve_resource_budget_policy(request, &mut provenance);


### PR DESCRIPTION
## Context

Default planned-driver registration branch. It adds the registry/profile helpers that let Reborn select the planned default path while keeping live production cutover deferred.

Master spec: `docs/reborn/agent-loop-skeleton.md`
Workstream brief: `docs/reborn/agent-loop-briefs/planned-driver-registration.md`
Stack base: `arch/ws-14-parent`

Latest stack maintenance on 2026-05-14:
- Rebased this branch onto its current stack base after the WS0 prompt-authority fix and the follow-up WS8/WS14-parent/WS16/WS17 conflict resolutions.
- Pushed the updated branch with force-with-lease where the remote already existed, or published it as a new branch where it did not.
- Verified the final ancestry chain from `origin/reborn-integration` through WS17 before publishing the PR descriptions.

## What landed

- Planned driver factory and registration helpers.
- `reborn-planned-default` run-profile selection support.
- Explicit planned-default resolver constructor while preserving existing text-only/default resolver behavior.
- Planned-driver factory tests and E2E planned-driver coverage over the integrated host-port parent.
- Documentation alignment so WS14 is registration/profile selection, not full product-live cutover.

## Reviewer focus

- The planned default selector should be explicit; existing defaults should not silently change.
- Driver registration should compose through the registry/profile layer rather than hardcoding one-off paths.
- The branch should not claim product-live readiness; WS16/WS17 own that evidence.

## Non-goals / deferred work

- Production runtime composition with all live-required services is WS16.
- Product no-profile inbound cutover and persisted reply evidence is WS17.
- Text-only rollback profile behavior should remain available.

## Validation

- [x] `cargo test -p ironclaw_reborn planned_driver_factory --features ironclaw_agent_loop/test-support`
- [x] `cargo test -p ironclaw_reborn --test planned_driver_e2e --features ironclaw_agent_loop/test-support`
- [x] `cargo test -p ironclaw_turns --test run_profile_contract`
- [x] `cargo check -p ironclaw_turns -p ironclaw_loop_support -p ironclaw_agent_loop -p ironclaw_reborn --features ironclaw_agent_loop/test-support`
- [x] `git diff --check`

## Stack position

```
[#3550 ws-0] state/checkpoint foundation -> reborn-integration
   |-- #3551 ws-1 strategy alpha -> ws-0
   |-- #3552 ws-2 strategy beta -> ws-0
   |-- #3553 ws-3 strategy gamma -> ws-0
   |-- #3643 ws-3.5 loop family registry -> ws-0
   '-- #3554 level1-merged -> ws-0
         |-- #3555 ws-4 planner facade -> level1
         |-- #3556 ws-5 default strategies -> level1
         '-- #3557 level2-merged -> level1
               '-- #3596 ws-6a canonical executor -> level2
                     '-- #3597 ws-7 PlannedDriver adapter -> ws-6a
                           '-- #3598 ws-8 integration/test support -> ws-7
                                 |-- #3644 ws-9 capability host wiring -> ws-8
                                 |-- #3645 ws-10 checkpoint load/resume -> ws-8
                                 |-- #3646 ws-11 input port -> ws-8
                                 |-- #3647 ws-12 progress port -> ws-8
                                 |-- #3648 ws-13 cancellation accessor -> ws-8
                                 |-- #3649 ws-15 prompt/identity context -> ws-8
                                 '-- #3650 ws-14-parent integrated host ports -> ws-8
                                       '-- #3651 ws-14 planned default registration -> ws-14-parent
                                             '-- #3652 ws-16 live runtime wiring -> ws-14
                                                   '-- #3653 ws-17 product live cutover -> ws-16
```
