### PR TITLE
feat(ci): post "started" comment with link to dispatcher run

### DIFF
--- a/.github/workflows/nearai-bench.yml
+++ b/.github/workflows/nearai-bench.yml
@@ -134,6 +134,29 @@ jobs:
         run: |
           gh api "/repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -F content=rocket
 
+      - name: Post "started" comment with link to dispatcher run
+        # Closes the gap between the 🚀 reaction and the eventual result
+        # comment (~5–10 min later from the called workflow). Gives the
+        # maintainer a clickable link straight to the Actions run.
+        if: steps.auth.outputs.authorized == 'yes' && steps.parse.outputs.suite != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+          SUITE: ${{ steps.parse.outputs.suite }}
+          MODEL: ${{ steps.parse.outputs.model }}
+          HEAD_SHA: ${{ steps.parse.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          short_sha="${HEAD_SHA:0:10}"
+          model_part=""
+          if [ -n "$MODEL" ]; then
+            model_part=" (model \`$MODEL\`)"
+          fi
+          gh pr comment "$PR" --repo "$REPO" --body \
+            "🧪 Started \`$SUITE\`${model_part} against ironclaw \`$short_sha\` — [watch run]($RUN_URL)."
+
   bench:
     needs: parse
     if: needs.parse.outputs.authorized == 'yes' && needs.parse.outputs.suite != ''


### PR DESCRIPTION
## Why

Today's slash-command flow has a silent middle. From the maintainer's perspective:

| t | event |
|---|---|
| t+0 | comment `/benchmark ironclaw-smoke` |
| t+30s | 🚀 reaction appears |
| t+30s … t+10min | (silence — no indication where to watch) |
| t+10min | result comment posts; 🚀 toggles to 👍/👎 |

The middle is where this PR helps. Adds one step to the dispatcher's `parse` job, right after the 🚀 reaction, that posts a short ack comment with a clickable link straight to the Actions run.

## Result

```
you (trigger):       /benchmark ironclaw-smoke      [🚀 reaction]
bot (ack):           🧪 Started `ironclaw-smoke` against ironclaw `81be41c` —
                     [watch run](https://github.com/nearai/ironclaw/actions/runs/N).
bot (result, later): ## 🧪 nearai-bench `ironclaw-smoke` (10 tasks) — ✅ no regressions
                     | pass rate | 80% | …
```

When a maintainer passes `--model`, the ack reflects it:

```
bot (ack): 🧪 Started `ironclaw-smoke` (model `qwen/qwen3.5-35b-a3b`) against ironclaw `81be41c` —
           [watch run](url).
```

## Scope

- **One file changed**: `.github/workflows/nearai-bench.yml` — one new step in the `parse` job
- **No new permissions**: `gh pr comment` needs `issues: write`, which the workflow already has
- **Same gating as 🚀**: unauthorized comments and `/benchmark does-not-exist` paths are unchanged — the new step is behind the same auth + parse-success condition, so neither sees this ack
- **No reusable-workflow changes**: the eventual result comment still comes from `bench-pr-reusable.yml` on nearai/benchmarks; this PR only touches the dispatcher

## Test plan

After merge:
1. Re-comment `/benchmark ironclaw-smoke` on #3834 (the throwaway canary PR that's already there)
2. Expect within ~30s: 🚀 reaction + a new "Started" ack comment with a working link to the dispatcher run
3. Expect ~5 min later: result comment posts as before, 🚀 → 👍

Edge cases unchanged:
- `/benchmark does-not-exist` → one "Unknown suite. Available: …" comment, no 🚀, no ack
- Unauthorized commenter → zero output

🤖 Generated with [Claude Code](https://claude.com/claude-code)