### PR TITLE
fix(reborn): redact loop response output

### DIFF
--- a/crates/ironclaw_turns/src/run_profile/model.rs
+++ b/crates/ironclaw_turns/src/run_profile/model.rs
@@ -331,5 +331,8 @@ fn sanitize_model_response(mut response: LoopModelResponse) -> LoopModelResponse
         chunk.safe_text_delta =
             sanitize_model_visible_text(std::mem::take(&mut chunk.safe_text_delta));
     }
+    if let super::host::ParentLoopOutput::AssistantReply(reply) = &mut response.output {
+        reply.content = sanitize_model_visible_text(std::mem::take(&mut reply.content));
+    }
     response
 }


### PR DESCRIPTION
## Summary
- redact assistant reply content when sanitizing host-managed loop model responses
- keep serialized/debug `LoopModelResponse` surfaces free of credential-looking model output

## Tests
- `cargo test -p ironclaw_turns --test agent_loop_host_contract redaction_sentinels_never_leak_through_serialized_surfaces -- --nocapture`
- `cargo test -p ironclaw_turns --test agent_loop_host_contract -- --nocapture`
