### PR TITLE
[codex] Disable ANSI colors in worker containers

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -45,7 +45,10 @@ RUN apt-get update \
 # Install Rust toolchain for the sandbox user
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:$PATH \
+    NO_COLOR=1 \
+    RUST_LOG_STYLE=never \
+    FORCE_COLOR=0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.92.0 \
     && chmod -R a+r /usr/local/rustup /usr/local/cargo
 

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -18,6 +18,12 @@ use crate::sandbox::connect_docker;
 
 use ironclaw_common::MAX_WORKER_ITERATIONS;
 
+const DISABLE_ANSI_COLOR_ENV: &[&str] = &["NO_COLOR=1", "RUST_LOG_STYLE=never", "FORCE_COLOR=0"];
+
+fn extend_disable_ansi_color_env(env_vec: &mut Vec<String>) {
+    env_vec.extend(DISABLE_ANSI_COLOR_ENV.iter().map(|entry| entry.to_string()));
+}
+
 /// Which mode a sandbox container runs in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JobMode {
@@ -435,6 +441,7 @@ impl ContainerJobManager {
             format!("IRONCLAW_JOB_ID={}", job_id),
             format!("IRONCLAW_ORCHESTRATOR_URL={}", orchestrator_url),
         ];
+        extend_disable_ansi_color_env(&mut env_vec);
 
         // Build volume mounts (validate project_dir stays within ~/.ironclaw/projects/)
         let mut binds = Vec::new();
@@ -970,6 +977,16 @@ mod tests {
         let config = ContainerJobConfig::default();
         assert_eq!(config.orchestrator_port, 50051);
         assert_eq!(config.memory_limit_mb, 2048);
+    }
+
+    #[test]
+    fn test_worker_container_env_disables_ansi_colors() {
+        let mut env_vec = vec!["IRONCLAW_JOB_ID=test".to_string()];
+        extend_disable_ansi_color_env(&mut env_vec);
+
+        assert!(env_vec.contains(&"NO_COLOR=1".to_string()));
+        assert!(env_vec.contains(&"RUST_LOG_STYLE=never".to_string()));
+        assert!(env_vec.contains(&"FORCE_COLOR=0".to_string()));
     }
 
     #[test]

--- a/src/tracing_fmt.rs
+++ b/src/tracing_fmt.rs
@@ -36,10 +36,28 @@ pub fn init_cli_tracing() {
 /// Initialize tracing for worker/bridge processes (info level).
 pub fn init_worker_tracing() {
     tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("ironclaw=info")),
-        )
+        .with_ansi(false)
+        .with_env_filter(worker_env_filter())
         .init();
+}
+
+fn worker_env_filter() -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("ironclaw=info"))
+}
+
+#[cfg(test)]
+fn worker_tracing_subscriber_with_writer<W>(
+    writer: W,
+    env_filter: EnvFilter,
+) -> impl tracing::Subscriber + Send + Sync
+where
+    W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
+{
+    tracing_subscriber::fmt()
+        .with_ansi(false)
+        .with_env_filter(env_filter)
+        .with_writer(writer)
+        .finish()
 }
 
 /// Maximum bytes per tracing event written to the terminal.
@@ -168,7 +186,9 @@ impl Drop for EventBuffer {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use crate::tracing_fmt::{EventBuffer, TruncatingStderr, utf8_floor};
+    use crate::tracing_fmt::{
+        EventBuffer, TruncatingStderr, utf8_floor, worker_tracing_subscriber_with_writer,
+    };
 
     use std::io::Write;
 
@@ -288,6 +308,68 @@ mod tests {
     fn test_default_max_bytes() {
         let writer = TruncatingStderr::default();
         assert_eq!(writer.max_bytes, 500);
+    }
+
+    #[derive(Clone)]
+    struct CapturingWriter {
+        sink: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingSink;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CapturingSink {
+                sink: Arc::clone(&self.sink),
+            }
+        }
+    }
+
+    struct CapturingSink {
+        sink: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for CapturingSink {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            self.sink.lock().unwrap().extend_from_slice(data);
+            Ok(data.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_worker_tracing_formatter_emits_no_ansi_escape_bytes() {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = worker_tracing_subscriber_with_writer(
+            CapturingWriter {
+                sink: Arc::clone(&sink),
+            },
+            tracing_subscriber::EnvFilter::new("ironclaw=info"),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(
+                target: "ironclaw",
+                status = 200,
+                body_len = 23,
+                "HTTP response received"
+            );
+        });
+
+        let output = sink.lock().unwrap().clone();
+        assert!(
+            !output.contains(&0x1b),
+            "worker tracing output must not contain ANSI ESC bytes: {:?}",
+            String::from_utf8_lossy(&output)
+        );
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("HTTP response received"));
+        assert!(output.contains("status=200"));
+        assert!(output.contains("body_len=23"));
     }
 
     #[test]

--- a/tests/dockerfile_worker_log_style.rs
+++ b/tests/dockerfile_worker_log_style.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+fn worker_dockerfile() -> String {
+    let repo_root = std::env::var_os("CARGO_MANIFEST_DIR")
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())
+        .expect("repo root should be discoverable");
+    let path = repo_root.join("Dockerfile.worker");
+    std::fs::read_to_string(path).expect("Dockerfile.worker should be readable")
+}
+
+#[test]
+fn worker_image_disables_ansi_colored_output() {
+    let dockerfile = worker_dockerfile();
+
+    assert!(
+        dockerfile.contains("NO_COLOR=1"),
+        "worker image must request colorless output so journald keeps MESSAGE as a string",
+    );
+    assert!(
+        dockerfile.contains("RUST_LOG_STYLE=never"),
+        "worker image must disable tracing-subscriber ANSI escapes",
+    );
+    assert!(
+        dockerfile.contains("FORCE_COLOR=0"),
+        "worker image must disable forced color output from JS and CLI tools",
+    );
+}


### PR DESCRIPTION
## Summary
- disable ANSI output for worker/bridge tracing so journald sees printable log messages
- inject NO_COLOR, RUST_LOG_STYLE=never, and FORCE_COLOR=0 into orchestrated worker containers
- bake the same colorless defaults into Dockerfile.worker for rebuilt worker images

Closes #3756.

## Validation
- cargo fmt --check
- cargo test --lib test_worker_tracing_formatter_emits_no_ansi_escape_bytes
- cargo test --lib test_worker_container_env_disables_ansi_colors
- cargo test --test dockerfile_worker_log_style worker_image_disables_ansi_colored_output
- cargo test --test dockerfile_runtime_home --test dockerfile_worker_log_style