### PR TITLE
fix(reborn): flag in-memory durable logs

### DIFF
--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -24,7 +24,7 @@ use ironclaw_dispatcher::{
 };
 use ironclaw_events::{
     AuditSink, DurableAuditLog, DurableAuditSink, DurableEventLog, DurableEventSink, EventSink,
-    InMemoryAuditSink, InMemoryEventSink,
+    InMemoryAuditSink, InMemoryDurableAuditLog, InMemoryDurableEventLog, InMemoryEventSink,
 };
 use ironclaw_extensions::{ExtensionRegistry, ExtensionRuntime};
 #[cfg(feature = "libsql")]
@@ -324,7 +324,9 @@ fn classify_component_type<T: 'static>() -> ProductionImplementationReadiness {
             || type_id == TypeId::of::<InMemoryApprovalRequestStore>()
             || type_id == TypeId::of::<InMemoryCapabilityLeaseStore>()
             || type_id == TypeId::of::<InMemoryEventSink>()
+            || type_id == TypeId::of::<InMemoryDurableEventLog>()
             || type_id == TypeId::of::<InMemoryAuditSink>()
+            || type_id == TypeId::of::<InMemoryDurableAuditLog>()
             || type_id == TypeId::of::<InMemorySecretStore>()
             || type_id == TypeId::of::<EmptyWasmRuntimeCredentials>()
             || type_id == TypeId::of::<InMemoryTurnStateStore>()


### PR DESCRIPTION
## Summary
- classify in-memory durable event/audit logs as local-only production wiring components
- preserve `with_durable_event_log` / `with_durable_audit_log` visibility through production validation

## Tests
- `cargo test -p ironclaw_host_runtime --test host_runtime_services_contract production_wiring_validation_sees_underlying_in_memory_durable_logs -- --nocapture`
- `scripts/reborn-e2e-rust.sh architecture`
