### PR TITLE
Add capability provider host API contract

### DIFF
--- a/crates/ironclaw_extensions/src/host_api/capability_provider.rs
+++ b/crates/ironclaw_extensions/src/host_api/capability_provider.rs
@@ -1,0 +1,80 @@
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+
+use crate::v2::{
+    CapabilityDeclV2, HostApiId, HostApiManifestContext, HostApiManifestContract, HostApiRefV2,
+    ManifestSectionPath, ManifestV2Error, RawCapabilityV2,
+};
+
+pub const CAPABILITY_PROVIDER_HOST_API_ID: &str = "ironclaw.capability_provider/v1";
+pub const CAPABILITY_PROVIDER_SECTION: &str = "capability_provider.tools";
+
+#[derive(Debug)]
+pub struct CapabilityProviderHostApiContract {
+    id: HostApiId,
+}
+
+impl CapabilityProviderHostApiContract {
+    pub fn new() -> Result<Self, ManifestV2Error> {
+        Ok(Self {
+            id: HostApiId::new(CAPABILITY_PROVIDER_HOST_API_ID)?,
+        })
+    }
+}
+
+impl HostApiManifestContract for CapabilityProviderHostApiContract {
+    fn id(&self) -> &HostApiId {
+        &self.id
+    }
+
+    fn accepts_section_path(&self, section: &ManifestSectionPath) -> bool {
+        section.as_str() == CAPABILITY_PROVIDER_SECTION
+    }
+
+    fn validate_section(
+        &self,
+        _host_api: &HostApiRefV2,
+        _section: &toml::Value,
+    ) -> Result<(), String> {
+        Err("capability provider validation requires manifest context".to_string())
+    }
+
+    fn validate_section_with_context(
+        &self,
+        context: &HostApiManifestContext<'_>,
+        _host_api: &HostApiRefV2,
+        section: &toml::Value,
+    ) -> Result<(), String> {
+        let parsed: CapabilityProviderToolsSection = section
+            .clone()
+            .try_into()
+            .map_err(|error: toml::de::Error| error.to_string())?;
+        if parsed.capabilities.is_empty() {
+            return Err(
+                "capability_provider.tools must declare at least one capability".to_string(),
+            );
+        }
+
+        let mut seen = BTreeSet::new();
+        for raw in parsed.capabilities {
+            let capability =
+                CapabilityDeclV2::from_raw(raw, context.extension_id, context.host_port_catalog)
+                    .map_err(|error| error.to_string())?;
+            if !seen.insert(capability.id.clone()) {
+                return Err(format!(
+                    "duplicate capability id {}",
+                    capability.id.as_str()
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CapabilityProviderToolsSection {
+    #[serde(default)]
+    capabilities: Vec<RawCapabilityV2>,
+}

--- a/crates/ironclaw_extensions/src/host_api/mod.rs
+++ b/crates/ironclaw_extensions/src/host_api/mod.rs
@@ -1,0 +1,3 @@
+//! Built-in host API manifest contracts owned by `ironclaw_extensions`.
+
+pub mod capability_provider;

--- a/crates/ironclaw_extensions/src/lib.rs
+++ b/crates/ironclaw_extensions/src/lib.rs
@@ -326,15 +326,19 @@ impl ExtensionPackage {
     }
 }
 
+pub mod host_api;
 mod lifecycle;
 mod registry;
 pub mod v2;
 
+pub use host_api::capability_provider::{
+    CAPABILITY_PROVIDER_HOST_API_ID, CAPABILITY_PROVIDER_SECTION, CapabilityProviderHostApiContract,
+};
 pub use v2::{
     CapabilityDeclV2, CapabilityVisibility, ExtensionManifestV2, ExtensionRuntimeV2,
-    HostApiContractRegistry, HostApiId, HostApiManifestContract, HostApiMultiplicity, HostApiRefV2,
-    MANIFEST_SCHEMA_VERSION, MAX_MANIFEST_BYTES, ManifestSectionPath, ManifestSource,
-    ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX,
+    HostApiContractRegistry, HostApiId, HostApiManifestContext, HostApiManifestContract,
+    HostApiMultiplicity, HostApiRefV2, MANIFEST_SCHEMA_VERSION, MAX_MANIFEST_BYTES,
+    ManifestSectionPath, ManifestSource, ManifestV2Error, RESERVED_HOST_BUNDLED_ID_PREFIX,
 };
 
 pub type CapabilityManifest = CapabilityDeclV2;

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -165,6 +165,15 @@ pub enum HostApiMultiplicity {
     Multiple,
 }
 
+/// Manifest-level context available to host API contract validators.
+///
+/// This is validation-only metadata. It must not be treated as runtime
+/// authority, and it must not trigger side effects.
+pub struct HostApiManifestContext<'a> {
+    pub extension_id: &'a ExtensionId,
+    pub host_port_catalog: &'a HostPortCatalog,
+}
+
 /// Host API contract validator registered by composition.
 ///
 /// `ironclaw_extensions` owns the generic envelope and section dispatch. Domain
@@ -184,6 +193,16 @@ pub trait HostApiManifestContract: Send + Sync {
         host_api: &HostApiRefV2,
         section: &toml::Value,
     ) -> Result<(), String>;
+
+    fn validate_section_with_context(
+        &self,
+        context: &HostApiManifestContext<'_>,
+        host_api: &HostApiRefV2,
+        section: &toml::Value,
+    ) -> Result<(), String> {
+        let _ = context;
+        self.validate_section(host_api, section)
+    }
 }
 
 /// Composition-wired registry of host API manifest contracts.
@@ -214,6 +233,7 @@ impl HostApiContractRegistry {
         &self,
         manifest: &ExtensionManifestV2,
         sections: &ManifestSectionsV2,
+        host_port_catalog: &HostPortCatalog,
     ) -> Result<(), ManifestV2Error> {
         let mut counts: BTreeMap<&HostApiId, usize> = BTreeMap::new();
         for host_api in &manifest.host_apis {
@@ -237,8 +257,12 @@ impl HostApiContractRegistry {
                 });
             }
             let section = sections.get(&host_api.section)?;
+            let context = HostApiManifestContext {
+                extension_id: &manifest.id,
+                host_port_catalog,
+            };
             contract
-                .validate_section(host_api, section)
+                .validate_section_with_context(&context, host_api, section)
                 .map_err(|reason| ManifestV2Error::HostApiSectionRejected {
                     id: host_api.id.clone(),
                     section: host_api.section.clone(),
@@ -508,7 +532,7 @@ impl ExtensionManifestV2 {
         }
         let document = RawManifestDocumentV2::parse(input)?;
         let manifest = Self::from_raw(document.raw, source, host_port_catalog, &document.sections)?;
-        registry.validate_manifest(&manifest, &document.sections)?;
+        registry.validate_manifest(&manifest, &document.sections, host_port_catalog)?;
         Ok(manifest)
     }
 
@@ -538,7 +562,7 @@ impl ExtensionManifestV2 {
                 });
             }
         } else {
-            registry.validate_manifest(&manifest, &document.sections)?;
+            registry.validate_manifest(&manifest, &document.sections, host_port_catalog)?;
         }
         Ok(manifest)
     }
@@ -649,7 +673,7 @@ impl ExtensionManifestV2 {
 }
 
 impl CapabilityDeclV2 {
-    fn from_raw(
+    pub(crate) fn from_raw(
         raw: RawCapabilityV2,
         extension_id: &ExtensionId,
         host_port_catalog: &HostPortCatalog,
@@ -1265,7 +1289,7 @@ impl RawRuntimeV2 {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RawCapabilityV2 {
+pub(crate) struct RawCapabilityV2 {
     id: String,
     #[serde(default)]
     implements: Vec<String>,

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -346,6 +346,51 @@ fn capability_provider_host_api_reuses_capability_validation() {
 }
 
 #[test]
+fn capability_provider_host_api_rejects_duplicate_capability_ids() {
+    let manifest = CAPABILITY_PROVIDER_MANIFEST.replace(
+        "[[capability_provider.tools.capabilities]]",
+        r#"[[capability_provider.tools.capabilities]]
+id = "telegram.send_message"
+description = "Send a duplicate Telegram message"
+effects = ["network"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/telegram/send_message.input.v1.json"
+output_schema_ref = "schemas/telegram/send_message.output.v1.json"
+prompt_doc_ref = "prompts/telegram/send_message.md"
+
+[[capability_provider.tools.capabilities]]"#,
+    );
+    let err = ExtensionManifest::parse_with_host_api_contracts(
+        &manifest,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { reason, .. })
+            if reason.contains("duplicate capability id")
+    ));
+}
+
+#[test]
+fn capability_provider_host_api_rejects_contextless_validation() {
+    let contract = CapabilityProviderHostApiContract::new().unwrap();
+    let host_api = HostApiRefV2 {
+        id: HostApiId::new(CAPABILITY_PROVIDER_HOST_API_ID).unwrap(),
+        section: ManifestSectionPath::new(CAPABILITY_PROVIDER_SECTION).unwrap(),
+    };
+    let section = toml::Value::Table(toml::map::Map::new());
+
+    let err = contract.validate_section(&host_api, &section).unwrap_err();
+
+    assert!(err.contains("requires manifest context"));
+}
+
+#[test]
 fn capability_provider_host_api_validates_required_host_ports() {
     let manifest = CAPABILITY_PROVIDER_MANIFEST.replace(
         "prompt_doc_ref = \"prompts/telegram/send_message.md\"\n",

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -213,6 +213,202 @@ async fn discovery_validates_host_api_manifest_with_supplied_contracts() {
     assert_eq!(package.manifest.host_apis.len(), 1);
 }
 
+#[test]
+fn capability_provider_host_api_contract_accepts_valid_manifest() {
+    let manifest = ExtensionManifest::parse_with_host_api_contracts(
+        CAPABILITY_PROVIDER_MANIFEST,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
+    )
+    .unwrap();
+
+    assert_eq!(manifest.id.as_str(), "telegram");
+    assert_eq!(manifest.host_apis.len(), 1);
+    assert_eq!(
+        manifest.host_apis[0].id.as_str(),
+        CAPABILITY_PROVIDER_HOST_API_ID
+    );
+    assert_eq!(
+        manifest.host_apis[0].section.as_str(),
+        CAPABILITY_PROVIDER_SECTION
+    );
+    assert_eq!(manifest.capabilities.len(), 0);
+}
+
+#[test]
+fn capability_provider_host_api_fails_without_registered_contract() {
+    let err = ExtensionManifest::parse_with_host_api_contracts(
+        CAPABILITY_PROVIDER_MANIFEST,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::ManifestV2(ManifestV2Error::UnknownHostApi { id })
+            if id.as_str() == CAPABILITY_PROVIDER_HOST_API_ID
+    ));
+}
+
+#[test]
+fn capability_provider_host_api_rejects_wrong_section_path() {
+    let manifest = CAPABILITY_PROVIDER_MANIFEST
+        .replace(
+            "section = \"capability_provider.tools\"",
+            "section = \"capability_provider.other\"",
+        )
+        .replace("[capability_provider.tools]", "[capability_provider.other]")
+        .replace(
+            "[[capability_provider.tools.capabilities]]",
+            "[[capability_provider.other.capabilities]]",
+        );
+    let err = ExtensionManifest::parse_with_host_api_contracts(
+        &manifest,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { id, section, reason })
+            if id.as_str() == CAPABILITY_PROVIDER_HOST_API_ID
+                && section.as_str() == "capability_provider.other"
+                && reason.contains("section path")
+    ));
+}
+
+#[test]
+fn capability_provider_host_api_rejects_unknown_section_fields() {
+    let manifest = CAPABILITY_PROVIDER_MANIFEST.replace(
+        "[capability_provider.tools]",
+        "[capability_provider.tools]\nraw_secret = \"not allowed\"",
+    );
+    let err = ExtensionManifest::parse_with_host_api_contracts(
+        &manifest,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { id, reason, .. })
+            if id.as_str() == CAPABILITY_PROVIDER_HOST_API_ID && reason.contains("unknown field")
+    ));
+}
+
+#[test]
+fn capability_provider_host_api_reuses_capability_validation() {
+    let cases = [
+        (
+            CAPABILITY_PROVIDER_MANIFEST.replace("telegram.send_message", "other.send_message"),
+            "provider-prefixed",
+        ),
+        (
+            CAPABILITY_PROVIDER_MANIFEST.replace(
+                "prompt_doc_ref = \"prompts/telegram/send_message.md\"\n",
+                "",
+            ),
+            "prompt_doc_ref",
+        ),
+        (
+            CAPABILITY_PROVIDER_MANIFEST.replace(
+                "effects = [\"network\"]",
+                "effects = [\"network\", \"network\"]",
+            ),
+            "duplicate effect",
+        ),
+    ];
+
+    for (manifest, expected) in cases {
+        let err = ExtensionManifest::parse_with_host_api_contracts(
+            &manifest,
+            ManifestSource::InstalledLocal,
+            &HostPortCatalog::empty(),
+            &capability_provider_contracts(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { ref reason, .. })
+                    if reason.contains(expected)
+            ),
+            "expected reason containing {expected:?}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn capability_provider_host_api_validates_required_host_ports() {
+    let manifest = CAPABILITY_PROVIDER_MANIFEST.replace(
+        "prompt_doc_ref = \"prompts/telegram/send_message.md\"\n",
+        "prompt_doc_ref = \"prompts/telegram/send_message.md\"\nrequired_host_ports = [\"host.runtime.http_egress\"]\n",
+    );
+
+    let missing_port = ExtensionManifest::parse_with_host_api_contracts(
+        &manifest,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        missing_port,
+        ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { reason, .. })
+            if reason.contains("unknown host port")
+    ));
+
+    let catalog = HostPortCatalog::new(vec![HostPortCatalogEntry::new(
+        HostPortId::new("host.runtime.http_egress").unwrap(),
+    )])
+    .unwrap();
+    ExtensionManifest::parse_with_host_api_contracts(
+        &manifest,
+        ManifestSource::InstalledLocal,
+        &catalog,
+        &capability_provider_contracts(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn capability_provider_host_api_rejects_empty_capability_list() {
+    let manifest = CAPABILITY_PROVIDER_MANIFEST.replace(
+        r#"
+[[capability_provider.tools.capabilities]]
+id = "telegram.send_message"
+description = "Send a Telegram message"
+effects = ["network"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/telegram/send_message.input.v1.json"
+output_schema_ref = "schemas/telegram/send_message.output.v1.json"
+prompt_doc_ref = "prompts/telegram/send_message.md"
+"#,
+        "",
+    );
+    let err = ExtensionManifest::parse_with_host_api_contracts(
+        &manifest,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { reason, .. })
+            if reason.contains("at least one capability")
+    ));
+}
+
 #[tokio::test]
 async fn discovery_validates_capability_manifest_with_supplied_host_port_catalog() {
     let storage = tempdir().unwrap();
@@ -394,6 +590,16 @@ fn package_from_manifest(manifest: ExtensionManifest, id: &str) -> ExtensionPack
     .unwrap()
 }
 
+fn capability_provider_contracts() -> HostApiContractRegistry {
+    let mut contracts = HostApiContractRegistry::new();
+    contracts
+        .register(std::sync::Arc::new(
+            CapabilityProviderHostApiContract::new().unwrap(),
+        ))
+        .unwrap();
+    contracts
+}
+
 fn lifecycle_package(id: &str, capability: &str, version: &str) -> ExtensionPackage {
     let manifest = v2_manifest(
         id,
@@ -567,6 +773,34 @@ section = "product_adapter.inbound"
 
 [product_adapter.inbound]
 surface_kind = "telegram"
+"#;
+
+const CAPABILITY_PROVIDER_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
+id = "telegram"
+name = "Telegram"
+version = "0.1.0"
+description = "Telegram adapter"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/telegram.wasm"
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "telegram.send_message"
+description = "Send a Telegram message"
+effects = ["network"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/telegram/send_message.input.v1.json"
+output_schema_ref = "schemas/telegram/send_message.output.v1.json"
+prompt_doc_ref = "prompts/telegram/send_message.md"
 "#;
 
 const SCRIPT_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"


### PR DESCRIPTION
## Summary
- add `CapabilityProviderHostApiContract` for `ironclaw.capability_provider/v1`
- pass manifest context into host API contract validation so capability-provider sections can reuse capability validation and host-port catalog checks
- cover valid, missing contract, wrong section, unknown field, invalid capability metadata, empty list, and required host-port cases

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_extensions`
- `cargo clippy -p ironclaw_extensions --all-targets -- -D warnings`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`