### PR TITLE
feat(run-state): unified put/get for filesystem stores

### DIFF
--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ironclaw_filesystem::{FilesystemError, RootFilesystem};
+use ironclaw_filesystem::{CasExpectation, ContentType, Entry, FilesystemError, RootFilesystem};
 use ironclaw_host_api::{
     AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, HostApiError, InvocationId,
     MissionId, ProjectId, ResourceScope, TenantId, ThreadId, UserId, VirtualPath,
@@ -553,8 +553,11 @@ where
 
     async fn write_record(&self, record: &RunRecord) -> Result<(), RunStateError> {
         let path = run_record_path(&record.scope, record.invocation_id)?;
-        let bytes = serialize_pretty(record)?;
-        self.filesystem.write_file(&path, &bytes).await?;
+        let body = serialize_pretty(record)?;
+        let entry = Entry::bytes(body).with_content_type(ContentType::json());
+        self.filesystem
+            .put(&path, entry, CasExpectation::Any)
+            .await?;
         Ok(())
     }
 }
@@ -670,12 +673,10 @@ where
         invocation_id: InvocationId,
     ) -> Result<Option<RunRecord>, RunStateError> {
         let path = run_record_path(scope, invocation_id)?;
-        let bytes = match self.filesystem.read_file(&path).await {
-            Ok(bytes) => bytes,
-            Err(error) if is_not_found(&error) => return Ok(None),
-            Err(error) => return Err(error.into()),
+        let Some(versioned) = self.filesystem.get(&path).await? else {
+            return Ok(None);
         };
-        let record = deserialize::<RunRecord>(&bytes)?;
+        let record = deserialize::<RunRecord>(&versioned.entry.body)?;
         if same_scope_owner(&record.scope, scope) {
             Ok(Some(record))
         } else {
@@ -696,12 +697,10 @@ where
         let mut records = Vec::new();
         for entry in entries {
             if entry.name.ends_with(".json") {
-                let bytes = match self.filesystem.read_file(&entry.path).await {
-                    Ok(bytes) => bytes,
-                    Err(error) if is_not_found(&error) => continue,
-                    Err(error) => return Err(error.into()),
+                let Some(versioned) = self.filesystem.get(&entry.path).await? else {
+                    continue;
                 };
-                let record = deserialize::<RunRecord>(&bytes)?;
+                let record = deserialize::<RunRecord>(&versioned.entry.body)?;
                 if same_scope_owner(&record.scope, scope) {
                     records.push(record);
                 }
@@ -754,8 +753,11 @@ where
 
     async fn write_record(&self, record: &ApprovalRecord) -> Result<(), RunStateError> {
         let path = approval_record_path(&record.scope, record.request.id)?;
-        let bytes = serialize_pretty(record)?;
-        self.filesystem.write_file(&path, &bytes).await?;
+        let body = serialize_pretty(record)?;
+        let entry = Entry::bytes(body).with_content_type(ContentType::json());
+        self.filesystem
+            .put(&path, entry, CasExpectation::Any)
+            .await?;
         Ok(())
     }
 }
@@ -793,12 +795,10 @@ where
         request_id: ApprovalRequestId,
     ) -> Result<Option<ApprovalRecord>, RunStateError> {
         let path = approval_record_path(scope, request_id)?;
-        let bytes = match self.filesystem.read_file(&path).await {
-            Ok(bytes) => bytes,
-            Err(error) if is_not_found(&error) => return Ok(None),
-            Err(error) => return Err(error.into()),
+        let Some(versioned) = self.filesystem.get(&path).await? else {
+            return Ok(None);
         };
-        let record = deserialize::<ApprovalRecord>(&bytes)?;
+        let record = deserialize::<ApprovalRecord>(&versioned.entry.body)?;
         if same_scope_owner(&record.scope, scope) {
             Ok(Some(record))
         } else {
@@ -860,12 +860,10 @@ where
         let mut records = Vec::new();
         for entry in entries {
             if entry.name.ends_with(".json") {
-                let bytes = match self.filesystem.read_file(&entry.path).await {
-                    Ok(bytes) => bytes,
-                    Err(error) if is_not_found(&error) => continue,
-                    Err(error) => return Err(error.into()),
+                let Some(versioned) = self.filesystem.get(&entry.path).await? else {
+                    continue;
                 };
-                let record = deserialize::<ApprovalRecord>(&bytes)?;
+                let record = deserialize::<ApprovalRecord>(&versioned.entry.body)?;
                 if same_scope_owner(&record.scope, scope) {
                     records.push(record);
                 }

--- a/crates/ironclaw_run_state/tests/run_state_contract.rs
+++ b/crates/ironclaw_run_state/tests/run_state_contract.rs
@@ -843,6 +843,31 @@ impl RootFilesystem for ConcurrentMissingReadFilesystem {
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.create_dir_all(path).await
     }
+
+    // After PR #3659 the consumer's existence-check / read path goes
+    // through `get`, not `read_file`. Mirror the missing-read race
+    // behavior here so the duplicate-start serialization test still
+    // exercises the concurrent-create window it was designed for.
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: ironclaw_filesystem::Entry,
+        cas: ironclaw_filesystem::CasExpectation,
+    ) -> Result<ironclaw_filesystem::RecordVersion, FilesystemError> {
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Option<ironclaw_filesystem::VersionedEntry>, FilesystemError> {
+        let result = self.inner.get(path).await;
+        if matches!(result, Ok(None)) && Self::should_race_missing_read(path) {
+            self.missing_reads.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        result
+    }
 }
 
 struct DisappearingApprovalReadFilesystem {
@@ -900,6 +925,31 @@ impl RootFilesystem for DisappearingApprovalReadFilesystem {
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.create_dir_all(path).await
+    }
+
+    // After PR #3659 the approval-listing read path goes through `get`,
+    // not `read_file`. Mirror the fault injection so the
+    // disappearing-approval test still exercises its intended path.
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: ironclaw_filesystem::Entry,
+        cas: ironclaw_filesystem::CasExpectation,
+    ) -> Result<ironclaw_filesystem::RecordVersion, FilesystemError> {
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Option<ironclaw_filesystem::VersionedEntry>, FilesystemError> {
+        if path.as_str().contains("/approvals/")
+            && path.as_str().ends_with(".json")
+            && self.fail_next_approval_read.swap(false, Ordering::SeqCst)
+        {
+            return Ok(None);
+        }
+        self.inner.get(path).await
     }
 }
 


### PR DESCRIPTION
## Summary

Stacked on #3671. Mirrors the ironclaw_processes (#3666) and ironclaw_authorization (#3671) migrations. Switches all `read_file`/`write_file` calls in `FilesystemRunStateStore` and `FilesystemApprovalRequestStore` to the unified `get`/`put` ops with `Entry::bytes` + `CasExpectation::Any`. On-disk JSON layout unchanged.

The per-record `filesystem_record_lock` keeps transition serialization within a single instance; production shared roots still need the SQL backends or explicit CAS per the crate guardrail.

## Test plan

- [x] `cargo test -p ironclaw_run_state` — **32 tests pass** (6 lib + 26 contract)
- [x] `cargo clippy -p ironclaw_run_state --tests` — clean
- [x] `cargo fmt --check` — clean

## Stacked PR

Base is `reborn/fs-authorization` (#3671). Merge order: foundation → port → indexer → processes → outbound → authorization → this.