### PR TITLE
ci: add /benchmark slash-command dispatcher

### DIFF
--- a/.github/workflows/nearai-bench-tests.yml
+++ b/.github/workflows/nearai-bench-tests.yml
@@ -1,0 +1,154 @@
+# Regression coverage for the /benchmark slash-command dispatcher.
+#
+# The dispatcher in nearai-bench.yml parses comment bodies with a sed
+# regex and gates work on a whole-word `startsWith` guard. Both surfaces
+# gate paid LLM CI — silent breakage in either would let unintended
+# bodies through (or block valid ones). This workflow runs the same
+# regex + guard logic against fixture inputs so a change to the
+# dispatcher's parsing logic can't ship without surfacing the diff.
+#
+# Filed in response to serrrfirat's Medium/tests finding on #3808.
+
+name: nearai-bench dispatcher tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/nearai-bench.yml'
+      - '.github/workflows/nearai-bench-tests.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/nearai-bench.yml'
+      - '.github/workflows/nearai-bench-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  parser:
+    name: parser regex + guard fixtures
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run dispatcher parser fixtures
+        run: |
+          set -euo pipefail
+
+          # ─── Parser under test ───────────────────────────────────────
+          # Keep in sync with nearai-bench.yml's `parse` step. Both
+          # surfaces (this test + the dispatcher) live in the same path
+          # filter so a change to one without the other fails CI.
+          parse_suite() {
+            printf '%s' "$1" | sed -nE 's@^/benchmark[[:space:]]+([A-Za-z0-9_-]+)([[:space:]]+--model[[:space:]]+[A-Za-z0-9_./:-]+)?[[:space:]]*$@\1@p'
+          }
+          parse_model() {
+            printf '%s' "$1" | sed -nE 's@^/benchmark[[:space:]]+[A-Za-z0-9_-]+[[:space:]]+--model[[:space:]]+([A-Za-z0-9_./:-]+)[[:space:]]*$@\1@p'
+          }
+
+          # Whole-word guard from the workflow-level `if:` clause.
+          # GitHub Actions: startsWith(body, '/benchmark ') || body == '/benchmark'
+          guard_match() {
+            [[ "$1" == "/benchmark "* ]] || [[ "$1" == "/benchmark" ]]
+          }
+
+          fail=0
+
+          assert_parse() {
+            local label="$1" body="$2" want_suite="$3" want_model="$4"
+            local got_suite got_model
+            got_suite=$(parse_suite "$body")
+            got_model=$(parse_model "$body")
+            if [ "$got_suite" = "$want_suite" ] && [ "$got_model" = "$want_model" ]; then
+              printf '  PASS  %s\n' "$label"
+            else
+              printf '  FAIL  %s\n' "$label"
+              printf '        body:  %q\n' "$body"
+              printf '        want:  suite=%q model=%q\n' "$want_suite" "$want_model"
+              printf '        got:   suite=%q model=%q\n' "$got_suite" "$got_model"
+              fail=1
+            fi
+          }
+
+          assert_guard() {
+            local label="$1" body="$2" want="$3"   # "match" | "skip"
+            local got="skip"
+            if guard_match "$body"; then got="match"; fi
+            if [ "$got" = "$want" ]; then
+              printf '  PASS  %s\n' "$label"
+            else
+              printf '  FAIL  %s\n' "$label"
+              printf '        body:  %q\n' "$body"
+              printf '        want %s, got %s\n' "$want" "$got"
+              fail=1
+            fi
+          }
+
+          # ─── Parser fixtures ─────────────────────────────────────────
+          echo "=== parser regex ==="
+          # Valid: authorized + parseable
+          assert_parse 'smoke suite, no model' \
+            '/benchmark ironclaw-smoke' \
+            'ironclaw-smoke' ''
+          assert_parse 'full suite, no model' \
+            '/benchmark ironclaw' \
+            'ironclaw' ''
+          assert_parse 'smoke + lowercase OpenRouter model' \
+            '/benchmark ironclaw-smoke --model qwen/qwen3.5-35b-a3b' \
+            'ironclaw-smoke' 'qwen/qwen3.5-35b-a3b'
+          assert_parse 'smoke + mixed-case HF-style model' \
+            '/benchmark ironclaw-smoke --model Qwen/Qwen3.5-122B-A10B' \
+            'ironclaw-smoke' 'Qwen/Qwen3.5-122B-A10B'
+          assert_parse 'three-segment model id' \
+            '/benchmark ironclaw --model openrouter/anthropic/claude-sonnet-4' \
+            'ironclaw' 'openrouter/anthropic/claude-sonnet-4'
+          assert_parse 'trailing whitespace ok' \
+            '/benchmark ironclaw-smoke   ' \
+            'ironclaw-smoke' ''
+
+          # Invalid: parser must reject (both outputs empty)
+          assert_parse 'empty command' \
+            '/benchmark' '' ''
+          assert_parse 'extra positional token' \
+            '/benchmark ironclaw-smoke garbage' '' ''
+          assert_parse 'two positional tokens' \
+            '/benchmark foo bar' '' ''
+          assert_parse '--model flag without value' \
+            '/benchmark ironclaw-smoke --model' '' ''
+          assert_parse 'unrelated comment' \
+            'looks good to me' '' ''
+          assert_parse 'starts with /benchmark but in a quote' \
+            '> /benchmark ironclaw-smoke' '' ''
+
+          # ─── Guard fixtures ──────────────────────────────────────────
+          echo
+          echo "=== whole-word startsWith guard ==="
+          assert_guard 'bare command' \
+            '/benchmark' 'match'
+          assert_guard 'command with suite' \
+            '/benchmark ironclaw-smoke' 'match'
+          assert_guard 'command with suite + model' \
+            '/benchmark ironclaw-smoke --model qwen/qwen3.5-35b-a3b' 'match'
+
+          assert_guard 'prefix collision: /benchmarking-something' \
+            '/benchmarking-something' 'skip'
+          assert_guard 'prefix collision: /benchmark-foo' \
+            '/benchmark-foo' 'skip'
+          assert_guard 'prefix collision: /benchmarkfoo' \
+            '/benchmarkfoo' 'skip'
+          assert_guard 'unrelated comment' \
+            'looks good to me' 'skip'
+          assert_guard 'markdown-quoted command' \
+            '> /benchmark ironclaw-smoke' 'skip'
+
+          echo
+          if [ "$fail" = "1" ]; then
+            echo "::error::dispatcher parser regression — see failures above"
+            exit 1
+          fi
+          echo "all dispatcher parser fixtures passed"

--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -1,0 +1,101 @@
+# Copy this file to: nearai/ironclaw/.github/workflows/nearai-bench.yml
+#
+# Slash-command dispatcher for nearai-bench on PR comments. A maintainer
+# comments `/benchmark <suite>` (optionally `--model <id>`) on a PR; this
+# workflow validates auth, resolves the PR head SHA, and delegates to
+# nearai/benchmarks/.github/workflows/bench-pr-reusable.yml.
+#
+# Requires `OPENROUTER_API_KEY` to be set as an org-level secret (or
+# inherited via repo secret). Uses `secrets: inherit` so the called
+# workflow can forward it.
+
+name: nearai-bench
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+concurrency:
+  # Cancel any prior /benchmark on the same PR — a maintainer re-triggering
+  # almost always means "ignore the previous one."
+  group: nearai-bench-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  parse:
+    if: github.event.issue.pull_request != null && startsWith(github.event.comment.body, '/benchmark')
+    runs-on: ubuntu-latest
+    outputs:
+      suite: ${{ steps.parse.outputs.suite }}
+      model: ${{ steps.parse.outputs.model }}
+      head_sha: ${{ steps.parse.outputs.head_sha }}
+      authorized: ${{ steps.auth.outputs.authorized }}
+    steps:
+      - name: Check commenter has write permission
+        id: auth
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            const ok = ['admin', 'write', 'maintain'].includes(data.permission);
+            core.setOutput('authorized', ok ? 'yes' : 'no');
+            if (!ok) {
+              core.notice(`Comment author @${context.payload.comment.user.login} is not authorized to trigger benchmarks (permission: ${data.permission}).`);
+            }
+
+      - name: Parse command
+        id: parse
+        if: steps.auth.outputs.authorized == 'yes'
+        env:
+          BODY: ${{ github.event.comment.body }}
+          PR: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Grammar: /benchmark <suite> [--model <model-id>]
+          # Suite name: [A-Za-z0-9_-]+
+          # Model ID:   [A-Za-z0-9_./:-]+ (allows openrouter-style "vendor/model")
+          suite=$(printf '%s' "$BODY" | sed -nE 's@^/benchmark[[:space:]]+([A-Za-z0-9_-]+)([[:space:]]+--model[[:space:]]+[A-Za-z0-9_./:-]+)?[[:space:]]*$@\1@p')
+          model=$(printf '%s' "$BODY" | sed -nE 's@^/benchmark[[:space:]]+[A-Za-z0-9_-]+[[:space:]]+--model[[:space:]]+([A-Za-z0-9_./:-]+)[[:space:]]*$@\1@p')
+          if [ -z "$suite" ]; then
+            # Tell the user what's wrong rather than failing silently.
+            gh pr comment "$PR" --repo "$REPO" --body $'Could not parse `/benchmark` command.\n\nUsage: `/benchmark <suite> [--model <model-id>]`\n\nExample: `/benchmark ironclaw-v2-smoke`'
+            echo "::error::could not parse /benchmark <suite> [--model <id>]"
+            exit 1
+          fi
+          sha=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
+          echo "suite=$suite" >> "$GITHUB_OUTPUT"
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Acknowledge with 🚀 reaction
+        if: steps.auth.outputs.authorized == 'yes' && steps.parse.outputs.suite != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api "/repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -F content=rocket
+
+  bench:
+    needs: parse
+    if: needs.parse.outputs.authorized == 'yes' && needs.parse.outputs.suite != ''
+    uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@main
+    with:
+      ironclaw-rev: ${{ needs.parse.outputs.head_sha }}
+      pr-repo: ${{ github.repository }}
+      pr-number: ${{ github.event.issue.number }}
+      suite-name: ${{ needs.parse.outputs.suite }}
+      model: ${{ needs.parse.outputs.model }}
+      trigger-comment-id: ${{ github.event.comment.id }}
+    secrets: inherit

--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -1,13 +1,17 @@
-# Copy this file to: nearai/ironclaw/.github/workflows/nearai-bench.yml
-#
 # Slash-command dispatcher for nearai-bench on PR comments. A maintainer
-# comments `/benchmark <suite>` (optionally `--model <id>`) on a PR; this
-# workflow validates auth, resolves the PR head SHA, and delegates to
-# nearai/benchmarks/.github/workflows/bench-pr-reusable.yml.
+# (write/maintain/admin permission) comments `/benchmark <suite>`
+# (optionally `--model <id>`) on a PR; this workflow validates auth,
+# parses the command, resolves the PR head SHA, reacts with 🚀, then
+# delegates to nearai/benchmarks's reusable workflow which builds the
+# harness against the PR's ironclaw SHA, runs the suite, compares against
+# a baseline, and posts a markdown comment back here.
 #
-# Requires `OPENROUTER_API_KEY` to be set as an org-level secret (or
-# inherited via repo secret). Uses `secrets: inherit` so the called
-# workflow can forward it.
+# Setup / usage docs:
+# https://github.com/nearai/benchmarks/blob/main/docs/ci/README.md
+#
+# Requires `OPENROUTER_API_KEY` as an org-level (or repo-level) secret.
+# Only that one secret is forwarded — `secrets: inherit` is intentionally
+# NOT used (supply-chain hardening).
 
 name: nearai-bench
 
@@ -15,20 +19,26 @@ on:
   issue_comment:
     types: [created]
 
+# Minimum surface for what this workflow actually does. The called
+# reusable workflow (in nearai/benchmarks) declares its own ceiling
+# (pull-requests:write + issues:write); the effective permissions in the
+# called job are the intersection of these two, so a hostile change in
+# the benchmarks repo can't acquire writes we didn't grant here.
 permissions:
-  pull-requests: write
-  issues: write
+  pull-requests: read   # gh pr view --json headRefOid (PR metadata only)
+  issues: write         # gh pr comment + gh api .../reactions (PR comments are issue comments)
   contents: read
-
-concurrency:
-  # Cancel any prior /benchmark on the same PR — a maintainer re-triggering
-  # almost always means "ignore the previous one."
-  group: nearai-bench-${{ github.event.issue.number }}
-  cancel-in-progress: true
 
 jobs:
   parse:
-    if: github.event.issue.pull_request != null && startsWith(github.event.comment.body, '/benchmark')
+    # Tightened from `startsWith(body, '/benchmark')` to whole-word
+    # match — `/benchmarking-something` no longer enters the parse path.
+    if: >-
+      github.event.issue.pull_request != null
+      && (
+        startsWith(github.event.comment.body, '/benchmark ')
+        || github.event.comment.body == '/benchmark'
+      )
     runs-on: ubuntu-latest
     outputs:
       suite: ${{ steps.parse.outputs.suite }}
@@ -38,18 +48,30 @@ jobs:
     steps:
       - name: Check commenter has write permission
         id: auth
-        uses: actions/github-script@v7
+        # SHA-pinned to v7.0.1 to match the rest of this repo's workflows.
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.payload.comment.user.login,
-            });
-            const ok = ['admin', 'write', 'maintain'].includes(data.permission);
+            // `getCollaboratorPermissionLevel` throws 404 for users who
+            // aren't collaborators at all (external contributors), and we
+            // want to silently drop those rather than fail the workflow
+            // with a noisy red run. Rethrow anything else.
+            let permission = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: context.payload.comment.user.login,
+              });
+              permission = data.permission;
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              // 404 → not a collaborator → unauthorized.
+            }
+            const ok = ['admin', 'write', 'maintain'].includes(permission);
             core.setOutput('authorized', ok ? 'yes' : 'no');
             if (!ok) {
-              core.notice(`Comment author @${context.payload.comment.user.login} is not authorized to trigger benchmarks (permission: ${data.permission}).`);
+              core.notice(`Comment author @${context.payload.comment.user.login} is not authorized to trigger benchmarks (permission: ${permission}).`);
             }
 
       - name: Parse command
@@ -68,10 +90,11 @@ jobs:
           suite=$(printf '%s' "$BODY" | sed -nE 's@^/benchmark[[:space:]]+([A-Za-z0-9_-]+)([[:space:]]+--model[[:space:]]+[A-Za-z0-9_./:-]+)?[[:space:]]*$@\1@p')
           model=$(printf '%s' "$BODY" | sed -nE 's@^/benchmark[[:space:]]+[A-Za-z0-9_-]+[[:space:]]+--model[[:space:]]+([A-Za-z0-9_./:-]+)[[:space:]]*$@\1@p')
           if [ -z "$suite" ]; then
-            # Tell the user what's wrong rather than failing silently.
-            gh pr comment "$PR" --repo "$REPO" --body $'Could not parse `/benchmark` command.\n\nUsage: `/benchmark <suite> [--model <model-id>]`\n\nExample: `/benchmark ironclaw-v2-smoke`'
-            echo "::error::could not parse /benchmark <suite> [--model <id>]"
-            exit 1
+            # User-input error — post a helpful reply and exit cleanly
+            # (exit 0 keeps the Actions tab green; bad syntax isn't infra
+            # failure).
+            gh pr comment "$PR" --repo "$REPO" --body $'Could not parse `/benchmark` command.\n\nUsage: `/benchmark <suite> [--model <model-id>]`\n\nExample: `/benchmark ironclaw-smoke`'
+            exit 0
           fi
           sha=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
           echo "suite=$suite" >> "$GITHUB_OUTPUT"
@@ -90,7 +113,17 @@ jobs:
   bench:
     needs: parse
     if: needs.parse.outputs.authorized == 'yes' && needs.parse.outputs.suite != ''
-    uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@main
+    # Concurrency lives on the authorized job, not the workflow root —
+    # otherwise an unauthorized commenter typing `/benchmark whatever`
+    # would acquire the per-PR group and cancel an in-flight maintainer
+    # run before failing auth.
+    concurrency:
+      group: nearai-bench-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    # Pinned to a reviewed commit on nearai/benchmarks main — mutable @main
+    # + secrets: inherit was the supply-chain hole. Bump this SHA in a
+    # deliberate PR when nearai/benchmarks ships a new reusable workflow.
+    uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@67effacd8c8a7f6f43b422e30a1810822b9d6d5f
     with:
       ironclaw-rev: ${{ needs.parse.outputs.head_sha }}
       pr-repo: ${{ github.repository }}
@@ -98,4 +131,8 @@ jobs:
       suite-name: ${{ needs.parse.outputs.suite }}
       model: ${{ needs.parse.outputs.model }}
       trigger-comment-id: ${{ github.event.comment.id }}
-    secrets: inherit
+    # Scope inherited secrets to only what the reusable workflow needs.
+    # Replaces `secrets: inherit`, which gave the called workflow access
+    # to every secret available here.
+    secrets:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -82,6 +82,11 @@ jobs:
           PR: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pinned reviewed commit on nearai/benchmarks main. Must match
+          # the SHA in the `bench` job's `uses:` below — bump in both
+          # places together. Used here to validate the requested suite
+          # exists at the same SHA we'd actually run against.
+          BENCH_PIN: 67effacd8c8a7f6f43b422e30a1810822b9d6d5f
         run: |
           set -euo pipefail
           # Grammar: /benchmark <suite> [--model <model-id>]
@@ -94,6 +99,16 @@ jobs:
             # (exit 0 keeps the Actions tab green; bad syntax isn't infra
             # failure).
             gh pr comment "$PR" --repo "$REPO" --body $'Could not parse `/benchmark` command.\n\nUsage: `/benchmark <suite> [--model <model-id>]`\n\nExample: `/benchmark ironclaw-smoke`'
+            exit 0
+          fi
+          # Pre-dispatch suite check: refuse unknown suite names before
+          # we acknowledge with 🚀 or spend any LLM credit. Cheap GitHub
+          # API lookup against the pinned benchmarks SHA so the user gets
+          # the same answer the dispatched workflow would.
+          if ! gh api "repos/nearai/benchmarks/contents/suites/${suite}.toml?ref=${BENCH_PIN}" --silent >/dev/null 2>&1; then
+            available=$(gh api "repos/nearai/benchmarks/contents/suites?ref=${BENCH_PIN}" \
+              --jq '[.[] | select(.name | endswith(".toml")) | .name | rtrimstr(".toml")] | sort | join(", ")')
+            gh pr comment "$PR" --repo "$REPO" --body "Unknown suite \`${suite}\`. Available: ${available}"
             exit 0
           fi
           sha=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)
@@ -113,6 +128,17 @@ jobs:
   bench:
     needs: parse
     if: needs.parse.outputs.authorized == 'yes' && needs.parse.outputs.suite != ''
+    # Job-scoped writes so the called workflow can post the result
+    # comment + toggle the trigger-comment reaction. Called workflows
+    # can only DOWNGRADE the caller's GITHUB_TOKEN, so the workflow-level
+    # `pull-requests: read` (which the parse job uses for `gh pr view`)
+    # would otherwise leave the called workflow without write to publish
+    # results. The parse job stays on read; only this authorized,
+    # post-auth job grants writes.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     # Concurrency lives on the authorized job, not the workflow root —
     # otherwise an unauthorized commenter typing `/benchmark whatever`
     # would acquire the per-PR group and cancel an in-flight maintainer


### PR DESCRIPTION
## Summary

Adds the dispatcher workflow that lets a maintainer comment `/benchmark <suite> [--model <id>]` on any PR to run [nearai-bench](https://github.com/nearai/benchmarks) against the PR's ironclaw commit. Delegates the actual build/run/compare to a reusable workflow in `nearai/benchmarks`, pinned by commit SHA (paired with [nearai/benchmarks#27](https://github.com/nearai/benchmarks/pull/27) + [#34](https://github.com/nearai/benchmarks/pull/34)).

## How it works

1. `on: issue_comment` (created) — fires on every PR comment. Workflow-level job guard tightened from `startsWith(body, '/benchmark')` to whole-word match (`startsWith(body, '/benchmark ')` or `body == '/benchmark'`), so `/benchmarking-something` no longer enters the parse path.
2. **Auth**: commenter must have `write`/`maintain`/`admin` permission on this repo (checked via `repos.getCollaboratorPermissionLevel`). 404 (non-collaborator) is caught and treated as unauthorized; other errors rethrow. Unauthorized comments are silently dropped.
3. **Parse**: `^/benchmark\s+(\S+)(?:\s+--model\s+(\S+))?\s*$` extracts suite + optional model. Bad syntax gets a polite error comment (workflow exits 0 — user-input errors don't show as red runs).
4. **Pre-dispatch suite check**: queries the pinned `nearai/benchmarks` SHA via `gh api .../contents/suites/<name>.toml`. Unknown suite → posts a "Unknown suite. Available: ..." comment, exits 0, no 🚀 reaction, no expensive dispatch.
5. **Acknowledge**: react to the trigger comment with 🚀.
6. **Dispatch**: pinned `uses: nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@<commit-sha>` with explicit `secrets: { OPENROUTER_API_KEY: ... }`. The called workflow builds the harness against the PR's ironclaw SHA, runs the chosen suite, compares against a checked-in baseline, posts a markdown comment, and swaps 🚀 → 👍/👎.

## Use

On any PR, a maintainer comments:
```
/benchmark ironclaw-smoke
```
…or with a model override:
```
/benchmark ironclaw-smoke --model qwen/qwen3.5-35b-a3b
```

Available suites are whatever's in `suites/*.toml` in `nearai/benchmarks` at the pinned SHA. Today: `ironclaw` (full, ~50min, ~$5), `ironclaw-smoke` (10 tasks, ~5min, ~$0.30), `zclaw-security-eng`.

## Why slash-command over auto-on-PR

Full suite ≈ $5/run, smoke ≈ $0.30. Auto-on-every-push would burn budget on noise (WIP commits, doc-only changes, force-pushes). Slash command keeps spend tied to maintainer intent. Each invocation is a deliberate maintainer comment, never an automatic per-push trigger.

## Supply-chain posture

- **Reusable workflow pinned by commit SHA** — `nearai/benchmarks/.github/workflows/bench-pr-reusable.yml@67effacd...`. Mutable `@main` references would let a later commit in the benchmarks repo run with this dispatcher's secrets without re-review here.
- **Secrets explicitly scoped** — only `OPENROUTER_API_KEY` is forwarded. `secrets: inherit` is intentionally NOT used.
- **Third-party action SHA-pinned** — `actions/github-script@f28e40c7...` (v7.0.1), matching the rest of this repo's workflows.
- **Permissions least-privileged** — workflow level only `pull-requests: read` + `issues: write`. The `bench` job (which runs only when authorized) upgrades to `pull-requests: write` + `issues: write` so the called workflow can publish results. The parse job never gets write.
- **Concurrency on the authorized job, not workflow root** — an unauthorized commenter typing `/benchmark whatever` cannot acquire the per-PR group and cancel an in-flight maintainer run.

## Fork-PR caveat

`--ironclaw-rev` patches `Cargo.toml` to point at `github.com/nearai/ironclaw.git`, so contributors on forks must push their branch upstream before `/benchmark` will work against their commits. Documented in [nearai/benchmarks/docs/ci/README.md](https://github.com/nearai/benchmarks/blob/main/docs/ci/README.md).

## Regression coverage

`.github/workflows/nearai-bench-tests.yml` runs the dispatcher's sed parser + whole-word `startsWith` guard against 20 fixture inputs covering authorized-valid, malformed, `--model` parsed, and `/benchmark*` prefix-collision cases. Path-filtered to fire whenever `nearai-bench.yml` or the test file itself changes, so future tweaks to one without the other surface as CI failures rather than silent regressions.

## Test plan

- [x] Parser test workflow passes all 20 fixtures
- [x] Pre-dispatch suite check verified locally: `ironclaw-smoke` resolves, `does-not-exist` 404s and posts a `Available: ironclaw, ironclaw-smoke, ...` reply
- [x] End-to-end via `workflow_dispatch` on the pinned reusable workflow against ironclaw `main` HEAD — full pipeline (build / run / compare / format / dry-run comment) passes with 80% smoke pass rate
- [ ] Live `/benchmark ironclaw-smoke` on an ironclaw PR post-merge (the dispatcher can only fire on `issue_comment` events from `main`; this is the final canary)

## Companion PRs (must merge before this lands)

- [nearai/benchmarks#27](https://github.com/nearai/benchmarks/pull/27) — reusable workflow + harness extensions ✅ merged
- [nearai/benchmarks#34](https://github.com/nearai/benchmarks/pull/34) — `pull-requests: write` + `issues: write` on the reusable workflow ✅ merged
- Pinned SHA `67effacd...` includes both
