### PR TITLE
feat(reborn): add product-live planned adapter bundle

### DIFF
--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -21,6 +21,7 @@
 mod error;
 mod factory;
 mod input;
+mod product_live_adapters;
 mod profile;
 mod readiness;
 mod runtime;
@@ -29,6 +30,10 @@ mod runtime_input;
 pub use error::RebornBuildError;
 pub use factory::{RebornServices, build_reborn_services};
 pub use input::RebornBuildInput;
+pub use product_live_adapters::{
+    ProductLiveModelRouteSettings, ProductLivePlannedRuntimeAdapterConfig,
+    ProductLivePlannedRuntimeAdapterError, ProductLivePlannedRuntimeAdapters, capability_allowlist,
+};
 pub use profile::{RebornCompositionProfile, RebornCompositionProfileParseError};
 pub use readiness::{RebornFacadeReadiness, RebornReadiness, RebornReadinessState};
 pub use runtime::{

--- a/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
@@ -1,0 +1,206 @@
+//! Product-live adapter bundle for planned AgentLoop composition.
+//!
+//! This module does not cut app or gateway traffic over to Reborn. It provides
+//! the explicit adapter bundle the eventual app/gateway entrypoint can pass
+//! into `ironclaw_reborn::runtime::build_product_live_planned_runtime` once
+//! durable thread/checkpoint stores are selected by that caller.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use ironclaw_host_api::CapabilityId;
+use ironclaw_host_runtime::VisibleCapabilityRequest;
+use ironclaw_loop_support::{
+    CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,
+    HostIdentityContextSource, HostInputQueue, HostRuntimeLoopCapabilityPortFactory,
+    LoopCapabilityInputResolver, LoopCapabilityResultWriter, RunCancellationFactory,
+};
+use ironclaw_reborn::{
+    loop_driver_host::LoopCapabilityPortFactory,
+    model_routes::{
+        ModelRoute, ModelRouteError, ModelRoutePolicy, ModelRouteResolver, ModelSelectionMode,
+        ModelSlot, StaticModelRouteResolver,
+    },
+};
+use ironclaw_turns::run_profile::{
+    InstructionSafetyContext, LoopHostMilestoneSink, LoopModelBudgetAccountant,
+    LoopModelPolicyGuard, LoopRunContext,
+};
+
+use crate::RebornServices;
+
+#[derive(Debug, Error)]
+pub enum ProductLivePlannedRuntimeAdapterError {
+    #[error("product-live planned runtime adapters require a host runtime facade")]
+    MissingHostRuntime,
+    #[error("product-live model route is invalid: {0}")]
+    ModelRoute(#[from] ModelRouteError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProductLiveModelRoute {
+    provider_id: String,
+    model_id: String,
+}
+
+impl ProductLiveModelRoute {
+    fn new(
+        provider_id: impl Into<String>,
+        model_id: impl Into<String>,
+    ) -> Result<Self, ModelRouteError> {
+        let route = ModelRoute::new(provider_id, model_id)?;
+        Ok(Self {
+            provider_id: route.provider_id().to_string(),
+            model_id: route.model_id().to_string(),
+        })
+    }
+
+    fn to_model_route(&self) -> Result<ModelRoute, ModelRouteError> {
+        ModelRoute::new(self.provider_id.clone(), self.model_id.clone())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductLiveModelRouteSettings {
+    selection_mode: ModelSelectionMode,
+    default_route: ProductLiveModelRoute,
+    mission_route: Option<ProductLiveModelRoute>,
+}
+
+impl ProductLiveModelRouteSettings {
+    pub fn new(
+        provider_id: impl Into<String>,
+        model_id: impl Into<String>,
+    ) -> Result<Self, ModelRouteError> {
+        Ok(Self {
+            selection_mode: ModelSelectionMode::ManagedOnly,
+            default_route: ProductLiveModelRoute::new(provider_id, model_id)?,
+            mission_route: None,
+        })
+    }
+
+    pub fn with_selection_mode(mut self, selection_mode: ModelSelectionMode) -> Self {
+        self.selection_mode = selection_mode;
+        self
+    }
+
+    pub fn with_mission_route(
+        mut self,
+        provider_id: impl Into<String>,
+        model_id: impl Into<String>,
+    ) -> Result<Self, ModelRouteError> {
+        self.mission_route = Some(ProductLiveModelRoute::new(provider_id, model_id)?);
+        Ok(self)
+    }
+
+    fn into_resolver(self) -> Result<StaticModelRouteResolver, ModelRouteError> {
+        let default_route = self.default_route.to_model_route()?;
+        let mission_route = self
+            .mission_route
+            .map(|route| route.to_model_route())
+            .transpose()?;
+
+        let mut policy =
+            ModelRoutePolicy::new(self.selection_mode).with_approved_route(default_route.clone());
+        if let Some(route) = mission_route.clone() {
+            policy = policy.with_approved_route(route);
+        }
+
+        let mut resolver =
+            StaticModelRouteResolver::new(policy).with_route(ModelSlot::Default, default_route);
+        if let Some(route) = mission_route {
+            resolver = resolver.with_route(ModelSlot::Mission, route);
+        }
+        Ok(resolver)
+    }
+}
+
+pub struct ProductLivePlannedRuntimeAdapterConfig {
+    pub visible_capability_request: VisibleCapabilityRequest,
+    pub capability_input_resolver: Arc<dyn LoopCapabilityInputResolver>,
+    pub capability_result_writer: Arc<dyn LoopCapabilityResultWriter>,
+    pub capability_allow_set: CapabilityAllowSet,
+    pub model_routes: ProductLiveModelRouteSettings,
+    pub cancellation_factory: Arc<dyn RunCancellationFactory>,
+    pub input_queue: Arc<dyn HostInputQueue>,
+    pub identity_context_source: Arc<dyn HostIdentityContextSource>,
+    pub model_policy_guard: Arc<dyn LoopModelPolicyGuard>,
+    pub model_budget_accountant: Arc<dyn LoopModelBudgetAccountant>,
+    pub safety_context: InstructionSafetyContext,
+    pub milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
+}
+
+#[derive(Clone)]
+pub struct ProductLivePlannedRuntimeAdapters {
+    pub capability_factory: Arc<dyn LoopCapabilityPortFactory>,
+    pub capability_surface_resolver: Arc<dyn CapabilitySurfaceProfileResolver>,
+    pub model_route_resolver: Arc<dyn ModelRouteResolver>,
+    pub cancellation_factory: Arc<dyn RunCancellationFactory>,
+    pub input_queue: Arc<dyn HostInputQueue>,
+    pub identity_context_source: Arc<dyn HostIdentityContextSource>,
+    pub model_policy_guard: Arc<dyn LoopModelPolicyGuard>,
+    pub model_budget_accountant: Arc<dyn LoopModelBudgetAccountant>,
+    pub safety_context: InstructionSafetyContext,
+}
+
+impl ProductLivePlannedRuntimeAdapters {
+    pub fn from_services(
+        services: &RebornServices,
+        config: ProductLivePlannedRuntimeAdapterConfig,
+    ) -> Result<Self, ProductLivePlannedRuntimeAdapterError> {
+        let host_runtime = services
+            .host_runtime
+            .clone()
+            .ok_or(ProductLivePlannedRuntimeAdapterError::MissingHostRuntime)?;
+
+        let capability_factory = HostRuntimeLoopCapabilityPortFactory::new(
+            host_runtime,
+            config.visible_capability_request,
+            config.capability_input_resolver,
+            config.capability_result_writer,
+            config.milestone_sink,
+        );
+        let model_route_resolver: Arc<dyn ModelRouteResolver> =
+            Arc::new(config.model_routes.into_resolver()?);
+
+        Ok(Self {
+            capability_factory: Arc::new(capability_factory),
+            capability_surface_resolver: Arc::new(StaticCapabilitySurfaceResolver::new(
+                config.capability_allow_set,
+            )),
+            model_route_resolver,
+            cancellation_factory: config.cancellation_factory,
+            input_queue: config.input_queue,
+            identity_context_source: config.identity_context_source,
+            model_policy_guard: config.model_policy_guard,
+            model_budget_accountant: config.model_budget_accountant,
+            safety_context: config.safety_context,
+        })
+    }
+}
+
+struct StaticCapabilitySurfaceResolver {
+    allow_set: CapabilityAllowSet,
+}
+
+impl StaticCapabilitySurfaceResolver {
+    fn new(allow_set: CapabilityAllowSet) -> Self {
+        Self { allow_set }
+    }
+}
+
+#[async_trait]
+impl CapabilitySurfaceProfileResolver for StaticCapabilitySurfaceResolver {
+    async fn resolve(
+        &self,
+        _run_context: &LoopRunContext,
+    ) -> Result<CapabilityAllowSet, CapabilityResolveError> {
+        Ok(self.allow_set.clone())
+    }
+}
+
+pub fn capability_allowlist(ids: impl IntoIterator<Item = CapabilityId>) -> CapabilityAllowSet {
+    CapabilityAllowSet::allowlist(ids)
+}

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -1,0 +1,386 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    AgentId, CapabilityId, CapabilitySet, ExecutionContext, ExtensionId, RuntimeKind, TenantId,
+    ThreadId, TrustClass, UserId,
+};
+use ironclaw_host_runtime::{
+    SurfaceKind, VisibleCapabilityRequest as HostVisibleCapabilityRequest,
+};
+use ironclaw_loop_support::{
+    HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
+    HostInputBatch, HostInputEnvelope, HostInputQueue, HostInputQueueError, HostManagedModelError,
+    HostManagedModelErrorKind, HostManagedModelGateway, HostManagedModelRequest,
+    HostManagedModelResponse, LoopCapabilityInputResolver, LoopCapabilityResultWriter,
+    ProductLiveCancellationProbe, RunCancellationFactory, RunCancellationHandle,
+    verify_product_live_cancellation_probe,
+};
+use ironclaw_reborn::loop_exit_applier::ThreadCheckpointLoopExitEvidencePort;
+use ironclaw_reborn::model_routes::{ModelSelectionMode, ModelSlot};
+use ironclaw_reborn::runtime::{
+    DefaultPlannedRuntimeConfig, DefaultPlannedRuntimeParts, build_product_live_planned_runtime,
+};
+use ironclaw_reborn_composition::{
+    ProductLiveModelRouteSettings, ProductLivePlannedRuntimeAdapterConfig,
+    ProductLivePlannedRuntimeAdapterError, ProductLivePlannedRuntimeAdapters, RebornBuildInput,
+    RebornServices, build_reborn_services, capability_allowlist,
+};
+use ironclaw_threads::{InMemorySessionThreadService, ThreadScope};
+use ironclaw_turns::{
+    CheckpointStateStore, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
+    InMemoryTurnStateStore, LoopCheckpointStore, LoopResultRef, RunProfileResolutionRequest,
+    RunProfileResolver, TurnId, TurnRunId, TurnScope, TurnStateStore,
+    run_profile::{
+        AgentLoopHostError, CapabilityInputRef, InMemoryLoopHostMilestoneSink,
+        InstructionSafetyContext, LoopCancelReasonKind, LoopModelBudgetAccountant,
+        LoopModelPolicyGuard, LoopRunContext, NoOpBudgetAccountant, NoOpPolicyGuard, PromptMode,
+        VisibleCapabilityRequest,
+    },
+};
+
+#[tokio::test]
+async fn adapter_bundle_requires_host_runtime_facade() {
+    let result = ProductLivePlannedRuntimeAdapters::from_services(
+        &RebornServices::disabled(),
+        adapter_config(),
+    );
+
+    assert!(matches!(
+        result,
+        Err(ProductLivePlannedRuntimeAdapterError::MissingHostRuntime)
+    ));
+}
+
+#[tokio::test]
+async fn adapter_bundle_wires_required_product_live_components() {
+    let root = tempfile::tempdir().unwrap();
+    let services = build_reborn_services(RebornBuildInput::local_dev(
+        "adapter-test-owner",
+        root.path().join("local-dev"),
+    ))
+    .await
+    .unwrap();
+    let adapters =
+        ProductLivePlannedRuntimeAdapters::from_services(&services, adapter_config()).unwrap();
+
+    let route = adapters
+        .model_route_resolver
+        .resolve_model_route(ModelSlot::Default)
+        .unwrap();
+    assert_eq!(route.route().provider_id(), "nearai");
+    assert_eq!(route.route().model_id(), "qwen3-coder");
+    assert_eq!(route.policy_mode(), ModelSelectionMode::ManagedOnly);
+
+    let context = loop_run_context("adapter-config").await;
+    let allow_set = adapters
+        .capability_surface_resolver
+        .resolve(&context)
+        .await
+        .unwrap();
+    assert!(allow_set.permits(&capability_id("demo.allowed")));
+    assert!(!allow_set.permits(&capability_id("demo.denied")));
+
+    let readiness = verify_product_live_cancellation_probe(adapters.cancellation_factory.as_ref())
+        .expect("turn-state cancellation factory should expose a live probe");
+    assert_eq!(
+        readiness,
+        ironclaw_loop_support::ProductLiveCancellationReadiness::ExternallyControllable
+    );
+
+    let capability_port = adapters
+        .capability_factory
+        .create_capability_port(&context)
+        .await
+        .unwrap();
+    let visible = capability_port
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+    assert!(
+        !visible.version.as_str().is_empty(),
+        "host-runtime capability facade should supply a concrete surface version"
+    );
+}
+
+#[tokio::test]
+async fn adapter_bundle_satisfies_product_live_runtime_readiness_gate() {
+    let root = tempfile::tempdir().unwrap();
+    let services = build_reborn_services(RebornBuildInput::local_dev(
+        "runtime-gate-owner",
+        root.path().join("local-dev"),
+    ))
+    .await
+    .unwrap();
+    let thread_service = Arc::new(InMemorySessionThreadService::default());
+    let turn_state = Arc::new(InMemoryTurnStateStore::default());
+    let checkpoint_state_store = Arc::new(InMemoryCheckpointStateStore::default());
+    let loop_checkpoint_store = Arc::new(InMemoryLoopCheckpointStore::default());
+    let milestone_sink = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let thread_scope = thread_scope("runtime-gate");
+    let adapters =
+        ProductLivePlannedRuntimeAdapters::from_services(&services, adapter_config()).unwrap();
+
+    let turn_state_for_evidence: Arc<dyn TurnStateStore> = turn_state.clone();
+    let loop_checkpoint_for_evidence: Arc<dyn LoopCheckpointStore> = loop_checkpoint_store.clone();
+    let composition = build_product_live_planned_runtime(DefaultPlannedRuntimeParts {
+        turn_state,
+        thread_service: Arc::clone(&thread_service),
+        thread_scope: thread_scope.clone(),
+        model_gateway: Arc::new(StubModelGateway),
+        checkpoint_state_store: checkpoint_state_store as Arc<dyn CheckpointStateStore>,
+        loop_checkpoint_store,
+        milestone_sink,
+        capability_factory: adapters.capability_factory,
+        capability_surface_resolver: adapters.capability_surface_resolver,
+        loop_exit_evidence: Arc::new(ThreadCheckpointLoopExitEvidencePort::new_with_thread_scope(
+            thread_service,
+            turn_state_for_evidence,
+            loop_checkpoint_for_evidence,
+            thread_scope,
+        )),
+        config: DefaultPlannedRuntimeConfig::default(),
+        model_route_resolver: Some(adapters.model_route_resolver),
+        cancellation_factory: Some(adapters.cancellation_factory),
+        skill_context_source: None,
+        input_queue: Some(adapters.input_queue),
+        identity_context_source: adapters.identity_context_source,
+        model_policy_guard: Some(adapters.model_policy_guard),
+        model_budget_accountant: Some(adapters.model_budget_accountant),
+        safety_context: Some(adapters.safety_context),
+    })
+    .expect("adapter bundle should satisfy the product-live readiness gate");
+
+    let profile = composition
+        .run_profile_resolver
+        .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+        .await
+        .unwrap();
+    assert_eq!(profile.profile_id.as_str(), "reborn-planned-default");
+}
+
+#[tokio::test]
+async fn model_route_settings_wire_default_and_mission_slots() {
+    let root = tempfile::tempdir().unwrap();
+    let services = build_reborn_services(RebornBuildInput::local_dev(
+        "route-settings-owner",
+        root.path().join("local-dev"),
+    ))
+    .await
+    .unwrap();
+    let settings = ProductLiveModelRouteSettings::new("nearai", "qwen3-coder")
+        .unwrap()
+        .with_mission_route("openrouter", "anthropic/claude-sonnet-4")
+        .unwrap();
+    let adapters = ProductLivePlannedRuntimeAdapters::from_services(
+        &services,
+        ProductLivePlannedRuntimeAdapterConfig {
+            model_routes: settings,
+            ..adapter_config()
+        },
+    )
+    .unwrap();
+
+    let mission = adapters
+        .model_route_resolver
+        .resolve_model_route(ModelSlot::Mission)
+        .unwrap();
+    assert_eq!(mission.route().provider_id(), "openrouter");
+    assert_eq!(mission.route().model_id(), "anthropic/claude-sonnet-4");
+}
+
+fn adapter_config() -> ProductLivePlannedRuntimeAdapterConfig {
+    ProductLivePlannedRuntimeAdapterConfig {
+        visible_capability_request: host_visible_capability_request("adapter-config"),
+        capability_input_resolver: Arc::new(UnusedCapabilityIo),
+        capability_result_writer: Arc::new(UnusedCapabilityIo),
+        capability_allow_set: capability_allowlist([capability_id("demo.allowed")]),
+        model_routes: ProductLiveModelRouteSettings::new("nearai", "qwen3-coder").unwrap(),
+        cancellation_factory: Arc::new(ReadyRunCancellationFactory::default()),
+        input_queue: Arc::new(EmptyInputQueue),
+        identity_context_source: Arc::new(EmptyIdentityContextSource),
+        model_policy_guard: Arc::new(NoOpPolicyGuard) as Arc<dyn LoopModelPolicyGuard>,
+        model_budget_accountant: Arc::new(NoOpBudgetAccountant)
+            as Arc<dyn LoopModelBudgetAccountant>,
+        safety_context: InstructionSafetyContext::new(
+            "policy:adapter-test",
+            "adapter test safety policy",
+        )
+        .unwrap(),
+        milestone_sink: None,
+    }
+}
+
+async fn loop_run_context(label: &str) -> LoopRunContext {
+    let context = host_visible_capability_request(label).context;
+    let resolved = ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver()
+        .unwrap()
+        .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+        .await
+        .unwrap();
+    LoopRunContext::new(
+        TurnScope::new(
+            context.tenant_id,
+            context.agent_id,
+            context.project_id,
+            context.thread_id.unwrap(),
+        ),
+        TurnId::new(),
+        TurnRunId::new(),
+        resolved,
+    )
+}
+
+fn host_visible_capability_request(label: &str) -> HostVisibleCapabilityRequest {
+    let mut context = ExecutionContext::local_default(
+        UserId::new(format!("user-{label}")).unwrap(),
+        ExtensionId::new("adapter-test").unwrap(),
+        RuntimeKind::Wasm,
+        TrustClass::UserTrusted,
+        CapabilitySet::default(),
+        ironclaw_host_api::MountView::default(),
+    )
+    .unwrap();
+    let thread_id = ThreadId::new(format!("thread-{label}")).unwrap();
+    context.thread_id = Some(thread_id.clone());
+    context.resource_scope.thread_id = Some(thread_id);
+    HostVisibleCapabilityRequest::new(context, SurfaceKind::new("agent_loop").unwrap())
+}
+
+fn thread_scope(label: &str) -> ThreadScope {
+    ThreadScope {
+        tenant_id: TenantId::new(format!("tenant-{label}")).unwrap(),
+        agent_id: AgentId::new(format!("agent-{label}")).unwrap(),
+        project_id: None,
+        owner_user_id: None,
+        mission_id: None,
+    }
+}
+
+fn capability_id(value: &str) -> CapabilityId {
+    CapabilityId::new(value).unwrap()
+}
+
+struct EmptyInputQueue;
+
+#[async_trait]
+impl HostInputQueue for EmptyInputQueue {
+    async fn next_after(
+        &self,
+        _run_id: TurnRunId,
+        after: ironclaw_turns::run_profile::LoopInputCursorToken,
+        _limit: usize,
+    ) -> Result<HostInputBatch, HostInputQueueError> {
+        Ok(HostInputBatch {
+            inputs: Vec::<HostInputEnvelope>::new(),
+            next_cursor: after,
+        })
+    }
+
+    async fn ack_consumed(
+        &self,
+        _run_id: TurnRunId,
+        _tokens: Vec<ironclaw_turns::run_profile::LoopInputAckToken>,
+    ) -> Result<(), HostInputQueueError> {
+        Ok(())
+    }
+}
+
+struct EmptyIdentityContextSource;
+
+#[async_trait]
+impl HostIdentityContextSource for EmptyIdentityContextSource {
+    async fn load_identity_candidates(
+        &self,
+        _run_context: &LoopRunContext,
+        _mode: PromptMode,
+    ) -> Result<Vec<HostIdentityContextCandidate>, HostIdentityContextBuildError> {
+        Ok(Vec::new())
+    }
+}
+
+struct UnusedCapabilityIo;
+
+#[async_trait]
+impl LoopCapabilityInputResolver for UnusedCapabilityIo {
+    async fn resolve_capability_input(
+        &self,
+        _run_context: &LoopRunContext,
+        _input_ref: &CapabilityInputRef,
+    ) -> Result<serde_json::Value, AgentLoopHostError> {
+        Ok(serde_json::json!({}))
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityResultWriter for UnusedCapabilityIo {
+    async fn write_capability_result(
+        &self,
+        _run_context: &LoopRunContext,
+        _capability_id: &CapabilityId,
+        _output: serde_json::Value,
+    ) -> Result<LoopResultRef, AgentLoopHostError> {
+        Ok(LoopResultRef::new("result:adapter-test").unwrap())
+    }
+}
+
+struct StubModelGateway;
+
+#[async_trait]
+impl HostManagedModelGateway for StubModelGateway {
+    async fn stream_model(
+        &self,
+        _request: HostManagedModelRequest,
+    ) -> Result<HostManagedModelResponse, HostManagedModelError> {
+        Err(HostManagedModelError::safe(
+            HostManagedModelErrorKind::Unavailable,
+            "model gateway not exercised by adapter readiness test",
+        ))
+    }
+}
+
+#[derive(Default)]
+struct ReadyRunCancellationFactory {
+    handles: Arc<Mutex<HashMap<TurnRunId, RunCancellationHandle>>>,
+}
+
+#[async_trait]
+impl RunCancellationFactory for ReadyRunCancellationFactory {
+    async fn handle_for_run(
+        &self,
+        _scope: &TurnScope,
+        run_id: TurnRunId,
+    ) -> Result<RunCancellationHandle, AgentLoopHostError> {
+        let handle = RunCancellationHandle::default();
+        self.handles
+            .lock()
+            .expect("ready cancellation lock poisoned")
+            .insert(run_id, handle.clone());
+        Ok(handle)
+    }
+
+    fn product_live_cancellation_probe(&self) -> Option<Box<dyn ProductLiveCancellationProbe>> {
+        Some(Box::new(ReadyCancellationProbe {
+            handle: RunCancellationHandle::default(),
+        }))
+    }
+}
+
+struct ReadyCancellationProbe {
+    handle: RunCancellationHandle,
+}
+
+impl ProductLiveCancellationProbe for ReadyCancellationProbe {
+    fn request_cancellation(
+        &self,
+        reason_kind: LoopCancelReasonKind,
+    ) -> Result<(), AgentLoopHostError> {
+        self.handle.request(reason_kind);
+        Ok(())
+    }
+
+    fn is_cancellation_observed(&self) -> Result<bool, AgentLoopHostError> {
+        Ok(self.handle.is_requested())
+    }
+}


### PR DESCRIPTION
## Summary

Adds the next stacked slice after the planned AgentLoop capability harness: a composition-owned product-live adapter bundle for the planned runtime.

This PR does **not** cut app, gateway, or binary traffic over. It only gives the production composition layer a facade-shaped bundle that can be passed into `build_product_live_planned_runtime` once the eventual entrypoint supplies durable thread/checkpoint stores.

## What this wires

- Host-runtime capability execution through `HostRuntimeLoopCapabilityPortFactory`, using the `RebornServices` host-runtime facade.
- Capability surface resolution through an explicit allow set.
- Model route resolution through typed product-live route settings for default and optional mission slots.
- Cancellation, input queue, identity context, model policy guard, model budget accountant, and safety context as required caller-supplied product adapters.
- Fail-closed behavior when the host runtime facade is absent.

## Contract choices

- No app/gateway cutover in this PR.
- No local-only fallback is accepted for missing host runtime.
- Cancellation is **not** synthesized from a store here. The caller must provide a product-live-capable cancellation factory so the existing readiness probe remains meaningful.
- Policy, budget, input, identity, and safety adapters are required in the config instead of defaulting to no-op production behavior.
- The adapter uses existing runtime/loop-support facades; it does not construct raw capability ports outside `ironclaw_loop_support`.

## Enables

The next contributor can wire a production entrypoint by selecting the durable thread/checkpoint stores and passing this adapter bundle into the product-live planned runtime builder, without reaching into host-runtime internals or weakening the product-live readiness gate.

## Verification

- `cargo test -p ironclaw_reborn_composition --test product_live_adapters -- --nocapture`
- `cargo test -p ironclaw_reborn_composition`
- `cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings`

Coverage command attempted but blocked by the local toolchain:

- `cargo llvm-cov -p ironclaw_reborn_composition --test product_live_adapters --summary-only`
- failed because `llvm-tools-preview` is not installed and `LLVM_COV` / `LLVM_PROFDATA` are not configured.

## Stack

Stacked on #3713 (`reborn/product-live-agentloop-capability-harness`). #3713 currently includes the result-ref evidence fix from #3712 until #3712 lands and the stack is refreshed.
