### PR TITLE
test(reborn): cover identity prompt scope isolation

### DIFF
--- a/crates/ironclaw_loop_support/src/cancellation_port.rs
+++ b/crates/ironclaw_loop_support/src/cancellation_port.rs
@@ -469,14 +469,14 @@ mod tests {
 
     use async_trait::async_trait;
     use chrono::Utc;
-    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
+    use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
     use ironclaw_turns::run_profile::{LoopCancelReasonKind, LoopCancellationPort};
     use ironclaw_turns::{
         AcceptedMessageRef, CancelRunRequest, CancelRunResponse, EventCursor, GetRunStateRequest,
         ReplyTargetBindingRef, ResumeTurnRequest, ResumeTurnResponse, RunProfileId,
         RunProfileResolver, RunProfileVersion, SourceBindingRef, SubmitTurnRequest,
-        SubmitTurnResponse, TurnAdmissionPolicy, TurnError, TurnId, TurnRunId, TurnRunState,
-        TurnRunWake, TurnRunWakeNotifier, TurnScope, TurnStateStore, TurnStatus,
+        SubmitTurnResponse, TurnActor, TurnAdmissionPolicy, TurnError, TurnId, TurnRunId,
+        TurnRunState, TurnRunWake, TurnRunWakeNotifier, TurnScope, TurnStateStore, TurnStatus,
         run_profile::AgentLoopHostError,
     };
 
@@ -551,6 +551,7 @@ mod tests {
         let thread_id = ThreadId::new("thread-cancel-factory").unwrap();
         TurnRunState {
             scope: TurnScope::new(tenant_id, Some(agent_id), Some(project_id), thread_id),
+            actor: Some(TurnActor::new(UserId::new("user-cancel-factory").unwrap())),
             turn_id: TurnId::new(),
             run_id: TurnRunId::new(),
             status,

--- a/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/reborn_services_contract.rs
@@ -225,6 +225,7 @@ impl TurnCoordinator for FakeTurnCoordinator {
         self.run_state_requests.lock().expect("lock").push(request);
         Ok(TurnRunState {
             scope,
+            actor: None,
             turn_id: TurnId::new(),
             run_id,
             status: TurnStatus::Queued,

--- a/crates/ironclaw_reborn/src/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/src/loop_driver_host.rs
@@ -1267,6 +1267,9 @@ where
             claimed.state.run_id,
             claimed.resolved_run_profile.clone(),
         );
+        if let Some(actor) = claimed.state.actor.clone() {
+            loop_run_context = loop_run_context.with_actor(actor);
+        }
         if let Some(snapshot) = claimed.state.resolved_model_route.clone() {
             loop_run_context = loop_run_context.with_resolved_model_route(snapshot);
         }

--- a/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/loop_exit_applier/tests/mod.rs
@@ -1077,6 +1077,7 @@ fn claimed_run() -> ClaimedTurnRun {
     ClaimedTurnRun {
         state: TurnRunState {
             scope,
+            actor: None,
             turn_id: TurnId::new(),
             run_id: TurnRunId::new(),
             status: TurnStatus::Running,
@@ -1331,6 +1332,7 @@ fn state_for_mapping(
             None,
             ThreadId::new("thread").expect("valid"),
         ),
+        actor: None,
         turn_id: TurnId::new(),
         run_id,
         status,

--- a/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
+++ b/crates/ironclaw_reborn/src/turn_runner/tests/mod.rs
@@ -114,6 +114,7 @@ fn test_resolved_profile_with_driver(
 fn test_run_state(scope: TurnScope, status: TurnStatus) -> TurnRunState {
     TurnRunState {
         scope,
+        actor: None,
         turn_id: TurnId::new(),
         run_id: TurnRunId::new(),
         status,

--- a/crates/ironclaw_reborn/tests/loop_driver_host.rs
+++ b/crates/ironclaw_reborn/tests/loop_driver_host.rs
@@ -6297,6 +6297,7 @@ impl HostFixture {
         let run_id = TurnRunId::new();
         let state = ironclaw_turns::TurnRunState {
             scope: turn_scope.clone(),
+            actor: Some(TurnActor::new(user_id.clone())),
             turn_id,
             run_id,
             status: TurnStatus::Running,

--- a/crates/ironclaw_reborn/tests/loop_milestone_event_projection.rs
+++ b/crates/ironclaw_reborn/tests/loop_milestone_event_projection.rs
@@ -38,9 +38,9 @@ use ironclaw_turns::{
     InMemoryCheckpointStateStore, InMemoryLoopCheckpointStore, InMemoryRunProfileResolver,
     LoopCompletionKind, LoopExitId, LoopFailureKind, ReplyTargetBindingRef, ResumeTurnRequest,
     RunProfileId, RunProfileResolutionRequest, RunProfileResolver, RunProfileVersion,
-    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnAdmissionPolicy, TurnCheckpointId,
-    TurnError, TurnId, TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId, TurnScope,
-    TurnStateStore, TurnStatus,
+    SourceBindingRef, SubmitTurnRequest, SubmitTurnResponse, TurnActor, TurnAdmissionPolicy,
+    TurnCheckpointId, TurnError, TurnId, TurnLeaseToken, TurnRunId, TurnRunState, TurnRunnerId,
+    TurnScope, TurnStateStore, TurnStatus,
     run_profile::{
         AgentLoopHostErrorKind, BatchPolicyKind, FinalizeAssistantMessage, LoopCheckpointKind,
         LoopDriverId, LoopGateKind, LoopHostMilestone, LoopHostMilestoneEmitter,
@@ -770,6 +770,7 @@ impl HostFixture {
         let run_id = TurnRunId::new();
         let state = TurnRunState {
             scope: turn_scope.clone(),
+            actor: Some(TurnActor::new(user_id())),
             turn_id,
             run_id,
             status: TurnStatus::Running,

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -1843,9 +1843,9 @@ impl RunRecord {
     }
 
     fn state(&self) -> TurnRunState {
-        let _ = &self.actor;
         TurnRunState {
             scope: self.scope.clone(),
+            actor: Some(self.actor.clone()),
             turn_id: self.turn_id,
             run_id: self.run_id,
             status: self.status,

--- a/crates/ironclaw_turns/src/run_profile/host.rs
+++ b/crates/ironclaw_turns/src/run_profile/host.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use crate::{
     LoopDiagnosticRef, LoopGateRef, LoopMessageRef, LoopResultRef, RedactedCheckpointPayload,
-    RunProfileVersion, TurnCheckpointId, TurnId, TurnRunId, TurnScope,
+    RunProfileVersion, TurnActor, TurnCheckpointId, TurnId, TurnRunId, TurnScope,
 };
 
 use super::{
@@ -476,6 +476,8 @@ fn token_contains_sensitive_marker(token: &str, marker: &str) -> bool {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoopRunContext {
     pub scope: TurnScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<TurnActor>,
     pub thread_id: ThreadId,
     pub turn_id: TurnId,
     pub run_id: TurnRunId,
@@ -502,6 +504,7 @@ impl LoopRunContext {
         let checkpoint_schema_version = resolved_run_profile.checkpoint_schema_version;
         Self {
             scope,
+            actor: None,
             thread_id,
             turn_id,
             run_id,
@@ -512,6 +515,15 @@ impl LoopRunContext {
             checkpoint_schema_id,
             checkpoint_schema_version,
         }
+    }
+
+    pub fn with_actor(mut self, actor: TurnActor) -> Self {
+        self.actor = Some(actor);
+        self
+    }
+
+    pub fn actor(&self) -> Option<&TurnActor> {
+        self.actor.as_ref()
     }
 
     pub fn with_resolved_model_route(mut self, snapshot: LoopModelRouteSnapshot) -> Self {

--- a/crates/ironclaw_turns/src/status.rs
+++ b/crates/ironclaw_turns/src/status.rs
@@ -3,8 +3,9 @@ use thiserror::Error;
 
 use crate::{
     AcceptedMessageRef, GateRef, ReplyTargetBindingRef, ResolvedRunProfile, RunProfileId,
-    RunProfileVersion, SourceBindingRef, TurnAdmissionClass, TurnCheckpointId, TurnId, TurnRunId,
-    TurnScope, events::EventCursor, request::TurnTimestamp, run_profile::LoopModelRouteSnapshot,
+    RunProfileVersion, SourceBindingRef, TurnActor, TurnAdmissionClass, TurnCheckpointId, TurnId,
+    TurnRunId, TurnScope, events::EventCursor, request::TurnTimestamp,
+    run_profile::LoopModelRouteSnapshot,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -263,6 +264,8 @@ impl AdmissionRejection {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TurnRunState {
     pub scope: TurnScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<TurnActor>,
     pub turn_id: TurnId,
     pub run_id: TurnRunId,
     pub status: TurnStatus,

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -1474,6 +1474,26 @@ fn prompt_mode_wire_shape_uses_issue_contract_spelling() {
 }
 
 #[tokio::test]
+async fn loop_run_context_actor_is_serde_backward_compatible() {
+    let context = claimed_run_context().await;
+    assert!(context.actor().is_none());
+
+    let legacy_wire = serde_json::to_value(&context).unwrap();
+    assert!(
+        !legacy_wire.as_object().unwrap().contains_key("actor"),
+        "actor: None must stay omitted for legacy wire compatibility"
+    );
+    let decoded: LoopRunContext = serde_json::from_value(legacy_wire).unwrap();
+    assert!(decoded.actor().is_none());
+
+    let actor = TurnActor::new(UserId::new("user-loop-context-serde").unwrap());
+    let actor_context = context.with_actor(actor.clone());
+    let decoded_with_actor: LoopRunContext =
+        serde_json::from_value(serde_json::to_value(&actor_context).unwrap()).unwrap();
+    assert_eq!(decoded_with_actor.actor(), Some(&actor));
+}
+
+#[tokio::test]
 async fn prompt_bundle_refs_are_scoped_and_bounded() {
     let context = claimed_run_context().await;
     let bundle_ref = LoopPromptBundleRef::for_run(&context, "bundle-one").unwrap();

--- a/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
+++ b/crates/ironclaw_turns/tests/agent_loop_host_contract.rs
@@ -1434,6 +1434,7 @@ async fn loop_prompt_bundle_public_serialization_hides_raw_content() {
 
     let status = TurnRunState {
         scope: host.context.scope.clone(),
+        actor: Some(TurnActor::new(UserId::new("user-loop-host").unwrap())),
         turn_id: host.context.turn_id,
         run_id: host.context.run_id,
         status: TurnStatus::Running,

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -410,6 +410,47 @@ fn redacted_checkpoint_payload_is_not_serializable() {
 }
 
 #[test]
+fn turn_run_state_actor_is_serde_backward_compatible() {
+    let actor = TurnActor::new(UserId::new("user-run-state-serde").unwrap());
+    let state = TurnRunState {
+        scope: turn_scope("thread-run-state-serde"),
+        actor: None,
+        turn_id: TurnId::new(),
+        run_id: TurnRunId::new(),
+        status: TurnStatus::Running,
+        accepted_message_ref: AcceptedMessageRef::new("accepted-run-state-serde").unwrap(),
+        source_binding_ref: SourceBindingRef::new("source-run-state-serde").unwrap(),
+        reply_target_binding_ref: ReplyTargetBindingRef::new("reply-run-state-serde").unwrap(),
+        resolved_run_profile_id: RunProfileId::default_profile(),
+        resolved_run_profile_version: RunProfileVersion::new(1),
+        resolved_model_route: None,
+        received_at: fixed_time(),
+        checkpoint_id: None,
+        gate_ref: None,
+        failure: None,
+        event_cursor: EventCursor(1),
+    };
+
+    let legacy_wire = serde_json::to_value(&state).unwrap();
+    assert!(
+        !legacy_wire.as_object().unwrap().contains_key("actor"),
+        "actor: None must stay omitted for legacy wire compatibility"
+    );
+    let decoded: TurnRunState = serde_json::from_value(legacy_wire).unwrap();
+    assert!(decoded.actor.is_none());
+
+    let decoded_with_actor: TurnRunState = serde_json::from_value(
+        serde_json::to_value(TurnRunState {
+            actor: Some(actor.clone()),
+            ..state
+        })
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(decoded_with_actor.actor, Some(actor));
+}
+
+#[test]
 fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
     let payload = b"RAW_CHECKPOINT_PAYLOAD sk-secret /host/path tool_input".to_vec();
     let payload = RedactedCheckpointPayload::new(payload).unwrap();

--- a/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
+++ b/crates/ironclaw_turns/tests/checkpoint_state_store_contract.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId};
+use ironclaw_host_api::{AgentId, ProjectId, TenantId, ThreadId, UserId};
 use ironclaw_turns::{
     AcceptedMessageRef, CheckpointSchemaId, CheckpointStateRecord, CheckpointStateStore,
     EventCursor, GateRef, GetCheckpointStateRequest, GetLoopCheckpointRequest,
@@ -8,7 +8,7 @@ use ironclaw_turns::{
     InMemoryTurnStateStoreLimits, LoopCheckpointStateRef, LoopCheckpointStore,
     MAX_CHECKPOINT_STATE_PAYLOAD_BYTES, PutCheckpointStateRequest, PutLoopCheckpointRequest,
     RedactedCheckpointPayload, ReplyTargetBindingRef, RunProfileId, RunProfileVersion,
-    SourceBindingRef, TurnCheckpointId, TurnCheckpointRecord, TurnEventKind, TurnId,
+    SourceBindingRef, TurnActor, TurnCheckpointId, TurnCheckpointRecord, TurnEventKind, TurnId,
     TurnLifecycleEvent, TurnPersistenceSnapshot, TurnRunId, TurnRunState, TurnScope, TurnStatus,
     TurnTimestamp, run_profile::LoopCheckpointKind,
 };
@@ -419,6 +419,9 @@ fn turn_checkpoint_public_status_does_not_expose_checkpoint_payload() {
 
     let state = TurnRunState {
         scope: scope.clone(),
+        actor: Some(TurnActor::new(
+            UserId::new("user-checkpoint-public").unwrap(),
+        )),
         turn_id: TurnId::new(),
         run_id,
         status: TurnStatus::BlockedApproval,

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -4019,6 +4019,7 @@ impl TurnRunTransitionPort for AtomicLoopExitPort {
         drop(status);
         Ok(TurnRunState {
             scope: scope("thread-a"),
+            actor: Some(TurnActor::new(UserId::new("user-thread-a").unwrap())),
             turn_id: ironclaw_turns::TurnId::new(),
             run_id: request.run_id,
             status: next_status,

--- a/tests/reborn_identity_prompt_scope_isolation_parity.rs
+++ b/tests/reborn_identity_prompt_scope_isolation_parity.rs
@@ -27,6 +27,8 @@ const BOB_IDENTITY: &str = "Bob is a marine biologist who lives in Miami.";
 
 #[tokio::test]
 async fn reborn_identity_prompt_scope_isolation_parity() {
+    const SHARED_ROOM: &str = "room-identity-shared";
+
     let identity_source = Arc::new(ScopedIdentitySource::default());
     let model_gateway = RebornTraceReplayModelGateway::with_responses([
         HostManagedModelResponse::assistant_reply("alice scoped reply"),
@@ -34,7 +36,7 @@ async fn reborn_identity_prompt_scope_isolation_parity() {
     ]);
     let mut harness =
         RebornBinaryE2EHarness::with_model_gateway_identity_source_unscoped_shared_worker(
-            "room-identity-alice",
+            SHARED_ROOM,
             model_gateway,
             RecordingTestCapabilityPort::echo(),
             identity_source.clone(),
@@ -44,7 +46,7 @@ async fn reborn_identity_prompt_scope_isolation_parity() {
 
     let alice = harness
         .submit_text_for_with_trigger(
-            "room-identity-alice",
+            SHARED_ROOM,
             "alice",
             "event-identity-alice",
             "hello from alice",
@@ -62,7 +64,7 @@ async fn reborn_identity_prompt_scope_isolation_parity() {
 
     let bob = harness
         .submit_text_for_with_trigger(
-            "room-identity-bob",
+            SHARED_ROOM,
             "bob",
             "event-identity-bob",
             "hello from bob",
@@ -73,6 +75,14 @@ async fn reborn_identity_prompt_scope_isolation_parity() {
     assert_ne!(
         alice.actor.user_id, bob.actor.user_id,
         "distinct external actors must resolve to distinct canonical users before identity can isolate"
+    );
+    assert_eq!(
+        alice.thread_id, bob.thread_id,
+        "BotMention submissions in the same shared room should bind to one shared thread"
+    );
+    assert_eq!(
+        alice.thread_scope, bob.thread_scope,
+        "shared-thread identity isolation must be exercised inside one thread scope"
     );
     identity_source.set_identity(bob.actor.user_id.as_str(), BOB_IDENTITY);
     harness

--- a/tests/reborn_identity_prompt_scope_isolation_parity.rs
+++ b/tests/reborn_identity_prompt_scope_isolation_parity.rs
@@ -1,0 +1,200 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use ironclaw_loop_support::{
+    HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
+    HostIdentityMessageContent, HostManagedModelMessageRole, HostManagedModelResponse,
+    IdentityApplicability, IdentityFileName,
+};
+use ironclaw_product_adapters::ProductTriggerReason;
+use ironclaw_turns::{
+    LoopMessageRef, TurnStatus,
+    run_profile::{LoopRunContext, PromptMode},
+};
+use reborn_support::harness::{RebornBinaryE2EHarness, RecordingTestCapabilityPort};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+
+const ALICE_IDENTITY: &str = "Alice is a software engineer who lives in Seattle.";
+const BOB_IDENTITY: &str = "Bob is a marine biologist who lives in Miami.";
+
+#[tokio::test]
+async fn reborn_identity_prompt_scope_isolation_parity() {
+    let identity_source = Arc::new(ScopedIdentitySource::default());
+    let model_gateway = RebornTraceReplayModelGateway::with_responses([
+        HostManagedModelResponse::assistant_reply("alice scoped reply"),
+        HostManagedModelResponse::assistant_reply("bob scoped reply"),
+    ]);
+    let mut harness =
+        RebornBinaryE2EHarness::with_model_gateway_identity_source_unscoped_shared_worker(
+            "room-identity-alice",
+            model_gateway,
+            RecordingTestCapabilityPort::echo(),
+            identity_source.clone(),
+        )
+        .await
+        .expect("harness");
+
+    let alice = harness
+        .submit_text_for_with_trigger(
+            "room-identity-alice",
+            "alice",
+            "event-identity-alice",
+            "hello from alice",
+            ProductTriggerReason::BotMention,
+        )
+        .await
+        .expect("submit alice turn");
+    identity_source.set_identity(alice.actor.user_id.as_str(), ALICE_IDENTITY);
+
+    harness.start();
+    harness
+        .wait_for_submitted_status(&alice, TurnStatus::Completed)
+        .await
+        .expect("alice completed");
+
+    let bob = harness
+        .submit_text_for_with_trigger(
+            "room-identity-bob",
+            "bob",
+            "event-identity-bob",
+            "hello from bob",
+            ProductTriggerReason::BotMention,
+        )
+        .await
+        .expect("submit bob turn");
+    assert_ne!(
+        alice.actor.user_id, bob.actor.user_id,
+        "distinct external actors must resolve to distinct canonical users before identity can isolate"
+    );
+    identity_source.set_identity(bob.actor.user_id.as_str(), BOB_IDENTITY);
+    harness
+        .wait_for_submitted_status(&bob, TurnStatus::Completed)
+        .await
+        .expect("bob completed");
+
+    let seen_users = identity_source.seen_users();
+    assert_eq!(
+        seen_users.len(),
+        2,
+        "identity source should see two canonical users"
+    );
+    assert!(seen_users.contains(&alice.actor.user_id.as_str().to_string()));
+    assert!(seen_users.contains(&bob.actor.user_id.as_str().to_string()));
+
+    let requests = harness.model_requests();
+    assert_eq!(requests.len(), 2);
+    let prompts: Vec<String> = requests.iter().map(system_prompt_text).collect();
+    assert!(
+        prompts
+            .iter()
+            .any(|prompt| prompt.contains(ALICE_IDENTITY) && !prompt.contains(BOB_IDENTITY)),
+        "one model request should contain only Alice identity; prompts={prompts:#?}"
+    );
+    assert!(
+        prompts
+            .iter()
+            .any(|prompt| prompt.contains(BOB_IDENTITY) && !prompt.contains(ALICE_IDENTITY)),
+        "one model request should contain only Bob identity; prompts={prompts:#?}"
+    );
+
+    harness.assert_model_exhausted();
+    harness.shutdown().await;
+}
+
+fn system_prompt_text(request: &ironclaw_loop_support::HostManagedModelRequest) -> String {
+    request
+        .messages
+        .iter()
+        .filter(|message| message.role == HostManagedModelMessageRole::System)
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[derive(Default)]
+struct ScopedIdentitySource {
+    identities: Mutex<HashMap<String, IdentityEntry>>,
+    seen_users: Mutex<Vec<String>>,
+}
+
+impl ScopedIdentitySource {
+    fn set_identity(&self, user_id: &str, content: &str) {
+        let name = IdentityFileName::new("IDENTITY.md").expect("identity file name");
+        let candidate = HostIdentityContextCandidate::new_installed_summary_only(
+            name.clone(),
+            content.to_string(),
+            IdentityApplicability::Always,
+        );
+        self.identities
+            .lock()
+            .expect("identity source lock")
+            .insert(user_id.to_string(), IdentityEntry { candidate });
+    }
+
+    fn seen_users(&self) -> Vec<String> {
+        self.seen_users
+            .lock()
+            .expect("identity source lock")
+            .clone()
+    }
+
+    fn identity_for_user(&self, user_id: &str) -> Option<IdentityEntry> {
+        self.identities
+            .lock()
+            .expect("identity source lock")
+            .get(user_id)
+            .cloned()
+    }
+}
+
+#[derive(Clone)]
+struct IdentityEntry {
+    candidate: HostIdentityContextCandidate,
+}
+
+#[async_trait]
+impl HostIdentityContextSource for ScopedIdentitySource {
+    async fn load_identity_candidates(
+        &self,
+        run_context: &LoopRunContext,
+        _mode: PromptMode,
+    ) -> Result<Vec<HostIdentityContextCandidate>, HostIdentityContextBuildError> {
+        let actor = run_context
+            .actor()
+            .ok_or(HostIdentityContextBuildError::SourceUnavailable)?;
+        let user_id = actor.user_id.as_str().to_string();
+        {
+            let mut seen = self.seen_users.lock().expect("identity source lock");
+            if !seen.contains(&user_id) {
+                seen.push(user_id.clone());
+            }
+        }
+        for _ in 0..50 {
+            if let Some(entry) = self.identity_for_user(&user_id) {
+                return Ok(vec![entry.candidate]);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        Err(HostIdentityContextBuildError::SourceUnavailable)
+    }
+
+    async fn resolve_identity_message_content(
+        &self,
+        run_context: &LoopRunContext,
+        message_ref: &LoopMessageRef,
+    ) -> Result<Option<HostIdentityMessageContent>, HostIdentityContextBuildError> {
+        let actor = run_context
+            .actor()
+            .ok_or(HostIdentityContextBuildError::SourceUnavailable)?;
+        let _ = (actor, message_ref);
+        Ok(None)
+    }
+}

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -147,6 +147,7 @@ pub struct SubmittedTurn {
     pub thread_id: ThreadId,
     pub thread_scope: ThreadScope,
     pub scope: TurnScope,
+    pub actor: TurnActor,
 }
 
 #[derive(Debug, Clone)]
@@ -224,6 +225,42 @@ impl RebornBinaryE2EHarness {
             capability_port,
             false,
             false,
+        )
+        .await
+    }
+
+    pub async fn with_model_gateway_identity_source_unscoped_worker(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        identity_context_source: Arc<dyn HostIdentityContextSource>,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_options_identity_source_trigger_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            false,
+            false,
+            ProductTriggerReason::DirectChat,
+            identity_context_source,
+        )
+        .await
+    }
+
+    pub async fn with_model_gateway_identity_source_unscoped_shared_worker(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        identity_context_source: Arc<dyn HostIdentityContextSource>,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_options_identity_source_trigger_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            false,
+            false,
+            ProductTriggerReason::BotMention,
+            identity_context_source,
         )
         .await
     }
@@ -316,12 +353,54 @@ impl RebornBinaryE2EHarness {
         accept_harness_blocked_evidence: bool,
         restrict_worker_to_initial_scope: bool,
     ) -> HarnessResult<Self> {
-        Self::with_model_gateway_capability_mode_and_worker_scope(
+        Self::with_model_gateway_options_identity_source_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            accept_harness_blocked_evidence,
+            restrict_worker_to_initial_scope,
+            Arc::new(EmptyIdentityContextSource),
+        )
+        .await
+    }
+
+    async fn with_model_gateway_options_identity_source_and_worker_scope(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        accept_harness_blocked_evidence: bool,
+        restrict_worker_to_initial_scope: bool,
+        identity_context_source: Arc<dyn HostIdentityContextSource>,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_options_identity_source_trigger_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            accept_harness_blocked_evidence,
+            restrict_worker_to_initial_scope,
+            ProductTriggerReason::DirectChat,
+            identity_context_source,
+        )
+        .await
+    }
+
+    async fn with_model_gateway_options_identity_source_trigger_and_worker_scope(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        accept_harness_blocked_evidence: bool,
+        restrict_worker_to_initial_scope: bool,
+        initial_trigger: ProductTriggerReason,
+        identity_context_source: Arc<dyn HostIdentityContextSource>,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_capability_mode_identity_source_trigger_and_worker_scope(
             conversation_id,
             model_gateway,
             HarnessCapabilityMode::Recording(capability_port),
             accept_harness_blocked_evidence,
             restrict_worker_to_initial_scope,
+            initial_trigger,
+            identity_context_source,
         )
         .await
     }
@@ -349,14 +428,61 @@ impl RebornBinaryE2EHarness {
         accept_harness_blocked_evidence: bool,
         restrict_worker_to_initial_scope: bool,
     ) -> HarnessResult<Self> {
+        Self::with_model_gateway_capability_mode_identity_source_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_mode,
+            accept_harness_blocked_evidence,
+            restrict_worker_to_initial_scope,
+            Arc::new(EmptyIdentityContextSource),
+        )
+        .await
+    }
+
+    async fn with_model_gateway_capability_mode_identity_source_and_worker_scope(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_mode: HarnessCapabilityMode,
+        accept_harness_blocked_evidence: bool,
+        restrict_worker_to_initial_scope: bool,
+        identity_context_source: Arc<dyn HostIdentityContextSource>,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_capability_mode_identity_source_trigger_and_worker_scope(
+            conversation_id,
+            model_gateway,
+            capability_mode,
+            accept_harness_blocked_evidence,
+            restrict_worker_to_initial_scope,
+            ProductTriggerReason::DirectChat,
+            identity_context_source,
+        )
+        .await
+    }
+
+    async fn with_model_gateway_capability_mode_identity_source_trigger_and_worker_scope(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_mode: HarnessCapabilityMode,
+        accept_harness_blocked_evidence: bool,
+        restrict_worker_to_initial_scope: bool,
+        initial_trigger: ProductTriggerReason,
+        identity_context_source: Arc<dyn HostIdentityContextSource>,
+    ) -> HarnessResult<Self> {
         let adapter = RebornTestProductAdapter::new("reborn-test", "install-1")?;
         let ingress = RebornTestIngress::new(adapter);
         let product_harness = RebornProductWorkflowHarness::filesystem_temp(product_scope())?;
         let binding = product_harness
             .binding_service()?
-            .resolve_binding(binding_request(&ingress, conversation_id)?)
+            .resolve_binding(binding_request_with_trigger(
+                &ingress,
+                conversation_id,
+                initial_trigger,
+            )?)
             .await?;
-        let thread_scope = thread_scope_from_binding(&binding)?;
+        let thread_scope = thread_scope_from_binding_with_route_kind(
+            &binding,
+            route_kind_for_trigger(initial_trigger),
+        )?;
         let turn_scope = TurnScope::new(
             binding.tenant_id.clone(),
             binding.agent_id.clone(),
@@ -409,7 +535,7 @@ impl RebornBinaryE2EHarness {
             cancellation_factory: None,
             skill_context_source: None,
             input_queue: None,
-            identity_context_source: Arc::new(EmptyIdentityContextSource),
+            identity_context_source,
             model_policy_guard: None,
             model_budget_accountant: None,
             safety_context: None,
@@ -516,9 +642,31 @@ impl RebornBinaryE2EHarness {
         event_id: &str,
         text: &str,
     ) -> HarnessResult<SubmittedTurn> {
-        let envelope =
-            self.ingress
-                .verified_text_envelope(event_id, actor_id, conversation_id, text)?;
+        self.submit_text_for_with_trigger(
+            conversation_id,
+            actor_id,
+            event_id,
+            text,
+            ProductTriggerReason::DirectChat,
+        )
+        .await
+    }
+
+    pub async fn submit_text_for_with_trigger(
+        &self,
+        conversation_id: &str,
+        actor_id: &str,
+        event_id: &str,
+        text: &str,
+        trigger: ProductTriggerReason,
+    ) -> HarnessResult<SubmittedTurn> {
+        let envelope = self.ingress.verified_text_envelope_with_trigger(
+            event_id,
+            actor_id,
+            conversation_id,
+            text,
+            trigger,
+        )?;
         let binding_request = binding_request_from_envelope(&envelope);
         let route_kind = binding_request.route_kind;
         let binding = self
@@ -533,6 +681,7 @@ impl RebornBinaryE2EHarness {
             binding.project_id.clone(),
             binding.thread_id.clone(),
         );
+        let actor = TurnActor::new(binding.user_id.clone());
         let ack = self.workflow.accept_inbound(envelope).await?;
         let run_id = match &ack {
             ProductInboundAck::Accepted {
@@ -548,6 +697,7 @@ impl RebornBinaryE2EHarness {
             thread_id: binding.thread_id,
             thread_scope,
             scope: turn_scope,
+            actor,
         })
     }
 
@@ -1466,8 +1616,21 @@ fn binding_request(
     ingress: &RebornTestIngress,
     conversation_id: &str,
 ) -> HarnessResult<ResolveBindingRequest> {
-    let envelope =
-        ingress.verified_text_envelope("binding-probe", "alice", conversation_id, "hi")?;
+    binding_request_with_trigger(ingress, conversation_id, ProductTriggerReason::DirectChat)
+}
+
+fn binding_request_with_trigger(
+    ingress: &RebornTestIngress,
+    conversation_id: &str,
+    trigger: ProductTriggerReason,
+) -> HarnessResult<ResolveBindingRequest> {
+    let envelope = ingress.verified_text_envelope_with_trigger(
+        "binding-probe",
+        "alice",
+        conversation_id,
+        "hi",
+        trigger,
+    )?;
     Ok(binding_request_from_envelope(&envelope))
 }
 

--- a/tests/support/reborn/session_thread.rs
+++ b/tests/support/reborn/session_thread.rs
@@ -120,7 +120,10 @@ fn scoped_threads_fs_at<F>(
 where
     F: RootFilesystem,
 {
-    let user_id = scope.to_resource_scope().user_id;
+    let user_id = scope
+        .owner_user_id
+        .as_ref()
+        .map_or("_system", |user_id| user_id.as_str());
     let target = format!(
         "/engine/tenants/{}/users/{}/threads",
         scope.tenant_id, user_id

--- a/tests/support/reborn/test_adapter.rs
+++ b/tests/support/reborn/test_adapter.rs
@@ -37,11 +37,28 @@ impl RebornTestProductAdapter {
         thread_id: &str,
         text: &str,
     ) -> Result<Vec<u8>, ProductAdapterError> {
+        Self::text_payload_with_trigger(
+            event_id,
+            user_id,
+            thread_id,
+            text,
+            ProductTriggerReason::DirectChat,
+        )
+    }
+
+    pub fn text_payload_with_trigger(
+        event_id: &str,
+        user_id: &str,
+        thread_id: &str,
+        text: &str,
+        trigger: ProductTriggerReason,
+    ) -> Result<Vec<u8>, ProductAdapterError> {
         serde_json::to_vec(&RebornTestInboundPayload {
             event_id,
             user_id,
             thread_id,
             text,
+            trigger,
         })
         .map_err(|error| ProductAdapterError::MalformedInboundPayload {
             reason: ironclaw_product_adapters::RedactedString::new(error.to_string()),
@@ -101,7 +118,7 @@ impl ProductAdapter for RebornTestProductAdapter {
             ProductInboundPayload::UserMessage(UserMessagePayload::new(
                 payload.text,
                 Vec::new(),
-                ProductTriggerReason::DirectChat,
+                payload.trigger,
             )?),
         )
     }
@@ -148,8 +165,27 @@ impl RebornTestIngress {
         thread_id: &str,
         text: &str,
     ) -> Result<ProductInboundEnvelope, ProductAdapterError> {
+        self.verified_text_envelope_with_trigger(
+            event_id,
+            user_id,
+            thread_id,
+            text,
+            ProductTriggerReason::DirectChat,
+        )
+    }
+
+    pub fn verified_text_envelope_with_trigger(
+        &self,
+        event_id: &str,
+        user_id: &str,
+        thread_id: &str,
+        text: &str,
+        trigger: ProductTriggerReason,
+    ) -> Result<ProductInboundEnvelope, ProductAdapterError> {
         let evidence = ProtocolAuthEvidence::test_verified(AuthRequirement::BearerToken, user_id);
-        let raw = RebornTestProductAdapter::text_payload(event_id, user_id, thread_id, text)?;
+        let raw = RebornTestProductAdapter::text_payload_with_trigger(
+            event_id, user_id, thread_id, text, trigger,
+        )?;
         let parsed = self.adapter.parse_inbound(&raw, &evidence)?;
         let context = TrustedInboundContext::from_verified_evidence(
             self.adapter.adapter_id().clone(),
@@ -175,6 +211,7 @@ struct RebornTestInboundPayload<'a> {
     user_id: &'a str,
     thread_id: &'a str,
     text: &'a str,
+    trigger: ProductTriggerReason,
 }
 
 #[derive(Debug, Deserialize)]
@@ -183,4 +220,5 @@ struct OwnedRebornTestInboundPayload {
     user_id: String,
     thread_id: String,
     text: String,
+    trigger: ProductTriggerReason,
 }


### PR DESCRIPTION
## Summary
- add optional canonical actor propagation from `TurnRunState` into `LoopRunContext`
- add a Reborn binary-E2E identity prompt isolation test using an injected test-only `HostIdentityContextSource`
- extend the Reborn harness/test adapter to support trigger-specific submissions so shared conversation threads can exercise two canonical users in one harness
- keep direct loop/context/model ports behind `HostIdentityContextSource`; no production memory-backed identity adapter in this PR

## Contract changes
- `LoopRunContext` now carries optional `actor: Option<TurnActor>` with serde default/skip for compatibility
- `TurnRunState` now carries optional `actor: Option<TurnActor>` with serde default/skip for compatibility
- Reborn host factory propagates claimed run actor into `LoopRunContext` when present

## Boundary notes
- no `ironclaw_host_runtime -> ironclaw_loop_support` dependency added
- no `ironclaw_memory` dependency on loop abstractions added
- test source uses summary-only identity candidates; production userland/memory-backed identity source remains follow-up

## Validation
- `cargo test -p ironclaw_turns`
- `cargo test -p ironclaw_loop_support`
- `cargo test --features libsql --test reborn_identity_prompt_scope_isolation_parity reborn_identity_prompt_scope_isolation_parity -- --nocapture`
- `cargo test --features libsql --test reborn_thread_binding_isolation_parity reborn_thread_binding_isolation_parity -- --nocapture`
- `cargo test --features libsql --test support_unit_tests test_adapter -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Stacked on #3793.
