### PR TITLE
fix(web): restore NEAR AI API Key + fetch models in configure UI

### DIFF
--- a/crates/ironclaw_gateway/static/js/surfaces/config.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/config.js
@@ -376,7 +376,17 @@ function configureBuiltinProvider(id) {
   baseUrlInput.readOnly = false;
   baseUrlInput.style.opacity = '';
   baseUrlInput.placeholder = p.base_url || '';
-  document.getElementById('provider-api-key-row').style.display = p.api_key_required !== false ? '' : 'none';
+  // `accepts_api_key` tells us whether the provider supports API key
+  // auth at all (so the field should be visible) — distinct from
+  // `api_key_required`, which says whether API key is the *only* way to
+  // configure it. NEAR AI is dual-auth (session token or API key) and
+  // ships `api_key_required: false` + `accepts_api_key: true`. Fall back
+  // to `api_key_required !== false` for older payloads that haven't been
+  // upgraded yet.
+  const acceptsApiKey = p.accepts_api_key !== undefined
+    ? p.accepts_api_key !== false
+    : p.api_key_required !== false;
+  document.getElementById('provider-api-key-row').style.display = acceptsApiKey ? '' : 'none';
   document.getElementById('fetch-models-btn').style.display = p.can_list_models ? '' : 'none';
   const apiKeyInput = document.getElementById('provider-api-key');
   const hasDbKey = override.api_key === API_KEY_UNCHANGED;

--- a/crates/ironclaw_llm/src/registry.rs
+++ b/crates/ironclaw_llm/src/registry.rs
@@ -169,6 +169,12 @@ pub enum SetupHint {
         /// URL where the user can manually obtain a session token.
         #[serde(default)]
         key_url: Option<String>,
+        /// Whether this provider supports `/v1/models` listing.
+        /// NEAR AI's `/v1/models` endpoint works with either a session
+        /// token or an API key, so the configure UI should expose the
+        /// Fetch models button.
+        #[serde(default)]
+        can_list_models: bool,
     },
 }
 
@@ -196,10 +202,12 @@ impl SetupHint {
             Self::OpenAiCompatible {
                 can_list_models, ..
             } => *can_list_models,
+            Self::SessionToken {
+                can_list_models, ..
+            } => *can_list_models,
             Self::AwsCredentials { .. }
             | Self::OAuthDeviceCode { .. }
-            | Self::FileBasedCredentials { .. }
-            | Self::SessionToken { .. } => false,
+            | Self::FileBasedCredentials { .. } => false,
         }
     }
 
@@ -557,6 +565,55 @@ mod tests {
         let registry = ProviderRegistry::new(all);
         let tf = registry.find("tinfoil").expect("tinfoil should exist");
         assert_eq!(tf.default_model, "custom-model", "user override should win");
+    }
+
+    /// Regression for nearai/ironclaw#3734: NEAR AI is a dual-auth
+    /// (session token + API key) provider whose `/v1/models` endpoint
+    /// accepts either credential. Its `SetupHint::SessionToken` entry
+    /// in `providers.json` must carry `can_list_models: true` so the
+    /// configure UI exposes the "Fetch available models" button. Layer
+    /// C (PR #3416) silently lost this when NEAR AI moved into the
+    /// generic registry path because `SessionToken` did not yet expose
+    /// the `can_list_models` field.
+    #[test]
+    fn test_nearai_setup_hint_can_list_models() {
+        let registry = ProviderRegistry::new(
+            serde_json::from_str(include_str!("../../../providers.json")).unwrap(),
+        );
+        let def = registry.find("nearai").expect("nearai should exist");
+        let setup = def
+            .setup
+            .as_ref()
+            .expect("nearai must carry a SetupHint after Layer C");
+        assert!(
+            matches!(setup, SetupHint::SessionToken { .. }),
+            "nearai setup hint must remain SessionToken"
+        );
+        assert!(
+            setup.can_list_models(),
+            "nearai setup must report can_list_models=true so the \
+             configure UI shows the Fetch models button (issue #3734)",
+        );
+    }
+
+    /// SessionToken's `can_list_models` field has to be honoured by the
+    /// `SetupHint::can_list_models()` accessor — the handler reads
+    /// through that method, not the field directly.
+    #[test]
+    fn test_session_token_can_list_models_accessor() {
+        let with = SetupHint::SessionToken {
+            display_name: "T".into(),
+            key_url: None,
+            can_list_models: true,
+        };
+        assert!(with.can_list_models());
+
+        let without = SetupHint::SessionToken {
+            display_name: "T".into(),
+            key_url: None,
+            can_list_models: false,
+        };
+        assert!(!without.can_list_models());
     }
 
     #[test]

--- a/providers.json
+++ b/providers.json
@@ -15,7 +15,8 @@
     "setup": {
       "kind": "session_token",
       "display_name": "NEAR AI",
-      "key_url": "https://app.near.ai"
+      "key_url": "https://app.near.ai",
+      "can_list_models": true
     }
   },
   {

--- a/src/channels/web/handlers/llm.rs
+++ b/src/channels/web/handlers/llm.rs
@@ -434,6 +434,16 @@ fn build_llm_providers(nearai_has_session_token: bool) -> serde_json::Value {
         );
         entry.insert("api_key_required".into(), def.api_key_required.into());
         entry.insert("base_url_required".into(), def.base_url_required.into());
+        // `accepts_api_key` answers "should the configure UI show the
+        // API key input?", which is different from "is the API key
+        // required to make this provider work?". NEAR AI has dual auth
+        // (session token OR API key) — `api_key_required: false` but
+        // we still want the user to be able to enter `NEARAI_API_KEY`
+        // from the settings dialog. Drive the UI off the presence of
+        // an `api_key_env` declaration in the registry, which is true
+        // for every provider that actually consumes an API key.
+        let accepts_api_key = def.api_key_env.is_some();
+        entry.insert("accepts_api_key".into(), accepts_api_key.into());
         let can_list = def.setup.as_ref().is_some_and(|s| s.can_list_models());
         entry.insert("can_list_models".into(), can_list.into());
 
@@ -924,6 +934,65 @@ mod tests {
             assert!(
                 p.get("has_credentials").is_some(),
                 "{id} missing has_credentials"
+            );
+        }
+    }
+
+    /// Regression for nearai/ironclaw#3734: NEAR AI is dual-auth
+    /// (session token + API key). The configure UI must show the
+    /// API Key input and the "Fetch available models" button even
+    /// though `api_key_required: false` (because session_token alone
+    /// is a valid configuration). PR #3416 collapsed NEAR AI into the
+    /// generic registry path with the SessionToken setup hint, which
+    /// silently flipped both flags off on the wire. Lock in:
+    ///
+    ///   - `accepts_api_key: true` (provider has an api_key_env, so
+    ///     the API key field must be visible)
+    ///   - `can_list_models: true` (SessionToken setup hint propagates
+    ///     the per-provider can_list_models from providers.json)
+    ///
+    /// Also covers the corollary that providers without an api_key_env
+    /// (Bedrock, Codex device-code, Gemini OAuth) emit
+    /// `accepts_api_key: false`.
+    #[tokio::test]
+    async fn test_nearai_configure_ui_flags_3734() {
+        let _env_lock = crate::config::helpers::lock_env();
+        let arr = build_llm_providers(false);
+        let arr = arr.as_array().expect("array");
+
+        let nearai = find_provider(arr, "nearai").expect("nearai");
+        assert_eq!(
+            nearai.get("accepts_api_key").and_then(|v| v.as_bool()),
+            Some(true),
+            "nearai must expose accepts_api_key=true so the configure \
+             UI shows the API Key input (#3734)"
+        );
+        assert_eq!(
+            nearai.get("can_list_models").and_then(|v| v.as_bool()),
+            Some(true),
+            "nearai must expose can_list_models=true so the configure \
+             UI shows the Fetch models button (#3734)"
+        );
+
+        // Sanity-check the corollary: backends with no api_key_env
+        // (Bedrock, OpenAI Codex device-code, Gemini OAuth) must NOT
+        // surface the API Key field.
+        for id in ["bedrock", "openai_codex", "gemini_oauth"] {
+            let p = find_provider(arr, id).unwrap_or_else(|| panic!("{id} should exist"));
+            assert_eq!(
+                p.get("accepts_api_key").and_then(|v| v.as_bool()),
+                Some(false),
+                "{id}: no api_key_env means accepts_api_key must be false"
+            );
+        }
+
+        // Every entry must carry the field so the frontend gate is
+        // never undefined for any provider.
+        for p in arr {
+            let id = p.get("id").and_then(|v| v.as_str()).unwrap_or("<missing>");
+            assert!(
+                p.get("accepts_api_key").is_some(),
+                "{id} missing accepts_api_key"
             );
         }
     }


### PR DESCRIPTION
## Summary

Fixes #3734 — in v0.28.2 the Settings → Inference configure dialog for NEAR AI was missing the API Key input and "Fetch available models" button, leaving only Base URL + Default Model + Save/Test/Cancel.

**Root cause**: PR #3416 moved NEAR AI from a dedicated-config backend into the generic registry path with `SetupHint::SessionToken` + `api_key_required: false`. Two UI gates flipped off as a side effect:

- The frontend hid `provider-api-key-row` because it read `api_key_required: false` as "no API key field at all" — but NEAR AI is **dual-auth** (`NEARAI_SESSION_TOKEN` OR `NEARAI_API_KEY`).
- The frontend hid `fetch-models-btn` because `SetupHint::SessionToken::can_list_models()` was hardcoded to `false` with no field to opt back in.

**Fix**: Decouple "API key is required" from "UI should show the API key input":

- New wire flag `accepts_api_key` on `/api/llm/providers`, derived from `ProviderDefinition::api_key_env.is_some()`. NEAR AI keeps `api_key_required: false` (so a session-token-only host stays "configured" in `isProviderConfigured`), but `accepts_api_key: true` re-exposes the input.
- `SetupHint::SessionToken` gains a `can_list_models: bool` field (`#[serde(default)]`); `providers.json` sets it to `true` for NEAR AI.
- Frontend gates `provider-api-key-row` on `accepts_api_key`, with a fallback to the old `api_key_required` for stale-cached payloads.

## Changes

- `crates/ironclaw_llm/src/registry.rs` — add `can_list_models` to `SetupHint::SessionToken`; thread through `can_list_models()` accessor.
- `providers.json` — NEAR AI setup gets `"can_list_models": true`.
- `src/channels/web/handlers/llm.rs` — emit `accepts_api_key` per provider.
- `crates/ironclaw_gateway/static/js/surfaces/config.js` — `configureBuiltinProvider` reads `accepts_api_key` (with fallback) instead of `api_key_required`.

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Fixes #3734 

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
