### PR TITLE
fix(ci): grant pull-requests:write for /benchmark reactions endpoint

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -24,9 +24,18 @@ on:
 # (pull-requests:write + issues:write); the effective permissions in the
 # called job are the intersection of these two, so a hostile change in
 # the benchmarks repo can't acquire writes we didn't grant here.
+#
+# `pull-requests: write` (not just `issues: write`) is required because
+# GitHub's reactions endpoint for PR-issue-comments rejects an
+# `issues: write`-only GITHUB_TOKEN with `403 Resource not accessible by
+# integration`, despite the docs at
+# https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue-comment
+# listing only `issues: write`. Observed in
+# https://github.com/nearai/ironclaw/actions/runs/26197185339 (the
+# canary on PR #3834 that found this bug).
 permissions:
-  pull-requests: read   # gh pr view --json headRefOid (PR metadata only)
-  issues: write         # gh pr comment + gh api .../reactions (PR comments are issue comments)
+  pull-requests: write  # gh pr view + gh pr comment + reactions on PR comments
+  issues: write         # belt-and-suspenders; also covers parse-error comment
   contents: read
 
 jobs:


### PR DESCRIPTION
## Why

The first live `/benchmark` canary on #3834 failed with:

```
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration",
 "documentation_url":"https://docs.github.com/rest/reactions/reactions#create-reaction-for-an-issue-comment"}
```

Run of record: https://github.com/nearai/ironclaw/actions/runs/26197185339

The dispatcher's 🚀 acknowledgment step posts to `POST /repos/.../issues/comments/{id}/reactions`. The reactions API docs say this requires `issues: write` — which the workflow already had — but in practice the GITHUB_TOKEN scope check treats reactions on PR-issue-comments as a PR resource and demands `pull-requests: write`. The dispatcher's workflow-level perms had `pull-requests: read` (which Firat asked for in #3808 review for least-privilege) — sufficient for `gh pr view --json headRefOid` but not for the reactions endpoint.

## Why the pre-merge `workflow_dispatch` test didn't catch this

We tested cross-repo posting with a `dry-run=false` dispatch targeting nearai/benchmarks#34. That validated `gh pr comment` (which only needs `issues: write` — and that path works). But the reaction-toggle step in `bench-pr-reusable.yml` has `if: env.COMMENT_ID != '0'`, and we passed `COMMENT_ID=0` (workflow_dispatch can't pass a real comment ID), so the reactions API was never exercised with the workflow GITHUB_TOKEN before today's live canary.

## Fix

Bump dispatcher's workflow-level `pull-requests: read` → `write`. The parse job (where 🚀 lives) inherits this. The bench job keeps its job-scoped `pull-requests: write` override (same effective scope, no behavior change there).

Updated the inline comment in the file with a link to the failure-of-record so a future maintainer knows where this requirement came from.

## Test plan

After merge: re-comment `/benchmark ironclaw-smoke` on #3834. Expect:
- 🚀 reaction on the trigger comment within ~30s
- `bench` job runs (~5 min)
- Result comment posts on #3834
- 🚀 → 👍 / 👎 toggle

## Note for @serrrfirat

This nudges back from the strict least-privilege posture you suggested in #3808 — but only because the platform requires it for the reactions endpoint we already shipped using. Net effect on attack surface: minimal. The parse job already needed write access to post comments + reactions; this just makes the write declaration honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)