### PR TITLE
feat(reborn): add memory product surface contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4559,6 +4559,7 @@ dependencies = [
  "ironclaw_host_api",
  "ironclaw_host_runtime",
  "ironclaw_loop_support",
+ "ironclaw_memory",
  "ironclaw_product_adapters",
  "ironclaw_product_workflow",
  "ironclaw_reborn",

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -358,6 +358,76 @@ fn reborn_turns_public_surface_keeps_runner_api_explicit() {
 }
 
 #[test]
+fn reborn_memory_product_facade_stays_on_typed_memory_services() {
+    let root = workspace_root();
+    let facade = std::fs::read_to_string(
+        root.join("crates/ironclaw_product_workflow/src/memory_product.rs"),
+    )
+    .expect("memory product facade source must be readable");
+    let contract =
+        std::fs::read_to_string(root.join("docs/reborn/contracts/memory-product-surfaces.md"))
+            .expect("memory product surface contract must be readable");
+
+    for required in [
+        "MemoryProductFacade",
+        "MemoryDocumentService",
+        "MemorySearchService",
+        "MemoryLayerService",
+        "MemoryVersionService",
+        "MemorySeedService",
+        "MemoryProfileService",
+        "MemoryPromptWriteSafetyPolicy",
+    ] {
+        assert!(
+            facade.contains(required),
+            "memory product facade must consume typed Reborn memory service `{required}`"
+        );
+    }
+
+    for forbidden in [
+        "crate::workspace",
+        "src::workspace",
+        "Workspace::",
+        "WorkspacePool",
+        "WorkspaceResolver",
+        "MemoryDocumentRepository",
+        "InMemoryMemoryDocumentRepository",
+        "FilesystemMemoryDocumentRepository",
+        "EmbeddingProvider",
+        "LlmProvider",
+        "SecretsStore",
+        "HostRuntime",
+        "std::fs",
+        "tokio::fs",
+        "std::net",
+        "reqwest",
+    ] {
+        assert!(
+            !facade.contains(forbidden),
+            "MemoryProductFacade must not depend on v1 workspace/raw substrate escape hatch `{forbidden}`"
+        );
+    }
+
+    for required_phrase in [
+        "#3287 migrates memory-document product behavior",
+        "legacy-relative paths",
+        "MemoryDocumentService",
+        "MemorySearchService",
+        "MemoryLayerService",
+        "MemoryVersionService",
+        "MemorySeedService",
+        "MemoryProfileService",
+        "legacy `Workspace` remains the production writer",
+        "no silent legacy/Reborn dual-write",
+    ] {
+        assert!(
+            contract.contains(required_phrase),
+            "memory product surface contract missing `{required_phrase}`"
+        );
+    }
+}
+
+#[test]
 fn reborn_loop_support_llm_wiring_stays_out_of_root_src() {
     let root = workspace_root();
     let root_lib =

--- a/crates/ironclaw_memory/src/lib.rs
+++ b/crates/ironclaw_memory/src/lib.rs
@@ -16,6 +16,7 @@ mod repo;
 mod safety;
 mod schema;
 mod search;
+mod services;
 
 pub use backend::{
     MemoryBackend, MemoryBackendCapabilities, MemoryContext, RepositoryMemoryBackend,
@@ -46,3 +47,17 @@ pub use safety::{
     PromptWriteSafetyPolicy, PromptWriteSafetyRequest, PromptWriteSource,
 };
 pub use search::{FusionStrategy, MemorySearchRequest, MemorySearchResult};
+pub use services::{
+    MemoryAppendDocumentRequest, MemoryBootstrapClearOutcome, MemoryBootstrapClearRequest,
+    MemoryDocumentEntry, MemoryDocumentRecord, MemoryDocumentService, MemoryLayerService,
+    MemoryLayerWriteMode, MemoryLayerWriteOutcome, MemoryLayerWriteRequest,
+    MemoryListDocumentsRequest, MemoryPatchDocumentOutcome, MemoryPatchDocumentRequest,
+    MemoryProductSearchHit, MemoryProductSearchRequest, MemoryProfileService,
+    MemoryProfileSyncOutcome, MemoryProfileSyncRequest, MemoryPromptWriteSafetyDecision,
+    MemoryPromptWriteSafetyPolicy, MemoryPromptWriteSafetyRequest, MemoryReadDocumentRequest,
+    MemorySearchGroupContext, MemorySearchService, MemorySeedService, MemoryServiceError,
+    MemoryServiceErrorCode, MemoryStatus, MemoryStatusRequest, MemoryTreeRequest,
+    MemoryVersionListRequest, MemoryVersionReadRequest, MemoryVersionRecord, MemoryVersionService,
+    MemoryVersionSummary, MemoryWriteActor, MemoryWriteAuthority, MemoryWriteDocumentOutcome,
+    MemoryWriteDocumentRequest, MemoryWritePurpose, MemoryWriteSurface,
+};

--- a/crates/ironclaw_memory/src/metadata.rs
+++ b/crates/ironclaw_memory/src/metadata.rs
@@ -79,7 +79,7 @@ fn default_retention_days() -> u32 {
 }
 
 /// Options resolved by the memory backend before persisting a document write.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct MemoryWriteOptions {
     pub metadata: DocumentMetadata,
     pub changed_by: Option<String>,

--- a/crates/ironclaw_memory/src/services.rs
+++ b/crates/ironclaw_memory/src/services.rs
@@ -1,0 +1,458 @@
+//! Focused Reborn memory service contracts.
+//!
+//! These traits are the product-facing service vocabulary above repository
+//! backends. They intentionally carry resolved memory scope plus legacy-relative
+//! paths; product callers must not construct scoped `/memory/tenants/...` paths.
+
+use async_trait::async_trait;
+use ironclaw_host_api::HostApiError;
+
+use crate::metadata::MemoryWriteOptions;
+use crate::path::{MemoryDocumentPath, MemoryDocumentScope};
+use crate::safety::{PromptProtectedPathClass, PromptWriteOperation};
+
+/// Stable service error code returned by Reborn memory service facades.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryServiceErrorCode {
+    InvalidRequest,
+    NotFound,
+    AccessDenied,
+    Conflict,
+    Unavailable,
+    PromptWriteRejected,
+    Internal,
+}
+
+impl MemoryServiceErrorCode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::NotFound => "not_found",
+            Self::AccessDenied => "access_denied",
+            Self::Conflict => "conflict",
+            Self::Unavailable => "unavailable",
+            Self::PromptWriteRejected => "prompt_write_rejected",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+/// Sanitized error returned by focused memory services.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryServiceError {
+    code: MemoryServiceErrorCode,
+    message: String,
+}
+
+impl MemoryServiceError {
+    pub fn new(code: MemoryServiceErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: sanitize_service_message(message.into()),
+        }
+    }
+
+    pub fn invalid_request(message: impl Into<String>) -> Self {
+        Self::new(MemoryServiceErrorCode::InvalidRequest, message)
+    }
+
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(MemoryServiceErrorCode::NotFound, message)
+    }
+
+    pub fn prompt_write_rejected(message: impl Into<String>) -> Self {
+        Self::new(MemoryServiceErrorCode::PromptWriteRejected, message)
+    }
+
+    pub fn code(&self) -> MemoryServiceErrorCode {
+        self.code
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl std::fmt::Display for MemoryServiceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.code.as_str(), self.message)
+    }
+}
+
+impl std::error::Error for MemoryServiceError {}
+
+impl From<HostApiError> for MemoryServiceError {
+    fn from(value: HostApiError) -> Self {
+        Self::invalid_request(value.to_string())
+    }
+}
+
+const MEMORY_SERVICE_DETAIL_MARKERS: &[&str] = &[
+    "no such table",
+    "drop table",
+    "sql",
+    "sqlite",
+    "libsql",
+    "postgres",
+    "provider",
+    "api key",
+    "secret",
+    "token",
+    "/tmp/",
+    "/private/",
+    "/var/folders/",
+    "\\appdata\\",
+];
+
+fn sanitize_service_message(message: String) -> String {
+    let lower = message.to_ascii_lowercase();
+    if MEMORY_SERVICE_DETAIL_MARKERS
+        .iter()
+        .any(|marker| lower.contains(marker))
+    {
+        "memory service operation failed".to_string()
+    } else {
+        message
+    }
+}
+
+/// Product actor that caused a memory write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryWriteActor {
+    User { user_id: String },
+    Agent { agent_id: String },
+    Admin { user_id: String },
+    Tool { tool_name: String },
+}
+
+/// Product surface that caused a memory write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryWriteSurface {
+    Cli,
+    Web,
+    LlmTool,
+    SetupAdmin,
+    PromptContext,
+}
+
+/// Product intent for a memory write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryWritePurpose {
+    Memory,
+    DailyLog,
+    Heartbeat,
+    Bootstrap,
+    CustomPath,
+    Metadata,
+    LayerWrite,
+    ProfileSync,
+    Seed,
+}
+
+/// Actor/surface/purpose authority that must flow into prompt-write policy and audit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryWriteAuthority {
+    pub actor: MemoryWriteActor,
+    pub surface: MemoryWriteSurface,
+    pub purpose: MemoryWritePurpose,
+}
+
+impl MemoryWriteAuthority {
+    pub fn new(
+        actor: MemoryWriteActor,
+        surface: MemoryWriteSurface,
+        purpose: MemoryWritePurpose,
+    ) -> Self {
+        Self {
+            actor,
+            surface,
+            purpose,
+        }
+    }
+}
+
+/// Current memory document content returned by document reads.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryDocumentRecord {
+    pub path: MemoryDocumentPath,
+    pub content: String,
+    pub metadata: serde_json::Value,
+}
+
+/// Summary entry returned by list/tree operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryDocumentEntry {
+    pub relative_path: String,
+    pub is_directory: bool,
+}
+
+/// Memory workspace status DTO.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryStatus {
+    pub document_count: usize,
+    pub indexed_document_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryReadDocumentRequest {
+    pub path: MemoryDocumentPath,
+    pub primary_scope_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryWriteDocumentRequest {
+    pub path: MemoryDocumentPath,
+    pub content: String,
+    pub options: MemoryWriteOptions,
+    pub authority: MemoryWriteAuthority,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryAppendDocumentRequest {
+    pub path: MemoryDocumentPath,
+    pub content: String,
+    pub options: MemoryWriteOptions,
+    pub authority: MemoryWriteAuthority,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryPatchDocumentRequest {
+    pub path: MemoryDocumentPath,
+    pub old_string: String,
+    pub new_string: String,
+    pub replace_all: bool,
+    pub authority: MemoryWriteAuthority,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryPatchDocumentOutcome {
+    pub replacements: usize,
+    pub content_length: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryWriteDocumentOutcome {
+    pub relative_path: String,
+    pub content_length: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryListDocumentsRequest {
+    pub scope: MemoryDocumentScope,
+    pub parent: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryTreeRequest {
+    pub scope: MemoryDocumentScope,
+    pub root: Option<String>,
+    pub max_depth: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryStatusRequest {
+    pub scope: MemoryDocumentScope,
+}
+
+#[async_trait]
+pub trait MemoryDocumentService: Send + Sync {
+    async fn read_current(
+        &self,
+        request: MemoryReadDocumentRequest,
+    ) -> Result<MemoryDocumentRecord, MemoryServiceError>;
+
+    async fn write(
+        &self,
+        request: MemoryWriteDocumentRequest,
+    ) -> Result<MemoryWriteDocumentOutcome, MemoryServiceError>;
+
+    async fn append(
+        &self,
+        request: MemoryAppendDocumentRequest,
+    ) -> Result<MemoryWriteDocumentOutcome, MemoryServiceError>;
+
+    async fn patch(
+        &self,
+        request: MemoryPatchDocumentRequest,
+    ) -> Result<MemoryPatchDocumentOutcome, MemoryServiceError>;
+
+    async fn list(
+        &self,
+        request: MemoryListDocumentsRequest,
+    ) -> Result<Vec<MemoryDocumentEntry>, MemoryServiceError>;
+
+    async fn tree(
+        &self,
+        request: MemoryTreeRequest,
+    ) -> Result<Vec<MemoryDocumentEntry>, MemoryServiceError>;
+
+    async fn status(
+        &self,
+        request: MemoryStatusRequest,
+    ) -> Result<MemoryStatus, MemoryServiceError>;
+}
+
+/// Product search request. Query embedding generation belongs inside the service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProductSearchRequest {
+    pub scope: MemoryDocumentScope,
+    pub query: String,
+    pub limit: usize,
+    pub secondary_scopes: Vec<MemoryDocumentScope>,
+    pub exclude_identity_documents_from_secondary: bool,
+    pub group_context: Option<MemorySearchGroupContext>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemorySearchGroupContext {
+    pub conversation_id: String,
+    pub personal_memory_allowed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryProductSearchHit {
+    pub relative_path: String,
+    pub content: String,
+    pub score: f32,
+}
+
+#[async_trait]
+pub trait MemorySearchService: Send + Sync {
+    async fn search(
+        &self,
+        request: MemoryProductSearchRequest,
+    ) -> Result<Vec<MemoryProductSearchHit>, MemoryServiceError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryLayerWriteMode {
+    Append,
+    Replace,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryLayerWriteRequest {
+    pub path: MemoryDocumentPath,
+    pub layer_name: String,
+    pub content: String,
+    pub mode: MemoryLayerWriteMode,
+    pub force: bool,
+    pub options: MemoryWriteOptions,
+    pub authority: MemoryWriteAuthority,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryLayerWriteOutcome {
+    pub relative_path: String,
+    pub actual_layer: String,
+    pub redirected: bool,
+}
+
+#[async_trait]
+pub trait MemoryLayerService: Send + Sync {
+    async fn write_layer(
+        &self,
+        request: MemoryLayerWriteRequest,
+    ) -> Result<MemoryLayerWriteOutcome, MemoryServiceError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryVersionListRequest {
+    pub path: MemoryDocumentPath,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryVersionReadRequest {
+    pub path: MemoryDocumentPath,
+    pub version: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryVersionSummary {
+    pub version: i32,
+    pub content_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryVersionRecord {
+    pub path: MemoryDocumentPath,
+    pub version: i32,
+    pub content: String,
+    pub content_hash: String,
+}
+
+#[async_trait]
+pub trait MemoryVersionService: Send + Sync {
+    async fn list_versions(
+        &self,
+        request: MemoryVersionListRequest,
+    ) -> Result<Vec<MemoryVersionSummary>, MemoryServiceError>;
+
+    async fn read_version(
+        &self,
+        request: MemoryVersionReadRequest,
+    ) -> Result<MemoryVersionRecord, MemoryServiceError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryBootstrapClearRequest {
+    pub scope: MemoryDocumentScope,
+    pub authority: MemoryWriteAuthority,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryBootstrapClearOutcome {
+    pub relative_path: String,
+}
+
+#[async_trait]
+pub trait MemorySeedService: Send + Sync {
+    async fn clear_bootstrap(
+        &self,
+        request: MemoryBootstrapClearRequest,
+    ) -> Result<MemoryBootstrapClearOutcome, MemoryServiceError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProfileSyncRequest {
+    pub scope: MemoryDocumentScope,
+    pub profile_path: MemoryDocumentPath,
+    pub authority: MemoryWriteAuthority,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProfileSyncOutcome {
+    pub synced_relative_paths: Vec<String>,
+}
+
+#[async_trait]
+pub trait MemoryProfileService: Send + Sync {
+    async fn sync_profile_documents(
+        &self,
+        request: MemoryProfileSyncRequest,
+    ) -> Result<MemoryProfileSyncOutcome, MemoryServiceError>;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryPromptWriteSafetyRequest {
+    pub path: MemoryDocumentPath,
+    pub operation: PromptWriteOperation,
+    pub protected_path_class: PromptProtectedPathClass,
+    pub content: String,
+    pub authority: MemoryWriteAuthority,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryPromptWriteSafetyDecision {
+    Allow,
+    Reject { reason: String },
+}
+
+#[async_trait]
+pub trait MemoryPromptWriteSafetyPolicy: Send + Sync {
+    async fn check_product_write(
+        &self,
+        request: MemoryPromptWriteSafetyRequest,
+    ) -> Result<MemoryPromptWriteSafetyDecision, MemoryServiceError>;
+}

--- a/crates/ironclaw_product_workflow/CLAUDE.md
+++ b/crates/ironclaw_product_workflow/CLAUDE.md
@@ -19,6 +19,7 @@ handling, gate routing, mission routing, and redacted acknowledgements.
 | `IdempotencyLedger` | Durable action deduplication port |
 | `ProductInboundAction` | Durable ledger record for inbound actions |
 | `RebornServicesApi` / `RebornServices` | Native WebChat v2 facade — stable surface beta WebUI route handlers consume in place of reaching into turn coordination, thread stores, runtime lanes, dispatchers, or capability hosts. Enforces caller ownership of the thread before any turn mutation; rejects stale or attacker-supplied `gate_ref` on denied/cancelled gate resolutions; refuses persistent (`always: true`) approvals until an approval-policy port lands |
+| `MemoryProductFacade` | #3287 first-slice memory product boundary. Resolves product targets and relative paths into typed Reborn memory service requests, carries actor/surface/purpose authority, and keeps v1 `Workspace` out of Reborn product memory code |
 
 ## Dependencies
 
@@ -26,6 +27,7 @@ handling, gate routing, mission routing, and redacted acknowledgements.
 - `ironclaw_turns` — turn coordinator, scope, IDs
 - `ironclaw_threads` — session thread service contract
 - `ironclaw_host_api` — canonical identifiers (TenantId, UserId, etc.)
+- `ironclaw_memory` — focused Reborn memory service contracts and prompt-write safety vocabulary
 
 ## Boundary rules
 
@@ -37,6 +39,14 @@ Agent-loop note: product-facing turns enter through workflow services and
 canonical turn submission. Do not shortcut directly to `AgentLoopDriver`,
 `PlannedDriver`, host runtime services, or loop host factories from adapters or
 workflow callers.
+
+Memory note: `MemoryProductFacade` is a contract boundary only in the first
+#3287 slice. It may consume typed `ironclaw_memory` service traits, but must not
+depend on v1 `Workspace`, `WorkspacePool`, `WorkspaceResolver`, raw memory
+repositories, raw provider clients, secret stores, filesystem/process/network
+handles, or HostRuntime internals. LLM-facing memory tools must eventually enter
+through HostRuntime-mediated capability execution, not by directly calling
+memory services from route/tool code.
 
 ## Test support
 

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -21,6 +21,7 @@ test-support = ["ironclaw_product_adapters/test-support"]
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
+ironclaw_memory = { path = "../ironclaw_memory", version = "0.1.0" }
 ironclaw_product_adapters = { path = "../ironclaw_product_adapters", version = "0.1.0" }
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }
 ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }

--- a/crates/ironclaw_product_workflow/src/lib.rs
+++ b/crates/ironclaw_product_workflow/src/lib.rs
@@ -26,6 +26,7 @@ mod error;
 mod fakes;
 mod inbound_turn;
 mod ledger;
+mod memory_product;
 mod reborn_services;
 mod webui_inbound;
 mod workflow;
@@ -40,6 +41,13 @@ pub use error::ProductWorkflowError;
 pub use fakes::{FakeConversationBindingService, FakeIdempotencyLedger, FakeInboundTurnService};
 pub use inbound_turn::{DefaultInboundTurnService, InboundTurnOutcome, InboundTurnService};
 pub use ledger::{IdempotencyDecision, IdempotencyLedger};
+pub use memory_product::{
+    MemoryProductError, MemoryProductFacade, MemoryProductListRequest, MemoryProductReadMode,
+    MemoryProductReadRequest, MemoryProductReadResponse, MemoryProductSearchRequest,
+    MemoryProductServices, MemoryProductStatusRequest, MemoryProductTreeRequest,
+    MemoryProductWriteMode, MemoryProductWriteRequest, MemoryProductWriteResponse,
+    MemoryProductWriteTarget,
+};
 pub use reborn_services::{
     RebornCancelRunResponse, RebornCreateThreadResponse, RebornGetRunStateRequest,
     RebornGetRunStateResponse, RebornResolveGateResponse, RebornResumeGateResponse, RebornServices,

--- a/crates/ironclaw_product_workflow/src/memory_product.rs
+++ b/crates/ironclaw_product_workflow/src/memory_product.rs
@@ -1,0 +1,611 @@
+//! Product-facing memory facade for the #3287 first slice.
+//!
+//! This module is deliberately a thin adapter boundary. It resolves product
+//! targets and relative paths, carries actor/surface/purpose authority into
+//! memory service DTOs, and leaves storage/search/provider execution to focused
+//! `ironclaw_memory` services.
+
+use std::sync::Arc;
+
+use ironclaw_memory::{
+    DocumentMetadata, MemoryAppendDocumentRequest, MemoryBootstrapClearRequest,
+    MemoryDocumentEntry, MemoryDocumentPath, MemoryDocumentRecord, MemoryDocumentScope,
+    MemoryDocumentService, MemoryLayerService, MemoryLayerWriteMode, MemoryLayerWriteRequest,
+    MemoryListDocumentsRequest, MemoryPatchDocumentRequest, MemoryProductSearchHit,
+    MemoryProfileService, MemoryProfileSyncRequest, MemoryPromptWriteSafetyDecision,
+    MemoryPromptWriteSafetyPolicy, MemoryPromptWriteSafetyRequest, MemoryReadDocumentRequest,
+    MemorySearchGroupContext, MemorySearchService, MemorySeedService, MemoryServiceError,
+    MemoryStatus, MemoryStatusRequest, MemoryTreeRequest, MemoryVersionListRequest,
+    MemoryVersionReadRequest, MemoryVersionRecord, MemoryVersionService, MemoryVersionSummary,
+    MemoryWriteActor, MemoryWriteAuthority, MemoryWriteDocumentRequest, MemoryWriteOptions,
+    MemoryWritePurpose, MemoryWriteSurface, PromptProtectedPathRegistry, PromptWriteOperation,
+};
+use thiserror::Error;
+
+const MEMORY_PATH: &str = "MEMORY.md";
+const HEARTBEAT_PATH: &str = "HEARTBEAT.md";
+const BOOTSTRAP_PATH: &str = "BOOTSTRAP.md";
+const PROFILE_PATH: &str = "context/profile.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum MemoryProductError {
+    #[error("invalid memory product request: {reason}")]
+    InvalidRequest { reason: String },
+    #[error("memory prompt write rejected: {reason}")]
+    PromptWriteRejected { reason: String },
+    #[error("memory service failed: {source}")]
+    Service { source: MemoryServiceError },
+}
+
+impl From<MemoryServiceError> for MemoryProductError {
+    fn from(source: MemoryServiceError) -> Self {
+        Self::Service { source }
+    }
+}
+
+impl From<ironclaw_host_api::HostApiError> for MemoryProductError {
+    fn from(value: ironclaw_host_api::HostApiError) -> Self {
+        Self::InvalidRequest {
+            reason: value.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryProductWriteTarget {
+    Memory,
+    DailyLog { local_date: String },
+    Heartbeat,
+    Bootstrap,
+    CustomPath(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryProductWriteMode {
+    Append,
+    Replace,
+    Patch {
+        old_string: String,
+        new_string: String,
+        replace_all: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryProductWriteRequest {
+    pub scope: MemoryDocumentScope,
+    pub target: MemoryProductWriteTarget,
+    pub mode: MemoryProductWriteMode,
+    pub content: String,
+    pub metadata: Option<serde_json::Value>,
+    pub layer_name: Option<String>,
+    pub force: bool,
+    pub actor: MemoryWriteActor,
+    pub surface: MemoryWriteSurface,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProductWriteResponse {
+    pub relative_path: String,
+    pub status: String,
+    pub content_length: usize,
+    pub actual_layer: Option<String>,
+    pub redirected: Option<bool>,
+    pub replacements: Option<usize>,
+    pub synced_relative_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryProductReadMode {
+    Current,
+    ListVersions { limit: usize },
+    Version { version: i32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProductReadRequest {
+    pub scope: MemoryDocumentScope,
+    pub relative_path: String,
+    pub mode: MemoryProductReadMode,
+    pub primary_scope_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MemoryProductReadResponse {
+    Current(MemoryDocumentRecord),
+    Versions(Vec<MemoryVersionSummary>),
+    Version(MemoryVersionRecord),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProductSearchRequest {
+    pub scope: MemoryDocumentScope,
+    pub query: String,
+    pub limit: usize,
+    pub secondary_scopes: Vec<MemoryDocumentScope>,
+    pub group_context: Option<MemorySearchGroupContext>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProductListRequest {
+    pub scope: MemoryDocumentScope,
+    pub parent: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProductTreeRequest {
+    pub scope: MemoryDocumentScope,
+    pub root: Option<String>,
+    pub max_depth: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryProductStatusRequest {
+    pub scope: MemoryDocumentScope,
+}
+
+pub struct MemoryProductServices {
+    pub document_service: Arc<dyn MemoryDocumentService>,
+    pub search_service: Arc<dyn MemorySearchService>,
+    pub layer_service: Arc<dyn MemoryLayerService>,
+    pub version_service: Arc<dyn MemoryVersionService>,
+    pub seed_service: Arc<dyn MemorySeedService>,
+    pub profile_service: Arc<dyn MemoryProfileService>,
+    pub prompt_write_policy: Arc<dyn MemoryPromptWriteSafetyPolicy>,
+}
+
+pub struct MemoryProductFacade {
+    document_service: Arc<dyn MemoryDocumentService>,
+    search_service: Arc<dyn MemorySearchService>,
+    layer_service: Arc<dyn MemoryLayerService>,
+    version_service: Arc<dyn MemoryVersionService>,
+    seed_service: Arc<dyn MemorySeedService>,
+    profile_service: Arc<dyn MemoryProfileService>,
+    prompt_write_policy: Arc<dyn MemoryPromptWriteSafetyPolicy>,
+    protected_paths: PromptProtectedPathRegistry,
+}
+
+impl MemoryProductFacade {
+    pub fn new(services: MemoryProductServices) -> Self {
+        Self {
+            document_service: services.document_service,
+            search_service: services.search_service,
+            layer_service: services.layer_service,
+            version_service: services.version_service,
+            seed_service: services.seed_service,
+            profile_service: services.profile_service,
+            prompt_write_policy: services.prompt_write_policy,
+            protected_paths: PromptProtectedPathRegistry::default(),
+        }
+    }
+
+    pub async fn write(
+        &self,
+        request: MemoryProductWriteRequest,
+    ) -> Result<MemoryProductWriteResponse, MemoryProductError> {
+        let (relative_path, purpose) = resolve_write_target(&request.target)?;
+        let purpose = if request.layer_name.is_some() {
+            MemoryWritePurpose::LayerWrite
+        } else {
+            purpose
+        };
+        validate_write_mode(&request)?;
+        let authority = MemoryWriteAuthority::new(request.actor.clone(), request.surface, purpose);
+        let path = document_path(&request.scope, &relative_path)?;
+        let operation = operation_for_mode(&request.mode);
+        let prompt_content = prompt_check_content(&request);
+
+        self.check_prompt_write(path.clone(), operation, prompt_content, authority.clone())
+            .await?;
+
+        if matches!(request.target, MemoryProductWriteTarget::Bootstrap) {
+            let outcome = self
+                .seed_service
+                .clear_bootstrap(MemoryBootstrapClearRequest {
+                    scope: request.scope,
+                    authority,
+                })
+                .await?;
+            return Ok(MemoryProductWriteResponse {
+                relative_path: outcome.relative_path,
+                status: "cleared".to_string(),
+                content_length: 0,
+                actual_layer: None,
+                redirected: None,
+                replacements: None,
+                synced_relative_paths: Vec::new(),
+            });
+        }
+
+        let options = write_options(request.metadata.as_ref(), &authority);
+        if let Some(layer_name) = request.layer_name {
+            let mode = match request.mode {
+                MemoryProductWriteMode::Append => MemoryLayerWriteMode::Append,
+                MemoryProductWriteMode::Replace => MemoryLayerWriteMode::Replace,
+                MemoryProductWriteMode::Patch { .. } => unreachable!("validated above"),
+            };
+            let outcome = self
+                .layer_service
+                .write_layer(MemoryLayerWriteRequest {
+                    path,
+                    layer_name,
+                    content: request.content,
+                    mode,
+                    force: request.force,
+                    options,
+                    authority,
+                })
+                .await?;
+            return Ok(MemoryProductWriteResponse {
+                relative_path: outcome.relative_path,
+                status: "written".to_string(),
+                content_length: 0,
+                actual_layer: Some(outcome.actual_layer),
+                redirected: Some(outcome.redirected),
+                replacements: None,
+                synced_relative_paths: Vec::new(),
+            });
+        }
+
+        let mut synced_relative_paths = Vec::new();
+        let (status, content_length, replacements) = match request.mode {
+            MemoryProductWriteMode::Append => {
+                let outcome = self
+                    .document_service
+                    .append(MemoryAppendDocumentRequest {
+                        path: path.clone(),
+                        content: request.content,
+                        options,
+                        authority: authority.clone(),
+                    })
+                    .await?;
+                ("written".to_string(), outcome.content_length, None)
+            }
+            MemoryProductWriteMode::Replace => {
+                let outcome = self
+                    .document_service
+                    .write(MemoryWriteDocumentRequest {
+                        path: path.clone(),
+                        content: request.content,
+                        options,
+                        authority: authority.clone(),
+                    })
+                    .await?;
+                ("written".to_string(), outcome.content_length, None)
+            }
+            MemoryProductWriteMode::Patch {
+                old_string,
+                new_string,
+                replace_all,
+            } => {
+                if old_string.is_empty() {
+                    return Err(MemoryProductError::InvalidRequest {
+                        reason: "old_string cannot be empty".to_string(),
+                    });
+                }
+                let outcome = self
+                    .document_service
+                    .patch(MemoryPatchDocumentRequest {
+                        path: path.clone(),
+                        old_string,
+                        new_string,
+                        replace_all,
+                        authority: authority.clone(),
+                    })
+                    .await?;
+                (
+                    "patched".to_string(),
+                    outcome.content_length,
+                    Some(outcome.replacements),
+                )
+            }
+        };
+
+        if path.relative_path() == PROFILE_PATH {
+            let outcome = self
+                .profile_service
+                .sync_profile_documents(MemoryProfileSyncRequest {
+                    scope: path.scope().clone(),
+                    profile_path: path.clone(),
+                    authority,
+                })
+                .await?;
+            synced_relative_paths = outcome.synced_relative_paths;
+        }
+
+        Ok(MemoryProductWriteResponse {
+            relative_path,
+            status,
+            content_length,
+            actual_layer: None,
+            redirected: None,
+            replacements,
+            synced_relative_paths,
+        })
+    }
+
+    pub async fn read(
+        &self,
+        request: MemoryProductReadRequest,
+    ) -> Result<MemoryProductReadResponse, MemoryProductError> {
+        ensure_product_relative_path(&request.relative_path)?;
+        if !request.primary_scope_only
+            && self
+                .protected_paths
+                .classify_relative_path(&request.relative_path)
+                .is_some()
+        {
+            return Err(MemoryProductError::InvalidRequest {
+                reason:
+                    "identity and prompt-context documents must be read from primary scope only"
+                        .to_string(),
+            });
+        }
+        let path = document_path(&request.scope, &request.relative_path)?;
+        match request.mode {
+            MemoryProductReadMode::Current => {
+                let record = self
+                    .document_service
+                    .read_current(MemoryReadDocumentRequest {
+                        path,
+                        primary_scope_only: request.primary_scope_only,
+                    })
+                    .await?;
+                Ok(MemoryProductReadResponse::Current(record))
+            }
+            MemoryProductReadMode::ListVersions { limit } => {
+                let versions = self
+                    .version_service
+                    .list_versions(MemoryVersionListRequest { path, limit })
+                    .await?;
+                Ok(MemoryProductReadResponse::Versions(versions))
+            }
+            MemoryProductReadMode::Version { version } => {
+                let record = self
+                    .version_service
+                    .read_version(MemoryVersionReadRequest { path, version })
+                    .await?;
+                Ok(MemoryProductReadResponse::Version(record))
+            }
+        }
+    }
+
+    pub async fn search(
+        &self,
+        request: MemoryProductSearchRequest,
+    ) -> Result<Vec<MemoryProductSearchHit>, MemoryProductError> {
+        let hits = self
+            .search_service
+            .search(ironclaw_memory::MemoryProductSearchRequest {
+                scope: request.scope,
+                query: request.query,
+                limit: request.limit,
+                secondary_scopes: request.secondary_scopes,
+                exclude_identity_documents_from_secondary: true,
+                group_context: request.group_context,
+            })
+            .await?;
+        Ok(hits)
+    }
+
+    pub async fn list(
+        &self,
+        request: MemoryProductListRequest,
+    ) -> Result<Vec<MemoryDocumentEntry>, MemoryProductError> {
+        validate_optional_parent(request.parent.as_deref())?;
+        let entries = self
+            .document_service
+            .list(MemoryListDocumentsRequest {
+                scope: request.scope,
+                parent: request.parent,
+            })
+            .await?;
+        Ok(entries)
+    }
+
+    pub async fn tree(
+        &self,
+        request: MemoryProductTreeRequest,
+    ) -> Result<Vec<MemoryDocumentEntry>, MemoryProductError> {
+        validate_optional_parent(request.root.as_deref())?;
+        let entries = self
+            .document_service
+            .tree(MemoryTreeRequest {
+                scope: request.scope,
+                root: request.root,
+                max_depth: request.max_depth,
+            })
+            .await?;
+        Ok(entries)
+    }
+
+    pub async fn status(
+        &self,
+        request: MemoryProductStatusRequest,
+    ) -> Result<MemoryStatus, MemoryProductError> {
+        let status = self
+            .document_service
+            .status(MemoryStatusRequest {
+                scope: request.scope,
+            })
+            .await?;
+        Ok(status)
+    }
+
+    async fn check_prompt_write(
+        &self,
+        path: MemoryDocumentPath,
+        operation: PromptWriteOperation,
+        content: String,
+        authority: MemoryWriteAuthority,
+    ) -> Result<(), MemoryProductError> {
+        let Some(protected_path_class) = self.protected_paths.classify_path(&path) else {
+            return Ok(());
+        };
+        match self
+            .prompt_write_policy
+            .check_product_write(MemoryPromptWriteSafetyRequest {
+                path,
+                operation,
+                protected_path_class,
+                content,
+                authority,
+            })
+            .await?
+        {
+            MemoryPromptWriteSafetyDecision::Allow => Ok(()),
+            MemoryPromptWriteSafetyDecision::Reject { reason } => {
+                Err(MemoryProductError::PromptWriteRejected { reason })
+            }
+        }
+    }
+}
+
+fn resolve_write_target(
+    target: &MemoryProductWriteTarget,
+) -> Result<(String, MemoryWritePurpose), MemoryProductError> {
+    match target {
+        MemoryProductWriteTarget::Memory => {
+            Ok((MEMORY_PATH.to_string(), MemoryWritePurpose::Memory))
+        }
+        MemoryProductWriteTarget::DailyLog { local_date } => {
+            validate_daily_log_date(local_date)?;
+            Ok((
+                format!("daily/{local_date}.md"),
+                MemoryWritePurpose::DailyLog,
+            ))
+        }
+        MemoryProductWriteTarget::Heartbeat => {
+            Ok((HEARTBEAT_PATH.to_string(), MemoryWritePurpose::Heartbeat))
+        }
+        MemoryProductWriteTarget::Bootstrap => {
+            Ok((BOOTSTRAP_PATH.to_string(), MemoryWritePurpose::Bootstrap))
+        }
+        MemoryProductWriteTarget::CustomPath(path) => {
+            ensure_product_relative_path(path)?;
+            Ok((path.clone(), MemoryWritePurpose::CustomPath))
+        }
+    }
+}
+
+fn document_path(
+    scope: &MemoryDocumentScope,
+    relative_path: &str,
+) -> Result<MemoryDocumentPath, MemoryProductError> {
+    ensure_product_relative_path(relative_path)?;
+    Ok(MemoryDocumentPath::new_with_agent(
+        scope.tenant_id(),
+        scope.user_id(),
+        scope.agent_id(),
+        scope.project_id(),
+        relative_path,
+    )?)
+}
+
+fn ensure_product_relative_path(path: &str) -> Result<(), MemoryProductError> {
+    if path.trim() != path {
+        return Err(MemoryProductError::InvalidRequest {
+            reason: "memory product paths must not contain leading or trailing whitespace"
+                .to_string(),
+        });
+    }
+    if looks_like_filesystem_path(path) || path.contains("://") {
+        return Err(MemoryProductError::InvalidRequest {
+            reason: "memory product paths must be legacy-relative workspace paths".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_optional_parent(parent: Option<&str>) -> Result<(), MemoryProductError> {
+    if let Some(parent) = parent
+        && !parent.is_empty()
+    {
+        ensure_product_relative_path(parent)?;
+    }
+    Ok(())
+}
+
+fn validate_write_mode(request: &MemoryProductWriteRequest) -> Result<(), MemoryProductError> {
+    if request.layer_name.is_some() && matches!(request.mode, MemoryProductWriteMode::Patch { .. })
+    {
+        return Err(MemoryProductError::InvalidRequest {
+            reason: "patch mode cannot be combined with layer writes".to_string(),
+        });
+    }
+    if matches!(request.target, MemoryProductWriteTarget::Bootstrap)
+        && matches!(request.mode, MemoryProductWriteMode::Patch { .. })
+    {
+        return Err(MemoryProductError::InvalidRequest {
+            reason: "bootstrap clear cannot be combined with patch mode".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_daily_log_date(local_date: &str) -> Result<(), MemoryProductError> {
+    let bytes = local_date.as_bytes();
+    let valid = bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(idx, byte)| matches!(idx, 4 | 7) || byte.is_ascii_digit());
+    if !valid {
+        return Err(MemoryProductError::InvalidRequest {
+            reason: "daily log target requires a YYYY-MM-DD local date".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn looks_like_filesystem_path(path: &str) -> bool {
+    if path.starts_with('/') || path.starts_with("~/") || path.contains('\\') {
+        return true;
+    }
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'/' || bytes[2] == b'\\')
+}
+
+fn operation_for_mode(mode: &MemoryProductWriteMode) -> PromptWriteOperation {
+    match mode {
+        MemoryProductWriteMode::Append => PromptWriteOperation::Append,
+        MemoryProductWriteMode::Replace => PromptWriteOperation::Write,
+        MemoryProductWriteMode::Patch { .. } => PromptWriteOperation::Patch,
+    }
+}
+
+fn prompt_check_content(request: &MemoryProductWriteRequest) -> String {
+    if matches!(request.target, MemoryProductWriteTarget::Bootstrap) {
+        return String::new();
+    }
+    match &request.mode {
+        MemoryProductWriteMode::Patch { new_string, .. } => new_string.clone(),
+        MemoryProductWriteMode::Append | MemoryProductWriteMode::Replace => request.content.clone(),
+    }
+}
+
+fn write_options(
+    metadata: Option<&serde_json::Value>,
+    authority: &MemoryWriteAuthority,
+) -> MemoryWriteOptions {
+    MemoryWriteOptions {
+        metadata: metadata
+            .map(DocumentMetadata::from_value)
+            .unwrap_or_default(),
+        changed_by: Some(actor_label(&authority.actor)),
+    }
+}
+
+fn actor_label(actor: &MemoryWriteActor) -> String {
+    match actor {
+        MemoryWriteActor::User { user_id } => format!("user:{user_id}"),
+        MemoryWriteActor::Agent { agent_id } => format!("agent:{agent_id}"),
+        MemoryWriteActor::Admin { user_id } => format!("admin:{user_id}"),
+        MemoryWriteActor::Tool { tool_name } => format!("tool:{tool_name}"),
+    }
+}

--- a/crates/ironclaw_product_workflow/tests/memory_product_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/memory_product_contract.rs
@@ -1,0 +1,651 @@
+//! Contract tests for the #3287 Reborn memory product facade first slice.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_memory::{
+    MemoryAppendDocumentRequest, MemoryBootstrapClearOutcome, MemoryBootstrapClearRequest,
+    MemoryDocumentEntry, MemoryDocumentPath, MemoryDocumentRecord, MemoryDocumentScope,
+    MemoryDocumentService, MemoryLayerService, MemoryLayerWriteMode, MemoryLayerWriteOutcome,
+    MemoryLayerWriteRequest, MemoryListDocumentsRequest, MemoryPatchDocumentOutcome,
+    MemoryPatchDocumentRequest, MemoryProductSearchHit, MemoryProductSearchRequest,
+    MemoryProfileService, MemoryProfileSyncOutcome, MemoryProfileSyncRequest,
+    MemoryPromptWriteSafetyDecision, MemoryPromptWriteSafetyPolicy, MemoryPromptWriteSafetyRequest,
+    MemoryReadDocumentRequest, MemorySearchService, MemorySeedService, MemoryServiceError,
+    MemoryStatus, MemoryStatusRequest, MemoryTreeRequest, MemoryVersionListRequest,
+    MemoryVersionReadRequest, MemoryVersionRecord, MemoryVersionService, MemoryVersionSummary,
+    MemoryWriteActor, MemoryWriteDocumentOutcome, MemoryWriteDocumentRequest, MemoryWriteSurface,
+};
+use ironclaw_product_workflow::{
+    MemoryProductError, MemoryProductFacade, MemoryProductReadMode, MemoryProductReadRequest,
+    MemoryProductReadResponse, MemoryProductSearchRequest as FacadeSearchRequest,
+    MemoryProductServices, MemoryProductWriteMode, MemoryProductWriteRequest,
+    MemoryProductWriteTarget,
+};
+
+#[derive(Default)]
+struct FakeMemoryProductServices {
+    reads: Mutex<Vec<MemoryReadDocumentRequest>>,
+    writes: Mutex<Vec<MemoryWriteDocumentRequest>>,
+    appends: Mutex<Vec<MemoryAppendDocumentRequest>>,
+    patches: Mutex<Vec<MemoryPatchDocumentRequest>>,
+    lists: Mutex<Vec<MemoryListDocumentsRequest>>,
+    trees: Mutex<Vec<MemoryTreeRequest>>,
+    statuses: Mutex<Vec<MemoryStatusRequest>>,
+    searches: Mutex<Vec<MemoryProductSearchRequest>>,
+    layer_writes: Mutex<Vec<MemoryLayerWriteRequest>>,
+    version_lists: Mutex<Vec<MemoryVersionListRequest>>,
+    version_reads: Mutex<Vec<MemoryVersionReadRequest>>,
+    bootstrap_clears: Mutex<Vec<MemoryBootstrapClearRequest>>,
+    profile_syncs: Mutex<Vec<MemoryProfileSyncRequest>>,
+    prompt_checks: Mutex<Vec<MemoryPromptWriteSafetyRequest>>,
+}
+
+impl FakeMemoryProductServices {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn prompt_checks(&self) -> Vec<MemoryPromptWriteSafetyRequest> {
+        self.prompt_checks.lock().expect("prompt checks").clone()
+    }
+
+    fn writes(&self) -> Vec<MemoryWriteDocumentRequest> {
+        self.writes.lock().expect("writes").clone()
+    }
+
+    fn appends(&self) -> Vec<MemoryAppendDocumentRequest> {
+        self.appends.lock().expect("appends").clone()
+    }
+
+    fn layer_writes(&self) -> Vec<MemoryLayerWriteRequest> {
+        self.layer_writes.lock().expect("layer writes").clone()
+    }
+
+    fn searches(&self) -> Vec<MemoryProductSearchRequest> {
+        self.searches.lock().expect("searches").clone()
+    }
+
+    fn version_lists(&self) -> Vec<MemoryVersionListRequest> {
+        self.version_lists.lock().expect("version lists").clone()
+    }
+
+    fn bootstrap_clears(&self) -> Vec<MemoryBootstrapClearRequest> {
+        self.bootstrap_clears
+            .lock()
+            .expect("bootstrap clears")
+            .clone()
+    }
+
+    fn profile_syncs(&self) -> Vec<MemoryProfileSyncRequest> {
+        self.profile_syncs.lock().expect("profile syncs").clone()
+    }
+}
+
+#[async_trait]
+impl MemoryDocumentService for FakeMemoryProductServices {
+    async fn read_current(
+        &self,
+        request: MemoryReadDocumentRequest,
+    ) -> Result<MemoryDocumentRecord, MemoryServiceError> {
+        self.reads.lock().expect("reads").push(request.clone());
+        Ok(MemoryDocumentRecord {
+            path: request.path,
+            content: "current content".to_string(),
+            metadata: serde_json::json!({}),
+        })
+    }
+
+    async fn write(
+        &self,
+        request: MemoryWriteDocumentRequest,
+    ) -> Result<MemoryWriteDocumentOutcome, MemoryServiceError> {
+        let relative_path = request.path.relative_path().to_string();
+        let content_length = request.content.len();
+        self.writes.lock().expect("writes").push(request);
+        Ok(MemoryWriteDocumentOutcome {
+            relative_path,
+            content_length,
+        })
+    }
+
+    async fn append(
+        &self,
+        request: MemoryAppendDocumentRequest,
+    ) -> Result<MemoryWriteDocumentOutcome, MemoryServiceError> {
+        let relative_path = request.path.relative_path().to_string();
+        let content_length = request.content.len();
+        self.appends.lock().expect("appends").push(request);
+        Ok(MemoryWriteDocumentOutcome {
+            relative_path,
+            content_length,
+        })
+    }
+
+    async fn patch(
+        &self,
+        request: MemoryPatchDocumentRequest,
+    ) -> Result<MemoryPatchDocumentOutcome, MemoryServiceError> {
+        self.patches.lock().expect("patches").push(request);
+        Ok(MemoryPatchDocumentOutcome {
+            replacements: 1,
+            content_length: 12,
+        })
+    }
+
+    async fn list(
+        &self,
+        request: MemoryListDocumentsRequest,
+    ) -> Result<Vec<MemoryDocumentEntry>, MemoryServiceError> {
+        self.lists.lock().expect("lists").push(request);
+        Ok(vec![MemoryDocumentEntry {
+            relative_path: "MEMORY.md".to_string(),
+            is_directory: false,
+        }])
+    }
+
+    async fn tree(
+        &self,
+        request: MemoryTreeRequest,
+    ) -> Result<Vec<MemoryDocumentEntry>, MemoryServiceError> {
+        self.trees.lock().expect("trees").push(request);
+        Ok(vec![MemoryDocumentEntry {
+            relative_path: "daily".to_string(),
+            is_directory: true,
+        }])
+    }
+
+    async fn status(
+        &self,
+        request: MemoryStatusRequest,
+    ) -> Result<MemoryStatus, MemoryServiceError> {
+        self.statuses.lock().expect("statuses").push(request);
+        Ok(MemoryStatus {
+            document_count: 2,
+            indexed_document_count: 1,
+        })
+    }
+}
+
+#[async_trait]
+impl MemorySearchService for FakeMemoryProductServices {
+    async fn search(
+        &self,
+        request: MemoryProductSearchRequest,
+    ) -> Result<Vec<MemoryProductSearchHit>, MemoryServiceError> {
+        self.searches.lock().expect("searches").push(request);
+        Ok(vec![MemoryProductSearchHit {
+            relative_path: "MEMORY.md".to_string(),
+            content: "hit".to_string(),
+            score: 0.8,
+        }])
+    }
+}
+
+#[async_trait]
+impl MemoryLayerService for FakeMemoryProductServices {
+    async fn write_layer(
+        &self,
+        request: MemoryLayerWriteRequest,
+    ) -> Result<MemoryLayerWriteOutcome, MemoryServiceError> {
+        let relative_path = request.path.relative_path().to_string();
+        let actual_layer = request.layer_name.clone();
+        self.layer_writes
+            .lock()
+            .expect("layer writes")
+            .push(request);
+        Ok(MemoryLayerWriteOutcome {
+            relative_path,
+            actual_layer,
+            redirected: false,
+        })
+    }
+}
+
+#[async_trait]
+impl MemoryVersionService for FakeMemoryProductServices {
+    async fn list_versions(
+        &self,
+        request: MemoryVersionListRequest,
+    ) -> Result<Vec<MemoryVersionSummary>, MemoryServiceError> {
+        self.version_lists
+            .lock()
+            .expect("version lists")
+            .push(request);
+        Ok(vec![MemoryVersionSummary {
+            version: 1,
+            content_hash: "sha256:test".to_string(),
+        }])
+    }
+
+    async fn read_version(
+        &self,
+        request: MemoryVersionReadRequest,
+    ) -> Result<MemoryVersionRecord, MemoryServiceError> {
+        self.version_reads
+            .lock()
+            .expect("version reads")
+            .push(request.clone());
+        Ok(MemoryVersionRecord {
+            path: request.path,
+            version: request.version,
+            content: "old content".to_string(),
+            content_hash: "sha256:test".to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl MemorySeedService for FakeMemoryProductServices {
+    async fn clear_bootstrap(
+        &self,
+        request: MemoryBootstrapClearRequest,
+    ) -> Result<MemoryBootstrapClearOutcome, MemoryServiceError> {
+        self.bootstrap_clears
+            .lock()
+            .expect("bootstrap clears")
+            .push(request);
+        Ok(MemoryBootstrapClearOutcome {
+            relative_path: "BOOTSTRAP.md".to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl MemoryProfileService for FakeMemoryProductServices {
+    async fn sync_profile_documents(
+        &self,
+        request: MemoryProfileSyncRequest,
+    ) -> Result<MemoryProfileSyncOutcome, MemoryServiceError> {
+        self.profile_syncs
+            .lock()
+            .expect("profile syncs")
+            .push(request);
+        Ok(MemoryProfileSyncOutcome {
+            synced_relative_paths: vec![
+                "USER.md".to_string(),
+                "context/assistant-directives.md".to_string(),
+            ],
+        })
+    }
+}
+
+#[async_trait]
+impl MemoryPromptWriteSafetyPolicy for FakeMemoryProductServices {
+    async fn check_product_write(
+        &self,
+        request: MemoryPromptWriteSafetyRequest,
+    ) -> Result<MemoryPromptWriteSafetyDecision, MemoryServiceError> {
+        self.prompt_checks
+            .lock()
+            .expect("prompt checks")
+            .push(request);
+        Ok(MemoryPromptWriteSafetyDecision::Allow)
+    }
+}
+
+fn scope() -> MemoryDocumentScope {
+    MemoryDocumentScope::new_with_agent(
+        "tenant-alpha",
+        "user-alpha",
+        Some("agent-alpha"),
+        Some("project-alpha"),
+    )
+    .expect("valid scope")
+}
+
+fn custom_path(path: &str) -> MemoryDocumentPath {
+    MemoryDocumentPath::new_with_agent(
+        "tenant-alpha",
+        "user-alpha",
+        Some("agent-alpha"),
+        Some("project-alpha"),
+        path,
+    )
+    .expect("valid path")
+}
+
+fn actor() -> MemoryWriteActor {
+    MemoryWriteActor::User {
+        user_id: "user-alpha".to_string(),
+    }
+}
+
+fn build_facade() -> (MemoryProductFacade, Arc<FakeMemoryProductServices>) {
+    let fake = Arc::new(FakeMemoryProductServices::new());
+    let facade = MemoryProductFacade::new(MemoryProductServices {
+        document_service: fake.clone(),
+        search_service: fake.clone(),
+        layer_service: fake.clone(),
+        version_service: fake.clone(),
+        seed_service: fake.clone(),
+        profile_service: fake.clone(),
+        prompt_write_policy: fake.clone(),
+    });
+    (facade, fake)
+}
+
+#[tokio::test]
+async fn memory_target_resolves_legacy_path_and_checks_prompt_policy() {
+    let (facade, fake) = build_facade();
+
+    let response = facade
+        .write(MemoryProductWriteRequest {
+            scope: scope(),
+            target: MemoryProductWriteTarget::Memory,
+            mode: MemoryProductWriteMode::Replace,
+            content: "remember this".to_string(),
+            metadata: Some(serde_json::json!({ "skip_indexing": true })),
+            layer_name: None,
+            force: false,
+            actor: actor(),
+            surface: MemoryWriteSurface::LlmTool,
+        })
+        .await
+        .expect("write succeeds");
+
+    assert_eq!(response.relative_path, "MEMORY.md");
+    assert_eq!(response.status, "written");
+
+    let prompt_checks = fake.prompt_checks();
+    assert_eq!(prompt_checks.len(), 1);
+    assert_eq!(prompt_checks[0].path.relative_path(), "MEMORY.md");
+    assert_eq!(prompt_checks[0].protected_path_class.as_str(), "memory_md");
+    assert_eq!(
+        prompt_checks[0].authority.surface,
+        MemoryWriteSurface::LlmTool
+    );
+
+    let writes = fake.writes();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path.relative_path(), "MEMORY.md");
+    assert_eq!(writes[0].options.metadata.skip_indexing, Some(true));
+    assert_eq!(
+        writes[0].options.changed_by.as_deref(),
+        Some("user:user-alpha")
+    );
+}
+
+#[tokio::test]
+async fn filesystem_looking_paths_fail_before_service_calls() {
+    let (facade, fake) = build_facade();
+
+    let err = facade
+        .write(MemoryProductWriteRequest {
+            scope: scope(),
+            target: MemoryProductWriteTarget::CustomPath("/Users/alice/secrets.md".to_string()),
+            mode: MemoryProductWriteMode::Replace,
+            content: "nope".to_string(),
+            metadata: None,
+            layer_name: None,
+            force: false,
+            actor: actor(),
+            surface: MemoryWriteSurface::Cli,
+        })
+        .await
+        .expect_err("absolute host path rejected");
+
+    assert!(matches!(err, MemoryProductError::InvalidRequest { .. }));
+    assert!(fake.prompt_checks().is_empty());
+    assert!(fake.writes().is_empty());
+    assert!(fake.appends().is_empty());
+}
+
+#[tokio::test]
+async fn malformed_relative_paths_fail_before_service_calls() {
+    for path in [
+        " notes.md",
+        "notes.md ",
+        "notes//idea.md",
+        "notes/../secret.md",
+        "./notes.md",
+        "notes/./idea.md",
+        "C:/Users/alice/secret.md",
+    ] {
+        let (facade, fake) = build_facade();
+
+        let err = facade
+            .write(MemoryProductWriteRequest {
+                scope: scope(),
+                target: MemoryProductWriteTarget::CustomPath(path.to_string()),
+                mode: MemoryProductWriteMode::Replace,
+                content: "nope".to_string(),
+                metadata: None,
+                layer_name: None,
+                force: false,
+                actor: actor(),
+                surface: MemoryWriteSurface::Cli,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, MemoryProductError::InvalidRequest { .. }));
+        assert!(fake.prompt_checks().is_empty());
+        assert!(fake.writes().is_empty());
+        assert!(fake.appends().is_empty());
+    }
+}
+
+#[tokio::test]
+async fn layer_writes_route_through_layer_service_with_force_and_authority() {
+    let (facade, fake) = build_facade();
+
+    let response = facade
+        .write(MemoryProductWriteRequest {
+            scope: scope(),
+            target: MemoryProductWriteTarget::CustomPath("projects/alpha/notes.md".to_string()),
+            mode: MemoryProductWriteMode::Append,
+            content: "layer note".to_string(),
+            metadata: Some(serde_json::json!({ "hygiene": { "enabled": true } })),
+            layer_name: Some("shared".to_string()),
+            force: true,
+            actor: actor(),
+            surface: MemoryWriteSurface::Web,
+        })
+        .await
+        .expect("layer write succeeds");
+
+    assert_eq!(response.actual_layer.as_deref(), Some("shared"));
+    assert_eq!(response.redirected, Some(false));
+    assert!(fake.writes().is_empty());
+    assert!(fake.appends().is_empty());
+
+    let layer_writes = fake.layer_writes();
+    assert_eq!(layer_writes.len(), 1);
+    assert_eq!(
+        layer_writes[0].path.relative_path(),
+        "projects/alpha/notes.md"
+    );
+    assert_eq!(layer_writes[0].mode, MemoryLayerWriteMode::Append);
+    assert!(layer_writes[0].force);
+}
+
+#[tokio::test]
+async fn invalid_layer_patch_is_rejected_before_prompt_policy() {
+    let (facade, fake) = build_facade();
+
+    let err = facade
+        .write(MemoryProductWriteRequest {
+            scope: scope(),
+            target: MemoryProductWriteTarget::CustomPath("MEMORY.md".to_string()),
+            mode: MemoryProductWriteMode::Patch {
+                old_string: "old".to_string(),
+                new_string: "new".to_string(),
+                replace_all: false,
+            },
+            content: String::new(),
+            metadata: None,
+            layer_name: Some("shared".to_string()),
+            force: false,
+            actor: actor(),
+            surface: MemoryWriteSurface::Web,
+        })
+        .await
+        .expect_err("layer patch is invalid");
+
+    assert!(matches!(err, MemoryProductError::InvalidRequest { .. }));
+    assert!(fake.prompt_checks().is_empty());
+    assert!(fake.layer_writes().is_empty());
+}
+
+#[tokio::test]
+async fn read_version_listing_routes_to_version_service() {
+    let (facade, fake) = build_facade();
+
+    let response = facade
+        .read(MemoryProductReadRequest {
+            scope: scope(),
+            relative_path: "daily/2026-05-19.md".to_string(),
+            mode: MemoryProductReadMode::ListVersions { limit: 25 },
+            primary_scope_only: true,
+        })
+        .await
+        .expect("version list succeeds");
+
+    assert!(matches!(response, MemoryProductReadResponse::Versions(_)));
+    let version_lists = fake.version_lists();
+    assert_eq!(version_lists.len(), 1);
+    assert_eq!(version_lists[0].path.relative_path(), "daily/2026-05-19.md");
+    assert_eq!(version_lists[0].limit, 25);
+}
+
+#[tokio::test]
+async fn identity_prompt_docs_require_primary_scope_reads() {
+    let (facade, fake) = build_facade();
+
+    let err = facade
+        .read(MemoryProductReadRequest {
+            scope: scope(),
+            relative_path: "IDENTITY.md".to_string(),
+            mode: MemoryProductReadMode::Current,
+            primary_scope_only: false,
+        })
+        .await
+        .expect_err("identity docs cannot use secondary scopes");
+
+    assert!(matches!(err, MemoryProductError::InvalidRequest { .. }));
+    assert!(fake.version_lists().is_empty());
+}
+
+#[tokio::test]
+async fn search_excludes_secondary_identity_documents_and_carries_group_context() {
+    let (facade, fake) = build_facade();
+    let secondary = MemoryDocumentScope::new_with_agent(
+        "tenant-alpha",
+        "user-beta",
+        Some("agent-alpha"),
+        Some("project-alpha"),
+    )
+    .expect("valid secondary scope");
+
+    let hits = facade
+        .search(FacadeSearchRequest {
+            scope: scope(),
+            query: "old decision".to_string(),
+            limit: 7,
+            secondary_scopes: vec![secondary],
+            group_context: Some(ironclaw_memory::MemorySearchGroupContext {
+                conversation_id: "group-1".to_string(),
+                personal_memory_allowed: false,
+            }),
+        })
+        .await
+        .expect("search succeeds");
+
+    assert_eq!(hits.len(), 1);
+    let searches = fake.searches();
+    assert_eq!(searches.len(), 1);
+    assert_eq!(searches[0].query, "old decision");
+    assert_eq!(searches[0].limit, 7);
+    assert!(searches[0].exclude_identity_documents_from_secondary);
+    assert!(
+        !searches[0]
+            .group_context
+            .as_ref()
+            .expect("group context")
+            .personal_memory_allowed
+    );
+}
+
+#[tokio::test]
+async fn profile_write_syncs_derived_profile_documents_after_document_write() {
+    let (facade, fake) = build_facade();
+
+    let response = facade
+        .write(MemoryProductWriteRequest {
+            scope: scope(),
+            target: MemoryProductWriteTarget::CustomPath("context/profile.json".to_string()),
+            mode: MemoryProductWriteMode::Replace,
+            content: "{}".to_string(),
+            metadata: None,
+            layer_name: None,
+            force: false,
+            actor: actor(),
+            surface: MemoryWriteSurface::Web,
+        })
+        .await
+        .expect("profile write succeeds");
+
+    assert_eq!(
+        response.synced_relative_paths,
+        vec![
+            "USER.md".to_string(),
+            "context/assistant-directives.md".to_string()
+        ]
+    );
+    let profile_syncs = fake.profile_syncs();
+    assert_eq!(profile_syncs.len(), 1);
+    assert_eq!(
+        profile_syncs[0].profile_path.relative_path(),
+        "context/profile.json"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_target_routes_to_seed_service_not_document_write() {
+    let (facade, fake) = build_facade();
+
+    let response = facade
+        .write(MemoryProductWriteRequest {
+            scope: scope(),
+            target: MemoryProductWriteTarget::Bootstrap,
+            mode: MemoryProductWriteMode::Replace,
+            content: "ignored".to_string(),
+            metadata: None,
+            layer_name: None,
+            force: false,
+            actor: actor(),
+            surface: MemoryWriteSurface::SetupAdmin,
+        })
+        .await
+        .expect("bootstrap clear succeeds");
+
+    assert_eq!(response.status, "cleared");
+    assert_eq!(response.relative_path, "BOOTSTRAP.md");
+    assert_eq!(fake.bootstrap_clears().len(), 1);
+    assert_eq!(fake.prompt_checks().len(), 1);
+    assert!(fake.prompt_checks()[0].content.is_empty());
+    assert!(fake.writes().is_empty());
+    assert!(fake.appends().is_empty());
+}
+
+#[test]
+fn memory_service_errors_sanitize_backend_details() {
+    let err = MemoryServiceError::new(
+        ironclaw_memory::MemoryServiceErrorCode::Unavailable,
+        "postgres error: host=/private/tmp/db socket token=abc",
+    );
+
+    assert_eq!(err.message(), "memory service operation failed");
+}
+
+#[test]
+fn fake_path_helper_keeps_tests_on_reborn_scope_shape() {
+    let path = custom_path("projects/alpha/notes.md");
+
+    assert_eq!(path.scope().tenant_id(), "tenant-alpha");
+    assert_eq!(path.scope().user_id(), "user-alpha");
+    assert_eq!(path.scope().agent_id(), Some("agent-alpha"));
+    assert_eq!(path.scope().project_id(), Some("project-alpha"));
+    assert_eq!(path.relative_path(), "projects/alpha/notes.md");
+}

--- a/crates/ironclaw_reborn_event_store/src/lib.rs
+++ b/crates/ironclaw_reborn_event_store/src/lib.rs
@@ -37,10 +37,11 @@ use ironclaw_events::{
     DurableAuditLog, DurableEventLog, EventCursor, EventError, EventLogEntry, EventReplay,
     EventStreamKey, InMemoryDurableAuditLog, InMemoryDurableEventLog, ReadScope, RuntimeEvent,
 };
+#[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_filesystem::{RootFilesystem, ScopedFilesystem};
-use ironclaw_host_api::{
-    AgentId, AuditEnvelope, MountAlias, MountGrant, MountPermissions, MountView, VirtualPath,
-};
+use ironclaw_host_api::{AgentId, AuditEnvelope};
+#[cfg(any(feature = "libsql", feature = "postgres"))]
+use ironclaw_host_api::{MountAlias, MountGrant, MountPermissions, MountView, VirtualPath};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;

--- a/docs/reborn/contracts/memory-product-surfaces.md
+++ b/docs/reborn/contracts/memory-product-surfaces.md
@@ -1,0 +1,133 @@
+# Reborn Contract — Memory Product Surfaces
+
+**Status:** First-slice contract and inventory
+**Issue:** #3287
+**Date:** 2026-05-19
+
+---
+
+## Purpose
+
+#3287 migrates memory-document product behavior onto focused Reborn memory
+services without recreating the v1 monolithic `Workspace` as the Reborn source
+of truth.
+
+This document covers product-surface mapping only. Physical storage, schema,
+backfill, readiness, and production cutover remain owned by #3118, #3029, and
+their follow-ups.
+
+The first implementation slice is:
+
+- focused service contracts in `ironclaw_memory`;
+- an adapter-safe `MemoryProductFacade` in `ironclaw_product_workflow`;
+- fake-service contract tests proving path, scope, policy, and service routing;
+- guardrails preventing v1 `Workspace` or raw substrate dependencies from
+  entering the Reborn product memory facade.
+
+## Product Boundary
+
+Product callers use legacy-relative paths such as:
+
+```text
+MEMORY.md
+daily/2026-05-19.md
+projects/alpha/notes.md
+context/profile.json
+```
+
+Product callers must not construct or expose scoped internal paths such as:
+
+```text
+/memory/tenants/{tenant}/users/{user}/agents/{agent}/projects/{project}/...
+```
+
+`MemoryProductFacade` receives a resolved `MemoryDocumentScope` from product or
+binding context and passes `(scope, relative_path)` into typed memory services.
+It rejects local-filesystem-looking paths before service calls.
+
+## Service Ownership
+
+| Owner service | Product behavior |
+| --- | --- |
+| `MemoryDocumentService` | current read, write, append, patch, list, tree, status |
+| `MemorySearchService` | search options, full-text/vector/hybrid handling, embedding/query generation |
+| `MemoryLayerService` | private/shared/custom layer writes, force flag, privacy redirects |
+| `MemoryVersionService` | version list and specific version read |
+| `MemorySeedService` | bootstrap clear and future seed/upgrade flows |
+| `MemoryProfileService` | profile-derived document sync |
+| `MemoryPromptWriteSafetyPolicy` | product-level protected prompt-path gate with actor, surface, and purpose |
+
+`MemoryPromptContextService` / #3091 owns loop prompt assembly. #3287 supplies
+scoped memory service data and product surface behavior only.
+
+## Behavior Inventory
+
+| Surface | Current v1 path | Reborn owner | Scope inputs | Path handling | Compatibility |
+| --- | --- | --- | --- | --- | --- |
+| CLI `memory search` | `src/cli/memory.rs` → `Workspace::search_with_config` | `MemorySearchService` | tenant/user/agent/project from CLI product context | query + limit only; no embedding in product layer | preserve text output shape where practical; sanitized unavailable errors |
+| CLI `memory read` | `src/cli/memory.rs` → `Workspace::read` | `MemoryDocumentService` / `MemoryVersionService` | primary scope | relative path | preserve content output and not-found semantics |
+| CLI `memory write --append` | `src/cli/memory.rs` → `Workspace::append` | `MemoryDocumentService` | primary scope | relative path | preserve "Appended to {path}" success; protected paths go through policy |
+| CLI `memory write` replace | `src/cli/memory.rs` → `Workspace::write` | `MemoryDocumentService` | primary scope | relative path | preserve "Wrote to {path}" success; protected paths go through policy |
+| CLI `memory tree` | `src/cli/memory.rs` → `Workspace::list` recursion | `MemoryDocumentService` | configured read scope policy | relative root | preserve directory-like display |
+| CLI `memory status` | `src/cli/memory.rs` → `Workspace::list_all` / `exists` | `MemoryDocumentService` | primary scope | key identity paths | preserve counts/key-file checks where practical |
+| Web `GET /api/memory/tree` | `src/channels/web/handlers/memory.rs` → `Workspace::list_all` | `MemoryDocumentService` | authenticated user scope | relative paths only | preserve `TreeEntry { path, is_dir }` |
+| Web `GET /api/memory/list` | `src/channels/web/handlers/memory.rs` → `Workspace::list` | `MemoryDocumentService` | authenticated user scope | relative parent | preserve `ListEntry` fields |
+| Web `GET /api/memory/read` | `src/channels/web/handlers/memory.rs` → `Workspace::read` | `MemoryDocumentService` / `MemoryVersionService` | authenticated user scope | relative path | preserve `path/content/updated_at` success shape where practical |
+| Web `POST /api/memory/write` | `src/channels/web/handlers/memory.rs` → `Workspace::write/append` | `MemoryDocumentService` / `MemoryLayerService` | authenticated user scope | relative path + optional layer | preserve `status`, `redirected`, `actual_layer`; policy differs by actor/surface |
+| Web `POST /api/memory/search` | `src/channels/web/handlers/memory.rs` → `Workspace::search` | `MemorySearchService` | authenticated user scope | query + limit only | preserve hit fields where practical; sanitize provider/backend failures |
+| Tool `memory_search` | `src/tools/builtin/memory.rs` → `WorkspaceResolver` + `Workspace::search` | HostRuntime capability execution → `MemorySearchService` | host-mediated capability scope | query + limit; optional reasoning stays outside service contract until #3090/#3016 | tool output keeps `query/results/result_count`; no raw provider errors |
+| Tool `memory_read` current | `src/tools/builtin/memory.rs` → `Workspace::read` | HostRuntime capability execution → `MemoryDocumentService` | host-mediated capability scope | relative path; reject filesystem-looking paths | preserve `path/content/word_count/updated_at` |
+| Tool `memory_read` versions | `src/tools/builtin/memory.rs` → `Workspace::list_versions/get_version` | HostRuntime capability execution → `MemoryVersionService` | host-mediated capability scope | relative path + version mode | preserve version list/read fields |
+| Tool `memory_tree` | `src/tools/builtin/memory.rs` → `Workspace::list` recursion | HostRuntime capability execution → `MemoryDocumentService` | host-mediated capability scope | relative root + depth | preserve compact tree output |
+| Tool `memory_write target=memory` | `src/tools/builtin/memory.rs` → `append_memory` or `write(MEMORY.md)` | HostRuntime capability execution → `MemoryDocumentService` + prompt policy | host-mediated capability scope | shortcut resolves to `MEMORY.md` | protected prompt-path policy required |
+| Tool `memory_write target=daily_log` | `src/tools/builtin/memory.rs` → `append_daily_log_tz` | HostRuntime capability execution → `MemoryDocumentService` | host-mediated capability scope + local date | shortcut resolves to `daily/YYYY-MM-DD.md` | preserve append-oriented default |
+| Tool `memory_write target=heartbeat` | `src/tools/builtin/memory.rs` → `HEARTBEAT.md` | HostRuntime capability execution → `MemoryDocumentService` + prompt policy | host-mediated capability scope | shortcut resolves to `HEARTBEAT.md` | protected prompt-path policy required |
+| Tool `memory_write target=bootstrap` | `src/tools/builtin/memory.rs` → clear `BOOTSTRAP.md` and mark bootstrap complete | HostRuntime capability execution → `MemorySeedService` + prompt policy | host-mediated capability scope | shortcut resolves to `BOOTSTRAP.md` | content ignored; success reports cleared |
+| Tool `memory_write target=<path>` | `src/tools/builtin/memory.rs` → `Workspace::write/append` | HostRuntime capability execution → document/layer/profile services | host-mediated capability scope | custom relative path only | reject local filesystem-looking paths |
+| Tool patch mode | `src/tools/builtin/memory.rs` → `Workspace::patch` | HostRuntime capability execution → `MemoryDocumentService` | host-mediated capability scope | relative path + exact old/new strings | old string cannot be empty; layer + patch rejected |
+| Metadata writes | `src/tools/builtin/memory.rs` applies metadata before write | `MemoryDocumentService` / `MemoryLayerService` | actor/surface/purpose authority | relative path | preserve `skip_indexing`, `skip_versioning`, hygiene, schema metadata |
+| Layer writes | v1 `Workspace::write_to_layer/append_to_layer` | `MemoryLayerService` | canonical layer ref; no raw user-id layer authority | relative path + layer + force | preserve redirect result and read-only errors |
+| Profile writes | v1 `sync_profile_documents` after `context/profile.json` | `MemoryProfileService` | primary scope | `context/profile.json` | preserve USER/directive derived-doc sync |
+| Seed/bootstrap | v1 seed files under `src/workspace/seeds` and bootstrap clear behavior | `MemorySeedService` | setup/admin or tool authority | protected relative paths | no production migration in first slice |
+| Prompt context | v1 workspace prompt assembly | #3091 `MemoryPromptContextService` | primary scope + explicit secondary scopes/group policy | identity docs primary-only | #3287 does not implement ordering/formatting |
+
+## Privacy And Policy Rules
+
+- Identity and prompt-context files are primary-scope only.
+- Secondary memory scopes may contribute ordinary memory reads/search results,
+  but not identity/profile/system prompt documents by default.
+- Group-chat prompt context excludes personal memory/profile/directives unless
+  explicit policy allows it.
+- Protected prompt-path writes carry:
+  - actor (`user`, `agent`, `admin`, or `tool`);
+  - surface (`cli`, `web`, `llm_tool`, `setup_admin`, or `prompt_context`);
+  - purpose (`memory`, `daily_log`, `heartbeat`, `bootstrap`, `custom_path`,
+    `metadata`, `layer_write`, `profile_sync`, or `seed`).
+- Policy and service errors must be sanitized; raw host paths, provider details,
+  SQL strings, tokens, or secret-like values must not cross the product facade.
+
+## Coexistence
+
+Until migration/readiness work lands:
+
+- legacy `Workspace` remains the production writer;
+- Reborn product memory surfaces remain contracts/fakes/default-off;
+- comparison bridges, if any, are read-only or dry-run validation;
+- no silent legacy/Reborn dual-write or hidden fallback writer is allowed.
+
+## First-Slice Test Coverage
+
+The first implementation tests cover:
+
+- shortcut resolution for `memory` and `bootstrap`;
+- rejection of filesystem-looking paths before service calls;
+- protected prompt-path policy calls with actor/surface/purpose;
+- layer write routing with force and metadata;
+- version-list routing;
+- identity prompt doc primary-scope enforcement;
+- search request options and secondary identity exclusion;
+- profile-derived document sync;
+- sanitized service errors.
+
+Future production route/tool PRs must add caller-level tests at the actual
+handler/tool entrypoint, not only helper tests.

--- a/docs/reborn/contracts/memory.md
+++ b/docs/reborn/contracts/memory.md
@@ -143,6 +143,11 @@ The current type name is `MemoryBackendCapabilities` for implementation continui
 
 Reborn memory should expose focused services over the shared backend, not one monolithic production `Workspace` clone.
 
+The product-surface mapping and first-slice facade contract live in
+[`memory-product-surfaces.md`](memory-product-surfaces.md). That document is the
+#3287 inventory for CLI, Web, and LLM-facing `memory_*` behavior. Storage,
+schema, and migration choices remain outside #3287.
+
 ### 5.1 `MemoryDocumentService`
 
 Owns user-facing document operations:


### PR DESCRIPTION
## Summary

- Added the first #3287 Reborn memory product-surface slice: focused memory service contracts plus a `MemoryProductFacade` boundary.
- Mapped product-facing memory targets, relative paths, actor/surface/purpose authority, prompt-write policy checks, layers, versions, search, profile sync, and bootstrap clear into typed Reborn memory service requests.
- Added fake-service contract tests and an architecture guardrail to keep the facade off v1 `Workspace`, raw repositories/providers/secrets, HostRuntime internals, and local filesystem/network handles.
- Documented the CLI/Web/tool memory behavior inventory and Reborn service ownership in `docs/reborn/contracts/memory-product-surfaces.md`.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Related #3287

## Validation

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `cargo test -p ironclaw_product_workflow`, `cargo test -p ironclaw_memory`, `cargo test -p ironclaw_architecture reborn_memory_product_facade_stays_on_typed_memory_services`, `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: Not applicable; this is a contracts/fake-service first slice.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional validation:
- `cargo test -p ironclaw_product_workflow --test memory_product_contract`
- `cargo clippy -p ironclaw_product_workflow --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_memory --all-targets -- -D warnings`
- `cargo clippy -p ironclaw_architecture --all-targets -- -D warnings`
- `git diff --check`

## Security Impact

Yes. This adds the contract boundary for memory product surfaces and explicitly routes protected prompt-path writes through actor/surface/purpose-aware policy vocabulary. It also rejects filesystem-looking or malformed product paths before service calls and adds architecture guardrails preventing v1 `Workspace`, raw repositories/providers/secrets, HostRuntime internals, and raw filesystem/network handles from entering the Reborn memory product facade. No new production listener, route, storage migration, secret access, network call, or runtime execution path is introduced.

## Database Impact

None. This first slice adds contracts, fake-service tests, and documentation only. It does not add migrations, change schema, or cut production memory reads/writes over from legacy `Workspace`.

## Blast Radius

Limited to Reborn memory/product workflow contracts, tests, and docs. `ironclaw_product_workflow` now depends on `ironclaw_memory` for typed service contracts. Production CLI/Web/tool memory behavior is not switched in this PR.

## Rollback Plan

Revert this PR to remove the memory product-surface contracts, `MemoryProductFacade`, fake-service tests, inventory document, and guardrail. Since no production storage/routes/tools are cut over, rollback should not require data migration.

## Review Follow-Through

This is the first #3287 implementation slice, not the full production migration. Reviewer judgment requested on the service split, DTO names, and whether any inventory rows need compatibility notes before follow-up PRs wire CLI/Web/tool surfaces to these contracts.

---

**Review track**: B