### PR TITLE
feat(reborn): add product-live capability IO adapters

### DIFF
--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -68,6 +68,7 @@ libsql = { version = "0.6", optional = true, default-features = false, features 
 chrono = "0.4"
 secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["rt"] }
@@ -75,7 +76,6 @@ tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-serde_json = "1"
 tempfile = "3"
 testcontainers-modules = { version = "0.11", features = ["postgres"] }
 tokio = { version = "1", features = ["macros", "rt", "time"] }

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -31,8 +31,10 @@ pub use error::RebornBuildError;
 pub use factory::{RebornServices, build_reborn_services};
 pub use input::RebornBuildInput;
 pub use product_live_adapters::{
-    ProductLiveModelRouteSettings, ProductLivePlannedRuntimeAdapterConfig,
-    ProductLivePlannedRuntimeAdapterError, ProductLivePlannedRuntimeAdapters, capability_allowlist,
+    ProductLiveCapabilityIo, ProductLiveModelRouteSettings, ProductLivePlannedRuntimeAdapterConfig,
+    ProductLivePlannedRuntimeAdapterError, ProductLivePlannedRuntimeAdapters,
+    ProductLiveVisibleCapabilityRequestConfig, capability_allowlist,
+    visible_capability_request_for_run,
 };
 pub use profile::{RebornCompositionProfile, RebornCompositionProfileParseError};
 pub use readiness::{RebornFacadeReadiness, RebornReadiness, RebornReadinessState};

--- a/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/src/product_live_adapters.rs
@@ -5,13 +5,19 @@
 //! into `ironclaw_reborn::runtime::build_product_live_planned_runtime` once
 //! durable thread/checkpoint stores are selected by that caller.
 
-use std::sync::Arc;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use chrono::Utc;
 use thiserror::Error;
+use uuid::Uuid;
 
-use ironclaw_host_api::CapabilityId;
-use ironclaw_host_runtime::VisibleCapabilityRequest;
+use ironclaw_host_api::{
+    CapabilityId, CapabilitySet, EffectKind, ExecutionContext, ExtensionId, MountView, RuntimeKind,
+    TrustClass, UserId,
+};
+use ironclaw_host_runtime::{CapabilitySurfacePolicy, SurfaceKind, VisibleCapabilityRequest};
 use ironclaw_loop_support::{
     CapabilityAllowSet, CapabilityResolveError, CapabilitySurfaceProfileResolver,
     HostIdentityContextSource, HostInputQueue, HostRuntimeLoopCapabilityPortFactory,
@@ -24,9 +30,13 @@ use ironclaw_reborn::{
         ModelSlot, StaticModelRouteResolver,
     },
 };
-use ironclaw_turns::run_profile::{
-    InstructionSafetyContext, LoopHostMilestoneSink, LoopModelBudgetAccountant,
-    LoopModelPolicyGuard, LoopRunContext,
+use ironclaw_trust::{AuthorityCeiling, EffectiveTrustClass, TrustDecision, TrustProvenance};
+use ironclaw_turns::{
+    LoopResultRef,
+    run_profile::{
+        AgentLoopHostError, AgentLoopHostErrorKind, CapabilityInputRef, InstructionSafetyContext,
+        LoopHostMilestoneSink, LoopModelBudgetAccountant, LoopModelPolicyGuard, LoopRunContext,
+    },
 };
 
 use crate::RebornServices;
@@ -37,6 +47,257 @@ pub enum ProductLivePlannedRuntimeAdapterError {
     MissingHostRuntime,
     #[error("product-live model route is invalid: {0}")]
     ModelRoute(#[from] ModelRouteError),
+    #[error("product-live capability execution scope is invalid: {reason}")]
+    InvalidCapabilityScope { reason: String },
+}
+
+#[derive(Default)]
+pub struct ProductLiveCapabilityIo {
+    inputs: Mutex<HashMap<String, StagedCapabilityInput>>,
+    results: Mutex<HashMap<String, StagedCapabilityResult>>,
+}
+
+#[derive(Clone)]
+struct StagedCapabilityInput {
+    run_id: String,
+    payload: serde_json::Value,
+}
+
+#[derive(Clone)]
+struct StagedCapabilityResult {
+    run_id: String,
+    output: serde_json::Value,
+}
+
+impl ProductLiveCapabilityIo {
+    pub fn stage_input(
+        &self,
+        run_context: &LoopRunContext,
+        payload: serde_json::Value,
+    ) -> Result<CapabilityInputRef, AgentLoopHostError> {
+        let input_ref =
+            CapabilityInputRef::new(format!("input:{}:{}", run_context.run_id, Uuid::new_v4()))
+                .map_err(|_| {
+                    AgentLoopHostError::new(
+                        AgentLoopHostErrorKind::Internal,
+                        "capability input ref could not be represented",
+                    )
+                })?;
+        self.inputs
+            .lock()
+            .map_err(|_| capability_io_internal_error())?
+            .insert(
+                input_ref.as_str().to_string(),
+                StagedCapabilityInput {
+                    run_id: run_context.run_id.to_string(),
+                    payload,
+                },
+            );
+        Ok(input_ref)
+    }
+
+    pub fn result_for_ref(
+        &self,
+        run_context: &LoopRunContext,
+        result_ref: &LoopResultRef,
+    ) -> Result<serde_json::Value, AgentLoopHostError> {
+        ensure_ref_scoped_to_run("result", result_ref.as_str(), run_context)?;
+        let results = self
+            .results
+            .lock()
+            .map_err(|_| capability_io_internal_error())?;
+        let result = results.get(result_ref.as_str()).ok_or_else(|| {
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "capability result ref was not staged for this loop run",
+            )
+        })?;
+        if result.run_id != run_context.run_id.to_string() {
+            return Err(cross_run_ref_error("capability result ref"));
+        }
+        Ok(result.output.clone())
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityInputResolver for ProductLiveCapabilityIo {
+    async fn resolve_capability_input(
+        &self,
+        run_context: &LoopRunContext,
+        input_ref: &CapabilityInputRef,
+    ) -> Result<serde_json::Value, AgentLoopHostError> {
+        ensure_ref_scoped_to_run("input", input_ref.as_str(), run_context)?;
+        let inputs = self
+            .inputs
+            .lock()
+            .map_err(|_| capability_io_internal_error())?;
+        let input = inputs.get(input_ref.as_str()).ok_or_else(|| {
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::InvalidInvocation,
+                "capability input ref was not staged for this loop run",
+            )
+        })?;
+        if input.run_id != run_context.run_id.to_string() {
+            return Err(cross_run_ref_error("capability input ref"));
+        }
+        Ok(input.payload.clone())
+    }
+}
+
+#[async_trait]
+impl LoopCapabilityResultWriter for ProductLiveCapabilityIo {
+    async fn write_capability_result(
+        &self,
+        run_context: &LoopRunContext,
+        _capability_id: &CapabilityId,
+        output: serde_json::Value,
+    ) -> Result<LoopResultRef, AgentLoopHostError> {
+        let result_ref =
+            LoopResultRef::new(format!("result:{}.{}", run_context.run_id, Uuid::new_v4()))
+                .map_err(|_| {
+                    AgentLoopHostError::new(
+                        AgentLoopHostErrorKind::Internal,
+                        "capability result ref could not be represented",
+                    )
+                })?;
+        self.results
+            .lock()
+            .map_err(|_| capability_io_internal_error())?
+            .insert(
+                result_ref.as_str().to_string(),
+                StagedCapabilityResult {
+                    run_id: run_context.run_id.to_string(),
+                    output,
+                },
+            );
+        Ok(result_ref)
+    }
+}
+
+fn ensure_ref_scoped_to_run(
+    prefix: &str,
+    reference: &str,
+    run_context: &LoopRunContext,
+) -> Result<(), AgentLoopHostError> {
+    let separator = if prefix == "result" { "." } else { ":" };
+    let expected_prefix = format!("{prefix}:{}{separator}", run_context.run_id);
+    if reference.starts_with(&expected_prefix) {
+        Ok(())
+    } else {
+        Err(cross_run_ref_error(match prefix {
+            "input" => "capability input ref",
+            "result" => "capability result ref",
+            _ => "capability ref",
+        }))
+    }
+}
+
+fn cross_run_ref_error(ref_name: &'static str) -> AgentLoopHostError {
+    AgentLoopHostError::new(
+        AgentLoopHostErrorKind::ScopeMismatch,
+        format!("{ref_name} is not scoped to this loop run"),
+    )
+}
+
+fn capability_io_internal_error() -> AgentLoopHostError {
+    AgentLoopHostError::new(
+        AgentLoopHostErrorKind::Internal,
+        "capability io store is unavailable",
+    )
+}
+
+#[derive(Clone)]
+pub struct ProductLiveVisibleCapabilityRequestConfig {
+    user_id: UserId,
+    extension_id: ExtensionId,
+    runtime: RuntimeKind,
+    trust: TrustClass,
+    grants: CapabilitySet,
+    surface_kind: SurfaceKind,
+    policy: CapabilitySurfacePolicy,
+    provider_trust: BTreeMap<ExtensionId, TrustDecision>,
+}
+
+impl ProductLiveVisibleCapabilityRequestConfig {
+    pub fn new(
+        user_id: UserId,
+        extension_id: ExtensionId,
+        runtime: RuntimeKind,
+        trust: TrustClass,
+        surface_kind: SurfaceKind,
+        policy: CapabilitySurfacePolicy,
+    ) -> Self {
+        Self {
+            user_id,
+            extension_id,
+            runtime,
+            trust,
+            grants: CapabilitySet::default(),
+            surface_kind,
+            policy,
+            provider_trust: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_grants(mut self, grants: CapabilitySet) -> Self {
+        self.grants = grants;
+        self
+    }
+
+    pub fn with_provider_trust(
+        mut self,
+        provider: ExtensionId,
+        effective_trust: EffectiveTrustClass,
+    ) -> Self {
+        self.provider_trust.insert(
+            provider,
+            TrustDecision {
+                effective_trust,
+                authority_ceiling: AuthorityCeiling {
+                    allowed_effects: vec![EffectKind::DispatchCapability],
+                    max_resource_ceiling: None,
+                },
+                provenance: TrustProvenance::AdminConfig,
+                evaluated_at: Utc::now(),
+            },
+        );
+        self
+    }
+}
+
+pub fn visible_capability_request_for_run(
+    run_context: &LoopRunContext,
+    config: ProductLiveVisibleCapabilityRequestConfig,
+) -> Result<VisibleCapabilityRequest, ProductLivePlannedRuntimeAdapterError> {
+    let mut context = ExecutionContext::local_default(
+        config.user_id,
+        config.extension_id,
+        config.runtime,
+        config.trust,
+        config.grants,
+        MountView::default(),
+    )
+    .map_err(
+        |error| ProductLivePlannedRuntimeAdapterError::InvalidCapabilityScope {
+            reason: error.to_string(),
+        },
+    )?;
+    context.tenant_id = run_context.scope.tenant_id.clone();
+    context.agent_id = run_context.scope.agent_id.clone();
+    context.project_id = run_context.scope.project_id.clone();
+    context.thread_id = Some(run_context.thread_id.clone());
+    context.resource_scope.tenant_id = context.tenant_id.clone();
+    context.resource_scope.agent_id = context.agent_id.clone();
+    context.resource_scope.project_id = context.project_id.clone();
+    context.resource_scope.thread_id = context.thread_id.clone();
+    context.validate().map_err(|error| {
+        ProductLivePlannedRuntimeAdapterError::InvalidCapabilityScope {
+            reason: error.to_string(),
+        }
+    })?;
+    Ok(VisibleCapabilityRequest::new(context, config.surface_kind)
+        .with_policy(config.policy)
+        .with_provider_trust(config.provider_trust))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -7,7 +7,7 @@ use ironclaw_host_api::{
     ThreadId, TrustClass, UserId,
 };
 use ironclaw_host_runtime::{
-    SurfaceKind, VisibleCapabilityRequest as HostVisibleCapabilityRequest,
+    CapabilitySurfacePolicy, SurfaceKind, VisibleCapabilityRequest as HostVisibleCapabilityRequest,
 };
 use ironclaw_loop_support::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
@@ -23,11 +23,13 @@ use ironclaw_reborn::runtime::{
     DefaultPlannedRuntimeConfig, DefaultPlannedRuntimeParts, build_product_live_planned_runtime,
 };
 use ironclaw_reborn_composition::{
-    ProductLiveModelRouteSettings, ProductLivePlannedRuntimeAdapterConfig,
-    ProductLivePlannedRuntimeAdapterError, ProductLivePlannedRuntimeAdapters, RebornBuildInput,
-    RebornServices, build_reborn_services, capability_allowlist,
+    ProductLiveCapabilityIo, ProductLiveModelRouteSettings, ProductLivePlannedRuntimeAdapterConfig,
+    ProductLivePlannedRuntimeAdapterError, ProductLivePlannedRuntimeAdapters,
+    ProductLiveVisibleCapabilityRequestConfig, RebornBuildInput, RebornServices,
+    build_reborn_services, capability_allowlist, visible_capability_request_for_run,
 };
 use ironclaw_threads::{InMemorySessionThreadService, ThreadScope};
+use ironclaw_trust::EffectiveTrustClass;
 use ironclaw_turns::{
     CheckpointStateStore, InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore,
     InMemoryTurnStateStore, LoopCheckpointStore, LoopResultRef, RunProfileResolutionRequest,
@@ -39,6 +41,116 @@ use ironclaw_turns::{
         VisibleCapabilityRequest,
     },
 };
+
+#[tokio::test]
+async fn capability_io_resolves_staged_inputs_and_materializes_run_scoped_results() {
+    let io = ProductLiveCapabilityIo::default();
+    let run_context = loop_run_context("capability-io").await;
+    let input_ref = io
+        .stage_input(&run_context, serde_json::json!({ "text": "hello" }))
+        .unwrap();
+
+    let resolved = io
+        .resolve_capability_input(&run_context, &input_ref)
+        .await
+        .unwrap();
+    assert_eq!(resolved, serde_json::json!({ "text": "hello" }));
+
+    let result_ref = io
+        .write_capability_result(
+            &run_context,
+            &capability_id("demo.echo"),
+            serde_json::json!({ "reply": "hello" }),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result_ref
+            .as_str()
+            .starts_with(&format!("result:{}.", run_context.run_id)),
+        "result refs must be scoped to the loop run: {}",
+        result_ref.as_str()
+    );
+    assert_eq!(
+        io.result_for_ref(&run_context, &result_ref).unwrap(),
+        serde_json::json!({ "reply": "hello" })
+    );
+}
+
+#[tokio::test]
+async fn capability_io_rejects_cross_run_input_and_result_refs() {
+    let io = ProductLiveCapabilityIo::default();
+    let first_run = loop_run_context("capability-io-first").await;
+    let second_run = loop_run_context("capability-io-second").await;
+    let input_ref = io
+        .stage_input(&first_run, serde_json::json!({ "text": "first" }))
+        .unwrap();
+
+    let input_error = io
+        .resolve_capability_input(&second_run, &input_ref)
+        .await
+        .expect_err("cross-run input refs must fail closed");
+    assert_eq!(
+        input_error.kind,
+        ironclaw_turns::run_profile::AgentLoopHostErrorKind::ScopeMismatch
+    );
+
+    let result_ref = io
+        .write_capability_result(
+            &first_run,
+            &capability_id("demo.echo"),
+            serde_json::json!({ "reply": "first" }),
+        )
+        .await
+        .unwrap();
+    let result_error = io
+        .result_for_ref(&second_run, &result_ref)
+        .expect_err("cross-run result refs must fail closed");
+    assert_eq!(
+        result_error.kind,
+        ironclaw_turns::run_profile::AgentLoopHostErrorKind::ScopeMismatch
+    );
+}
+
+#[tokio::test]
+async fn visible_capability_request_builder_scopes_context_to_loop_run() {
+    let run_context = loop_run_context("visible-builder").await;
+    let request = visible_capability_request_for_run(
+        &run_context,
+        ProductLiveVisibleCapabilityRequestConfig::new(
+            UserId::new("user-visible-builder").unwrap(),
+            ExtensionId::new("planned-driver").unwrap(),
+            RuntimeKind::FirstParty,
+            TrustClass::System,
+            SurfaceKind::new("agent_loop").unwrap(),
+            CapabilitySurfacePolicy::allow_all(),
+        )
+        .with_grants(CapabilitySet::default())
+        .with_provider_trust(
+            ExtensionId::new("demo").unwrap(),
+            EffectiveTrustClass::user_trusted(),
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(request.context.tenant_id, run_context.scope.tenant_id);
+    assert_eq!(request.context.agent_id, run_context.scope.agent_id);
+    assert_eq!(request.context.project_id, run_context.scope.project_id);
+    assert_eq!(
+        request.context.thread_id.as_ref(),
+        Some(&run_context.thread_id)
+    );
+    assert_eq!(
+        request.context.resource_scope.thread_id.as_ref(),
+        Some(&run_context.thread_id)
+    );
+    assert!(
+        request
+            .provider_trust
+            .contains_key(&ExtensionId::new("demo").unwrap())
+    );
+}
 
 #[tokio::test]
 async fn adapter_bundle_requires_host_runtime_facade() {


### PR DESCRIPTION
## Summary

Adds the first e2e-enabling adapter slice on top of #3714: composition-owned capability IO and scoped visible-capability request construction.

This is deliberately not an app/gateway cutover. It gives local/product-live runtime tests a real tool-call boundary without reaching into lower-level internals.

## TDD flow

1. Added failing tests for:
   - staged capability input resolution
   - run-scoped result ref materialization
   - cross-run input/result ref rejection
   - visible capability request construction from an actual `LoopRunContext`
2. Implemented the minimal adapter code to satisfy those tests.
3. Re-ran focused and package validation.

## What this wires

- `ProductLiveCapabilityIo`
  - stages JSON payloads behind `CapabilityInputRef`
  - implements `LoopCapabilityInputResolver`
  - implements `LoopCapabilityResultWriter`
  - materializes `LoopResultRef`s scoped to the current run
  - fails closed for cross-run refs
- `ProductLiveVisibleCapabilityRequestConfig`
- `visible_capability_request_for_run(...)`
  - derives tenant/agent/project/thread scope from `LoopRunContext`
  - keeps the visibility policy explicit
  - requires provider trust to be supplied by the caller

## Why this shape

For e2e, the immediate blocker is moving model-emitted tool calls through `HostRuntime` without test-only inline fakes. This PR keeps that adapter in the composition layer and uses existing loop-support/host-runtime facades. It does not invent durable result storage; the store is process-local and explicitly scoped to enabling local/e2e runtime execution. Durable production result storage remains a follow-up.

## Enables

The next stacked PR can assemble a runnable local product-live planned runtime that:

1. builds a scoped capability surface,
2. stages a model tool-call input,
3. dispatches through host-runtime capability execution,
4. stores the result behind a `LoopResultRef`, and
5. lets the model continue to a final reply.

## Verification

- `cargo test -p ironclaw_reborn_composition --test product_live_adapters -- --nocapture`
- `cargo test -p ironclaw_reborn_composition`
- `cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings`

## Stack

Stacked on #3714.
