### PR TITLE
Register default host API contracts in composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4353,6 +4353,7 @@ dependencies = [
  "ironclaw_memory",
  "ironclaw_network",
  "ironclaw_processes",
+ "ironclaw_product_adapter_registry",
  "ironclaw_reborn_event_store",
  "ironclaw_resources",
  "ironclaw_run_state",

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -30,6 +30,7 @@ ironclaw_memory = { path = "../ironclaw_memory" }
 ironclaw_mcp = { path = "../ironclaw_mcp" }
 ironclaw_network = { path = "../ironclaw_network" }
 ironclaw_processes = { path = "../ironclaw_processes" }
+ironclaw_product_adapter_registry = { path = "../ironclaw_product_adapter_registry" }
 ironclaw_reborn_event_store = { path = "../ironclaw_reborn_event_store" }
 ironclaw_resources = { path = "../ironclaw_resources" }
 ironclaw_run_state = { path = "../ironclaw_run_state" }

--- a/crates/ironclaw_host_runtime/src/extension_contracts.rs
+++ b/crates/ironclaw_host_runtime/src/extension_contracts.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use ironclaw_extensions::{
+    CapabilityProviderHostApiContract, ExtensionDiscovery, ExtensionError, ExtensionRegistry,
+    HostApiContractRegistry, ManifestV2Error,
+};
+use ironclaw_filesystem::RootFilesystem;
+use ironclaw_host_api::{HostPortCatalog, VirtualPath};
+use ironclaw_product_adapter_registry::ProductAdapterHostApiContract;
+
+/// Build the host-runtime default set of Extension Manifest v2 host API contracts.
+///
+/// This is composition-only: contracts validate and project manifest declarations,
+/// but do not execute runtime code, resolve schema files, or publish hot surfaces.
+pub fn default_host_api_contract_registry() -> Result<HostApiContractRegistry, ManifestV2Error> {
+    let mut registry = HostApiContractRegistry::new();
+    registry.register(Arc::new(CapabilityProviderHostApiContract::new()?))?;
+    let product_adapter_contract =
+        ProductAdapterHostApiContract::new().map_err(|error| ManifestV2Error::Invalid {
+            reason: format!("product adapter host API contract registration failed: {error}"),
+        })?;
+    registry.register(Arc::new(product_adapter_contract))?;
+    Ok(registry)
+}
+
+/// Discover installed extensions through host-runtime's default host API contracts.
+///
+/// Callers still own the supported [`HostPortCatalog`]; PR3 intentionally keeps
+/// that catalog empty unless composition supplies real host ports in a later slice.
+pub async fn discover_extensions_with_default_host_api_contracts<F>(
+    fs: &F,
+    root: &VirtualPath,
+    host_port_catalog: &HostPortCatalog,
+) -> Result<ExtensionRegistry, ExtensionError>
+where
+    F: RootFilesystem,
+{
+    let contracts = default_host_api_contract_registry()?;
+    ExtensionDiscovery::discover_with_manifest_contracts(
+        fs,
+        root,
+        ironclaw_extensions::ManifestSource::InstalledLocal,
+        host_port_catalog,
+        &contracts,
+    )
+    .await
+}

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -45,6 +45,7 @@ use serde_json::Value;
 use std::{collections::BTreeMap, fmt, sync::Arc};
 use thiserror::Error;
 
+mod extension_contracts;
 mod first_party;
 mod first_party_tools;
 pub mod memory_context;
@@ -55,6 +56,9 @@ mod services;
 mod surface;
 mod turn_scheduler;
 
+pub use extension_contracts::{
+    default_host_api_contract_registry, discover_extensions_with_default_host_api_contracts,
+};
 pub use first_party::{
     FirstPartyCapabilityError, FirstPartyCapabilityHandler, FirstPartyCapabilityRegistry,
     FirstPartyCapabilityRequest, FirstPartyCapabilityResult,

--- a/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
+++ b/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
@@ -2,6 +2,7 @@ use ironclaw_extensions::{CAPABILITY_PROVIDER_HOST_API_ID, CAPABILITY_PROVIDER_S
 use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_host_api::{CapabilityId, ExtensionId, HostPath, HostPortCatalog, VirtualPath};
 use ironclaw_host_runtime::discover_extensions_with_default_host_api_contracts;
+use ironclaw_product_adapter_registry::PRODUCT_ADAPTER_HOST_API_ID;
 use tempfile::tempdir;
 
 #[tokio::test]
@@ -50,6 +51,46 @@ async fn default_host_api_contracts_discover_capability_provider_manifest() {
     assert_eq!(capability.description, "Send a Telegram message");
 }
 
+#[tokio::test]
+async fn default_host_api_contracts_discover_product_adapter_manifest() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("telegram-v2")).unwrap();
+    std::fs::write(
+        storage.path().join("telegram-v2/manifest.toml"),
+        PRODUCT_ADAPTER_MANIFEST,
+    )
+    .unwrap();
+
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let registry = discover_extensions_with_default_host_api_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+        &HostPortCatalog::empty(),
+    )
+    .await
+    .unwrap();
+
+    let package = registry
+        .get_extension(&ExtensionId::new("telegram-v2").unwrap())
+        .unwrap();
+    assert_eq!(package.manifest.host_apis.len(), 1);
+    assert_eq!(
+        package.manifest.host_apis[0].id.as_str(),
+        PRODUCT_ADAPTER_HOST_API_ID
+    );
+    assert_eq!(
+        package.manifest.host_apis[0].section.as_str(),
+        "product_adapter.inbound"
+    );
+    assert!(package.capabilities.is_empty());
+}
+
 const CAPABILITY_PROVIDER_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "telegram"
 name = "Telegram"
@@ -76,4 +117,37 @@ visibility = "model"
 input_schema_ref = "schemas/telegram/send_message.input.v1.json"
 output_schema_ref = "schemas/telegram/send_message.output.v1.json"
 prompt_doc_ref = "prompts/telegram/send_message.md"
+"#;
+
+const PRODUCT_ADAPTER_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
+id = "telegram-v2"
+name = "Telegram"
+version = "0.1.0"
+description = "Telegram product adapter"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "adapters/telegram-v2.wasm"
+
+[[host_api]]
+id = "ironclaw.product_adapter/v1"
+section = "product_adapter.inbound"
+
+[product_adapter.inbound]
+surface_kind = "external_channel"
+
+[product_adapter.inbound.auth]
+kind = "shared_secret_header"
+header_name = "X-Telegram-Bot-Api-Secret-Token"
+
+[product_adapter.inbound.capabilities]
+flags = ["inbound_messages", "external_final_reply_push"]
+
+[[product_adapter.inbound.required_credentials]]
+handle = "telegram_bot_token"
+
+[[product_adapter.inbound.egress]]
+host = "api.telegram.org"
+credential_handle = "telegram_bot_token"
 "#;

--- a/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
+++ b/crates/ironclaw_host_runtime/tests/host_api_contract_composition.rs
@@ -1,0 +1,79 @@
+use ironclaw_extensions::{CAPABILITY_PROVIDER_HOST_API_ID, CAPABILITY_PROVIDER_SECTION};
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::{CapabilityId, ExtensionId, HostPath, HostPortCatalog, VirtualPath};
+use ironclaw_host_runtime::discover_extensions_with_default_host_api_contracts;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn default_host_api_contracts_discover_capability_provider_manifest() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("telegram")).unwrap();
+    std::fs::write(
+        storage.path().join("telegram/manifest.toml"),
+        CAPABILITY_PROVIDER_MANIFEST,
+    )
+    .unwrap();
+
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let registry = discover_extensions_with_default_host_api_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+        &HostPortCatalog::empty(),
+    )
+    .await
+    .unwrap();
+
+    let package = registry
+        .get_extension(&ExtensionId::new("telegram").unwrap())
+        .unwrap();
+    assert_eq!(package.manifest.host_apis.len(), 1);
+    assert_eq!(
+        package.manifest.host_apis[0].id.as_str(),
+        CAPABILITY_PROVIDER_HOST_API_ID
+    );
+    assert_eq!(
+        package.manifest.host_apis[0].section.as_str(),
+        CAPABILITY_PROVIDER_SECTION
+    );
+    assert_eq!(package.capabilities.len(), 1);
+
+    let capability = registry
+        .get_capability(&CapabilityId::new("telegram.send_message").unwrap())
+        .unwrap();
+    assert_eq!(capability.provider.as_str(), "telegram");
+    assert_eq!(capability.description, "Send a Telegram message");
+}
+
+const CAPABILITY_PROVIDER_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
+id = "telegram"
+name = "Telegram"
+version = "0.1.0"
+description = "Telegram adapter"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "wasm/telegram.wasm"
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "telegram.send_message"
+description = "Send a Telegram message"
+effects = ["network"]
+default_permission = "ask"
+visibility = "model"
+input_schema_ref = "schemas/telegram/send_message.input.v1.json"
+output_schema_ref = "schemas/telegram/send_message.output.v1.json"
+prompt_doc_ref = "prompts/telegram/send_message.md"
+"#;


### PR DESCRIPTION
## Summary
- add host-runtime default host API contract registry with capability-provider and product-adapter contracts
- add host-runtime discovery helper that calls `ExtensionDiscovery::discover_with_manifest_contracts(...)` with default contracts
- cover caller-level discovery of a `ironclaw.capability_provider/v1` manifest into package/registry capabilities

Stacked on #3783. Retarget to `reborn-integration` after PR2 merges.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_host_runtime default_host_api_contracts_discover_capability_provider_manifest`
- `cargo test -p ironclaw_host_runtime --test tool_surface_contract`
- `cargo test -p ironclaw_product_adapter_registry`
- `cargo test -p ironclaw_dispatcher`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `cargo clippy -p ironclaw_host_runtime -p ironclaw_product_adapter_registry --all-targets -- -D warnings`