### PR TITLE
Convert representative runtime fixtures to host API manifests

### DIFF
--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -1367,14 +1367,23 @@ impl ResourceGovernor for ReleaseFailingGovernor {
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse(
+    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
     ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn capability_provider_contracts() -> HostApiContractRegistry {
+    let mut contracts = HostApiContractRegistry::new();
+    contracts
+        .register(Arc::new(CapabilityProviderHostApiContract::new().unwrap()))
+        .unwrap();
+    contracts
 }
 
 fn sample_scope() -> ResourceScope {
@@ -1408,7 +1417,7 @@ fn mcp_http_policy() -> NetworkPolicy {
     }
 }
 
-const MCP_MANIFEST: &str = r#"
+const MCP_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
@@ -1420,15 +1429,23 @@ kind = "mcp"
 transport = "http"
 url = "https://mcp.example.test/mcp"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "github-mcp.search"
 description = "Search GitHub"
 effects = ["network", "dispatch_capability"]
 default_permission = "ask"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/github-mcp/search.input.v1.json"
+output_schema_ref = "schemas/github-mcp/search.output.v1.json"
 "#;
 
-const STDIO_MCP_MANIFEST: &str = r#"
+const STDIO_MCP_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
@@ -1446,10 +1463,12 @@ id = "github-mcp.search"
 description = "Search GitHub"
 effects = ["network", "dispatch_capability"]
 default_permission = "ask"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/github-mcp/search.input.v1.json"
+output_schema_ref = "schemas/github-mcp/search.output.v1.json"
 "#;
 
-const SCRIPT_MANIFEST: &str = r#"
+const SCRIPT_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "script"
 name = "Script Echo"
 version = "0.1.0"
@@ -1467,5 +1486,7 @@ id = "script.echo"
 description = "Echo text"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/script/echo.input.v1.json"
+output_schema_ref = "schemas/script/echo.output.v1.json"
 "#;

--- a/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
+++ b/crates/ironclaw_mcp/tests/mcp_dispatch_integration.rs
@@ -1,7 +1,10 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ManifestSource};
+use ironclaw_extensions::{
+    CapabilityProviderHostApiContract, ExtensionManifest, ExtensionPackage,
+    HostApiContractRegistry, ManifestSource,
+};
 use ironclaw_host_api::*;
 use ironclaw_mcp::*;
 use ironclaw_resources::*;
@@ -123,14 +126,23 @@ fn mcp_governor() -> (InMemoryResourceGovernor, ResourceAccount) {
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse(
+    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
     ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn capability_provider_contracts() -> HostApiContractRegistry {
+    let mut contracts = HostApiContractRegistry::new();
+    contracts
+        .register(Arc::new(CapabilityProviderHostApiContract::new().unwrap()))
+        .unwrap();
+    contracts
 }
 
 fn governor_with_default_limit(account: ResourceAccount) -> InMemoryResourceGovernor {
@@ -183,7 +195,7 @@ fn sample_account() -> ResourceAccount {
     ResourceAccount::tenant(TenantId::new("tenant-a").unwrap())
 }
 
-const MCP_MANIFEST: &str = r#"
+const MCP_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "github-mcp"
 name = "GitHub MCP"
 version = "0.1.0"
@@ -195,10 +207,18 @@ kind = "mcp"
 transport = "http"
 url = "https://mcp.example.test/rpc"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "github-mcp.search"
 description = "Search GitHub"
 effects = ["network", "dispatch_capability"]
 default_permission = "ask"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/github-mcp/search.input.v1.json"
+output_schema_ref = "schemas/github-mcp/search.output.v1.json"
 "#;

--- a/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
+++ b/crates/ironclaw_scripts/tests/script_dispatch_integration.rs
@@ -1,6 +1,9 @@
 use std::sync::{Arc, Mutex};
 
-use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ManifestSource};
+use ironclaw_extensions::{
+    CapabilityProviderHostApiContract, ExtensionManifest, ExtensionPackage,
+    HostApiContractRegistry, ManifestSource,
+};
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
 use ironclaw_scripts::*;
@@ -114,10 +117,11 @@ fn script_governor() -> (InMemoryResourceGovernor, ResourceAccount) {
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse(
+    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
@@ -159,6 +163,14 @@ fn script_request(input: serde_json::Value) -> ScriptExecutionRequest<'static> {
     }
 }
 
+fn capability_provider_contracts() -> HostApiContractRegistry {
+    let mut contracts = HostApiContractRegistry::new();
+    contracts
+        .register(Arc::new(CapabilityProviderHostApiContract::new().unwrap()))
+        .unwrap();
+    contracts
+}
+
 fn sample_scope() -> ResourceScope {
     ResourceScope {
         tenant_id: TenantId::new("tenant-a").unwrap(),
@@ -175,7 +187,7 @@ fn sample_account() -> ResourceAccount {
     ResourceAccount::tenant(TenantId::new("tenant-a").unwrap())
 }
 
-const SCRIPT_MANIFEST: &str = r#"
+const SCRIPT_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "script"
 name = "Script Echo"
 version = "0.1.0"
@@ -189,10 +201,18 @@ image = "alpine:latest"
 command = "script-echo"
 args = ["--json"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "script.echo"
 description = "Echo through Script"
 effects = ["dispatch_capability", "execute_code"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/script/echo.input.v1.json"
+output_schema_ref = "schemas/script/echo.output.v1.json"
 "#;

--- a/crates/ironclaw_scripts/tests/script_runner_contract.rs
+++ b/crates/ironclaw_scripts/tests/script_runner_contract.rs
@@ -424,14 +424,23 @@ fn wasm_package() -> ExtensionPackage {
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse(
+    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
     ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn capability_provider_contracts() -> HostApiContractRegistry {
+    let mut contracts = HostApiContractRegistry::new();
+    contracts
+        .register(Arc::new(CapabilityProviderHostApiContract::new().unwrap()))
+        .unwrap();
+    contracts
 }
 
 fn sample_scope() -> ResourceScope {
@@ -446,7 +455,7 @@ fn sample_scope() -> ResourceScope {
     }
 }
 
-const SCRIPT_MANIFEST: &str = r#"
+const SCRIPT_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "script"
 name = "Script Echo"
 version = "0.1.0"
@@ -455,20 +464,28 @@ trust = "untrusted"
 
 [runtime]
 kind = "script"
-backend = "docker"
+runner = "docker"
 image = "alpine:latest"
 command = "script-echo"
 args = ["--json"]
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "script.echo"
 description = "Echo text"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/script/echo.input.v1.json"
+output_schema_ref = "schemas/script/echo.output.v1.json"
 "#;
 
-const WASM_MANIFEST: &str = r#"
+const WASM_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "echo"
 name = "Echo"
 version = "0.1.0"
@@ -484,5 +501,7 @@ id = "echo.say"
 description = "Echo text"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/echo/say.input.v1.json"
+output_schema_ref = "schemas/echo/say.output.v1.json"
 "#;

--- a/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
+++ b/crates/ironclaw_wasm/tests/wasm_dispatch_integration.rs
@@ -12,7 +12,10 @@ use ironclaw_dispatcher::{
     RuntimeAdapter, RuntimeAdapterRequest, RuntimeAdapterResult, RuntimeDispatcher,
 };
 use ironclaw_events::{InMemoryEventSink, RuntimeEventKind};
-use ironclaw_extensions::{ExtensionManifest, ExtensionPackage, ExtensionRuntime, ManifestSource};
+use ironclaw_extensions::{
+    CapabilityProviderHostApiContract, ExtensionManifest, ExtensionPackage, ExtensionRuntime,
+    HostApiContractRegistry, ManifestSource,
+};
 use ironclaw_filesystem::{LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 use ironclaw_resources::*;
@@ -780,14 +783,23 @@ fn registry_with_package(manifest: &str) -> ironclaw_extensions::ExtensionRegist
 }
 
 fn package_from_manifest(manifest: &str) -> ExtensionPackage {
-    let manifest = ExtensionManifest::parse(
+    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
         manifest,
         ManifestSource::InstalledLocal,
         &HostPortCatalog::empty(),
+        &capability_provider_contracts(),
     )
     .unwrap();
     let root = VirtualPath::new(format!("/system/extensions/{}", manifest.id.as_str())).unwrap();
     ExtensionPackage::from_manifest(manifest, root).unwrap()
+}
+
+fn capability_provider_contracts() -> HostApiContractRegistry {
+    let mut contracts = HostApiContractRegistry::new();
+    contracts
+        .register(Arc::new(CapabilityProviderHostApiContract::new().unwrap()))
+        .unwrap();
+    contracts
 }
 
 fn mounted_empty_extension_root() -> LocalFilesystem {
@@ -1111,7 +1123,7 @@ const TRAP_TOOL_WAT: &str = r#"
 )
 "#;
 
-const WASM_MANIFEST: &str = r#"
+const WASM_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "wasm-smoke"
 name = "WASM Smoke"
 version = "0.1.0"
@@ -1122,15 +1134,23 @@ trust = "untrusted"
 kind = "wasm"
 module = "wasm/counter.wasm"
 
-[[capabilities]]
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
 id = "wasm-smoke.count"
 description = "Count through WASM"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/wasm-smoke/count.input.v1.json"
+output_schema_ref = "schemas/wasm-smoke/count.output.v1.json"
 "#;
 
-const WASM_TRAP_MANIFEST: &str = r#"
+const WASM_TRAP_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "wasm-smoke"
 name = "WASM Trap"
 version = "0.1.0"
@@ -1146,10 +1166,12 @@ id = "wasm-smoke.trap"
 description = "Trap through WASM"
 effects = ["dispatch_capability"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/wasm-smoke/trap.input.v1.json"
+output_schema_ref = "schemas/wasm-smoke/trap.output.v1.json"
 "#;
 
-const WASM_HTTP_TRAP_MANIFEST: &str = r#"
+const WASM_HTTP_TRAP_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
 id = "wasm-smoke"
 name = "WASM HTTP Trap"
 version = "0.1.0"
@@ -1165,5 +1187,7 @@ id = "wasm-smoke.httptrap"
 description = "Trap after host HTTP through WASM"
 effects = ["dispatch_capability", "network"]
 default_permission = "allow"
-parameters_schema = { type = "object" }
+visibility = "api"
+input_schema_ref = "schemas/wasm-smoke/httptrap.input.v1.json"
+output_schema_ref = "schemas/wasm-smoke/httptrap.output.v1.json"
 "#;


### PR DESCRIPTION
## Summary
- convert representative script, WASM, and MCP runtime fixture manifests to `[[host_api]] ironclaw.capability_provider/v1`
- parse fixture manifests through the capability-provider host API contract registry
- update adjacent runtime fixtures to current v2 top-level schema refs where needed so package tests remain green

Stacked on #3790. Retarget to `reborn-integration` after PR5 merges.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_scripts`
- `cargo test -p ironclaw_wasm`
- `cargo test -p ironclaw_mcp`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `cargo clippy -p ironclaw_scripts -p ironclaw_wasm -p ironclaw_mcp --all-targets -- -D warnings`