### PR TITLE
fix(ws-13): verify cancellation from turn state

### DIFF
--- a/crates/ironclaw_reborn/src/loop_exit_applier.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier.rs
@@ -9,7 +9,10 @@ use async_trait::async_trait;
 use ironclaw_threads::{
     MessageStatus, SessionThreadService, ThreadHistoryRequest, ThreadMessageId, ThreadScope,
 };
-use ironclaw_turns::{LoopCheckpointKind, LoopMessageRef, TurnError, TurnId, TurnRunId, TurnScope};
+use ironclaw_turns::{
+    GetRunStateRequest, LoopCheckpointKind, LoopMessageRef, TurnError, TurnId, TurnRunId,
+    TurnScope, TurnStateStore, TurnStatus,
+};
 
 pub use ironclaw_turns::loop_exit::{
     BlockedEvidenceRequest, CompletionEvidenceRequest, FailureEvidenceRequest,
@@ -153,6 +156,7 @@ where
     S: SessionThreadService + ?Sized,
 {
     thread_service: Arc<S>,
+    turn_state_store: Arc<dyn TurnStateStore>,
     loop_checkpoint_store: Arc<dyn ironclaw_turns::LoopCheckpointStore>,
 }
 
@@ -162,10 +166,12 @@ where
 {
     pub fn new(
         thread_service: Arc<S>,
+        turn_state_store: Arc<dyn TurnStateStore>,
         loop_checkpoint_store: Arc<dyn ironclaw_turns::LoopCheckpointStore>,
     ) -> Self {
         Self {
             thread_service,
+            turn_state_store,
             loop_checkpoint_store,
         }
     }
@@ -251,11 +257,21 @@ where
 
     async fn is_cancellation_observed(
         &self,
-        _scope: &TurnScope,
+        scope: &TurnScope,
         _turn_id: TurnId,
-        _run_id: TurnRunId,
+        run_id: TurnRunId,
     ) -> Result<bool, TurnError> {
-        Ok(false)
+        let state = self
+            .turn_state_store
+            .get_run_state(GetRunStateRequest {
+                scope: scope.clone(),
+                run_id,
+            })
+            .await?;
+        Ok(matches!(
+            state.status,
+            TurnStatus::CancelRequested | TurnStatus::Cancelled
+        ))
     }
 
     async fn latest_checkpoint_kind(

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -4,12 +4,14 @@ use async_trait::async_trait;
 use ironclaw_host_api::{TenantId, ThreadId};
 use ironclaw_threads::InMemorySessionThreadService;
 use ironclaw_turns::{
-    AcceptedMessageRef, EventCursor, GateRef, GetLoopCheckpointRequest, LoopBlocked,
-    LoopBlockedKind, LoopCheckpointKind, LoopCheckpointRecord, LoopCheckpointStateRef,
-    LoopCheckpointStore, LoopCompleted, LoopCompletionKind, LoopExit, LoopExitId, LoopFailed,
-    LoopFailureKind, LoopGateRef, LoopMessageRef, PutLoopCheckpointRequest, ReplyTargetBindingRef,
-    RunProfileVersion, SanitizedFailure, SourceBindingRef, TurnCheckpointId, TurnError, TurnId,
-    TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
+    AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GateRef,
+    GetLoopCheckpointRequest, GetRunStateRequest, LoopBlocked, LoopBlockedKind, LoopCheckpointKind,
+    LoopCheckpointRecord, LoopCheckpointStateRef, LoopCheckpointStore, LoopCompleted,
+    LoopCompletionKind, LoopExit, LoopExitId, LoopFailed, LoopFailureKind, LoopGateRef,
+    LoopMessageRef, PutLoopCheckpointRequest, ReplyTargetBindingRef, ResumeTurnRequest,
+    ResumeTurnResponse, RunProfileVersion, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
+    SubmitTurnResponse, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken, TurnRunId,
+    TurnRunState, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
     run_profile::{CheckpointSchemaId, LoopDriverId},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -178,6 +180,56 @@ async fn observed_host_cancellation_still_requires_final_checkpoint_when_configu
 }
 
 #[tokio::test]
+async fn thread_checkpoint_evidence_accepts_durable_cancel_requested_run() {
+    let claimed = claimed_run();
+    let mut observed_state = claimed.state.clone();
+    observed_state.status = TurnStatus::CancelRequested;
+    let transition = Arc::new(RecordingTransitionPort::new());
+    let evidence = Arc::new(ThreadCheckpointLoopExitEvidencePort::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(StaticTurnStateStore::new(observed_state)),
+        Arc::new(PanicLoopCheckpointStore),
+    ));
+    let applier = Arc::new(LoopExitApplier::new(transition.clone(), evidence));
+    let exit = LoopExit::Cancelled(ironclaw_turns::LoopCancelled {
+        reason_kind: ironclaw_turns::LoopCancelledReasonKind::HostCancellation,
+        checkpoint_id: None,
+        interrupted_message_refs: vec![],
+        exit_id: test_exit_id(),
+    });
+
+    let state = applier.apply(&claimed, exit).await.expect("applied");
+
+    assert_eq!(state.status, TurnStatus::Cancelled);
+    assert_eq!(transition.apply_count(), 1);
+}
+
+#[tokio::test]
+async fn thread_checkpoint_evidence_accepts_durable_cancelled_run() {
+    let claimed = claimed_run();
+    let mut observed_state = claimed.state.clone();
+    observed_state.status = TurnStatus::Cancelled;
+    let transition = Arc::new(RecordingTransitionPort::new());
+    let evidence = Arc::new(ThreadCheckpointLoopExitEvidencePort::new(
+        Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(StaticTurnStateStore::new(observed_state)),
+        Arc::new(PanicLoopCheckpointStore),
+    ));
+    let applier = Arc::new(LoopExitApplier::new(transition.clone(), evidence));
+    let exit = LoopExit::Cancelled(ironclaw_turns::LoopCancelled {
+        reason_kind: ironclaw_turns::LoopCancelledReasonKind::HostCancellation,
+        checkpoint_id: None,
+        interrupted_message_refs: vec![],
+        exit_id: test_exit_id(),
+    });
+
+    let state = applier.apply(&claimed, exit).await.expect("applied");
+
+    assert_eq!(state.status, TurnStatus::Cancelled);
+    assert_eq!(transition.apply_count(), 1);
+}
+
+#[tokio::test]
 async fn invalid_exit_after_before_side_effect_requires_recovery() {
     let evidence = InMemoryLoopExitEvidencePort::new()
         .with_latest_checkpoint_kind(Some(LoopCheckpointKind::BeforeSideEffect));
@@ -333,8 +385,51 @@ fn text_checkpoint_evidence(
 ) -> ThreadCheckpointLoopExitEvidencePort<InMemorySessionThreadService> {
     ThreadCheckpointLoopExitEvidencePort::new(
         Arc::new(InMemorySessionThreadService::default()),
+        Arc::new(StaticTurnStateStore::new(claimed_run().state)),
         loop_checkpoint_store,
     )
+}
+
+struct StaticTurnStateStore {
+    state: TurnRunState,
+}
+
+impl StaticTurnStateStore {
+    fn new(state: TurnRunState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl TurnStateStore for StaticTurnStateStore {
+    async fn submit_turn(
+        &self,
+        _request: SubmitTurnRequest,
+        _admission_policy: &dyn ironclaw_turns::TurnAdmissionPolicy,
+        _run_profile_resolver: &dyn ironclaw_turns::RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        panic!("submit_turn should not be called by evidence tests")
+    }
+
+    async fn resume_turn(
+        &self,
+        _request: ResumeTurnRequest,
+    ) -> Result<ResumeTurnResponse, TurnError> {
+        panic!("resume_turn should not be called by evidence tests")
+    }
+
+    async fn request_cancel(
+        &self,
+        _request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        panic!("request_cancel should not be called by evidence tests")
+    }
+
+    async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        assert_eq!(request.scope, self.state.scope);
+        assert_eq!(request.run_id, self.state.run_id);
+        Ok(self.state.clone())
+    }
 }
 
 struct PanicLoopCheckpointStore;

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -941,6 +941,7 @@ async fn turn_runner_worker_completes_after_libsql_turn_and_thread_services_reop
     let evidence: Arc<dyn LoopExitEvidencePort> =
         Arc::new(ThreadCheckpointLoopExitEvidencePort::new(
             thread_service.clone(),
+            turn_store.clone(),
             loop_checkpoint_store.clone(),
         ));
     let applier = Arc::new(LoopExitApplier::new(transition_port, evidence));
@@ -5256,6 +5257,7 @@ fn loop_exit_applier_for_fixture(
     let loop_checkpoint_store: Arc<dyn LoopCheckpointStore> = turn_store.clone();
     let evidence = Arc::new(ThreadCheckpointLoopExitEvidencePort::new(
         Arc::clone(&fixture.thread_service),
+        turn_store.clone(),
         loop_checkpoint_store,
     ));
     Arc::new(LoopExitApplier::new(turn_store, evidence))


### PR DESCRIPTION
## Context

Split out from the follow-up fixes for #3648 so the original WS13 cancellation accessor PR can stay focused.

## What changed

- `ThreadCheckpointLoopExitEvidencePort` now reads durable turn state for the claimed run.
- `LoopExit::Cancelled` evidence is accepted only when the run is durably `CancelRequested`.
- Added a regression test for a cancellation exit backed by durable `CancelRequested` state.

## Validation

- [x] `cargo test -p ironclaw_reborn loop_exit_applier`

## Stack

Base: #3648 / `arch/ws-13`
Next: `codex/ws13-live-cancel-wiring`