### PR TITLE
Add hot capability catalog publication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,6 +4364,7 @@ dependencies = [
  "ironclaw_trust",
  "ironclaw_turns",
  "ironclaw_wasm",
+ "jsonschema",
  "libsql",
  "regex",
  "rust_decimal",

--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -288,6 +288,17 @@ impl RootFilesystem for CompositeRootFilesystem {
         self.matching_mount(path)?.backend.read_file(path).await
     }
 
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .read_file_bounded(path, max_bytes)
+            .await
+    }
+
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         self.matching_mount(path)?
             .backend

--- a/crates/ironclaw_filesystem/src/catalog.rs
+++ b/crates/ironclaw_filesystem/src/catalog.rs
@@ -288,17 +288,6 @@ impl RootFilesystem for CompositeRootFilesystem {
         self.matching_mount(path)?.backend.read_file(path).await
     }
 
-    async fn read_file_bounded(
-        &self,
-        path: &VirtualPath,
-        max_bytes: usize,
-    ) -> Result<Option<Vec<u8>>, FilesystemError> {
-        self.matching_mount(path)?
-            .backend
-            .read_file_bounded(path, max_bytes)
-            .await
-    }
-
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         self.matching_mount(path)?
             .backend

--- a/crates/ironclaw_filesystem/src/in_memory.rs
+++ b/crates/ironclaw_filesystem/src/in_memory.rs
@@ -923,6 +923,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bounded_read_default_impl_routes_through_stat_and_get() {
+        let fs = InMemoryBackend::new();
+        let path = vpath("/tmp/bounded.bin");
+        fs.put(
+            &path,
+            Entry::bytes(b"bounded payload".to_vec()),
+            CasExpectation::Absent,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            fs.read_file_bounded(&path, 15).await.unwrap(),
+            Some(b"bounded payload".to_vec())
+        );
+        assert_eq!(fs.read_file_bounded(&path, 14).await.unwrap(), None);
+    }
+
+    #[tokio::test]
     async fn get_and_query_populate_versioned_entry_path() {
         // PR #3659 review fix: `VersionedEntry` now carries the
         // [`VirtualPath`] of the record so query consumers can drive

--- a/crates/ironclaw_filesystem/src/libsql.rs
+++ b/crates/ironclaw_filesystem/src/libsql.rs
@@ -650,6 +650,58 @@ impl RootFilesystem for LibSqlRootFilesystem {
             .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))
     }
 
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        let conn = self.connect().await?;
+        let max_bytes = max_bytes as i64;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT
+                    CASE
+                        WHEN length(contents) <= ?2 THEN contents
+                        ELSE NULL
+                    END,
+                    length(contents),
+                    is_dir
+                FROM root_filesystem_entries
+                WHERE path = ?1
+                "#,
+                libsql::params![path.as_str(), max_bytes],
+            )
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?
+        else {
+            return Err(not_found(path.clone(), FilesystemOperation::ReadFile));
+        };
+        let is_dir: i64 = row
+            .get(2)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        if is_dir != 0 {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+                reason: "is a directory".to_string(),
+            });
+        }
+        let len: i64 = row
+            .get(1)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        if len > max_bytes {
+            return Ok(None);
+        }
+        row.get(0)
+            .map(Some)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))
+    }
+
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         if matches!(
             self.exact_entry(path).await?,

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use ironclaw_host_api::{HostPath, VirtualPath};
 use ironclaw_safety::sensitive_paths::is_sensitive_path;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::{
     CasExpectation, DirEntry, Entry, FileStat, FileType, FilesystemError, FilesystemOperation,
@@ -226,6 +226,43 @@ impl RootFilesystem for LocalFilesystem {
         tokio::fs::read(resolved)
             .await
             .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))
+    }
+
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        let resolved = self
+            .resolve_existing(path, FilesystemOperation::ReadFile)
+            .await?;
+        let file = tokio::fs::File::open(&resolved)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let metadata = file
+            .metadata()
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        if !metadata.is_file() {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+                reason: "not a file".to_string(),
+            });
+        }
+        if metadata.len() > max_bytes as u64 {
+            return Ok(None);
+        }
+
+        let mut bytes = Vec::with_capacity(max_bytes.min(metadata.len() as usize));
+        file.take((max_bytes as u64).saturating_add(1))
+            .read_to_end(&mut bytes)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        if bytes.len() > max_bytes {
+            return Ok(None);
+        }
+        Ok(Some(bytes))
     }
 
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use ironclaw_host_api::{HostPath, VirtualPath};
 use ironclaw_safety::sensitive_paths::is_sensitive_path;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::{
     CasExpectation, DirEntry, Entry, FileStat, FileType, FilesystemError, FilesystemOperation,
@@ -226,6 +226,28 @@ impl RootFilesystem for LocalFilesystem {
         tokio::fs::read(resolved)
             .await
             .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))
+    }
+
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        let resolved = self
+            .resolve_existing(path, FilesystemOperation::ReadFile)
+            .await?;
+        let file = tokio::fs::File::open(resolved)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let mut bytes = Vec::with_capacity(max_bytes.min(8 * 1024));
+        file.take(max_bytes.saturating_add(1) as u64)
+            .read_to_end(&mut bytes)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        if bytes.len() > max_bytes {
+            return Ok(None);
+        }
+        Ok(Some(bytes))
     }
 
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {

--- a/crates/ironclaw_filesystem/src/local.rs
+++ b/crates/ironclaw_filesystem/src/local.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use ironclaw_host_api::{HostPath, VirtualPath};
 use ironclaw_safety::sensitive_paths::is_sensitive_path;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 
 use crate::{
     CasExpectation, DirEntry, Entry, FileStat, FileType, FilesystemError, FilesystemOperation,
@@ -226,28 +226,6 @@ impl RootFilesystem for LocalFilesystem {
         tokio::fs::read(resolved)
             .await
             .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))
-    }
-
-    async fn read_file_bounded(
-        &self,
-        path: &VirtualPath,
-        max_bytes: usize,
-    ) -> Result<Option<Vec<u8>>, FilesystemError> {
-        let resolved = self
-            .resolve_existing(path, FilesystemOperation::ReadFile)
-            .await?;
-        let file = tokio::fs::File::open(resolved)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
-        let mut bytes = Vec::with_capacity(max_bytes.min(8 * 1024));
-        file.take(max_bytes.saturating_add(1) as u64)
-            .read_to_end(&mut bytes)
-            .await
-            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))?;
-        if bytes.len() > max_bytes {
-            return Ok(None);
-        }
-        Ok(Some(bytes))
     }
 
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {

--- a/crates/ironclaw_filesystem/src/postgres.rs
+++ b/crates/ironclaw_filesystem/src/postgres.rs
@@ -469,6 +469,48 @@ impl RootFilesystem for PostgresRootFilesystem {
         Ok(row.get("contents"))
     }
 
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        let client = self.client().await?;
+        let max_bytes = max_bytes as i64;
+        let row = client
+            .query_opt(
+                r#"
+                SELECT
+                    CASE
+                        WHEN octet_length(contents)::BIGINT <= $2 THEN contents
+                        ELSE NULL
+                    END AS contents,
+                    octet_length(contents)::BIGINT AS len,
+                    is_dir
+                FROM root_filesystem_entries
+                WHERE path = $1
+                "#,
+                &[&path.as_str(), &max_bytes],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let Some(row) = row else {
+            return Err(not_found(path.clone(), FilesystemOperation::ReadFile));
+        };
+        let is_dir: bool = row.get("is_dir");
+        if is_dir {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+                reason: "is a directory".to_string(),
+            });
+        }
+        let len: i64 = row.get("len");
+        if len > max_bytes {
+            return Ok(None);
+        }
+        Ok(Some(row.get("contents")))
+    }
+
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         let client = self.client().await?;
         if matches!(

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -111,6 +111,31 @@ pub trait RootFilesystem: Send + Sync {
     /// Returns metadata for a canonical virtual path without revealing raw host paths.
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError>;
 
+    /// Read an opaque file only when its body is at most `max_bytes`.
+    ///
+    /// Returns `Ok(None)` when the file exists but exceeds the caller's limit.
+    /// Streaming backends should enforce this before materializing the full body.
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        let stat = self.stat(path).await?;
+        if stat.len > max_bytes as u64 {
+            return Ok(None);
+        }
+        let Some(entry) = self.get(path).await? else {
+            return Err(FilesystemError::NotFound {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+            });
+        };
+        if entry.entry.body.len() > max_bytes {
+            return Ok(None);
+        }
+        Ok(Some(entry.entry.body))
+    }
+
     /// Deletes an existing canonical virtual file or directory. Missing paths
     /// return [`FilesystemError::NotFound`]; backends that do not support
     /// delete must fail closed before side effects.

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -27,6 +27,8 @@ use crate::{
 ///   (`put` + `CasExpectation::Version`) as the floor.
 /// - **Event plane** — [`append`](Self::append) / [`tail`](Self::tail) for
 ///   log-shaped mounts.
+/// - **Bounded bytes reads** — [`read_file_bounded`](Self::read_file_bounded)
+///   for callers that must reject oversized assets before publication.
 /// - **Legacy bytes plane** — [`read_file`](Self::read_file) /
 ///   [`write_file`](Self::write_file) / [`append_file`](Self::append_file) /
 ///   [`list_dir_bytes`](Self::list_dir_bytes) / [`create_dir_all`](Self::create_dir_all).
@@ -154,6 +156,27 @@ pub trait RootFilesystem: Send + Sync {
         _from: SeqNo,
     ) -> Result<Vec<EventRecord>, FilesystemError> {
         unsupported(path, FilesystemOperation::Tail)
+    }
+
+    /// Read at most `max_bytes` from a canonical virtual file.
+    ///
+    /// Returns `Ok(None)` when the file exceeds the caller's limit. Backends with
+    /// native streaming reads should override this so hostile files cannot force
+    /// full allocation before the limit is enforced.
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        let stat = self.stat(path).await?;
+        if stat.len > max_bytes as u64 {
+            return Ok(None);
+        }
+        let bytes = self.read_file(path).await?;
+        if bytes.len() > max_bytes {
+            return Ok(None);
+        }
+        Ok(Some(bytes))
     }
 
     // ─── Legacy bytes plane (DEPRECATED — removed after consumer migration) ─

--- a/crates/ironclaw_filesystem/src/root.rs
+++ b/crates/ironclaw_filesystem/src/root.rs
@@ -27,8 +27,6 @@ use crate::{
 ///   (`put` + `CasExpectation::Version`) as the floor.
 /// - **Event plane** — [`append`](Self::append) / [`tail`](Self::tail) for
 ///   log-shaped mounts.
-/// - **Bounded bytes reads** — [`read_file_bounded`](Self::read_file_bounded)
-///   for callers that must reject oversized assets before publication.
 /// - **Legacy bytes plane** — [`read_file`](Self::read_file) /
 ///   [`write_file`](Self::write_file) / [`append_file`](Self::append_file) /
 ///   [`list_dir_bytes`](Self::list_dir_bytes) / [`create_dir_all`](Self::create_dir_all).
@@ -156,27 +154,6 @@ pub trait RootFilesystem: Send + Sync {
         _from: SeqNo,
     ) -> Result<Vec<EventRecord>, FilesystemError> {
         unsupported(path, FilesystemOperation::Tail)
-    }
-
-    /// Read at most `max_bytes` from a canonical virtual file.
-    ///
-    /// Returns `Ok(None)` when the file exceeds the caller's limit. Backends with
-    /// native streaming reads should override this so hostile files cannot force
-    /// full allocation before the limit is enforced.
-    async fn read_file_bounded(
-        &self,
-        path: &VirtualPath,
-        max_bytes: usize,
-    ) -> Result<Option<Vec<u8>>, FilesystemError> {
-        let stat = self.stat(path).await?;
-        if stat.len > max_bytes as u64 {
-            return Ok(None);
-        }
-        let bytes = self.read_file(path).await?;
-        if bytes.len() > max_bytes {
-            return Ok(None);
-        }
-        Ok(Some(bytes))
     }
 
     // ─── Legacy bytes plane (DEPRECATED — removed after consumer migration) ─

--- a/crates/ironclaw_filesystem/tests/catalog_contract.rs
+++ b/crates/ironclaw_filesystem/tests/catalog_contract.rs
@@ -113,6 +113,24 @@ async fn composite_routes_filesystem_operations_to_matching_backend() {
             .unwrap(),
         b"project readme"
     );
+    assert_eq!(
+        root.read_file_bounded(&VirtualPath::new("/memory/MEMORY.md").unwrap(), 13)
+            .await
+            .unwrap(),
+        Some(b"remember this".to_vec())
+    );
+    assert_eq!(
+        root.read_file_bounded(&VirtualPath::new("/projects/README.md").unwrap(), 14)
+            .await
+            .unwrap(),
+        Some(b"project readme".to_vec())
+    );
+    assert_eq!(
+        root.read_file_bounded(&VirtualPath::new("/projects/README.md").unwrap(), 12)
+            .await
+            .unwrap(),
+        None
+    );
 
     root.write_file(
         &VirtualPath::new("/memory/notes/new.md").unwrap(),
@@ -223,6 +241,13 @@ async fn missing_composite_mount_fails_without_backend_side_effects() {
     let root = CompositeRootFilesystem::new();
     let err = root
         .read_file(&VirtualPath::new("/memory/MEMORY.md").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, FilesystemError::MountNotFound { .. }));
+
+    let err = root
+        .read_file_bounded(&VirtualPath::new("/memory/MEMORY.md").unwrap(), 1024)
         .await
         .unwrap_err();
 

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -43,6 +43,28 @@ async fn scoped_read_resolves_mount_view_and_reads_bytes() {
 }
 
 #[tokio::test]
+async fn bounded_read_returns_none_without_materializing_oversized_local_file() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/schema.json"), b"abcdef").unwrap();
+
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let path = VirtualPath::new("/projects/project1/schema.json").unwrap();
+
+    assert_eq!(
+        root.read_file_bounded(&path, 6).await.unwrap(),
+        Some(b"abcdef".to_vec())
+    );
+    assert_eq!(root.read_file_bounded(&path, 5).await.unwrap(), None);
+}
+
+#[tokio::test]
 async fn scoped_write_is_denied_on_read_only_mount() {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("project1")).unwrap();

--- a/crates/ironclaw_host_runtime/Cargo.toml
+++ b/crates/ironclaw_host_runtime/Cargo.toml
@@ -42,6 +42,7 @@ ironclaw_trust = { path = "../ironclaw_trust" }
 ironclaw_turns = { path = "../ironclaw_turns" }
 ironclaw_wasm = { path = "../ironclaw_wasm" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+jsonschema = { version = "0.45", default-features = false }
 regex = "1"
 rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
 secrecy = "0.10"

--- a/crates/ironclaw_host_runtime/src/capability_catalog.rs
+++ b/crates/ironclaw_host_runtime/src/capability_catalog.rs
@@ -122,12 +122,19 @@ where
 {
     let path = resolve_under_root(root, reference)?;
     let bytes = read_bounded(fs, &path, MAX_HOT_SCHEMA_BYTES, field).await?;
-    serde_json::from_slice(&bytes).map_err(|error| {
+    let schema = serde_json::from_slice(&bytes).map_err(|error| {
         HostRuntimeError::invalid_request(format!(
             "{field} {} must contain valid JSON schema: {error}",
             reference.as_str()
         ))
-    })
+    })?;
+    jsonschema::validator_for(&schema).map_err(|error| {
+        HostRuntimeError::invalid_request(format!(
+            "{field} {} must contain valid JSON schema: {error}",
+            reference.as_str()
+        ))
+    })?;
+    Ok(schema)
 }
 
 async fn read_text_ref<F>(
@@ -157,16 +164,20 @@ async fn read_bounded<F>(
 where
     F: RootFilesystem,
 {
-    let bytes = fs.read_file(path).await.map_err(|_error| {
-        HostRuntimeError::invalid_request(format!("failed to read {field} at {}", path.as_str()))
-    })?;
-    if bytes.len() > max_bytes {
-        return Err(HostRuntimeError::invalid_request(format!(
-            "{field} at {} exceeds {max_bytes} bytes",
-            path.as_str()
-        )));
-    }
-    Ok(bytes)
+    fs.read_file_bounded(path, max_bytes)
+        .await
+        .map_err(|_error| {
+            HostRuntimeError::invalid_request(format!(
+                "failed to read {field} at {}",
+                path.as_str()
+            ))
+        })?
+        .ok_or_else(|| {
+            HostRuntimeError::invalid_request(format!(
+                "{field} at {} exceeds {max_bytes} bytes",
+                path.as_str()
+            ))
+        })
 }
 
 fn resolve_under_root(

--- a/crates/ironclaw_host_runtime/src/capability_catalog.rs
+++ b/crates/ironclaw_host_runtime/src/capability_catalog.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ironclaw_extensions::{CapabilityVisibility, ExtensionPackage, ExtensionRegistry};
 use ironclaw_filesystem::RootFilesystem;
 use ironclaw_host_api::{
@@ -62,12 +64,17 @@ async fn publish_package_capabilities<F>(
 where
     F: RootFilesystem,
 {
+    let declarations_by_id: HashMap<_, _> = package
+        .manifest
+        .capabilities
+        .iter()
+        .map(|declaration| (&declaration.id, declaration))
+        .collect();
+
     for descriptor in &package.capabilities {
-        let declaration = package
-            .manifest
-            .capabilities
-            .iter()
-            .find(|declaration| declaration.id == descriptor.id)
+        let declaration = declarations_by_id
+            .get(&descriptor.id)
+            .copied()
             .ok_or_else(|| {
                 HostRuntimeError::invalid_request(format!(
                     "capability {} is missing manifest declaration",
@@ -166,9 +173,9 @@ where
 {
     fs.read_file_bounded(path, max_bytes)
         .await
-        .map_err(|_error| {
+        .map_err(|error| {
             HostRuntimeError::invalid_request(format!(
-                "failed to read {field} at {}",
+                "failed to read {field} at {}: {error}",
                 path.as_str()
             ))
         })?
@@ -184,6 +191,7 @@ fn resolve_under_root(
     root: &VirtualPath,
     reference: &CapabilityProfileSchemaRef,
 ) -> Result<VirtualPath, HostRuntimeError> {
+    validate_relative_manifest_asset_ref(reference)?;
     VirtualPath::new(format!(
         "{}/{}",
         root.as_str().trim_end_matches('/'),
@@ -196,4 +204,22 @@ fn resolve_under_root(
             root.as_str()
         ))
     })
+}
+
+fn validate_relative_manifest_asset_ref(
+    reference: &CapabilityProfileSchemaRef,
+) -> Result<(), HostRuntimeError> {
+    let value = reference.as_str();
+    if value.starts_with('/')
+        || value.contains('\\')
+        || value.chars().any(|ch| ch == '\0' || ch.is_control())
+        || value
+            .split('/')
+            .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        return Err(HostRuntimeError::invalid_request(format!(
+            "invalid manifest asset ref {value}: path traversal characters are not allowed"
+        )));
+    }
+    Ok(())
 }

--- a/crates/ironclaw_host_runtime/src/capability_catalog.rs
+++ b/crates/ironclaw_host_runtime/src/capability_catalog.rs
@@ -171,20 +171,32 @@ async fn read_bounded<F>(
 where
     F: RootFilesystem,
 {
-    fs.read_file_bounded(path, max_bytes)
-        .await
-        .map_err(|error| {
-            HostRuntimeError::invalid_request(format!(
-                "failed to read {field} at {}: {error}",
-                path.as_str()
-            ))
-        })?
-        .ok_or_else(|| {
-            HostRuntimeError::invalid_request(format!(
-                "{field} at {} exceeds {max_bytes} bytes",
-                path.as_str()
-            ))
-        })
+    let stat = fs.stat(path).await.map_err(|error| {
+        HostRuntimeError::invalid_request(format!(
+            "failed to stat {field} at {}: {error}",
+            path.as_str()
+        ))
+    })?;
+    if stat.len > max_bytes as u64 {
+        return Err(HostRuntimeError::invalid_request(format!(
+            "{field} at {} exceeds {max_bytes} bytes",
+            path.as_str()
+        )));
+    }
+
+    let bytes = fs.read_file(path).await.map_err(|error| {
+        HostRuntimeError::invalid_request(format!(
+            "failed to read {field} at {}: {error}",
+            path.as_str()
+        ))
+    })?;
+    if bytes.len() > max_bytes {
+        return Err(HostRuntimeError::invalid_request(format!(
+            "{field} at {} exceeds {max_bytes} bytes",
+            path.as_str()
+        )));
+    }
+    Ok(bytes)
 }
 
 fn resolve_under_root(

--- a/crates/ironclaw_host_runtime/src/capability_catalog.rs
+++ b/crates/ironclaw_host_runtime/src/capability_catalog.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ironclaw_extensions::{CapabilityVisibility, ExtensionPackage, ExtensionRegistry};
-use ironclaw_filesystem::RootFilesystem;
+use ironclaw_filesystem::{FilesystemError, RootFilesystem};
 use ironclaw_host_api::{
     CapabilityDescriptor, CapabilityId, CapabilityProfileSchemaRef, VirtualPath,
 };
@@ -81,6 +81,9 @@ where
                     descriptor.id
                 ))
             })?;
+        if declaration.visibility != CapabilityVisibility::Model {
+            continue;
+        }
 
         let input_schema = read_json_ref(
             fs,
@@ -171,25 +174,16 @@ async fn read_bounded<F>(
 where
     F: RootFilesystem,
 {
-    let stat = fs.stat(path).await.map_err(|error| {
-        HostRuntimeError::invalid_request(format!(
-            "failed to stat {field} at {}: {error}",
-            path.as_str()
-        ))
-    })?;
-    if stat.len > max_bytes as u64 {
-        return Err(HostRuntimeError::invalid_request(format!(
-            "{field} at {} exceeds {max_bytes} bytes",
-            path.as_str()
-        )));
-    }
-
-    let bytes = fs.read_file(path).await.map_err(|error| {
-        HostRuntimeError::invalid_request(format!(
-            "failed to read {field} at {}: {error}",
-            path.as_str()
-        ))
-    })?;
+    let bytes = fs
+        .read_file_bounded(path, max_bytes)
+        .await
+        .map_err(|error| map_read_error(path, field, error))?
+        .ok_or_else(|| {
+            HostRuntimeError::invalid_request(format!(
+                "{field} at {} exceeds {max_bytes} bytes",
+                path.as_str()
+            ))
+        })?;
     if bytes.len() > max_bytes {
         return Err(HostRuntimeError::invalid_request(format!(
             "{field} at {} exceeds {max_bytes} bytes",
@@ -197,6 +191,20 @@ where
         )));
     }
     Ok(bytes)
+}
+
+fn map_read_error(
+    path: &VirtualPath,
+    field: &'static str,
+    error: FilesystemError,
+) -> HostRuntimeError {
+    let message = match error {
+        FilesystemError::NotFound { .. } => {
+            format!("missing {field} at {}", path.as_str())
+        }
+        _ => format!("failed to read {field} at {}", path.as_str()),
+    };
+    HostRuntimeError::invalid_request(message)
 }
 
 fn resolve_under_root(

--- a/crates/ironclaw_host_runtime/src/capability_catalog.rs
+++ b/crates/ironclaw_host_runtime/src/capability_catalog.rs
@@ -1,0 +1,188 @@
+use ironclaw_extensions::{CapabilityVisibility, ExtensionPackage, ExtensionRegistry};
+use ironclaw_filesystem::RootFilesystem;
+use ironclaw_host_api::{
+    CapabilityDescriptor, CapabilityId, CapabilityProfileSchemaRef, VirtualPath,
+};
+use serde_json::Value;
+
+use crate::HostRuntimeError;
+
+pub const MAX_HOT_SCHEMA_BYTES: usize = 64 * 1024;
+pub const MAX_HOT_PROMPT_BYTES: usize = 16 * 1024;
+
+/// Resolved, model-facing capability catalog derived from cold extension manifests.
+///
+/// This catalog is publication metadata only. It does not grant authority and it
+/// does not execute extension code.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct HotCapabilityCatalog {
+    pub capabilities: Vec<HotCapabilityRecord>,
+}
+
+impl HotCapabilityCatalog {
+    pub fn get(&self, id: &CapabilityId) -> Option<&HotCapabilityRecord> {
+        self.capabilities
+            .iter()
+            .find(|record| &record.descriptor.id == id)
+    }
+}
+
+/// One resolved capability record safe for hot surface publication.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HotCapabilityRecord {
+    /// Descriptor with `parameters_schema` replaced by resolved input schema.
+    pub descriptor: CapabilityDescriptor,
+    /// Resolved output schema retained adjacent to the descriptor.
+    pub output_schema: Value,
+    /// Resolved prompt document. Required for model-visible capabilities.
+    pub prompt_doc: Option<String>,
+}
+
+pub async fn publish_hot_capability_catalog<F>(
+    fs: &F,
+    registry: &ExtensionRegistry,
+) -> Result<HotCapabilityCatalog, HostRuntimeError>
+where
+    F: RootFilesystem,
+{
+    let mut records = Vec::new();
+    for package in registry.extensions() {
+        publish_package_capabilities(fs, package, &mut records).await?;
+    }
+    Ok(HotCapabilityCatalog {
+        capabilities: records,
+    })
+}
+
+async fn publish_package_capabilities<F>(
+    fs: &F,
+    package: &ExtensionPackage,
+    records: &mut Vec<HotCapabilityRecord>,
+) -> Result<(), HostRuntimeError>
+where
+    F: RootFilesystem,
+{
+    for descriptor in &package.capabilities {
+        let declaration = package
+            .manifest
+            .capabilities
+            .iter()
+            .find(|declaration| declaration.id == descriptor.id)
+            .ok_or_else(|| {
+                HostRuntimeError::invalid_request(format!(
+                    "capability {} is missing manifest declaration",
+                    descriptor.id
+                ))
+            })?;
+
+        let input_schema = read_json_ref(
+            fs,
+            &package.root,
+            &declaration.input_schema_ref,
+            "input_schema_ref",
+        )
+        .await?;
+        let output_schema = read_json_ref(
+            fs,
+            &package.root,
+            &declaration.output_schema_ref,
+            "output_schema_ref",
+        )
+        .await?;
+        let prompt_doc = match &declaration.prompt_doc_ref {
+            Some(prompt_ref) => Some(read_text_ref(fs, &package.root, prompt_ref).await?),
+            None if declaration.visibility == CapabilityVisibility::Model => {
+                return Err(HostRuntimeError::invalid_request(format!(
+                    "model-visible capability {} is missing prompt_doc_ref",
+                    declaration.id
+                )));
+            }
+            None => None,
+        };
+
+        let mut hot_descriptor = descriptor.clone();
+        hot_descriptor.parameters_schema = input_schema;
+        records.push(HotCapabilityRecord {
+            descriptor: hot_descriptor,
+            output_schema,
+            prompt_doc,
+        });
+    }
+    Ok(())
+}
+
+async fn read_json_ref<F>(
+    fs: &F,
+    root: &VirtualPath,
+    reference: &CapabilityProfileSchemaRef,
+    field: &'static str,
+) -> Result<Value, HostRuntimeError>
+where
+    F: RootFilesystem,
+{
+    let path = resolve_under_root(root, reference)?;
+    let bytes = read_bounded(fs, &path, MAX_HOT_SCHEMA_BYTES, field).await?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        HostRuntimeError::invalid_request(format!(
+            "{field} {} must contain valid JSON schema: {error}",
+            reference.as_str()
+        ))
+    })
+}
+
+async fn read_text_ref<F>(
+    fs: &F,
+    root: &VirtualPath,
+    reference: &CapabilityProfileSchemaRef,
+) -> Result<String, HostRuntimeError>
+where
+    F: RootFilesystem,
+{
+    let path = resolve_under_root(root, reference)?;
+    let bytes = read_bounded(fs, &path, MAX_HOT_PROMPT_BYTES, "prompt_doc_ref").await?;
+    String::from_utf8(bytes).map_err(|error| {
+        HostRuntimeError::invalid_request(format!(
+            "prompt_doc_ref {} must be valid UTF-8: {error}",
+            reference.as_str()
+        ))
+    })
+}
+
+async fn read_bounded<F>(
+    fs: &F,
+    path: &VirtualPath,
+    max_bytes: usize,
+    field: &'static str,
+) -> Result<Vec<u8>, HostRuntimeError>
+where
+    F: RootFilesystem,
+{
+    let bytes = fs.read_file(path).await.map_err(|_error| {
+        HostRuntimeError::invalid_request(format!("failed to read {field} at {}", path.as_str()))
+    })?;
+    if bytes.len() > max_bytes {
+        return Err(HostRuntimeError::invalid_request(format!(
+            "{field} at {} exceeds {max_bytes} bytes",
+            path.as_str()
+        )));
+    }
+    Ok(bytes)
+}
+
+fn resolve_under_root(
+    root: &VirtualPath,
+    reference: &CapabilityProfileSchemaRef,
+) -> Result<VirtualPath, HostRuntimeError> {
+    VirtualPath::new(format!(
+        "{}/{}",
+        root.as_str().trim_end_matches('/'),
+        reference.as_str()
+    ))
+    .map_err(|error| {
+        HostRuntimeError::invalid_request(format!(
+            "invalid manifest asset ref {} under {}: {error}",
+            reference.as_str(),
+            root.as_str()
+        ))
+    })
+}

--- a/crates/ironclaw_host_runtime/src/lib.rs
+++ b/crates/ironclaw_host_runtime/src/lib.rs
@@ -45,6 +45,7 @@ use serde_json::Value;
 use std::{collections::BTreeMap, fmt, sync::Arc};
 use thiserror::Error;
 
+mod capability_catalog;
 mod extension_contracts;
 mod first_party;
 mod first_party_tools;
@@ -56,6 +57,10 @@ mod services;
 mod surface;
 mod turn_scheduler;
 
+pub use capability_catalog::{
+    HotCapabilityCatalog, HotCapabilityRecord, MAX_HOT_PROMPT_BYTES, MAX_HOT_SCHEMA_BYTES,
+    publish_hot_capability_catalog,
+};
 pub use extension_contracts::{
     default_host_api_contract_registry, default_host_port_catalog,
     discover_extensions_with_default_host_api_contracts,

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -229,6 +229,26 @@ async fn hot_capability_catalog_fails_closed_for_oversized_prompt_doc() {
     );
 }
 
+#[test]
+fn hot_capability_manifest_rejects_traversal_schema_ref_at_parse_boundary() {
+    let manifest = HOT_CAPABILITY_MANIFEST.replace(
+        r#"input_schema_ref = "schemas/echo/say.input.v1.json""#,
+        r#"input_schema_ref = "../secrets/schema.json""#,
+    );
+
+    let err = ExtensionManifest::parse(
+        &manifest,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("..") || err.to_string().contains("dot path segments"),
+        "unexpected error: {err:?}"
+    );
+}
+
 #[tokio::test]
 async fn visible_surface_empty_registry_returns_deterministic_empty_version() {
     let runtime = runtime_with(ExtensionRegistry::new(), Arc::new(GrantAuthorizer));

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -18,8 +18,9 @@ use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime,
-    RuntimeCapabilityOutcome, RuntimeCapabilityRequest, SurfaceKind, VisibleCapabilityAccess,
-    VisibleCapabilityRequest, VisibleCapabilitySurface, publish_hot_capability_catalog,
+    MAX_HOT_PROMPT_BYTES, MAX_HOT_SCHEMA_BYTES, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
+    SurfaceKind, VisibleCapabilityAccess, VisibleCapabilityRequest, VisibleCapabilitySurface,
+    publish_hot_capability_catalog,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
@@ -87,6 +88,143 @@ async fn hot_capability_catalog_fails_closed_for_invalid_json_schema_file() {
     assert!(
         matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
             if reason.contains("input_schema_ref") && reason.contains("valid JSON schema")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_invalid_json_schema_semantics() {
+    let (_storage, fs, registry) = hot_catalog_fixture(
+        Some(r#"{"type":"not-a-json-schema-type"}"#),
+        r#"{"type":"object"}"#,
+        "Prompt docs exist.",
+    );
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("input_schema_ref") && reason.contains("valid JSON schema")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_invalid_output_schema_file() {
+    let (_storage, fs, registry) = hot_catalog_fixture(
+        Some(r#"{"type":"object"}"#),
+        "not-json",
+        "Prompt docs exist.",
+    );
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("output_schema_ref") && reason.contains("valid JSON schema")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_missing_prompt_doc_file() {
+    let (storage, fs, registry) = hot_catalog_fixture(
+        Some(r#"{"type":"object"}"#),
+        r#"{"type":"object"}"#,
+        "Prompt docs exist.",
+    );
+    std::fs::remove_file(storage.path().join("echo/prompts/echo/say.md")).unwrap();
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("failed to read prompt_doc_ref")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_model_visible_capability_without_prompt_doc_ref() {
+    let (_storage, fs, registry) = hot_catalog_fixture_with_manifest(
+        Some(r#"{"type":"object"}"#),
+        r#"{"type":"object"}"#,
+        b"Prompt docs exist.",
+        manifest_without_prompt_doc_ref(),
+    );
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("model-visible capability echo.say is missing prompt_doc_ref")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_invalid_utf8_prompt_doc() {
+    let (_storage, fs, registry) = hot_catalog_fixture_with_prompt_bytes(
+        Some(r#"{"type":"object"}"#),
+        r#"{"type":"object"}"#,
+        &[0xff, 0xfe, 0xfd],
+    );
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("prompt_doc_ref") && reason.contains("valid UTF-8")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_oversized_schema_file() {
+    let oversized_schema = " ".repeat(MAX_HOT_SCHEMA_BYTES + 1);
+    let (_storage, fs, registry) = hot_catalog_fixture(
+        Some(&oversized_schema),
+        r#"{"type":"object"}"#,
+        "Prompt docs exist.",
+    );
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("input_schema_ref") && reason.contains("exceeds")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_oversized_prompt_doc() {
+    let oversized_prompt = vec![b'a'; MAX_HOT_PROMPT_BYTES + 1];
+    let (_storage, fs, registry) = hot_catalog_fixture_with_prompt_bytes(
+        Some(r#"{"type":"object"}"#),
+        r#"{"type":"object"}"#,
+        &oversized_prompt,
+    );
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("prompt_doc_ref") && reason.contains("exceeds")),
         "unexpected error: {err:?}"
     );
 }
@@ -785,6 +923,29 @@ fn hot_catalog_fixture(
     output_schema: &str,
     prompt_doc: &str,
 ) -> (tempfile::TempDir, LocalFilesystem, ExtensionRegistry) {
+    hot_catalog_fixture_with_prompt_bytes(input_schema, output_schema, prompt_doc.as_bytes())
+}
+
+fn hot_catalog_fixture_with_prompt_bytes(
+    input_schema: Option<&str>,
+    output_schema: &str,
+    prompt_doc: &[u8],
+) -> (tempfile::TempDir, LocalFilesystem, ExtensionRegistry) {
+    let manifest = ExtensionManifest::parse(
+        HOT_CAPABILITY_MANIFEST,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    hot_catalog_fixture_with_manifest(input_schema, output_schema, prompt_doc, manifest)
+}
+
+fn hot_catalog_fixture_with_manifest(
+    input_schema: Option<&str>,
+    output_schema: &str,
+    prompt_doc: &[u8],
+    manifest: ExtensionManifest,
+) -> (tempfile::TempDir, LocalFilesystem, ExtensionRegistry) {
     let storage = tempdir().unwrap();
     let extension_root = storage.path().join("echo");
     std::fs::create_dir_all(extension_root.join("schemas/echo")).unwrap();
@@ -810,12 +971,6 @@ fn hot_catalog_fixture(
     )
     .unwrap();
 
-    let manifest = ExtensionManifest::parse(
-        HOT_CAPABILITY_MANIFEST,
-        ManifestSource::InstalledLocal,
-        &HostPortCatalog::empty(),
-    )
-    .unwrap();
     let package = ExtensionPackage::from_manifest(
         manifest,
         VirtualPath::new("/system/extensions/echo").unwrap(),
@@ -825,6 +980,17 @@ fn hot_catalog_fixture(
     registry.insert(package).unwrap();
 
     (storage, fs, registry)
+}
+
+fn manifest_without_prompt_doc_ref() -> ExtensionManifest {
+    let mut manifest = ExtensionManifest::parse(
+        HOT_CAPABILITY_MANIFEST,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    manifest.capabilities[0].prompt_doc_ref = None;
+    manifest
 }
 
 fn runtime_with(

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -68,7 +68,7 @@ async fn hot_capability_catalog_fails_closed_for_missing_schema_file() {
 
     assert!(
         matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
-            if reason.contains("failed to read input_schema_ref")),
+            if reason.contains("failed to stat input_schema_ref")),
         "unexpected error: {err:?}"
     );
 }
@@ -145,7 +145,7 @@ async fn hot_capability_catalog_fails_closed_for_missing_prompt_doc_file() {
 
     assert!(
         matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
-            if reason.contains("failed to read prompt_doc_ref")),
+            if reason.contains("failed to stat prompt_doc_ref")),
         "unexpected error: {err:?}"
     );
 }

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -13,8 +13,13 @@ use std::{
 use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
-use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_extensions::{
+    CapabilityVisibility, ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource,
+};
+use ironclaw_filesystem::{
+    DirEntry, FileStat, FileType, FilesystemError, FilesystemOperation, LocalFilesystem,
+    RootFilesystem,
+};
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime,
@@ -68,7 +73,7 @@ async fn hot_capability_catalog_fails_closed_for_missing_schema_file() {
 
     assert!(
         matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
-            if reason.contains("failed to stat input_schema_ref")),
+            if reason.contains("missing input_schema_ref")),
         "unexpected error: {err:?}"
     );
 }
@@ -131,6 +136,45 @@ async fn hot_capability_catalog_fails_closed_for_invalid_output_schema_file() {
 }
 
 #[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_missing_output_schema_file() {
+    let (storage, fs, registry) = hot_catalog_fixture(
+        Some(r#"{"type":"object"}"#),
+        r#"{"type":"object"}"#,
+        "Prompt docs exist.",
+    );
+    std::fs::remove_file(storage.path().join("echo/schemas/echo/say.output.v1.json")).unwrap();
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("missing output_schema_ref")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_invalid_output_schema_semantics() {
+    let (_storage, fs, registry) = hot_catalog_fixture(
+        Some(r#"{"type":"object"}"#),
+        r#"{"type":"not-a-json-schema-type"}"#,
+        "Prompt docs exist.",
+    );
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("output_schema_ref") && reason.contains("valid JSON schema")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn hot_capability_catalog_fails_closed_for_missing_prompt_doc_file() {
     let (storage, fs, registry) = hot_catalog_fixture(
         Some(r#"{"type":"object"}"#),
@@ -145,7 +189,7 @@ async fn hot_capability_catalog_fails_closed_for_missing_prompt_doc_file() {
 
     assert!(
         matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
-            if reason.contains("failed to stat prompt_doc_ref")),
+            if reason.contains("missing prompt_doc_ref")),
         "unexpected error: {err:?}"
     );
 }
@@ -225,6 +269,42 @@ async fn hot_capability_catalog_fails_closed_for_oversized_prompt_doc() {
     assert!(
         matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
             if reason.contains("prompt_doc_ref") && reason.contains("exceeds")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_skips_non_model_capabilities() {
+    let (_storage, fs, registry) = hot_catalog_fixture_with_manifest(
+        Some(r#"{"type":"object"}"#),
+        r#"{"type":"object"}"#,
+        b"Prompt docs exist.",
+        manifest_with_visibility(CapabilityVisibility::Api),
+    );
+
+    let catalog = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap();
+
+    assert!(catalog.capabilities.is_empty());
+    assert!(catalog.get(&capability_id("echo.say")).is_none());
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_when_bounded_backend_returns_too_many_bytes() {
+    let (_storage, _fs, registry) = hot_catalog_fixture(
+        Some(r#"{"type":"object"}"#),
+        r#"{"type":"object"}"#,
+        "Prompt docs exist.",
+    );
+
+    let err = publish_hot_capability_catalog(&OversizedReadFilesystem, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("input_schema_ref") && reason.contains("exceeds")),
         "unexpected error: {err:?}"
     );
 }
@@ -1011,6 +1091,48 @@ fn manifest_without_prompt_doc_ref() -> ExtensionManifest {
     .unwrap();
     manifest.capabilities[0].prompt_doc_ref = None;
     manifest
+}
+
+fn manifest_with_visibility(visibility: CapabilityVisibility) -> ExtensionManifest {
+    let mut manifest = ExtensionManifest::parse(
+        HOT_CAPABILITY_MANIFEST,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    manifest.capabilities[0].visibility = visibility;
+    manifest.capabilities[0].prompt_doc_ref = None;
+    manifest
+}
+
+struct OversizedReadFilesystem;
+
+#[async_trait]
+impl RootFilesystem for OversizedReadFilesystem {
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        Err(FilesystemError::Unsupported {
+            path: path.clone(),
+            operation: FilesystemOperation::ListDir,
+        })
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        Ok(FileStat {
+            path: path.clone(),
+            file_type: FileType::File,
+            len: 1,
+            modified: None,
+            sensitive: false,
+        })
+    }
+
+    async fn read_file_bounded(
+        &self,
+        _path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        Ok(Some(vec![b'a'; max_bytes + 1]))
+    }
 }
 
 fn runtime_with(

--- a/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/tool_surface_contract.rs
@@ -14,17 +14,82 @@ use async_trait::async_trait;
 use chrono::Utc;
 use ironclaw_authorization::{GrantAuthorizer, TrustAwareCapabilityDispatchAuthorizer};
 use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRegistry, ManifestSource};
+use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_host_api::*;
 use ironclaw_host_runtime::{
     CapabilitySurfacePolicy, CapabilitySurfaceVersion, DefaultHostRuntime, HostRuntime,
     RuntimeCapabilityOutcome, RuntimeCapabilityRequest, SurfaceKind, VisibleCapabilityAccess,
-    VisibleCapabilityRequest, VisibleCapabilitySurface,
+    VisibleCapabilityRequest, VisibleCapabilitySurface, publish_hot_capability_catalog,
 };
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustError, TrustPolicy, TrustPolicyInput, TrustProvenance,
 };
 use serde_json::json;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn hot_capability_catalog_resolves_schema_and_prompt_refs() {
+    let (_storage, fs, registry) = hot_catalog_fixture(
+        Some(r#"{"type":"object","properties":{"message":{"type":"string"}}}"#),
+        r#"{"type":"object","properties":{"ok":{"type":"boolean"}}}"#,
+        "Use this tool to echo user text.",
+    );
+
+    let catalog = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap();
+
+    let record = catalog.get(&capability_id("echo.say")).unwrap();
+    assert_eq!(record.descriptor.id, capability_id("echo.say"));
+    assert_eq!(
+        record.descriptor.parameters_schema,
+        json!({"type":"object","properties":{"message":{"type":"string"}}})
+    );
+    assert_eq!(
+        record.output_schema,
+        json!({"type":"object","properties":{"ok":{"type":"boolean"}}})
+    );
+    assert_eq!(
+        record.prompt_doc.as_deref(),
+        Some("Use this tool to echo user text.")
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_missing_schema_file() {
+    let (_storage, fs, registry) =
+        hot_catalog_fixture(None, r#"{"type":"object"}"#, "Prompt docs exist.");
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("failed to read input_schema_ref")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn hot_capability_catalog_fails_closed_for_invalid_json_schema_file() {
+    let (_storage, fs, registry) = hot_catalog_fixture(
+        Some("not-json"),
+        r#"{"type":"object"}"#,
+        "Prompt docs exist.",
+    );
+
+    let err = publish_hot_capability_catalog(&fs, &registry)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, ironclaw_host_runtime::HostRuntimeError::InvalidRequest { ref reason }
+            if reason.contains("input_schema_ref") && reason.contains("valid JSON schema")),
+        "unexpected error: {err:?}"
+    );
+}
 
 #[tokio::test]
 async fn visible_surface_empty_registry_returns_deterministic_empty_version() {
@@ -715,6 +780,53 @@ fn visible_ids(surface: &VisibleCapabilitySurface) -> Vec<CapabilityId> {
         .collect()
 }
 
+fn hot_catalog_fixture(
+    input_schema: Option<&str>,
+    output_schema: &str,
+    prompt_doc: &str,
+) -> (tempfile::TempDir, LocalFilesystem, ExtensionRegistry) {
+    let storage = tempdir().unwrap();
+    let extension_root = storage.path().join("echo");
+    std::fs::create_dir_all(extension_root.join("schemas/echo")).unwrap();
+    std::fs::create_dir_all(extension_root.join("prompts/echo")).unwrap();
+    if let Some(input_schema) = input_schema {
+        std::fs::write(
+            extension_root.join("schemas/echo/say.input.v1.json"),
+            input_schema,
+        )
+        .unwrap();
+    }
+    std::fs::write(
+        extension_root.join("schemas/echo/say.output.v1.json"),
+        output_schema,
+    )
+    .unwrap();
+    std::fs::write(extension_root.join("prompts/echo/say.md"), prompt_doc).unwrap();
+
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let manifest = ExtensionManifest::parse(
+        HOT_CAPABILITY_MANIFEST,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+    )
+    .unwrap();
+    let package = ExtensionPackage::from_manifest(
+        manifest,
+        VirtualPath::new("/system/extensions/echo").unwrap(),
+    )
+    .unwrap();
+    let mut registry = ExtensionRegistry::new();
+    registry.insert(package).unwrap();
+
+    (storage, fs, registry)
+}
+
 fn runtime_with(
     registry: ExtensionRegistry,
     authorizer: Arc<dyn TrustAwareCapabilityDispatchAuthorizer>,
@@ -954,6 +1066,28 @@ impl TrustAwareCapabilityDispatchAuthorizer for PanicAuthorizer {
         }
     }
 }
+
+const HOT_CAPABILITY_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
+id = "echo"
+name = "Echo"
+version = "0.1.0"
+description = "Echo test extension"
+trust = "third_party"
+
+[runtime]
+kind = "wasm"
+module = "echo.wasm"
+
+[[capabilities]]
+id = "echo.say"
+description = "Echoes input"
+effects = ["dispatch_capability"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/echo/say.input.v1.json"
+output_schema_ref = "schemas/echo/say.output.v1.json"
+prompt_doc_ref = "prompts/echo/say.md"
+"#;
 
 const ECHO_MANIFEST: &str = r#"
 id = "echo"

--- a/docs/reborn/contracts/filesystem.md
+++ b/docs/reborn/contracts/filesystem.md
@@ -405,10 +405,17 @@ Backend errors may keep raw errors for logs, but public/display errors should us
 
 ## 14. Initial Rust API sketch
 
+`read_file_bounded` returns `Ok(None)` when the file exceeds the caller's limit; streaming backends should enforce that without allocating the full file first.
+
 ```rust
 #[async_trait]
 pub trait RootFilesystem {
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError>;
+    async fn read_file_bounded(
+        &self,
+        path: &VirtualPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError>;
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError>;
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError>;
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError>;

--- a/docs/reborn/contracts/host-runtime.md
+++ b/docs/reborn/contracts/host-runtime.md
@@ -40,6 +40,8 @@ Supported built-in behavior:
 
 Surface versioning returns `sha256:<lower-hex>` over canonical JSON that includes the configured base version, `SurfaceKind`, visibility policy, visibility-affecting context fields, grants, relevant provider trust ceilings, visible capability ids/providers/runtimes/effects/schemas, selected resource estimates, and visible access status. Policy allow-lists and visible capability payloads are canonicalized before hashing, so semantically equivalent allow-list ordering or registry insertion ordering does not churn the version; returned capabilities still preserve filtered registry order for deterministic rendering. The hash is stable across process runs so upper loop services can checkpoint the visible tool surface. Direct invocation remains authoritative: a capability omitted from the visible surface must still fail closed through `CapabilityHost` authorization if a caller tries to invoke it directly.
 
+The hot capability catalog resolves cold manifest refs through the package's virtual root before model/tool publication. `input_schema_ref` replaces the descriptor's `$ref`-style `parameters_schema`, while `output_schema_ref` and `prompt_doc_ref` are retained as adjacent resolved publication records. Resolution is bounded, fails closed on missing/invalid files, and remains publication metadata only: it does not grant authority, execute runtime code, or construct host-port implementations.
+
 ## FirstParty runtime adapter
 
 `HostRuntimeServices` can register host-owned first-party capability handlers through `FirstPartyCapabilityRegistry`. When a declared capability uses `RuntimeKind::FirstParty`, dispatch still follows the normal path:


### PR DESCRIPTION
## Summary
- add host-runtime hot capability catalog publication for Extension Manifest v2 packages
- resolve `input_schema_ref`, `output_schema_ref`, and `prompt_doc_ref` through package virtual roots
- replace descriptor `parameters_schema` with resolved input schema and keep output schema/prompt docs adjacent
- fail closed on missing refs, invalid JSON schema files, invalid UTF-8 prompts, and over-size schema/prompt docs
- document hot/cold catalog split in host-runtime contract

Stacked on #3788. Retarget to `reborn-integration` after PR4 merges.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_host_runtime --test tool_surface_contract`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings`