### PR TITLE
fix(ws-13): wire live cancellation into host

### DIFF
--- a/crates/ironclaw_loop_support/Cargo.toml
+++ b/crates/ironclaw_loop_support/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 parking_lot = "0.12"
 tracing = "0.1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["rt", "sync", "time"] }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime", version = "0.1.0" }
 ironclaw_skills = { path = "../ironclaw_skills", version = "0.3.0", default-features = false }

--- a/crates/ironclaw_loop_support/src/cancellation_port.rs
+++ b/crates/ironclaw_loop_support/src/cancellation_port.rs
@@ -1,44 +1,90 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
 };
 
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_turns::{
-    TurnRunId,
+    GetRunStateRequest, TurnRunId, TurnRunWake, TurnRunWakeNotifier, TurnScope, TurnStateStore,
+    TurnStatus,
     run_profile::{
-        AgentLoopHostError, LoopCancelReasonKind, LoopCancellationPort, LoopCancellationSignal,
+        AgentLoopHostError, AgentLoopHostErrorKind, LoopCancelReasonKind, LoopCancellationPort,
+        LoopCancellationSignal,
     },
 };
 use parking_lot::RwLock;
+
+const DEFAULT_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+#[derive(Clone)]
+struct RunCancellationRequester {
+    fired: Arc<AtomicBool>,
+    signal: Arc<RwLock<Option<LoopCancellationSignal>>>,
+    owner: Weak<()>,
+}
+
+impl RunCancellationRequester {
+    fn request(&self, reason_kind: LoopCancelReasonKind) {
+        request_cancellation(&self.fired, &self.signal, reason_kind);
+    }
+
+    fn is_owner_alive(&self) -> bool {
+        self.owner.upgrade().is_some()
+    }
+}
+
+fn request_cancellation(
+    fired: &AtomicBool,
+    signal: &RwLock<Option<LoopCancellationSignal>>,
+    reason_kind: LoopCancelReasonKind,
+) {
+    if fired.load(Ordering::Acquire) {
+        return;
+    }
+    let mut signal_lock = signal.write();
+    if signal_lock.is_some() {
+        return;
+    }
+    let new_signal = LoopCancellationSignal {
+        reason_kind,
+        requested_at: Utc::now(),
+    };
+    *signal_lock = Some(new_signal);
+    // Publish `fired` while the write guard is still held so any reader that
+    // observes `fired == true` via Acquire is also guaranteed to see the
+    // populated `signal_lock`, independent of the RwLock's own ordering.
+    fired.store(true, Ordering::Release);
+    drop(signal_lock);
+}
 
 /// Snapshot handle the host runtime owns and flips on cancellation.
 #[derive(Clone, Default)]
 pub struct RunCancellationHandle {
     fired: Arc<AtomicBool>,
     signal: Arc<RwLock<Option<LoopCancellationSignal>>>,
+    owner: Arc<()>,
 }
 
 impl RunCancellationHandle {
     pub fn request(&self, reason_kind: LoopCancelReasonKind) {
-        if self.fired.load(Ordering::Acquire) {
-            return;
-        }
-        let mut signal_lock = self.signal.write();
-        if signal_lock.is_some() {
-            return;
-        }
-        let signal = LoopCancellationSignal {
-            reason_kind,
-            requested_at: Utc::now(),
-        };
-        *signal_lock = Some(signal);
-        self.fired.store(true, Ordering::Release);
+        request_cancellation(&self.fired, &self.signal, reason_kind);
     }
 
     pub fn is_requested(&self) -> bool {
         self.fired.load(Ordering::Acquire)
+    }
+
+    fn requester(&self) -> RunCancellationRequester {
+        RunCancellationRequester {
+            fired: Arc::clone(&self.fired),
+            signal: Arc::clone(&self.signal),
+            owner: Arc::downgrade(&self.owner),
+        }
     }
 }
 
@@ -82,8 +128,11 @@ pub trait RunCancellationFactory: Send + Sync {
 
     async fn handle_for_run(
         &self,
+        scope: &TurnScope,
         run_id: TurnRunId,
     ) -> Result<RunCancellationHandle, AgentLoopHostError>;
+
+    fn notify_run_wake(&self, _wake: &TurnRunWake) {}
 }
 
 /// Runtime liveness contract for run cancellation observation.
@@ -101,6 +150,189 @@ impl RunCancellationObservationKind {
     }
 }
 
+/// Run cancellation factory backed by durable turn state.
+///
+/// Handles are seeded from the current run state before being returned and are
+/// registered for later wake-driven flips. A lightweight polling fallback
+/// covers runtimes that have not yet wired the wake notifier into their cancel
+/// path.
+pub struct TurnStateRunCancellationFactory {
+    store: Arc<dyn TurnStateStore>,
+    handles: Arc<RwLock<HashMap<TurnRunId, Vec<RunCancellationRequester>>>>,
+    poll_interval: Duration,
+}
+
+impl TurnStateRunCancellationFactory {
+    pub fn new(store: Arc<dyn TurnStateStore>) -> Self {
+        Self {
+            store,
+            handles: Arc::new(RwLock::new(HashMap::new())),
+            poll_interval: DEFAULT_CANCEL_POLL_INTERVAL,
+        }
+    }
+
+    pub fn with_poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+
+    fn notify_cancel_requested(&self, run_id: TurnRunId) {
+        // Atomically drain the entry so any concurrent `register` that arrives
+        // after this point starts a fresh vec instead of being silently dropped
+        // by a follow-up `remove_run`.
+        let requesters = self.handles.write().remove(&run_id);
+        if let Some(requesters) = requesters {
+            for requester in requesters {
+                requester.request(LoopCancelReasonKind::UserRequested);
+            }
+        }
+    }
+
+    async fn read_run_status(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> Result<TurnStatus, AgentLoopHostError> {
+        self.store
+            .get_run_state(GetRunStateRequest {
+                scope: scope.clone(),
+                run_id,
+            })
+            .await
+            .map(|state| state.status)
+            .map_err(turn_state_error_to_host_error)
+    }
+
+    async fn seed_from_state(
+        &self,
+        scope: &TurnScope,
+        requester: &RunCancellationRequester,
+        run_id: TurnRunId,
+    ) -> Result<TurnStatus, AgentLoopHostError> {
+        let status = self.read_run_status(scope, run_id).await?;
+        if status == TurnStatus::CancelRequested {
+            requester.request(LoopCancelReasonKind::UserRequested);
+        }
+        Ok(status)
+    }
+
+    fn register(&self, run_id: TurnRunId, requester: RunCancellationRequester) {
+        self.handles
+            .write()
+            .entry(run_id)
+            .or_default()
+            .push(requester);
+    }
+
+    fn remove_run(&self, run_id: TurnRunId) {
+        remove_run_handles(&self.handles, run_id);
+    }
+
+    #[cfg(test)]
+    fn registered_run_count(&self) -> usize {
+        self.handles.read().len()
+    }
+
+    fn spawn_polling_fallback(
+        &self,
+        scope: TurnScope,
+        run_id: TurnRunId,
+        requester: RunCancellationRequester,
+    ) {
+        let store = Arc::clone(&self.store);
+        let handles = Arc::clone(&self.handles);
+        let base_interval = self.poll_interval;
+        tokio::spawn(async move {
+            // Exponential backoff caps long-lived stuck runs (e.g. `RecoveryRequired`)
+            // at one poll every `MAX_POLL_INTERVAL` instead of hammering the store at
+            // `base_interval` for the full owner lifetime.
+            const MAX_POLL_INTERVAL: Duration = Duration::from_secs(5);
+            let mut interval = base_interval;
+            while requester.is_owner_alive() && !requester.fired.load(Ordering::Acquire) {
+                let status = store
+                    .get_run_state(GetRunStateRequest {
+                        scope: scope.clone(),
+                        run_id,
+                    })
+                    .await
+                    .map(|state| state.status);
+                match status {
+                    Ok(TurnStatus::CancelRequested) => {
+                        requester.request(LoopCancelReasonKind::UserRequested);
+                        break;
+                    }
+                    Ok(status) if status.is_terminal() => break,
+                    Ok(_) | Err(_) => {
+                        interval = (interval.saturating_mul(2)).min(MAX_POLL_INTERVAL);
+                    }
+                }
+                tokio::time::sleep(interval).await;
+            }
+            remove_run_handles(&handles, run_id);
+        });
+    }
+}
+
+#[async_trait]
+impl RunCancellationFactory for TurnStateRunCancellationFactory {
+    async fn handle_for_run(
+        &self,
+        scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> Result<RunCancellationHandle, AgentLoopHostError> {
+        let handle = RunCancellationHandle::default();
+        let requester = handle.requester();
+        let first_status = self.seed_from_state(scope, &requester, run_id).await?;
+        if first_status == TurnStatus::CancelRequested || first_status.is_terminal() {
+            return Ok(handle);
+        }
+        self.register(run_id, requester.clone());
+        // Once registered, any error path MUST drop the entry; otherwise the
+        // caller never receives `handle`, the `Weak<()>` owner dies, and the
+        // `RunCancellationRequester` leaks in `self.handles` forever.
+        match self.seed_from_state(scope, &requester, run_id).await {
+            Ok(second_status)
+                if second_status == TurnStatus::CancelRequested || second_status.is_terminal() =>
+            {
+                self.remove_run(run_id);
+            }
+            Ok(_) => {
+                self.spawn_polling_fallback(scope.clone(), run_id, requester);
+            }
+            Err(error) => {
+                self.remove_run(run_id);
+                return Err(error);
+            }
+        }
+        Ok(handle)
+    }
+
+    fn notify_run_wake(&self, wake: &TurnRunWake) {
+        if wake.status == TurnStatus::CancelRequested {
+            self.notify_cancel_requested(wake.run_id);
+        } else if wake.status.is_terminal() {
+            self.remove_run(wake.run_id);
+        }
+    }
+}
+
+impl TurnRunWakeNotifier for TurnStateRunCancellationFactory {
+    fn notify_queued_run(
+        &self,
+        wake: TurnRunWake,
+    ) -> Result<(), ironclaw_turns::TurnRunWakeNotifyError> {
+        self.notify_run_wake(&wake);
+        Ok(())
+    }
+}
+
+fn turn_state_error_to_host_error(_error: ironclaw_turns::TurnError) -> AgentLoopHostError {
+    AgentLoopHostError::new(
+        AgentLoopHostErrorKind::Unavailable,
+        "turn state was unavailable while building cancellation handle",
+    )
+}
+
 /// Default factory used until the host runtime wires real cancel observation.
 pub struct AlwaysAliveRunCancellationFactory;
 
@@ -112,10 +344,18 @@ impl RunCancellationFactory for AlwaysAliveRunCancellationFactory {
 
     async fn handle_for_run(
         &self,
+        _scope: &TurnScope,
         _run_id: TurnRunId,
     ) -> Result<RunCancellationHandle, AgentLoopHostError> {
         Ok(RunCancellationHandle::default())
     }
+}
+
+fn remove_run_handles(
+    handles: &RwLock<HashMap<TurnRunId, Vec<RunCancellationRequester>>>,
+    run_id: TurnRunId,
+) {
+    handles.write().remove(&run_id);
 }
 
 #[cfg(test)]
@@ -125,12 +365,21 @@ mod tests {
 
     use async_trait::async_trait;
     use chrono::Utc;
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
     use ironclaw_turns::run_profile::{LoopCancelReasonKind, LoopCancellationPort};
-    use ironclaw_turns::{TurnRunId, run_profile::AgentLoopHostError};
+    use ironclaw_turns::{
+        AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GetRunStateRequest,
+        ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,
+        RunProfileResolver, RunProfileVersion, SourceBindingRef, SubmitTurnRequest,
+        SubmitTurnResponse, TurnAdmissionPolicy, TurnError, TurnId, TurnRunId, TurnRunState,
+        TurnRunWake, TurnRunWakeNotifier, TurnScope, TurnStateStore, TurnStatus,
+        run_profile::AgentLoopHostError,
+    };
 
     use super::{
         AlwaysAliveLoopCancellationPort, AlwaysAliveRunCancellationFactory, RunCancellationFactory,
         RunCancellationHandle, RunCancellationObservationKind, RunStateLoopCancellationPort,
+        TurnStateRunCancellationFactory,
     };
 
     struct TestLiveCancellationFactory;
@@ -139,9 +388,79 @@ mod tests {
     impl RunCancellationFactory for TestLiveCancellationFactory {
         async fn handle_for_run(
             &self,
+            _scope: &TurnScope,
             _run_id: TurnRunId,
         ) -> Result<RunCancellationHandle, AgentLoopHostError> {
             Ok(RunCancellationHandle::default())
+        }
+    }
+
+    struct StaticTurnStateStore {
+        state: TurnRunState,
+    }
+
+    impl StaticTurnStateStore {
+        fn new(state: TurnRunState) -> Self {
+            Self { state }
+        }
+    }
+
+    #[async_trait]
+    impl TurnStateStore for StaticTurnStateStore {
+        async fn submit_turn(
+            &self,
+            _request: SubmitTurnRequest,
+            _admission_policy: &dyn TurnAdmissionPolicy,
+            _run_profile_resolver: &dyn RunProfileResolver,
+        ) -> Result<SubmitTurnResponse, TurnError> {
+            panic!("submit_turn should not be called by cancellation factory tests")
+        }
+
+        async fn resume_turn(
+            &self,
+            _request: ResumeTurnRequest,
+        ) -> Result<ResumeTurnResponse, TurnError> {
+            panic!("resume_turn should not be called by cancellation factory tests")
+        }
+
+        async fn request_cancel(
+            &self,
+            _request: CancelRunRequest,
+        ) -> Result<CancelRunResponse, TurnError> {
+            panic!("request_cancel should not be called by cancellation factory tests")
+        }
+
+        async fn get_run_state(
+            &self,
+            request: GetRunStateRequest,
+        ) -> Result<TurnRunState, TurnError> {
+            assert_eq!(request.scope, self.state.scope);
+            assert_eq!(request.run_id, self.state.run_id);
+            Ok(self.state.clone())
+        }
+    }
+
+    fn test_run_state(status: TurnStatus) -> TurnRunState {
+        let tenant_id = TenantId::new("tenant-cancel-factory").unwrap();
+        let agent_id = AgentId::new("agent-cancel-factory").unwrap();
+        let project_id = ProjectId::new("project-cancel-factory").unwrap();
+        let thread_id = ThreadId::new("thread-cancel-factory").unwrap();
+        TurnRunState {
+            scope: TurnScope::new(tenant_id, Some(agent_id), Some(project_id), thread_id),
+            turn_id: TurnId::new(),
+            run_id: TurnRunId::new(),
+            status,
+            accepted_message_ref: AcceptedMessageRef::new("accepted-cancel-factory").unwrap(),
+            source_binding_ref: SourceBindingRef::new("source-cancel-factory").unwrap(),
+            reply_target_binding_ref: ReplyTargetBindingRef::new("reply-cancel-factory").unwrap(),
+            resolved_run_profile_id: RunProfileId::default_profile(),
+            resolved_run_profile_version: RunProfileVersion::new(1),
+            resolved_model_route: None,
+            received_at: Utc::now(),
+            checkpoint_id: None,
+            gate_ref: None,
+            failure: None,
+            event_cursor: EventCursor(1),
         }
     }
 
@@ -244,8 +563,180 @@ mod tests {
         );
         assert!(!factory.observation_kind().is_live_capable());
 
-        let handle = factory.handle_for_run(TurnRunId::new()).await.unwrap();
+        let state = test_run_state(TurnStatus::Running);
+        let handle = factory
+            .handle_for_run(&state.scope, TurnRunId::new())
+            .await
+            .unwrap();
         assert!(!handle.is_requested());
+    }
+
+    #[tokio::test]
+    async fn turn_state_factory_seeds_already_cancel_requested_run() {
+        let state = test_run_state(TurnStatus::CancelRequested);
+        let factory = TurnStateRunCancellationFactory::new(Arc::new(StaticTurnStateStore::new(
+            state.clone(),
+        )));
+
+        let handle = factory
+            .handle_for_run(&state.scope, state.run_id)
+            .await
+            .unwrap();
+
+        assert!(handle.is_requested());
+        let port = RunStateLoopCancellationPort::new(handle);
+        let signal = port.observe_cancellation().expect("cancel signal");
+        assert_eq!(signal.reason_kind, LoopCancelReasonKind::UserRequested);
+    }
+
+    #[tokio::test]
+    async fn turn_state_factory_flips_registered_handle_from_cancel_wake() {
+        let state = test_run_state(TurnStatus::Running);
+        let factory = TurnStateRunCancellationFactory::new(Arc::new(StaticTurnStateStore::new(
+            state.clone(),
+        )))
+        .with_poll_interval(Duration::from_secs(60));
+        let handle = factory
+            .handle_for_run(&state.scope, state.run_id)
+            .await
+            .unwrap();
+        assert!(!handle.is_requested());
+
+        factory
+            .notify_queued_run(TurnRunWake {
+                scope: state.scope,
+                run_id: state.run_id,
+                status: TurnStatus::CancelRequested,
+                event_cursor: EventCursor(2),
+            })
+            .unwrap();
+
+        assert!(handle.is_requested());
+    }
+
+    #[tokio::test]
+    async fn turn_state_factory_prunes_run_after_cancel_wake() {
+        let state = test_run_state(TurnStatus::Running);
+        let factory = TurnStateRunCancellationFactory::new(Arc::new(StaticTurnStateStore::new(
+            state.clone(),
+        )))
+        .with_poll_interval(Duration::from_secs(60));
+        let _handle = factory
+            .handle_for_run(&state.scope, state.run_id)
+            .await
+            .unwrap();
+        assert_eq!(factory.registered_run_count(), 1);
+
+        factory
+            .notify_queued_run(TurnRunWake {
+                scope: state.scope,
+                run_id: state.run_id,
+                status: TurnStatus::CancelRequested,
+                event_cursor: EventCursor(2),
+            })
+            .unwrap();
+
+        assert_eq!(factory.registered_run_count(), 0);
+    }
+
+    struct MutableTurnStateStore {
+        state: std::sync::Mutex<TurnRunState>,
+    }
+
+    impl MutableTurnStateStore {
+        fn new(state: TurnRunState) -> Self {
+            Self {
+                state: std::sync::Mutex::new(state),
+            }
+        }
+
+        fn set_status(&self, status: TurnStatus) {
+            self.state.lock().unwrap().status = status;
+        }
+    }
+
+    #[async_trait]
+    impl TurnStateStore for MutableTurnStateStore {
+        async fn submit_turn(
+            &self,
+            _request: SubmitTurnRequest,
+            _admission_policy: &dyn TurnAdmissionPolicy,
+            _run_profile_resolver: &dyn RunProfileResolver,
+        ) -> Result<SubmitTurnResponse, TurnError> {
+            panic!("submit_turn should not be called by cancellation factory tests")
+        }
+
+        async fn resume_turn(
+            &self,
+            _request: ResumeTurnRequest,
+        ) -> Result<ResumeTurnResponse, TurnError> {
+            panic!("resume_turn should not be called by cancellation factory tests")
+        }
+
+        async fn request_cancel(
+            &self,
+            _request: CancelRunRequest,
+        ) -> Result<CancelRunResponse, TurnError> {
+            panic!("request_cancel should not be called by cancellation factory tests")
+        }
+
+        async fn get_run_state(
+            &self,
+            _request: GetRunStateRequest,
+        ) -> Result<TurnRunState, TurnError> {
+            Ok(self.state.lock().unwrap().clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn turn_state_factory_polling_fallback_fires_without_wake() {
+        let initial = test_run_state(TurnStatus::Running);
+        let store = Arc::new(MutableTurnStateStore::new(initial.clone()));
+        let factory = TurnStateRunCancellationFactory::new(store.clone())
+            .with_poll_interval(Duration::from_millis(5));
+        let handle = factory
+            .handle_for_run(&initial.scope, initial.run_id)
+            .await
+            .unwrap();
+        assert!(!handle.is_requested());
+
+        // Transition durable state without dispatching a wake — only the
+        // polling-fallback task can discover the flip.
+        store.set_status(TurnStatus::CancelRequested);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while !handle.is_requested() {
+            if std::time::Instant::now() > deadline {
+                panic!("polling fallback never observed cancel-requested transition");
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn turn_state_factory_prunes_run_after_terminal_wake() {
+        let state = test_run_state(TurnStatus::Running);
+        let factory = TurnStateRunCancellationFactory::new(Arc::new(StaticTurnStateStore::new(
+            state.clone(),
+        )))
+        .with_poll_interval(Duration::from_secs(60));
+        let handle = factory
+            .handle_for_run(&state.scope, state.run_id)
+            .await
+            .unwrap();
+        assert_eq!(factory.registered_run_count(), 1);
+
+        factory
+            .notify_queued_run(TurnRunWake {
+                scope: state.scope,
+                run_id: state.run_id,
+                status: TurnStatus::Completed,
+                event_cursor: EventCursor(2),
+            })
+            .unwrap();
+
+        assert!(!handle.is_requested());
+        assert_eq!(factory.registered_run_count(), 0);
     }
 
     #[test]

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -22,6 +22,7 @@ mod skill_context;
 pub use cancellation_port::{
     AlwaysAliveLoopCancellationPort, AlwaysAliveRunCancellationFactory, RunCancellationFactory,
     RunCancellationHandle, RunCancellationObservationKind, RunStateLoopCancellationPort,
+    TurnStateRunCancellationFactory,
 };
 pub use capability_allow_set::{
     CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -6,11 +6,11 @@ use std::{
 
 use async_trait::async_trait;
 use ironclaw_loop_support::{
-    AlwaysAliveRunCancellationFactory, CapabilitySurfaceProfileFilter,
-    CapabilitySurfaceProfileResolver, EmptyLoopCapabilityPort, HostIdentityContextSource,
-    HostInputQueue, HostManagedModelGateway, HostQueueLoopInputPort, HostSkillContextSource,
-    RunCancellationFactory, RunCancellationObservationKind, RunStateLoopCancellationPort,
-    ThreadBackedLoopContextPort, ThreadBackedLoopModelPort, ThreadBackedLoopTranscriptPort,
+    CapabilitySurfaceProfileFilter, CapabilitySurfaceProfileResolver, EmptyLoopCapabilityPort,
+    HostIdentityContextSource, HostInputQueue, HostManagedModelGateway, HostQueueLoopInputPort,
+    HostSkillContextSource, RunCancellationFactory, RunCancellationObservationKind,
+    RunStateLoopCancellationPort, ThreadBackedLoopContextPort, ThreadBackedLoopModelPort,
+    ThreadBackedLoopTranscriptPort, TurnStateRunCancellationFactory,
 };
 use ironclaw_threads::{SessionThreadService, ThreadScope};
 
@@ -19,7 +19,8 @@ use crate::model_routes::{ModelRouteError, ModelRouteResolver, ModelSlot};
 use ironclaw_turns::{
     CheckpointStateStore, GetCheckpointStateRequest, GetLoopCheckpointRequest,
     LoopCheckpointStateRef, LoopCheckpointStore, PutCheckpointStateRequest,
-    PutLoopCheckpointRequest, RunProfileId, TurnCheckpointId, TurnError, TurnStatus,
+    PutLoopCheckpointRequest, RunProfileId, TurnCheckpointId, TurnError, TurnRunWake,
+    TurnRunWakeNotifier, TurnRunWakeNotifyError, TurnStateStore, TurnStatus,
     run_profile::{
         AgentLoopHostError, AgentLoopHostErrorKind, AppendCapabilityResultRef, BeginAssistantDraft,
         CapabilityBatchInvocation, CapabilityBatchOutcome, CapabilityInvocation, CapabilityOutcome,
@@ -179,15 +180,20 @@ where
     S: SessionThreadService + ?Sized + Send + Sync + 'static,
     G: HostManagedModelGateway + ?Sized + Send + Sync + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         thread_service: Arc<S>,
         thread_scope: ThreadScope,
         model_gateway: Arc<G>,
         checkpoint_state_store: Arc<dyn CheckpointStateStore>,
+        turn_state_store: Arc<dyn TurnStateStore>,
         loop_checkpoint_store: Arc<dyn LoopCheckpointStore>,
         milestone_sink: Arc<dyn LoopHostMilestoneSink>,
         config: TextOnlyLoopHostConfig,
     ) -> Self {
+        let cancellation_factory: Arc<dyn RunCancellationFactory> = Arc::new(
+            TurnStateRunCancellationFactory::new(Arc::clone(&turn_state_store)),
+        );
         Self {
             thread_service,
             thread_scope,
@@ -198,7 +204,7 @@ where
             milestone_sink,
             model_accountant: Arc::new(NoOpBudgetAccountant),
             model_policy_guard: Arc::new(NoOpPolicyGuard),
-            cancellation_factory: Arc::new(AlwaysAliveRunCancellationFactory),
+            cancellation_factory,
             config,
             skill_context_source: None,
             safety_context: None,
@@ -395,7 +401,7 @@ where
         ));
         let cancellation_handle = self
             .cancellation_factory
-            .handle_for_run(run_context.run_id)
+            .handle_for_run(&run_context.scope, run_context.run_id)
             .await
             .map_err(|error| RebornLoopDriverHostError::InvalidRequest {
                 reason: error.safe_summary,
@@ -454,6 +460,17 @@ where
             .resolve_model_route(slot)
             .map_err(model_route_error_to_host_error)?;
         Ok(run_context.with_resolved_model_route(snapshot.to_loop_model_route_snapshot()))
+    }
+}
+
+impl<S, G> TurnRunWakeNotifier for RebornLoopDriverHostFactory<S, G>
+where
+    S: SessionThreadService + ?Sized + Send + Sync + 'static,
+    G: HostManagedModelGateway + ?Sized + Send + Sync + 'static,
+{
+    fn notify_queued_run(&self, wake: TurnRunWake) -> Result<(), TurnRunWakeNotifyError> {
+        self.cancellation_factory.notify_run_wake(&wake);
+        Ok(())
     }
 }
 

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -66,29 +66,31 @@ use ironclaw_trust::{
 };
 use ironclaw_turns::{
     AcceptedMessageRef, AgentLoopDriver, AgentLoopDriverDescriptor, AgentLoopDriverError,
-    AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, CheckpointStateStore,
-    DefaultTurnCoordinator, EventCursor, GetCheckpointStateRequest, GetLoopCheckpointRequest,
-    GetRunStateRequest, IdempotencyKey, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
-    InMemoryRunProfileResolver, InMemoryTurnStateStore, InMemoryTurnStateStoreLimits, LoopBlocked,
-    LoopBlockedKind, LoopCheckpointRecord, LoopCheckpointStore, LoopCompleted, LoopCompletionKind,
-    LoopExit, LoopExitId, LoopGateRef, LoopMessageRef, LoopResultRef, PutCheckpointStateRequest,
-    PutLoopCheckpointRequest, ReplyTargetBindingRef, ResumeTurnRequest, RunProfileId,
-    RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion, SourceBindingRef,
-    SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnCoordinator, TurnError, TurnId,
-    TurnLeaseToken, TurnRunId, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
+    AgentLoopDriverResumeRequest, AgentLoopDriverRunRequest, CancelRunRequest, CancelRunResponse,
+    CheckpointStateStore, DefaultTurnCoordinator, EventCursor, GetCheckpointStateRequest,
+    GetLoopCheckpointRequest, GetRunStateRequest, IdempotencyKey, InMemoryCheckpointStateStore,
+    InMemoryLoopCheckpointStore, InMemoryRunProfileResolver, InMemoryTurnStateStore,
+    InMemoryTurnStateStoreLimits, LoopBlocked, LoopBlockedKind, LoopCheckpointRecord,
+    LoopCheckpointStore, LoopCompleted, LoopCompletionKind, LoopExit, LoopExitId, LoopGateRef,
+    LoopMessageRef, LoopResultRef, PutCheckpointStateRequest, PutLoopCheckpointRequest,
+    ReplyTargetBindingRef, ResumeTurnRequest, RunProfileId, RunProfileResolutionRequest,
+    RunProfileResolver, RunProfileVersion, SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse,
+    TurnActor, TurnAdmissionPolicy, TurnCoordinator, TurnError, TurnId, TurnLeaseToken, TurnRunId,
+    TurnRunState, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
     run_profile::{
         AgentLoopDriverHost, AgentLoopHostError, AgentLoopHostErrorKind, AssistantReply,
         BatchPolicyKind, CapabilityDeniedReasonKind, CapabilityFailureKind, CapabilityInputRef,
         CapabilityInvocation, CapabilityOutcome, CapabilitySurfaceVersion,
         FinalizeAssistantMessage, InMemoryLoopHostMilestoneSink, InstructionSafetyContext,
-        LoopCapabilityPort, LoopCheckpointKind, LoopCheckpointPort, LoopCheckpointRequest,
-        LoopCheckpointStateRef, LoopContextRequest, LoopDriverId, LoopDriverNoteKind, LoopGateKind,
-        LoopHostMilestone, LoopHostMilestoneKind, LoopInlineMessage, LoopInlineMessageRole,
-        LoopInput, LoopInputAckToken, LoopInputCursor, LoopInputCursorToken, LoopInputPort,
-        LoopModelBudgetAccountant, LoopModelGatewayError, LoopModelPort, LoopModelRequest,
-        LoopModelRouteSnapshot, LoopProgressEvent, LoopPromptBundleRequest, LoopPromptPort,
-        LoopRunContext, LoopSafeSummary, ModelCallOutcome, ParentLoopOutput, PromptMode,
-        SkillVisibility, StageCheckpointPayloadRequest, VisibleCapabilityRequest,
+        LoopCancelReasonKind, LoopCancellationPort, LoopCapabilityPort, LoopCheckpointKind,
+        LoopCheckpointPort, LoopCheckpointRequest, LoopCheckpointStateRef, LoopContextRequest,
+        LoopDriverId, LoopDriverNoteKind, LoopGateKind, LoopHostMilestone, LoopHostMilestoneKind,
+        LoopInlineMessage, LoopInlineMessageRole, LoopInput, LoopInputAckToken, LoopInputCursor,
+        LoopInputCursorToken, LoopInputPort, LoopModelBudgetAccountant, LoopModelGatewayError,
+        LoopModelPort, LoopModelRequest, LoopModelRouteSnapshot, LoopProgressEvent,
+        LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, LoopSafeSummary, ModelCallOutcome,
+        ParentLoopOutput, PromptMode, SkillVisibility, StageCheckpointPayloadRequest,
+        VisibleCapabilityRequest,
     },
     runner::ClaimedTurnRun,
 };
@@ -952,6 +954,7 @@ async fn turn_runner_worker_completes_after_libsql_turn_and_thread_services_reop
         thread_scope.clone(),
         gateway.clone(),
         Arc::new(InMemoryCheckpointStateStore::default()),
+        turn_store.clone(),
         loop_checkpoint_store,
         milestone_sink,
         TextOnlyLoopHostConfig {
@@ -1640,6 +1643,7 @@ async fn turn_runner_worker_records_recovery_when_real_host_factory_rejects_clai
         wrong_thread_scope,
         Arc::clone(&fixture.gateway),
         fixture.checkpoint_state_store.clone(),
+        turn_store.clone(),
         turn_store.clone(),
         fixture.milestone_sink.clone(),
         TextOnlyLoopHostConfig {
@@ -2388,6 +2392,38 @@ async fn text_only_host_factory_threads_identity_source_to_prompt_and_model() {
 }
 
 #[tokio::test]
+async fn text_only_host_default_cancellation_factory_observes_durable_cancel_request() {
+    let fixture = HostFixture::new("thread-host-default-cancel", "hello").await;
+    let mut durable_state = fixture.claimed.state.clone();
+    durable_state.status = TurnStatus::CancelRequested;
+    let factory = RebornLoopDriverHostFactory::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        Arc::clone(&fixture.gateway),
+        fixture.checkpoint_state_store.clone(),
+        Arc::new(StaticTurnStateStore::new(durable_state)),
+        fixture.loop_checkpoint_store.clone(),
+        fixture.milestone_sink.clone(),
+        TextOnlyLoopHostConfig {
+            max_messages: 8,
+            require_model_route_snapshot: false,
+        },
+    );
+
+    assert!(factory.cancellation_observation_kind().is_live_capable());
+    let host = factory
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: fixture.claimed.clone(),
+            loop_run_context: fixture.context.clone(),
+        })
+        .await
+        .unwrap();
+
+    let signal = host.observe_cancellation().expect("cancel signal");
+    assert_eq!(signal.reason_kind, LoopCancelReasonKind::UserRequested);
+}
+
+#[tokio::test]
 async fn text_only_host_factory_rejects_thread_scope_mismatch() {
     let fixture = HostFixture::new("thread-host-thread-scope-mismatch", "hello").await;
     let wrong_scope = ThreadScope {
@@ -2399,6 +2435,7 @@ async fn text_only_host_factory_rejects_thread_scope_mismatch() {
         wrong_scope,
         Arc::clone(&fixture.gateway),
         fixture.checkpoint_state_store.clone(),
+        fixture.turn_state_store.clone(),
         fixture.loop_checkpoint_store.clone(),
         fixture.milestone_sink.clone(),
         TextOnlyLoopHostConfig {
@@ -5012,6 +5049,7 @@ impl HostFactory for CapabilityHostFactory {
             self.thread_scope.clone(),
             self.model_gateway.clone(),
             self.checkpoint_state_store.clone(),
+            Arc::new(StaticTurnStateStore::new(claimed.state.clone())),
             self.loop_checkpoint_store.clone(),
             self.milestone_sink.clone(),
             TextOnlyLoopHostConfig {
@@ -5263,6 +5301,48 @@ fn loop_exit_applier_for_fixture(
     Arc::new(LoopExitApplier::new(turn_store, evidence))
 }
 
+struct StaticTurnStateStore {
+    state: Mutex<TurnRunState>,
+}
+
+impl StaticTurnStateStore {
+    fn new(state: TurnRunState) -> Self {
+        Self {
+            state: Mutex::new(state),
+        }
+    }
+}
+
+#[async_trait]
+impl TurnStateStore for StaticTurnStateStore {
+    async fn submit_turn(
+        &self,
+        _request: SubmitTurnRequest,
+        _admission_policy: &dyn TurnAdmissionPolicy,
+        _run_profile_resolver: &dyn RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        panic!("submit_turn should not be called by static test turn state store")
+    }
+
+    async fn resume_turn(
+        &self,
+        _request: ResumeTurnRequest,
+    ) -> Result<ironclaw_turns::ResumeTurnResponse, TurnError> {
+        panic!("resume_turn should not be called by static test turn state store")
+    }
+
+    async fn request_cancel(
+        &self,
+        _request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        panic!("request_cancel should not be called by static test turn state store")
+    }
+
+    async fn get_run_state(&self, _request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        Ok(self.state.lock().unwrap().clone())
+    }
+}
+
 async fn queue_fixture_turn(
     fixture: &HostFixture,
     turn_store: &InMemoryTurnStateStore,
@@ -5314,6 +5394,7 @@ async fn queue_fixture_turn(
 struct HostFixture {
     thread_service: Arc<InMemorySessionThreadService>,
     checkpoint_state_store: Arc<InMemoryCheckpointStateStore>,
+    turn_state_store: Arc<StaticTurnStateStore>,
     loop_checkpoint_store: Arc<InMemoryLoopCheckpointStore>,
     gateway: Arc<RecordingGateway>,
     milestone_sink: Arc<InMemoryLoopHostMilestoneSink>,
@@ -5414,6 +5495,7 @@ impl HostFixture {
             runner_id: TurnRunnerId::new(),
             lease_token: TurnLeaseToken::new(),
         };
+        let turn_state_store = Arc::new(StaticTurnStateStore::new(claimed.state.clone()));
         let context = LoopRunContext::new(turn_scope, turn_id, run_id, resolved);
         if mark_submitted {
             thread_service
@@ -5431,6 +5513,7 @@ impl HostFixture {
         Self {
             thread_service,
             checkpoint_state_store,
+            turn_state_store,
             loop_checkpoint_store,
             gateway,
             milestone_sink,
@@ -5481,6 +5564,7 @@ impl HostFixture {
             self.thread_scope.clone(),
             Arc::clone(&self.gateway),
             self.checkpoint_state_store.clone(),
+            self.turn_state_store.clone(),
             loop_checkpoint_store,
             self.milestone_sink.clone(),
             config,

--- a/crates/ironclaw_reborn/tests/loop_milestone_event_projection.rs
+++ b/crates/ironclaw_reborn/tests/loop_milestone_event_projection.rs
@@ -31,11 +31,13 @@ use ironclaw_threads::{
     SessionThreadService, ThreadScope,
 };
 use ironclaw_turns::{
-    AcceptedMessageRef, EventCursor, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
-    InMemoryRunProfileResolver, LoopCompletionKind, LoopExitId, LoopFailureKind,
-    ReplyTargetBindingRef, RunProfileId, RunProfileResolutionRequest, RunProfileResolver,
-    RunProfileVersion, SourceBindingRef, TurnCheckpointId, TurnId, TurnLeaseToken, TurnRunId,
-    TurnRunState, TurnRunnerId, TurnScope, TurnStatus,
+    AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GetRunStateRequest,
+    InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore, InMemoryRunProfileResolver,
+    LoopCompletionKind, LoopExitId, LoopFailureKind, ReplyTargetBindingRef, ResumeTurnRequest,
+    RunProfileId, RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnAdmissionPolicy, TurnCheckpointId,
+    TurnError, TurnId, TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope,
+    TurnStateStore, TurnStatus,
     run_profile::{
         AgentLoopHostErrorKind, BatchPolicyKind, FinalizeAssistantMessage, LoopCheckpointKind,
         LoopDriverId, LoopGateKind, LoopHostMilestone, LoopHostMilestoneEmitter,
@@ -655,12 +657,55 @@ fn read_all_file_bytes_lossy(root: &Path) -> String {
 struct HostFixture {
     thread_service: Arc<InMemorySessionThreadService>,
     checkpoint_state_store: Arc<InMemoryCheckpointStateStore>,
+    turn_state_store: Arc<StaticTurnStateStore>,
     loop_checkpoint_store: Arc<InMemoryLoopCheckpointStore>,
     gateway: Arc<ControlledGateway>,
     milestone_sink: Arc<dyn LoopHostMilestoneSink>,
     thread_scope: ThreadScope,
     claimed: ClaimedTurnRun,
     context: LoopRunContext,
+}
+
+struct StaticTurnStateStore {
+    state: Mutex<TurnRunState>,
+}
+
+impl StaticTurnStateStore {
+    fn new(state: TurnRunState) -> Self {
+        Self {
+            state: Mutex::new(state),
+        }
+    }
+}
+
+#[async_trait]
+impl TurnStateStore for StaticTurnStateStore {
+    async fn submit_turn(
+        &self,
+        _request: SubmitTurnRequest,
+        _admission_policy: &dyn TurnAdmissionPolicy,
+        _run_profile_resolver: &dyn RunProfileResolver,
+    ) -> Result<SubmitTurnResponse, TurnError> {
+        panic!("submit_turn should not be called by static test turn state store")
+    }
+
+    async fn resume_turn(
+        &self,
+        _request: ResumeTurnRequest,
+    ) -> Result<ironclaw_turns::ResumeTurnResponse, TurnError> {
+        panic!("resume_turn should not be called by static test turn state store")
+    }
+
+    async fn request_cancel(
+        &self,
+        _request: CancelRunRequest,
+    ) -> Result<CancelRunResponse, TurnError> {
+        panic!("request_cancel should not be called by static test turn state store")
+    }
+
+    async fn get_run_state(&self, _request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {
+        Ok(self.state.lock().unwrap().clone())
+    }
 }
 
 impl HostFixture {
@@ -739,6 +784,7 @@ impl HostFixture {
             runner_id: TurnRunnerId::new(),
             lease_token: TurnLeaseToken::new(),
         };
+        let turn_state_store = Arc::new(StaticTurnStateStore::new(claimed.state.clone()));
         let context = LoopRunContext::new(turn_scope, turn_id, run_id, resolved);
         thread_service
             .mark_message_submitted(
@@ -762,6 +808,7 @@ impl HostFixture {
         Self {
             thread_service,
             checkpoint_state_store,
+            turn_state_store,
             loop_checkpoint_store,
             gateway,
             milestone_sink,
@@ -777,6 +824,7 @@ impl HostFixture {
             self.thread_scope.clone(),
             Arc::clone(&self.gateway),
             self.checkpoint_state_store.clone(),
+            self.turn_state_store.clone(),
             self.loop_checkpoint_store.clone(),
             Arc::clone(&self.milestone_sink),
             TextOnlyLoopHostConfig {

--- a/crates/ironclaw_turns/src/coordinator.rs
+++ b/crates/ironclaw_turns/src/coordinator.rs
@@ -140,6 +140,15 @@ fn resume_wake(scope: TurnScope, response: &ResumeTurnResponse) -> TurnRunWake {
     }
 }
 
+fn cancel_wake(scope: TurnScope, response: &CancelRunResponse) -> TurnRunWake {
+    TurnRunWake {
+        scope,
+        run_id: response.run_id,
+        status: response.status,
+        event_cursor: response.event_cursor,
+    }
+}
+
 fn notify_queued_run_best_effort(notifier: &dyn TurnRunWakeNotifier, wake: TurnRunWake) {
     match catch_unwind(AssertUnwindSafe(|| notifier.notify_queued_run(wake))) {
         Ok(Ok(())) => {}
@@ -181,7 +190,19 @@ where
     }
 
     async fn cancel_run(&self, request: CancelRunRequest) -> Result<CancelRunResponse, TurnError> {
-        self.store.request_cancel(request).await
+        let scope = request.scope.clone();
+        let response = self.store.request_cancel(request).await?;
+        // Wake on `CancelRequested` (the cooperative case) AND on any terminal
+        // transition. Registered handles otherwise rely solely on the polling
+        // fallback to discover a direct-to-terminal cancellation, which would
+        // leave them in the requester map until the polling task next ticks.
+        if response.status == TurnStatus::CancelRequested || response.status.is_terminal() {
+            notify_queued_run_best_effort(
+                self.wake_notifier.as_ref(),
+                cancel_wake(scope, &response),
+            );
+        }
+        Ok(response)
     }
 
     async fn get_run_state(&self, request: GetRunStateRequest) -> Result<TurnRunState, TurnError> {

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -809,6 +809,45 @@ async fn resume_turn_wakes_runner_for_same_run_after_requeue() {
 }
 
 #[tokio::test]
+async fn cancel_run_wakes_runner_for_active_cancel_requested_run() {
+    let store = Arc::new(InMemoryTurnStateStore::default());
+    let notifier = Arc::new(RecordingWakeNotifier::default());
+    let coordinator =
+        DefaultTurnCoordinator::new(store.clone()).with_wake_notifier(notifier.clone());
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    notifier.clear();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id: TurnRunnerId::new(),
+            lease_token: TurnLeaseToken::new(),
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    let cancelled = coordinator
+        .cancel_run(cancel_request("thread-a", run_id, "idem-cancel-a"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        notifier.wakes(),
+        vec![TurnRunWake {
+            scope: scope("thread-a"),
+            run_id,
+            status: TurnStatus::CancelRequested,
+            event_cursor: cancelled.event_cursor,
+        }]
+    );
+}
+
+#[tokio::test]
 async fn submit_turn_ignores_wake_notification_failure_after_persisting_run() {
     let store = Arc::new(InMemoryTurnStateStore::default());
     let coordinator = DefaultTurnCoordinator::new(store.clone())


### PR DESCRIPTION
## Context

Stacked follow-up to #3684. This keeps live host cancellation wiring separate from the minimal durable-evidence fix.

## What changed

- Added a turn-state-backed `RunCancellationFactory` that seeds from durable run state.
- Wired Reborn text host construction to use the live turn-state cancellation factory by default.
- Forwarded turn-run wake notifications into the shared cancellation factory.
- Notified runner wake handlers when `cancel_run` persists `CancelRequested`.
- Added tests for cancellation seeding, wake flipping, terminal pruning, and default host observation.

## Validation

- [x] `cargo test -p ironclaw_loop_support cancellation_port`
- [x] `cargo test -p ironclaw_reborn text_only_host_default_cancellation_factory_observes_durable_cancel_request`
- [x] `cargo test -p ironclaw_turns cancel_run_wakes_runner_for_active_cancel_requested_run`

Note: one initial run in a separate `/tmp` worktree hit `No space left on device` compiling `wasmtime-wasi`; reran the relevant checks with the shared target dir and they passed.

## Stack

Base: #3684 / `codex/ws13-cancel-evidence`
Next: `codex/ws13-cancel-ack-safety`