### PR TITLE
test(reborn): add capability path to planned AgentLoop harness

### DIFF
--- a/crates/ironclaw_product_workflow/tests/planned_agent_loop_harness.rs
+++ b/crates/ironclaw_product_workflow/tests/planned_agent_loop_harness.rs
@@ -5,7 +5,12 @@ use ironclaw_reborn::planned_driver_factory::PLANNED_DEFAULT_PROFILE_ID;
 use ironclaw_threads::MessageStatus;
 use ironclaw_turns::TurnStatus;
 
-use support::planned_agent_loop::{ProductLiveAgentLoopHarness, ProductLiveAgentLoopHarnessConfig};
+use ironclaw_loop_support::HostManagedModelResponse;
+
+use support::planned_agent_loop::{
+    HarnessCapabilityConfig, ProductLiveAgentLoopHarness, ProductLiveAgentLoopHarnessConfig,
+    capability_call_response,
+};
 
 #[tokio::test]
 async fn product_live_harness_runs_planned_loop_and_persists_reply() {
@@ -125,6 +130,54 @@ async fn ported_product_live_fixture_cancels_through_public_turn_path() {
         message.status == MessageStatus::Finalized
             && message.turn_run_id.as_deref() == Some(submitted_run_id.to_string().as_str())
             && message.content.as_deref() == Some("reply after cancel")
+    }));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn product_live_harness_invokes_capability_then_persists_final_reply() {
+    let harness = ProductLiveAgentLoopHarness::new(ProductLiveAgentLoopHarnessConfig {
+        assistant_reply: "unused fallback".to_string(),
+        model_responses: vec![
+            capability_call_response("harness.echo", "input:harness-echo-1"),
+            HostManagedModelResponse::assistant_reply("final reply after capability"),
+        ],
+        capability: Some(HarnessCapabilityConfig {
+            capability_id: "harness.echo".to_string(),
+            result_ref: "result:harness-echo-1".to_string(),
+            safe_summary: "echo completed".to_string(),
+            terminate_hint: false,
+        }),
+        ..ProductLiveAgentLoopHarnessConfig::default()
+    })
+    .await;
+    let envelope = harness.user_message("planned-harness-capability", "use echo");
+
+    let outcome = harness
+        .accept_user_message(&envelope)
+        .await
+        .expect("harness inbound turn should submit");
+    let InboundTurnOutcome::Submitted {
+        submitted_run_id, ..
+    } = outcome
+    else {
+        panic!("expected submitted outcome, got {outcome:?}");
+    };
+    let state = harness.wait_for_terminal(submitted_run_id).await;
+
+    assert_eq!(state.status, TurnStatus::Completed);
+    assert_eq!(harness.model_requests().len(), 2);
+    let invocations = harness.capability_invocations();
+    assert_eq!(invocations.len(), 1);
+    assert_eq!(invocations[0].capability_id.as_str(), "harness.echo");
+    assert_eq!(invocations[0].input_ref.as_str(), "input:harness-echo-1");
+
+    let history = harness.thread_history().await;
+    assert!(history.iter().any(|message| {
+        message.status == MessageStatus::Finalized
+            && message.turn_run_id.as_deref() == Some(submitted_run_id.to_string().as_str())
+            && message.content.as_deref() == Some("final reply after capability")
     }));
 
     harness.shutdown().await;

--- a/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
+++ b/crates/ironclaw_product_workflow/tests/support/planned_agent_loop.rs
@@ -1,10 +1,12 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
-use ironclaw_host_api::{AgentId, TenantId, ThreadId, UserId};
+use ironclaw_host_api::{
+    AgentId, CapabilityId, ExtensionId, RuntimeKind, TenantId, ThreadId, UserId,
+};
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,
     EmptyLoopCapabilityPort, HostIdentityContextBuildError, HostIdentityContextCandidate,
@@ -38,12 +40,17 @@ use ironclaw_threads::{
 };
 use ironclaw_turns::{
     CancelRunRequest, GetRunStateRequest, IdempotencyKey, InMemoryCheckpointStateStore,
-    InMemoryLoopCheckpointStore, InMemoryTurnStateStore, SanitizedCancelReason, TurnActor,
-    TurnCoordinator, TurnRunId, TurnRunState, TurnRunWake, TurnScope, TurnStateStore, TurnStatus,
+    InMemoryLoopCheckpointStore, InMemoryTurnStateStore, LoopResultRef, SanitizedCancelReason,
+    TurnActor, TurnCoordinator, TurnRunId, TurnRunState, TurnRunWake, TurnScope, TurnStateStore,
+    TurnStatus,
     run_profile::{
-        AgentLoopHostError, InMemoryLoopHostMilestoneSink, InstructionSafetyContext,
+        AgentLoopHostError, CapabilityBatchInvocation, CapabilityBatchOutcome,
+        CapabilityCallCandidate, CapabilityDescriptorView, CapabilityInputRef,
+        CapabilityInvocation, CapabilityOutcome, CapabilityResultMessage, CapabilitySurfaceVersion,
+        ConcurrencyHint, InMemoryLoopHostMilestoneSink, InstructionSafetyContext,
         LoopCancelReasonKind, LoopCapabilityPort, LoopInputAckToken, LoopInputCursorToken,
-        LoopRunContext, NoOpBudgetAccountant, NoOpPolicyGuard, PromptMode,
+        LoopRunContext, NoOpBudgetAccountant, NoOpPolicyGuard, ParentLoopOutput, PromptMode,
+        VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
 };
 use tokio::task::JoinHandle;
@@ -63,6 +70,7 @@ pub struct ProductLiveAgentLoopHarness {
         RecordingModelGateway,
     >,
     model_requests: Arc<Mutex<Vec<HostManagedModelRequest>>>,
+    capability_invocations: Arc<Mutex<Vec<CapabilityInvocation>>>,
     model_release: Option<CancellationToken>,
     worker_cancel: CancellationToken,
     worker_handle: JoinHandle<()>,
@@ -78,6 +86,8 @@ pub struct ProductLiveAgentLoopHarnessConfig {
     pub model_provider: String,
     pub model_id: String,
     pub pause_model_until_released: bool,
+    pub model_responses: Vec<HostManagedModelResponse>,
+    pub capability: Option<HarnessCapabilityConfig>,
 }
 
 impl Default for ProductLiveAgentLoopHarnessConfig {
@@ -91,7 +101,31 @@ impl Default for ProductLiveAgentLoopHarnessConfig {
             model_provider: "nearai".to_string(),
             model_id: "qwen3-coder".to_string(),
             pause_model_until_released: false,
+            model_responses: Vec::new(),
+            capability: None,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HarnessCapabilityConfig {
+    pub capability_id: String,
+    pub result_ref: String,
+    pub safe_summary: String,
+    pub terminate_hint: bool,
+}
+
+pub fn capability_call_response(
+    capability_id: impl Into<String>,
+    input_ref: impl Into<String>,
+) -> HostManagedModelResponse {
+    HostManagedModelResponse {
+        safe_text_deltas: Vec::new(),
+        output: ParentLoopOutput::CapabilityCalls(vec![CapabilityCallCandidate {
+            surface_version: harness_surface_version(),
+            capability_id: harness_capability_id(capability_id.into()),
+            input_ref: CapabilityInputRef::new(input_ref.into()).expect("valid harness input ref"),
+        }]),
     }
 }
 
@@ -116,14 +150,24 @@ impl ProductLiveAgentLoopHarness {
         let turn_store = Arc::new(InMemoryTurnStateStore::default());
         let checkpoint_store = Arc::new(InMemoryLoopCheckpointStore::default());
         let model_requests = Arc::new(Mutex::new(Vec::new()));
+        let model_responses = VecDeque::from(config.model_responses);
         let model_release = config
             .pause_model_until_released
             .then(CancellationToken::new);
         let model_gateway = Arc::new(RecordingModelGateway {
             reply: config.assistant_reply,
             requests: Arc::clone(&model_requests),
+            responses: Mutex::new(model_responses),
             release: model_release.clone(),
         });
+        let capability_invocations = Arc::new(Mutex::new(Vec::new()));
+        let capability_factory: Arc<dyn LoopCapabilityPortFactory> = match config.capability {
+            Some(capability) => Arc::new(RecordingCapabilityFactory {
+                capability,
+                invocations: Arc::clone(&capability_invocations),
+            }),
+            None => Arc::new(EmptyCapabilityFactory),
+        };
         let model_route_resolver = Arc::new(
             StaticModelRouteResolver::new(ModelRoutePolicy::new(
                 ModelSelectionMode::DeveloperAnyConfigured,
@@ -143,7 +187,7 @@ impl ProductLiveAgentLoopHarness {
             checkpoint_state_store: Arc::new(InMemoryCheckpointStateStore::default()),
             loop_checkpoint_store: checkpoint_store.clone(),
             milestone_sink: Arc::new(InMemoryLoopHostMilestoneSink::default()),
-            capability_factory: Arc::new(EmptyCapabilityFactory),
+            capability_factory,
             capability_surface_resolver: Arc::new(AllowAllCapabilitySurfaceResolver),
             loop_exit_evidence: Arc::new(
                 ThreadCheckpointLoopExitEvidencePort::new_with_thread_scope(
@@ -180,6 +224,7 @@ impl ProductLiveAgentLoopHarness {
             cancellation_factory,
             composition,
             model_requests,
+            capability_invocations,
             model_release,
             worker_cancel,
             worker_handle,
@@ -190,6 +235,13 @@ impl ProductLiveAgentLoopHarness {
         self.model_requests
             .lock()
             .expect("harness model requests lock poisoned")
+            .clone()
+    }
+
+    pub fn capability_invocations(&self) -> Vec<CapabilityInvocation> {
+        self.capability_invocations
+            .lock()
+            .expect("harness capability invocation lock poisoned")
             .clone()
     }
 
@@ -323,6 +375,7 @@ impl ProductLiveAgentLoopHarness {
 struct RecordingModelGateway {
     reply: String,
     requests: Arc<Mutex<Vec<HostManagedModelRequest>>>,
+    responses: Mutex<VecDeque<HostManagedModelResponse>>,
     release: Option<CancellationToken>,
 }
 
@@ -339,9 +392,96 @@ impl HostManagedModelGateway for RecordingModelGateway {
         if let Some(release) = &self.release {
             release.cancelled().await;
         }
+        if let Some(response) = self
+            .responses
+            .lock()
+            .expect("recording model gateway responses lock poisoned")
+            .pop_front()
+        {
+            return Ok(response);
+        }
         Ok(HostManagedModelResponse::assistant_reply(
             self.reply.clone(),
         ))
+    }
+}
+
+struct RecordingCapabilityFactory {
+    capability: HarnessCapabilityConfig,
+    invocations: Arc<Mutex<Vec<CapabilityInvocation>>>,
+}
+
+#[async_trait]
+impl LoopCapabilityPortFactory for RecordingCapabilityFactory {
+    async fn create_capability_port(
+        &self,
+        _run_context: &LoopRunContext,
+    ) -> Result<Arc<dyn LoopCapabilityPort>, AgentLoopHostError> {
+        Ok(Arc::new(RecordingCapabilityPort {
+            capability: self.capability.clone(),
+            invocations: Arc::clone(&self.invocations),
+        }))
+    }
+}
+
+struct RecordingCapabilityPort {
+    capability: HarnessCapabilityConfig,
+    invocations: Arc<Mutex<Vec<CapabilityInvocation>>>,
+}
+
+#[async_trait]
+impl LoopCapabilityPort for RecordingCapabilityPort {
+    async fn visible_capabilities(
+        &self,
+        _request: VisibleCapabilityRequest,
+    ) -> Result<VisibleCapabilitySurface, AgentLoopHostError> {
+        Ok(VisibleCapabilitySurface {
+            version: harness_surface_version(),
+            descriptors: vec![CapabilityDescriptorView {
+                capability_id: harness_capability_id(&self.capability.capability_id),
+                provider: Some(ExtensionId::new("harness.provider").expect("valid provider id")),
+                runtime: RuntimeKind::FirstParty,
+                safe_name: self.capability.capability_id.clone(),
+                safe_description: "harness capability".to_string(),
+                concurrency_hint: ConcurrencyHint::Exclusive,
+            }],
+        })
+    }
+
+    async fn invoke_capability(
+        &self,
+        request: CapabilityInvocation,
+    ) -> Result<CapabilityOutcome, AgentLoopHostError> {
+        self.invocations
+            .lock()
+            .expect("harness capability invocation lock poisoned")
+            .push(request);
+        Ok(CapabilityOutcome::Completed(CapabilityResultMessage {
+            result_ref: LoopResultRef::new(self.capability.result_ref.clone())
+                .expect("valid harness result ref"),
+            safe_summary: self.capability.safe_summary.clone(),
+            terminate_hint: self.capability.terminate_hint,
+        }))
+    }
+
+    async fn invoke_capability_batch(
+        &self,
+        request: CapabilityBatchInvocation,
+    ) -> Result<CapabilityBatchOutcome, AgentLoopHostError> {
+        let mut outcomes = Vec::new();
+        let mut stopped_on_suspension = false;
+        for invocation in request.invocations {
+            let outcome = self.invoke_capability(invocation).await?;
+            stopped_on_suspension |= request.stop_on_first_suspension && outcome.is_suspension();
+            outcomes.push(outcome);
+            if stopped_on_suspension {
+                break;
+            }
+        }
+        Ok(CapabilityBatchOutcome {
+            outcomes,
+            stopped_on_suspension,
+        })
     }
 }
 
@@ -523,4 +663,12 @@ fn user_message_envelope(event_suffix: &str, text: &str) -> ProductInboundEnvelo
 fn test_safety_context() -> InstructionSafetyContext {
     InstructionSafetyContext::new("policy:test", "test safety context")
         .expect("test safety context")
+}
+
+fn harness_surface_version() -> CapabilitySurfaceVersion {
+    CapabilitySurfaceVersion::new("surface:harness-v1").expect("valid harness surface version")
+}
+
+fn harness_capability_id(capability_id: impl Into<String>) -> CapabilityId {
+    CapabilityId::new(capability_id.into()).expect("valid harness capability id")
 }

--- a/crates/ironclaw_reborn/src/loop_exit_applier.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier.rs
@@ -149,9 +149,12 @@ impl LoopExitEvidencePort for InMemoryLoopExitEvidencePort {
     }
 }
 
-/// Durable text/checkpoint-backed evidence adapter for the current Reborn
-/// text-only host. Capability-result and gate/process evidence deliberately
-/// remain untrusted until dedicated durable stores are wired.
+/// Durable text/checkpoint-backed evidence adapter for the current Reborn host.
+///
+/// A completion that includes a durable finalized assistant reply remains
+/// trusted even if the loop also reports capability result refs. Standalone
+/// result-ref-only completion still fails closed until a dedicated durable
+/// result evidence store is wired.
 pub struct ThreadCheckpointLoopExitEvidencePort<S>
 where
     S: SessionThreadService + ?Sized,
@@ -214,7 +217,7 @@ where
         &self,
         request: CompletionEvidenceRequest<'_>,
     ) -> Result<bool, TurnError> {
-        if !request.result_refs.is_empty() {
+        if !request.result_refs.is_empty() && request.reply_message_refs.is_empty() {
             return Ok(false);
         }
         if request.reply_message_refs.is_empty() {

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -11,10 +11,10 @@ use ironclaw_turns::{
     GetLoopCheckpointRequest, GetRunStateRequest, LoopBlocked, LoopBlockedKind, LoopCheckpointKind,
     LoopCheckpointRecord, LoopCheckpointStateRef, LoopCheckpointStore, LoopCompleted,
     LoopCompletionKind, LoopExit, LoopExitId, LoopFailed, LoopFailureKind, LoopGateRef,
-    LoopMessageRef, PutLoopCheckpointRequest, ReplyTargetBindingRef, ResumeTurnRequest,
-    ResumeTurnResponse, RunProfileVersion, SanitizedFailure, SourceBindingRef, SubmitTurnRequest,
-    SubmitTurnResponse, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken, TurnRunId,
-    TurnRunState, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
+    LoopMessageRef, LoopResultRef, PutLoopCheckpointRequest, ReplyTargetBindingRef,
+    ResumeTurnRequest, ResumeTurnResponse, RunProfileVersion, SanitizedFailure, SourceBindingRef,
+    SubmitTurnRequest, SubmitTurnResponse, TurnCheckpointId, TurnError, TurnId, TurnLeaseToken,
+    TurnRunId, TurnRunState, TurnRunnerId, TurnScope, TurnStateStore, TurnStatus,
     run_profile::{CheckpointSchemaId, LoopDriverId},
     runner::{
         ApplyValidatedLoopExitRequest, BlockRunRequest, CancelRunCompletionRequest,
@@ -303,6 +303,95 @@ async fn thread_checkpoint_evidence_rejects_agentless_completion_refs_explicitly
 
     assert!(matches!(err, TurnError::InvalidRequest { .. }));
     assert!(err.to_string().contains("agent-scoped"));
+}
+
+#[tokio::test]
+async fn thread_checkpoint_evidence_accepts_result_refs_with_durable_reply_ref() {
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let turn_scope = TurnScope::new(
+        TenantId::new("tenant").expect("valid"),
+        Some(AgentId::new("agent").expect("valid")),
+        None,
+        ThreadId::new("thread").expect("valid"),
+    );
+    let thread_scope = ThreadScope {
+        tenant_id: turn_scope.tenant_id.clone(),
+        agent_id: turn_scope.agent_id.clone().expect("agent id"),
+        project_id: None,
+        owner_user_id: None,
+        mission_id: None,
+    };
+    thread_service
+        .ensure_thread(EnsureThreadRequest {
+            scope: thread_scope.clone(),
+            thread_id: Some(turn_scope.thread_id.clone()),
+            created_by_actor_id: "user:test".to_string(),
+            title: None,
+            metadata_json: None,
+        })
+        .await
+        .expect("thread");
+    let run_id = TurnRunId::new();
+    let draft = thread_service
+        .append_assistant_draft(AppendAssistantDraftRequest {
+            scope: thread_scope.clone(),
+            thread_id: turn_scope.thread_id.clone(),
+            turn_run_id: run_id.to_string(),
+            content: MessageContent::text("reply after tool"),
+        })
+        .await
+        .expect("draft");
+    thread_service
+        .finalize_assistant_message(
+            &thread_scope,
+            &turn_scope.thread_id,
+            draft.message_id,
+            MessageContent::text("reply after tool"),
+        )
+        .await
+        .expect("finalized");
+    let evidence = ThreadCheckpointLoopExitEvidencePort::new_with_thread_scope(
+        thread_service,
+        Arc::new(ironclaw_turns::InMemoryTurnStateStore::default()) as Arc<dyn TurnStateStore>,
+        Arc::new(PanicLoopCheckpointStore),
+        thread_scope,
+    );
+    let message_ref =
+        LoopMessageRef::new(format!("msg:{}", draft.message_id)).expect("valid message ref");
+    let result_ref = LoopResultRef::new("result:tool-output").expect("valid result ref");
+
+    let verified = evidence
+        .verify_completion_refs(CompletionEvidenceRequest {
+            scope: &turn_scope,
+            turn_id: TurnId::new(),
+            run_id,
+            reply_message_refs: &[message_ref],
+            result_refs: &[result_ref],
+        })
+        .await
+        .expect("completion evidence should verify durable reply refs");
+
+    assert!(verified);
+}
+
+#[tokio::test]
+async fn thread_checkpoint_evidence_rejects_result_only_completion_refs() {
+    let evidence = text_checkpoint_evidence(Arc::new(PanicLoopCheckpointStore));
+    let claimed = claimed_run();
+    let result_ref = LoopResultRef::new("result:tool-output").expect("valid result ref");
+
+    let verified = evidence
+        .verify_completion_refs(CompletionEvidenceRequest {
+            scope: &claimed.state.scope,
+            turn_id: claimed.state.turn_id,
+            run_id: claimed.state.run_id,
+            reply_message_refs: &[],
+            result_refs: &[result_ref],
+        })
+        .await
+        .expect("result-only completion should fail closed without checkpoint I/O");
+
+    assert!(!verified);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Stacks on #3711 and adds the first planned AgentLoop capability/tool path coverage through the product-live harness.

This PR does not cut over the app or gateway. It proves the planned runtime can run the actual agent loop shape beyond simple text replies:

1. product inbound message submits a run
2. planned loop calls the model
3. model returns a capability call
4. harness capability port is invoked
5. model is called again
6. final assistant reply is persisted to thread history

## Dependency

This PR also pulls in #3712 (`fix(reborn): trust result refs with durable replies`) because the capability completion path produces both `result_refs` and a durable assistant reply ref. Without that fix, product-live loop-exit evidence correctly rejects the run as `RecoveryRequired`.

Once #3712 lands in `reborn-integration` and the stack is refreshed, this PR can drop the copied fix commit and keep only the harness capability changes.

## What this enables

- Existing E2E fixtures can start asserting real agent/tool behavior rather than only text reply behavior.
- Adapter-wiring PRs can target real capability invocation seams with regression coverage already in place.
- The next slice can replace harness capability mocks with production composition adapters incrementally.

## Coverage / validation

- `cargo test -p ironclaw_product_workflow --test planned_agent_loop_harness -- --nocapture`
- `cargo test -p ironclaw_product_workflow`
- `cargo clippy -p ironclaw_product_workflow --all-targets -- -D warnings`
- `cargo test -p ironclaw_reborn loop_exit_applier -- --nocapture`

Coverage note: local `cargo llvm-cov` remains unavailable because `llvm-tools-preview` is not installed in this worktree. This PR adds branch-level behavioral coverage for the capability path: model call -> capability invocation -> second model call -> persisted final reply.
