### PR TITLE
feat:[extensions] Add first-party HTTP egress tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4323,6 +4323,7 @@ name = "ironclaw_host_runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "blake3",
  "chrono",
  "chrono-tz",

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -88,6 +88,17 @@ pub struct RuntimeHttpEgressResponse {
     pub redaction_applied: bool,
 }
 
+pub const RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED: &str = "response_body_limit_exceeded";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeHttpEgressReasonCode {
+    CredentialUnavailable,
+    RequestDenied,
+    NetworkError,
+    ResponseError,
+    ResponseBodyLimitExceeded,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum RuntimeHttpEgressError {
     #[error("runtime HTTP credential error: {reason}")]
@@ -131,13 +142,30 @@ impl RuntimeHttpEgressError {
         }
     }
 
+    pub fn reason_code(&self) -> RuntimeHttpEgressReasonCode {
+        match self {
+            Self::Credential { .. } => RuntimeHttpEgressReasonCode::CredentialUnavailable,
+            Self::Request { .. } => RuntimeHttpEgressReasonCode::RequestDenied,
+            Self::Network { reason, .. } | Self::Response { reason, .. }
+                if reason == RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED =>
+            {
+                RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded
+            }
+            Self::Network { .. } => RuntimeHttpEgressReasonCode::NetworkError,
+            Self::Response { .. } => RuntimeHttpEgressReasonCode::ResponseError,
+        }
+    }
+
     /// Stable reason token safe to expose to runtime/plugin callers.
     pub fn stable_runtime_reason(&self) -> &'static str {
-        match self {
-            Self::Credential { .. } => "credential_unavailable",
-            Self::Request { .. } => "request_denied",
-            Self::Network { .. } => "network_error",
-            Self::Response { .. } => "response_error",
+        match self.reason_code() {
+            RuntimeHttpEgressReasonCode::CredentialUnavailable => "credential_unavailable",
+            RuntimeHttpEgressReasonCode::RequestDenied => "request_denied",
+            RuntimeHttpEgressReasonCode::NetworkError => "network_error",
+            RuntimeHttpEgressReasonCode::ResponseError => "response_error",
+            RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
+                RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED
+            }
         }
     }
 }

--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -19,6 +19,9 @@ pub struct RuntimeHttpEgressRequest {
     pub url: String,
     pub headers: Vec<(String, String)>,
     pub body: Vec<u8>,
+    /// Request-carried fallback policy used only by legacy/test egress services.
+    /// Production first-party dispatch stages network policy in the host service
+    /// before this request is executed, so the field is ignored on that path.
     pub network_policy: NetworkPolicy,
     /// Host-derived credential injection plan.
     ///

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -11,6 +11,7 @@ libsql = ["dep:libsql", "ironclaw_filesystem/libsql", "ironclaw_resources/libsql
 
 [dependencies]
 async-trait = "0.1"
+base64 = "0.22.1"
 blake3 = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = "0.10"

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -17,6 +17,10 @@ use ironclaw_host_api::{
 use serde_json::Value;
 
 /// Already-authorized first-party capability dispatch input.
+///
+/// This is host-composed first-party surface, so the struct is `non_exhaustive`:
+/// external crates may inspect fields in custom handlers but must not construct
+/// it with a struct literal.
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct FirstPartyCapabilityRequest {

--- a/crates/ironclaw_host_runtime/src/first_party.rs
+++ b/crates/ironclaw_host_runtime/src/first_party.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
     CapabilityId, MountView, ResourceEstimate, ResourceScope, ResourceUsage,
-    RuntimeDispatchErrorKind,
+    RuntimeDispatchErrorKind, RuntimeHttpEgress,
 };
 use serde_json::Value;
 
@@ -25,6 +25,7 @@ pub struct FirstPartyCapabilityRequest {
     pub estimate: ResourceEstimate,
     pub mounts: Option<MountView>,
     pub filesystem: Arc<dyn RootFilesystem>,
+    pub runtime_http_egress: Option<Arc<dyn RuntimeHttpEgress>>,
     pub input: Value,
 }
 
@@ -37,6 +38,13 @@ impl fmt::Debug for FirstPartyCapabilityRequest {
             .field("estimate", &self.estimate)
             .field("mounts", &self.mounts)
             .field("filesystem", &"<root filesystem>")
+            .field(
+                "runtime_http_egress",
+                &self
+                    .runtime_http_egress
+                    .as_ref()
+                    .map(|_| "<runtime http egress>"),
+            )
             .field("input", &self.input)
             .finish()
     }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -3,7 +3,8 @@ use ironclaw_extensions::{CapabilityManifest, ExtensionError};
 use ironclaw_host_api::{
     CapabilityId, EffectKind, NetworkMethod, NetworkPolicy, PermissionMode, ResourceCeiling,
     ResourceEstimate, ResourceProfile, ResourceUsage, RuntimeDispatchErrorKind,
-    RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeKind, SandboxQuota,
+    RuntimeHttpEgressError, RuntimeHttpEgressReasonCode, RuntimeHttpEgressRequest, RuntimeKind,
+    SandboxQuota,
 };
 use serde_json::{Map, Value, json};
 
@@ -13,7 +14,7 @@ use super::{FIRST_PARTY_MAX_OUTPUT_BYTES, input_error};
 
 pub const HTTP_CAPABILITY_ID: &str = "builtin.http";
 
-const DEFAULT_HTTP_TIMEOUT_MS: u32 = 30_000;
+const DEFAULT_HTTP_TIMEOUT_MS: u32 = 10_000;
 const MAX_HTTP_TIMEOUT_MS: u32 = 30_000;
 const DEFAULT_RESPONSE_BODY_LIMIT: u64 = 512 * 1024;
 const MAX_RESPONSE_BODY_LIMIT: u64 = 700 * 1024;
@@ -63,7 +64,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                     ]
                 },
                 "body": {
-                    "description": "UTF-8 string or JSON value to send as the request body"
+                    "description": "UTF-8 string or JSON value to send as the request body. No Content-Type is set automatically; pass it via headers."
                 },
                 "body_base64": {
                     "type": "string",
@@ -71,7 +72,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                 },
                 "response_body_limit": {
                     "type": "integer",
-                    "description": "Maximum response body bytes to return. Omit to use the built-in fail-closed default cap; values must be at least 1.",
+                    "description": "Maximum raw response body bytes to return. Omit to use the built-in fail-closed default cap; values must be at least 1. Binary responses are base64-encoded and must still fit the first-party output ceiling.",
                     "minimum": 1,
                     "maximum": MAX_RESPONSE_BODY_LIMIT
                 },
@@ -133,7 +134,12 @@ pub(super) async fn dispatch(
     };
     let response = tokio::task::spawn_blocking(move || egress.execute(http_request))
         .await
-        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend))?
+        .map_err(|error| {
+            if error.is_panic() {
+                tracing::error!("first-party HTTP egress worker panicked");
+            }
+            FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend)
+        })?
         .map_err(http_error)?;
     let mut output = Map::new();
     output.insert("status".to_string(), json!(response.status));
@@ -218,12 +224,9 @@ fn headers(input: &Value) -> Result<Vec<(String, String)>, FirstPartyCapabilityE
 }
 
 fn header_pair(name: &str, value: &str) -> Result<(String, String), FirstPartyCapabilityError> {
-    if name.trim().is_empty()
+    if !valid_header_name(name)
         || name.len() > MAX_HTTP_HEADER_NAME_BYTES
         || value.len() > MAX_HTTP_HEADER_VALUE_BYTES
-        || name
-            .chars()
-            .any(|character| matches!(character, '\r' | '\n' | '\0'))
         || value
             .chars()
             .any(|character| matches!(character, '\r' | '\n' | '\0'))
@@ -231,6 +234,33 @@ fn header_pair(name: &str, value: &str) -> Result<(String, String), FirstPartyCa
         return Err(input_error());
     }
     Ok((name.to_string(), value.to_string()))
+}
+
+fn valid_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|byte| {
+            matches!(
+                byte,
+                b'0'..=b'9'
+                    | b'A'..=b'Z'
+                    | b'a'..=b'z'
+                    | b'!'
+                    | b'#'
+                    | b'$'
+                    | b'%'
+                    | b'&'
+                    | b'\''
+                    | b'*'
+                    | b'+'
+                    | b'-'
+                    | b'.'
+                    | b'^'
+                    | b'_'
+                    | b'`'
+                    | b'|'
+                    | b'~'
+            )
+        })
 }
 
 fn body(input: &Value) -> Result<Vec<u8>, FirstPartyCapabilityError> {
@@ -296,14 +326,14 @@ fn response_headers(headers: Vec<(String, String)>) -> Value {
 }
 
 fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
-    let kind = match &error {
-        RuntimeHttpEgressError::Credential { .. } => RuntimeDispatchErrorKind::Client,
-        RuntimeHttpEgressError::Request { .. } => RuntimeDispatchErrorKind::InputEncode,
-        RuntimeHttpEgressError::Network { reason, .. } if response_body_limit_reason(reason) => {
+    let kind = match error.reason_code() {
+        RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
+        RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
+        RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
+        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OutputDecode,
+        RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
             RuntimeDispatchErrorKind::OutputTooLarge
         }
-        RuntimeHttpEgressError::Network { .. } => RuntimeDispatchErrorKind::NetworkDenied,
-        RuntimeHttpEgressError::Response { reason, .. } => response_error_kind(reason),
     };
     tracing::debug!(
         runtime_http_reason = error.stable_runtime_reason(),
@@ -315,16 +345,4 @@ fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
         usage.network_egress_bytes = error.request_bytes();
     }
     FirstPartyCapabilityError::new(kind).with_usage(usage)
-}
-
-fn response_error_kind(reason: &str) -> RuntimeDispatchErrorKind {
-    if response_body_limit_reason(reason) || reason.contains("too_large") {
-        RuntimeDispatchErrorKind::OutputTooLarge
-    } else {
-        RuntimeDispatchErrorKind::OutputDecode
-    }
-}
-
-fn response_body_limit_reason(reason: &str) -> bool {
-    reason.contains("response_body_limit") || reason.contains("body_limit")
 }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -1,0 +1,292 @@
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use ironclaw_extensions::{CapabilityManifest, ExtensionError};
+use ironclaw_host_api::{
+    CapabilityId, EffectKind, NetworkMethod, NetworkPolicy, PermissionMode, ResourceCeiling,
+    ResourceEstimate, ResourceProfile, ResourceUsage, RuntimeDispatchErrorKind,
+    RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeKind, SandboxQuota,
+};
+use serde_json::{Map, Value, json};
+
+use crate::{FirstPartyCapabilityError, FirstPartyCapabilityRequest};
+
+use super::{FIRST_PARTY_MAX_OUTPUT_BYTES, input_error};
+
+pub const HTTP_CAPABILITY_ID: &str = "builtin.http";
+
+const DEFAULT_HTTP_TIMEOUT_MS: u32 = 30_000;
+const MAX_HTTP_TIMEOUT_MS: u32 = 30_000;
+const DEFAULT_RESPONSE_BODY_LIMIT: u64 = 512 * 1024;
+const MAX_RESPONSE_BODY_LIMIT: u64 = 700 * 1024;
+const DEFAULT_NETWORK_EGRESS_BYTES: u64 = 16 * 1024;
+
+pub(super) struct HttpDispatchOutput {
+    pub output: Value,
+    pub network_egress_bytes: u64,
+}
+
+pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
+    Ok(CapabilityManifest {
+        id: CapabilityId::new(HTTP_CAPABILITY_ID)?,
+        description: "Perform an outbound HTTP request through host egress".to_string(),
+        effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
+        default_permission: PermissionMode::Ask,
+        parameters_schema: json!({
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "enum": ["get", "post", "put", "patch", "delete", "head"]
+                },
+                "url": { "type": "string" },
+                "headers": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string" },
+                                    "value": { "type": "string" }
+                                },
+                                "required": ["name", "value"]
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                        }
+                    ]
+                },
+                "body": {
+                    "description": "UTF-8 string or JSON value to send as the request body"
+                },
+                "body_base64": {
+                    "type": "string",
+                    "description": "Base64-encoded bytes to send as the request body"
+                },
+                "response_body_limit": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": MAX_RESPONSE_BODY_LIMIT
+                },
+                "timeout_ms": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_HTTP_TIMEOUT_MS
+                }
+            },
+            "required": ["url"]
+        }),
+        resource_profile: Some(ResourceProfile {
+            default_estimate: ResourceEstimate {
+                wall_clock_ms: Some(DEFAULT_HTTP_TIMEOUT_MS.into()),
+                output_bytes: Some(DEFAULT_RESPONSE_BODY_LIMIT),
+                network_egress_bytes: Some(DEFAULT_NETWORK_EGRESS_BYTES),
+                ..ResourceEstimate::default()
+            },
+            hard_ceiling: Some(ResourceCeiling {
+                max_usd: None,
+                max_input_tokens: None,
+                max_output_tokens: None,
+                max_wall_clock_ms: Some(MAX_HTTP_TIMEOUT_MS.into()),
+                max_output_bytes: Some(FIRST_PARTY_MAX_OUTPUT_BYTES),
+                sandbox: Some(SandboxQuota {
+                    network_egress_bytes: Some(FIRST_PARTY_MAX_OUTPUT_BYTES),
+                    ..SandboxQuota::default()
+                }),
+            }),
+        }),
+    })
+}
+
+pub(super) fn dispatch(
+    request: &FirstPartyCapabilityRequest,
+) -> Result<HttpDispatchOutput, FirstPartyCapabilityError> {
+    let egress = request
+        .runtime_http_egress
+        .as_ref()
+        .ok_or_else(|| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied))?;
+    let http_request = RuntimeHttpEgressRequest {
+        runtime: RuntimeKind::FirstParty,
+        scope: request.scope.clone(),
+        capability_id: request.capability_id.clone(),
+        method: method(&request.input)?,
+        url: required_string(&request.input, "url")?.to_string(),
+        headers: headers(&request.input)?,
+        body: body(&request.input)?,
+        network_policy: NetworkPolicy::default(),
+        credential_injections: Vec::new(),
+        response_body_limit: Some(response_body_limit(&request.input)?),
+        timeout_ms: Some(timeout_ms(&request.input)?),
+    };
+    let response = egress.execute(http_request).map_err(http_error)?;
+    let mut output = Map::new();
+    output.insert("status".to_string(), json!(response.status));
+    output.insert("headers".to_string(), response_headers(response.headers));
+    match String::from_utf8(response.body) {
+        Ok(body_text) => {
+            output.insert("body_text".to_string(), Value::String(body_text));
+        }
+        Err(error) => {
+            output.insert(
+                "body_base64".to_string(),
+                Value::String(BASE64_STANDARD.encode(error.into_bytes())),
+            );
+        }
+    }
+    output.insert("request_bytes".to_string(), json!(response.request_bytes));
+    output.insert("response_bytes".to_string(), json!(response.response_bytes));
+    output.insert(
+        "redaction_applied".to_string(),
+        json!(response.redaction_applied),
+    );
+    Ok(HttpDispatchOutput {
+        output: Value::Object(output),
+        network_egress_bytes: response.request_bytes,
+    })
+}
+
+fn method(input: &Value) -> Result<NetworkMethod, FirstPartyCapabilityError> {
+    match input
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("get")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "get" => Ok(NetworkMethod::Get),
+        "post" => Ok(NetworkMethod::Post),
+        "put" => Ok(NetworkMethod::Put),
+        "patch" => Ok(NetworkMethod::Patch),
+        "delete" => Ok(NetworkMethod::Delete),
+        "head" => Ok(NetworkMethod::Head),
+        _ => Err(input_error()),
+    }
+}
+
+fn required_string<'a>(
+    input: &'a Value,
+    field: &str,
+) -> Result<&'a str, FirstPartyCapabilityError> {
+    input
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(input_error)
+}
+
+fn headers(input: &Value) -> Result<Vec<(String, String)>, FirstPartyCapabilityError> {
+    let Some(headers) = input.get("headers") else {
+        return Ok(Vec::new());
+    };
+    match headers {
+        Value::Object(object) => object
+            .iter()
+            .map(|(name, value)| {
+                let value = value.as_str().ok_or_else(input_error)?;
+                header_pair(name, value)
+            })
+            .collect(),
+        Value::Array(items) => items
+            .iter()
+            .map(|item| {
+                let name = required_string(item, "name")?;
+                let value = required_string(item, "value")?;
+                header_pair(name, value)
+            })
+            .collect(),
+        _ => Err(input_error()),
+    }
+}
+
+fn header_pair(name: &str, value: &str) -> Result<(String, String), FirstPartyCapabilityError> {
+    if name.trim().is_empty()
+        || name
+            .chars()
+            .any(|character| matches!(character, '\r' | '\n'))
+        || value
+            .chars()
+            .any(|character| matches!(character, '\r' | '\n'))
+    {
+        return Err(input_error());
+    }
+    Ok((name.to_string(), value.to_string()))
+}
+
+fn body(input: &Value) -> Result<Vec<u8>, FirstPartyCapabilityError> {
+    if input.get("body").is_some() && input.get("body_base64").is_some() {
+        return Err(input_error());
+    }
+    if let Some(encoded) = input.get("body_base64") {
+        let encoded = encoded.as_str().ok_or_else(input_error)?;
+        return BASE64_STANDARD.decode(encoded).map_err(|_| input_error());
+    }
+    match input.get("body") {
+        None | Some(Value::Null) => Ok(Vec::new()),
+        Some(Value::String(value)) => Ok(value.as_bytes().to_vec()),
+        Some(value) => serde_json::to_vec(value).map_err(|_| input_error()),
+    }
+}
+
+fn response_body_limit(input: &Value) -> Result<u64, FirstPartyCapabilityError> {
+    capped_u64(
+        input,
+        "response_body_limit",
+        DEFAULT_RESPONSE_BODY_LIMIT,
+        MAX_RESPONSE_BODY_LIMIT,
+    )
+}
+
+fn timeout_ms(input: &Value) -> Result<u32, FirstPartyCapabilityError> {
+    let value = ranged_u64(
+        input,
+        "timeout_ms",
+        DEFAULT_HTTP_TIMEOUT_MS.into(),
+        1,
+        MAX_HTTP_TIMEOUT_MS.into(),
+    )?;
+    u32::try_from(value).map_err(|_| input_error())
+}
+
+fn capped_u64(
+    input: &Value,
+    field: &str,
+    default: u64,
+    max: u64,
+) -> Result<u64, FirstPartyCapabilityError> {
+    ranged_u64(input, field, default, 0, max)
+}
+
+fn ranged_u64(
+    input: &Value,
+    field: &str,
+    default: u64,
+    min: u64,
+    max: u64,
+) -> Result<u64, FirstPartyCapabilityError> {
+    let Some(value) = input.get(field) else {
+        return Ok(default);
+    };
+    let value = value.as_u64().ok_or_else(input_error)?;
+    if value < min || value > max {
+        return Err(input_error());
+    }
+    Ok(value)
+}
+
+fn response_headers(headers: Vec<(String, String)>) -> Value {
+    Value::Array(
+        headers
+            .into_iter()
+            .map(|(name, value)| json!({ "name": name, "value": value }))
+            .collect(),
+    )
+}
+
+fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
+    FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied).with_usage(
+        ResourceUsage {
+            network_egress_bytes: error.request_bytes(),
+            ..ResourceUsage::default()
+        },
+    )
+}

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -147,13 +147,11 @@ pub(super) fn dispatch(
 }
 
 fn method(input: &Value) -> Result<NetworkMethod, FirstPartyCapabilityError> {
-    match input
-        .get("method")
-        .and_then(Value::as_str)
-        .unwrap_or("get")
-        .to_ascii_lowercase()
-        .as_str()
-    {
+    let method = match input.get("method") {
+        Some(value) => value.as_str().ok_or_else(input_error)?,
+        None => "get",
+    };
+    match method.to_ascii_lowercase().as_str() {
         "get" => Ok(NetworkMethod::Get),
         "post" => Ok(NetworkMethod::Post),
         "put" => Ok(NetworkMethod::Put),

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -18,6 +18,10 @@ const MAX_HTTP_TIMEOUT_MS: u32 = 30_000;
 const DEFAULT_RESPONSE_BODY_LIMIT: u64 = 512 * 1024;
 const MAX_RESPONSE_BODY_LIMIT: u64 = 700 * 1024;
 const DEFAULT_NETWORK_EGRESS_BYTES: u64 = 16 * 1024;
+const MAX_NETWORK_EGRESS_BYTES: u64 = 256 * 1024;
+const MAX_HTTP_HEADERS: usize = 64;
+const MAX_HTTP_HEADER_NAME_BYTES: usize = 512;
+const MAX_HTTP_HEADER_VALUE_BYTES: usize = 8 * 1024;
 
 pub(super) struct HttpDispatchOutput {
     pub output: Value,
@@ -39,6 +43,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                 },
                 "url": { "type": "string" },
                 "headers": {
+                    "description": "Request headers as either an array of {name,value} pairs or an object. Array form preserves duplicate header names; object form does not.",
                     "oneOf": [
                         {
                             "type": "array",
@@ -66,7 +71,8 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                 },
                 "response_body_limit": {
                     "type": "integer",
-                    "minimum": 0,
+                    "description": "Maximum response body bytes to return. Omit to use the built-in fail-closed default cap; values must be at least 1.",
+                    "minimum": 1,
                     "maximum": MAX_RESPONSE_BODY_LIMIT
                 },
                 "timeout_ms": {
@@ -91,7 +97,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                 max_wall_clock_ms: Some(MAX_HTTP_TIMEOUT_MS.into()),
                 max_output_bytes: Some(FIRST_PARTY_MAX_OUTPUT_BYTES),
                 sandbox: Some(SandboxQuota {
-                    network_egress_bytes: Some(FIRST_PARTY_MAX_OUTPUT_BYTES),
+                    network_egress_bytes: Some(MAX_NETWORK_EGRESS_BYTES),
                     ..SandboxQuota::default()
                 }),
             }),
@@ -99,13 +105,17 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
     })
 }
 
-pub(super) fn dispatch(
+pub(super) async fn dispatch(
     request: &FirstPartyCapabilityRequest,
 ) -> Result<HttpDispatchOutput, FirstPartyCapabilityError> {
     let egress = request
         .runtime_http_egress
         .as_ref()
-        .ok_or_else(|| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied))?;
+        .ok_or_else(|| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied))?
+        .clone();
+    // Keep this handler as a translator only: URL parsing, DNS/private-IP
+    // enforcement, allowlists, transport, and credential injection remain in
+    // HostHttpEgressService / ironclaw_network.
     let http_request = RuntimeHttpEgressRequest {
         runtime: RuntimeKind::FirstParty,
         scope: request.scope.clone(),
@@ -116,13 +126,20 @@ pub(super) fn dispatch(
         body: body(&request.input)?,
         network_policy: NetworkPolicy::default(),
         credential_injections: Vec::new(),
+        // Always send a bounded limit, even when caller omits the field, so the
+        // host transport stays fail-closed instead of inheriting an unbounded cap.
         response_body_limit: Some(response_body_limit(&request.input)?),
         timeout_ms: Some(timeout_ms(&request.input)?),
     };
-    let response = egress.execute(http_request).map_err(http_error)?;
+    let response = tokio::task::spawn_blocking(move || egress.execute(http_request))
+        .await
+        .map_err(|_| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::Backend))?
+        .map_err(http_error)?;
     let mut output = Map::new();
     output.insert("status".to_string(), json!(response.status));
     output.insert("headers".to_string(), response_headers(response.headers));
+    // Response bodies must be valid UTF-8 to appear as body_text. Any invalid
+    // byte returns the full response as body_base64 to avoid lossy surprises.
     match String::from_utf8(response.body) {
         Ok(body_text) => {
             output.insert("body_text".to_string(), Value::String(body_text));
@@ -176,14 +193,14 @@ fn headers(input: &Value) -> Result<Vec<(String, String)>, FirstPartyCapabilityE
     let Some(headers) = input.get("headers") else {
         return Ok(Vec::new());
     };
-    match headers {
+    let parsed: Vec<(String, String)> = match headers {
         Value::Object(object) => object
             .iter()
             .map(|(name, value)| {
                 let value = value.as_str().ok_or_else(input_error)?;
                 header_pair(name, value)
             })
-            .collect(),
+            .collect::<Result<_, _>>()?,
         Value::Array(items) => items
             .iter()
             .map(|item| {
@@ -191,19 +208,25 @@ fn headers(input: &Value) -> Result<Vec<(String, String)>, FirstPartyCapabilityE
                 let value = required_string(item, "value")?;
                 header_pair(name, value)
             })
-            .collect(),
-        _ => Err(input_error()),
+            .collect::<Result<_, _>>()?,
+        _ => return Err(input_error()),
+    };
+    if parsed.len() > MAX_HTTP_HEADERS {
+        return Err(input_error());
     }
+    Ok(parsed)
 }
 
 fn header_pair(name: &str, value: &str) -> Result<(String, String), FirstPartyCapabilityError> {
     if name.trim().is_empty()
+        || name.len() > MAX_HTTP_HEADER_NAME_BYTES
+        || value.len() > MAX_HTTP_HEADER_VALUE_BYTES
         || name
             .chars()
-            .any(|character| matches!(character, '\r' | '\n'))
+            .any(|character| matches!(character, '\r' | '\n' | '\0'))
         || value
             .chars()
-            .any(|character| matches!(character, '\r' | '\n'))
+            .any(|character| matches!(character, '\r' | '\n' | '\0'))
     {
         return Err(input_error());
     }
@@ -226,10 +249,11 @@ fn body(input: &Value) -> Result<Vec<u8>, FirstPartyCapabilityError> {
 }
 
 fn response_body_limit(input: &Value) -> Result<u64, FirstPartyCapabilityError> {
-    capped_u64(
+    ranged_u64(
         input,
         "response_body_limit",
         DEFAULT_RESPONSE_BODY_LIMIT,
+        1,
         MAX_RESPONSE_BODY_LIMIT,
     )
 }
@@ -243,15 +267,6 @@ fn timeout_ms(input: &Value) -> Result<u32, FirstPartyCapabilityError> {
         MAX_HTTP_TIMEOUT_MS.into(),
     )?;
     u32::try_from(value).map_err(|_| input_error())
-}
-
-fn capped_u64(
-    input: &Value,
-    field: &str,
-    default: u64,
-    max: u64,
-) -> Result<u64, FirstPartyCapabilityError> {
-    ranged_u64(input, field, default, 0, max)
 }
 
 fn ranged_u64(
@@ -281,10 +296,35 @@ fn response_headers(headers: Vec<(String, String)>) -> Value {
 }
 
 fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
-    FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied).with_usage(
-        ResourceUsage {
-            network_egress_bytes: error.request_bytes(),
-            ..ResourceUsage::default()
-        },
-    )
+    let kind = match &error {
+        RuntimeHttpEgressError::Credential { .. } => RuntimeDispatchErrorKind::Client,
+        RuntimeHttpEgressError::Request { .. } => RuntimeDispatchErrorKind::InputEncode,
+        RuntimeHttpEgressError::Network { reason, .. } if response_body_limit_reason(reason) => {
+            RuntimeDispatchErrorKind::OutputTooLarge
+        }
+        RuntimeHttpEgressError::Network { .. } => RuntimeDispatchErrorKind::NetworkDenied,
+        RuntimeHttpEgressError::Response { reason, .. } => response_error_kind(reason),
+    };
+    tracing::debug!(
+        runtime_http_reason = error.stable_runtime_reason(),
+        dispatch_error_kind = kind.as_str(),
+        "first-party HTTP egress failed"
+    );
+    let mut usage = ResourceUsage::default();
+    if !matches!(error, RuntimeHttpEgressError::Credential { .. }) {
+        usage.network_egress_bytes = error.request_bytes();
+    }
+    FirstPartyCapabilityError::new(kind).with_usage(usage)
+}
+
+fn response_error_kind(reason: &str) -> RuntimeDispatchErrorKind {
+    if response_body_limit_reason(reason) || reason.contains("too_large") {
+        RuntimeDispatchErrorKind::OutputTooLarge
+    } else {
+        RuntimeDispatchErrorKind::OutputDecode
+    }
+}
+
+fn response_body_limit_reason(reason: &str) -> bool {
+    reason.contains("response_body_limit") || reason.contains("body_limit")
 }

--- a/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/http.rs
@@ -32,7 +32,8 @@ pub(super) struct HttpDispatchOutput {
 pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
     Ok(CapabilityManifest {
         id: CapabilityId::new(HTTP_CAPABILITY_ID)?,
-        description: "Perform an outbound HTTP request through host egress".to_string(),
+        description: "Perform an outbound HTTP request through host egress. Redirect responses are returned; the host transport does not follow them."
+            .to_string(),
         effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
         default_permission: PermissionMode::Ask,
         parameters_schema: json!({
@@ -64,7 +65,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                     ]
                 },
                 "body": {
-                    "description": "UTF-8 string or JSON value to send as the request body. No Content-Type is set automatically; pass it via headers."
+                    "description": "UTF-8 string or JSON value to send as the request body. Non-string JSON bodies default Content-Type to application/json unless a content-type header is supplied."
                 },
                 "body_base64": {
                     "type": "string",
@@ -72,7 +73,7 @@ pub(super) fn manifest() -> Result<CapabilityManifest, ExtensionError> {
                 },
                 "response_body_limit": {
                     "type": "integer",
-                    "description": "Maximum raw response body bytes to return. Omit to use the built-in fail-closed default cap; values must be at least 1. Binary responses are base64-encoded and must still fit the first-party output ceiling.",
+                    "description": "Maximum raw response body bytes to return. Omit to use the built-in fail-closed default cap; values must be at least 1. Binary responses are base64-encoded, raise effective output cost by about 33%, and must still fit the first-party output ceiling.",
                     "minimum": 1,
                     "maximum": MAX_RESPONSE_BODY_LIMIT
                 },
@@ -117,15 +118,20 @@ pub(super) async fn dispatch(
     // Keep this handler as a translator only: URL parsing, DNS/private-IP
     // enforcement, allowlists, transport, and credential injection remain in
     // HostHttpEgressService / ironclaw_network.
+    let mut headers = headers(&request.input)?;
+    if json_body_needs_default_content_type(&request.input) && !has_header(&headers, "content-type")
+    {
+        headers.push(("content-type".to_string(), "application/json".to_string()));
+    }
     let http_request = RuntimeHttpEgressRequest {
         runtime: RuntimeKind::FirstParty,
         scope: request.scope.clone(),
         capability_id: request.capability_id.clone(),
         method: method(&request.input)?,
         url: required_string(&request.input, "url")?.to_string(),
-        headers: headers(&request.input)?,
+        headers,
         body: body(&request.input)?,
-        network_policy: NetworkPolicy::default(),
+        network_policy: staged_policy_placeholder(),
         credential_injections: Vec::new(),
         // Always send a bounded limit, even when caller omits the field, so the
         // host transport stays fail-closed instead of inheriting an unbounded cap.
@@ -267,15 +273,43 @@ fn body(input: &Value) -> Result<Vec<u8>, FirstPartyCapabilityError> {
     if input.get("body").is_some() && input.get("body_base64").is_some() {
         return Err(input_error());
     }
-    if let Some(encoded) = input.get("body_base64") {
+    let body = if let Some(encoded) = input.get("body_base64") {
         let encoded = encoded.as_str().ok_or_else(input_error)?;
-        return BASE64_STANDARD.decode(encoded).map_err(|_| input_error());
+        BASE64_STANDARD.decode(encoded).map_err(|_| input_error())?
+    } else {
+        match input.get("body") {
+            None | Some(Value::Null) => Vec::new(),
+            Some(Value::String(value)) => value.as_bytes().to_vec(),
+            Some(value) => serde_json::to_vec(value).map_err(|_| input_error())?,
+        }
+    };
+    if body.len() as u64 > MAX_NETWORK_EGRESS_BYTES {
+        return Err(input_error());
     }
-    match input.get("body") {
-        None | Some(Value::Null) => Ok(Vec::new()),
-        Some(Value::String(value)) => Ok(value.as_bytes().to_vec()),
-        Some(value) => serde_json::to_vec(value).map_err(|_| input_error()),
-    }
+    Ok(body)
+}
+
+fn json_body_needs_default_content_type(input: &Value) -> bool {
+    matches!(
+        input.get("body"),
+        Some(Value::Array(_))
+            | Some(Value::Bool(_))
+            | Some(Value::Number(_))
+            | Some(Value::Object(_))
+    )
+}
+
+fn has_header(headers: &[(String, String)], expected: &str) -> bool {
+    headers
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case(expected))
+}
+
+fn staged_policy_placeholder() -> NetworkPolicy {
+    // First-party HTTP policy is staged in HostHttpEgressService from the grant
+    // obligation for this scope/capability. This fallback request field is
+    // ignored on that path and only exists for request-policy test services.
+    NetworkPolicy::default()
 }
 
 fn response_body_limit(input: &Value) -> Result<u64, FirstPartyCapabilityError> {
@@ -327,6 +361,8 @@ fn response_headers(headers: Vec<(String, String)>) -> Value {
 
 fn http_error(error: RuntimeHttpEgressError) -> FirstPartyCapabilityError {
     let kind = match error.reason_code() {
+        // Host credential injection failures are backend/client integration faults;
+        // production maps RuntimeDispatchErrorKind::Client to RuntimeFailureKind::Backend.
         RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
         RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
         RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -7,6 +7,7 @@
 
 mod coding;
 mod echo;
+mod http;
 mod json;
 mod time;
 
@@ -30,6 +31,7 @@ pub use coding::{
     READ_FILE_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
 };
 pub use echo::ECHO_CAPABILITY_ID;
+pub use http::HTTP_CAPABILITY_ID;
 pub use json::JSON_CAPABILITY_ID;
 pub use time::TIME_CAPABILITY_ID;
 
@@ -60,8 +62,12 @@ pub fn builtin_first_party_package() -> Result<ExtensionPackage, ExtensionError>
                 service: "builtin".to_string(),
             },
             capabilities: {
-                let mut capabilities =
-                    vec![echo::manifest()?, time::manifest()?, json::manifest()?];
+                let mut capabilities = vec![
+                    echo::manifest()?,
+                    time::manifest()?,
+                    json::manifest()?,
+                    http::manifest()?,
+                ];
                 capabilities.extend(coding::manifests()?);
                 capabilities
             },
@@ -77,6 +83,7 @@ pub fn builtin_first_party_handlers() -> Result<FirstPartyCapabilityRegistry, Ho
         .with_handler(CapabilityId::new(ECHO_CAPABILITY_ID)?, handler.clone())
         .with_handler(CapabilityId::new(TIME_CAPABILITY_ID)?, handler.clone())
         .with_handler(CapabilityId::new(JSON_CAPABILITY_ID)?, handler.clone())
+        .with_handler(CapabilityId::new(HTTP_CAPABILITY_ID)?, handler.clone())
         .with_handler(CapabilityId::new(READ_FILE_CAPABILITY_ID)?, handler.clone())
         .with_handler(
             CapabilityId::new(WRITE_FILE_CAPABILITY_ID)?,
@@ -102,10 +109,16 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
     ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
         bounded_input_size(request.capability_id.as_str(), &request.input)?;
         let start = Instant::now();
+        let mut network_egress_bytes = 0;
         let output = match request.capability_id.as_str() {
             ECHO_CAPABILITY_ID => echo::dispatch(&request.input)?,
             TIME_CAPABILITY_ID => time::dispatch(&request.input)?,
             JSON_CAPABILITY_ID => json::dispatch(&request.input)?,
+            HTTP_CAPABILITY_ID => {
+                let result = http::dispatch(&request)?;
+                network_egress_bytes = result.network_egress_bytes;
+                result.output
+            }
             READ_FILE_CAPABILITY_ID
             | WRITE_FILE_CAPABILITY_ID
             | LIST_DIR_CAPABILITY_ID
@@ -124,6 +137,7 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
         let usage = ResourceUsage {
             wall_clock_ms: start.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
             output_bytes,
+            network_egress_bytes,
             ..ResourceUsage::default()
         };
         Ok(FirstPartyCapabilityResult::new(output, usage))

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -133,9 +133,20 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
                 ));
             }
         };
-        let output_bytes = bounded_output_bytes(&output)?;
+        let wall_clock_ms = start.elapsed().as_millis().try_into().unwrap_or(u64::MAX);
+        let output_bytes = bounded_output_bytes(&output).map_err(|error| {
+            if network_egress_bytes > 0 {
+                error.with_usage(ResourceUsage {
+                    wall_clock_ms,
+                    network_egress_bytes,
+                    ..ResourceUsage::default()
+                })
+            } else {
+                error
+            }
+        })?;
         let usage = ResourceUsage {
-            wall_clock_ms: start.elapsed().as_millis().try_into().unwrap_or(u64::MAX),
+            wall_clock_ms,
             output_bytes,
             network_egress_bytes,
             ..ResourceUsage::default()

--- a/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
+++ b/crates/ironclaw_host_runtime/src/first_party_tools/mod.rs
@@ -115,7 +115,7 @@ impl FirstPartyCapabilityHandler for BuiltinFirstPartyTools {
             TIME_CAPABILITY_ID => time::dispatch(&request.input)?,
             JSON_CAPABILITY_ID => json::dispatch(&request.input)?,
             HTTP_CAPABILITY_ID => {
-                let result = http::dispatch(&request)?;
+                let result = http::dispatch(&request).await?;
                 network_egress_bytes = result.network_egress_bytes;
                 result.output
             }

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -61,9 +61,9 @@ pub use first_party::{
 };
 pub use first_party_tools::{
     APPLY_PATCH_CAPABILITY_ID, BUILTIN_FIRST_PARTY_PROVIDER, BuiltinFirstPartyTools,
-    ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, JSON_CAPABILITY_ID,
-    LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, TIME_CAPABILITY_ID, WRITE_FILE_CAPABILITY_ID,
-    builtin_first_party_handlers, builtin_first_party_package,
+    ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID,
+    JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, TIME_CAPABILITY_ID,
+    WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
 };
 pub use obligations::{
     BuiltinObligationHandler, BuiltinObligationServices, ProcessObligationLifecycleStore,

--- a/crates/ironclaw_host_runtime/src/services.rs
+++ b/crates/ironclaw_host_runtime/src/services.rs
@@ -1546,6 +1546,7 @@ where
                 Arc::new(FirstPartyRuntimeAdapter::from_registry(
                     Arc::clone(runtime),
                     Arc::clone(&self.filesystem) as Arc<dyn RootFilesystem>,
+                    Arc::clone(&self.runtime_http_egress),
                 )),
             );
         }
@@ -1881,16 +1882,19 @@ where
 struct FirstPartyRuntimeAdapter {
     registry: Arc<FirstPartyCapabilityRegistry>,
     filesystem: Arc<dyn RootFilesystem>,
+    runtime_http_egress: SharedRuntimeHttpEgress,
 }
 
 impl FirstPartyRuntimeAdapter {
     pub(crate) fn from_registry(
         registry: Arc<FirstPartyCapabilityRegistry>,
         filesystem: Arc<dyn RootFilesystem>,
+        runtime_http_egress: SharedRuntimeHttpEgress,
     ) -> Self {
         Self {
             registry,
             filesystem,
+            runtime_http_egress,
         }
     }
 }
@@ -1936,6 +1940,7 @@ where
             estimate: request.estimate,
             mounts: request.mounts,
             filesystem: Arc::clone(&self.filesystem),
+            runtime_http_egress: runtime_http_egress(&self.runtime_http_egress),
             input: request.input,
         }))
         .catch_unwind()

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -421,12 +421,14 @@ async fn builtin_http_documents_mixed_utf8_response_as_binary() {
     .await
     .unwrap();
 
+    // Invalid UTF-8 makes the whole response binary so callers never receive
+    // split or lossy text/body fragments.
     assert_eq!(output["body_base64"], json!("aGVsbG//d29ybGQ="));
     assert!(output.get("body_text").is_none());
 }
 
 #[tokio::test]
-async fn builtin_http_rejects_header_nulls_and_oversized_header_sets() {
+async fn builtin_http_rejects_invalid_header_names_and_oversized_header_sets() {
     let egress = Arc::new(RecordingRuntimeHttpEgress::default());
     let runtime = runtime_with_http_egress(egress);
     let context = execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy());
@@ -442,6 +444,18 @@ async fn builtin_http_rejects_header_nulls_and_oversized_header_sets() {
         json!({
             "url": "https://api.example.test/v1/items",
             "headers": [{"name": "x\0bad", "value": "ok"}]
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": [{"name": "x bad", "value": "ok"}]
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": [{"name": "x:bad", "value": "ok"}]
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": [{"name": "x-é", "value": "ok"}]
         }),
         json!({
             "url": "https://api.example.test/v1/items",

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -8,11 +8,11 @@ use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     APPLY_PATCH_CAPABILITY_ID, CapabilitySurfacePolicy, CapabilitySurfaceVersion,
-    ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HostRuntime, HostRuntimeServices,
-    JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID, RuntimeCapabilityOutcome,
-    RuntimeCapabilityRequest, RuntimeFailureKind, SurfaceKind, TIME_CAPABILITY_ID,
-    VisibleCapabilityAccess, VisibleCapabilityRequest, WRITE_FILE_CAPABILITY_ID,
-    builtin_first_party_handlers, builtin_first_party_package,
+    ECHO_CAPABILITY_ID, GLOB_CAPABILITY_ID, GREP_CAPABILITY_ID, HTTP_CAPABILITY_ID, HostRuntime,
+    HostRuntimeServices, JSON_CAPABILITY_ID, LIST_DIR_CAPABILITY_ID, READ_FILE_CAPABILITY_ID,
+    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, RuntimeFailureKind, SurfaceKind,
+    TIME_CAPABILITY_ID, VisibleCapabilityAccess, VisibleCapabilityRequest,
+    WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
 };
 use ironclaw_resources::InMemoryResourceGovernor;
 use ironclaw_trust::{
@@ -249,6 +249,112 @@ async fn builtin_json_rejects_v1_tool_output_stash_refs_without_leaking_input() 
     let debug = format!("{failure:?}");
     assert!(!debug.contains("RAW_SECRET"));
     assert!(!debug.contains("sk-provider-secret"));
+}
+
+#[tokio::test]
+async fn builtin_http_invokes_through_host_runtime_egress() {
+    let egress = Arc::new(RecordingRuntimeHttpEgress::with_body(
+        br#"{"accepted":true}"#.to_vec(),
+    ));
+    let runtime = runtime_with_http_egress(Arc::clone(&egress));
+
+    let output = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({
+            "method": "post",
+            "url": "https://api.example.test/v1/items",
+            "headers": {
+                "content-type": "application/json",
+                "x-request-id": "first-party-http"
+            },
+            "body": {"ok": true},
+            "response_body_limit": 4096,
+            "timeout_ms": 2500
+        }),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap_or_else(|error| {
+        panic!(
+            "expected HTTP egress success, got {error:?}; recorded requests: {:?}",
+            egress.requests()
+        )
+    });
+
+    assert_eq!(output["status"], json!(200));
+    assert_eq!(output["body_text"], json!(r#"{"accepted":true}"#));
+    assert_eq!(output["request_bytes"], json!(11));
+    assert_eq!(output["response_bytes"], json!(17));
+
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 1);
+    let request = &requests[0];
+    assert_eq!(request.runtime, RuntimeKind::FirstParty);
+    assert_eq!(request.capability_id, capability_id(HTTP_CAPABILITY_ID));
+    assert_eq!(request.method, NetworkMethod::Post);
+    assert_eq!(request.url, "https://api.example.test/v1/items");
+    assert_eq!(request.body, br#"{"ok":true}"#);
+    assert_eq!(request.response_body_limit, Some(4096));
+    assert_eq!(request.timeout_ms, Some(2500));
+    assert!(request.credential_injections.is_empty());
+}
+
+#[tokio::test]
+async fn builtin_http_fails_closed_without_runtime_egress() {
+    let runtime = runtime();
+    let error = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({"url": "https://api.example.test/v1/items"}),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::Network);
+}
+
+#[tokio::test]
+async fn builtin_http_rejects_ambiguous_body_and_zero_timeout() {
+    let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+    let runtime = runtime_with_http_egress(egress);
+    let context = execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy());
+
+    for input in [
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "body": "plain",
+            "body_base64": "YmluYXJ5"
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "timeout_ms": 0
+        }),
+    ] {
+        let error = invoke_with_context(&runtime, HTTP_CAPABILITY_ID, input, context.clone())
+            .await
+            .unwrap_err();
+        assert_eq!(error, RuntimeFailureKind::InvalidInput);
+    }
+}
+
+#[tokio::test]
+async fn builtin_http_returns_binary_responses_as_base64() {
+    let egress = Arc::new(RecordingRuntimeHttpEgress::with_body(vec![0, 159, 255]));
+    let runtime = runtime_with_http_egress(Arc::clone(&egress));
+
+    let output = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({"url": "https://api.example.test/v1/items"}),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(output["body_base64"], json!("AJ//"));
+    assert!(output.get("body_text").is_none());
 }
 
 #[tokio::test]
@@ -1178,6 +1284,24 @@ where
     .host_runtime_for_local_testing()
 }
 
+fn runtime_with_http_egress<T>(egress: Arc<T>) -> impl HostRuntime
+where
+    T: RuntimeHttpEgress + 'static,
+{
+    HostRuntimeServices::new(
+        Arc::new(registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(builtin_first_party_handlers().unwrap()))
+    .with_runtime_http_egress(egress)
+    .with_trust_policy(Arc::new(trust_policy()))
+    .host_runtime_for_local_testing()
+}
+
 fn registry() -> ExtensionRegistry {
     let mut registry = ExtensionRegistry::new();
     registry
@@ -1194,11 +1318,12 @@ fn provider_id() -> ExtensionId {
     ExtensionId::new("builtin").unwrap()
 }
 
-fn all_builtin_capability_ids() -> [&'static str; 9] {
+fn all_builtin_capability_ids() -> [&'static str; 10] {
     [
         ECHO_CAPABILITY_ID,
         TIME_CAPABILITY_ID,
         JSON_CAPABILITY_ID,
+        HTTP_CAPABILITY_ID,
         READ_FILE_CAPABILITY_ID,
         WRITE_FILE_CAPABILITY_ID,
         LIST_DIR_CAPABILITY_ID,
@@ -1223,6 +1348,42 @@ fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (LocalFiles
     )])
     .unwrap();
     (filesystem, mounts)
+}
+
+#[derive(Debug, Clone, Default)]
+struct RecordingRuntimeHttpEgress {
+    requests: Arc<std::sync::Mutex<Vec<RuntimeHttpEgressRequest>>>,
+    body: Vec<u8>,
+}
+
+impl RecordingRuntimeHttpEgress {
+    fn with_body(body: Vec<u8>) -> Self {
+        Self {
+            requests: Arc::new(std::sync::Mutex::new(Vec::new())),
+            body,
+        }
+    }
+
+    fn requests(&self) -> Vec<RuntimeHttpEgressRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
+    fn execute(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        self.requests.lock().unwrap().push(request.clone());
+        Ok(RuntimeHttpEgressResponse {
+            status: 200,
+            headers: vec![("content-type".to_string(), "application/json".to_string())],
+            body: self.body.clone(),
+            request_bytes: request.body.len() as u64,
+            response_bytes: self.body.len() as u64,
+            redaction_applied: false,
+        })
+    }
 }
 
 fn execution_context<const N: usize>(grants: [&str; N]) -> ExecutionContext {
@@ -1261,11 +1422,44 @@ fn execution_context_with_mounts<const N: usize>(
     .unwrap()
 }
 
+fn execution_context_with_network<const N: usize>(
+    grants: [&str; N],
+    network: NetworkPolicy,
+) -> ExecutionContext {
+    let capability_set = CapabilitySet {
+        grants: grants
+            .into_iter()
+            .map(|grant| dispatch_grant_with_network(grant, network.clone()))
+            .collect(),
+    };
+    ExecutionContext::local_default(
+        UserId::new("user").unwrap(),
+        ExtensionId::new("caller").unwrap(),
+        RuntimeKind::FirstParty,
+        TrustClass::FirstParty,
+        capability_set,
+        MountView::default(),
+    )
+    .unwrap()
+}
+
 fn dispatch_grant(capability: &str) -> CapabilityGrant {
     dispatch_grant_with_mounts(capability, MountView::default())
 }
 
 fn dispatch_grant_with_mounts(capability: &str, mounts: MountView) -> CapabilityGrant {
+    dispatch_grant_with_mounts_and_network(capability, mounts, NetworkPolicy::default())
+}
+
+fn dispatch_grant_with_network(capability: &str, network: NetworkPolicy) -> CapabilityGrant {
+    dispatch_grant_with_mounts_and_network(capability, MountView::default(), network)
+}
+
+fn dispatch_grant_with_mounts_and_network(
+    capability: &str,
+    mounts: MountView,
+    network: NetworkPolicy,
+) -> CapabilityGrant {
     CapabilityGrant {
         id: CapabilityGrantId::new(),
         capability: capability_id(capability),
@@ -1274,7 +1468,7 @@ fn dispatch_grant_with_mounts(capability: &str, mounts: MountView) -> Capability
         constraints: GrantConstraints {
             allowed_effects: builtin_effects(),
             mounts,
-            network: NetworkPolicy::default(),
+            network,
             secrets: Vec::new(),
             resource_ceiling: None,
             expires_at: None,
@@ -1288,7 +1482,20 @@ fn builtin_effects() -> Vec<EffectKind> {
         EffectKind::DispatchCapability,
         EffectKind::ReadFilesystem,
         EffectKind::WriteFilesystem,
+        EffectKind::Network,
     ]
+}
+
+fn http_test_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "api.example.test".to_string(),
+            port: None,
+        }],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(10_000),
+    }
 }
 
 fn trust_policy() -> HostTrustPolicy {

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -14,7 +14,7 @@ use ironclaw_host_runtime::{
     TIME_CAPABILITY_ID, VisibleCapabilityAccess, VisibleCapabilityRequest,
     WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
 };
-use ironclaw_resources::InMemoryResourceGovernor;
+use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount};
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustProvenance,
@@ -324,6 +324,10 @@ async fn builtin_http_rejects_ambiguous_body_and_zero_timeout() {
     for input in [
         json!({
             "url": "https://api.example.test/v1/items",
+            "method": 123
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
             "body": "plain",
             "body_base64": "YmluYXJ5"
         }),
@@ -337,6 +341,34 @@ async fn builtin_http_rejects_ambiguous_body_and_zero_timeout() {
             .unwrap_err();
         assert_eq!(error, RuntimeFailureKind::InvalidInput);
     }
+}
+
+#[tokio::test]
+async fn builtin_http_accounts_request_bytes_when_output_is_too_large() {
+    let egress = Arc::new(RecordingRuntimeHttpEgress::with_body(vec![
+        b'\\';
+        700 * 1024
+    ]));
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let runtime = runtime_with_http_egress_and_governor(Arc::clone(&egress), Arc::clone(&governor));
+
+    let error = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({
+            "method": "post",
+            "url": "https://api.example.test/v1/items",
+            "body": "paid",
+            "response_body_limit": 700 * 1024
+        }),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::OutputTooLarge);
+    let tenant_account = ResourceAccount::tenant(TenantId::new(LOCAL_DEFAULT_TENANT_ID).unwrap());
+    assert_eq!(governor.usage_for(&tenant_account).network_egress_bytes, 4);
 }
 
 #[tokio::test]
@@ -1288,10 +1320,20 @@ fn runtime_with_http_egress<T>(egress: Arc<T>) -> impl HostRuntime
 where
     T: RuntimeHttpEgress + 'static,
 {
+    runtime_with_http_egress_and_governor(egress, Arc::new(InMemoryResourceGovernor::new()))
+}
+
+fn runtime_with_http_egress_and_governor<T>(
+    egress: Arc<T>,
+    governor: Arc<InMemoryResourceGovernor>,
+) -> impl HostRuntime
+where
+    T: RuntimeHttpEgress + 'static,
+{
     HostRuntimeServices::new(
         Arc::new(registry()),
         Arc::new(LocalFilesystem::new()),
-        Arc::new(InMemoryResourceGovernor::new()),
+        governor,
         Arc::new(GrantAuthorizer::new()),
         ironclaw_processes::ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("surface-v1").unwrap(),

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -1,4 +1,11 @@
-use std::{collections::BTreeMap, path::Path, sync::Arc, thread, time::Duration};
+use std::{
+    collections::BTreeMap,
+    net::{IpAddr, Ipv4Addr},
+    path::Path,
+    sync::Arc,
+    thread,
+    time::Duration,
+};
 
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
@@ -14,7 +21,12 @@ use ironclaw_host_runtime::{
     TIME_CAPABILITY_ID, VisibleCapabilityAccess, VisibleCapabilityRequest,
     WRITE_FILE_CAPABILITY_ID, builtin_first_party_handlers, builtin_first_party_package,
 };
+use ironclaw_network::{
+    NetworkHttpEgress, NetworkHttpError, NetworkHttpResponse, NetworkHttpTransport,
+    NetworkResolver, NetworkTransportRequest, NetworkUsage, PolicyNetworkHttpEgress,
+};
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount};
+use ironclaw_secrets::InMemorySecretStore;
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustProvenance,
@@ -316,7 +328,7 @@ async fn builtin_http_fails_closed_without_runtime_egress() {
 }
 
 #[tokio::test]
-async fn builtin_http_rejects_ambiguous_body_and_zero_timeout() {
+async fn builtin_http_rejects_ambiguous_body_zero_timeout_and_zero_response_limit() {
     let egress = Arc::new(RecordingRuntimeHttpEgress::default());
     let runtime = runtime_with_http_egress(egress);
     let context = execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy());
@@ -334,6 +346,10 @@ async fn builtin_http_rejects_ambiguous_body_and_zero_timeout() {
         json!({
             "url": "https://api.example.test/v1/items",
             "timeout_ms": 0
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "response_body_limit": 0
         }),
     ] {
         let error = invoke_with_context(&runtime, HTTP_CAPABILITY_ID, input, context.clone())
@@ -387,6 +403,208 @@ async fn builtin_http_returns_binary_responses_as_base64() {
 
     assert_eq!(output["body_base64"], json!("AJ//"));
     assert!(output.get("body_text").is_none());
+}
+
+#[tokio::test]
+async fn builtin_http_documents_mixed_utf8_response_as_binary() {
+    let egress = Arc::new(RecordingRuntimeHttpEgress::with_body(
+        b"hello\xFFworld".to_vec(),
+    ));
+    let runtime = runtime_with_http_egress(Arc::clone(&egress));
+
+    let output = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({"url": "https://api.example.test/v1/items"}),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(output["body_base64"], json!("aGVsbG//d29ybGQ="));
+    assert!(output.get("body_text").is_none());
+}
+
+#[tokio::test]
+async fn builtin_http_rejects_header_nulls_and_oversized_header_sets() {
+    let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+    let runtime = runtime_with_http_egress(egress);
+    let context = execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy());
+    let too_many_headers = (0..65)
+        .map(|index| json!({"name": format!("x-{index}"), "value": "ok"}))
+        .collect::<Vec<_>>();
+
+    for input in [
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": {"x-bad": "value\0tail"}
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": [{"name": "x\0bad", "value": "ok"}]
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": too_many_headers
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": {"x-large": "a".repeat(8 * 1024 + 1)}
+        }),
+    ] {
+        let error = invoke_with_context(&runtime, HTTP_CAPABILITY_ID, input, context.clone())
+            .await
+            .unwrap_err();
+        assert_eq!(error, RuntimeFailureKind::InvalidInput);
+    }
+}
+
+#[tokio::test]
+async fn builtin_http_maps_runtime_egress_errors_by_source() {
+    let context = execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy());
+    let cases = [
+        (
+            RuntimeHttpEgressError::Credential {
+                reason: "credential missing".to_string(),
+            },
+            RuntimeFailureKind::Backend,
+        ),
+        (
+            RuntimeHttpEgressError::Request {
+                reason: "sensitive_header_denied:authorization".to_string(),
+                request_bytes: 0,
+                response_bytes: 0,
+            },
+            RuntimeFailureKind::InvalidInput,
+        ),
+        (
+            RuntimeHttpEgressError::Network {
+                reason: "policy_denied".to_string(),
+                request_bytes: 0,
+                response_bytes: 0,
+            },
+            RuntimeFailureKind::Network,
+        ),
+        (
+            RuntimeHttpEgressError::Network {
+                reason: "response_body_limit_exceeded".to_string(),
+                request_bytes: 4,
+                response_bytes: 1024,
+            },
+            RuntimeFailureKind::OutputTooLarge,
+        ),
+        (
+            RuntimeHttpEgressError::Response {
+                reason: "response_body_limit_exceeded".to_string(),
+                request_bytes: 4,
+                response_bytes: 1024,
+            },
+            RuntimeFailureKind::OutputTooLarge,
+        ),
+        (
+            RuntimeHttpEgressError::Response {
+                reason: "response_decode_failed".to_string(),
+                request_bytes: 4,
+                response_bytes: 1024,
+            },
+            RuntimeFailureKind::InvalidInput,
+        ),
+    ];
+
+    for (error, expected) in cases {
+        let runtime =
+            runtime_with_http_egress(Arc::new(RecordingRuntimeHttpEgress::with_error(error)));
+        let actual = invoke_with_context(
+            &runtime,
+            HTTP_CAPABILITY_ID,
+            json!({"url": "https://api.example.test/v1/items"}),
+            context.clone(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(actual, expected);
+    }
+}
+
+#[tokio::test]
+async fn builtin_http_rejects_sensitive_headers_through_host_validator() {
+    let transport = RecordingTransport::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![],
+        body: b"ok".to_vec(),
+        usage: NetworkUsage::default(),
+    });
+    let requests = transport.requests.clone();
+    let network = PolicyNetworkHttpEgress::new_with_resolver(
+        transport,
+        StaticResolver::new(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))]),
+    );
+    let runtime = runtime_with_host_http_egress(network);
+
+    let error = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "headers": {"authorization": "Bearer token"}
+        }),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::InvalidInput);
+    assert!(requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn builtin_http_exercises_real_policy_private_ip_rejection() {
+    let transport = RecordingTransport::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![],
+        body: b"ok".to_vec(),
+        usage: NetworkUsage::default(),
+    });
+    let requests = transport.requests.clone();
+    let network = PolicyNetworkHttpEgress::new_with_resolver(
+        transport,
+        StaticResolver::new(vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 7))]),
+    );
+    let runtime = runtime_with_host_http_egress(network);
+
+    let error = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({"url": "https://api.example.test/v1/items"}),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(error, RuntimeFailureKind::Network);
+    assert!(requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn builtin_http_runs_blocking_egress_off_tokio_worker() {
+    let egress = Arc::new(SleepingRuntimeHttpEgress {
+        delay: Duration::from_millis(100),
+    });
+    let runtime = runtime_with_http_egress(egress);
+    let invocation = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({"url": "https://api.example.test/v1/items"}),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    );
+    tokio::pin!(invocation);
+
+    tokio::select! {
+        _ = &mut invocation => panic!("HTTP dispatch blocked the tokio worker"),
+        _ = tokio::time::sleep(Duration::from_millis(20)) => {}
+    }
+
+    invocation.await.unwrap();
 }
 
 #[tokio::test]
@@ -1344,6 +1562,26 @@ where
     .host_runtime_for_local_testing()
 }
 
+fn runtime_with_host_http_egress<N>(network: N) -> impl HostRuntime
+where
+    N: NetworkHttpEgress + 'static,
+{
+    HostRuntimeServices::new(
+        Arc::new(registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_secret_store(Arc::new(InMemorySecretStore::new()))
+    .with_first_party_capabilities(Arc::new(builtin_first_party_handlers().unwrap()))
+    .try_with_host_http_egress(network)
+    .unwrap()
+    .with_trust_policy(Arc::new(trust_policy()))
+    .host_runtime_for_local_testing()
+}
+
 fn registry() -> ExtensionRegistry {
     let mut registry = ExtensionRegistry::new();
     registry
@@ -1396,6 +1634,7 @@ fn mounted_filesystem(path: &Path, permissions: MountPermissions) -> (LocalFiles
 struct RecordingRuntimeHttpEgress {
     requests: Arc<std::sync::Mutex<Vec<RuntimeHttpEgressRequest>>>,
     body: Vec<u8>,
+    error: Option<RuntimeHttpEgressError>,
 }
 
 impl RecordingRuntimeHttpEgress {
@@ -1403,6 +1642,15 @@ impl RecordingRuntimeHttpEgress {
         Self {
             requests: Arc::new(std::sync::Mutex::new(Vec::new())),
             body,
+            error: None,
+        }
+    }
+
+    fn with_error(error: RuntimeHttpEgressError) -> Self {
+        Self {
+            requests: Arc::new(std::sync::Mutex::new(Vec::new())),
+            body: Vec::new(),
+            error: Some(error),
         }
     }
 
@@ -1417,6 +1665,9 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
         request: RuntimeHttpEgressRequest,
     ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
         self.requests.lock().unwrap().push(request.clone());
+        if let Some(error) = &self.error {
+            return Err(error.clone());
+        }
         Ok(RuntimeHttpEgressResponse {
             status: 200,
             headers: vec![("content-type".to_string(), "application/json".to_string())],
@@ -1425,6 +1676,70 @@ impl RuntimeHttpEgress for RecordingRuntimeHttpEgress {
             response_bytes: self.body.len() as u64,
             redaction_applied: false,
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SleepingRuntimeHttpEgress {
+    delay: Duration,
+}
+
+impl RuntimeHttpEgress for SleepingRuntimeHttpEgress {
+    fn execute(
+        &self,
+        request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        thread::sleep(self.delay);
+        Ok(RuntimeHttpEgressResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: b"ok".to_vec(),
+            request_bytes: request.body.len() as u64,
+            response_bytes: 2,
+            redaction_applied: false,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RecordingTransport {
+    response: Result<NetworkHttpResponse, NetworkHttpError>,
+    requests: Arc<std::sync::Mutex<Vec<NetworkTransportRequest>>>,
+}
+
+impl RecordingTransport {
+    fn ok(response: NetworkHttpResponse) -> Self {
+        Self {
+            response: Ok(response),
+            requests: Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl NetworkHttpTransport for RecordingTransport {
+    fn execute(
+        &self,
+        request: NetworkTransportRequest,
+    ) -> Result<NetworkHttpResponse, NetworkHttpError> {
+        self.requests.lock().unwrap().push(request);
+        self.response.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StaticResolver {
+    ips: Vec<IpAddr>,
+}
+
+impl StaticResolver {
+    fn new(ips: Vec<IpAddr>) -> Self {
+        Self { ips }
+    }
+}
+
+impl NetworkResolver for StaticResolver {
+    fn resolve_ips(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, NetworkHttpError> {
+        Ok(self.ips.clone())
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_builtin_tools.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
 #[cfg(feature = "libsql")]
@@ -313,6 +314,30 @@ async fn builtin_http_invokes_through_host_runtime_egress() {
 }
 
 #[tokio::test]
+async fn builtin_http_defaults_json_body_content_type() {
+    let egress = Arc::new(RecordingRuntimeHttpEgress::with_body(b"ok".to_vec()));
+    let runtime = runtime_with_http_egress(Arc::clone(&egress));
+
+    invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "body": {"ok": true}
+        }),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap();
+
+    let requests = egress.requests();
+    assert_eq!(
+        requests[0].headers,
+        vec![("content-type".to_string(), "application/json".to_string())]
+    );
+}
+
+#[tokio::test]
 async fn builtin_http_fails_closed_without_runtime_egress() {
     let runtime = runtime();
     let error = invoke_with_context(
@@ -357,6 +382,32 @@ async fn builtin_http_rejects_ambiguous_body_zero_timeout_and_zero_response_limi
             .unwrap_err();
         assert_eq!(error, RuntimeFailureKind::InvalidInput);
     }
+}
+
+#[tokio::test]
+async fn builtin_http_rejects_request_bodies_over_network_egress_cap() {
+    let egress = Arc::new(RecordingRuntimeHttpEgress::default());
+    let runtime = runtime_with_http_egress(Arc::clone(&egress));
+    let context = execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy());
+    let oversized = vec![b'a'; 256 * 1024 + 1];
+
+    for input in [
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "body": String::from_utf8(oversized.clone()).unwrap()
+        }),
+        json!({
+            "url": "https://api.example.test/v1/items",
+            "body_base64": BASE64_STANDARD.encode(&oversized)
+        }),
+    ] {
+        let error = invoke_with_context(&runtime, HTTP_CAPABILITY_ID, input, context.clone())
+            .await
+            .unwrap_err();
+        assert_eq!(error, RuntimeFailureKind::InvalidInput);
+    }
+
+    assert!(egress.requests().is_empty());
 }
 
 #[tokio::test]
@@ -597,6 +648,39 @@ async fn builtin_http_exercises_real_policy_private_ip_rejection() {
 
     assert_eq!(error, RuntimeFailureKind::Network);
     assert!(requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn builtin_http_returns_redirects_without_following_private_location() {
+    let transport = RecordingTransport::ok(NetworkHttpResponse {
+        status: 302,
+        headers: vec![(
+            "location".to_string(),
+            "http://169.254.169.254/latest/meta-data".to_string(),
+        )],
+        body: Vec::new(),
+        usage: NetworkUsage::default(),
+    });
+    let requests = transport.requests.clone();
+    let network = PolicyNetworkHttpEgress::new_with_resolver(
+        transport,
+        StaticResolver::new(vec![IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))]),
+    );
+    let runtime = runtime_with_host_http_egress(network);
+
+    let output = invoke_with_context(
+        &runtime,
+        HTTP_CAPABILITY_ID,
+        json!({"url": "https://api.example.test/v1/items"}),
+        execution_context_with_network([HTTP_CAPABILITY_ID], http_test_policy()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(output["status"], json!(302));
+    let recorded = requests.lock().unwrap();
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].url, "https://api.example.test/v1/items");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Adds a built-in first-party `builtin.http` capability for Reborn first-party tools. The tool accepts method, URL, headers, UTF-8/JSON or base64 request bodies, response limits, and timeouts, then delegates outbound calls to the existing host `RuntimeHttpEgress` path.

## Details

- Registers `builtin.http` alongside the existing built-in first-party tools.
- Passes the configured runtime HTTP egress handle into first-party dispatch requests.
- Keeps credential injection host-derived only: the tool sends an empty `credential_injections` list and cannot mint secret authority from tool input.
- Returns text responses as `body_text` and binary responses as `body_base64`.
- Adds tests for egress dispatch, fail-closed missing egress, ambiguous body inputs, zero timeout rejection, and binary response output.

## Validation

- `cargo fmt --check`
- `cargo check -p ironclaw_host_runtime --lib`
- `cargo clippy -p ironclaw_host_runtime --lib --tests -- -D warnings`
- `cargo test -p ironclaw_host_runtime --test first_party_builtin_tools`