### PR TITLE
Gate Reborn personal context by run profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,3 @@ tests/fixtures/llm_traces/live/github_dev_workflow_full_loop.log
 # tests locally. Only the .json fixtures for each scenario are checked
 # in; the .log files are local debugging artifacts.
 tests/fixtures/llm_traces/live/*.log
-
-# Multi-agent code review findings (local only, never commit)
-.review/

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ tests/fixtures/llm_traces/live/github_dev_workflow_full_loop.log
 # tests locally. Only the .json fixtures for each scenario are checked
 # in; the .log files are local debugging artifacts.
 tests/fixtures/llm_traces/live/*.log
+
+# Multi-agent code review findings (local only, never commit)
+.review/

--- a/crates/ironclaw_agent_loop/src/default_planner.rs
+++ b/crates/ironclaw_agent_loop/src/default_planner.rs
@@ -354,6 +354,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/executor.rs
+++ b/crates/ironclaw_agent_loop/src/executor.rs
@@ -3732,6 +3732,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/state.rs
+++ b/crates/ironclaw_agent_loop/src/state.rs
@@ -211,6 +211,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/batch.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/batch.rs
@@ -144,6 +144,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/budget.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/budget.rs
@@ -154,6 +154,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/capability.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/capability.rs
@@ -132,6 +132,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/context.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/context.rs
@@ -140,6 +140,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/drain.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/drain.rs
@@ -135,6 +135,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/gate.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/gate.rs
@@ -179,6 +179,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/mod.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/mod.rs
@@ -188,6 +188,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/model.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/model.rs
@@ -131,6 +131,7 @@ mod tests {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/recovery.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/recovery.rs
@@ -751,6 +751,8 @@ mod tests {
                     max_model_calls: 32,
                     max_capability_invocations: 64,
                 },
+                personal_context_policy:
+                    ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
                 runtime_constraints: RuntimeProfileConstraints {
                     allow_raw_runtime_backend_selection: false,
                     allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/strategies/stop.rs
+++ b/crates/ironclaw_agent_loop/src/strategies/stop.rs
@@ -334,6 +334,8 @@ mod tests {
                     max_model_calls: 32,
                     max_capability_invocations: 64,
                 },
+                personal_context_policy:
+                    ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
                 runtime_constraints: RuntimeProfileConstraints {
                     allow_raw_runtime_backend_selection: false,
                     allow_broad_capability_surface: false,

--- a/crates/ironclaw_agent_loop/src/test_support/mod.rs
+++ b/crates/ironclaw_agent_loop/src/test_support/mod.rs
@@ -818,6 +818,7 @@ pub fn test_run_context(label: &str) -> LoopRunContext {
             max_model_calls: 32,
             max_capability_invocations: 64,
         },
+        personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
         runtime_constraints: RuntimeProfileConstraints {
             allow_raw_runtime_backend_selection: false,
             allow_broad_capability_surface: false,

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -157,6 +157,8 @@ pub enum HostIdentityContextBuildError {
     UnknownIdentityFile,
     #[error("identity context path is invalid")]
     InvalidIdentityFile,
+    #[error("identity context denied by run policy")]
+    PolicyDenied,
     /// Reserved for a future hard-limit mode. Currently, `build_identity_messages_for_run`
     /// truncates silently on budget overflow rather than returning this error.
     #[error("identity context budget exceeded")]
@@ -171,7 +173,7 @@ impl HostIdentityContextBuildError {
     pub fn into_host_error(self) -> AgentLoopHostError {
         let kind = match self {
             Self::SourceUnavailable => AgentLoopHostErrorKind::Unavailable,
-            Self::UnknownIdentityFile | Self::InvalidIdentityFile => {
+            Self::UnknownIdentityFile | Self::InvalidIdentityFile | Self::PolicyDenied => {
                 AgentLoopHostErrorKind::PolicyDenied
             }
             Self::ContextBudgetExceeded => AgentLoopHostErrorKind::BudgetExceeded,
@@ -194,11 +196,11 @@ pub async fn build_identity_messages(
     build_identity_messages_for_run(&candidates, run_context, mode, budget)
 }
 
-fn identity_candidate_allowed_for_run(
-    candidate: &HostIdentityContextCandidate,
+pub fn identity_applicability_allowed_for_run(
+    applicability: IdentityApplicability,
     run_context: &LoopRunContext,
 ) -> bool {
-    match candidate.applies_when {
+    match applicability {
         IdentityApplicability::Always | IdentityApplicability::OnCodeAct => true,
         IdentityApplicability::OnPersonalContextAllowed => {
             match run_context.resolved_run_profile.personal_context_policy {
@@ -218,7 +220,7 @@ pub fn build_identity_messages_for_run(
     let mut out = Vec::with_capacity(candidates.len());
     let mut used = 0u32;
     for candidate in candidates {
-        if !identity_candidate_allowed_for_run(candidate, run_context) {
+        if !identity_applicability_allowed_for_run(candidate.applies_when, run_context) {
             continue;
         }
         if !applies(candidate.applies_when, mode) {

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -422,6 +422,17 @@ mod tests {
         assert!(messages.is_empty());
     }
 
+    #[test]
+    fn identity_budget_rejects_zero_token_ceiling() {
+        let error = IdentityBudget::new(0).unwrap_err();
+
+        assert_eq!(error, HostIdentityContextBuildError::BudgetMisconfigured);
+        assert_eq!(
+            error.into_host_error().kind,
+            AgentLoopHostErrorKind::Internal
+        );
+    }
+
     #[tokio::test]
     async fn installed_trust_summary_only() {
         let context = run_context().await;

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -357,10 +357,40 @@ mod tests {
     use ironclaw_host_api::{TenantId, ThreadId};
     use ironclaw_turns::{
         RunProfileResolutionRequest, RunProfileResolver, TurnId, TurnRunId, TurnScope,
-        run_profile::{InMemoryRunProfileResolver, LoopRunContext},
+        run_profile::{InMemoryRunProfileResolver, LoopRunContext, PersonalContextPolicy},
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn identity_applicability_allowed_for_run_all_variants_covering_excluded_and_allowed() {
+        let excluded_context = run_context().await;
+        let mut allowed_context = run_context().await;
+        allowed_context.resolved_run_profile.personal_context_policy =
+            PersonalContextPolicy::Allowed;
+
+        for applicability in [
+            IdentityApplicability::Always,
+            IdentityApplicability::OnCodeAct,
+        ] {
+            assert!(identity_applicability_allowed_for_run(
+                applicability,
+                &excluded_context
+            ));
+            assert!(identity_applicability_allowed_for_run(
+                applicability,
+                &allowed_context
+            ));
+        }
+        assert!(!identity_applicability_allowed_for_run(
+            IdentityApplicability::OnPersonalContextAllowed,
+            &excluded_context
+        ));
+        assert!(identity_applicability_allowed_for_run(
+            IdentityApplicability::OnPersonalContextAllowed,
+            &allowed_context
+        ));
+    }
 
     #[tokio::test]
     async fn filters_by_applies_when() {
@@ -484,6 +514,35 @@ mod tests {
             serde_json::to_vec(&second).unwrap()
         );
         assert_eq!(source.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn build_identity_messages_for_run_detailed_mixed_candidates_excluded_covering_filtering()
+    {
+        let context = run_context().await;
+        let candidates = vec![
+            trusted("AGENTS.md", "agent", IdentityApplicability::Always),
+            trusted(
+                "USER.md",
+                "private user profile",
+                IdentityApplicability::OnPersonalContextAllowed,
+            ),
+        ];
+
+        let outcome = build_identity_messages_for_run_detailed(
+            &candidates,
+            &context,
+            PromptMode::TextOnly,
+            IdentityBudget::default(),
+        )
+        .unwrap();
+
+        assert_eq!(outcome.messages.len(), 1);
+        assert_eq!(
+            outcome.messages[0].safe_summary,
+            "identity file AGENTS.md available"
+        );
+        assert!(outcome.admitted_personal_context_paths.is_empty());
     }
 
     fn trusted(

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -194,17 +194,6 @@ pub async fn build_identity_messages(
     build_identity_messages_for_run(&candidates, run_context, mode, budget)
 }
 
-fn filter_identity_candidates_for_run(
-    candidates: &[HostIdentityContextCandidate],
-    run_context: &LoopRunContext,
-) -> Vec<HostIdentityContextCandidate> {
-    candidates
-        .iter()
-        .filter(|candidate| identity_candidate_allowed_for_run(candidate, run_context))
-        .cloned()
-        .collect()
-}
-
 fn identity_candidate_allowed_for_run(
     candidate: &HostIdentityContextCandidate,
     run_context: &LoopRunContext,
@@ -226,21 +215,12 @@ pub fn build_identity_messages_for_run(
     mode: PromptMode,
     budget: IdentityBudget,
 ) -> Result<Vec<LoopContextMessage>, AgentLoopHostError> {
-    build_identity_messages_from_candidates(
-        &filter_identity_candidates_for_run(candidates, run_context),
-        mode,
-        budget,
-    )
-}
-
-fn build_identity_messages_from_candidates(
-    candidates: &[HostIdentityContextCandidate],
-    mode: PromptMode,
-    budget: IdentityBudget,
-) -> Result<Vec<LoopContextMessage>, AgentLoopHostError> {
     let mut out = Vec::with_capacity(candidates.len());
     let mut used = 0u32;
     for candidate in candidates {
+        if !identity_candidate_allowed_for_run(candidate, run_context) {
+            continue;
+        }
         if !applies(candidate.applies_when, mode) {
             continue;
         }

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -260,6 +260,8 @@ fn applies(applicability: IdentityApplicability, mode: PromptMode) -> bool {
     match applicability {
         IdentityApplicability::Always => true,
         IdentityApplicability::OnCodeAct => mode == PromptMode::CodeAct,
+        // Personal-context applicability is policy-only today. Add a combined
+        // variant if a future personal directive must also be mode-specific.
         IdentityApplicability::OnPersonalContextAllowed => true,
     }
 }

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -3,7 +3,8 @@ use ironclaw_memory::DEFAULT_PROMPT_PROTECTED_PATHS;
 use ironclaw_turns::{
     LoopMessageRef,
     run_profile::{
-        AgentLoopHostError, AgentLoopHostErrorKind, LoopContextMessage, LoopRunContext, PromptMode,
+        AgentLoopHostError, AgentLoopHostErrorKind, LoopContextMessage, LoopRunContext,
+        PersonalContextPolicy, PromptMode,
     },
 };
 use thiserror::Error;
@@ -90,6 +91,7 @@ pub enum IdentityTrustLevel {
 pub enum IdentityApplicability {
     Always,
     OnCodeAct,
+    OnPersonalContextAllowed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -155,7 +157,7 @@ pub enum HostIdentityContextBuildError {
     UnknownIdentityFile,
     #[error("identity context path is invalid")]
     InvalidIdentityFile,
-    /// Reserved for a future hard-limit mode. Currently, `build_identity_messages_from_candidates`
+    /// Reserved for a future hard-limit mode. Currently, `build_identity_messages_for_run`
     /// truncates silently on budget overflow rather than returning this error.
     #[error("identity context budget exceeded")]
     ContextBudgetExceeded,
@@ -189,10 +191,49 @@ pub async fn build_identity_messages(
         .load_identity_candidates(run_context, mode)
         .await
         .map_err(HostIdentityContextBuildError::into_host_error)?;
-    build_identity_messages_from_candidates(&candidates, mode, budget)
+    build_identity_messages_for_run(&candidates, run_context, mode, budget)
 }
 
-pub fn build_identity_messages_from_candidates(
+fn filter_identity_candidates_for_run(
+    candidates: &[HostIdentityContextCandidate],
+    run_context: &LoopRunContext,
+) -> Vec<HostIdentityContextCandidate> {
+    candidates
+        .iter()
+        .filter(|candidate| identity_candidate_allowed_for_run(candidate, run_context))
+        .cloned()
+        .collect()
+}
+
+fn identity_candidate_allowed_for_run(
+    candidate: &HostIdentityContextCandidate,
+    run_context: &LoopRunContext,
+) -> bool {
+    match candidate.applies_when {
+        IdentityApplicability::Always | IdentityApplicability::OnCodeAct => true,
+        IdentityApplicability::OnPersonalContextAllowed => {
+            match run_context.resolved_run_profile.personal_context_policy {
+                PersonalContextPolicy::Excluded => false,
+                PersonalContextPolicy::Allowed => true,
+            }
+        }
+    }
+}
+
+pub fn build_identity_messages_for_run(
+    candidates: &[HostIdentityContextCandidate],
+    run_context: &LoopRunContext,
+    mode: PromptMode,
+    budget: IdentityBudget,
+) -> Result<Vec<LoopContextMessage>, AgentLoopHostError> {
+    build_identity_messages_from_candidates(
+        &filter_identity_candidates_for_run(candidates, run_context),
+        mode,
+        budget,
+    )
+}
+
+fn build_identity_messages_from_candidates(
     candidates: &[HostIdentityContextCandidate],
     mode: PromptMode,
     budget: IdentityBudget,
@@ -239,6 +280,7 @@ fn applies(applicability: IdentityApplicability, mode: PromptMode) -> bool {
     match applicability {
         IdentityApplicability::Always => true,
         IdentityApplicability::OnCodeAct => mode == PromptMode::CodeAct,
+        IdentityApplicability::OnPersonalContextAllowed => true,
     }
 }
 

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -100,6 +100,12 @@ pub struct HostIdentityMessageContent {
     pub content: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityMessageBuildOutcome {
+    pub messages: Vec<LoopContextMessage>,
+    pub admitted_personal_context_paths: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IdentityBudget {
     pub token_ceiling: u32,
@@ -217,7 +223,17 @@ pub fn build_identity_messages_for_run(
     mode: PromptMode,
     budget: IdentityBudget,
 ) -> Result<Vec<LoopContextMessage>, AgentLoopHostError> {
+    Ok(build_identity_messages_for_run_detailed(candidates, run_context, mode, budget)?.messages)
+}
+
+pub fn build_identity_messages_for_run_detailed(
+    candidates: &[HostIdentityContextCandidate],
+    run_context: &LoopRunContext,
+    mode: PromptMode,
+    budget: IdentityBudget,
+) -> Result<IdentityMessageBuildOutcome, AgentLoopHostError> {
     let mut out = Vec::with_capacity(candidates.len());
+    let mut admitted_personal_context_paths = Vec::new();
     let mut used = 0u32;
     for candidate in candidates {
         if !identity_applicability_allowed_for_run(candidate.applies_when, run_context) {
@@ -231,13 +247,19 @@ pub fn build_identity_messages_for_run(
             break;
         }
         used = used.saturating_add(cost);
+        if candidate.applies_when == IdentityApplicability::OnPersonalContextAllowed {
+            admitted_personal_context_paths.push(candidate.name.as_str().to_string());
+        }
         out.push(LoopContextMessage {
             message_ref: candidate.message_ref.clone(),
             role: LOOP_SYSTEM_ROLE.to_string(),
             safe_summary: candidate.safe_summary.clone(),
         });
     }
-    Ok(out)
+    Ok(IdentityMessageBuildOutcome {
+        messages: out,
+        admitted_personal_context_paths,
+    })
 }
 
 pub fn identity_message_ref(

--- a/crates/ironclaw_loop_support/src/identity_context.rs
+++ b/crates/ironclaw_loop_support/src/identity_context.rs
@@ -103,7 +103,7 @@ pub struct HostIdentityMessageContent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IdentityMessageBuildOutcome {
     pub messages: Vec<LoopContextMessage>,
-    pub admitted_personal_context_paths: Vec<String>,
+    pub admitted_personal_context_paths: Vec<IdentityFileName>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -248,7 +248,7 @@ pub fn build_identity_messages_for_run_detailed(
         }
         used = used.saturating_add(cost);
         if candidate.applies_when == IdentityApplicability::OnPersonalContextAllowed {
-            admitted_personal_context_paths.push(candidate.name.as_str().to_string());
+            admitted_personal_context_paths.push(candidate.name.clone());
         }
         out.push(LoopContextMessage {
             message_ref: candidate.message_ref.clone(),

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -206,8 +206,9 @@ where
                             .map_err(HostIdentityContextBuildError::into_host_error)
                     })
                     .await?;
-                identity_context::build_identity_messages_from_candidates(
+                identity_context::build_identity_messages_for_run(
                     candidates,
+                    &self.run_context,
                     mode,
                     self.identity_budget,
                 )?

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -329,18 +329,7 @@ fn personal_context_admitted_summary(
 ) -> Result<LoopSafeSummary, AgentLoopHostError> {
     let source_labels = admitted_paths
         .iter()
-        .map(|path| {
-            path.as_str()
-                .rsplit('/')
-                .next()
-                .unwrap_or(path.as_str())
-                .chars()
-                .filter(|character| {
-                    character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
-                })
-                .collect::<String>()
-        })
-        .filter(|label| !label.is_empty())
+        .filter_map(|path| personal_context_source_label(path.as_str()))
         .collect::<Vec<_>>()
         .join(" ");
     let summary = if source_labels.is_empty() {
@@ -358,6 +347,21 @@ fn personal_context_admitted_summary(
             format!("personal context milestone summary invalid: {reason}"),
         )
     })
+}
+
+fn personal_context_source_label(path: &str) -> Option<String> {
+    let basename = path
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|label| !label.is_empty())
+        .unwrap_or(path);
+    let label = basename
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
+        })
+        .collect::<String>();
+    (!label.is_empty()).then_some(label)
 }
 
 /// Thread-backed transcript adapter for text-only assistant replies.
@@ -1529,5 +1533,48 @@ fn safe_model_summary(kind: HostManagedModelErrorKind) -> &'static str {
         HostManagedModelErrorKind::CredentialUnavailable => "model credentials are unavailable",
         HostManagedModelErrorKind::Unavailable => "model service is unavailable",
         HostManagedModelErrorKind::Cancelled => "model request was cancelled",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn personal_context_admitted_summary_empty_paths_uses_count_only() {
+        let summary = personal_context_admitted_summary(&[]).unwrap();
+
+        assert_eq!(summary.as_str(), "personal context admitted count 0");
+    }
+
+    #[test]
+    fn personal_context_admitted_summary_uses_safe_basenames_only() {
+        let paths = vec![
+            IdentityFileName::new("USER.md").unwrap(),
+            IdentityFileName::new("context/assistant-directives.md").unwrap(),
+        ];
+
+        let summary = personal_context_admitted_summary(&paths).unwrap();
+
+        assert_eq!(
+            summary.as_str(),
+            "personal context admitted count 2 sources USER.md assistant-directives.md"
+        );
+        assert!(!summary.as_str().contains("context/assistant-directives.md"));
+        assert!(!summary.as_str().contains('/'));
+        assert!(!summary.as_str().contains('\\'));
+    }
+
+    #[test]
+    fn personal_context_source_label_drops_empty_and_separator_only_labels() {
+        assert_eq!(
+            personal_context_source_label(r"private\USER.md").as_deref(),
+            Some("USER.md")
+        );
+        assert_eq!(
+            personal_context_source_label("context/%2Fassistant-directives.md").as_deref(),
+            Some("2Fassistant-directives.md")
+        );
+        assert_eq!(personal_context_source_label("///"), None);
     }
 }

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -39,7 +39,8 @@ pub use capability_surface_filter::{
 pub use identity_context::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
     HostIdentityMessageContent, IdentityApplicability, IdentityBudget, IdentityFileName,
-    IdentityTrustLevel, build_identity_messages, identity_message_ref,
+    IdentityTrustLevel, build_identity_messages, identity_applicability_allowed_for_run,
+    identity_message_ref,
 };
 pub use input_port::HostQueueLoopInputPort;
 pub use input_queue::{HostInputBatch, HostInputEnvelope, HostInputQueue, HostInputQueueError};

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -40,7 +40,8 @@ pub use identity_context::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
     HostIdentityMessageContent, IdentityApplicability, IdentityBudget, IdentityFileName,
     IdentityMessageBuildOutcome, IdentityTrustLevel, build_identity_messages,
-    identity_applicability_allowed_for_run, identity_message_ref,
+    build_identity_messages_for_run_detailed, identity_applicability_allowed_for_run,
+    identity_message_ref,
 };
 pub use input_port::HostQueueLoopInputPort;
 pub use input_queue::{HostInputBatch, HostInputEnvelope, HostInputQueue, HostInputQueueError};
@@ -100,6 +101,8 @@ where
 struct IdentityCandidateCache {
     text_only: OnceCell<Vec<HostIdentityContextCandidate>>,
     codeact: OnceCell<Vec<HostIdentityContextCandidate>>,
+    text_only_personal_context_admitted: OnceCell<()>,
+    codeact_personal_context_admitted: OnceCell<()>,
 }
 
 impl IdentityCandidateCache {
@@ -107,6 +110,8 @@ impl IdentityCandidateCache {
         Self {
             text_only: OnceCell::new(),
             codeact: OnceCell::new(),
+            text_only_personal_context_admitted: OnceCell::new(),
+            codeact_personal_context_admitted: OnceCell::new(),
         }
     }
 
@@ -114,6 +119,13 @@ impl IdentityCandidateCache {
         match mode {
             PromptMode::TextOnly => &self.text_only,
             PromptMode::CodeAct => &self.codeact,
+        }
+    }
+
+    fn personal_context_admitted_cell_for_mode(&self, mode: PromptMode) -> &OnceCell<()> {
+        match mode {
+            PromptMode::TextOnly => &self.text_only_personal_context_admitted,
+            PromptMode::CodeAct => &self.codeact_personal_context_admitted,
         }
     }
 }
@@ -221,8 +233,11 @@ where
                     mode,
                     self.identity_budget,
                 )?;
-                self.publish_personal_context_admitted(&outcome.admitted_personal_context_paths)
-                    .await?;
+                self.publish_personal_context_admitted(
+                    mode,
+                    &outcome.admitted_personal_context_paths,
+                )
+                .await;
                 outcome.messages
             }
             None => Vec::new(),
@@ -245,20 +260,28 @@ impl<S> ThreadBackedLoopContextPort<S>
 where
     S: SessionThreadService + ?Sized + Send + Sync,
 {
-    async fn publish_personal_context_admitted(
-        &self,
-        admitted_paths: &[String],
-    ) -> Result<(), AgentLoopHostError> {
+    async fn publish_personal_context_admitted(&self, mode: PromptMode, admitted_paths: &[String]) {
         if admitted_paths.is_empty() {
-            return Ok(());
+            return;
         }
         let Some(milestone_sink) = self.milestone_sink.as_ref() else {
-            return Ok(());
+            return;
         };
-        let summary = personal_context_admitted_summary(admitted_paths)?;
-        LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink))
-            .driver_note(LoopDriverNoteKind::Context, summary)
-            .await
+        let emitted_cell = self
+            .identity_candidates
+            .personal_context_admitted_cell_for_mode(mode);
+        let publish_result = emitted_cell
+            .get_or_try_init(|| async {
+                let summary = personal_context_admitted_summary(admitted_paths)?;
+                LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink))
+                    .driver_note(LoopDriverNoteKind::Context, summary)
+                    .await?;
+                Ok::<(), AgentLoopHostError>(())
+            })
+            .await;
+        if let Err(error) = publish_result {
+            tracing::warn!("failed to emit personal context admitted milestone: {error}");
+        }
     }
 }
 

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -7,7 +7,10 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 mod cancellation_port;
@@ -70,8 +73,7 @@ use ironclaw_turns::{
         CapabilitySurfaceVersion, FinalizeAssistantMessage, InstructionMaterializationStore,
         LoopCapabilityPort, LoopContextBundle, LoopContextMessage, LoopContextPort,
         LoopContextRequest, LoopDriverNoteKind, LoopHostMilestoneEmitter, LoopHostMilestoneSink,
-        LoopInputCursor,
-        LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelResponse,
+        LoopInputCursor, LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelResponse,
         LoopPromptBundleAuthority, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
         LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, PromptMode, UpdateAssistantDraft,
         VisibleCapabilityRequest, VisibleCapabilitySurface, sanitize_model_visible_text,
@@ -103,6 +105,8 @@ struct IdentityCandidateCache {
     codeact: OnceCell<Vec<HostIdentityContextCandidate>>,
     text_only_personal_context_admitted: OnceCell<()>,
     codeact_personal_context_admitted: OnceCell<()>,
+    text_only_personal_context_admitted_in_flight: AtomicBool,
+    codeact_personal_context_admitted_in_flight: AtomicBool,
 }
 
 impl IdentityCandidateCache {
@@ -112,6 +116,8 @@ impl IdentityCandidateCache {
             codeact: OnceCell::new(),
             text_only_personal_context_admitted: OnceCell::new(),
             codeact_personal_context_admitted: OnceCell::new(),
+            text_only_personal_context_admitted_in_flight: AtomicBool::new(false),
+            codeact_personal_context_admitted_in_flight: AtomicBool::new(false),
         }
     }
 
@@ -126,6 +132,13 @@ impl IdentityCandidateCache {
         match mode {
             PromptMode::TextOnly => &self.text_only_personal_context_admitted,
             PromptMode::CodeAct => &self.codeact_personal_context_admitted,
+        }
+    }
+
+    fn personal_context_admitted_in_flight_for_mode(&self, mode: PromptMode) -> &AtomicBool {
+        match mode {
+            PromptMode::TextOnly => &self.text_only_personal_context_admitted_in_flight,
+            PromptMode::CodeAct => &self.codeact_personal_context_admitted_in_flight,
         }
     }
 }
@@ -236,8 +249,7 @@ where
                 self.publish_personal_context_admitted(
                     mode,
                     &outcome.admitted_personal_context_paths,
-                )
-                .await;
+                );
                 outcome.messages
             }
             None => Vec::new(),
@@ -260,7 +272,11 @@ impl<S> ThreadBackedLoopContextPort<S>
 where
     S: SessionThreadService + ?Sized + Send + Sync,
 {
-    async fn publish_personal_context_admitted(&self, mode: PromptMode, admitted_paths: &[String]) {
+    fn publish_personal_context_admitted(
+        &self,
+        mode: PromptMode,
+        admitted_paths: &[IdentityFileName],
+    ) {
         if admitted_paths.is_empty() {
             return;
         }
@@ -270,30 +286,54 @@ where
         let emitted_cell = self
             .identity_candidates
             .personal_context_admitted_cell_for_mode(mode);
-        let publish_result = emitted_cell
-            .get_or_try_init(|| async {
-                let summary = personal_context_admitted_summary(admitted_paths)?;
-                LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink))
-                    .driver_note(LoopDriverNoteKind::Context, summary)
-                    .await?;
-                Ok::<(), AgentLoopHostError>(())
-            })
-            .await;
-        if let Err(error) = publish_result {
-            tracing::warn!("failed to emit personal context admitted milestone: {error}");
+        if emitted_cell.get().is_some() {
+            return;
         }
+        let in_flight = self
+            .identity_candidates
+            .personal_context_admitted_in_flight_for_mode(mode);
+        if in_flight.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let summary = match personal_context_admitted_summary(admitted_paths) {
+            Ok(summary) => summary,
+            Err(error) => {
+                in_flight.store(false, Ordering::Release);
+                tracing::debug!("failed to build personal context admitted milestone: {error}");
+                return;
+            }
+        };
+        let context = self.run_context.clone();
+        let milestone_sink = Arc::clone(milestone_sink);
+        let identity_candidates = Arc::clone(&self.identity_candidates);
+        tokio::spawn(async move {
+            let publish_result = LoopHostMilestoneEmitter::new(context, milestone_sink)
+                .driver_note(LoopDriverNoteKind::Context, summary)
+                .await;
+            if let Err(error) = publish_result {
+                tracing::debug!("failed to emit personal context admitted milestone: {error}");
+            } else {
+                let _ = identity_candidates
+                    .personal_context_admitted_cell_for_mode(mode)
+                    .set(());
+            }
+            identity_candidates
+                .personal_context_admitted_in_flight_for_mode(mode)
+                .store(false, Ordering::Release);
+        });
     }
 }
 
 fn personal_context_admitted_summary(
-    admitted_paths: &[String],
+    admitted_paths: &[IdentityFileName],
 ) -> Result<LoopSafeSummary, AgentLoopHostError> {
     let source_labels = admitted_paths
         .iter()
         .map(|path| {
-            path.rsplit('/')
+            path.as_str()
+                .rsplit('/')
                 .next()
-                .unwrap_or(path)
+                .unwrap_or(path.as_str())
                 .chars()
                 .filter(|character| {
                     character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -39,8 +39,8 @@ pub use capability_surface_filter::{
 pub use identity_context::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
     HostIdentityMessageContent, IdentityApplicability, IdentityBudget, IdentityFileName,
-    IdentityTrustLevel, build_identity_messages, identity_applicability_allowed_for_run,
-    identity_message_ref,
+    IdentityMessageBuildOutcome, IdentityTrustLevel, build_identity_messages,
+    identity_applicability_allowed_for_run, identity_message_ref,
 };
 pub use input_port::HostQueueLoopInputPort;
 pub use input_queue::{HostInputBatch, HostInputEnvelope, HostInputQueue, HostInputQueueError};
@@ -68,7 +68,8 @@ use ironclaw_turns::{
         CapabilityDeniedReasonKind, CapabilityInvocation, CapabilityOutcome,
         CapabilitySurfaceVersion, FinalizeAssistantMessage, InstructionMaterializationStore,
         LoopCapabilityPort, LoopContextBundle, LoopContextMessage, LoopContextPort,
-        LoopContextRequest, LoopHostMilestoneEmitter, LoopHostMilestoneSink, LoopInputCursor,
+        LoopContextRequest, LoopDriverNoteKind, LoopHostMilestoneEmitter, LoopHostMilestoneSink,
+        LoopInputCursor,
         LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelResponse,
         LoopPromptBundleAuthority, LoopRunContext, LoopRunInfoPort, LoopSafeSummary,
         LoopTranscriptPort, ModelStreamChunk, ParentLoopOutput, PromptMode, UpdateAssistantDraft,
@@ -93,6 +94,7 @@ where
     identity_context_source: Option<Arc<dyn HostIdentityContextSource>>,
     identity_budget: IdentityBudget,
     identity_candidates: Arc<IdentityCandidateCache>,
+    milestone_sink: Option<Arc<dyn LoopHostMilestoneSink>>,
 }
 
 struct IdentityCandidateCache {
@@ -135,6 +137,7 @@ where
             identity_context_source: None,
             identity_budget: IdentityBudget::default(),
             identity_candidates: Arc::new(IdentityCandidateCache::new()),
+            milestone_sink: None,
         }
     }
 
@@ -153,6 +156,11 @@ where
 
     pub fn with_identity_budget(mut self, budget: IdentityBudget) -> Self {
         self.identity_budget = budget;
+        self
+    }
+
+    pub fn with_milestone_sink(mut self, sink: Arc<dyn LoopHostMilestoneSink>) -> Self {
+        self.milestone_sink = Some(sink);
         self
     }
 }
@@ -207,12 +215,15 @@ where
                             .map_err(HostIdentityContextBuildError::into_host_error)
                     })
                     .await?;
-                identity_context::build_identity_messages_for_run(
+                let outcome = identity_context::build_identity_messages_for_run_detailed(
                     candidates,
                     &self.run_context,
                     mode,
                     self.identity_budget,
-                )?
+                )?;
+                self.publish_personal_context_admitted(&outcome.admitted_personal_context_paths)
+                    .await?;
+                outcome.messages
             }
             None => Vec::new(),
         };
@@ -228,6 +239,62 @@ where
             memory_snippets: Vec::new(),
         })
     }
+}
+
+impl<S> ThreadBackedLoopContextPort<S>
+where
+    S: SessionThreadService + ?Sized + Send + Sync,
+{
+    async fn publish_personal_context_admitted(
+        &self,
+        admitted_paths: &[String],
+    ) -> Result<(), AgentLoopHostError> {
+        if admitted_paths.is_empty() {
+            return Ok(());
+        }
+        let Some(milestone_sink) = self.milestone_sink.as_ref() else {
+            return Ok(());
+        };
+        let summary = personal_context_admitted_summary(admitted_paths)?;
+        LoopHostMilestoneEmitter::new(self.run_context.clone(), Arc::clone(milestone_sink))
+            .driver_note(LoopDriverNoteKind::Context, summary)
+            .await
+    }
+}
+
+fn personal_context_admitted_summary(
+    admitted_paths: &[String],
+) -> Result<LoopSafeSummary, AgentLoopHostError> {
+    let source_labels = admitted_paths
+        .iter()
+        .map(|path| {
+            path.rsplit('/')
+                .next()
+                .unwrap_or(path)
+                .chars()
+                .filter(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
+                })
+                .collect::<String>()
+        })
+        .filter(|label| !label.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let summary = if source_labels.is_empty() {
+        format!("personal context admitted count {}", admitted_paths.len())
+    } else {
+        format!(
+            "personal context admitted count {} sources {}",
+            admitted_paths.len(),
+            source_labels
+        )
+    };
+    LoopSafeSummary::new(summary).map_err(|reason| {
+        AgentLoopHostError::new(
+            AgentLoopHostErrorKind::Internal,
+            format!("personal context milestone summary invalid: {reason}"),
+        )
+    })
 }
 
 /// Thread-backed transcript adapter for text-only assistant replies.

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -884,6 +884,38 @@ async fn prompt_and_model_ports_resolve_instruction_memory_and_identity_refs() {
 }
 
 #[tokio::test]
+async fn model_port_rejects_policy_denied_identity_ref_before_gateway_call() {
+    let fixture = ThreadFixture::new().await;
+    let name = IdentityFileName::new("USER.md").unwrap();
+    let messages = vec![LoopModelMessage {
+        role: "system".to_string(),
+        content_ref: identity_message_ref(&name, "private user profile").unwrap(),
+    }];
+    issue_prompt_grant(&fixture.run_context, &messages);
+    let gateway = Arc::new(RecordingGateway::reply("should not be called"));
+    let model_port = ThreadBackedLoopModelPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        gateway.clone(),
+        16,
+    )
+    .with_identity_context_source(Arc::new(PolicyDeniedIdentityContextSource));
+
+    let error = model_port
+        .stream_model(LoopModelRequest {
+            messages,
+            surface_version: None,
+            model_preference: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentLoopHostErrorKind::PolicyDenied);
+    assert!(gateway.calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn prompt_port_records_installed_skill_trust_metadata_without_prompt_payload() {
     let fixture = ThreadFixture::new().await;
     let source = Arc::new(StaticSkillContextSource::new(vec![
@@ -2442,6 +2474,27 @@ impl HostIdentityContextSource for StaticIdentityContextSource {
         message_ref: &LoopMessageRef,
     ) -> Result<Option<HostIdentityMessageContent>, HostIdentityContextBuildError> {
         Ok(self.content_by_ref.get(message_ref.as_str()).cloned())
+    }
+}
+
+struct PolicyDeniedIdentityContextSource;
+
+#[async_trait]
+impl HostIdentityContextSource for PolicyDeniedIdentityContextSource {
+    async fn load_identity_candidates(
+        &self,
+        _run_context: &LoopRunContext,
+        _mode: PromptMode,
+    ) -> Result<Vec<HostIdentityContextCandidate>, HostIdentityContextBuildError> {
+        Ok(Vec::new())
+    }
+
+    async fn resolve_identity_message_content(
+        &self,
+        _run_context: &LoopRunContext,
+        _message_ref: &LoopMessageRef,
+    ) -> Result<Option<HostIdentityMessageContent>, HostIdentityContextBuildError> {
+        Err(HostIdentityContextBuildError::PolicyDenied)
     }
 }
 

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -456,7 +456,7 @@ async fn context_port_emits_safe_milestone_when_personal_identity_is_admitted() 
 
     assert_eq!(bundle.identity_messages.len(), 2);
     assert_eq!(second_bundle.identity_messages.len(), 2);
-    let recorded = milestones.milestones();
+    let recorded = wait_for_in_memory_milestones(&milestones, 1).await;
     assert_eq!(recorded.len(), 1);
     assert!(matches!(
         &recorded[0].kind,
@@ -502,6 +502,7 @@ async fn context_port_survives_personal_context_admitted_milestone_sink_failure(
         .await
         .unwrap();
     assert_eq!(first.identity_messages.len(), 1);
+    wait_for_fail_once_attempts(&milestone_sink, 1).await;
     assert!(milestone_sink.milestones().is_empty());
     assert!(logs_contain(
         "failed to emit personal context admitted milestone"
@@ -517,6 +518,7 @@ async fn context_port_survives_personal_context_admitted_milestone_sink_failure(
         .unwrap();
     assert_eq!(second.identity_messages.len(), 1);
 
+    wait_for_fail_once_attempts(&milestone_sink, 2).await;
     let milestones = milestone_sink.milestones();
     assert_eq!(milestones.len(), 1);
     assert!(matches!(
@@ -525,6 +527,90 @@ async fn context_port_survives_personal_context_admitted_milestone_sink_failure(
             if *kind == LoopDriverNoteKind::Context
                 && safe_summary.as_str() == "personal context admitted count 1 sources USER.md"
     ));
+}
+
+#[tokio::test]
+async fn context_port_milestone_counts_only_budget_admitted_personal_identity() {
+    let fixture = ThreadFixture::new().await;
+    let mut run_context = fixture.run_context.clone();
+    run_context.resolved_run_profile.personal_context_policy = PersonalContextPolicy::Allowed;
+    let source = Arc::new(StaticIdentityContextSource::new(vec![
+        personal_identity("USER.md", "p"),
+        personal_identity(
+            "context/assistant-directives.md",
+            "private assistant directive that exceeds the tiny budget",
+        ),
+    ]));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let milestone_sink: Arc<dyn LoopHostMilestoneSink> = milestones.clone();
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    )
+    .with_identity_context_source(source)
+    .with_identity_budget(IdentityBudget::new(3).unwrap())
+    .with_milestone_sink(milestone_sink);
+
+    let bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(bundle.identity_messages.len(), 1);
+    let recorded = wait_for_in_memory_milestones(&milestones, 1).await;
+    assert_eq!(recorded.len(), 1);
+    assert!(matches!(
+        &recorded[0].kind,
+        LoopHostMilestoneKind::DriverNote { kind, safe_summary }
+            if *kind == LoopDriverNoteKind::Context
+                && safe_summary.as_str() == "personal context admitted count 1 sources USER.md"
+    ));
+    let wire = serde_json::to_string(&recorded).unwrap();
+    assert!(!wire.contains("assistant-directives.md"));
+}
+
+#[tokio::test]
+async fn context_port_dedupes_personal_context_admitted_milestone_under_concurrent_loads() {
+    let fixture = ThreadFixture::new().await;
+    let mut run_context = fixture.run_context.clone();
+    run_context.resolved_run_profile.personal_context_policy = PersonalContextPolicy::Allowed;
+    let source = Arc::new(StaticIdentityContextSource::new(vec![personal_identity(
+        "USER.md",
+        "private user profile",
+    )]));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let milestone_sink: Arc<dyn LoopHostMilestoneSink> = milestones.clone();
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    )
+    .with_identity_context_source(source)
+    .with_milestone_sink(milestone_sink);
+
+    let first = adapter.load_loop_context(LoopContextRequest {
+        after: None,
+        limit: 16,
+        mode: PromptMode::TextOnly,
+    });
+    let second = adapter.load_loop_context(LoopContextRequest {
+        after: None,
+        limit: 16,
+        mode: PromptMode::TextOnly,
+    });
+    let (first, second) = tokio::join!(first, second);
+
+    assert_eq!(first.unwrap().identity_messages.len(), 1);
+    assert_eq!(second.unwrap().identity_messages.len(), 1);
+    let recorded = wait_for_in_memory_milestones(&milestones, 1).await;
+    assert_eq!(recorded.len(), 1);
 }
 
 #[tokio::test]
@@ -1053,6 +1139,7 @@ async fn model_port_rejects_policy_denied_identity_ref_before_gateway_call() {
             messages,
             surface_version: None,
             model_preference: None,
+            capability_view: None,
         })
         .await
         .unwrap_err();
@@ -3096,6 +3183,33 @@ impl FailOnceMilestoneSink {
             .skip(1)
             .cloned()
             .collect()
+    }
+
+    fn attempts_len(&self) -> usize {
+        self.attempts.lock().unwrap().len()
+    }
+}
+
+async fn wait_for_in_memory_milestones(
+    sink: &InMemoryLoopHostMilestoneSink,
+    expected: usize,
+) -> Vec<ironclaw_turns::run_profile::LoopHostMilestone> {
+    for _ in 0..20 {
+        let milestones = sink.milestones();
+        if milestones.len() == expected {
+            return milestones;
+        }
+        tokio::task::yield_now().await;
+    }
+    sink.milestones()
+}
+
+async fn wait_for_fail_once_attempts(sink: &FailOnceMilestoneSink, expected: usize) {
+    for _ in 0..20 {
+        if sink.attempts_len() == expected {
+            return;
+        }
+        tokio::task::yield_now().await;
     }
 }
 

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -39,9 +39,9 @@ use ironclaw_turns::{
         LoopInputCursor, LoopInputCursorToken, LoopModelCapabilityView, LoopModelMessage,
         LoopModelPort, LoopModelRequest, LoopModelRouteSnapshot, LoopPromptBundle,
         LoopPromptBundleAuthority, LoopPromptBundleRef, LoopPromptPort, LoopRunContext,
-        LoopTranscriptPort, ParentLoopOutput, PromptMode, PromptSkillContextMetadata,
-        ProviderToolCallReference, ProviderToolDefinition, SkillVisibility, UpdateAssistantDraft,
-        VisibleCapabilityRequest, VisibleCapabilitySurface,
+        LoopTranscriptPort, ParentLoopOutput, PersonalContextPolicy, PromptMode,
+        PromptSkillContextMetadata, ProviderToolCallReference, ProviderToolDefinition,
+        SkillVisibility, UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
 };
 use tracing_test::traced_test;
@@ -343,6 +343,74 @@ async fn context_port_caches_identity_candidates_per_prompt_mode() {
         "identity file TOOLS.md available"
     );
     assert_eq!(source.load_calls(), 2);
+}
+
+#[tokio::test]
+async fn context_port_excludes_personal_identity_by_default_policy() {
+    let fixture = ThreadFixture::new().await;
+    let source = Arc::new(StaticIdentityContextSource::new(vec![
+        trusted_identity(
+            "AGENTS.md",
+            "stable identity",
+            IdentityApplicability::Always,
+        ),
+        personal_identity("USER.md", "private user profile"),
+    ]));
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        16,
+    )
+    .with_identity_context_source(source);
+
+    let bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(bundle.identity_messages.len(), 1);
+    assert_eq!(
+        bundle.identity_messages[0].safe_summary,
+        "identity file AGENTS.md available"
+    );
+}
+
+#[tokio::test]
+async fn context_port_includes_personal_identity_when_profile_allows_it() {
+    let fixture = ThreadFixture::new().await;
+    let mut run_context = fixture.run_context.clone();
+    run_context.resolved_run_profile.personal_context_policy = PersonalContextPolicy::Allowed;
+    let source = Arc::new(StaticIdentityContextSource::new(vec![personal_identity(
+        "USER.md",
+        "private user profile",
+    )]));
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    )
+    .with_identity_context_source(source);
+
+    let bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(bundle.identity_messages.len(), 1);
+    assert_eq!(
+        bundle.identity_messages[0].safe_summary,
+        "identity file USER.md available"
+    );
 }
 
 #[tokio::test]
@@ -2393,6 +2461,14 @@ fn trusted_identity(
             content.len(),
         ),
         content.to_string(),
+    )
+}
+
+fn personal_identity(name: &str, content: &str) -> (HostIdentityContextCandidate, String) {
+    trusted_identity(
+        name,
+        content,
+        IdentityApplicability::OnPersonalContextAllowed,
     )
 }
 

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -36,12 +36,13 @@ use ironclaw_turns::{
         InMemoryInstructionMaterializationStore, InMemoryLoopHostMilestoneSink,
         InMemoryRunProfileResolver, LoopCapabilityPort, LoopContextBundle, LoopContextMessage,
         LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopDriverNoteKind,
-        LoopHostMilestoneKind, LoopInputCursor, LoopInputCursorToken, LoopModelCapabilityView,
-        LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelRouteSnapshot,
-        LoopPromptBundle, LoopPromptBundleAuthority, LoopPromptBundleRef, LoopPromptPort,
-        LoopRunContext, LoopTranscriptPort, ParentLoopOutput, PersonalContextPolicy, PromptMode,
-        PromptSkillContextMetadata, ProviderToolCallReference, ProviderToolDefinition,
-        SkillVisibility, UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
+        LoopHostMilestoneKind, LoopHostMilestoneSink, LoopInputCursor, LoopInputCursorToken,
+        LoopModelCapabilityView, LoopModelMessage, LoopModelPort, LoopModelRequest,
+        LoopModelRouteSnapshot, LoopPromptBundle, LoopPromptBundleAuthority, LoopPromptBundleRef,
+        LoopPromptPort, LoopRunContext, LoopTranscriptPort, ParentLoopOutput,
+        PersonalContextPolicy, PromptMode, PromptSkillContextMetadata, ProviderToolCallReference,
+        ProviderToolDefinition, SkillVisibility, UpdateAssistantDraft, VisibleCapabilityRequest,
+        VisibleCapabilitySurface,
     },
 };
 use tracing_test::traced_test;
@@ -426,8 +427,7 @@ async fn context_port_emits_safe_milestone_when_personal_identity_is_admitted() 
         ),
     ]));
     let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
-    let milestone_sink: Arc<dyn ironclaw_turns::run_profile::LoopHostMilestoneSink> =
-        milestones.clone();
+    let milestone_sink: Arc<dyn LoopHostMilestoneSink> = milestones.clone();
     let adapter = ThreadBackedLoopContextPort::new(
         Arc::clone(&fixture.thread_service),
         fixture.thread_scope.clone(),
@@ -445,8 +445,17 @@ async fn context_port_emits_safe_milestone_when_personal_identity_is_admitted() 
         })
         .await
         .unwrap();
+    let second_bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
 
     assert_eq!(bundle.identity_messages.len(), 2);
+    assert_eq!(second_bundle.identity_messages.len(), 2);
     let recorded = milestones.milestones();
     assert_eq!(recorded.len(), 1);
     assert!(matches!(
@@ -462,6 +471,92 @@ async fn context_port_emits_safe_milestone_when_personal_identity_is_admitted() 
     assert!(!wire.contains("private user profile"));
     assert!(!wire.contains("private assistant directive"));
     assert!(!wire.contains("context/assistant-directives.md"));
+}
+
+#[traced_test]
+#[tokio::test]
+async fn context_port_survives_personal_context_admitted_milestone_sink_failure() {
+    let fixture = ThreadFixture::new().await;
+    let mut run_context = fixture.run_context.clone();
+    run_context.resolved_run_profile.personal_context_policy = PersonalContextPolicy::Allowed;
+    let source = Arc::new(StaticIdentityContextSource::new(vec![personal_identity(
+        "USER.md",
+        "private user profile",
+    )]));
+    let milestone_sink = Arc::new(FailOnceMilestoneSink::default());
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    )
+    .with_identity_context_source(source)
+    .with_milestone_sink(milestone_sink.clone());
+
+    let first = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+    assert_eq!(first.identity_messages.len(), 1);
+    assert!(milestone_sink.milestones().is_empty());
+    assert!(logs_contain(
+        "failed to emit personal context admitted milestone"
+    ));
+
+    let second = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+    assert_eq!(second.identity_messages.len(), 1);
+
+    let milestones = milestone_sink.milestones();
+    assert_eq!(milestones.len(), 1);
+    assert!(matches!(
+        &milestones[0].kind,
+        LoopHostMilestoneKind::DriverNote { kind, safe_summary }
+            if *kind == LoopDriverNoteKind::Context
+                && safe_summary.as_str() == "personal context admitted count 1 sources USER.md"
+    ));
+}
+
+#[tokio::test]
+async fn context_port_does_not_emit_milestone_when_no_personal_context_admitted() {
+    let fixture = ThreadFixture::new().await;
+    let source = Arc::new(StaticIdentityContextSource::new(vec![trusted_identity(
+        "AGENTS.md",
+        "stable identity",
+        IdentityApplicability::Always,
+    )]));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let milestone_sink: Arc<dyn LoopHostMilestoneSink> = milestones.clone();
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        fixture.run_context.clone(),
+        16,
+    )
+    .with_identity_context_source(source)
+    .with_milestone_sink(milestone_sink);
+
+    let _bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+
+    let recorded = milestones.milestones();
+    assert!(recorded.is_empty());
 }
 
 #[tokio::test]

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -415,6 +415,50 @@ async fn context_port_includes_personal_identity_when_profile_allows_it() {
 }
 
 #[tokio::test]
+async fn context_port_includes_personal_identity_in_codeact_mode_covering_codeact_prompt_mode() {
+    let fixture = ThreadFixture::new().await;
+    let mut run_context = fixture.run_context.clone();
+    run_context.resolved_run_profile.personal_context_policy = PersonalContextPolicy::Allowed;
+    let source = Arc::new(StaticIdentityContextSource::new(vec![personal_identity(
+        "USER.md",
+        "private user profile",
+    )]));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let milestone_sink: Arc<dyn LoopHostMilestoneSink> = milestones.clone();
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    )
+    .with_identity_context_source(source)
+    .with_milestone_sink(milestone_sink);
+
+    let bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::CodeAct,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(bundle.identity_messages.len(), 1);
+    assert_eq!(
+        bundle.identity_messages[0].safe_summary,
+        "identity file USER.md available"
+    );
+    let recorded = wait_for_in_memory_milestones(&milestones, 1).await;
+    assert_eq!(recorded.len(), 1);
+    assert!(matches!(
+        &recorded[0].kind,
+        LoopHostMilestoneKind::DriverNote { kind, safe_summary }
+            if *kind == LoopDriverNoteKind::Context
+                && safe_summary.as_str() == "personal context admitted count 1 sources USER.md"
+    ));
+}
+
+#[tokio::test]
 async fn context_port_emits_safe_milestone_when_personal_identity_is_admitted() {
     let fixture = ThreadFixture::new().await;
     let mut run_context = fixture.run_context.clone();

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -346,7 +346,7 @@ async fn context_port_caches_identity_candidates_per_prompt_mode() {
 }
 
 #[tokio::test]
-async fn context_port_excludes_personal_identity_by_default_policy() {
+async fn context_port_defense_gate_excludes_personal_identity_from_host_source_by_default_policy() {
     let fixture = ThreadFixture::new().await;
     let source = Arc::new(StaticIdentityContextSource::new(vec![
         trusted_identity(

--- a/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
+++ b/crates/ironclaw_loop_support/tests/thread_loop_support_contract.rs
@@ -35,11 +35,11 @@ use ironclaw_turns::{
         CapabilitySurfaceVersion, FinalizeAssistantMessage, HostManagedLoopPromptPort,
         InMemoryInstructionMaterializationStore, InMemoryLoopHostMilestoneSink,
         InMemoryRunProfileResolver, LoopCapabilityPort, LoopContextBundle, LoopContextMessage,
-        LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopHostMilestoneKind,
-        LoopInputCursor, LoopInputCursorToken, LoopModelCapabilityView, LoopModelMessage,
-        LoopModelPort, LoopModelRequest, LoopModelRouteSnapshot, LoopPromptBundle,
-        LoopPromptBundleAuthority, LoopPromptBundleRef, LoopPromptPort, LoopRunContext,
-        LoopTranscriptPort, ParentLoopOutput, PersonalContextPolicy, PromptMode,
+        LoopContextPort, LoopContextRequest, LoopContextSnippet, LoopDriverNoteKind,
+        LoopHostMilestoneKind, LoopInputCursor, LoopInputCursorToken, LoopModelCapabilityView,
+        LoopModelMessage, LoopModelPort, LoopModelRequest, LoopModelRouteSnapshot,
+        LoopPromptBundle, LoopPromptBundleAuthority, LoopPromptBundleRef, LoopPromptPort,
+        LoopRunContext, LoopTranscriptPort, ParentLoopOutput, PersonalContextPolicy, PromptMode,
         PromptSkillContextMetadata, ProviderToolCallReference, ProviderToolDefinition,
         SkillVisibility, UpdateAssistantDraft, VisibleCapabilityRequest, VisibleCapabilitySurface,
     },
@@ -411,6 +411,57 @@ async fn context_port_includes_personal_identity_when_profile_allows_it() {
         bundle.identity_messages[0].safe_summary,
         "identity file USER.md available"
     );
+}
+
+#[tokio::test]
+async fn context_port_emits_safe_milestone_when_personal_identity_is_admitted() {
+    let fixture = ThreadFixture::new().await;
+    let mut run_context = fixture.run_context.clone();
+    run_context.resolved_run_profile.personal_context_policy = PersonalContextPolicy::Allowed;
+    let source = Arc::new(StaticIdentityContextSource::new(vec![
+        personal_identity("USER.md", "private user profile"),
+        personal_identity(
+            "context/assistant-directives.md",
+            "private assistant directive",
+        ),
+    ]));
+    let milestones = Arc::new(InMemoryLoopHostMilestoneSink::default());
+    let milestone_sink: Arc<dyn ironclaw_turns::run_profile::LoopHostMilestoneSink> =
+        milestones.clone();
+    let adapter = ThreadBackedLoopContextPort::new(
+        Arc::clone(&fixture.thread_service),
+        fixture.thread_scope.clone(),
+        run_context,
+        16,
+    )
+    .with_identity_context_source(source)
+    .with_milestone_sink(milestone_sink);
+
+    let bundle = adapter
+        .load_loop_context(LoopContextRequest {
+            after: None,
+            limit: 16,
+            mode: PromptMode::TextOnly,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(bundle.identity_messages.len(), 2);
+    let recorded = milestones.milestones();
+    assert_eq!(recorded.len(), 1);
+    assert!(matches!(
+        &recorded[0].kind,
+        LoopHostMilestoneKind::DriverNote { kind, safe_summary }
+            if *kind == LoopDriverNoteKind::Context
+                && safe_summary.as_str()
+                    == "personal context admitted count 2 sources USER.md assistant-directives.md"
+    ));
+    let wire = serde_json::to_string(&recorded).unwrap();
+    assert!(wire.contains("USER.md"));
+    assert!(wire.contains("assistant-directives.md"));
+    assert!(!wire.contains("private user profile"));
+    assert!(!wire.contains("private assistant directive"));
+    assert!(!wire.contains("context/assistant-directives.md"));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -383,6 +383,7 @@ where
         if let Some(source) = self.identity_context_source.as_ref() {
             context_adapter = context_adapter.with_identity_context_source(source.clone());
         }
+        context_adapter = context_adapter.with_milestone_sink(Arc::clone(&self.milestone_sink));
         let context: Arc<dyn LoopContextPort> = Arc::new(context_adapter);
         let instruction_materialization_store: Arc<dyn InstructionMaterializationStore> =
             Arc::new(InMemoryInstructionMaterializationStore::default());

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -1305,6 +1305,7 @@ fn test_profile(
             max_model_calls: 32,
             max_capability_invocations: 64,
         },
+        personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
         runtime_constraints: RuntimeProfileConstraints {
             allow_raw_runtime_backend_selection: false,
             allow_broad_capability_surface: false,

--- a/crates/ironclaw_reborn/src/planned_driver_factory.rs
+++ b/crates/ironclaw_reborn/src/planned_driver_factory.rs
@@ -12,8 +12,7 @@ use ironclaw_turns::{
     RunProfileVersion,
     run_profile::{
         CapabilitySurfaceProfileId, CheckpointSchemaId, InMemoryRunProfileRegistry,
-        InMemoryRunProfileResolver, PersonalContextPolicy, RunProfileDefinition,
-        RunProfileRegistryError,
+        InMemoryRunProfileResolver, RunProfileDefinition, RunProfileRegistryError,
     },
 };
 
@@ -170,8 +169,7 @@ pub fn planned_default_profile_definition() -> Result<RunProfileDefinition, RunP
         checkpoint_schema_id,
         planned_driver_checkpoint_schema_version(),
         capability_surface_profile_id,
-    )
-    .with_personal_context_policy(PersonalContextPolicy::Allowed))
+    ))
 }
 
 pub fn register_default_planned_profile(
@@ -279,7 +277,7 @@ mod tests {
         assert_eq!(snapshot.loop_driver.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
         assert_eq!(
             snapshot.personal_context_policy,
-            PersonalContextPolicy::Allowed
+            PersonalContextPolicy::Excluded
         );
         assert_eq!(
             snapshot
@@ -304,7 +302,7 @@ mod tests {
         assert_eq!(snapshot.loop_driver.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
         assert_eq!(
             snapshot.personal_context_policy,
-            PersonalContextPolicy::Allowed
+            PersonalContextPolicy::Excluded
         );
     }
 

--- a/crates/ironclaw_reborn/src/planned_driver_factory.rs
+++ b/crates/ironclaw_reborn/src/planned_driver_factory.rs
@@ -196,7 +196,7 @@ pub fn default_planned_run_profile_resolver()
 mod tests {
     use ironclaw_turns::{
         RunProfileRequest, RunProfileResolutionRequest, RunProfileResolver,
-        run_profile::{LoopDriverId, PersonalContextPolicy},
+        run_profile::{LoopDriverId, PersonalContextAuthority, PersonalContextPolicy},
     };
 
     use super::*;
@@ -324,6 +324,58 @@ mod tests {
         assert_eq!(
             snapshot.loop_driver.id,
             LoopDriverId::new("lightweight_loop").unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_authority_downgrades_allowed_to_excluded() {
+        let mut registry = InMemoryRunProfileRegistry::with_builtin_profiles();
+        let allowed_profile = planned_default_profile_definition()
+            .expect("profile should build")
+            .with_personal_context_policy(PersonalContextPolicy::Allowed);
+        registry
+            .register(allowed_profile)
+            .expect("profile should register");
+        let resolver = InMemoryRunProfileResolver::new(registry);
+        let snapshot = resolver
+            .resolve_run_profile(
+                RunProfileResolutionRequest::interactive_default()
+                    .with_requested_run_profile(
+                        RunProfileRequest::new(PLANNED_DEFAULT_PROFILE_ID).unwrap(),
+                    )
+                    .with_personal_context_authority(PersonalContextAuthority::Shared),
+            )
+            .await
+            .expect("profile should resolve");
+        assert_eq!(
+            snapshot.personal_context_policy,
+            PersonalContextPolicy::Excluded
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_authority_preserves_allowed() {
+        let mut registry = InMemoryRunProfileRegistry::with_builtin_profiles();
+        let allowed_profile = planned_default_profile_definition()
+            .expect("profile should build")
+            .with_personal_context_policy(PersonalContextPolicy::Allowed);
+        registry
+            .register(allowed_profile)
+            .expect("profile should register");
+        let resolver = InMemoryRunProfileResolver::new(registry);
+        let snapshot = resolver
+            .resolve_run_profile(
+                RunProfileResolutionRequest::interactive_default()
+                    .with_requested_run_profile(
+                        RunProfileRequest::new(PLANNED_DEFAULT_PROFILE_ID).unwrap(),
+                    )
+                    .with_personal_context_authority(PersonalContextAuthority::Direct),
+            )
+            .await
+            .expect("profile should resolve");
+        assert_eq!(
+            snapshot.personal_context_policy,
+            PersonalContextPolicy::Allowed
         );
     }
 }

--- a/crates/ironclaw_reborn/src/planned_driver_factory.rs
+++ b/crates/ironclaw_reborn/src/planned_driver_factory.rs
@@ -12,7 +12,8 @@ use ironclaw_turns::{
     RunProfileVersion,
     run_profile::{
         CapabilitySurfaceProfileId, CheckpointSchemaId, InMemoryRunProfileRegistry,
-        InMemoryRunProfileResolver, RunProfileDefinition, RunProfileRegistryError,
+        InMemoryRunProfileResolver, PersonalContextPolicy, RunProfileDefinition,
+        RunProfileRegistryError,
     },
 };
 
@@ -169,7 +170,8 @@ pub fn planned_default_profile_definition() -> Result<RunProfileDefinition, RunP
         checkpoint_schema_id,
         planned_driver_checkpoint_schema_version(),
         capability_surface_profile_id,
-    ))
+    )
+    .with_personal_context_policy(PersonalContextPolicy::Allowed))
 }
 
 pub fn register_default_planned_profile(
@@ -275,6 +277,10 @@ mod tests {
 
         assert_eq!(snapshot.profile_id.as_str(), PLANNED_DEFAULT_PROFILE_ID);
         assert_eq!(snapshot.loop_driver.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
+        assert_eq!(
+            snapshot.personal_context_policy,
+            PersonalContextPolicy::Allowed
+        );
         assert_eq!(
             snapshot
                 .loop_driver

--- a/crates/ironclaw_reborn/src/planned_driver_factory.rs
+++ b/crates/ironclaw_reborn/src/planned_driver_factory.rs
@@ -302,6 +302,10 @@ mod tests {
 
         assert_eq!(snapshot.profile_id.as_str(), PLANNED_DEFAULT_PROFILE_ID);
         assert_eq!(snapshot.loop_driver.id.as_str(), PLANNED_DRIVER_DEFAULT_ID);
+        assert_eq!(
+            snapshot.personal_context_policy,
+            PersonalContextPolicy::Allowed
+        );
     }
 
     #[tokio::test]

--- a/crates/ironclaw_reborn/src/planned_driver_factory.rs
+++ b/crates/ironclaw_reborn/src/planned_driver_factory.rs
@@ -196,7 +196,7 @@ pub fn default_planned_run_profile_resolver()
 mod tests {
     use ironclaw_turns::{
         RunProfileRequest, RunProfileResolutionRequest, RunProfileResolver,
-        run_profile::LoopDriverId,
+        run_profile::{LoopDriverId, PersonalContextPolicy},
     };
 
     use super::*;

--- a/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
@@ -95,6 +95,7 @@ fn test_resolved_profile_with_driver(
             max_model_calls: 32,
             max_capability_invocations: 64,
         },
+        personal_context_policy: ironclaw_turns::run_profile::PersonalContextPolicy::Excluded,
         runtime_constraints: RuntimeProfileConstraints {
             allow_raw_runtime_backend_selection: false,
             allow_broad_capability_surface: false,

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -100,8 +100,8 @@ use ironclaw_turns::{
         LoopInputCursorToken, LoopInputPort, LoopModelBudgetAccountant, LoopModelGatewayError,
         LoopModelPort, LoopModelRequest, LoopModelRouteSnapshot, LoopProgressEvent,
         LoopPromptBundleRequest, LoopPromptPort, LoopRunContext, LoopSafeSummary, ModelCallOutcome,
-        NoOpBudgetAccountant, NoOpPolicyGuard, ParentLoopOutput, PromptMode, SkillVisibility,
-        StageCheckpointPayloadRequest, VisibleCapabilityRequest,
+        NoOpBudgetAccountant, NoOpPolicyGuard, ParentLoopOutput, PersonalContextPolicy, PromptMode,
+        SkillVisibility, StageCheckpointPayloadRequest, VisibleCapabilityRequest,
     },
     runner::{ClaimRunRequest, ClaimedTurnRun, TurnRunTransitionPort},
 };
@@ -2937,6 +2937,50 @@ async fn text_only_host_factory_threads_identity_source_to_prompt_and_model() {
 
     let requests = fixture.gateway.requests();
     assert_eq!(requests[0].messages[0].content, "factory identity content");
+}
+
+#[tokio::test]
+async fn text_only_host_factory_excludes_personal_identity_when_profile_excludes_it() {
+    let fixture = HostFixture::new("thread-host-personal-excluded", "hello reborn").await;
+    assert_eq!(
+        fixture.context.resolved_run_profile.personal_context_policy,
+        PersonalContextPolicy::Excluded
+    );
+    let source = Arc::new(StaticIdentityContextSource::new(vec![trusted_identity(
+        "USER.md",
+        "private user profile",
+        IdentityApplicability::OnPersonalContextAllowed,
+    )]));
+    let host = fixture
+        .factory()
+        .with_identity_context_source(source)
+        .build_text_only_host(RebornLoopDriverHostRequest {
+            claimed_run: fixture.claimed.clone(),
+            loop_run_context: fixture.context.clone(),
+        })
+        .await
+        .unwrap();
+    let host_dyn: &(dyn AgentLoopDriverHost + Send + Sync) = &host;
+
+    let prompt_bundle = host_dyn
+        .build_prompt_bundle(LoopPromptBundleRequest {
+            mode: PromptMode::TextOnly,
+            context_cursor: None,
+            surface_version: None,
+            checkpoint_state_ref: None,
+            max_messages: Some(8),
+            inline_messages: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(prompt_bundle.identity_message_count, 0);
+    assert!(
+        prompt_bundle
+            .messages
+            .iter()
+            .all(|message| !message.content_ref.as_str().starts_with("msg:identity."))
+    );
 }
 
 #[tokio::test]

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -2970,6 +2970,7 @@ async fn text_only_host_factory_excludes_personal_identity_when_profile_excludes
             checkpoint_state_ref: None,
             max_messages: Some(8),
             inline_messages: Vec::new(),
+            capability_view: None,
         })
         .await
         .unwrap();

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -1722,6 +1722,7 @@ pub enum LoopGateKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LoopDriverNoteKind {
+    Context,
     Planning,
     Waiting,
     Retrying,

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -88,5 +88,5 @@ pub use skill_context::{
     SkillTrustLevel, SkillVisibility, is_skill_snippet_model_message_ref,
     skill_snippet_model_message_ref,
 };
-pub use snapshot::ResolvedRunProfile;
+pub use snapshot::{PersonalContextPolicy, ResolvedRunProfile};
 pub use snippet_ref::memory_snippet_display_ref;

--- a/crates/ironclaw_turns/src/run_profile/mod.rs
+++ b/crates/ironclaw_turns/src/run_profile/mod.rs
@@ -67,7 +67,7 @@ pub use model::{
     NoOpPolicyGuard,
 };
 pub use policy::{
-    CancellationPolicy, CheckpointPolicy, PrivilegedRunProfileDimension,
+    CancellationPolicy, CheckpointPolicy, PersonalContextAuthority, PrivilegedRunProfileDimension,
     RedactedRunProfileProvenance, RedactedRunProfileSource, ResourceBudgetPolicy,
     RunProfileRequestAuthority, RunProfileResolutionError, RuntimeProfileConstraints,
     SteeringPolicy,

--- a/crates/ironclaw_turns/src/run_profile/policy.rs
+++ b/crates/ironclaw_turns/src/run_profile/policy.rs
@@ -72,6 +72,13 @@ pub enum RunProfileRequestAuthority {
     System,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PersonalContextAuthority {
+    Direct,
+    #[default]
+    Shared,
+}
+
 impl RunProfileRequestAuthority {
     pub(super) fn allows(self, dimension: PrivilegedRunProfileDimension) -> bool {
         match dimension {

--- a/crates/ironclaw_turns/src/run_profile/resolver.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolver.rs
@@ -18,7 +18,7 @@ use super::{
         LoopDriverId, ModelProfileId, ResourceBudgetTier, RunClassId, RunProfileFingerprint,
         RunProfileSourceLayer, RunProfileSourceRef, RunnerPoolId, SchedulingClass,
     },
-    snapshot::ResolvedRunProfile,
+    snapshot::{PersonalContextPolicy, ResolvedRunProfile},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -189,6 +189,7 @@ pub struct RunProfileDefinition {
     cancellation_policy: CancellationPolicy,
     checkpoint_policy: CheckpointPolicy,
     resource_budget_policy: ResourceBudgetPolicy,
+    personal_context_policy: PersonalContextPolicy,
     runtime_constraints: RuntimeProfileConstraints,
     runner_pool_id: Option<RunnerPoolId>,
     scheduling_class: SchedulingClass,
@@ -214,6 +215,11 @@ impl RunProfileDefinition {
         definition
     }
 
+    pub fn with_personal_context_policy(mut self, policy: PersonalContextPolicy) -> Self {
+        self.personal_context_policy = policy;
+        self
+    }
+
     fn resolve(&self, request: &RunProfileResolutionRequest) -> ResolvedRunProfile {
         let mut provenance = provenance_for(self, request);
         let resource_budget_policy = self.resolve_resource_budget_policy(request, &mut provenance);
@@ -232,6 +238,7 @@ impl RunProfileDefinition {
             cancellation_policy: self.cancellation_policy.clone(),
             checkpoint_policy: self.checkpoint_policy.clone(),
             resource_budget_policy,
+            personal_context_policy: self.personal_context_policy,
             runtime_constraints: self.runtime_constraints.clone(),
             runner_pool_id: self.runner_pool_id.clone(),
             scheduling_class: self.scheduling_class.clone(),
@@ -313,6 +320,7 @@ fn interactive_profile() -> RunProfileDefinition {
             max_model_calls: 32,
             max_capability_invocations: 64,
         },
+        personal_context_policy: PersonalContextPolicy::Excluded,
         runtime_constraints: RuntimeProfileConstraints {
             allow_raw_runtime_backend_selection: false,
             allow_broad_capability_surface: false,
@@ -366,6 +374,7 @@ fn long_running_mission_profile() -> RunProfileDefinition {
             max_model_calls: 256,
             max_capability_invocations: 1024,
         },
+        personal_context_policy: PersonalContextPolicy::Excluded,
         runtime_constraints: RuntimeProfileConstraints {
             allow_raw_runtime_backend_selection: false,
             allow_broad_capability_surface: false,
@@ -452,6 +461,7 @@ fn fingerprint_for(
     update(definition.model_profile_id.as_str());
     update(definition.capability_surface_profile_id.as_str());
     update(definition.context_profile_id.as_str());
+    update(definition.personal_context_policy.as_str());
     update_bool(definition.steering_policy.allow_steering, &mut update);
     update_bool(definition.steering_policy.allow_interrupt, &mut update);
     update_bool(

--- a/crates/ironclaw_turns/src/run_profile/resolver.rs
+++ b/crates/ironclaw_turns/src/run_profile/resolver.rs
@@ -8,10 +8,10 @@ use crate::{RunProfileId, RunProfileRequest, RunProfileVersion};
 use super::{
     driver::AgentLoopDriverDescriptor,
     policy::{
-        CancellationPolicy, CheckpointPolicy, PrivilegedRunProfileDimension,
-        RedactedRunProfileProvenance, RedactedRunProfileSource, ResourceBudgetPolicy,
-        RunProfileRequestAuthority, RunProfileResolutionError, RuntimeProfileConstraints,
-        SteeringPolicy,
+        CancellationPolicy, CheckpointPolicy, PersonalContextAuthority,
+        PrivilegedRunProfileDimension, RedactedRunProfileProvenance, RedactedRunProfileSource,
+        ResourceBudgetPolicy, RunProfileRequestAuthority, RunProfileResolutionError,
+        RuntimeProfileConstraints, SteeringPolicy,
     },
     refs::{
         CapabilitySurfaceProfileId, CheckpointSchemaId, ConcurrencyClass, ContextProfileId,
@@ -26,6 +26,8 @@ pub struct RunProfileResolutionRequest {
     pub requested_run_profile: Option<RunProfileRequest>,
     #[serde(skip, default)]
     pub authority: RunProfileRequestAuthority,
+    #[serde(skip, default)]
+    pub personal_context_authority: PersonalContextAuthority,
 }
 
 impl RunProfileResolutionRequest {
@@ -33,6 +35,7 @@ impl RunProfileResolutionRequest {
         Self {
             requested_run_profile: None,
             authority: RunProfileRequestAuthority::User,
+            personal_context_authority: PersonalContextAuthority::Direct,
         }
     }
 
@@ -43,6 +46,11 @@ impl RunProfileResolutionRequest {
 
     pub fn with_authority(mut self, authority: RunProfileRequestAuthority) -> Self {
         self.authority = authority;
+        self
+    }
+
+    pub fn with_personal_context_authority(mut self, authority: PersonalContextAuthority) -> Self {
+        self.personal_context_authority = authority;
         self
     }
 }
@@ -223,7 +231,21 @@ impl RunProfileDefinition {
     fn resolve(&self, request: &RunProfileResolutionRequest) -> ResolvedRunProfile {
         let mut provenance = provenance_for(self, request);
         let resource_budget_policy = self.resolve_resource_budget_policy(request, &mut provenance);
-        let fingerprint = fingerprint_for(self, &resource_budget_policy, &provenance);
+        let effective_personal_context_policy = match (
+            self.personal_context_policy,
+            request.personal_context_authority,
+        ) {
+            (PersonalContextPolicy::Allowed, PersonalContextAuthority::Shared) => {
+                PersonalContextPolicy::Excluded
+            }
+            (policy, _) => policy,
+        };
+        let fingerprint = fingerprint_for(
+            self,
+            &resource_budget_policy,
+            effective_personal_context_policy,
+            &provenance,
+        );
         ResolvedRunProfile {
             run_class_id: self.run_class_id.clone(),
             profile_id: self.profile_id.clone(),
@@ -238,7 +260,7 @@ impl RunProfileDefinition {
             cancellation_policy: self.cancellation_policy.clone(),
             checkpoint_policy: self.checkpoint_policy.clone(),
             resource_budget_policy,
-            personal_context_policy: self.personal_context_policy,
+            personal_context_policy: effective_personal_context_policy,
             runtime_constraints: self.runtime_constraints.clone(),
             runner_pool_id: self.runner_pool_id.clone(),
             scheduling_class: self.scheduling_class.clone(),
@@ -426,6 +448,7 @@ fn update_bool(value: bool, update: &mut impl FnMut(&str)) {
 fn fingerprint_for(
     definition: &RunProfileDefinition,
     resource_budget_policy: &ResourceBudgetPolicy,
+    personal_context_policy: PersonalContextPolicy,
     provenance: &RedactedRunProfileProvenance,
 ) -> RunProfileFingerprint {
     let mut hash = 0xcbf29ce484222325_u64;
@@ -461,7 +484,7 @@ fn fingerprint_for(
     update(definition.model_profile_id.as_str());
     update(definition.capability_surface_profile_id.as_str());
     update(definition.context_profile_id.as_str());
-    update(definition.personal_context_policy.as_str());
+    update(personal_context_policy.as_str());
     update_bool(definition.steering_policy.allow_steering, &mut update);
     update_bool(definition.steering_policy.allow_interrupt, &mut update);
     update_bool(
@@ -570,9 +593,65 @@ mod tests {
             fingerprint_for(
                 &relaxed,
                 &relaxed.resource_budget_policy,
+                relaxed.personal_context_policy,
                 &relaxed_provenance
             ),
-            fingerprint_for(&strict, &strict.resource_budget_policy, &strict_provenance),
+            fingerprint_for(
+                &strict,
+                &strict.resource_budget_policy,
+                strict.personal_context_policy,
+                &strict_provenance
+            ),
         );
+    }
+
+    #[test]
+    fn shared_authority_downgrades_allowed_to_excluded() {
+        let allowed_profile =
+            interactive_profile().with_personal_context_policy(PersonalContextPolicy::Allowed);
+        let request = RunProfileResolutionRequest::interactive_default()
+            .with_personal_context_authority(PersonalContextAuthority::Shared);
+        let snapshot = allowed_profile.resolve(&request);
+        assert_eq!(
+            snapshot.personal_context_policy,
+            PersonalContextPolicy::Excluded
+        );
+    }
+
+    #[test]
+    fn direct_authority_preserves_allowed() {
+        let allowed_profile =
+            interactive_profile().with_personal_context_policy(PersonalContextPolicy::Allowed);
+        let request = RunProfileResolutionRequest::interactive_default()
+            .with_personal_context_authority(PersonalContextAuthority::Direct);
+        let snapshot = allowed_profile.resolve(&request);
+        assert_eq!(
+            snapshot.personal_context_policy,
+            PersonalContextPolicy::Allowed
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_authority_downgrades_personal_context_policy() {
+        let allowed_profile =
+            interactive_profile().with_personal_context_policy(PersonalContextPolicy::Allowed);
+        let direct = allowed_profile.resolve(
+            &RunProfileResolutionRequest::interactive_default()
+                .with_personal_context_authority(PersonalContextAuthority::Direct),
+        );
+        let shared = allowed_profile.resolve(
+            &RunProfileResolutionRequest::interactive_default()
+                .with_personal_context_authority(PersonalContextAuthority::Shared),
+        );
+
+        assert_eq!(
+            direct.personal_context_policy,
+            PersonalContextPolicy::Allowed
+        );
+        assert_eq!(
+            shared.personal_context_policy,
+            PersonalContextPolicy::Excluded
+        );
+        assert_ne!(direct.resolution_fingerprint, shared.resolution_fingerprint);
     }
 }

--- a/crates/ironclaw_turns/src/run_profile/snapshot.rs
+++ b/crates/ironclaw_turns/src/run_profile/snapshot.rs
@@ -30,12 +30,31 @@ pub struct ResolvedRunProfile {
     pub cancellation_policy: CancellationPolicy,
     pub checkpoint_policy: CheckpointPolicy,
     pub resource_budget_policy: ResourceBudgetPolicy,
+    #[serde(default)]
+    pub personal_context_policy: PersonalContextPolicy,
     pub runtime_constraints: RuntimeProfileConstraints,
     pub runner_pool_id: Option<RunnerPoolId>,
     pub scheduling_class: SchedulingClass,
     pub concurrency_class: ConcurrencyClass,
     pub resolution_fingerprint: RunProfileFingerprint,
     pub provenance: RedactedRunProfileProvenance,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PersonalContextPolicy {
+    #[default]
+    Excluded,
+    Allowed,
+}
+
+impl PersonalContextPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Excluded => "excluded",
+            Self::Allowed => "allowed",
+        }
+    }
 }
 
 impl ResolvedRunProfile {
@@ -86,6 +105,7 @@ impl ResolvedRunProfile {
                 max_model_calls: 32,
                 max_capability_invocations: 64,
             },
+            personal_context_policy: PersonalContextPolicy::Excluded,
             runtime_constraints: RuntimeProfileConstraints {
                 allow_raw_runtime_backend_selection: false,
                 allow_broad_capability_surface: false,

--- a/crates/ironclaw_turns/tests/run_profile_contract.rs
+++ b/crates/ironclaw_turns/tests/run_profile_contract.rs
@@ -112,6 +112,10 @@ async fn authorized_long_running_profile_resolves_distinct_driver_and_budget_env
     assert_eq!(snapshot.checkpoint_schema_id.as_str(), "durable_mission_v1");
     assert_eq!(snapshot.model_profile_id.as_str(), "mission_model");
     assert_eq!(
+        snapshot.personal_context_policy,
+        PersonalContextPolicy::Excluded
+    );
+    assert_eq!(
         snapshot.resource_budget_policy.tier.as_str(),
         "mission_standard"
     );

--- a/crates/ironclaw_turns/tests/run_profile_contract.rs
+++ b/crates/ironclaw_turns/tests/run_profile_contract.rs
@@ -3,6 +3,7 @@ use ironclaw_turns::{
     InMemoryRunProfileResolver, ModelProfileId, PrivilegedRunProfileDimension, RunProfileId,
     RunProfileRequest, RunProfileRequestAuthority, RunProfileResolutionError,
     RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion,
+    run_profile::{PersonalContextPolicy, ResolvedRunProfile},
 };
 
 #[test]
@@ -44,6 +45,10 @@ async fn default_interactive_profile_resolves_stable_driver_and_redacted_snapsho
         "interactive_tools"
     );
     assert_eq!(snapshot.context_profile_id.as_str(), "interactive_context");
+    assert_eq!(
+        snapshot.personal_context_policy,
+        PersonalContextPolicy::Excluded
+    );
     assert!(snapshot.steering_policy.allow_steering);
     assert!(!snapshot.steering_policy.allow_driver_specific_nudges);
     assert_eq!(snapshot.provenance.sources.len(), 1);
@@ -53,6 +58,26 @@ async fn default_interactive_profile_resolves_stable_driver_and_redacted_snapsho
     assert!(!wire.contains("api_key"));
     assert!(!wire.contains("raw_config"));
     assert!(!wire.contains("RuntimeDispatcher"));
+}
+
+#[tokio::test]
+async fn resolved_profile_deserializes_old_payload_with_personal_context_excluded() {
+    let resolver = InMemoryRunProfileResolver::default();
+    let snapshot = resolver
+        .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+        .await
+        .unwrap();
+    let mut wire = serde_json::to_value(snapshot).unwrap();
+    wire.as_object_mut()
+        .unwrap()
+        .remove("personal_context_policy");
+
+    let decoded: ResolvedRunProfile = serde_json::from_value(wire).unwrap();
+
+    assert_eq!(
+        decoded.personal_context_policy,
+        PersonalContextPolicy::Excluded
+    );
 }
 
 #[tokio::test]

--- a/docs/reborn/contracts/memory.md
+++ b/docs/reborn/contracts/memory.md
@@ -272,6 +272,9 @@ Loop/userland assembly rules:
 - active loops may choose prompt order, summarization, model-specific formatting, and inclusion heuristics over authorized reads;
 - loops that admit personal context must emit safe observability metadata such
   as admitted source count and source names, never raw file contents;
+- that admission metadata is best-effort/eventually consistent; consumers must
+  not rely on its absence before terminal turn events to prove personal context
+  was not admitted;
 - custom loops cannot bypass primary-scope identity filtering, group-chat privacy filtering, write-safety checks, or event/audit redaction;
 - reference loop prompt assemblers are replaceable behavior, not memory backend source of truth.
 

--- a/docs/reborn/contracts/memory.md
+++ b/docs/reborn/contracts/memory.md
@@ -253,6 +253,13 @@ context/assistant-directives.md
 Kernel-mediated safety rules:
 
 - identity files are primary-scope only;
+- stable identity files (`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `TOOLS.md`,
+  and `BOOTSTRAP.md`) may be considered for default prompt assembly;
+- personal identity files (`USER.md` and `context/assistant-directives.md`) are
+  primary-scope only and excluded unless the resolved run profile explicitly
+  allows personal context;
+- `HEARTBEAT.md` is volatile routine/proactive context, not stable default-loop
+  identity context;
 - admin `SYSTEM.md` is admin-scope only and may be cached;
 - `MEMORY.md` and daily logs may read configured secondary scopes only through explicit read-scope policy;
 - group chat contexts exclude personal memory/profile/directives unless explicit policy allows them;
@@ -263,6 +270,8 @@ Kernel-mediated safety rules:
 Loop/userland assembly rules:
 
 - active loops may choose prompt order, summarization, model-specific formatting, and inclusion heuristics over authorized reads;
+- loops that admit personal context must emit safe observability metadata such
+  as admitted source count and source names, never raw file contents;
 - custom loops cannot bypass primary-scope identity filtering, group-chat privacy filtering, write-safety checks, or event/audit redaction;
 - reference loop prompt assemblers are replaceable behavior, not memory backend source of truth.
 

--- a/docs/reborn/contracts/turns-agent-loop.md
+++ b/docs/reborn/contracts/turns-agent-loop.md
@@ -153,7 +153,14 @@ admin/system run
 Kernel-mediated prompt safety rules:
 
 - identity/system-prompt files are primary-scope only;
+- `USER.md` and `context/assistant-directives.md` are personal context and are
+  excluded unless the resolved run profile explicitly allows personal context;
+- when personal context is admitted, the loop emits safe observability metadata
+  such as source count and source names, never raw file content;
 - group chat must not receive personal memory/profile context unless explicit policy allows it;
+- `HEARTBEAT.md` is not part of the default planned or interactive loop prompt
+  prefix; routine, mission, or proactive profiles must own any volatile
+  heartbeat injection semantics;
 - writes to prompt-injected files are guarded by prompt-injection write-safety policy;
 - assembled prompts are not emitted in events/audit by default;
 - prompt read/build failures are explicit turn failures unless a contract marks a missing optional doc as ignorable;
@@ -245,8 +252,11 @@ Transport-specific auth/webhook checks happen before the turn is accepted.
 - shipped and custom loops both send privileged effects through `CapabilityHost` only;
 - trust class alone does not let a loop bypass grants, mounts, leases, obligations, or resource policy;
 - approval-blocked turn resumes with exact invocation fingerprint;
-- group chat prompt excludes personal memory/profile docs;
+- group chat prompt excludes personal memory/profile docs unless the resolved
+  run profile explicitly allows them;
 - primary identity docs are not read from secondary scopes;
+- personal-context inclusion emits safe source metadata and does not expose raw
+  `USER.md` or assistant-directive content;
 - prompt-injected file writes are scanned or fail closed regardless of loop implementation;
 - cancellation propagates to process/capability work;
 - durable event cursor can replay turn progress after reconnect;

--- a/docs/reborn/contracts/turns-agent-loop.md
+++ b/docs/reborn/contracts/turns-agent-loop.md
@@ -157,6 +157,10 @@ Kernel-mediated prompt safety rules:
   excluded unless the resolved run profile explicitly allows personal context;
 - when personal context is admitted, the loop emits safe observability metadata
   such as source count and source names, never raw file content;
+- personal-context admission metadata is best-effort and may be emitted
+  asynchronously after prompt assembly or model consumption; consumers must not
+  treat absence of that metadata as proof that no personal context was admitted
+  until the turn's terminal event stream has been inspected;
 - group chat must not receive personal memory/profile context unless explicit policy allows it;
 - `HEARTBEAT.md` is not part of the default planned or interactive loop prompt
   prefix; routine, mission, or proactive profiles must own any volatile

--- a/src/workspace/CLAUDE.md
+++ b/src/workspace/CLAUDE.md
@@ -5,7 +5,8 @@ Owns persistent workspace memory and file-like project/user context.
 ## Agent-loop boundary
 
 - `reborn_identity_context.rs` is the workspace-owned reader for stable identity
-  files exposed to Reborn prompt context.
+  files and policy-gated personal identity files exposed to Reborn prompt
+  context.
 - Workspace may read and summarize identity files through narrow source traits.
 - Prompt bundle assembly, strategy decisions, driver execution, and model calls
   stay outside this directory.
@@ -24,8 +25,8 @@ Owns persistent workspace memory and file-like project/user context.
 - Add a new file when a workspace-backed source has its own trust, scope, or
   summarization rules.
 - Reuse existing workspace read/search APIs before adding a side path.
-- Keep identity-context code narrow: stable identity file discovery, read, safe
-  summary, and trust classification.
+- Keep identity-context code narrow: identity file discovery, primary-scope
+  read, policy applicability, safe summary, and trust classification.
 
 ## Common mistakes
 

--- a/src/workspace/reborn_identity_context.rs
+++ b/src/workspace/reborn_identity_context.rs
@@ -323,6 +323,40 @@ mod tests {
 
     #[cfg(feature = "libsql")]
     #[tokio::test]
+    async fn workspace_identity_context_allowed_policy_still_excludes_heartbeat() {
+        let test_db = test_db().await;
+        let workspace = Arc::new(Workspace::new_with_db("primary", test_db.db.clone()));
+        workspace
+            .write(paths::USER, "private user profile")
+            .await
+            .unwrap();
+        workspace
+            .write(paths::HEARTBEAT, "routine heartbeat")
+            .await
+            .unwrap();
+
+        let source = WorkspaceIdentityContextSource::new(workspace);
+        let mut context = run_context().await;
+        context.resolved_run_profile.personal_context_policy = PersonalContextPolicy::Allowed;
+        let candidates = source
+            .load_identity_candidates(&context, PromptMode::TextOnly)
+            .await
+            .unwrap();
+
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.name.as_str() == paths::USER)
+        );
+        assert!(
+            candidates
+                .iter()
+                .all(|candidate| candidate.name.as_str() != paths::HEARTBEAT)
+        );
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
     async fn workspace_identity_context_denies_cached_personal_ref_when_policy_excludes() {
         let test_db = test_db().await;
         let workspace = Arc::new(Workspace::new_with_db("primary", test_db.db.clone()));

--- a/src/workspace/reborn_identity_context.rs
+++ b/src/workspace/reborn_identity_context.rs
@@ -9,7 +9,10 @@ use ironclaw_loop_support::{
     HostIdentityMessageContent, IdentityApplicability, IdentityFileName, identity_message_ref,
 };
 use ironclaw_memory::DEFAULT_PROMPT_PROTECTED_PATHS;
-use ironclaw_turns::{LoopMessageRef, run_profile::LoopRunContext, run_profile::PromptMode};
+use ironclaw_turns::{
+    LoopMessageRef,
+    run_profile::{LoopRunContext, PersonalContextPolicy, PromptMode},
+};
 
 use crate::{error::WorkspaceError, workspace::paths};
 
@@ -22,6 +25,8 @@ const STABLE_IDENTITY_PATHS: &[&str] = &[
     paths::TOOLS,
     paths::BOOTSTRAP,
 ];
+
+const PERSONAL_IDENTITY_PATHS: &[&str] = &[paths::USER, paths::ASSISTANT_DIRECTIVES];
 
 #[derive(Clone)]
 pub struct WorkspaceIdentityContextSource {
@@ -45,6 +50,14 @@ impl WorkspaceIdentityContextSource {
             .collect()
     }
 
+    pub fn personal_identity_paths() -> Vec<&'static str> {
+        DEFAULT_PROMPT_PROTECTED_PATHS
+            .iter()
+            .copied()
+            .filter(|path| PERSONAL_IDENTITY_PATHS.contains(path))
+            .collect()
+    }
+
     async fn read_identity_content(&self, path: &str) -> Result<Option<String>, WorkspaceError> {
         match self.workspace.read_primary(path).await {
             Ok(document) if document.content.is_empty() => Ok(None),
@@ -57,8 +70,9 @@ impl WorkspaceIdentityContextSource {
     async fn candidate_for_path(
         &self,
         path: &'static str,
+        applies_when: IdentityApplicability,
     ) -> Result<Option<HostIdentityContextCandidate>, HostIdentityContextBuildError> {
-        let Some(content) = self
+        let Some(raw_content) = self
             .read_identity_content(path)
             .await
             .map_err(|_| HostIdentityContextBuildError::SourceUnavailable)?
@@ -66,6 +80,7 @@ impl WorkspaceIdentityContextSource {
             return Ok(None);
         };
         let name = IdentityFileName::new(path)?;
+        let content = render_identity_content(path, raw_content);
 
         let message_ref = identity_message_ref(&name, &content)
             .map_err(|_| HostIdentityContextBuildError::Internal)?;
@@ -84,7 +99,7 @@ impl WorkspaceIdentityContextSource {
             name,
             message_ref,
             format!("identity file {path} available"),
-            applicability_for_path(path),
+            applies_when,
             model_visible_bytes,
         )))
     }
@@ -94,13 +109,29 @@ impl WorkspaceIdentityContextSource {
 impl HostIdentityContextSource for WorkspaceIdentityContextSource {
     async fn load_identity_candidates(
         &self,
-        _run_context: &LoopRunContext,
+        run_context: &LoopRunContext,
         _mode: PromptMode,
     ) -> Result<Vec<HostIdentityContextCandidate>, HostIdentityContextBuildError> {
         let mut candidates = Vec::new();
         for path in Self::stable_identity_paths() {
-            if let Some(candidate) = self.candidate_for_path(path).await? {
+            if let Some(candidate) = self
+                .candidate_for_path(path, applicability_for_path(path))
+                .await?
+            {
                 candidates.push(candidate);
+            }
+        }
+
+        if run_context.resolved_run_profile.personal_context_policy
+            == PersonalContextPolicy::Allowed
+        {
+            for path in Self::personal_identity_paths() {
+                if let Some(candidate) = self
+                    .candidate_for_path(path, IdentityApplicability::OnPersonalContextAllowed)
+                    .await?
+                {
+                    candidates.push(candidate);
+                }
             }
         }
         Ok(candidates)
@@ -115,6 +146,16 @@ impl HostIdentityContextSource for WorkspaceIdentityContextSource {
             .read()
             .map_err(|_| HostIdentityContextBuildError::Internal)
             .map(|loaded| loaded.get(message_ref).cloned())
+    }
+}
+
+fn render_identity_content(path: &str, content: String) -> String {
+    if PERSONAL_IDENTITY_PATHS.contains(&path) {
+        format!(
+            "## User Profile Context\n\nInformational; not authoritative runtime policy.\n\n{content}"
+        )
+    } else {
+        content
     }
 }
 
@@ -223,7 +264,7 @@ mod tests {
 
     #[cfg(feature = "libsql")]
     #[tokio::test]
-    async fn workspace_identity_context_excludes_personal_files_without_policy() {
+    async fn workspace_identity_context_excludes_personal_files_until_policy_allows() {
         let test_db = test_db().await;
         let workspace = Arc::new(Workspace::new_with_db("primary", test_db.db.clone()));
         workspace
@@ -243,6 +284,19 @@ mod tests {
             .unwrap();
 
         assert!(candidates.is_empty());
+
+        let mut context = run_context().await;
+        context.resolved_run_profile.personal_context_policy = PersonalContextPolicy::Allowed;
+        let candidates = source
+            .load_identity_candidates(&context, PromptMode::TextOnly)
+            .await
+            .unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert!(
+            candidates.iter().all(|candidate| candidate.applies_when
+                == IdentityApplicability::OnPersonalContextAllowed)
+        );
     }
 
     #[cfg(feature = "libsql")]

--- a/src/workspace/reborn_identity_context.rs
+++ b/src/workspace/reborn_identity_context.rs
@@ -216,6 +216,18 @@ mod tests {
         assert!(!stable.contains(&paths::PROFILE));
     }
 
+    #[test]
+    fn render_identity_content_wraps_personal_context_only() {
+        let personal = render_identity_content(paths::USER, "private user profile".to_string());
+        assert_eq!(
+            personal,
+            "## User Profile Context\n\nInformational; not authoritative runtime policy.\n\nprivate user profile"
+        );
+
+        let stable = render_identity_content(paths::AGENTS, "stable instructions".to_string());
+        assert_eq!(stable, "stable instructions");
+    }
+
     #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn workspace_identity_context_reads_primary_scope_only() {

--- a/src/workspace/reborn_identity_context.rs
+++ b/src/workspace/reborn_identity_context.rs
@@ -6,7 +6,8 @@ use std::{
 use async_trait::async_trait;
 use ironclaw_loop_support::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
-    HostIdentityMessageContent, IdentityApplicability, IdentityFileName, identity_message_ref,
+    HostIdentityMessageContent, IdentityApplicability, IdentityFileName,
+    identity_applicability_allowed_for_run, identity_message_ref,
 };
 use ironclaw_memory::DEFAULT_PROMPT_PROTECTED_PATHS;
 use ironclaw_turns::{
@@ -31,7 +32,13 @@ const PERSONAL_IDENTITY_PATHS: &[&str] = &[paths::USER, paths::ASSISTANT_DIRECTI
 #[derive(Clone)]
 pub struct WorkspaceIdentityContextSource {
     workspace: Arc<Workspace>,
-    loaded_identity_content: Arc<RwLock<HashMap<LoopMessageRef, HostIdentityMessageContent>>>,
+    loaded_identity_content: Arc<RwLock<HashMap<LoopMessageRef, CachedIdentityMessageContent>>>,
+}
+
+#[derive(Clone)]
+struct CachedIdentityMessageContent {
+    content: HostIdentityMessageContent,
+    applies_when: IdentityApplicability,
 }
 
 impl WorkspaceIdentityContextSource {
@@ -90,9 +97,12 @@ impl WorkspaceIdentityContextSource {
             .map_err(|_| HostIdentityContextBuildError::Internal)?
             .insert(
                 message_ref.clone(),
-                HostIdentityMessageContent {
-                    name: name.clone(),
-                    content,
+                CachedIdentityMessageContent {
+                    content: HostIdentityMessageContent {
+                        name: name.clone(),
+                        content,
+                    },
+                    applies_when,
                 },
             );
         Ok(Some(HostIdentityContextCandidate::new_trusted(
@@ -139,13 +149,22 @@ impl HostIdentityContextSource for WorkspaceIdentityContextSource {
 
     async fn resolve_identity_message_content(
         &self,
-        _run_context: &LoopRunContext,
+        run_context: &LoopRunContext,
         message_ref: &LoopMessageRef,
     ) -> Result<Option<HostIdentityMessageContent>, HostIdentityContextBuildError> {
-        self.loaded_identity_content
+        let cached = self
+            .loaded_identity_content
             .read()
-            .map_err(|_| HostIdentityContextBuildError::Internal)
-            .map(|loaded| loaded.get(message_ref).cloned())
+            .map_err(|_| HostIdentityContextBuildError::Internal)?
+            .get(message_ref)
+            .cloned();
+        let Some(cached) = cached else {
+            return Ok(None);
+        };
+        if !identity_applicability_allowed_for_run(cached.applies_when, run_context) {
+            return Err(HostIdentityContextBuildError::PolicyDenied);
+        }
+        Ok(Some(cached.content))
     }
 }
 
@@ -297,6 +316,45 @@ mod tests {
             candidates.iter().all(|candidate| candidate.applies_when
                 == IdentityApplicability::OnPersonalContextAllowed)
         );
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn workspace_identity_context_denies_cached_personal_ref_when_policy_excludes() {
+        let test_db = test_db().await;
+        let workspace = Arc::new(Workspace::new_with_db("primary", test_db.db.clone()));
+        workspace
+            .write(paths::USER, "private user profile")
+            .await
+            .unwrap();
+
+        let source = WorkspaceIdentityContextSource::new(workspace);
+        let mut allowed_context = run_context().await;
+        allowed_context.resolved_run_profile.personal_context_policy =
+            PersonalContextPolicy::Allowed;
+        let candidates = source
+            .load_identity_candidates(&allowed_context, PromptMode::TextOnly)
+            .await
+            .unwrap();
+        let user_ref = candidates
+            .iter()
+            .find(|candidate| candidate.name.as_str() == paths::USER)
+            .and_then(|candidate| candidate.message_ref.clone())
+            .expect("user identity ref loaded");
+
+        let allowed_content = source
+            .resolve_identity_message_content(&allowed_context, &user_ref)
+            .await
+            .unwrap()
+            .expect("allowed personal identity content");
+        assert!(allowed_content.content.contains("private user profile"));
+
+        let excluded_context = run_context().await;
+        let error = source
+            .resolve_identity_message_content(&excluded_context, &user_ref)
+            .await
+            .unwrap_err();
+        assert_eq!(error, HostIdentityContextBuildError::PolicyDenied);
     }
 
     #[cfg(feature = "libsql")]

--- a/src/workspace/reborn_identity_context.rs
+++ b/src/workspace/reborn_identity_context.rs
@@ -27,6 +27,9 @@ const STABLE_IDENTITY_PATHS: &[&str] = &[
     paths::BOOTSTRAP,
 ];
 
+// These basenames are surfaced in safe admission milestones after path
+// sanitization. Keep future additions collision-free and clear of
+// `validate_loop_safe_summary` forbidden tokens such as secret/password/bearer.
 const PERSONAL_IDENTITY_PATHS: &[&str] = &[paths::USER, paths::ASSISTANT_DIRECTIVES];
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- add `ResolvedRunProfile.personal_context_policy` with backward-compatible default exclusion
- keep builtin and planned default profiles excluded by default; explicitly allowed profiles remain direct-authority only, while shared authority downgrades them to excluded
- gate `USER.md` and `context/assistant-directives.md` through the resolved profile, without owner-id reauthorization
- re-check cached identity refs on dereference so stale personal refs fail closed under excluded profiles
- emit a safe `context` driver-note milestone when personal context is admitted, carrying source count + sanitized source labels only
- make personal-context admission milestones best-effort, retryable after sink failure, and deduped after successful publish
- preserve and document the existing `HEARTBEAT.md` default-loop exclusion as routine/mission/proactive context

Fixes #3692

## Follow-up split
This PR closes the default-loop personal identity / heartbeat contract in #3692. The stricter owner/shared-context authorization layer and privileged profile-upgrade dimension are intentionally split to #3745, because they need owner/surface authority threaded through both identity candidate admission and identity ref dereference rather than a partial check in this PR.

## Verification
- `cargo test -p ironclaw_turns -p ironclaw_loop_support`
- `cargo test -p ironclaw_reborn planned_driver_factory --lib`
- `cargo test -p ironclaw_loop_support --test thread_loop_support_contract personal_context`
- `cargo test -p ironclaw_turns --test run_profile_contract`
- `git diff --check`

## Review follow-up
- addressed the 2026-05-18 review comment by aligning personal-context admission milestone failure with best-effort milestone behavior and adding sink-failure coverage
- added a safety comment for future personal identity path labels to avoid basename collisions and forbidden safe-summary tokens
- added explicit profile-policy assertions for excluded named profiles
- confirmed #3745 is filed and open for owner-aware personal context authorization