### PR TITLE
refactor:[arch] Route Reborn production builders through factory

### DIFF
--- a/crates/ironclaw_reborn_composition/src/error.rs
+++ b/crates/ironclaw_reborn_composition/src/error.rs
@@ -41,3 +41,27 @@ impl From<ironclaw_host_runtime::ProductionWiringReport> for RebornBuildError {
         Self::ProductionWiring { report }
     }
 }
+
+impl From<crate::RebornCompositionError> for RebornBuildError {
+    fn from(error: crate::RebornCompositionError) -> Self {
+        match error {
+            crate::RebornCompositionError::MissingSecretMasterKey => Self::InvalidConfig {
+                reason: "reborn production composition requires explicit secret master key"
+                    .to_string(),
+            },
+            crate::RebornCompositionError::Filesystem(error) => Self::Filesystem(error),
+            crate::RebornCompositionError::Resource(error) => Self::Resource(error),
+            crate::RebornCompositionError::RunState(error) => Self::RunState(error),
+            crate::RebornCompositionError::CapabilityLease(error) => Self::CapabilityLease(error),
+            crate::RebornCompositionError::Secret(error) => Self::Secret(error),
+            crate::RebornCompositionError::EventStore(error) => Self::EventStore(error),
+            crate::RebornCompositionError::Turn(error) => Self::Turn(error),
+            crate::RebornCompositionError::RunProfile(error) => Self::PlannedRunProfileResolver {
+                reason: error.to_string(),
+            },
+            crate::RebornCompositionError::ProductionWiring { report } => {
+                Self::ProductionWiring { report }
+            }
+        }
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -2,14 +2,30 @@ use std::sync::Arc;
 
 use ironclaw_authorization::GrantAuthorizer;
 use ironclaw_extensions::ExtensionRegistry;
+#[cfg(feature = "libsql")]
+use ironclaw_filesystem::LibSqlRootFilesystem;
 use ironclaw_filesystem::LocalFilesystem;
+#[cfg(feature = "postgres")]
+use ironclaw_filesystem::PostgresRootFilesystem;
 use ironclaw_host_runtime::{CapabilitySurfaceVersion, HostRuntimeServices};
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_network::{PolicyNetworkHttpEgress, ReqwestNetworkTransport};
 use ironclaw_processes::ProcessServices;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_reborn_event_store::RebornProfile;
 use ironclaw_resources::InMemoryResourceGovernor;
+#[cfg(feature = "libsql")]
+use ironclaw_resources::LibSqlResourceGovernorStore;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_resources::PersistentResourceGovernor;
+#[cfg(feature = "postgres")]
+use ironclaw_resources::PostgresResourceGovernorStore;
 use ironclaw_run_state::{InMemoryApprovalRequestStore, InMemoryRunStateStore};
 use ironclaw_trust::HostTrustPolicy;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_turns::InMemoryRunProfileResolver;
+use ironclaw_trust::TrustPolicy;
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_turns::TurnRunWakeNotifier;
 use ironclaw_turns::{DefaultTurnCoordinator, InMemoryTurnStateStore};
 
 use crate::input::RebornStorageInput;
@@ -228,15 +244,122 @@ fn production_wiring(
     })
 }
 
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-fn planned_run_profile_resolver() -> Result<Arc<InMemoryRunProfileResolver>, RebornBuildError> {
-    Ok(Arc::new(
-        ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver().map_err(
-            |error| RebornBuildError::PlannedRunProfileResolver {
-                reason: error.to_string(),
-            },
-        )?,
+#[cfg(feature = "libsql")]
+pub(crate) async fn build_libsql_production_host_runtime_services<TPolicy, TWake>(
+    config: crate::LibSqlProductionSubstrateConfig<TPolicy, TWake>,
+) -> Result<crate::LibSqlProductionHostRuntimeServices, crate::RebornCompositionError>
+where
+    TPolicy: TrustPolicy + 'static,
+    TWake: TurnRunWakeNotifier + 'static,
+{
+    let secret_master_key = config
+        .secret_master_key
+        .ok_or(crate::RebornCompositionError::MissingSecretMasterKey)?;
+    let secret_store = crate::secret_store::build_libsql_secret_store(
+        Arc::clone(&config.database),
+        secret_master_key,
+    )
+    .await?;
+
+    let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&config.database)));
+    filesystem.run_migrations().await?;
+
+    let process_services = ProcessServices::filesystem(Arc::clone(&filesystem));
+
+    let resource_store = LibSqlResourceGovernorStore::new(Arc::clone(&config.database));
+    resource_store.run_migrations().await?;
+    let governor = Arc::new(PersistentResourceGovernor::new(resource_store));
+
+    let capability_leases = Arc::new(ironclaw_authorization::LibSqlCapabilityLeaseStore::new(
+        Arc::clone(&config.database),
+    ));
+    capability_leases.run_migrations().await?;
+
+    let services = HostRuntimeServices::new(
+        Arc::new(ExtensionRegistry::new()),
+        filesystem,
+        governor,
+        Arc::new(GrantAuthorizer::new()),
+        process_services,
+        config.surface_version,
+    )
+    .with_trust_policy(config.trust_policy)
+    .with_capability_leases(capability_leases)
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_turn_run_wake_notifier(config.turn_run_wake_notifier)
+    .with_run_profile_resolver(Arc::new(
+        ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver()?,
     ))
+    .with_libsql_run_state_approval_store(Arc::clone(&config.database))
+    .await?
+    .with_libsql_turn_state_store(Arc::clone(&config.database))
+    .await?
+    .with_reborn_event_store_config(RebornProfile::Production, config.event_store)
+    .await?;
+
+    let services = services.try_with_host_http_egress(PolicyNetworkHttpEgress::new(
+        ReqwestNetworkTransport::default(),
+    ))?;
+
+    Ok(services)
+}
+
+#[cfg(feature = "postgres")]
+pub(crate) async fn build_postgres_production_host_runtime_services<TPolicy, TWake>(
+    config: crate::PostgresProductionSubstrateConfig<TPolicy, TWake>,
+) -> Result<crate::PostgresProductionHostRuntimeServices, crate::RebornCompositionError>
+where
+    TPolicy: TrustPolicy + 'static,
+    TWake: TurnRunWakeNotifier + 'static,
+{
+    let secret_master_key = config
+        .secret_master_key
+        .ok_or(crate::RebornCompositionError::MissingSecretMasterKey)?;
+    let secret_store =
+        crate::secret_store::build_postgres_secret_store(config.pool.clone(), secret_master_key)
+            .await?;
+
+    let filesystem = Arc::new(PostgresRootFilesystem::new(config.pool.clone()));
+    filesystem.run_migrations().await?;
+
+    let process_services = ProcessServices::filesystem(Arc::clone(&filesystem));
+
+    let resource_store = PostgresResourceGovernorStore::new(config.pool.clone());
+    resource_store.run_migrations().await?;
+    let governor = Arc::new(PersistentResourceGovernor::new(resource_store));
+
+    let capability_leases = Arc::new(ironclaw_authorization::PostgresCapabilityLeaseStore::new(
+        config.pool.clone(),
+    ));
+    capability_leases.run_migrations().await?;
+
+    let services = HostRuntimeServices::new(
+        Arc::new(ExtensionRegistry::new()),
+        filesystem,
+        governor,
+        Arc::new(GrantAuthorizer::new()),
+        process_services,
+        config.surface_version,
+    )
+    .with_trust_policy(config.trust_policy)
+    .with_capability_leases(capability_leases)
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_turn_run_wake_notifier(config.turn_run_wake_notifier)
+    .with_run_profile_resolver(Arc::new(
+        ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver()?,
+    ))
+    .with_postgres_run_state_approval_store(config.pool.clone())
+    .await?
+    .with_postgres_turn_state_store(config.pool.clone())
+    .await?
+    .with_reborn_event_store_config(RebornProfile::Production, config.event_store)
+    .await?;
+
+    let services = services.try_with_host_http_egress(PolicyNetworkHttpEgress::new(
+        ReqwestNetworkTransport::default(),
+    ))?;
+
+    Ok(services)
 }
 
 #[cfg(feature = "libsql")]
@@ -249,44 +372,20 @@ async fn build_libsql_production(
     auth_token: Option<ironclaw_secrets::SecretMaterial>,
     secret_master_key: ironclaw_secrets::SecretMaterial,
 ) -> Result<RebornServices, RebornBuildError> {
-    use ironclaw_authorization::LibSqlCapabilityLeaseStore;
-    use ironclaw_filesystem::LibSqlRootFilesystem;
-
-    let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&db)));
-    filesystem.run_migrations().await?;
-
-    let leases = Arc::new(LibSqlCapabilityLeaseStore::new(Arc::clone(&db)));
-    leases.run_migrations().await?;
-
-    let secret_store =
-        crate::secret_store::build_libsql_secret_store(Arc::clone(&db), secret_master_key).await?;
-
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Libsql {
         path_or_url,
         auth_token,
     };
-
-    let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
-        Arc::clone(&filesystem),
-        Arc::new(InMemoryResourceGovernor::new()),
-        Arc::new(GrantAuthorizer::new()),
-        ProcessServices::filesystem(Arc::clone(&filesystem)),
-        CapabilitySurfaceVersion::new("reborn-app-v1")?,
-    )
-    .with_trust_policy(production_wiring.trust_policy)
-    .with_capability_leases(leases)
-    .with_secret_store(secret_store)
-    .with_libsql_resource_governor(Arc::clone(&db))
-    .await?
-    .with_reborn_event_store_config(profile.to_event_store_profile(), event_store)
-    .await?
-    .with_libsql_run_state_approval_store(Arc::clone(&db))
-    .await?
-    .with_libsql_turn_state_store(db)
-    .await?
-    .with_run_profile_resolver(planned_run_profile_resolver()?)
-    .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
+    let services =
+        build_libsql_production_host_runtime_services(crate::LibSqlProductionSubstrateConfig {
+            database: Arc::clone(&db),
+            event_store,
+            secret_master_key: Some(secret_master_key),
+            trust_policy: production_wiring.trust_policy,
+            turn_run_wake_notifier: production_wiring.turn_run_wake_notifier,
+            surface_version: CapabilitySurfaceVersion::new("reborn-app-v1")?,
+        })
+        .await?;
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);
@@ -309,41 +408,17 @@ async fn build_postgres_production(
     url: ironclaw_secrets::SecretMaterial,
     secret_master_key: ironclaw_secrets::SecretMaterial,
 ) -> Result<RebornServices, RebornBuildError> {
-    use ironclaw_authorization::PostgresCapabilityLeaseStore;
-    use ironclaw_filesystem::PostgresRootFilesystem;
-
-    let filesystem = Arc::new(PostgresRootFilesystem::new(pool.clone()));
-    filesystem.run_migrations().await?;
-
-    let leases = Arc::new(PostgresCapabilityLeaseStore::new(pool.clone()));
-    leases.run_migrations().await?;
-
-    let secret_store =
-        crate::secret_store::build_postgres_secret_store(pool.clone(), secret_master_key).await?;
-
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Postgres { url };
-
-    let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
-        Arc::clone(&filesystem),
-        Arc::new(InMemoryResourceGovernor::new()),
-        Arc::new(GrantAuthorizer::new()),
-        ProcessServices::filesystem(Arc::clone(&filesystem)),
-        CapabilitySurfaceVersion::new("reborn-app-v1")?,
-    )
-    .with_trust_policy(production_wiring.trust_policy)
-    .with_capability_leases(leases)
-    .with_secret_store(secret_store)
-    .with_postgres_resource_governor(pool.clone())
-    .await?
-    .with_reborn_event_store_config(profile.to_event_store_profile(), event_store)
-    .await?
-    .with_postgres_run_state_approval_store(pool.clone())
-    .await?
-    .with_postgres_turn_state_store(pool)
-    .await?
-    .with_run_profile_resolver(planned_run_profile_resolver()?)
-    .with_turn_run_wake_notifier(production_wiring.turn_run_wake_notifier);
+    let services =
+        build_postgres_production_host_runtime_services(crate::PostgresProductionSubstrateConfig {
+            pool,
+            event_store,
+            secret_master_key: Some(secret_master_key),
+            trust_policy: production_wiring.trust_policy,
+            turn_run_wake_notifier: production_wiring.turn_run_wake_notifier,
+            surface_version: CapabilitySurfaceVersion::new("reborn-app-v1")?,
+        })
+        .await?;
 
     let turn_coordinator: Arc<dyn ironclaw_turns::TurnCoordinator> =
         Arc::new(services.turn_coordinator_for_production()?);

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -118,10 +118,6 @@ pub fn reborn_runtime_readiness_snapshot() -> RebornRuntimeReadinessSnapshot {
 use std::sync::Arc;
 
 use ironclaw_authorization::CapabilityLeaseError;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_authorization::GrantAuthorizer;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_extensions::ExtensionRegistry;
 #[cfg(feature = "libsql")]
 use ironclaw_filesystem::LibSqlRootFilesystem;
 #[cfg(feature = "postgres")]
@@ -129,12 +125,10 @@ use ironclaw_filesystem::PostgresRootFilesystem;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_runtime::{CapabilitySurfaceVersion, HostRuntimeServices};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_network::{PolicyNetworkHttpEgress, ReqwestNetworkTransport};
+use ironclaw_processes::{FilesystemProcessResultStore, FilesystemProcessStore};
 #[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_processes::{FilesystemProcessResultStore, FilesystemProcessStore, ProcessServices};
+use ironclaw_reborn_event_store::RebornEventStoreConfig;
 use ironclaw_reborn_event_store::RebornEventStoreError;
-#[cfg(any(feature = "libsql", feature = "postgres"))]
-use ironclaw_reborn_event_store::{RebornEventStoreConfig, RebornProfile};
 #[cfg(feature = "libsql")]
 use ironclaw_resources::LibSqlResourceGovernorStore;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
@@ -219,6 +213,16 @@ pub enum RebornCompositionError {
     Turn(#[from] TurnError),
     #[error("reborn run-profile resolver substrate failed: {0}")]
     RunProfile(#[from] ironclaw_turns::run_profile::RunProfileRegistryError),
+    #[error("reborn production wiring failed")]
+    ProductionWiring {
+        report: ironclaw_host_runtime::ProductionWiringReport,
+    },
+}
+
+impl From<ironclaw_host_runtime::ProductionWiringReport> for RebornCompositionError {
+    fn from(report: ironclaw_host_runtime::ProductionWiringReport) -> Self {
+        Self::ProductionWiring { report }
+    }
 }
 
 /// Build production-wired host-runtime services over libSQL-backed substrates.
@@ -238,60 +242,7 @@ where
     TPolicy: TrustPolicy + 'static,
     TWake: TurnRunWakeNotifier + 'static,
 {
-    let secret_master_key = config
-        .secret_master_key
-        .ok_or(RebornCompositionError::MissingSecretMasterKey)?;
-    let secret_store =
-        secret_store::build_libsql_secret_store(Arc::clone(&config.database), secret_master_key)
-            .await?;
-
-    let filesystem = Arc::new(LibSqlRootFilesystem::new(Arc::clone(&config.database)));
-    filesystem.run_migrations().await?;
-
-    let process_services = ProcessServices::filesystem(Arc::clone(&filesystem));
-
-    let resource_store = LibSqlResourceGovernorStore::new(Arc::clone(&config.database));
-    resource_store.run_migrations().await?;
-    let governor = Arc::new(PersistentResourceGovernor::new(resource_store));
-
-    let capability_leases = Arc::new(ironclaw_authorization::LibSqlCapabilityLeaseStore::new(
-        Arc::clone(&config.database),
-    ));
-    capability_leases.run_migrations().await?;
-
-    let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
-        filesystem,
-        governor,
-        Arc::new(GrantAuthorizer::new()),
-        process_services,
-        config.surface_version,
-    )
-    .with_trust_policy(config.trust_policy)
-    .with_capability_leases(capability_leases)
-    .with_secret_store(Arc::clone(&secret_store))
-    .with_turn_run_wake_notifier(config.turn_run_wake_notifier)
-    .with_run_profile_resolver(Arc::new(
-        ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver()?,
-    ))
-    .with_libsql_run_state_approval_store(Arc::clone(&config.database))
-    .await?
-    .with_libsql_turn_state_store(Arc::clone(&config.database))
-    .await?
-    .with_reborn_event_store_config(RebornProfile::Production, config.event_store)
-    .await?;
-
-    // safety: `with_secret_store` is called unconditionally above on the same
-    // builder chain, so `try_with_host_http_egress` can only return a
-    // `Missing(SecretStore)` wiring report if the host-runtime builder API
-    // regresses; treat that as infallible here.
-    let services = services
-        .try_with_host_http_egress(PolicyNetworkHttpEgress::new(
-            ReqwestNetworkTransport::default(),
-        ))
-        .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
-
-    Ok(services)
+    factory::build_libsql_production_host_runtime_services(config).await
 }
 
 /// Build production-wired host-runtime services over PostgreSQL-backed substrates.
@@ -308,57 +259,5 @@ where
     TPolicy: TrustPolicy + 'static,
     TWake: TurnRunWakeNotifier + 'static,
 {
-    let secret_master_key = config
-        .secret_master_key
-        .ok_or(RebornCompositionError::MissingSecretMasterKey)?;
-    let secret_store =
-        secret_store::build_postgres_secret_store(config.pool.clone(), secret_master_key).await?;
-
-    let filesystem = Arc::new(PostgresRootFilesystem::new(config.pool.clone()));
-    filesystem.run_migrations().await?;
-
-    let process_services = ProcessServices::filesystem(Arc::clone(&filesystem));
-
-    let resource_store = PostgresResourceGovernorStore::new(config.pool.clone());
-    resource_store.run_migrations().await?;
-    let governor = Arc::new(PersistentResourceGovernor::new(resource_store));
-
-    let capability_leases = Arc::new(ironclaw_authorization::PostgresCapabilityLeaseStore::new(
-        config.pool.clone(),
-    ));
-    capability_leases.run_migrations().await?;
-
-    let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
-        filesystem,
-        governor,
-        Arc::new(GrantAuthorizer::new()),
-        process_services,
-        config.surface_version,
-    )
-    .with_trust_policy(config.trust_policy)
-    .with_capability_leases(capability_leases)
-    .with_secret_store(Arc::clone(&secret_store))
-    .with_turn_run_wake_notifier(config.turn_run_wake_notifier)
-    .with_run_profile_resolver(Arc::new(
-        ironclaw_reborn::planned_driver_factory::default_planned_run_profile_resolver()?,
-    ))
-    .with_postgres_run_state_approval_store(config.pool.clone())
-    .await?
-    .with_postgres_turn_state_store(config.pool.clone())
-    .await?
-    .with_reborn_event_store_config(RebornProfile::Production, config.event_store)
-    .await?;
-
-    // safety: `with_secret_store` is called unconditionally above on the same
-    // builder chain, so `try_with_host_http_egress` can only return a
-    // `Missing(SecretStore)` wiring report if the host-runtime builder API
-    // regresses; treat that as infallible here.
-    let services = services
-        .try_with_host_http_egress(PolicyNetworkHttpEgress::new(
-            ReqwestNetworkTransport::default(),
-        ))
-        .expect("secret_store wired above guarantees host HTTP egress is buildable"); // safety: see comment above
-
-    Ok(services)
+    factory::build_postgres_production_host_runtime_services(config).await
 }

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -336,7 +336,8 @@ async fn migration_dry_run_validates_libsql_shape() {
             test_master_key(),
         )
         .with_production_trust_policy(production_trust_policy())
-        .with_turn_run_wake_notifier(notifier),
+        .with_turn_run_wake_notifier(notifier)
+        .require_runtime_http_egress(),
     )
     .await
     .unwrap();
@@ -384,7 +385,8 @@ async fn migration_dry_run_validates_postgres_planned_turn_profile() {
             test_master_key(),
         )
         .with_production_trust_policy(production_trust_policy())
-        .with_turn_run_wake_notifier(notifier),
+        .with_turn_run_wake_notifier(notifier)
+        .require_runtime_http_egress(),
     )
     .await
     .unwrap();


### PR DESCRIPTION
## Summary
- Moves the libSQL/Postgres production service graph assembly into factory-owned helpers.
- Keeps the existing public substrate APIs in `lib.rs` as thin wrappers that delegate to `factory.rs`.
- Updates the facade production path to call the same factory helper, removing the duplicate builder drift.
- Extends facade happy-path coverage to require runtime HTTP egress so the old factory wiring gap is caught.

Stacks on #3746.
Closes #3748.

## Why
`lib.rs` and `factory.rs` had independently evolved production builders. That exposed lower-level wiring choices above the factory boundary and allowed the facade path to drift from the substrate path. The intended shape is now:

`lib.rs public API wrappers -> factory.rs production graph builders -> private Reborn composition helpers -> lower substrate crates`

This stays entirely inside Reborn crates and does not move wiring into root `/src`.

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p ironclaw_reborn_composition --no-default-features`
- `cargo check -p ironclaw_reborn_composition --features libsql --tests`
- `cargo check -p ironclaw_reborn_composition --features postgres --tests`
- `cargo check -p ironclaw_reborn_composition --features libsql,postgres`
- `cargo test -p ironclaw_reborn_composition --features libsql --test libsql_substrate --test facade_factory`
- `cargo test -p ironclaw_reborn_composition --features postgres --test postgres_substrate --test facade_factory`
- `cargo clippy -p ironclaw_reborn_composition --features libsql,postgres -- -D warnings`

Known pre-existing failure:
- `cargo clippy -p ironclaw_reborn_composition --features libsql,postgres --tests -- -D warnings` fails on `crates/ironclaw_reborn_composition/src/runtime.rs` for `clippy::items-after-test-module`, unrelated to this diff.
