### PR TITLE
[codex] Fix Reborn event store feature imports

### DIFF
--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -37,10 +37,11 @@ use ironclaw_events::{
     DurableAuditLog, DurableEventLog, EventCursor, EventError, EventLogEntry, EventReplay,
     EventStreamKey, InMemoryDurableAuditLog, InMemoryDurableEventLog, ReadScope, RuntimeEvent,
 };
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
-use ironclaw_host_api::{
-    AgentId, AuditEnvelope, MountAlias, MountGrant, MountPermissions, MountView, VirtualPath,
-};
+use ironclaw_host_api::{AgentId, AuditEnvelope};
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;


### PR DESCRIPTION
## Summary

- Gate Reborn event store filesystem and mount imports behind the same `libsql`/`postgres` feature condition as the backend helper code that uses them.
- Keeps the default build free of unused import warnings without breaking backend-enabled builds.

## Root cause

The warning cleanup removed imports that are unused in the default build, but those symbols are still required when `ironclaw_reborn_event_store` is compiled with the `libsql` or `postgres` feature.

## Validation

- `cargo fmt --package ironclaw_reborn_event_store`
- `cargo check -p ironclaw_reborn_event_store`
- `cargo check -p ironclaw_reborn_event_store --features libsql`
- `cargo check -p ironclaw_reborn_event_store --features postgres`
- `cargo clippy -p ironclaw_reborn_event_store --all-targets --all-features -- -D warnings`
- `git diff --check`