### PR TITLE
test(reborn): cover tenant binding isolation

### DIFF
--- a/tests/reborn_adapter_installation_scope_isolation_parity.rs
+++ b/tests/reborn_adapter_installation_scope_isolation_parity.rs
@@ -1,0 +1,140 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_loop_support::HostManagedModelResponse;
+use ironclaw_threads::{MessageKind, MessageStatus, ThreadMessageRecord};
+use ironclaw_turns::TurnStatus;
+use reborn_support::harness::{
+    RebornBinaryE2EHarness, RebornHarnessSharedStorage, RecordingTestCapabilityPort,
+    test_product_scope,
+};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+
+#[tokio::test]
+async fn reborn_adapter_installation_scope_isolation_parity() {
+    const ROOM: &str = "room-installation-shared";
+    const EVENT: &str = "event-installation-shared";
+
+    let shared_storage = RebornHarnessSharedStorage::new().expect("shared storage");
+    let scope = test_product_scope(
+        "tenant-install-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-e2e"),
+    );
+
+    let mut install_a = RebornBinaryE2EHarness::with_model_gateway_scope_installation_shared_storage_unscoped_worker(
+        ROOM,
+        RebornTraceReplayModelGateway::with_responses([HostManagedModelResponse::assistant_reply(
+            "installation alpha isolated reply",
+        )]),
+        RecordingTestCapabilityPort::echo(),
+        scope.clone(),
+        "reborn-test",
+        "install-alpha",
+        shared_storage.clone(),
+    )
+    .await
+    .expect("install A harness");
+    let mut install_b = RebornBinaryE2EHarness::with_model_gateway_scope_installation_shared_storage_unscoped_worker(
+        ROOM,
+        RebornTraceReplayModelGateway::with_responses([HostManagedModelResponse::assistant_reply(
+            "installation beta isolated reply",
+        )]),
+        RecordingTestCapabilityPort::echo(),
+        scope,
+        "reborn-test",
+        "install-beta",
+        shared_storage,
+    )
+    .await
+    .expect("install B harness");
+
+    install_a.start();
+    install_b.start();
+
+    let alpha = install_a
+        .submit_text_for(ROOM, "alice", EVENT, "installation alpha turn")
+        .await
+        .expect("submit installation alpha turn");
+    install_a
+        .wait_for_submitted_status(&alpha, TurnStatus::Completed)
+        .await
+        .expect("install alpha completed");
+
+    let beta = install_b
+        .submit_text_for(ROOM, "alice", EVENT, "installation beta turn")
+        .await
+        .expect("submit installation beta turn with same external event id");
+    install_b
+        .wait_for_submitted_status(&beta, TurnStatus::Completed)
+        .await
+        .expect("install beta completed");
+
+    assert_ne!(
+        alpha.thread_id, beta.thread_id,
+        "same external conversation under different adapter installations must bind to distinct threads"
+    );
+    assert_ne!(
+        alpha.run_id, beta.run_id,
+        "same external event id under different adapter installations must not replay the same run"
+    );
+
+    let alpha_history = install_a
+        .history_for_submitted_thread(&alpha)
+        .await
+        .expect("install alpha history");
+    let beta_history = install_b
+        .history_for_submitted_thread(&beta)
+        .await
+        .expect("install beta history");
+
+    assert_history_contains_user(&alpha_history, "installation alpha turn");
+    assert_history_contains_assistant(&alpha_history, "installation alpha isolated reply");
+    assert_history_excludes(&alpha_history, "installation beta turn");
+    assert_history_excludes(&alpha_history, "installation beta isolated reply");
+
+    assert_history_contains_user(&beta_history, "installation beta turn");
+    assert_history_contains_assistant(&beta_history, "installation beta isolated reply");
+    assert_history_excludes(&beta_history, "installation alpha turn");
+    assert_history_excludes(&beta_history, "installation alpha isolated reply");
+
+    install_a.assert_model_exhausted();
+    install_b.assert_model_exhausted();
+
+    install_a.shutdown().await;
+    install_b.shutdown().await;
+}
+
+fn assert_history_contains_user(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::User
+                && message.status == MessageStatus::Submitted
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain submitted user message {text:?}"
+    );
+}
+
+fn assert_history_contains_assistant(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::Assistant
+                && message.status == MessageStatus::Finalized
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain finalized assistant reply {text:?}"
+    );
+}
+
+fn assert_history_excludes(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .all(|message| message.content.as_deref() != Some(text)),
+        "thread history should not contain message from another adapter installation: {text:?}"
+    );
+}

--- a/tests/reborn_direct_chat_user_scope_isolation_parity.rs
+++ b/tests/reborn_direct_chat_user_scope_isolation_parity.rs
@@ -1,0 +1,145 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_loop_support::HostManagedModelResponse;
+use ironclaw_threads::{MessageKind, MessageStatus, ThreadMessageRecord};
+use ironclaw_turns::TurnStatus;
+use reborn_support::harness::{
+    RebornBinaryE2EHarness, RebornHarnessSharedStorage, RecordingTestCapabilityPort,
+    test_product_scope,
+};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+
+#[tokio::test]
+async fn reborn_direct_chat_user_scope_isolation_parity() {
+    const DIRECT_ROOM: &str = "room-direct-user-shared-id";
+
+    let shared_storage = RebornHarnessSharedStorage::new().expect("shared storage");
+    let scope = test_product_scope(
+        "tenant-direct-user-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-e2e"),
+    );
+
+    let mut alice_harness = RebornBinaryE2EHarness::with_model_gateway_scope_initial_actor_installation_shared_storage_unscoped_worker(
+        DIRECT_ROOM,
+        "alice",
+        RebornTraceReplayModelGateway::with_responses([HostManagedModelResponse::assistant_reply(
+            "alice direct isolated reply",
+        )]),
+        RecordingTestCapabilityPort::echo(),
+        scope.clone(),
+        "reborn-test",
+        "install-1",
+        shared_storage.clone(),
+    )
+    .await
+    .expect("alice harness");
+    let mut bob_harness = RebornBinaryE2EHarness::with_model_gateway_scope_initial_actor_installation_shared_storage_unscoped_worker(
+        DIRECT_ROOM,
+        "bob",
+        RebornTraceReplayModelGateway::with_responses([HostManagedModelResponse::assistant_reply(
+            "bob direct isolated reply",
+        )]),
+        RecordingTestCapabilityPort::echo(),
+        scope,
+        "reborn-test",
+        "install-1",
+        shared_storage,
+    )
+    .await
+    .expect("bob harness");
+
+    alice_harness.start();
+    bob_harness.start();
+
+    let alice = alice_harness
+        .submit_text_for(
+            DIRECT_ROOM,
+            "alice",
+            "event-direct-alice",
+            "alice direct turn",
+        )
+        .await
+        .expect("submit alice direct turn");
+    alice_harness
+        .wait_for_submitted_status(&alice, TurnStatus::Completed)
+        .await
+        .expect("alice completed");
+
+    let bob = bob_harness
+        .submit_text_for(DIRECT_ROOM, "bob", "event-direct-bob", "bob direct turn")
+        .await
+        .expect("submit bob direct turn");
+    bob_harness
+        .wait_for_submitted_status(&bob, TurnStatus::Completed)
+        .await
+        .expect("bob completed");
+
+    assert_ne!(
+        alice.thread_scope, bob.thread_scope,
+        "direct chat thread scopes must remain owner-user isolated"
+    );
+    assert_ne!(
+        alice.thread_scope.owner_user_id, bob.thread_scope.owner_user_id,
+        "direct chat owner user controls thread history isolation"
+    );
+
+    let alice_history = alice_harness
+        .history_for_submitted_thread(&alice)
+        .await
+        .expect("alice history");
+    let bob_history = bob_harness
+        .history_for_submitted_thread(&bob)
+        .await
+        .expect("bob history");
+
+    assert_history_contains_user(&alice_history, "alice direct turn");
+    assert_history_contains_assistant(&alice_history, "alice direct isolated reply");
+    assert_history_excludes(&alice_history, "bob direct turn");
+    assert_history_excludes(&alice_history, "bob direct isolated reply");
+
+    assert_history_contains_user(&bob_history, "bob direct turn");
+    assert_history_contains_assistant(&bob_history, "bob direct isolated reply");
+    assert_history_excludes(&bob_history, "alice direct turn");
+    assert_history_excludes(&bob_history, "alice direct isolated reply");
+
+    alice_harness.assert_model_exhausted();
+    bob_harness.assert_model_exhausted();
+    alice_harness.shutdown().await;
+    bob_harness.shutdown().await;
+}
+
+fn assert_history_contains_user(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::User
+                && message.status == MessageStatus::Submitted
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain submitted user message {text:?}"
+    );
+}
+
+fn assert_history_contains_assistant(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::Assistant
+                && message.status == MessageStatus::Finalized
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain finalized assistant reply {text:?}"
+    );
+}
+
+fn assert_history_excludes(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .all(|message| message.content.as_deref() != Some(text)),
+        "thread history should not contain message from another direct-chat user: {text:?}"
+    );
+}

--- a/tests/reborn_identity_tenant_scope_isolation_parity.rs
+++ b/tests/reborn_identity_tenant_scope_isolation_parity.rs
@@ -1,0 +1,255 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use std::{collections::HashMap, sync::Arc};
+
+use tokio::sync::RwLock;
+
+use async_trait::async_trait;
+use ironclaw_loop_support::{
+    HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
+    HostIdentityMessageContent, HostManagedModelMessageRole, HostManagedModelResponse,
+    IdentityApplicability, IdentityFileName,
+};
+use ironclaw_product_adapters::ProductTriggerReason;
+use ironclaw_turns::{
+    LoopMessageRef, TurnStatus,
+    run_profile::{LoopRunContext, PromptMode},
+};
+use reborn_support::harness::{
+    RebornBinaryE2EHarness, RebornHarnessSharedStorage, RecordingTestCapabilityPort,
+    test_product_scope,
+};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+
+const TENANT_ALPHA_IDENTITY: &str = "Alice alpha tenant identity: likes rust ferris.";
+const TENANT_BETA_IDENTITY: &str = "Alice beta tenant identity: likes neon orchids.";
+
+#[tokio::test]
+async fn reborn_identity_tenant_scope_isolation_parity() {
+    const ROOM: &str = "room-tenant-identity-shared";
+
+    let shared_storage = RebornHarnessSharedStorage::new().expect("shared storage");
+    let identity_source = Arc::new(TenantIdentitySource::default());
+    let tenant_alpha = test_product_scope(
+        "tenant-alpha-identity-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-e2e"),
+    );
+    let tenant_beta = test_product_scope(
+        "tenant-beta-identity-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-e2e"),
+    );
+
+    let mut alpha = RebornBinaryE2EHarness::with_model_gateway_scope_identity_source_trigger_installation_shared_storage_unscoped_worker(
+        ROOM,
+        RebornTraceReplayModelGateway::with_responses([HostManagedModelResponse::assistant_reply(
+            "tenant alpha identity reply",
+        )]),
+        RecordingTestCapabilityPort::echo(),
+        tenant_alpha,
+        identity_source.clone(),
+        ProductTriggerReason::DirectChat,
+        "reborn-test",
+        "install-1",
+        "alice",
+        shared_storage.clone(),
+    )
+    .await
+    .expect("tenant alpha harness");
+    let mut beta = RebornBinaryE2EHarness::with_model_gateway_scope_identity_source_trigger_installation_shared_storage_unscoped_worker(
+        ROOM,
+        RebornTraceReplayModelGateway::with_responses([HostManagedModelResponse::assistant_reply(
+            "tenant beta identity reply",
+        )]),
+        RecordingTestCapabilityPort::echo(),
+        tenant_beta,
+        identity_source.clone(),
+        ProductTriggerReason::DirectChat,
+        "reborn-test",
+        "install-1",
+        "alice",
+        shared_storage,
+    )
+    .await
+    .expect("tenant beta harness");
+
+    let alpha_turn = alpha
+        .submit_text_for(ROOM, "alice", "event-tenant-alpha-identity", "alpha asks")
+        .await
+        .expect("submit tenant alpha turn");
+    let beta_turn = beta
+        .submit_text_for(ROOM, "alice", "event-tenant-beta-identity", "beta asks")
+        .await
+        .expect("submit tenant beta turn");
+
+    identity_source
+        .set_identity(
+            alpha_turn.scope.tenant_id.as_str(),
+            alpha_turn.actor.user_id.as_str(),
+            TENANT_ALPHA_IDENTITY,
+        )
+        .await;
+    identity_source
+        .set_identity(
+            beta_turn.scope.tenant_id.as_str(),
+            beta_turn.actor.user_id.as_str(),
+            TENANT_BETA_IDENTITY,
+        )
+        .await;
+
+    alpha.start();
+    beta.start();
+
+    alpha
+        .wait_for_submitted_status(&alpha_turn, TurnStatus::Completed)
+        .await
+        .expect("tenant alpha completed");
+    beta.wait_for_submitted_status(&beta_turn, TurnStatus::Completed)
+        .await
+        .expect("tenant beta completed");
+
+    assert_ne!(
+        alpha_turn.scope.tenant_id, beta_turn.scope.tenant_id,
+        "test must exercise distinct tenant scopes"
+    );
+
+    let alpha_prompts: Vec<String> = alpha
+        .model_requests()
+        .iter()
+        .map(system_prompt_text)
+        .collect();
+    let beta_prompts: Vec<String> = beta
+        .model_requests()
+        .iter()
+        .map(system_prompt_text)
+        .collect();
+
+    assert_prompt_contains_only(
+        &alpha_prompts,
+        TENANT_ALPHA_IDENTITY,
+        TENANT_BETA_IDENTITY,
+        "tenant alpha",
+    );
+    assert_prompt_contains_only(
+        &beta_prompts,
+        TENANT_BETA_IDENTITY,
+        TENANT_ALPHA_IDENTITY,
+        "tenant beta",
+    );
+
+    let seen = identity_source.seen_keys().await;
+    assert!(seen.contains(&TenantIdentityKey::from_turn(&alpha_turn)));
+    assert!(seen.contains(&TenantIdentityKey::from_turn(&beta_turn)));
+
+    alpha.assert_model_exhausted();
+    beta.assert_model_exhausted();
+    alpha.shutdown().await;
+    beta.shutdown().await;
+}
+
+fn system_prompt_text(request: &ironclaw_loop_support::HostManagedModelRequest) -> String {
+    request
+        .messages
+        .iter()
+        .filter(|message| message.role == HostManagedModelMessageRole::System)
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn assert_prompt_contains_only(prompts: &[String], expected: &str, forbidden: &str, label: &str) {
+    assert!(
+        !prompts.is_empty()
+            && prompts
+                .iter()
+                .all(|prompt| prompt.contains(expected) && !prompt.contains(forbidden)),
+        "{label} prompt should contain only matching tenant identity; prompts={prompts:#?}"
+    );
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TenantIdentityKey {
+    tenant_id: String,
+    user_id: String,
+}
+
+impl TenantIdentityKey {
+    fn from_turn(turn: &reborn_support::harness::SubmittedTurn) -> Self {
+        Self {
+            tenant_id: turn.scope.tenant_id.as_str().to_string(),
+            user_id: turn.actor.user_id.as_str().to_string(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct TenantIdentitySource {
+    identities: RwLock<HashMap<TenantIdentityKey, HostIdentityContextCandidate>>,
+    seen: RwLock<Vec<TenantIdentityKey>>,
+}
+
+impl TenantIdentitySource {
+    async fn set_identity(&self, tenant_id: &str, user_id: &str, content: &str) {
+        let name = IdentityFileName::new("IDENTITY.md").expect("identity file name");
+        let candidate = HostIdentityContextCandidate::new_installed_summary_only(
+            name,
+            content.to_string(),
+            IdentityApplicability::Always,
+        );
+        self.identities.write().await.insert(
+            TenantIdentityKey {
+                tenant_id: tenant_id.to_string(),
+                user_id: user_id.to_string(),
+            },
+            candidate,
+        );
+    }
+
+    async fn seen_keys(&self) -> Vec<TenantIdentityKey> {
+        self.seen.read().await.clone()
+    }
+}
+
+#[async_trait]
+impl HostIdentityContextSource for TenantIdentitySource {
+    async fn load_identity_candidates(
+        &self,
+        run_context: &LoopRunContext,
+        _mode: PromptMode,
+    ) -> Result<Vec<HostIdentityContextCandidate>, HostIdentityContextBuildError> {
+        let actor = run_context
+            .actor()
+            .ok_or(HostIdentityContextBuildError::SourceUnavailable)?;
+        let key = TenantIdentityKey {
+            tenant_id: run_context.scope.tenant_id.as_str().to_string(),
+            user_id: actor.user_id.as_str().to_string(),
+        };
+        {
+            let mut seen = self.seen.write().await;
+            if !seen.contains(&key) {
+                seen.push(key.clone());
+            }
+        }
+        self.identities
+            .read()
+            .await
+            .get(&key)
+            .cloned()
+            .map(|candidate| vec![candidate])
+            .ok_or(HostIdentityContextBuildError::SourceUnavailable)
+    }
+
+    async fn resolve_identity_message_content(
+        &self,
+        _run_context: &LoopRunContext,
+        _message_ref: &LoopMessageRef,
+    ) -> Result<Option<HostIdentityMessageContent>, HostIdentityContextBuildError> {
+        Ok(None)
+    }
+}

--- a/tests/reborn_tenant_binding_scope_isolation_parity.rs
+++ b/tests/reborn_tenant_binding_scope_isolation_parity.rs
@@ -1,0 +1,155 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_loop_support::HostManagedModelResponse;
+use ironclaw_threads::{MessageKind, MessageStatus, ThreadMessageRecord};
+use ironclaw_turns::TurnStatus;
+use reborn_support::harness::{
+    RebornBinaryE2EHarness, RebornHarnessSharedStorage, RecordingTestCapabilityPort,
+    test_product_scope,
+};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+
+#[tokio::test]
+async fn reborn_tenant_binding_scope_isolation_parity() {
+    let shared_storage = RebornHarnessSharedStorage::new().expect("shared storage");
+    let tenant_a_scope = test_product_scope(
+        "tenant-alpha-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-e2e"),
+    );
+    let tenant_b_scope = test_product_scope(
+        "tenant-beta-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-e2e"),
+    );
+
+    let mut tenant_a =
+        RebornBinaryE2EHarness::with_model_gateway_scope_shared_storage_unscoped_worker(
+            "room-shared-tenant",
+            RebornTraceReplayModelGateway::with_responses([
+                HostManagedModelResponse::assistant_reply("tenant alpha isolated reply"),
+            ]),
+            RecordingTestCapabilityPort::echo(),
+            tenant_a_scope,
+            shared_storage.clone(),
+        )
+        .await
+        .expect("tenant A harness");
+    let mut tenant_b =
+        RebornBinaryE2EHarness::with_model_gateway_scope_shared_storage_unscoped_worker(
+            "room-shared-tenant",
+            RebornTraceReplayModelGateway::with_responses([
+                HostManagedModelResponse::assistant_reply("tenant beta isolated reply"),
+            ]),
+            RecordingTestCapabilityPort::echo(),
+            tenant_b_scope,
+            shared_storage,
+        )
+        .await
+        .expect("tenant B harness");
+
+    tenant_a.start();
+    tenant_b.start();
+
+    let alpha = tenant_a
+        .submit_text_for(
+            "room-shared-tenant",
+            "alice",
+            "event-same-external-id",
+            "tenant alpha turn",
+        )
+        .await
+        .expect("submit tenant A turn");
+    tenant_a
+        .wait_for_submitted_status(&alpha, TurnStatus::Completed)
+        .await
+        .expect("tenant A completed");
+
+    let beta = tenant_b
+        .submit_text_for(
+            "room-shared-tenant",
+            "alice",
+            "event-same-external-id",
+            "tenant beta turn",
+        )
+        .await
+        .expect("submit tenant B turn with same external event id");
+    tenant_b
+        .wait_for_submitted_status(&beta, TurnStatus::Completed)
+        .await
+        .expect("tenant B completed");
+
+    assert_ne!(
+        alpha.scope.tenant_id, beta.scope.tenant_id,
+        "test must exercise distinct tenant scopes"
+    );
+    assert_ne!(
+        alpha.thread_id, beta.thread_id,
+        "same external conversation under different tenants must resolve to distinct canonical threads"
+    );
+    assert_ne!(
+        alpha.run_id, beta.run_id,
+        "same external event id under different tenants must not replay the same run"
+    );
+
+    let alpha_history = tenant_a
+        .history_for_submitted_thread(&alpha)
+        .await
+        .expect("tenant A history");
+    let beta_history = tenant_b
+        .history_for_submitted_thread(&beta)
+        .await
+        .expect("tenant B history");
+
+    assert_history_contains_user(&alpha_history, "tenant alpha turn");
+    assert_history_contains_assistant(&alpha_history, "tenant alpha isolated reply");
+    assert_history_excludes(&alpha_history, "tenant beta turn");
+    assert_history_excludes(&alpha_history, "tenant beta isolated reply");
+
+    assert_history_contains_user(&beta_history, "tenant beta turn");
+    assert_history_contains_assistant(&beta_history, "tenant beta isolated reply");
+    assert_history_excludes(&beta_history, "tenant alpha turn");
+    assert_history_excludes(&beta_history, "tenant alpha isolated reply");
+
+    tenant_a.assert_model_exhausted();
+    tenant_b.assert_model_exhausted();
+
+    tenant_a.shutdown().await;
+    tenant_b.shutdown().await;
+}
+
+fn assert_history_contains_user(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::User
+                && message.status == MessageStatus::Submitted
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain submitted user message {text:?}"
+    );
+}
+
+fn assert_history_contains_assistant(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::Assistant
+                && message.status == MessageStatus::Finalized
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain finalized assistant reply {text:?}"
+    );
+}
+
+fn assert_history_excludes(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .all(|message| message.content.as_deref() != Some(text)),
+        "thread history should not contain message from another tenant: {text:?}"
+    );
+}

--- a/tests/reborn_wrong_scope_access_isolation_parity.rs
+++ b/tests/reborn_wrong_scope_access_isolation_parity.rs
@@ -1,0 +1,126 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_host_api::{TenantId, UserId};
+use ironclaw_loop_support::HostManagedModelResponse;
+use ironclaw_threads::ThreadScope;
+use ironclaw_turns::{TurnActor, TurnScope, TurnStatus};
+use reborn_support::{
+    harness::{RebornBinaryE2EHarness, RecordingTestCapabilityPort, trace_tool_call_response},
+    model_replay::RebornTraceReplayModelGateway,
+};
+
+#[tokio::test]
+async fn reborn_wrong_scope_access_isolation_parity() {
+    let model_gateway = RebornTraceReplayModelGateway::with_responses([
+        trace_tool_call_response(),
+        HostManagedModelResponse::assistant_reply("wrong scope must not resume this reply"),
+    ]);
+    let mut harness = RebornBinaryE2EHarness::with_harness_blocked_evidence(
+        "room-wrong-scope-access",
+        model_gateway,
+        RecordingTestCapabilityPort::approval_then_echo(),
+    )
+    .await
+    .expect("harness");
+    harness.start();
+
+    let submitted = harness
+        .submit_text("event-wrong-scope-access", "needs approval")
+        .await
+        .expect("submit approval turn");
+    let blocked = harness
+        .wait_for_submitted_status(&submitted, TurnStatus::BlockedApproval)
+        .await
+        .expect("blocked approval");
+    let gate_ref = blocked.gate_ref.expect("blocked run exposes gate ref");
+
+    let wrong_turn_scope = wrong_tenant_turn_scope(&submitted.scope);
+    assert!(
+        harness
+            .run_state_in_scope(wrong_turn_scope.clone(), submitted.run_id)
+            .await
+            .is_err(),
+        "wrong tenant scope must not read run state or leak run existence"
+    );
+
+    let wrong_thread_scope = wrong_tenant_thread_scope(&submitted.thread_scope);
+    assert!(
+        harness
+            .history_for_thread_in_scope(wrong_thread_scope, submitted.thread_id.clone())
+            .await
+            .is_err(),
+        "wrong tenant scope must not access thread history"
+    );
+
+    assert!(
+        harness
+            .cancel_run_as(
+                wrong_turn_scope.clone(),
+                submitted.actor.clone(),
+                submitted.run_id,
+                format!("wrong-tenant-cancel-{}", submitted.run_id),
+            )
+            .await
+            .is_err(),
+        "wrong tenant scope must not cancel another tenant run"
+    );
+    assert_eq!(
+        harness
+            .run_state(submitted.run_id)
+            .await
+            .expect("state after wrong tenant cancel")
+            .status,
+        TurnStatus::BlockedApproval,
+        "wrong tenant cancel must not mutate original run"
+    );
+
+    let wrong_actor = TurnActor::new(UserId::new("wrong-actor-e2e").expect("valid user id"));
+    assert!(
+        harness
+            .resume_with_gate_as(
+                submitted.scope.clone(),
+                wrong_actor.clone(),
+                submitted.run_id,
+                gate_ref.clone(),
+                format!("wrong-actor-resume-{}", submitted.run_id),
+            )
+            .await
+            .is_err(),
+        "wrong actor must not resume another user's blocked run"
+    );
+    assert_eq!(
+        harness
+            .run_state(submitted.run_id)
+            .await
+            .expect("state after wrong actor resume")
+            .status,
+        TurnStatus::BlockedApproval,
+        "wrong actor resume must not mutate original run"
+    );
+
+    harness
+        .cancel_blocked_turn(submitted.run_id)
+        .await
+        .expect("owner can still cancel after wrong-scope attempts");
+    harness
+        .wait_for_status(submitted.run_id, TurnStatus::Cancelled)
+        .await
+        .expect("owner cancel completes");
+
+    harness.shutdown().await;
+}
+
+fn wrong_tenant_turn_scope(scope: &TurnScope) -> TurnScope {
+    let mut wrong = scope.clone();
+    wrong.tenant_id = TenantId::new("tenant-wrong-scope-e2e").expect("valid tenant id");
+    wrong
+}
+
+fn wrong_tenant_thread_scope(scope: &ThreadScope) -> ThreadScope {
+    let mut wrong = scope.clone();
+    wrong.tenant_id = TenantId::new("tenant-wrong-scope-e2e").expect("valid tenant id");
+    wrong
+}

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -150,6 +150,32 @@ pub struct SubmittedTurn {
     pub actor: TurnActor,
 }
 
+#[derive(Clone)]
+pub struct RebornHarnessSharedStorage {
+    product_backend: Arc<LocalFilesystem>,
+    product_root: Arc<tempfile::TempDir>,
+    thread_backend: Arc<LocalFilesystem>,
+    thread_root: Arc<tempfile::TempDir>,
+    turn_backend: Arc<LocalFilesystem>,
+    turn_root: Arc<tempfile::TempDir>,
+}
+
+impl RebornHarnessSharedStorage {
+    pub fn new() -> HarnessResult<Self> {
+        let product_root = Arc::new(tempfile::tempdir()?);
+        let thread_root = Arc::new(tempfile::tempdir()?);
+        let turn_root = Arc::new(tempfile::tempdir()?);
+        Ok(Self {
+            product_backend: Arc::new(local_filesystem(product_root.path())?),
+            product_root,
+            thread_backend: Arc::new(local_filesystem(thread_root.path())?),
+            thread_root,
+            turn_backend: Arc::new(local_filesystem(turn_root.path())?),
+            turn_root,
+        })
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RecordedCapabilityResult {
     pub capability_id: CapabilityId,
@@ -225,6 +251,27 @@ impl RebornBinaryE2EHarness {
             capability_port,
             false,
             false,
+        )
+        .await
+    }
+
+    pub async fn with_model_gateway_scope_shared_storage_unscoped_worker(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        scope: ResourceScope,
+        shared_storage: RebornHarnessSharedStorage,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_capability_mode_identity_source_trigger_worker_scope_and_storage(
+            conversation_id,
+            model_gateway,
+            HarnessCapabilityMode::Recording(capability_port),
+            false,
+            false,
+            ProductTriggerReason::DirectChat,
+            Arc::new(EmptyIdentityContextSource),
+            scope,
+            Some(shared_storage),
         )
         .await
     }
@@ -468,9 +515,42 @@ impl RebornBinaryE2EHarness {
         initial_trigger: ProductTriggerReason,
         identity_context_source: Arc<dyn HostIdentityContextSource>,
     ) -> HarnessResult<Self> {
+        Self::with_model_gateway_capability_mode_identity_source_trigger_worker_scope_and_storage(
+            conversation_id,
+            model_gateway,
+            capability_mode,
+            accept_harness_blocked_evidence,
+            restrict_worker_to_initial_scope,
+            initial_trigger,
+            identity_context_source,
+            product_scope(),
+            None,
+        )
+        .await
+    }
+
+    async fn with_model_gateway_capability_mode_identity_source_trigger_worker_scope_and_storage(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_mode: HarnessCapabilityMode,
+        accept_harness_blocked_evidence: bool,
+        restrict_worker_to_initial_scope: bool,
+        initial_trigger: ProductTriggerReason,
+        identity_context_source: Arc<dyn HostIdentityContextSource>,
+        product_scope: ResourceScope,
+        shared_storage: Option<RebornHarnessSharedStorage>,
+    ) -> HarnessResult<Self> {
         let adapter = RebornTestProductAdapter::new("reborn-test", "install-1")?;
         let ingress = RebornTestIngress::new(adapter);
-        let product_harness = RebornProductWorkflowHarness::filesystem_temp(product_scope())?;
+        let product_harness = if let Some(storage) = shared_storage.as_ref() {
+            RebornProductWorkflowHarness::filesystem_shared_backend(
+                product_scope.clone(),
+                Arc::clone(&storage.product_backend),
+                Arc::clone(&storage.product_root),
+            )?
+        } else {
+            RebornProductWorkflowHarness::filesystem_temp(product_scope)?
+        };
         let binding = product_harness
             .binding_service()?
             .resolve_binding(binding_request_with_trigger(
@@ -489,10 +569,26 @@ impl RebornBinaryE2EHarness {
             binding.project_id.clone(),
             binding.thread_id.clone(),
         );
-        let thread_harness = RebornThreadHarness::filesystem_temp(thread_scope.clone())?;
-        let turn_root = Arc::new(tempfile::tempdir()?);
+        let thread_harness = if let Some(storage) = shared_storage.as_ref() {
+            RebornThreadHarness::filesystem_shared_backend(
+                thread_scope.clone(),
+                Arc::clone(&storage.thread_backend),
+                Arc::clone(&storage.thread_root),
+            )?
+        } else {
+            RebornThreadHarness::filesystem_temp(thread_scope.clone())?
+        };
+        let (turn_backend, turn_root) = if let Some(storage) = shared_storage.as_ref() {
+            (
+                Arc::clone(&storage.turn_backend),
+                Arc::clone(&storage.turn_root),
+            )
+        } else {
+            let turn_root = Arc::new(tempfile::tempdir()?);
+            (Arc::new(local_filesystem(turn_root.path())?), turn_root)
+        };
         let turn_store = Arc::new(FilesystemTurnStateStore::new(scoped_turns_fs(
-            Arc::new(local_filesystem(turn_root.path())?),
+            turn_backend,
             &binding,
         )?));
         let checkpoint_state_store = Arc::new(InMemoryCheckpointStateStore::default());
@@ -1604,11 +1700,20 @@ impl HostIdentityContextSource for EmptyIdentityContextSource {
 }
 
 fn product_scope() -> ResourceScope {
+    test_product_scope("tenant-e2e", "host-user", "agent-e2e", Some("project-e2e"))
+}
+
+pub fn test_product_scope(
+    tenant_id: &str,
+    host_user_id: &str,
+    agent_id: &str,
+    project_id: Option<&str>,
+) -> ResourceScope {
     resource_scope(
-        TenantId::new("tenant-e2e").expect("valid tenant"),
-        UserId::new("host-user").expect("valid user"),
-        AgentId::new("agent-e2e").expect("valid agent"),
-        Some(ProjectId::new("project-e2e").expect("valid project")),
+        TenantId::new(tenant_id).expect("valid tenant"),
+        UserId::new(host_user_id).expect("valid user"),
+        AgentId::new(agent_id).expect("valid agent"),
+        project_id.map(|id| ProjectId::new(id).expect("valid project")),
     )
 }
 

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -262,16 +262,95 @@ impl RebornBinaryE2EHarness {
         scope: ResourceScope,
         shared_storage: RebornHarnessSharedStorage,
     ) -> HarnessResult<Self> {
-        Self::with_model_gateway_capability_mode_identity_source_trigger_worker_scope_and_storage(
+        Self::with_model_gateway_scope_identity_source_trigger_installation_shared_storage_unscoped_worker(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            scope,
+            Arc::new(EmptyIdentityContextSource),
+            ProductTriggerReason::DirectChat,
+            "reborn-test",
+            "install-1",
+            "alice",
+            shared_storage,
+        )
+        .await
+    }
+
+    pub async fn with_model_gateway_scope_installation_shared_storage_unscoped_worker(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        scope: ResourceScope,
+        adapter_id: &str,
+        installation_id: &str,
+        shared_storage: RebornHarnessSharedStorage,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_scope_initial_actor_installation_shared_storage_unscoped_worker(
+            conversation_id,
+            "alice",
+            model_gateway,
+            capability_port,
+            scope,
+            adapter_id,
+            installation_id,
+            shared_storage,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn with_model_gateway_scope_initial_actor_installation_shared_storage_unscoped_worker(
+        conversation_id: &str,
+        initial_actor_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        scope: ResourceScope,
+        adapter_id: &str,
+        installation_id: &str,
+        shared_storage: RebornHarnessSharedStorage,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_scope_identity_source_trigger_installation_shared_storage_unscoped_worker(
+            conversation_id,
+            model_gateway,
+            capability_port,
+            scope,
+            Arc::new(EmptyIdentityContextSource),
+            ProductTriggerReason::DirectChat,
+            adapter_id,
+            installation_id,
+            initial_actor_id,
+            shared_storage,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn with_model_gateway_scope_identity_source_trigger_installation_shared_storage_unscoped_worker(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        capability_port: RecordingTestCapabilityPort,
+        scope: ResourceScope,
+        identity_context_source: Arc<dyn HostIdentityContextSource>,
+        initial_trigger: ProductTriggerReason,
+        adapter_id: &str,
+        installation_id: &str,
+        initial_actor_id: &str,
+        shared_storage: RebornHarnessSharedStorage,
+    ) -> HarnessResult<Self> {
+        Self::with_model_gateway_capability_mode_identity_source_trigger_worker_scope_storage_and_adapter(
             conversation_id,
             model_gateway,
             HarnessCapabilityMode::Recording(capability_port),
             false,
             false,
-            ProductTriggerReason::DirectChat,
-            Arc::new(EmptyIdentityContextSource),
+            initial_trigger,
+            identity_context_source,
             scope,
             Some(shared_storage),
+            adapter_id,
+            installation_id,
+            initial_actor_id,
         )
         .await
     }
@@ -515,7 +594,7 @@ impl RebornBinaryE2EHarness {
         initial_trigger: ProductTriggerReason,
         identity_context_source: Arc<dyn HostIdentityContextSource>,
     ) -> HarnessResult<Self> {
-        Self::with_model_gateway_capability_mode_identity_source_trigger_worker_scope_and_storage(
+        Self::with_model_gateway_capability_mode_identity_source_trigger_worker_scope_storage_and_adapter(
             conversation_id,
             model_gateway,
             capability_mode,
@@ -525,11 +604,15 @@ impl RebornBinaryE2EHarness {
             identity_context_source,
             product_scope(),
             None,
+            "reborn-test",
+            "install-1",
+            "alice",
         )
         .await
     }
 
-    async fn with_model_gateway_capability_mode_identity_source_trigger_worker_scope_and_storage(
+    #[allow(clippy::too_many_arguments)]
+    async fn with_model_gateway_capability_mode_identity_source_trigger_worker_scope_storage_and_adapter(
         conversation_id: &str,
         model_gateway: RebornTraceReplayModelGateway,
         capability_mode: HarnessCapabilityMode,
@@ -539,8 +622,11 @@ impl RebornBinaryE2EHarness {
         identity_context_source: Arc<dyn HostIdentityContextSource>,
         product_scope: ResourceScope,
         shared_storage: Option<RebornHarnessSharedStorage>,
+        adapter_id: &str,
+        installation_id: &str,
+        initial_actor_id: &str,
     ) -> HarnessResult<Self> {
-        let adapter = RebornTestProductAdapter::new("reborn-test", "install-1")?;
+        let adapter = RebornTestProductAdapter::new(adapter_id, installation_id)?;
         let ingress = RebornTestIngress::new(adapter);
         let product_harness = if let Some(storage) = shared_storage.as_ref() {
             RebornProductWorkflowHarness::filesystem_shared_backend(
@@ -553,9 +639,10 @@ impl RebornBinaryE2EHarness {
         };
         let binding = product_harness
             .binding_service()?
-            .resolve_binding(binding_request_with_trigger(
+            .resolve_binding(binding_request_with_trigger_and_actor(
                 &ingress,
                 conversation_id,
+                initial_actor_id,
                 initial_trigger,
             )?)
             .await?;
@@ -811,16 +898,34 @@ impl RebornBinaryE2EHarness {
         run_id: TurnRunId,
         gate_ref: GateRef,
     ) -> HarnessResult<()> {
+        self.resume_with_gate_as(
+            self.turn_scope.clone(),
+            TurnActor::new(self.binding.user_id.clone()),
+            run_id,
+            gate_ref,
+            format!("resume-{run_id}"),
+        )
+        .await
+    }
+
+    pub async fn resume_with_gate_as(
+        &self,
+        scope: TurnScope,
+        actor: TurnActor,
+        run_id: TurnRunId,
+        gate_ref: GateRef,
+        idempotency_key: impl Into<String>,
+    ) -> HarnessResult<()> {
         let response = self
             .coordinator
             .resume_turn(ResumeTurnRequest {
-                scope: self.turn_scope.clone(),
-                actor: TurnActor::new(self.binding.user_id.clone()),
+                scope,
+                actor,
                 run_id,
                 gate_resolution_ref: gate_ref,
                 source_binding_ref: SourceBindingRef::new("src:resume")?,
                 reply_target_binding_ref: ReplyTargetBindingRef::new("reply:resume")?,
-                idempotency_key: IdempotencyKey::new(format!("resume-{run_id}"))?,
+                idempotency_key: IdempotencyKey::new(idempotency_key.into())?,
             })
             .await?;
         if response.status != TurnStatus::Queued {
@@ -830,14 +935,30 @@ impl RebornBinaryE2EHarness {
     }
 
     pub async fn cancel_blocked_turn(&self, run_id: TurnRunId) -> HarnessResult<()> {
+        self.cancel_run_as(
+            self.turn_scope.clone(),
+            TurnActor::new(self.binding.user_id.clone()),
+            run_id,
+            format!("cancel-{run_id}"),
+        )
+        .await
+    }
+
+    pub async fn cancel_run_as(
+        &self,
+        scope: TurnScope,
+        actor: TurnActor,
+        run_id: TurnRunId,
+        idempotency_key: impl Into<String>,
+    ) -> HarnessResult<()> {
         let response = self
             .coordinator
             .cancel_run(CancelRunRequest {
-                scope: self.turn_scope.clone(),
-                actor: TurnActor::new(self.binding.user_id.clone()),
+                scope,
+                actor,
                 run_id,
                 reason: SanitizedCancelReason::UserRequested,
-                idempotency_key: IdempotencyKey::new(format!("cancel-{run_id}"))?,
+                idempotency_key: IdempotencyKey::new(idempotency_key.into())?,
             })
             .await?;
         if !matches!(
@@ -1729,9 +1850,18 @@ fn binding_request_with_trigger(
     conversation_id: &str,
     trigger: ProductTriggerReason,
 ) -> HarnessResult<ResolveBindingRequest> {
+    binding_request_with_trigger_and_actor(ingress, conversation_id, "alice", trigger)
+}
+
+fn binding_request_with_trigger_and_actor(
+    ingress: &RebornTestIngress,
+    conversation_id: &str,
+    actor_id: &str,
+    trigger: ProductTriggerReason,
+) -> HarnessResult<ResolveBindingRequest> {
     let envelope = ingress.verified_text_envelope_with_trigger(
         "binding-probe",
-        "alice",
+        actor_id,
         conversation_id,
         "hi",
         trigger,

--- a/tests/support/reborn/test_adapter.rs
+++ b/tests/support/reborn/test_adapter.rs
@@ -107,6 +107,20 @@ impl ProductAdapter for RebornTestProductAdapter {
                     reason: ironclaw_product_adapters::RedactedString::new(error.to_string()),
                 }
             })?;
+        let claim = auth_evidence
+            .claim()
+            .ok_or(ProductAdapterError::Authentication(
+                ProtocolAuthFailure::Missing,
+            ))?;
+        if claim.subject() != payload.user_id {
+            return Err(ProductAdapterError::Authentication(
+                ProtocolAuthFailure::Other {
+                    detail: ironclaw_product_adapters::RedactedString::new(
+                        "verified subject does not match inbound actor",
+                    ),
+                },
+            ));
+        }
         ParsedProductInbound::new(
             ExternalEventId::new(payload.event_id)?,
             ExternalActorRef::new(

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -1728,6 +1728,18 @@ mod reborn_support_tests {
     }
 
     #[test]
+    fn test_adapter_rejects_actor_spoofing_against_verified_subject() {
+        let adapter = RebornTestProductAdapter::new("reborn-test", "install-1").expect("adapter");
+        let evidence = ProtocolAuthEvidence::test_verified(AuthRequirement::BearerToken, "alice");
+        let raw = RebornTestProductAdapter::text_payload("event-1", "bob", "thread-1", "hi")
+            .expect("payload");
+        let error = adapter
+            .parse_inbound(&raw, &evidence)
+            .expect_err("actor mismatch should reject");
+        assert!(matches!(error, ProductAdapterError::Authentication(_)));
+    }
+
+    #[test]
     fn test_adapter_rejects_malformed_inbound_payload() {
         let adapter = RebornTestProductAdapter::new("reborn-test", "install-1").expect("adapter");
         let evidence = ProtocolAuthEvidence::test_verified(AuthRequirement::BearerToken, "alice");


### PR DESCRIPTION
## Summary
- reject Reborn test-adapter actor spoofing when verified auth subject differs from payload user id
- add shared-storage/custom-scope Reborn harness support so tenant tests do not isolate by tempdir
- add Reborn tenant binding/idempotency isolation E2E using same external conversation id and same external event id across two tenants

## What this covers
- auth/product boundary remains source of actor identity
- tenant A and tenant B can accept the same external event id without idempotency replay/collision
- same external conversation under different tenants resolves to distinct canonical threads
- tenant A/B histories do not leak messages or replies across shared backing stores

## What this does not claim
- not production memory-backed identity isolation
- not full tenant prompt/memory/tool isolation
- not gateway auth/SSE/job multi-tenant coverage

## Validation
- `cargo test -q --features libsql --test support_unit_tests test_adapter -- --nocapture`
- `cargo test -q --features libsql --test reborn_tenant_binding_scope_isolation_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_identity_prompt_scope_isolation_parity reborn_identity_prompt_scope_isolation_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_thread_binding_isolation_parity reborn_thread_binding_isolation_parity -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: validation emits existing `ironclaw_llm` unused import warnings.
