### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.2](https://github.com/nearai/ironclaw/compare/ironclaw-v0.28.1...ironclaw-v0.28.2) - 2026-05-14
+
+### Fixed
+
+- *(extensions)* restore chat-driven `tool_install` + fix double-invoke + auto-approve footgun ([#3559](https://github.com/nearai/ironclaw/pull/3559))
+
+### Changed
+
+- *(llm)* hide provider-specific auth, model fetch, and embeddings config behind facades ([#3416](https://github.com/nearai/ironclaw/pull/3416))
+
+### Tests
+
+- *(e2e)* unxfail two auth-matrix tests now that contracts match ([#3589](https://github.com/nearai/ironclaw/pull/3589))
+- *(e2e)* make Skills lifecycle deterministic ([#3309](https://github.com/nearai/ironclaw/pull/3309))
+
 ## [0.28.1](https://github.com/nearai/ironclaw/compare/ironclaw-v0.28.0...ironclaw-v0.28.1) - 2026-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 
 [package]
 name = "ironclaw"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2024"
 rust-version = "1.92"
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"


### PR DESCRIPTION
## 🤖 New release

* `ironclaw`: 0.28.1 -> 0.28.2 (manual bump — same pattern as PR #3388)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ironclaw`

<blockquote>

## [0.28.2](https://github.com/nearai/ironclaw/compare/ironclaw-v0.28.1...ironclaw-v0.28.2) - 2026-05-14

### Fixed

- *(extensions)* restore chat-driven `tool_install` + fix double-invoke + auto-approve footgun ([#3559](https://github.com/nearai/ironclaw/pull/3559))

### Changed

- *(llm)* hide provider-specific auth, model fetch, and embeddings config behind facades ([#3416](https://github.com/nearai/ironclaw/pull/3416))

### Tests

- *(e2e)* unxfail two auth-matrix tests now that contracts match ([#3589](https://github.com/nearai/ironclaw/pull/3589))
- *(e2e)* make Skills lifecycle deterministic ([#3309](https://github.com/nearai/ironclaw/pull/3309))

</blockquote>

</p></details>

---
This PR mirrors the 0.28.1 manual-bump pattern (#3388). `release-plz` doesn't auto-bump `ironclaw` because it's \`publish = false\` (the binary's git-only \`monty\` dep blocks crates.io), so the maintainer-driven manual bump is the established path for cutting an \`ironclaw-v*\` tag. Once this merges, the tag triggers \`cargo-dist\` (\`release.yml\`) to build binaries and create the GitHub Release.

No subcrate bumps this cycle — none of the four commits since v0.28.1 touched \`crates/ironclaw_common/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)