### PR TITLE
chore(crates): enable unreachable_pub on tier-2 crates

### DIFF
--- a/crates/ironclaw_capabilities/src/lib.rs
+++ b/crates/ironclaw_capabilities/src/lib.rs
@@ -3,6 +3,7 @@
 //! `ironclaw_capabilities` is the caller-facing capability invocation service.
 //! It coordinates authorization, approval resume, run-state transitions, and
 //! neutral runtime dispatch without depending on concrete runtime crates.
+#![warn(unreachable_pub)]
 
 mod conformance;
 mod error;

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -13,6 +13,7 @@
 //! The engine defines traits for external dependencies ([`LlmBackend`],
 //! [`Store`], [`EffectExecutor`]) that the host crate implements via bridge
 //! adapters over existing infrastructure.
+#![warn(unreachable_pub)]
 
 // Security: `__regex_match__` (in `executor/orchestrator.rs`) accepts
 // arbitrary patterns from the Python orchestrator and runs them on
@@ -139,7 +140,7 @@ pub(crate) mod tests {
     ///
     /// Stores all entity types with proper CRUD semantics and filtering by
     /// project_id / user_id. Use this instead of defining per-module mocks.
-    pub struct InMemoryStore {
+    pub(crate) struct InMemoryStore {
         threads: RwLock<Vec<Thread>>,
         steps: RwLock<Vec<Step>>,
         events: RwLock<Vec<ThreadEvent>>,
@@ -151,7 +152,7 @@ pub(crate) mod tests {
     }
 
     impl InMemoryStore {
-        pub fn new() -> Self {
+        pub(crate) fn new() -> Self {
             Self {
                 threads: RwLock::new(Vec::new()),
                 steps: RwLock::new(Vec::new()),
@@ -164,7 +165,7 @@ pub(crate) mod tests {
             }
         }
 
-        pub fn with_docs(docs: Vec<MemoryDoc>) -> Self {
+        pub(crate) fn with_docs(docs: Vec<MemoryDoc>) -> Self {
             Self {
                 docs: RwLock::new(docs),
                 ..Self::new()

--- a/crates/ironclaw_engine/src/types/step.rs
+++ b/crates/ironclaw_engine/src/types/step.rs
@@ -195,11 +195,11 @@ mod duration_millis {
 
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
+    pub(super) fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_u64(d.as_millis() as u64)
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
         let millis = u64::deserialize(d)?;
         Ok(Duration::from_millis(millis))
     }

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -22,6 +22,7 @@
 //!   filtering of which surface a particular UI or upper service is allowed to
 //!   render is intentionally an upper-layer concern — the host does not bake
 //!   in upper-stack vocabulary (e.g. agent loop / adapter / admin).
+#![warn(unreachable_pub)]
 
 use async_trait::async_trait;
 use ironclaw_host_api::{

--- a/crates/ironclaw_host_runtime/src/obligations.rs
+++ b/crates/ironclaw_host_runtime/src/obligations.rs
@@ -28,7 +28,7 @@ use ironclaw_secrets::{
 };
 
 /// Default maximum lifetime for one-shot runtime secret material staged in memory.
-pub const DEFAULT_RUNTIME_SECRET_INJECTION_TTL: Duration = Duration::from_secs(300);
+pub(crate) const DEFAULT_RUNTIME_SECRET_INJECTION_TTL: Duration = Duration::from_secs(300);
 
 /// One-shot runtime secret material staged after `InjectSecretOnce` lease consumption.
 ///

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -1882,7 +1882,7 @@ struct FirstPartyRuntimeAdapter {
 }
 
 impl FirstPartyRuntimeAdapter {
-    pub fn from_registry(
+    pub(crate) fn from_registry(
         registry: Arc<FirstPartyCapabilityRegistry>,
         filesystem: Arc<dyn RootFilesystem>,
     ) -> Self {
@@ -1998,7 +1998,7 @@ struct WasmRuntimeAdapter {
 }
 
 impl WasmRuntimeAdapter {
-    pub fn new(
+    pub(crate) fn new(
         runtime: WitToolRuntime,
         host: WitToolHost,
         network_policy_store: Arc<NetworkObligationPolicyStore>,
@@ -2015,7 +2015,7 @@ impl WasmRuntimeAdapter {
         }
     }
 
-    pub fn try_new(
+    pub(crate) fn try_new(
         config: WitToolRuntimeConfig,
         host: WitToolHost,
         network_policy_store: Arc<NetworkObligationPolicyStore>,
@@ -2145,7 +2145,7 @@ struct RuntimeDispatchProcessExecutor {
 }
 
 impl RuntimeDispatchProcessExecutor {
-    pub fn new(dispatcher: Arc<dyn CapabilityDispatcher>) -> Self {
+    pub(crate) fn new(dispatcher: Arc<dyn CapabilityDispatcher>) -> Self {
         Self { dispatcher }
     }
 }

--- a/crates/ironclaw_llm/src/anthropic_oauth.rs
+++ b/crates/ironclaw_llm/src/anthropic_oauth.rs
@@ -75,7 +75,7 @@ const ANTHROPIC_OAUTH_BETA: &str = "oauth-2025-04-20";
 const DEFAULT_MAX_TOKENS: u32 = 8192;
 
 /// Anthropic provider using OAuth Bearer authentication.
-pub struct AnthropicOAuthProvider {
+pub(crate) struct AnthropicOAuthProvider {
     client: Client,
     /// OAuth token, wrapped in RwLock so it can be updated after a successful
     /// Keychain refresh (fixes #1136: stale token reuse after expiry).
@@ -88,7 +88,7 @@ pub struct AnthropicOAuthProvider {
 }
 
 impl AnthropicOAuthProvider {
-    pub fn new(config: &RegistryProviderConfig) -> Result<Self, LlmError> {
+    pub(crate) fn new(config: &RegistryProviderConfig) -> Result<Self, LlmError> {
         let token = config
             .oauth_token
             .clone()

--- a/crates/ironclaw_llm/src/bedrock.rs
+++ b/crates/ironclaw_llm/src/bedrock.rs
@@ -28,7 +28,7 @@ use crate::provider::{
 };
 
 /// AWS Bedrock provider using the native Converse API.
-pub struct BedrockProvider {
+pub(crate) struct BedrockProvider {
     client: Client,
     /// Base model ID for display purposes (without prefix).
     display_model: String,
@@ -43,7 +43,7 @@ impl BedrockProvider {
     ///
     /// Async because the AWS SDK config loader requires an async context
     /// to resolve credentials from SSO profiles, IMDS, etc.
-    pub async fn new(config: &BedrockConfig) -> Result<Self, LlmError> {
+    pub(crate) async fn new(config: &BedrockConfig) -> Result<Self, LlmError> {
         let cross_region_prefix = config
             .cross_region
             .as_ref()

--- a/crates/ironclaw_llm/src/codex_chatgpt.rs
+++ b/crates/ironclaw_llm/src/codex_chatgpt.rs
@@ -33,7 +33,7 @@ use super::provider::{
 };
 
 /// Provider that speaks the Responses API protocol against the ChatGPT backend.
-pub struct CodexChatGptProvider {
+pub(crate) struct CodexChatGptProvider {
     client: Client,
     base_url: String,
     api_key: RwLock<SecretString>,
@@ -79,7 +79,7 @@ impl CodexChatGptProvider {
     ///    warning with available models and fall back to the top model.
     /// 2. If `configured_model` is empty (or a generic placeholder like
     ///    "default"), auto-detect the highest-priority model from the API.
-    pub fn with_lazy_model(
+    pub(crate) fn with_lazy_model(
         base_url: &str,
         api_key: SecretString,
         configured_model: &str,

--- a/crates/ironclaw_llm/src/github_copilot.rs
+++ b/crates/ironclaw_llm/src/github_copilot.rs
@@ -29,7 +29,7 @@ use crate::provider::{
 };
 
 /// GitHub Copilot provider with automatic token exchange.
-pub struct GithubCopilotProvider {
+pub(crate) struct GithubCopilotProvider {
     client: Client,
     token_manager: Arc<CopilotTokenManager>,
     model: String,
@@ -41,7 +41,7 @@ pub struct GithubCopilotProvider {
 }
 
 impl GithubCopilotProvider {
-    pub fn new(
+    pub(crate) fn new(
         config: &RegistryProviderConfig,
         request_timeout_secs: u64,
     ) -> Result<Self, LlmError> {

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -7,6 +7,7 @@
 //! - **Ollama**: Local model inference
 //! - **OpenAI-compatible**: Any endpoint that speaks the OpenAI API
 //! - **AWS Bedrock**: Native Converse API via aws-sdk-bedrockruntime
+#![warn(unreachable_pub)]
 
 mod anthropic_oauth;
 #[cfg(feature = "bedrock")]

--- a/crates/ironclaw_llm/src/provider.rs
+++ b/crates/ironclaw_llm/src/provider.rs
@@ -47,7 +47,7 @@ impl ImageUrl {
 }
 
 /// Normalize an OpenAI image detail hint, defaulting to `"auto"` when absent.
-pub fn normalize_openai_image_detail(detail: Option<&str>) -> String {
+pub(crate) fn normalize_openai_image_detail(detail: Option<&str>) -> String {
     match detail
         .map(str::trim)
         .filter(|detail| !detail.is_empty())
@@ -675,7 +675,7 @@ pub fn sanitize_tool_messages(messages: &mut [ChatMessage]) {
 /// This typed enum replaces stringly-typed parameter names across the codebase,
 /// providing type safety and single-point-of-maintenance for parameter handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum UnsupportedParam {
+pub(crate) enum UnsupportedParam {
     Temperature,
     MaxTokens,
     StopSequences,
@@ -683,7 +683,7 @@ pub enum UnsupportedParam {
 
 impl UnsupportedParam {
     /// Get the string name of this parameter for config/error messages.
-    pub fn name(&self) -> &'static str {
+    pub(crate) fn name(&self) -> &'static str {
         match self {
             UnsupportedParam::Temperature => "temperature",
             UnsupportedParam::MaxTokens => "max_tokens",
@@ -696,7 +696,7 @@ impl UnsupportedParam {
 ///
 /// This is the single helper function used by all providers to remove
 /// parameters they don't support, replacing duplicate stringly-typed logic.
-pub fn strip_unsupported_completion_params(
+pub(crate) fn strip_unsupported_completion_params(
     unsupported: &std::collections::HashSet<String>,
     req: &mut CompletionRequest,
 ) {
@@ -719,7 +719,7 @@ pub fn strip_unsupported_completion_params(
 /// This is the single helper function used by all providers to remove
 /// parameters they don't support from tool calls, replacing duplicate stringly-typed logic.
 ///
-pub fn strip_unsupported_tool_params(
+pub(crate) fn strip_unsupported_tool_params(
     unsupported: &std::collections::HashSet<String>,
     req: &mut ToolCompletionRequest,
 ) {

--- a/crates/ironclaw_llm/src/registry.rs
+++ b/crates/ironclaw_llm/src/registry.rs
@@ -139,7 +139,7 @@ mod unsupported_params_de {
 
     const VALID_PARAMS: &[&str] = &["temperature", "max_tokens", "stop_sequences"];
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate adapts durable Reborn support boundaries (threads/transcripts plus
 //! host-managed model gateways) into the narrow `AgentLoopHost` ports. It does
 //! not own provider clients, tool dispatchers, secrets, or runtime handles.
+#![warn(unreachable_pub)]
 
 use std::{
     collections::{HashMap, HashSet},

--- a/crates/ironclaw_loop_support/src/skill_context.rs
+++ b/crates/ironclaw_loop_support/src/skill_context.rs
@@ -105,7 +105,7 @@ impl HostSkillContextBuildError {
     }
 }
 
-pub async fn build_skill_instruction_snippets(
+pub(crate) async fn build_skill_instruction_snippets(
     source: &(dyn HostSkillContextSource + Send + Sync),
     run_context: &LoopRunContext,
 ) -> Result<Vec<LoopContextSnippet>, AgentLoopHostError> {

--- a/crates/ironclaw_network/src/policy.rs
+++ b/crates/ironclaw_network/src/policy.rs
@@ -154,7 +154,10 @@ pub(crate) fn network_policy_allows(policy: &NetworkPolicy, target: &NetworkTarg
         .any(|pattern| target_matches_pattern(target, pattern))
 }
 
-pub(crate) fn target_matches_pattern(target: &NetworkTarget, pattern: &NetworkTargetPattern) -> bool {
+pub(crate) fn target_matches_pattern(
+    target: &NetworkTarget,
+    pattern: &NetworkTargetPattern,
+) -> bool {
     if let Some(scheme) = pattern.scheme
         && scheme != target.scheme
     {

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -14,6 +14,7 @@
 //! invocation boundary. Adding it requires changes to `ironclaw_events`,
 //! the SQL schemas, the JSONL/in-memory `matches_event` / `matches_audit`
 //! predicates, and every replay caller — tracked as a follow-up.
+#![warn(unreachable_pub)]
 
 use std::{
     collections::HashMap,

--- a/crates/ironclaw_reborn_event_store/src/libsql_store.rs
+++ b/crates/ironclaw_reborn_event_store/src/libsql_store.rs
@@ -620,7 +620,7 @@ impl LibSqlStore {
 }
 
 #[derive(Clone)]
-pub struct LibSqlDurableEventLog {
+pub(crate) struct LibSqlDurableEventLog {
     store: LibSqlStore,
 }
 
@@ -657,7 +657,7 @@ impl DurableEventLog for LibSqlDurableEventLog {
 }
 
 #[derive(Clone)]
-pub struct LibSqlDurableAuditLog {
+pub(crate) struct LibSqlDurableAuditLog {
     store: LibSqlStore,
 }
 

--- a/crates/ironclaw_reborn_event_store/src/postgres_store.rs
+++ b/crates/ironclaw_reborn_event_store/src/postgres_store.rs
@@ -514,7 +514,7 @@ impl PostgresStore {
 }
 
 #[derive(Clone)]
-pub struct PostgresDurableEventLog {
+pub(crate) struct PostgresDurableEventLog {
     store: PostgresStore,
 }
 
@@ -551,7 +551,7 @@ impl DurableEventLog for PostgresDurableEventLog {
 }
 
 #[derive(Clone)]
-pub struct PostgresDurableAuditLog {
+pub(crate) struct PostgresDurableAuditLog {
     store: PostgresStore,
 }
 

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -23,12 +23,12 @@ use std::sync::{OnceLock, mpsc};
 
 use fs2::FileExt;
 
+use ironclaw_host_api::ReservationStatus;
 use ironclaw_host_api::{
     AgentId, MissionId, ProjectId, ResourceEstimate, ResourceReservationId, ResourceScope,
     ResourceUsage, TenantId, ThreadId, UserId,
 };
 pub use ironclaw_host_api::{ResourceReceipt, ResourceReservation};
-use ironclaw_host_api::ReservationStatus;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -28,8 +28,8 @@ use ironclaw_host_api::{
     AgentId, CapabilityId, ExtensionId, InvocationId, MissionId, NetworkMethod, ProjectId,
     ResourceScope, SecretHandle, TenantId, ThreadId, Timestamp, UserId,
 };
-pub use legacy_store::{CreateSecretParams, SecretConsumeResult, SecretError, SecretsStore};
 use legacy_store::InMemorySecretsStore;
+pub use legacy_store::{CreateSecretParams, SecretConsumeResult, SecretError, SecretsStore};
 pub use secrecy::SecretString as SecretMaterial;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/ironclaw_trust/src/tests/policy_contract.rs
+++ b/crates/ironclaw_trust/src/tests/policy_contract.rs
@@ -26,8 +26,7 @@ use crate::fixtures::{
     effective_first_party_for_test, effective_system_for_test,
 };
 use crate::invalidation::{
-    TrustChange, TrustChangeListener, authority_changed, grant_retention_eligible,
-    identity_changed,
+    TrustChange, TrustChangeListener, authority_changed, grant_retention_eligible, identity_changed,
 };
 use crate::sources::{LocalDevOverride, PolicySource};
 use crate::{

--- a/crates/ironclaw_wasm_product_adapters/src/auth_verifier.rs
+++ b/crates/ironclaw_wasm_product_adapters/src/auth_verifier.rs
@@ -244,7 +244,7 @@ impl WebhookAuthVerifier for SharedSecretHeaderAuth {
 mod hex {
     use std::fmt::Write as _;
 
-    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
+    pub(super) fn encode(bytes: impl AsRef<[u8]>) -> String {
         let mut out = String::with_capacity(bytes.as_ref().len() * 2);
         for byte in bytes.as_ref() {
             let _ = write!(&mut out, "{byte:02x}");

--- a/crates/ironclaw_wasm_product_adapters/src/lib.rs
+++ b/crates/ironclaw_wasm_product_adapters/src/lib.rs
@@ -30,6 +30,7 @@
 //!   tooling lands.
 
 #![forbid(unsafe_code)]
+#![warn(unreachable_pub)]
 
 pub mod auth_verifier;
 pub mod egress_policy;


### PR DESCRIPTION
## Summary
- Turn on \`#![warn(unreachable_pub)]\` on seven more workspace crates: \`ironclaw_engine\`, \`ironclaw_host_runtime\`, \`ironclaw_llm\`, \`ironclaw_reborn_event_store\`, \`ironclaw_loop_support\`, \`ironclaw_wasm_product_adapters\`, \`ironclaw_capabilities\`.
- Demote 30 internal-only items to \`pub(crate)\` (or \`pub(super)\` for the two serde-attribute helpers inside private modules: \`engine::types::step::duration_millis\` and \`llm::registry::unsupported_params_de\`).
- No behavior changes — only public-surface tightening so future drift triggers a warning.

## Scope notes
- Follow-up to #3654 which enabled the same lint on the contract crates (\`common\`, \`events\`, \`filesystem\`, \`host_api\`, \`network\`, \`resources\`, \`runtime_policy\`, \`secrets\`, \`threads\`, \`trust\`, \`tui\`, \`turns\`).
- The root \`ironclaw\` crate is intentionally **not** included — workspace-wide scan showed ~80 violations in \`src/\` and ~250 in \`tests/support/*\` test helpers. That's a separate, larger follow-up.

## Test plan
- [ ] \`cargo clippy --workspace --all-features --tests --benches --examples\` — verified locally, zero warnings
- [ ] CI green on \`reborn-integration\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)