### PR TITLE
feat(processes): route FilesystemProcessStore through unified put/get

### DIFF
--- a/crates/ironclaw_processes/src/filesystem_store.rs
+++ b/crates/ironclaw_processes/src/filesystem_store.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_events::sanitize_error_kind;
-use ironclaw_filesystem::{FilesystemError, RootFilesystem};
+use ironclaw_filesystem::{CasExpectation, ContentType, Entry, FilesystemError, RootFilesystem};
 use ironclaw_host_api::{ProcessId, ResourceScope, VirtualPath};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -87,8 +87,20 @@ where
 
     async fn write_record(&self, record: &ProcessRecord) -> Result<(), ProcessError> {
         let path = process_record_path(&record.scope, record.process_id)?;
-        let bytes = serialize_pretty(record)?;
-        self.filesystem.as_ref().write_file(&path, &bytes).await?;
+        let body = serialize_pretty(record)?;
+        // Entry::bytes (kind=None) keeps the legacy on-disk layout — JSON
+        // file at `process_record_path`. The unified `put` op gives us the
+        // same write semantics as `write_file` against any backend, and
+        // backends that support records natively (libSQL, Postgres,
+        // InMemoryBackend) will still store the body as an opaque entry.
+        // Once LocalFilesystem grows native put with sidecar metadata, the
+        // consumer can switch to Entry::record(process_record_kind, ...)
+        // without changing the on-disk layout.
+        let entry = Entry::bytes(body).with_content_type(ContentType::json());
+        self.filesystem
+            .as_ref()
+            .put(&path, entry, CasExpectation::Any)
+            .await?;
         Ok(())
     }
 
@@ -120,12 +132,12 @@ where
     async fn start(&self, start: ProcessStart) -> Result<ProcessRecord, ProcessError> {
         let _guard = self.transition_lock.lock().await;
         let path = process_record_path(&start.scope, start.process_id)?;
-        let existing = match self.filesystem.as_ref().read_file(&path).await {
-            Ok(_) => true,
-            Err(error) if is_not_found(&error) => false,
-            Err(error) => return Err(error.into()),
-        };
-        if existing {
+        // Existence check uses `get` (unified read) so it works regardless of
+        // whether the backend has native put. Atomicity is provided by the
+        // transition_lock per the single-instance invariant in this struct's
+        // docstring. A future migration can switch to `CasExpectation::Absent`
+        // once every backend in production exposes native put.
+        if self.filesystem.as_ref().get(&path).await?.is_some() {
             return Err(ProcessError::ProcessAlreadyExists {
                 process_id: start.process_id,
             });
@@ -188,12 +200,10 @@ where
         process_id: ProcessId,
     ) -> Result<Option<ProcessRecord>, ProcessError> {
         let path = process_record_path(scope, process_id)?;
-        let bytes = match self.filesystem.as_ref().read_file(&path).await {
-            Ok(bytes) => bytes,
-            Err(error) if is_not_found(&error) => return Ok(None),
-            Err(error) => return Err(error.into()),
+        let Some(versioned) = self.filesystem.as_ref().get(&path).await? else {
+            return Ok(None);
         };
-        let record = deserialize::<ProcessRecord>(&bytes)?;
+        let record = deserialize::<ProcessRecord>(&versioned.entry.body)?;
         ensure_process_record_matches(&record, process_id)?;
         if same_scope_owner(&record.scope, scope) {
             Ok(Some(record))
@@ -215,8 +225,19 @@ where
         let mut records = Vec::new();
         for entry in entries {
             if entry.name.ends_with(".json") {
-                let bytes = self.filesystem.as_ref().read_file(&entry.path).await?;
-                let record = deserialize::<ProcessRecord>(&bytes)?;
+                // Reviewer (PR #3666) flagged: a `get` returning `None` after
+                // `list_dir` enumerated the path indicates a race or backend
+                // inconsistency. Returning a partial process list silently
+                // hides this; surface it as `NotFound` so callers see the
+                // same failure shape they got with the legacy `read_file`
+                // path.
+                let Some(versioned) = self.filesystem.as_ref().get(&entry.path).await? else {
+                    return Err(ProcessError::Filesystem(format!(
+                        "process record listed but missing at {}",
+                        entry.path
+                    )));
+                };
+                let record = deserialize::<ProcessRecord>(&versioned.entry.body)?;
                 if same_scope_owner(&record.scope, scope) {
                     records.push(record);
                 }
@@ -252,8 +273,12 @@ where
 
     async fn write_result(&self, record: &ProcessResultRecord) -> Result<(), ProcessError> {
         let path = process_result_path(&record.scope, record.process_id)?;
-        let bytes = serialize_pretty(record)?;
-        self.filesystem.as_ref().write_file(&path, &bytes).await?;
+        let body = serialize_pretty(record)?;
+        let entry = Entry::bytes(body).with_content_type(ContentType::json());
+        self.filesystem
+            .as_ref()
+            .put(&path, entry, CasExpectation::Any)
+            .await?;
         Ok(())
     }
 
@@ -264,8 +289,15 @@ where
         output: &Value,
     ) -> Result<VirtualPath, ProcessError> {
         let path = process_output_path(scope, process_id)?;
-        let bytes = serialize_pretty(output)?;
-        self.filesystem.as_ref().write_file(&path, &bytes).await?;
+        let body = serialize_pretty(output)?;
+        // Output blobs are opaque JSON files — no schema kind, no indexed
+        // projection. Stored as an Entry with `kind=None` so reads stay
+        // backwards-compatible with any caller that uses `read_file`.
+        let entry = Entry::bytes(body).with_content_type(ContentType::json());
+        self.filesystem
+            .as_ref()
+            .put(&path, entry, CasExpectation::Any)
+            .await?;
         Ok(path)
     }
 
@@ -355,12 +387,10 @@ where
         process_id: ProcessId,
     ) -> Result<Option<ProcessResultRecord>, ProcessError> {
         let path = process_result_path(scope, process_id)?;
-        let bytes = match self.filesystem.as_ref().read_file(&path).await {
-            Ok(bytes) => bytes,
-            Err(error) if is_not_found(&error) => return Ok(None),
-            Err(error) => return Err(error.into()),
+        let Some(versioned) = self.filesystem.as_ref().get(&path).await? else {
+            return Ok(None);
         };
-        let record = deserialize::<ProcessResultRecord>(&bytes)?;
+        let record = deserialize::<ProcessResultRecord>(&versioned.entry.body)?;
         ensure_result_record_matches(&record, process_id)?;
         if same_scope_owner(&record.scope, scope) {
             Ok(Some(record))
@@ -391,12 +421,10 @@ where
                 expected_output_ref.as_str()
             )));
         }
-        let bytes = match self.filesystem.as_ref().read_file(&output_ref).await {
-            Ok(bytes) => bytes,
-            Err(error) if is_not_found(&error) => return Ok(None),
-            Err(error) => return Err(error.into()),
+        let Some(versioned) = self.filesystem.as_ref().get(&output_ref).await? else {
+            return Ok(None);
         };
-        deserialize::<Value>(&bytes).map(Some)
+        deserialize::<Value>(&versioned.entry.body).map(Some)
     }
 }
 

--- a/crates/ironclaw_processes/tests/process_store_contract.rs
+++ b/crates/ironclaw_processes/tests/process_store_contract.rs
@@ -1873,6 +1873,19 @@ impl RootFilesystem for BackendErrorFilesystem {
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
         Err(backend_error(path, FilesystemOperation::Stat))
     }
+
+    // After the PR #3666 fix that breaks the put/write_file recursion, the
+    // trait's default `get` is `Unsupported`. A test backend that wants to
+    // fault-inject through the unified read path has to override `get`
+    // explicitly — same shape that `LocalFilesystem` adopts in its native
+    // impl. Mirroring the same fault here keeps the consumer test
+    // exercising the "backend error mentions not_found" propagation.
+    async fn get(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Option<ironclaw_filesystem::VersionedEntry>, FilesystemError> {
+        Err(backend_error(path, FilesystemOperation::ReadFile))
+    }
 }
 
 fn backend_error(path: &VirtualPath, operation: FilesystemOperation) -> FilesystemError {


### PR DESCRIPTION
## Summary

First consumer migration onto the new `RootFilesystem` surface. Stacked on #3661 (indexer). Scope is deliberately tight: switch the byte-plane `read_file`/`write_file` calls inside `ironclaw_processes`' filesystem-backed store to the unified `put`/`get` ops. The on-disk JSON layout is unchanged, every existing test passes, and downstream crates that construct `FilesystemProcessStore` (`ironclaw_host_runtime` + 4 test files) don't need to change.

## Why only `Entry::bytes` + `CasExpectation::Any`

`LocalFilesystem` (used by the `ironclaw_processes` tests via `ProcessServices::filesystem(LocalFilesystem)`) still only implements the legacy bytes plane — no native `put`. The trait's default `put` impl now **bridges that case**: opaque-file entries (`kind = None`, `indexed = {}`) with `CAS::Any` route through `write_file` so legacy backends keep working unchanged.

Record-shaped writes (`kind = Some(_)` / non-empty `indexed`) and `CAS::Absent` / `CAS::Version` modes remain `Unsupported` on legacy backends. Consumers using them must run against a backend with native `put` (libSQL, Postgres, `InMemoryBackend`).

Once `LocalFilesystem` grows native `put` with sidecar metadata in a follow-up, this consumer can switch to:

```rust
let entry = Entry::record(process_record_kind(), &serde_json::to_value(&record)?)?
    .with_indexed(IndexKey::new("scope")?, IndexValue::Text(scope.to_string()));
self.filesystem.put(&path, entry, CasExpectation::Absent).await?;
```

without changing the on-disk layout.

## What changed in `ironclaw_processes`

- `FilesystemProcessStore::write_record` — uses `put(path, Entry::bytes(body), CAS::Any)`.
- `FilesystemProcessStore::start` — keeps the `transition_lock` and uses `get` (unified read) for the existence probe; once every backend supports native `put`, this can collapse to a single `CAS::Absent` call.
- `FilesystemProcessStore::update_status` — reads via `get` instead of `read_file`. The `transition_lock` still provides per-instance atomicity per the single-instance invariant in the docstring.
- `FilesystemProcessStore::get` / `records_for_scope` — read via `get` and the new `VersionedEntry.body`.
- `FilesystemProcessResultStore::{write_result, write_output, get, output}` — all migrated to the same unified pattern.
- `FilesystemProcessResultStore::write_output` — output blobs stay opaque (`Entry::bytes` with `ContentType::json()`), no record metadata, so they round-trip through legacy `read_file`/`write_file` if any consumer still uses those.

## What changed in `ironclaw_filesystem`

Single change in `root.rs`: the trait's default `put` now bridges to `write_file` instead of returning `Unsupported`, *only* when the entry is an opaque file (`kind = None`, `indexed = {}`) and CAS is `Any`. Anything richer still returns `Unsupported` since legacy backends can't honour kinds, indexed projections, or CAS preconditions.

## Test plan

- [x] `cargo test -p ironclaw_processes` — **64 tests pass** (no regressions from the migration)
- [x] `cargo test -p ironclaw_filesystem --all-features` — **65 tests pass** (foundation + port + indexer tests still green)
- [x] `cargo clippy --all-features --tests` on both crates — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --workspace --all-features` — clean
- [x] Pre-push lib-test gate (4967 tests) — pass
- [ ] Reviewer: the `e2e_builtin_tool_coverage::tests::job_list_cancel` integration test fails on this branch but **also fails on baseline `reborn-integration`** — pre-existing, unrelated to this PR.

## Stacked PR

Base is `reborn/fs-indexer` (PR #3661). Merge order: foundation (#3659) → port (#3660) → indexer (#3661) → this. Each subsequent consumer migration will be its own PR per the agreed cadence.