### PR TITLE
test(reborn): exercise product-live builtin tool path

### DIFF
--- a/crates/ironclaw_loop_support/src/capability_port.rs
+++ b/crates/ironclaw_loop_support/src/capability_port.rs
@@ -690,13 +690,7 @@ fn invocation_context_from_visible(
     allowed_effects: &[EffectKind],
 ) -> Result<ExecutionContext, AgentLoopHostError> {
     let mut context = base.clone();
-    let loop_driver_extension =
-        ExtensionId::new(run_context.loop_driver_id.as_str()).map_err(|_| {
-            AgentLoopHostError::new(
-                AgentLoopHostErrorKind::Internal,
-                "loop driver id could not be represented as an execution extension",
-            )
-        })?;
+    let loop_driver_extension = loop_driver_execution_extension_id(run_context)?;
     context.extension_id = loop_driver_extension.clone();
     context.runtime = capability.runtime;
     context.trust = trust;
@@ -720,6 +714,20 @@ fn invocation_context_from_visible(
         )
     })?;
     Ok(context)
+}
+
+fn loop_driver_execution_extension_id(
+    run_context: &LoopRunContext,
+) -> Result<ExtensionId, AgentLoopHostError> {
+    let raw = run_context.loop_driver_id.as_str();
+    ExtensionId::new(raw)
+        .or_else(|_| ExtensionId::new(raw.replace(':', "-")))
+        .map_err(|_| {
+            AgentLoopHostError::new(
+                AgentLoopHostErrorKind::Internal,
+                "loop driver id could not be represented as an execution extension",
+            )
+        })
 }
 
 fn invocation_grants_from_visible(
@@ -986,8 +994,8 @@ mod tests {
         MountPermissions, NetworkPolicy, ProjectId, TenantId, TrustClass, UserId, VirtualPath,
     };
     use ironclaw_turns::{
-        InMemoryRunProfileResolver, RunProfileResolutionRequest, RunProfileResolver, TurnId,
-        TurnRunId, TurnScope,
+        InMemoryRunProfileResolver, LoopDriverId, RunProfileResolutionRequest, RunProfileResolver,
+        TurnId, TurnRunId, TurnScope,
     };
 
     #[test]
@@ -1219,6 +1227,51 @@ mod tests {
             &invocation_context.grants.grants[0].grantee,
             Principal::Thread(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn invocation_context_derives_extension_id_for_planned_driver_namespaced_id() {
+        let capability_id = CapabilityId::new("demo.echo").expect("valid capability id");
+        let mut context = execution_context("thread-planned-driver-id");
+        let mut run_context = loop_run_context(&context).await;
+        run_context.loop_driver_id =
+            LoopDriverId::new("reborn:planned-default").expect("valid loop driver id");
+        context.grants.grants.push(CapabilityGrant {
+            id: CapabilityGrantId::new(),
+            capability: capability_id.clone(),
+            grantee: Principal::User(context.user_id.clone()),
+            issued_by: Principal::HostRuntime,
+            constraints: GrantConstraints {
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: MountView::default(),
+                network: NetworkPolicy::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at: None,
+                max_invocations: None,
+            },
+        });
+        let capability = SurfaceCapabilitySnapshot {
+            provider: ExtensionId::new("demo").expect("valid provider"),
+            runtime: RuntimeKind::FirstParty,
+            estimate: ResourceEstimate::default(),
+        };
+
+        let invocation_context = invocation_context_from_visible(
+            &context,
+            &run_context,
+            &capability_id,
+            &capability,
+            TrustClass::FirstParty,
+            &[EffectKind::DispatchCapability],
+        )
+        .expect("planned driver id should derive a valid execution principal");
+
+        assert_eq!(
+            invocation_context.extension_id,
+            ExtensionId::new("reborn-planned-default").expect("valid extension")
+        );
+        assert_eq!(invocation_context.grants.grants.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -3,11 +3,15 @@ use std::sync::Arc;
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::LocalFilesystem;
-use ironclaw_host_runtime::{CapabilitySurfaceVersion, HostRuntimeServices};
+use ironclaw_host_api::{EffectKind, PackageId};
+use ironclaw_host_runtime::{
+    CapabilitySurfaceVersion, FirstPartyCapabilityRegistry, HostRuntimeServices,
+    builtin_first_party_handlers, builtin_first_party_package,
+};
 use ironclaw_processes::ProcessServices;
 use ironclaw_resources::InMemoryResourceGovernor;
 use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore};
-use ironclaw_trust::HostTrustPolicy;
+use ironclaw_trust::{AdminConfig, AdminEntry, HostTrustAssignment, HostTrustPolicy};
 use ironclaw_turns::{DefaultTurnCoordinator, InMemoryTurnStateStore};
 
 use crate::input::RebornStorageInput;
@@ -101,14 +105,15 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     let turn_state = Arc::new(InMemoryTurnStateStore::default());
 
     let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
+        Arc::new(local_dev_extension_registry()?),
         Arc::new(filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("reborn-app-v1")?,
     )
-    .with_trust_policy(Arc::new(HostTrustPolicy::empty()))
+    .with_first_party_capabilities(Arc::new(local_dev_first_party_handlers()?))
+    .with_trust_policy(Arc::new(local_dev_first_party_trust_policy()?))
     .with_run_state(Arc::clone(&run_state))
     .with_approval_requests(Arc::clone(&approval_requests))
     .with_turn_state(Arc::clone(&turn_state));
@@ -122,6 +127,48 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
         host_runtime: Some(host_runtime),
         turn_coordinator: Some(turn_coordinator),
         readiness: readiness_for(input.profile, true, true),
+    })
+}
+
+fn local_dev_extension_registry() -> Result<ExtensionRegistry, RebornBuildError> {
+    let mut registry = ExtensionRegistry::new();
+    registry
+        .insert(
+            builtin_first_party_package().map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!("built-in first-party package is invalid: {error}"),
+            })?,
+        )
+        .map_err(|error| RebornBuildError::InvalidConfig {
+            reason: format!("built-in first-party registry is invalid: {error}"),
+        })?;
+    Ok(registry)
+}
+
+fn local_dev_first_party_handlers() -> Result<FirstPartyCapabilityRegistry, RebornBuildError> {
+    builtin_first_party_handlers().map_err(|error| RebornBuildError::InvalidConfig {
+        reason: format!("built-in first-party handlers are invalid: {error}"),
+    })
+}
+
+fn local_dev_first_party_trust_policy() -> Result<HostTrustPolicy, RebornBuildError> {
+    HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
+        AdminEntry::for_local_manifest(
+            PackageId::new("builtin").map_err(|error| RebornBuildError::InvalidConfig {
+                reason: format!("built-in first-party package id is invalid: {error}"),
+            })?,
+            "/system/extensions/builtin/manifest.toml".to_string(),
+            None,
+            HostTrustAssignment::first_party(),
+            vec![
+                EffectKind::DispatchCapability,
+                EffectKind::ReadFilesystem,
+                EffectKind::WriteFilesystem,
+            ],
+            None,
+        ),
+    ]))])
+    .map_err(|error| RebornBuildError::InvalidConfig {
+        reason: format!("built-in first-party trust policy is invalid: {error}"),
     })
 }
 

--- a/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
+++ b/crates/ironclaw_reborn_composition/tests/product_live_adapters.rs
@@ -3,11 +3,13 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    AgentId, CapabilityId, CapabilitySet, ExecutionContext, ExtensionId, RuntimeKind, TenantId,
-    ThreadId, TrustClass, UserId,
+    AgentId, CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, EffectKind,
+    ExecutionContext, ExtensionId, GrantConstraints, NetworkPolicy, Principal, RuntimeKind,
+    TenantId, ThreadId, TrustClass, UserId,
 };
 use ironclaw_host_runtime::{
-    CapabilitySurfacePolicy, SurfaceKind, VisibleCapabilityRequest as HostVisibleCapabilityRequest,
+    CapabilitySurfacePolicy, ECHO_CAPABILITY_ID, SurfaceKind,
+    VisibleCapabilityRequest as HostVisibleCapabilityRequest,
 };
 use ironclaw_loop_support::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
@@ -35,10 +37,10 @@ use ironclaw_turns::{
     InMemoryTurnStateStore, LoopCheckpointStore, LoopResultRef, RunProfileResolutionRequest,
     RunProfileResolver, TurnId, TurnRunId, TurnScope, TurnStateStore,
     run_profile::{
-        AgentLoopHostError, CapabilityInputRef, InMemoryLoopHostMilestoneSink,
-        InstructionSafetyContext, LoopCancelReasonKind, LoopModelBudgetAccountant,
-        LoopModelPolicyGuard, LoopRunContext, NoOpBudgetAccountant, NoOpPolicyGuard, PromptMode,
-        VisibleCapabilityRequest,
+        AgentLoopHostError, CapabilityInputRef, CapabilityInvocation, CapabilityOutcome,
+        InMemoryLoopHostMilestoneSink, InstructionSafetyContext, LoopCancelReasonKind,
+        LoopModelBudgetAccountant, LoopModelPolicyGuard, LoopRunContext, NoOpBudgetAccountant,
+        NoOpPolicyGuard, PromptMode, VisibleCapabilityRequest,
     },
 };
 
@@ -149,6 +151,91 @@ async fn visible_capability_request_builder_scopes_context_to_loop_run() {
         request
             .provider_trust
             .contains_key(&ExtensionId::new("demo").unwrap())
+    );
+}
+
+#[tokio::test]
+async fn local_dev_adapter_invokes_builtin_echo_through_host_runtime_port() {
+    let root = tempfile::tempdir().unwrap();
+    let services = build_reborn_services(RebornBuildInput::local_dev(
+        "builtin-echo-owner",
+        root.path().join("local-dev"),
+    ))
+    .await
+    .unwrap();
+    let run_context = loop_run_context("builtin-echo").await;
+    let io = Arc::new(ProductLiveCapabilityIo::default());
+    let input_ref = io
+        .stage_input(
+            &run_context,
+            serde_json::json!({ "message": "hello product live" }),
+        )
+        .unwrap();
+    let capability_id = capability_id(ECHO_CAPABILITY_ID);
+    let adapters = ProductLivePlannedRuntimeAdapters::from_services(
+        &services,
+        ProductLivePlannedRuntimeAdapterConfig {
+            visible_capability_request: visible_capability_request_for_run(
+                &run_context,
+                ProductLiveVisibleCapabilityRequestConfig::new(
+                    UserId::new("user-builtin-echo").unwrap(),
+                    ExtensionId::new("planned-driver").unwrap(),
+                    RuntimeKind::FirstParty,
+                    TrustClass::FirstParty,
+                    SurfaceKind::new("agent_loop").unwrap(),
+                    CapabilitySurfacePolicy::allow_all(),
+                )
+                .with_grants(dispatch_grants_for_user(
+                    UserId::new("user-builtin-echo").unwrap(),
+                    [ECHO_CAPABILITY_ID],
+                ))
+                .with_provider_trust(
+                    ExtensionId::new("builtin").unwrap(),
+                    EffectiveTrustClass::user_trusted(),
+                ),
+            )
+            .unwrap(),
+            capability_input_resolver: io.clone(),
+            capability_result_writer: io.clone(),
+            capability_allow_set: capability_allowlist([capability_id.clone()]),
+            ..adapter_config()
+        },
+    )
+    .unwrap();
+    let capability_port = adapters
+        .capability_factory
+        .create_capability_port(&run_context)
+        .await
+        .unwrap();
+
+    let surface = capability_port
+        .visible_capabilities(VisibleCapabilityRequest)
+        .await
+        .unwrap();
+    assert!(
+        surface
+            .descriptors
+            .iter()
+            .any(|descriptor| descriptor.capability_id == capability_id),
+        "builtin echo must be visible through the product-live adapter surface"
+    );
+
+    let outcome = capability_port
+        .invoke_capability(CapabilityInvocation {
+            surface_version: surface.version,
+            capability_id: capability_id.clone(),
+            input_ref,
+        })
+        .await
+        .unwrap();
+    let CapabilityOutcome::Completed(completed) = outcome else {
+        panic!("expected completed builtin echo outcome, got {outcome:?}");
+    };
+    assert_eq!(completed.safe_summary, "capability completed");
+    assert_eq!(
+        io.result_for_ref(&run_context, &completed.result_ref)
+            .unwrap(),
+        serde_json::json!("hello product live")
     );
 }
 
@@ -372,6 +459,36 @@ fn thread_scope(label: &str) -> ThreadScope {
 
 fn capability_id(value: &str) -> CapabilityId {
     CapabilityId::new(value).unwrap()
+}
+
+fn dispatch_grants_for_user<const N: usize>(
+    user_id: UserId,
+    capabilities: [&str; N],
+) -> CapabilitySet {
+    CapabilitySet {
+        grants: capabilities
+            .into_iter()
+            .map(|capability| dispatch_grant_for_user(user_id.clone(), capability))
+            .collect(),
+    }
+}
+
+fn dispatch_grant_for_user(user_id: UserId, capability: &str) -> CapabilityGrant {
+    CapabilityGrant {
+        id: CapabilityGrantId::new(),
+        capability: capability_id(capability),
+        grantee: Principal::User(user_id),
+        issued_by: Principal::HostRuntime,
+        constraints: GrantConstraints {
+            allowed_effects: vec![EffectKind::DispatchCapability],
+            mounts: ironclaw_host_api::MountView::default(),
+            network: NetworkPolicy::default(),
+            secrets: Vec::new(),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
+    }
 }
 
 struct EmptyInputQueue;


### PR DESCRIPTION
## What this PR does

This is the next stacked layer after #3715. It proves the product-live planned adapter bundle can drive a real host-runtime capability, not only staged IO and fake/recording ports.

The wiring path exercised here is:

1. `build_reborn_services(RebornCompositionProfile::LocalDev)` now registers the built-in first-party package in the local host-runtime extension registry.
2. The same local-dev composition installs the built-in first-party handlers and a host trust policy for the `builtin` provider.
3. `ProductLiveCapabilityIo` stages a run-scoped input ref for `builtin.echo`.
4. `visible_capability_request_for_run` scopes a host visible capability request to the planned `LoopRunContext`.
5. `ProductLivePlannedRuntimeAdapters::from_services` builds the host-runtime-backed `LoopCapabilityPortFactory`.
6. The loop capability port lists the real `builtin.echo` descriptor and invokes it through `HostRuntime`.
7. The completed runtime output is written back through `ProductLiveCapabilityIo` as a run-scoped result ref.

## Why this exists

The previous PR gave us the adapter bundle and process-local capability IO needed by product-live e2e tests. This PR verifies that the same bundle can cross the actual host-runtime capability boundary and execute a concrete built-in tool.

This enables the next PR to port an agent-loop e2e fixture that lets the planned model path request a tool call and consume the resulting `LoopResultRef`.

## Boundary fix included

While writing the failing test first, the planned driver hit a real boundary bug: `reborn:planned-default` is a valid `LoopDriverId`, but not a valid `ExtensionId` for host-runtime execution context. The loop-support facade now derives a valid execution principal by preserving valid driver ids and replacing `:` with `-` when needed. This keeps the conversion private to the capability-port boundary instead of exposing lower-level host-runtime internals to composition callers.

## TDD / verification

Initial failing proof:

```text
cargo test -p ironclaw_reborn_composition --test product_live_adapters local_dev_adapter_invokes_builtin_echo_through_host_runtime_port -- --nocapture
# failed because builtin echo was not visible through the product-live adapter surface
```

After implementation:

```text
cargo test -p ironclaw_loop_support
cargo test -p ironclaw_reborn_composition
cargo clippy -p ironclaw_loop_support -p ironclaw_reborn_composition --all-targets -- -D warnings
cargo fmt --check
LLVM_COV=$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata cargo llvm-cov -p ironclaw_loop_support -p ironclaw_reborn_composition --summary-only
```

Coverage summary for the touched package set:

```text
TOTAL regions: 81.98%
TOTAL lines:   80.89%
```

## Not included

This does not cut over the app, gateway, or binary. It also does not yet run the full planned AgentLoop with a model-produced tool call; that is the next stacked PR now that the real host-runtime tool boundary is proven.
