### PR TITLE
[codex] refactor Reborn secret-store wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4792,6 +4792,7 @@ dependencies = [
  "chrono",
  "deadpool-postgres",
  "hkdf",
+ "ironclaw_filesystem",
  "ironclaw_host_api",
  "libsql",
  "rand 0.8.6",

--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -7,7 +7,8 @@ use crate::backend::{EventRecord, StorageTxn};
 use crate::{
     BackendCapabilities, BackendId, BackendKind, Capability, CasExpectation, ContentKind, DirEntry,
     Entry, FileStat, FilesystemError, Filter, IndexPolicy, IndexSpec, Page, RecordVersion,
-    RootFilesystem, SeqNo, StorageClass, VersionedEntry, path_prefix_matches,
+    RootFilesystem, SeqNo, StorageClass, VersionedEntry, VersionedIndexedEntry,
+    path_prefix_matches,
 };
 
 /// Trusted catalog record for one virtual filesystem mount.
@@ -250,6 +251,18 @@ impl RootFilesystem for CompositeRootFilesystem {
             .await
     }
 
+    async fn query_indexed(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedIndexedEntry>, FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .query_indexed(path, filter, page)
+            .await
+    }
+
     async fn ensure_index(
         &self,
         path: &VirtualPath,
@@ -312,6 +325,17 @@ impl RootFilesystem for CompositeRootFilesystem {
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.matching_mount(path)?.backend.delete(path).await
+    }
+
+    async fn delete_if_version(
+        &self,
+        path: &VirtualPath,
+        version: RecordVersion,
+    ) -> Result<(), FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .delete_if_version(path, version)
+            .await
     }
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {

--- a/crates/ironclaw_filesystem/src/encrypted.rs
+++ b/crates/ironclaw_filesystem/src/encrypted.rs
@@ -1,0 +1,327 @@
+//! Encryption-at-rest decorator for [`RootFilesystem`] backends.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_host_api::VirtualPath;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BackendCapabilities, Capability, CasExpectation, DirEntry, Entry, FilesystemError,
+    FilesystemOperation, Filter, IndexValue, RecordVersion, RootFilesystem, SeqNo, TxnCapability,
+    VersionedEntry,
+};
+use crate::{EventRecord, FileStat, IndexSpec, Page};
+
+const ENCRYPTED_BYTES_VERSION: u8 = 1;
+
+pub trait EntryCipher: Send + Sync {
+    fn encrypt_entry_bytes(
+        &self,
+        plaintext: &[u8],
+        aad: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>), String>;
+
+    fn decrypt_entry_bytes(
+        &self,
+        ciphertext: &[u8],
+        salt: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, String>;
+}
+
+#[derive(Debug)]
+pub struct EncryptedBackend<F, C> {
+    inner: Arc<F>,
+    cipher: Arc<C>,
+}
+
+impl<F, C> EncryptedBackend<F, C> {
+    pub fn new(inner: Arc<F>, cipher: Arc<C>) -> Self {
+        Self { inner, cipher }
+    }
+}
+
+#[async_trait]
+impl<F, C> RootFilesystem for EncryptedBackend<F, C>
+where
+    F: RootFilesystem + 'static,
+    C: EntryCipher + 'static,
+{
+    fn capabilities(&self) -> BackendCapabilities {
+        let inner = self.inner.capabilities();
+        let mut capabilities = BackendCapabilities::empty();
+        for capability in inner
+            .iter()
+            .filter(|capability| *capability != Capability::Events)
+        {
+            capabilities = capabilities.with(capability);
+        }
+        let txn = match inner.txn() {
+            TxnCapability::None => TxnCapability::None,
+            TxnCapability::Cas | TxnCapability::MultiKey => TxnCapability::Cas,
+        };
+        capabilities.with_txn(txn)
+    }
+
+    async fn put(
+        &self,
+        path: &VirtualPath,
+        entry: Entry,
+        cas: CasExpectation,
+    ) -> Result<RecordVersion, FilesystemError> {
+        let entry = self.encrypt_entry(path, entry, FilesystemOperation::WriteFile)?;
+        self.inner.put(path, entry, cas).await
+    }
+
+    async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+        let Some(versioned) = self.inner.get(path).await? else {
+            return Ok(None);
+        };
+        self.decrypt_versioned_entry(versioned, FilesystemOperation::ReadFile)
+            .map(Some)
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.inner.list_dir(path).await
+    }
+
+    async fn query(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        let entries = self.inner.query(path, filter, page).await?;
+        entries
+            .into_iter()
+            .map(|entry| self.decrypt_versioned_entry(entry, FilesystemOperation::Query))
+            .collect()
+    }
+
+    async fn ensure_index(
+        &self,
+        path: &VirtualPath,
+        spec: &IndexSpec,
+    ) -> Result<(), FilesystemError> {
+        self.inner.ensure_index(path, spec).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn append(
+        &self,
+        path: &VirtualPath,
+        _payload: Vec<u8>,
+    ) -> Result<SeqNo, FilesystemError> {
+        Err(FilesystemError::Unsupported {
+            path: path.clone(),
+            operation: FilesystemOperation::Tail,
+        })
+    }
+
+    async fn tail(
+        &self,
+        path: &VirtualPath,
+        _from: SeqNo,
+    ) -> Result<Vec<EventRecord>, FilesystemError> {
+        Err(FilesystemError::Unsupported {
+            path: path.clone(),
+            operation: FilesystemOperation::Tail,
+        })
+    }
+}
+
+impl<F, C> EncryptedBackend<F, C>
+where
+    C: EntryCipher,
+{
+    fn encrypt_entry(
+        &self,
+        path: &VirtualPath,
+        mut entry: Entry,
+        operation: FilesystemOperation,
+    ) -> Result<Entry, FilesystemError> {
+        entry.body = self.encrypt_bytes(path, "body", entry.body, operation)?;
+        for (key, value) in entry.indexed.iter_mut() {
+            if let IndexValue::Bytes(bytes) = value {
+                *bytes = self.encrypt_bytes(
+                    path,
+                    &format!("indexed:{}", key.as_str()),
+                    bytes.clone(),
+                    operation,
+                )?;
+            }
+        }
+        Ok(entry)
+    }
+
+    fn decrypt_versioned_entry(
+        &self,
+        mut versioned: VersionedEntry,
+        operation: FilesystemOperation,
+    ) -> Result<VersionedEntry, FilesystemError> {
+        versioned.entry.body =
+            self.decrypt_bytes(&versioned.path, "body", &versioned.entry.body, operation)?;
+        for (key, value) in versioned.entry.indexed.iter_mut() {
+            if let IndexValue::Bytes(bytes) = value {
+                *bytes = self.decrypt_bytes(
+                    &versioned.path,
+                    &format!("indexed:{}", key.as_str()),
+                    bytes,
+                    operation,
+                )?;
+            }
+        }
+        Ok(versioned)
+    }
+
+    fn encrypt_bytes(
+        &self,
+        path: &VirtualPath,
+        component: &str,
+        plaintext: Vec<u8>,
+        operation: FilesystemOperation,
+    ) -> Result<Vec<u8>, FilesystemError> {
+        let aad = encrypted_entry_aad(path, component);
+        let (ciphertext, salt) = self
+            .cipher
+            .encrypt_entry_bytes(&plaintext, &aad)
+            .map_err(|reason| encrypted_backend_error(path, operation, reason))?;
+        let envelope = EncryptedBytes {
+            version: ENCRYPTED_BYTES_VERSION,
+            salt,
+            ciphertext,
+        };
+        serde_json::to_vec(&envelope).map_err(|error| {
+            encrypted_backend_error(
+                path,
+                operation,
+                format!("serialize encrypted entry: {error}"),
+            )
+        })
+    }
+
+    fn decrypt_bytes(
+        &self,
+        path: &VirtualPath,
+        component: &str,
+        encrypted: &[u8],
+        operation: FilesystemOperation,
+    ) -> Result<Vec<u8>, FilesystemError> {
+        let envelope: EncryptedBytes = serde_json::from_slice(encrypted).map_err(|error| {
+            encrypted_backend_error(path, operation, format!("parse encrypted entry: {error}"))
+        })?;
+        if envelope.version != ENCRYPTED_BYTES_VERSION {
+            return Err(encrypted_backend_error(
+                path,
+                operation,
+                "unsupported encrypted entry version".to_string(),
+            ));
+        }
+        let aad = encrypted_entry_aad(path, component);
+        self.cipher
+            .decrypt_entry_bytes(&envelope.ciphertext, &envelope.salt, &aad)
+            .map_err(|reason| encrypted_backend_error(path, operation, reason))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EncryptedBytes {
+    version: u8,
+    salt: Vec<u8>,
+    ciphertext: Vec<u8>,
+}
+
+fn encrypted_entry_aad(path: &VirtualPath, component: &str) -> Vec<u8> {
+    format!(
+        "ironclaw_filesystem:encrypted-entry:v1\0{}\0{}",
+        path.as_str(),
+        component
+    )
+    .into_bytes()
+}
+
+fn encrypted_backend_error(
+    path: &VirtualPath,
+    operation: FilesystemOperation,
+    reason: String,
+) -> FilesystemError {
+    FilesystemError::Backend {
+        path: path.clone(),
+        operation,
+        reason: format!("encrypted filesystem backend error: {reason}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ironclaw_host_api::VirtualPath;
+
+    use super::*;
+    use crate::{Entry, InMemoryBackend};
+
+    #[derive(Debug)]
+    struct XorCipher;
+
+    impl EntryCipher for XorCipher {
+        fn encrypt_entry_bytes(
+            &self,
+            plaintext: &[u8],
+            aad: &[u8],
+        ) -> Result<(Vec<u8>, Vec<u8>), String> {
+            Ok((xor(plaintext, aad), vec![1]))
+        }
+
+        fn decrypt_entry_bytes(
+            &self,
+            ciphertext: &[u8],
+            _salt: &[u8],
+            aad: &[u8],
+        ) -> Result<Vec<u8>, String> {
+            Ok(xor(ciphertext, aad))
+        }
+    }
+
+    #[tokio::test]
+    async fn encrypted_backend_hides_body_from_inner_backend() {
+        let inner = Arc::new(InMemoryBackend::new());
+        let backend = EncryptedBackend::new(Arc::clone(&inner), Arc::new(XorCipher));
+        let path = VirtualPath::new("/secrets/record.json").unwrap();
+        backend
+            .put(
+                &path,
+                Entry::record(
+                    crate::RecordKind::new("secret_record").unwrap(),
+                    &serde_json::json!({"value":"sk-test"}),
+                )
+                .unwrap(),
+                CasExpectation::Absent,
+            )
+            .await
+            .unwrap();
+
+        let raw = inner.get(&path).await.unwrap().unwrap();
+        assert!(!String::from_utf8_lossy(&raw.entry.body).contains("sk-test"));
+
+        let decrypted = backend.get(&path).await.unwrap().unwrap();
+        let parsed: serde_json::Value = decrypted.entry.parse_json().unwrap();
+        assert_eq!(parsed["value"], "sk-test");
+    }
+
+    fn xor(bytes: &[u8], aad: &[u8]) -> Vec<u8> {
+        bytes
+            .iter()
+            .enumerate()
+            .map(|(index, byte)| byte ^ aad[index % aad.len()])
+            .collect()
+    }
+}

--- a/crates/ironclaw_filesystem/src/encrypted.rs
+++ b/crates/ironclaw_filesystem/src/encrypted.rs
@@ -9,25 +9,39 @@ use serde::{Deserialize, Serialize};
 use crate::{
     BackendCapabilities, Capability, CasExpectation, DirEntry, Entry, FilesystemError,
     FilesystemOperation, Filter, IndexValue, RecordVersion, RootFilesystem, SeqNo, TxnCapability,
-    VersionedEntry,
+    VersionedEntry, VersionedIndexedEntry,
 };
 use crate::{EventRecord, FileStat, IndexSpec, Page};
 
 const ENCRYPTED_BYTES_VERSION: u8 = 1;
+
+#[derive(Debug, thiserror::Error)]
+#[error("{reason}")]
+pub struct EntryCipherError {
+    reason: String,
+}
+
+impl EntryCipherError {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
 
 pub trait EntryCipher: Send + Sync {
     fn encrypt_entry_bytes(
         &self,
         plaintext: &[u8],
         aad: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>), String>;
+    ) -> Result<(Vec<u8>, Vec<u8>), EntryCipherError>;
 
     fn decrypt_entry_bytes(
         &self,
         ciphertext: &[u8],
         salt: &[u8],
         aad: &[u8],
-    ) -> Result<Vec<u8>, String>;
+    ) -> Result<Vec<u8>, EntryCipherError>;
 }
 
 #[derive(Debug)]
@@ -92,10 +106,36 @@ where
         filter: &Filter,
         page: Page,
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+        if filter_contains_bytes(filter) {
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::Query,
+            });
+        }
         let entries = self.inner.query(path, filter, page).await?;
         entries
             .into_iter()
             .map(|entry| self.decrypt_versioned_entry(entry, FilesystemOperation::Query))
+            .collect()
+    }
+
+    async fn query_indexed(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedIndexedEntry>, FilesystemError> {
+        if filter_contains_bytes(filter) {
+            return Err(FilesystemError::Unsupported {
+                path: path.clone(),
+                operation: FilesystemOperation::Query,
+            });
+        }
+        self.inner
+            .query_indexed(path, filter, page)
+            .await?
+            .into_iter()
+            .map(|entry| self.decrypt_indexed_entry(entry, FilesystemOperation::Query))
             .collect()
     }
 
@@ -113,6 +153,14 @@ where
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         self.inner.delete(path).await
+    }
+
+    async fn delete_if_version(
+        &self,
+        path: &VirtualPath,
+        version: RecordVersion,
+    ) -> Result<(), FilesystemError> {
+        self.inner.delete_if_version(path, version).await
     }
 
     async fn append(
@@ -170,6 +218,24 @@ where
         versioned.entry.body =
             self.decrypt_bytes(&versioned.path, "body", &versioned.entry.body, operation)?;
         for (key, value) in versioned.entry.indexed.iter_mut() {
+            if let IndexValue::Bytes(bytes) = value {
+                *bytes = self.decrypt_bytes(
+                    &versioned.path,
+                    &format!("indexed:{}", key.as_str()),
+                    bytes,
+                    operation,
+                )?;
+            }
+        }
+        Ok(versioned)
+    }
+
+    fn decrypt_indexed_entry(
+        &self,
+        mut versioned: VersionedIndexedEntry,
+        operation: FilesystemOperation,
+    ) -> Result<VersionedIndexedEntry, FilesystemError> {
+        for (key, value) in versioned.indexed.iter_mut() {
             if let IndexValue::Bytes(bytes) = value {
                 *bytes = self.decrypt_bytes(
                     &versioned.path,
@@ -251,12 +317,25 @@ fn encrypted_entry_aad(path: &VirtualPath, component: &str) -> Vec<u8> {
 fn encrypted_backend_error(
     path: &VirtualPath,
     operation: FilesystemOperation,
-    reason: String,
+    error: impl std::fmt::Display,
 ) -> FilesystemError {
     FilesystemError::Backend {
         path: path.clone(),
         operation,
-        reason: format!("encrypted filesystem backend error: {reason}"),
+        reason: format!("encrypted filesystem backend error: {error}"),
+    }
+}
+
+fn filter_contains_bytes(filter: &Filter) -> bool {
+    match filter {
+        Filter::All => false,
+        Filter::Eq { value, .. } | Filter::PrefixOn { value, .. } => {
+            matches!(value, IndexValue::Bytes(_))
+        }
+        Filter::Range { lo, hi, .. } => {
+            matches!(lo, IndexValue::Bytes(_)) || matches!(hi, IndexValue::Bytes(_))
+        }
+        Filter::And(filters) | Filter::Or(filters) => filters.iter().any(filter_contains_bytes),
     }
 }
 
@@ -277,7 +356,7 @@ mod tests {
             &self,
             plaintext: &[u8],
             aad: &[u8],
-        ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        ) -> Result<(Vec<u8>, Vec<u8>), EntryCipherError> {
             Ok((xor(plaintext, aad), vec![1]))
         }
 
@@ -286,7 +365,7 @@ mod tests {
             ciphertext: &[u8],
             _salt: &[u8],
             aad: &[u8],
-        ) -> Result<Vec<u8>, String> {
+        ) -> Result<Vec<u8>, EntryCipherError> {
             Ok(xor(ciphertext, aad))
         }
     }
@@ -315,6 +394,66 @@ mod tests {
         let decrypted = backend.get(&path).await.unwrap().unwrap();
         let parsed: serde_json::Value = decrypted.entry.parse_json().unwrap();
         assert_eq!(parsed["value"], "sk-test");
+    }
+
+    #[tokio::test]
+    async fn encrypted_backend_encrypts_indexed_bytes_and_decrypts_indexed_query_results() {
+        let inner = Arc::new(InMemoryBackend::new());
+        let backend = EncryptedBackend::new(Arc::clone(&inner), Arc::new(XorCipher));
+        let path = VirtualPath::new("/secrets/record.json").unwrap();
+        let bytes_key = crate::IndexKey::new("secret_bytes").unwrap();
+        let kind_key = crate::IndexKey::new("kind").unwrap();
+        let entry = Entry::record(
+            crate::RecordKind::new("secret_record").unwrap(),
+            &serde_json::json!({"value":"metadata-only"}),
+        )
+        .unwrap()
+        .with_indexed(bytes_key.clone(), IndexValue::Bytes(b"sk-test".to_vec()))
+        .with_indexed(kind_key.clone(), IndexValue::Text("secret".to_string()));
+        backend
+            .put(&path, entry, CasExpectation::Absent)
+            .await
+            .unwrap();
+
+        let raw = inner.get(&path).await.unwrap().unwrap();
+        let Some(IndexValue::Bytes(raw_indexed)) = raw.entry.indexed.get(&bytes_key) else {
+            panic!("indexed byte projection must be present");
+        };
+        assert!(
+            !raw_indexed
+                .windows(b"sk-test".len())
+                .any(|w| w == b"sk-test")
+        );
+
+        let indexed = backend
+            .query_indexed(
+                &VirtualPath::new("/secrets").unwrap(),
+                &Filter::Eq {
+                    key: kind_key,
+                    value: IndexValue::Text("secret".to_string()),
+                },
+                Page::first(10),
+            )
+            .await
+            .unwrap();
+        assert_eq!(indexed.len(), 1);
+        assert_eq!(
+            indexed[0].indexed.get(&bytes_key),
+            Some(&IndexValue::Bytes(b"sk-test".to_vec()))
+        );
+
+        let err = backend
+            .query(
+                &VirtualPath::new("/secrets").unwrap(),
+                &Filter::Eq {
+                    key: bytes_key,
+                    value: IndexValue::Bytes(b"sk-test".to_vec()),
+                },
+                Page::first(10),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FilesystemError::Unsupported { .. }));
     }
 
     fn xor(bytes: &[u8], aad: &[u8]) -> Vec<u8> {

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -139,6 +139,31 @@ impl RootFilesystem for InMemoryBackend {
         Ok(())
     }
 
+    async fn delete_if_version(
+        &self,
+        path: &VirtualPath,
+        version: RecordVersion,
+    ) -> Result<(), FilesystemError> {
+        let mut state = self.state.lock().await;
+        let Some(current) = state.entries.get(path.as_str()).map(|entry| entry.version) else {
+            return Err(FilesystemError::NotFound {
+                path: path.clone(),
+                operation: FilesystemOperation::Delete,
+            });
+        };
+        if current != version {
+            return Err(FilesystemError::VersionMismatch {
+                path: path.clone(),
+                expected: Some(version),
+                found: Some(current),
+            });
+        }
+        state.entries.remove(path.as_str());
+        let prefix = with_trailing_slash(path.as_str());
+        state.entries.retain(|key, _| !key.starts_with(&prefix));
+        Ok(())
+    }
+
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
         let state = self.state.lock().await;
         let prefix = with_trailing_slash(path.as_str());

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -19,6 +19,7 @@ mod backend;
 mod catalog;
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 mod db;
+mod encrypted;
 mod in_memory;
 mod index;
 #[cfg(feature = "libsql")]
@@ -33,6 +34,7 @@ mod types;
 
 pub use backend::{EventRecord, StorageTxn};
 pub use catalog::{CompositeRootFilesystem, FilesystemCatalog, MountDescriptor, PathPlacement};
+pub use encrypted::{EncryptedBackend, EntryCipher};
 pub use in_memory::InMemoryBackend;
 pub use index::{Filter, IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, Page};
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -34,7 +34,7 @@ mod types;
 
 pub use backend::{EventRecord, StorageTxn};
 pub use catalog::{CompositeRootFilesystem, FilesystemCatalog, MountDescriptor, PathPlacement};
-pub use encrypted::{EncryptedBackend, EntryCipher};
+pub use encrypted::{EncryptedBackend, EntryCipher, EntryCipherError};
 pub use in_memory::InMemoryBackend;
 pub use index::{Filter, IndexKey, IndexKind, IndexName, IndexSpec, IndexValue, Page};
 #[cfg(feature = "libsql")]
@@ -44,6 +44,7 @@ pub use local::LocalFilesystem;
 pub use postgres::PostgresRootFilesystem;
 pub use record::{
     CasExpectation, ContentType, Entry, RecordKind, RecordVersion, SeqNo, VersionedEntry,
+    VersionedIndexedEntry,
 };
 pub use root::RootFilesystem;
 pub use scoped::ScopedFilesystem;

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -616,6 +616,32 @@ impl RootFilesystem for LibSqlRootFilesystem {
         Ok(())
     }
 
+    async fn delete_if_version(
+        &self,
+        path: &VirtualPath,
+        version: RecordVersion,
+    ) -> Result<(), FilesystemError> {
+        let conn = self.connect().await?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM root_filesystem_entries WHERE path = ?1 AND is_dir = 0 AND version = ?2",
+                libsql::params![path.as_str(), version.get() as i64],
+            )
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Delete, error))?;
+        if deleted != 0 {
+            return Ok(());
+        }
+        match self.current_version(path).await? {
+            Some(found) => Err(FilesystemError::VersionMismatch {
+                path: path.clone(),
+                expected: Some(version),
+                found: Some(found),
+            }),
+            None => Err(not_found(path.clone(), FilesystemOperation::Delete)),
+        }
+    }
+
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let conn = self.connect().await?;
         let transaction = conn.transaction().await.map_err(|error| {

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -538,6 +538,32 @@ impl RootFilesystem for PostgresRootFilesystem {
         Ok(())
     }
 
+    async fn delete_if_version(
+        &self,
+        path: &VirtualPath,
+        version: RecordVersion,
+    ) -> Result<(), FilesystemError> {
+        let client = self.client().await?;
+        let deleted = client
+            .execute(
+                "DELETE FROM root_filesystem_entries WHERE path = $1 AND is_dir = FALSE AND version = $2",
+                &[&path.as_str(), &(version.get() as i64)],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::Delete, error))?;
+        if deleted != 0 {
+            return Ok(());
+        }
+        match self.current_version_with_client(&client, path).await? {
+            Some(found) => Err(FilesystemError::VersionMismatch {
+                path: path.clone(),
+                expected: Some(version),
+                found: Some(found),
+            }),
+            None => Err(not_found(path.clone(), FilesystemOperation::Delete)),
+        }
+    }
+
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let mut client = self.client().await?;
         let transaction = client

--- a/crates/ironclaw_filesystem/src/record.rs
+++ b/crates/ironclaw_filesystem/src/record.rs
@@ -349,6 +349,18 @@ pub struct VersionedEntry {
     pub version: RecordVersion,
 }
 
+/// Query result carrying only indexed projections and version metadata.
+///
+/// Consumers that need listing or routing metadata can avoid fetching large or
+/// sensitive entry bodies. Encrypted backends still decrypt any
+/// [`IndexValue::Bytes`](crate::IndexValue) projections before returning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionedIndexedEntry {
+    pub path: ironclaw_host_api::VirtualPath,
+    pub indexed: BTreeMap<IndexKey, IndexValue>,
+    pub version: RecordVersion,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -5,6 +5,7 @@ use crate::backend::{EventRecord, StorageTxn};
 use crate::{
     BackendCapabilities, CasExpectation, DirEntry, Entry, FileStat, FilesystemError,
     FilesystemOperation, Filter, IndexSpec, Page, RecordVersion, SeqNo, VersionedEntry,
+    VersionedIndexedEntry,
 };
 
 /// Unified filesystem interface over canonical virtual paths.
@@ -97,6 +98,28 @@ pub trait RootFilesystem: Send + Sync {
         unsupported(path, FilesystemOperation::Query)
     }
 
+    /// Filtered query returning only indexed projections and versions.
+    ///
+    /// Default implementation delegates to [`query`](Self::query) and drops
+    /// bodies. Backends may override to avoid loading entry bodies at all.
+    async fn query_indexed(
+        &self,
+        path: &VirtualPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedIndexedEntry>, FilesystemError> {
+        Ok(self
+            .query(path, filter, page)
+            .await?
+            .into_iter()
+            .map(|entry| VersionedIndexedEntry {
+                path: entry.path,
+                indexed: entry.entry.indexed,
+                version: entry.version,
+            })
+            .collect())
+    }
+
     /// Declare an index on a mount prefix. Idempotent: re-declaring the same
     /// spec is a no-op; declaring a conflicting spec returns
     /// [`FilesystemError::IndexConflict`].
@@ -120,6 +143,19 @@ pub trait RootFilesystem: Send + Sync {
             operation: FilesystemOperation::Delete,
             reason: "delete is not supported by this backend".to_string(),
         })
+    }
+
+    /// Delete an existing entry only if it still has the supplied version.
+    ///
+    /// This is the delete-side CAS companion to [`put`](Self::put). Stores use
+    /// it for one-shot consume paths where an unconditional delete could remove
+    /// a value that was overwritten after the caller validated an older entry.
+    async fn delete_if_version(
+        &self,
+        path: &VirtualPath,
+        _version: RecordVersion,
+    ) -> Result<(), FilesystemError> {
+        unsupported(path, FilesystemOperation::Delete)
     }
 
     // ─── Atomicity ────────────────────────────────────────────────────────

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -5,7 +5,7 @@ use ironclaw_host_api::{MountPermissions, MountView, ScopedPath, VirtualPath};
 use crate::backend::{EventRecord, StorageTxn};
 use crate::{
     CasExpectation, DirEntry, Entry, FileStat, FilesystemError, FilesystemOperation, Filter,
-    IndexSpec, Page, RecordVersion, RootFilesystem, SeqNo, VersionedEntry,
+    IndexSpec, Page, RecordVersion, RootFilesystem, SeqNo, VersionedEntry, VersionedIndexedEntry,
 };
 
 /// Invocation-scoped filesystem view over [`ScopedPath`] values.
@@ -60,6 +60,17 @@ where
     ) -> Result<Vec<VersionedEntry>, FilesystemError> {
         let virtual_path = self.resolve_with_permission(prefix, FilesystemOperation::Query)?;
         self.root.query(&virtual_path, filter, page).await
+    }
+
+    /// Filtered query over `prefix`, returning only indexed projections.
+    pub async fn query_indexed(
+        &self,
+        prefix: &ScopedPath,
+        filter: &Filter,
+        page: Page,
+    ) -> Result<Vec<VersionedIndexedEntry>, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(prefix, FilesystemOperation::Query)?;
+        self.root.query_indexed(&virtual_path, filter, page).await
     }
 
     /// Declare an index on the mount under `prefix`.
@@ -169,6 +180,15 @@ where
     pub async fn delete(&self, path: &ScopedPath) -> Result<(), FilesystemError> {
         let virtual_path = self.resolve_with_permission(path, FilesystemOperation::Delete)?;
         self.root.delete(&virtual_path).await
+    }
+
+    pub async fn delete_if_version(
+        &self,
+        path: &ScopedPath,
+        version: crate::RecordVersion,
+    ) -> Result<(), FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::Delete)?;
+        self.root.delete_if_version(&virtual_path, version).await
     }
 
     /// **DEPRECATED — the unified entry plane infers directories from path

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -251,7 +251,6 @@ async fn build_libsql_production(
 ) -> Result<RebornServices, RebornBuildError> {
     use ironclaw_authorization::LibSqlCapabilityLeaseStore;
     use ironclaw_filesystem::LibSqlRootFilesystem;
-    use ironclaw_secrets::{LibSqlSecretsStore, ScopedSecretsStoreAdapter};
 
     let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&db)));
     filesystem.run_migrations().await?;
@@ -259,16 +258,8 @@ async fn build_libsql_production(
     let leases = Arc::new(LibSqlCapabilityLeaseStore::new(Arc::clone(&db)));
     leases.run_migrations().await?;
 
-    let secret_crypto = Arc::new(ironclaw_secrets::SecretsCrypto::new(secret_master_key)?);
-    let legacy_secret_store = Arc::new(LibSqlSecretsStore::new(
-        Arc::clone(&db),
-        Arc::clone(&secret_crypto),
-    ));
-    legacy_secret_store.run_migrations().await?;
-    legacy_secret_store
-        .verify_can_decrypt_existing_secrets()
-        .await?;
-    let secret_store = Arc::new(ScopedSecretsStoreAdapter::new(legacy_secret_store));
+    let secret_store =
+        crate::secret_store::build_libsql_secret_store(Arc::clone(&db), secret_master_key).await?;
 
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Libsql {
         path_or_url,
@@ -320,7 +311,6 @@ async fn build_postgres_production(
 ) -> Result<RebornServices, RebornBuildError> {
     use ironclaw_authorization::PostgresCapabilityLeaseStore;
     use ironclaw_filesystem::PostgresRootFilesystem;
-    use ironclaw_secrets::{PostgresSecretsStore, ScopedSecretsStoreAdapter};
 
     let filesystem = Arc::new(PostgresRootFilesystem::new(pool.clone()));
     filesystem.run_migrations().await?;
@@ -328,13 +318,8 @@ async fn build_postgres_production(
     let leases = Arc::new(PostgresCapabilityLeaseStore::new(pool.clone()));
     leases.run_migrations().await?;
 
-    let secret_crypto = Arc::new(ironclaw_secrets::SecretsCrypto::new(secret_master_key)?);
-    let legacy_secret_store = Arc::new(PostgresSecretsStore::new(pool.clone(), secret_crypto));
-    legacy_secret_store.run_migrations().await?;
-    legacy_secret_store
-        .verify_can_decrypt_existing_secrets()
-        .await?;
-    let secret_store = Arc::new(ScopedSecretsStoreAdapter::new(legacy_secret_store));
+    let secret_store =
+        crate::secret_store::build_postgres_secret_store(pool.clone(), secret_master_key).await?;
 
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Postgres { url };
 

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -259,7 +259,8 @@ async fn build_libsql_production(
     leases.run_migrations().await?;
 
     let secret_store =
-        crate::secret_store::build_libsql_secret_store(Arc::clone(&db), secret_master_key).await?;
+        crate::secret_store::build_libsql_secret_store(Arc::clone(&filesystem), secret_master_key)
+            .await?;
 
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Libsql {
         path_or_url,
@@ -318,8 +319,11 @@ async fn build_postgres_production(
     let leases = Arc::new(PostgresCapabilityLeaseStore::new(pool.clone()));
     leases.run_migrations().await?;
 
-    let secret_store =
-        crate::secret_store::build_postgres_secret_store(pool.clone(), secret_master_key).await?;
+    let secret_store = crate::secret_store::build_postgres_secret_store(
+        Arc::clone(&filesystem),
+        secret_master_key,
+    )
+    .await?;
 
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Postgres { url };
 

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -25,6 +25,8 @@ mod profile;
 mod readiness;
 mod runtime;
 mod runtime_input;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+mod secret_store;
 
 pub use error::RebornBuildError;
 pub use factory::{RebornServices, build_reborn_services};
@@ -115,8 +117,6 @@ pub fn reborn_runtime_readiness_snapshot() -> RebornRuntimeReadinessSnapshot {
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use std::sync::Arc;
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use async_trait::async_trait;
 use ironclaw_authorization::CapabilityLeaseError;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_authorization::GrantAuthorizer;
@@ -126,8 +126,6 @@ use ironclaw_extensions::ExtensionRegistry;
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "postgres")]
 use ironclaw_filesystem::PostgresRootFilesystem;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_host_api::{ResourceScope, SecretHandle};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_runtime::{CapabilitySurfaceVersion, HostRuntimeServices};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -145,16 +143,9 @@ use ironclaw_resources::PersistentResourceGovernor;
 use ironclaw_resources::PostgresResourceGovernorStore;
 use ironclaw_resources::ResourceError;
 use ironclaw_run_state::RunStateError;
-#[cfg(feature = "libsql")]
-use ironclaw_secrets::LibSqlSecretsStore;
-#[cfg(feature = "postgres")]
-use ironclaw_secrets::PostgresSecretsStore;
 use ironclaw_secrets::SecretError;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_secrets::{
-    ScopedSecretsStoreAdapter, SecretLease, SecretLeaseId, SecretMaterial, SecretMetadata,
-    SecretStore, SecretStoreError, SecretsCrypto,
-};
+use ironclaw_secrets::SecretMaterial;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_trust::TrustPolicy;
 use ironclaw_turns::TurnError;
@@ -247,8 +238,12 @@ where
     TPolicy: TrustPolicy + 'static,
     TWake: TurnRunWakeNotifier + 'static,
 {
+    let secret_master_key = config
+        .secret_master_key
+        .ok_or(RebornCompositionError::MissingSecretMasterKey)?;
     let secret_store =
-        build_libsql_secret_store(Arc::clone(&config.database), config.secret_master_key).await?;
+        secret_store::build_libsql_secret_store(Arc::clone(&config.database), secret_master_key)
+            .await?;
 
     let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&config.database)));
     filesystem.run_migrations().await?;
@@ -313,8 +308,11 @@ where
     TPolicy: TrustPolicy + 'static,
     TWake: TurnRunWakeNotifier + 'static,
 {
+    let secret_master_key = config
+        .secret_master_key
+        .ok_or(RebornCompositionError::MissingSecretMasterKey)?;
     let secret_store =
-        build_postgres_secret_store(config.pool.clone(), config.secret_master_key).await?;
+        secret_store::build_postgres_secret_store(config.pool.clone(), secret_master_key).await?;
 
     let filesystem = Arc::new(PostgresRootFilesystem::new(config.pool.clone()));
     filesystem.run_migrations().await?;
@@ -363,107 +361,4 @@ where
         .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
 
     Ok(services)
-}
-
-#[cfg(feature = "libsql")]
-async fn build_libsql_secret_store(
-    database: Arc<libsql::Database>,
-    master_key: Option<SecretMaterial>,
-) -> Result<Arc<SharedSecretStore>, RebornCompositionError> {
-    let crypto = secrets_crypto(master_key)?;
-    let backend = Arc::new(LibSqlSecretsStore::new(database, crypto));
-    backend.run_migrations().await?;
-    backend.verify_can_decrypt_existing_secrets().await?;
-    let store: Arc<dyn SecretStore> = Arc::new(ScopedSecretsStoreAdapter::new(backend));
-    Ok(Arc::new(SharedSecretStore::new(store)))
-}
-
-#[cfg(feature = "postgres")]
-async fn build_postgres_secret_store(
-    pool: deadpool_postgres::Pool,
-    master_key: Option<SecretMaterial>,
-) -> Result<Arc<SharedSecretStore>, RebornCompositionError> {
-    let crypto = secrets_crypto(master_key)?;
-    let backend = Arc::new(PostgresSecretsStore::new(pool, crypto));
-    backend.run_migrations().await?;
-    backend.verify_can_decrypt_existing_secrets().await?;
-    let store: Arc<dyn SecretStore> = Arc::new(ScopedSecretsStoreAdapter::new(backend));
-    Ok(Arc::new(SharedSecretStore::new(store)))
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-fn secrets_crypto(
-    master_key: Option<SecretMaterial>,
-) -> Result<Arc<SecretsCrypto>, RebornCompositionError> {
-    let master_key = master_key.ok_or(RebornCompositionError::MissingSecretMasterKey)?;
-    Ok(Arc::new(SecretsCrypto::new(master_key)?))
-}
-
-// TODO(#3571): remove this adapter when the host-runtime services builder
-// accepts `Arc<dyn SecretStore>` directly. Until then, this newtype lets the
-// composition root pass a single concrete `SecretStore` impl to both the
-// substrate wiring and any future per-store adapters.
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-#[derive(Clone)]
-struct SharedSecretStore {
-    inner: Arc<dyn SecretStore>,
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-impl SharedSecretStore {
-    fn new(inner: Arc<dyn SecretStore>) -> Self {
-        Self { inner }
-    }
-}
-
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-#[async_trait]
-impl SecretStore for SharedSecretStore {
-    async fn put(
-        &self,
-        scope: ResourceScope,
-        handle: SecretHandle,
-        material: SecretMaterial,
-    ) -> Result<SecretMetadata, SecretStoreError> {
-        self.inner.put(scope, handle, material).await
-    }
-
-    async fn metadata(
-        &self,
-        scope: &ResourceScope,
-        handle: &SecretHandle,
-    ) -> Result<Option<SecretMetadata>, SecretStoreError> {
-        self.inner.metadata(scope, handle).await
-    }
-
-    async fn lease_once(
-        &self,
-        scope: &ResourceScope,
-        handle: &SecretHandle,
-    ) -> Result<SecretLease, SecretStoreError> {
-        self.inner.lease_once(scope, handle).await
-    }
-
-    async fn consume(
-        &self,
-        scope: &ResourceScope,
-        lease_id: SecretLeaseId,
-    ) -> Result<SecretMaterial, SecretStoreError> {
-        self.inner.consume(scope, lease_id).await
-    }
-
-    async fn revoke(
-        &self,
-        scope: &ResourceScope,
-        lease_id: SecretLeaseId,
-    ) -> Result<SecretLease, SecretStoreError> {
-        self.inner.revoke(scope, lease_id).await
-    }
-
-    async fn leases_for_scope(
-        &self,
-        scope: &ResourceScope,
-    ) -> Result<Vec<SecretLease>, SecretStoreError> {
-        self.inner.leases_for_scope(scope).await
-    }
 }

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -238,15 +238,14 @@ where
     TPolicy: TrustPolicy + 'static,
     TWake: TurnRunWakeNotifier + 'static,
 {
+    let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&config.database)));
+    filesystem.run_migrations().await?;
+
     let secret_master_key = config
         .secret_master_key
         .ok_or(RebornCompositionError::MissingSecretMasterKey)?;
     let secret_store =
-        secret_store::build_libsql_secret_store(Arc::clone(&config.database), secret_master_key)
-            .await?;
-
-    let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&config.database)));
-    filesystem.run_migrations().await?;
+        secret_store::build_libsql_secret_store(Arc::clone(&filesystem), secret_master_key).await?;
 
     let process_services = ProcessServices::filesystem(Arc::clone(&filesystem));
 
@@ -308,14 +307,15 @@ where
     TPolicy: TrustPolicy + 'static,
     TWake: TurnRunWakeNotifier + 'static,
 {
+    let filesystem = Arc::new(PostgresRootFilesystem::new(config.pool.clone()));
+    filesystem.run_migrations().await?;
+
     let secret_master_key = config
         .secret_master_key
         .ok_or(RebornCompositionError::MissingSecretMasterKey)?;
     let secret_store =
-        secret_store::build_postgres_secret_store(config.pool.clone(), secret_master_key).await?;
-
-    let filesystem = Arc::new(PostgresRootFilesystem::new(config.pool.clone()));
-    filesystem.run_migrations().await?;
+        secret_store::build_postgres_secret_store(Arc::clone(&filesystem), secret_master_key)
+            .await?;
 
     let process_services = ProcessServices::filesystem(Arc::clone(&filesystem));
 

--- a/crates/ironclaw_reborn_composition/src/secret_store.rs
+++ b/crates/ironclaw_reborn_composition/src/secret_store.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use ironclaw_filesystem::EncryptedBackend;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "postgres")]
@@ -17,7 +18,8 @@ pub(crate) async fn build_libsql_secret_store(
     master_key: SecretMaterial,
 ) -> Result<Arc<SharedSecretStore>, SecretError> {
     let crypto = Arc::new(SecretsCrypto::new(master_key)?);
-    let backend = Arc::new(FilesystemSecretsStore::over_root(filesystem, crypto)?);
+    let filesystem = Arc::new(EncryptedBackend::new(filesystem, crypto));
+    let backend = Arc::new(FilesystemSecretsStore::over_root(filesystem)?);
     backend.verify_can_decrypt_existing_secrets().await?;
     let store: Arc<dyn SecretStore> = Arc::new(ScopedSecretsStoreAdapter::new(backend));
     Ok(Arc::new(SharedSecretStore::new(store)))
@@ -29,7 +31,8 @@ pub(crate) async fn build_postgres_secret_store(
     master_key: SecretMaterial,
 ) -> Result<Arc<SharedSecretStore>, SecretError> {
     let crypto = Arc::new(SecretsCrypto::new(master_key)?);
-    let backend = Arc::new(FilesystemSecretsStore::over_root(filesystem, crypto)?);
+    let filesystem = Arc::new(EncryptedBackend::new(filesystem, crypto));
+    let backend = Arc::new(FilesystemSecretsStore::over_root(filesystem)?);
     backend.verify_can_decrypt_existing_secrets().await?;
     let store: Arc<dyn SecretStore> = Arc::new(ScopedSecretsStoreAdapter::new(backend));
     Ok(Arc::new(SharedSecretStore::new(store)))

--- a/crates/ironclaw_reborn_composition/src/secret_store.rs
+++ b/crates/ironclaw_reborn_composition/src/secret_store.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{ResourceScope, SecretHandle};
+use ironclaw_secrets::{
+    ScopedSecretsStoreAdapter, SecretError, SecretLease, SecretLeaseId, SecretMaterial,
+    SecretMetadata, SecretStore, SecretStoreError, SecretsCrypto,
+};
+
+#[cfg(feature = "libsql")]
+use ironclaw_secrets::LibSqlSecretsStore;
+#[cfg(feature = "postgres")]
+use ironclaw_secrets::PostgresSecretsStore;
+
+#[cfg(feature = "libsql")]
+pub(crate) async fn build_libsql_secret_store(
+    database: Arc<libsql::Database>,
+    master_key: SecretMaterial,
+) -> Result<Arc<SharedSecretStore>, SecretError> {
+    let crypto = Arc::new(SecretsCrypto::new(master_key)?);
+    let backend = Arc::new(LibSqlSecretsStore::new(database, crypto));
+    backend.run_migrations().await?;
+    backend.verify_can_decrypt_existing_secrets().await?;
+    let store: Arc<dyn SecretStore> = Arc::new(ScopedSecretsStoreAdapter::new(backend));
+    Ok(Arc::new(SharedSecretStore::new(store)))
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) async fn build_postgres_secret_store(
+    pool: deadpool_postgres::Pool,
+    master_key: SecretMaterial,
+) -> Result<Arc<SharedSecretStore>, SecretError> {
+    let crypto = Arc::new(SecretsCrypto::new(master_key)?);
+    let backend = Arc::new(PostgresSecretsStore::new(pool, crypto));
+    backend.run_migrations().await?;
+    backend.verify_can_decrypt_existing_secrets().await?;
+    let store: Arc<dyn SecretStore> = Arc::new(ScopedSecretsStoreAdapter::new(backend));
+    Ok(Arc::new(SharedSecretStore::new(store)))
+}
+
+// TODO(#3571): remove this adapter when the host-runtime services builder
+// accepts `Arc<dyn SecretStore>` directly. Until then, this crate-private
+// newtype keeps low-level `ironclaw_secrets` construction details out of the
+// higher Reborn composition entrypoints.
+#[derive(Clone)]
+pub(crate) struct SharedSecretStore {
+    inner: Arc<dyn SecretStore>,
+}
+
+impl SharedSecretStore {
+    fn new(inner: Arc<dyn SecretStore>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl SecretStore for SharedSecretStore {
+    async fn put(
+        &self,
+        scope: ResourceScope,
+        handle: SecretHandle,
+        material: SecretMaterial,
+    ) -> Result<SecretMetadata, SecretStoreError> {
+        self.inner.put(scope, handle, material).await
+    }
+
+    async fn metadata(
+        &self,
+        scope: &ResourceScope,
+        handle: &SecretHandle,
+    ) -> Result<Option<SecretMetadata>, SecretStoreError> {
+        self.inner.metadata(scope, handle).await
+    }
+
+    async fn lease_once(
+        &self,
+        scope: &ResourceScope,
+        handle: &SecretHandle,
+    ) -> Result<SecretLease, SecretStoreError> {
+        self.inner.lease_once(scope, handle).await
+    }
+
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretMaterial, SecretStoreError> {
+        self.inner.consume(scope, lease_id).await
+    }
+
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: SecretLeaseId,
+    ) -> Result<SecretLease, SecretStoreError> {
+        self.inner.revoke(scope, lease_id).await
+    }
+
+    async fn leases_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<SecretLease>, SecretStoreError> {
+        self.inner.leases_for_scope(scope).await
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/secret_store.rs
+++ b/crates/ironclaw_reborn_composition/src/secret_store.rs
@@ -1,25 +1,23 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+#[cfg(feature = "libsql")]
+use ironclaw_filesystem::LibSqlRootFilesystem;
+#[cfg(feature = "postgres")]
+use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_host_api::{ResourceScope, SecretHandle};
 use ironclaw_secrets::{
-    ScopedSecretsStoreAdapter, SecretError, SecretLease, SecretLeaseId, SecretMaterial,
-    SecretMetadata, SecretStore, SecretStoreError, SecretsCrypto,
+    FilesystemSecretsStore, ScopedSecretsStoreAdapter, SecretError, SecretLease, SecretLeaseId,
+    SecretMaterial, SecretMetadata, SecretStore, SecretStoreError, SecretsCrypto,
 };
 
 #[cfg(feature = "libsql")]
-use ironclaw_secrets::LibSqlSecretsStore;
-#[cfg(feature = "postgres")]
-use ironclaw_secrets::PostgresSecretsStore;
-
-#[cfg(feature = "libsql")]
 pub(crate) async fn build_libsql_secret_store(
-    database: Arc<libsql::Database>,
+    filesystem: Arc<LibSqlRootFilesystem>,
     master_key: SecretMaterial,
 ) -> Result<Arc<SharedSecretStore>, SecretError> {
     let crypto = Arc::new(SecretsCrypto::new(master_key)?);
-    let backend = Arc::new(LibSqlSecretsStore::new(database, crypto));
-    backend.run_migrations().await?;
+    let backend = Arc::new(FilesystemSecretsStore::over_root(filesystem, crypto)?);
     backend.verify_can_decrypt_existing_secrets().await?;
     let store: Arc<dyn SecretStore> = Arc::new(ScopedSecretsStoreAdapter::new(backend));
     Ok(Arc::new(SharedSecretStore::new(store)))
@@ -27,12 +25,11 @@ pub(crate) async fn build_libsql_secret_store(
 
 #[cfg(feature = "postgres")]
 pub(crate) async fn build_postgres_secret_store(
-    pool: deadpool_postgres::Pool,
+    filesystem: Arc<PostgresRootFilesystem>,
     master_key: SecretMaterial,
 ) -> Result<Arc<SharedSecretStore>, SecretError> {
     let crypto = Arc::new(SecretsCrypto::new(master_key)?);
-    let backend = Arc::new(PostgresSecretsStore::new(pool, crypto));
-    backend.run_migrations().await?;
+    let backend = Arc::new(FilesystemSecretsStore::over_root(filesystem, crypto)?);
     backend.verify_can_decrypt_existing_secrets().await?;
     let store: Arc<dyn SecretStore> = Arc::new(ScopedSecretsStoreAdapter::new(backend));
     Ok(Arc::new(SharedSecretStore::new(store)))

--- a/crates/ironclaw_reborn_composition/tests/libsql_substrate.rs
+++ b/crates/ironclaw_reborn_composition/tests/libsql_substrate.rs
@@ -25,7 +25,7 @@ async fn libsql_substrate_builder_wires_production_components_without_local_only
     );
 
     let services = build_libsql_production_host_runtime_services(LibSqlProductionSubstrateConfig {
-        database,
+        database: Arc::clone(&database),
         event_store: RebornEventStoreConfig::Libsql {
             path_or_url: events_db_path.display().to_string(),
             auth_token: None,
@@ -42,6 +42,19 @@ async fn libsql_substrate_builder_wires_production_components_without_local_only
     services
         .validate_production_wiring(&production_config)
         .expect("substrate-only production wiring should not use fake seams");
+
+    let conn = database.connect().unwrap();
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM root_filesystem_entries WHERE path = ?1",
+            libsql::params!["/secrets/key-check/active.json"],
+        )
+        .await
+        .unwrap();
+    assert!(
+        rows.next().await.unwrap().is_some(),
+        "secret readiness sentinel should be stored through root filesystem entries"
+    );
 }
 
 #[tokio::test]
@@ -73,6 +86,49 @@ async fn libsql_substrate_builder_rejects_missing_secret_master_key() {
         result,
         Err(RebornCompositionError::MissingSecretMasterKey)
     ));
+}
+
+#[tokio::test]
+async fn libsql_substrate_builder_rejects_wrong_secret_master_key_from_filesystem_store() {
+    let dir = tempdir().unwrap();
+    let state_db_path = dir.path().join("state.db");
+    let first_events_db_path = dir.path().join("events-a.db");
+    let second_events_db_path = dir.path().join("events-b.db");
+    let database = Arc::new(
+        libsql::Builder::new_local(state_db_path.display().to_string())
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    build_libsql_production_host_runtime_services(LibSqlProductionSubstrateConfig {
+        database: Arc::clone(&database),
+        event_store: RebornEventStoreConfig::Libsql {
+            path_or_url: first_events_db_path.display().to_string(),
+            auth_token: None,
+        },
+        secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
+        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
+        turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
+        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+    })
+    .await
+    .unwrap();
+
+    let result = build_libsql_production_host_runtime_services(LibSqlProductionSubstrateConfig {
+        database,
+        event_store: RebornEventStoreConfig::Libsql {
+            path_or_url: second_events_db_path.display().to_string(),
+            auth_token: None,
+        },
+        secret_master_key: Some(SecretString::from("abcdefghijklmnopqrstuvwxyzABCDEF")),
+        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
+        turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
+        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+    })
+    .await;
+
+    assert!(matches!(result, Err(RebornCompositionError::Secret(_))));
 }
 
 #[derive(Debug)]

--- a/crates/ironclaw_reborn_composition/tests/postgres_substrate.rs
+++ b/crates/ironclaw_reborn_composition/tests/postgres_substrate.rs
@@ -20,7 +20,7 @@ async fn postgres_substrate_builder_wires_production_components_without_local_on
 
     let services =
         build_postgres_production_host_runtime_services(PostgresProductionSubstrateConfig {
-            pool,
+            pool: pool.clone(),
             event_store: RebornEventStoreConfig::Postgres {
                 url: SecretString::from(database_url),
             },
@@ -36,6 +36,19 @@ async fn postgres_substrate_builder_wires_production_components_without_local_on
     services
         .validate_production_wiring(&production_config)
         .expect("postgres substrate production wiring should not use fake seams");
+
+    let client = pool.get().await.unwrap();
+    let row = client
+        .query_opt(
+            "SELECT 1 FROM root_filesystem_entries WHERE path = $1",
+            &[&"/secrets/key-check/active.json"],
+        )
+        .await
+        .unwrap();
+    assert!(
+        row.is_some(),
+        "secret readiness sentinel should be stored through root filesystem entries"
+    );
 }
 
 #[tokio::test]
@@ -61,6 +74,41 @@ async fn postgres_substrate_builder_rejects_missing_secret_master_key() {
         result,
         Err(RebornCompositionError::MissingSecretMasterKey)
     ));
+}
+
+#[tokio::test]
+async fn postgres_substrate_builder_rejects_wrong_secret_master_key_from_filesystem_store() {
+    let Some((_container, pool, database_url)) = postgres_pool_or_skip().await else {
+        return;
+    };
+
+    build_postgres_production_host_runtime_services(PostgresProductionSubstrateConfig {
+        pool: pool.clone(),
+        event_store: RebornEventStoreConfig::Postgres {
+            url: SecretString::from(database_url.clone()),
+        },
+        secret_master_key: Some(SecretString::from("01234567890123456789012345678901")),
+        trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
+        turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
+        surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+    })
+    .await
+    .unwrap();
+
+    let result =
+        build_postgres_production_host_runtime_services(PostgresProductionSubstrateConfig {
+            pool,
+            event_store: RebornEventStoreConfig::Postgres {
+                url: SecretString::from(database_url),
+            },
+            secret_master_key: Some(SecretString::from("abcdefghijklmnopqrstuvwxyzABCDEF")),
+            trust_policy: Arc::new(ironclaw_trust::HostTrustPolicy::fail_closed()),
+            turn_run_wake_notifier: Arc::new(RecordingSchedulerWakeNotifier),
+            surface_version: CapabilitySurfaceVersion::new("test-surface").unwrap(),
+        })
+        .await;
+
+    assert!(matches!(result, Err(RebornCompositionError::Secret(_))));
 }
 
 async fn postgres_pool_or_skip() -> Option<(

--- a/crates/ironclaw_secrets/Cargo.toml
+++ b/crates/ironclaw_secrets/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 deadpool-postgres = { version = "0.14", optional = true }
 hkdf = "0.12"
 ironclaw_host_api = { path = "../ironclaw_host_api" }
+ironclaw_filesystem = { path = "../ironclaw_filesystem" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 rand = "0.8"
 secrecy = "0.10"

--- a/crates/ironclaw_secrets/src/crypto.rs
+++ b/crates/ironclaw_secrets/src/crypto.rs
@@ -102,6 +102,15 @@ impl SecretsCrypto {
         salt: &[u8],
         aad: &[u8],
     ) -> Result<DecryptedSecret, SecretError> {
+        DecryptedSecret::from_bytes(self.decrypt_bytes(encrypted_value, salt, aad)?)
+    }
+
+    pub fn decrypt_bytes(
+        &self,
+        encrypted_value: &[u8],
+        salt: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, SecretError> {
         if encrypted_value.len() < NONCE_SIZE + TAG_SIZE {
             return Err(SecretError::DecryptionFailed(
                 "encrypted value too short".to_string(),
@@ -121,7 +130,7 @@ impl SecretsCrypto {
                 },
             )
             .map_err(|error| SecretError::DecryptionFailed(error.to_string()))?;
-        DecryptedSecret::from_bytes(plaintext)
+        Ok(plaintext)
     }
 
     fn derive_key(&self, salt: &[u8]) -> Result<[u8; KEY_SIZE], SecretError> {
@@ -139,6 +148,27 @@ impl std::fmt::Debug for SecretsCrypto {
             .debug_struct("SecretsCrypto")
             .field("master_key", &"[REDACTED]")
             .finish()
+    }
+}
+
+impl ironclaw_filesystem::EntryCipher for SecretsCrypto {
+    fn encrypt_entry_bytes(
+        &self,
+        plaintext: &[u8],
+        aad: &[u8],
+    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+        self.encrypt(plaintext, aad)
+            .map_err(|error| error.to_string())
+    }
+
+    fn decrypt_entry_bytes(
+        &self,
+        ciphertext: &[u8],
+        salt: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        self.decrypt_bytes(ciphertext, salt, aad)
+            .map_err(|error| error.to_string())
     }
 }
 

--- a/crates/ironclaw_secrets/src/crypto.rs
+++ b/crates/ironclaw_secrets/src/crypto.rs
@@ -156,9 +156,9 @@ impl ironclaw_filesystem::EntryCipher for SecretsCrypto {
         &self,
         plaintext: &[u8],
         aad: &[u8],
-    ) -> Result<(Vec<u8>, Vec<u8>), String> {
+    ) -> Result<(Vec<u8>, Vec<u8>), ironclaw_filesystem::EntryCipherError> {
         self.encrypt(plaintext, aad)
-            .map_err(|error| error.to_string())
+            .map_err(|error| ironclaw_filesystem::EntryCipherError::new(error.to_string()))
     }
 
     fn decrypt_entry_bytes(
@@ -166,9 +166,9 @@ impl ironclaw_filesystem::EntryCipher for SecretsCrypto {
         ciphertext: &[u8],
         salt: &[u8],
         aad: &[u8],
-    ) -> Result<Vec<u8>, String> {
+    ) -> Result<Vec<u8>, ironclaw_filesystem::EntryCipherError> {
         self.decrypt_bytes(ciphertext, salt, aad)
-            .map_err(|error| error.to_string())
+            .map_err(|error| ironclaw_filesystem::EntryCipherError::new(error.to_string()))
     }
 }
 

--- a/crates/ironclaw_secrets/src/filesystem.rs
+++ b/crates/ironclaw_secrets/src/filesystem.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_filesystem::{
-    CasExpectation, Entry, FileType, FilesystemError, RecordKind, RootFilesystem, ScopedFilesystem,
-    VersionedEntry,
+    CasExpectation, Entry, FileType, FilesystemError, Filter, IndexKey, IndexValue, Page,
+    RecordKind, RootFilesystem, ScopedFilesystem, VersionedEntry,
 };
 use ironclaw_host_api::{
     MountAlias, MountGrant, MountPermissions, MountView, ScopedPath, VirtualPath,
@@ -15,31 +15,30 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::crypto::{secret_record_aad, secret_store_key_check_aad};
 use crate::legacy_store::{DecryptedSecret, Secret, SecretRef};
-use crate::{CreateSecretParams, SecretConsumeResult, SecretError, SecretsCrypto, SecretsStore};
+use crate::{CreateSecretParams, SecretConsumeResult, SecretError, SecretsStore};
 
 const SECRET_RECORD_KIND: &str = "secret_record";
 const SECRET_KEY_CHECK_KIND: &str = "secret_store_key_check";
 const SECRET_STORE_KEY_CHECK_ID: &str = "active";
 const SECRET_STORE_KEY_CHECK_PLAINTEXT: &str = "reborn-secret-store-key-check-v1";
+const SECRET_ID_INDEX_KEY: &str = "secret_id";
 
 /// Durable [`SecretsStore`] implementation over the unified Reborn filesystem surface.
 #[derive(Debug)]
 pub struct FilesystemSecretsStore<F> {
     filesystem: ScopedFilesystem<F>,
-    crypto: Arc<SecretsCrypto>,
 }
 
 impl<F> FilesystemSecretsStore<F>
 where
     F: RootFilesystem + 'static,
 {
-    pub fn new(filesystem: ScopedFilesystem<F>, crypto: Arc<SecretsCrypto>) -> Self {
-        Self { filesystem, crypto }
+    pub fn new(filesystem: ScopedFilesystem<F>) -> Self {
+        Self { filesystem }
     }
 
-    pub fn over_root(root: Arc<F>, crypto: Arc<SecretsCrypto>) -> Result<Self, SecretError> {
+    pub fn over_root(root: Arc<F>) -> Result<Self, SecretError> {
         let mounts = MountView::new(vec![MountGrant::new(
             MountAlias::new("/secrets").map_err(secret_filesystem_error)?,
             VirtualPath::new("/secrets").map_err(secret_filesystem_error)?,
@@ -52,21 +51,17 @@ where
             },
         )])
         .map_err(secret_filesystem_error)?;
-        Ok(Self::new(ScopedFilesystem::new(root, mounts), crypto))
+        Ok(Self::new(ScopedFilesystem::new(root, mounts)))
     }
 
     pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
         if let Some(check) = self.get_optional_entry(&key_check_path()?).await? {
             let record: StoredKeyCheck = parse_entry(check)?;
-            return verify_secret_store_key_check(
-                &self.crypto,
-                &record.encrypted_value,
-                &record.key_salt,
-            );
+            return verify_secret_store_key_check(&record);
         }
 
         self.verify_all_secret_payloads().await?;
-        let record = build_key_check_record(&self.crypto)?;
+        let record = build_key_check_record();
         let entry = record_entry(SECRET_KEY_CHECK_KIND, &record)?;
         match self
             .filesystem
@@ -83,7 +78,7 @@ where
             ));
         };
         let record: StoredKeyCheck = parse_entry(check)?;
-        verify_secret_store_key_check(&self.crypto, &record.encrypted_value, &record.key_salt)
+        verify_secret_store_key_check(&record)
     }
 
     async fn get_optional_entry(
@@ -105,14 +100,22 @@ where
         self.get_optional_entry(&record_path(user_id, name)?).await
     }
 
-    async fn get_secret_record(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
+    async fn get_stored_secret_record(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<StoredSecret, SecretError> {
         let name = normalize_secret_name(name);
         let Some(entry) = self.get_secret_entry(user_id, &name).await? else {
             return Err(SecretError::NotFound(name));
         };
-        let secret: Secret = parse_stored_secret(entry)?;
-        ensure_secret_not_expired(&secret)?;
+        let secret: StoredSecret = parse_entry(entry)?;
+        ensure_stored_secret_not_expired(&secret)?;
         Ok(secret)
+    }
+
+    async fn get_secret_record(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
+        Ok(self.get_stored_secret_record(user_id, name).await?.into())
     }
 
     async fn verify_all_secret_payloads(&self) -> Result<(), SecretError> {
@@ -131,10 +134,7 @@ where
                 else {
                     continue;
                 };
-                let secret: Secret = parse_stored_secret(versioned)?;
-                let aad = secret_record_aad(&secret.user_id, &secret.name);
-                self.crypto
-                    .decrypt(&secret.encrypted_value, &secret.key_salt, &aad)?;
+                let _: StoredSecret = parse_entry(versioned)?;
             }
         }
         Ok(())
@@ -162,17 +162,41 @@ where
         user_id: &str,
         params: CreateSecretParams,
     ) -> Result<Secret, SecretError> {
-        let secret = build_encrypted_secret(user_id, params, &self.crypto)?;
-        let entry = record_entry(SECRET_RECORD_KIND, &StoredSecret::from(secret.clone()))?;
-        self.filesystem
-            .put(
-                &record_path(user_id, &secret.name)?,
-                entry,
-                CasExpectation::Any,
-            )
-            .await
-            .map_err(secret_filesystem_error)?;
-        Ok(secret)
+        let name = normalize_secret_name(&params.name);
+        let value = params.value.expose_secret().to_string();
+        let provider = params.provider;
+        let expires_at = params.expires_at;
+        let path = record_path(user_id, &name)?;
+
+        loop {
+            let existing = self.get_optional_entry(&path).await?;
+            let (record, cas) = match existing {
+                Some(versioned) => {
+                    let existing_record: StoredSecret = parse_entry(versioned.clone())?;
+                    (
+                        build_stored_secret(
+                            user_id,
+                            &name,
+                            &value,
+                            provider.clone(),
+                            expires_at,
+                            Some(&existing_record),
+                        ),
+                        CasExpectation::Version(versioned.version),
+                    )
+                }
+                None => (
+                    build_stored_secret(user_id, &name, &value, provider.clone(), expires_at, None),
+                    CasExpectation::Absent,
+                ),
+            };
+            let entry = secret_record_entry(&record)?;
+            match self.filesystem.put(&path, entry, cas).await {
+                Ok(_) => return Ok(record.into()),
+                Err(FilesystemError::VersionMismatch { .. }) => continue,
+                Err(error) => return Err(secret_filesystem_error(error)),
+            }
+        }
     }
 
     async fn get(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
@@ -185,9 +209,8 @@ where
         name: &str,
     ) -> Result<DecryptedSecret, SecretError> {
         let secret = self.get(user_id, name).await?;
-        let aad = secret_record_aad(user_id, &secret.name);
-        self.crypto
-            .decrypt(&secret.encrypted_value, &secret.key_salt, &aad)
+        let record = self.get_stored_secret_record(user_id, &secret.name).await?;
+        DecryptedSecret::from_bytes(record.value.into_bytes())
     }
 
     async fn consume_if_matches(
@@ -200,13 +223,9 @@ where
         let Some(entry) = self.get_secret_entry(user_id, &name).await? else {
             return Ok(SecretConsumeResult::NotFound);
         };
-        let secret: Secret = parse_stored_secret(entry)?;
-        ensure_secret_not_expired(&secret)?;
-        let aad = secret_record_aad(user_id, &secret.name);
-        let decrypted = self
-            .crypto
-            .decrypt(&secret.encrypted_value, &secret.key_salt, &aad)?;
-        if decrypted.expose() != expected_value {
+        let secret: StoredSecret = parse_entry(entry)?;
+        ensure_stored_secret_not_expired(&secret)?;
+        if secret.value != expected_value {
             return Ok(SecretConsumeResult::Mismatched);
         }
         self.filesystem
@@ -244,8 +263,8 @@ where
             else {
                 continue;
             };
-            let secret: Secret = parse_stored_secret(versioned)?;
-            ensure_secret_not_expired(&secret)?;
+            let secret: StoredSecret = parse_entry(versioned)?;
+            ensure_stored_secret_not_expired(&secret)?;
             refs.push(SecretRef {
                 name: secret.name,
                 provider: secret.provider,
@@ -264,39 +283,47 @@ where
     }
 
     async fn record_usage(&self, secret_id: Uuid) -> Result<(), SecretError> {
-        for user_dir in self.list_dir_or_empty(&records_root_path()?).await? {
-            if user_dir.file_type != FileType::Directory {
-                continue;
+        let mut matches = self
+            .filesystem
+            .query(
+                &records_root_path()?,
+                &Filter::Eq {
+                    key: secret_id_index_key()?,
+                    value: IndexValue::Text(secret_id.to_string()),
+                },
+                Page::first(2),
+            )
+            .await
+            .map_err(secret_filesystem_error)?;
+        let Some(mut versioned) = matches.pop() else {
+            return Err(SecretError::NotFound(secret_id.to_string()));
+        };
+
+        loop {
+            let mut secret: StoredSecret = parse_entry(versioned.clone())?;
+            if secret.id != secret_id {
+                return Err(SecretError::NotFound(secret_id.to_string()));
             }
-            let user_records_path = scoped_from_virtual(&user_dir.path)?;
-            for dir_entry in self.list_dir_or_empty(&user_records_path).await? {
-                if dir_entry.file_type != FileType::File {
-                    continue;
+            secret.last_used_at = Some(Utc::now());
+            secret.usage_count += 1;
+            secret.updated_at = Utc::now();
+            let path = scoped_from_virtual(&versioned.path)?;
+            let entry = secret_record_entry(&secret)?;
+            match self
+                .filesystem
+                .put(&path, entry, CasExpectation::Version(versioned.version))
+                .await
+            {
+                Ok(_) => return Ok(()),
+                Err(FilesystemError::VersionMismatch { .. }) => {
+                    let Some(fresh) = self.get_optional_entry(&path).await? else {
+                        return Err(SecretError::NotFound(secret_id.to_string()));
+                    };
+                    versioned = fresh;
                 }
-                let record_path = scoped_from_virtual(&dir_entry.path)?;
-                let Some(versioned) = self.get_optional_entry(&record_path).await? else {
-                    continue;
-                };
-                let mut secret: Secret = parse_stored_secret(versioned.clone())?;
-                if secret.id != secret_id {
-                    continue;
-                }
-                secret.last_used_at = Some(Utc::now());
-                secret.usage_count += 1;
-                secret.updated_at = Utc::now();
-                let entry = record_entry(SECRET_RECORD_KIND, &StoredSecret::from(secret))?;
-                self.filesystem
-                    .put(
-                        &record_path,
-                        entry,
-                        CasExpectation::Version(versioned.version),
-                    )
-                    .await
-                    .map_err(secret_filesystem_error)?;
-                return Ok(());
+                Err(error) => return Err(secret_filesystem_error(error)),
             }
         }
-        Err(SecretError::NotFound(secret_id.to_string()))
     }
 
     async fn is_accessible(
@@ -324,13 +351,12 @@ where
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 struct StoredSecret {
     id: Uuid,
     user_id: String,
     name: String,
-    encrypted_value: Vec<u8>,
-    key_salt: Vec<u8>,
+    value: String,
     provider: Option<String>,
     expires_at: Option<chrono::DateTime<Utc>>,
     last_used_at: Option<chrono::DateTime<Utc>>,
@@ -339,32 +365,14 @@ struct StoredSecret {
     updated_at: chrono::DateTime<Utc>,
 }
 
-impl From<Secret> for StoredSecret {
-    fn from(secret: Secret) -> Self {
-        Self {
-            id: secret.id,
-            user_id: secret.user_id,
-            name: secret.name,
-            encrypted_value: secret.encrypted_value,
-            key_salt: secret.key_salt,
-            provider: secret.provider,
-            expires_at: secret.expires_at,
-            last_used_at: secret.last_used_at,
-            usage_count: secret.usage_count,
-            created_at: secret.created_at,
-            updated_at: secret.updated_at,
-        }
-    }
-}
-
 impl From<StoredSecret> for Secret {
     fn from(record: StoredSecret) -> Self {
         Self {
             id: record.id,
             user_id: record.user_id,
             name: record.name,
-            encrypted_value: record.encrypted_value,
-            key_salt: record.key_salt,
+            encrypted_value: Vec::new(),
+            key_salt: Vec::new(),
             provider: record.provider,
             expires_at: record.expires_at,
             last_used_at: record.last_used_at,
@@ -375,65 +383,49 @@ impl From<StoredSecret> for Secret {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 struct StoredKeyCheck {
-    encrypted_value: Vec<u8>,
-    key_salt: Vec<u8>,
+    value: String,
 }
 
-fn build_encrypted_secret(
+fn build_stored_secret(
     user_id: &str,
-    params: CreateSecretParams,
-    crypto: &SecretsCrypto,
-) -> Result<Secret, SecretError> {
-    let name = normalize_secret_name(&params.name);
-    let aad = secret_record_aad(user_id, &name);
-    let (encrypted_value, key_salt) =
-        crypto.encrypt(params.value.expose_secret().as_bytes(), &aad)?;
+    name: &str,
+    value: &str,
+    provider: Option<String>,
+    expires_at: Option<chrono::DateTime<Utc>>,
+    existing: Option<&StoredSecret>,
+) -> StoredSecret {
     let now = Utc::now();
-    Ok(Secret {
-        id: Uuid::new_v4(),
+    StoredSecret {
+        id: existing
+            .map(|secret| secret.id)
+            .unwrap_or_else(Uuid::new_v4),
         user_id: user_id.to_string(),
-        name,
-        encrypted_value,
-        key_salt,
-        provider: params.provider,
-        expires_at: params.expires_at,
-        last_used_at: None,
-        usage_count: 0,
-        created_at: now,
+        name: name.to_string(),
+        value: value.to_string(),
+        provider,
+        expires_at,
+        last_used_at: existing.and_then(|secret| secret.last_used_at),
+        usage_count: existing.map(|secret| secret.usage_count).unwrap_or(0),
+        created_at: existing.map(|secret| secret.created_at).unwrap_or(now),
         updated_at: now,
-    })
+    }
 }
 
-fn build_key_check_record(crypto: &SecretsCrypto) -> Result<StoredKeyCheck, SecretError> {
-    let aad = secret_store_key_check_aad();
-    let (encrypted_value, key_salt) =
-        crypto.encrypt(SECRET_STORE_KEY_CHECK_PLAINTEXT.as_bytes(), &aad)?;
-    Ok(StoredKeyCheck {
-        encrypted_value,
-        key_salt,
-    })
+fn build_key_check_record() -> StoredKeyCheck {
+    StoredKeyCheck {
+        value: SECRET_STORE_KEY_CHECK_PLAINTEXT.to_string(),
+    }
 }
 
-fn verify_secret_store_key_check(
-    crypto: &SecretsCrypto,
-    encrypted_value: &[u8],
-    key_salt: &[u8],
-) -> Result<(), SecretError> {
-    let aad = secret_store_key_check_aad();
-    let decrypted = crypto.decrypt(encrypted_value, key_salt, &aad)?;
-    if decrypted.expose() != SECRET_STORE_KEY_CHECK_PLAINTEXT {
+fn verify_secret_store_key_check(record: &StoredKeyCheck) -> Result<(), SecretError> {
+    if record.value != SECRET_STORE_KEY_CHECK_PLAINTEXT {
         return Err(SecretError::DecryptionFailed(
             "secret store key check mismatch".to_string(),
         ));
     }
     Ok(())
-}
-
-fn parse_stored_secret(entry: VersionedEntry) -> Result<Secret, SecretError> {
-    let record: StoredSecret = parse_entry(entry)?;
-    Ok(record.into())
 }
 
 fn parse_entry<T: serde::de::DeserializeOwned>(entry: VersionedEntry) -> Result<T, SecretError> {
@@ -452,17 +444,28 @@ fn record_entry<T: Serialize>(kind: &str, value: &T) -> Result<Entry, SecretErro
     .map_err(|error| SecretError::Database(format!("serialize secret record: {error}")))
 }
 
+fn secret_record_entry(secret: &StoredSecret) -> Result<Entry, SecretError> {
+    Ok(record_entry(SECRET_RECORD_KIND, secret)?.with_indexed(
+        secret_id_index_key()?,
+        IndexValue::Text(secret.id.to_string()),
+    ))
+}
+
 fn normalize_secret_name(name: &str) -> String {
     name.to_lowercase()
 }
 
-fn ensure_secret_not_expired(secret: &Secret) -> Result<(), SecretError> {
+fn ensure_stored_secret_not_expired(secret: &StoredSecret) -> Result<(), SecretError> {
     if let Some(expires_at) = secret.expires_at
         && expires_at < Utc::now()
     {
         return Err(SecretError::Expired);
     }
     Ok(())
+}
+
+fn secret_id_index_key() -> Result<IndexKey, SecretError> {
+    IndexKey::new(SECRET_ID_INDEX_KEY).map_err(secret_filesystem_error)
 }
 
 fn records_root_path() -> Result<ScopedPath, SecretError> {
@@ -512,10 +515,13 @@ fn secret_filesystem_error(error: impl std::fmt::Display) -> SecretError {
 mod tests {
     use std::sync::Arc;
 
-    use ironclaw_filesystem::InMemoryBackend;
+    use chrono::Duration;
+    use ironclaw_filesystem::{EncryptedBackend, InMemoryBackend, RootFilesystem};
+    use ironclaw_host_api::VirtualPath;
     use secrecy::SecretString;
 
     use super::*;
+    use crate::SecretsCrypto;
 
     #[tokio::test]
     async fn filesystem_secret_store_persists_records_through_root_filesystem() {
@@ -531,7 +537,7 @@ mod tests {
             .await
             .unwrap();
 
-        let reopened = filesystem_store(root, "01234567890123456789012345678901");
+        let reopened = filesystem_store(Arc::clone(&root), "01234567890123456789012345678901");
         reopened
             .verify_can_decrypt_existing_secrets()
             .await
@@ -546,6 +552,14 @@ mod tests {
         assert_eq!(refs.len(), 1);
         assert_eq!(refs[0].name, "openai_key");
         assert!(reopened.any_exist().await.unwrap());
+
+        let raw_path =
+            VirtualPath::new(record_path("tenant-user", "openai_key").unwrap().as_str()).unwrap();
+        let raw = root.get(&raw_path).await.unwrap().unwrap();
+        assert!(
+            !String::from_utf8_lossy(&raw.entry.body).contains("sk-test-filesystem"),
+            "raw filesystem body must be encrypted by the backend decorator"
+        );
     }
 
     #[tokio::test]
@@ -569,11 +583,167 @@ mod tests {
         assert!(!format!("{error:?}").contains("sk-test-filesystem"));
     }
 
+    #[tokio::test]
+    async fn filesystem_secret_store_key_check_bootstrap_scans_all_existing_records() {
+        let root = Arc::new(InMemoryBackend::new());
+        let store = filesystem_store(Arc::clone(&root), "01234567890123456789012345678901");
+        store
+            .create(
+                "tenant-user",
+                CreateSecretParams::new("openai_key", "sk-test-filesystem"),
+            )
+            .await
+            .unwrap();
+        assert!(
+            root.get(&VirtualPath::new(key_check_path().unwrap().as_str()).unwrap())
+                .await
+                .unwrap()
+                .is_none(),
+            "test setup should exercise the pre-sentinel scan path"
+        );
+
+        let wrong_key_store = filesystem_store(root, "abcdefghijklmnopqrstuvwxyzABCDEF");
+        let error = wrong_key_store
+            .verify_can_decrypt_existing_secrets()
+            .await
+            .expect_err("wrong key must fail while scanning pre-sentinel records");
+        assert!(!format!("{error:?}").contains("sk-test-filesystem"));
+    }
+
+    #[tokio::test]
+    async fn filesystem_secret_store_preserves_metadata_on_overwrite() {
+        let root = Arc::new(InMemoryBackend::new());
+        let store = filesystem_store(root, "01234567890123456789012345678901");
+        let first = store
+            .create("tenant-user", CreateSecretParams::new("api_key", "first"))
+            .await
+            .unwrap();
+        store.record_usage(first.id).await.unwrap();
+
+        let second = store
+            .create("tenant-user", CreateSecretParams::new("api_key", "second"))
+            .await
+            .unwrap();
+
+        assert_eq!(second.id, first.id);
+        assert_eq!(second.created_at, first.created_at);
+        assert_eq!(second.usage_count, 1);
+        assert!(second.last_used_at.is_some());
+        assert_eq!(
+            store
+                .get_decrypted("tenant-user", "api_key")
+                .await
+                .unwrap()
+                .expose(),
+            "second"
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_secret_store_consume_if_matches_is_one_shot_and_preserves_mismatch_and_expired()
+     {
+        let root = Arc::new(InMemoryBackend::new());
+        let store = filesystem_store(root, "01234567890123456789012345678901");
+
+        assert_eq!(
+            store
+                .consume_if_matches("tenant-user", "missing", "expected")
+                .await
+                .unwrap(),
+            SecretConsumeResult::NotFound
+        );
+        store
+            .create(
+                "tenant-user",
+                CreateSecretParams::new("api_key", "expected"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .consume_if_matches("tenant-user", "api_key", "wrong")
+                .await
+                .unwrap(),
+            SecretConsumeResult::Mismatched
+        );
+        assert!(store.exists("tenant-user", "api_key").await.unwrap());
+        assert_eq!(
+            store
+                .consume_if_matches("tenant-user", "api_key", "expected")
+                .await
+                .unwrap(),
+            SecretConsumeResult::Matched
+        );
+        assert!(!store.exists("tenant-user", "api_key").await.unwrap());
+
+        let mut expired = CreateSecretParams::new("expired", "expected");
+        expired.expires_at = Some(Utc::now() - Duration::seconds(1));
+        store.create("tenant-user", expired).await.unwrap();
+        assert!(matches!(
+            store
+                .consume_if_matches("tenant-user", "expired", "expected")
+                .await,
+            Err(SecretError::Expired)
+        ));
+    }
+
+    #[tokio::test]
+    async fn filesystem_secret_store_tracks_usage_delete_and_access_edges() {
+        let root = Arc::new(InMemoryBackend::new());
+        let store = filesystem_store(root, "01234567890123456789012345678901");
+        let secret = store
+            .create(
+                "tenant-user",
+                CreateSecretParams::new("OpenAI_Key", "secret"),
+            )
+            .await
+            .unwrap();
+
+        store.record_usage(secret.id).await.unwrap();
+        let used = store.get("tenant-user", "openai_key").await.unwrap();
+        assert_eq!(used.usage_count, 1);
+        assert!(used.last_used_at.is_some());
+        assert!(matches!(
+            store.record_usage(Uuid::new_v4()).await,
+            Err(SecretError::NotFound(_))
+        ));
+
+        assert!(
+            store
+                .is_accessible("tenant-user", "openai_key", &["openai_key".to_string()])
+                .await
+                .unwrap()
+        );
+        assert!(
+            store
+                .is_accessible("tenant-user", "openai_key", &["openai_*".to_string()])
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .is_accessible("tenant-user", "openai_key", &["anthropic_*".to_string()])
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .is_accessible("tenant-user", "missing", &["*".to_string()])
+                .await
+                .unwrap()
+        );
+
+        assert!(store.delete("tenant-user", "openai_key").await.unwrap());
+        assert!(!store.exists("tenant-user", "openai_key").await.unwrap());
+        assert!(!store.delete("tenant-user", "openai_key").await.unwrap());
+    }
+
     fn filesystem_store(
         root: Arc<InMemoryBackend>,
         key: &str,
-    ) -> FilesystemSecretsStore<InMemoryBackend> {
+    ) -> FilesystemSecretsStore<EncryptedBackend<InMemoryBackend, SecretsCrypto>> {
         let crypto = Arc::new(SecretsCrypto::new(SecretString::from(key)).unwrap());
-        FilesystemSecretsStore::over_root(root, crypto).unwrap()
+        let root = Arc::new(EncryptedBackend::new(root, crypto));
+        FilesystemSecretsStore::over_root(root).unwrap()
     }
 }

--- a/crates/ironclaw_secrets/src/filesystem.rs
+++ b/crates/ironclaw_secrets/src/filesystem.rs
@@ -19,10 +19,13 @@ use crate::legacy_store::{DecryptedSecret, Secret, SecretRef};
 use crate::{CreateSecretParams, SecretConsumeResult, SecretError, SecretsStore};
 
 const SECRET_RECORD_KIND: &str = "secret_record";
+const SECRET_VALUE_KIND: &str = "secret_value";
 const SECRET_KEY_CHECK_KIND: &str = "secret_store_key_check";
 const SECRET_STORE_KEY_CHECK_ID: &str = "active";
 const SECRET_STORE_KEY_CHECK_PLAINTEXT: &str = "reborn-secret-store-key-check-v1";
 const SECRET_ID_INDEX_KEY: &str = "secret_id";
+const SECRET_NAME_INDEX_KEY: &str = "name";
+const SECRET_PROVIDER_INDEX_KEY: &str = "provider";
 
 /// Durable [`SecretsStore`] implementation over the unified Reborn filesystem surface.
 #[derive(Debug)]
@@ -100,6 +103,14 @@ where
         self.get_optional_entry(&record_path(user_id, name)?).await
     }
 
+    async fn get_value_entry(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<Option<VersionedEntry>, SecretError> {
+        self.get_optional_entry(&value_path(user_id, name)?).await
+    }
+
     async fn get_stored_secret_record(
         &self,
         user_id: &str,
@@ -137,6 +148,24 @@ where
                 let _: StoredSecret = parse_entry(versioned)?;
             }
         }
+        for user_dir in self.list_dir_or_empty(&values_root_path()?).await? {
+            if user_dir.file_type != FileType::Directory {
+                continue;
+            }
+            let user_values_path = scoped_from_virtual(&user_dir.path)?;
+            for value_entry in self.list_dir_or_empty(&user_values_path).await? {
+                if value_entry.file_type != FileType::File {
+                    continue;
+                }
+                let Some(versioned) = self
+                    .get_optional_entry(&scoped_from_virtual(&value_entry.path)?)
+                    .await?
+                else {
+                    continue;
+                };
+                let _: StoredSecretValue = parse_entry(versioned)?;
+            }
+        }
         Ok(())
     }
 
@@ -167,6 +196,7 @@ where
         let provider = params.provider;
         let expires_at = params.expires_at;
         let path = record_path(user_id, &name)?;
+        let value_path = value_path(user_id, &name)?;
 
         loop {
             let existing = self.get_optional_entry(&path).await?;
@@ -177,7 +207,6 @@ where
                         build_stored_secret(
                             user_id,
                             &name,
-                            &value,
                             provider.clone(),
                             expires_at,
                             Some(&existing_record),
@@ -186,11 +215,21 @@ where
                     )
                 }
                 None => (
-                    build_stored_secret(user_id, &name, &value, provider.clone(), expires_at, None),
+                    build_stored_secret(user_id, &name, provider.clone(), expires_at, None),
                     CasExpectation::Absent,
                 ),
             };
-            let entry = secret_record_entry(&record)?;
+            let value_entry = record_entry(
+                SECRET_VALUE_KIND,
+                &StoredSecretValue {
+                    value: value.clone(),
+                },
+            )?;
+            self.filesystem
+                .put(&value_path, value_entry, CasExpectation::Any)
+                .await
+                .map_err(secret_filesystem_error)?;
+            let entry = secret_metadata_entry(&record)?;
             match self.filesystem.put(&path, entry, cas).await {
                 Ok(_) => return Ok(record.into()),
                 Err(FilesystemError::VersionMismatch { .. }) => continue,
@@ -209,7 +248,10 @@ where
         name: &str,
     ) -> Result<DecryptedSecret, SecretError> {
         let secret = self.get(user_id, name).await?;
-        let record = self.get_stored_secret_record(user_id, &secret.name).await?;
+        let Some(value_entry) = self.get_value_entry(user_id, &secret.name).await? else {
+            return Err(SecretError::NotFound(secret.name));
+        };
+        let record: StoredSecretValue = parse_entry(value_entry)?;
         DecryptedSecret::from_bytes(record.value.into_bytes())
     }
 
@@ -220,19 +262,36 @@ where
         expected_value: &str,
     ) -> Result<SecretConsumeResult, SecretError> {
         let name = normalize_secret_name(name);
-        let Some(entry) = self.get_secret_entry(user_id, &name).await? else {
-            return Ok(SecretConsumeResult::NotFound);
-        };
-        let secret: StoredSecret = parse_entry(entry)?;
-        ensure_stored_secret_not_expired(&secret)?;
-        if secret.value != expected_value {
-            return Ok(SecretConsumeResult::Mismatched);
+        loop {
+            let Some(metadata_entry) = self.get_secret_entry(user_id, &name).await? else {
+                return Ok(SecretConsumeResult::NotFound);
+            };
+            let secret: StoredSecret = parse_entry(metadata_entry)?;
+            ensure_stored_secret_not_expired(&secret)?;
+            let Some(value_entry) = self.get_value_entry(user_id, &name).await? else {
+                return Ok(SecretConsumeResult::NotFound);
+            };
+            let value: StoredSecretValue = parse_entry(value_entry.clone())?;
+            if value.value != expected_value {
+                return Ok(SecretConsumeResult::Mismatched);
+            }
+            match self
+                .filesystem
+                .delete_if_version(&value_path(user_id, &name)?, value_entry.version)
+                .await
+            {
+                Ok(()) => {
+                    match self.filesystem.delete(&record_path(user_id, &name)?).await {
+                        Ok(()) | Err(FilesystemError::NotFound { .. }) => {}
+                        Err(error) => return Err(secret_filesystem_error(error)),
+                    }
+                    return Ok(SecretConsumeResult::Matched);
+                }
+                Err(FilesystemError::VersionMismatch { .. }) => continue,
+                Err(FilesystemError::NotFound { .. }) => return Ok(SecretConsumeResult::NotFound),
+                Err(error) => return Err(secret_filesystem_error(error)),
+            }
         }
-        self.filesystem
-            .delete(&record_path(user_id, &name)?)
-            .await
-            .map_err(secret_filesystem_error)?;
-        Ok(SecretConsumeResult::Matched)
     }
 
     async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
@@ -252,40 +311,39 @@ where
     async fn list(&self, user_id: &str) -> Result<Vec<SecretRef>, SecretError> {
         let mut refs = Vec::new();
         for entry in self
-            .list_dir_or_empty(&user_records_path(user_id)?)
-            .await?
-            .into_iter()
-            .filter(|entry| entry.file_type == FileType::File)
+            .filesystem
+            .query_indexed(
+                &user_records_path(user_id)?,
+                &Filter::All,
+                Page::first(Page::MAX_LIMIT),
+            )
+            .await
+            .map_err(secret_filesystem_error)?
         {
-            let Some(versioned) = self
-                .get_optional_entry(&scoped_from_virtual(&entry.path)?)
-                .await?
-            else {
-                continue;
-            };
-            let secret: StoredSecret = parse_entry(versioned)?;
-            ensure_stored_secret_not_expired(&secret)?;
-            refs.push(SecretRef {
-                name: secret.name,
-                provider: secret.provider,
-            });
+            refs.push(secret_ref_from_indexed(&entry.indexed)?);
         }
         refs.sort_by(|left, right| left.name.cmp(&right.name));
         Ok(refs)
     }
 
     async fn delete(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
-        match self.filesystem.delete(&record_path(user_id, name)?).await {
-            Ok(()) => Ok(true),
-            Err(FilesystemError::NotFound { .. }) => Ok(false),
-            Err(error) => Err(secret_filesystem_error(error)),
-        }
+        let deleted_metadata = match self.filesystem.delete(&record_path(user_id, name)?).await {
+            Ok(()) => true,
+            Err(FilesystemError::NotFound { .. }) => false,
+            Err(error) => return Err(secret_filesystem_error(error)),
+        };
+        let deleted_value = match self.filesystem.delete(&value_path(user_id, name)?).await {
+            Ok(()) => true,
+            Err(FilesystemError::NotFound { .. }) => false,
+            Err(error) => return Err(secret_filesystem_error(error)),
+        };
+        Ok(deleted_metadata || deleted_value)
     }
 
     async fn record_usage(&self, secret_id: Uuid) -> Result<(), SecretError> {
         let mut matches = self
             .filesystem
-            .query(
+            .query_indexed(
                 &records_root_path()?,
                 &Filter::Eq {
                     key: secret_id_index_key()?,
@@ -300,15 +358,18 @@ where
         };
 
         loop {
-            let mut secret: StoredSecret = parse_entry(versioned.clone())?;
+            let path = scoped_from_virtual(&versioned.path)?;
+            let Some(current) = self.get_optional_entry(&path).await? else {
+                return Err(SecretError::NotFound(secret_id.to_string()));
+            };
+            let mut secret: StoredSecret = parse_entry(current)?;
             if secret.id != secret_id {
                 return Err(SecretError::NotFound(secret_id.to_string()));
             }
             secret.last_used_at = Some(Utc::now());
             secret.usage_count += 1;
             secret.updated_at = Utc::now();
-            let path = scoped_from_virtual(&versioned.path)?;
-            let entry = secret_record_entry(&secret)?;
+            let entry = secret_metadata_entry(&secret)?;
             match self
                 .filesystem
                 .put(&path, entry, CasExpectation::Version(versioned.version))
@@ -319,7 +380,11 @@ where
                     let Some(fresh) = self.get_optional_entry(&path).await? else {
                         return Err(SecretError::NotFound(secret_id.to_string()));
                     };
-                    versioned = fresh;
+                    versioned = ironclaw_filesystem::VersionedIndexedEntry {
+                        path: fresh.path,
+                        indexed: fresh.entry.indexed,
+                        version: fresh.version,
+                    };
                 }
                 Err(error) => return Err(secret_filesystem_error(error)),
             }
@@ -356,13 +421,17 @@ struct StoredSecret {
     id: Uuid,
     user_id: String,
     name: String,
-    value: String,
     provider: Option<String>,
     expires_at: Option<chrono::DateTime<Utc>>,
     last_used_at: Option<chrono::DateTime<Utc>>,
     usage_count: i64,
     created_at: chrono::DateTime<Utc>,
     updated_at: chrono::DateTime<Utc>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct StoredSecretValue {
+    value: String,
 }
 
 impl From<StoredSecret> for Secret {
@@ -391,7 +460,6 @@ struct StoredKeyCheck {
 fn build_stored_secret(
     user_id: &str,
     name: &str,
-    value: &str,
     provider: Option<String>,
     expires_at: Option<chrono::DateTime<Utc>>,
     existing: Option<&StoredSecret>,
@@ -403,7 +471,6 @@ fn build_stored_secret(
             .unwrap_or_else(Uuid::new_v4),
         user_id: user_id.to_string(),
         name: name.to_string(),
-        value: value.to_string(),
         provider,
         expires_at,
         last_used_at: existing.and_then(|secret| secret.last_used_at),
@@ -444,11 +511,55 @@ fn record_entry<T: Serialize>(kind: &str, value: &T) -> Result<Entry, SecretErro
     .map_err(|error| SecretError::Database(format!("serialize secret record: {error}")))
 }
 
-fn secret_record_entry(secret: &StoredSecret) -> Result<Entry, SecretError> {
-    Ok(record_entry(SECRET_RECORD_KIND, secret)?.with_indexed(
-        secret_id_index_key()?,
-        IndexValue::Text(secret.id.to_string()),
-    ))
+fn secret_metadata_entry(secret: &StoredSecret) -> Result<Entry, SecretError> {
+    let mut entry = record_entry(SECRET_RECORD_KIND, secret)?
+        .with_indexed(
+            secret_id_index_key()?,
+            IndexValue::Text(secret.id.to_string()),
+        )
+        .with_indexed(
+            secret_name_index_key()?,
+            IndexValue::Text(secret.name.clone()),
+        );
+    if let Some(provider) = &secret.provider {
+        entry = entry.with_indexed(
+            secret_provider_index_key()?,
+            IndexValue::Text(provider.clone()),
+        );
+    }
+    Ok(entry)
+}
+
+fn secret_ref_from_indexed(
+    indexed: &std::collections::BTreeMap<IndexKey, IndexValue>,
+) -> Result<SecretRef, SecretError> {
+    Ok(SecretRef {
+        name: indexed_text(indexed, &secret_name_index_key()?)?.to_string(),
+        provider: indexed
+            .get(&secret_provider_index_key()?)
+            .map(index_value_as_text)
+            .transpose()?
+            .map(ToString::to_string),
+    })
+}
+
+fn indexed_text<'a>(
+    indexed: &'a std::collections::BTreeMap<IndexKey, IndexValue>,
+    key: &IndexKey,
+) -> Result<&'a str, SecretError> {
+    indexed
+        .get(key)
+        .ok_or_else(|| SecretError::Database(format!("missing filesystem secret index: {key}")))
+        .and_then(index_value_as_text)
+}
+
+fn index_value_as_text(value: &IndexValue) -> Result<&str, SecretError> {
+    match value {
+        IndexValue::Text(value) => Ok(value.as_str()),
+        other => Err(SecretError::Database(format!(
+            "invalid filesystem secret text index: {other}"
+        ))),
+    }
 }
 
 fn normalize_secret_name(name: &str) -> String {
@@ -468,8 +579,20 @@ fn secret_id_index_key() -> Result<IndexKey, SecretError> {
     IndexKey::new(SECRET_ID_INDEX_KEY).map_err(secret_filesystem_error)
 }
 
+fn secret_name_index_key() -> Result<IndexKey, SecretError> {
+    IndexKey::new(SECRET_NAME_INDEX_KEY).map_err(secret_filesystem_error)
+}
+
+fn secret_provider_index_key() -> Result<IndexKey, SecretError> {
+    IndexKey::new(SECRET_PROVIDER_INDEX_KEY).map_err(secret_filesystem_error)
+}
+
 fn records_root_path() -> Result<ScopedPath, SecretError> {
     ScopedPath::new("/secrets/records").map_err(secret_filesystem_error)
+}
+
+fn values_root_path() -> Result<ScopedPath, SecretError> {
+    ScopedPath::new("/secrets/values").map_err(secret_filesystem_error)
 }
 
 fn user_records_path(user_id: &str) -> Result<ScopedPath, SecretError> {
@@ -480,6 +603,15 @@ fn user_records_path(user_id: &str) -> Result<ScopedPath, SecretError> {
 fn record_path(user_id: &str, name: &str) -> Result<ScopedPath, SecretError> {
     ScopedPath::new(format!(
         "/secrets/records/{}/{}.json",
+        encode_path_segment(user_id),
+        encode_path_segment(&normalize_secret_name(name))
+    ))
+    .map_err(secret_filesystem_error)
+}
+
+fn value_path(user_id: &str, name: &str) -> Result<ScopedPath, SecretError> {
+    ScopedPath::new(format!(
+        "/secrets/values/{}/{}.json",
         encode_path_segment(user_id),
         encode_path_segment(&normalize_secret_name(name))
     ))
@@ -554,11 +686,11 @@ mod tests {
         assert!(reopened.any_exist().await.unwrap());
 
         let raw_path =
-            VirtualPath::new(record_path("tenant-user", "openai_key").unwrap().as_str()).unwrap();
+            VirtualPath::new(value_path("tenant-user", "openai_key").unwrap().as_str()).unwrap();
         let raw = root.get(&raw_path).await.unwrap().unwrap();
         assert!(
             !String::from_utf8_lossy(&raw.entry.body).contains("sk-test-filesystem"),
-            "raw filesystem body must be encrypted by the backend decorator"
+            "raw filesystem value body must be encrypted by the backend decorator"
         );
     }
 
@@ -611,6 +743,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn filesystem_secret_store_key_check_bootstrap_scans_every_existing_user_record() {
+        let root = Arc::new(InMemoryBackend::new());
+        let first = filesystem_store(Arc::clone(&root), "01234567890123456789012345678901");
+        first
+            .create("a-user", CreateSecretParams::new("openai_key", "sk-first"))
+            .await
+            .unwrap();
+        let second = filesystem_store(Arc::clone(&root), "abcdefghijklmnopqrstuvwxyzABCDEF");
+        second
+            .create("z-user", CreateSecretParams::new("openai_key", "sk-second"))
+            .await
+            .unwrap();
+
+        let error = first
+            .verify_can_decrypt_existing_secrets()
+            .await
+            .expect_err("scan must fail when any existing record uses a different key");
+        assert!(!format!("{error:?}").contains("sk-first"));
+        assert!(!format!("{error:?}").contains("sk-second"));
+        assert!(
+            root.get(&VirtualPath::new(key_check_path().unwrap().as_str()).unwrap())
+                .await
+                .unwrap()
+                .is_none(),
+            "failed pre-sentinel scan must not install the key-check sentinel"
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_secret_store_key_check_rejects_concurrent_conflict_winner_with_wrong_key() {
+        let inner = Arc::new(InMemoryBackend::new());
+        let winner_crypto = Arc::new(
+            SecretsCrypto::new(SecretString::from("abcdefghijklmnopqrstuvwxyzABCDEF")).unwrap(),
+        );
+        let conflict_backend = Arc::new(KeyCheckConflictBackend::new(
+            Arc::clone(&inner),
+            Arc::new(EncryptedBackend::new(Arc::clone(&inner), winner_crypto)),
+        ));
+        let crypto = Arc::new(
+            SecretsCrypto::new(SecretString::from("01234567890123456789012345678901")).unwrap(),
+        );
+        let store = FilesystemSecretsStore::over_root(Arc::new(EncryptedBackend::new(
+            conflict_backend,
+            crypto,
+        )))
+        .unwrap();
+
+        let error = store
+            .verify_can_decrypt_existing_secrets()
+            .await
+            .expect_err("conflict winner written with another key must fail verification");
+        assert!(!format!("{error:?}").contains(SECRET_STORE_KEY_CHECK_PLAINTEXT));
+    }
+
+    #[tokio::test]
     async fn filesystem_secret_store_preserves_metadata_on_overwrite() {
         let root = Arc::new(InMemoryBackend::new());
         let store = filesystem_store(root, "01234567890123456789012345678901");
@@ -636,6 +823,27 @@ mod tests {
                 .unwrap()
                 .expose(),
             "second"
+        );
+    }
+
+    #[tokio::test]
+    async fn filesystem_secret_store_list_returns_metadata_when_another_secret_is_expired() {
+        let root = Arc::new(InMemoryBackend::new());
+        let store = filesystem_store(root, "01234567890123456789012345678901");
+        store
+            .create("tenant-user", CreateSecretParams::new("active", "secret"))
+            .await
+            .unwrap();
+        let mut expired = CreateSecretParams::new("expired", "secret");
+        expired.expires_at = Some(Utc::now() - Duration::seconds(1));
+        store.create("tenant-user", expired).await.unwrap();
+
+        let refs = store.list("tenant-user").await.unwrap();
+        assert_eq!(
+            refs.iter()
+                .map(|secret| secret.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["active", "expired"]
         );
     }
 
@@ -745,5 +953,112 @@ mod tests {
         let crypto = Arc::new(SecretsCrypto::new(SecretString::from(key)).unwrap());
         let root = Arc::new(EncryptedBackend::new(root, crypto));
         FilesystemSecretsStore::over_root(root).unwrap()
+    }
+
+    struct KeyCheckConflictBackend {
+        inner: Arc<InMemoryBackend>,
+        winner: Arc<EncryptedBackend<InMemoryBackend, SecretsCrypto>>,
+        triggered: std::sync::atomic::AtomicBool,
+    }
+
+    impl KeyCheckConflictBackend {
+        fn new(
+            inner: Arc<InMemoryBackend>,
+            winner: Arc<EncryptedBackend<InMemoryBackend, SecretsCrypto>>,
+        ) -> Self {
+            Self {
+                inner,
+                winner,
+                triggered: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RootFilesystem for KeyCheckConflictBackend {
+        fn capabilities(&self) -> ironclaw_filesystem::BackendCapabilities {
+            self.inner.capabilities()
+        }
+
+        async fn put(
+            &self,
+            path: &VirtualPath,
+            entry: Entry,
+            cas: CasExpectation,
+        ) -> Result<ironclaw_filesystem::RecordVersion, FilesystemError> {
+            if path.as_str() == key_check_path().unwrap().as_str()
+                && !self
+                    .triggered
+                    .swap(true, std::sync::atomic::Ordering::SeqCst)
+            {
+                let winner_entry =
+                    record_entry(SECRET_KEY_CHECK_KIND, &build_key_check_record()).unwrap();
+                self.winner
+                    .put(path, winner_entry, CasExpectation::Absent)
+                    .await?;
+                return Err(FilesystemError::VersionMismatch {
+                    path: path.clone(),
+                    expected: None,
+                    found: Some(ironclaw_filesystem::RecordVersion::from_backend(1)),
+                });
+            }
+            self.inner.put(path, entry, cas).await
+        }
+
+        async fn get(&self, path: &VirtualPath) -> Result<Option<VersionedEntry>, FilesystemError> {
+            self.inner.get(path).await
+        }
+
+        async fn list_dir(
+            &self,
+            path: &VirtualPath,
+        ) -> Result<Vec<ironclaw_filesystem::DirEntry>, FilesystemError> {
+            self.inner.list_dir(path).await
+        }
+
+        async fn query(
+            &self,
+            path: &VirtualPath,
+            filter: &Filter,
+            page: Page,
+        ) -> Result<Vec<VersionedEntry>, FilesystemError> {
+            self.inner.query(path, filter, page).await
+        }
+
+        async fn query_indexed(
+            &self,
+            path: &VirtualPath,
+            filter: &Filter,
+            page: Page,
+        ) -> Result<Vec<ironclaw_filesystem::VersionedIndexedEntry>, FilesystemError> {
+            self.inner.query_indexed(path, filter, page).await
+        }
+
+        async fn ensure_index(
+            &self,
+            path: &VirtualPath,
+            spec: &ironclaw_filesystem::IndexSpec,
+        ) -> Result<(), FilesystemError> {
+            self.inner.ensure_index(path, spec).await
+        }
+
+        async fn stat(
+            &self,
+            path: &VirtualPath,
+        ) -> Result<ironclaw_filesystem::FileStat, FilesystemError> {
+            self.inner.stat(path).await
+        }
+
+        async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+            self.inner.delete(path).await
+        }
+
+        async fn delete_if_version(
+            &self,
+            path: &VirtualPath,
+            version: ironclaw_filesystem::RecordVersion,
+        ) -> Result<(), FilesystemError> {
+            self.inner.delete_if_version(path, version).await
+        }
     }
 }

--- a/crates/ironclaw_secrets/src/filesystem.rs
+++ b/crates/ironclaw_secrets/src/filesystem.rs
@@ -1,0 +1,579 @@
+//! Filesystem-backed durable secret storage.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_filesystem::{
+    CasExpectation, Entry, FileType, FilesystemError, RecordKind, RootFilesystem, ScopedFilesystem,
+    VersionedEntry,
+};
+use ironclaw_host_api::{
+    MountAlias, MountGrant, MountPermissions, MountView, ScopedPath, VirtualPath,
+};
+use secrecy::ExposeSecret;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::crypto::{secret_record_aad, secret_store_key_check_aad};
+use crate::legacy_store::{DecryptedSecret, Secret, SecretRef};
+use crate::{CreateSecretParams, SecretConsumeResult, SecretError, SecretsCrypto, SecretsStore};
+
+const SECRET_RECORD_KIND: &str = "secret_record";
+const SECRET_KEY_CHECK_KIND: &str = "secret_store_key_check";
+const SECRET_STORE_KEY_CHECK_ID: &str = "active";
+const SECRET_STORE_KEY_CHECK_PLAINTEXT: &str = "reborn-secret-store-key-check-v1";
+
+/// Durable [`SecretsStore`] implementation over the unified Reborn filesystem surface.
+#[derive(Debug)]
+pub struct FilesystemSecretsStore<F> {
+    filesystem: ScopedFilesystem<F>,
+    crypto: Arc<SecretsCrypto>,
+}
+
+impl<F> FilesystemSecretsStore<F>
+where
+    F: RootFilesystem + 'static,
+{
+    pub fn new(filesystem: ScopedFilesystem<F>, crypto: Arc<SecretsCrypto>) -> Self {
+        Self { filesystem, crypto }
+    }
+
+    pub fn over_root(root: Arc<F>, crypto: Arc<SecretsCrypto>) -> Result<Self, SecretError> {
+        let mounts = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/secrets").map_err(secret_filesystem_error)?,
+            VirtualPath::new("/secrets").map_err(secret_filesystem_error)?,
+            MountPermissions {
+                read: true,
+                write: true,
+                delete: true,
+                list: true,
+                execute: false,
+            },
+        )])
+        .map_err(secret_filesystem_error)?;
+        Ok(Self::new(ScopedFilesystem::new(root, mounts), crypto))
+    }
+
+    pub async fn verify_can_decrypt_existing_secrets(&self) -> Result<(), SecretError> {
+        if let Some(check) = self.get_optional_entry(&key_check_path()?).await? {
+            let record: StoredKeyCheck = parse_entry(check)?;
+            return verify_secret_store_key_check(
+                &self.crypto,
+                &record.encrypted_value,
+                &record.key_salt,
+            );
+        }
+
+        self.verify_all_secret_payloads().await?;
+        let record = build_key_check_record(&self.crypto)?;
+        let entry = record_entry(SECRET_KEY_CHECK_KIND, &record)?;
+        match self
+            .filesystem
+            .put(&key_check_path()?, entry, CasExpectation::Absent)
+            .await
+        {
+            Ok(_) => {}
+            Err(FilesystemError::VersionMismatch { .. }) => {}
+            Err(error) => return Err(secret_filesystem_error(error)),
+        }
+        let Some(check) = self.get_optional_entry(&key_check_path()?).await? else {
+            return Err(SecretError::Database(
+                "secret store key check missing after bootstrap".to_string(),
+            ));
+        };
+        let record: StoredKeyCheck = parse_entry(check)?;
+        verify_secret_store_key_check(&self.crypto, &record.encrypted_value, &record.key_salt)
+    }
+
+    async fn get_optional_entry(
+        &self,
+        path: &ScopedPath,
+    ) -> Result<Option<VersionedEntry>, SecretError> {
+        match self.filesystem.get(path).await {
+            Ok(entry) => Ok(entry),
+            Err(FilesystemError::NotFound { .. }) => Ok(None),
+            Err(error) => Err(secret_filesystem_error(error)),
+        }
+    }
+
+    async fn get_secret_entry(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<Option<VersionedEntry>, SecretError> {
+        self.get_optional_entry(&record_path(user_id, name)?).await
+    }
+
+    async fn get_secret_record(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
+        let name = normalize_secret_name(name);
+        let Some(entry) = self.get_secret_entry(user_id, &name).await? else {
+            return Err(SecretError::NotFound(name));
+        };
+        let secret: Secret = parse_stored_secret(entry)?;
+        ensure_secret_not_expired(&secret)?;
+        Ok(secret)
+    }
+
+    async fn verify_all_secret_payloads(&self) -> Result<(), SecretError> {
+        for user_dir in self.list_dir_or_empty(&records_root_path()?).await? {
+            if user_dir.file_type != FileType::Directory {
+                continue;
+            }
+            let user_records_path = scoped_from_virtual(&user_dir.path)?;
+            for record_entry in self.list_dir_or_empty(&user_records_path).await? {
+                if record_entry.file_type != FileType::File {
+                    continue;
+                }
+                let Some(versioned) = self
+                    .get_optional_entry(&scoped_from_virtual(&record_entry.path)?)
+                    .await?
+                else {
+                    continue;
+                };
+                let secret: Secret = parse_stored_secret(versioned)?;
+                let aad = secret_record_aad(&secret.user_id, &secret.name);
+                self.crypto
+                    .decrypt(&secret.encrypted_value, &secret.key_salt, &aad)?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn list_dir_or_empty(
+        &self,
+        path: &ScopedPath,
+    ) -> Result<Vec<ironclaw_filesystem::DirEntry>, SecretError> {
+        match self.filesystem.list_dir(path).await {
+            Ok(entries) => Ok(entries),
+            Err(FilesystemError::NotFound { .. }) => Ok(Vec::new()),
+            Err(error) => Err(secret_filesystem_error(error)),
+        }
+    }
+}
+
+#[async_trait]
+impl<F> SecretsStore for FilesystemSecretsStore<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn create(
+        &self,
+        user_id: &str,
+        params: CreateSecretParams,
+    ) -> Result<Secret, SecretError> {
+        let secret = build_encrypted_secret(user_id, params, &self.crypto)?;
+        let entry = record_entry(SECRET_RECORD_KIND, &StoredSecret::from(secret.clone()))?;
+        self.filesystem
+            .put(
+                &record_path(user_id, &secret.name)?,
+                entry,
+                CasExpectation::Any,
+            )
+            .await
+            .map_err(secret_filesystem_error)?;
+        Ok(secret)
+    }
+
+    async fn get(&self, user_id: &str, name: &str) -> Result<Secret, SecretError> {
+        self.get_secret_record(user_id, name).await
+    }
+
+    async fn get_decrypted(
+        &self,
+        user_id: &str,
+        name: &str,
+    ) -> Result<DecryptedSecret, SecretError> {
+        let secret = self.get(user_id, name).await?;
+        let aad = secret_record_aad(user_id, &secret.name);
+        self.crypto
+            .decrypt(&secret.encrypted_value, &secret.key_salt, &aad)
+    }
+
+    async fn consume_if_matches(
+        &self,
+        user_id: &str,
+        name: &str,
+        expected_value: &str,
+    ) -> Result<SecretConsumeResult, SecretError> {
+        let name = normalize_secret_name(name);
+        let Some(entry) = self.get_secret_entry(user_id, &name).await? else {
+            return Ok(SecretConsumeResult::NotFound);
+        };
+        let secret: Secret = parse_stored_secret(entry)?;
+        ensure_secret_not_expired(&secret)?;
+        let aad = secret_record_aad(user_id, &secret.name);
+        let decrypted = self
+            .crypto
+            .decrypt(&secret.encrypted_value, &secret.key_salt, &aad)?;
+        if decrypted.expose() != expected_value {
+            return Ok(SecretConsumeResult::Mismatched);
+        }
+        self.filesystem
+            .delete(&record_path(user_id, &name)?)
+            .await
+            .map_err(secret_filesystem_error)?;
+        Ok(SecretConsumeResult::Matched)
+    }
+
+    async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
+        Ok(self
+            .get_secret_entry(user_id, &normalize_secret_name(name))
+            .await?
+            .is_some())
+    }
+
+    async fn any_exist(&self) -> Result<bool, SecretError> {
+        Ok(!self
+            .list_dir_or_empty(&records_root_path()?)
+            .await?
+            .is_empty())
+    }
+
+    async fn list(&self, user_id: &str) -> Result<Vec<SecretRef>, SecretError> {
+        let mut refs = Vec::new();
+        for entry in self
+            .list_dir_or_empty(&user_records_path(user_id)?)
+            .await?
+            .into_iter()
+            .filter(|entry| entry.file_type == FileType::File)
+        {
+            let Some(versioned) = self
+                .get_optional_entry(&scoped_from_virtual(&entry.path)?)
+                .await?
+            else {
+                continue;
+            };
+            let secret: Secret = parse_stored_secret(versioned)?;
+            ensure_secret_not_expired(&secret)?;
+            refs.push(SecretRef {
+                name: secret.name,
+                provider: secret.provider,
+            });
+        }
+        refs.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(refs)
+    }
+
+    async fn delete(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
+        match self.filesystem.delete(&record_path(user_id, name)?).await {
+            Ok(()) => Ok(true),
+            Err(FilesystemError::NotFound { .. }) => Ok(false),
+            Err(error) => Err(secret_filesystem_error(error)),
+        }
+    }
+
+    async fn record_usage(&self, secret_id: Uuid) -> Result<(), SecretError> {
+        for user_dir in self.list_dir_or_empty(&records_root_path()?).await? {
+            if user_dir.file_type != FileType::Directory {
+                continue;
+            }
+            let user_records_path = scoped_from_virtual(&user_dir.path)?;
+            for dir_entry in self.list_dir_or_empty(&user_records_path).await? {
+                if dir_entry.file_type != FileType::File {
+                    continue;
+                }
+                let record_path = scoped_from_virtual(&dir_entry.path)?;
+                let Some(versioned) = self.get_optional_entry(&record_path).await? else {
+                    continue;
+                };
+                let mut secret: Secret = parse_stored_secret(versioned.clone())?;
+                if secret.id != secret_id {
+                    continue;
+                }
+                secret.last_used_at = Some(Utc::now());
+                secret.usage_count += 1;
+                secret.updated_at = Utc::now();
+                let entry = record_entry(SECRET_RECORD_KIND, &StoredSecret::from(secret))?;
+                self.filesystem
+                    .put(
+                        &record_path,
+                        entry,
+                        CasExpectation::Version(versioned.version),
+                    )
+                    .await
+                    .map_err(secret_filesystem_error)?;
+                return Ok(());
+            }
+        }
+        Err(SecretError::NotFound(secret_id.to_string()))
+    }
+
+    async fn is_accessible(
+        &self,
+        user_id: &str,
+        secret_name: &str,
+        allowed_secrets: &[String],
+    ) -> Result<bool, SecretError> {
+        let secret_name_lower = normalize_secret_name(secret_name);
+        if !self.exists(user_id, &secret_name_lower).await? {
+            return Ok(false);
+        }
+        for pattern in allowed_secrets {
+            let pattern_lower = pattern.to_lowercase();
+            if pattern_lower == secret_name_lower {
+                return Ok(true);
+            }
+            if let Some(prefix) = pattern_lower.strip_suffix('*')
+                && secret_name_lower.starts_with(prefix)
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredSecret {
+    id: Uuid,
+    user_id: String,
+    name: String,
+    encrypted_value: Vec<u8>,
+    key_salt: Vec<u8>,
+    provider: Option<String>,
+    expires_at: Option<chrono::DateTime<Utc>>,
+    last_used_at: Option<chrono::DateTime<Utc>>,
+    usage_count: i64,
+    created_at: chrono::DateTime<Utc>,
+    updated_at: chrono::DateTime<Utc>,
+}
+
+impl From<Secret> for StoredSecret {
+    fn from(secret: Secret) -> Self {
+        Self {
+            id: secret.id,
+            user_id: secret.user_id,
+            name: secret.name,
+            encrypted_value: secret.encrypted_value,
+            key_salt: secret.key_salt,
+            provider: secret.provider,
+            expires_at: secret.expires_at,
+            last_used_at: secret.last_used_at,
+            usage_count: secret.usage_count,
+            created_at: secret.created_at,
+            updated_at: secret.updated_at,
+        }
+    }
+}
+
+impl From<StoredSecret> for Secret {
+    fn from(record: StoredSecret) -> Self {
+        Self {
+            id: record.id,
+            user_id: record.user_id,
+            name: record.name,
+            encrypted_value: record.encrypted_value,
+            key_salt: record.key_salt,
+            provider: record.provider,
+            expires_at: record.expires_at,
+            last_used_at: record.last_used_at,
+            usage_count: record.usage_count,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredKeyCheck {
+    encrypted_value: Vec<u8>,
+    key_salt: Vec<u8>,
+}
+
+fn build_encrypted_secret(
+    user_id: &str,
+    params: CreateSecretParams,
+    crypto: &SecretsCrypto,
+) -> Result<Secret, SecretError> {
+    let name = normalize_secret_name(&params.name);
+    let aad = secret_record_aad(user_id, &name);
+    let (encrypted_value, key_salt) =
+        crypto.encrypt(params.value.expose_secret().as_bytes(), &aad)?;
+    let now = Utc::now();
+    Ok(Secret {
+        id: Uuid::new_v4(),
+        user_id: user_id.to_string(),
+        name,
+        encrypted_value,
+        key_salt,
+        provider: params.provider,
+        expires_at: params.expires_at,
+        last_used_at: None,
+        usage_count: 0,
+        created_at: now,
+        updated_at: now,
+    })
+}
+
+fn build_key_check_record(crypto: &SecretsCrypto) -> Result<StoredKeyCheck, SecretError> {
+    let aad = secret_store_key_check_aad();
+    let (encrypted_value, key_salt) =
+        crypto.encrypt(SECRET_STORE_KEY_CHECK_PLAINTEXT.as_bytes(), &aad)?;
+    Ok(StoredKeyCheck {
+        encrypted_value,
+        key_salt,
+    })
+}
+
+fn verify_secret_store_key_check(
+    crypto: &SecretsCrypto,
+    encrypted_value: &[u8],
+    key_salt: &[u8],
+) -> Result<(), SecretError> {
+    let aad = secret_store_key_check_aad();
+    let decrypted = crypto.decrypt(encrypted_value, key_salt, &aad)?;
+    if decrypted.expose() != SECRET_STORE_KEY_CHECK_PLAINTEXT {
+        return Err(SecretError::DecryptionFailed(
+            "secret store key check mismatch".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn parse_stored_secret(entry: VersionedEntry) -> Result<Secret, SecretError> {
+    let record: StoredSecret = parse_entry(entry)?;
+    Ok(record.into())
+}
+
+fn parse_entry<T: serde::de::DeserializeOwned>(entry: VersionedEntry) -> Result<T, SecretError> {
+    entry.entry.parse_json().map_err(|error| {
+        SecretError::Database(format!("invalid filesystem secret record: {error}"))
+    })
+}
+
+fn record_entry<T: Serialize>(kind: &str, value: &T) -> Result<Entry, SecretError> {
+    let value = serde_json::to_value(value)
+        .map_err(|error| SecretError::Database(format!("serialize secret record: {error}")))?;
+    Entry::record(
+        RecordKind::new(kind).map_err(secret_filesystem_error)?,
+        &value,
+    )
+    .map_err(|error| SecretError::Database(format!("serialize secret record: {error}")))
+}
+
+fn normalize_secret_name(name: &str) -> String {
+    name.to_lowercase()
+}
+
+fn ensure_secret_not_expired(secret: &Secret) -> Result<(), SecretError> {
+    if let Some(expires_at) = secret.expires_at
+        && expires_at < Utc::now()
+    {
+        return Err(SecretError::Expired);
+    }
+    Ok(())
+}
+
+fn records_root_path() -> Result<ScopedPath, SecretError> {
+    ScopedPath::new("/secrets/records").map_err(secret_filesystem_error)
+}
+
+fn user_records_path(user_id: &str) -> Result<ScopedPath, SecretError> {
+    ScopedPath::new(format!("/secrets/records/{}", encode_path_segment(user_id)))
+        .map_err(secret_filesystem_error)
+}
+
+fn record_path(user_id: &str, name: &str) -> Result<ScopedPath, SecretError> {
+    ScopedPath::new(format!(
+        "/secrets/records/{}/{}.json",
+        encode_path_segment(user_id),
+        encode_path_segment(&normalize_secret_name(name))
+    ))
+    .map_err(secret_filesystem_error)
+}
+
+fn key_check_path() -> Result<ScopedPath, SecretError> {
+    ScopedPath::new(format!(
+        "/secrets/key-check/{SECRET_STORE_KEY_CHECK_ID}.json"
+    ))
+    .map_err(secret_filesystem_error)
+}
+
+fn scoped_from_virtual(path: &VirtualPath) -> Result<ScopedPath, SecretError> {
+    ScopedPath::new(path.as_str()).map_err(secret_filesystem_error)
+}
+
+fn encode_path_segment(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(value.len() * 2);
+    for byte in value.as_bytes() {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn secret_filesystem_error(error: impl std::fmt::Display) -> SecretError {
+    SecretError::Database(format!("filesystem secret store error: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ironclaw_filesystem::InMemoryBackend;
+    use secrecy::SecretString;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn filesystem_secret_store_persists_records_through_root_filesystem() {
+        let root = Arc::new(InMemoryBackend::new());
+        let store = filesystem_store(Arc::clone(&root), "01234567890123456789012345678901");
+        store.verify_can_decrypt_existing_secrets().await.unwrap();
+
+        store
+            .create(
+                "tenant-user",
+                CreateSecretParams::new("openai_key", "sk-test-filesystem"),
+            )
+            .await
+            .unwrap();
+
+        let reopened = filesystem_store(root, "01234567890123456789012345678901");
+        reopened
+            .verify_can_decrypt_existing_secrets()
+            .await
+            .unwrap();
+        let decrypted = reopened
+            .get_decrypted("tenant-user", "openai_key")
+            .await
+            .unwrap();
+        assert_eq!(decrypted.expose(), "sk-test-filesystem");
+
+        let refs = reopened.list("tenant-user").await.unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "openai_key");
+        assert!(reopened.any_exist().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn filesystem_secret_store_key_check_rejects_wrong_key() {
+        let root = Arc::new(InMemoryBackend::new());
+        let store = filesystem_store(Arc::clone(&root), "01234567890123456789012345678901");
+        store.verify_can_decrypt_existing_secrets().await.unwrap();
+        store
+            .create(
+                "tenant-user",
+                CreateSecretParams::new("openai_key", "sk-test-filesystem"),
+            )
+            .await
+            .unwrap();
+
+        let wrong_key_store = filesystem_store(root, "abcdefghijklmnopqrstuvwxyzABCDEF");
+        let error = wrong_key_store
+            .verify_can_decrypt_existing_secrets()
+            .await
+            .expect_err("wrong key must fail filesystem secret readiness");
+        assert!(!format!("{error:?}").contains("sk-test-filesystem"));
+    }
+
+    fn filesystem_store(
+        root: Arc<InMemoryBackend>,
+        key: &str,
+    ) -> FilesystemSecretsStore<InMemoryBackend> {
+        let crypto = Arc::new(SecretsCrypto::new(SecretString::from(key)).unwrap());
+        FilesystemSecretsStore::over_root(root, crypto).unwrap()
+    }
+}

--- a/crates/ironclaw_secrets/src/lib.rs
+++ b/crates/ironclaw_secrets/src/lib.rs
@@ -10,6 +10,7 @@
 mod crypto;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 mod db;
+mod filesystem;
 mod legacy_store;
 
 #[cfg(feature = "libsql")]
@@ -18,6 +19,7 @@ pub use db::{LibSqlCredentialStore, LibSqlSecretsStore};
 pub use db::{PostgresCredentialStore, PostgresSecretsStore};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 pub use db::{credential_account_aad, credential_session_aad};
+pub use filesystem::FilesystemSecretsStore;
 
 use std::collections::HashMap;
 use std::fmt;


### PR DESCRIPTION
## Summary

- Add a private `ironclaw_reborn_composition::secret_store` module that owns production `ironclaw_secrets` construction.
- Route both Reborn composition entrypoints through that module instead of assembling `SecretsCrypto`, backend stores, migrations, decryptability checks, and `ScopedSecretsStoreAdapter` inline.
- Keep the change entirely inside Reborn crates; no root `/src` or v1 app wiring is touched.

## Why

The Reborn composition layer had two internal production secret-store construction paths. That leaked low-level `ironclaw_secrets` backend details into higher composition code and made future secret-related PRs easier to drift. This keeps `ironclaw_secrets` as the canonical owner of secret semantics while making Reborn composition expose one private construction path.

The module is private (`mod secret_store`, not re-exported). The `SharedSecretStore` wrapper remains crate-private because `HostRuntimeServices::with_secret_store(...)` currently needs a concrete `SecretStore` implementor.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p ironclaw_reborn_composition --no-default-features`
- `cargo check -p ironclaw_reborn_composition --features libsql --tests`
- `cargo check -p ironclaw_reborn_composition --features postgres --tests`
- `cargo check -p ironclaw_reborn_composition --features libsql,postgres`
- `cargo clippy -p ironclaw_reborn_composition --features libsql,postgres -- -D warnings`
- `cargo test -p ironclaw_reborn_composition --no-default-features`

Note: `cargo clippy -p ironclaw_reborn_composition --features libsql,postgres --tests -- -D warnings` still hits an existing `clippy::items-after-test-module` warning in `crates/ironclaw_reborn_composition/src/runtime.rs`, outside this change.
