### PR TITLE
[codex] Finish staged secret egress framework

### DIFF
--- a/crates/ironclaw_host_api/src/http.rs
+++ b/crates/ironclaw_host_api/src/http.rs
@@ -46,13 +46,12 @@ pub struct RuntimeHttpEgressRequest {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeCredentialInjection {
     pub handle: SecretHandle,
-    #[serde(default)]
     pub source: RuntimeCredentialSource,
     pub target: RuntimeCredentialTarget,
     pub required: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum RuntimeCredentialSource {
     /// Lease and consume material directly from the scoped secret store.
@@ -60,7 +59,6 @@ pub enum RuntimeCredentialSource {
     /// This is the legacy/test compatibility path for host-derived credentials
     /// that are not backed by an already-satisfied authorization obligation.
     /// Production runtime tool egress must use [`Self::StagedObligation`].
-    #[default]
     SecretStoreLease,
     /// Consume material staged by an `InjectSecretOnce` obligation handler.
     ///

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -155,6 +155,27 @@ fn dispatch_errors_preserve_typed_failure_kind() {
 }
 
 #[test]
+fn runtime_credential_injection_rejects_missing_source() {
+    let missing_source = json!({
+        "handle": "api-token",
+        "target": {
+            "type": "header",
+            "name": "authorization",
+            "prefix": "Bearer "
+        },
+        "required": true
+    });
+
+    let error = serde_json::from_value::<RuntimeCredentialInjection>(missing_source)
+        .expect_err("credential injection source is authority-bearing and must be explicit");
+
+    assert!(
+        error.to_string().contains("missing field `source`"),
+        "unexpected deserialization error: {error}"
+    );
+}
+
+#[test]
 fn dispatch_failure_kind_display_preserves_stable_literals() {
     assert_eq!(
         DispatchFailureKind::UnknownCapability.as_str(),

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -693,9 +693,12 @@ impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
         &self,
         request: FirstPartyCapabilityRequest,
     ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
-        let egress = request.runtime_http_egress.ok_or_else(|| {
-            FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied)
-        })?;
+        let egress = request
+            .services
+            .runtime_http_egress
+            .as_ref()
+            .ok_or_else(|| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied))?
+            .clone();
         let url = request
             .input
             .get("url")

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -21,8 +21,12 @@ use ironclaw_host_runtime::{
     ProductionWiringIssueKind, RuntimeCapabilityOutcome, RuntimeCapabilityRequest,
     RuntimeFailureKind,
 };
+use ironclaw_network::{
+    NetworkHttpEgress, NetworkHttpError, NetworkHttpRequest, NetworkHttpResponse, NetworkUsage,
+};
 use ironclaw_resources::{InMemoryResourceGovernor, ResourceAccount, ResourceTally};
 use ironclaw_run_state::{InMemoryRunStateStore, RunStateStore, RunStatus};
+use ironclaw_secrets::{InMemorySecretStore, SecretMaterial, SecretStore};
 use ironclaw_trust::{
     AdminConfig, AdminEntry, AuthorityCeiling, EffectiveTrustClass, HostTrustAssignment,
     HostTrustPolicy, TrustDecision, TrustProvenance,
@@ -103,6 +107,82 @@ async fn host_runtime_invokes_first_party_handler_through_capability_host() {
             RuntimeEventKind::RuntimeSelected,
             RuntimeEventKind::DispatchSucceeded,
         ],
+    );
+}
+
+#[tokio::test]
+async fn first_party_handler_uses_staged_secret_through_production_host_egress() {
+    let handle = SecretHandle::new("api-token").unwrap();
+    let handler = Arc::new(HttpFirstPartyHandler {
+        handle: handle.clone(),
+    });
+    let first_party =
+        FirstPartyCapabilityRegistry::new().with_handler(capability_id(), Arc::clone(&handler));
+    let secret_store = Arc::new(InMemorySecretStore::new());
+    let network = RecordingNetworkHttpEgress::default();
+    let network_recorder = network.requests.clone();
+    let runtime = HostRuntimeServices::new(
+        Arc::new(first_party_registry_with_effects(vec![
+            EffectKind::DispatchCapability,
+            EffectKind::Network,
+            EffectKind::UseSecret,
+        ])),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_secret_store(Arc::clone(&secret_store))
+    .with_first_party_capabilities(Arc::new(first_party))
+    .try_with_host_http_egress(network)
+    .unwrap()
+    .with_trust_policy(Arc::new(first_party_trust_policy()))
+    .host_runtime_for_local_testing();
+    let context = execution_context(CapabilitySet {
+        grants: vec![dispatch_grant_with_secret(&handle)],
+    });
+    let scope = context.resource_scope.clone();
+    secret_store
+        .put(
+            scope.clone(),
+            handle.clone(),
+            SecretMaterial::from("sk-first-party-staged-secret"),
+        )
+        .await
+        .unwrap();
+
+    let outcome = runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            capability_id(),
+            ResourceEstimate {
+                network_egress_bytes: Some(100),
+                output_bytes: Some(1024),
+                ..ResourceEstimate::default()
+            },
+            json!({"url":"https://api.example.test/v1/native"}),
+            trust_decision(),
+        ))
+        .await
+        .unwrap();
+
+    let RuntimeCapabilityOutcome::Completed(completed) = outcome else {
+        panic!("expected completed first-party HTTP fixture, got {outcome:?}");
+    };
+    assert_eq!(completed.output["status"], json!(200));
+    let requests = network_recorder.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].url, "https://api.example.test/v1/native");
+    assert_eq!(
+        requests[0]
+            .headers
+            .iter()
+            .find(|(name, _)| name == "authorization"),
+        Some(&(
+            "authorization".to_string(),
+            "Bearer sk-first-party-staged-secret".to_string()
+        ))
     );
 }
 
@@ -352,6 +432,10 @@ impl FailingFirstPartyHandler {
 
 struct PanickingFirstPartyHandler;
 
+struct HttpFirstPartyHandler {
+    handle: SecretHandle,
+}
+
 #[async_trait]
 impl FirstPartyCapabilityHandler for FailingFirstPartyHandler {
     async fn dispatch(
@@ -399,6 +483,10 @@ impl FirstPartyCapabilityHandler for RecordingFirstPartyHandler {
 }
 
 fn first_party_registry() -> ExtensionRegistry {
+    first_party_registry_with_effects(vec![EffectKind::DispatchCapability])
+}
+
+fn first_party_registry_with_effects(effects: Vec<EffectKind>) -> ExtensionRegistry {
     let package = ExtensionPackage::from_manifest(
         ExtensionManifest {
             schema_version: MANIFEST_SCHEMA_VERSION.to_string(),
@@ -417,7 +505,7 @@ fn first_party_registry() -> ExtensionRegistry {
                 id: capability_id(),
                 implements: Vec::new(),
                 description: "Reports host status".to_string(),
-                effects: vec![EffectKind::DispatchCapability],
+                effects,
                 default_permission: PermissionMode::Allow,
                 visibility: CapabilityVisibility::Model,
                 input_schema_ref: CapabilityProfileSchemaRef::new(
@@ -441,6 +529,71 @@ fn first_party_registry() -> ExtensionRegistry {
     let mut registry = ExtensionRegistry::new();
     registry.insert(package).unwrap();
     registry
+}
+
+#[async_trait]
+impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
+    async fn dispatch(
+        &self,
+        request: FirstPartyCapabilityRequest,
+    ) -> Result<FirstPartyCapabilityResult, FirstPartyCapabilityError> {
+        let egress = request.runtime_http_egress.ok_or_else(|| {
+            FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::NetworkDenied)
+        })?;
+        let url = request
+            .input
+            .get("url")
+            .and_then(Value::as_str)
+            .ok_or_else(|| FirstPartyCapabilityError::new(RuntimeDispatchErrorKind::InputEncode))?
+            .to_string();
+        let response = egress
+            .execute(RuntimeHttpEgressRequest {
+                runtime: RuntimeKind::FirstParty,
+                scope: request.scope.clone(),
+                capability_id: request.capability_id.clone(),
+                method: NetworkMethod::Get,
+                url,
+                headers: vec![],
+                body: Vec::new(),
+                network_policy: NetworkPolicy::default(),
+                credential_injections: vec![RuntimeCredentialInjection {
+                    handle: self.handle.clone(),
+                    source: RuntimeCredentialSource::StagedObligation {
+                        capability_id: request.capability_id,
+                    },
+                    target: RuntimeCredentialTarget::Header {
+                        name: "authorization".to_string(),
+                        prefix: Some("Bearer ".to_string()),
+                    },
+                    required: true,
+                }],
+                response_body_limit: Some(4096),
+                timeout_ms: Some(1000),
+            })
+            .map_err(|error| {
+                FirstPartyCapabilityError::new(http_error_kind(error.reason_code()))
+            })?;
+        Ok(FirstPartyCapabilityResult::new(
+            json!({"status": response.status}),
+            ResourceUsage {
+                network_egress_bytes: response.request_bytes,
+                output_bytes: 14,
+                ..ResourceUsage::default()
+            },
+        ))
+    }
+}
+
+fn http_error_kind(reason: RuntimeHttpEgressReasonCode) -> RuntimeDispatchErrorKind {
+    match reason {
+        RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,
+        RuntimeHttpEgressReasonCode::RequestDenied => RuntimeDispatchErrorKind::InputEncode,
+        RuntimeHttpEgressReasonCode::NetworkError => RuntimeDispatchErrorKind::NetworkDenied,
+        RuntimeHttpEgressReasonCode::ResponseError => RuntimeDispatchErrorKind::OutputDecode,
+        RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded => {
+            RuntimeDispatchErrorKind::OutputDecode
+        }
+    }
 }
 
 fn execution_context(grants: CapabilitySet) -> ExecutionContext {
@@ -473,6 +626,28 @@ fn dispatch_grant() -> CapabilityGrant {
     }
 }
 
+fn dispatch_grant_with_secret(handle: &SecretHandle) -> CapabilityGrant {
+    CapabilityGrant {
+        id: CapabilityGrantId::new(),
+        capability: capability_id(),
+        grantee: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        issued_by: Principal::HostRuntime,
+        constraints: GrantConstraints {
+            allowed_effects: vec![
+                EffectKind::DispatchCapability,
+                EffectKind::Network,
+                EffectKind::UseSecret,
+            ],
+            mounts: MountView::default(),
+            network: test_network_policy(),
+            secrets: vec![handle.clone()],
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
+    }
+}
+
 fn first_party_trust_policy() -> HostTrustPolicy {
     HostTrustPolicy::new(vec![Box::new(AdminConfig::with_entries(vec![
         AdminEntry::for_local_manifest(
@@ -480,11 +655,27 @@ fn first_party_trust_policy() -> HostTrustPolicy {
             "/system/extensions/host/manifest.toml".to_string(),
             None,
             HostTrustAssignment::first_party(),
-            vec![EffectKind::DispatchCapability],
+            vec![
+                EffectKind::DispatchCapability,
+                EffectKind::Network,
+                EffectKind::UseSecret,
+            ],
             None,
         ),
     ]))])
     .unwrap()
+}
+
+fn test_network_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "api.example.test".to_string(),
+            port: None,
+        }],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(10_000),
+    }
 }
 
 fn trust_decision() -> TrustDecision {
@@ -514,4 +705,28 @@ fn assert_event_kinds(events: &InMemoryEventSink, expected: &[RuntimeEventKind])
         .map(|event| event.kind)
         .collect::<Vec<_>>();
     assert_eq!(actual, expected);
+}
+
+#[derive(Debug, Clone, Default)]
+struct RecordingNetworkHttpEgress {
+    requests: Arc<Mutex<Vec<NetworkHttpRequest>>>,
+}
+
+impl NetworkHttpEgress for RecordingNetworkHttpEgress {
+    fn execute(
+        &self,
+        request: NetworkHttpRequest,
+    ) -> Result<NetworkHttpResponse, NetworkHttpError> {
+        self.requests.lock().unwrap().push(request.clone());
+        Ok(NetworkHttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: b"ok".to_vec(),
+            usage: NetworkUsage {
+                request_bytes: request.body.len() as u64,
+                response_bytes: 2,
+                resolved_ip: None,
+            },
+        })
+    }
 }

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -287,6 +287,31 @@ async fn first_party_handler_maps_egress_error_codes_to_dispatch_errors() {
     assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
 }
 
+#[tokio::test]
+async fn first_party_handler_rejects_non_string_url_input() {
+    for input in [json!({"url": 123}), json!({"url": true})] {
+        let handle = SecretHandle::new("api-token").unwrap();
+        let runtime = http_first_party_services(&handle)
+            .with_runtime_http_egress(Arc::new(UnreachableRuntimeHttpEgress))
+            .with_trust_policy(Arc::new(first_party_trust_policy()))
+            .host_runtime_for_local_testing();
+
+        let outcome = invoke_http_fixture(
+            &runtime,
+            execution_context(CapabilitySet {
+                grants: vec![dispatch_grant_with_secret(&handle)],
+            }),
+            input,
+        )
+        .await;
+
+        let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+            panic!("expected non-string URL to fail, got {outcome:?}");
+        };
+        assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+    }
+}
+
 #[test]
 fn http_error_kind_maps_all_reason_codes() {
     let cases = [
@@ -689,6 +714,8 @@ impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
                 network_policy: NetworkPolicy::default(),
                 credential_injections: vec![RuntimeCredentialInjection {
                     handle: self.handle.clone(),
+                    // Production first-party egress must use StagedObligation;
+                    // SecretStoreLease is only for test/legacy paths.
                     source: RuntimeCredentialSource::StagedObligation {
                         capability_id: request.capability_id,
                     },
@@ -715,6 +742,7 @@ impl FirstPartyCapabilityHandler for HttpFirstPartyHandler {
     }
 }
 
+// Keep in sync with production error mapping if one is introduced.
 fn http_error_kind(reason: RuntimeHttpEgressReasonCode) -> RuntimeDispatchErrorKind {
     match reason {
         RuntimeHttpEgressReasonCode::CredentialUnavailable => RuntimeDispatchErrorKind::Client,

--- a/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/first_party_runtime_contract.rs
@@ -187,6 +187,137 @@ async fn first_party_handler_uses_staged_secret_through_production_host_egress()
 }
 
 #[tokio::test]
+async fn first_party_handler_maps_egress_error_codes_to_dispatch_errors() {
+    let cases = [
+        (
+            RuntimeHttpEgressError::Credential {
+                reason: "missing staged credential".to_string(),
+            },
+            RuntimeFailureKind::Backend,
+        ),
+        (
+            RuntimeHttpEgressError::Request {
+                reason: "request denied".to_string(),
+                request_bytes: 11,
+                response_bytes: 0,
+            },
+            RuntimeFailureKind::InvalidInput,
+        ),
+        (
+            RuntimeHttpEgressError::Network {
+                reason: "network blocked".to_string(),
+                request_bytes: 11,
+                response_bytes: 0,
+            },
+            RuntimeFailureKind::Network,
+        ),
+        (
+            RuntimeHttpEgressError::Response {
+                reason: "bad response".to_string(),
+                request_bytes: 11,
+                response_bytes: 22,
+            },
+            RuntimeFailureKind::InvalidInput,
+        ),
+        (
+            RuntimeHttpEgressError::Response {
+                reason: RUNTIME_HTTP_REASON_RESPONSE_BODY_LIMIT_EXCEEDED.to_string(),
+                request_bytes: 11,
+                response_bytes: 4097,
+            },
+            RuntimeFailureKind::InvalidInput,
+        ),
+    ];
+
+    for (error, expected_kind) in cases {
+        let handle = SecretHandle::new("api-token").unwrap();
+        let runtime = http_first_party_services(&handle)
+            .with_runtime_http_egress(Arc::new(FailingRuntimeHttpEgress { error }))
+            .with_trust_policy(Arc::new(first_party_trust_policy()))
+            .host_runtime_for_local_testing();
+
+        let outcome = invoke_http_fixture(
+            &runtime,
+            execution_context(CapabilitySet {
+                grants: vec![dispatch_grant_with_secret(&handle)],
+            }),
+            json!({"url":"https://api.example.test/v1/native"}),
+        )
+        .await;
+
+        let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+            panic!("expected failed first-party HTTP fixture, got {outcome:?}");
+        };
+        assert_eq!(failure.kind, expected_kind);
+    }
+
+    let handle = SecretHandle::new("api-token").unwrap();
+    let runtime = http_first_party_services(&handle)
+        .with_trust_policy(Arc::new(first_party_trust_policy()))
+        .host_runtime_for_local_testing();
+    let outcome = invoke_http_fixture(
+        &runtime,
+        execution_context(CapabilitySet {
+            grants: vec![dispatch_grant_with_secret(&handle)],
+        }),
+        json!({"url":"https://api.example.test/v1/native"}),
+    )
+    .await;
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected missing egress to fail, got {outcome:?}");
+    };
+    assert_eq!(failure.kind, RuntimeFailureKind::Network);
+
+    let handle = SecretHandle::new("api-token").unwrap();
+    let runtime = http_first_party_services(&handle)
+        .with_runtime_http_egress(Arc::new(UnreachableRuntimeHttpEgress))
+        .with_trust_policy(Arc::new(first_party_trust_policy()))
+        .host_runtime_for_local_testing();
+    let outcome = invoke_http_fixture(
+        &runtime,
+        execution_context(CapabilitySet {
+            grants: vec![dispatch_grant_with_secret(&handle)],
+        }),
+        json!({"missing_url": true}),
+    )
+    .await;
+    let RuntimeCapabilityOutcome::Failed(failure) = outcome else {
+        panic!("expected missing URL to fail, got {outcome:?}");
+    };
+    assert_eq!(failure.kind, RuntimeFailureKind::InvalidInput);
+}
+
+#[test]
+fn http_error_kind_maps_all_reason_codes() {
+    let cases = [
+        (
+            RuntimeHttpEgressReasonCode::CredentialUnavailable,
+            RuntimeDispatchErrorKind::Client,
+        ),
+        (
+            RuntimeHttpEgressReasonCode::RequestDenied,
+            RuntimeDispatchErrorKind::InputEncode,
+        ),
+        (
+            RuntimeHttpEgressReasonCode::NetworkError,
+            RuntimeDispatchErrorKind::NetworkDenied,
+        ),
+        (
+            RuntimeHttpEgressReasonCode::ResponseError,
+            RuntimeDispatchErrorKind::OutputDecode,
+        ),
+        (
+            RuntimeHttpEgressReasonCode::ResponseBodyLimitExceeded,
+            RuntimeDispatchErrorKind::OutputDecode,
+        ),
+    ];
+
+    for (reason, expected_kind) in cases {
+        assert_eq!(http_error_kind(reason), expected_kind);
+    }
+}
+
+#[tokio::test]
 async fn production_wiring_rejects_first_party_registry_without_declared_handler() {
     let services = HostRuntimeServices::new(
         Arc::new(first_party_registry()),
@@ -596,6 +727,52 @@ fn http_error_kind(reason: RuntimeHttpEgressReasonCode) -> RuntimeDispatchErrorK
     }
 }
 
+fn http_first_party_services(
+    handle: &SecretHandle,
+) -> HostRuntimeServices<
+    LocalFilesystem,
+    InMemoryResourceGovernor,
+    ironclaw_processes::InMemoryProcessStore,
+    ironclaw_processes::InMemoryProcessResultStore,
+> {
+    let handler = Arc::new(HttpFirstPartyHandler {
+        handle: handle.clone(),
+    });
+    let first_party =
+        FirstPartyCapabilityRegistry::new().with_handler(capability_id(), Arc::clone(&handler));
+
+    HostRuntimeServices::new(
+        Arc::new(first_party_registry()),
+        Arc::new(LocalFilesystem::new()),
+        Arc::new(InMemoryResourceGovernor::new()),
+        Arc::new(GrantAuthorizer::new()),
+        ironclaw_processes::ProcessServices::in_memory(),
+        CapabilitySurfaceVersion::new("surface-v1").unwrap(),
+    )
+    .with_first_party_capabilities(Arc::new(first_party))
+}
+
+async fn invoke_http_fixture(
+    runtime: &impl HostRuntime,
+    context: ExecutionContext,
+    input: Value,
+) -> RuntimeCapabilityOutcome {
+    runtime
+        .invoke_capability(RuntimeCapabilityRequest::new(
+            context,
+            capability_id(),
+            ResourceEstimate {
+                network_egress_bytes: Some(100),
+                output_bytes: Some(1024),
+                ..ResourceEstimate::default()
+            },
+            input,
+            trust_decision(),
+        ))
+        .await
+        .unwrap()
+}
+
 fn execution_context(grants: CapabilitySet) -> ExecutionContext {
     ExecutionContext::local_default(
         UserId::new("user").unwrap(),
@@ -710,6 +887,30 @@ fn assert_event_kinds(events: &InMemoryEventSink, expected: &[RuntimeEventKind])
 #[derive(Debug, Clone, Default)]
 struct RecordingNetworkHttpEgress {
     requests: Arc<Mutex<Vec<NetworkHttpRequest>>>,
+}
+
+struct FailingRuntimeHttpEgress {
+    error: RuntimeHttpEgressError,
+}
+
+struct UnreachableRuntimeHttpEgress;
+
+impl RuntimeHttpEgress for FailingRuntimeHttpEgress {
+    fn execute(
+        &self,
+        _request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        Err(self.error.clone())
+    }
+}
+
+impl RuntimeHttpEgress for UnreachableRuntimeHttpEgress {
+    fn execute(
+        &self,
+        _request: RuntimeHttpEgressRequest,
+    ) -> Result<RuntimeHttpEgressResponse, RuntimeHttpEgressError> {
+        panic!("runtime HTTP egress should not be called before URL validation")
+    }
 }
 
 impl NetworkHttpEgress for RecordingNetworkHttpEgress {

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -751,6 +751,68 @@ fn host_http_egress_injects_leased_credentials_and_redacts_errors() {
 }
 
 #[test]
+fn request_policy_fallback_accepts_secret_store_lease_for_legacy_tests() {
+    let network = RecordingNetwork::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![],
+        body: br#"{"ok":true}"#.to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 5,
+            response_bytes: 11,
+            resolved_ip: None,
+        },
+    });
+    let network_recorder = network.requests.clone();
+    let secrets = InMemorySecretStore::new();
+    let scope = sample_scope();
+    let handle = SecretHandle::new("api-token").unwrap();
+    block_on_test(secrets.put(
+        scope.clone(),
+        handle.clone(),
+        SecretMaterial::from("sk-test-secret"),
+    ))
+    .unwrap();
+    let service = HostHttpEgressService::new_with_request_policy_for_tests(network, secrets);
+
+    service
+        .execute(RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::Script,
+            scope,
+            capability_id: sample_capability_id(),
+            method: NetworkMethod::Post,
+            url: "https://api.example.test/v1/run".to_string(),
+            headers: vec![],
+            body: b"hello".to_vec(),
+            network_policy: sample_policy(),
+            credential_injections: vec![RuntimeCredentialInjection {
+                handle,
+                source: RuntimeCredentialSource::SecretStoreLease,
+                target: RuntimeCredentialTarget::Header {
+                    name: "authorization".to_string(),
+                    prefix: Some("Bearer ".to_string()),
+                },
+                required: true,
+            }],
+            response_body_limit: Some(4096),
+            timeout_ms: None,
+        })
+        .expect("legacy/test fallback keeps direct leases available outside production wiring");
+
+    let requests = network_recorder.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0]
+            .headers
+            .iter()
+            .find(|(name, _)| name == "authorization"),
+        Some(&(
+            "authorization".to_string(),
+            "Bearer sk-test-secret".to_string()
+        ))
+    );
+}
+
+#[test]
 fn host_http_egress_requires_available_required_credentials_before_network() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,
@@ -1532,7 +1594,18 @@ async fn mcp_http_client_cannot_use_direct_secret_store_lease_with_production_eg
         .expect_err("production MCP egress must require staged credentials");
 
     assert_eq!(error, "credential_unavailable");
-    assert!(network_recorder.lock().unwrap().is_empty());
+    let requests = network_recorder.lock().unwrap();
+    assert_eq!(
+        requests.len(),
+        2,
+        "MCP handshake may run unauthenticated, but credentials must not be exposed before tools/call"
+    );
+    assert!(requests.iter().all(|request| {
+        !request
+            .headers
+            .iter()
+            .any(|(name, _)| name == "authorization")
+    }));
 }
 
 #[test]

--- a/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
+++ b/crates/ironclaw_host_runtime/tests/runtime_http_egress_contract.rs
@@ -1609,6 +1609,57 @@ async fn mcp_http_client_cannot_use_direct_secret_store_lease_with_production_eg
 }
 
 #[test]
+fn first_party_http_egress_cannot_use_direct_secret_store_lease_with_production_egress() {
+    let network = RecordingNetwork::ok(NetworkHttpResponse {
+        status: 200,
+        headers: vec![],
+        body: br#"{"ok":true}"#.to_vec(),
+        usage: NetworkUsage {
+            request_bytes: 5,
+            response_bytes: 11,
+            resolved_ip: None,
+        },
+    });
+    let network_recorder = network.requests.clone();
+    let services = test_obligation_services();
+    let scope = sample_scope();
+    let capability_id = sample_capability_id();
+    stage_policy_sync(&services, &scope, &capability_id, sample_policy());
+    let service = services.host_http_egress(network);
+
+    let error = service
+        .execute(RuntimeHttpEgressRequest {
+            runtime: RuntimeKind::FirstParty,
+            scope,
+            capability_id,
+            method: NetworkMethod::Post,
+            url: "https://api.example.test/v1/run".to_string(),
+            headers: vec![],
+            body: b"hello".to_vec(),
+            network_policy: sample_policy(),
+            credential_injections: vec![RuntimeCredentialInjection {
+                handle: SecretHandle::new("api-token").unwrap(),
+                source: RuntimeCredentialSource::SecretStoreLease,
+                target: RuntimeCredentialTarget::Header {
+                    name: "authorization".to_string(),
+                    prefix: Some("Bearer ".to_string()),
+                },
+                required: true,
+            }],
+            response_body_limit: Some(4096),
+            timeout_ms: None,
+        })
+        .expect_err("production first-party egress must require staged credentials");
+
+    assert!(matches!(
+        error,
+        RuntimeHttpEgressError::Credential { reason }
+            if reason == "direct secret-store leases are unavailable for production runtime egress"
+    ));
+    assert!(network_recorder.lock().unwrap().is_empty());
+}
+
+#[test]
 fn host_http_egress_fails_closed_without_staged_network_policy() {
     let network = RecordingNetwork::ok(NetworkHttpResponse {
         status: 200,

--- a/crates/ironclaw_llm/src/lib.rs
+++ b/crates/ironclaw_llm/src/lib.rs
@@ -91,10 +91,14 @@ pub use session::{SessionConfig, SessionManager, create_session_manager};
 pub use smart_routing::{SmartRoutingConfig, SmartRoutingProvider, TaskComplexity};
 pub use token_refreshing::TokenRefreshingProvider;
 
-use std::{path::Path, sync::Arc};
+#[cfg(feature = "registry-provider-factory")]
+use std::path::Path;
+use std::sync::Arc;
 
 use rig::client::CompletionClient;
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::ExposeSecret;
+#[cfg(feature = "registry-provider-factory")]
+use secrecy::SecretString;
 
 // LlmConfig, NearAiConfig, RegistryProviderConfig, and LlmError are
 // re-exported via `pub use` above from config and error submodules.

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -562,6 +562,11 @@ struct McpJsonRpcExchange {
     usage: ResourceUsage,
 }
 
+/// Known MCP JSON-RPC methods whose credential-routing behavior is host-owned.
+///
+/// Handshake methods must remain credential-free. Only `tools/call` can receive
+/// host-planned credentials, and even then only credentials staged by satisfied
+/// obligations are forwarded to production egress.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum McpJsonRpcMethod {
     Initialize,

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -18,8 +18,8 @@ use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, NetworkMethod, NetworkPolicy, ResourceEstimate, ResourceReservation,
     ResourceReservationId, ResourceScope, ResourceUsage, RuntimeCredentialInjection,
-    RuntimeCredentialSource, RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
-    RuntimeHttpEgressResponse, RuntimeKind,
+    RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
+    RuntimeKind,
 };
 use ironclaw_resources::{ResourceError, ResourceGovernor, ResourceReceipt};
 use serde_json::Value;
@@ -364,11 +364,11 @@ where
         request: &McpClientRequest,
         session_key: &McpHostHttpSessionKey,
         id: Option<u64>,
-        method: &str,
+        method: McpJsonRpcMethod,
         params: Option<Value>,
     ) -> Result<McpJsonRpcExchange, String> {
         let url = request.url.as_deref().ok_or_else(request_denied)?;
-        let body = encode_json_rpc_request(id, method, params)?;
+        let body = encode_json_rpc_request(id, method.as_str(), params)?;
         let mut headers = vec![
             ("Content-Type".to_string(), "application/json".to_string()),
             (
@@ -393,8 +393,7 @@ where
 
         let response_body_limit =
             effective_mcp_response_body_limit(plan.response_body_limit, request.max_output_bytes);
-        let credential_injections =
-            mcp_credentials_for_exchange(method, plan.credential_injections);
+        let credential_injections = method.credential_injections(plan.credential_injections);
         let response = self
             .http
             .request(McpHostHttpRequest {
@@ -502,7 +501,7 @@ where
             &request,
             &session_key,
             Some(self.next_request_id()),
-            "initialize",
+            McpJsonRpcMethod::Initialize,
             Some(json_rpc_initialize_params()),
         )?;
         accumulate_usage(&mut usage, initialize.usage);
@@ -514,7 +513,7 @@ where
             &request,
             &session_key,
             None,
-            "notifications/initialized",
+            McpJsonRpcMethod::InitializedNotification,
             None,
         )?;
         accumulate_usage(&mut usage, initialized.usage);
@@ -527,7 +526,7 @@ where
             &request,
             &session_key,
             Some(self.next_request_id()),
-            "tools/call",
+            McpJsonRpcMethod::ToolsCall,
             Some(serde_json::json!({
                 "name": tool_name,
                 "arguments": request.input,
@@ -563,29 +562,37 @@ struct McpJsonRpcExchange {
     usage: ResourceUsage,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpJsonRpcMethod {
+    Initialize,
+    InitializedNotification,
+    ToolsCall,
+}
+
+impl McpJsonRpcMethod {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Initialize => "initialize",
+            Self::InitializedNotification => "notifications/initialized",
+            Self::ToolsCall => "tools/call",
+        }
+    }
+
+    fn credential_injections(
+        self,
+        credential_injections: Vec<RuntimeCredentialInjection>,
+    ) -> Vec<RuntimeCredentialInjection> {
+        match self {
+            Self::ToolsCall => credential_injections,
+            Self::Initialize | Self::InitializedNotification => Vec::new(),
+        }
+    }
+}
+
 fn mcp_client_http_error(error: McpHostHttpError) -> String {
     match error {
         McpHostHttpError::Egress { reason } => reason,
     }
-}
-
-fn mcp_credentials_for_exchange(
-    method: &str,
-    credential_injections: Vec<RuntimeCredentialInjection>,
-) -> Vec<RuntimeCredentialInjection> {
-    if method == "tools/call" {
-        return credential_injections;
-    }
-
-    credential_injections
-        .into_iter()
-        .filter(|injection| {
-            !matches!(
-                injection.source,
-                RuntimeCredentialSource::StagedObligation { .. }
-            )
-        })
-        .collect()
 }
 
 fn effective_mcp_response_body_limit(host_limit: Option<u64>, client_limit: u64) -> Option<u64> {

--- a/crates/ironclaw_mcp/src/lib.rs
+++ b/crates/ironclaw_mcp/src/lib.rs
@@ -18,8 +18,8 @@ use ironclaw_extensions::{ExtensionPackage, ExtensionRuntime};
 use ironclaw_host_api::{
     CapabilityId, ExtensionId, NetworkMethod, NetworkPolicy, ResourceEstimate, ResourceReservation,
     ResourceReservationId, ResourceScope, ResourceUsage, RuntimeCredentialInjection,
-    RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest, RuntimeHttpEgressResponse,
-    RuntimeKind,
+    RuntimeCredentialSource, RuntimeHttpEgress, RuntimeHttpEgressError, RuntimeHttpEgressRequest,
+    RuntimeHttpEgressResponse, RuntimeKind,
 };
 use ironclaw_resources::{ResourceError, ResourceGovernor, ResourceReceipt};
 use serde_json::Value;
@@ -583,7 +583,15 @@ impl McpJsonRpcMethod {
         credential_injections: Vec<RuntimeCredentialInjection>,
     ) -> Vec<RuntimeCredentialInjection> {
         match self {
-            Self::ToolsCall => credential_injections,
+            Self::ToolsCall => credential_injections
+                .into_iter()
+                .filter(|injection| {
+                    matches!(
+                        injection.source,
+                        RuntimeCredentialSource::StagedObligation { .. }
+                    )
+                })
+                .collect(),
             Self::Initialize | Self::InitializedNotification => Vec::new(),
         }
     }

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -241,6 +241,53 @@ async fn concrete_mcp_http_client_routes_json_rpc_through_shared_egress() {
 }
 
 #[tokio::test]
+async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange() {
+    let scope = sample_scope();
+    let mut plan = host_http_plan();
+    plan.credential_injections = vec![RuntimeCredentialInjection {
+        handle: SecretHandle::new("github-token").unwrap(),
+        source: RuntimeCredentialSource::SecretStoreLease,
+        target: RuntimeCredentialTarget::Header {
+            name: "Authorization".to_string(),
+            prefix: Some("Bearer ".to_string()),
+        },
+        required: true,
+    }];
+    let egress = RecordingRuntimeEgress::json_rpc();
+    let client = McpHostHttpClient::new(
+        McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
+        RecordingEgressPlanner::new(plan.clone()),
+    );
+
+    client
+        .call_tool(McpClientRequest {
+            provider: ExtensionId::new("github-mcp").unwrap(),
+            capability_id: CapabilityId::new("github-mcp.search").unwrap(),
+            scope,
+            transport: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://mcp.example.test/mcp".to_string()),
+            input: json!({"query": "ironclaw"}),
+            max_output_bytes: 4096,
+        })
+        .await
+        .unwrap();
+
+    let requests = egress.requests();
+    assert_eq!(requests.len(), 3);
+    assert!(
+        requests[..2]
+            .iter()
+            .all(|request| request.credential_injections.is_empty())
+    );
+    assert_eq!(
+        requests[2].credential_injections,
+        plan.credential_injections
+    );
+}
+
+#[tokio::test]
 async fn concrete_mcp_http_client_scopes_session_ids_per_invocation() {
     let egress = ScopedSessionRuntimeEgress::new();
     let client = McpHostHttpClient::new(

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -244,15 +244,17 @@ async fn concrete_mcp_http_client_routes_json_rpc_through_shared_egress() {
 async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange() {
     let scope = sample_scope();
     let mut plan = host_http_plan();
-    plan.credential_injections = vec![RuntimeCredentialInjection {
-        handle: SecretHandle::new("github-token").unwrap(),
+    let staged_obligation = plan.credential_injections[0].clone();
+    let secret_store_lease = RuntimeCredentialInjection {
+        handle: SecretHandle::new("legacy-token").unwrap(),
         source: RuntimeCredentialSource::SecretStoreLease,
         target: RuntimeCredentialTarget::Header {
             name: "Authorization".to_string(),
             prefix: Some("Bearer ".to_string()),
         },
         required: true,
-    }];
+    };
+    plan.credential_injections = vec![secret_store_lease, staged_obligation.clone()];
     let egress = RecordingRuntimeEgress::json_rpc();
     let client = McpHostHttpClient::new(
         McpRuntimeHttpAdapter::new(Arc::new(egress.clone())),
@@ -283,7 +285,8 @@ async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange(
     );
     assert_eq!(
         requests[2].credential_injections,
-        plan.credential_injections
+        vec![staged_obligation],
+        "MCP tools/call must only receive credentials staged by satisfied obligations"
     );
 }
 

--- a/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
+++ b/crates/ironclaw_mcp/tests/mcp_adapter_contract.rs
@@ -279,9 +279,12 @@ async fn concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange(
     let requests = egress.requests();
     assert_eq!(requests.len(), 3);
     assert!(
-        requests[..2]
-            .iter()
-            .all(|request| request.credential_injections.is_empty())
+        requests[0].credential_injections.is_empty(),
+        "initialize handshake must not receive credential injections"
+    );
+    assert!(
+        requests[1].credential_injections.is_empty(),
+        "initialized notification must not receive credential injections"
     );
     assert_eq!(
         requests[2].credential_injections,

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -177,6 +177,8 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
 }
 
 fn builtin_extension_registry() -> Result<ExtensionRegistry, RebornBuildError> {
+    // Shared by local-dev and production composition so host-owned first-party
+    // capabilities expose the same built-in package contract in both profiles.
     let mut registry = ExtensionRegistry::new();
     registry
         .insert(

--- a/crates/ironclaw_reborn_composition/src/factory.rs
+++ b/crates/ironclaw_reborn_composition/src/factory.rs
@@ -145,14 +145,14 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     });
 
     let mut services = HostRuntimeServices::new(
-        Arc::new(local_dev_extension_registry()?),
+        Arc::new(builtin_extension_registry()?),
         Arc::new(filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
         ProcessServices::in_memory(),
         CapabilitySurfaceVersion::new("reborn-app-v1")?,
     )
-    .with_first_party_capabilities(Arc::new(local_dev_first_party_handlers()?))
+    .with_first_party_capabilities(Arc::new(builtin_first_party_registry()?))
     .with_trust_policy(Arc::new(local_dev_first_party_trust_policy()?))
     .with_run_state(Arc::clone(&run_state))
     .with_approval_requests(Arc::clone(&approval_requests))
@@ -176,7 +176,7 @@ async fn build_local_dev(input: RebornBuildInput) -> Result<RebornServices, Rebo
     })
 }
 
-fn local_dev_extension_registry() -> Result<ExtensionRegistry, RebornBuildError> {
+fn builtin_extension_registry() -> Result<ExtensionRegistry, RebornBuildError> {
     let mut registry = ExtensionRegistry::new();
     registry
         .insert(
@@ -190,7 +190,7 @@ fn local_dev_extension_registry() -> Result<ExtensionRegistry, RebornBuildError>
     Ok(registry)
 }
 
-fn local_dev_first_party_handlers() -> Result<FirstPartyCapabilityRegistry, RebornBuildError> {
+fn builtin_first_party_registry() -> Result<FirstPartyCapabilityRegistry, RebornBuildError> {
     builtin_first_party_handlers().map_err(|error| RebornBuildError::InvalidConfig {
         reason: format!("built-in first-party handlers are invalid: {error}"),
     })
@@ -387,7 +387,7 @@ async fn build_libsql_production(
     };
 
     let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
+        Arc::new(builtin_extension_registry()?),
         Arc::clone(&filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
@@ -396,8 +396,12 @@ async fn build_libsql_production(
     )
     .with_trust_policy(production_wiring.trust_policy)
     .with_runtime_policy(production_wiring.runtime_policy)
+    .with_first_party_capabilities(Arc::new(builtin_first_party_registry()?))
     .with_capability_leases(leases)
     .with_secret_store(secret_store)
+    .try_with_host_http_egress(ironclaw_network::PolicyNetworkHttpEgress::new(
+        ironclaw_network::ReqwestNetworkTransport::default(),
+    ))?
     .with_filesystem_resource_governor(Arc::clone(&scoped_filesystem))
     .with_reborn_event_store_config(profile.to_event_store_profile(), event_store)
     .await?
@@ -451,7 +455,7 @@ async fn build_postgres_production(
     let event_store = ironclaw_reborn_event_store::RebornEventStoreConfig::Postgres { url };
 
     let services = HostRuntimeServices::new(
-        Arc::new(ExtensionRegistry::new()),
+        Arc::new(builtin_extension_registry()?),
         Arc::clone(&filesystem),
         Arc::new(InMemoryResourceGovernor::new()),
         Arc::new(GrantAuthorizer::new()),
@@ -460,8 +464,12 @@ async fn build_postgres_production(
     )
     .with_trust_policy(production_wiring.trust_policy)
     .with_runtime_policy(production_wiring.runtime_policy)
+    .with_first_party_capabilities(Arc::new(builtin_first_party_registry()?))
     .with_capability_leases(leases)
     .with_secret_store(secret_store)
+    .try_with_host_http_egress(ironclaw_network::PolicyNetworkHttpEgress::new(
+        ironclaw_network::ReqwestNetworkTransport::default(),
+    ))?
     .with_filesystem_resource_governor(Arc::clone(&scoped_filesystem))
     .with_reborn_event_store_config(profile.to_event_store_profile(), event_store)
     .await?

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -10,13 +10,14 @@ use deadpool_postgres::tokio_postgres;
 #[cfg(any(feature = "libsql", feature = "postgres"))]
 use ironclaw_host_api::{
     AgentId, AuditMode, DeploymentMode, EffectKind, FilesystemBackendKind, NetworkMode, PackageId,
-    ProcessBackendKind, ProjectId, RuntimeProfile, SecretMode, TenantId, ThreadId, UserId,
+    ProcessBackendKind, ProjectId, RuntimeKind, RuntimeProfile, SecretMode, TenantId, ThreadId,
+    UserId,
     runtime_policy::{ApprovalPolicy, EffectiveRuntimePolicy},
 };
 #[cfg(feature = "libsql")]
 use ironclaw_host_api::{
     CapabilityGrant, CapabilityGrantId, CapabilityId, CapabilitySet, ExecutionContext, ExtensionId,
-    GrantConstraints, MountView, NetworkPolicy, Principal, RuntimeKind, TrustClass,
+    GrantConstraints, MountView, NetworkPolicy, Principal, TrustClass,
 };
 #[cfg(feature = "libsql")]
 use ironclaw_host_runtime::{CapabilitySurfacePolicy, SurfaceKind, VisibleCapabilityRequest};
@@ -535,6 +536,52 @@ async fn production_rejects_memory_libsql_event_store() {
     let rendered = error.to_string();
     assert!(!rendered.contains("postgres://"));
     assert!(!rendered.contains("token"));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn production_libsql_services_wire_first_party_runtime_http_egress() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("reborn.db");
+    let db = libsql_db_at(&db_path).await;
+    let (notifier, handle) = live_wake_notifier();
+
+    let services = build_reborn_services(
+        RebornBuildInput::libsql(
+            RebornCompositionProfile::Production,
+            "test-owner",
+            db,
+            dir.path().join("events.db").to_string_lossy(),
+            None,
+            test_master_key(),
+        )
+        .with_production_trust_policy(production_trust_policy())
+        .with_runtime_policy(production_runtime_policy())
+        .with_turn_run_wake_notifier(notifier)
+        .with_required_runtime_backends([RuntimeKind::FirstParty])
+        .require_runtime_http_egress(),
+    )
+    .await
+    .unwrap();
+
+    let health = services
+        .host_runtime
+        .as_ref()
+        .expect("production must expose host runtime")
+        .health()
+        .await
+        .unwrap();
+
+    handle.shutdown().await;
+
+    assert_eq!(
+        services.readiness.state,
+        RebornReadinessState::ProductionValidated
+    );
+    assert!(
+        health.ready,
+        "first-party runtime and production HTTP egress should satisfy production wiring: {health:?}"
+    );
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_reborn_composition/tests/facade_factory.rs
+++ b/crates/ironclaw_reborn_composition/tests/facade_factory.rs
@@ -584,6 +584,51 @@ async fn production_libsql_services_wire_first_party_runtime_http_egress() {
     );
 }
 
+#[cfg(feature = "postgres")]
+#[tokio::test]
+async fn production_postgres_services_wire_first_party_runtime_http_egress() {
+    let Some((_container, pool, database_url)) = postgres_pool_or_skip().await else {
+        return;
+    };
+    let (notifier, handle) = live_wake_notifier();
+
+    let services = build_reborn_services(
+        RebornBuildInput::postgres(
+            RebornCompositionProfile::Production,
+            "test-owner",
+            pool,
+            SecretMaterial::from(database_url),
+            test_master_key(),
+        )
+        .with_production_trust_policy(production_trust_policy())
+        .with_runtime_policy(production_runtime_policy())
+        .with_turn_run_wake_notifier(notifier)
+        .with_required_runtime_backends([RuntimeKind::FirstParty])
+        .require_runtime_http_egress(),
+    )
+    .await
+    .unwrap();
+
+    let health = services
+        .host_runtime
+        .as_ref()
+        .expect("production must expose host runtime")
+        .health()
+        .await
+        .unwrap();
+
+    handle.shutdown().await;
+
+    assert_eq!(
+        services.readiness.state,
+        RebornReadinessState::ProductionValidated
+    );
+    assert!(
+        health.ready,
+        "first-party runtime and production HTTP egress should satisfy Postgres production wiring: {health:?}"
+    );
+}
+
 #[cfg(feature = "libsql")]
 #[tokio::test]
 async fn migration_dry_run_validates_libsql_shape() {


### PR DESCRIPTION
## Summary

- make staged obligations the explicit production credential source for runtime HTTP egress
- route MCP credentials only to the `tools/call` exchange and keep handshake requests credential-free
- wire production Reborn services with built-in first-party capabilities and policy-backed host HTTP egress
- add first-party/native staged secret coverage plus production composition coverage

## Compatibility

`RuntimeCredentialInjection.source` is now required on serialized inputs. Payloads that previously omitted `source` and relied on the implicit `SecretStoreLease` default now fail deserialization; callers must send either `secret_store_lease` for legacy/test fallback paths or `staged_obligation` for production runtime egress.

## Issue closeout

This completes the #3803 framework scope: scoped secret storage, one-shot staging, host-mediated egress injection, and production composition wiring are in place for follow-on MCP/WASM/OAuth work. Once this PR merges, #3803 can be closed.

## Validation

- `cargo fmt`
- `cargo test -p ironclaw_mcp concrete_mcp_http_client_sends_credentials_only_for_tool_call_exchange --test mcp_adapter_contract`
- `cargo test -p ironclaw_mcp concrete_mcp_http_client_routes_json_rpc_through_shared_egress --test mcp_adapter_contract`
- `cargo test -p ironclaw_host_api`
- `cargo test -p ironclaw_host_api runtime_credential_injection_rejects_missing_source --test host_api_contract`
- `cargo test -p ironclaw_host_runtime request_policy_fallback_accepts_secret_store_lease_for_legacy_tests --test runtime_http_egress_contract`
- `cargo test -p ironclaw_host_runtime production_host_http_egress --test runtime_http_egress_contract`
- `cargo test -p ironclaw_host_runtime mcp_http_client_cannot_use_direct_secret_store_lease_with_production_egress --test runtime_http_egress_contract`
- `cargo test -p ironclaw_host_runtime first_party_http_egress_cannot_use_direct_secret_store_lease_with_production_egress --test runtime_http_egress_contract`
- `cargo test -p ironclaw_host_runtime first_party_handler_uses_staged_secret_through_production_host_egress --test first_party_runtime_contract`
- `cargo test -p ironclaw_host_runtime first_party_handler_rejects_non_string_url_input --test first_party_runtime_contract`
- `cargo test -p ironclaw_host_runtime --test first_party_runtime_contract`
- `cargo test -p ironclaw_reborn_composition --features libsql production_libsql_services_wire_first_party_runtime_http_egress --test facade_factory`
- `cargo test -p ironclaw_reborn_composition --features postgres production_postgres_services_wire_first_party_runtime_http_egress --test facade_factory`
- `cargo check -p ironclaw_reborn_composition`
- `cargo check -p ironclaw_reborn_composition --features postgres`
- `git diff --check`
