### PR TITLE
test(reborn): cover thread binding isolation parity

### DIFF
--- a/tests/reborn_thread_binding_isolation_parity.rs
+++ b/tests/reborn_thread_binding_isolation_parity.rs
@@ -1,0 +1,118 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_loop_support::HostManagedModelResponse;
+use ironclaw_threads::{MessageKind, MessageStatus, ThreadMessageRecord};
+use ironclaw_turns::TurnStatus;
+use reborn_support::harness::{RebornBinaryE2EHarness, RecordingTestCapabilityPort};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+
+#[tokio::test]
+async fn reborn_thread_binding_isolation_parity() {
+    let model_gateway = RebornTraceReplayModelGateway::with_responses([
+        HostManagedModelResponse::assistant_reply("alpha isolated reply"),
+        HostManagedModelResponse::assistant_reply("beta isolated reply"),
+    ]);
+    let mut harness = RebornBinaryE2EHarness::with_model_gateway_unscoped_worker(
+        "room-thread-alpha",
+        model_gateway,
+        RecordingTestCapabilityPort::echo(),
+    )
+    .await
+    .expect("harness");
+    harness.start();
+
+    let alpha = harness
+        .submit_text_for(
+            "room-thread-alpha",
+            "alice",
+            "event-thread-alpha",
+            "alpha turn",
+        )
+        .await
+        .expect("submit alpha turn");
+    harness
+        .wait_for_submitted_status(&alpha, TurnStatus::Completed)
+        .await
+        .expect("alpha completed");
+
+    let beta = harness
+        .submit_text_for(
+            "room-thread-beta",
+            "alice",
+            "event-thread-beta",
+            "beta turn",
+        )
+        .await
+        .expect("submit beta turn");
+    harness
+        .wait_for_submitted_status(&beta, TurnStatus::Completed)
+        .await
+        .expect("beta completed");
+
+    assert_ne!(
+        alpha.thread_id, beta.thread_id,
+        "distinct external conversations must resolve to distinct canonical threads"
+    );
+    assert_ne!(
+        alpha.scope.thread_id, beta.scope.thread_id,
+        "submitted turn scopes should remain thread-isolated"
+    );
+
+    let alpha_history = harness
+        .history_for_thread(alpha.thread_id.clone())
+        .await
+        .expect("alpha history");
+    let beta_history = harness
+        .history_for_thread(beta.thread_id.clone())
+        .await
+        .expect("beta history");
+
+    assert_history_contains_user(&alpha_history, "alpha turn");
+    assert_history_contains_assistant(&alpha_history, "alpha isolated reply");
+    assert_history_excludes(&alpha_history, "beta turn");
+    assert_history_excludes(&alpha_history, "beta isolated reply");
+
+    assert_history_contains_user(&beta_history, "beta turn");
+    assert_history_contains_assistant(&beta_history, "beta isolated reply");
+    assert_history_excludes(&beta_history, "alpha turn");
+    assert_history_excludes(&beta_history, "alpha isolated reply");
+
+    assert_eq!(harness.model_requests().len(), 2);
+    harness.assert_model_exhausted();
+
+    harness.shutdown().await;
+}
+
+fn assert_history_contains_user(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::User
+                && message.status == MessageStatus::Submitted
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain submitted user message {text:?}"
+    );
+}
+
+fn assert_history_contains_assistant(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::Assistant
+                && message.status == MessageStatus::Finalized
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain finalized assistant reply {text:?}"
+    );
+}
+
+fn assert_history_excludes(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .all(|message| message.content.as_deref() != Some(text)),
+        "thread history should not contain message from another conversation: {text:?}"
+    );
+}

--- a/tests/reborn_thread_binding_isolation_parity.rs
+++ b/tests/reborn_thread_binding_isolation_parity.rs
@@ -62,11 +62,11 @@ async fn reborn_thread_binding_isolation_parity() {
     );
 
     let alpha_history = harness
-        .history_for_thread(alpha.thread_id.clone())
+        .history_for_submitted_thread(&alpha)
         .await
         .expect("alpha history");
     let beta_history = harness
-        .history_for_thread(beta.thread_id.clone())
+        .history_for_submitted_thread(&beta)
         .await
         .expect("beta history");
 

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -47,7 +47,7 @@ use ironclaw_loop_support::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
     HostManagedModelRequest, HostRuntimeLoopCapabilityPortFactory, LoopCapabilityResultWriter,
 };
-use ironclaw_product_adapters::{ProductInboundAck, ProductWorkflow};
+use ironclaw_product_adapters::{ProductInboundAck, ProductInboundEnvelope, ProductWorkflow};
 use ironclaw_product_workflow::{
     ConversationBindingService, DefaultInboundTurnService, DefaultProductWorkflow,
     IdempotencyLedger, InboundTurnService, ProductConversationRouteKind, ResolveBindingRequest,
@@ -209,6 +209,21 @@ impl RebornBinaryE2EHarness {
             .await
     }
 
+    pub async fn with_model_gateway_unscoped_worker(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_options_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            false,
+            false,
+        )
+        .await
+    }
+
     pub async fn with_host_runtime_file_capabilities(
         conversation_id: &str,
         model_gateway: RebornTraceReplayModelGateway,
@@ -280,11 +295,29 @@ impl RebornBinaryE2EHarness {
         capability_port: RecordingTestCapabilityPort,
         accept_harness_blocked_evidence: bool,
     ) -> HarnessResult<Self> {
-        Self::with_model_gateway_capability_mode(
+        Self::with_model_gateway_options_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            accept_harness_blocked_evidence,
+            true,
+        )
+        .await
+    }
+
+    async fn with_model_gateway_options_and_worker_scope(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        accept_harness_blocked_evidence: bool,
+        restrict_worker_to_initial_scope: bool,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_capability_mode_and_worker_scope(
             conversation_id,
             model_gateway,
             HarnessCapabilityMode::Recording(capability_port),
             accept_harness_blocked_evidence,
+            restrict_worker_to_initial_scope,
         )
         .await
     }
@@ -294,6 +327,23 @@ impl RebornBinaryE2EHarness {
         model_gateway: RebornTraceReplayModelGateway,
         capability_mode: HarnessCapabilityMode,
         accept_harness_blocked_evidence: bool,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_capability_mode_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_mode,
+            accept_harness_blocked_evidence,
+            true,
+        )
+        .await
+    }
+
+    async fn with_model_gateway_capability_mode_and_worker_scope(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_mode: HarnessCapabilityMode,
+        accept_harness_blocked_evidence: bool,
+        restrict_worker_to_initial_scope: bool,
     ) -> HarnessResult<Self> {
         let adapter = RebornTestProductAdapter::new("reborn-test", "install-1")?;
         let ingress = RebornTestIngress::new(adapter);
@@ -347,7 +397,7 @@ impl RebornBinaryE2EHarness {
                 worker: TurnRunnerWorkerConfig {
                     heartbeat_interval: Duration::from_millis(20),
                     poll_interval: Duration::from_millis(10),
-                    scope_filter: Some(turn_scope.clone()),
+                    scope_filter: restrict_worker_to_initial_scope.then(|| turn_scope.clone()),
                 },
                 ..DefaultPlannedRuntimeConfig::default()
             },
@@ -451,12 +501,32 @@ impl RebornBinaryE2EHarness {
     }
 
     pub async fn submit_text(&self, event_id: &str, text: &str) -> HarnessResult<SubmittedTurn> {
-        let envelope = self.ingress.verified_text_envelope(
-            event_id,
-            "alice",
-            &self.external_conversation_id,
-            text,
-        )?;
+        self.submit_text_for(&self.external_conversation_id, "alice", event_id, text)
+            .await
+    }
+
+    pub async fn submit_text_for(
+        &self,
+        conversation_id: &str,
+        actor_id: &str,
+        event_id: &str,
+        text: &str,
+    ) -> HarnessResult<SubmittedTurn> {
+        let envelope =
+            self.ingress
+                .verified_text_envelope(event_id, actor_id, conversation_id, text)?;
+        let binding_request = binding_request_from_envelope(&envelope);
+        let binding = self
+            ._product_harness
+            .binding_service()?
+            .resolve_binding(binding_request)
+            .await?;
+        let turn_scope = TurnScope::new(
+            binding.tenant_id.clone(),
+            binding.agent_id.clone(),
+            binding.project_id.clone(),
+            binding.thread_id.clone(),
+        );
         let ack = self.workflow.accept_inbound(envelope).await?;
         let run_id = match &ack {
             ProductInboundAck::Accepted {
@@ -469,8 +539,8 @@ impl RebornBinaryE2EHarness {
         Ok(SubmittedTurn {
             ack,
             run_id,
-            thread_id: self.binding.thread_id.clone(),
-            scope: self.turn_scope.clone(),
+            thread_id: binding.thread_id,
+            scope: turn_scope,
         })
     }
 
@@ -535,10 +605,29 @@ impl RebornBinaryE2EHarness {
         run_id: TurnRunId,
         expected: TurnStatus,
     ) -> HarnessResult<TurnRunState> {
+        self.wait_for_status_in_scope(self.turn_scope.clone(), run_id, expected)
+            .await
+    }
+
+    pub async fn wait_for_submitted_status(
+        &self,
+        submitted: &SubmittedTurn,
+        expected: TurnStatus,
+    ) -> HarnessResult<TurnRunState> {
+        self.wait_for_status_in_scope(submitted.scope.clone(), submitted.run_id, expected)
+            .await
+    }
+
+    pub async fn wait_for_status_in_scope(
+        &self,
+        scope: TurnScope,
+        run_id: TurnRunId,
+        expected: TurnStatus,
+    ) -> HarnessResult<TurnRunState> {
         let wait = WaitConfig::default();
         let deadline = tokio::time::Instant::now() + wait.timeout;
         loop {
-            let state = self.run_state(run_id).await?;
+            let state = self.run_state_in_scope(scope.clone(), run_id).await?;
             if state.status == expected {
                 return Ok(state);
             }
@@ -554,12 +643,18 @@ impl RebornBinaryE2EHarness {
     }
 
     pub async fn run_state(&self, run_id: TurnRunId) -> HarnessResult<TurnRunState> {
+        self.run_state_in_scope(self.turn_scope.clone(), run_id)
+            .await
+    }
+
+    pub async fn run_state_in_scope(
+        &self,
+        scope: TurnScope,
+        run_id: TurnRunId,
+    ) -> HarnessResult<TurnRunState> {
         Ok(self
             .turn_store
-            .get_run_state(GetRunStateRequest {
-                scope: self.turn_scope.clone(),
-                run_id,
-            })
+            .get_run_state(GetRunStateRequest { scope, run_id })
             .await?)
     }
 
@@ -571,12 +666,20 @@ impl RebornBinaryE2EHarness {
     }
 
     pub async fn history(&self) -> HarnessResult<Vec<ThreadMessageRecord>> {
+        self.history_for_thread(self.binding.thread_id.clone())
+            .await
+    }
+
+    pub async fn history_for_thread(
+        &self,
+        thread_id: ThreadId,
+    ) -> HarnessResult<Vec<ThreadMessageRecord>> {
         Ok(self
             .thread_harness
             .service
             .list_thread_history(ThreadHistoryRequest {
                 scope: self.thread_scope.clone(),
-                thread_id: self.binding.thread_id.clone(),
+                thread_id,
             })
             .await?
             .messages)
@@ -1341,7 +1444,11 @@ fn binding_request(
 ) -> HarnessResult<ResolveBindingRequest> {
     let envelope =
         ingress.verified_text_envelope("binding-probe", "alice", conversation_id, "hi")?;
-    Ok(ResolveBindingRequest {
+    Ok(binding_request_from_envelope(&envelope))
+}
+
+fn binding_request_from_envelope(envelope: &ProductInboundEnvelope) -> ResolveBindingRequest {
+    ResolveBindingRequest {
         adapter_id: envelope.adapter_id().clone(),
         installation_id: envelope.installation_id().clone(),
         external_actor_ref: envelope.external_actor_ref().clone(),
@@ -1349,7 +1456,7 @@ fn binding_request(
         external_event_id: envelope.external_event_id().clone(),
         route_kind: ProductConversationRouteKind::Direct,
         auth_claim: envelope.auth_claim().clone(),
-    })
+    }
 }
 
 fn thread_scope_from_binding(binding: &ResolvedBinding) -> HarnessResult<ThreadScope> {

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -47,7 +47,10 @@ use ironclaw_loop_support::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
     HostManagedModelRequest, HostRuntimeLoopCapabilityPortFactory, LoopCapabilityResultWriter,
 };
-use ironclaw_product_adapters::{ProductInboundAck, ProductInboundEnvelope, ProductWorkflow};
+use ironclaw_product_adapters::{
+    ProductInboundAck, ProductInboundEnvelope, ProductInboundPayload, ProductTriggerReason,
+    ProductWorkflow,
+};
 use ironclaw_product_workflow::{
     ConversationBindingService, DefaultInboundTurnService, DefaultProductWorkflow,
     IdempotencyLedger, InboundTurnService, ProductConversationRouteKind, ResolveBindingRequest,
@@ -142,6 +145,7 @@ pub struct SubmittedTurn {
     pub ack: ProductInboundAck,
     pub run_id: TurnRunId,
     pub thread_id: ThreadId,
+    pub thread_scope: ThreadScope,
     pub scope: TurnScope,
 }
 
@@ -516,11 +520,13 @@ impl RebornBinaryE2EHarness {
             self.ingress
                 .verified_text_envelope(event_id, actor_id, conversation_id, text)?;
         let binding_request = binding_request_from_envelope(&envelope);
+        let route_kind = binding_request.route_kind;
         let binding = self
             ._product_harness
             .binding_service()?
             .resolve_binding(binding_request)
             .await?;
+        let thread_scope = thread_scope_from_binding_with_route_kind(&binding, route_kind)?;
         let turn_scope = TurnScope::new(
             binding.tenant_id.clone(),
             binding.agent_id.clone(),
@@ -540,6 +546,7 @@ impl RebornBinaryE2EHarness {
             ack,
             run_id,
             thread_id: binding.thread_id,
+            thread_scope,
             scope: turn_scope,
         })
     }
@@ -670,17 +677,34 @@ impl RebornBinaryE2EHarness {
             .await
     }
 
+    pub async fn history_for_submitted_thread(
+        &self,
+        submitted: &SubmittedTurn,
+    ) -> HarnessResult<Vec<ThreadMessageRecord>> {
+        self.history_for_thread_in_scope(
+            submitted.thread_scope.clone(),
+            submitted.thread_id.clone(),
+        )
+        .await
+    }
+
     pub async fn history_for_thread(
         &self,
+        thread_id: ThreadId,
+    ) -> HarnessResult<Vec<ThreadMessageRecord>> {
+        self.history_for_thread_in_scope(self.thread_scope.clone(), thread_id)
+            .await
+    }
+
+    pub async fn history_for_thread_in_scope(
+        &self,
+        scope: ThreadScope,
         thread_id: ThreadId,
     ) -> HarnessResult<Vec<ThreadMessageRecord>> {
         Ok(self
             .thread_harness
             .service
-            .list_thread_history(ThreadHistoryRequest {
-                scope: self.thread_scope.clone(),
-                thread_id,
-            })
+            .list_thread_history(ThreadHistoryRequest { scope, thread_id })
             .await?
             .messages)
     }
@@ -1454,12 +1478,19 @@ fn binding_request_from_envelope(envelope: &ProductInboundEnvelope) -> ResolveBi
         external_actor_ref: envelope.external_actor_ref().clone(),
         external_conversation_ref: envelope.external_conversation_ref().clone(),
         external_event_id: envelope.external_event_id().clone(),
-        route_kind: ProductConversationRouteKind::Direct,
+        route_kind: route_kind_for_envelope(envelope),
         auth_claim: envelope.auth_claim().clone(),
     }
 }
 
 fn thread_scope_from_binding(binding: &ResolvedBinding) -> HarnessResult<ThreadScope> {
+    thread_scope_from_binding_with_route_kind(binding, ProductConversationRouteKind::Direct)
+}
+
+fn thread_scope_from_binding_with_route_kind(
+    binding: &ResolvedBinding,
+    route_kind: ProductConversationRouteKind,
+) -> HarnessResult<ThreadScope> {
     Ok(ThreadScope {
         tenant_id: binding.tenant_id.clone(),
         agent_id: binding
@@ -1467,9 +1498,30 @@ fn thread_scope_from_binding(binding: &ResolvedBinding) -> HarnessResult<ThreadS
             .clone()
             .ok_or("resolved binding missing agent id")?,
         project_id: binding.project_id.clone(),
-        owner_user_id: Some(binding.user_id.clone()),
+        owner_user_id: match route_kind {
+            ProductConversationRouteKind::Direct => Some(binding.user_id.clone()),
+            ProductConversationRouteKind::Shared => None,
+        },
         mission_id: None,
     })
+}
+
+fn route_kind_for_envelope(envelope: &ProductInboundEnvelope) -> ProductConversationRouteKind {
+    match envelope.payload() {
+        ProductInboundPayload::UserMessage(message) => route_kind_for_trigger(message.trigger),
+        ProductInboundPayload::Command(command) => route_kind_for_trigger(command.trigger),
+        _ => ProductConversationRouteKind::Direct,
+    }
+}
+
+fn route_kind_for_trigger(trigger: ProductTriggerReason) -> ProductConversationRouteKind {
+    match trigger {
+        ProductTriggerReason::DirectChat => ProductConversationRouteKind::Direct,
+        ProductTriggerReason::BotMention
+        | ProductTriggerReason::ReplyToBot
+        | ProductTriggerReason::BotCommand
+        | ProductTriggerReason::LinkedThreadAction => ProductConversationRouteKind::Shared,
+    }
 }
 
 fn scoped_turns_fs<F>(


### PR DESCRIPTION
## Summary
- add `reborn_thread_binding_isolation_parity` to cover external conversation -> canonical thread binding isolation through the Reborn binary-E2E path
- add harness helpers for submitting to a specific external conversation/actor, waiting by submitted turn scope, and reading history for an arbitrary thread
- assert two conversations for the same actor resolve to distinct threads, complete independently, and do not leak transcript messages across thread histories

## Scope caveat
This covers conversation/thread binding isolation, not full multi-tenant identity prompt isolation. The prompt identity tests remain blocked until the Reborn binary-E2E harness uses a real policy-gated identity context source instead of the current empty source.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --features libsql --test reborn_thread_binding_isolation_parity reborn_thread_binding_isolation_parity -- --nocapture`
- `cargo test --features libsql --test reborn_minimal_dispatch_parity -- --nocapture`
