### PR TITLE
feat(reborn): add private WebUI services composition hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4647,6 +4647,8 @@ dependencies = [
  "ironclaw_loop_support",
  "ironclaw_network",
  "ironclaw_processes",
+ "ironclaw_product_adapters",
+ "ironclaw_product_workflow",
  "ironclaw_reborn",
  "ironclaw_reborn_config",
  "ironclaw_reborn_event_store",

--- a/crates/ironclaw_reborn_composition/CLAUDE.md
+++ b/crates/ironclaw_reborn_composition/CLAUDE.md
@@ -1,7 +1,7 @@
 # ironclaw_reborn_composition guardrails
 
 - Own only top-level Reborn composition for production/app startup.
-- Expose facade-shaped handles only: `HostRuntime`, `TurnCoordinator`, readiness.
+- Expose facade-shaped handles only: `HostRuntime`, `TurnCoordinator`, WebUI `RebornServicesApi`, readiness.
 - Keep lower substrate handles private to factories and owning crates.
 - Do not depend on the root `ironclaw` crate or `src/` modules.
 - Do not add legacy bridge modes here until an accepted migration contract exists.

--- a/crates/ironclaw_reborn_composition/Cargo.toml
+++ b/crates/ironclaw_reborn_composition/Cargo.toml
@@ -52,6 +52,8 @@ ironclaw_llm = { path = "../ironclaw_llm", optional = true, default-features = f
 ironclaw_loop_support = { path = "../ironclaw_loop_support" }
 ironclaw_network = { path = "../ironclaw_network" }
 ironclaw_processes = { path = "../ironclaw_processes" }
+ironclaw_product_adapters = { path = "../ironclaw_product_adapters" }
+ironclaw_product_workflow = { path = "../ironclaw_product_workflow" }
 ironclaw_reborn = { path = "../ironclaw_reborn" }
 ironclaw_reborn_config = { path = "../ironclaw_reborn_config" }
 ironclaw_reborn_event_store = { path = "../ironclaw_reborn_event_store" }

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -28,6 +28,7 @@ mod profile;
 mod readiness;
 mod runtime;
 mod runtime_input;
+mod webui;
 
 pub use error::RebornBuildError;
 pub use factory::{RebornServices, build_reborn_services};

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -166,6 +166,10 @@ impl RebornRuntime {
         &self.default_run_profile_id
     }
 
+    pub(crate) fn webui_thread_service(&self) -> Arc<dyn SessionThreadService> {
+        self.thread_service.clone()
+    }
+
     /// Create a fresh conversation. Returns the opaque conversation id used
     /// in subsequent `send_user_message` calls.
     ///

--- a/crates/ironclaw_reborn_composition/src/runtime.rs
+++ b/crates/ironclaw_reborn_composition/src/runtime.rs
@@ -170,6 +170,10 @@ impl RebornRuntime {
         self.thread_service.clone()
     }
 
+    pub(crate) fn webui_turn_coordinator(&self) -> Arc<dyn TurnCoordinator> {
+        self.turn_coordinator.clone()
+    }
+
     /// Create a fresh conversation. Returns the opaque conversation id used
     /// in subsequent `send_user_message` calls.
     ///

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+
+use ironclaw_product_adapters::ProjectionStream;
+use ironclaw_product_workflow::{RebornServices as ProductRebornServices, RebornServicesApi};
+
+use crate::{RebornBuildError, RebornReadiness, RebornRuntime};
+
+/// WebUI-facing Reborn service bundle for host composition.
+///
+/// This bundle deliberately exposes only the product facade consumed by WebChat
+/// v2 routes. HTTP routing, auth middleware, static assets, and SSE transport
+/// stay in the WebUI crate; lower runtime handles stay behind the existing
+/// Reborn runtime/composition services.
+#[allow(dead_code)] // Private follow-up hook for WebUI route mounting.
+#[derive(Clone)]
+pub(crate) struct RebornWebuiBundle {
+    pub(crate) api: Arc<dyn RebornServicesApi>,
+    pub(crate) readiness: RebornReadiness,
+}
+
+impl std::fmt::Debug for RebornWebuiBundle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RebornWebuiBundle")
+            .field("api", &"Arc<dyn RebornServicesApi>")
+            .field("readiness", &self.readiness)
+            .finish()
+    }
+}
+
+/// Compose the WebUI-facing product facade from an already-built Reborn runtime.
+///
+/// This function does not create a second turn coordinator, thread service,
+/// host runtime, route server, or event stream. It reuses the runtime's existing
+/// task-level composition and accepts an optional projection stream owned by the
+/// caller's event-stream composition layer.
+#[allow(dead_code)] // Private follow-up hook for WebUI route mounting.
+pub(crate) fn build_webui_services(
+    runtime: &RebornRuntime,
+    event_stream: Option<Arc<dyn ProjectionStream>>,
+) -> Result<RebornWebuiBundle, RebornBuildError> {
+    let services = runtime.services();
+    let turn_coordinator =
+        services
+            .turn_coordinator
+            .clone()
+            .ok_or_else(|| RebornBuildError::InvalidConfig {
+                reason: "webui services require an initialized turn coordinator".to_string(),
+            })?;
+
+    let mut api = ProductRebornServices::new(runtime.webui_thread_service(), turn_coordinator);
+    if let Some(event_stream) = event_stream {
+        api = api.with_event_stream(event_stream);
+    }
+
+    Ok(RebornWebuiBundle {
+        api: Arc::new(api),
+        readiness: services.readiness,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::{
+        RebornBuildInput, RebornReadinessState, RebornRuntimeIdentity, RebornRuntimeInput,
+        TurnRunnerSettings, build_reborn_runtime,
+    };
+
+    use super::build_webui_services;
+
+    #[tokio::test]
+    async fn webui_bundle_reuses_runtime_thread_and_turn_facades() {
+        let root = tempfile::tempdir().unwrap();
+        let input = RebornRuntimeInput::from_services(RebornBuildInput::local_dev(
+            "runtime-webui-owner",
+            root.path().join("local-dev"),
+        ))
+        .with_identity(RebornRuntimeIdentity {
+            tenant_id: "runtime-webui-tenant".to_string(),
+            agent_id: "runtime-webui-agent".to_string(),
+            source_binding_id: "runtime-webui-source".to_string(),
+            reply_target_binding_id: "runtime-webui-reply".to_string(),
+        })
+        .with_runner_settings(TurnRunnerSettings {
+            heartbeat_interval: Duration::from_secs(60),
+            poll_interval: Duration::from_secs(60),
+        });
+
+        let runtime = build_reborn_runtime(input).await.unwrap();
+        let bundle = build_webui_services(&runtime, None).unwrap();
+
+        let _api = bundle.api.clone();
+        assert_eq!(bundle.readiness, runtime.services().readiness);
+        assert_eq!(bundle.readiness.state, RebornReadinessState::DevOnly);
+
+        runtime.shutdown().await.unwrap();
+    }
+}

--- a/crates/ironclaw_reborn_composition/src/webui.rs
+++ b/crates/ironclaw_reborn_composition/src/webui.rs
@@ -40,15 +40,11 @@ pub(crate) fn build_webui_services(
     event_stream: Option<Arc<dyn ProjectionStream>>,
 ) -> Result<RebornWebuiBundle, RebornBuildError> {
     let services = runtime.services();
-    let turn_coordinator =
-        services
-            .turn_coordinator
-            .clone()
-            .ok_or_else(|| RebornBuildError::InvalidConfig {
-                reason: "webui services require an initialized turn coordinator".to_string(),
-            })?;
 
-    let mut api = ProductRebornServices::new(runtime.webui_thread_service(), turn_coordinator);
+    let mut api = ProductRebornServices::new(
+        runtime.webui_thread_service(),
+        runtime.webui_turn_coordinator(),
+    );
     if let Some(event_stream) = event_stream {
         api = api.with_event_stream(event_stream);
     }
@@ -61,6 +57,7 @@ pub(crate) fn build_webui_services(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use crate::{
@@ -89,9 +86,14 @@ mod tests {
         });
 
         let runtime = build_reborn_runtime(input).await.unwrap();
+        let runtime_turn_coordinator = runtime.webui_turn_coordinator();
         let bundle = build_webui_services(&runtime, None).unwrap();
 
         let _api = bundle.api.clone();
+        assert!(Arc::ptr_eq(
+            &runtime_turn_coordinator,
+            &runtime.webui_turn_coordinator()
+        ));
         assert_eq!(bundle.readiness, runtime.services().readiness);
         assert_eq!(bundle.readiness.state, RebornReadinessState::DevOnly);
 


### PR DESCRIPTION
## Summary

- add a private `ironclaw_reborn_composition::webui` module that composes the WebUI-facing `RebornServicesApi` from an already-built `RebornRuntime`
- reuse the runtime's existing turn coordinator and thread service instead of creating parallel product/turn state
- keep the hook private to the composition crate; no public `pub use` export yet
- document the composition guardrail update for WebUI `RebornServicesApi`

## Boundary notes

This intentionally does **not** mount Axum routes, serve static assets, import the v1 gateway, call dispatcher/runtime internals, or construct a second turn coordinator/thread service. It is stacked on top of #3747 so the WebChat v2 route crate can be mounted in a follow-up without widening public API first.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-webui-stack cargo test -p ironclaw_reborn_composition webui_bundle -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/ironclaw-target-webui-stack cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold -- --nocapture`

## Known validation note

- `CARGO_TARGET_DIR=/tmp/ironclaw-target-webui-stack cargo clippy -p ironclaw_reborn_composition --all-targets -- -D warnings` currently fails before this crate on existing `ironclaw_reborn_event_store` unused imports (`ScopedFilesystem`, `MountAlias`, `MountGrant`, `MountPermissions`, `MountView`, `VirtualPath`, `RootFilesystem`).
