### PR TITLE
engine v2: expose channel-supplied thread/response ids to tools

### DIFF
--- a/crates/ironclaw_engine/src/executor/context.rs
+++ b/crates/ironclaw_engine/src/executor/context.rs
@@ -188,6 +188,8 @@ mod tests {
                 gate_controller: crate::gate::CancellingGateController::arc(),
                 call_approval_granted: false,
                 conversation_id: None,
+                client_thread_id: None,
+                client_response_id: None,
             },
         )
         .await
@@ -232,6 +234,8 @@ mod tests {
                 gate_controller: crate::gate::CancellingGateController::arc(),
                 call_approval_granted: false,
                 conversation_id: None,
+                client_thread_id: None,
+                client_response_id: None,
             },
         )
         .await
@@ -272,6 +276,8 @@ mod tests {
                 gate_controller: crate::gate::CancellingGateController::arc(),
                 call_approval_granted: false,
                 conversation_id: None,
+                client_thread_id: None,
+                client_response_id: None,
             },
         )
         .await

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -2872,6 +2872,8 @@ mod tests {
             gate_controller: crate::gate::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -944,6 +944,8 @@ mod tests {
             gate_controller: crate::gate::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/executor/thread_context.rs
+++ b/crates/ironclaw_engine/src/executor/thread_context.rs
@@ -54,5 +54,15 @@ pub(crate) fn thread_execution_context(
             .and_then(|v| v.as_str())
             .and_then(|s| Uuid::from_str(s).ok())
             .map(ConversationId),
+        client_thread_id: thread
+            .metadata
+            .get("client_thread_id")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        client_response_id: thread
+            .metadata
+            .get("client_response_id")
+            .and_then(|v| v.as_str())
+            .map(String::from),
     }
 }

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -277,22 +277,44 @@ impl ConversationManager {
                         "failed to refresh client_response_id on inject"
                     );
                 }
-                // Spawn-only contract; log if a later turn changes it.
-                if let Some(new_cid) = client_thread_id
-                    && let Ok(Some(thread)) = self.store.load_thread(thread_id).await
-                    && let Some(stored) = thread
-                        .metadata
-                        .get("client_thread_id")
-                        .and_then(|v| v.as_str())
-                    && stored != new_cid
-                {
-                    tracing::warn!(
-                        thread_id = %thread_id,
-                        stored = %stored,
-                        incoming = %new_cid,
-                        phase = "inject",
-                        "client_thread_id drift detected; keeping stored value"
-                    );
+                // Spawn-only contract; log if a later turn changes it. Read
+                // the spawn-time id from the in-memory running set first to
+                // avoid a store round-trip on every injected message; only a
+                // thread that isn't in the running set (resumed post-restart)
+                // falls back to a store load.
+                if let Some(new_cid) = client_thread_id {
+                    let stored = match self
+                        .thread_manager
+                        .running_client_thread_id(thread_id)
+                        .await
+                    {
+                        Some(cid) => Some(cid),
+                        // silent-ok: best-effort drift diagnostic; a failed or
+                        // missing load just skips the warn, never changes routing.
+                        None => self
+                            .store
+                            .load_thread(thread_id)
+                            .await
+                            .ok()
+                            .flatten()
+                            .and_then(|t| {
+                                t.metadata
+                                    .get("client_thread_id")
+                                    .and_then(|v| v.as_str())
+                                    .map(str::to_string)
+                            }),
+                    };
+                    if let Some(stored) = stored
+                        && stored != new_cid
+                    {
+                        tracing::warn!(
+                            thread_id = %thread_id,
+                            stored = %stored,
+                            incoming = %new_cid,
+                            phase = "inject",
+                            "client_thread_id drift detected; keeping stored value"
+                        );
+                    }
                 }
                 self.thread_manager
                     .inject_message(thread_id, user_id, ThreadMessage::user(content))

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -205,6 +205,16 @@ impl ConversationManager {
     /// so the engine reload picks it up. Extending this method to
     /// also write metadata on inject/resume is a future change, not
     /// the current contract.
+    ///
+    /// `client_thread_id` / `client_response_id` are stable channel-
+    /// supplied correlation ids (e.g. the thread UUID embedded in a
+    /// Responses API `previous_response_id`). They flow into thread
+    /// metadata so tools can stamp them on outbound notifications
+    /// (`notify_thread_id` / `notify_response_id`) for async callback
+    /// round-trips. `client_response_id` is refreshed on inject/resume
+    /// (best-effort persist, in-memory thread copy is a turn behind);
+    /// `client_thread_id` is spawn-only — drift on inject/resume is
+    /// logged but not overwritten.
     // Bundling these into an options struct would just push the
     // argument list around without making any caller easier to read —
     // every caller passes literal None for the optional fields and
@@ -219,6 +229,8 @@ impl ConversationManager {
         thread_config: ThreadConfig,
         user_timezone: Option<&str>,
         extra_initial_metadata: Option<serde_json::Map<String, serde_json::Value>>,
+        client_thread_id: Option<&str>,
+        client_response_id: Option<&str>,
     ) -> Result<ThreadId, EngineError> {
         let conv_arc = self.get_conversation_lock(conversation_id).await?;
         let mut conv = conv_arc.lock().await;
@@ -248,12 +260,40 @@ impl ConversationManager {
                     thread_id = %thread_id,
                     "injecting message into active thread"
                 );
-                // Known limitation: a tz change mid-turn (user travels between
-                // messages of the same active thread) is not propagated. The
-                // running ExecutionLoop holds an in-memory copy of the Thread
-                // and cannot be updated externally without a new signal type.
-                // Updating the persisted record here would not affect the live
-                // step. Rare in practice; defer to a follow-up if needed.
+                // Known limitation: the running loop holds an in-memory Thread
+                // copy; set_thread_metadata writes only reach it on reload, so
+                // tz/client_response_id changes mid-turn are best-effort. Safe
+                // because the thread_uuid half stays stable — a stale
+                // response_uuid still routes previous_response_id correctly.
+                if let Some(rid) = client_response_id
+                    && let Err(e) = self
+                        .thread_manager
+                        .set_thread_metadata(thread_id, "client_response_id", rid)
+                        .await
+                {
+                    debug!(
+                        thread_id = %thread_id,
+                        error = %e,
+                        "failed to refresh client_response_id on inject"
+                    );
+                }
+                // Spawn-only contract; log if a later turn changes it.
+                if let Some(new_cid) = client_thread_id
+                    && let Ok(Some(thread)) = self.store.load_thread(thread_id).await
+                    && let Some(stored) = thread
+                        .metadata
+                        .get("client_thread_id")
+                        .and_then(|v| v.as_str())
+                    && stored != new_cid
+                {
+                    tracing::warn!(
+                        thread_id = %thread_id,
+                        stored = %stored,
+                        incoming = %new_cid,
+                        phase = "inject",
+                        "client_thread_id drift detected; keeping stored value"
+                    );
+                }
                 self.thread_manager
                     .inject_message(thread_id, user_id, ThreadMessage::user(content))
                     .await?;
@@ -281,6 +321,18 @@ impl ConversationManager {
                         thread_id = %thread_id,
                         error = %e,
                         "failed to refresh user_timezone on resume; thread will use previous value"
+                    );
+                }
+                if let Some(rid) = client_response_id
+                    && let Err(e) = self
+                        .thread_manager
+                        .set_thread_metadata(thread_id, "client_response_id", rid)
+                        .await
+                {
+                    debug!(
+                        thread_id = %thread_id,
+                        error = %e,
+                        "failed to refresh client_response_id on resume; thread will use previous value"
                     );
                 }
                 self.thread_manager
@@ -346,6 +398,18 @@ impl ConversationManager {
                     for (k, v) in extra {
                         initial_metadata.entry(k).or_insert(v);
                     }
+                }
+                if let Some(cid) = client_thread_id {
+                    initial_metadata.insert(
+                        "client_thread_id".into(),
+                        serde_json::Value::String(cid.to_string()),
+                    );
+                }
+                if let Some(rid) = client_response_id {
+                    initial_metadata.insert(
+                        "client_response_id".into(),
+                        serde_json::Value::String(rid.to_string()),
+                    );
                 }
 
                 // Spawn new foreground thread with conversation history.
@@ -905,6 +969,8 @@ mod tests {
                 ThreadConfig::default(),
                 None,
                 None,
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -972,6 +1038,8 @@ mod tests {
                 project,
                 "user1",
                 ThreadConfig::default(),
+                None,
+                None,
                 None,
                 None,
             )
@@ -1074,6 +1142,8 @@ mod tests {
                 ThreadConfig::default(),
                 None,
                 None,
+                None,
+                None,
             )
             .await
             .unwrap();
@@ -1124,6 +1194,8 @@ mod tests {
                 ThreadConfig::default(),
                 None,
                 None,
+                None,
+                None,
             )
             .await
         });
@@ -1134,6 +1206,8 @@ mod tests {
                 project,
                 "user1",
                 ThreadConfig::default(),
+                None,
+                None,
                 None,
                 None,
             )
@@ -1211,6 +1285,8 @@ mod tests {
                 project,
                 "user1",
                 ThreadConfig::default(),
+                None,
+                None,
                 None,
                 None,
             )

--- a/crates/ironclaw_engine/src/runtime/manager.rs
+++ b/crates/ironclaw_engine/src/runtime/manager.rs
@@ -26,6 +26,10 @@ use crate::types::thread::{Thread, ThreadConfig, ThreadId, ThreadState, ThreadTy
 struct RunningThread {
     signal_tx: SignalSender,
     handle: tokio::task::JoinHandle<Result<ThreadOutcome, EngineError>>,
+    /// Spawn-time `client_thread_id` (if the channel supplied one), cached
+    /// here so the drift check on message inject can compare in memory
+    /// instead of round-tripping the store on every injected message.
+    client_thread_id: Option<String>,
 }
 
 /// Top-level orchestrator for thread lifecycle.
@@ -337,6 +341,14 @@ impl ThreadManager {
         is_resume: bool,
     ) -> Result<ThreadId, EngineError> {
         let thread_id = thread.id;
+        // Capture the spawn-time client_thread_id before `thread` is moved
+        // into the execution loop, so the inject-path drift check can read it
+        // from `self.running` without a store round-trip.
+        let client_thread_id = thread
+            .metadata
+            .get("client_thread_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
 
         reconcile_dynamic_tool_lease(
             &mut thread,
@@ -439,6 +451,7 @@ impl ThreadManager {
             RunningThread {
                 signal_tx: tx,
                 handle,
+                client_thread_id,
             },
         );
 
@@ -547,6 +560,19 @@ impl ThreadManager {
                 reason: format!("set_thread_metadata: save failed: {e}"),
             })?;
         Ok(())
+    }
+
+    /// Spawn-time `client_thread_id` for a running thread, if one was
+    /// supplied by the channel. Returns `None` when the thread isn't in the
+    /// running set (e.g. resumed from the store after a restart) or carried
+    /// no `client_thread_id`. Lets callers compare against the in-memory
+    /// value without a store round-trip on the message-inject hot path.
+    pub async fn running_client_thread_id(&self, thread_id: ThreadId) -> Option<String> {
+        self.running
+            .read()
+            .await
+            .get(&thread_id)
+            .and_then(|rt| rt.client_thread_id.clone())
     }
 
     /// Check if a thread is still running.

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -3004,6 +3004,8 @@ async fn dispatch_protected_write(
         gate_controller: crate::gate::CancellingGateController::arc(),
         call_approval_granted: false,
         conversation_id: None,
+        client_thread_id: None,
+        client_response_id: None,
     };
 
     effects

--- a/crates/ironclaw_engine/src/traits/effect.rs
+++ b/crates/ironclaw_engine/src/traits/effect.rs
@@ -81,9 +81,13 @@ pub struct ThreadExecutionContext {
     pub conversation_id: Option<ConversationId>,
     /// Channel-supplied stable thread id (Responses API thread half).
     /// Stable across turns. `None` for callers that don't supply one.
+    // TODO(Z2): newtype as `ClientThreadId` per .claude/rules/types.md
+    // (stringly-typed id deferred from PR #3669).
     pub client_thread_id: Option<String>,
     /// Channel-supplied per-turn response id (full Responses API `resp_...`).
     /// Changes every turn. `None` for callers that don't supply one.
+    // TODO(Z2): newtype as `ClientResponseId` per .claude/rules/types.md
+    // (stringly-typed id deferred from PR #3669).
     pub client_response_id: Option<String>,
 }
 

--- a/crates/ironclaw_engine/src/traits/effect.rs
+++ b/crates/ironclaw_engine/src/traits/effect.rs
@@ -81,13 +81,15 @@ pub struct ThreadExecutionContext {
     pub conversation_id: Option<ConversationId>,
     /// Channel-supplied stable thread id (Responses API thread half).
     /// Stable across turns. `None` for callers that don't supply one.
-    // TODO(Z2): newtype as `ClientThreadId` per .claude/rules/types.md
-    // (stringly-typed id deferred from PR #3669).
+    // TODO: wrap in a `ClientThreadId(Uuid)` newtype so it can't be swapped
+    // with `client_response_id` or with the engine's own `ThreadId` (both
+    // wrap a Uuid but mean different things). See .claude/rules/types.md.
     pub client_thread_id: Option<String>,
     /// Channel-supplied per-turn response id (full Responses API `resp_...`).
     /// Changes every turn. `None` for callers that don't supply one.
-    // TODO(Z2): newtype as `ClientResponseId` per .claude/rules/types.md
-    // (stringly-typed id deferred from PR #3669).
+    // TODO: wrap in a `ClientResponseId` newtype validating the `resp_`
+    // prefix, so it can't be swapped with `client_thread_id`. See
+    // .claude/rules/types.md.
     pub client_response_id: Option<String>,
 }
 

--- a/crates/ironclaw_engine/src/traits/effect.rs
+++ b/crates/ironclaw_engine/src/traits/effect.rs
@@ -79,6 +79,12 @@ pub struct ThreadExecutionContext {
     /// `None` for background mission threads with no user-facing
     /// conversation.
     pub conversation_id: Option<ConversationId>,
+    /// Channel-supplied stable thread id (Responses API thread half).
+    /// Stable across turns. `None` for callers that don't supply one.
+    pub client_thread_id: Option<String>,
+    /// Channel-supplied per-turn response id (full Responses API `resp_...`).
+    /// Changes every turn. `None` for callers that don't supply one.
+    pub client_response_id: Option<String>,
 }
 
 // Manual Debug impl: `dyn GateController` is not Debug, but the rest of
@@ -108,6 +114,8 @@ impl std::fmt::Debug for ThreadExecutionContext {
             .field("gate_controller", &"<dyn GateController>")
             .field("call_approval_granted", &self.call_approval_granted)
             .field("conversation_id", &self.conversation_id)
+            .field("client_thread_id", &self.client_thread_id)
+            .field("client_response_id", &self.client_response_id)
             .finish()
     }
 }

--- a/docs/api/responses.mdx
+++ b/docs/api/responses.mdx
@@ -390,7 +390,7 @@ A turn that completes but fails mid-flight (the model errored, a required tool r
 Two cases do **not** use the JSON envelope and need separate handling:
 
 - **`401` Unauthorized** comes from the gateway auth middleware before the request reaches the handler, and the body is a plain-text string (`Invalid or missing auth token`). Same for `403` (`Forbidden` for OIDC domain violations) and the `503` (`Database unavailable`) emitted by the middleware when the token store is down.
-- **`GET /api/v1/responses/{id}`** returns `404` (still JSON-enveloped) when the response id is unknown or the thread does not belong to the authenticated user. `POST` with a foreign `previous_response_id` does **not** return `404`; the handler only decodes the UUID and dispatches into the agent, where the cross-user resume surfaces as a turn-level failure rather than an HTTP error. Treat cross-user resume as undefined and avoid relying on the response shape.
+- **`GET /api/v1/responses/{id}`** and **`POST /api/v1/responses`** with a foreign `previous_response_id` both return `404` (still JSON-enveloped) when the response id is unknown or the thread does not belong to the authenticated user. The check runs before the agent dispatch on POST, so cross-user resume now surfaces as an HTTP error rather than a turn-level failure.
 
 The Responses API does **not** support interactive approvals or authentication gates in the response stream. If the agent hits a tool that requires user approval (e.g. shell with a destructive command) or an extension OAuth flow, the turn fails with a clear error directing you to resolve the gate via the web UI or a different channel.
 

--- a/src/bridge/action_projector.rs
+++ b/src/bridge/action_projector.rs
@@ -652,6 +652,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         }
     }
 

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -1539,13 +1539,26 @@ impl EffectBridgeAdapter {
             .client_thread_id
             .clone()
             .unwrap_or_else(|| context.thread_id.to_string());
-        let mut job_metadata = serde_json::json!({
-            "notify_thread_id": notify_thread_id,
-        });
-        if let Some(ref rid) = context.client_response_id {
-            job_metadata["notify_response_id"] = serde_json::Value::String(rid.clone());
+        // Merge into the existing metadata map rather than replacing it, so a
+        // future caller that pre-stamps `job_ctx.metadata` upstream can't have
+        // its keys silently clobbered. `JobContext::with_user` initializes
+        // `metadata` to `Value::Null`, so promote it to an object before
+        // inserting.
+        if !job_ctx.metadata.is_object() {
+            job_ctx.metadata = serde_json::Value::Object(serde_json::Map::new());
         }
-        job_ctx.metadata = job_metadata;
+        if let Some(meta) = job_ctx.metadata.as_object_mut() {
+            meta.insert(
+                "notify_thread_id".into(),
+                serde_json::Value::String(notify_thread_id),
+            );
+            if let Some(ref rid) = context.client_response_id {
+                meta.insert(
+                    "notify_response_id".into(),
+                    serde_json::Value::String(rid.clone()),
+                );
+            }
+        }
         // Stamp the trace HTTP interceptor onto the per-call JobContext so
         // tools that respect it (http, web_fetch, etc.) route their outbound
         // requests through the recorder/replayer.

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -1532,6 +1532,20 @@ impl EffectBridgeAdapter {
             "engine_v2",
             format!("Thread {}", context.thread_id),
         );
+        // notify_thread_id: stable thread id for routing (falls back to engine
+        // ThreadId for legacy channels). notify_response_id: full per-turn
+        // resp_... for tools that round-trip it to external services.
+        let notify_thread_id = context
+            .client_thread_id
+            .clone()
+            .unwrap_or_else(|| context.thread_id.to_string());
+        let mut job_metadata = serde_json::json!({
+            "notify_thread_id": notify_thread_id,
+        });
+        if let Some(ref rid) = context.client_response_id {
+            job_metadata["notify_response_id"] = serde_json::Value::String(rid.clone());
+        }
+        job_ctx.metadata = job_metadata;
         // Stamp the trace HTTP interceptor onto the per-call JobContext so
         // tools that respect it (http, web_fetch, etc.) route their outbound
         // requests through the recorder/replayer.
@@ -3148,6 +3162,58 @@ mod tests {
         }
     }
 
+    /// Test tool that captures the `notify_thread_id` and `notify_response_id`
+    /// it observes in `JobContext.metadata`. Lets tests assert that the
+    /// engine-v2 adapter plumbs the channel-supplied ids into the tool-visible
+    /// context (which is what `abound_send_wire` reads for outbound
+    /// notifications).
+    #[derive(Default)]
+    struct CapturedNotifyIds {
+        thread_id: Option<String>,
+        response_id: Option<String>,
+    }
+
+    struct NotifyThreadIdCaptureTool {
+        captured: Arc<tokio::sync::Mutex<CapturedNotifyIds>>,
+    }
+
+    #[async_trait]
+    impl Tool for NotifyThreadIdCaptureTool {
+        fn name(&self) -> &str {
+            "notify_thread_id_capture"
+        }
+
+        fn description(&self) -> &str {
+            "Test tool that captures notify_thread_id / notify_response_id"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object", "properties": {} })
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            let mut slot = self.captured.lock().await;
+            slot.thread_id = ctx
+                .metadata
+                .get("notify_thread_id")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            slot.response_id = ctx
+                .metadata
+                .get("notify_response_id")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            Ok(ToolOutput::success(
+                serde_json::json!({}),
+                std::time::Duration::from_millis(1),
+            ))
+        }
+    }
+
     fn lease() -> ironclaw_engine::CapabilityLease {
         ironclaw_engine::CapabilityLease {
             id: ironclaw_engine::types::capability::LeaseId::new(),
@@ -3183,6 +3249,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         }
     }
 
@@ -5034,6 +5102,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -5059,6 +5129,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         assert!(!should_reject_immediate_mission_create(&ctx));
@@ -5082,6 +5154,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -5105,6 +5179,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -5131,6 +5207,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         // Should NOT be rejected — "monitoring" implies scheduling intent.
@@ -5155,6 +5233,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         assert!(!should_reject_immediate_mission_create(&ctx));
@@ -5383,6 +5463,8 @@ mod tests {
                 gate_controller: ironclaw_engine::CancellingGateController::arc(),
                 call_approval_granted: false,
                 conversation_id: None,
+                client_thread_id: None,
+                client_response_id: None,
             }
         }
 
@@ -5668,6 +5750,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         let result = adapter.execute_action("http", params, &lease, &ctx).await;
@@ -5772,6 +5856,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         let result = adapter
@@ -6384,6 +6470,8 @@ mod tests {
             gate_controller: ironclaw_engine::CancellingGateController::arc(),
             call_approval_granted: false,
             conversation_id: None,
+            client_thread_id: None,
+            client_response_id: None,
         };
 
         let capabilities = adapter
@@ -8625,5 +8713,200 @@ Use this skill to set up a Pika meeting.
         ctx_diff.conversation_scope = Some(scope);
         let keys: Vec<_> = EffectBridgeAdapter::external_tool_catalog_keys(&ctx_diff).collect();
         assert_eq!(keys, vec![thread_id, ironclaw_engine::ThreadId(scope)]);
+    }
+
+    /// When the caller supplies `client_thread_id` (the Responses API thread
+    /// UUID decoded from `previous_response_id`), the adapter must stamp
+    /// that exact value into `JobContext.metadata["notify_thread_id"]` so
+    /// tools like `abound_send_wire` send the stable, client-visible id in
+    /// outbound notifications — not the engine's internal `ThreadId`.
+    #[tokio::test]
+    async fn notify_thread_id_uses_client_thread_id_when_set() {
+        use ironclaw_safety::SafetyConfig;
+
+        let captured = Arc::new(tokio::sync::Mutex::new(CapturedNotifyIds::default()));
+        let tools = Arc::new(ToolRegistry::new());
+        tools
+            .register(Arc::new(NotifyThreadIdCaptureTool {
+                captured: Arc::clone(&captured),
+            }))
+            .await;
+
+        let adapter = EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        )
+        .with_global_auto_approve(true);
+
+        let client_thread_id = "f3cd4882-f5b1-44ac-a47f-0ee5e742b0bd".to_string();
+        let engine_thread_id = ironclaw_engine::ThreadId::new();
+        let ctx = ironclaw_engine::ThreadExecutionContext {
+            thread_id: engine_thread_id,
+            thread_type: ironclaw_engine::types::thread::ThreadType::Foreground,
+            project_id: ironclaw_engine::ProjectId::new(),
+            user_id: "test_user".to_string(),
+            step_id: ironclaw_engine::StepId::new(),
+            current_call_id: Some("call_notify_1".to_string()),
+            source_channel: None,
+            user_timezone: None,
+            thread_goal: None,
+            available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
+            gate_controller: ironclaw_engine::CancellingGateController::arc(),
+            call_approval_granted: false,
+            conversation_id: None,
+            conversation_scope: None,
+            client_thread_id: Some(client_thread_id.clone()),
+            client_response_id: None,
+        };
+
+        adapter
+            .execute_action(
+                "notify_thread_id_capture",
+                serde_json::json!({}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("tool executed");
+
+        let observed = captured.lock().await;
+        assert_eq!(
+            observed.thread_id.as_deref(),
+            Some(client_thread_id.as_str()),
+            "tool should see the client-supplied thread id, not the engine id"
+        );
+        assert_ne!(
+            observed.thread_id.as_deref(),
+            Some(engine_thread_id.to_string().as_str()),
+            "tool must not see the engine's internal ThreadId when a client id was supplied"
+        );
+    }
+
+    /// Legacy callers (CLI, TUI, non-Responses-API channels) don't supply a
+    /// client thread id. The adapter must fall back to the engine's internal
+    /// `ThreadId` so existing tool behavior is preserved.
+    #[tokio::test]
+    async fn notify_thread_id_falls_back_to_engine_thread_id_when_absent() {
+        use ironclaw_safety::SafetyConfig;
+
+        let captured = Arc::new(tokio::sync::Mutex::new(CapturedNotifyIds::default()));
+        let tools = Arc::new(ToolRegistry::new());
+        tools
+            .register(Arc::new(NotifyThreadIdCaptureTool {
+                captured: Arc::clone(&captured),
+            }))
+            .await;
+
+        let adapter = EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        )
+        .with_global_auto_approve(true);
+
+        let engine_thread_id = ironclaw_engine::ThreadId::new();
+        adapter
+            .execute_action(
+                "notify_thread_id_capture",
+                serde_json::json!({}),
+                &lease(),
+                &exec_ctx(engine_thread_id, Some("call_notify_2")),
+            )
+            .await
+            .expect("tool executed");
+
+        let observed = captured.lock().await;
+        assert_eq!(
+            observed.thread_id.as_deref(),
+            Some(engine_thread_id.to_string().as_str()),
+            "fallback must be the engine ThreadId"
+        );
+        assert!(
+            observed.response_id.is_none(),
+            "notify_response_id must be absent when no client_response_id is supplied"
+        );
+    }
+
+    /// When the caller supplies `client_response_id` (the full per-turn
+    /// `resp_{response_uuid}{thread_uuid}` from the current Responses API
+    /// POST), the adapter must stamp that exact value into
+    /// `JobContext.metadata["notify_response_id"]` so tools can include it
+    /// in outbound notifications. The integrator can then paste it straight
+    /// into `previous_response_id` to continue the conversation after an
+    /// out-of-band approval callback.
+    #[tokio::test]
+    async fn notify_response_id_is_stamped_when_client_response_id_is_set() {
+        use ironclaw_safety::SafetyConfig;
+
+        let captured = Arc::new(tokio::sync::Mutex::new(CapturedNotifyIds::default()));
+        let tools = Arc::new(ToolRegistry::new());
+        tools
+            .register(Arc::new(NotifyThreadIdCaptureTool {
+                captured: Arc::clone(&captured),
+            }))
+            .await;
+
+        let adapter = EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        )
+        .with_global_auto_approve(true);
+
+        let client_thread_id = "f3cd4882-f5b1-44ac-a47f-0ee5e742b0bd".to_string();
+        let client_response_id =
+            "resp_70c9f2b6940e495c8cb5b5a290ca661df3cd4882f5b144aca47f0ee5e742b0bd".to_string();
+        let ctx = ironclaw_engine::ThreadExecutionContext {
+            thread_id: ironclaw_engine::ThreadId::new(),
+            thread_type: ironclaw_engine::types::thread::ThreadType::Foreground,
+            project_id: ironclaw_engine::ProjectId::new(),
+            user_id: "test_user".to_string(),
+            step_id: ironclaw_engine::StepId::new(),
+            current_call_id: Some("call_notify_resp".to_string()),
+            source_channel: None,
+            user_timezone: None,
+            thread_goal: None,
+            available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
+            gate_controller: ironclaw_engine::CancellingGateController::arc(),
+            call_approval_granted: false,
+            conversation_id: None,
+            conversation_scope: None,
+            client_thread_id: Some(client_thread_id.clone()),
+            client_response_id: Some(client_response_id.clone()),
+        };
+
+        adapter
+            .execute_action(
+                "notify_thread_id_capture",
+                serde_json::json!({}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("tool executed");
+
+        let observed = captured.lock().await;
+        assert_eq!(
+            observed.thread_id.as_deref(),
+            Some(client_thread_id.as_str()),
+            "notify_thread_id should carry the client thread uuid"
+        );
+        assert_eq!(
+            observed.response_id.as_deref(),
+            Some(client_response_id.as_str()),
+            "notify_response_id should carry the full per-turn resp_... id"
+        );
     }
 }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1208,6 +1208,16 @@ async fn execute_pending_gate_action(
         // Post-resolution replay never triggers a fresh inline gate;
         // the conversation routing is moot here.
         conversation_id: None,
+        client_thread_id: thread
+            .metadata
+            .get("client_thread_id")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        client_response_id: thread
+            .metadata
+            .get("client_response_id")
+            .and_then(|v| v.as_str())
+            .map(String::from),
     };
     let active_leases = state
         .thread_manager
@@ -4708,11 +4718,31 @@ async fn handle_with_engine_inner(
         .await;
 
     // Handle the message — spawns a new thread or injects into active one.
+    //
+    // `client_thread_id` / `client_response_id` are channel-explicit
+    // correlation ids: only channels that opt in (today: the Responses
+    // API handler) stamp them into message metadata. Reading from a
+    // dedicated metadata key — *not* `conversation_scope()` — avoids
+    // Telegram/Slack/web channels accidentally surfacing their external
+    // chat id as `notify_thread_id`, which would change v1-era tool
+    // behavior for those channels (engine ThreadId remains the fallback
+    // when the keys are absent).
+    //
     // On error we must clear the pre-execution slot we just installed:
     // without this, a failed `handle_user_message` (engine spawn / inject
     // failed before any thread_id was allocated) leaves a stale entry
     // keyed by user_id that would mis-route the next gate prompt for
     // the same user.
+    let client_thread_id = message
+        .metadata
+        .get("client_thread_id")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let client_response_id = message
+        .metadata
+        .get("client_response_id")
+        .and_then(|v| v.as_str())
+        .map(String::from);
     let thread_id = match state
         .conversation_manager
         .handle_user_message(
@@ -4723,6 +4753,8 @@ async fn handle_with_engine_inner(
             thread_config,
             validated_tz.as_ref().map(|tz| tz.name()),
             extra_metadata,
+            client_thread_id.as_deref(),
+            client_response_id.as_deref(),
         )
         .await
     {

--- a/src/channels/web/responses_api.rs
+++ b/src/channels/web/responses_api.rs
@@ -1242,24 +1242,33 @@ pub async fn create_response_handler(
             // Mirror the GET-path `conversation_belongs_to_user` check.
             // Without this, a foreign thread_uuid taints outbound
             // `notify_thread_id` and routes callbacks to the wrong user.
-            if let Some(store) = state.store.as_ref() {
-                let owns = store
-                    .conversation_belongs_to_user(thread, &user.user_id)
-                    .await
-                    .map_err(|e| {
-                        api_error(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("Failed to verify ownership: {e}"),
-                            "server_error",
-                        )
-                    })?;
-                if !owns {
-                    return Err(api_error(
-                        StatusCode::NOT_FOUND,
-                        format!("Response '{prev_id}' not found"),
-                        "invalid_request_error",
-                    ));
-                }
+            // Fail closed when the store is unavailable so a misconfigured
+            // deployment cannot silently bypass cross-tenant authz — matches
+            // the GET path's `SERVICE_UNAVAILABLE` behaviour rather than
+            // dropping the check on the floor.
+            let store = state.store.as_ref().ok_or_else(|| {
+                api_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Database not configured",
+                    "server_error",
+                )
+            })?;
+            let owns = store
+                .conversation_belongs_to_user(thread, &user.user_id)
+                .await
+                .map_err(|e| {
+                    api_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Failed to verify ownership: {e}"),
+                        "server_error",
+                    )
+                })?;
+            if !owns {
+                return Err(api_error(
+                    StatusCode::NOT_FOUND,
+                    format!("Response '{prev_id}' not found"),
+                    "invalid_request_error",
+                ));
             }
             thread
         }

--- a/src/channels/web/responses_api.rs
+++ b/src/channels/web/responses_api.rs
@@ -1239,6 +1239,31 @@ pub async fn create_response_handler(
         Some(prev_id) => {
             let (_prev_resp, thread) = decode_response_id(prev_id)
                 .map_err(|e| api_error(StatusCode::BAD_REQUEST, e, "invalid_request_error"))?;
+            // Cross-tenant authz: `thread_uuid` flows into outbound
+            // tool notifications as `notify_thread_id`. Without this
+            // check, user A could POST `previous_response_id` carrying
+            // user B's thread_uuid and tag outbound notifications with
+            // B's correlation id — callbacks would route back to B's
+            // conversation. Mirror the retrieve-path check at L1994.
+            if let Some(store) = state.store.as_ref() {
+                let owns = store
+                    .conversation_belongs_to_user(thread, &user.user_id)
+                    .await
+                    .map_err(|e| {
+                        api_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Failed to verify ownership: {e}"),
+                            "server_error",
+                        )
+                    })?;
+                if !owns {
+                    return Err(api_error(
+                        StatusCode::NOT_FOUND,
+                        format!("Response '{prev_id}' not found"),
+                        "invalid_request_error",
+                    ));
+                }
+            }
             thread
         }
         None => Uuid::new_v4(),

--- a/src/channels/web/responses_api.rs
+++ b/src/channels/web/responses_api.rs
@@ -1247,6 +1247,7 @@ pub async fn create_response_handler(
 
     // Each POST gets its own unique response UUID.
     let response_uuid = Uuid::new_v4();
+    let resp_id = encode_response_id(&response_uuid, &thread_uuid);
 
     // Register caller-supplied tools in the engine's per-thread external
     // tool catalog. The engine's `EffectBridgeAdapter` consults this on
@@ -1388,8 +1389,21 @@ pub async fn create_response_handler(
     }
 
     // Build the message for the agent loop.
+    //
+    // `client_thread_id` and `client_response_id` are channel-explicit
+    // opt-ins for the notify-correlation contract: stamping them here
+    // (and only here) is what makes `notify_thread_id` carry the stable
+    // Responses-API thread UUID and `notify_response_id` carry the
+    // per-turn `resp_…` for outbound notifications (see
+    // `abound_send_wire`). Other channels (Telegram, Slack, web) do not
+    // stamp these keys, so tools fall back to the engine `ThreadId` —
+    // matches v1 behavior. `response_id` / `thread_id` keys are also
+    // kept for legacy consumers.
     let mut metadata = serde_json::json!({
         "thread_id": &thread_id_str,
+        "response_id": &resp_id,
+        "client_thread_id": &thread_id_str,
+        "client_response_id": &resp_id,
         "user_id": &user.user_id,
         "source": "responses_api",
     });
@@ -1403,8 +1417,6 @@ pub async fn create_response_handler(
         Some(&thread_id_str),
         metadata,
     );
-
-    let resp_id = encode_response_id(&response_uuid, &thread_uuid);
     let model = req.model.clone();
     let stream = req.stream.unwrap_or(false);
     let user_id = user.user_id.clone();

--- a/src/channels/web/responses_api.rs
+++ b/src/channels/web/responses_api.rs
@@ -1239,12 +1239,9 @@ pub async fn create_response_handler(
         Some(prev_id) => {
             let (_prev_resp, thread) = decode_response_id(prev_id)
                 .map_err(|e| api_error(StatusCode::BAD_REQUEST, e, "invalid_request_error"))?;
-            // Cross-tenant authz: `thread_uuid` flows into outbound
-            // tool notifications as `notify_thread_id`. Without this
-            // check, user A could POST `previous_response_id` carrying
-            // user B's thread_uuid and tag outbound notifications with
-            // B's correlation id — callbacks would route back to B's
-            // conversation. Mirror the retrieve-path check at L1994.
+            // Mirror the GET-path `conversation_belongs_to_user` check.
+            // Without this, a foreign thread_uuid taints outbound
+            // `notify_thread_id` and routes callbacks to the wrong user.
             if let Some(store) = state.store.as_ref() {
                 let owns = store
                     .conversation_belongs_to_user(thread, &user.user_id)

--- a/src/channels/web/test_helpers.rs
+++ b/src/channels/web/test_helpers.rs
@@ -48,6 +48,7 @@ pub struct TestGatewayBuilder {
     llm_provider: Option<Arc<dyn ironclaw_llm::LlmProvider>>,
     user_id: String,
     tool_registry: Option<Arc<crate::tools::ToolRegistry>>,
+    store: Option<Arc<dyn crate::db::Database>>,
 }
 
 impl Default for TestGatewayBuilder {
@@ -57,6 +58,7 @@ impl Default for TestGatewayBuilder {
             llm_provider: None,
             user_id: "test-user".to_string(),
             tool_registry: None,
+            store: None,
         }
     }
 }
@@ -94,6 +96,16 @@ impl TestGatewayBuilder {
         self
     }
 
+    /// Attach a `Database` store. Required for handler paths that
+    /// touch persisted state (conversation ownership, history,
+    /// settings). Without this, `GatewayState.store` is `None` and
+    /// store-conditional checks (e.g. cross-tenant authz on
+    /// `create_response_handler`) silently no-op.
+    pub fn store(mut self, store: Arc<dyn crate::db::Database>) -> Self {
+        self.store = Some(store);
+        self
+    }
+
     /// Build the `Arc<GatewayState>` without starting a server.
     pub fn build(self) -> Arc<GatewayState> {
         Arc::new(GatewayState {
@@ -107,7 +119,7 @@ impl TestGatewayBuilder {
             log_level_handle: None,
             extension_manager: None,
             tool_registry: self.tool_registry,
-            store: None,
+            store: self.store,
             settings_cache: None,
             job_manager: None,
             prompt_queue: None,

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -1395,6 +1395,8 @@ async fn auth_resolution_retries_same_pending_action_without_second_pause() {
         gate_controller: ironclaw_engine::CancellingGateController::arc(),
         call_approval_granted: false,
         conversation_id: None,
+        client_thread_id: None,
+        client_response_id: None,
     };
 
     effects.mark_authenticated("http").await;
@@ -1561,6 +1563,8 @@ async fn approval_chains_directly_into_auth_for_install_flow() {
         gate_controller: ironclaw_engine::CancellingGateController::arc(),
         call_approval_granted: false,
         conversation_id: None,
+        client_thread_id: None,
+        client_response_id: None,
     };
     let install_result = effects
         .execute_action("tool_install", install_params, &lease, &exec_ctx)
@@ -1672,6 +1676,8 @@ async fn install_auth_resume_followed_by_aliased_tool_call_completes_without_han
         gate_controller: ironclaw_engine::CancellingGateController::arc(),
         call_approval_granted: false,
         conversation_id: None,
+        client_thread_id: None,
+        client_response_id: None,
     };
 
     effects.mark_authenticated("tool_install").await;

--- a/tests/engine_v2_sandbox_integration.rs
+++ b/tests/engine_v2_sandbox_integration.rs
@@ -98,6 +98,8 @@ fn make_context(project_id: ProjectId) -> ThreadExecutionContext {
         gate_controller: ironclaw_engine::CancellingGateController::arc(),
         call_approval_granted: false,
         conversation_id: None,
+        client_thread_id: None,
+        client_response_id: None,
     }
 }
 

--- a/tests/responses_api_cross_tenant.rs
+++ b/tests/responses_api_cross_tenant.rs
@@ -17,7 +17,6 @@
 //! libsql-gated: needs a real DB to seed conversations and to satisfy
 //! the fail-closed `state.store.is_some()` requirement.
 
-
 #![cfg(feature = "libsql")]
 
 use std::collections::HashMap;

--- a/tests/responses_api_cross_tenant.rs
+++ b/tests/responses_api_cross_tenant.rs
@@ -1,38 +1,22 @@
 //! Cross-tenant authz regression for `POST /v1/responses`.
 //!
-//! Z1 (zmanian, 2026-05-17): `create_response_handler` used to stamp
-//! whatever `thread_uuid` the caller's `previous_response_id` decoded
-//! to into the outbound `notify_thread_id` / `client_thread_id`
-//! metadata without checking conversation ownership. Alice could
-//! therefore POST a `previous_response_id` belonging to Bob and the
-//! agent loop would tag callbacks back to Bob.
+//! `create_response_handler` decodes a `thread_uuid` from the caller's
+//! `previous_response_id` and stamps it into outbound
+//! `notify_thread_id` / `client_thread_id`. Without an ownership check,
+//! Alice could POST Bob's `previous_response_id` and have callbacks
+//! tagged to Bob's thread. The handler mirrors the GET-path
+//! `conversation_belongs_to_user` check and 404s on a foreign id
+//! (404 not 403 — don't leak existence); it fails closed when
+//! `state.store` is `None`.
 //!
-//! PR #3669 fixed the handler to mirror the GET-path
-//! `conversation_belongs_to_user` check, returning 404 for foreign
-//! `previous_response_id` (404 — not 403 — so the endpoint doesn't
-//! leak existence). zmanian's re-review at HEAD `35dcd225` flagged
-//! that the new check no-ops when `state.store` is `None` (silent
-//! authz bypass on a misconfigured deployment) AND that the claimed
-//! cross-tenant integration test was missing.
+//! Drives the handler over real HTTP with two tokens:
+//!   1. Alice's token + Bob's response id ⇒ 404, no `IncomingMessage`.
+//!   2. Alice's token + her own response id ⇒ passes; message lands on
+//!      `msg_tx` (pins against over-rotating to "404 everything").
 //!
-//! This file is the missing test. Per `.claude/rules/testing.md`
-//! ("Test Through the Caller"), the assertion drives
-//! `create_response_handler` over real HTTP with a real
-//! `Database`-backed store and two distinct tokens. Two cases:
-//!
-//! 1. Foreign-`previous_response_id` (Alice's token, Bob's response
-//!    id) must reject with **404 `invalid_request_error`** and must
-//!    NOT enqueue an `IncomingMessage` on the agent channel.
-//! 2. Same-user `previous_response_id` (Alice's token, Alice's
-//!    response id) must pass the gate. We pin this by capturing the
-//!    `IncomingMessage` on `msg_tx` — proof the request reached the
-//!    agent-loop dispatch past the authz check. Without this pin a
-//!    future over-rotation that 404s every `previous_response_id`
-//!    would silently still satisfy case 1.
-//!
-//! Gated on `feature = "libsql"` because the suite needs a real DB
-//! backend to seed conversations into and to satisfy the new
-//! fail-closed `state.store.is_some()` requirement on the POST path.
+//! libsql-gated: needs a real DB to seed conversations and to satisfy
+//! the fail-closed `state.store.is_some()` requirement.
+
 
 #![cfg(feature = "libsql")]
 

--- a/tests/responses_api_cross_tenant.rs
+++ b/tests/responses_api_cross_tenant.rs
@@ -1,0 +1,272 @@
+//! Cross-tenant authz regression for `POST /v1/responses`.
+//!
+//! Z1 (zmanian, 2026-05-17): `create_response_handler` used to stamp
+//! whatever `thread_uuid` the caller's `previous_response_id` decoded
+//! to into the outbound `notify_thread_id` / `client_thread_id`
+//! metadata without checking conversation ownership. Alice could
+//! therefore POST a `previous_response_id` belonging to Bob and the
+//! agent loop would tag callbacks back to Bob.
+//!
+//! PR #3669 fixed the handler to mirror the GET-path
+//! `conversation_belongs_to_user` check, returning 404 for foreign
+//! `previous_response_id` (404 — not 403 — so the endpoint doesn't
+//! leak existence). zmanian's re-review at HEAD `35dcd225` flagged
+//! that the new check no-ops when `state.store` is `None` (silent
+//! authz bypass on a misconfigured deployment) AND that the claimed
+//! cross-tenant integration test was missing.
+//!
+//! This file is the missing test. Per `.claude/rules/testing.md`
+//! ("Test Through the Caller"), the assertion drives
+//! `create_response_handler` over real HTTP with a real
+//! `Database`-backed store and two distinct tokens. Two cases:
+//!
+//! 1. Foreign-`previous_response_id` (Alice's token, Bob's response
+//!    id) must reject with **404 `invalid_request_error`** and must
+//!    NOT enqueue an `IncomingMessage` on the agent channel.
+//! 2. Same-user `previous_response_id` (Alice's token, Alice's
+//!    response id) must pass the gate. We pin this by capturing the
+//!    `IncomingMessage` on `msg_tx` — proof the request reached the
+//!    agent-loop dispatch past the authz check. Without this pin a
+//!    future over-rotation that 404s every `previous_response_id`
+//!    would silently still satisfy case 1.
+//!
+//! Gated on `feature = "libsql"` because the suite needs a real DB
+//! backend to seed conversations into and to satisfy the new
+//! fail-closed `state.store.is_some()` requirement on the POST path.
+
+#![cfg(feature = "libsql")]
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ironclaw::channels::IncomingMessage;
+use ironclaw::channels::web::auth::{MultiAuthState, UserIdentity};
+use ironclaw::channels::web::platform::router::start_server;
+use ironclaw::channels::web::platform::state::GatewayState;
+use ironclaw::channels::web::test_helpers::TestGatewayBuilder;
+use ironclaw::db::Database;
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+const ALICE_TOKEN: &str = "tok-alice-responses-cross-tenant";
+const BOB_TOKEN: &str = "tok-bob-responses-cross-tenant";
+const ALICE_USER_ID: &str = "alice-responses-cross-tenant";
+const BOB_USER_ID: &str = "bob-responses-cross-tenant";
+
+struct ServerGuard {
+    shutdown: Option<oneshot::Sender<()>>,
+    _tmp: tempfile::TempDir,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+fn two_user_auth() -> MultiAuthState {
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        ALICE_TOKEN.to_string(),
+        UserIdentity {
+            user_id: ALICE_USER_ID.to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        },
+    );
+    tokens.insert(
+        BOB_TOKEN.to_string(),
+        UserIdentity {
+            user_id: BOB_USER_ID.to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        },
+    );
+    MultiAuthState::multi(tokens)
+}
+
+/// Spin up the gateway with a real libSQL store + msg_tx capture so
+/// tests can assert both the negative (no enqueue) and positive
+/// (enqueued past the gate) outcomes of the authz check.
+async fn start_test_server() -> (
+    SocketAddr,
+    Arc<GatewayState>,
+    Arc<dyn Database>,
+    mpsc::Receiver<IncomingMessage>,
+    ServerGuard,
+) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("responses_cross_tenant.db");
+    let backend = ironclaw::db::libsql::LibSqlBackend::new_local(&path)
+        .await
+        .expect("libsql backend");
+    backend.run_migrations().await.expect("migrations");
+    let db: Arc<dyn Database> = Arc::new(backend);
+
+    let (tx, rx) = mpsc::channel::<IncomingMessage>(16);
+    let state = TestGatewayBuilder::new()
+        .user_id(ALICE_USER_ID)
+        .msg_tx(tx)
+        .store(Arc::clone(&db))
+        .build();
+
+    let auth = two_user_auth();
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
+    let bound = start_server(addr, state.clone(), auth.into())
+        .await
+        .expect("start_server");
+    let shutdown = state.shutdown_tx.write().await.take();
+    (
+        bound,
+        state,
+        db,
+        rx,
+        ServerGuard {
+            shutdown,
+            _tmp: tmp,
+        },
+    )
+}
+
+async fn seed_conversation(db: &Arc<dyn Database>, user_id: &str) -> Uuid {
+    db.create_conversation_with_metadata(
+        "gateway",
+        user_id,
+        &serde_json::json!({ "title": format!("{user_id}'s thread") }),
+    )
+    .await
+    .expect("create conversation")
+}
+
+/// Reconstruct a Responses-API response id pointing at a given thread.
+/// Format is documented on `encode_response_id` in `responses_api.rs`:
+/// `resp_{response_uuid_hex}{thread_uuid_hex}` with both UUIDs in
+/// `simple()` (32-char, no-hyphen) form. We build it directly so the
+/// test does not need to be in the same crate as the private helper.
+fn make_response_id(thread_uuid: Uuid) -> String {
+    let response_uuid = Uuid::new_v4();
+    format!("resp_{}{}", response_uuid.simple(), thread_uuid.simple())
+}
+
+fn client() -> reqwest::Client {
+    // Short client-side timeout: the same-user path passes the gate
+    // and then waits for SSE events that never arrive in this fixture.
+    // We assert the captured msg on msg_tx, not the HTTP response.
+    reqwest::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+        .expect("http client")
+}
+
+/// Alice's token + Bob's `previous_response_id` ⇒ **404
+/// `invalid_request_error`**, and no `IncomingMessage` enqueued.
+/// Regression: pre-#3669 this returned 200 and tagged callbacks to
+/// Bob's `notify_thread_id`. Post-Z1, the new fail-closed gate must
+/// reject before any agent-loop side effects.
+#[tokio::test]
+async fn alice_with_bobs_previous_response_id_returns_404_and_does_not_enqueue() {
+    let (addr, _state, db, mut rx, _guard) = start_test_server().await;
+    let bob_thread = seed_conversation(&db, BOB_USER_ID).await;
+    let foreign_resp_id = make_response_id(bob_thread);
+    let url = format!("http://{}/v1/responses", addr);
+
+    let resp = client()
+        .post(&url)
+        .bearer_auth(ALICE_TOKEN)
+        .json(&serde_json::json!({
+            "model": "default",
+            "input": "hello",
+            "previous_response_id": foreign_resp_id,
+        }))
+        .send()
+        .await
+        .expect("send /v1/responses request");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "foreign previous_response_id must be rejected with 404",
+    );
+    let body: serde_json::Value = resp.json().await.expect("parse JSON body");
+    let kind = body
+        .get("error")
+        .and_then(|e| e.get("type"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+    assert_eq!(
+        kind, "invalid_request_error",
+        "error.type for foreign previous_response_id should be \
+         invalid_request_error, body={body}",
+    );
+
+    // No IncomingMessage may have been enqueued on the agent channel
+    // before the rejection.
+    match tokio::time::timeout(Duration::from_millis(200), rx.recv()).await {
+        Ok(Some(msg)) => panic!(
+            "rejected cross-tenant request must not enqueue an \
+             IncomingMessage; got metadata: {:?}",
+            msg.metadata
+        ),
+        Ok(None) => panic!("agent channel must not be closed"),
+        Err(_) => {} // timeout = nothing enqueued, expected
+    }
+}
+
+/// Same-user pin: Alice's token + Alice's own `previous_response_id`
+/// must pass the gate. Without this case, over-rotating the check to
+/// "404 every previous_response_id" would still satisfy the negative
+/// test above.
+///
+/// We assert the `IncomingMessage` lands on the captured `msg_tx`,
+/// which proves the request reached the agent-loop dispatch past the
+/// authz check. The HTTP response itself isn't asserted because the
+/// handler then waits for SSE events that never arrive in this
+/// fixture and the request times out from the client side.
+#[tokio::test]
+async fn alice_with_own_previous_response_id_passes_authz_and_enqueues() {
+    let (addr, _state, db, mut rx, _guard) = start_test_server().await;
+    let alice_thread = seed_conversation(&db, ALICE_USER_ID).await;
+    let own_resp_id = make_response_id(alice_thread);
+    let url = format!("http://{}/v1/responses", addr);
+
+    let http = client();
+    let request = async move {
+        // Don't care about the HTTP response — handler will time out
+        // waiting for SSE. We only care that the message reaches the
+        // agent channel, which happens before the SSE wait.
+        let _ = http
+            .post(&url)
+            .bearer_auth(ALICE_TOKEN)
+            .json(&serde_json::json!({
+                "model": "default",
+                "input": "hello",
+                "previous_response_id": own_resp_id,
+            }))
+            .send()
+            .await;
+    };
+    let captured = async {
+        tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("agent channel must receive a message within 2s")
+            .expect("agent channel must not be closed")
+    };
+
+    let (_, msg) = tokio::join!(request, captured);
+
+    let thread_id = msg
+        .metadata
+        .get("thread_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("captured message missing thread_id: {}", msg.metadata));
+    assert_eq!(
+        thread_id,
+        alice_thread.to_string(),
+        "same-user request must reach the agent loop carrying Alice's \
+         thread_uuid, proving the authz gate passed",
+    );
+}

--- a/tests/responses_api_path_prefix.rs
+++ b/tests/responses_api_path_prefix.rs
@@ -339,28 +339,77 @@ async fn external_tools_rejected_when_engine_v2_disabled() {
 
 /// `function_call_output` items are a resume signal: they must be
 /// matched against a pending external-tool gate for the resolved
-/// thread. Without one (e.g. because the caller fabricates a
-/// `previous_response_id` or the gate already expired), the handler
-/// must reject with 400 instead of silently sending the resume into a
-/// fresh thread.
+/// thread. Without one (the caller resumes against a thread that has
+/// no live external-tool gate, or the gate already expired), the
+/// handler must reject with 400 instead of silently sending the
+/// resume into a fresh thread.
+///
+/// Z1 reconciliation note (#3669 zmanian re-review):
+/// `create_response_handler` now fail-closes the
+/// `conversation_belongs_to_user` check whenever `previous_response_id`
+/// is present. The pending-gate branch is reached only *after* that
+/// check passes, so this test seeds a real same-user conversation and
+/// builds the `previous_response_id` against its thread uuid. Before
+/// the Z1 fix, a wholly-fabricated id used to flow through to the
+/// pending-gate check; now that path is correctly blocked at the
+/// authz layer (see `tests/responses_api_cross_tenant.rs`).
+#[cfg(feature = "libsql")]
 #[tokio::test]
 async fn resume_without_pending_gate_returns_400() {
-    let (addr, _state, _guard) = start_test_server().await;
-    let url = format!("http://{}/api/v1/responses", addr);
+    use ironclaw::db::Database;
 
-    // Synthesize a wire-valid previous_response_id (resp_<32hex><32hex>)
-    // that names a thread the gateway has never seen. The handler
-    // accepts the format, looks for a pending gate, finds none, and
-    // must respond 400 — not silently drop the function_call_output
-    // and start a fresh turn against the thread.
-    let fake_prev = format!("resp_{}{}", "0".repeat(32), "1".repeat(32));
+    // Spin up a store-backed gateway so the authz check passes. We
+    // can't use the shared `start_test_server()` helper because it
+    // builds a store-less `GatewayState`.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("resume_pending_gate.db");
+    let backend = ironclaw::db::libsql::LibSqlBackend::new_local(&path)
+        .await
+        .expect("libsql backend");
+    backend.run_migrations().await.expect("migrations");
+    let db: Arc<dyn Database> = Arc::new(backend);
+
+    // Seed a conversation owned by `test-user` so the authz check
+    // passes — we want to exercise the *pending-gate* branch, not the
+    // (now separately tested) cross-tenant 404 branch.
+    let thread_uuid = db
+        .create_conversation_with_metadata(
+            "gateway",
+            "test-user",
+            &serde_json::json!({ "title": "resume w/o pending gate" }),
+        )
+        .await
+        .expect("seed conversation");
+
+    let state = TestGatewayBuilder::new()
+        .user_id("test-user")
+        .store(Arc::clone(&db))
+        .build();
+    let auth = MultiAuthState::single(AUTH_TOKEN.to_string(), "test-user".to_string());
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("addr");
+    let bound = start_server(addr, state.clone(), auth.into())
+        .await
+        .expect("start_server");
+    let shutdown = state.shutdown_tx.write().await.take();
+    let _guard = ServerGuard { shutdown };
+
+    let url = format!("http://{}/api/v1/responses", bound);
+    // Build a wire-valid previous_response_id pointing at Alice's
+    // seeded thread. The handler decodes it, authz passes (same
+    // user), and the pending-gate check fires next — there is no
+    // live external-tool gate for this thread, so 400.
+    let prev_id = format!(
+        "resp_{}{}",
+        uuid::Uuid::new_v4().simple(),
+        thread_uuid.simple()
+    );
 
     let resp = client()
         .post(&url)
         .bearer_auth(AUTH_TOKEN)
         .json(&serde_json::json!({
             "model": "default",
-            "previous_response_id": fake_prev,
+            "previous_response_id": prev_id,
             "input": [
                 {
                     "type": "function_call_output",


### PR DESCRIPTION
## Summary

Restores engine v1's contract that every tool call receives `notify_thread_id` (and now `notify_response_id`) in its `JobContext.metadata`, so tools can correlate outbound side-effects — external API calls, notifications, approval callbacks — with the originating conversation turn.

## Why this matters

A customer integration that posts a notification to their own backend and expects a callback to resume the conversation later needs a stable identifier in the outbound payload. The customer pastes that identifier back into `previous_response_id` when the eventual approval (or other async signal) lands, and IronClaw routes it to the correct turn.

Engine v1 produced these identifiers automatically via `chat_tool_execution_metadata()` in `src/agent/agent_loop.rs`. Builtin tools like `message_tool` and `job_tool` already depend on `notify_thread_id`; v1 just worked.

Engine v2 was silently dropping them: `EffectBridgeAdapter::execute_action` built `JobContext` with empty metadata. Customers on engine v2 saw outbound notifications go out with empty `notify_thread_id`, so the remote system would accept the POST but couldn't route the eventual callback back to the right turn — round-trip broken.

## What changed

**Engine surface** — two new optional fields on `ThreadExecutionContext`:
- `client_thread_id`: stable per-thread identifier supplied by the channel
- `client_response_id`: per-turn identifier (e.g. the full Responses API `resp_…`); changes every turn

Both `None` for callers that don't supply them — legacy CLI/REPL/TUI still works.

**Plumbing chain** (channel → tool):
- `responses_api.rs` stamps the per-turn `resp_…` and the thread UUID into dedicated `IncomingMessage.metadata` keys (`client_response_id`, `client_thread_id`) before dispatch
- `router.rs` reads both from the explicit metadata keys (NOT `conversation_scope()`) and passes them to `ConversationManager::handle_user_message`. Other channels (Telegram, Slack, web) do not stamp these keys, so they fall back to the engine `ThreadId` — v1 behavior preserved
- `ConversationManager` stores them into `Thread.metadata` on spawn (and refreshes the per-turn `client_response_id` on inject/resume so a long-lived thread keeps current correlation); a different `client_thread_id` on a later turn is logged as drift, stored value kept
- The orchestrator helper `thread_execution_context()` reads both back into the context for every tool execution
- `EffectBridgeAdapter::execute_action` translates them into `JobContext.metadata.notify_thread_id` and `notify_response_id`, matching v1's contract

**Fallbacks**: when no `client_thread_id` is supplied (CLI/REPL/legacy channels), `notify_thread_id` falls back to the engine's internal `ThreadId.to_string()` so existing tool behavior is preserved. `notify_response_id` is omitted entirely when no per-turn id is supplied.

## Review feedback addressed (zmanian + Copilot)

- **Z1 — cross-tenant authz on POST `create_response_handler`** (gate). User A POSTing `previous_response_id` whose decoded `thread_uuid` belongs to user B now returns `404` before the agent dispatches, mirroring the GET-path `conversation_belongs_to_user` check. Without this, `notify_thread_id` would carry user B's id and route the eventual async callback to B's conversation. `docs/api/responses.mdx` (line 393) is updated to match — both GET and POST now return 404 on cross-tenant access.
- **Z1 fail-closed follow-up** (re-review at `35dcd225`). zmanian flagged that the new check was wrapped in `if let Some(store) = state.store.as_ref()` and would silently no-op when the store was unconfigured — exactly the failure mode the new `TestGatewayBuilder::store()` setter docstring calls out. The POST path now matches the GET path's behaviour: returns `503 SERVICE_UNAVAILABLE` instead of dropping the authz check, so a misconfigured production deployment is a hard fail rather than a quiet bypass.
- **Z1 regression test** (re-review at `35dcd225`). The earlier "tests added" claim referred to the `.store()` builder only — the actual cross-tenant test was missing. It now lives at `tests/responses_api_cross_tenant.rs` and drives the full router with two users: (a) Alice + Bob's `previous_response_id` ⇒ `404 invalid_request_error` AND no `IncomingMessage` enqueued on the agent channel, (b) Alice + her own `previous_response_id` reaches the agent loop (captured on `msg_tx` carrying her `thread_uuid`) — the over-rotation pin Zaki asked for. `tests/responses_api_path_prefix.rs::resume_without_pending_gate_returns_400` was also updated to seed a same-user conversation so the pending-gate branch is still exercised once the authz check passes.
- **C1 — channel fallback** (gate). The router no longer reads `client_thread_id` via `message.conversation_scope()`, which falls back to `thread_id` for Telegram / Slack / web. It now reads only the dedicated `metadata.client_thread_id` key, which only the Responses API channel stamps. Telegram / Slack / web tools see the engine `ThreadId` exactly as in v1.
- **C2 — drift detection.** When a later turn supplies a different `client_thread_id` for the same conversation (silent contract violation per the spawn-only invariant), a `warn!` line is emitted with the stored and incoming ids; the stored value is kept so the round-trip remains stable.
- **Z3/C3 — drift-check DB round-trip** (re-review). The drift check now caches the spawn-time `client_thread_id` on the in-memory `RunningThread` and reads it via `ThreadManager::running_client_thread_id()`, so the inject path no longer issues a `load_thread` per injected message; the store load remains only as a fallback for threads resumed after a restart (not in the running set). The fallback is annotated `silent-ok`.
- **Z4/C4 + `effect_adapter.rs` clobber** (re-review). `EffectBridgeAdapter` now *merges* `notify_thread_id` / `notify_response_id` into `JobContext.metadata` (promoting the `Null`-initialized map to an object first) instead of replacing the whole map, so a future upstream caller that pre-populates `JobContext.metadata` can't be silently clobbered.
- **Test infra:** `TestGatewayBuilder::store()` setter added so handler tests can wire a real `Database`; the libsql in-memory backend doesn't share state across connections, so the new test uses `LibSqlBackend::new_local` with a tempdir per `src/db/CLAUDE.md`.

## Rebase note

Rebased onto current `main` (`4fea8b354`). Conflict resolution kept both the `extra_initial_metadata` parameter introduced on main and the `client_thread_id` / `client_response_id` parameters introduced on this branch — they serve independent purposes (`extra_initial_metadata` for the bridge's external tool catalog scoped to `conversation_scope`, the new pair for outbound notification correlation). PR's `ThreadExecutionContext` literals now include the `conversation_scope: None` field main added.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `notify_thread_id_uses_client_thread_id_when_set` — tool sees the channel-supplied thread id
- [x] `notify_thread_id_falls_back_to_engine_thread_id_when_absent` — legacy callers still get the engine ThreadId
- [x] `notify_response_id_is_stamped_when_client_response_id_is_set` — per-turn `resp_…` reaches the tool
- [x] `tests/responses_api_cross_tenant::alice_with_bobs_previous_response_id_returns_404_and_does_not_enqueue` — Z1 regression: cross-tenant POST 404s before agent dispatch and never enqueues
- [x] `tests/responses_api_cross_tenant::alice_with_own_previous_response_id_passes_authz_and_enqueues` — Z1 over-rotation pin: same-user resume reaches the agent loop carrying the right `thread_uuid`
- [x] `tests/responses_api_path_prefix::resume_without_pending_gate_returns_400` — exercises the pending-gate branch *after* the new authz check passes
- [x] `cargo test -p ironclaw_engine` — full engine suite (527 passing)
- [x] `cargo test --lib` — full library suite

## Deferred (acknowledged, not in this PR)

- **Newtypes for the two ids.** `client_thread_id` / `client_response_id` remain `Option<String>` on `ThreadExecutionContext`. Wrapping them in `ClientThreadId(Uuid)` / `ClientResponseId` — to make swapping the two a compile error, and to disambiguate `client_thread_id` from the engine's own `ThreadId` (both wrap a `Uuid` but mean different things) — per `.claude/rules/types.md` is a low-priority follow-up. The intent is recorded as `TODO`s on the fields in `crates/ironclaw_engine/src/traits/effect.rs`. Deferred to keep this PR scoped to restoring the v1 `notify_thread_id` contract; **not filed as a standalone issue** (no owner/schedule yet — the code TODOs plus this note are the record).
- **`tracing-test` assertion on the drift `warn!`.** The inject/resume `client_thread_id`-drift warning isn't pinned by a `tracing-test` assertion. Nice-to-have; the in-memory cache above is the substantive part of that re-review item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
