### PR TITLE
feat(reborn): add CLI serve handoff

### DIFF
--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -132,6 +132,7 @@ fn reborn_cli_binary_crate_stays_separate_from_v1_root() {
         "crates/ironclaw_reborn_cli/src/commands/completion.rs",
         "crates/ironclaw_reborn_cli/src/commands/doctor.rs",
         "crates/ironclaw_reborn_cli/src/commands/run.rs",
+        "crates/ironclaw_reborn_cli/src/commands/serve.rs",
         "crates/ironclaw_reborn_cli/src/context.rs",
     ];
     for path in command_module_paths {

--- a/crates/ironclaw_reborn_cli/src/commands/mod.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod logs;
 pub(crate) mod models;
 pub(crate) mod profile;
 pub(crate) mod run;
+pub(crate) mod serve;
 pub(crate) mod skills;
 
 #[derive(Debug, Subcommand)]
@@ -31,6 +32,8 @@ pub(crate) enum Command {
     Profile(profile::ProfileCommand),
     /// Initialize the minimal Reborn runtime shell and exit.
     Run(run::RunCommand),
+    /// Start the Reborn WebUI service.
+    Serve(serve::ServeCommand),
     /// Inspect configured Reborn skills.
     Skills(skills::SkillsCommand),
 }
@@ -51,6 +54,9 @@ impl Command {
             Self::Models(command) => command.execute(),
             Self::Profile(command) => command.execute(),
             Self::Run(command) => {
+                command.execute(crate::context::RebornCliContext::resolve_from_env()?)
+            }
+            Self::Serve(command) => {
                 command.execute(crate::context::RebornCliContext::resolve_from_env()?)
             }
             Self::Skills(command) => command.execute(),

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -1,0 +1,39 @@
+use clap::Args;
+
+use crate::context::RebornCliContext;
+
+const DEFAULT_SERVE_HOST: &str = "127.0.0.1";
+const DEFAULT_SERVE_PORT: u16 = 3000;
+
+#[derive(Debug, Args)]
+pub(crate) struct ServeCommand {
+    /// Host interface for the future Reborn WebUI HTTP listener.
+    #[arg(long, default_value = DEFAULT_SERVE_HOST)]
+    host: String,
+
+    /// Port for the future Reborn WebUI HTTP listener.
+    #[arg(long, default_value_t = DEFAULT_SERVE_PORT)]
+    port: u16,
+}
+
+impl ServeCommand {
+    pub(crate) fn execute(self, context: RebornCliContext) -> anyhow::Result<()> {
+        if self.port == 0 {
+            anyhow::bail!("--port must be greater than 0");
+        }
+
+        let boot_config = context.boot_config();
+        println!("IronClaw Reborn WebUI service");
+        println!("binary: ironclaw-reborn");
+        println!("version: {}", env!("CARGO_PKG_VERSION"));
+        println!("reborn_home: {}", boot_config.home().path().display());
+        println!("home_source: {}", boot_config.home().source_label());
+        println!("profile: {}", boot_config.profile());
+        println!("listen_url: http://{}:{}", self.host, self.port);
+        println!("v1_state: not-used");
+
+        anyhow::bail!(
+            "Reborn WebUI server composition is not linked yet; next slice must wire ironclaw_reborn_composition and ironclaw_webui_v2"
+        );
+    }
+}

--- a/crates/ironclaw_reborn_cli/src/commands/serve.rs
+++ b/crates/ironclaw_reborn_cli/src/commands/serve.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, SocketAddr};
+
 use clap::Args;
 
 use crate::context::RebornCliContext;
@@ -9,7 +11,7 @@ const DEFAULT_SERVE_PORT: u16 = 3000;
 pub(crate) struct ServeCommand {
     /// Host interface for the future Reborn WebUI HTTP listener.
     #[arg(long, default_value = DEFAULT_SERVE_HOST)]
-    host: String,
+    host: IpAddr,
 
     /// Port for the future Reborn WebUI HTTP listener.
     #[arg(long, default_value_t = DEFAULT_SERVE_PORT)]
@@ -29,11 +31,10 @@ impl ServeCommand {
         println!("reborn_home: {}", boot_config.home().path().display());
         println!("home_source: {}", boot_config.home().source_label());
         println!("profile: {}", boot_config.profile());
-        println!("listen_url: http://{}:{}", self.host, self.port);
+        let listen_addr = SocketAddr::new(self.host, self.port);
+        println!("listen_url: http://{listen_addr}");
         println!("v1_state: not-used");
 
-        anyhow::bail!(
-            "Reborn WebUI server composition is not linked yet; next slice must wire ironclaw_reborn_composition and ironclaw_webui_v2"
-        );
+        anyhow::bail!("Reborn WebUI server composition is not linked yet");
     }
 }

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -558,6 +558,51 @@ fn serve_resolves_context_and_fails_closed_until_webui_is_linked() {
 }
 
 #[test]
+fn serve_formats_ipv6_listen_url_with_socket_addr_brackets() {
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    let output = Command::new(reborn_bin())
+        .arg("serve")
+        .arg("--host")
+        .arg("::1")
+        .arg("--port")
+        .arg("3000")
+        .env("IRONCLAW_REBORN_HOME", temp.path().join("reborn-home"))
+        .output()
+        .expect("ironclaw-reborn serve should run");
+
+    assert!(
+        !output.status.success(),
+        "serve should fail closed until WebUI composition is linked"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("listen_url: http://[::1]:3000"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn serve_rejects_malformed_host_before_webui_handoff() {
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    let output = Command::new(reborn_bin())
+        .arg("serve")
+        .arg("--host")
+        .arg("localhost:3000")
+        .env("IRONCLAW_REBORN_HOME", temp.path().join("reborn-home"))
+        .output()
+        .expect("ironclaw-reborn serve should run");
+
+    assert!(
+        !output.status.success(),
+        "serve should reject malformed host"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid value"), "stderr: {stderr}");
+}
+
+#[test]
 fn serve_rejects_zero_port_before_webui_handoff() {
     let temp = tempfile::tempdir().expect("tempdir");
 

--- a/crates/ironclaw_reborn_cli/tests/smoke.rs
+++ b/crates/ironclaw_reborn_cli/tests/smoke.rs
@@ -35,6 +35,7 @@ fn help_mentions_reborn_commands() {
     assert!(stdout.contains("models"), "stdout: {stdout}");
     assert!(stdout.contains("profile"), "stdout: {stdout}");
     assert!(stdout.contains("run"), "stdout: {stdout}");
+    assert!(stdout.contains("serve"), "stdout: {stdout}");
     assert!(stdout.contains("skills"), "stdout: {stdout}");
 }
 
@@ -483,6 +484,97 @@ fn completion_generates_bash_script_without_reborn_home() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("_ironclaw-reborn()"), "stdout: {stdout}");
     assert!(stdout.contains("COMPREPLY"), "stdout: {stdout}");
+}
+
+#[test]
+fn serve_help_mentions_host_and_port() {
+    let output = Command::new(reborn_bin())
+        .arg("serve")
+        .arg("--help")
+        .env_clear()
+        .output()
+        .expect("ironclaw-reborn serve --help should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--host"), "stdout: {stdout}");
+    assert!(stdout.contains("--port"), "stdout: {stdout}");
+}
+
+#[test]
+fn serve_resolves_context_and_fails_closed_until_webui_is_linked() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let reborn_home = temp.path().join("reborn-home");
+    let v1_base_dir = temp.path().join("v1-state");
+
+    let output = Command::new(reborn_bin())
+        .arg("serve")
+        .arg("--host")
+        .arg("127.0.0.1")
+        .arg("--port")
+        .arg("3000")
+        .env("IRONCLAW_REBORN_HOME", &reborn_home)
+        .env("IRONCLAW_BASE_DIR", &v1_base_dir)
+        .env_remove("IRONCLAW_REBORN_PROFILE")
+        .output()
+        .expect("ironclaw-reborn serve should run");
+
+    assert!(
+        !output.status.success(),
+        "serve should fail closed until WebUI composition is linked"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("IronClaw Reborn WebUI service"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(reborn_home.to_str().expect("utf8 path")),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("profile: local-dev"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("listen_url: http://127.0.0.1:3000"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("v1_state: not-used"), "stdout: {stdout}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Reborn WebUI server composition is not linked yet"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !reborn_home.exists(),
+        "serve handoff stub should not create Reborn state directories"
+    );
+    assert!(
+        !v1_base_dir.exists(),
+        "serve handoff stub should not create explicit v1 base directories"
+    );
+}
+
+#[test]
+fn serve_rejects_zero_port_before_webui_handoff() {
+    let temp = tempfile::tempdir().expect("tempdir");
+
+    let output = Command::new(reborn_bin())
+        .arg("serve")
+        .arg("--port")
+        .arg("0")
+        .env("IRONCLAW_REBORN_HOME", temp.path().join("reborn-home"))
+        .output()
+        .expect("ironclaw-reborn serve should run");
+
+    assert!(!output.status.success(), "serve should reject port 0");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--port must be greater than 0"),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the first `ironclaw-reborn serve` CLI slice for the Reborn WebUI path.

- registers a thin `serve` command in `ironclaw_reborn_cli`
- accepts `--host` (default `127.0.0.1`) and `--port` (default `3000`)
- resolves `RebornCliContext` and prints the Reborn home/profile/listen target
- rejects `--port 0`
- fails closed with a clear "WebUI server composition is not linked yet" handoff message
- keeps CLI dependency boundaries unchanged; no v1 gateway imports and no new workspace deps

## Dependency / follow-up shape

This PR is intentionally a scaffold, not the WebUI server itself.

It depends only on the already-merged standalone Reborn CLI boundary (#3455). It does **not** depend on #3727 or the current WebUI/ProductWorkflow stacks, so it can land directly on `reborn-integration`.

Follow-up PRs should replace the fail-closed handoff with real wiring once these pieces are available/landed:

- Reborn WebUI route/server crate (`ironclaw_webui_v2` / #3747 direction)
- composition builder that returns WebUI-facing Reborn services from `ironclaw_reborn_composition`
- `RebornServicesApi` / ProductWorkflow facade wiring for create-thread/send-message/timeline/SSE
- TurnRunner + HostRuntime capability-port composition for actual loop/tool execution

Until those land, `serve` is safe to expose because it validates CLI parsing/context resolution but refuses to start a partial or misleading server.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ironclaw_reborn_cli`
- `cargo test -p ironclaw_architecture reborn_cli_binary_crate_stays_separate_from_v1_root`
