### PR TITLE
feat(engine): IRONCLAW_DISABLE_CODEACT flag to disable v2 CodeAct

### DIFF
--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -32,6 +32,36 @@ const CODEACT_PREAMBLE: &str = include_str!("../../prompts/codeact_preamble.md")
 /// The strategy/closing block appended after the dynamic metadata sections.
 const CODEACT_POSTAMBLE: &str = include_str!("../../prompts/codeact_postamble.md");
 
+/// Structured-tools-only preamble used when `IRONCLAW_DISABLE_CODEACT` is set.
+const STRUCTURED_TOOL_PREAMBLE: &str = r#"You are IronClaw, a personal AI assistant.
+
+## Execution mode
+
+Use the provider's structured tool_calls interface for every action.
+Do not emit Python, repl, py, or other executable fenced code blocks.
+Do not call tools as Python functions.
+Do not write tool invocations in assistant text. Never output `[[call_tool ...]]`, `<tool_call>`, `<function_call>`, JSON tool-call blobs, or function-style calls such as `tool_name(...)`.
+Only the provider-level `tool_calls` field invokes tools. If you need a tool, return a structured tool call instead of describing or printing the call.
+When no action is needed, answer in plain text.
+"#;
+
+/// Structured-tools-only postamble used when `IRONCLAW_DISABLE_CODEACT` is set.
+const STRUCTURED_TOOL_POSTAMBLE: &str = r#"
+## Strategy
+
+Use structured tool calls when you need data, persistence, external effects, or system state.
+After tool results are available, continue with another structured tool call or return the final plain-text answer.
+Some integrations use literal UI blocks such as `[[choice_set]]...[[/choice_set]]` in final user-facing text. These are UI markup only; do not invent other bracketed control blocks, especially `[[call_tool ...]]`.
+"#;
+
+/// Whether CodeAct (Tier 1 Python execution) is disabled by env var.
+pub fn codeact_disabled() -> bool {
+    matches!(
+        std::env::var("IRONCLAW_DISABLE_CODEACT").as_deref(),
+        Ok("true" | "1")
+    )
+}
+
 /// Marker for the engine-owned CodeAct system prompt.
 const CODEACT_SYSTEM_PROMPT_MARKER: &str = "<!-- ironclaw:codeact-system-prompt -->\n";
 const CODEACT_LEGACY_OPENING: &str = "You are an AI assistant with a Python REPL environment.";
@@ -104,8 +134,19 @@ fn build_codeact_system_prompt_inner(
     overlay: Option<&str>,
     platform: Option<&PlatformInfo>,
 ) -> String {
+    let disable_codeact = codeact_disabled();
+    tracing::debug!(
+        codeact_disabled = disable_codeact,
+        "engine v2 prompt mode"
+    );
+    let (preamble, postamble) = if disable_codeact {
+        (STRUCTURED_TOOL_PREAMBLE, STRUCTURED_TOOL_POSTAMBLE)
+    } else {
+        (CODEACT_PREAMBLE, CODEACT_POSTAMBLE)
+    };
+
     let mut prompt = String::from(CODEACT_SYSTEM_PROMPT_MARKER);
-    prompt.push_str(CODEACT_PREAMBLE);
+    prompt.push_str(preamble);
 
     // Inject platform identity and runtime metadata
     if let Some(info) = platform {
@@ -163,7 +204,7 @@ fn build_codeact_system_prompt_inner(
         }
     }
 
-    prompt.push_str(CODEACT_POSTAMBLE);
+    prompt.push_str(postamble);
     prompt
 }
 

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -109,7 +109,13 @@ pub async fn build_codeact_system_prompt(
     } else {
         None
     };
-    build_codeact_system_prompt_inner(capabilities, compact_actions, overlay.as_deref(), platform)
+    build_codeact_system_prompt_inner(
+        codeact_disabled(),
+        capabilities,
+        compact_actions,
+        overlay.as_deref(),
+        platform,
+    )
 }
 
 /// Build the system prompt using pre-fetched memory docs.
@@ -124,17 +130,27 @@ pub fn build_codeact_system_prompt_with_docs(
     platform: Option<&PlatformInfo>,
 ) -> String {
     let overlay = extract_prompt_overlay(system_docs);
-    build_codeact_system_prompt_inner(capabilities, compact_actions, overlay.as_deref(), platform)
+    build_codeact_system_prompt_inner(
+        codeact_disabled(),
+        capabilities,
+        compact_actions,
+        overlay.as_deref(),
+        platform,
+    )
 }
 
 /// Shared prompt builder used by both the async and pre-fetched-docs variants.
-fn build_codeact_system_prompt_inner(
+///
+/// `disable_codeact` is threaded as an explicit parameter (rather than read
+/// from the env directly) so tests can exercise both branches without
+/// process-global env mutation.
+pub(crate) fn build_codeact_system_prompt_inner(
+    disable_codeact: bool,
     capabilities: &[CapabilitySummary],
     compact_actions: &[ActionDef],
     overlay: Option<&str>,
     platform: Option<&PlatformInfo>,
 ) -> String {
-    let disable_codeact = codeact_disabled();
     tracing::debug!(codeact_disabled = disable_codeact, "engine v2 prompt mode");
     let (preamble, postamble) = if disable_codeact {
         (STRUCTURED_TOOL_PREAMBLE, STRUCTURED_TOOL_POSTAMBLE)
@@ -168,19 +184,28 @@ fn build_codeact_system_prompt_inner(
         }
     }
 
-    let compact_actions: Vec<_> = compact_actions
-        .iter()
-        .filter(|action| matches!(action.model_tool_surface, ModelToolSurface::CompactToolInfo))
-        .collect();
+    // In disabled-CodeAct mode the "Enabled Tools" listing is omitted:
+    // compact actions are emitted into the provider tool list (see
+    // `LlmBridgeAdapter::complete`) with their full schemas, so the prompt
+    // would only duplicate that surface and the `tool_info` schema-lookup
+    // instruction wouldn't apply. Without this guard, compact tools used to
+    // appear in the prompt as "available" but never made it into
+    // `tool_calls`, leaving them effectively unreachable (PR #3665 review).
+    if !disable_codeact {
+        let compact_actions: Vec<_> = compact_actions
+            .iter()
+            .filter(|action| matches!(action.model_tool_surface, ModelToolSurface::CompactToolInfo))
+            .collect();
 
-    if !compact_actions.is_empty() {
-        prompt.push_str(CODEACT_ENABLED_TOOLS_HEADING);
-        prompt.push('\n');
-        prompt.push_str(
-            "These enabled tools are shown in compact form. Before calling one, always check its schema with `tool_info(name=\"<tool>\", detail=\"schema\")`.\n\n",
-        );
-        for action in compact_actions {
-            prompt.push_str(&render_enabled_tool(action));
+        if !compact_actions.is_empty() {
+            prompt.push_str(CODEACT_ENABLED_TOOLS_HEADING);
+            prompt.push('\n');
+            prompt.push_str(
+                "These enabled tools are shown in compact form. Before calling one, always check its schema with `tool_info(name=\"<tool>\", detail=\"schema\")`.\n\n",
+            );
+            for action in compact_actions {
+                prompt.push_str(&render_enabled_tool(action));
+            }
         }
     }
 
@@ -792,5 +817,76 @@ mod tests {
         assert!(refreshed.contains("## Prior Knowledge (from completed threads)"));
         assert!(refreshed.contains("GitHub API Skill"));
         assert!(refreshed.contains("/missing"));
+    }
+
+    /// PR #3665 review (serrrfirat). With CodeAct disabled the structured-tool
+    /// prompt previously listed compact actions under "## Enabled Tools" with
+    /// a `tool_info` schema-lookup instruction — but the LLM adapter only
+    /// emitted FullSchema actions to the provider tool list. The result was
+    /// that compact tools (mission_create, gmail_send, notion_search, ...)
+    /// appeared in the prompt as "available" but could not be called via
+    /// `tool_calls`. Fix: skip the "Enabled Tools" section in disabled mode
+    /// and emit every action into the provider tool list instead (the
+    /// adapter-side half of this fix lives in `src/bridge/llm_adapter.rs`).
+    #[test]
+    fn disabled_codeact_omits_enabled_tools_section_and_keeps_activatable() {
+        let actions = vec![
+            ActionDef {
+                name: "mission_create".into(),
+                description: "Create scheduled or event-driven missions.".into(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: Vec::new(),
+                requires_approval: false,
+                model_tool_surface: ModelToolSurface::CompactToolInfo,
+                discovery: None,
+            },
+            ActionDef {
+                name: "http".into(),
+                description: "Make HTTP requests.".into(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: Vec::new(),
+                requires_approval: false,
+                model_tool_surface: ModelToolSurface::FullSchema,
+                discovery: None,
+            },
+        ];
+        let capabilities = vec![CapabilitySummary {
+            name: "gmail".into(),
+            display_name: Some("Gmail".into()),
+            kind: CapabilitySummaryKind::Provider,
+            status: CapabilityStatus::NeedsSetup,
+            description: Some("Gmail integration".into()),
+            action_preview: vec!["gmail_send".into()],
+            routing_hint: None,
+        }];
+
+        // Enabled (control): the existing section renders.
+        let enabled = build_codeact_system_prompt_inner(false, &capabilities, &actions, None, None);
+        assert!(enabled.contains("## Enabled Tools"));
+        assert!(enabled.contains("- `mission_create`"));
+        assert!(enabled.contains("## Activatable Integrations"));
+
+        // Disabled: section is gone, but Activatable Integrations stays
+        // (the model still needs to know what `tool_install` can target),
+        // and `mission_create` does NOT appear in the prompt — it's only
+        // reachable via the provider tool list now.
+        let disabled = build_codeact_system_prompt_inner(true, &capabilities, &actions, None, None);
+        assert!(
+            !disabled.contains("## Enabled Tools"),
+            "Enabled Tools section must be omitted in disabled-CodeAct mode"
+        );
+        assert!(
+            !disabled.contains("mission_create"),
+            "compact action must not appear in prompt — it's in the provider tool list"
+        );
+        assert!(
+            !disabled.contains("detail=\"schema\""),
+            "schema-lookup instruction is meaningless when provider sends full schemas \
+             (the `detail=\"summary\"` reference in Activatable Integrations is fine)"
+        );
+        assert!(
+            disabled.contains("## Activatable Integrations"),
+            "Activatable Integrations is still needed so the model can tool_install"
+        );
     }
 }

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -135,10 +135,7 @@ fn build_codeact_system_prompt_inner(
     platform: Option<&PlatformInfo>,
 ) -> String {
     let disable_codeact = codeact_disabled();
-    tracing::debug!(
-        codeact_disabled = disable_codeact,
-        "engine v2 prompt mode"
-    );
+    tracing::debug!(codeact_disabled = disable_codeact, "engine v2 prompt mode");
     let (preamble, postamble) = if disable_codeact {
         (STRUCTURED_TOOL_PREAMBLE, STRUCTURED_TOOL_POSTAMBLE)
     } else {

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -110,8 +110,20 @@ impl LlmBackend for LlmBridgeAdapter {
         sanitize_tool_messages(&mut chat_messages);
 
         // Convert actions to tool definitions
+        //
+        // In disabled-CodeAct mode the model has no Python escape hatch, so
+        // every callable action MUST be reachable via the provider's
+        // structured `tool_calls` interface. Filtering down to
+        // `emits_full_schema_tool()` in that mode would leave compact-info
+        // actions (e.g. `mission_create`, `gmail_send`, `notion_search`)
+        // visible in the prompt as "available" but absent from the provider
+        // tool list — i.e. unreachable. The prompt builder mirrors this by
+        // omitting the "Enabled Tools" section when CodeAct is disabled
+        // (see `prompt::build_codeact_system_prompt_inner`). PR #3665 review.
         let tools: Vec<ToolDefinition> = if config.force_text {
             vec![] // No tools when forcing text
+        } else if ironclaw_engine::executor::prompt::codeact_disabled() {
+            actions.iter().map(action_def_to_tool_def).collect()
         } else {
             actions
                 .iter()
@@ -1133,15 +1145,27 @@ mod tests {
         assert_eq!(models[0], None);
     }
 
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn complete_with_tools_only_emits_full_schema_provider_tools() {
+        // Both this test and `complete_emits_compact_actions_when_codeact_disabled`
+        // read the process-global `IRONCLAW_DISABLE_CODEACT` env var. Serialize
+        // via lock_env() and pin the value here so the other test setting
+        // `=true` can't leak across when `cargo test` runs them in parallel.
+        let _guard = crate::config::helpers::lock_env();
+        let original = std::env::var_os("IRONCLAW_DISABLE_CODEACT");
+        // SAFETY: serialized via lock_env().
+        unsafe {
+            std::env::remove_var("IRONCLAW_DISABLE_CODEACT");
+        }
+
         let state = Arc::new(CapturingProviderState::default());
         let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
             state: state.clone(),
         });
         let adapter = LlmBridgeAdapter::new(provider, None);
 
-        adapter
+        let result = adapter
             .complete(
                 &[ThreadMessage::user("hi")],
                 &[
@@ -1166,8 +1190,18 @@ mod tests {
                 ],
                 &LlmCallConfig::default(),
             )
-            .await
-            .unwrap();
+            .await;
+
+        // SAFETY: serialized via lock_env().
+        unsafe {
+            if let Some(value) = original {
+                std::env::set_var("IRONCLAW_DISABLE_CODEACT", value);
+            } else {
+                std::env::remove_var("IRONCLAW_DISABLE_CODEACT");
+            }
+        }
+
+        result.unwrap();
 
         let tool_definitions = state.tool_definitions.lock().await;
         let emitted = tool_definitions.last().expect("tool completion request");
@@ -1177,6 +1211,78 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(names, vec!["http"]);
+    }
+
+    /// PR #3665 review (serrrfirat). Disabled-CodeAct mode strips the Python
+    /// escape hatch, so any callable action MUST be reachable via the
+    /// provider's structured `tool_calls`. Filtering down to FullSchema in
+    /// that mode left compact actions (`mission_create`, `gmail_send`, ...)
+    /// visible in the prompt but absent from the provider tool list — i.e.
+    /// unreachable. This test pins the relaxed filter.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn complete_emits_compact_actions_when_codeact_disabled() {
+        let _guard = crate::config::helpers::lock_env();
+        let original = std::env::var_os("IRONCLAW_DISABLE_CODEACT");
+        // SAFETY: serialized via lock_env().
+        unsafe {
+            std::env::set_var("IRONCLAW_DISABLE_CODEACT", "true");
+        }
+
+        let state = Arc::new(CapturingProviderState::default());
+        let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
+            state: state.clone(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let result = adapter
+            .complete(
+                &[ThreadMessage::user("hi")],
+                &[
+                    ActionDef {
+                        name: "http".into(),
+                        description: "fetch".into(),
+                        parameters_schema: serde_json::json!({"type": "object"}),
+                        effects: vec![EffectType::ReadExternal],
+                        requires_approval: false,
+                        model_tool_surface: ModelToolSurface::FullSchema,
+                        discovery: None,
+                    },
+                    ActionDef {
+                        name: "mission_create".into(),
+                        description: "create mission".into(),
+                        parameters_schema: serde_json::json!({"type": "object"}),
+                        effects: vec![EffectType::WriteLocal],
+                        requires_approval: false,
+                        model_tool_surface: ModelToolSurface::CompactToolInfo,
+                        discovery: None,
+                    },
+                ],
+                &LlmCallConfig::default(),
+            )
+            .await;
+
+        // SAFETY: serialized via lock_env().
+        unsafe {
+            if let Some(value) = original {
+                std::env::set_var("IRONCLAW_DISABLE_CODEACT", value);
+            } else {
+                std::env::remove_var("IRONCLAW_DISABLE_CODEACT");
+            }
+        }
+
+        result.expect("adapter.complete should succeed");
+
+        let tool_definitions = state.tool_definitions.lock().await;
+        let emitted = tool_definitions.last().expect("tool completion request");
+        let mut names: Vec<&str> = emitted.iter().map(|t| t.name.as_str()).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["http", "mission_create"],
+            "disabled-CodeAct must emit BOTH FullSchema and CompactToolInfo actions \
+             — otherwise compact actions are unreachable"
+        );
     }
 
     // ── extract_code_block tests ────────────────────────────

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -515,6 +515,12 @@ fn extract_code_block(text: &str) -> Option<String> {
 }
 
 fn text_response_from_cleaned_text(cleaned_text: String) -> LlmResponse {
+    if ironclaw_engine::executor::prompt::codeact_disabled() {
+        if cleaned_text.trim().is_empty() {
+            return LlmResponse::Text(EMPTY_CLEANED_RESPONSE_FALLBACK.to_string());
+        }
+        return LlmResponse::Text(cleaned_text);
+    }
     match extract_code_block(&cleaned_text) {
         Some(code) => LlmResponse::Code {
             code,


### PR DESCRIPTION
## Summary

- Adds env-toggleable `IRONCLAW_DISABLE_CODEACT` (accepts `true` or `1`) to switch engine v2 from CodeAct (Tier 1 Python via Monty) to a structured-tools-only prompt + adapter.
- Default unset/false → behavior bit-identical to today (zero risk).
- When set, swaps `CODEACT_PREAMBLE`/`POSTAMBLE` for `STRUCTURED_TOOL_PREAMBLE`/`POSTAMBLE`, and the LLM adapter never produces `LlmResponse::Code` from fenced Python text.
- Includes a per-turn `tracing::debug!` log `engine v2 prompt mode codeact_disabled=…` so the mode is visible in diagnostics.

## Motivation

In CodeAct mode the LLM has a "text response exit" after each Python step that can short-circuit multi-step recovery flows — e.g. when a tool error returns actionable hints, the model can finalize with the error narration instead of retrying with corrected args. Structured `tool_calls` mode keeps the loop running until the model emits a finished response without pending tool intent, which is closer to the production behavior on `nearai/demo/abound`.

## Behavior matrix

| Flag | Preamble/Postamble | LLM adapter |
|---|---|---|
| unset / `false` | `CODEACT_PREAMBLE` / `CODEACT_POSTAMBLE` (existing) | Existing: detect ` ```repl `/Python → `LlmResponse::Code` |
| `true` / `1` | `STRUCTURED_TOOL_PREAMBLE` / `STRUCTURED_TOOL_POSTAMBLE` | Always `LlmResponse::Text` (no code extraction) |

## What's preserved

- All existing prompt `.md` files unchanged
- `CODEACT_SYSTEM_PROMPT_MARKER` sentinel intact (refresh logic in `loop_engine.rs` still works in both modes)
- Monty / `executor/scripting.rs` / orchestrator untouched — just unreachable when flag is on
- No new dependencies, no config struct changes, no arg threading

## Files

- `crates/ironclaw_engine/src/executor/prompt.rs` — inline structured-tool constants, `pub fn codeact_disabled()`, branch preamble/postamble selection in `build_codeact_system_prompt_inner`, debug log
- `src/bridge/llm_adapter.rs` — `text_response_from_cleaned_text` early-return guard when codeact is disabled

## Test plan

- [ ] `cargo check -p ironclaw_engine` — passes
- [ ] `cargo check` — passes
- [ ] With flag unset, send a multi-turn agent task; verify orchestrator emits `__execute_code_step__` (CodeAct path active)
- [ ] With `IRONCLAW_DISABLE_CODEACT=true`, send the same task; verify orchestrator emits only `__execute_actions_parallel__` (structured tool_calls path), no `__execute_code_step__`, and trace summary has no `NameError`/CodeAct quirks

🤖 Generated with [Claude Code](https://claude.com/claude-code)