### PR TITLE
feat(reborn): webui turn scope

### DIFF
--- a/crates/ironclaw_product_workflow/CLAUDE.md
+++ b/crates/ironclaw_product_workflow/CLAUDE.md
@@ -32,6 +32,12 @@ Must NOT depend on: `ironclaw_dispatcher`, `ironclaw_extensions`,
 `ironclaw_host_runtime`, `ironclaw_mcp`, `ironclaw_wasm`, `ironclaw_scripts`,
 `ironclaw_network`, `ironclaw_engine`, `ironclaw_gateway`.
 
+WebUI-facing facade methods must bind browser thread ids through
+`SessionThreadService` using a `ThreadScope` derived from the authenticated
+caller before accepting messages, streaming events, canceling runs, or resolving
+gates. Browser/session metadata is not authority by itself, and send-message
+must not implicitly create missing threads.
+
 ## Test support
 
 Enable `test-support` feature for in-memory fakes:

--- a/crates/ironclaw_product_workflow/src/reborn_services.rs
+++ b/crates/ironclaw_product_workflow/src/reborn_services.rs
@@ -118,7 +118,9 @@ impl RebornServicesApi for RebornServices {
             return Err(RebornServicesError::internal_invariant());
         };
 
-        let thread_scope = thread_scope_from_turn_scope(&scope, Some(actor.user_id.clone()))?;
+        let resolved = self.resolve_webui_thread(scope, &actor).await?;
+        let scope = resolved.scope;
+        let thread_scope = resolved.thread_scope;
         let source_binding_id = webui_source_binding_id(&scope, &actor);
         let external_event_id = client_action_id.as_str().to_string();
 
@@ -166,17 +168,6 @@ impl RebornServicesApi for RebornServices {
                 }
             }
         } else {
-            self.thread_service
-                .ensure_thread(EnsureThreadRequest {
-                    scope: thread_scope.clone(),
-                    thread_id: Some(scope.thread_id.clone()),
-                    created_by_actor_id: actor.user_id.as_str().to_string(),
-                    title: None,
-                    metadata_json: None,
-                })
-                .await
-                .map_err(map_thread_error)?;
-
             let accepted = self
                 .thread_service
                 .accept_inbound_message(AcceptInboundMessageRequest {
@@ -273,16 +264,11 @@ impl RebornServicesApi for RebornServices {
         request: RebornTimelineRequest,
     ) -> Result<RebornTimelineResponse, RebornServicesError> {
         let thread_id = parse_thread_id_field("thread_id", request.thread_id)?;
-        let scope = caller.turn_scope(thread_id.clone());
-        let thread_scope = thread_scope_from_turn_scope(&scope, Some(caller.user_id.clone()))?;
+        let actor = caller.actor();
         let history = self
-            .thread_service
-            .list_thread_history(ThreadHistoryRequest {
-                scope: thread_scope,
-                thread_id,
-            })
-            .await
-            .map_err(map_thread_error)?;
+            .resolve_webui_thread(caller.turn_scope(thread_id), &actor)
+            .await?
+            .history;
 
         Ok(RebornTimelineResponse {
             thread: history.thread,
@@ -297,13 +283,18 @@ impl RebornServicesApi for RebornServices {
         request: RebornStreamEventsRequest,
     ) -> Result<RebornStreamEventsResponse, RebornServicesError> {
         let thread_id = parse_thread_id_field("thread_id", request.thread_id)?;
+        let actor = caller.actor();
+        let scope = self
+            .resolve_webui_thread(caller.turn_scope(thread_id), &actor)
+            .await?
+            .scope;
         let Some(event_stream) = &self.event_stream else {
             return Err(RebornServicesError::service_unavailable(false));
         };
         let events = event_stream
             .drain(ProjectionSubscriptionRequest {
-                actor: caller.actor(),
-                scope: caller.turn_scope(thread_id),
+                actor,
+                scope,
                 after_cursor: request.after_cursor,
             })
             .await
@@ -320,6 +311,8 @@ impl RebornServicesApi for RebornServices {
         let WebUiInboundCommand::CancelRun { request } = command else {
             return Err(RebornServicesError::internal_invariant());
         };
+        self.resolve_webui_thread(request.scope.clone(), &request.actor)
+            .await?;
         let response = self
             .turn_coordinator
             .cancel_run(request)
@@ -346,6 +339,7 @@ impl RebornServicesApi for RebornServices {
             return Err(RebornServicesError::internal_invariant());
         };
 
+        self.resolve_webui_thread(scope.clone(), &actor).await?;
         match resolution {
             WebUiGateResolution::Approved { .. } => {
                 let binding_id = webui_gate_binding_id(&scope, &gate_ref_string(&gate_ref));
@@ -397,6 +391,12 @@ struct AcceptedWebUiMessage {
     reply_target_binding_id: String,
 }
 
+struct ResolvedWebUiThread {
+    scope: TurnScope,
+    thread_scope: ThreadScope,
+    history: ironclaw_threads::ThreadHistory,
+}
+
 /// Optional create-thread helper for routes that want an explicit allocation
 /// before first turn submission.
 ///
@@ -435,6 +435,28 @@ impl RebornServices {
             .await
             .map_err(map_thread_error)?;
         Ok(RebornCreateThreadResponse { thread })
+    }
+
+    async fn resolve_webui_thread(
+        &self,
+        scope: TurnScope,
+        actor: &TurnActor,
+    ) -> Result<ResolvedWebUiThread, RebornServicesError> {
+        let thread_scope = thread_scope_from_turn_scope(&scope, Some(actor.user_id.clone()))?;
+        let history = self
+            .thread_service
+            .list_thread_history(ThreadHistoryRequest {
+                scope: thread_scope.clone(),
+                thread_id: scope.thread_id.clone(),
+            })
+            .await
+            .map_err(map_thread_error)?;
+
+        Ok(ResolvedWebUiThread {
+            scope,
+            thread_scope,
+            history,
+        })
     }
 }
 

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -25,9 +25,13 @@ use ironclaw_turns::{
 use serde_json::json;
 
 fn caller() -> WebUiAuthenticatedCaller {
+    caller_for_user("user-alpha")
+}
+
+fn caller_for_user(user_id: &str) -> WebUiAuthenticatedCaller {
     WebUiAuthenticatedCaller::new(
         TenantId::new("tenant-alpha").expect("valid tenant"),
-        UserId::new("user-alpha").expect("valid user"),
+        UserId::new(user_id).expect("valid user"),
         Some(AgentId::new("agent-alpha").expect("valid agent")),
         Some(ProjectId::new("project-alpha").expect("valid project")),
     )
@@ -71,6 +75,14 @@ impl FakeTurnCoordinator {
             .expect("lock")
             .last()
             .map(|request| request.source_binding_ref.as_str().to_string())
+    }
+
+    fn last_submission_scope(&self) -> Option<ironclaw_turns::TurnScope> {
+        self.submissions
+            .lock()
+            .expect("lock")
+            .last()
+            .map(|request| request.scope.clone())
     }
 }
 
@@ -155,6 +167,24 @@ impl ProjectionStream for AuthFailureProjectionStream {
     }
 }
 
+async fn create_thread_for(
+    services: &RebornServices,
+    caller: WebUiAuthenticatedCaller,
+    thread_id: &str,
+) {
+    services
+        .create_thread(
+            caller,
+            serde_json::from_value::<WebUiCreateThreadRequest>(json!({
+                "client_action_id": format!("create-{thread_id}"),
+                "requested_thread_id": thread_id
+            }))
+            .expect("create request"),
+        )
+        .await
+        .expect("create thread");
+}
+
 #[tokio::test]
 async fn duplicate_create_thread_replays_generated_thread_for_same_client_action() {
     let services = RebornServices::new(
@@ -213,6 +243,7 @@ async fn submit_turn_uses_facade_and_thread_history_without_route_store_access()
     let threads: Arc<dyn SessionThreadService> = Arc::new(InMemorySessionThreadService::default());
     let coordinator = Arc::new(FakeTurnCoordinator::default());
     let services = RebornServices::new(threads, coordinator.clone());
+    create_thread_for(&services, caller(), "thread-alpha").await;
 
     let response = services
         .submit_turn(
@@ -256,6 +287,19 @@ async fn submit_turn_uses_facade_and_thread_history_without_route_store_access()
         timeline.messages[0].content.as_deref(),
         Some("hello from webui")
     );
+    let submission_scope = coordinator
+        .last_submission_scope()
+        .expect("submission scope");
+    assert_eq!(submission_scope.thread_id.as_str(), "thread-alpha");
+    assert_eq!(submission_scope.tenant_id.as_str(), "tenant-alpha");
+    assert_eq!(
+        submission_scope.agent_id.expect("agent").as_str(),
+        "agent-alpha"
+    );
+    assert_eq!(
+        submission_scope.project_id.expect("project").as_str(),
+        "project-alpha"
+    );
 }
 
 #[tokio::test]
@@ -263,6 +307,7 @@ async fn duplicate_submit_replays_prior_handoff_without_second_submission() {
     let threads: Arc<dyn SessionThreadService> = Arc::new(InMemorySessionThreadService::default());
     let coordinator = Arc::new(FakeTurnCoordinator::default());
     let services = RebornServices::new(threads, coordinator.clone());
+    create_thread_for(&services, caller(), "thread-alpha").await;
 
     let request = || {
         serde_json::from_value::<WebUiSendMessageRequest>(json!({
@@ -287,6 +332,107 @@ async fn duplicate_submit_replays_prior_handoff_without_second_submission() {
         RebornSubmitTurnResponse::AlreadySubmitted { .. }
     ));
     assert_eq!(coordinator.submission_count(), 1);
+}
+
+#[tokio::test]
+async fn submit_turn_rejects_missing_thread_before_turn_submission() {
+    let threads: Arc<dyn SessionThreadService> = Arc::new(InMemorySessionThreadService::default());
+    let coordinator = Arc::new(FakeTurnCoordinator::default());
+    let services = RebornServices::new(threads, coordinator.clone());
+
+    let err = services
+        .submit_turn(
+            caller(),
+            serde_json::from_value::<WebUiSendMessageRequest>(json!({
+                "client_action_id": "send-missing",
+                "thread_id": "thread-missing",
+                "content": "this thread was never created"
+            }))
+            .expect("request"),
+        )
+        .await
+        .expect_err("missing thread must reject");
+
+    assert_eq!(err.code, RebornServicesErrorCode::NotFound);
+    assert_eq!(err.status_code, 404);
+    assert_eq!(coordinator.submission_count(), 0);
+}
+
+#[tokio::test]
+async fn submit_turn_rejects_non_owner_before_turn_submission() {
+    let threads: Arc<dyn SessionThreadService> = Arc::new(InMemorySessionThreadService::default());
+    let coordinator = Arc::new(FakeTurnCoordinator::default());
+    let services = RebornServices::new(threads, coordinator.clone());
+    create_thread_for(&services, caller(), "thread-alpha").await;
+
+    let err = services
+        .submit_turn(
+            caller_for_user("user-beta"),
+            serde_json::from_value::<WebUiSendMessageRequest>(json!({
+                "client_action_id": "send-denied",
+                "thread_id": "thread-alpha",
+                "content": "wrong participant"
+            }))
+            .expect("request"),
+        )
+        .await
+        .expect_err("non-owner must reject");
+
+    assert_eq!(err.code, RebornServicesErrorCode::NotFound);
+    assert_eq!(err.status_code, 404);
+    assert_eq!(coordinator.submission_count(), 0);
+
+    let timeline = services
+        .get_timeline(
+            caller(),
+            RebornTimelineRequest {
+                thread_id: "thread-alpha".to_string(),
+            },
+        )
+        .await
+        .expect("owner timeline");
+    assert!(timeline.messages.is_empty());
+}
+
+#[tokio::test]
+async fn refresh_reresolves_thread_to_same_canonical_scope() {
+    let threads: Arc<dyn SessionThreadService> = Arc::new(InMemorySessionThreadService::default());
+    let coordinator = Arc::new(FakeTurnCoordinator::default());
+    let services = RebornServices::new(threads, coordinator);
+    create_thread_for(&services, caller(), "thread-alpha").await;
+
+    let first = services
+        .get_timeline(
+            caller(),
+            RebornTimelineRequest {
+                thread_id: "thread-alpha".to_string(),
+            },
+        )
+        .await
+        .expect("first resolve");
+    let refreshed = services
+        .get_timeline(
+            caller(),
+            RebornTimelineRequest {
+                thread_id: "thread-alpha".to_string(),
+            },
+        )
+        .await
+        .expect("refresh resolve");
+
+    assert_eq!(first.thread, refreshed.thread);
+    assert_eq!(refreshed.thread.thread_id.as_str(), "thread-alpha");
+    assert_eq!(refreshed.thread.scope.tenant_id.as_str(), "tenant-alpha");
+    assert_eq!(refreshed.thread.scope.agent_id.as_str(), "agent-alpha");
+    assert_eq!(
+        refreshed
+            .thread
+            .scope
+            .owner_user_id
+            .expect("owner")
+            .as_str(),
+        "user-alpha"
+    );
 }
 
 #[tokio::test]
@@ -328,6 +474,7 @@ async fn turn_unauthorized_maps_to_forbidden() {
             TurnError::Unauthorized,
         )),
     );
+    create_thread_for(&services, caller(), "thread-alpha").await;
 
     let err = services
         .submit_turn(
@@ -353,6 +500,7 @@ async fn adapter_authentication_maps_to_unauthenticated() {
         Arc::new(FakeTurnCoordinator::default()),
     )
     .with_event_stream(Arc::new(AuthFailureProjectionStream));
+    create_thread_for(&services, caller(), "thread-alpha").await;
 
     let err = services
         .stream_events(
@@ -376,6 +524,7 @@ async fn cancel_run_uses_turn_facade_and_stable_response() {
         Arc::new(InMemorySessionThreadService::default()),
         coordinator.clone(),
     );
+    create_thread_for(&services, caller(), "thread-alpha").await;
 
     let response = services
         .cancel_run(
@@ -404,6 +553,7 @@ async fn approved_gate_resolution_resumes_turn() {
         Arc::new(InMemorySessionThreadService::default()),
         coordinator.clone(),
     );
+    create_thread_for(&services, caller(), "thread-alpha").await;
 
     let response = services
         .resolve_gate(
@@ -437,6 +587,7 @@ async fn credential_gate_resolution_returns_sanitized_stable_error_until_gate_po
         Arc::new(InMemorySessionThreadService::default()),
         coordinator.clone(),
     );
+    create_thread_for(&services, caller(), "thread-alpha").await;
 
     let err = services
         .resolve_gate(
@@ -468,6 +619,7 @@ async fn denied_gate_resolution_cancels_run() {
         Arc::new(InMemorySessionThreadService::default()),
         coordinator.clone(),
     );
+    create_thread_for(&services, caller(), "thread-alpha").await;
 
     let response = services
         .resolve_gate(


### PR DESCRIPTION
## Summary

- Bind WebUI `caller + thread_id` through `SessionThreadService` before thread-bound Reborn facade operations.
- Prevent `submit_turn` from implicitly creating missing WebUI threads.
- Add contract coverage for allowed caller, denied caller, missing thread, and refresh/re-resolve behavior.
- Document that WebUI browser/session metadata is not authority by itself.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Fixes #3626

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_product_workflow`; `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: None
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Also ran targeted clippy: `cargo clippy -p ironclaw_product_workflow --all-targets -- -D warnings`.

## Security Impact

Yes. WebUI thread-bound facade operations now resolve the authenticated caller and browser-provided thread id to a canonical scoped thread before accepting messages, streaming events, canceling runs, or resolving gates. Browser/session metadata is not treated as authority by itself.

## Database Impact

None. No migrations or schema changes.

## Blast Radius

Touches `ironclaw_product_workflow` WebUI-facing `RebornServices` facade. WebUI send/cancel/resolve/stream calls against missing or wrong-scope threads now fail before reaching turn coordination.

## Rollback Plan

Revert this PR. That restores the previous facade behavior, including implicit thread creation on `submit_turn`.

## Review Follow-Through

Potential follow-up: add a metadata-only scoped thread resolve API to avoid using `list_thread_history` as the thread binding check.

---

**Review track**: C