### PR TITLE
fix(reborn): trust result refs with durable replies

### DIFF
--- a/crates/ironclaw_reborn/src/loop_exit_applier.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier.rs
@@ -149,9 +149,12 @@ impl LoopExitEvidencePort for InMemoryLoopExitEvidencePort {
     }
 }
 
-/// Durable text/checkpoint-backed evidence adapter for the current Reborn
-/// text-only host. Capability-result and gate/process evidence deliberately
-/// remain untrusted until dedicated durable stores are wired.
+/// Durable text/checkpoint-backed evidence adapter for the current Reborn host.
+///
+/// A completion that includes a durable finalized assistant reply remains
+/// trusted even if the loop also reports capability result refs. Standalone
+/// result-ref-only completion still fails closed until a dedicated durable
+/// result evidence store is wired.
 pub struct ThreadCheckpointLoopExitEvidencePort<S>
 where
     S: SessionThreadService + ?Sized,
@@ -214,7 +217,7 @@ where
         &self,
         request: CompletionEvidenceRequest<'_>,
     ) -> Result<bool, TurnError> {
-        if !request.result_refs.is_empty() {
+        if !request.result_refs.is_empty() && request.reply_message_refs.is_empty() {
             return Ok(false);
         }
         if request.reply_message_refs.is_empty() {

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -11,10 +11,10 @@ use ironclaw_turns::{
     GetLoopCheckpointRequest, GetRunStateRequest, LoopBlocked, LoopBlockedKind, LoopCheckpointKind,
     LoopCheckpointRecord, LoopCheckpointStateRef, LoopCheckpointStore, LoopCompleted,
     LoopCompletionKind, LoopExit, LoopExitId, LoopFailed, LoopFailureKind, LoopGateRef,
-    LoopMessageRef, PutLoopCheckpointRequest, ReplyTargetBindingRef, ResumeTurnRequest,
-    ResumeTurnResponse, RunProfileVersion, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
-    SubmitTurnResponse, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken, TurnRunId,
-    TurnRunState, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
+    LoopMessageRef, LoopResultRef, PutLoopCheckpointRequest, ReplyTargetBindingRef,
+    ResumeTurnRequest, ResumeTurnResponse, RunProfileVersion, SanitizedFailure, SourceBindingRef,
+    SubmitTurnRequest, SubmitTurnResponse, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken,
+    TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
     run_profile::{CheckpointSchemaId, LoopDriverId},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -303,6 +303,95 @@ async fn thread_checkpoint_evidence_rejects_agentless_completion_refs_explicitly
 
     assert!(matches!(err, TurnError::InvalidRequest { .. }));
     assert!(err.to_string().contains("agent-scoped"));
+}
+
+#[tokio::test]
+async fn thread_checkpoint_evidence_accepts_result_refs_with_durable_reply_ref() {
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let turn_scope = TurnScope::new(
+        TenantId::new("tenant").expect("valid"),
+        Some(AgentId::new("agent").expect("valid")),
+        None,
+        ThreadId::new("thread").expect("valid"),
+    );
+    let thread_scope = ThreadScope {
+        tenant_id: turn_scope.tenant_id.clone(),
+        agent_id: turn_scope.agent_id.clone().expect("agent id"),
+        project_id: None,
+        owner_user_id: None,
+        mission_id: None,
+    };
+    thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: thread_scope.clone(),
+            thread_id: Some(turn_scope.thread_id.clone()),
+            created_by_actor_id: "user:test".to_string(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .expect("thread");
+    let run_id = TurnRunId::new();
+    let draft = thread_service
+        .append_assistant_draft(AppendAssistantDraftRequest {
+            scope: thread_scope.clone(),
+            thread_id: turn_scope.thread_id.clone(),
+            turn_run_id: run_id.to_string(),
+            content: MessageContent::text("reply after tool"),
+        })
+        .await
+        .expect("draft");
+    thread_service
+        .finalize_assistant_message(
+            &thread_scope,
+            &turn_scope.thread_id,
+            draft.message_id,
+            MessageContent::text("reply after tool"),
+        )
+        .await
+        .expect("finalized");
+    let evidence = ThreadCheckpointLoopExitEvidencePort::new_with_thread_scope(
+        thread_service,
+        Arc::new(ironclaw_turns::InMemoryTurnStateStore::default()) as Arc<dyn TurnStateStore>,
+        Arc::new(PanicLoopCheckpointStore),
+        thread_scope,
+    );
+    let message_ref =
+        LoopMessageRef::new(format!("msg:{}", draft.message_id)).expect("valid message ref");
+    let result_ref = LoopResultRef::new("result:tool-output").expect("valid result ref");
+
+    let verified = evidence
+        .verify_completion_refs(CompletionEvidenceRequest {
+            scope: &turn_scope,
+            turn_id: TurnId::new(),
+            run_id,
+            reply_message_refs: &[message_ref],
+            result_refs: &[result_ref],
+        })
+        .await
+        .expect("completion evidence should verify durable reply refs");
+
+    assert!(verified);
+}
+
+#[tokio::test]
+async fn thread_checkpoint_evidence_rejects_result_only_completion_refs() {
+    let evidence = text_checkpoint_evidence(Arc::new(PanicLoopCheckpointStore));
+    let claimed = claimed_run();
+    let result_ref = LoopResultRef::new("result:tool-output").expect("valid result ref");
+
+    let verified = evidence
+        .verify_completion_refs(CompletionEvidenceRequest {
+            scope: &claimed.state.scope,
+            turn_id: claimed.state.turn_id,
+            run_id: claimed.state.run_id,
+            reply_message_refs: &[],
+            result_refs: &[result_ref],
+        })
+        .await
+        .expect("result-only completion should fail closed without checkpoint I/O");
+
+    assert!(!verified);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes Reborn loop-exit completion evidence so a completed run is not rejected solely because it reports capability `result_refs` alongside a verified durable assistant reply.

This is a direct PR into `reborn-integration` because the behavior is generic loop-exit evidence, not specific to the product-live harness stack.

## What this achieves

- Keeps result-only completions fail-closed until a dedicated result evidence store exists.
- Allows completed runs with both:
  - verified finalized assistant reply refs, and
  - capability result refs produced earlier in the loop.
- Preserves the existing agentless scope and thread-scope mismatch safeguards.

## What this enables

The planned AgentLoop capability harness can now prove this real flow without mocking loop-exit evidence:

1. model emits capability call
2. loop invokes capability
3. model emits final assistant reply
4. loop exits completed with both result refs and reply refs
5. product-live evidence accepts the durable reply-backed completion

## Coverage / validation

- `cargo test -p ironclaw_reborn loop_exit_applier -- --nocapture`
- `cargo clippy -p ironclaw_reborn --all-targets -- -D warnings`

Added focused tests for:

- result refs accepted when accompanied by a durable finalized reply ref
- result-only completions still rejected without checkpoint I/O
