### PR TITLE
Tighten legacy extension v2 capability manifests

### DIFF
--- a/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/event_dispatch_contract.rs
@@ -16,10 +16,7 @@ use tracing_test::traced_test;
 #[tokio::test]
 async fn dispatcher_emits_events_for_wasm_and_script_success() {
     let fs = filesystem_with_echo_extensions();
-    let registry =
-        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-            .await
-            .unwrap();
+    let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
     let wasm_adapter = EchoAdapter::new(RuntimeKind::Wasm);
     let script_adapter = EchoAdapter::new(RuntimeKind::Script);
@@ -95,10 +92,7 @@ async fn dispatcher_emits_events_for_wasm_and_script_success() {
 #[tokio::test]
 async fn dispatcher_ignores_event_sink_failures_on_success() {
     let fs = filesystem_with_echo_extensions();
-    let registry =
-        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-            .await
-            .unwrap();
+    let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
     let wasm_adapter = EchoAdapter::new(RuntimeKind::Wasm);
     let events = FailingEventSink;
@@ -128,10 +122,7 @@ async fn dispatcher_ignores_event_sink_failures_on_success() {
 #[tokio::test]
 async fn dispatcher_preserves_original_error_when_failure_event_sink_fails() {
     let fs = filesystem_with_echo_extensions();
-    let registry =
-        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-            .await
-            .unwrap();
+    let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
     let events = FailingEventSink;
     let dispatcher = RuntimeDispatcher::new(&registry, &fs, &governor).with_event_sink(&events);
@@ -164,10 +155,7 @@ async fn dispatcher_preserves_original_error_when_failure_event_sink_fails() {
 #[traced_test]
 async fn dispatcher_logs_release_failure_without_masking_dispatch_error() {
     let fs = filesystem_with_echo_extensions();
-    let registry =
-        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-            .await
-            .unwrap();
+    let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let reservation = ResourceReservation {
@@ -215,10 +203,7 @@ async fn dispatcher_logs_release_failure_without_masking_dispatch_error() {
 #[tokio::test]
 async fn dispatcher_emits_redacted_runtime_error_kind_for_adapter_failure() {
     let fs = filesystem_with_echo_extensions();
-    let registry =
-        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-            .await
-            .unwrap();
+    let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
     let script_adapter =
         FailingRuntimeAdapter::new(RuntimeKind::Script, RuntimeDispatchErrorKind::ExitFailure);
@@ -303,10 +288,7 @@ async fn dispatcher_emits_events_for_mcp_success() {
 #[tokio::test]
 async fn dispatcher_emits_failed_event_for_missing_backend_without_reserving() {
     let fs = filesystem_with_echo_extensions();
-    let registry =
-        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-            .await
-            .unwrap();
+    let registry = discover_legacy_fixture_registry(&fs).await;
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope();
     let account = ResourceAccount::tenant(scope.tenant_id.clone());
@@ -489,6 +471,18 @@ fn filesystem_with_echo_extensions() -> LocalFilesystem {
     )
     .unwrap();
     fs
+}
+
+async fn discover_legacy_fixture_registry(fs: &LocalFilesystem) -> ExtensionRegistry {
+    ExtensionDiscovery::discover_with_manifest_contracts(
+        fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
+    )
+    .await
+    .unwrap()
 }
 
 fn write_echo_extensions(root: &std::path::Path) {

--- a/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
+++ b/crates/ironclaw_dispatcher/tests/vertical_slice_contract.rs
@@ -13,10 +13,7 @@ use serde_json::json;
 #[tokio::test]
 async fn vertical_slice_discovers_and_dispatches_registered_runtime_adapters() {
     let fs = filesystem_with_echo_extensions();
-    let registry =
-        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-            .await
-            .unwrap();
+    let registry = discover_legacy_fixture_registry(&fs).await;
     assert_eq!(registry.extensions().count(), 3);
 
     let governor = InMemoryResourceGovernor::new();
@@ -211,6 +208,18 @@ fn filesystem_with_echo_extensions() -> LocalFilesystem {
     )
     .unwrap();
     fs
+}
+
+async fn discover_legacy_fixture_registry(fs: &LocalFilesystem) -> ExtensionRegistry {
+    ExtensionDiscovery::discover_with_manifest_contracts(
+        fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
+    )
+    .await
+    .unwrap()
 }
 
 fn sample_scope() -> ResourceScope {

--- a/crates/ironclaw_extensions/src/v2.rs
+++ b/crates/ironclaw_extensions/src/v2.rs
@@ -465,6 +465,10 @@ pub enum ManifestV2Error {
         prefix: &'static str,
     },
     #[error(
+        "manifest source {manifest_source:?} is not allowed to use legacy top-level capabilities; declare ironclaw.capability_provider/v1 host_api instead"
+    )]
+    LegacyTopLevelCapabilitiesForInstalledSource { manifest_source: ManifestSource },
+    #[error(
         "capability {capability} declares unknown host port '{port}' (not in host-defined catalog)"
     )]
     UnknownHostPort {
@@ -592,6 +596,13 @@ impl ExtensionManifestV2 {
                 return Err(ManifestV2Error::Parse {
                     reason: format!("unknown top-level field {key:?}"),
                 });
+            }
+            if !source.allows_first_party() && !manifest.capabilities.is_empty() {
+                return Err(
+                    ManifestV2Error::LegacyTopLevelCapabilitiesForInstalledSource {
+                        manifest_source: source,
+                    },
+                );
             }
         } else {
             let projection =

--- a/crates/ironclaw_extensions/tests/extension_contract.rs
+++ b/crates/ironclaw_extensions/tests/extension_contract.rs
@@ -114,7 +114,7 @@ fn script_and_mcp_runtime_metadata_stays_declarative() {
 }
 
 #[tokio::test]
-async fn discovery_reads_v2_manifests_from_filesystem_virtual_root() {
+async fn discovery_reads_host_bundled_legacy_manifests_from_filesystem_virtual_root() {
     let storage = tempdir().unwrap();
     std::fs::create_dir_all(storage.path().join("echo")).unwrap();
     std::fs::write(storage.path().join("echo/manifest.toml"), WASM_MANIFEST).unwrap();
@@ -126,10 +126,15 @@ async fn discovery_reads_v2_manifests_from_filesystem_virtual_root() {
     )
     .unwrap();
 
-    let registry =
-        ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-            .await
-            .unwrap();
+    let registry = ExtensionDiscovery::discover_with_manifest_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
+    )
+    .await
+    .unwrap();
 
     assert!(
         registry
@@ -170,6 +175,67 @@ async fn discovery_rejects_installed_local_privileged_manifest() {
             manifest_source: ManifestSource::InstalledLocal,
             requested: RequestedTrustClass::FirstPartyRequested,
         })
+    ));
+}
+
+#[test]
+fn production_parser_rejects_installed_legacy_top_level_capabilities() {
+    let err = ExtensionManifest::parse_with_optional_host_api_contracts(
+        WASM_MANIFEST,
+        ManifestSource::InstalledLocal,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::ManifestV2(
+            ManifestV2Error::LegacyTopLevelCapabilitiesForInstalledSource {
+                manifest_source: ManifestSource::InstalledLocal,
+            }
+        )
+    ));
+}
+
+#[test]
+fn production_parser_allows_host_bundled_legacy_top_level_capabilities() {
+    let manifest = ExtensionManifest::parse_with_optional_host_api_contracts(
+        WASM_MANIFEST,
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
+    )
+    .unwrap();
+
+    assert_eq!(manifest.id.as_str(), "echo");
+    assert_eq!(manifest.capabilities.len(), 1);
+}
+
+#[tokio::test]
+async fn discovery_rejects_installed_legacy_top_level_capabilities() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("echo")).unwrap();
+    std::fs::write(storage.path().join("echo/manifest.toml"), WASM_MANIFEST).unwrap();
+
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/system/extensions").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let err = ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ExtensionError::ManifestV2(
+            ManifestV2Error::LegacyTopLevelCapabilitiesForInstalledSource {
+                manifest_source: ManifestSource::InstalledLocal,
+            }
+        )
     ));
 }
 
@@ -451,7 +517,7 @@ async fn discovery_validates_capability_manifest_with_supplied_host_port_catalog
     let registry = ExtensionDiscovery::discover_with_manifest_contracts(
         &fs,
         &VirtualPath::new("/system/extensions").unwrap(),
-        ManifestSource::InstalledLocal,
+        ManifestSource::HostBundled,
         &catalog,
         &HostApiContractRegistry::new(),
     )
@@ -484,9 +550,15 @@ async fn discovery_rejects_manifest_id_mismatch_with_directory() {
     )
     .unwrap();
 
-    let err = ExtensionDiscovery::discover(&fs, &VirtualPath::new("/system/extensions").unwrap())
-        .await
-        .unwrap_err();
+    let err = ExtensionDiscovery::discover_with_manifest_contracts(
+        &fs,
+        &VirtualPath::new("/system/extensions").unwrap(),
+        ManifestSource::HostBundled,
+        &HostPortCatalog::empty(),
+        &HostApiContractRegistry::new(),
+    )
+    .await
+    .unwrap_err();
 
     assert!(matches!(
         err,

--- a/docs/reborn/contracts/extensions.md
+++ b/docs/reborn/contracts/extensions.md
@@ -81,7 +81,13 @@ Production manifests use `schema_version = "reborn.extension_manifest.v2"`.
 The older top-level `parameters_schema` manifest shape is no longer parsed on
 production discovery paths.
 
-Minimal V2 WASM manifest:
+Installed third-party manifests (`InstalledLocal` / `RegistryInstalled`) declare
+model-visible tools through `[[host_api]] id = "ironclaw.capability_provider/v1"`.
+Legacy top-level `[[capabilities]]` declarations are accepted only for
+`ManifestSource::HostBundled` packages such as host-owned built-ins and explicit
+compatibility fixtures.
+
+Legacy host-bundled WASM manifest:
 
 ```toml
 schema_version = "reborn.extension_manifest.v2"
@@ -106,7 +112,7 @@ output_schema_ref = "schemas/echo/say.output.v1.json"
 prompt_doc_ref = "prompts/echo/say.md"
 ```
 
-Script/CLI manifest example:
+Legacy host-bundled script/CLI manifest:
 
 ```toml
 schema_version = "reborn.extension_manifest.v2"
@@ -134,7 +140,7 @@ output_schema_ref = "schemas/project-tools/pytest.output.v1.json"
 prompt_doc_ref = "prompts/project-tools/pytest.md"
 ```
 
-MCP adapter manifest example:
+Legacy host-bundled MCP adapter manifest:
 
 ```toml
 schema_version = "reborn.extension_manifest.v2"
@@ -214,6 +220,13 @@ Rules:
 - Operational sections must be referenced by `[[host_api]]`; inert metadata may live under `[metadata.*]` or `[x.*]`.
 - Manifest validation is atomic: any invalid host API contract invalidates the extension manifest.
 - Runtime loading, handshakes, catalog publication, authority grants, and execution remain outside `ironclaw_extensions`.
+
+Migration rules:
+
+- Installed third-party extensions must move each model-visible top-level `[[capabilities]]` entry under `[[capability_provider.tools.capabilities]]` and reference it from `[[host_api]] id = "ironclaw.capability_provider/v1"`.
+- Host-bundled built-ins may keep top-level `[[capabilities]]` while first-party packaging remains synthetic/host-owned.
+- Do not mix `[[host_api]]` with top-level `[[capabilities]]` in one manifest.
+- Deprecated path scope is only legacy top-level capability declarations for installed third-party manifests; extension manifest v2 itself remains active.
 
 ---
 


### PR DESCRIPTION
## Summary\n- reject installed third-party legacy top-level  in production optional host-api parsing\n- keep host-bundled legacy capability manifests allowed for built-ins/fixtures\n- document migration to  and update dispatcher fixtures to mark legacy shape as host-bundled\n\n## Validation\n- cargo fmt --check\n- cargo test -p ironclaw_extensions\n- cargo test -p ironclaw_dispatcher --test event_dispatch_contract\n- cargo test -p ironclaw_dispatcher --test vertical_slice_contract\n- cargo test -p ironclaw_host_runtime --test extension_v2_lifecycle_e2e\n- cargo test -p ironclaw_architecture reborn_crate_dependency_boundaries_hold\n- cargo clippy -p ironclaw_extensions -p ironclaw_dispatcher --all-targets -- -D warnings