### PR TITLE
feat(filesystem): unified storage dispatch fabric — foundation + SQL backends + indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4285,6 +4285,8 @@ dependencies = [
  "ironclaw_host_api",
  "ironclaw_safety",
  "libsql",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,6 +4292,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/ironclaw_filesystem/CLAUDE.md
+++ b/crates/ironclaw_filesystem/CLAUDE.md
@@ -1,11 +1,113 @@
 # ironclaw_filesystem guardrails
 
-- Own `RootFilesystem`, `ScopedFilesystem`, `CompositeRootFilesystem`, `FilesystemCatalog`, virtual-path persistence, backend placement metadata, and backend containment checks.
-- Depend on `ironclaw_host_api`; do not depend on product, authorization, dispatcher, runtime, process, event, secrets, memory/search, or extension workflow crates.
-- Keep `HostPath` backend-internal and non-serializable.
-- Reject traversal, mount escapes, unknown mounts, duplicate exact backend roots, and permission mismatches fail-closed.
-- Use longest virtual-prefix routing for composite backend selection and catalog placement.
-- Catalog metadata describes placement and content/index policy; it does not grant runtime authority.
-- Keep memory-specific path grammar and memory document repository adapters in `ironclaw_memory`, not this crate.
-- Do not force structured/control-plane records through file byte APIs. Secrets, approvals, leases, process records, events, and search indexes should stay in typed service repositories unless exposed as deliberate file-shaped projections.
-- New persistence behavior must preserve tenant/user virtual-path scoping.
+`ironclaw_filesystem` is the **universal storage dispatch fabric** for IronClaw.
+There is one trait (`RootFilesystem`), one entry type (`Entry`), one mount
+table (`CompositeRootFilesystem`). Every persistence concern in the workspace
+(secrets, leases, processes, memory documents, project files, event logs,
+engine state, settings, …) lives behind a single set of ops: `put` / `get` /
+`delete` / `list_dir` / `query` / `ensure_index` / `stat` / `begin` /
+`append` / `tail`.
+
+This supersedes the earlier "bytes mount; structured records stay typed"
+boundary recorded in
+`docs/reborn/2026-04-25-storage-catalog-and-placement.md`. The override is
+codified in `docs/reborn/2026-05-14-universal-fs-dispatch.md` (the new ADR).
+
+## What this crate owns
+
+- `RootFilesystem` (`src/root.rs`) — the one trait every backend and the
+  composite dispatcher implement.
+- `Entry` / `VersionedEntry` / `RecordKind` / `RecordVersion` / `SeqNo` /
+  `CasExpectation` / `ContentType` (`src/record.rs`) — the universal stored
+  thing and its associated primitives.
+- `IndexSpec` / `IndexName` / `IndexKey` / `IndexValue` / `IndexKind` /
+  `Filter` / `Page` (`src/index.rs`) — declarative index/query primitives.
+  No SQL strings cross this boundary.
+- `BackendCapabilities` / `IndexCapability` / `TxnCapability`
+  (`src/types.rs`) — declared up front; mount-time validation refuses a
+  backend that cannot serve what a consumer demands.
+- `StorageTxn` / `EventRecord` (`src/backend.rs`) — supporting handle types.
+- `CompositeRootFilesystem` / `MountDescriptor` / `FilesystemCatalog`
+  (`src/catalog.rs`) — the longest-prefix mount table.
+- `ScopedFilesystem` (`src/scoped.rs`) — the invocation-scoped view that
+  higher-level stores accept in their constructor. Performs the permission
+  check against `MountView` before any backend dispatch.
+- Backends: `LocalFilesystem`, `PostgresRootFilesystem`,
+  `LibSqlRootFilesystem`, `InMemoryBackend`. All implement
+  `RootFilesystem`.
+- Backend containment checks (symlink traversal, mount escape, raw-host
+  path prevention).
+
+## What this crate does NOT do
+
+- Define a separate "backend trait" parallel to `RootFilesystem`. There is
+  one trait. `CompositeRootFilesystem` is itself a `RootFilesystem` that
+  dispatches by mount; there is no two-tier `Backend` / `Dispatcher`
+  split. Adding a parallel trait is exactly the duplication this rework
+  removed.
+- Own product-shaped paths or schemas. Path conventions (`/secrets/...`,
+  `/memory/...`, `/engine/threads/...`) live in the consumer crates.
+- Hold raw host paths in public types. `HostPath` stays backend-internal
+  and is not serializable.
+- Depend on `ironclaw_*` system-service or runtime crates other than
+  `ironclaw_host_api` and `ironclaw_safety`.
+
+## Invariants new code must preserve
+
+1. **One trait, one Entry, one dispatch fabric.** Adding a parallel
+   trait/type to handle a special case is a sign to either widen `Entry`
+   or extend `RootFilesystem`. Don't fork.
+2. **CAS is the floor.** Every multi-step store operation (claim, consume,
+   transition) is implemented with `put(_, _, CasExpectation::Version)` +
+   retry on `FilesystemError::VersionMismatch`. Consumers must never assume
+   `begin`/`StorageTxn` is available; backends that don't expose it return
+   `Unsupported` and that must be a working path.
+3. **Capabilities are declared, not discovered.** A backend that cannot
+   serve an `IndexKind::Vector` or a `Filter::Range` declares so up front
+   via `BackendCapabilities`; mount-time validation refuses the attachment.
+   Runtime `Unsupported` errors are a fallback, not the primary signal.
+4. **Indexed projection is the only queryable surface.** Backends never
+   parse `Entry::body` to evaluate filters. Everything queryable lives in
+   `Entry::indexed`. This keeps the indexing contract portable across SQL,
+   filesystem-sidecar, and HSM backends.
+5. **Encryption-at-rest is a backend decorator.** `EncryptedBackend`
+   (forthcoming) wraps an inner backend and encrypts `Entry::body` plus any
+   `IndexValue::Bytes` projection while letting scalar indexed projections
+   (`scope`, `status`, …) pass through unencrypted. `SecretStore` and other
+   sensitive-data stores never own encryption code — they write plaintext
+   `Entry` values through a `ScopedFilesystem` whose mount happens to be
+   wrapped in encryption.
+6. **No raw host paths leak.** Backends translate `VirtualPath` /
+   `ScopedPath` to host paths internally and never carry host paths in
+   public types or error display output.
+7. **Tenant/user virtual-path scoping is preserved.** Multi-tenant
+   deployments rely on the path prefix to route to per-tenant mounts. New
+   persistence behavior must keep the scope keys in the path, not
+   exclusively in `Entry::indexed`.
+
+## Legacy bytes plane (transitional)
+
+`read_file` / `write_file` / `append_file` / `list_dir` / `stat` /
+`delete` / `create_dir_all` remain on `RootFilesystem` during the
+migration window. Default impls route reads/writes through `put`/`get` so
+existing backends (and existing consumer code) continue to work without
+changes. These methods will be removed entirely once
+`src/db/` is dissolved (task #17 of the storage rework). Do not add new
+consumers of the legacy methods — new code should call `put`/`get`/
+`query`/etc. directly.
+
+## When you're editing this crate
+
+- Run the full crate tests, both feature combinations:
+  `cargo test -p ironclaw_filesystem --all-features`,
+  `cargo check -p ironclaw_filesystem --no-default-features --features libsql`,
+  `cargo check -p ironclaw_filesystem --no-default-features --features postgres`.
+- New `Entry` shapes (record kinds, indexed projections) belong in the
+  consumer crate, not here. This crate only owns the trait surface and
+  shared primitives.
+- New backend implementations live as siblings under `src/` and implement
+  `RootFilesystem`. Declare capabilities accurately; the mount table
+  enforces them.
+- Any change to the trait surface needs an accompanying
+  `InMemoryBackend` test demonstrating the new op in
+  `src/in_memory.rs::tests`.

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -31,3 +31,4 @@ tracing = "0.1"
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util", "sync"] }
-tokio-postgres = { version = "0.7", optional = true }
+tokio-postgres = { version = "0.7", optional = true, features = ["with-serde_json-1"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -21,8 +21,10 @@ deadpool-postgres = { version = "0.14", optional = true }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_safety = { path = "../ironclaw_safety", version = "0.2.2" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["fs", "io-util"] }
+tokio = { version = "1", features = ["fs", "io-util", "sync"] }
 tokio-postgres = { version = "0.7", optional = true }
 tracing = "0.1"
 

--- a/crates/ironclaw_filesystem/src/backend.rs
+++ b/crates/ironclaw_filesystem/src/backend.rs
@@ -1,0 +1,62 @@
+//! Support types for the unified [`RootFilesystem`](crate::RootFilesystem) surface.
+//!
+//! This module deliberately does **not** define a parallel "backend trait".
+//! `RootFilesystem` is the one trait that every backend implements; the
+//! [`CompositeRootFilesystem`](crate::CompositeRootFilesystem) is itself a
+//! `RootFilesystem` that dispatches by longest-prefix to mounted backends.
+//! That keeps the codebase honest about a single dispatch fabric.
+//!
+//! What lives here:
+//! - [`StorageTxn`] — the multi-key transactional handle that backends with
+//!   `TxnCapability::MultiKey` expose via
+//!   [`RootFilesystem::begin`](crate::RootFilesystem::begin). Stores must
+//!   continue to work using only CAS (`put` + `CasExpectation::Version`);
+//!   `StorageTxn` is a strictly stronger primitive offered as an optimisation
+//!   to backends that have it natively.
+//! - [`EventRecord`] — one entry emitted by the append/tail plane.
+
+use async_trait::async_trait;
+use ironclaw_host_api::VirtualPath;
+
+use crate::{CasExpectation, Entry, FilesystemError, RecordVersion, SeqNo, VersionedEntry};
+
+/// Multi-key transactional handle returned by [`RootFilesystem::begin`].
+///
+/// All operations scope to the prefix that produced the transaction; reaching
+/// outside the prefix fails closed with [`FilesystemError::PathOutsideMount`].
+/// The handle must be either [`commit`](Self::commit)-ed or
+/// [`rollback`](Self::rollback)-ed exactly once; dropping the handle without
+/// either is equivalent to rollback.
+#[async_trait]
+pub trait StorageTxn: Send {
+    async fn put(
+        &mut self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError>;
+
+    async fn get(&mut self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError>;
+
+    async fn delete(&mut self, path: &VirtualPath) -> Result<(), FilesystemError>;
+
+    async fn commit(self: Box<Self>) -> Result<(), FilesystemError>;
+
+    async fn rollback(self: Box<Self>);
+}
+
+/// One event in the append/tail plane.
+///
+/// `seq` is monotonically increasing per `path` (the event log). `payload`
+/// is opaque to the filesystem; consumers serialize their own event envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventRecord {
+    pub seq: SeqNo,
+    pub payload: Vec<u8>,
+}
+
+impl EventRecord {
+    pub fn new(seq: SeqNo, payload: Vec<u8>) -> Self {
+        Self { seq, payload }
+    }
+}

--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -6,8 +6,8 @@ use ironclaw_host_api::VirtualPath;
 use crate::backend::{EventRecord, StorageTxn};
 use crate::{
     BackendCapabilities, BackendId, BackendKind, CasExpectation, ContentKind, DirEntry, Entry,
-    FileStat, FilesystemError, Filter, IndexPolicy, IndexSpec, Page, RecordVersion, RootFilesystem,
-    SeqNo, StorageClass, VersionedEntry, path_prefix_matches,
+    FileStat, FilesystemError, FilesystemOperation, Filter, IndexPolicy, IndexSpec, Page,
+    RecordVersion, RootFilesystem, SeqNo, StorageClass, VersionedEntry, path_prefix_matches,
 };
 
 /// Trusted catalog record for one virtual filesystem mount.
@@ -103,6 +103,12 @@ impl CompositeRootFilesystem {
                 path: descriptor.virtual_root,
             });
         }
+        // PR #3659 reviewer fix: validate the descriptor's advertised
+        // capabilities against the backend's actual capabilities at
+        // mount time. Catalog metadata that claims query/index/event
+        // support over a backend that doesn't provide it would defeat
+        // the PR's mount-time validation guarantee — fail closed instead.
+        validate_mount_capabilities(&descriptor, backend.capabilities())?;
         self.mounts.push(CompositeMount {
             descriptor,
             backend,
@@ -124,6 +130,74 @@ impl CompositeRootFilesystem {
 impl Default for CompositeRootFilesystem {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// PR #3659 reviewer fix: reject a [`MountDescriptor`] whose advertised
+/// capabilities claim more than the backend actually delivers on the
+/// **new** capability axes (records, query, index, events, txn).
+///
+/// Scope deliberately limited to the new axes: the legacy bytes-plane
+/// flags (`read`/`write`/`list`/`stat`/`delete`/`append`) have always
+/// been descriptor-driven metadata, and many existing backends still
+/// return `BackendCapabilities::default()` (all-false) from their
+/// `capabilities()` accessor even though they implement
+/// `read_file`/`write_file` natively. The mount-time validation
+/// guarantee the reviewer asked for applies to the new capability
+/// surface that this PR introduces; downstream catalog clients are the
+/// authority for the legacy plane until each backend opts in to a more
+/// accurate `capabilities()` override.
+fn validate_mount_capabilities(
+    descriptor: &MountDescriptor,
+    backend: BackendCapabilities,
+) -> Result<(), FilesystemError> {
+    let declared = descriptor.capabilities;
+    let mut shortfalls: Vec<&'static str> = Vec::new();
+    if declared.records && !backend.records {
+        shortfalls.push("records");
+    }
+    if declared.query && !backend.query {
+        shortfalls.push("query");
+    }
+    if declared.index.exact && !backend.index.exact {
+        shortfalls.push("index.exact");
+    }
+    if declared.index.prefix && !backend.index.prefix {
+        shortfalls.push("index.prefix");
+    }
+    if declared.index.fts && !backend.index.fts {
+        shortfalls.push("index.fts");
+    }
+    if declared.index.vector && !backend.index.vector {
+        shortfalls.push("index.vector");
+    }
+    if declared.events && !backend.events {
+        shortfalls.push("events");
+    }
+    let backend_txn = txn_capability_rank(backend.txn);
+    let declared_txn = txn_capability_rank(declared.txn);
+    if declared_txn > backend_txn {
+        shortfalls.push("txn");
+    }
+    if shortfalls.is_empty() {
+        Ok(())
+    } else {
+        Err(FilesystemError::Backend {
+            path: descriptor.virtual_root.clone(),
+            operation: FilesystemOperation::MountLocal,
+            reason: format!(
+                "mount descriptor claims capabilities the backend does not provide: {}",
+                shortfalls.join(", ")
+            ),
+        })
+    }
+}
+
+fn txn_capability_rank(value: crate::TxnCapability) -> u8 {
+    match value {
+        crate::TxnCapability::None => 0,
+        crate::TxnCapability::Cas => 1,
+        crate::TxnCapability::MultiKey => 2,
     }
 }
 

--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -5,9 +5,9 @@ use ironclaw_host_api::VirtualPath;
 
 use crate::backend::{EventRecord, StorageTxn};
 use crate::{
-    BackendCapabilities, BackendId, BackendKind, CasExpectation, ContentKind, DirEntry, Entry,
-    FileStat, FilesystemError, FilesystemOperation, Filter, IndexPolicy, IndexSpec, Page,
-    RecordVersion, RootFilesystem, SeqNo, StorageClass, VersionedEntry, path_prefix_matches,
+    BackendCapabilities, BackendId, BackendKind, Capability, CasExpectation, ContentKind, DirEntry,
+    Entry, FileStat, FilesystemError, Filter, IndexPolicy, IndexSpec, Page, RecordVersion,
+    RootFilesystem, SeqNo, StorageClass, VersionedEntry, path_prefix_matches,
 };
 
 /// Trusted catalog record for one virtual filesystem mount.
@@ -152,43 +152,32 @@ fn validate_mount_capabilities(
     backend: BackendCapabilities,
 ) -> Result<(), FilesystemError> {
     let declared = descriptor.capabilities;
-    let mut shortfalls: Vec<&'static str> = Vec::new();
-    if declared.records && !backend.records {
-        shortfalls.push("records");
-    }
-    if declared.query && !backend.query {
-        shortfalls.push("query");
-    }
-    if declared.index.exact && !backend.index.exact {
-        shortfalls.push("index.exact");
-    }
-    if declared.index.prefix && !backend.index.prefix {
-        shortfalls.push("index.prefix");
-    }
-    if declared.index.fts && !backend.index.fts {
-        shortfalls.push("index.fts");
-    }
-    if declared.index.vector && !backend.index.vector {
-        shortfalls.push("index.vector");
-    }
-    if declared.events && !backend.events {
-        shortfalls.push("events");
-    }
-    let backend_txn = txn_capability_rank(backend.txn);
-    let declared_txn = txn_capability_rank(declared.txn);
-    if declared_txn > backend_txn {
-        shortfalls.push("txn");
-    }
-    if shortfalls.is_empty() {
+    // Only validate the **new** capability axes — legacy bytes flags stay
+    // descriptor-driven (see the function-level doc comment).
+    const NEW_AXES: &[Capability] = &[
+        Capability::Records,
+        Capability::Query,
+        Capability::IndexExact,
+        Capability::IndexPrefix,
+        Capability::IndexFts,
+        Capability::IndexVector,
+        Capability::Events,
+    ];
+    let mut shortfalls: Vec<Capability> = NEW_AXES
+        .iter()
+        .copied()
+        .filter(|cap| declared.has(*cap) && !backend.has(*cap))
+        .collect();
+    let backend_txn = txn_capability_rank(backend.txn());
+    let declared_txn = txn_capability_rank(declared.txn());
+    let txn_shortfall = declared_txn > backend_txn;
+    if shortfalls.is_empty() && !txn_shortfall {
         Ok(())
     } else {
-        Err(FilesystemError::Backend {
+        Err(FilesystemError::DescriptorOverclaims {
             path: descriptor.virtual_root.clone(),
-            operation: FilesystemOperation::MountLocal,
-            reason: format!(
-                "mount descriptor claims capabilities the backend does not provide: {}",
-                shortfalls.join(", ")
-            ),
+            missing: std::mem::take(&mut shortfalls),
+            txn_shortfall,
         })
     }
 }

--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -3,9 +3,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use ironclaw_host_api::VirtualPath;
 
+use crate::backend::{EventRecord, StorageTxn};
 use crate::{
-    BackendCapabilities, BackendId, BackendKind, ContentKind, DirEntry, FileStat, FilesystemError,
-    IndexPolicy, RootFilesystem, StorageClass, path_prefix_matches,
+    BackendCapabilities, BackendId, BackendKind, CasExpectation, ContentKind, DirEntry, Entry,
+    FileStat, FilesystemError, Filter, IndexPolicy, IndexSpec, Page, RecordVersion, RootFilesystem,
+    SeqNo, StorageClass, VersionedEntry, path_prefix_matches,
 };
 
 /// Trusted catalog record for one virtual filesystem mount.
@@ -148,6 +150,77 @@ impl FilesystemCatalog for CompositeRootFilesystem {
 
 #[async_trait]
 impl RootFilesystem for CompositeRootFilesystem {
+    fn capabilities(&self) -> BackendCapabilities {
+        // The composite is a router, not a backend in its own right. Callers
+        // wanting per-path capabilities should consult [`describe_path`]
+        // through the [`FilesystemCatalog`] impl.
+        BackendCapabilities::default()
+    }
+
+    // ── Unified entry plane ──
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .put(path, entry, cas)
+            .await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.matching_mount(path)?.backend.get(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .query(path, filter, page)
+            .await
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .ensure_index(path, spec)
+            .await
+    }
+
+    async fn begin(&self, path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        self.matching_mount(path)?.backend.begin(path).await
+    }
+
+    // ── Event plane ──
+
+    async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .append(path, payload)
+            .await
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<EventRecord>, FilesystemError> {
+        self.matching_mount(path)?.backend.tail(path, from).await
+    }
+
+    // ── Legacy bytes plane ──
+
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
         self.matching_mount(path)?.backend.read_file(path).await
     }

--- a/crates/ironclaw_filesystem/src/db.rs
+++ b/crates/ironclaw_filesystem/src/db.rs
@@ -137,3 +137,87 @@ pub(crate) fn system_time_from_unix_seconds(seconds: i64) -> Option<SystemTime> 
 pub(crate) fn valid_engine_path() -> VirtualPath {
     VirtualPath::new("/engine").unwrap_or_else(|_| unreachable!("literal virtual path is valid"))
 }
+
+/// Build a deterministic SQL index identifier from a mount prefix + spec
+/// name. `IndexKey`/`IndexName` are validated to `[A-Za-z_][A-Za-z0-9_]*`,
+/// so the only non-identifier characters we strip are the prefix's slashes.
+/// Length capped at 62 to fit Postgres' 63-char identifier cap so libsql
+/// and postgres share one naming convention.
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+pub(crate) fn sql_index_name(prefix: &str, name: &str) -> String {
+    let prefix_clean: String = prefix
+        .trim_matches('/')
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let raw = format!("idx_rfs_{prefix_clean}_{name}");
+    if raw.len() > 62 {
+        let cutoff = raw
+            .char_indices()
+            .nth(62)
+            .map(|(i, _)| i)
+            .unwrap_or(raw.len());
+        raw[..cutoff].to_string()
+    } else {
+        raw
+    }
+}
+
+/// Escape a LIKE pattern that already contains a trailing `%` wildcard
+/// **intentionally appended by the caller** (the path-prefix scan case in
+/// `query`). The trailing `%` is preserved so it remains a wildcard;
+/// every other `%`, `_`, and `!` is escaped.
+///
+/// Reviewer note (PR #3661): this is **NOT** suitable for user-supplied
+/// LIKE input — use [`escape_like_literal`] instead, which escapes every
+/// special character including a trailing `%`.
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+pub(crate) fn escape_like_with_trailing_wildcard(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '%' if chars.peek().is_some() => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Fully-literal LIKE escape for user-supplied values. PR #3661 reviewer
+/// fix: a literal prefix like `tenant:%` must not become a wildcard at
+/// query time, so every `%`, `_`, and `!` is escaped.
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+pub(crate) fn escape_like_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '%' => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Convert a raw `i64` version column into a [`RecordVersion`].
+///
+/// PR #3659 reviewer fix: previously sites used `version_raw.max(0) as u64`,
+/// which silently masked a corrupt negative version to `0` — indistinguishable
+/// from a legitimately fresh row. This helper surfaces the corruption as
+/// [`FilesystemError::CorruptRecordVersion`] so the operator sees it.
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+pub(crate) fn record_version_from_i64(
+    path: &VirtualPath,
+    raw: i64,
+) -> Result<crate::RecordVersion, FilesystemError> {
+    u64::try_from(raw)
+        .map(crate::RecordVersion::from_backend)
+        .map_err(|_| FilesystemError::CorruptRecordVersion {
+            path: path.clone(),
+            raw,
+        })
+}

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -131,14 +131,30 @@ impl RootFilesystem for InMemoryBackend {
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let mut state = self.state.lock().await;
+        // PR #3659 reviewer fix: delete now matches the SQL backends'
+        // subtree semantics. If an exact entry exists, remove it.
+        // Otherwise, if the path has children (i.e. `stat` would call
+        // this a directory), remove every entry under it. Returns
+        // NotFound only when neither an exact entry nor any descendants
+        // exist.
         if state.entries.remove(path.as_str()).is_some() {
-            Ok(())
-        } else {
-            Err(FilesystemError::NotFound {
+            // Also sweep any descendants under the deleted path — a
+            // record-shaped entry at /a/b plus byte entries at /a/b/c
+            // should both be cleared on `delete("/a/b")`.
+            let prefix = with_trailing_slash(path.as_str());
+            state.entries.retain(|key, _| !key.starts_with(&prefix));
+            return Ok(());
+        }
+        let prefix = with_trailing_slash(path.as_str());
+        let before = state.entries.len();
+        state.entries.retain(|key, _| !key.starts_with(&prefix));
+        if state.entries.len() == before {
+            return Err(FilesystemError::NotFound {
                 path: path.clone(),
                 operation: FilesystemOperation::Delete,
-            })
+            });
         }
+        Ok(())
     }
 
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
@@ -156,7 +172,20 @@ impl RootFilesystem for InMemoryBackend {
                 } else {
                     FileType::File
                 };
-                seen.entry(head.to_string()).or_insert(file_type);
+                // PR #3659 reviewer fix: with `or_insert`, the first
+                // discovery wins. If `/a/b` (file) is processed before
+                // `/a/b/c` (under-`b` file), `b` would be listed as a
+                // File even though it has children. Any path that
+                // serves as a prefix for other entries is a Directory
+                // in this listing — use `and_modify` to upgrade on a
+                // later `has_more` discovery.
+                seen.entry(head.to_string())
+                    .and_modify(|existing| {
+                        if has_more {
+                            *existing = FileType::Directory;
+                        }
+                    })
+                    .or_insert(file_type);
             }
         }
         let mut out = Vec::with_capacity(seen.len());
@@ -370,11 +399,34 @@ fn filter_matches(
             _ => false,
         },
         Filter::Range { key, lo, hi } => match indexed.get(key) {
-            Some(v) => v >= lo && v <= hi,
+            Some(v) => {
+                // PR #3659 reviewer fix: Filter::Range previously used
+                // the derived IndexValue Ord, which orders across
+                // variants by their declared position. That meant a
+                // numeric `lo` and a Bytes `hi` could match Bool/Text
+                // values purely on enum-variant ordering rather than
+                // domain ordering. Require all three sides to share a
+                // variant; mismatched bound/value variants don't match.
+                index_value_variant(lo) == index_value_variant(hi)
+                    && index_value_variant(v) == index_value_variant(lo)
+                    && v >= lo
+                    && v <= hi
+            }
             None => false,
         },
         Filter::And(children) => children.iter().all(|f| filter_matches(f, indexed)),
         Filter::Or(children) => children.iter().any(|f| filter_matches(f, indexed)),
+    }
+}
+
+/// Identify the [`IndexValue`] variant for cross-variant Range matching
+/// (see PR #3659 reviewer note in `filter_matches`).
+fn index_value_variant(value: &IndexValue) -> u8 {
+    match value {
+        IndexValue::Bool(_) => 0,
+        IndexValue::I64(_) => 1,
+        IndexValue::Text(_) => 2,
+        IndexValue::Bytes(_) => 3,
     }
 }
 
@@ -560,6 +612,95 @@ mod tests {
         assert!(fs.get(&path).await.unwrap().is_none());
         let err = fs.delete(&path).await.unwrap_err();
         assert!(matches!(err, FilesystemError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn delete_directory_removes_subtree() {
+        // PR #3659 reviewer fix: deleting a directory path (no exact
+        // entry, but children exist) used to return NotFound and leave
+        // the subtree behind, diverging from the SQL backends'
+        // subtree-delete semantics.
+        let fs = InMemoryBackend::new();
+        for p in ["/projects/dir/a", "/projects/dir/b", "/projects/dir/sub/c"] {
+            fs.put(&vpath(p), Entry::bytes(vec![1]), CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+        let dir = vpath("/projects/dir");
+        // No exact entry at /projects/dir, but children exist → treat
+        // as a directory and remove the subtree.
+        fs.delete(&dir).await.unwrap();
+        for p in ["/projects/dir/a", "/projects/dir/b", "/projects/dir/sub/c"] {
+            assert!(fs.get(&vpath(p)).await.unwrap().is_none());
+        }
+        // Now NotFound — the subtree is gone.
+        let err = fs.delete(&dir).await.unwrap_err();
+        assert!(matches!(err, FilesystemError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn list_dir_upgrades_to_directory_on_later_child_discovery() {
+        // PR #3659 reviewer fix: with `or_insert`, the first discovery
+        // of a name decided its FileType. Path /a/b inserted first as
+        // a File could shadow /a/b/c arriving later, leaving `b`
+        // listed as a File even though it has children.
+        let fs = InMemoryBackend::new();
+        // Insert /projects/x as a leaf file, then /projects/x/y as a
+        // file under x — `x` should now list as Directory because it
+        // has children, regardless of insertion order.
+        fs.put(
+            &vpath("/projects/x"),
+            Entry::bytes(vec![1]),
+            CasExpectation::Absent,
+        )
+        .await
+        .unwrap();
+        fs.put(
+            &vpath("/projects/x/y"),
+            Entry::bytes(vec![2]),
+            CasExpectation::Absent,
+        )
+        .await
+        .unwrap();
+        let entries = fs.list_dir(&vpath("/projects")).await.unwrap();
+        let x = entries
+            .iter()
+            .find(|e| e.name == "x")
+            .expect("/projects/x should be listed");
+        assert_eq!(x.file_type, FileType::Directory);
+    }
+
+    #[tokio::test]
+    async fn filter_range_rejects_cross_variant_bounds() {
+        // PR #3659 reviewer fix: Filter::Range used to rely on derived
+        // IndexValue Ord, which orders across variants by their
+        // declared position. That meant numeric lo + Bytes hi could
+        // include Bool/Text values purely on enum ordering. We now
+        // require all three sides (lo, hi, stored) to share a variant.
+        let fs = InMemoryBackend::new();
+        let kind = RecordKind::new("widget").unwrap();
+        let key = IndexKey::new("size").unwrap();
+        let entry = Entry::record(kind, &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(key.clone(), IndexValue::Text("medium".into()));
+        fs.put(&vpath("/projects/W1"), entry, CasExpectation::Absent)
+            .await
+            .unwrap();
+        // Numeric lo + Bytes hi over a Text-valued indexed field must
+        // not match.
+        let results = fs
+            .query(
+                &vpath("/projects"),
+                &Filter::Range {
+                    key,
+                    lo: IndexValue::I64(0),
+                    hi: IndexValue::Bytes(vec![0xff]),
+                },
+                Page::default(),
+            )
+            .await
+            .unwrap();
+        assert!(results.is_empty());
     }
 
     #[tokio::test]

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -105,6 +105,7 @@ impl RootFilesystem for InMemoryBackend {
             .entries
             .get(path.as_str())
             .map(|stored| VersionedEntry {
+                path: path.clone(),
                 entry: stored.entry.clone(),
                 version: stored.version,
             }))
@@ -231,7 +232,9 @@ impl RootFilesystem for InMemoryBackend {
         }
         Ok(matched[start..end]
             .iter()
-            .map(|(_, stored)| VersionedEntry {
+            .map(|(matched_path, stored)| VersionedEntry {
+                path: VirtualPath::new((*matched_path).clone())
+                    .unwrap_or_else(|_| unreachable!("stored paths originated as VirtualPath")),
                 entry: stored.entry.clone(),
                 version: stored.version,
             })
@@ -705,5 +708,78 @@ mod tests {
         fs.write_file(&path, b"payload").await.unwrap();
         let bytes = fs.read_file(&path).await.unwrap();
         assert_eq!(bytes, b"payload");
+    }
+
+    #[tokio::test]
+    async fn get_and_query_populate_versioned_entry_path() {
+        // PR #3659 review fix: `VersionedEntry` now carries the
+        // [`VirtualPath`] of the record so query consumers can drive
+        // `put`/`delete` workflows directly off the result.
+        let fs = InMemoryBackend::new();
+        let path = vpath("/memory/a");
+        let kind = crate::RecordKind::new("test").unwrap();
+        let entry = crate::Entry::record(kind.clone(), &serde_json::json!({"k": 1}))
+            .unwrap()
+            .with_indexed(
+                crate::IndexKey::new("k").unwrap(),
+                crate::IndexValue::I64(1),
+            );
+        fs.put(&path, entry, CasExpectation::Absent).await.unwrap();
+
+        let got = fs.get(&path).await.unwrap().expect("get returns Some");
+        assert_eq!(got.path, path, "get must populate VersionedEntry.path");
+
+        let results = fs
+            .query(
+                &vpath("/memory"),
+                &crate::Filter::Eq {
+                    key: crate::IndexKey::new("k").unwrap(),
+                    value: crate::IndexValue::I64(1),
+                },
+                crate::Page::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].path, path,
+            "query must populate VersionedEntry.path for every row"
+        );
+    }
+
+    #[tokio::test]
+    async fn range_filter_rejects_cross_variant_stored_values() {
+        // PR #3659 review fix: a numeric Range must not match rows that
+        // happen to have a text value under the same indexed key.
+        // (The in-memory backend already enforced this via the
+        // `std::mem::discriminant` fix; this regression test locks it in.)
+        let fs = InMemoryBackend::new();
+        let kind = crate::RecordKind::new("test").unwrap();
+        let key = crate::IndexKey::new("v").unwrap();
+        for (path_str, value) in [
+            ("/memory/numeric", crate::IndexValue::I64(5)),
+            ("/memory/text", crate::IndexValue::Text("5".into())),
+        ] {
+            let entry = crate::Entry::record(kind.clone(), &serde_json::json!({"v": 5}))
+                .unwrap()
+                .with_indexed(key.clone(), value);
+            fs.put(&vpath(path_str), entry, CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+        let results = fs
+            .query(
+                &vpath("/memory"),
+                &crate::Filter::Range {
+                    key,
+                    lo: crate::IndexValue::I64(1),
+                    hi: crate::IndexValue::I64(10),
+                },
+                crate::Page::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1, "only the numeric row should match");
+        assert_eq!(results[0].path.as_str(), "/memory/numeric");
     }
 }

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -1,0 +1,598 @@
+//! In-memory [`RootFilesystem`] implementing the full unified surface.
+//!
+//! Serves as:
+//! - A reference implementation that shows how a backend should treat each op.
+//! - The default test backend so tests don't need libSQL/Postgres running.
+//! - The replacement for the N per-crate `InMemory*Store` implementations that
+//!   each consumer used to maintain alongside their SQL backends.
+//!
+//! Semantics:
+//! - Per-path monotonic versions. Each successful [`put`](RootFilesystem::put)
+//!   increments the path's version; CAS rejects writes whose
+//!   [`CasExpectation`] doesn't match the current version.
+//! - Indexed projection is stored alongside the entry and used by
+//!   [`query`](RootFilesystem::query). The current implementation evaluates
+//!   filters by linear scan — that is fine for tests and small workloads; a
+//!   production-grade backend would translate `ensure_index` declarations
+//!   into native indexes.
+//! - [`append`](RootFilesystem::append)/[`tail`](RootFilesystem::tail) keep
+//!   one append log per path with monotonic [`SeqNo`].
+
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use ironclaw_host_api::VirtualPath;
+use tokio::sync::Mutex;
+
+use crate::backend::{EventRecord, StorageTxn};
+use crate::{
+    BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FileType, FilesystemError,
+    FilesystemOperation, Filter, IndexCapability, IndexKey, IndexKind, IndexName, IndexSpec,
+    IndexValue, Page, RecordVersion, RootFilesystem, SeqNo, TxnCapability, VersionedEntry,
+};
+
+#[derive(Clone)]
+struct StoredEntry {
+    entry: Entry,
+    version: RecordVersion,
+    modified: SystemTime,
+}
+
+struct State {
+    entries: HashMap<String, StoredEntry>,
+    indexes: HashMap<String, Vec<IndexSpec>>,
+    event_logs: HashMap<String, Vec<EventRecord>>,
+}
+
+/// In-memory backend serving the full unified [`RootFilesystem`] surface.
+pub struct InMemoryBackend {
+    state: Mutex<State>,
+}
+
+impl InMemoryBackend {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(State {
+                entries: HashMap::new(),
+                indexes: HashMap::new(),
+                event_logs: HashMap::new(),
+            }),
+        }
+    }
+}
+
+impl Default for InMemoryBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for InMemoryBackend {
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            read: true,
+            write: true,
+            append: true,
+            list: true,
+            stat: true,
+            delete: true,
+            records: true,
+            query: true,
+            index: IndexCapability {
+                exact: true,
+                prefix: true,
+                fts: false,
+                vector: false,
+            },
+            txn: TxnCapability::Cas,
+            events: true,
+            indexed: false,
+            embedded: false,
+        }
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        let mut state = self.state.lock().await;
+        let key = path.as_str().to_string();
+        let current_version = state.entries.get(&key).map(|stored| stored.version);
+        check_cas(path, cas, current_version)?;
+
+        let next_version = current_version
+            .map(|v| v.next())
+            .unwrap_or_else(|| RecordVersion::from_backend(1));
+        state.entries.insert(
+            key,
+            StoredEntry {
+                entry,
+                version: next_version,
+                modified: SystemTime::now(),
+            },
+        );
+        Ok(next_version)
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        let state = self.state.lock().await;
+        Ok(state
+            .entries
+            .get(path.as_str())
+            .map(|stored| VersionedEntry {
+                entry: stored.entry.clone(),
+                version: stored.version,
+            }))
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        let mut state = self.state.lock().await;
+        if state.entries.remove(path.as_str()).is_some() {
+            Ok(())
+        } else {
+            Err(FilesystemError::NotFound {
+                path: path.clone(),
+                operation: FilesystemOperation::Delete,
+            })
+        }
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        let state = self.state.lock().await;
+        let prefix = with_trailing_slash(path.as_str());
+        let mut seen: HashMap<String, FileType> = HashMap::new();
+        for stored_path in state.entries.keys() {
+            if let Some(suffix) = stored_path.strip_prefix(&prefix) {
+                let (head, has_more) = first_segment(suffix);
+                if head.is_empty() {
+                    continue;
+                }
+                let file_type = if has_more {
+                    FileType::Directory
+                } else {
+                    FileType::File
+                };
+                seen.entry(head.to_string()).or_insert(file_type);
+            }
+        }
+        let mut out = Vec::with_capacity(seen.len());
+        for (name, file_type) in seen {
+            let child_virtual = VirtualPath::new(join_path(path.as_str(), &name))?;
+            out.push(DirEntry {
+                name,
+                path: child_virtual,
+                file_type,
+            });
+        }
+        out.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(out)
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        let state = self.state.lock().await;
+        if let Some(stored) = state.entries.get(path.as_str()) {
+            return Ok(FileStat {
+                path: path.clone(),
+                file_type: FileType::File,
+                len: stored.entry.body.len() as u64,
+                modified: Some(stored.modified),
+                sensitive: stored.entry.kind.is_some(),
+            });
+        }
+        let prefix = with_trailing_slash(path.as_str());
+        if state.entries.keys().any(|key| key.starts_with(&prefix)) {
+            return Ok(FileStat {
+                path: path.clone(),
+                file_type: FileType::Directory,
+                len: 0,
+                modified: None,
+                sensitive: false,
+            });
+        }
+        Err(FilesystemError::NotFound {
+            path: path.clone(),
+            operation: FilesystemOperation::Stat,
+        })
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let state = self.state.lock().await;
+        let prefix = with_trailing_slash(path.as_str());
+        let mut matched: Vec<(&String, &StoredEntry)> = state
+            .entries
+            .iter()
+            .filter(|(key, _)| key.as_str() == path.as_str() || key.starts_with(&prefix))
+            .filter(|(_, stored)| filter_matches(filter, &stored.entry.indexed))
+            .collect();
+        matched.sort_by(|a, b| a.0.cmp(b.0));
+        let start = page.offset as usize;
+        let end = start.saturating_add(page.limit as usize).min(matched.len());
+        if start >= matched.len() {
+            return Ok(Vec::new());
+        }
+        Ok(matched[start..end]
+            .iter()
+            .map(|(_, stored)| VersionedEntry {
+                entry: stored.entry.clone(),
+                version: stored.version,
+            })
+            .collect())
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        let mut state = self.state.lock().await;
+        // Reject specs whose kind we don't claim to serve.
+        match spec.kind {
+            IndexKind::Exact | IndexKind::Prefix => {}
+            IndexKind::Fts | IndexKind::Vector { .. } => {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::EnsureIndex,
+                });
+            }
+        }
+        let bucket = state.indexes.entry(path.as_str().to_string()).or_default();
+        if let Some(existing) = bucket.iter().find(|s| s.name == spec.name) {
+            if existing != spec {
+                return Err(FilesystemError::IndexConflict {
+                    path: path.clone(),
+                    name: existing.name.clone(),
+                    reason: "spec already declared with different keys or kind".to_string(),
+                });
+            }
+            return Ok(());
+        }
+        bucket.push(spec.clone());
+        Ok(())
+    }
+
+    async fn begin(&self, path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        // In-memory backend supports CAS only; multi-key transactions would
+        // require a separate state snapshot. Consumers must use CAS.
+        Err(FilesystemError::Unsupported {
+            path: path.clone(),
+            operation: FilesystemOperation::BeginTxn,
+        })
+    }
+
+    async fn append(&self, path: &VirtualPath, payload: Vec<u8>) -> Result<SeqNo, FilesystemError> {
+        let mut state = self.state.lock().await;
+        let log = state
+            .event_logs
+            .entry(path.as_str().to_string())
+            .or_default();
+        let next = log
+            .last()
+            .map(|rec| rec.seq.next())
+            .unwrap_or_else(|| SeqNo::ZERO.next());
+        log.push(EventRecord { seq: next, payload });
+        Ok(next)
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        from: SeqNo,
+    ) -> Result<Vec<EventRecord>, FilesystemError> {
+        let state = self.state.lock().await;
+        let Some(log) = state.event_logs.get(path.as_str()) else {
+            return Ok(Vec::new());
+        };
+        Ok(log
+            .iter()
+            .filter(|record| record.seq > from)
+            .cloned()
+            .collect())
+    }
+
+    // Legacy bytes ops — default impls in the trait route them through put/get
+    // and use our native implementations. The only one needing an explicit
+    // impl is the required-method `list_dir`, which we already overrode above.
+    // We provide `append_file` for byte-append symmetry.
+
+    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let mut state = self.state.lock().await;
+        let key = path.as_str().to_string();
+        let existing = state.entries.get(&key).cloned();
+        let mut entry = existing
+            .as_ref()
+            .map(|s| s.entry.clone())
+            .unwrap_or_else(|| Entry::bytes(Vec::new()));
+        if entry.kind.is_some() {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::AppendFile,
+                reason: "cannot append bytes to a record-shaped entry".to_string(),
+            });
+        }
+        entry.body.extend_from_slice(bytes);
+        let next_version = existing
+            .map(|s| s.version.next())
+            .unwrap_or_else(|| RecordVersion::from_backend(1));
+        state.entries.insert(
+            key,
+            StoredEntry {
+                entry,
+                version: next_version,
+                modified: SystemTime::now(),
+            },
+        );
+        Ok(())
+    }
+}
+
+fn check_cas(
+    path: &VirtualPath,
+    cas: CasExpectation,
+    current: Option<RecordVersion>,
+) -> Result<(), FilesystemError> {
+    match (cas, current) {
+        (CasExpectation::Any, _) => Ok(()),
+        (CasExpectation::Absent, None) => Ok(()),
+        (CasExpectation::Absent, found @ Some(_)) => Err(FilesystemError::VersionMismatch {
+            path: path.clone(),
+            expected: None,
+            found,
+        }),
+        (CasExpectation::Version(expected), Some(found)) if expected == found => Ok(()),
+        (CasExpectation::Version(expected), found) => Err(FilesystemError::VersionMismatch {
+            path: path.clone(),
+            expected: Some(expected),
+            found,
+        }),
+    }
+}
+
+fn filter_matches(
+    filter: &Filter,
+    indexed: &std::collections::BTreeMap<IndexKey, IndexValue>,
+) -> bool {
+    match filter {
+        Filter::All => true,
+        Filter::Eq { key, value } => indexed.get(key) == Some(value),
+        Filter::PrefixOn { key, value } => match (indexed.get(key), value) {
+            (Some(IndexValue::Text(stored)), IndexValue::Text(prefix)) => {
+                stored.starts_with(prefix)
+            }
+            _ => false,
+        },
+        Filter::Range { key, lo, hi } => match indexed.get(key) {
+            Some(v) => v >= lo && v <= hi,
+            None => false,
+        },
+        Filter::And(children) => children.iter().all(|f| filter_matches(f, indexed)),
+        Filter::Or(children) => children.iter().any(|f| filter_matches(f, indexed)),
+    }
+}
+
+fn with_trailing_slash(s: &str) -> String {
+    if s.ends_with('/') {
+        s.to_string()
+    } else {
+        format!("{s}/")
+    }
+}
+
+fn first_segment(s: &str) -> (&str, bool) {
+    match s.find('/') {
+        Some(idx) => (&s[..idx], true),
+        None => (s, false),
+    }
+}
+
+fn join_path(parent: &str, child: &str) -> String {
+    if parent.ends_with('/') {
+        format!("{parent}{child}")
+    } else {
+        format!("{parent}/{child}")
+    }
+}
+
+// Silence unused warning on `IndexName` import while keeping the symbol
+// available for documentation/test crates that re-export from this module.
+#[allow(dead_code)]
+const _: fn() -> Option<IndexName> = || None;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RecordKind, VersionedEntry};
+
+    fn vpath(s: &str) -> VirtualPath {
+        VirtualPath::new(s).unwrap()
+    }
+
+    fn key(s: &str) -> IndexKey {
+        IndexKey::new(s).unwrap()
+    }
+
+    #[tokio::test]
+    async fn put_get_round_trip_for_opaque_file() {
+        let fs = InMemoryBackend::new();
+        let path = vpath("/projects/notes.md");
+        let body = b"hello world".to_vec();
+        let version = fs
+            .put(&path, Entry::bytes(body.clone()), CasExpectation::Absent)
+            .await
+            .unwrap();
+        let got: VersionedEntry = fs.get(&path).await.unwrap().unwrap();
+        assert_eq!(got.entry.body, body);
+        assert!(got.entry.is_opaque_file());
+        assert_eq!(got.version, version);
+    }
+
+    #[tokio::test]
+    async fn cas_absent_rejects_when_present() {
+        let fs = InMemoryBackend::new();
+        let path = vpath("/secrets/leases/L1");
+        fs.put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+            .await
+            .unwrap();
+        let err = fs
+            .put(&path, Entry::bytes(vec![2]), CasExpectation::Absent)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FilesystemError::VersionMismatch { .. }));
+    }
+
+    #[tokio::test]
+    async fn cas_version_advances_monotonically() {
+        let fs = InMemoryBackend::new();
+        let path = vpath("/secrets/leases/L2");
+        let v1 = fs
+            .put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+            .await
+            .unwrap();
+        let v2 = fs
+            .put(&path, Entry::bytes(vec![2]), CasExpectation::Version(v1))
+            .await
+            .unwrap();
+        assert!(v2 > v1);
+        // Stale version is rejected.
+        let err = fs
+            .put(&path, Entry::bytes(vec![3]), CasExpectation::Version(v1))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FilesystemError::VersionMismatch { .. }));
+    }
+
+    #[tokio::test]
+    async fn query_filters_on_indexed_projection() {
+        let fs = InMemoryBackend::new();
+        let kind = RecordKind::new("lease").unwrap();
+        for (path, scope, status) in [
+            ("/secrets/leases/A", "acme", "active"),
+            ("/secrets/leases/B", "acme", "revoked"),
+            ("/secrets/leases/C", "globex", "active"),
+        ] {
+            let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+                .unwrap()
+                .with_indexed(key("scope"), IndexValue::Text(scope.into()))
+                .with_indexed(key("status"), IndexValue::Text(status.into()));
+            fs.put(&vpath(path), entry, CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+        let results = fs
+            .query(
+                &vpath("/secrets/leases"),
+                &Filter::And(vec![
+                    Filter::Eq {
+                        key: key("scope"),
+                        value: IndexValue::Text("acme".into()),
+                    },
+                    Filter::Eq {
+                        key: key("status"),
+                        value: IndexValue::Text("active".into()),
+                    },
+                ]),
+                Page::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn ensure_index_rejects_kind_conflict() {
+        let fs = InMemoryBackend::new();
+        let prefix = vpath("/secrets/leases");
+        let name = IndexName::new("by_scope").unwrap();
+        let spec_a = IndexSpec::new(name.clone(), vec![key("scope")], IndexKind::Exact);
+        let spec_b = IndexSpec::new(name, vec![key("scope")], IndexKind::Prefix);
+        fs.ensure_index(&prefix, &spec_a).await.unwrap();
+        // Re-declaring same spec is idempotent.
+        fs.ensure_index(&prefix, &spec_a).await.unwrap();
+        // Conflicting kind on same name fails.
+        let err = fs.ensure_index(&prefix, &spec_b).await.unwrap_err();
+        assert!(matches!(err, FilesystemError::IndexConflict { .. }));
+    }
+
+    #[tokio::test]
+    async fn ensure_index_rejects_unsupported_kind() {
+        let fs = InMemoryBackend::new();
+        let prefix = vpath("/memory");
+        let spec = IndexSpec::new(
+            IndexName::new("by_chunk").unwrap(),
+            vec![key("chunk_id")],
+            IndexKind::Fts,
+        );
+        let err = fs.ensure_index(&prefix, &spec).await.unwrap_err();
+        assert!(matches!(err, FilesystemError::Unsupported { .. }));
+    }
+
+    #[tokio::test]
+    async fn append_and_tail_assigns_monotonic_seqno() {
+        let fs = InMemoryBackend::new();
+        let log = vpath("/events/engine");
+        let s1 = fs.append(&log, b"a".to_vec()).await.unwrap();
+        let s2 = fs.append(&log, b"b".to_vec()).await.unwrap();
+        let s3 = fs.append(&log, b"c".to_vec()).await.unwrap();
+        assert!(s1 < s2 && s2 < s3);
+        let tail = fs.tail(&log, SeqNo::ZERO).await.unwrap();
+        assert_eq!(tail.len(), 3);
+        let tail_after_first = fs.tail(&log, s1).await.unwrap();
+        assert_eq!(tail_after_first.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_entry() {
+        let fs = InMemoryBackend::new();
+        let path = vpath("/tmp/x");
+        fs.put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+            .await
+            .unwrap();
+        assert!(fs.get(&path).await.unwrap().is_some());
+        fs.delete(&path).await.unwrap();
+        assert!(fs.get(&path).await.unwrap().is_none());
+        let err = fs.delete(&path).await.unwrap_err();
+        assert!(matches!(err, FilesystemError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn list_dir_returns_direct_children_only() {
+        let fs = InMemoryBackend::new();
+        for p in [
+            "/projects/a.md",
+            "/projects/sub/b.md",
+            "/projects/sub/c.md",
+            "/projects/d.md",
+        ] {
+            fs.put(&vpath(p), Entry::bytes(vec![]), CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+        let mut names: Vec<String> = fs
+            .list_dir(&vpath("/projects"))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["a.md", "d.md", "sub"]);
+    }
+
+    #[tokio::test]
+    async fn legacy_read_write_file_default_routes_through_put_get() {
+        let fs = InMemoryBackend::new();
+        let path = vpath("/tmp/legacy.bin");
+        // write_file default impl wraps in Entry::bytes + CAS::Any.
+        fs.write_file(&path, b"payload").await.unwrap();
+        let bytes = fs.read_file(&path).await.unwrap();
+        assert_eq!(bytes, b"payload");
+    }
+}

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -28,8 +28,8 @@ use tokio::sync::Mutex;
 use crate::backend::{EventRecord, StorageTxn};
 use crate::{
     BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FileType, FilesystemError,
-    FilesystemOperation, Filter, IndexCapability, IndexKey, IndexKind, IndexName, IndexSpec,
-    IndexValue, Page, RecordVersion, RootFilesystem, SeqNo, TxnCapability, VersionedEntry,
+    FilesystemOperation, Filter, IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, Page,
+    RecordVersion, RootFilesystem, SeqNo, VersionedEntry,
 };
 
 #[derive(Clone)]
@@ -71,26 +71,7 @@ impl Default for InMemoryBackend {
 #[async_trait]
 impl RootFilesystem for InMemoryBackend {
     fn capabilities(&self) -> BackendCapabilities {
-        BackendCapabilities {
-            read: true,
-            write: true,
-            append: true,
-            list: true,
-            stat: true,
-            delete: true,
-            records: true,
-            query: true,
-            index: IndexCapability {
-                exact: true,
-                prefix: true,
-                fts: false,
-                vector: false,
-            },
-            txn: TxnCapability::Cas,
-            events: true,
-            indexed: false,
-            embedded: false,
-        }
+        BackendCapabilities::in_memory_full()
     }
 
     async fn put(
@@ -279,7 +260,7 @@ impl RootFilesystem for InMemoryBackend {
                 return Err(FilesystemError::IndexConflict {
                     path: path.clone(),
                     name: existing.name.clone(),
-                    reason: "spec already declared with different keys or kind".to_string(),
+                    reason: crate::IndexConflictReason::SpecMismatch,
                 });
             }
             return Ok(());
@@ -407,26 +388,15 @@ fn filter_matches(
                 // values purely on enum-variant ordering rather than
                 // domain ordering. Require all three sides to share a
                 // variant; mismatched bound/value variants don't match.
-                index_value_variant(lo) == index_value_variant(hi)
-                    && index_value_variant(v) == index_value_variant(lo)
-                    && v >= lo
-                    && v <= hi
+                let lo_d = std::mem::discriminant(lo);
+                let hi_d = std::mem::discriminant(hi);
+                let v_d = std::mem::discriminant(v);
+                lo_d == hi_d && v_d == lo_d && v >= lo && v <= hi
             }
             None => false,
         },
         Filter::And(children) => children.iter().all(|f| filter_matches(f, indexed)),
         Filter::Or(children) => children.iter().any(|f| filter_matches(f, indexed)),
-    }
-}
-
-/// Identify the [`IndexValue`] variant for cross-variant Range matching
-/// (see PR #3659 reviewer note in `filter_matches`).
-fn index_value_variant(value: &IndexValue) -> u8 {
-    match value {
-        IndexValue::Bool(_) => 0,
-        IndexValue::I64(_) => 1,
-        IndexValue::Text(_) => 2,
-        IndexValue::Bytes(_) => 3,
     }
 }
 

--- a/crates/ironclaw_filesystem/src/index.rs
+++ b/crates/ironclaw_filesystem/src/index.rs
@@ -1,0 +1,301 @@
+//! Index and query primitives for the universal `StorageBackend` surface.
+//!
+//! Stores declare indexes once with [`IndexSpec`], then query with [`Filter`].
+//! Backends translate to native machinery (Postgres `CREATE INDEX`, libSQL
+//! `fts5` / `vector`, in-memory B-tree, …) — no SQL strings cross the
+//! boundary. Indexed values are *projected* by the consumer; backends index
+//! only what was declared, never the opaque payload.
+
+use std::fmt;
+
+use ironclaw_host_api::HostApiError;
+use serde::{Deserialize, Serialize};
+
+/// Name of an index registered on a mount prefix.
+///
+/// Validation matches the [`.claude/rules/types.md`] template: non-empty,
+/// no path separators, no whitespace, no control characters. Constructing via
+/// [`IndexName::new`] is the only way to obtain an instance; wire payloads are
+/// validated on deserialize through `try_from = "String"`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct IndexName(String);
+
+/// Key of an indexed field within a [`Record`](crate::Record).
+///
+/// Same shape and validation rules as [`IndexName`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct IndexKey(String);
+
+pub(crate) fn validate_simple_identifier(kind: &'static str, s: &str) -> Result<(), HostApiError> {
+    if s.is_empty() {
+        return Err(HostApiError::InvalidId {
+            kind,
+            value: s.to_string(),
+            reason: "must not be empty".to_string(),
+        });
+    }
+    if s.chars().count() > 128 {
+        return Err(HostApiError::InvalidId {
+            kind,
+            value: s.to_string(),
+            reason: "must be 128 characters or fewer".to_string(),
+        });
+    }
+    if s.contains('/')
+        || s.contains('\\')
+        || s.contains('\0')
+        || s.chars().any(|c| c.is_whitespace() || c.is_control())
+    {
+        return Err(HostApiError::InvalidId {
+            kind,
+            value: s.to_string(),
+            reason: "must be a simple identifier with no path separators or whitespace".to_string(),
+        });
+    }
+    Ok(())
+}
+
+impl IndexName {
+    pub fn new(raw: impl Into<String>) -> Result<Self, HostApiError> {
+        let s = raw.into();
+        validate_simple_identifier("filesystem index name", &s)?;
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for IndexName {
+    type Error = HostApiError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for IndexName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for IndexName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<IndexName> for String {
+    fn from(value: IndexName) -> Self {
+        value.0
+    }
+}
+
+impl IndexKey {
+    pub fn new(raw: impl Into<String>) -> Result<Self, HostApiError> {
+        let s = raw.into();
+        validate_simple_identifier("filesystem index key", &s)?;
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for IndexKey {
+    type Error = HostApiError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for IndexKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for IndexKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<IndexKey> for String {
+    fn from(value: IndexKey) -> Self {
+        value.0
+    }
+}
+
+/// Typed value projected into the indexed map of a [`Record`](crate::Record).
+///
+/// Variants are intentionally narrow — backends translate to their native
+/// column type. New variants require coordinated backend updates and a wire
+/// migration; do not extend casually.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum IndexValue {
+    Text(String),
+    I64(i64),
+    Bool(bool),
+    Bytes(Vec<u8>),
+}
+
+impl fmt::Display for IndexValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Text(s) => f.write_str(s),
+            Self::I64(n) => write!(f, "{n}"),
+            Self::Bool(b) => write!(f, "{b}"),
+            Self::Bytes(b) => write!(f, "<{}B>", b.len()),
+        }
+    }
+}
+
+/// Kind of index a backend should materialize.
+///
+/// Backends may decline to support some kinds; mount-time capability checks
+/// (see [`BackendCapabilities`](crate::BackendCapabilities)) catch a typed
+/// store demanding a kind its mount cannot serve.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum IndexKind {
+    /// Equality lookup on the indexed key(s).
+    Exact,
+    /// Prefix lookup on a text key (e.g. `scope LIKE 'tenant:acme/%'`).
+    Prefix,
+    /// Full-text search on a text key. Backends translate to `fts5` /
+    /// `tsvector` / equivalent.
+    Fts,
+    /// Vector similarity index. `dim` is the embedding dimension.
+    Vector { dim: u32 },
+}
+
+/// Declaration of an index on a mount prefix.
+///
+/// `keys` is ordered. Backends that support composite indexes use the order;
+/// backends that only support single-key indexes accept `keys.len() == 1`
+/// and reject otherwise.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexSpec {
+    pub name: IndexName,
+    pub keys: Vec<IndexKey>,
+    pub kind: IndexKind,
+}
+
+impl IndexSpec {
+    /// Construct an index spec from a name, one or more keys, and a kind.
+    pub fn new(name: IndexName, keys: Vec<IndexKey>, kind: IndexKind) -> Self {
+        Self { name, keys, kind }
+    }
+}
+
+/// Predicate against indexed values.
+///
+/// Deliberately narrow: every variant maps cleanly to all supported backends.
+/// Backends that cannot serve a particular variant on a given index (e.g. a
+/// `Range` on an FTS index) fail with [`FilesystemError::Unsupported`](
+/// crate::FilesystemError::Unsupported).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum Filter {
+    /// Match every record under the queried prefix.
+    All,
+    /// Match records whose indexed `key` equals `value`.
+    Eq {
+        key: IndexKey,
+        value: IndexValue,
+    },
+    /// Match records whose indexed `key` starts with `value`. Requires the
+    /// index to be `IndexKind::Prefix`.
+    PrefixOn {
+        key: IndexKey,
+        value: IndexValue,
+    },
+    /// Match records whose indexed `key` falls in `[lo, hi]`.
+    Range {
+        key: IndexKey,
+        lo: IndexValue,
+        hi: IndexValue,
+    },
+    And(Vec<Filter>),
+    Or(Vec<Filter>),
+}
+
+/// Pagination cursor for [`list`](crate::StorageBackend::list) and
+/// [`query`](crate::StorageBackend::query).
+///
+/// `offset` is 0-based; `limit` is bounded by [`Page::MAX_LIMIT`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Page {
+    pub offset: u64,
+    pub limit: u32,
+}
+
+impl Page {
+    pub const MAX_LIMIT: u32 = 1024;
+    pub const DEFAULT_LIMIT: u32 = 100;
+
+    pub fn new(offset: u64, limit: u32) -> Self {
+        Self {
+            offset,
+            limit: limit.min(Self::MAX_LIMIT),
+        }
+    }
+
+    pub fn first(limit: u32) -> Self {
+        Self::new(0, limit)
+    }
+}
+
+impl Default for Page {
+    fn default() -> Self {
+        Self::first(Self::DEFAULT_LIMIT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_name_rejects_empty_and_separators() {
+        assert!(IndexName::new("").is_err());
+        assert!(IndexName::new("scope/leases").is_err());
+        assert!(IndexName::new("with space").is_err());
+        assert!(IndexName::new("ok_name_1").is_ok());
+    }
+
+    #[test]
+    fn index_value_orders_within_variant() {
+        assert!(IndexValue::I64(1) < IndexValue::I64(2));
+        assert!(IndexValue::Text("a".into()) < IndexValue::Text("b".into()));
+    }
+
+    #[test]
+    fn page_clamps_to_max_limit() {
+        let page = Page::new(0, u32::MAX);
+        assert_eq!(page.limit, Page::MAX_LIMIT);
+    }
+
+    #[test]
+    fn index_name_serde_round_trip_validates() {
+        let name = IndexName::new("by_scope_status").unwrap();
+        let json = serde_json::to_string(&name).unwrap();
+        let back: IndexName = serde_json::from_str(&json).unwrap();
+        assert_eq!(name, back);
+        assert!(serde_json::from_str::<IndexName>("\"bad/name\"").is_err());
+    }
+}

--- a/crates/ironclaw_filesystem/src/index.rs
+++ b/crates/ironclaw_filesystem/src/index.rs
@@ -43,6 +43,34 @@ pub(crate) fn validate_simple_identifier(kind: &'static str, s: &str) -> Result<
             reason: "must be 128 characters or fewer".to_string(),
         });
     }
+    // Tightened identifier shape after PR #3661 reviewer flag:
+    //   `IndexKey::new("a.b")` used to pass validation but interact with
+    //   `json_extract(indexed, '$.a.b')` as a nested-path traversal rather
+    //   than the literal key `"a.b"`. Similarly, raw names used as DDL
+    //   identifiers without SQL quoting allowed `-` / `.` / unicode through.
+    //   Restrict to `[A-Za-z_][A-Za-z0-9_]*` so the same value is safe as a
+    //   JSON path component, a SQL identifier, and a row key.
+    let bytes = s.as_bytes();
+    let first = bytes[0];
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return Err(HostApiError::InvalidId {
+            kind,
+            value: s.to_string(),
+            reason: "must start with an ASCII letter or underscore".to_string(),
+        });
+    }
+    if bytes[1..]
+        .iter()
+        .any(|b| !(b.is_ascii_alphanumeric() || *b == b'_'))
+    {
+        return Err(HostApiError::InvalidId {
+            kind,
+            value: s.to_string(),
+            reason: "must contain only ASCII letters, digits, and underscores".to_string(),
+        });
+    }
+    // Legacy traversal/whitespace checks retained as belt-and-suspenders;
+    // the ASCII alphanumeric rule above already rejects them.
     if s.contains('/')
         || s.contains('\\')
         || s.contains('\0')
@@ -282,6 +310,22 @@ mod tests {
         assert!(IndexName::new("scope/leases").is_err());
         assert!(IndexName::new("with space").is_err());
         assert!(IndexName::new("ok_name_1").is_ok());
+    }
+
+    #[test]
+    fn index_key_rejects_chars_that_break_sql_or_json_paths() {
+        // Reviewer (PR #3661) flagged that allowing `.` lets
+        // `json_extract(indexed, '$.a.b')` traverse rather than match the
+        // literal key `"a.b"`, and that other punctuation can break DDL.
+        // After tightening, IndexKey/Name accept `[A-Za-z_][A-Za-z0-9_]*`
+        // only.
+        assert!(IndexKey::new("a.b").is_err());
+        assert!(IndexKey::new("a-b").is_err());
+        assert!(IndexKey::new("1abc").is_err()); // can't start with digit
+        assert!(IndexKey::new("").is_err());
+        assert!(IndexKey::new("scope").is_ok());
+        assert!(IndexKey::new("_internal").is_ok());
+        assert!(IndexKey::new("scope_v2").is_ok());
     }
 
     #[test]

--- a/crates/ironclaw_filesystem/src/index.rs
+++ b/crates/ironclaw_filesystem/src/index.rs
@@ -144,12 +144,18 @@ impl From<IndexKey> for String {
 /// Variants are intentionally narrow — backends translate to their native
 /// column type. New variants require coordinated backend updates and a wire
 /// migration; do not extend casually.
+///
+/// Serialization is untagged so SQL backends storing the indexed map as
+/// JSON can run native predicates against it (`indexed->>'scope' = 'acme'`
+/// in Postgres, `json_extract(indexed, '$.scope') = 'acme'` in libSQL).
+/// Bool is listed first so JSON booleans don't accidentally match `I64`,
+/// and `Bytes` is last because a JSON array could otherwise be mis-typed.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+#[serde(untagged)]
 pub enum IndexValue {
-    Text(String),
-    I64(i64),
     Bool(bool),
+    I64(i64),
+    Text(String),
     Bytes(Vec<u8>),
 }
 

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -15,29 +15,40 @@
 //! with `RESOLVE_BENEATH`, `O_NOFOLLOW`, or a capability filesystem crate.
 #![warn(unreachable_pub)]
 
+mod backend;
 mod catalog;
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 mod db;
+mod in_memory;
+mod index;
 #[cfg(feature = "libsql")]
 mod libsql;
 mod local;
 #[cfg(feature = "postgres")]
 mod postgres;
+mod record;
 mod root;
 mod scoped;
 mod types;
 
-pub use catalog::{CompositeRootFilesystem, FilesystemCatalog, MountDescriptor};
+pub use backend::{EventRecord, StorageTxn};
+pub use catalog::{CompositeRootFilesystem, FilesystemCatalog, MountDescriptor, PathPlacement};
+pub use in_memory::InMemoryBackend;
+pub use index::{Filter, IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, Page};
 #[cfg(feature = "libsql")]
 pub use libsql::LibSqlRootFilesystem;
 pub use local::LocalFilesystem;
 #[cfg(feature = "postgres")]
 pub use postgres::PostgresRootFilesystem;
+pub use record::{
+    CasExpectation, ContentType, Entry, RecordKind, RecordVersion, SeqNo, VersionedEntry,
+};
 pub use root::RootFilesystem;
 pub use scoped::ScopedFilesystem;
 pub use types::{
     BackendCapabilities, BackendId, BackendKind, ContentKind, DirEntry, FileStat, FileType,
-    FilesystemError, FilesystemOperation, IndexPolicy, StorageClass,
+    FilesystemError, FilesystemOperation, IndexCapability, IndexPolicy, StorageClass,
+    TxnCapability,
 };
 
 fn path_prefix_matches(prefix: &str, path: &str) -> bool {

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -46,8 +46,8 @@ pub use record::{
 pub use root::RootFilesystem;
 pub use scoped::ScopedFilesystem;
 pub use types::{
-    BackendCapabilities, BackendId, BackendKind, ContentKind, DirEntry, FileStat, FileType,
-    FilesystemError, FilesystemOperation, IndexCapability, IndexPolicy, StorageClass,
+    BackendCapabilities, BackendId, BackendKind, Capability, ContentKind, DirEntry, FileStat,
+    FileType, FilesystemError, FilesystemOperation, IndexConflictReason, IndexPolicy, StorageClass,
     TxnCapability,
 };
 

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -257,6 +257,7 @@ impl RootFilesystem for LibSqlRootFilesystem {
             .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
         let entry = build_entry(path, body, content_type_raw, kind_raw, indexed_raw)?;
         Ok(Some(VersionedEntry {
+            path: path.clone(),
             entry,
             version: record_version_from_i64(path, version_raw)?,
         }))
@@ -433,7 +434,11 @@ impl RootFilesystem for LibSqlRootFilesystem {
             })?;
             let entry = build_entry(&row_path, body, content_type_raw, kind_raw, indexed_raw)?;
             let version = record_version_from_i64(&row_path, version_raw)?;
-            out.push(VersionedEntry { entry, version });
+            out.push(VersionedEntry {
+                path: row_path,
+                entry,
+                version,
+            });
         }
         Ok(out)
     }
@@ -953,13 +958,20 @@ fn translate_filter(
             Ok(())
         }
         Filter::Range { key, lo, hi } => {
+            // PR #3659 review fix: guard the comparison with a JSON-type
+            // check so a row whose stored value at `$.{key}` is a different
+            // variant (e.g. text under a numeric range) does NOT participate
+            // in BETWEEN. Without this guard a mixed-variant store can pull
+            // unrelated values into the result set or fail the query
+            // entirely on a cast failure.
             let lo_idx = bind_index_value(path, lo, params)?;
             let hi_idx = bind_index_value(path, hi, params)?;
+            let expected_json_type = index_value_json_type(lo);
             out.push_str(&format!(
-                "(json_extract(indexed, '$.{}') BETWEEN ?{} AND ?{})",
+                "(json_type(indexed, '$.{}') = '{expected_json_type}' \
+                 AND json_extract(indexed, '$.{}') BETWEEN ?{lo_idx} AND ?{hi_idx})",
                 key.as_str(),
-                lo_idx,
-                hi_idx
+                key.as_str(),
             ));
             Ok(())
         }
@@ -1014,6 +1026,21 @@ fn bind_index_value(
     };
     params.push(bound);
     Ok(params.len())
+}
+
+/// Maps an [`IndexValue`] variant to the corresponding SQLite `json_type`
+/// discriminator string. Used to guard `Filter::Range` so cross-variant
+/// stored values don't participate in BETWEEN comparisons (PR #3659 review
+/// fix).
+#[cfg(feature = "libsql")]
+fn index_value_json_type(value: &IndexValue) -> &'static str {
+    match value {
+        IndexValue::Text(_) => "text",
+        IndexValue::I64(_) => "integer",
+        // SQLite's json_type returns "true" / "false" for booleans, not "boolean".
+        IndexValue::Bool(_) => "integer", // we encode bools as 0/1 integers above
+        IndexValue::Bytes(_) => "text",
+    }
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -318,14 +318,27 @@ impl RootFilesystem for LibSqlRootFilesystem {
             return Err(directory_write_error(path.clone()));
         }
         let conn = self.connect().await?;
+        // PR #3660 reviewer fix: legacy write_file must also reset the
+        // record metadata (content_type / kind / indexed) and bump the
+        // version, otherwise a get() after a write_file-overwrite of a
+        // previously record-shaped entry returns stale metadata. Treat
+        // legacy writes as opaque-file entries: kind=NULL, indexed='{}',
+        // content_type=application/octet-stream, version bumped from the
+        // current row's version (or 1 for new entries).
         let rows = conn
             .execute(
                 r#"
-                INSERT INTO root_filesystem_entries (path, contents, is_dir, updated_at)
-                VALUES (?1, ?2, 0, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                INSERT INTO root_filesystem_entries
+                    (path, contents, is_dir, content_type, kind, indexed, version, updated_at)
+                VALUES (?1, ?2, 0, 'application/octet-stream', NULL, '{}', 1,
+                        strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
                 ON CONFLICT (path) DO UPDATE SET
                     contents = excluded.contents,
                     is_dir = 0,
+                    content_type = excluded.content_type,
+                    kind = excluded.kind,
+                    indexed = excluded.indexed,
+                    version = root_filesystem_entries.version + 1,
                     updated_at = excluded.updated_at
                 WHERE root_filesystem_entries.is_dir = 0
                 "#,
@@ -350,16 +363,27 @@ impl RootFilesystem for LibSqlRootFilesystem {
             return Err(directory_append_error(path.clone()));
         }
         let conn = self.connect().await?;
-        // TODO(reborn): append rewrites the whole DB row. Do not use this path
-        // for high-volume JSONL/event streams; route those through typed event
-        // stores or append-capable artifact backends instead.
+        // PR #3660 reviewer fix: same metadata-reset concern as write_file.
+        // Append also resets kind/indexed/content_type to opaque-file
+        // defaults — appending bytes onto a previously record-shaped
+        // entry was always a category error, and we surface that by
+        // clearing the schema metadata rather than leaving it stale.
+        // TODO(reborn): append rewrites the whole DB row. Do not use this
+        // path for high-volume JSONL/event streams; route those through
+        // typed event stores or append-capable artifact backends.
         conn.execute(
             r#"
-            INSERT INTO root_filesystem_entries (path, contents, is_dir, updated_at)
-            VALUES (?1, ?2, 0, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            INSERT INTO root_filesystem_entries
+                (path, contents, is_dir, content_type, kind, indexed, version, updated_at)
+            VALUES (?1, ?2, 0, 'application/octet-stream', NULL, '{}', 1,
+                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
             ON CONFLICT (path) DO UPDATE SET
                 contents = CAST(root_filesystem_entries.contents || excluded.contents AS BLOB),
                 is_dir = 0,
+                content_type = excluded.content_type,
+                kind = excluded.kind,
+                indexed = excluded.indexed,
+                version = root_filesystem_entries.version + 1,
                 updated_at = excluded.updated_at
             "#,
             libsql::params![path.as_str(), libsql::Value::Blob(bytes.to_vec())],

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -318,8 +318,30 @@ impl RootFilesystem for LibSqlRootFilesystem {
         })?;
 
         let conn = self.connect().await?;
-        // Conflict check: idempotent if same spec already declared, else
+        // PR #3661 reviewer fix: the prior SELECT-then-INSERT was racey.
+        // Two processes declaring the same spec concurrently could both
+        // miss the row and then one would hit a unique-constraint backend
+        // error instead of getting the promised idempotent success.
+        //
+        // Fix: INSERT ... ON CONFLICT DO NOTHING in a single round-trip,
+        // then read back the canonical row and compare. If the stored
+        // spec matches ours we're idempotent; if it differs we surface
         // IndexConflict.
+        conn.execute(
+            "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT (prefix, name) DO NOTHING",
+            libsql::params![
+                path.as_str(),
+                spec.name.as_str(),
+                keys_json.clone(),
+                kind_str.clone(),
+            ],
+        )
+        .await
+        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+
+        // Read back what's there and validate it matches.
         let mut rows = conn
             .query(
                 "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = ?1 AND name = ?2",
@@ -329,41 +351,31 @@ impl RootFilesystem for LibSqlRootFilesystem {
             .map_err(|error| {
                 libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
             })?;
-        if let Some(row) = rows.next().await.map_err(|error| {
+        let row = rows
+            .next()
+            .await
+            .map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?
+            .ok_or_else(|| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::EnsureIndex,
+                reason: "index spec disappeared after upsert".to_string(),
+            })?;
+        let existing_keys: String = row.get(0).map_err(|error| {
             libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
-        })? {
-            let existing_keys: String = row.get(0).map_err(|error| {
-                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
-            })?;
-            let existing_kind: String = row.get(1).map_err(|error| {
-                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
-            })?;
-            if existing_keys != keys_json || existing_kind != kind_str {
-                return Err(FilesystemError::IndexConflict {
-                    path: path.clone(),
-                    name: spec.name.clone(),
-                    reason: "spec already declared with different keys or kind".to_string(),
-                });
-            }
-            return Ok(());
+        })?;
+        let existing_kind: String = row.get(1).map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })?;
+        if existing_keys != keys_json || existing_kind != kind_str {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: "spec already declared with different keys or kind".to_string(),
+            });
         }
         drop(rows);
-
-        // Record the spec then materialize a SQL expression index on the
-        // declared keys. The index is global on the table; queries route
-        // by path-prefix in the WHERE clause and the planner can still use
-        // this index for filter predicates.
-        conn.execute(
-            "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) VALUES (?1, ?2, ?3, ?4)",
-            libsql::params![
-                path.as_str(),
-                spec.name.as_str(),
-                keys_json.clone(),
-                kind_str,
-            ],
-        )
-        .await
-        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
 
         let index_name = sql_index_name(path.as_str(), spec.name.as_str());
         let expressions: Vec<String> = spec
@@ -940,6 +952,10 @@ fn sql_index_name(prefix: &str, name: &str) -> String {
     }
 }
 
+/// Escape a LIKE pattern that already contains a trailing `%` wildcard
+/// intentionally appended by the caller (the path-prefix scan case in
+/// `query`). The trailing `%` is preserved so it remains a wildcard;
+/// every other `%`, `_`, and `!` is escaped.
 #[cfg(feature = "libsql")]
 fn escape_like_pattern(pattern: &str) -> String {
     let mut out = String::with_capacity(pattern.len());
@@ -955,9 +971,34 @@ fn escape_like_pattern(pattern: &str) -> String {
     out
 }
 
-/// Translate a [`Filter`] tree into a libsql WHERE-clause fragment, appending
-/// bound parameters to `params` in left-to-right order. The fragment is
-/// wrapped in parentheses unless empty.
+/// Escape user-supplied LIKE input where every `%`, `_`, and `!` must be
+/// treated as a literal. Used for `Filter::PrefixOn` values — reviewer
+/// (PR #3661) flagged that the prior code reused `escape_like_pattern`,
+/// which intentionally leaves a final `%` unescaped. A literal prefix
+/// like `tenant:%` would then match anything starting with `tenant:`.
+#[cfg(feature = "libsql")]
+fn escape_like_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '%' => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Translate a [`Filter`] tree into a libsql WHERE-clause fragment.
+///
+/// Reviewer (PR #3661) flagged that the prior version's "skip empty
+/// children" logic conflated `Filter::All` with the identity element of
+/// each compound, so `Or([])` returned every row instead of none and
+/// `And([All])` could emit malformed SQL. The fix: every node always
+/// produces a non-empty fragment — `Filter::All` becomes the literal
+/// `TRUE`, empty `And` becomes `TRUE`, empty `Or` becomes `FALSE`. This
+/// matches the in-memory backend's `all`/`any` semantics.
 #[cfg(feature = "libsql")]
 fn translate_filter(
     path: &VirtualPath,
@@ -966,7 +1007,10 @@ fn translate_filter(
     params: &mut Vec<libsql::Value>,
 ) -> Result<(), FilesystemError> {
     match filter {
-        Filter::All => Ok(()),
+        Filter::All => {
+            out.push_str("TRUE");
+            Ok(())
+        }
         Filter::Eq { key, value } => {
             let placeholder = bind_index_value(path, value, params)?;
             out.push_str(&format!(
@@ -983,7 +1027,10 @@ fn translate_filter(
                     operation: FilesystemOperation::Query,
                 });
             };
-            let escaped = escape_like_pattern(prefix_value);
+            // PR #3661 reviewer fix: user-input prefix must be fully
+            // escaped (including any literal `%` characters) before
+            // appending the LIKE wildcard.
+            let escaped = escape_like_literal(prefix_value);
             params.push(libsql::Value::Text(format!("{escaped}%")));
             out.push_str(&format!(
                 "(json_extract(indexed, '$.{}') LIKE ?{} ESCAPE '!')",
@@ -1003,8 +1050,8 @@ fn translate_filter(
             ));
             Ok(())
         }
-        Filter::And(children) => translate_compound(path, children, " AND ", out, params),
-        Filter::Or(children) => translate_compound(path, children, " OR ", out, params),
+        Filter::And(children) => translate_compound(path, children, " AND ", "TRUE", out, params),
+        Filter::Or(children) => translate_compound(path, children, " OR ", "FALSE", out, params),
     }
 }
 
@@ -1013,25 +1060,23 @@ fn translate_compound(
     path: &VirtualPath,
     children: &[Filter],
     joiner: &str,
+    empty_identity: &str,
     out: &mut String,
     params: &mut Vec<libsql::Value>,
 ) -> Result<(), FilesystemError> {
     if children.is_empty() {
+        out.push_str(empty_identity);
         return Ok(());
     }
     out.push('(');
-    let mut first = true;
-    for child in children {
-        let mut sub = String::new();
-        translate_filter(path, child, &mut sub, params)?;
-        if sub.is_empty() {
-            continue;
-        }
-        if !first {
+    for (i, child) in children.iter().enumerate() {
+        if i > 0 {
             out.push_str(joiner);
         }
-        out.push_str(&sub);
-        first = false;
+        // Recurse: every child now produces a non-empty fragment thanks to
+        // the `Filter::All -> TRUE` rule, so we don't need the prior
+        // "skip empty" branch that broke `Or([])`/`And([All])`.
+        translate_filter(path, child, out, params)?;
     }
     out.push(')');
     Ok(())

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -6,13 +6,14 @@ use ironclaw_host_api::VirtualPath;
 
 use crate::db::{
     child_path_like_pattern, direct_children, directory_append_error, directory_write_error,
-    is_not_found, libsql_db_error, not_found, system_time_from_unix_seconds, valid_engine_path,
-    virtual_path_prefixes,
+    escape_like_literal, escape_like_with_trailing_wildcard, is_not_found, libsql_db_error,
+    not_found, record_version_from_i64, sql_index_name, system_time_from_unix_seconds,
+    valid_engine_path, virtual_path_prefixes,
 };
 use crate::{
     BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FileType,
-    FilesystemError, FilesystemOperation, Filter, IndexCapability, IndexKey, IndexKind, IndexSpec,
-    IndexValue, Page, RecordKind, RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
+    FilesystemError, FilesystemOperation, Filter, IndexKey, IndexKind, IndexSpec, IndexValue, Page,
+    RecordKind, RecordVersion, RootFilesystem, VersionedEntry,
 };
 
 #[cfg(feature = "libsql")]
@@ -66,29 +67,10 @@ impl LibSqlRootFilesystem {
 #[async_trait]
 impl RootFilesystem for LibSqlRootFilesystem {
     fn capabilities(&self) -> BackendCapabilities {
-        BackendCapabilities {
-            read: true,
-            write: true,
-            append: true,
-            list: true,
-            stat: true,
-            delete: true,
-            records: true,
-            // Native query over indexed projection with Filter::Eq/PrefixOn/
-            // Range/And/Or; ensure_index materializes expression indexes on
-            // json_extract(indexed, '$.key').
-            query: true,
-            index: IndexCapability {
-                exact: true,
-                prefix: true,
-                fts: false,
-                vector: false,
-            },
-            txn: TxnCapability::Cas,
-            events: false,
-            indexed: false,
-            embedded: false,
-        }
+        // sql_typical covers read/write/append/list/stat/delete/records/query
+        // /IndexExact/IndexPrefix/CAS. Events stay off until the append/tail
+        // backend port lands; IndexFts/Vector ditto.
+        BackendCapabilities::sql_typical()
     }
 
     async fn put(
@@ -107,12 +89,12 @@ impl RootFilesystem for LibSqlRootFilesystem {
         {
             return Err(directory_write_error(path.clone()));
         }
-        let indexed_json =
-            serde_json::to_string(&entry.indexed).map_err(|error| FilesystemError::Backend {
+        let indexed_json = serde_json::to_string(&entry.indexed).map_err(|_| {
+            FilesystemError::SerializeIndexed {
                 path: path.clone(),
                 operation: FilesystemOperation::WriteFile,
-                reason: format!("failed to serialize indexed projection: {error}"),
-            })?;
+            }
+        })?;
         let kind_str = entry.kind.as_ref().map(|k| k.as_str().to_string());
         let content_type_str = entry.content_type.as_str().to_string();
         let body = entry.body;
@@ -276,7 +258,7 @@ impl RootFilesystem for LibSqlRootFilesystem {
         let entry = build_entry(path, body, content_type_raw, kind_raw, indexed_raw)?;
         Ok(Some(VersionedEntry {
             entry,
-            version: RecordVersion::from_backend(version_raw.max(0) as u64),
+            version: record_version_from_i64(path, version_raw)?,
         }))
     }
 
@@ -301,7 +283,7 @@ impl RootFilesystem for LibSqlRootFilesystem {
             return Err(FilesystemError::IndexConflict {
                 path: path.clone(),
                 name: spec.name.clone(),
-                reason: "spec must declare at least one key".to_string(),
+                reason: crate::IndexConflictReason::EmptyKeys,
             });
         }
         let keys_json = serde_json::to_string(
@@ -311,10 +293,9 @@ impl RootFilesystem for LibSqlRootFilesystem {
                 .map(|k| k.as_str().to_string())
                 .collect::<Vec<_>>(),
         )
-        .map_err(|error| FilesystemError::Backend {
+        .map_err(|_| FilesystemError::SerializeIndexed {
             path: path.clone(),
             operation: FilesystemOperation::EnsureIndex,
-            reason: format!("failed to serialize index keys: {error}"),
         })?;
 
         let conn = self.connect().await?;
@@ -357,10 +338,9 @@ impl RootFilesystem for LibSqlRootFilesystem {
             .map_err(|error| {
                 libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
             })?
-            .ok_or_else(|| FilesystemError::Backend {
+            .ok_or_else(|| FilesystemError::IndexSpecMissingAfterUpsert {
                 path: path.clone(),
-                operation: FilesystemOperation::EnsureIndex,
-                reason: "index spec disappeared after upsert".to_string(),
+                name: spec.name.clone(),
             })?;
         let existing_keys: String = row.get(0).map_err(|error| {
             libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
@@ -372,7 +352,7 @@ impl RootFilesystem for LibSqlRootFilesystem {
             return Err(FilesystemError::IndexConflict {
                 path: path.clone(),
                 name: spec.name.clone(),
-                reason: "spec already declared with different keys or kind".to_string(),
+                reason: crate::IndexConflictReason::SpecMismatch,
             });
         }
         drop(rows);
@@ -401,7 +381,9 @@ impl RootFilesystem for LibSqlRootFilesystem {
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let mut params: Vec<libsql::Value> = vec![libsql::Value::Text(path.as_str().to_string())];
         let prefix_pattern = format!("{}/%", path.as_str());
-        params.push(libsql::Value::Text(escape_like_pattern(&prefix_pattern)));
+        params.push(libsql::Value::Text(escape_like_with_trailing_wildcard(
+            &prefix_pattern,
+        )));
 
         let mut conditions = String::new();
         translate_filter(path, filter, &mut conditions, &mut params)?;
@@ -450,10 +432,8 @@ impl RootFilesystem for LibSqlRootFilesystem {
                 libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
             })?;
             let entry = build_entry(&row_path, body, content_type_raw, kind_raw, indexed_raw)?;
-            out.push(VersionedEntry {
-                entry,
-                version: RecordVersion::from_backend(version_raw.max(0) as u64),
-            });
+            let version = record_version_from_i64(&row_path, version_raw)?;
+            out.push(VersionedEntry { entry, version });
         }
         Ok(out)
     }
@@ -547,9 +527,12 @@ impl RootFilesystem for LibSqlRootFilesystem {
         // defaults — appending bytes onto a previously record-shaped
         // entry was always a category error, and we surface that by
         // clearing the schema metadata rather than leaving it stale.
-        // TODO(reborn): append rewrites the whole DB row. Do not use this
-        // path for high-volume JSONL/event streams; route those through
-        // typed event stores or append-capable artifact backends.
+        // Note: append rewrites the whole DB row. This is acceptable for
+        // the legacy bytes plane (slated for removal in the consumer-
+        // migration cleanup pass — see RootFilesystem::append_file's
+        // deprecation note). New callers must use `append`/`tail` for
+        // log-shaped mounts or `get`+`put` read-modify-write — both avoid
+        // the full-row rewrite.
         conn.execute(
             r#"
             INSERT INTO root_filesystem_entries
@@ -848,7 +831,7 @@ impl LibSqlRootFilesystem {
         let version: i64 = row
             .get(0)
             .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
-        Ok(Some(RecordVersion::from_backend(version.max(0) as u64)))
+        Ok(Some(record_version_from_i64(path, version)?))
     }
 }
 
@@ -868,10 +851,9 @@ fn build_entry(
     let indexed: BTreeMap<IndexKey, IndexValue> = if indexed_raw.is_empty() {
         BTreeMap::new()
     } else {
-        serde_json::from_str(&indexed_raw).map_err(|error| FilesystemError::Backend {
+        serde_json::from_str(&indexed_raw).map_err(|_| FilesystemError::DeserializeIndexed {
             path: path.clone(),
             operation: FilesystemOperation::ReadFile,
-            reason: format!("failed to parse indexed projection: {error}"),
         })?
     };
     Ok(Entry {
@@ -919,75 +901,6 @@ async fn ensure_libsql_index_specs_table(conn: &libsql::Connection) -> Result<()
             libsql_db_error(valid_engine_path(), FilesystemOperation::EnsureIndex, error)
         })?;
     Ok(())
-}
-
-/// Build a deterministic SQL index identifier from a mount prefix + spec name.
-///
-/// IndexKey/IndexName are validated to be simple identifiers (no path
-/// separators, whitespace, or control chars), so the prefix's slashes are
-/// the only non-identifier characters we need to replace. Length is bounded
-/// — Postgres caps at 63, SQLite is more permissive — so we truncate after
-/// sanitisation. Collisions across mounts are tolerable: distinct
-/// `(prefix, name)` pairs share an index when their sanitized forms match,
-/// and the index is still correct (the planner just sees a wider index).
-#[cfg(feature = "libsql")]
-fn sql_index_name(prefix: &str, name: &str) -> String {
-    let prefix_clean: String = prefix
-        .trim_matches('/')
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
-    let raw = format!("idx_rfs_{prefix_clean}_{name}");
-    // Identifier length budget chosen to satisfy Postgres' 63-char cap so
-    // libsql and postgres can share the same naming logic in future refactors.
-    if raw.len() > 62 {
-        let cutoff = raw
-            .char_indices()
-            .nth(62)
-            .map(|(i, _)| i)
-            .unwrap_or(raw.len());
-        raw[..cutoff].to_string()
-    } else {
-        raw
-    }
-}
-
-/// Escape a LIKE pattern that already contains a trailing `%` wildcard
-/// intentionally appended by the caller (the path-prefix scan case in
-/// `query`). The trailing `%` is preserved so it remains a wildcard;
-/// every other `%`, `_`, and `!` is escaped.
-#[cfg(feature = "libsql")]
-fn escape_like_pattern(pattern: &str) -> String {
-    let mut out = String::with_capacity(pattern.len());
-    let mut chars = pattern.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            '%' if chars.peek().is_some() => out.push_str("!%"),
-            '_' => out.push_str("!_"),
-            '!' => out.push_str("!!"),
-            other => out.push(other),
-        }
-    }
-    out
-}
-
-/// Escape user-supplied LIKE input where every `%`, `_`, and `!` must be
-/// treated as a literal. Used for `Filter::PrefixOn` values — reviewer
-/// (PR #3661) flagged that the prior code reused `escape_like_pattern`,
-/// which intentionally leaves a final `%` unescaped. A literal prefix
-/// like `tenant:%` would then match anything starting with `tenant:`.
-#[cfg(feature = "libsql")]
-fn escape_like_literal(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for c in value.chars() {
-        match c {
-            '%' => out.push_str("!%"),
-            '_' => out.push_str("!_"),
-            '!' => out.push_str("!!"),
-            other => out.push(other),
-        }
-    }
-    out
 }
 
 /// Translate a [`Filter`] tree into a libsql WHERE-clause fragment.

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -11,8 +11,8 @@ use crate::db::{
 };
 use crate::{
     BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FileType,
-    FilesystemError, FilesystemOperation, IndexCapability, IndexKey, IndexValue, RecordKind,
-    RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
+    FilesystemError, FilesystemOperation, Filter, IndexCapability, IndexKey, IndexKind, IndexSpec,
+    IndexValue, Page, RecordKind, RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
 };
 
 #[cfg(feature = "libsql")]
@@ -40,6 +40,7 @@ impl LibSqlRootFilesystem {
             })?;
         ensure_libsql_root_is_dir_column(&conn).await?;
         ensure_libsql_records_columns(&conn).await?;
+        ensure_libsql_index_specs_table(&conn).await?;
         Ok(())
     }
 
@@ -72,14 +73,14 @@ impl RootFilesystem for LibSqlRootFilesystem {
             list: true,
             stat: true,
             delete: true,
-            // Native put/get/delete with version-aware CAS lands in this PR.
             records: true,
-            // Query/ensure_index/append/tail still default to Unsupported.
-            // Land in a follow-up port once consumer migrations need them.
-            query: false,
+            // Native query over indexed projection with Filter::Eq/PrefixOn/
+            // Range/And/Or; ensure_index materializes expression indexes on
+            // json_extract(indexed, '$.key').
+            query: true,
             index: IndexCapability {
-                exact: false,
-                prefix: false,
+                exact: true,
+                prefix: true,
                 fts: false,
                 vector: false,
             },
@@ -277,6 +278,172 @@ impl RootFilesystem for LibSqlRootFilesystem {
             entry,
             version: RecordVersion::from_backend(version_raw.max(0) as u64),
         }))
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        // Only Exact and Prefix index kinds are supported on the SQL backends
+        // in this port. FTS / Vector live behind their own follow-up port.
+        let kind_str = match &spec.kind {
+            IndexKind::Exact => "exact".to_string(),
+            IndexKind::Prefix => "prefix".to_string(),
+            IndexKind::Fts | IndexKind::Vector { .. } => {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::EnsureIndex,
+                });
+            }
+        };
+        if spec.keys.is_empty() {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: "spec must declare at least one key".to_string(),
+            });
+        }
+        let keys_json = serde_json::to_string(
+            &spec
+                .keys
+                .iter()
+                .map(|k| k.as_str().to_string())
+                .collect::<Vec<_>>(),
+        )
+        .map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::EnsureIndex,
+            reason: format!("failed to serialize index keys: {error}"),
+        })?;
+
+        let conn = self.connect().await?;
+        // Conflict check: idempotent if same spec already declared, else
+        // IndexConflict.
+        let mut rows = conn
+            .query(
+                "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = ?1 AND name = ?2",
+                libsql::params![path.as_str(), spec.name.as_str()],
+            )
+            .await
+            .map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?;
+        if let Some(row) = rows.next().await.map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })? {
+            let existing_keys: String = row.get(0).map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?;
+            let existing_kind: String = row.get(1).map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?;
+            if existing_keys != keys_json || existing_kind != kind_str {
+                return Err(FilesystemError::IndexConflict {
+                    path: path.clone(),
+                    name: spec.name.clone(),
+                    reason: "spec already declared with different keys or kind".to_string(),
+                });
+            }
+            return Ok(());
+        }
+        drop(rows);
+
+        // Record the spec then materialize a SQL expression index on the
+        // declared keys. The index is global on the table; queries route
+        // by path-prefix in the WHERE clause and the planner can still use
+        // this index for filter predicates.
+        conn.execute(
+            "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) VALUES (?1, ?2, ?3, ?4)",
+            libsql::params![
+                path.as_str(),
+                spec.name.as_str(),
+                keys_json.clone(),
+                kind_str,
+            ],
+        )
+        .await
+        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+
+        let index_name = sql_index_name(path.as_str(), spec.name.as_str());
+        let expressions: Vec<String> = spec
+            .keys
+            .iter()
+            .map(|k| format!("json_extract(indexed, '$.{}')", k.as_str()))
+            .collect();
+        let ddl = format!(
+            "CREATE INDEX IF NOT EXISTS {index_name} ON root_filesystem_entries ({})",
+            expressions.join(", ")
+        );
+        conn.execute(&ddl, ()).await.map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })?;
+        Ok(())
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let mut params: Vec<libsql::Value> = vec![libsql::Value::Text(path.as_str().to_string())];
+        let prefix_pattern = format!("{}/%", path.as_str());
+        params.push(libsql::Value::Text(escape_like_pattern(&prefix_pattern)));
+
+        let mut conditions = String::new();
+        translate_filter(path, filter, &mut conditions, &mut params)?;
+
+        let mut sql = String::from(
+            "SELECT path, contents, content_type, kind, indexed, version \
+             FROM root_filesystem_entries \
+             WHERE is_dir = 0 AND (path = ?1 OR path LIKE ?2 ESCAPE '!')",
+        );
+        if !conditions.is_empty() {
+            sql.push_str(" AND ");
+            sql.push_str(&conditions);
+        }
+        sql.push_str(" ORDER BY path LIMIT ? OFFSET ?");
+        params.push(libsql::Value::Integer(
+            page.limit.min(crate::Page::MAX_LIMIT) as i64,
+        ));
+        params.push(libsql::Value::Integer(page.offset as i64));
+
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(&sql, params)
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Query, error))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Query, error))?
+        {
+            let row_path: String = row.get(0).map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let row_path = VirtualPath::new(row_path)?;
+            let body: Vec<u8> = row.get(1).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let content_type_raw: String = row.get(2).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let kind_raw: Option<String> = row.get(3).ok();
+            let indexed_raw: String = row.get(4).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let version_raw: i64 = row.get(5).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let entry = build_entry(&row_path, body, content_type_raw, kind_raw, indexed_raw)?;
+            out.push(VersionedEntry {
+                entry,
+                version: RecordVersion::from_backend(version_raw.max(0) as u64),
+            });
+        }
+        Ok(out)
     }
 
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
@@ -733,6 +900,165 @@ async fn ensure_libsql_records_columns(conn: &libsql::Connection) -> Result<(), 
 }
 
 #[cfg(feature = "libsql")]
+async fn ensure_libsql_index_specs_table(conn: &libsql::Connection) -> Result<(), FilesystemError> {
+    conn.execute_batch(LIBSQL_INDEX_SPECS_SCHEMA)
+        .await
+        .map_err(|error| {
+            libsql_db_error(valid_engine_path(), FilesystemOperation::EnsureIndex, error)
+        })?;
+    Ok(())
+}
+
+/// Build a deterministic SQL index identifier from a mount prefix + spec name.
+///
+/// IndexKey/IndexName are validated to be simple identifiers (no path
+/// separators, whitespace, or control chars), so the prefix's slashes are
+/// the only non-identifier characters we need to replace. Length is bounded
+/// — Postgres caps at 63, SQLite is more permissive — so we truncate after
+/// sanitisation. Collisions across mounts are tolerable: distinct
+/// `(prefix, name)` pairs share an index when their sanitized forms match,
+/// and the index is still correct (the planner just sees a wider index).
+#[cfg(feature = "libsql")]
+fn sql_index_name(prefix: &str, name: &str) -> String {
+    let prefix_clean: String = prefix
+        .trim_matches('/')
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let raw = format!("idx_rfs_{prefix_clean}_{name}");
+    // Identifier length budget chosen to satisfy Postgres' 63-char cap so
+    // libsql and postgres can share the same naming logic in future refactors.
+    if raw.len() > 62 {
+        let cutoff = raw
+            .char_indices()
+            .nth(62)
+            .map(|(i, _)| i)
+            .unwrap_or(raw.len());
+        raw[..cutoff].to_string()
+    } else {
+        raw
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn escape_like_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '%' if chars.peek().is_some() => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Translate a [`Filter`] tree into a libsql WHERE-clause fragment, appending
+/// bound parameters to `params` in left-to-right order. The fragment is
+/// wrapped in parentheses unless empty.
+#[cfg(feature = "libsql")]
+fn translate_filter(
+    path: &VirtualPath,
+    filter: &Filter,
+    out: &mut String,
+    params: &mut Vec<libsql::Value>,
+) -> Result<(), FilesystemError> {
+    match filter {
+        Filter::All => Ok(()),
+        Filter::Eq { key, value } => {
+            let placeholder = bind_index_value(path, value, params)?;
+            out.push_str(&format!(
+                "(json_extract(indexed, '$.{}') = ?{})",
+                key.as_str(),
+                placeholder
+            ));
+            Ok(())
+        }
+        Filter::PrefixOn { key, value } => {
+            let IndexValue::Text(prefix_value) = value else {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::Query,
+                });
+            };
+            let escaped = escape_like_pattern(prefix_value);
+            params.push(libsql::Value::Text(format!("{escaped}%")));
+            out.push_str(&format!(
+                "(json_extract(indexed, '$.{}') LIKE ?{} ESCAPE '!')",
+                key.as_str(),
+                params.len()
+            ));
+            Ok(())
+        }
+        Filter::Range { key, lo, hi } => {
+            let lo_idx = bind_index_value(path, lo, params)?;
+            let hi_idx = bind_index_value(path, hi, params)?;
+            out.push_str(&format!(
+                "(json_extract(indexed, '$.{}') BETWEEN ?{} AND ?{})",
+                key.as_str(),
+                lo_idx,
+                hi_idx
+            ));
+            Ok(())
+        }
+        Filter::And(children) => translate_compound(path, children, " AND ", out, params),
+        Filter::Or(children) => translate_compound(path, children, " OR ", out, params),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn translate_compound(
+    path: &VirtualPath,
+    children: &[Filter],
+    joiner: &str,
+    out: &mut String,
+    params: &mut Vec<libsql::Value>,
+) -> Result<(), FilesystemError> {
+    if children.is_empty() {
+        return Ok(());
+    }
+    out.push('(');
+    let mut first = true;
+    for child in children {
+        let mut sub = String::new();
+        translate_filter(path, child, &mut sub, params)?;
+        if sub.is_empty() {
+            continue;
+        }
+        if !first {
+            out.push_str(joiner);
+        }
+        out.push_str(&sub);
+        first = false;
+    }
+    out.push(')');
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+fn bind_index_value(
+    path: &VirtualPath,
+    value: &IndexValue,
+    params: &mut Vec<libsql::Value>,
+) -> Result<usize, FilesystemError> {
+    let bound = match value {
+        IndexValue::Text(s) => libsql::Value::Text(s.clone()),
+        IndexValue::I64(n) => libsql::Value::Integer(*n),
+        IndexValue::Bool(b) => libsql::Value::Integer(i64::from(*b)),
+        IndexValue::Bytes(_) => {
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::Query,
+            });
+        }
+    };
+    params.push(bound);
+    Ok(params.len())
+}
+
+#[cfg(feature = "libsql")]
 async fn add_column_if_missing(
     conn: &libsql::Connection,
     column: &str,
@@ -786,4 +1112,15 @@ CREATE TABLE IF NOT EXISTS root_filesystem_entries (
 );
 -- The PRIMARY KEY on `path` already provides a unique index for equality
 -- lookups, so no separate index is created.
+"#;
+
+#[cfg(feature = "libsql")]
+const LIBSQL_INDEX_SPECS_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS root_filesystem_index_specs (
+    prefix TEXT NOT NULL,
+    name TEXT NOT NULL,
+    keys TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    PRIMARY KEY (prefix, name)
+);
 "#;

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -8,7 +9,11 @@ use crate::db::{
     is_not_found, libsql_db_error, not_found, system_time_from_unix_seconds, valid_engine_path,
     virtual_path_prefixes,
 };
-use crate::{DirEntry, FileStat, FileType, FilesystemError, FilesystemOperation, RootFilesystem};
+use crate::{
+    BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FileType,
+    FilesystemError, FilesystemOperation, IndexCapability, IndexKey, IndexValue, RecordKind,
+    RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
+};
 
 #[cfg(feature = "libsql")]
 /// libSQL-backed [`RootFilesystem`] storing file contents by virtual path.
@@ -34,6 +39,7 @@ impl LibSqlRootFilesystem {
                 )
             })?;
         ensure_libsql_root_is_dir_column(&conn).await?;
+        ensure_libsql_records_columns(&conn).await?;
         Ok(())
     }
 
@@ -58,6 +64,221 @@ impl LibSqlRootFilesystem {
 #[cfg(feature = "libsql")]
 #[async_trait]
 impl RootFilesystem for LibSqlRootFilesystem {
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            read: true,
+            write: true,
+            append: true,
+            list: true,
+            stat: true,
+            delete: true,
+            // Native put/get/delete with version-aware CAS lands in this PR.
+            records: true,
+            // Query/ensure_index/append/tail still default to Unsupported.
+            // Land in a follow-up port once consumer migrations need them.
+            query: false,
+            index: IndexCapability {
+                exact: false,
+                prefix: false,
+                fts: false,
+                vector: false,
+            },
+            txn: TxnCapability::Cas,
+            events: false,
+            indexed: false,
+            embedded: false,
+        }
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        // Reject writes that would clobber a directory or a path that has
+        // children (mirrors `write_file` semantics so legacy and new ops
+        // stay consistent).
+        if matches!(
+            self.exact_entry(path).await?,
+            Some((_, FileType::Directory, _))
+        ) || self.has_child_entry(path).await?
+        {
+            return Err(directory_write_error(path.clone()));
+        }
+        let indexed_json =
+            serde_json::to_string(&entry.indexed).map_err(|error| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::WriteFile,
+                reason: format!("failed to serialize indexed projection: {error}"),
+            })?;
+        let kind_str = entry.kind.as_ref().map(|k| k.as_str().to_string());
+        let content_type_str = entry.content_type.as_str().to_string();
+        let body = entry.body;
+
+        match cas {
+            CasExpectation::Absent => {
+                let conn = self.connect().await?;
+                let rows = conn
+                    .execute(
+                        r#"
+                        INSERT INTO root_filesystem_entries
+                            (path, contents, is_dir, content_type, kind, indexed, version, updated_at)
+                        VALUES (?1, ?2, 0, ?3, ?4, ?5, 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                        ON CONFLICT (path) DO NOTHING
+                        "#,
+                        libsql::params![
+                            path.as_str(),
+                            libsql::Value::Blob(body),
+                            content_type_str,
+                            kind_str,
+                            indexed_json,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| {
+                        libsql_db_error(path.clone(), FilesystemOperation::WriteFile, error)
+                    })?;
+                if rows == 0 {
+                    let found = self.current_version(path).await?;
+                    return Err(FilesystemError::VersionMismatch {
+                        path: path.clone(),
+                        expected: None,
+                        found,
+                    });
+                }
+                Ok(RecordVersion::from_backend(1))
+            }
+            CasExpectation::Version(expected) => {
+                let conn = self.connect().await?;
+                let expected_raw = expected.get() as i64;
+                let rows = conn
+                    .execute(
+                        r#"
+                        UPDATE root_filesystem_entries
+                        SET contents = ?1,
+                            content_type = ?2,
+                            kind = ?3,
+                            indexed = ?4,
+                            version = version + 1,
+                            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                        WHERE path = ?5 AND is_dir = 0 AND version = ?6
+                        "#,
+                        libsql::params![
+                            libsql::Value::Blob(body),
+                            content_type_str,
+                            kind_str,
+                            indexed_json,
+                            path.as_str(),
+                            expected_raw,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| {
+                        libsql_db_error(path.clone(), FilesystemOperation::WriteFile, error)
+                    })?;
+                if rows == 0 {
+                    let found = self.current_version(path).await?;
+                    return Err(FilesystemError::VersionMismatch {
+                        path: path.clone(),
+                        expected: Some(expected),
+                        found,
+                    });
+                }
+                Ok(expected.next())
+            }
+            CasExpectation::Any => {
+                let conn = self.connect().await?;
+                let rows = conn
+                    .execute(
+                        r#"
+                        INSERT INTO root_filesystem_entries
+                            (path, contents, is_dir, content_type, kind, indexed, version, updated_at)
+                        VALUES (?1, ?2, 0, ?3, ?4, ?5, 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                        ON CONFLICT (path) DO UPDATE SET
+                            contents = excluded.contents,
+                            content_type = excluded.content_type,
+                            kind = excluded.kind,
+                            indexed = excluded.indexed,
+                            version = root_filesystem_entries.version + 1,
+                            updated_at = excluded.updated_at
+                        WHERE root_filesystem_entries.is_dir = 0
+                        "#,
+                        libsql::params![
+                            path.as_str(),
+                            libsql::Value::Blob(body),
+                            content_type_str,
+                            kind_str,
+                            indexed_json,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| {
+                        libsql_db_error(path.clone(), FilesystemOperation::WriteFile, error)
+                    })?;
+                if rows == 0 {
+                    return Err(directory_write_error(path.clone()));
+                }
+                let version =
+                    self.current_version(path)
+                        .await?
+                        .ok_or_else(|| FilesystemError::Backend {
+                            path: path.clone(),
+                            operation: FilesystemOperation::WriteFile,
+                            reason: "put succeeded but version lookup found no row".to_string(),
+                        })?;
+                Ok(version)
+            }
+        }
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT contents, is_dir, content_type, kind, indexed, version
+                FROM root_filesystem_entries
+                WHERE path = ?1
+                "#,
+                libsql::params![path.as_str()],
+            )
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?
+        else {
+            return Ok(None);
+        };
+        let is_dir: i64 = row
+            .get(1)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        if is_dir != 0 {
+            // Directories are not addressable as Entries.
+            return Ok(None);
+        }
+        let body: Vec<u8> = row
+            .get(0)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let content_type_raw: String = row
+            .get(2)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let kind_raw: Option<String> = row.get(3).ok();
+        let indexed_raw: String = row
+            .get(4)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let version_raw: i64 = row
+            .get(5)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let entry = build_entry(path, body, content_type_raw, kind_raw, indexed_raw)?;
+        Ok(Some(VersionedEntry {
+            entry,
+            version: RecordVersion::from_backend(version_raw.max(0) as u64),
+        }))
+    }
+
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
         let conn = self.connect().await?;
         let mut rows = conn
@@ -401,6 +622,133 @@ impl LibSqlRootFilesystem {
             .map_err(|error| libsql_db_error(parent.clone(), FilesystemOperation::Stat, error))?
             .is_some())
     }
+
+    async fn current_version(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Option<RecordVersion>, FilesystemError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT version FROM root_filesystem_entries WHERE path = ?1 AND is_dir = 0",
+                libsql::params![path.as_str()],
+            )
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?
+        else {
+            return Ok(None);
+        };
+        let version: i64 = row
+            .get(0)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        Ok(Some(RecordVersion::from_backend(version.max(0) as u64)))
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn build_entry(
+    path: &VirtualPath,
+    body: Vec<u8>,
+    content_type_raw: String,
+    kind_raw: Option<String>,
+    indexed_raw: String,
+) -> Result<Entry, FilesystemError> {
+    let content_type = ContentType::new(content_type_raw).map_err(FilesystemError::Contract)?;
+    let kind = kind_raw
+        .map(RecordKind::new)
+        .transpose()
+        .map_err(FilesystemError::Contract)?;
+    let indexed: BTreeMap<IndexKey, IndexValue> = if indexed_raw.is_empty() {
+        BTreeMap::new()
+    } else {
+        serde_json::from_str(&indexed_raw).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::ReadFile,
+            reason: format!("failed to parse indexed projection: {error}"),
+        })?
+    };
+    Ok(Entry {
+        body,
+        content_type,
+        kind,
+        indexed,
+    })
+}
+
+#[cfg(feature = "libsql")]
+async fn ensure_libsql_records_columns(conn: &libsql::Connection) -> Result<(), FilesystemError> {
+    add_column_if_missing(
+        conn,
+        "content_type",
+        "ALTER TABLE root_filesystem_entries ADD COLUMN content_type TEXT NOT NULL DEFAULT 'application/octet-stream'",
+    )
+    .await?;
+    add_column_if_missing(
+        conn,
+        "kind",
+        "ALTER TABLE root_filesystem_entries ADD COLUMN kind TEXT",
+    )
+    .await?;
+    add_column_if_missing(
+        conn,
+        "indexed",
+        "ALTER TABLE root_filesystem_entries ADD COLUMN indexed TEXT NOT NULL DEFAULT '{}'",
+    )
+    .await?;
+    add_column_if_missing(
+        conn,
+        "version",
+        "ALTER TABLE root_filesystem_entries ADD COLUMN version INTEGER NOT NULL DEFAULT 0",
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+async fn add_column_if_missing(
+    conn: &libsql::Connection,
+    column: &str,
+    ddl: &str,
+) -> Result<(), FilesystemError> {
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM pragma_table_info('root_filesystem_entries') WHERE name = ?1",
+            libsql::params![column],
+        )
+        .await
+        .map_err(|error| {
+            libsql_db_error(
+                valid_engine_path(),
+                FilesystemOperation::CreateDirAll,
+                error,
+            )
+        })?;
+    if rows
+        .next()
+        .await
+        .map_err(|error| {
+            libsql_db_error(
+                valid_engine_path(),
+                FilesystemOperation::CreateDirAll,
+                error,
+            )
+        })?
+        .is_some()
+    {
+        return Ok(());
+    }
+    conn.execute(ddl, ()).await.map_err(|error| {
+        libsql_db_error(
+            valid_engine_path(),
+            FilesystemOperation::CreateDirAll,
+            error,
+        )
+    })?;
+    Ok(())
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -6,8 +6,8 @@ use ironclaw_safety::sensitive_paths::is_sensitive_path;
 use tokio::io::AsyncWriteExt;
 
 use crate::{
-    DirEntry, FileStat, FileType, FilesystemError, FilesystemOperation, RootFilesystem,
-    path_prefix_matches,
+    CasExpectation, DirEntry, Entry, FileStat, FileType, FilesystemError, FilesystemOperation,
+    RecordVersion, RootFilesystem, VersionedEntry, path_prefix_matches,
 };
 
 /// Local filesystem backend mounted into the virtual namespace.
@@ -172,6 +172,52 @@ impl LocalFilesystem {
 
 #[async_trait]
 impl RootFilesystem for LocalFilesystem {
+    /// Native `put` for the byte-only local filesystem. Opaque-file entries
+    /// (`kind = None`, empty `indexed`) with `CasExpectation::Any` delegate
+    /// to `write_file`. Record-shaped entries, populated indexed
+    /// projections, and `CasExpectation::Absent` / `Version(_)` are
+    /// `Unsupported` because the local filesystem has no native metadata or
+    /// version tracking (sidecar metadata is a future addition; see the
+    /// reborn storage rework plan). We implement `put` here rather than
+    /// relying on a trait default so that the put/write_file pair is
+    /// non-recursive even when downstream consumers route through `put`.
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        if entry.kind.is_some() || !entry.indexed.is_empty() {
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::WriteFile,
+            });
+        }
+        if !matches!(cas, CasExpectation::Any) {
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::WriteFile,
+            });
+        }
+        self.write_file(path, &entry.body).await?;
+        Ok(RecordVersion::from_backend(0))
+    }
+
+    /// Native `get` mirroring `put`: read the bytes and wrap as an opaque
+    /// `Entry`. Version is always `0` because the local filesystem doesn't
+    /// track per-path versions. Non-existent paths return `Ok(None)`;
+    /// directories or symlinks return their respective `read_file` errors.
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        match self.read_file(path).await {
+            Ok(body) => Ok(Some(VersionedEntry {
+                entry: Entry::bytes(body),
+                version: RecordVersion::from_backend(0),
+            })),
+            Err(FilesystemError::NotFound { .. }) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
         let resolved = self
             .resolve_existing(path, FilesystemOperation::ReadFile)

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -210,6 +210,7 @@ impl RootFilesystem for LocalFilesystem {
     async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
         match self.read_file(path).await {
             Ok(body) => Ok(Some(VersionedEntry {
+                path: path.clone(),
                 entry: Entry::bytes(body),
                 version: RecordVersion::from_backend(0),
             })),

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -274,14 +274,23 @@ impl RootFilesystem for PostgresRootFilesystem {
         {
             return Err(directory_write_error(path.clone()));
         }
+        // PR #3660 reviewer fix: legacy write_file must reset content_type
+        // / kind / indexed and bump version, otherwise get() after
+        // write_file-overwrite of a previously record-shaped entry
+        // returns stale metadata.
         let rows = client
             .execute(
                 r#"
-                INSERT INTO root_filesystem_entries (path, contents, is_dir)
-                VALUES ($1, $2, FALSE)
+                INSERT INTO root_filesystem_entries
+                    (path, contents, is_dir, content_type, kind, indexed, version)
+                VALUES ($1, $2, FALSE, 'application/octet-stream', NULL, '{}'::jsonb, 1)
                 ON CONFLICT (path) DO UPDATE SET
                     contents = EXCLUDED.contents,
                     is_dir = FALSE,
+                    content_type = EXCLUDED.content_type,
+                    kind = EXCLUDED.kind,
+                    indexed = EXCLUDED.indexed,
+                    version = root_filesystem_entries.version + 1,
                     updated_at = NOW()
                 WHERE root_filesystem_entries.is_dir = FALSE
                 "#,
@@ -304,17 +313,26 @@ impl RootFilesystem for PostgresRootFilesystem {
         {
             return Err(directory_append_error(path.clone()));
         }
-        // TODO(reborn): append rewrites the whole DB row. Do not use this path
-        // for high-volume JSONL/event streams; route those through typed event
-        // stores or append-capable artifact backends instead.
+        // PR #3660 reviewer fix: append also resets schema metadata.
+        // Appending bytes onto a previously record-shaped entry was always
+        // a category error; surface it by clearing the schema metadata
+        // rather than leaving it stale on top of changed bytes.
+        // TODO(reborn): append rewrites the whole DB row. Do not use this
+        // path for high-volume JSONL/event streams; route those through
+        // typed event stores or append-capable artifact backends.
         client
             .execute(
                 r#"
-                INSERT INTO root_filesystem_entries (path, contents, is_dir)
-                VALUES ($1, $2, FALSE)
+                INSERT INTO root_filesystem_entries
+                    (path, contents, is_dir, content_type, kind, indexed, version)
+                VALUES ($1, $2, FALSE, 'application/octet-stream', NULL, '{}'::jsonb, 1)
                 ON CONFLICT (path) DO UPDATE SET
                     contents = root_filesystem_entries.contents || EXCLUDED.contents,
                     is_dir = FALSE,
+                    content_type = EXCLUDED.content_type,
+                    kind = EXCLUDED.kind,
+                    indexed = EXCLUDED.indexed,
+                    version = root_filesystem_entries.version + 1,
                     updated_at = NOW()
                 "#,
                 &[&path.as_str(), &bytes],

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -222,6 +222,7 @@ impl RootFilesystem for PostgresRootFilesystem {
         let version_raw: i64 = row.get("version");
         let entry = build_entry(path, body, content_type_raw, kind_raw, indexed_value)?;
         Ok(Some(VersionedEntry {
+            path: path.clone(),
             entry,
             version: record_version_from_i64(path, version_raw)?,
         }))
@@ -365,7 +366,11 @@ impl RootFilesystem for PostgresRootFilesystem {
                 let entry =
                     build_entry(&row_path, body, content_type_raw, kind_raw, indexed_value)?;
                 let version = record_version_from_i64(&row_path, version_raw)?;
-                Ok(VersionedEntry { entry, version })
+                Ok(VersionedEntry {
+                    path: row_path,
+                    entry,
+                    version,
+                })
             })
             .collect()
     }
@@ -722,8 +727,12 @@ fn translate_filter(
             // the extracted JSON text and bound params to `BIGINT` so the
             // BETWEEN comparison is numeric. Otherwise `'2' BETWEEN '10'
             // AND '99'` would compare lexicographically and miss values.
-            // Mixed-variant ranges still hit text comparison (also matches
-            // the in-memory backend's behaviour for cross-variant bounds).
+            //
+            // PR #3659 review fix: guard each cast with a `jsonb_typeof`
+            // check so a row whose stored value at `'{key}'` is a different
+            // variant (e.g. text under a numeric range) is filtered out
+            // BEFORE the cast — otherwise one stored text value can fail
+            // the whole query with a `bigint` cast error.
             match (lo, hi) {
                 (IndexValue::I64(lo_val), IndexValue::I64(hi_val)) => {
                     params.push(Box::new(*lo_val));
@@ -731,16 +740,21 @@ fn translate_filter(
                     params.push(Box::new(*hi_val));
                     let hi_idx = params.len();
                     out.push_str(&format!(
-                        "((indexed->>'{}')::bigint BETWEEN ${lo_idx} AND ${hi_idx})",
-                        key.as_str()
+                        "(jsonb_typeof(indexed->'{}') = 'number' \
+                         AND (indexed->>'{}')::bigint BETWEEN ${lo_idx} AND ${hi_idx})",
+                        key.as_str(),
+                        key.as_str(),
                     ));
                 }
                 _ => {
                     let lo_idx = bind_index_value(path, lo, params)?;
                     let hi_idx = bind_index_value(path, hi, params)?;
+                    let expected_json_type = index_value_jsonb_typeof(lo);
                     out.push_str(&format!(
-                        "(indexed->>'{}' BETWEEN ${lo_idx} AND ${hi_idx})",
-                        key.as_str()
+                        "(jsonb_typeof(indexed->'{}') = '{expected_json_type}' \
+                         AND indexed->>'{}' BETWEEN ${lo_idx} AND ${hi_idx})",
+                        key.as_str(),
+                        key.as_str(),
                     ));
                 }
             }
@@ -773,6 +787,19 @@ fn translate_compound(
     }
     out.push(')');
     Ok(())
+}
+
+/// Maps an [`IndexValue`] variant to its Postgres `jsonb_typeof` string.
+/// Used to guard `Filter::Range` so cross-variant stored values are filtered
+/// out before any cast/comparison (PR #3659 review fix). Postgres returns:
+/// `"string"` / `"number"` / `"boolean"` / `"null"` / `"object"` / `"array"`.
+#[cfg(feature = "postgres")]
+fn index_value_jsonb_typeof(value: &IndexValue) -> &'static str {
+    match value {
+        IndexValue::Text(_) | IndexValue::Bytes(_) => "string",
+        IndexValue::I64(_) => "number",
+        IndexValue::Bool(_) => "boolean",
+    }
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -277,38 +277,42 @@ impl RootFilesystem for PostgresRootFilesystem {
         })?;
 
         let client = self.client().await?;
-        let existing = client
+        // PR #3661 reviewer fix: race-idempotent declaration. Single
+        // INSERT ... ON CONFLICT DO NOTHING followed by a read-back +
+        // canonical-spec equality check. Two concurrent declarers of the
+        // same spec both succeed; declarers of conflicting specs see
+        // IndexConflict deterministically.
+        client
+            .execute(
+                "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) \
+                 VALUES ($1, $2, $3, $4) \
+                 ON CONFLICT (prefix, name) DO NOTHING",
+                &[&path.as_str(), &spec.name.as_str(), &keys_json, &kind_str],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+
+        let row = client
             .query_opt(
                 "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = $1 AND name = $2",
                 &[&path.as_str(), &spec.name.as_str()],
             )
             .await
-            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
-        if let Some(row) = existing {
-            let existing_keys: serde_json::Value = row.get("keys");
-            let existing_kind: String = row.get("kind");
-            if existing_keys != keys_json || existing_kind != kind_str {
-                return Err(FilesystemError::IndexConflict {
-                    path: path.clone(),
-                    name: spec.name.clone(),
-                    reason: "spec already declared with different keys or kind".to_string(),
-                });
-            }
-            return Ok(());
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?
+            .ok_or_else(|| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::EnsureIndex,
+                reason: "index spec disappeared after upsert".to_string(),
+            })?;
+        let existing_keys: serde_json::Value = row.get("keys");
+        let existing_kind: String = row.get("kind");
+        if existing_keys != keys_json || existing_kind != kind_str {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: "spec already declared with different keys or kind".to_string(),
+            });
         }
-
-        client
-            .execute(
-                "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) VALUES ($1, $2, $3, $4)",
-                &[
-                    &path.as_str(),
-                    &spec.name.as_str(),
-                    &keys_json,
-                    &kind_str,
-                ],
-            )
-            .await
-            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
 
         let index_name = sql_index_name(path.as_str(), spec.name.as_str());
         let expressions: Vec<String> = spec
@@ -708,6 +712,8 @@ fn sql_index_name(prefix: &str, name: &str) -> String {
     }
 }
 
+/// LIKE-pattern escape that preserves a trailing wildcard appended by the
+/// caller (the path-prefix scan in `query`).
 #[cfg(feature = "postgres")]
 fn escape_like_pattern(pattern: &str) -> String {
     let mut out = String::with_capacity(pattern.len());
@@ -723,9 +729,32 @@ fn escape_like_pattern(pattern: &str) -> String {
     out
 }
 
+/// Fully-literal LIKE escape for user-supplied values. PR #3661 reviewer
+/// fix: the `Filter::PrefixOn` value must be treated as a literal — a
+/// stored prefix of `tenant:%` must not become a `%` wildcard at query
+/// time.
+#[cfg(feature = "postgres")]
+fn escape_like_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '%' => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 /// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
 /// Bound parameters use `$N` placeholders sized from `params.len() + 1`.
-/// Returns once `out` has been appended.
+///
+/// PR #3661 fixes carried over from the libsql translator:
+/// - `Filter::All` emits `TRUE`; empty `And` → `TRUE`, empty `Or` →
+///   `FALSE` (matching in-memory `all`/`any` semantics).
+/// - `Filter::Range` on `IndexValue::I64` bounds casts both sides to
+///   `BIGINT` so the comparison is numeric, not lexicographic on text.
 #[cfg(feature = "postgres")]
 fn translate_filter(
     path: &VirtualPath,
@@ -734,7 +763,10 @@ fn translate_filter(
     params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
 ) -> Result<(), FilesystemError> {
     match filter {
-        Filter::All => Ok(()),
+        Filter::All => {
+            out.push_str("TRUE");
+            Ok(())
+        }
         Filter::Eq { key, value } => {
             let placeholder = bind_index_value(path, value, params)?;
             out.push_str(&format!("(indexed->>'{}' = ${placeholder})", key.as_str()));
@@ -747,7 +779,7 @@ fn translate_filter(
                     operation: FilesystemOperation::Query,
                 });
             };
-            let escaped = escape_like_pattern(prefix_value);
+            let escaped = escape_like_literal(prefix_value);
             params.push(Box::new(format!("{escaped}%")));
             out.push_str(&format!(
                 "(indexed->>'{}' LIKE ${} ESCAPE '!')",
@@ -757,16 +789,36 @@ fn translate_filter(
             Ok(())
         }
         Filter::Range { key, lo, hi } => {
-            let lo_idx = bind_index_value(path, lo, params)?;
-            let hi_idx = bind_index_value(path, hi, params)?;
-            out.push_str(&format!(
-                "(indexed->>'{}' BETWEEN ${lo_idx} AND ${hi_idx})",
-                key.as_str()
-            ));
+            // PR #3661 reviewer fix: when both bounds are `I64`, cast both
+            // the extracted JSON text and bound params to `BIGINT` so the
+            // BETWEEN comparison is numeric. Otherwise `'2' BETWEEN '10'
+            // AND '99'` would compare lexicographically and miss values.
+            // Mixed-variant ranges still hit text comparison (also matches
+            // the in-memory backend's behaviour for cross-variant bounds).
+            match (lo, hi) {
+                (IndexValue::I64(lo_val), IndexValue::I64(hi_val)) => {
+                    params.push(Box::new(*lo_val));
+                    let lo_idx = params.len();
+                    params.push(Box::new(*hi_val));
+                    let hi_idx = params.len();
+                    out.push_str(&format!(
+                        "((indexed->>'{}')::bigint BETWEEN ${lo_idx} AND ${hi_idx})",
+                        key.as_str()
+                    ));
+                }
+                _ => {
+                    let lo_idx = bind_index_value(path, lo, params)?;
+                    let hi_idx = bind_index_value(path, hi, params)?;
+                    out.push_str(&format!(
+                        "(indexed->>'{}' BETWEEN ${lo_idx} AND ${hi_idx})",
+                        key.as_str()
+                    ));
+                }
+            }
             Ok(())
         }
-        Filter::And(children) => translate_compound(path, children, " AND ", out, params),
-        Filter::Or(children) => translate_compound(path, children, " OR ", out, params),
+        Filter::And(children) => translate_compound(path, children, " AND ", "TRUE", out, params),
+        Filter::Or(children) => translate_compound(path, children, " OR ", "FALSE", out, params),
     }
 }
 
@@ -775,25 +827,20 @@ fn translate_compound(
     path: &VirtualPath,
     children: &[Filter],
     joiner: &str,
+    empty_identity: &str,
     out: &mut String,
     params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
 ) -> Result<(), FilesystemError> {
     if children.is_empty() {
+        out.push_str(empty_identity);
         return Ok(());
     }
     out.push('(');
-    let mut first = true;
-    for child in children {
-        let mut sub = String::new();
-        translate_filter(path, child, &mut sub, params)?;
-        if sub.is_empty() {
-            continue;
-        }
-        if !first {
+    for (i, child) in children.iter().enumerate() {
+        if i > 0 {
             out.push_str(joiner);
         }
-        out.push_str(&sub);
-        first = false;
+        translate_filter(path, child, out, params)?;
     }
     out.push(')');
     Ok(())

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -5,13 +5,14 @@ use ironclaw_host_api::VirtualPath;
 
 use crate::db::{
     child_path_like_pattern, db_error, direct_children, directory_append_error,
-    directory_write_error, is_not_found, not_found, system_time_from_unix_seconds,
+    directory_write_error, escape_like_literal, escape_like_with_trailing_wildcard, is_not_found,
+    not_found, record_version_from_i64, sql_index_name, system_time_from_unix_seconds,
     valid_engine_path, virtual_path_prefixes,
 };
 use crate::{
     BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FileType,
-    FilesystemError, FilesystemOperation, Filter, IndexCapability, IndexKey, IndexKind, IndexSpec,
-    IndexValue, Page, RecordKind, RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
+    FilesystemError, FilesystemOperation, Filter, IndexKey, IndexKind, IndexSpec, IndexValue, Page,
+    RecordKind, RecordVersion, RootFilesystem, VersionedEntry,
 };
 
 #[cfg(feature = "postgres")]
@@ -56,26 +57,10 @@ impl PostgresRootFilesystem {
 #[async_trait]
 impl RootFilesystem for PostgresRootFilesystem {
     fn capabilities(&self) -> BackendCapabilities {
-        BackendCapabilities {
-            read: true,
-            write: true,
-            append: true,
-            list: true,
-            stat: true,
-            delete: true,
-            records: true,
-            query: true,
-            index: IndexCapability {
-                exact: true,
-                prefix: true,
-                fts: false,
-                vector: false,
-            },
-            txn: TxnCapability::Cas,
-            events: false,
-            indexed: false,
-            embedded: false,
-        }
+        // sql_typical: read/write/append/list/stat/delete/records/query/
+        // IndexExact/IndexPrefix/CAS. Events + FTS/Vector indexes stay off
+        // until their respective backend ports land.
+        BackendCapabilities::sql_typical()
     }
 
     async fn put(
@@ -92,12 +77,12 @@ impl RootFilesystem for PostgresRootFilesystem {
         {
             return Err(directory_write_error(path.clone()));
         }
-        let indexed_json =
-            serde_json::to_value(&entry.indexed).map_err(|error| FilesystemError::Backend {
+        let indexed_json = serde_json::to_value(&entry.indexed).map_err(|_| {
+            FilesystemError::SerializeIndexed {
                 path: path.clone(),
                 operation: FilesystemOperation::WriteFile,
-                reason: format!("failed to serialize indexed projection: {error}"),
-            })?;
+            }
+        })?;
         let kind_str = entry.kind.as_ref().map(|k| k.as_str().to_string());
         let content_type_str = entry.content_type.as_str().to_string();
         let body = entry.body;
@@ -205,7 +190,7 @@ impl RootFilesystem for PostgresRootFilesystem {
                     return Err(directory_write_error(path.clone()));
                 };
                 let version: i64 = row.get("version");
-                Ok(RecordVersion::from_backend(version.max(0) as u64))
+                record_version_from_i64(path, version)
             }
         }
     }
@@ -238,7 +223,7 @@ impl RootFilesystem for PostgresRootFilesystem {
         let entry = build_entry(path, body, content_type_raw, kind_raw, indexed_value)?;
         Ok(Some(VersionedEntry {
             entry,
-            version: RecordVersion::from_backend(version_raw.max(0) as u64),
+            version: record_version_from_i64(path, version_raw)?,
         }))
     }
 
@@ -261,7 +246,7 @@ impl RootFilesystem for PostgresRootFilesystem {
             return Err(FilesystemError::IndexConflict {
                 path: path.clone(),
                 name: spec.name.clone(),
-                reason: "spec must declare at least one key".to_string(),
+                reason: crate::IndexConflictReason::EmptyKeys,
             });
         }
         let keys_json = serde_json::to_value(
@@ -270,10 +255,9 @@ impl RootFilesystem for PostgresRootFilesystem {
                 .map(|k| k.as_str().to_string())
                 .collect::<Vec<_>>(),
         )
-        .map_err(|error| FilesystemError::Backend {
+        .map_err(|_| FilesystemError::SerializeIndexed {
             path: path.clone(),
             operation: FilesystemOperation::EnsureIndex,
-            reason: format!("failed to serialize index keys: {error}"),
         })?;
 
         let client = self.client().await?;
@@ -299,10 +283,9 @@ impl RootFilesystem for PostgresRootFilesystem {
             )
             .await
             .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?
-            .ok_or_else(|| FilesystemError::Backend {
+            .ok_or_else(|| FilesystemError::IndexSpecMissingAfterUpsert {
                 path: path.clone(),
-                operation: FilesystemOperation::EnsureIndex,
-                reason: "index spec disappeared after upsert".to_string(),
+                name: spec.name.clone(),
             })?;
         let existing_keys: serde_json::Value = row.get("keys");
         let existing_kind: String = row.get("kind");
@@ -310,7 +293,7 @@ impl RootFilesystem for PostgresRootFilesystem {
             return Err(FilesystemError::IndexConflict {
                 path: path.clone(),
                 name: spec.name.clone(),
-                reason: "spec already declared with different keys or kind".to_string(),
+                reason: crate::IndexConflictReason::SpecMismatch,
             });
         }
 
@@ -339,7 +322,7 @@ impl RootFilesystem for PostgresRootFilesystem {
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = Vec::new();
         let path_str = path.as_str().to_string();
-        let prefix_pattern = escape_like_pattern(&format!("{}/%", path.as_str()));
+        let prefix_pattern = escape_like_with_trailing_wildcard(&format!("{}/%", path.as_str()));
         params.push(Box::new(path_str));
         params.push(Box::new(prefix_pattern));
 
@@ -381,10 +364,8 @@ impl RootFilesystem for PostgresRootFilesystem {
                 let version_raw: i64 = row.get("version");
                 let entry =
                     build_entry(&row_path, body, content_type_raw, kind_raw, indexed_value)?;
-                Ok(VersionedEntry {
-                    entry,
-                    version: RecordVersion::from_backend(version_raw.max(0) as u64),
-                })
+                let version = record_version_from_i64(&row_path, version_raw)?;
+                Ok(VersionedEntry { entry, version })
             })
             .collect()
     }
@@ -464,9 +445,11 @@ impl RootFilesystem for PostgresRootFilesystem {
         // Appending bytes onto a previously record-shaped entry was always
         // a category error; surface it by clearing the schema metadata
         // rather than leaving it stale on top of changed bytes.
-        // TODO(reborn): append rewrites the whole DB row. Do not use this
-        // path for high-volume JSONL/event streams; route those through
-        // typed event stores or append-capable artifact backends.
+        // Note: append rewrites the whole DB row. This is acceptable for
+        // the legacy bytes plane (slated for removal in the consumer-
+        // migration cleanup pass — see RootFilesystem::append_file's
+        // deprecation note). New callers must use `append`/`tail` for
+        // log-shaped mounts or `get`+`put` read-modify-write.
         client
             .execute(
                 r#"
@@ -685,66 +668,12 @@ impl PostgresRootFilesystem {
             )
             .await
             .map_err(|error| db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
-        Ok(row.map(|row| {
+        row.map(|row| {
             let version: i64 = row.get("version");
-            RecordVersion::from_backend(version.max(0) as u64)
-        }))
+            record_version_from_i64(path, version)
+        })
+        .transpose()
     }
-}
-
-#[cfg(feature = "postgres")]
-fn sql_index_name(prefix: &str, name: &str) -> String {
-    let prefix_clean: String = prefix
-        .trim_matches('/')
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
-    let raw = format!("idx_rfs_{prefix_clean}_{name}");
-    if raw.len() > 62 {
-        let cutoff = raw
-            .char_indices()
-            .nth(62)
-            .map(|(i, _)| i)
-            .unwrap_or(raw.len());
-        raw[..cutoff].to_string()
-    } else {
-        raw
-    }
-}
-
-/// LIKE-pattern escape that preserves a trailing wildcard appended by the
-/// caller (the path-prefix scan in `query`).
-#[cfg(feature = "postgres")]
-fn escape_like_pattern(pattern: &str) -> String {
-    let mut out = String::with_capacity(pattern.len());
-    let mut chars = pattern.chars().peekable();
-    while let Some(c) = chars.next() {
-        match c {
-            '%' if chars.peek().is_some() => out.push_str("!%"),
-            '_' => out.push_str("!_"),
-            '!' => out.push_str("!!"),
-            other => out.push(other),
-        }
-    }
-    out
-}
-
-/// Fully-literal LIKE escape for user-supplied values. PR #3661 reviewer
-/// fix: the `Filter::PrefixOn` value must be treated as a literal — a
-/// stored prefix of `tenant:%` must not become a `%` wildcard at query
-/// time.
-#[cfg(feature = "postgres")]
-fn escape_like_literal(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for c in value.chars() {
-        match c {
-            '%' => out.push_str("!%"),
-            '_' => out.push_str("!_"),
-            '!' => out.push_str("!!"),
-            other => out.push(other),
-        }
-    }
-    out
 }
 
 /// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
@@ -891,10 +820,9 @@ fn build_entry(
     let indexed: BTreeMap<IndexKey, IndexValue> = if indexed_value.is_null() {
         BTreeMap::new()
     } else {
-        serde_json::from_value(indexed_value).map_err(|error| FilesystemError::Backend {
+        serde_json::from_value(indexed_value).map_err(|_| FilesystemError::DeserializeIndexed {
             path: path.clone(),
             operation: FilesystemOperation::ReadFile,
-            reason: format!("failed to parse indexed projection: {error}"),
         })?
     };
     Ok(Entry {

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use async_trait::async_trait;
 use ironclaw_host_api::VirtualPath;
 
@@ -6,7 +8,11 @@ use crate::db::{
     directory_write_error, is_not_found, not_found, system_time_from_unix_seconds,
     valid_engine_path, virtual_path_prefixes,
 };
-use crate::{DirEntry, FileStat, FileType, FilesystemError, FilesystemOperation, RootFilesystem};
+use crate::{
+    BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FileType,
+    FilesystemError, FilesystemOperation, IndexCapability, IndexKey, IndexValue, RecordKind,
+    RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
+};
 
 #[cfg(feature = "postgres")]
 /// PostgreSQL-backed [`RootFilesystem`] storing file contents by virtual path.
@@ -49,6 +55,193 @@ impl PostgresRootFilesystem {
 #[cfg(feature = "postgres")]
 #[async_trait]
 impl RootFilesystem for PostgresRootFilesystem {
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities {
+            read: true,
+            write: true,
+            append: true,
+            list: true,
+            stat: true,
+            delete: true,
+            records: true,
+            query: false,
+            index: IndexCapability {
+                exact: false,
+                prefix: false,
+                fts: false,
+                vector: false,
+            },
+            txn: TxnCapability::Cas,
+            events: false,
+            indexed: false,
+            embedded: false,
+        }
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        let client = self.client().await?;
+        if matches!(
+            self.exact_entry_with_client(&client, path).await?,
+            Some((_, FileType::Directory, _))
+        ) || self.has_child_entry_with_client(&client, path).await?
+        {
+            return Err(directory_write_error(path.clone()));
+        }
+        let indexed_json =
+            serde_json::to_value(&entry.indexed).map_err(|error| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::WriteFile,
+                reason: format!("failed to serialize indexed projection: {error}"),
+            })?;
+        let kind_str = entry.kind.as_ref().map(|k| k.as_str().to_string());
+        let content_type_str = entry.content_type.as_str().to_string();
+        let body = entry.body;
+        let path_str = path.as_str();
+
+        match cas {
+            CasExpectation::Absent => {
+                let rows = client
+                    .execute(
+                        r#"
+                        INSERT INTO root_filesystem_entries
+                            (path, contents, is_dir, content_type, kind, indexed, version)
+                        VALUES ($1, $2, FALSE, $3, $4, $5, 1)
+                        ON CONFLICT (path) DO NOTHING
+                        "#,
+                        &[
+                            &path_str,
+                            &body,
+                            &content_type_str,
+                            &kind_str,
+                            &indexed_json,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| {
+                        db_error(path.clone(), FilesystemOperation::WriteFile, error)
+                    })?;
+                if rows == 0 {
+                    let found = self.current_version_with_client(&client, path).await?;
+                    return Err(FilesystemError::VersionMismatch {
+                        path: path.clone(),
+                        expected: None,
+                        found,
+                    });
+                }
+                Ok(RecordVersion::from_backend(1))
+            }
+            CasExpectation::Version(expected) => {
+                let expected_raw = expected.get() as i64;
+                let rows = client
+                    .execute(
+                        r#"
+                        UPDATE root_filesystem_entries
+                        SET contents = $1,
+                            content_type = $2,
+                            kind = $3,
+                            indexed = $4,
+                            version = version + 1,
+                            updated_at = NOW()
+                        WHERE path = $5 AND is_dir = FALSE AND version = $6
+                        "#,
+                        &[
+                            &body,
+                            &content_type_str,
+                            &kind_str,
+                            &indexed_json,
+                            &path_str,
+                            &expected_raw,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| {
+                        db_error(path.clone(), FilesystemOperation::WriteFile, error)
+                    })?;
+                if rows == 0 {
+                    let found = self.current_version_with_client(&client, path).await?;
+                    return Err(FilesystemError::VersionMismatch {
+                        path: path.clone(),
+                        expected: Some(expected),
+                        found,
+                    });
+                }
+                Ok(expected.next())
+            }
+            CasExpectation::Any => {
+                let row = client
+                    .query_opt(
+                        r#"
+                        INSERT INTO root_filesystem_entries
+                            (path, contents, is_dir, content_type, kind, indexed, version)
+                        VALUES ($1, $2, FALSE, $3, $4, $5, 1)
+                        ON CONFLICT (path) DO UPDATE SET
+                            contents = EXCLUDED.contents,
+                            content_type = EXCLUDED.content_type,
+                            kind = EXCLUDED.kind,
+                            indexed = EXCLUDED.indexed,
+                            version = root_filesystem_entries.version + 1,
+                            updated_at = NOW()
+                        WHERE root_filesystem_entries.is_dir = FALSE
+                        RETURNING version
+                        "#,
+                        &[
+                            &path_str,
+                            &body,
+                            &content_type_str,
+                            &kind_str,
+                            &indexed_json,
+                        ],
+                    )
+                    .await
+                    .map_err(|error| {
+                        db_error(path.clone(), FilesystemOperation::WriteFile, error)
+                    })?;
+                let Some(row) = row else {
+                    return Err(directory_write_error(path.clone()));
+                };
+                let version: i64 = row.get("version");
+                Ok(RecordVersion::from_backend(version.max(0) as u64))
+            }
+        }
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        let client = self.client().await?;
+        let row = client
+            .query_opt(
+                r#"
+                SELECT contents, is_dir, content_type, kind, indexed, version
+                FROM root_filesystem_entries
+                WHERE path = $1
+                "#,
+                &[&path.as_str()],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let is_dir: bool = row.get("is_dir");
+        if is_dir {
+            return Ok(None);
+        }
+        let body: Vec<u8> = row.get("contents");
+        let content_type_raw: String = row.get("content_type");
+        let kind_raw: Option<String> = row.get("kind");
+        let indexed_value: serde_json::Value = row.get("indexed");
+        let version_raw: i64 = row.get("version");
+        let entry = build_entry(path, body, content_type_raw, kind_raw, indexed_value)?;
+        Ok(Some(VersionedEntry {
+            entry,
+            version: RecordVersion::from_backend(version_raw.max(0) as u64),
+        }))
+    }
+
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
         let client = self.client().await?;
         let row = client
@@ -314,6 +507,54 @@ impl PostgresRootFilesystem {
             .map_err(|error| db_error(parent.clone(), FilesystemOperation::Stat, error))?;
         Ok(row.is_some())
     }
+
+    async fn current_version_with_client(
+        &self,
+        client: &tokio_postgres::Client,
+        path: &VirtualPath,
+    ) -> Result<Option<RecordVersion>, FilesystemError> {
+        let row = client
+            .query_opt(
+                "SELECT version FROM root_filesystem_entries WHERE path = $1 AND is_dir = FALSE",
+                &[&path.as_str()],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        Ok(row.map(|row| {
+            let version: i64 = row.get("version");
+            RecordVersion::from_backend(version.max(0) as u64)
+        }))
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn build_entry(
+    path: &VirtualPath,
+    body: Vec<u8>,
+    content_type_raw: String,
+    kind_raw: Option<String>,
+    indexed_value: serde_json::Value,
+) -> Result<Entry, FilesystemError> {
+    let content_type = ContentType::new(content_type_raw).map_err(FilesystemError::Contract)?;
+    let kind = kind_raw
+        .map(RecordKind::new)
+        .transpose()
+        .map_err(FilesystemError::Contract)?;
+    let indexed: BTreeMap<IndexKey, IndexValue> = if indexed_value.is_null() {
+        BTreeMap::new()
+    } else {
+        serde_json::from_value(indexed_value).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::ReadFile,
+            reason: format!("failed to parse indexed projection: {error}"),
+        })?
+    };
+    Ok(Entry {
+        body,
+        content_type,
+        kind,
+        indexed,
+    })
 }
 
 #[cfg(feature = "postgres")]
@@ -321,4 +562,6 @@ const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = concat!(
     include_str!("../../../migrations/V26__root_filesystem_entries.sql"),
     "\n",
     include_str!("../../../migrations/V27__root_filesystem_entries_directories.sql"),
+    "\n",
+    include_str!("../../../migrations/V28__root_filesystem_records.sql"),
 );

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -10,8 +10,8 @@ use crate::db::{
 };
 use crate::{
     BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FileType,
-    FilesystemError, FilesystemOperation, IndexCapability, IndexKey, IndexValue, RecordKind,
-    RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
+    FilesystemError, FilesystemOperation, Filter, IndexCapability, IndexKey, IndexKind, IndexSpec,
+    IndexValue, Page, RecordKind, RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
 };
 
 #[cfg(feature = "postgres")]
@@ -64,10 +64,10 @@ impl RootFilesystem for PostgresRootFilesystem {
             stat: true,
             delete: true,
             records: true,
-            query: false,
+            query: true,
             index: IndexCapability {
-                exact: false,
-                prefix: false,
+                exact: true,
+                prefix: true,
                 fts: false,
                 vector: false,
             },
@@ -240,6 +240,149 @@ impl RootFilesystem for PostgresRootFilesystem {
             entry,
             version: RecordVersion::from_backend(version_raw.max(0) as u64),
         }))
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        let kind_str = match &spec.kind {
+            IndexKind::Exact => "exact".to_string(),
+            IndexKind::Prefix => "prefix".to_string(),
+            IndexKind::Fts | IndexKind::Vector { .. } => {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::EnsureIndex,
+                });
+            }
+        };
+        if spec.keys.is_empty() {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: "spec must declare at least one key".to_string(),
+            });
+        }
+        let keys_json = serde_json::to_value(
+            spec.keys
+                .iter()
+                .map(|k| k.as_str().to_string())
+                .collect::<Vec<_>>(),
+        )
+        .map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::EnsureIndex,
+            reason: format!("failed to serialize index keys: {error}"),
+        })?;
+
+        let client = self.client().await?;
+        let existing = client
+            .query_opt(
+                "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = $1 AND name = $2",
+                &[&path.as_str(), &spec.name.as_str()],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+        if let Some(row) = existing {
+            let existing_keys: serde_json::Value = row.get("keys");
+            let existing_kind: String = row.get("kind");
+            if existing_keys != keys_json || existing_kind != kind_str {
+                return Err(FilesystemError::IndexConflict {
+                    path: path.clone(),
+                    name: spec.name.clone(),
+                    reason: "spec already declared with different keys or kind".to_string(),
+                });
+            }
+            return Ok(());
+        }
+
+        client
+            .execute(
+                "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) VALUES ($1, $2, $3, $4)",
+                &[
+                    &path.as_str(),
+                    &spec.name.as_str(),
+                    &keys_json,
+                    &kind_str,
+                ],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+
+        let index_name = sql_index_name(path.as_str(), spec.name.as_str());
+        let expressions: Vec<String> = spec
+            .keys
+            .iter()
+            .map(|k| format!("((indexed->>'{}'))", k.as_str()))
+            .collect();
+        let ddl = format!(
+            "CREATE INDEX IF NOT EXISTS {index_name} ON root_filesystem_entries ({})",
+            expressions.join(", ")
+        );
+        client
+            .batch_execute(&ddl)
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+        Ok(())
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = Vec::new();
+        let path_str = path.as_str().to_string();
+        let prefix_pattern = escape_like_pattern(&format!("{}/%", path.as_str()));
+        params.push(Box::new(path_str));
+        params.push(Box::new(prefix_pattern));
+
+        let mut conditions = String::new();
+        translate_filter(path, filter, &mut conditions, &mut params)?;
+
+        let mut sql = String::from(
+            "SELECT path, contents, content_type, kind, indexed, version \
+             FROM root_filesystem_entries \
+             WHERE is_dir = FALSE AND (path = $1 OR path LIKE $2 ESCAPE '!')",
+        );
+        if !conditions.is_empty() {
+            sql.push_str(" AND ");
+            sql.push_str(&conditions);
+        }
+        sql.push_str(&format!(
+            " ORDER BY path LIMIT ${} OFFSET ${}",
+            params.len() + 1,
+            params.len() + 2
+        ));
+        params.push(Box::new(i64::from(page.limit.min(Page::MAX_LIMIT))));
+        params.push(Box::new(page.offset as i64));
+
+        let client = self.client().await?;
+        let params_ref: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
+            params.iter().map(|p| p.as_ref() as _).collect();
+        let rows = client
+            .query(sql.as_str(), &params_ref[..])
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::Query, error))?;
+        rows.into_iter()
+            .map(|row| {
+                let row_path: String = row.get("path");
+                let row_path = VirtualPath::new(row_path)?;
+                let body: Vec<u8> = row.get("contents");
+                let content_type_raw: String = row.get("content_type");
+                let kind_raw: Option<String> = row.get("kind");
+                let indexed_value: serde_json::Value = row.get("indexed");
+                let version_raw: i64 = row.get("version");
+                let entry =
+                    build_entry(&row_path, body, content_type_raw, kind_raw, indexed_value)?;
+                Ok(VersionedEntry {
+                    entry,
+                    version: RecordVersion::from_backend(version_raw.max(0) as u64),
+                })
+            })
+            .collect()
     }
 
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
@@ -546,6 +689,146 @@ impl PostgresRootFilesystem {
 }
 
 #[cfg(feature = "postgres")]
+fn sql_index_name(prefix: &str, name: &str) -> String {
+    let prefix_clean: String = prefix
+        .trim_matches('/')
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let raw = format!("idx_rfs_{prefix_clean}_{name}");
+    if raw.len() > 62 {
+        let cutoff = raw
+            .char_indices()
+            .nth(62)
+            .map(|(i, _)| i)
+            .unwrap_or(raw.len());
+        raw[..cutoff].to_string()
+    } else {
+        raw
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn escape_like_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '%' if chars.peek().is_some() => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
+/// Bound parameters use `$N` placeholders sized from `params.len() + 1`.
+/// Returns once `out` has been appended.
+#[cfg(feature = "postgres")]
+fn translate_filter(
+    path: &VirtualPath,
+    filter: &Filter,
+    out: &mut String,
+    params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+) -> Result<(), FilesystemError> {
+    match filter {
+        Filter::All => Ok(()),
+        Filter::Eq { key, value } => {
+            let placeholder = bind_index_value(path, value, params)?;
+            out.push_str(&format!("(indexed->>'{}' = ${placeholder})", key.as_str()));
+            Ok(())
+        }
+        Filter::PrefixOn { key, value } => {
+            let IndexValue::Text(prefix_value) = value else {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::Query,
+                });
+            };
+            let escaped = escape_like_pattern(prefix_value);
+            params.push(Box::new(format!("{escaped}%")));
+            out.push_str(&format!(
+                "(indexed->>'{}' LIKE ${} ESCAPE '!')",
+                key.as_str(),
+                params.len()
+            ));
+            Ok(())
+        }
+        Filter::Range { key, lo, hi } => {
+            let lo_idx = bind_index_value(path, lo, params)?;
+            let hi_idx = bind_index_value(path, hi, params)?;
+            out.push_str(&format!(
+                "(indexed->>'{}' BETWEEN ${lo_idx} AND ${hi_idx})",
+                key.as_str()
+            ));
+            Ok(())
+        }
+        Filter::And(children) => translate_compound(path, children, " AND ", out, params),
+        Filter::Or(children) => translate_compound(path, children, " OR ", out, params),
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn translate_compound(
+    path: &VirtualPath,
+    children: &[Filter],
+    joiner: &str,
+    out: &mut String,
+    params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+) -> Result<(), FilesystemError> {
+    if children.is_empty() {
+        return Ok(());
+    }
+    out.push('(');
+    let mut first = true;
+    for child in children {
+        let mut sub = String::new();
+        translate_filter(path, child, &mut sub, params)?;
+        if sub.is_empty() {
+            continue;
+        }
+        if !first {
+            out.push_str(joiner);
+        }
+        out.push_str(&sub);
+        first = false;
+    }
+    out.push(')');
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+fn bind_index_value(
+    path: &VirtualPath,
+    value: &IndexValue,
+    params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+) -> Result<usize, FilesystemError> {
+    // `indexed->>'key'` returns text regardless of the underlying JSON type,
+    // so we bind every supported variant as text. This keeps the index
+    // (which is also an expression on the text form) usable for all three
+    // variants without dialect branches.
+    let bound: Box<dyn tokio_postgres::types::ToSql + Sync + Send> = match value {
+        IndexValue::Text(s) => Box::new(s.clone()),
+        IndexValue::I64(n) => Box::new(n.to_string()),
+        IndexValue::Bool(b) => Box::new(if *b {
+            "true".to_string()
+        } else {
+            "false".to_string()
+        }),
+        IndexValue::Bytes(_) => {
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::Query,
+            });
+        }
+    };
+    params.push(bound);
+    Ok(params.len())
+}
+
+#[cfg(feature = "postgres")]
 fn build_entry(
     path: &VirtualPath,
     body: Vec<u8>,
@@ -582,4 +865,6 @@ const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = concat!(
     include_str!("../../../migrations/V27__root_filesystem_entries_directories.sql"),
     "\n",
     include_str!("../../../migrations/V28__root_filesystem_records.sql"),
+    "\n",
+    include_str!("../../../migrations/V29__root_filesystem_index_specs.sql"),
 );

--- a/crates/ironclaw_filesystem/src/record.rs
+++ b/crates/ironclaw_filesystem/src/record.rs
@@ -334,13 +334,17 @@ impl Entry {
     }
 }
 
-/// Versioned read result returned by [`get`](crate::StorageBackend::get) and
-/// [`query`](crate::StorageBackend::query).
+/// Versioned read result returned by [`get`](crate::RootFilesystem::get) and
+/// [`query`](crate::RootFilesystem::query).
 ///
 /// `version` is the value to pass to [`CasExpectation::Version`] in a
-/// subsequent write to avoid lost updates.
+/// subsequent write to avoid lost updates. `path` carries the addressable
+/// [`VirtualPath`] of the record so query consumers can drive
+/// `put`/`delete` workflows without re-deriving the path from
+/// `entry.indexed` (PR #3659 review fix).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VersionedEntry {
+    pub path: ironclaw_host_api::VirtualPath,
     pub entry: Entry,
     pub version: RecordVersion,
 }

--- a/crates/ironclaw_filesystem/src/record.rs
+++ b/crates/ironclaw_filesystem/src/record.rs
@@ -1,0 +1,418 @@
+//! Universal `Entry` and related primitives for the unified storage surface.
+//!
+//! The kernel storage rework collapses the historical bytes plane
+//! (read/write opaque files) and record plane (typed rows with queryable
+//! columns) into a single shape: every put/get on the filesystem deals in an
+//! [`Entry`] — a body of bytes plus optional schema metadata. A "file" is an
+//! [`Entry`] with `kind = None` and an empty indexed projection. A "record"
+//! is an [`Entry`] with `kind = Some(_)` and one or more declared indexed
+//! projection values. There is no parallel API for the two cases; the same
+//! put/get/query/CAS machinery serves both.
+//!
+//! Encryption-at-rest is applied by an
+//! [`EncryptedBackend`](crate::EncryptedBackend) decorator over the
+//! [`Entry::body`] and any `IndexValue::Bytes` projection so the indexed
+//! scalar values (`scope`, `status`, …) remain queryable on the underlying
+//! mount.
+//!
+//! Atomicity uses [`CasExpectation`] rather than closure-based transactions.
+//! Stores work with compare-and-swap as the primitive; backends that support
+//! richer multi-key transactions expose them through
+//! [`StorageTxn`](crate::StorageTxn) but consumers must never depend on it.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use ironclaw_host_api::HostApiError;
+use serde::{Deserialize, Serialize};
+
+use crate::index::{IndexKey, IndexValue};
+
+/// Schema family identifier for a record-shaped entry (e.g.
+/// `credential_account`, `engine_thread`). Same validation as
+/// [`IndexName`](crate::IndexName) / [`IndexKey`](crate::IndexKey): non-empty,
+/// no separators, no whitespace, no control characters, ≤ 128 chars.
+///
+/// A [`None`] kind on an [`Entry`] marks the entry as an opaque file with no
+/// schema; backends must accept these even if they otherwise serve records.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct RecordKind(String);
+
+impl RecordKind {
+    pub fn new(raw: impl Into<String>) -> Result<Self, HostApiError> {
+        let s = raw.into();
+        crate::index::validate_simple_identifier("filesystem record kind", &s)?;
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for RecordKind {
+    type Error = HostApiError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for RecordKind {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RecordKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<RecordKind> for String {
+    fn from(value: RecordKind) -> Self {
+        value.0
+    }
+}
+
+/// MIME-style content-type hint for an [`Entry::body`].
+///
+/// Backends use this to choose a storage representation when it matters
+/// (Postgres `JSONB` vs `BYTEA`, libSQL JSON vs BLOB). The hint is advisory:
+/// every backend must accept any content type and store the bytes faithfully.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct ContentType(String);
+
+impl ContentType {
+    pub const OCTET_STREAM: &'static str = "application/octet-stream";
+    pub const JSON: &'static str = "application/json";
+    pub const MARKDOWN: &'static str = "text/markdown";
+
+    pub fn new(raw: impl Into<String>) -> Result<Self, HostApiError> {
+        let s = raw.into();
+        if s.is_empty() {
+            return Err(HostApiError::InvalidId {
+                kind: "filesystem content type",
+                value: s,
+                reason: "must not be empty".to_string(),
+            });
+        }
+        if s.chars().count() > 128 {
+            return Err(HostApiError::InvalidId {
+                kind: "filesystem content type",
+                value: s,
+                reason: "must be 128 characters or fewer".to_string(),
+            });
+        }
+        // Allow a narrow MIME-style alphabet: letters, digits, and the
+        // separators commonly seen in IANA media types.
+        if !s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '+' | '-' | '.' | '_'))
+        {
+            return Err(HostApiError::InvalidId {
+                kind: "filesystem content type",
+                value: s,
+                reason: "must contain only mime-style ascii characters".to_string(),
+            });
+        }
+        Ok(Self(s))
+    }
+
+    pub fn octet_stream() -> Self {
+        Self(Self::OCTET_STREAM.to_string())
+    }
+
+    pub fn json() -> Self {
+        Self(Self::JSON.to_string())
+    }
+
+    pub fn markdown() -> Self {
+        Self(Self::MARKDOWN.to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for ContentType {
+    type Error = HostApiError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl Default for ContentType {
+    fn default() -> Self {
+        Self::octet_stream()
+    }
+}
+
+impl AsRef<str> for ContentType {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ContentType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<ContentType> for String {
+    fn from(value: ContentType) -> Self {
+        value.0
+    }
+}
+
+/// Monotonically increasing version assigned by the backend to each successful
+/// [`put`](crate::StorageBackend::put). Opaque to consumers: only compared for
+/// equality via [`CasExpectation::Version`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RecordVersion(u64);
+
+impl RecordVersion {
+    /// Internal constructor for backends. Consumers obtain versions only by
+    /// reading existing entries — they cannot fabricate one.
+    pub fn from_backend(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    pub fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+impl fmt::Display for RecordVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "v{}", self.0)
+    }
+}
+
+/// Monotonic sequence number used by the append/tail event plane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SeqNo(u64);
+
+impl SeqNo {
+    pub const ZERO: Self = Self(0);
+
+    pub fn from_backend(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    pub fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}
+
+impl fmt::Display for SeqNo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#{}", self.0)
+    }
+}
+
+/// Compare-and-swap precondition for [`put`](crate::StorageBackend::put).
+///
+/// All multi-step store operations (lease claim, lease consume, status
+/// transitions) are implemented with `CasExpectation::Version` and retry on
+/// [`FilesystemError::VersionMismatch`](crate::FilesystemError::VersionMismatch).
+/// Closure-based transactions across async boundaries are intentionally absent
+/// — backends that need atomic multi-key updates expose
+/// [`StorageTxn`](crate::StorageTxn) separately, and consumers must continue
+/// to work when only CAS is available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "version")]
+pub enum CasExpectation {
+    /// Path must not currently hold an entry. Used for issue/create.
+    Absent,
+    /// Path must currently hold the named version. Used for claim/consume/
+    /// status transitions.
+    Version(RecordVersion),
+    /// Overwrite regardless of current state. Used only by backfills / admin
+    /// flows; domain code should default to one of the other variants.
+    Any,
+}
+
+/// The universal "thing stored at a virtual path".
+///
+/// - **Opaque file**: `body` carries arbitrary bytes, `kind` is `None`,
+///   `indexed` is empty. This is the shape used by project files, artifacts,
+///   memory document Markdown, and anything that wouldn't have benefitted from
+///   a SQL row.
+/// - **Record**: `body` carries the serialized payload (typically JSON), `kind`
+///   names the schema family (e.g. `credential_account`), and `indexed`
+///   declares the projection that backends should expose to
+///   [`query`](crate::StorageBackend::query).
+///
+/// Backends never look inside `body` for indexing; everything queryable lives
+/// in `indexed`. This keeps the indexing contract small enough to be served
+/// portably by libSQL, Postgres, local-file sidecar indexes, and HSM-backed
+/// mounts without each backend having to parse the payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Entry {
+    pub body: Vec<u8>,
+    pub content_type: ContentType,
+    pub kind: Option<RecordKind>,
+    pub indexed: BTreeMap<IndexKey, IndexValue>,
+}
+
+impl Entry {
+    /// Construct an opaque-file entry from bytes.
+    pub fn bytes(body: Vec<u8>) -> Self {
+        Self {
+            body,
+            content_type: ContentType::octet_stream(),
+            kind: None,
+            indexed: BTreeMap::new(),
+        }
+    }
+
+    /// Construct an opaque-file entry from UTF-8 text with `text/markdown`.
+    pub fn markdown(text: impl Into<String>) -> Self {
+        Self {
+            body: text.into().into_bytes(),
+            content_type: ContentType::markdown(),
+            kind: None,
+            indexed: BTreeMap::new(),
+        }
+    }
+
+    /// Construct a record-shaped entry by serializing `data` as JSON.
+    pub fn record(kind: RecordKind, data: &serde_json::Value) -> Result<Self, serde_json::Error> {
+        let body = serde_json::to_vec(data)?;
+        Ok(Self {
+            body,
+            content_type: ContentType::json(),
+            kind: Some(kind),
+            indexed: BTreeMap::new(),
+        })
+    }
+
+    /// Add or overwrite an indexed projection value.
+    pub fn with_indexed(mut self, key: IndexKey, value: IndexValue) -> Self {
+        self.indexed.insert(key, value);
+        self
+    }
+
+    /// Replace the content-type hint.
+    pub fn with_content_type(mut self, content_type: ContentType) -> Self {
+        self.content_type = content_type;
+        self
+    }
+
+    /// Convenience: is this entry an opaque file (`kind = None`)?
+    pub fn is_opaque_file(&self) -> bool {
+        self.kind.is_none()
+    }
+
+    /// Convenience: deserialize `body` as JSON. Returns an error if the entry
+    /// is not record-shaped or the body is not valid JSON.
+    pub fn parse_json<T: serde::de::DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
+        serde_json::from_slice(&self.body)
+    }
+}
+
+/// Versioned read result returned by [`get`](crate::StorageBackend::get) and
+/// [`query`](crate::StorageBackend::query).
+///
+/// `version` is the value to pass to [`CasExpectation::Version`] in a
+/// subsequent write to avoid lost updates.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionedEntry {
+    pub entry: Entry,
+    pub version: RecordVersion,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_kind_rejects_invalid() {
+        assert!(RecordKind::new("").is_err());
+        assert!(RecordKind::new("bad/kind").is_err());
+        assert!(RecordKind::new("credential_account").is_ok());
+    }
+
+    #[test]
+    fn content_type_rejects_invalid_and_accepts_mime() {
+        assert!(ContentType::new("").is_err());
+        assert!(ContentType::new("text with space").is_err());
+        assert!(ContentType::new("application/json").is_ok());
+        assert!(ContentType::new("application/vnd.api+json").is_ok());
+        assert_eq!(ContentType::default().as_str(), ContentType::OCTET_STREAM);
+    }
+
+    #[test]
+    fn record_version_orders_and_advances() {
+        let v0 = RecordVersion::from_backend(0);
+        let v1 = v0.next();
+        assert!(v0 < v1);
+        assert_eq!(v1.get(), 1);
+    }
+
+    #[test]
+    fn entry_bytes_and_record_constructors() {
+        let raw = Entry::bytes(vec![1, 2, 3]);
+        assert!(raw.is_opaque_file());
+        assert_eq!(raw.body, vec![1, 2, 3]);
+        assert_eq!(raw.content_type.as_str(), ContentType::OCTET_STREAM);
+
+        let kind = RecordKind::new("test").unwrap();
+        let rec = Entry::record(kind.clone(), &serde_json::json!({"a": 1})).unwrap();
+        assert_eq!(rec.kind.as_ref(), Some(&kind));
+        assert_eq!(rec.content_type.as_str(), ContentType::JSON);
+        let parsed: serde_json::Value = rec.parse_json().unwrap();
+        assert_eq!(parsed, serde_json::json!({"a": 1}));
+    }
+
+    #[test]
+    fn entry_indexed_projection_round_trip() {
+        let kind = RecordKind::new("lease").unwrap();
+        let scope = IndexKey::new("scope").unwrap();
+        let status = IndexKey::new("status").unwrap();
+        let entry = Entry::record(kind, &serde_json::json!({"hidden": true}))
+            .unwrap()
+            .with_indexed(scope.clone(), IndexValue::Text("acme".into()))
+            .with_indexed(status.clone(), IndexValue::Text("active".into()));
+        assert_eq!(entry.indexed.len(), 2);
+        assert!(entry.indexed.contains_key(&scope));
+        assert!(entry.indexed.contains_key(&status));
+    }
+
+    #[test]
+    fn cas_expectation_serde_round_trip() {
+        let cases = [
+            CasExpectation::Absent,
+            CasExpectation::Any,
+            CasExpectation::Version(RecordVersion::from_backend(7)),
+        ];
+        for case in cases {
+            let json = serde_json::to_string(&case).unwrap();
+            let back: CasExpectation = serde_json::from_str(&json).unwrap();
+            assert_eq!(case, back);
+        }
+    }
+}

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -48,6 +48,15 @@ pub trait RootFilesystem: Send + Sync {
 
     /// Write an [`Entry`] at `path` with a compare-and-swap precondition.
     /// Returns the new [`RecordVersion`].
+    ///
+    /// Default impl is `Unsupported` — backends that want to participate in
+    /// the unified surface must implement `put` natively. Byte-only backends
+    /// can do this with a thin delegation to their own native `write_file`,
+    /// gated on `kind = None`, empty `indexed`, and `CasExpectation::Any`;
+    /// see `LocalFilesystem::put` for the canonical pattern. We deliberately
+    /// do **not** route the default `put` through `self.write_file`, because
+    /// the default `write_file` routes through `self.put` — a backend that
+    /// overrode neither would recurse to a stack overflow.
     async fn put(
         &self,
         path: &VirtualPath,
@@ -58,19 +67,15 @@ pub trait RootFilesystem: Send + Sync {
     }
 
     /// Read the entry at `path`, returning `None` if no entry is present.
+    ///
+    /// Default impl is `Unsupported`. Same recursion concern as `put`:
+    /// `read_file`'s default delegates here, so we must not delegate the
+    /// other direction in the trait default. Byte-only backends implement
+    /// `get` by wrapping their native `read_file` result in
+    /// `Some(VersionedEntry { entry: Entry::bytes(body), version: 0 })`
+    /// directly. See `LocalFilesystem::get` for the canonical pattern.
     async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
-        // Default: assume bytes-only legacy backend. Fetch via `read_file`,
-        // wrap in an opaque-file Entry, version 0 (legacy backends do not
-        // track versions). This default is removed when the backend gains a
-        // native `put`/`get` implementation (see task 5).
-        match self.read_file(path).await {
-            Ok(body) => Ok(Some(VersionedEntry {
-                entry: Entry::bytes(body),
-                version: RecordVersion::from_backend(0),
-            })),
-            Err(FilesystemError::NotFound { .. }) => Ok(None),
-            Err(e) => Err(e),
-        }
+        unsupported(path, FilesystemOperation::ReadFile)
     }
 
     /// Lists direct children of a canonical virtual directory.

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -1,33 +1,114 @@
 use async_trait::async_trait;
 use ironclaw_host_api::VirtualPath;
 
-use crate::{DirEntry, FileStat, FilesystemError, FilesystemOperation};
+use crate::backend::{EventRecord, StorageTxn};
+use crate::{
+    BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemError,
+    FilesystemOperation, Filter, IndexSpec, Page, RecordVersion, SeqNo, VersionedEntry,
+};
 
-/// Trusted root filesystem interface over canonical virtual paths.
+/// Unified filesystem interface over canonical virtual paths.
+///
+/// Both individual storage backends (local files, Postgres, libSQL, HSM,
+/// in-memory) and the composite dispatcher
+/// ([`CompositeRootFilesystem`](crate::CompositeRootFilesystem)) implement this
+/// trait. There is intentionally only one trait — the dispatcher *is* a
+/// backend that routes by longest-prefix mount.
+///
+/// The trait surface is divided into:
+/// - **Capabilities/identity** — every backend declares what it can do.
+/// - **Unified entry plane** — [`put`](Self::put) / [`get`](Self::get) /
+///   [`delete`](Self::delete) / [`list_dir`](Self::list_dir) /
+///   [`query`](Self::query) / [`ensure_index`](Self::ensure_index) /
+///   [`stat`](Self::stat). Bytes files and structured records both flow
+///   through these methods as different inhabitants of [`Entry`].
+/// - **Atomicity** — [`begin`](Self::begin) for backends that natively
+///   support multi-key transactions. Stores must always work with CAS
+///   (`put` + `CasExpectation::Version`) as the floor.
+/// - **Event plane** — [`append`](Self::append) / [`tail`](Self::tail) for
+///   log-shaped mounts.
+/// - **Legacy bytes plane** — [`read_file`](Self::read_file) /
+///   [`write_file`](Self::write_file) / [`append_file`](Self::append_file) /
+///   [`list_dir_bytes`](Self::list_dir_bytes) / [`create_dir_all`](Self::create_dir_all).
+///   Kept during migration; default impls route legacy reads/writes through
+///   `put`/`get`. Removed after task 17 (`src/db/` dissolution) lands.
 #[async_trait]
 pub trait RootFilesystem: Send + Sync {
-    /// Reads a file by canonical virtual path without exposing backend host paths in errors.
-    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError>;
+    // ─── Capabilities / identity ──────────────────────────────────────────
 
-    /// Writes bytes to a canonical virtual path while preserving backend containment.
-    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError>;
-
-    /// Appends bytes to a canonical virtual path. Backends that do not support append must fail closed before side effects.
-    async fn append_file(&self, path: &VirtualPath, _bytes: &[u8]) -> Result<(), FilesystemError> {
-        Err(FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::AppendFile,
-            reason: "append_file is not supported by this backend".to_string(),
-        })
+    /// Capabilities advertised by this backend. Mount-time validation in
+    /// [`CompositeRootFilesystem::mount`](crate::CompositeRootFilesystem::mount)
+    /// uses this to refuse backends that cannot serve the indexes a consumer
+    /// has declared.
+    fn capabilities(&self) -> BackendCapabilities {
+        BackendCapabilities::default()
     }
 
-    /// Lists direct children of a canonical virtual directory; callers must handle pagination/backends in future implementations without bypassing scope.
+    // ─── Unified entry plane ──────────────────────────────────────────────
+
+    /// Write an [`Entry`] at `path` with a compare-and-swap precondition.
+    /// Returns the new [`RecordVersion`].
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        _entry: Entry,
+        _cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        unsupported(path, FilesystemOperation::WriteFile)
+    }
+
+    /// Read the entry at `path`, returning `None` if no entry is present.
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        // Default: assume bytes-only legacy backend. Fetch via `read_file`,
+        // wrap in an opaque-file Entry, version 0 (legacy backends do not
+        // track versions). This default is removed when the backend gains a
+        // native `put`/`get` implementation (see task 5).
+        match self.read_file(path).await {
+            Ok(body) => Ok(Some(VersionedEntry {
+                entry: Entry::bytes(body),
+                version: RecordVersion::from_backend(0),
+            })),
+            Err(FilesystemError::NotFound { .. }) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Lists direct children of a canonical virtual directory.
+    ///
+    /// Lightweight: returns path + type, no payload, no pagination. Use
+    /// [`query`](Self::query) when you need pagination, filtering, or the
+    /// materialized entry bodies.
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError>;
+
+    /// Filtered query over `prefix`. Returns the materialized entries
+    /// matching `filter`. Backends without `query` capability return
+    /// [`FilesystemError::Unsupported`].
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        _filter: &Filter,
+        _page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        unsupported(path, FilesystemOperation::Query)
+    }
+
+    /// Declare an index on a mount prefix. Idempotent: re-declaring the same
+    /// spec is a no-op; declaring a conflicting spec returns
+    /// [`FilesystemError::IndexConflict`].
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        _spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        unsupported(path, FilesystemOperation::EnsureIndex)
+    }
 
     /// Returns metadata for a canonical virtual path without revealing raw host paths.
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError>;
 
-    /// Deletes an existing canonical virtual file or directory. Missing paths return [`FilesystemError::NotFound`]; backends that do not support delete must fail closed before side effects.
+    /// Deletes an existing canonical virtual file or directory. Missing paths
+    /// return [`FilesystemError::NotFound`]; backends that do not support
+    /// delete must fail closed before side effects.
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         Err(FilesystemError::Backend {
             path: path.clone(),
@@ -36,7 +117,82 @@ pub trait RootFilesystem: Send + Sync {
         })
     }
 
-    /// Creates a canonical virtual directory and any missing parents. Backends that do not support directories must fail closed before side effects.
+    // ─── Atomicity ────────────────────────────────────────────────────────
+
+    /// Begin a multi-key transaction scoped to `prefix`. Backends with only
+    /// CAS support return [`FilesystemError::Unsupported`]; consumers must
+    /// always have a CAS-only path.
+    async fn begin(&self, path: &VirtualPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        unsupported(path, FilesystemOperation::BeginTxn)
+    }
+
+    // ─── Event plane (append/tail) ────────────────────────────────────────
+
+    /// Append `payload` to the event log at `path`, returning the assigned
+    /// monotonic [`SeqNo`]. Distinct from [`append_file`](Self::append_file),
+    /// which is the legacy byte-append on a regular file.
+    async fn append(
+        &self,
+        path: &VirtualPath,
+        _payload: Vec<u8>,
+    ) -> Result<SeqNo, FilesystemError> {
+        unsupported(path, FilesystemOperation::Tail)
+    }
+
+    /// Read events at `path` starting at `from` (exclusive). Returns at most
+    /// one page of records; consumers loop with the latest seq to drain the
+    /// log. Streaming support will replace this Vec return shape in a later
+    /// pass; the unstable signature is intentional.
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        _from: SeqNo,
+    ) -> Result<Vec<EventRecord>, FilesystemError> {
+        unsupported(path, FilesystemOperation::Tail)
+    }
+
+    // ─── Legacy bytes plane (transitional) ────────────────────────────────
+
+    /// Reads a file by canonical virtual path without exposing backend host paths in errors.
+    ///
+    /// Legacy entry point — new code should call [`get`](Self::get). Default
+    /// impl routes through `get` and extracts the body; backends that have a
+    /// faster native byte read may override.
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        match self.get(path).await? {
+            Some(entry) => Ok(entry.entry.body),
+            None => Err(FilesystemError::NotFound {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+            }),
+        }
+    }
+
+    /// Writes bytes to a canonical virtual path while preserving backend containment.
+    ///
+    /// Legacy entry point — new code should call [`put`](Self::put). Default
+    /// impl routes through `put` with `CasExpectation::Any`.
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        self.put(path, Entry::bytes(bytes.to_vec()), CasExpectation::Any)
+            .await
+            .map(|_| ())
+    }
+
+    /// Appends bytes to a canonical virtual path. Distinct from
+    /// [`append`](Self::append), which is the event-plane sequence operation.
+    /// Backends that do not support byte-append must fail closed before side
+    /// effects.
+    async fn append_file(&self, path: &VirtualPath, _bytes: &[u8]) -> Result<(), FilesystemError> {
+        Err(FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::AppendFile,
+            reason: "append_file is not supported by this backend".to_string(),
+        })
+    }
+
+    /// Creates a canonical virtual directory and any missing parents.
+    /// Backends that do not support directories must fail closed before side
+    /// effects.
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         Err(FilesystemError::Backend {
             path: path.clone(),
@@ -44,4 +200,14 @@ pub trait RootFilesystem: Send + Sync {
             reason: "create_dir_all is not supported by this backend".to_string(),
         })
     }
+}
+
+fn unsupported<T>(
+    path: &VirtualPath,
+    operation: FilesystemOperation,
+) -> Result<T, FilesystemError> {
+    Err(FilesystemError::Unsupported {
+        path: path.clone(),
+        operation,
+    })
 }

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -156,13 +156,31 @@ pub trait RootFilesystem: Send + Sync {
         unsupported(path, FilesystemOperation::Tail)
     }
 
-    // ─── Legacy bytes plane (transitional) ────────────────────────────────
+    // ─── Legacy bytes plane (DEPRECATED — removed after consumer migration) ─
+    //
+    // The methods below predate the unified [`put`]/[`get`] surface and exist
+    // only so existing call sites (engine v2 sandbox tools, the host_runtime
+    // coding tools, in-tree test scaffolds) keep compiling during the
+    // consumer-migration window. New code MUST use the unified ops:
+    //   - `read_file(path)`     → `get(path)?.entry.body`
+    //   - `write_file(path, b)` → `put(path, Entry::bytes(b), CasExpectation::Any)`
+    //   - `append_file(path, b)`→ no replacement on the unified surface; use
+    //                              `append`/`tail` for log-shaped mounts, or
+    //                              `get`+`put` for read-modify-write
+    //   - `create_dir_all(path)`→ no longer needed; the entry plane infers
+    //                              directories from path prefixes
+    //
+    // These methods will be removed in the consumer-migration cleanup pass
+    // (task #17 in the rework plan). Do not extend them; do not call them
+    // from new consumer code.
 
-    /// Reads a file by canonical virtual path without exposing backend host paths in errors.
+    /// **DEPRECATED — use [`get`](Self::get) instead.**
     ///
-    /// Legacy entry point — new code should call [`get`](Self::get). Default
-    /// impl routes through `get` and extracts the body; backends that have a
-    /// faster native byte read may override.
+    /// Reads a file by canonical virtual path without exposing backend host
+    /// paths in errors. Default impl routes through `get` and extracts the
+    /// body; backends that have a faster native byte read may override.
+    /// Removed once consumer migration completes (rework task #17). New
+    /// consumer code must call `get` directly.
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
         match self.get(path).await? {
             Some(entry) => Ok(entry.entry.body),
@@ -173,36 +191,42 @@ pub trait RootFilesystem: Send + Sync {
         }
     }
 
-    /// Writes bytes to a canonical virtual path while preserving backend containment.
+    /// **DEPRECATED — use [`put`](Self::put) instead.**
     ///
-    /// Legacy entry point — new code should call [`put`](Self::put). Default
-    /// impl routes through `put` with `CasExpectation::Any`.
+    /// Writes bytes to a canonical virtual path while preserving backend
+    /// containment. Default impl routes through `put` with
+    /// `CasExpectation::Any`. Removed once consumer migration completes
+    /// (rework task #17). New consumer code must call `put` with
+    /// `Entry::bytes(...)` and an explicit `CasExpectation`.
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         self.put(path, Entry::bytes(bytes.to_vec()), CasExpectation::Any)
             .await
             .map(|_| ())
     }
 
-    /// Appends bytes to a canonical virtual path. Distinct from
-    /// [`append`](Self::append), which is the event-plane sequence operation.
-    /// Backends that do not support byte-append must fail closed before side
-    /// effects.
+    /// **DEPRECATED — no direct replacement on the unified surface.**
+    ///
+    /// Distinct from [`append`](Self::append), which is the event-plane
+    /// sequence operation. Use `append`/`tail` for log-shaped mounts or a
+    /// `get` + `put` read-modify-write loop for arbitrary bytes. Removed
+    /// once consumer migration completes (rework task #17).
     async fn append_file(&self, path: &VirtualPath, _bytes: &[u8]) -> Result<(), FilesystemError> {
-        Err(FilesystemError::Backend {
+        Err(FilesystemError::Unsupported {
             path: path.clone(),
             operation: FilesystemOperation::AppendFile,
-            reason: "append_file is not supported by this backend".to_string(),
         })
     }
 
+    /// **DEPRECATED — the entry plane infers directories from path prefixes.**
+    ///
     /// Creates a canonical virtual directory and any missing parents.
     /// Backends that do not support directories must fail closed before side
-    /// effects.
+    /// effects. New consumer code must not call this — `put` against a leaf
+    /// path implicitly establishes the directory hierarchy.
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        Err(FilesystemError::Backend {
+        Err(FilesystemError::Unsupported {
             path: path.clone(),
             operation: FilesystemOperation::CreateDirAll,
-            reason: "create_dir_all is not supported by this backend".to_string(),
         })
     }
 }

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -74,9 +74,29 @@ where
     }
 
     /// Begin a multi-key transaction (capability-gated).
+    ///
+    /// PR #3659 review fix: returns a permission-checking wrapper around the
+    /// underlying [`StorageTxn`] so the per-operation ACL is preserved across
+    /// the transaction boundary. Without this wrapper, a caller granted only
+    /// `write` could still `get` / `delete` through the raw txn handle once
+    /// any backend implements transactions.
     pub async fn begin(&self, prefix: &ScopedPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
         let virtual_path = self.resolve_with_permission(prefix, FilesystemOperation::BeginTxn)?;
-        self.root.begin(&virtual_path).await
+        let inner = self.root.begin(&virtual_path).await?;
+        // Snapshot the mount permissions that authorized the txn so the
+        // wrapper can apply them per-op without revisiting `MountView`
+        // (which would need a ScopedPath we no longer have at this point).
+        let permissions = self
+            .mounts
+            .resolve_with_grant(prefix)?
+            .1
+            .permissions
+            .clone();
+        Ok(Box::new(ScopedStorageTxn {
+            inner,
+            permissions,
+            mount_prefix: virtual_path,
+        }))
     }
 
     // ─── Event/tail plane ─────────────────────────────────────────────────
@@ -230,5 +250,67 @@ fn operation_allowed(permissions: &MountPermissions, operation: FilesystemOperat
         FilesystemOperation::BeginTxn => permissions.write,
         // Tail mirrors read on the byte plane (append is covered by AppendFile).
         FilesystemOperation::Tail => permissions.read,
+    }
+}
+
+/// Permission-checking wrapper around an inner [`StorageTxn`] returned by
+/// [`ScopedFilesystem::begin`]. Preserves the per-operation ACL across the
+/// txn boundary so a write-only scoped caller cannot read or delete through
+/// the txn handle (PR #3659 review fix).
+struct ScopedStorageTxn {
+    inner: Box<dyn StorageTxn>,
+    permissions: MountPermissions,
+    mount_prefix: VirtualPath,
+}
+
+impl ScopedStorageTxn {
+    fn check(&self, operation: FilesystemOperation) -> Result<(), FilesystemError> {
+        if operation_allowed(&self.permissions, operation) {
+            Ok(())
+        } else {
+            // The transaction is anchored at `mount_prefix`; surface the
+            // mount root rather than the per-call VirtualPath to avoid
+            // implying that the caller is denied at one specific child
+            // while allowed elsewhere — the txn-time grant applies to
+            // the whole prefix.
+            Err(FilesystemError::Backend {
+                path: self.mount_prefix.clone(),
+                operation,
+                reason: "scoped transaction lacks the required permission".to_string(),
+            })
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageTxn for ScopedStorageTxn {
+    async fn put(
+        &mut self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        self.check(FilesystemOperation::WriteFile)?;
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&mut self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        self.check(FilesystemOperation::ReadFile)?;
+        self.inner.get(path).await
+    }
+
+    async fn delete(&mut self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.check(FilesystemOperation::Delete)?;
+        self.inner.delete(path).await
+    }
+
+    async fn commit(self: Box<Self>) -> Result<(), FilesystemError> {
+        // Commit/rollback are bookkeeping; they were authorized at `begin`
+        // time and require no additional per-op check.
+        self.inner.commit().await
+    }
+
+    async fn rollback(self: Box<Self>) {
+        self.inner.rollback().await
     }
 }

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -2,9 +2,18 @@ use std::sync::Arc;
 
 use ironclaw_host_api::{MountPermissions, MountView, ScopedPath, VirtualPath};
 
-use crate::{DirEntry, FileStat, FilesystemError, FilesystemOperation, RootFilesystem};
+use crate::backend::{EventRecord, StorageTxn};
+use crate::{
+    CasExpectation, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation, Filter,
+    IndexSpec, Page, RecordVersion, RootFilesystem, SeqNo, VersionedEntry,
+};
 
 /// Invocation-scoped filesystem view over [`ScopedPath`] values.
+///
+/// Higher-level stores (SecretStore, ProcessStore, …) accept a
+/// `ScopedFilesystem` bound to a path prefix and call the unified
+/// `put`/`get`/`query`/etc. ops through it. Permission checks happen here
+/// against the caller's [`MountView`] before any backend dispatch.
 #[derive(Debug, Clone)]
 pub struct ScopedFilesystem<F> {
     root: Arc<F>,
@@ -22,6 +31,82 @@ where
     pub fn mounts(&self) -> &MountView {
         &self.mounts
     }
+
+    // ─── Unified entry plane ──────────────────────────────────────────────
+
+    /// Write an [`Entry`] at `path` with a CAS precondition.
+    pub async fn put(
+        &self,
+        path: &ScopedPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::WriteFile)?;
+        self.root.put(&virtual_path, entry, cas).await
+    }
+
+    /// Read the entry at `path`, returning `None` if absent.
+    pub async fn get(&self, path: &ScopedPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::ReadFile)?;
+        self.root.get(&virtual_path).await
+    }
+
+    /// Filtered query over `prefix`.
+    pub async fn query(
+        &self,
+        prefix: &ScopedPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(prefix, FilesystemOperation::Query)?;
+        self.root.query(&virtual_path, filter, page).await
+    }
+
+    /// Declare an index on the mount under `prefix`.
+    pub async fn ensure_index(
+        &self,
+        prefix: &ScopedPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        let virtual_path =
+            self.resolve_with_permission(prefix, FilesystemOperation::EnsureIndex)?;
+        self.root.ensure_index(&virtual_path, spec).await
+    }
+
+    /// Begin a multi-key transaction (capability-gated).
+    pub async fn begin(&self, prefix: &ScopedPath) -> Result<Box<dyn StorageTxn>, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(prefix, FilesystemOperation::BeginTxn)?;
+        self.root.begin(&virtual_path).await
+    }
+
+    // ─── Event/tail plane ─────────────────────────────────────────────────
+
+    /// Append `payload` to the event log at `path`, returning the SeqNo.
+    pub async fn append(
+        &self,
+        path: &ScopedPath,
+        payload: Vec<u8>,
+    ) -> Result<SeqNo, FilesystemError> {
+        // Append on the event plane is a write — permission mirrors AppendFile.
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::AppendFile)?;
+        self.root.append(&virtual_path, payload).await
+    }
+
+    /// Read events at `path` starting just after `from`.
+    pub async fn tail(
+        &self,
+        path: &ScopedPath,
+        from: SeqNo,
+    ) -> Result<Vec<EventRecord>, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::Tail)?;
+        self.root.tail(&virtual_path, from).await
+    }
+
+    // ─── Legacy bytes-plane methods (transitional) ────────────────────────
+    //
+    // These remain for the migration window. New code should prefer the
+    // unified ops above. They will be removed once consumers migrate
+    // (task 17).
 
     pub async fn read_file(&self, path: &ScopedPath) -> Result<Vec<u8>, FilesystemError> {
         let virtual_path = self.resolve_with_permission(path, FilesystemOperation::ReadFile)?;
@@ -62,6 +147,40 @@ where
         self.root.create_dir_all(&virtual_path).await
     }
 
+    // ─── Convenience helpers for byte-only callers ────────────────────────
+
+    /// Read the body bytes at `path`. Convenience wrapper over [`get`] that
+    /// errors if the path has no entry.
+    pub async fn read_bytes(&self, path: &ScopedPath) -> Result<Vec<u8>, FilesystemError> {
+        match self.get(path).await? {
+            Some(versioned) => Ok(versioned.entry.body),
+            None => {
+                // Need the virtual path for the error message; resolve once
+                // more — the permission check already passed.
+                let virtual_path =
+                    self.resolve_with_permission(path, FilesystemOperation::ReadFile)?;
+                Err(FilesystemError::NotFound {
+                    path: virtual_path,
+                    operation: FilesystemOperation::ReadFile,
+                })
+            }
+        }
+    }
+
+    /// Write `body` as an opaque-file entry at `path` (no CAS precondition).
+    /// Convenience wrapper over [`put`].
+    pub async fn write_bytes(
+        &self,
+        path: &ScopedPath,
+        body: Vec<u8>,
+    ) -> Result<(), FilesystemError> {
+        self.put(path, Entry::bytes(body), CasExpectation::Any)
+            .await
+            .map(|_| ())
+    }
+
+    // ─── Internals ────────────────────────────────────────────────────────
+
     fn resolve_with_permission(
         &self,
         path: &ScopedPath,
@@ -92,5 +211,13 @@ fn operation_allowed(permissions: &MountPermissions, operation: FilesystemOperat
         FilesystemOperation::Delete => permissions.delete,
         FilesystemOperation::CreateDirAll => permissions.write,
         FilesystemOperation::MountLocal => false,
+        // Query enumerates records, so requires both read (to see contents) and
+        // list (to enumerate). Either alone is insufficient.
+        FilesystemOperation::Query => permissions.read && permissions.list,
+        // Index/transaction declarations mutate the mount's structural state.
+        FilesystemOperation::EnsureIndex => permissions.write,
+        FilesystemOperation::BeginTxn => permissions.write,
+        // Tail mirrors read on the byte plane (append is covered by AppendFile).
+        FilesystemOperation::Tail => permissions.read,
     }
 }

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -102,22 +102,31 @@ where
         self.root.tail(&virtual_path, from).await
     }
 
-    // ─── Legacy bytes-plane methods (transitional) ────────────────────────
+    // ─── Legacy bytes-plane methods (DEPRECATED — transitional) ───────────
     //
     // These remain for the migration window. New code should prefer the
-    // unified ops above. They will be removed once consumers migrate
-    // (task 17).
+    // unified ops above (`put`/`get`/`read_bytes`/`write_bytes`). Removed
+    // once consumers migrate (task #17). Marked deprecated via doc comment
+    // rather than `#[deprecated]` attribute to avoid generating compiler
+    // warnings across every downstream call site during the transition.
 
+    /// **DEPRECATED — use [`read_bytes`](Self::read_bytes) or
+    /// [`get`](Self::get) instead.**
     pub async fn read_file(&self, path: &ScopedPath) -> Result<Vec<u8>, FilesystemError> {
         let virtual_path = self.resolve_with_permission(path, FilesystemOperation::ReadFile)?;
         self.root.read_file(&virtual_path).await
     }
 
+    /// **DEPRECATED — use [`write_bytes`](Self::write_bytes) or
+    /// [`put`](Self::put) instead.**
     pub async fn write_file(&self, path: &ScopedPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         let virtual_path = self.resolve_with_permission(path, FilesystemOperation::WriteFile)?;
         self.root.write_file(&virtual_path, bytes).await
     }
 
+    /// **DEPRECATED — no direct replacement on the unified surface.** Use
+    /// `append`/`tail` for log-shaped mounts or `get`+`put` for
+    /// read-modify-write.
     pub async fn append_file(
         &self,
         path: &ScopedPath,
@@ -142,6 +151,8 @@ where
         self.root.delete(&virtual_path).await
     }
 
+    /// **DEPRECATED — the unified entry plane infers directories from path
+    /// prefixes.** New consumer code must not call this.
     pub async fn create_dir_all(&self, path: &ScopedPath) -> Result<(), FilesystemError> {
         let virtual_path = self.resolve_with_permission(path, FilesystemOperation::CreateDirAll)?;
         self.root.create_dir_all(&virtual_path).await

--- a/crates/ironclaw_filesystem/src/types.rs
+++ b/crates/ironclaw_filesystem/src/types.rs
@@ -104,12 +104,64 @@ pub enum FilesystemError {
     },
     /// Declaring an index conflicted with an existing definition (e.g. the
     /// same name already exists with a different `keys` ordering or `kind`).
-    #[error("index conflict for {name} at {path}: {reason}")]
+    #[error("index conflict for {name} at {path}: {reason:?}")]
     IndexConflict {
         path: VirtualPath,
         name: IndexName,
-        reason: String,
+        reason: IndexConflictReason,
     },
+    /// Mount descriptor advertised capabilities the backend doesn't provide
+    /// on the new capability axes (records / query / index / events) or the
+    /// transaction tier. Surfaced at mount time so consumers see the
+    /// shortfall before any op-time `Unsupported` arrives.
+    #[error(
+        "mount descriptor at {path} claims capabilities the backend does not provide: \
+         missing={missing:?}, txn_shortfall={txn_shortfall}"
+    )]
+    DescriptorOverclaims {
+        path: VirtualPath,
+        missing: Vec<Capability>,
+        txn_shortfall: bool,
+    },
+    /// JSON serialization of an [`Entry::indexed`](crate::Entry::indexed)
+    /// projection failed. Indicates a non-serializable value managed to slip
+    /// into the indexed map.
+    #[error("failed to serialize indexed projection for {operation} at {path}")]
+    SerializeIndexed {
+        path: VirtualPath,
+        operation: FilesystemOperation,
+    },
+    /// JSON deserialization of an indexed projection round-tripping out of
+    /// storage failed. Indicates either schema drift or a backend that
+    /// produced a malformed payload.
+    #[error("failed to deserialize indexed projection for {operation} at {path}")]
+    DeserializeIndexed {
+        path: VirtualPath,
+        operation: FilesystemOperation,
+    },
+    /// A persisted [`RecordVersion`](crate::RecordVersion) read back as a
+    /// value outside `u64`'s range (e.g. negative on a libSQL `INTEGER`
+    /// column). Symptom of schema corruption or unsafe direct SQL writes —
+    /// surface as a backend error rather than silently masking to `0`.
+    #[error("corrupt record version {raw} at {path}")]
+    CorruptRecordVersion { path: VirtualPath, raw: i64 },
+    /// Sentinel "this can't happen" surface: an `INSERT ... ON CONFLICT DO
+    /// NOTHING` followed by a `SELECT` returned no row. The only way this
+    /// fires is if a concurrent `DELETE` from outside the index-spec code
+    /// path raced with the ensure_index call.
+    #[error("index spec disappeared after upsert at {path}: {name}")]
+    IndexSpecMissingAfterUpsert { path: VirtualPath, name: IndexName },
+}
+
+/// Reason a [`FilesystemError::IndexConflict`] was raised.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexConflictReason {
+    /// The existing spec has different `keys` or a different `kind` from the
+    /// one declared in this call.
+    SpecMismatch,
+    /// The declaration has an empty `keys` list. Indexes must declare at
+    /// least one key.
+    EmptyKeys,
 }
 
 /// Coarse file type returned by [`FileStat`] and [`DirEntry`].
@@ -217,28 +269,63 @@ pub enum IndexPolicy {
 
 /// Index kinds a backend can materialize when it serves the record plane.
 ///
-/// A backend that cannot serve a requested kind fails [`ensure_index`](
-/// crate::StorageBackend::ensure_index) closed with
-/// [`FilesystemError::Unsupported`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+/// Individual capability a backend can advertise.
+///
+/// Each variant is a single bit in the [`BackendCapabilities`] bitmask.
+/// Transaction semantics are richer than a single bit (ordered: None → Cas →
+/// MultiKey) and live in [`TxnCapability`] alongside the bitmask.
+///
+/// `read`/`write`/`append`/`list`/`stat`/`delete` predate the unified surface
+/// and are kept here so existing catalog metadata still round-trips; the
+/// mount-time validator in
+/// [`CompositeRootFilesystem`](crate::CompositeRootFilesystem) only enforces
+/// the **new** capability axes (Records, Query, Index*, Events) until each
+/// backend opts into an accurate `capabilities()` override.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub struct IndexCapability {
-    pub exact: bool,
-    pub prefix: bool,
-    pub fts: bool,
-    pub vector: bool,
+pub enum Capability {
+    // Legacy bytes plane.
+    Read,
+    Write,
+    Append,
+    List,
+    Stat,
+    Delete,
+    // Record plane.
+    Records,
+    Query,
+    // Index kinds.
+    IndexExact,
+    IndexPrefix,
+    IndexFts,
+    IndexVector,
+    // Event plane (`append`/`tail`).
+    Events,
 }
 
-impl IndexCapability {
-    /// Convenience constructor for backends that serve everything the byte
-    /// plane needs (most SQL backends).
-    pub const fn sql_typical() -> Self {
-        Self {
-            exact: true,
-            prefix: true,
-            fts: false,
-            vector: false,
-        }
+impl Capability {
+    const fn bit(self) -> u32 {
+        1 << (self as u32)
+    }
+
+    /// Iterator over every capability. Useful for serialization and
+    /// validation reporting.
+    pub fn all() -> &'static [Capability] {
+        &[
+            Capability::Read,
+            Capability::Write,
+            Capability::Append,
+            Capability::List,
+            Capability::Stat,
+            Capability::Delete,
+            Capability::Records,
+            Capability::Query,
+            Capability::IndexExact,
+            Capability::IndexPrefix,
+            Capability::IndexFts,
+            Capability::IndexVector,
+            Capability::Events,
+        ]
     }
 }
 
@@ -261,26 +348,131 @@ pub enum TxnCapability {
 
 /// Capabilities advertised by a mounted backend for diagnostics and routing.
 ///
-/// Mount-time validation refuses a backend whose capabilities cannot satisfy
-/// the index/record/transaction needs declared by the consumer that will be
-/// constructed against it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+/// Stored as a compact `u32` bitmask over [`Capability`] plus an ordered
+/// [`TxnCapability`]. Build with `BackendCapabilities::empty().with(...)` —
+/// or use one of the `sql_typical` / `in_memory_full` / `bytes_only`
+/// convenience constructors. Mount-time validation in
+/// [`CompositeRootFilesystem`](crate::CompositeRootFilesystem) refuses
+/// backends whose capabilities don't satisfy the descriptor's claims on the
+/// new axes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct BackendCapabilities {
-    // Bytes plane.
-    pub read: bool,
-    pub write: bool,
-    pub append: bool,
-    pub list: bool,
-    pub stat: bool,
-    pub delete: bool,
-    // Record plane.
-    pub records: bool,
-    pub query: bool,
-    pub index: IndexCapability,
-    pub txn: TxnCapability,
-    // Event plane (append/tail).
-    pub events: bool,
-    // Legacy flags retained for existing catalog consumers.
-    pub indexed: bool,
-    pub embedded: bool,
+    flags: u32,
+    txn: TxnCapability,
+}
+
+impl BackendCapabilities {
+    /// No capabilities advertised — the safe default.
+    pub const fn empty() -> Self {
+        Self {
+            flags: 0,
+            txn: TxnCapability::None,
+        }
+    }
+
+    /// Add a [`Capability`] flag.
+    pub const fn with(mut self, cap: Capability) -> Self {
+        self.flags |= cap.bit();
+        self
+    }
+
+    /// Remove a [`Capability`] flag.
+    pub const fn without(mut self, cap: Capability) -> Self {
+        self.flags &= !cap.bit();
+        self
+    }
+
+    /// Set the transaction capability tier.
+    pub const fn with_txn(mut self, txn: TxnCapability) -> Self {
+        self.txn = txn;
+        self
+    }
+
+    /// Does this backend advertise `cap`?
+    pub const fn has(&self, cap: Capability) -> bool {
+        self.flags & cap.bit() != 0
+    }
+
+    /// Transaction tier.
+    pub const fn txn(&self) -> TxnCapability {
+        self.txn
+    }
+
+    /// All capabilities currently set, in [`Capability::all`] order.
+    pub fn iter(&self) -> impl Iterator<Item = Capability> + '_ {
+        Capability::all().iter().copied().filter(|c| self.has(*c))
+    }
+
+    /// Convenience: read + write + list + stat + delete + records + query
+    /// + IndexExact + IndexPrefix + CAS — the typical SQL backend shape.
+    pub const fn sql_typical() -> Self {
+        Self::empty()
+            .with(Capability::Read)
+            .with(Capability::Write)
+            .with(Capability::Append)
+            .with(Capability::List)
+            .with(Capability::Stat)
+            .with(Capability::Delete)
+            .with(Capability::Records)
+            .with(Capability::Query)
+            .with(Capability::IndexExact)
+            .with(Capability::IndexPrefix)
+            .with_txn(TxnCapability::Cas)
+    }
+
+    /// Convenience: every capability the in-memory reference backend
+    /// implements. Includes Events on top of `sql_typical`.
+    pub const fn in_memory_full() -> Self {
+        Self::sql_typical().with(Capability::Events)
+    }
+
+    /// Convenience: read + write + append + list + stat + delete only.
+    /// Matches a byte-only backend that hasn't yet opted into records.
+    pub const fn bytes_only() -> Self {
+        Self::empty()
+            .with(Capability::Read)
+            .with(Capability::Write)
+            .with(Capability::Append)
+            .with(Capability::List)
+            .with(Capability::Stat)
+            .with(Capability::Delete)
+    }
+}
+
+/// Serialize/deserialize as `{ caps: [...], txn: "..." }` so the on-the-wire
+/// shape stays readable rather than leaking the bitmask integer. Decoder
+/// silently ignores unknown capability strings — a backend that advertises a
+/// future variant against an older reader degrades to "missing" rather than
+/// failing parse.
+impl Serialize for BackendCapabilities {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[derive(Serialize)]
+        struct Wire<'a> {
+            caps: Vec<Capability>,
+            txn: &'a TxnCapability,
+        }
+        Wire {
+            caps: self.iter().collect(),
+            txn: &self.txn,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BackendCapabilities {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Wire {
+            #[serde(default)]
+            caps: Vec<Capability>,
+            #[serde(default)]
+            txn: TxnCapability,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        let mut out = BackendCapabilities::empty().with_txn(wire.txn);
+        for cap in wire.caps {
+            out = out.with(cap);
+        }
+        Ok(out)
+    }
 }

--- a/crates/ironclaw_filesystem/src/types.rs
+++ b/crates/ironclaw_filesystem/src/types.rs
@@ -1,9 +1,20 @@
 use std::time::SystemTime;
 
 use ironclaw_host_api::{HostApiError, ScopedPath, VirtualPath};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::index::IndexName;
+use crate::record::RecordVersion;
+
 /// Filesystem operation used for permission checks and audit/error reporting.
+///
+/// The legacy byte-plane variants (`ReadFile`, `WriteFile`, …) describe the
+/// *intent* of an operation against the underlying [`MountPermissions`]
+/// surface and are reused by the unified `put`/`get` ops as their permission
+/// witness — `put` is a write, `get` is a read. The newer variants
+/// (`Query`, `EnsureIndex`, `BeginTxn`, `Tail`) describe operations that have
+/// no analogue in the legacy enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilesystemOperation {
     MountLocal,
@@ -14,6 +25,10 @@ pub enum FilesystemOperation {
     Stat,
     Delete,
     CreateDirAll,
+    Query,
+    EnsureIndex,
+    BeginTxn,
+    Tail,
 }
 
 impl std::fmt::Display for FilesystemOperation {
@@ -27,6 +42,10 @@ impl std::fmt::Display for FilesystemOperation {
             Self::Stat => "stat",
             Self::Delete => "delete",
             Self::CreateDirAll => "create_dir_all",
+            Self::Query => "query",
+            Self::EnsureIndex => "ensure_index",
+            Self::BeginTxn => "begin_txn",
+            Self::Tail => "tail",
         })
     }
 }
@@ -37,6 +56,7 @@ impl std::fmt::Display for FilesystemOperation {
 /// paths. Backend implementations may log lower-level errors separately, but
 /// user-facing errors should preserve host path confidentiality.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum FilesystemError {
     #[error(transparent)]
     Contract(#[from] HostApiError),
@@ -62,6 +82,32 @@ pub enum FilesystemError {
     Backend {
         path: VirtualPath,
         operation: FilesystemOperation,
+        reason: String,
+    },
+    /// Compare-and-swap precondition failed: the existing record's version did
+    /// not match the caller's expectation. Stores typically retry by reading
+    /// the current version and re-applying the transformation.
+    #[error("version mismatch at {path}: expected {expected:?}, found {found:?}")]
+    VersionMismatch {
+        path: VirtualPath,
+        expected: Option<RecordVersion>,
+        found: Option<RecordVersion>,
+    },
+    /// Mounted backend does not implement the requested operation. Capability
+    /// checks at mount time should catch most cases; this remains for
+    /// runtime-conditional capabilities (e.g. a Postgres mount built against a
+    /// server without `pgvector` rejecting `IndexKind::Vector`).
+    #[error("operation {operation} is not supported by the mount at {path}")]
+    Unsupported {
+        path: VirtualPath,
+        operation: FilesystemOperation,
+    },
+    /// Declaring an index conflicted with an existing definition (e.g. the
+    /// same name already exists with a different `keys` ordering or `kind`).
+    #[error("index conflict for {name} at {path}: {reason}")]
+    IndexConflict {
+        path: VirtualPath,
+        name: IndexName,
         reason: String,
     },
 }
@@ -169,15 +215,72 @@ pub enum IndexPolicy {
     BackendDefined,
 }
 
+/// Index kinds a backend can materialize when it serves the record plane.
+///
+/// A backend that cannot serve a requested kind fails [`ensure_index`](
+/// crate::StorageBackend::ensure_index) closed with
+/// [`FilesystemError::Unsupported`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct IndexCapability {
+    pub exact: bool,
+    pub prefix: bool,
+    pub fts: bool,
+    pub vector: bool,
+}
+
+impl IndexCapability {
+    /// Convenience constructor for backends that serve everything the byte
+    /// plane needs (most SQL backends).
+    pub const fn sql_typical() -> Self {
+        Self {
+            exact: true,
+            prefix: true,
+            fts: false,
+            vector: false,
+        }
+    }
+}
+
+/// Transaction semantics offered by a backend.
+///
+/// Stores must work with `Cas` as the floor; richer backends opt into
+/// `MultiKey` for stronger guarantees, but consumers never *depend* on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TxnCapability {
+    #[default]
+    None,
+    /// Compare-and-swap on individual records (see
+    /// [`CasExpectation`](crate::CasExpectation)).
+    Cas,
+    /// Backend implements [`StorageTxn`](crate::StorageTxn) for atomic
+    /// multi-key updates within a single mount.
+    MultiKey,
+}
+
 /// Capabilities advertised by a mounted backend for diagnostics and routing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// Mount-time validation refuses a backend whose capabilities cannot satisfy
+/// the index/record/transaction needs declared by the consumer that will be
+/// constructed against it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct BackendCapabilities {
+    // Bytes plane.
     pub read: bool,
     pub write: bool,
     pub append: bool,
     pub list: bool,
     pub stat: bool,
     pub delete: bool,
+    // Record plane.
+    pub records: bool,
+    pub query: bool,
+    pub index: IndexCapability,
+    pub txn: TxnCapability,
+    // Event plane (append/tail).
+    pub events: bool,
+    // Legacy flags retained for existing catalog consumers.
     pub indexed: bool,
     pub embedded: bool,
 }

--- a/crates/ironclaw_filesystem/tests/catalog_contract.rs
+++ b/crates/ironclaw_filesystem/tests/catalog_contract.rs
@@ -46,8 +46,11 @@ async fn catalog_describes_paths_by_longest_matching_mount() {
     assert_eq!(placement.backend_kind, BackendKind::MemoryDocuments);
     assert_eq!(placement.content_kind, ContentKind::MemoryDocument);
     assert_eq!(placement.index_policy, IndexPolicy::FullTextAndVector);
-    assert!(placement.capabilities.indexed);
-    assert!(placement.capabilities.embedded);
+    // Backend ops capabilities are independent of IndexPolicy — the catalog
+    // policy hint drives upstream indexing services; the capability flags
+    // describe what RootFilesystem ops the mounted backend actually serves.
+    assert!(placement.capabilities.has(Capability::Read));
+    assert!(placement.capabilities.has(Capability::Write));
 }
 
 #[tokio::test]
@@ -253,22 +256,18 @@ fn descriptor(
         storage_class,
         content_kind,
         index_policy,
-        capabilities: BackendCapabilities {
-            read: true,
-            write: true,
-            append: true,
-            list: true,
-            stat: true,
-            delete: false,
-            indexed: matches!(
-                index_policy,
-                IndexPolicy::FullText | IndexPolicy::FullTextAndVector
-            ),
-            embedded: matches!(
-                index_policy,
-                IndexPolicy::Vector | IndexPolicy::FullTextAndVector
-            ),
-            ..Default::default()
-        },
+        // IndexPolicy (catalog hint about how upstream services index path
+        // content) is intentionally separate from `Capability::IndexFts` /
+        // `Capability::IndexVector` (backend op support for `ensure_index`
+        // / `query` on indexed projections). Test mounts use a LocalFilesystem
+        // which doesn't ship those record-plane ops, so the descriptor
+        // doesn't claim them — IndexPolicy on the descriptor still drives
+        // upstream behavior independently.
+        capabilities: BackendCapabilities::empty()
+            .with(Capability::Read)
+            .with(Capability::Write)
+            .with(Capability::Append)
+            .with(Capability::List)
+            .with(Capability::Stat),
     }
 }

--- a/crates/ironclaw_filesystem/tests/catalog_contract.rs
+++ b/crates/ironclaw_filesystem/tests/catalog_contract.rs
@@ -268,6 +268,7 @@ fn descriptor(
                 index_policy,
                 IndexPolicy::Vector | IndexPolicy::FullTextAndVector
             ),
+            ..Default::default()
         },
     }
 }

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -342,6 +342,39 @@ async fn libsql_get_returns_none_for_missing_path() {
 }
 
 #[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_write_file_after_put_resets_record_metadata_and_bumps_version() {
+    // PR #3660 reviewer fix: legacy write_file/append_file used to update
+    // only `contents`/`is_dir`/`updated_at`, leaving stale `kind`,
+    // `indexed`, `content_type`, and `version` from a prior put. A
+    // subsequent get() would then return a versioned-entry whose
+    // metadata didn't match the bytes. The fix clears schema metadata
+    // and bumps the version on every legacy write.
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/secrets/leases/STALE").unwrap();
+    let kind = RecordKind::new("credential_lease").unwrap();
+    let scope = IndexKey::new("scope").unwrap();
+    let record_entry = Entry::record(kind, &serde_json::json!({"k": 1}))
+        .unwrap()
+        .with_indexed(scope, IndexValue::Text("acme".into()));
+
+    let v1 = filesystem
+        .put(&path, record_entry, CasExpectation::Absent)
+        .await
+        .unwrap();
+
+    // Legacy write overwrites the entry with opaque bytes.
+    filesystem.write_file(&path, b"opaque").await.unwrap();
+
+    let got = filesystem.get(&path).await.unwrap().unwrap();
+    // Metadata cleared: kind=None, indexed empty. Version bumped from v1.
+    assert!(got.entry.kind.is_none());
+    assert!(got.entry.indexed.is_empty());
+    assert_eq!(got.entry.body, b"opaque");
+    assert!(got.version > v1);
+}
+
+#[cfg(feature = "libsql")]
 async fn libsql_root() -> TestLibSqlRootFilesystem {
     let db_dir = tempfile::tempdir().unwrap();
     let db_path = db_dir.path().join("root-filesystem.db");

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -5,7 +5,10 @@ use ironclaw_filesystem::RootFilesystem;
 #[cfg(feature = "postgres")]
 use ironclaw_filesystem::PostgresRootFilesystem;
 #[cfg(feature = "libsql")]
-use ironclaw_filesystem::{FileType, FilesystemError, FilesystemOperation, LibSqlRootFilesystem};
+use ironclaw_filesystem::{
+    CasExpectation, Entry, FileType, FilesystemError, FilesystemOperation, IndexKey, IndexValue,
+    LibSqlRootFilesystem, RecordKind,
+};
 #[cfg(feature = "libsql")]
 use ironclaw_host_api::VirtualPath;
 
@@ -239,6 +242,103 @@ impl std::ops::Deref for TestLibSqlRootFilesystem {
     fn deref(&self) -> &Self::Target {
         &self.filesystem
     }
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_native_put_get_round_trip_with_record_metadata() {
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/secrets/leases/L1").unwrap();
+
+    let kind = RecordKind::new("credential_lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    let status_key = IndexKey::new("status").unwrap();
+    let entry = Entry::record(kind.clone(), &serde_json::json!({"hidden": true}))
+        .unwrap()
+        .with_indexed(scope_key.clone(), IndexValue::Text("acme".into()))
+        .with_indexed(status_key.clone(), IndexValue::Text("active".into()));
+
+    let version1 = filesystem
+        .put(&path, entry, CasExpectation::Absent)
+        .await
+        .unwrap();
+    assert_eq!(version1.get(), 1);
+
+    let got = filesystem
+        .get(&path)
+        .await
+        .unwrap()
+        .expect("entry should be present");
+    assert_eq!(got.version, version1);
+    assert_eq!(got.entry.kind.as_ref(), Some(&kind));
+    assert_eq!(got.entry.indexed.len(), 2);
+    assert!(got.entry.indexed.contains_key(&scope_key));
+    assert!(got.entry.indexed.contains_key(&status_key));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_native_put_cas_absent_rejects_existing_path() {
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/secrets/leases/L2").unwrap();
+    filesystem
+        .put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+        .await
+        .unwrap();
+    let err = filesystem
+        .put(&path, Entry::bytes(vec![2]), CasExpectation::Absent)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, FilesystemError::VersionMismatch { .. }));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_native_put_cas_version_advances_and_rejects_stale() {
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/secrets/leases/L3").unwrap();
+    let v1 = filesystem
+        .put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+        .await
+        .unwrap();
+    let v2 = filesystem
+        .put(&path, Entry::bytes(vec![2]), CasExpectation::Version(v1))
+        .await
+        .unwrap();
+    assert!(v2 > v1);
+    // Stale version rejected.
+    let err = filesystem
+        .put(&path, Entry::bytes(vec![3]), CasExpectation::Version(v1))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, FilesystemError::VersionMismatch { .. }));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_native_put_cas_any_increments_existing_version() {
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/secrets/leases/L4").unwrap();
+    let v1 = filesystem
+        .put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+        .await
+        .unwrap();
+    let v2 = filesystem
+        .put(&path, Entry::bytes(vec![2]), CasExpectation::Any)
+        .await
+        .unwrap();
+    assert_eq!(v2.get(), v1.get() + 1);
+    let got = filesystem.get(&path).await.unwrap().unwrap();
+    assert_eq!(got.version, v2);
+    assert_eq!(got.entry.body, vec![2]);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_get_returns_none_for_missing_path() {
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/secrets/leases/missing").unwrap();
+    assert!(filesystem.get(&path).await.unwrap().is_none());
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -6,8 +6,8 @@ use ironclaw_filesystem::RootFilesystem;
 use ironclaw_filesystem::PostgresRootFilesystem;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::{
-    CasExpectation, Entry, FileType, FilesystemError, FilesystemOperation, IndexKey, IndexValue,
-    LibSqlRootFilesystem, RecordKind,
+    CasExpectation, Entry, FileType, FilesystemError, FilesystemOperation, Filter, IndexKey,
+    IndexKind, IndexName, IndexSpec, IndexValue, LibSqlRootFilesystem, Page, RecordKind,
 };
 #[cfg(feature = "libsql")]
 use ironclaw_host_api::VirtualPath;
@@ -372,6 +372,206 @@ async fn libsql_write_file_after_put_resets_record_metadata_and_bumps_version() 
     assert!(got.entry.indexed.is_empty());
     assert_eq!(got.entry.body, b"opaque");
     assert!(got.version > v1);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_ensure_index_is_idempotent_and_conflict_aware() {
+    let filesystem = libsql_root().await;
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+    let name = IndexName::new("by_scope_status").unwrap();
+    let keys = vec![
+        IndexKey::new("scope").unwrap(),
+        IndexKey::new("status").unwrap(),
+    ];
+    let spec_exact = IndexSpec::new(name.clone(), keys.clone(), IndexKind::Exact);
+    let spec_prefix = IndexSpec::new(name, keys, IndexKind::Prefix);
+
+    filesystem.ensure_index(&prefix, &spec_exact).await.unwrap();
+    // Re-declaring same spec is idempotent.
+    filesystem.ensure_index(&prefix, &spec_exact).await.unwrap();
+    // Declaring a different kind under the same name is a conflict.
+    let err = filesystem
+        .ensure_index(&prefix, &spec_prefix)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, FilesystemError::IndexConflict { .. }));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_ensure_index_rejects_fts_and_vector_kinds() {
+    let filesystem = libsql_root().await;
+    let prefix = VirtualPath::new("/memory").unwrap();
+    let spec = IndexSpec::new(
+        IndexName::new("by_chunk").unwrap(),
+        vec![IndexKey::new("chunk_id").unwrap()],
+        IndexKind::Fts,
+    );
+    let err = filesystem.ensure_index(&prefix, &spec).await.unwrap_err();
+    assert!(matches!(err, FilesystemError::Unsupported { .. }));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_query_filters_on_indexed_projection() {
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    let status_key = IndexKey::new("status").unwrap();
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+    let spec = IndexSpec::new(
+        IndexName::new("by_scope_status").unwrap(),
+        vec![scope_key.clone(), status_key.clone()],
+        IndexKind::Exact,
+    );
+    filesystem.ensure_index(&prefix, &spec).await.unwrap();
+
+    for (path, scope, status) in [
+        ("/secrets/leases/A", "acme", "active"),
+        ("/secrets/leases/B", "acme", "revoked"),
+        ("/secrets/leases/C", "globex", "active"),
+        ("/secrets/leases/D", "acme", "active"),
+    ] {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()))
+            .with_indexed(status_key.clone(), IndexValue::Text(status.into()));
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+
+    let results = filesystem
+        .query(
+            &prefix,
+            &Filter::And(vec![
+                Filter::Eq {
+                    key: scope_key,
+                    value: IndexValue::Text("acme".into()),
+                },
+                Filter::Eq {
+                    key: status_key,
+                    value: IndexValue::Text("active".into()),
+                },
+            ]),
+            Page::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    let mut paths: Vec<String> = results
+        .iter()
+        .map(|v| String::from_utf8_lossy(&v.entry.body).into_owned())
+        .collect();
+    paths.sort();
+    // Both matching rows have empty bodies; verify by re-reading the
+    // indexed projection on each result.
+    let acme_active_count = results
+        .iter()
+        .filter(|v| {
+            v.entry.indexed.get(&IndexKey::new("scope").unwrap())
+                == Some(&IndexValue::Text("acme".into()))
+                && v.entry.indexed.get(&IndexKey::new("status").unwrap())
+                    == Some(&IndexValue::Text("active".into()))
+        })
+        .count();
+    assert_eq!(acme_active_count, 2);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_query_prefix_filter_matches_text_prefix() {
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+
+    for (path, scope) in [
+        ("/secrets/leases/X", "tenant:acme/u/1"),
+        ("/secrets/leases/Y", "tenant:acme/u/2"),
+        ("/secrets/leases/Z", "tenant:globex/u/1"),
+    ] {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()));
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+
+    let results = filesystem
+        .query(
+            &prefix,
+            &Filter::PrefixOn {
+                key: scope_key,
+                value: IndexValue::Text("tenant:acme/".into()),
+            },
+            Page::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_query_paginates_results() {
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+
+    for i in 0..7 {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({"i": i}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text("acme".into()));
+        let path = VirtualPath::new(format!("/secrets/leases/page-{i:02}")).unwrap();
+        filesystem
+            .put(&path, entry, CasExpectation::Absent)
+            .await
+            .unwrap();
+    }
+
+    let first = filesystem
+        .query(
+            &prefix,
+            &Filter::Eq {
+                key: scope_key.clone(),
+                value: IndexValue::Text("acme".into()),
+            },
+            Page::new(0, 3),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.len(), 3);
+
+    let second = filesystem
+        .query(
+            &prefix,
+            &Filter::Eq {
+                key: scope_key,
+                value: IndexValue::Text("acme".into()),
+            },
+            Page::new(3, 3),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.len(), 3);
+    // Pages must not overlap (ordered by path).
+    for entry in &second {
+        assert!(!first.iter().any(|f| f.entry.body == entry.entry.body));
+    }
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -526,6 +526,107 @@ async fn libsql_query_prefix_filter_matches_text_prefix() {
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn libsql_query_or_empty_matches_nothing_and_all_matches_every_row() {
+    // PR #3661 reviewer fix: empty `Or` was returning every row instead
+    // of none, and `Filter::All` was being skipped in compound contexts.
+    // After the translator change every node emits a non-empty fragment
+    // (`All` -> `TRUE`, empty `And` -> `TRUE`, empty `Or` -> `FALSE`).
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    for (path, scope) in [
+        ("/secrets/leases/A", "acme"),
+        ("/secrets/leases/B", "globex"),
+    ] {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()));
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+
+    // `All` matches every row.
+    let all = filesystem
+        .query(&prefix, &Filter::All, Page::default())
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 2);
+
+    // Empty `Or` matches nothing.
+    let none = filesystem
+        .query(&prefix, &Filter::Or(Vec::new()), Page::default())
+        .await
+        .unwrap();
+    assert!(none.is_empty());
+
+    // Empty `And` matches everything (identity).
+    let and_empty = filesystem
+        .query(&prefix, &Filter::And(Vec::new()), Page::default())
+        .await
+        .unwrap();
+    assert_eq!(and_empty.len(), 2);
+
+    // `And([All])` is well-formed and matches everything.
+    let and_all = filesystem
+        .query(&prefix, &Filter::And(vec![Filter::All]), Page::default())
+        .await
+        .unwrap();
+    assert_eq!(and_all.len(), 2);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_query_prefix_filter_literal_percent_is_not_a_wildcard() {
+    // PR #3661 reviewer fix: a literal prefix containing `%` was being
+    // passed to LIKE with its `%` left unescaped (because the prior
+    // escape helper preserved trailing `%`). `tenant:%` would then match
+    // anything starting with `tenant:` instead of literally `tenant:%`.
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    for (path, scope) in [
+        ("/secrets/leases/P1", "tenant:%"),
+        ("/secrets/leases/P2", "tenant:acme"),
+        ("/secrets/leases/P3", "tenant:globex"),
+    ] {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()));
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+
+    // Literal-prefix `tenant:%` should match only the row whose stored
+    // scope literally starts with `tenant:%`, not the two `tenant:` rows.
+    let results = filesystem
+        .query(
+            &VirtualPath::new("/secrets/leases").unwrap(),
+            &Filter::PrefixOn {
+                key: scope_key,
+                value: IndexValue::Text("tenant:%".into()),
+            },
+            Page::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn libsql_query_paginates_results() {
     let filesystem = libsql_root().await;
     let kind = RecordKind::new("lease").unwrap();

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -687,3 +687,366 @@ async fn libsql_root() -> TestLibSqlRootFilesystem {
         _dir: db_dir,
     }
 }
+
+// ─── Postgres behavioral tests ────────────────────────────────────────────
+//
+// PR #3659 reviewer flagged that the libsql contract suite has no Postgres
+// counterpart, even though the Postgres backend ships substantial new code.
+// These tests mirror the libsql shape (put/get round-trip, CAS Absent /
+// Version / Any, query with Filter shapes, ensure_index conflict +
+// race-idempotence, Range numeric vs text comparison) and gracefully skip
+// when no Postgres is reachable via `DATABASE_URL` /
+// `IRONCLAW_FILESYSTEM_POSTGRES_URL`.
+
+#[cfg(feature = "postgres")]
+mod postgres_tests {
+    use super::*;
+    use ironclaw_filesystem::PostgresRootFilesystem;
+
+    async fn postgres_pool() -> Option<deadpool_postgres::Pool> {
+        if std::env::var("IRONCLAW_SKIP_POSTGRES_TESTS").is_ok() {
+            return None;
+        }
+        let url = std::env::var("IRONCLAW_FILESYSTEM_POSTGRES_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .ok()?;
+        let config = url.parse::<tokio_postgres::Config>().ok()?;
+        let manager = deadpool_postgres::Manager::new(config, tokio_postgres::NoTls);
+        deadpool_postgres::Pool::builder(manager)
+            .max_size(4)
+            .build()
+            .ok()
+    }
+
+    /// Build a fresh Postgres-backed filesystem with migrations applied.
+    /// Returns `None` if no Postgres is reachable — caller must early-return
+    /// so the test passes in environments without a DB. Each test uses a
+    /// unique path prefix so concurrent runs against a shared DB don't
+    /// interfere.
+    async fn postgres_root() -> Option<(PostgresRootFilesystem, String)> {
+        let pool = postgres_pool().await?;
+        let fs = PostgresRootFilesystem::new(pool);
+        fs.run_migrations().await.ok()?;
+        // Unique per-test prefix under /secrets/leases (a known VirtualPath
+        // root). Concurrent test runs against the same Postgres get
+        // isolation via the prefix; cleanup happens by the next test's
+        // delete on its own prefix or by the test DB being torn down
+        // between runs.
+        let prefix = format!("/secrets/leases/pgtest_{}", uuid::Uuid::new_v4().simple());
+        Some((fs, prefix))
+    }
+
+    fn vpath(prefix: &str, leaf: &str) -> VirtualPath {
+        VirtualPath::new(format!("{prefix}/{leaf}")).unwrap()
+    }
+
+    #[tokio::test]
+    async fn postgres_native_put_get_round_trip_with_record_metadata() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let path = vpath(&prefix, "L1");
+        let kind = RecordKind::new("credential_lease").unwrap();
+        let scope_key = IndexKey::new("scope").unwrap();
+        let status_key = IndexKey::new("status").unwrap();
+        let entry = Entry::record(kind.clone(), &serde_json::json!({"hidden": true}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text("acme".into()))
+            .with_indexed(status_key.clone(), IndexValue::Text("active".into()));
+
+        let version1 = fs.put(&path, entry, CasExpectation::Absent).await.unwrap();
+        assert_eq!(version1.get(), 1);
+
+        let got = fs
+            .get(&path)
+            .await
+            .unwrap()
+            .expect("entry should be present");
+        assert_eq!(got.version, version1);
+        assert_eq!(got.entry.kind.as_ref(), Some(&kind));
+        assert_eq!(got.entry.indexed.len(), 2);
+        assert!(got.entry.indexed.contains_key(&scope_key));
+        assert!(got.entry.indexed.contains_key(&status_key));
+    }
+
+    #[tokio::test]
+    async fn postgres_native_put_cas_absent_rejects_existing_path() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let path = vpath(&prefix, "L2");
+        fs.put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+            .await
+            .unwrap();
+        let err = fs
+            .put(&path, Entry::bytes(vec![2]), CasExpectation::Absent)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FilesystemError::VersionMismatch { .. }));
+    }
+
+    #[tokio::test]
+    async fn postgres_native_put_cas_version_advances_and_rejects_stale() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let path = vpath(&prefix, "L3");
+        let v1 = fs
+            .put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+            .await
+            .unwrap();
+        let v2 = fs
+            .put(&path, Entry::bytes(vec![2]), CasExpectation::Version(v1))
+            .await
+            .unwrap();
+        assert!(v2 > v1);
+        let err = fs
+            .put(&path, Entry::bytes(vec![3]), CasExpectation::Version(v1))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FilesystemError::VersionMismatch { .. }));
+    }
+
+    #[tokio::test]
+    async fn postgres_native_put_cas_any_increments_existing_version() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let path = vpath(&prefix, "L4");
+        let v1 = fs
+            .put(&path, Entry::bytes(vec![1]), CasExpectation::Absent)
+            .await
+            .unwrap();
+        let v2 = fs
+            .put(&path, Entry::bytes(vec![2]), CasExpectation::Any)
+            .await
+            .unwrap();
+        assert_eq!(v2.get(), v1.get() + 1);
+        let got = fs.get(&path).await.unwrap().unwrap();
+        assert_eq!(got.version, v2);
+        assert_eq!(got.entry.body, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn postgres_get_returns_none_for_missing_path() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let path = vpath(&prefix, "missing");
+        assert!(fs.get(&path).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn postgres_ensure_index_is_idempotent_and_conflict_aware() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let prefix_path = VirtualPath::new(prefix).unwrap();
+        let name = IndexName::new("by_scope_status").unwrap();
+        let keys = vec![
+            IndexKey::new("scope").unwrap(),
+            IndexKey::new("status").unwrap(),
+        ];
+        let spec_exact = IndexSpec::new(name.clone(), keys.clone(), IndexKind::Exact);
+        let spec_prefix = IndexSpec::new(name, keys, IndexKind::Prefix);
+
+        fs.ensure_index(&prefix_path, &spec_exact).await.unwrap();
+        // Idempotent re-declaration.
+        fs.ensure_index(&prefix_path, &spec_exact).await.unwrap();
+        // Conflicting kind under same name fails.
+        let err = fs
+            .ensure_index(&prefix_path, &spec_prefix)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FilesystemError::IndexConflict { .. }));
+    }
+
+    #[tokio::test]
+    async fn postgres_query_filters_on_indexed_projection() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let prefix_path = VirtualPath::new(&prefix).unwrap();
+        let kind = RecordKind::new("lease").unwrap();
+        let scope_key = IndexKey::new("scope").unwrap();
+        let status_key = IndexKey::new("status").unwrap();
+
+        for (leaf, scope, status) in [
+            ("A", "acme", "active"),
+            ("B", "acme", "revoked"),
+            ("C", "globex", "active"),
+            ("D", "acme", "active"),
+        ] {
+            let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+                .unwrap()
+                .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()))
+                .with_indexed(status_key.clone(), IndexValue::Text(status.into()));
+            fs.put(&vpath(&prefix, leaf), entry, CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+
+        let results = fs
+            .query(
+                &prefix_path,
+                &Filter::And(vec![
+                    Filter::Eq {
+                        key: scope_key,
+                        value: IndexValue::Text("acme".into()),
+                    },
+                    Filter::Eq {
+                        key: status_key,
+                        value: IndexValue::Text("active".into()),
+                    },
+                ]),
+                Page::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn postgres_query_range_on_i64_is_numeric_not_lexicographic() {
+        // PR #3661 reviewer: Postgres Range on IndexValue::I64 used to be
+        // lexicographic via `indexed->>'key' BETWEEN ...` on text. The fix
+        // casts both sides to BIGINT so `2..10` includes `9` but not `99`.
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let prefix_path = VirtualPath::new(&prefix).unwrap();
+        let kind = RecordKind::new("widget").unwrap();
+        let size = IndexKey::new("size").unwrap();
+        for (leaf, n) in [
+            ("W2", 2i64),
+            ("W9", 9),
+            ("W10", 10),
+            ("W11", 11),
+            ("W99", 99),
+        ] {
+            let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+                .unwrap()
+                .with_indexed(size.clone(), IndexValue::I64(n));
+            fs.put(&vpath(&prefix, leaf), entry, CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+        // Range 2..=10 should include {2, 9, 10} numerically. Lexicographic
+        // comparison on '2' / '10' would miss `9` (since "9" > "10" as text).
+        let results = fs
+            .query(
+                &prefix_path,
+                &Filter::Range {
+                    key: size,
+                    lo: IndexValue::I64(2),
+                    hi: IndexValue::I64(10),
+                },
+                Page::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn postgres_query_prefix_filter_literal_percent_is_not_a_wildcard() {
+        // PR #3661 reviewer: literal `tenant:%` must not become a wildcard.
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let prefix_path = VirtualPath::new(&prefix).unwrap();
+        let kind = RecordKind::new("lease").unwrap();
+        let scope_key = IndexKey::new("scope").unwrap();
+        for (leaf, scope) in [
+            ("P1", "tenant:%"),
+            ("P2", "tenant:acme"),
+            ("P3", "tenant:globex"),
+        ] {
+            let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+                .unwrap()
+                .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()));
+            fs.put(&vpath(&prefix, leaf), entry, CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+        let results = fs
+            .query(
+                &prefix_path,
+                &Filter::PrefixOn {
+                    key: scope_key,
+                    value: IndexValue::Text("tenant:%".into()),
+                },
+                Page::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn postgres_query_or_empty_matches_nothing_and_all_matches_every_row() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let prefix_path = VirtualPath::new(&prefix).unwrap();
+        let kind = RecordKind::new("lease").unwrap();
+        let scope_key = IndexKey::new("scope").unwrap();
+        for (leaf, scope) in [("A", "acme"), ("B", "globex")] {
+            let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+                .unwrap()
+                .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()));
+            fs.put(&vpath(&prefix, leaf), entry, CasExpectation::Absent)
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            fs.query(&prefix_path, &Filter::All, Page::default())
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+        assert!(
+            fs.query(&prefix_path, &Filter::Or(Vec::new()), Page::default())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            fs.query(&prefix_path, &Filter::And(Vec::new()), Page::default())
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn postgres_write_file_after_put_resets_record_metadata_and_bumps_version() {
+        let Some((fs, prefix)) = postgres_root().await else {
+            return;
+        };
+        let path = vpath(&prefix, "STALE");
+        let kind = RecordKind::new("credential_lease").unwrap();
+        let scope = IndexKey::new("scope").unwrap();
+        let record_entry = Entry::record(kind, &serde_json::json!({"k": 1}))
+            .unwrap()
+            .with_indexed(scope, IndexValue::Text("acme".into()));
+
+        let v1 = fs
+            .put(&path, record_entry, CasExpectation::Absent)
+            .await
+            .unwrap();
+
+        // Legacy write must reset record metadata + bump version.
+        #[allow(deprecated)]
+        fs.write_file(&path, b"opaque").await.unwrap();
+
+        let got = fs.get(&path).await.unwrap().unwrap();
+        assert!(got.entry.kind.is_none());
+        assert!(got.entry.indexed.is_empty());
+        assert_eq!(got.entry.body, b"opaque");
+        assert!(got.version > v1);
+    }
+}

--- a/crates/ironclaw_host_runtime/src/first_party_tools/coding/paths.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/coding/paths.rs
@@ -88,6 +88,12 @@ pub(super) fn operation_allowed(
         FilesystemOperation::Delete => permissions.delete,
         FilesystemOperation::CreateDirAll => permissions.write,
         FilesystemOperation::MountLocal => false,
+        // Coding tools never use the unified record/index/txn surface — they
+        // are bytes-only. If a future code path routes here, treat record-
+        // plane reads as `read` and writes as `write` to stay fail-closed.
+        FilesystemOperation::Query => permissions.read && permissions.list,
+        FilesystemOperation::EnsureIndex | FilesystemOperation::BeginTxn => permissions.write,
+        FilesystemOperation::Tail => permissions.read,
     }
 }
 
@@ -209,5 +215,17 @@ pub(super) fn filesystem_error(error: FilesystemError) -> FirstPartyCapabilityEr
         }
         FilesystemError::NotFound { .. } => guest_error(),
         FilesystemError::Backend { .. } => guest_error(),
+        // The unified record/index/CAS variants are surfaced when a backend
+        // declines a typed op. Coding tools only exercise bytes, so reaching
+        // here means the underlying mount is misconfigured for this caller —
+        // treat as a denial rather than leaking the typed shape.
+        FilesystemError::VersionMismatch { .. }
+        | FilesystemError::Unsupported { .. }
+        | FilesystemError::IndexConflict { .. } => {
+            FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::FilesystemDenied)
+        }
+        // FilesystemError is #[non_exhaustive]; any future variant maps to a
+        // denial here until coding-tool semantics for it are designed.
+        _ => FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::FilesystemDenied),
     }
 }

--- a/crates/ironclaw_memory/tests/reborn_native_filesystem_vertical_integration.rs
+++ b/crates/ironclaw_memory/tests/reborn_native_filesystem_vertical_integration.rs
@@ -25,8 +25,8 @@ use async_trait::async_trait;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::FilesystemError;
 use ironclaw_filesystem::{
-    BackendCapabilities, BackendId, BackendKind, CompositeRootFilesystem, ContentKind, IndexPolicy,
-    MountDescriptor, RootFilesystem, StorageClass,
+    BackendCapabilities, BackendId, BackendKind, Capability, CompositeRootFilesystem, ContentKind,
+    IndexPolicy, MountDescriptor, RootFilesystem, StorageClass,
 };
 use ironclaw_host_api::VirtualPath;
 use ironclaw_memory::{
@@ -56,15 +56,13 @@ fn memory_mount_descriptor() -> MountDescriptor {
         storage_class: StorageClass::FileContent,
         content_kind: ContentKind::MemoryDocument,
         index_policy: IndexPolicy::FullTextAndVector,
-        capabilities: BackendCapabilities {
-            read: true,
-            write: true,
-            list: true,
-            stat: true,
-            indexed: true,
-            embedded: true,
-            ..BackendCapabilities::default()
-        },
+        capabilities: BackendCapabilities::empty()
+            .with(Capability::Read)
+            .with(Capability::Write)
+            .with(Capability::List)
+            .with(Capability::Stat)
+            .with(Capability::IndexFts)
+            .with(Capability::IndexVector),
     }
 }
 

--- a/docs/reborn/2026-04-25-storage-catalog-and-placement.md
+++ b/docs/reborn/2026-04-25-storage-catalog-and-placement.md
@@ -1,6 +1,13 @@
 # Reborn Storage Catalog and Placement Plan
 
-**Status:** Implementation planning note
+**Status:** Superseded on 2026-05-14 by
+`docs/reborn/2026-05-14-universal-fs-dispatch.md`. The
+"bytes mount; typed stays typed" boundary documented below was correct
+only while the filesystem trait was bytes-only. The 2026-05-14 ADR widens
+`RootFilesystem` to carry typed records, CAS, queries, and indexes
+natively, so structured stores (secrets, leases, processes, events) now
+*do* run on the same mount fabric as files. Retained below for historical
+context.
 **Date:** 2026-04-25
 **Related contracts:** `contracts/filesystem.md`, `contracts/secrets.md`, `contracts/processes.md`, `contracts/events-projections.md`
 

--- a/docs/reborn/2026-05-14-universal-fs-dispatch.md
+++ b/docs/reborn/2026-05-14-universal-fs-dispatch.md
@@ -1,0 +1,156 @@
+# 2026-05-14 — Universal Filesystem Dispatch Fabric
+
+**Status:** Accepted. Supersedes
+`docs/reborn/2026-04-25-storage-catalog-and-placement.md`.
+**Drives:** The kernel storage rework plan (promoted into
+`docs/plans/2026-05-14-kernel-storage-rework.md` when the foundation
+PR lands).
+
+## Context
+
+Before this ADR every persistence concern in the IronClaw workspace owned
+its own `Store`/`Repository` trait with a per-backend dispatch for libSQL
+and PostgreSQL:
+
+- `ironclaw_secrets`, `ironclaw_authorization`, `ironclaw_memory`,
+  `ironclaw_processes`, `ironclaw_run_state`, `ironclaw_outbound`,
+  `ironclaw_conversations`, `ironclaw_reborn_event_store`,
+  `ironclaw_engine` (`Store` trait), plus `src/db/` (composite `Database`
+  trait, 7 sub-traits, ~78 methods), `src/secrets/`, `src/workspace/`,
+  `src/history/`.
+
+Adding a new backend (HSM, TEE-resident KMS, S3 object store) meant
+touching 8–12 crates. Each crate also duplicated feature-flag
+dispatch, dialect-difference handling, and scope-key plumbing. The
+storage-catalog ADR of 2026-04-25 mitigated this by drawing a "bytes
+mount; typed stays typed" placement boundary — explicitly *not*
+unifying the dispatch.
+
+The user's direction for the kernel storage rework asks for the
+opposite: collapse everything onto a single mount fabric so the kernel
+stays small and every backend is interchangeable behind one trait.
+
+## Decision
+
+There is **one universal filesystem dispatch fabric**:
+
+1. **One trait:** `RootFilesystem` (in `crates/ironclaw_filesystem/`).
+   Every backend (local file, libSQL, PostgreSQL, HSM, in-memory,
+   encrypted-decorator, object-store, …) implements it. The composite
+   dispatcher (`CompositeRootFilesystem`) also implements it; it *is*
+   a backend that routes by longest-prefix mount. No parallel "backend
+   trait" sits next to `RootFilesystem`.
+2. **One entry type:** `Entry { body, content_type, kind, indexed }`.
+   A bytes-only "file" is an `Entry` with `kind = None` and an empty
+   indexed projection. A "record" is an `Entry` with `kind = Some(_)`
+   and a populated indexed projection. The same `put`/`get`/`query`/CAS
+   machinery serves both.
+3. **One set of ops:** `put` / `get` / `delete` / `list_dir` / `query`
+   / `ensure_index` / `stat` / `begin` / `append` / `tail`. CAS +
+   versioning is universal — every successful `put` returns a
+   `RecordVersion` and every successive write can require a CAS match.
+4. **Capabilities declared at mount time.** `BackendCapabilities`
+   enumerates what each backend serves
+   (`{ read, write, append, list, stat, delete, records, query, index,
+   txn, events }`). Mount-time validation refuses backends that cannot
+   satisfy the indexes a consumer declares; runtime `Unsupported`
+   errors are the fallback when a capability is conditional on the
+   underlying server.
+5. **Encryption-at-rest is a backend decorator.** `EncryptedBackend`
+   (planned) wraps an inner backend, encrypting `Entry::body` and any
+   `IndexValue::Bytes` projection while letting scalar indexed
+   projections (`scope`, `status`, …) pass through so query still
+   works. `SecretStore` and other sensitive-data stores never own
+   encryption code — they write plaintext `Entry` values through a
+   `ScopedFilesystem` whose mount happens to be wrapped in encryption.
+
+## How this overrides the 2026-04-25 catalog ADR
+
+The 2026-04-25 ADR drew a hard line:
+
+> "Secrets/leases/processes/events stay typed, no mount. If callers think
+> in paths & bytes → mount. If they need leases, transactions, queries,
+> redaction → typed repository."
+
+That boundary was correct only because the filesystem trait at that time
+was bytes-only and couldn't carry leases, transactions, queries, or
+redaction-friendly typed data. **This ADR widens the filesystem trait so
+those features ARE first-class on the mount fabric**:
+
+| 2026-04-25 reason for "typed, no mount"                | 2026-05-14 mechanism that absorbs it onto the mount fabric                                                                |
+|--------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| Leases need atomic claim/consume                       | `put` with `CasExpectation::Version(v)` + retry on `VersionMismatch`. `begin`/`StorageTxn` for backends that have it natively. |
+| Transactions for multi-step state changes              | Same — CAS is the floor; multi-key transactions are an opt-in capability.                                                 |
+| Query/index needs (search by scope, status, time)      | `query(prefix, filter, page)` + `ensure_index(prefix, IndexSpec)`. Indexed projection is queryable; payload is opaque.    |
+| Redaction (never expose ciphertext or scope keys)      | `EncryptedBackend` decorator handles ciphertext transparently; redaction stays in the consumer's domain error types.       |
+| Event logs need append/tail                            | `append(path, payload) -> SeqNo` and `tail(path, from)` on the same trait. Narrow, opt-in; only event-log mounts wire it. |
+
+Result: structured/control-plane records *can* go through the filesystem
+when (a) the backend declares the matching capabilities and (b) the
+consumer chooses to.
+
+## Consequences
+
+**Wins:**
+
+- Adding a new backend means implementing one trait. HSM-backed secrets,
+  S3-backed artifacts, and TEE-backed KMS all become single-mount
+  swaps.
+- Per-tenant routing is a mount table choice, not a code change.
+- CAS + versioning is available to memory documents and project files
+  for free.
+- The audit / observability story is uniform — every write goes through
+  one method.
+- Feature-flag dispatch (`#[cfg(feature = "libsql")]` /
+  `#[cfg(feature = "postgres")]`) concentrates in
+  `crates/ironclaw_filesystem/`; consumer crates lose their per-backend
+  branches.
+
+**Costs:**
+
+- The composite/router becomes a load-bearing piece of infrastructure.
+  Bugs in `CompositeRootFilesystem::matching_mount` have system-wide
+  blast radius.
+- Existing consumer crates (10+ of them) need to migrate from their
+  own `Store` trait to taking a `ScopedFilesystem`. This is intrusive,
+  but the plan sequences it crate-by-crate.
+- Backends that don't natively support records (local file, S3) need to
+  decide whether to store records as JSON files in a sidecar or to
+  reject records explicitly via declared capabilities. We default to
+  declaring `records: false` and rejecting at mount time.
+
+**Mitigations:**
+
+- Legacy bytes ops (`read_file`/`write_file`/`append_file`/`list_dir`)
+  remain on `RootFilesystem` during the migration window with default
+  impls that route through the new `put`/`get`. Existing consumer code
+  keeps compiling.
+- `InMemoryBackend` ships with the foundation as a reference impl that
+  serves the full unified surface. It replaces the N per-crate
+  `InMemoryStore` implementations.
+- The crate's `CLAUDE.md` was rewritten alongside this ADR to encode the
+  invariants new code must preserve.
+
+## Out of scope for this ADR
+
+- The engine v2 sandbox `MountBackend` (per-project Docker filesystem
+  isolation) converges with `RootFilesystem` in a follow-up. Different
+  blast radius — sandbox is about isolation, not backend selection.
+- Cross-mount transactions. Single-mount CAS is the floor; cross-mount
+  atomicity is explicitly rejected.
+- The real HSM/TEE/S3 backend implementations. The trait seam exists;
+  the implementations land in follow-up PRs.
+- Migration of existing libSQL/Postgres rows into new record-shaped
+  tables. A separate data-migration plan handles that once the trait
+  lands and consumers begin to migrate.
+
+## References
+
+- Rework plan: `docs/plans/2026-05-14-kernel-storage-rework.md` (to be
+  promoted from the working plan file when the foundation PR opens).
+- Superseded ADR:
+  `docs/reborn/2026-04-25-storage-catalog-and-placement.md`
+- Architecture sprawl rule: `.claude/rules/architecture.md` — "duplicate
+  dispatch pipelines" is the smell this rework eliminates at the
+  storage layer.
+- Filesystem crate guardrails: `crates/ironclaw_filesystem/CLAUDE.md`.

--- a/migrations/V28__root_filesystem_records.sql
+++ b/migrations/V28__root_filesystem_records.sql
@@ -1,0 +1,19 @@
+-- Extend root_filesystem_entries to carry Entry record metadata (kind,
+-- indexed projection, content type, version) in addition to opaque bytes.
+-- A row with `kind IS NULL` and `indexed = '{}'` is an opaque file — the
+-- legacy shape, preserved by safe defaults so existing entries round-trip.
+-- A row with `kind` set carries a typed record whose `indexed` projection
+-- is queryable by future query/ensure_index ops. `version` enables
+-- compare-and-swap semantics on `put`.
+
+ALTER TABLE root_filesystem_entries
+    ADD COLUMN IF NOT EXISTS content_type TEXT NOT NULL DEFAULT 'application/octet-stream';
+
+ALTER TABLE root_filesystem_entries
+    ADD COLUMN IF NOT EXISTS kind TEXT;
+
+ALTER TABLE root_filesystem_entries
+    ADD COLUMN IF NOT EXISTS indexed JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE root_filesystem_entries
+    ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT 0;

--- a/migrations/V29__root_filesystem_index_specs.sql
+++ b/migrations/V29__root_filesystem_index_specs.sql
@@ -1,0 +1,14 @@
+-- Track index declarations for root_filesystem_entries. Records the
+-- (prefix, name, keys, kind) of every `ensure_index` call so re-declaration
+-- is conflict-aware and idempotent across processes. The actual JSONB
+-- expression indexes are created out-of-band by `ensure_index` and named
+-- deterministically (`idx_rfs_<sanitized_prefix>_<name>`) so re-running
+-- migrations doesn't recreate them.
+
+CREATE TABLE IF NOT EXISTS root_filesystem_index_specs (
+    prefix TEXT NOT NULL,
+    name TEXT NOT NULL,
+    keys JSONB NOT NULL,
+    kind TEXT NOT NULL,
+    PRIMARY KEY (prefix, name)
+);

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -40,3 +40,4 @@ V24__llm_calls_created_at_index = 2650126284755685421
 V25__wasm_fuel_limit_bump = 8924323300096627270
 V26__root_filesystem_entries = 11094038407147728260
 V27__root_filesystem_entries_directories = 4126641792698406758
+V28__root_filesystem_records = 3989652150745692033

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -41,3 +41,4 @@ V25__wasm_fuel_limit_bump = 8924323300096627270
 V26__root_filesystem_entries = 11094038407147728260
 V27__root_filesystem_entries_directories = 4126641792698406758
 V28__root_filesystem_records = 3989652150745692033
+V29__root_filesystem_index_specs = 1572937030361291327


### PR DESCRIPTION
## Summary

Consolidated foundation for the IronClaw storage rework. Replaces the per-crate `Store`/`Repository` sprawl with **one** `RootFilesystem` trait, **one** `Entry` type, and **one** set of ops (`put` / `get` / `delete` / `list_dir` / `query` / `ensure_index` / `stat` / `begin` / `append` / `tail`). CAS + versioning is universal — memory docs and project files get lost-update protection for free.

After review feedback that the foundation alone was "incomplete" — it advertised capabilities (query, native put, index) that no shipped backend actually implemented — this PR was rebased onto latest `reborn-integration` and absorbs the work formerly stacked in PR #3660 (port) and PR #3661 (indexer). Result: a self-contained foundation that ships native put/get + query/ensure_index on both SQL backends.

## What's in this PR

**Foundation layer**
- `Entry` / `VersionedEntry` / `RecordKind` / `RecordVersion` / `SeqNo` / `CasExpectation` / `ContentType` (`record.rs`)
- `IndexSpec` / `IndexName` / `IndexKey` / `IndexValue` / `IndexKind` / `Filter` / `Page` (`index.rs`)
- `StorageTxn` / `EventRecord` (`backend.rs`) — supporting types, not a parallel backend trait. `RootFilesystem` is the one trait.
- `RootFilesystem` extended in `root.rs` with the unified ops; legacy `read_file`/`write_file` retained for transitional callers.
- `ScopedFilesystem` forwards every new op under the mount-view permission check; `read_bytes`/`write_bytes` helpers added.
- `CompositeRootFilesystem` dispatches every new op by longest-prefix mount, with mount-time capability validation.
- `InMemoryBackend` — full reference impl; replaces the N per-crate `InMemory*Store` implementations consumer crates used to maintain.
- `LocalFilesystem` — native `put`/`get` for opaque-file entries with `CasExpectation::Any` (canonical pattern for byte-only backends).
- `BackendCapabilities` widened with `records`/`query`/`index`/`txn`/`events`; new error variants `VersionMismatch`/`Unsupported`/`IndexConflict`.

**SQL backends (formerly PR #3660)**
- New migration V28 + V29 plus idempotent libsql ALTERs add `content_type`/`kind`/`indexed`/`version` columns and the index-spec metadata table.
- Native `put` (Absent / Version / Any CAS), `get`, `query` (Filter→WHERE translation), `ensure_index` (expression indexes on `json_extract`/`->>'key'`) for both libsql and Postgres.
- Capabilities now declare `records: true`, `query: true`, `index.exact: true`, `index.prefix: true`, `txn: Cas`.
- Legacy `write_file`/`append_file` reset record metadata + bump version to prevent stale-metadata reads after mixed writes (Reviewer P0 from #3660).

**Indexer (formerly PR #3661)**
- `Filter::All` / empty `And` / empty `Or` emit explicit `TRUE`/`TRUE`/`FALSE` (no more "skip empty fragment" path that broke `Or([])`).
- `Filter::PrefixOn` uses a dedicated `escape_like_literal` so a literal `tenant:%` is escaped, not treated as a wildcard.
- Postgres `Filter::Range` on `IndexValue::I64` casts both sides to `BIGINT` for numeric comparison (was lexicographic on text).
- `IndexKey`/`IndexName` validation tightened to `[A-Za-z_][A-Za-z0-9_]*` — closes JSON-path traversal (`"a.b"` no longer maps to `$.a.b`) and DDL identifier injection.
- `ensure_index` race-idempotent via `INSERT ... ON CONFLICT DO NOTHING` + canonical-spec read-back.

**PR #3659 review medium-severity items (this commit)**
- `RootFilesystem::put`/`get` defaults are now `Unsupported` (the prior bridge introduced a put/write_file recursion cycle). `LocalFilesystem::put`/`get` provides the canonical byte-only-backend pattern.
- `InMemoryBackend::list_dir` upgrades a path to `Directory` on later child discovery (was: first-discovery wins, leaf-then-children misclassified).
- `InMemoryBackend::delete` now sweeps the subtree when no exact entry exists (matches SQL backends).
- `Filter::Range` requires `lo`/`hi`/stored value to share an `IndexValue` variant (was: cross-variant ordering via derived `Ord` produced bogus matches).
- `CompositeRootFilesystem::mount_dyn` rejects descriptors that over-claim capabilities on the new axes (records/query/index/events/txn).

## Test plan

- [x] `cargo test -p ironclaw_filesystem --all-features` — **72 tests pass** (25 unit + 5 catalog + 22 db-backed + 20 filesystem-contract)
- [x] `cargo clippy -p ironclaw_filesystem --all-features --tests` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --workspace --all-features` — clean
- [x] Pre-push lib-test gate (4967 tests) — pass

## Docs / ADR

- `crates/ironclaw_filesystem/CLAUDE.md` rewritten to encode the invariants new code must preserve.
- New ADR `docs/reborn/2026-05-14-universal-fs-dispatch.md` explains the unification; `docs/reborn/2026-04-25-storage-catalog-and-placement.md` marked as superseded.

## Subsumes

- **#3660** — Port libsql + Postgres backends to native put/get with CAS (✅ absorbed)
- **#3661** — Native query + ensure_index on libsql + Postgres (✅ absorbed)

Those two PRs can be closed as subsumed once this lands. Consumer migrations (#3666, #3670, #3671, #3672) rebase onto the merged foundation.