### PR TITLE
docs: add crates agent guidance maps

### DIFF
--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,0 +1,198 @@
+# IronClaw Crates Map
+
+Instructions for AI coding assistants entering `crates/` on `reborn-integration`.
+
+This file is a routing map, not a full architecture spec. Pick the crate(s) that match the change, then read crate-local guidance before editing:
+
+1. `crates/<crate>/AGENTS.md` (every crate has one).
+2. `crates/<crate>/CLAUDE.md` if present.
+3. `crates/<crate>/CONTRACT.md` or `README.md` if present.
+4. Matching `docs/reborn/contracts/*.md` when behavior crosses crate boundaries.
+
+Do **not** eagerly load every crate guide. Use this map to choose.
+
+## Branch and Workspace
+
+This map was refreshed from `reborn-integration` after inspecting every crate directory, manifest, source layout, tests, and crate-local docs. Every crate with `Cargo.toml` now has a crate-local `AGENTS.md`.
+
+Run crate work from repo root unless crate-local docs say otherwise.
+
+```bash
+cargo test -p <crate_name>
+cargo clippy -p <crate_name> --all-targets --all-features -- -D warnings
+cargo test -p ironclaw_architecture
+scripts/check-boundaries.sh
+scripts/reborn-e2e-rust.sh
+```
+
+Use targeted crate tests first. Add `ironclaw_architecture` when dependency edges or layer ownership change. Run Reborn e2e when turns, runtime lanes, host services, authorization, approvals, networking, secrets, product workflow, or capability dispatch change.
+
+## Guidance Files
+
+- `AGENTS.md` — crate-local agent entrypoint; read first.
+- `CLAUDE.md` — crate guardrails/spec; read before changing behavior.
+- `CONTRACT.md` — public cross-crate contract; update with semantic changes.
+- `README.md` — helper/user/operator details.
+- `docs/reborn/contracts/*.md` — Reborn source-of-truth contracts.
+- `crates/ironclaw_architecture` — mechanical dependency-boundary enforcement.
+
+Every crate has `AGENTS.md`; treat it as first file to load even if this table becomes stale.
+
+## Dependency Mental Model
+
+Keep lower layers neutral. Product and runtime composition flows downward through typed contracts, not concrete shortcuts.
+
+```text
+common / host_api / storage
+  -> filesystem / memory / events / event_projections / extensions / trust / resources
+  -> secrets / network / outbound / run_state / authorization / approvals / runtime_policy
+  -> host_runtime / processes / dispatcher / runtime lanes (scripts, mcp, wasm)
+  -> turns / threads / agent_loop / loop_support / capabilities
+  -> reborn composition / product adapters / product workflow / CLI
+  -> engine / llm / gateway / tui / root product integration
+```
+
+Boundary rule: if you need an upstream crate in a low-level crate, stop and check `crates/ironclaw_architecture` plus matching Reborn contract.
+
+## Crate Map
+
+### Foundation and substrate
+
+| Crate | Load first | Owns / go here for | Avoid moving in |
+| --- | --- | --- | --- |
+| `ironclaw_common` | `ironclaw_common/AGENTS.md`, `Cargo.toml` | Low-dependency shared types/utilities: app events, identity, trust-boundary helpers, paths, platform/env/timezone, attachment helpers. | Runtime orchestration, persistence, clients, policy, product domain logic. |
+| `ironclaw_host_api` | `ironclaw_host_api/AGENTS.md`, `ironclaw_host_api/CLAUDE.md`, `docs/reborn/contracts/host-api.md` | Neutral authority vocabulary: IDs, scopes, paths, actions, decisions, resources, approvals, audit, HTTP, dispatch, runtime-policy, trust types. | Runtime execution, persistence, HTTP clients, product workflow, policy engines. |
+| `ironclaw_storage` | `ironclaw_storage/AGENTS.md`, `ironclaw_storage/CLAUDE.md` | Generic storage substrate: backend identity, redacted errors, migration descriptors, pagination, serialization, primitive blob/record store traits. | Domain schemas/semantics for turns, threads, outbound, secrets, events. |
+| `ironclaw_architecture` | `ironclaw_architecture/AGENTS.md`, `ironclaw_architecture/CLAUDE.md` | Workspace architecture tests, Reborn dependency boundaries, composition-boundary checks. | Production runtime code or production deps. |
+
+### Files, memory, events, projections
+
+| Crate | Load first | Owns / go here for | Avoid moving in |
+| --- | --- | --- | --- |
+| `ironclaw_filesystem` | `ironclaw_filesystem/AGENTS.md`, `ironclaw_filesystem/CLAUDE.md`, `docs/reborn/contracts/filesystem.md` | Root/scoped/composite filesystem, catalog, virtual path authority, backend containment, mount routing. | Memory-domain grammar, network/secrets/dispatcher/product workflow. |
+| `ironclaw_memory` | `ironclaw_memory/AGENTS.md`, `ironclaw_memory/CLAUDE.md`, `docs/reborn/contracts/memory.md` | Memory docs, `/memory` paths, metadata/schema, chunking, embeddings, search, indexer hooks, memory filesystem adapter, backend contracts. | Generic mount/catalog logic or product workflow. |
+| `ironclaw_events` | `ironclaw_events/AGENTS.md`, `ironclaw_events/CLAUDE.md`, `docs/reborn/contracts/events.md` | Typed redacted event/audit substrate, event envelopes, sinks/log traits, durable adapters. | SSE/WebSocket/product transport or projection policy. |
+| `ironclaw_event_projections` | `ironclaw_event_projections/AGENTS.md`, `ironclaw_event_projections/CLAUDE.md`, `docs/reborn/contracts/events-projections.md` | Event projection model, cursor/visibility contracts, product-facing projection boundaries. | Canonical event storage or transport delivery. |
+| `ironclaw_reborn_event_store` | `ironclaw_reborn_event_store/AGENTS.md`, `docs/reborn/contracts/events.md` | Reborn-owned durable event/audit store backends and fixtures. | Product projections, transport fanout, workflow policy. |
+
+### Authority, policy, state
+
+| Crate | Load first | Owns / go here for | Avoid moving in |
+| --- | --- | --- | --- |
+| `ironclaw_trust` | `ironclaw_trust/AGENTS.md`, `ironclaw_trust/CLAUDE.md`, `ironclaw_trust/CONTRACT.md` | Host-controlled trust classes, policy sources, requested-vs-effective trust, invalidation. | Authorization grants, runtime dispatch, product workflow. |
+| `ironclaw_authorization` | `ironclaw_authorization/AGENTS.md`, `ironclaw_authorization/CLAUDE.md` | Grant matching, leases, dispatch/spawn authorization decisions, DB-backed auth state. | Execution, approvals, run-state persistence, prompting. |
+| `ironclaw_approvals` | `ironclaw_approvals/AGENTS.md`, `ironclaw_approvals/CLAUDE.md` | Exact-invocation approval requests, leases, resume coordination, approval events. | Reusable broad approvals or dispatch before fingerprinted lease claim. |
+| `ironclaw_run_state` | `ironclaw_run_state/AGENTS.md`, `ironclaw_run_state/CLAUDE.md` | Durable invocation state and approval request records. | Authorization policy, approval resolution, dispatch, runtime execution, process lifecycle. |
+| `ironclaw_resources` | `ironclaw_resources/AGENTS.md`, `ironclaw_resources/CLAUDE.md` | Reservation, reconciliation, release, quota accounting. | Runtime dispatch, product workflow, hidden costed work without reservation. |
+| `ironclaw_runtime_policy` | `ironclaw_runtime_policy/AGENTS.md`, `ironclaw_runtime_policy/CLAUDE.md`, `docs/reborn/contracts/runtime-profiles.md` | Runtime profile resolver and runtime selection policy. | Runtime startup, action dispatch, product strategy outside selection. |
+| `ironclaw_outbound` | `ironclaw_outbound/AGENTS.md`, `ironclaw_outbound/CLAUDE.md` | Metadata-only outbound egress policy, notification opt-in, projection subscription cursors, delivery attempt/status metadata. | Transport sends, concrete Slack/Telegram/Web payload validation, transcript/projection mutation. |
+
+### Host services and runtime lanes
+
+| Crate | Load first | Owns / go here for | Avoid moving in |
+| --- | --- | --- | --- |
+| `ironclaw_secrets` | `ironclaw_secrets/AGENTS.md`, `ironclaw_secrets/CLAUDE.md` | Secret metadata, encrypted repositories, leases, one-shot consumption, legacy/db stores. | Raw secret exposure, provider HTTP, injection beyond mediated handoff. |
+| `ironclaw_network` | `ironclaw_network/AGENTS.md`, `ironclaw_network/CLAUDE.md`, `docs/reborn/contracts/network.md` | Network policy boundary, URL targets, resolver, hardened transport, host/provider HTTP egress. | Runtime-lane behavior above boundary or manual credential injection. |
+| `ironclaw_host_runtime` | `ironclaw_host_runtime/AGENTS.md`, `ironclaw_host_runtime/CLAUDE.md` | Host-side Reborn service composition: production services, obligations, HTTP egress, redaction, secrets/network/resource mediation. | Product workflow, runtime-specific request shapes, duplicate network/secret logic. |
+| `ironclaw_processes` | `ironclaw_processes/AGENTS.md`, `ironclaw_processes/CLAUDE.md` | Process lifecycle, cancellation, stores, status/output helpers, `ProcessHost`, wrappers. | Authorization, approval policy, runtime lane internals beyond adapter contracts. |
+| `ironclaw_dispatcher` | `ironclaw_dispatcher/AGENTS.md`, `ironclaw_dispatcher/CLAUDE.md` | Already-authorized runtime routing through `RuntimeAdapter`, redacted dispatch results, event dispatch contracts. | Authorization, approvals, run-state, concrete runtime deps, product workflow. |
+| `ironclaw_scripts` | `ironclaw_scripts/AGENTS.md`, `ironclaw_scripts/CLAUDE.md` | Script runtime lane over host-mediated filesystem/events/resources/dispatcher/HTTP, Docker/backend output parsing. | Manual credentials, direct provider HTTP, duplicated dispatcher/process/resource policy. |
+| `ironclaw_mcp` | `ironclaw_mcp/AGENTS.md`, `ironclaw_mcp/CLAUDE.md` | MCP runtime lane, execution request/result types, JSON-RPC exchange, client abstraction, HTTP adapter, resource accounting. | Direct outbound networking, ad-hoc credential injection, product workflow. |
+| `ironclaw_wasm` | `ironclaw_wasm/AGENTS.md`, `ironclaw_wasm/CLAUDE.md`, `docs/reborn/contracts/wasm.md`, `wit/tool.wit` | WASM runtime lane, component/WIT bindings, limiter, store, host adapters, runtime config. | Privileged host effects outside mediated APIs; copied secrets/network/resource logic. |
+| `ironclaw_wasm_sandbox_core` | `ironclaw_wasm_sandbox_core/AGENTS.md`, `ironclaw_wasm_sandbox_core/CLAUDE.md` | Shared WASM sandbox core primitives used below product adapters/runtime. | Product adapter workflow or host product policy. |
+
+### Turns, threads, loops, engine
+
+| Crate | Load first | Owns / go here for | Avoid moving in |
+| --- | --- | --- | --- |
+| `ironclaw_turns` | `ironclaw_turns/AGENTS.md`, `ironclaw_turns/CLAUDE.md` | Host-layer turn coordination: requests/responses, coordinator, runner, run profiles, loop exit, memory/context handoff, turn store. | Product adapter rendering, raw runtime lanes, UI behavior. |
+| `ironclaw_threads` | `ironclaw_threads/AGENTS.md`, `ironclaw_threads/CLAUDE.md` | Canonical session thread/transcript service contracts, identifiers, tool-result references, db/in-memory stores. | Product delivery policy or model/provider behavior. |
+| `ironclaw_conversations` | `ironclaw_conversations/AGENTS.md`, `ironclaw_conversations/CLAUDE.md` | Conversation binding, session thread contracts, inbound/state store, libSQL/Postgres conversation persistence. | Capability runtime internals or UI transport. |
+| `ironclaw_agent_loop` | `ironclaw_agent_loop/AGENTS.md`, `ironclaw_agent_loop/CLAUDE.md` | Agent-loop framework state, planner/executor, strategy/family contracts, test support. | Product adapters, transport, concrete provider auth. |
+| `ironclaw_loop_support` | `ironclaw_loop_support/AGENTS.md`, `ironclaw_loop_support/CLAUDE.md` | Loop host support services: capability/input ports, allow sets, input queue, identity/skill context, cancellation. | Owning core loop strategy or runtime lane execution. |
+| `ironclaw_capabilities` | `ironclaw_capabilities/AGENTS.md`, `ironclaw_capabilities/CLAUDE.md` | Caller-facing `CapabilityHost` invoke/resume/spawn workflow, obligation seams, conformance helpers. | Process lifecycle APIs, direct concrete runtime dependencies. |
+| `ironclaw_engine` | `ironclaw_engine/AGENTS.md`, `ironclaw_engine/CLAUDE.md`, `ironclaw_engine/MONTY.md` | Thread/capability/CodeAct engine: runtime manager, executor, gates, leases, memory retrieval, workspace mounts, traits/types. | Product transport, provider-specific auth, lower-layer host policy shortcuts. |
+
+### Product, adapters, Reborn binary
+
+| Crate | Load first | Owns / go here for | Avoid moving in |
+| --- | --- | --- | --- |
+| `ironclaw_reborn` | `ironclaw_reborn/AGENTS.md`, `ironclaw_reborn/CLAUDE.md` | Standalone Reborn composition/adapters: driver registry, home/profile/doctor support, runtime composition seams. | V1 root runtime imports unless explicitly bridged. |
+| `ironclaw_reborn_config` | `ironclaw_reborn_config/AGENTS.md`, `Cargo.toml`, `src/lib.rs` | Boot configuration contracts for standalone Reborn binary. | Runtime execution or product adapter behavior. |
+| `ironclaw_reborn_composition` | `ironclaw_reborn_composition/AGENTS.md`, `ironclaw_reborn_composition/CLAUDE.md` | Facade-shaped production composition root for Reborn. | Low-level policy internals that belong to service crates. |
+| `ironclaw_reborn_cli` | `ironclaw_reborn_cli/AGENTS.md` | Standalone Reborn CLI, command files, CLI context, shell completions, doctor/home/profile commands. | V1 runtime imports, root `ironclaw` deps, side effects in pure commands. |
+| `ironclaw_product_adapters` | `ironclaw_product_adapters/AGENTS.md`, `ironclaw_product_adapters/CLAUDE.md` | Product-adapter contracts: adapter trait, auth, egress, identity, workflow, external/projection/inbound, redaction, fakes. | Host runtime internals or specific WASM runner implementation. |
+| `ironclaw_product_adapter_registry` | `ironclaw_product_adapter_registry/AGENTS.md`, `ironclaw_product_adapter_registry/CLAUDE.md` | ProductAdapter host-api projection and installation registry. | Adapter execution or product workflow orchestration. |
+| `ironclaw_product_workflow` | `ironclaw_product_workflow/AGENTS.md`, `ironclaw_product_workflow/CLAUDE.md` | Product-facing workflow facade: inbound turns, bindings, ledger, workflow/errors, Reborn service bridges. | Low-level runtime lane internals or direct provider-specific transports. |
+| `ironclaw_wasm_product_adapters` | `ironclaw_wasm_product_adapters/AGENTS.md`, `ironclaw_wasm_product_adapters/CLAUDE.md` | WASM v2 ProductAdapter runtime: component runner, egress policy, auth verifier, bindings, store. | Generic WASM lane semantics or product workflow decisions. |
+| `ironclaw_telegram_v2_adapter` | `ironclaw_telegram_v2_adapter/AGENTS.md`, `Cargo.toml`, `src/lib.rs` | Telegram WASM v2 ProductAdapter tracer bullet: payload parsing, rendering, adapter implementation. | Shared adapter contracts or registry semantics. |
+
+### LLM, skills, safety, UI, helpers
+
+| Crate | Load first | Owns / go here for | Avoid moving in |
+| --- | --- | --- | --- |
+| `ironclaw_llm` | `ironclaw_llm/AGENTS.md`, `ironclaw_llm/CLAUDE.md` | Multi-provider LLM integration: provider trait, auth, registry, retry/failover/circuit breaker/cache, tool schemas, reasoning, tracing, transcription/vision. | Engine loop ownership or product workflow. |
+| `ironclaw_skills` | `ironclaw_skills/AGENTS.md` | Skill catalog, parser, gating, selector/scoring, registry, validation, v2 skill types. | Agent-loop execution or UI command routing. |
+| `ironclaw_safety` | `ironclaw_safety/AGENTS.md`, `crates/ironclaw_safety/fuzz/README.md` | Prompt-injection detection, validation, sanitization, safety policy, sensitive paths, credential detection, leak scanning, fuzz/benches. | Sandbox execution, credential storage/injection, network allowlists, dispatch, UI decisions. |
+| `ironclaw_gateway` | `ironclaw_gateway/AGENTS.md` | Gateway frontend assets, layout config, bundle metadata, widget extension system. | Browser API/web channel runtime (`src/channels/web/`) or product workflow. |
+| `ironclaw_tui` | `ironclaw_tui/AGENTS.md`, `ironclaw_tui/CLAUDE.md` | Ratatui app, widgets, layout, render, theme, event/input loop, spinner. | Main crate channel bridge (`src/channels/tui.rs`) or backend workflow. |
+| `ironclaw_silk_decoder` | `ironclaw_silk_decoder/AGENTS.md`, `ironclaw_silk_decoder/README.md` | Excluded helper binary that decodes WeChat SILK v3 voice notes to WAV. | Main workspace build dependencies; keep libclang isolated. |
+
+## Common Change Routes
+
+- Host API shape: `ironclaw_host_api` -> matching `docs/reborn/contracts/*.md` -> affected service/runtime crates -> `ironclaw_architecture`.
+- Storage abstraction: `ironclaw_storage` for generic mechanics; owning domain crate for schemas/queries; preserve libSQL/PostgreSQL parity.
+- Files/memory: `ironclaw_filesystem` for mount/path authority; `ironclaw_memory` for memory documents/search/chunking/indexing.
+- Events/projections/outbound: `ironclaw_events` for canonical redacted events; `ironclaw_event_projections` for projection model; `ironclaw_outbound` for metadata-only delivery/subscription policy; adapters for concrete delivery.
+- Trust/auth/approval: `ironclaw_trust` -> `ironclaw_authorization` -> `ironclaw_run_state`/`ironclaw_approvals` -> `ironclaw_capabilities` as needed.
+- Runtime execution: lane crate (`scripts`, `mcp`, `wasm`) first; `dispatcher` for routing; `host_runtime` for secrets/network/resources/redaction; `processes` for background lifecycle.
+- Turns/agent loop: `ironclaw_turns` for turn coordination; `ironclaw_agent_loop` for strategy/planner/executor contracts; `ironclaw_loop_support` for host support ports; `ironclaw_engine` for CodeAct/thread runtime.
+- Product adapter flow: `ironclaw_product_adapters` contracts -> `ironclaw_product_adapter_registry` installation/projection -> `ironclaw_product_workflow` orchestration -> concrete adapter crate.
+- Reborn binary/composition: `ironclaw_reborn_config` for boot config; `ironclaw_reborn_composition` for production wiring; `ironclaw_reborn_cli` for commands; `ironclaw_reborn` for standalone adapters/driver registry.
+- Model/provider behavior: `ironclaw_llm`; do not leak provider auth/cache/retry concerns into engine or product workflow.
+- UI presentation: `ironclaw_tui` or `ironclaw_gateway`; backend API/web channel code remains under root `src/`.
+
+## Testing
+
+Prefer narrow tests during iteration:
+
+```bash
+cargo test -p ironclaw_host_api
+cargo test -p ironclaw_network network_policy_contract
+cargo test -p ironclaw_outbound --all-features
+cargo test -p ironclaw_product_workflow
+cargo test -p ironclaw_wasm --test wit_tool_runtime_contract
+```
+
+Then expand by risk:
+
+```bash
+cargo test -p ironclaw_architecture
+scripts/check-boundaries.sh
+scripts/reborn-e2e-rust.sh
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Persistence behavior must support PostgreSQL and libSQL where applicable. If local Postgres is unavailable, follow crate-local skip flags only when docs/tests explicitly permit them.
+
+## Guardrails
+
+- Avoid `.unwrap()` / `.expect()` in production; use typed errors with context.
+- Preserve tenant/user/agent/project/mission/thread scope on authority, state, memory, process, network, outbound, resource, and event records.
+- Fail closed for auth, approvals, trust, filesystem containment, network policy, secret leases, runtime selection, and adapter identity.
+- Do not expose raw secrets, backend paths, private URLs, transport internals, raw SQL/backend errors, or unredacted runtime/user content across public surfaces.
+- Keep runtime crates untrusted: host-runtime mediates secrets/network/redaction/accounting.
+- Keep declarative crates declarative: manifests, contracts, registries, and policy descriptions should not perform execution side effects.
+- Use existing traits/ports/registries; avoid hardcoded cross-crate shortcuts.
+- Test through caller when a helper gates dispatch, persistence, network, secrets, approvals, resources, events, process, adapter, or UI side effects.
+
+## Docs / Parity Checklist
+
+Behavior changes may require updates to:
+
+- crate-local `AGENTS.md`, `CLAUDE.md`, `CONTRACT.md`, or `README.md`
+- `docs/reborn/contracts/*.md`
+- `FEATURE_PARITY.md`
+- crate changelogs for packages that publish independently
+- architecture boundary tests in `crates/ironclaw_architecture`

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -131,12 +131,12 @@ Boundary rule: if you need an upstream crate in a low-level crate, stop and chec
 
 | Crate | Load first | Owns / go here for | Avoid moving in |
 | --- | --- | --- | --- |
-| `ironclaw_llm` | `ironclaw_llm/AGENTS.md`, `ironclaw_llm/CLAUDE.md` | Multi-provider LLM integration: provider trait, auth, registry, retry/failover/circuit breaker/cache, tool schemas, reasoning, tracing, transcription/vision. | Engine loop ownership or product workflow. |
+| `ironclaw_llm` | `ironclaw_llm/AGENTS.md`, `ironclaw_llm/CLAUDE.md`, `ironclaw_llm/Cargo.toml` | Multi-provider LLM integration: provider trait, auth, registry, retry/failover/circuit breaker/cache, tool schemas, reasoning, tracing, transcription/vision. | Engine loop ownership or product workflow. |
 | `ironclaw_skills` | `ironclaw_skills/AGENTS.md` | Skill catalog, parser, gating, selector/scoring, registry, validation, v2 skill types. | Agent-loop execution or UI command routing. |
 | `ironclaw_safety` | `ironclaw_safety/AGENTS.md`, `crates/ironclaw_safety/fuzz/README.md` | Prompt-injection detection, validation, sanitization, safety policy, sensitive paths, credential detection, leak scanning, fuzz/benches. | Sandbox execution, credential storage/injection, network allowlists, dispatch, UI decisions. |
 | `ironclaw_gateway` | `ironclaw_gateway/AGENTS.md` | Gateway frontend assets, layout config, bundle metadata, widget extension system. | Browser API/web channel runtime (`src/channels/web/`) or product workflow. |
 | `ironclaw_tui` | `ironclaw_tui/AGENTS.md`, `ironclaw_tui/CLAUDE.md` | Ratatui app, widgets, layout, render, theme, event/input loop, spinner. | Main crate channel bridge (`src/channels/tui.rs`) or backend workflow. |
-| `ironclaw_silk_decoder` | `ironclaw_silk_decoder/AGENTS.md`, `ironclaw_silk_decoder/README.md` | Excluded helper binary that decodes WeChat SILK v3 voice notes to WAV. | Main workspace build dependencies; keep libclang isolated. |
+| `ironclaw_silk_decoder` | `ironclaw_silk_decoder/AGENTS.md`, `ironclaw_silk_decoder/README.md`, `ironclaw_silk_decoder/Cargo.toml`, `ironclaw_silk_decoder/src/main.rs` | Excluded helper binary that decodes WeChat SILK v3 voice notes to WAV. | Main workspace build dependencies; keep libclang isolated. |
 
 ## Common Change Routes
 

--- a/crates/ironclaw_agent_loop/AGENTS.md
+++ b/crates/ironclaw_agent_loop/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Map — ironclaw_agent_loop
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these neighboring contracts before changing cross-crate behavior:
+  - `crates/ironclaw_turns/AGENTS.md`
+  - `crates/ironclaw_loop_support/CLAUDE.md`
+  - `crates/ironclaw_reborn/CLAUDE.md`
+
+## What This Crate Owns
+
+- Agent-loop framework state and strategy contracts for Reborn.
+- `executor.rs` loop mechanics, canonical tick behavior, and deterministic execution flow.
+- `family.rs`, `families/`, `planner.rs`, `default_planner.rs`, and `strategies/` for sealed built-in loop-family/planning strategy composition.
+- `state.rs` and `state/` for resumable loop state: refs, cursors, counters, versions, and safe summaries only.
+- `test_support/` fixture code for framework and driver tests.
+
+## Do Not Move In Here
+
+- Product-specific logic, product adapters, transport behavior, or Reborn app composition.
+- `AgentLoopDriver` / `PlannedDriver` host wiring; that bridge belongs in `ironclaw_reborn`.
+- Runtime lanes, host-runtime services, provider auth, network/secrets, or UI concerns.
+- Raw prompts, raw assistant content, tool input JSON, secrets, host paths, or backend diagnostics in state.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_agent_loop`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- Run `cargo test -p ironclaw_reborn` when changes affect drivers or loop-host integration.
+
+## Agent Notes
+
+- Add new strategy files only for independent decision axes.
+- Add typed state-slot types instead of `serde_json::Value` shortcuts.
+- Keep strategy traits private unless a contract explicitly makes them public.
+- Strategies return decisions/state deltas; they should not mutate shared state by reference.

--- a/crates/ironclaw_conversations/AGENTS.md
+++ b/crates/ironclaw_conversations/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Map — ironclaw_conversations
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and backend feature shape.
+- Use these neighboring contracts before changing behavior:
+  - `crates/ironclaw_turns/AGENTS.md`
+  - `crates/ironclaw_threads/CLAUDE.md`
+  - `crates/ironclaw_product_adapters/CLAUDE.md`
+  - `docs/reborn/contracts/events-projections.md`
+
+## What This Crate Owns
+
+- Adapter-safe conversation binding and inbound-turn facade contracts.
+- External actor/conversation refs, source/reply binding refs, participant checks, message acceptance refs, and idempotency semantics.
+- Binding/state-store persistence for conversation binding, accepted-message idempotency, and turn-submission state.
+- Canonical `TurnCoordinator` inputs: `TurnScope`, `TurnActor`, `AcceptedMessageRef`, `SourceBindingRef`, and `ReplyTargetBindingRef`.
+
+## Do Not Move In Here
+
+- Concrete Slack/Telegram/Web/CLI payload parsing; product adapters normalize protocol payloads first.
+- Raw user/assistant message content in turn-facing records; transcript content belongs to thread/transcript storage.
+- Capability runtime internals, runtime dispatch, model/provider behavior, or UI transport.
+- Silent retargeting of explicit links or route drift during adapter retries.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_conversations`
+- Backend parity check when durable adapters change: run crate tests with all relevant features and DB harness settings.
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Binding resolution must fail closed for unknown threads, invalid refs, tenant/installation mismatches, participant-policy denial, or delimiter-like external IDs.
+- Source binding refs and reply target binding refs are distinct; egress must revalidate current reply targets.
+- Preserve typed `ironclaw_turns::TurnError`; do not flatten turn failures to strings.

--- a/crates/ironclaw_event_projections/AGENTS.md
+++ b/crates/ironclaw_event_projections/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Map — ironclaw_event_projections
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these Reborn contracts before changing behavior:
+  - `docs/reborn/contracts/events.md`
+  - `docs/reborn/contracts/events-projections.md`
+  - `crates/ironclaw_events/AGENTS.md`
+  - `crates/ironclaw_outbound/AGENTS.md`
+
+## What This Crate Owns
+
+- Replay/materialization-agnostic projection traits and DTOs.
+- Metadata-only projection outputs for product/read-model consumers.
+- Scoped reads with explicit stream and read-scope filters.
+- Projection contract tests for extension lifecycle, memory prompt safety, significant memory events, and replay behavior.
+
+## Do Not Move In Here
+
+- Backend rows or direct JSONL/PostgreSQL/libSQL adapter dependencies.
+- Mutations to durable logs or kernel state from projection failures.
+- Raw inputs, raw outputs, host paths, secrets, approval reasons, invocation fingerprints, backend details, or unredacted payloads.
+- Transport delivery or outbound delivery status persistence.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_event_projections`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- Run outbound/product workflow tests when projection shape changes affect delivery candidates or UI-visible feeds.
+
+## Agent Notes
+
+- Keep projections backend-independent and replayable.
+- Add new DTO fields only when they remain metadata-only and explicitly scoped.
+- Projection failures should be observable but non-mutating.

--- a/crates/ironclaw_llm/AGENTS.md
+++ b/crates/ironclaw_llm/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Map — ironclaw_llm
+
+## Start Here
+
+- Read `CLAUDE.md` first; it contains detailed provider and reasoning notes.
+- Read `Cargo.toml` for provider dependencies and feature shape.
+- Relevant files by area:
+  - `provider.rs`, `registry.rs`, `runtime.rs`, `host.rs` — provider contracts and host seams.
+  - `retry.rs`, `failover.rs`, `circuit_breaker.rs`, `response_cache.rs` — reliability and caching.
+  - `tool_schema.rs`, `rig_adapter.rs`, `openai_codex_provider.rs` — tool-call/schema boundaries.
+  - `reasoning.rs` — legacy reasoning engine and response shaping.
+  - `*_oauth.rs`, `*_auth.rs`, `session.rs`, `token_refreshing.rs` — provider auth/session handling.
+
+## What This Crate Owns
+
+- Multi-provider LLM integration with retry, failover, circuit breaker, and response caching.
+- `LlmProvider` trait, provider registry/chain construction, runtime adapters, tracing/recording, model/cost metadata.
+- Provider-specific auth for NEAR AI, Anthropic/Gemini OAuth, GitHub Copilot, OpenAI Codex/ChatGPT, AWS Bedrock.
+- Tool schema normalization and provider-specific tool-call compatibility.
+- Transcription, image/vision model helpers, smart routing, and test fault-injection support.
+
+## Do Not Move In Here
+
+- Agent-loop/thread ownership or product workflow; those live in engine/turns/product crates.
+- Tool execution side effects; `complete_with_tools()` must pass through cache and leave side effects to callers.
+- Unredacted tokens, refresh tokens, request bodies, or provider internals in public errors/logs.
+- Direct assumptions that one provider's model override/schema/auth behavior applies globally.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_llm`
+- Lint check: `cargo clippy -p ironclaw_llm --all-targets --all-features -- -D warnings`
+- Run caller tests when changing provider trait, tool schemas, reasoning output, auth refresh, or failover behavior.
+
+## Agent Notes
+
+- `RigAdapter` ignores per-request model overrides; only providers that explicitly support overrides should honor them.
+- `complete_with_tools()` is never cached because tool calls can have side effects.
+- OpenAI strict schema normalization rewrites optional object fields into required-nullable strict mode where required.
+- 401 handling differs by auth mode; preserve provider-specific semantics from `CLAUDE.md`.

--- a/crates/ironclaw_loop_support/AGENTS.md
+++ b/crates/ironclaw_loop_support/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent Map — ironclaw_loop_support
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these neighboring contracts before changing behavior:
+  - `crates/ironclaw_turns/AGENTS.md`
+  - `crates/ironclaw_capabilities/AGENTS.md`
+  - `crates/ironclaw_skills/AGENTS.md`
+  - `crates/ironclaw_reborn/CLAUDE.md`
+
+## What This Crate Owns
+
+- Loop host support services for `AgentLoopHost` / `ironclaw_turns` loop ports.
+- `skill_context.rs` and `identity_context.rs` prompt-safe instruction/context builders.
+- `capability_port.rs`, `capability_surface_filter.rs`, and `capability_allow_set.rs` capability-surface adapters.
+- `input_queue.rs` / `input_port.rs` steering and followup queues.
+- `cancellation_port.rs` cancellation observation adapter.
+
+## Do Not Move In Here
+
+- Core loop strategy or runner state transitions.
+- Product workflow composition, runtime lane execution, or Reborn app wiring.
+- Bypasses around `CapabilityHost` or dispatcher authority paths.
+- Full prompt content where safe summaries/refs are required.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_loop_support`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- Run `cargo test -p ironclaw_turns` and `cargo test -p ironclaw_reborn` when host-port contracts change.
+
+## Agent Notes
+
+- Add one file per host adapter or context source.
+- Put capability filtering policy in `capability_surface_filter.rs`.
+- Add traits here only for host-owned inputs to existing loop ports.
+- Do not fold unrelated ports into `lib.rs`.

--- a/crates/ironclaw_product_adapters/AGENTS.md
+++ b/crates/ironclaw_product_adapters/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent Map — ironclaw_product_adapters
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for feature shape (`test-support`, `host-auth-mint`, etc.).
+- Use these neighboring contracts before changing behavior:
+  - `crates/ironclaw_product_adapter_registry/AGENTS.md`
+  - `crates/ironclaw_product_workflow/AGENTS.md`
+  - `crates/ironclaw_wasm_product_adapters/CLAUDE.md`
+  - `crates/ironclaw_outbound/AGENTS.md`
+
+## What This Crate Owns
+
+- ProductAdapter contracts: typed inbound/outbound DTOs, adapter trait, workflow bridge types, and fakes.
+- External refs for actor/conversation/reply identity and presentation metadata.
+- Adapter auth evidence contracts, declared egress, projection/outbound envelope DTOs, and redaction helpers.
+- Adapter-safe parse/render/health boundaries independent of concrete product workflow.
+
+## Do Not Move In Here
+
+- Kernel/dispatcher internals, canonical user/thread resolution, turn coordination, or workflow orchestration.
+- ProductAdapter registry installation state or WASM runner implementation.
+- Direct network egress outside `ProtocolHttpEgress`.
+- Public constructors for sealed trusted auth evidence in production code.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_product_adapters`
+- Contract checks: `cargo test -p ironclaw_product_adapters --test product_adapter_contract`
+- Review-regression checks: `cargo test -p ironclaw_product_adapters --test review_findings_contract`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Inbound DTOs carry structured external refs only; no flattened string identities.
+- Adapters return parsed DTOs; host/product workflow stamps trusted context and performs canonical binding.
+- Delivery failures are best-effort status metadata, not transcript/run failure state.
+- Keep validation/redaction tests close to DTO changes.

--- a/crates/ironclaw_reborn/AGENTS.md
+++ b/crates/ironclaw_reborn/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent Map — ironclaw_reborn
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these neighboring contracts before changing behavior:
+  - `crates/ironclaw_agent_loop/CLAUDE.md`
+  - `crates/ironclaw_turns/AGENTS.md`
+  - `crates/ironclaw_loop_support/CLAUDE.md`
+  - `crates/ironclaw_reborn_composition/CLAUDE.md`
+
+## What This Crate Owns
+
+- Standalone Reborn composition/adapters bridging neutral contracts to concrete Reborn loop execution.
+- `planned_driver.rs`, `planned_driver_factory.rs`, `driver_registry.rs`, and `text_loop_driver.rs` driver behavior/registration/readiness.
+- `loop_driver_host.rs` concrete loop host-port composition for claimed runs.
+- `loop_exit_applier.rs` validation/application of loop exits and runner transitions.
+- `runtime.rs`, `model_gateway.rs`, `model_routes.rs`, `production_readiness.rs`, and secrets/model runtime seams.
+
+## Do Not Move In Here
+
+- Loop family/executor behavior owned by `ironclaw_agent_loop`.
+- Neutral runner/host contracts owned by `ironclaw_turns`.
+- Product-facing binding/idempotency/gate routing owned by product workflow.
+- Hidden fallback from planned to text-only paths; fallback must be explicit product/ops policy.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_reborn`
+- Run specific integration tests when touched: `driver_registry`, `planned_driver_e2e`, `loop_driver_host`, `model_routes`, `production_readiness`.
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Add a new file when adding a new driver, registry concern, host factory concern, or runtime adapter.
+- Keep `runtime.rs` limited to planned-runtime composition and explicit profile/runtime setup.
+- Do not expose planner strategy slots through Reborn APIs.
+- Do not duplicate neutral DTOs from `ironclaw_turns`.

--- a/crates/ironclaw_reborn_composition/AGENTS.md
+++ b/crates/ironclaw_reborn_composition/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Map — ironclaw_reborn_composition
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these neighboring contracts before changing behavior:
+  - `crates/ironclaw_reborn/AGENTS.md`
+  - `crates/ironclaw_reborn_config/AGENTS.md`
+  - `crates/ironclaw_host_runtime/AGENTS.md`
+  - `crates/ironclaw_turns/AGENTS.md`
+
+## What This Crate Owns
+
+- Facade-shaped production composition root for Reborn.
+- Top-level factories that expose `HostRuntime`, `TurnCoordinator`, readiness, runtime/profile inputs, and LLM catalog wiring.
+- Production and migration-dry-run profile validation for required handles.
+
+## Do Not Move In Here
+
+- Root `ironclaw` crate or `src/` module dependencies.
+- Lower substrate handles in public facade APIs.
+- Legacy bridge modes without accepted migration contract.
+- Live v1/product traffic routing; callers must opt into explicit Reborn adapters.
+- Low-level policy internals owned by service crates.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_reborn_composition`
+- Run profile/runtime tests when composition/profile behavior changes.
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- Run `scripts/reborn-e2e-rust.sh` for production wiring changes.
+
+## Agent Notes
+
+- Keep composition facade small and explicit.
+- Fail closed on local-only or missing required handles in production/migration-dry-run profiles.
+- Add readiness checks near the composed dependency they validate.

--- a/crates/ironclaw_reborn_config/AGENTS.md
+++ b/crates/ironclaw_reborn_config/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Map — ironclaw_reborn_config
+
+## Start Here
+
+- No crate-local CLAUDE.md exists yet; use this map plus `Cargo.toml` and source files.
+- Read `src/lib.rs` for exports, then area files:
+  - `home.rs` — Reborn home resolution.
+  - `profile.rs` — profile contracts.
+  - `boot.rs`, `config_file.rs` — boot/config file loading.
+  - `doctor.rs` — config diagnostics.
+  - `secrets_guard.rs` — secret/config guardrails.
+- Neighboring consumers: `crates/ironclaw_reborn_cli/AGENTS.md`, `crates/ironclaw_reborn_composition/AGENTS.md`.
+
+## What This Crate Owns
+
+- Boot configuration contracts for the standalone IronClaw Reborn binary.
+- Reborn home/profile/config-file/doctor/secrets-guard types and validation.
+- Pure config parsing/validation helpers that can be shared by CLI and composition.
+
+## Do Not Move In Here
+
+- Runtime execution, product adapter workflow, host-runtime service construction, or CLI command dispatch.
+- Writes to v1/current IronClaw state.
+- Network, secret retrieval, database connection, or product side effects.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_reborn_config`
+- Focused tests: `profile_contract`, `doctor_contract`, `home_contract`.
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Keep config contracts deterministic and side-effect light.
+- Use explicit Reborn home/profile inputs; do not read ambient env from deep helpers unless that is the contract being tested.
+- Add compatibility tests for serialized config/profile shapes.

--- a/crates/ironclaw_silk_decoder/AGENTS.md
+++ b/crates/ironclaw_silk_decoder/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Map — ironclaw_silk_decoder
+
+## Start Here
+
+- Read `README.md` first; it documents build/install/protocol and why this is isolated.
+- Read `Cargo.toml` and `src/main.rs` before changing behavior.
+- This crate is excluded from the workspace so the main IronClaw build does not require libclang.
+
+## What This Crate Owns
+
+- Standalone helper binary `ironclaw-silk-decoder`.
+- WeChat raw SILK v3 voice-note decoding to WAV.
+- CLI/protocol behavior for the helper process.
+
+## Do Not Move In Here
+
+- Main workspace dependencies or root IronClaw runtime behavior.
+- Channel/product workflow logic beyond the decoder protocol.
+- Secrets, network access, database access, or agent state.
+
+## Validation
+
+- Build/check from crate directory when touching decoder code: `cargo build --manifest-path crates/ironclaw_silk_decoder/Cargo.toml`
+- Follow `README.md` install/protocol checks for manual validation.
+- Do not use workspace-wide checks to prove this helper unless explicitly included.
+
+## Agent Notes
+
+- Keep libclang/native decoder requirements isolated here.
+- Preserve helper process protocol compatibility for callers.
+- Document any protocol change in `README.md`.

--- a/crates/ironclaw_silk_decoder/AGENTS.md
+++ b/crates/ironclaw_silk_decoder/AGENTS.md
@@ -20,7 +20,7 @@
 
 ## Validation
 
-- Build/check from crate directory when touching decoder code: `cargo build --manifest-path crates/ironclaw_silk_decoder/Cargo.toml`
+- Build/check from repo root: `cargo build --manifest-path crates/ironclaw_silk_decoder/Cargo.toml`
 - Follow `README.md` install/protocol checks for manual validation.
 - Do not use workspace-wide checks to prove this helper unless explicitly included.
 

--- a/crates/ironclaw_telegram_v2_adapter/AGENTS.md
+++ b/crates/ironclaw_telegram_v2_adapter/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Map — ironclaw_telegram_v2_adapter
+
+## Start Here
+
+- No crate-local CLAUDE.md exists yet; use this map plus `Cargo.toml` and source files.
+- Read `src/lib.rs` first, then:
+  - `adapter.rs` — ProductAdapter implementation.
+  - `payload.rs` — Telegram payload parsing/DTO handling.
+  - `render.rs` — Telegram outbound rendering.
+- Read upstream contracts before changing adapter behavior:
+  - `crates/ironclaw_product_adapters/AGENTS.md`
+  - `crates/ironclaw_wasm_product_adapters/CLAUDE.md`
+
+## What This Crate Owns
+
+- Telegram WASM v2 ProductAdapter tracer-bullet implementation.
+- Telegram payload parsing and outbound rendering for the adapter contract.
+- Adapter-specific mapping between Telegram shapes and shared ProductAdapter DTOs.
+
+## Do Not Move In Here
+
+- Shared ProductAdapter contracts, registry semantics, or product workflow orchestration.
+- Host auth minting, canonical conversation/thread binding, or turn coordination.
+- Network egress, webhook listener setup, or secret storage.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_telegram_v2_adapter`
+- Run `cargo test -p ironclaw_product_adapters` when shared DTO assumptions change.
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Keep Telegram-specific parsing/rendering here; move reusable DTO concerns upstream.
+- Preserve adapter outputs as untrusted parsed DTOs until host/workflow stamps trusted context.
+- Add tests before widening supported Telegram payload forms.

--- a/crates/ironclaw_threads/AGENTS.md
+++ b/crates/ironclaw_threads/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Map — ironclaw_threads
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for backend feature shape.
+- Use these neighboring contracts before changing behavior:
+  - `crates/ironclaw_turns/AGENTS.md`
+  - `crates/ironclaw_conversations/AGENTS.md`
+  - `crates/ironclaw_memory/AGENTS.md`
+
+## What This Crate Owns
+
+- Canonical Reborn `session_threads` and transcript service contracts.
+- Thread identifiers, transcript message contracts, message ordering/status/redaction semantics, context-window reads.
+- In-memory/fake stores and feature-gated durable contract stores.
+- Stable turn/run references supplied by `TurnCoordinator`.
+
+## Do Not Move In Here
+
+- V1 `Agent`, V1 `SessionManager`, product/channel adapters, raw runtime dispatchers, provider clients, capability execution internals, or workspace/memory services.
+- Turn/run lifecycle authority; this crate stores references, not lifecycle decisions.
+- Raw secrets, host paths, raw runtime/tool payloads, or private backend diagnostics as ordinary transcript content.
+- Product delivery policy or model/provider behavior.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_threads`
+- Focused contract checks: `session_thread_contract`, `db_session_thread_contract`.
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Preserve message identity and per-thread sequence across redaction/deletion.
+- Use policy-filtered read APIs for model-visible context.
+- Do not infer message status from nullable turn/run refs.

--- a/crates/ironclaw_wasm_product_adapters/AGENTS.md
+++ b/crates/ironclaw_wasm_product_adapters/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Map — ironclaw_wasm_product_adapters
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` for actual dependencies and feature shape.
+- Use these neighboring contracts before changing behavior:
+  - `crates/ironclaw_product_adapters/AGENTS.md`
+  - `crates/ironclaw_wasm_sandbox_core/CLAUDE.md`
+  - `crates/ironclaw_product_adapter_registry/AGENTS.md`
+  - `docs/reborn/contracts/network.md`
+
+## What This Crate Owns
+
+- WASM v2 host runtime for ProductAdapter components.
+- Adapter-specific host control-plane glue: protocol-auth verification, manifest egress preflight, component runtime, runner, bindings, store, config.
+- ProductAdapter WIT/request shapes and parse/render-only component execution path.
+- Seams for host-runtime egress injection; current HTTP egress import fails closed until wired.
+
+## Do Not Move In Here
+
+- Shared product-surface DTOs; keep those in `ironclaw_product_adapters`.
+- Product workflow, canonical user/thread binding, turn coordination, outbound projection cursors, delivery-status persistence, runtime dispatch, process spawning, or authorization/approval policy.
+- Production HTTP/DNS/private-IP checks/redirect handling/response limits/secret injection/leak scanning/redaction; delegate through host-runtime/network/secrets.
+- Auth evidence fabrication by WASM components.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_wasm_product_adapters`
+- Focused check: `cargo test -p ironclaw_wasm_product_adapters --test component_runtime_contract`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+
+## Agent Notes
+
+- Host glue stamps trusted adapter/installation/auth/received context after WASM returns parsed DTOs.
+- No-op/ignored authenticated events must be explicit parsed DTO payloads, not absent parse results.
+- Preserve minimal WASI p2: clock/random allowed; env,args,stdio,preopens,inherited network,DNS disabled.

--- a/crates/ironclaw_wasm_sandbox_core/AGENTS.md
+++ b/crates/ironclaw_wasm_sandbox_core/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Map — ironclaw_wasm_sandbox_core
+
+## Start Here
+
+- Read `CLAUDE.md` first; it is the crate-local guardrail file.
+- Read `Cargo.toml` and `src/lib.rs` for exported primitives.
+- Neighboring runtime crates:
+  - `crates/ironclaw_wasm/AGENTS.md`
+  - `crates/ironclaw_wasm_product_adapters/AGENTS.md`
+
+## What This Crate Owns
+
+- Domain-free Wasmtime/WASI sandbox kernel pieces.
+- Component-engine setup, epoch ticker, minimal WASI p2 linker, resource limiter, limits, and store-core helpers.
+- Reborn v1-style minimal WASI semantics and resource-limit primitives shared by runtime crates.
+
+## Do Not Move In Here
+
+- ProductAdapter, tool, channel, workflow, dispatcher, secret, network, filesystem, host-runtime, or app composition dependencies.
+- Runtime-specific WIT bindings, host trait implementations, or custom host imports.
+- HTTP, DNS/private-IP checks, secret injection, leak scanning, redaction, workspace reads, tool invocation, product workflow calls, or channel lifecycle logic.
+
+## Validation
+
+- Fast local check: `cargo test -p ironclaw_wasm_sandbox_core`
+- Boundary check after dependency/API changes: `cargo test -p ironclaw_architecture`
+- Run downstream runtime tests when changing exported sandbox primitives: `cargo test -p ironclaw_wasm` and `cargo test -p ironclaw_wasm_product_adapters`.
+
+## Agent Notes
+
+- Preserve minimal WASI p2: clock/random allowed; env,args,stdio inheritance, preopened directories, inherited network, and DNS lookup disabled.
+- Preserve fuel, epoch timeout, aggregate memory, table, instance, and memory limits per execution.
+- Multi-memory components must not multiply the configured `memory_bytes` budget.


### PR DESCRIPTION
## Summary
- add crates/AGENTS.md as the high-level crate routing map
- add crate-local AGENTS.md files for the 14 crates that were missing one
- update crates map to treat crate-local AGENTS.md as first-stop guidance for every crate

## Testing
- docs-only change; no test suite run
- validated every crate with Cargo.toml has AGENTS.md
- validated referenced paths in new/updated AGENTS docs exist
