### PR TITLE
test(reborn): port product-live fixtures onto planned harness

### DIFF
--- a/crates/ironclaw_product_workflow/tests/planned_agent_loop_harness.rs
+++ b/crates/ironclaw_product_workflow/tests/planned_agent_loop_harness.rs
@@ -44,3 +44,88 @@ async fn product_live_harness_runs_planned_loop_and_persists_reply() {
 
     harness.shutdown().await;
 }
+
+#[tokio::test]
+async fn ported_product_live_fixture_uses_shared_harness_for_no_profile_reply() {
+    let harness = ProductLiveAgentLoopHarness::new(ProductLiveAgentLoopHarnessConfig {
+        assistant_reply: "planned product reply".to_string(),
+        user_id: "user:product-live".to_string(),
+        thread_id: "thread:product-live".to_string(),
+        ..ProductLiveAgentLoopHarnessConfig::default()
+    })
+    .await;
+    let envelope = harness.user_message("planned-product-live-ported", "hello world");
+
+    let outcome = harness
+        .accept_user_message(&envelope)
+        .await
+        .expect("ported product live submit");
+    let InboundTurnOutcome::Submitted {
+        submitted_run_id, ..
+    } = outcome
+    else {
+        panic!("expected submitted outcome, got {outcome:?}");
+    };
+    let state = harness.wait_for_terminal(submitted_run_id).await;
+
+    assert_eq!(state.status, TurnStatus::Completed);
+    assert_eq!(
+        state.resolved_run_profile_id.as_str(),
+        PLANNED_DEFAULT_PROFILE_ID
+    );
+    assert_eq!(harness.model_requests().len(), 1);
+    let history = harness.thread_history().await;
+    assert!(history.iter().any(|message| {
+        message.status == MessageStatus::Finalized
+            && message.turn_run_id.as_deref() == Some(submitted_run_id.to_string().as_str())
+            && message.content.as_deref() == Some("planned product reply")
+    }));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn ported_product_live_fixture_cancels_through_public_turn_path() {
+    let harness = ProductLiveAgentLoopHarness::new(ProductLiveAgentLoopHarnessConfig {
+        assistant_reply: "reply after cancel".to_string(),
+        user_id: "user:product-live".to_string(),
+        thread_id: "thread:product-live-cancel-live".to_string(),
+        pause_model_until_released: true,
+        ..ProductLiveAgentLoopHarnessConfig::default()
+    })
+    .await;
+    let envelope = harness.user_message("planned-product-live-cancel-ported", "hello world");
+
+    let outcome = harness
+        .accept_user_message(&envelope)
+        .await
+        .expect("ported product live submit");
+    let InboundTurnOutcome::Submitted {
+        submitted_run_id, ..
+    } = outcome
+    else {
+        panic!("expected submitted outcome, got {outcome:?}");
+    };
+
+    harness.wait_for_model_request_count(1).await;
+    assert_eq!(
+        harness.cancel_run(submitted_run_id).await,
+        TurnStatus::CancelRequested
+    );
+    harness
+        .wait_for_cancellation_observed(submitted_run_id)
+        .await;
+
+    harness.release_model();
+    let state = harness.wait_for_terminal(submitted_run_id).await;
+
+    assert_eq!(state.status, TurnStatus::Cancelled);
+    let history = harness.thread_history().await;
+    assert!(history.iter().any(|message| {
+        message.status == MessageStatus::Finalized
+            && message.turn_run_id.as_deref() == Some(submitted_run_id.to_string().as_str())
+            && message.content.as_deref() == Some("reply after cancel")
+    }));
+
+    harness.shutdown().await;
+}

--- a/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
+++ b/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
@@ -37,9 +37,9 @@ use ironclaw_threads::{
     ThreadScope,
 };
 use ironclaw_turns::{
-    GetRunStateRequest, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
-    InMemoryTurnStateStore, TurnRunId, TurnRunState, TurnRunWake, TurnScope, TurnStateStore,
-    TurnStatus,
+    CancelRunRequest, GetRunStateRequest, IdempotencyKey, InMemoryCheckpointStateStore,
+    InMemoryLoopCheckpointStore, InMemoryTurnStateStore, SanitizedCancelReason, TurnActor,
+    TurnCoordinator, TurnRunId, TurnRunState, TurnRunWake, TurnScope, TurnStateStore, TurnStatus,
     run_profile::{
         AgentLoopHostError, InMemoryLoopHostMilestoneSink, InstructionSafetyContext,
         LoopCancelReasonKind, LoopCapabilityPort, LoopInputAckToken, LoopInputCursorToken,
@@ -56,12 +56,14 @@ pub struct ProductLiveAgentLoopHarness {
     thread_scope: ThreadScope,
     thread_service: InMemorySessionThreadService,
     turn_store: Arc<InMemoryTurnStateStore>,
+    cancellation_factory: Arc<ReadyRunCancellationFactory>,
     composition: RebornRuntimeLoopComposition<
         InMemoryTurnStateStore,
         InMemorySessionThreadService,
         RecordingModelGateway,
     >,
     model_requests: Arc<Mutex<Vec<HostManagedModelRequest>>>,
+    model_release: Option<CancellationToken>,
     worker_cancel: CancellationToken,
     worker_handle: JoinHandle<()>,
 }
@@ -75,6 +77,7 @@ pub struct ProductLiveAgentLoopHarnessConfig {
     pub agent_id: String,
     pub model_provider: String,
     pub model_id: String,
+    pub pause_model_until_released: bool,
 }
 
 impl Default for ProductLiveAgentLoopHarnessConfig {
@@ -87,6 +90,7 @@ impl Default for ProductLiveAgentLoopHarnessConfig {
             agent_id: "agent:harness".to_string(),
             model_provider: "nearai".to_string(),
             model_id: "qwen3-coder".to_string(),
+            pause_model_until_released: false,
         }
     }
 }
@@ -112,9 +116,13 @@ impl ProductLiveAgentLoopHarness {
         let turn_store = Arc::new(InMemoryTurnStateStore::default());
         let checkpoint_store = Arc::new(InMemoryLoopCheckpointStore::default());
         let model_requests = Arc::new(Mutex::new(Vec::new()));
+        let model_release = config
+            .pause_model_until_released
+            .then(CancellationToken::new);
         let model_gateway = Arc::new(RecordingModelGateway {
             reply: config.assistant_reply,
             requests: Arc::clone(&model_requests),
+            release: model_release.clone(),
         });
         let model_route_resolver = Arc::new(
             StaticModelRouteResolver::new(ModelRoutePolicy::new(
@@ -148,7 +156,7 @@ impl ProductLiveAgentLoopHarness {
             ),
             config: DefaultPlannedRuntimeConfig::default(),
             model_route_resolver: Some(model_route_resolver),
-            cancellation_factory: Some(cancellation_factory),
+            cancellation_factory: Some(cancellation_factory.clone()),
             skill_context_source: None,
             input_queue: Some(Arc::new(EmptyInputQueue)),
             identity_context_source: Arc::new(EmptyIdentityContextSource),
@@ -169,8 +177,10 @@ impl ProductLiveAgentLoopHarness {
             thread_scope,
             thread_service,
             turn_store,
+            cancellation_factory,
             composition,
             model_requests,
+            model_release,
             worker_cancel,
             worker_handle,
         }
@@ -181,6 +191,31 @@ impl ProductLiveAgentLoopHarness {
             .lock()
             .expect("harness model requests lock poisoned")
             .clone()
+    }
+
+    pub async fn wait_for_model_request_count(&self, expected: usize) {
+        timeout(Duration::from_secs(3), async {
+            loop {
+                if self
+                    .model_requests
+                    .lock()
+                    .expect("harness model requests lock poisoned")
+                    .len()
+                    >= expected
+                {
+                    return;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("harness model gateway should receive request count");
+    }
+
+    pub fn release_model(&self) {
+        if let Some(release) = &self.model_release {
+            release.cancel();
+        }
     }
 
     pub fn user_message(&self, event_suffix: &str, text: &str) -> ProductInboundEnvelope {
@@ -224,6 +259,38 @@ impl ProductLiveAgentLoopHarness {
         .expect("harness run should reach a terminal state")
     }
 
+    pub async fn cancel_run(&self, run_id: TurnRunId) -> TurnStatus {
+        self.composition
+            .coordinator
+            .cancel_run(CancelRunRequest {
+                scope: self.turn_scope(),
+                actor: TurnActor::new(self.binding.user_id.clone()),
+                run_id,
+                reason: SanitizedCancelReason::UserRequested,
+                idempotency_key: IdempotencyKey::new(format!("idem-harness-cancel-{run_id}"))
+                    .expect("valid harness cancellation idempotency key"),
+            })
+            .await
+            .expect("harness cancel run")
+            .status
+    }
+
+    pub async fn wait_for_cancellation_observed(&self, run_id: TurnRunId) {
+        timeout(Duration::from_secs(3), async {
+            loop {
+                if self
+                    .cancellation_factory
+                    .product_cancellation_observed(run_id)
+                {
+                    return;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("harness cancellation factory should observe run cancellation");
+    }
+
     pub async fn thread_history(&self) -> Vec<ThreadMessageRecord> {
         self.thread_service
             .list_thread_history(ThreadHistoryRequest {
@@ -256,6 +323,7 @@ impl ProductLiveAgentLoopHarness {
 struct RecordingModelGateway {
     reply: String,
     requests: Arc<Mutex<Vec<HostManagedModelRequest>>>,
+    release: Option<CancellationToken>,
 }
 
 #[async_trait]
@@ -268,6 +336,9 @@ impl HostManagedModelGateway for RecordingModelGateway {
             .lock()
             .expect("recording model gateway requests lock poisoned")
             .push(request);
+        if let Some(release) = &self.release {
+            release.cancelled().await;
+        }
         Ok(HostManagedModelResponse::assistant_reply(
             self.reply.clone(),
         ))
@@ -339,6 +410,17 @@ impl HostIdentityContextSource for EmptyIdentityContextSource {
 #[derive(Default)]
 struct ReadyRunCancellationFactory {
     handles: Arc<Mutex<HashMap<TurnRunId, RunCancellationHandle>>>,
+}
+
+impl ReadyRunCancellationFactory {
+    fn product_cancellation_observed(&self, run_id: TurnRunId) -> bool {
+        self.handles
+            .lock()
+            .expect("ready cancellation lock poisoned")
+            .get(&run_id)
+            .map(RunCancellationHandle::is_requested)
+            .unwrap_or(false)
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary

Stacks on #3710 and ports the product-live planned runtime fixtures onto the shared `ProductLiveAgentLoopHarness`.

This PR keeps production behavior unchanged. Its purpose is to prove that the harness from the previous PR can carry existing integration-style assertions instead of being a one-off happy-path smoke test.

## What this achieves

- Extends the harness with a pausable model gateway for cancellation tests.
- Adds public harness helpers for model-call observation, turn cancellation, and cancellation-probe observation.
- Ports the no-profile product-live reply fixture onto the harness.
- Ports the product-live cancellation fixture onto the harness through the public turn coordinator path.

## What this enables next

- Capability/tool execution tests can reuse the same submit/wait/history/cancel operations.
- Existing E2E fixtures can move one behavior at a time without reconstructing runtime composition boilerplate.
- Follow-up adapter wiring PRs can focus on real adapters rather than test setup.

## Coverage / validation

- `cargo test -p ironclaw_product_workflow --test planned_agent_loop_harness -- --nocapture`
- `cargo test -p ironclaw_product_workflow`
- `cargo clippy -p ironclaw_product_workflow --all-targets -- -D warnings`

Coverage note: attempted `cargo llvm-cov -p ironclaw_product_workflow --test planned_agent_loop_harness --summary-only`, but local `llvm-tools-preview` is not installed in this worktree. The PR adds branch coverage for both completed and cancelled product-live runs through the shared harness.
