### PR TITLE
Add extension v2 lifecycle E2E coverage

### DIFF
--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -10,8 +10,9 @@ use ironclaw_extensions::{
 };
 use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, HostPath, ReservationStatus, ResourceEstimate, ResourceScope,
-    ResourceUsage, RuntimeKind, TenantId, UserId, VirtualPath,
+    CapabilityId, ExtensionId, HostPath, ReservationStatus, ResourceEstimate,
+    ResourceReservationId, ResourceScope, ResourceUsage, RuntimeKind, TenantId, UserId,
+    VirtualPath,
 };
 use ironclaw_host_runtime::{
     discover_extensions_with_default_host_api_contracts, publish_hot_capability_catalog,
@@ -64,6 +65,12 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
     let governor = Arc::new(InMemoryResourceGovernor::new());
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let estimate = ResourceEstimate {
+        concurrency_slots: Some(1),
+        process_count: Some(1),
+        output_bytes: Some(10_000),
+        ..ResourceEstimate::default()
+    };
     governor
         .set_limit(
             account.clone(),
@@ -83,25 +90,24 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
         RuntimeDispatcher::from_arcs(Arc::new(discovered), Arc::new(fs), Arc::clone(&governor))
             .with_runtime_adapter_arc(RuntimeKind::Script, Arc::clone(&adapter));
     let dispatch_port: &dyn CapabilityDispatcher = &dispatcher;
+    let reservation = governor.reserve(scope.clone(), estimate.clone()).unwrap();
+    let reservation_id = reservation.id;
+    assert_eq!(governor.reserved_for(&account).concurrency_slots, 1);
 
     let result = dispatch_port
         .dispatch_json(ironclaw_host_api::CapabilityDispatchRequest {
             capability_id: CapabilityId::new("script.echo").unwrap(),
             scope: scope.clone(),
-            estimate: ResourceEstimate {
-                concurrency_slots: Some(1),
-                process_count: Some(1),
-                output_bytes: Some(10_000),
-                ..ResourceEstimate::default()
-            },
+            estimate,
             mounts: None,
-            resource_reservation: None,
+            resource_reservation: Some(reservation),
             input: json!({"message":"hello"}),
         })
         .await
         .unwrap();
 
     assert_eq!(result.output, json!({"message":"script ok"}));
+    assert_eq!(result.receipt.id, reservation_id);
     assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
     assert_eq!(governor.reserved_for(&account), ResourceTally::default());
     assert!(governor.usage_for(&account).output_bytes > 0);
@@ -115,6 +121,7 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
     );
     assert_eq!(requests[0].runtime, RuntimeKind::Script);
     assert_eq!(requests[0].scope, scope);
+    assert_eq!(requests[0].resource_reservation_id, Some(reservation_id));
     assert_eq!(requests[0].input, json!({"message":"hello"}));
 }
 
@@ -170,6 +177,7 @@ struct RecordedAdapterRequest {
     capability_id: CapabilityId,
     runtime: RuntimeKind,
     scope: ResourceScope,
+    resource_reservation_id: Option<ResourceReservationId>,
     input: Value,
 }
 
@@ -184,6 +192,10 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdap
             capability_id: request.capability_id.clone(),
             runtime: request.descriptor.runtime,
             scope: request.scope.clone(),
+            resource_reservation_id: request
+                .resource_reservation
+                .as_ref()
+                .map(|reservation| reservation.id),
             input: request.input.clone(),
         });
 
@@ -196,17 +208,20 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdap
             )),
             ..ResourceUsage::default()
         };
-        let reservation = request
-            .governor
-            .reserve(request.scope, request.estimate)
-            .map_err(|_| DispatchError::Script {
-                kind: RuntimeDispatchErrorKind::Resource,
-            })?;
+        let reservation = match request.resource_reservation {
+            Some(reservation) => reservation,
+            None => request
+                .governor
+                .reserve(request.scope, request.estimate)
+                .map_err(|_| {
+                    dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
+                })?,
+        };
         let receipt = request
             .governor
             .reconcile(reservation.id, usage.clone())
-            .map_err(|_| DispatchError::Script {
-                kind: RuntimeDispatchErrorKind::Resource,
+            .map_err(|_| {
+                dispatch_error_for_runtime(self.runtime, RuntimeDispatchErrorKind::Resource)
             })?;
 
         Ok(RuntimeAdapterResult {
@@ -215,6 +230,21 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdap
             receipt,
             output_bytes,
         })
+    }
+}
+
+fn dispatch_error_for_runtime(
+    runtime: RuntimeKind,
+    kind: RuntimeDispatchErrorKind,
+) -> DispatchError {
+    match runtime {
+        RuntimeKind::Script => DispatchError::Script { kind },
+        RuntimeKind::Wasm => DispatchError::Wasm { kind },
+        RuntimeKind::Mcp => DispatchError::Mcp { kind },
+        RuntimeKind::FirstParty | RuntimeKind::System => DispatchError::UnsupportedRuntime {
+            capability: CapabilityId::new("system.unsupported").unwrap(),
+            runtime,
+        },
     }
 }
 

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -10,7 +10,7 @@ use ironclaw_extensions::{
 };
 use ironclaw_filesystem::LocalFilesystem;
 use ironclaw_host_api::{
-    CapabilityId, ExtensionId, HostPath, ReservationStatus, ResourceEstimate,
+    CapabilityId, ExtensionId, HostPath, MountView, ReservationStatus, ResourceEstimate,
     ResourceReservationId, ResourceScope, ResourceUsage, RuntimeKind, TenantId, UserId,
     VirtualPath,
 };
@@ -98,7 +98,7 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
         .dispatch_json(ironclaw_host_api::CapabilityDispatchRequest {
             capability_id: CapabilityId::new("script.echo").unwrap(),
             scope: scope.clone(),
-            estimate,
+            estimate: estimate.clone(),
             mounts: None,
             resource_reservation: Some(reservation),
             input: json!({"message":"hello"}),
@@ -121,6 +121,8 @@ async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host
     );
     assert_eq!(requests[0].runtime, RuntimeKind::Script);
     assert_eq!(requests[0].scope, scope);
+    assert_eq!(requests[0].estimate, estimate);
+    assert_eq!(requests[0].mounts, None);
     assert_eq!(requests[0].resource_reservation_id, Some(reservation_id));
     assert_eq!(requests[0].input, json!({"message":"hello"}));
 }
@@ -177,6 +179,8 @@ struct RecordedAdapterRequest {
     capability_id: CapabilityId,
     runtime: RuntimeKind,
     scope: ResourceScope,
+    estimate: ResourceEstimate,
+    mounts: Option<MountView>,
     resource_reservation_id: Option<ResourceReservationId>,
     input: Value,
 }
@@ -192,6 +196,8 @@ impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdap
             capability_id: request.capability_id.clone(),
             runtime: request.descriptor.runtime,
             scope: request.scope.clone(),
+            estimate: request.estimate.clone(),
+            mounts: request.mounts.clone(),
             resource_reservation_id: request
                 .resource_reservation
                 .as_ref()

--- a/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
+++ b/crates/ironclaw_host_runtime/tests/extension_v2_lifecycle_e2e.rs
@@ -1,0 +1,294 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ironclaw_dispatcher::{
+    CapabilityDispatcher, DispatchError, RuntimeAdapter, RuntimeAdapterRequest,
+    RuntimeAdapterResult, RuntimeDispatchErrorKind, RuntimeDispatcher,
+};
+use ironclaw_extensions::{
+    ExtensionError, ExtensionLifecycleService, ExtensionRegistry, ManifestV2Error,
+};
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::{
+    CapabilityId, ExtensionId, HostPath, ReservationStatus, ResourceEstimate, ResourceScope,
+    ResourceUsage, RuntimeKind, TenantId, UserId, VirtualPath,
+};
+use ironclaw_host_runtime::{
+    discover_extensions_with_default_host_api_contracts, publish_hot_capability_catalog,
+};
+use ironclaw_resources::{
+    InMemoryResourceGovernor, ResourceAccount, ResourceGovernor, ResourceLimits, ResourceTally,
+};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn extension_v2_lifecycle_discovers_installs_publishes_and_dispatches_host_api_capability() {
+    let (_storage, fs) = mounted_extension_fs("script", SCRIPT_MANIFEST);
+    let discovered = discover_extensions_with_default_host_api_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+    )
+    .await
+    .unwrap();
+    let package = discovered
+        .get_extension(&ExtensionId::new("script").unwrap())
+        .unwrap()
+        .clone();
+
+    let mut lifecycle = ExtensionLifecycleService::new(ExtensionRegistry::new());
+    lifecycle.install(package).await.unwrap();
+    let extension_id = ExtensionId::new("script").unwrap();
+    assert!(lifecycle.is_enabled(&extension_id));
+    lifecycle.disable(&extension_id).await.unwrap();
+    assert!(!lifecycle.is_enabled(&extension_id));
+    lifecycle.enable(&extension_id).await.unwrap();
+    assert!(lifecycle.is_enabled(&extension_id));
+
+    let hot_catalog = publish_hot_capability_catalog(&fs, lifecycle.registry())
+        .await
+        .unwrap();
+    let hot_record = hot_catalog
+        .get(&CapabilityId::new("script.echo").unwrap())
+        .unwrap();
+    assert_eq!(
+        hot_record.descriptor.parameters_schema,
+        json!({"type":"object","properties":{"message":{"type":"string"}},"required":["message"]})
+    );
+    assert_eq!(hot_record.output_schema, json!({"type":"object"}));
+    assert_eq!(
+        hot_record.prompt_doc.as_deref(),
+        Some("Echo user-provided text through the script runtime.")
+    );
+
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let scope = sample_scope();
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor
+        .set_limit(
+            account.clone(),
+            ResourceLimits {
+                max_concurrency_slots: Some(1),
+                max_process_count: Some(1),
+                max_output_bytes: Some(10_000),
+                ..ResourceLimits::default()
+            },
+        )
+        .unwrap();
+    let adapter = Arc::new(RecordingAdapter::new(
+        RuntimeKind::Script,
+        json!({"message":"script ok"}),
+    ));
+    let dispatcher =
+        RuntimeDispatcher::from_arcs(Arc::new(discovered), Arc::new(fs), Arc::clone(&governor))
+            .with_runtime_adapter_arc(RuntimeKind::Script, Arc::clone(&adapter));
+    let dispatch_port: &dyn CapabilityDispatcher = &dispatcher;
+
+    let result = dispatch_port
+        .dispatch_json(ironclaw_host_api::CapabilityDispatchRequest {
+            capability_id: CapabilityId::new("script.echo").unwrap(),
+            scope: scope.clone(),
+            estimate: ResourceEstimate {
+                concurrency_slots: Some(1),
+                process_count: Some(1),
+                output_bytes: Some(10_000),
+                ..ResourceEstimate::default()
+            },
+            mounts: None,
+            resource_reservation: None,
+            input: json!({"message":"hello"}),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.output, json!({"message":"script ok"}));
+    assert_eq!(result.receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert!(governor.usage_for(&account).output_bytes > 0);
+
+    let requests = adapter.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].provider, extension_id);
+    assert_eq!(
+        requests[0].capability_id,
+        CapabilityId::new("script.echo").unwrap()
+    );
+    assert_eq!(requests[0].runtime, RuntimeKind::Script);
+    assert_eq!(requests[0].scope, scope);
+    assert_eq!(requests[0].input, json!({"message":"hello"}));
+}
+
+#[tokio::test]
+async fn extension_v2_lifecycle_fails_closed_before_install_for_unknown_required_host_port() {
+    let manifest =
+        SCRIPT_MANIFEST.replace("host.runtime.http_egress", "host.runtime.not_supported");
+    let (_storage, fs) = mounted_extension_fs("script", &manifest);
+
+    let err = discover_extensions_with_default_host_api_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            ExtensionError::ManifestV2(ManifestV2Error::HostApiSectionRejected { ref reason, .. })
+                if reason.contains("unknown host port 'host.runtime.not_supported'")
+        ),
+        "unexpected error: {err:?}"
+    );
+    let lifecycle = ExtensionLifecycleService::new(ExtensionRegistry::new());
+    assert!(!lifecycle.is_enabled(&ExtensionId::new("script").unwrap()));
+}
+
+#[derive(Clone)]
+struct RecordingAdapter {
+    runtime: RuntimeKind,
+    output: Value,
+    requests: Arc<Mutex<Vec<RecordedAdapterRequest>>>,
+}
+
+impl RecordingAdapter {
+    fn new(runtime: RuntimeKind, output: Value) -> Self {
+        Self {
+            runtime,
+            output,
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn requests(&self) -> Vec<RecordedAdapterRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RecordedAdapterRequest {
+    provider: ExtensionId,
+    capability_id: CapabilityId,
+    runtime: RuntimeKind,
+    scope: ResourceScope,
+    input: Value,
+}
+
+#[async_trait]
+impl RuntimeAdapter<LocalFilesystem, InMemoryResourceGovernor> for RecordingAdapter {
+    async fn dispatch_json(
+        &self,
+        request: RuntimeAdapterRequest<'_, LocalFilesystem, InMemoryResourceGovernor>,
+    ) -> Result<RuntimeAdapterResult, DispatchError> {
+        self.requests.lock().unwrap().push(RecordedAdapterRequest {
+            provider: request.package.id.clone(),
+            capability_id: request.capability_id.clone(),
+            runtime: request.descriptor.runtime,
+            scope: request.scope.clone(),
+            input: request.input.clone(),
+        });
+
+        let output_bytes = serde_json::to_vec(&self.output).unwrap().len() as u64;
+        let usage = ResourceUsage {
+            output_bytes,
+            process_count: u32::from(matches!(
+                self.runtime,
+                RuntimeKind::Script | RuntimeKind::Mcp
+            )),
+            ..ResourceUsage::default()
+        };
+        let reservation = request
+            .governor
+            .reserve(request.scope, request.estimate)
+            .map_err(|_| DispatchError::Script {
+                kind: RuntimeDispatchErrorKind::Resource,
+            })?;
+        let receipt = request
+            .governor
+            .reconcile(reservation.id, usage.clone())
+            .map_err(|_| DispatchError::Script {
+                kind: RuntimeDispatchErrorKind::Resource,
+            })?;
+
+        Ok(RuntimeAdapterResult {
+            output: self.output.clone(),
+            usage,
+            receipt,
+            output_bytes,
+        })
+    }
+}
+
+fn mounted_extension_fs(id: &str, manifest: &str) -> (tempfile::TempDir, LocalFilesystem) {
+    let storage = tempdir().unwrap();
+    let extension_root = storage.path().join(id);
+    std::fs::create_dir_all(extension_root.join("schemas/script")).unwrap();
+    std::fs::create_dir_all(extension_root.join("prompts/script")).unwrap();
+    std::fs::write(extension_root.join("manifest.toml"), manifest).unwrap();
+    std::fs::write(
+        extension_root.join("schemas/script/echo.input.v1.json"),
+        r#"{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        extension_root.join("schemas/script/echo.output.v1.json"),
+        r#"{"type":"object"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        extension_root.join("prompts/script/echo.md"),
+        "Echo user-provided text through the script runtime.",
+    )
+    .unwrap();
+
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+    (storage, fs)
+}
+
+fn sample_scope() -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new("tenant-a").unwrap(),
+        user_id: UserId::new("user-a").unwrap(),
+        agent_id: None,
+        project_id: None,
+        mission_id: None,
+        thread_id: None,
+        invocation_id: ironclaw_host_api::InvocationId::new(),
+    }
+}
+
+const SCRIPT_MANIFEST: &str = r#"schema_version = "reborn.extension_manifest.v2"
+id = "script"
+name = "Script Echo"
+version = "0.1.0"
+description = "Script lifecycle extension"
+trust = "third_party"
+
+[runtime]
+kind = "script"
+runner = "docker"
+image = "alpine:latest"
+command = "script-echo"
+args = ["--json"]
+
+[[host_api]]
+id = "ironclaw.capability_provider/v1"
+section = "capability_provider.tools"
+
+[capability_provider.tools]
+
+[[capability_provider.tools.capabilities]]
+id = "script.echo"
+description = "Echo through Script"
+effects = ["dispatch_capability", "execute_code"]
+default_permission = "allow"
+visibility = "model"
+input_schema_ref = "schemas/script/echo.input.v1.json"
+output_schema_ref = "schemas/script/echo.output.v1.json"
+prompt_doc_ref = "prompts/script/echo.md"
+required_host_ports = ["host.runtime.http_egress"]
+"#;


### PR DESCRIPTION
## Summary
- add host-runtime lifecycle E2E coverage for Extension Manifest v2 host API packages
- prove discover → install/enable → hot catalog publication → dispatch for a capability-provider script extension
- add fail-closed coverage for unknown required host ports before lifecycle install

Stacked on #3791. Retarget to `reborn-integration` after PR6 merges.

## Validation
- `cargo fmt --check`
- `cargo test -p ironclaw_host_runtime --test extension_v2_lifecycle_e2e`
- `cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold`
- `cargo clippy -p ironclaw_host_runtime --all-targets -- -D warnings`