### PR TITLE
test(reborn): cover approval cancellation parity

### DIFF
--- a/tests/reborn_approval_traces_parity.rs
+++ b/tests/reborn_approval_traces_parity.rs
@@ -71,3 +71,66 @@ async fn reborn_approval_traces_parity() {
 
     harness.shutdown().await;
 }
+
+#[tokio::test]
+async fn reborn_approval_cancel_traces_parity() {
+    let model_gateway = RebornTraceReplayModelGateway::with_responses([
+        trace_tool_call_response(),
+        HostManagedModelResponse::assistant_reply("must not be emitted after cancel"),
+    ]);
+    let mut harness = RebornBinaryE2EHarness::with_harness_blocked_evidence(
+        "room-approval-cancel-trace",
+        model_gateway,
+        RecordingTestCapabilityPort::approval_then_echo(),
+    )
+    .await
+    .expect("harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text("event-approval-cancel-trace", "needs approval then cancel")
+        .await
+        .expect("submit text");
+    let blocked = harness
+        .wait_for_status(submitted.run_id, TurnStatus::BlockedApproval)
+        .await
+        .expect("blocked approval");
+    assert!(
+        blocked.gate_ref.is_some(),
+        "blocked run should expose gate ref before cancellation"
+    );
+
+    harness
+        .cancel_blocked_turn(submitted.run_id)
+        .await
+        .expect("cancel blocked approval run");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Cancelled)
+        .await
+        .expect("cancelled after approval block");
+
+    let state = harness
+        .run_state(submitted.run_id)
+        .await
+        .expect("cancelled run state");
+    assert_eq!(state.status, TurnStatus::Cancelled);
+    assert_eq!(harness.capability_invocations().len(), 1);
+    assert_eq!(harness.model_requests().len(), 1);
+    assert_eq!(harness.remaining_model_responses(), 1);
+    assert!(
+        !harness.milestones().iter().any(|milestone| matches!(
+            milestone.kind,
+            LoopHostMilestoneKind::AssistantReplyFinalized { .. }
+        )),
+        "cancelled approval run must not finalize an assistant reply"
+    );
+    assert!(
+        harness
+            .milestones()
+            .iter()
+            .any(|milestone| matches!(milestone.kind, LoopHostMilestoneKind::GateBlocked { .. })),
+        "cancelled approval run should still record gate-blocked evidence"
+    );
+
+    harness.shutdown().await;
+}

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -496,8 +496,15 @@ impl RebornBinaryE2EHarness {
                 idempotency_key: IdempotencyKey::new(format!("cancel-{run_id}"))?,
             })
             .await?;
-        if !matches!(response.status, TurnStatus::Cancelled | TurnStatus::CancelRequested) {
-            return Err(format!("expected run to be cancelled or cancel-requested, got {:?}", response.status).into());
+        if !matches!(
+            response.status,
+            TurnStatus::Cancelled | TurnStatus::CancelRequested
+        ) {
+            return Err(format!(
+                "expected run to be cancelled or cancel-requested, got {:?}",
+                response.status
+            )
+            .into());
         }
         Ok(())
     }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -70,11 +70,11 @@ use ironclaw_threads::{
 };
 use ironclaw_trust::EffectiveTrustClass;
 use ironclaw_turns::{
-    DefaultTurnCoordinator, FilesystemTurnStateStore, GateRef, GetLoopCheckpointRequest,
-    GetRunStateRequest, IdempotencyKey, InMemoryCheckpointStateStore, LoopBlockedKind,
-    LoopCheckpointKind, LoopCheckpointStore, LoopGateRef, LoopResultRef, ReplyTargetBindingRef,
-    ResumeTurnRequest, SourceBindingRef, TurnActor, TurnCoordinator, TurnError, TurnRunId,
-    TurnRunState, TurnScope, TurnStateStore, TurnStatus,
+    CancelRunRequest, DefaultTurnCoordinator, FilesystemTurnStateStore, GateRef,
+    GetLoopCheckpointRequest, GetRunStateRequest, IdempotencyKey, InMemoryCheckpointStateStore,
+    LoopBlockedKind, LoopCheckpointKind, LoopCheckpointStore, LoopGateRef, LoopResultRef,
+    ReplyTargetBindingRef, ResumeTurnRequest, SanitizedCancelReason, SourceBindingRef, TurnActor,
+    TurnCoordinator, TurnError, TurnRunId, TurnRunState, TurnScope, TurnStateStore, TurnStatus,
     run_profile::{
         AgentLoopHostError, AgentLoopHostErrorKind, CapabilityBatchInvocation,
         CapabilityBatchOutcome, CapabilityCallCandidate, CapabilityDescriptorView,
@@ -481,6 +481,23 @@ impl RebornBinaryE2EHarness {
             .await?;
         if response.status != TurnStatus::Queued {
             return Err(format!("expected resumed run to queue, got {:?}", response.status).into());
+        }
+        Ok(())
+    }
+
+    pub async fn cancel_blocked_turn(&self, run_id: TurnRunId) -> HarnessResult<()> {
+        let response = self
+            .coordinator
+            .cancel_run(CancelRunRequest {
+                scope: self.turn_scope.clone(),
+                actor: TurnActor::new(self.binding.user_id.clone()),
+                run_id,
+                reason: SanitizedCancelReason::UserRequested,
+                idempotency_key: IdempotencyKey::new(format!("cancel-{run_id}"))?,
+            })
+            .await?;
+        if response.status != TurnStatus::Cancelled {
+            return Err(format!("expected cancelled run, got {:?}", response.status).into());
         }
         Ok(())
     }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -496,8 +496,8 @@ impl RebornBinaryE2EHarness {
                 idempotency_key: IdempotencyKey::new(format!("cancel-{run_id}"))?,
             })
             .await?;
-        if response.status != TurnStatus::Cancelled {
-            return Err(format!("expected cancelled run, got {:?}", response.status).into());
+        if !matches!(response.status, TurnStatus::Cancelled | TurnStatus::CancelRequested) {
+            return Err(format!("expected run to be cancelled or cancel-requested, got {:?}", response.status).into());
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- extend Reborn approval binary-E2E coverage beyond the existing approve/resume happy path
- add a harness `cancel_blocked_turn` helper that cancels through the real `TurnCoordinator::cancel_run` path
- assert a blocked approval run exposes a gate ref, cancels to `TurnStatus::Cancelled`, does not consume the follow-up model response, and never finalizes an assistant reply

## Scope caveat
This covers blocked approval cancellation, not a product-level “deny gate” resolution API. If/when Reborn exposes an explicit approval-deny surface, that should get its own parity test. Existing #3774 coverage still covers the approve/resume path.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -q --features libsql --test reborn_approval_traces_parity reborn_approval_cancel_traces_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_approval_traces_parity -- --nocapture`
