### PR TITLE
feat(filesystem): native query + ensure_index on libsql + postgres

### DIFF
--- a/crates/ironclaw_filesystem/src/index.rs
+++ b/crates/ironclaw_filesystem/src/index.rs
@@ -43,6 +43,34 @@ pub(crate) fn validate_simple_identifier(kind: &'static str, s: &str) -> Result<
             reason: "must be 128 characters or fewer".to_string(),
         });
     }
+    // Tightened identifier shape after PR #3661 reviewer flag:
+    //   `IndexKey::new("a.b")` used to pass validation but interact with
+    //   `json_extract(indexed, '$.a.b')` as a nested-path traversal rather
+    //   than the literal key `"a.b"`. Similarly, raw names used as DDL
+    //   identifiers without SQL quoting allowed `-` / `.` / unicode through.
+    //   Restrict to `[A-Za-z_][A-Za-z0-9_]*` so the same value is safe as a
+    //   JSON path component, a SQL identifier, and a row key.
+    let bytes = s.as_bytes();
+    let first = bytes[0];
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return Err(HostApiError::InvalidId {
+            kind,
+            value: s.to_string(),
+            reason: "must start with an ASCII letter or underscore".to_string(),
+        });
+    }
+    if bytes[1..]
+        .iter()
+        .any(|b| !(b.is_ascii_alphanumeric() || *b == b'_'))
+    {
+        return Err(HostApiError::InvalidId {
+            kind,
+            value: s.to_string(),
+            reason: "must contain only ASCII letters, digits, and underscores".to_string(),
+        });
+    }
+    // Legacy traversal/whitespace checks retained as belt-and-suspenders;
+    // the ASCII alphanumeric rule above already rejects them.
     if s.contains('/')
         || s.contains('\\')
         || s.contains('\0')
@@ -282,6 +310,22 @@ mod tests {
         assert!(IndexName::new("scope/leases").is_err());
         assert!(IndexName::new("with space").is_err());
         assert!(IndexName::new("ok_name_1").is_ok());
+    }
+
+    #[test]
+    fn index_key_rejects_chars_that_break_sql_or_json_paths() {
+        // Reviewer (PR #3661) flagged that allowing `.` lets
+        // `json_extract(indexed, '$.a.b')` traverse rather than match the
+        // literal key `"a.b"`, and that other punctuation can break DDL.
+        // After tightening, IndexKey/Name accept `[A-Za-z_][A-Za-z0-9_]*`
+        // only.
+        assert!(IndexKey::new("a.b").is_err());
+        assert!(IndexKey::new("a-b").is_err());
+        assert!(IndexKey::new("1abc").is_err()); // can't start with digit
+        assert!(IndexKey::new("").is_err());
+        assert!(IndexKey::new("scope").is_ok());
+        assert!(IndexKey::new("_internal").is_ok());
+        assert!(IndexKey::new("scope_v2").is_ok());
     }
 
     #[test]

--- a/crates/ironclaw_filesystem/src/index.rs
+++ b/crates/ironclaw_filesystem/src/index.rs
@@ -144,12 +144,18 @@ impl From<IndexKey> for String {
 /// Variants are intentionally narrow — backends translate to their native
 /// column type. New variants require coordinated backend updates and a wire
 /// migration; do not extend casually.
+///
+/// Serialization is untagged so SQL backends storing the indexed map as
+/// JSON can run native predicates against it (`indexed->>'scope' = 'acme'`
+/// in Postgres, `json_extract(indexed, '$.scope') = 'acme'` in libSQL).
+/// Bool is listed first so JSON booleans don't accidentally match `I64`,
+/// and `Bytes` is last because a JSON array could otherwise be mis-typed.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+#[serde(untagged)]
 pub enum IndexValue {
-    Text(String),
-    I64(i64),
     Bool(bool),
+    I64(i64),
+    Text(String),
     Bytes(Vec<u8>),
 }
 

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -318,8 +318,30 @@ impl RootFilesystem for LibSqlRootFilesystem {
         })?;
 
         let conn = self.connect().await?;
-        // Conflict check: idempotent if same spec already declared, else
+        // PR #3661 reviewer fix: the prior SELECT-then-INSERT was racey.
+        // Two processes declaring the same spec concurrently could both
+        // miss the row and then one would hit a unique-constraint backend
+        // error instead of getting the promised idempotent success.
+        //
+        // Fix: INSERT ... ON CONFLICT DO NOTHING in a single round-trip,
+        // then read back the canonical row and compare. If the stored
+        // spec matches ours we're idempotent; if it differs we surface
         // IndexConflict.
+        conn.execute(
+            "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT (prefix, name) DO NOTHING",
+            libsql::params![
+                path.as_str(),
+                spec.name.as_str(),
+                keys_json.clone(),
+                kind_str.clone(),
+            ],
+        )
+        .await
+        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+
+        // Read back what's there and validate it matches.
         let mut rows = conn
             .query(
                 "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = ?1 AND name = ?2",
@@ -329,41 +351,31 @@ impl RootFilesystem for LibSqlRootFilesystem {
             .map_err(|error| {
                 libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
             })?;
-        if let Some(row) = rows.next().await.map_err(|error| {
+        let row = rows
+            .next()
+            .await
+            .map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?
+            .ok_or_else(|| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::EnsureIndex,
+                reason: "index spec disappeared after upsert".to_string(),
+            })?;
+        let existing_keys: String = row.get(0).map_err(|error| {
             libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
-        })? {
-            let existing_keys: String = row.get(0).map_err(|error| {
-                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
-            })?;
-            let existing_kind: String = row.get(1).map_err(|error| {
-                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
-            })?;
-            if existing_keys != keys_json || existing_kind != kind_str {
-                return Err(FilesystemError::IndexConflict {
-                    path: path.clone(),
-                    name: spec.name.clone(),
-                    reason: "spec already declared with different keys or kind".to_string(),
-                });
-            }
-            return Ok(());
+        })?;
+        let existing_kind: String = row.get(1).map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })?;
+        if existing_keys != keys_json || existing_kind != kind_str {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: "spec already declared with different keys or kind".to_string(),
+            });
         }
         drop(rows);
-
-        // Record the spec then materialize a SQL expression index on the
-        // declared keys. The index is global on the table; queries route
-        // by path-prefix in the WHERE clause and the planner can still use
-        // this index for filter predicates.
-        conn.execute(
-            "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) VALUES (?1, ?2, ?3, ?4)",
-            libsql::params![
-                path.as_str(),
-                spec.name.as_str(),
-                keys_json.clone(),
-                kind_str,
-            ],
-        )
-        .await
-        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
 
         let index_name = sql_index_name(path.as_str(), spec.name.as_str());
         let expressions: Vec<String> = spec
@@ -940,6 +952,10 @@ fn sql_index_name(prefix: &str, name: &str) -> String {
     }
 }
 
+/// Escape a LIKE pattern that already contains a trailing `%` wildcard
+/// intentionally appended by the caller (the path-prefix scan case in
+/// `query`). The trailing `%` is preserved so it remains a wildcard;
+/// every other `%`, `_`, and `!` is escaped.
 #[cfg(feature = "libsql")]
 fn escape_like_pattern(pattern: &str) -> String {
     let mut out = String::with_capacity(pattern.len());
@@ -955,9 +971,34 @@ fn escape_like_pattern(pattern: &str) -> String {
     out
 }
 
-/// Translate a [`Filter`] tree into a libsql WHERE-clause fragment, appending
-/// bound parameters to `params` in left-to-right order. The fragment is
-/// wrapped in parentheses unless empty.
+/// Escape user-supplied LIKE input where every `%`, `_`, and `!` must be
+/// treated as a literal. Used for `Filter::PrefixOn` values — reviewer
+/// (PR #3661) flagged that the prior code reused `escape_like_pattern`,
+/// which intentionally leaves a final `%` unescaped. A literal prefix
+/// like `tenant:%` would then match anything starting with `tenant:`.
+#[cfg(feature = "libsql")]
+fn escape_like_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '%' => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Translate a [`Filter`] tree into a libsql WHERE-clause fragment.
+///
+/// Reviewer (PR #3661) flagged that the prior version's "skip empty
+/// children" logic conflated `Filter::All` with the identity element of
+/// each compound, so `Or([])` returned every row instead of none and
+/// `And([All])` could emit malformed SQL. The fix: every node always
+/// produces a non-empty fragment — `Filter::All` becomes the literal
+/// `TRUE`, empty `And` becomes `TRUE`, empty `Or` becomes `FALSE`. This
+/// matches the in-memory backend's `all`/`any` semantics.
 #[cfg(feature = "libsql")]
 fn translate_filter(
     path: &VirtualPath,
@@ -966,7 +1007,10 @@ fn translate_filter(
     params: &mut Vec<libsql::Value>,
 ) -> Result<(), FilesystemError> {
     match filter {
-        Filter::All => Ok(()),
+        Filter::All => {
+            out.push_str("TRUE");
+            Ok(())
+        }
         Filter::Eq { key, value } => {
             let placeholder = bind_index_value(path, value, params)?;
             out.push_str(&format!(
@@ -983,7 +1027,10 @@ fn translate_filter(
                     operation: FilesystemOperation::Query,
                 });
             };
-            let escaped = escape_like_pattern(prefix_value);
+            // PR #3661 reviewer fix: user-input prefix must be fully
+            // escaped (including any literal `%` characters) before
+            // appending the LIKE wildcard.
+            let escaped = escape_like_literal(prefix_value);
             params.push(libsql::Value::Text(format!("{escaped}%")));
             out.push_str(&format!(
                 "(json_extract(indexed, '$.{}') LIKE ?{} ESCAPE '!')",
@@ -1003,8 +1050,8 @@ fn translate_filter(
             ));
             Ok(())
         }
-        Filter::And(children) => translate_compound(path, children, " AND ", out, params),
-        Filter::Or(children) => translate_compound(path, children, " OR ", out, params),
+        Filter::And(children) => translate_compound(path, children, " AND ", "TRUE", out, params),
+        Filter::Or(children) => translate_compound(path, children, " OR ", "FALSE", out, params),
     }
 }
 
@@ -1013,25 +1060,23 @@ fn translate_compound(
     path: &VirtualPath,
     children: &[Filter],
     joiner: &str,
+    empty_identity: &str,
     out: &mut String,
     params: &mut Vec<libsql::Value>,
 ) -> Result<(), FilesystemError> {
     if children.is_empty() {
+        out.push_str(empty_identity);
         return Ok(());
     }
     out.push('(');
-    let mut first = true;
-    for child in children {
-        let mut sub = String::new();
-        translate_filter(path, child, &mut sub, params)?;
-        if sub.is_empty() {
-            continue;
-        }
-        if !first {
+    for (i, child) in children.iter().enumerate() {
+        if i > 0 {
             out.push_str(joiner);
         }
-        out.push_str(&sub);
-        first = false;
+        // Recurse: every child now produces a non-empty fragment thanks to
+        // the `Filter::All -> TRUE` rule, so we don't need the prior
+        // "skip empty" branch that broke `Or([])`/`And([All])`.
+        translate_filter(path, child, out, params)?;
     }
     out.push(')');
     Ok(())

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -11,8 +11,8 @@ use crate::db::{
 };
 use crate::{
     BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FileType,
-    FilesystemError, FilesystemOperation, IndexCapability, IndexKey, IndexValue, RecordKind,
-    RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
+    FilesystemError, FilesystemOperation, Filter, IndexCapability, IndexKey, IndexKind, IndexSpec,
+    IndexValue, Page, RecordKind, RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
 };
 
 #[cfg(feature = "libsql")]
@@ -40,6 +40,7 @@ impl LibSqlRootFilesystem {
             })?;
         ensure_libsql_root_is_dir_column(&conn).await?;
         ensure_libsql_records_columns(&conn).await?;
+        ensure_libsql_index_specs_table(&conn).await?;
         Ok(())
     }
 
@@ -72,14 +73,14 @@ impl RootFilesystem for LibSqlRootFilesystem {
             list: true,
             stat: true,
             delete: true,
-            // Native put/get/delete with version-aware CAS lands in this PR.
             records: true,
-            // Query/ensure_index/append/tail still default to Unsupported.
-            // Land in a follow-up port once consumer migrations need them.
-            query: false,
+            // Native query over indexed projection with Filter::Eq/PrefixOn/
+            // Range/And/Or; ensure_index materializes expression indexes on
+            // json_extract(indexed, '$.key').
+            query: true,
             index: IndexCapability {
-                exact: false,
-                prefix: false,
+                exact: true,
+                prefix: true,
                 fts: false,
                 vector: false,
             },
@@ -277,6 +278,172 @@ impl RootFilesystem for LibSqlRootFilesystem {
             entry,
             version: RecordVersion::from_backend(version_raw.max(0) as u64),
         }))
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        // Only Exact and Prefix index kinds are supported on the SQL backends
+        // in this port. FTS / Vector live behind their own follow-up port.
+        let kind_str = match &spec.kind {
+            IndexKind::Exact => "exact".to_string(),
+            IndexKind::Prefix => "prefix".to_string(),
+            IndexKind::Fts | IndexKind::Vector { .. } => {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::EnsureIndex,
+                });
+            }
+        };
+        if spec.keys.is_empty() {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: "spec must declare at least one key".to_string(),
+            });
+        }
+        let keys_json = serde_json::to_string(
+            &spec
+                .keys
+                .iter()
+                .map(|k| k.as_str().to_string())
+                .collect::<Vec<_>>(),
+        )
+        .map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::EnsureIndex,
+            reason: format!("failed to serialize index keys: {error}"),
+        })?;
+
+        let conn = self.connect().await?;
+        // Conflict check: idempotent if same spec already declared, else
+        // IndexConflict.
+        let mut rows = conn
+            .query(
+                "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = ?1 AND name = ?2",
+                libsql::params![path.as_str(), spec.name.as_str()],
+            )
+            .await
+            .map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?;
+        if let Some(row) = rows.next().await.map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })? {
+            let existing_keys: String = row.get(0).map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?;
+            let existing_kind: String = row.get(1).map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+            })?;
+            if existing_keys != keys_json || existing_kind != kind_str {
+                return Err(FilesystemError::IndexConflict {
+                    path: path.clone(),
+                    name: spec.name.clone(),
+                    reason: "spec already declared with different keys or kind".to_string(),
+                });
+            }
+            return Ok(());
+        }
+        drop(rows);
+
+        // Record the spec then materialize a SQL expression index on the
+        // declared keys. The index is global on the table; queries route
+        // by path-prefix in the WHERE clause and the planner can still use
+        // this index for filter predicates.
+        conn.execute(
+            "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) VALUES (?1, ?2, ?3, ?4)",
+            libsql::params![
+                path.as_str(),
+                spec.name.as_str(),
+                keys_json.clone(),
+                kind_str,
+            ],
+        )
+        .await
+        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+
+        let index_name = sql_index_name(path.as_str(), spec.name.as_str());
+        let expressions: Vec<String> = spec
+            .keys
+            .iter()
+            .map(|k| format!("json_extract(indexed, '$.{}')", k.as_str()))
+            .collect();
+        let ddl = format!(
+            "CREATE INDEX IF NOT EXISTS {index_name} ON root_filesystem_entries ({})",
+            expressions.join(", ")
+        );
+        conn.execute(&ddl, ()).await.map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::EnsureIndex, error)
+        })?;
+        Ok(())
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let mut params: Vec<libsql::Value> = vec![libsql::Value::Text(path.as_str().to_string())];
+        let prefix_pattern = format!("{}/%", path.as_str());
+        params.push(libsql::Value::Text(escape_like_pattern(&prefix_pattern)));
+
+        let mut conditions = String::new();
+        translate_filter(path, filter, &mut conditions, &mut params)?;
+
+        let mut sql = String::from(
+            "SELECT path, contents, content_type, kind, indexed, version \
+             FROM root_filesystem_entries \
+             WHERE is_dir = 0 AND (path = ?1 OR path LIKE ?2 ESCAPE '!')",
+        );
+        if !conditions.is_empty() {
+            sql.push_str(" AND ");
+            sql.push_str(&conditions);
+        }
+        sql.push_str(" ORDER BY path LIMIT ? OFFSET ?");
+        params.push(libsql::Value::Integer(
+            page.limit.min(crate::Page::MAX_LIMIT) as i64,
+        ));
+        params.push(libsql::Value::Integer(page.offset as i64));
+
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(&sql, params)
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Query, error))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Query, error))?
+        {
+            let row_path: String = row.get(0).map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let row_path = VirtualPath::new(row_path)?;
+            let body: Vec<u8> = row.get(1).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let content_type_raw: String = row.get(2).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let kind_raw: Option<String> = row.get(3).ok();
+            let indexed_raw: String = row.get(4).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let version_raw: i64 = row.get(5).map_err(|error| {
+                libsql_db_error(row_path.clone(), FilesystemOperation::Query, error)
+            })?;
+            let entry = build_entry(&row_path, body, content_type_raw, kind_raw, indexed_raw)?;
+            out.push(VersionedEntry {
+                entry,
+                version: RecordVersion::from_backend(version_raw.max(0) as u64),
+            });
+        }
+        Ok(out)
     }
 
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
@@ -733,6 +900,165 @@ async fn ensure_libsql_records_columns(conn: &libsql::Connection) -> Result<(), 
 }
 
 #[cfg(feature = "libsql")]
+async fn ensure_libsql_index_specs_table(conn: &libsql::Connection) -> Result<(), FilesystemError> {
+    conn.execute_batch(LIBSQL_INDEX_SPECS_SCHEMA)
+        .await
+        .map_err(|error| {
+            libsql_db_error(valid_engine_path(), FilesystemOperation::EnsureIndex, error)
+        })?;
+    Ok(())
+}
+
+/// Build a deterministic SQL index identifier from a mount prefix + spec name.
+///
+/// IndexKey/IndexName are validated to be simple identifiers (no path
+/// separators, whitespace, or control chars), so the prefix's slashes are
+/// the only non-identifier characters we need to replace. Length is bounded
+/// — Postgres caps at 63, SQLite is more permissive — so we truncate after
+/// sanitisation. Collisions across mounts are tolerable: distinct
+/// `(prefix, name)` pairs share an index when their sanitized forms match,
+/// and the index is still correct (the planner just sees a wider index).
+#[cfg(feature = "libsql")]
+fn sql_index_name(prefix: &str, name: &str) -> String {
+    let prefix_clean: String = prefix
+        .trim_matches('/')
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let raw = format!("idx_rfs_{prefix_clean}_{name}");
+    // Identifier length budget chosen to satisfy Postgres' 63-char cap so
+    // libsql and postgres can share the same naming logic in future refactors.
+    if raw.len() > 62 {
+        let cutoff = raw
+            .char_indices()
+            .nth(62)
+            .map(|(i, _)| i)
+            .unwrap_or(raw.len());
+        raw[..cutoff].to_string()
+    } else {
+        raw
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn escape_like_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '%' if chars.peek().is_some() => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Translate a [`Filter`] tree into a libsql WHERE-clause fragment, appending
+/// bound parameters to `params` in left-to-right order. The fragment is
+/// wrapped in parentheses unless empty.
+#[cfg(feature = "libsql")]
+fn translate_filter(
+    path: &VirtualPath,
+    filter: &Filter,
+    out: &mut String,
+    params: &mut Vec<libsql::Value>,
+) -> Result<(), FilesystemError> {
+    match filter {
+        Filter::All => Ok(()),
+        Filter::Eq { key, value } => {
+            let placeholder = bind_index_value(path, value, params)?;
+            out.push_str(&format!(
+                "(json_extract(indexed, '$.{}') = ?{})",
+                key.as_str(),
+                placeholder
+            ));
+            Ok(())
+        }
+        Filter::PrefixOn { key, value } => {
+            let IndexValue::Text(prefix_value) = value else {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::Query,
+                });
+            };
+            let escaped = escape_like_pattern(prefix_value);
+            params.push(libsql::Value::Text(format!("{escaped}%")));
+            out.push_str(&format!(
+                "(json_extract(indexed, '$.{}') LIKE ?{} ESCAPE '!')",
+                key.as_str(),
+                params.len()
+            ));
+            Ok(())
+        }
+        Filter::Range { key, lo, hi } => {
+            let lo_idx = bind_index_value(path, lo, params)?;
+            let hi_idx = bind_index_value(path, hi, params)?;
+            out.push_str(&format!(
+                "(json_extract(indexed, '$.{}') BETWEEN ?{} AND ?{})",
+                key.as_str(),
+                lo_idx,
+                hi_idx
+            ));
+            Ok(())
+        }
+        Filter::And(children) => translate_compound(path, children, " AND ", out, params),
+        Filter::Or(children) => translate_compound(path, children, " OR ", out, params),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn translate_compound(
+    path: &VirtualPath,
+    children: &[Filter],
+    joiner: &str,
+    out: &mut String,
+    params: &mut Vec<libsql::Value>,
+) -> Result<(), FilesystemError> {
+    if children.is_empty() {
+        return Ok(());
+    }
+    out.push('(');
+    let mut first = true;
+    for child in children {
+        let mut sub = String::new();
+        translate_filter(path, child, &mut sub, params)?;
+        if sub.is_empty() {
+            continue;
+        }
+        if !first {
+            out.push_str(joiner);
+        }
+        out.push_str(&sub);
+        first = false;
+    }
+    out.push(')');
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+fn bind_index_value(
+    path: &VirtualPath,
+    value: &IndexValue,
+    params: &mut Vec<libsql::Value>,
+) -> Result<usize, FilesystemError> {
+    let bound = match value {
+        IndexValue::Text(s) => libsql::Value::Text(s.clone()),
+        IndexValue::I64(n) => libsql::Value::Integer(*n),
+        IndexValue::Bool(b) => libsql::Value::Integer(i64::from(*b)),
+        IndexValue::Bytes(_) => {
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::Query,
+            });
+        }
+    };
+    params.push(bound);
+    Ok(params.len())
+}
+
+#[cfg(feature = "libsql")]
 async fn add_column_if_missing(
     conn: &libsql::Connection,
     column: &str,
@@ -786,4 +1112,15 @@ CREATE TABLE IF NOT EXISTS root_filesystem_entries (
 );
 -- The PRIMARY KEY on `path` already provides a unique index for equality
 -- lookups, so no separate index is created.
+"#;
+
+#[cfg(feature = "libsql")]
+const LIBSQL_INDEX_SPECS_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS root_filesystem_index_specs (
+    prefix TEXT NOT NULL,
+    name TEXT NOT NULL,
+    keys TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    PRIMARY KEY (prefix, name)
+);
 "#;

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -277,38 +277,42 @@ impl RootFilesystem for PostgresRootFilesystem {
         })?;
 
         let client = self.client().await?;
-        let existing = client
+        // PR #3661 reviewer fix: race-idempotent declaration. Single
+        // INSERT ... ON CONFLICT DO NOTHING followed by a read-back +
+        // canonical-spec equality check. Two concurrent declarers of the
+        // same spec both succeed; declarers of conflicting specs see
+        // IndexConflict deterministically.
+        client
+            .execute(
+                "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) \
+                 VALUES ($1, $2, $3, $4) \
+                 ON CONFLICT (prefix, name) DO NOTHING",
+                &[&path.as_str(), &spec.name.as_str(), &keys_json, &kind_str],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+
+        let row = client
             .query_opt(
                 "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = $1 AND name = $2",
                 &[&path.as_str(), &spec.name.as_str()],
             )
             .await
-            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
-        if let Some(row) = existing {
-            let existing_keys: serde_json::Value = row.get("keys");
-            let existing_kind: String = row.get("kind");
-            if existing_keys != keys_json || existing_kind != kind_str {
-                return Err(FilesystemError::IndexConflict {
-                    path: path.clone(),
-                    name: spec.name.clone(),
-                    reason: "spec already declared with different keys or kind".to_string(),
-                });
-            }
-            return Ok(());
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?
+            .ok_or_else(|| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::EnsureIndex,
+                reason: "index spec disappeared after upsert".to_string(),
+            })?;
+        let existing_keys: serde_json::Value = row.get("keys");
+        let existing_kind: String = row.get("kind");
+        if existing_keys != keys_json || existing_kind != kind_str {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: "spec already declared with different keys or kind".to_string(),
+            });
         }
-
-        client
-            .execute(
-                "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) VALUES ($1, $2, $3, $4)",
-                &[
-                    &path.as_str(),
-                    &spec.name.as_str(),
-                    &keys_json,
-                    &kind_str,
-                ],
-            )
-            .await
-            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
 
         let index_name = sql_index_name(path.as_str(), spec.name.as_str());
         let expressions: Vec<String> = spec
@@ -708,6 +712,8 @@ fn sql_index_name(prefix: &str, name: &str) -> String {
     }
 }
 
+/// LIKE-pattern escape that preserves a trailing wildcard appended by the
+/// caller (the path-prefix scan in `query`).
 #[cfg(feature = "postgres")]
 fn escape_like_pattern(pattern: &str) -> String {
     let mut out = String::with_capacity(pattern.len());
@@ -723,9 +729,32 @@ fn escape_like_pattern(pattern: &str) -> String {
     out
 }
 
+/// Fully-literal LIKE escape for user-supplied values. PR #3661 reviewer
+/// fix: the `Filter::PrefixOn` value must be treated as a literal — a
+/// stored prefix of `tenant:%` must not become a `%` wildcard at query
+/// time.
+#[cfg(feature = "postgres")]
+fn escape_like_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '%' => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 /// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
 /// Bound parameters use `$N` placeholders sized from `params.len() + 1`.
-/// Returns once `out` has been appended.
+///
+/// PR #3661 fixes carried over from the libsql translator:
+/// - `Filter::All` emits `TRUE`; empty `And` → `TRUE`, empty `Or` →
+///   `FALSE` (matching in-memory `all`/`any` semantics).
+/// - `Filter::Range` on `IndexValue::I64` bounds casts both sides to
+///   `BIGINT` so the comparison is numeric, not lexicographic on text.
 #[cfg(feature = "postgres")]
 fn translate_filter(
     path: &VirtualPath,
@@ -734,7 +763,10 @@ fn translate_filter(
     params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
 ) -> Result<(), FilesystemError> {
     match filter {
-        Filter::All => Ok(()),
+        Filter::All => {
+            out.push_str("TRUE");
+            Ok(())
+        }
         Filter::Eq { key, value } => {
             let placeholder = bind_index_value(path, value, params)?;
             out.push_str(&format!("(indexed->>'{}' = ${placeholder})", key.as_str()));
@@ -747,7 +779,7 @@ fn translate_filter(
                     operation: FilesystemOperation::Query,
                 });
             };
-            let escaped = escape_like_pattern(prefix_value);
+            let escaped = escape_like_literal(prefix_value);
             params.push(Box::new(format!("{escaped}%")));
             out.push_str(&format!(
                 "(indexed->>'{}' LIKE ${} ESCAPE '!')",
@@ -757,16 +789,36 @@ fn translate_filter(
             Ok(())
         }
         Filter::Range { key, lo, hi } => {
-            let lo_idx = bind_index_value(path, lo, params)?;
-            let hi_idx = bind_index_value(path, hi, params)?;
-            out.push_str(&format!(
-                "(indexed->>'{}' BETWEEN ${lo_idx} AND ${hi_idx})",
-                key.as_str()
-            ));
+            // PR #3661 reviewer fix: when both bounds are `I64`, cast both
+            // the extracted JSON text and bound params to `BIGINT` so the
+            // BETWEEN comparison is numeric. Otherwise `'2' BETWEEN '10'
+            // AND '99'` would compare lexicographically and miss values.
+            // Mixed-variant ranges still hit text comparison (also matches
+            // the in-memory backend's behaviour for cross-variant bounds).
+            match (lo, hi) {
+                (IndexValue::I64(lo_val), IndexValue::I64(hi_val)) => {
+                    params.push(Box::new(*lo_val));
+                    let lo_idx = params.len();
+                    params.push(Box::new(*hi_val));
+                    let hi_idx = params.len();
+                    out.push_str(&format!(
+                        "((indexed->>'{}')::bigint BETWEEN ${lo_idx} AND ${hi_idx})",
+                        key.as_str()
+                    ));
+                }
+                _ => {
+                    let lo_idx = bind_index_value(path, lo, params)?;
+                    let hi_idx = bind_index_value(path, hi, params)?;
+                    out.push_str(&format!(
+                        "(indexed->>'{}' BETWEEN ${lo_idx} AND ${hi_idx})",
+                        key.as_str()
+                    ));
+                }
+            }
             Ok(())
         }
-        Filter::And(children) => translate_compound(path, children, " AND ", out, params),
-        Filter::Or(children) => translate_compound(path, children, " OR ", out, params),
+        Filter::And(children) => translate_compound(path, children, " AND ", "TRUE", out, params),
+        Filter::Or(children) => translate_compound(path, children, " OR ", "FALSE", out, params),
     }
 }
 
@@ -775,25 +827,20 @@ fn translate_compound(
     path: &VirtualPath,
     children: &[Filter],
     joiner: &str,
+    empty_identity: &str,
     out: &mut String,
     params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
 ) -> Result<(), FilesystemError> {
     if children.is_empty() {
+        out.push_str(empty_identity);
         return Ok(());
     }
     out.push('(');
-    let mut first = true;
-    for child in children {
-        let mut sub = String::new();
-        translate_filter(path, child, &mut sub, params)?;
-        if sub.is_empty() {
-            continue;
-        }
-        if !first {
+    for (i, child) in children.iter().enumerate() {
+        if i > 0 {
             out.push_str(joiner);
         }
-        out.push_str(&sub);
-        first = false;
+        translate_filter(path, child, out, params)?;
     }
     out.push(')');
     Ok(())

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -10,8 +10,8 @@ use crate::db::{
 };
 use crate::{
     BackendCapabilities, CasExpectation, ContentType, DirEntry, Entry, FileStat, FileType,
-    FilesystemError, FilesystemOperation, IndexCapability, IndexKey, IndexValue, RecordKind,
-    RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
+    FilesystemError, FilesystemOperation, Filter, IndexCapability, IndexKey, IndexKind, IndexSpec,
+    IndexValue, Page, RecordKind, RecordVersion, RootFilesystem, TxnCapability, VersionedEntry,
 };
 
 #[cfg(feature = "postgres")]
@@ -64,10 +64,10 @@ impl RootFilesystem for PostgresRootFilesystem {
             stat: true,
             delete: true,
             records: true,
-            query: false,
+            query: true,
             index: IndexCapability {
-                exact: false,
-                prefix: false,
+                exact: true,
+                prefix: true,
                 fts: false,
                 vector: false,
             },
@@ -240,6 +240,149 @@ impl RootFilesystem for PostgresRootFilesystem {
             entry,
             version: RecordVersion::from_backend(version_raw.max(0) as u64),
         }))
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        let kind_str = match &spec.kind {
+            IndexKind::Exact => "exact".to_string(),
+            IndexKind::Prefix => "prefix".to_string(),
+            IndexKind::Fts | IndexKind::Vector { .. } => {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::EnsureIndex,
+                });
+            }
+        };
+        if spec.keys.is_empty() {
+            return Err(FilesystemError::IndexConflict {
+                path: path.clone(),
+                name: spec.name.clone(),
+                reason: "spec must declare at least one key".to_string(),
+            });
+        }
+        let keys_json = serde_json::to_value(
+            spec.keys
+                .iter()
+                .map(|k| k.as_str().to_string())
+                .collect::<Vec<_>>(),
+        )
+        .map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::EnsureIndex,
+            reason: format!("failed to serialize index keys: {error}"),
+        })?;
+
+        let client = self.client().await?;
+        let existing = client
+            .query_opt(
+                "SELECT keys, kind FROM root_filesystem_index_specs WHERE prefix = $1 AND name = $2",
+                &[&path.as_str(), &spec.name.as_str()],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+        if let Some(row) = existing {
+            let existing_keys: serde_json::Value = row.get("keys");
+            let existing_kind: String = row.get("kind");
+            if existing_keys != keys_json || existing_kind != kind_str {
+                return Err(FilesystemError::IndexConflict {
+                    path: path.clone(),
+                    name: spec.name.clone(),
+                    reason: "spec already declared with different keys or kind".to_string(),
+                });
+            }
+            return Ok(());
+        }
+
+        client
+            .execute(
+                "INSERT INTO root_filesystem_index_specs (prefix, name, keys, kind) VALUES ($1, $2, $3, $4)",
+                &[
+                    &path.as_str(),
+                    &spec.name.as_str(),
+                    &keys_json,
+                    &kind_str,
+                ],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+
+        let index_name = sql_index_name(path.as_str(), spec.name.as_str());
+        let expressions: Vec<String> = spec
+            .keys
+            .iter()
+            .map(|k| format!("((indexed->>'{}'))", k.as_str()))
+            .collect();
+        let ddl = format!(
+            "CREATE INDEX IF NOT EXISTS {index_name} ON root_filesystem_entries ({})",
+            expressions.join(", ")
+        );
+        client
+            .batch_execute(&ddl)
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::EnsureIndex, error))?;
+        Ok(())
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = Vec::new();
+        let path_str = path.as_str().to_string();
+        let prefix_pattern = escape_like_pattern(&format!("{}/%", path.as_str()));
+        params.push(Box::new(path_str));
+        params.push(Box::new(prefix_pattern));
+
+        let mut conditions = String::new();
+        translate_filter(path, filter, &mut conditions, &mut params)?;
+
+        let mut sql = String::from(
+            "SELECT path, contents, content_type, kind, indexed, version \
+             FROM root_filesystem_entries \
+             WHERE is_dir = FALSE AND (path = $1 OR path LIKE $2 ESCAPE '!')",
+        );
+        if !conditions.is_empty() {
+            sql.push_str(" AND ");
+            sql.push_str(&conditions);
+        }
+        sql.push_str(&format!(
+            " ORDER BY path LIMIT ${} OFFSET ${}",
+            params.len() + 1,
+            params.len() + 2
+        ));
+        params.push(Box::new(i64::from(page.limit.min(Page::MAX_LIMIT))));
+        params.push(Box::new(page.offset as i64));
+
+        let client = self.client().await?;
+        let params_ref: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
+            params.iter().map(|p| p.as_ref() as _).collect();
+        let rows = client
+            .query(sql.as_str(), &params_ref[..])
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::Query, error))?;
+        rows.into_iter()
+            .map(|row| {
+                let row_path: String = row.get("path");
+                let row_path = VirtualPath::new(row_path)?;
+                let body: Vec<u8> = row.get("contents");
+                let content_type_raw: String = row.get("content_type");
+                let kind_raw: Option<String> = row.get("kind");
+                let indexed_value: serde_json::Value = row.get("indexed");
+                let version_raw: i64 = row.get("version");
+                let entry =
+                    build_entry(&row_path, body, content_type_raw, kind_raw, indexed_value)?;
+                Ok(VersionedEntry {
+                    entry,
+                    version: RecordVersion::from_backend(version_raw.max(0) as u64),
+                })
+            })
+            .collect()
     }
 
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
@@ -546,6 +689,146 @@ impl PostgresRootFilesystem {
 }
 
 #[cfg(feature = "postgres")]
+fn sql_index_name(prefix: &str, name: &str) -> String {
+    let prefix_clean: String = prefix
+        .trim_matches('/')
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let raw = format!("idx_rfs_{prefix_clean}_{name}");
+    if raw.len() > 62 {
+        let cutoff = raw
+            .char_indices()
+            .nth(62)
+            .map(|(i, _)| i)
+            .unwrap_or(raw.len());
+        raw[..cutoff].to_string()
+    } else {
+        raw
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn escape_like_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '%' if chars.peek().is_some() => out.push_str("!%"),
+            '_' => out.push_str("!_"),
+            '!' => out.push_str("!!"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Translate a [`Filter`] tree into a postgres WHERE-clause fragment.
+/// Bound parameters use `$N` placeholders sized from `params.len() + 1`.
+/// Returns once `out` has been appended.
+#[cfg(feature = "postgres")]
+fn translate_filter(
+    path: &VirtualPath,
+    filter: &Filter,
+    out: &mut String,
+    params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+) -> Result<(), FilesystemError> {
+    match filter {
+        Filter::All => Ok(()),
+        Filter::Eq { key, value } => {
+            let placeholder = bind_index_value(path, value, params)?;
+            out.push_str(&format!("(indexed->>'{}' = ${placeholder})", key.as_str()));
+            Ok(())
+        }
+        Filter::PrefixOn { key, value } => {
+            let IndexValue::Text(prefix_value) = value else {
+                return Err(FilesystemError::Unsupported {
+                    path: path.clone(),
+                    operation: FilesystemOperation::Query,
+                });
+            };
+            let escaped = escape_like_pattern(prefix_value);
+            params.push(Box::new(format!("{escaped}%")));
+            out.push_str(&format!(
+                "(indexed->>'{}' LIKE ${} ESCAPE '!')",
+                key.as_str(),
+                params.len()
+            ));
+            Ok(())
+        }
+        Filter::Range { key, lo, hi } => {
+            let lo_idx = bind_index_value(path, lo, params)?;
+            let hi_idx = bind_index_value(path, hi, params)?;
+            out.push_str(&format!(
+                "(indexed->>'{}' BETWEEN ${lo_idx} AND ${hi_idx})",
+                key.as_str()
+            ));
+            Ok(())
+        }
+        Filter::And(children) => translate_compound(path, children, " AND ", out, params),
+        Filter::Or(children) => translate_compound(path, children, " OR ", out, params),
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn translate_compound(
+    path: &VirtualPath,
+    children: &[Filter],
+    joiner: &str,
+    out: &mut String,
+    params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+) -> Result<(), FilesystemError> {
+    if children.is_empty() {
+        return Ok(());
+    }
+    out.push('(');
+    let mut first = true;
+    for child in children {
+        let mut sub = String::new();
+        translate_filter(path, child, &mut sub, params)?;
+        if sub.is_empty() {
+            continue;
+        }
+        if !first {
+            out.push_str(joiner);
+        }
+        out.push_str(&sub);
+        first = false;
+    }
+    out.push(')');
+    Ok(())
+}
+
+#[cfg(feature = "postgres")]
+fn bind_index_value(
+    path: &VirtualPath,
+    value: &IndexValue,
+    params: &mut Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>>,
+) -> Result<usize, FilesystemError> {
+    // `indexed->>'key'` returns text regardless of the underlying JSON type,
+    // so we bind every supported variant as text. This keeps the index
+    // (which is also an expression on the text form) usable for all three
+    // variants without dialect branches.
+    let bound: Box<dyn tokio_postgres::types::ToSql + Sync + Send> = match value {
+        IndexValue::Text(s) => Box::new(s.clone()),
+        IndexValue::I64(n) => Box::new(n.to_string()),
+        IndexValue::Bool(b) => Box::new(if *b {
+            "true".to_string()
+        } else {
+            "false".to_string()
+        }),
+        IndexValue::Bytes(_) => {
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::Query,
+            });
+        }
+    };
+    params.push(bound);
+    Ok(params.len())
+}
+
+#[cfg(feature = "postgres")]
 fn build_entry(
     path: &VirtualPath,
     body: Vec<u8>,
@@ -582,4 +865,6 @@ const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = concat!(
     include_str!("../../../migrations/V27__root_filesystem_entries_directories.sql"),
     "\n",
     include_str!("../../../migrations/V28__root_filesystem_records.sql"),
+    "\n",
+    include_str!("../../../migrations/V29__root_filesystem_index_specs.sql"),
 );

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -6,8 +6,8 @@ use ironclaw_filesystem::RootFilesystem;
 use ironclaw_filesystem::PostgresRootFilesystem;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::{
-    CasExpectation, Entry, FileType, FilesystemError, FilesystemOperation, IndexKey, IndexValue,
-    LibSqlRootFilesystem, RecordKind,
+    CasExpectation, Entry, FileType, FilesystemError, FilesystemOperation, Filter, IndexKey,
+    IndexKind, IndexName, IndexSpec, IndexValue, LibSqlRootFilesystem, Page, RecordKind,
 };
 #[cfg(feature = "libsql")]
 use ironclaw_host_api::VirtualPath;
@@ -372,6 +372,206 @@ async fn libsql_write_file_after_put_resets_record_metadata_and_bumps_version() 
     assert!(got.entry.indexed.is_empty());
     assert_eq!(got.entry.body, b"opaque");
     assert!(got.version > v1);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_ensure_index_is_idempotent_and_conflict_aware() {
+    let filesystem = libsql_root().await;
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+    let name = IndexName::new("by_scope_status").unwrap();
+    let keys = vec![
+        IndexKey::new("scope").unwrap(),
+        IndexKey::new("status").unwrap(),
+    ];
+    let spec_exact = IndexSpec::new(name.clone(), keys.clone(), IndexKind::Exact);
+    let spec_prefix = IndexSpec::new(name, keys, IndexKind::Prefix);
+
+    filesystem.ensure_index(&prefix, &spec_exact).await.unwrap();
+    // Re-declaring same spec is idempotent.
+    filesystem.ensure_index(&prefix, &spec_exact).await.unwrap();
+    // Declaring a different kind under the same name is a conflict.
+    let err = filesystem
+        .ensure_index(&prefix, &spec_prefix)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, FilesystemError::IndexConflict { .. }));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_ensure_index_rejects_fts_and_vector_kinds() {
+    let filesystem = libsql_root().await;
+    let prefix = VirtualPath::new("/memory").unwrap();
+    let spec = IndexSpec::new(
+        IndexName::new("by_chunk").unwrap(),
+        vec![IndexKey::new("chunk_id").unwrap()],
+        IndexKind::Fts,
+    );
+    let err = filesystem.ensure_index(&prefix, &spec).await.unwrap_err();
+    assert!(matches!(err, FilesystemError::Unsupported { .. }));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_query_filters_on_indexed_projection() {
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    let status_key = IndexKey::new("status").unwrap();
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+    let spec = IndexSpec::new(
+        IndexName::new("by_scope_status").unwrap(),
+        vec![scope_key.clone(), status_key.clone()],
+        IndexKind::Exact,
+    );
+    filesystem.ensure_index(&prefix, &spec).await.unwrap();
+
+    for (path, scope, status) in [
+        ("/secrets/leases/A", "acme", "active"),
+        ("/secrets/leases/B", "acme", "revoked"),
+        ("/secrets/leases/C", "globex", "active"),
+        ("/secrets/leases/D", "acme", "active"),
+    ] {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()))
+            .with_indexed(status_key.clone(), IndexValue::Text(status.into()));
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+
+    let results = filesystem
+        .query(
+            &prefix,
+            &Filter::And(vec![
+                Filter::Eq {
+                    key: scope_key,
+                    value: IndexValue::Text("acme".into()),
+                },
+                Filter::Eq {
+                    key: status_key,
+                    value: IndexValue::Text("active".into()),
+                },
+            ]),
+            Page::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    let mut paths: Vec<String> = results
+        .iter()
+        .map(|v| String::from_utf8_lossy(&v.entry.body).into_owned())
+        .collect();
+    paths.sort();
+    // Both matching rows have empty bodies; verify by re-reading the
+    // indexed projection on each result.
+    let acme_active_count = results
+        .iter()
+        .filter(|v| {
+            v.entry.indexed.get(&IndexKey::new("scope").unwrap())
+                == Some(&IndexValue::Text("acme".into()))
+                && v.entry.indexed.get(&IndexKey::new("status").unwrap())
+                    == Some(&IndexValue::Text("active".into()))
+        })
+        .count();
+    assert_eq!(acme_active_count, 2);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_query_prefix_filter_matches_text_prefix() {
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+
+    for (path, scope) in [
+        ("/secrets/leases/X", "tenant:acme/u/1"),
+        ("/secrets/leases/Y", "tenant:acme/u/2"),
+        ("/secrets/leases/Z", "tenant:globex/u/1"),
+    ] {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()));
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+
+    let results = filesystem
+        .query(
+            &prefix,
+            &Filter::PrefixOn {
+                key: scope_key,
+                value: IndexValue::Text("tenant:acme/".into()),
+            },
+            Page::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_query_paginates_results() {
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+
+    for i in 0..7 {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({"i": i}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text("acme".into()));
+        let path = VirtualPath::new(format!("/secrets/leases/page-{i:02}")).unwrap();
+        filesystem
+            .put(&path, entry, CasExpectation::Absent)
+            .await
+            .unwrap();
+    }
+
+    let first = filesystem
+        .query(
+            &prefix,
+            &Filter::Eq {
+                key: scope_key.clone(),
+                value: IndexValue::Text("acme".into()),
+            },
+            Page::new(0, 3),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.len(), 3);
+
+    let second = filesystem
+        .query(
+            &prefix,
+            &Filter::Eq {
+                key: scope_key,
+                value: IndexValue::Text("acme".into()),
+            },
+            Page::new(3, 3),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.len(), 3);
+    // Pages must not overlap (ordered by path).
+    for entry in &second {
+        assert!(!first.iter().any(|f| f.entry.body == entry.entry.body));
+    }
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -526,6 +526,107 @@ async fn libsql_query_prefix_filter_matches_text_prefix() {
 
 #[cfg(feature = "libsql")]
 #[tokio::test]
+async fn libsql_query_or_empty_matches_nothing_and_all_matches_every_row() {
+    // PR #3661 reviewer fix: empty `Or` was returning every row instead
+    // of none, and `Filter::All` was being skipped in compound contexts.
+    // After the translator change every node emits a non-empty fragment
+    // (`All` -> `TRUE`, empty `And` -> `TRUE`, empty `Or` -> `FALSE`).
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    for (path, scope) in [
+        ("/secrets/leases/A", "acme"),
+        ("/secrets/leases/B", "globex"),
+    ] {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()));
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+    let prefix = VirtualPath::new("/secrets/leases").unwrap();
+
+    // `All` matches every row.
+    let all = filesystem
+        .query(&prefix, &Filter::All, Page::default())
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 2);
+
+    // Empty `Or` matches nothing.
+    let none = filesystem
+        .query(&prefix, &Filter::Or(Vec::new()), Page::default())
+        .await
+        .unwrap();
+    assert!(none.is_empty());
+
+    // Empty `And` matches everything (identity).
+    let and_empty = filesystem
+        .query(&prefix, &Filter::And(Vec::new()), Page::default())
+        .await
+        .unwrap();
+    assert_eq!(and_empty.len(), 2);
+
+    // `And([All])` is well-formed and matches everything.
+    let and_all = filesystem
+        .query(&prefix, &Filter::And(vec![Filter::All]), Page::default())
+        .await
+        .unwrap();
+    assert_eq!(and_all.len(), 2);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_query_prefix_filter_literal_percent_is_not_a_wildcard() {
+    // PR #3661 reviewer fix: a literal prefix containing `%` was being
+    // passed to LIKE with its `%` left unescaped (because the prior
+    // escape helper preserved trailing `%`). `tenant:%` would then match
+    // anything starting with `tenant:` instead of literally `tenant:%`.
+    let filesystem = libsql_root().await;
+    let kind = RecordKind::new("lease").unwrap();
+    let scope_key = IndexKey::new("scope").unwrap();
+    for (path, scope) in [
+        ("/secrets/leases/P1", "tenant:%"),
+        ("/secrets/leases/P2", "tenant:acme"),
+        ("/secrets/leases/P3", "tenant:globex"),
+    ] {
+        let entry = Entry::record(kind.clone(), &serde_json::json!({}))
+            .unwrap()
+            .with_indexed(scope_key.clone(), IndexValue::Text(scope.into()));
+        filesystem
+            .put(
+                &VirtualPath::new(path).unwrap(),
+                entry,
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+    }
+
+    // Literal-prefix `tenant:%` should match only the row whose stored
+    // scope literally starts with `tenant:%`, not the two `tenant:` rows.
+    let results = filesystem
+        .query(
+            &VirtualPath::new("/secrets/leases").unwrap(),
+            &Filter::PrefixOn {
+                key: scope_key,
+                value: IndexValue::Text("tenant:%".into()),
+            },
+            Page::default(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
 async fn libsql_query_paginates_results() {
     let filesystem = libsql_root().await;
     let kind = RecordKind::new("lease").unwrap();

--- a/migrations/V29__root_filesystem_index_specs.sql
+++ b/migrations/V29__root_filesystem_index_specs.sql
@@ -1,0 +1,14 @@
+-- Track index declarations for root_filesystem_entries. Records the
+-- (prefix, name, keys, kind) of every `ensure_index` call so re-declaration
+-- is conflict-aware and idempotent across processes. The actual JSONB
+-- expression indexes are created out-of-band by `ensure_index` and named
+-- deterministically (`idx_rfs_<sanitized_prefix>_<name>`) so re-running
+-- migrations doesn't recreate them.
+
+CREATE TABLE IF NOT EXISTS root_filesystem_index_specs (
+    prefix TEXT NOT NULL,
+    name TEXT NOT NULL,
+    keys JSONB NOT NULL,
+    kind TEXT NOT NULL,
+    PRIMARY KEY (prefix, name)
+);

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -41,3 +41,4 @@ V25__wasm_fuel_limit_bump = 8924323300096627270
 V26__root_filesystem_entries = 11094038407147728260
 V27__root_filesystem_entries_directories = 4126641792698406758
 V28__root_filesystem_records = 3989652150745692033
+V29__root_filesystem_index_specs = 1572937030361291327


### PR DESCRIPTION
## Summary

Stacked on top of #3660. Flips `capabilities { query: true, index.exact: true, index.prefix: true }` on both SQL backends so consumer stores can filter records by their declared indexed projection.

After this lands, the record/index/CAS triad is complete and 6 consumer crates (`ironclaw_secrets`, `ironclaw_authorization`, `ironclaw_processes`, `ironclaw_run_state`, `ironclaw_outbound`, `ironclaw_conversations`) can drop their own backend matrices and migrate to `ScopedFilesystem`. The other 4 consumers (`ironclaw_reborn_event_store`, `ironclaw_memory`, `ironclaw_engine` `Store`, `src/db/`) need follow-up capability work — append/tail plane and FTS/vector indexes — before they can migrate.

## What's in this PR

**Serde change:**
- `IndexValue` is now `#[serde(untagged)]` so SQL backends can run native predicates against the stored JSON. Previously the tagged shape (`{"type":"text","value":"acme"}`) would have required `indexed->'scope'->>'value' = ?`; now it's `indexed->>'scope' = ?` directly. Variant order is `Bool` → `I64` → `Text` → `Bytes` so JSON type detection on deserialize is deterministic.

**ensure_index:**
- Materializes expression indexes on `json_extract(indexed, '$.<key>')` (libsql) or `(indexed->>'<key>')` (postgres) for the declared keys.
- Spec metadata stored in a new `root_filesystem_index_specs` table (postgres: `JSONB` keys; libsql: text-JSON keys). Re-declaring the same spec is idempotent; conflicting specs (same name, different keys/kind) fail with `FilesystemError::IndexConflict`.
- `IndexKind::Fts` and `IndexKind::Vector` return `Unsupported` — separate port.

**query:**
- Translates `Filter::{Eq, PrefixOn, Range, And, Or}` into SQL WHERE-clause fragments with parameterized values.
- `IndexValue::Text` / `I64` / `Bool` supported as filter values. `IndexValue::Bytes` returns `Unsupported` (JSON representation makes byte comparison fragile).
- Postgres binds all variants as text since `->>'key'` returns text regardless of the underlying JSON type, keeping the expression index usable.
- Pagination via `Page::{offset, limit}` on `ORDER BY path`.

**Capabilities now declare:**

| Backend | records | query | index.exact | index.prefix | txn |
|---|---|---|---|---|---|
| `LibSqlRootFilesystem` | ✅ | ✅ | ✅ | ✅ | Cas |
| `PostgresRootFilesystem` | ✅ | ✅ | ✅ | ✅ | Cas |
| `InMemoryBackend` (unchanged) | ✅ | ✅ | ✅ | ✅ | Cas |

`events`, `index.fts`, and `index.vector` stay `false` — those land in follow-up ports.

## Migrations

- `migrations/V29__root_filesystem_index_specs.sql` (postgres, refinery-locked, checksum auto-regenerated).
- libsql gets an idempotent `CREATE TABLE IF NOT EXISTS` via `LIBSQL_INDEX_SPECS_SCHEMA` in `run_migrations`.

## Test plan

- [x] `cargo test -p ironclaw_filesystem --features libsql --test db_root_filesystem_contract` — **18 tests pass** (8 original + 5 CAS + 5 new indexer)
- [x] `cargo test -p ironclaw_filesystem --all-features` — **65 tests pass** (21 unit + 5 catalog + 19 db-backed + 20 filesystem-contract)
- [x] `cargo clippy -p ironclaw_filesystem --all-features --tests` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --workspace --all-features` — clean
- [x] Pre-push test suite (4967 tests) — pass
- [ ] Reviewer: confirm the IndexValue serde change is safe — no prior IndexValue payload has been persisted (foundation + port PRs both ship with the tagged form unused on the wire).

## Stacked PR

This PR's base is `reborn/fs-port-sql-backends` (PR #3660), which is itself stacked on `reborn/universal-fs-dispatch` (PR #3659). The final merge order is foundation → port → indexer → consumer migrations.