### PR TITLE
[codex] Add scoped Reborn skills mount

### DIFF
--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -727,7 +727,7 @@ mod mount_view_tests {
         let user_path = ScopedPath::new("/skills/code-review/SKILL.md").unwrap();
 
         let error = scoped
-            .write_file(&scope, &system_path, b"system skill")
+            .write_bytes(&scope, &system_path, b"system skill".to_vec())
             .await
             .expect_err("system skills must remain read-only");
         assert!(matches!(

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -743,7 +743,7 @@ mod mount_view_tests {
             .await
             .expect("user skills should be writable through the scoped alias");
         let content = scoped
-            .read_file(&scope, &user_path)
+            .read_bytes(&scope, &user_path)
             .await
             .expect("user skill should be readable");
         assert_eq!(content, b"user skill");

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -739,7 +739,7 @@ mod mount_view_tests {
         ));
 
         scoped
-            .write_file(&scope, &user_path, b"user skill")
+            .write_bytes(&scope, &user_path, b"user skill".to_vec())
             .await
             .expect("user skills should be writable through the scoped alias");
         let content = scoped

--- a/crates/ironclaw_reborn_composition/src/lib.rs
+++ b/crates/ironclaw_reborn_composition/src/lib.rs
@@ -221,6 +221,7 @@ const PER_USER_ALIASES: &[&str] = &[
     "/turns",
     "/resources",
     "/engine",
+    "/skills",
 ];
 
 /// Per-invocation [`MountView`] used as the production resolver.
@@ -580,6 +581,7 @@ impl SecretStore for SharedSecretStore {
 #[cfg(all(test, any(feature = "libsql", feature = "postgres")))]
 mod mount_view_tests {
     use super::*;
+    use ironclaw_filesystem::{FilesystemError, FilesystemOperation, InMemoryBackend};
     use ironclaw_host_api::{
         AgentId, InvocationId, MissionId, ProjectId, ScopedPath, TenantId, ThreadId, UserId,
     };
@@ -661,6 +663,90 @@ mod mount_view_tests {
                 .unwrap();
             assert_eq!(resolved.as_str(), &format!("{system_subroot}/foo"));
         }
+    }
+
+    #[test]
+    fn invocation_mount_view_routes_user_skills_to_tenant_user_root() {
+        let scope = sample_scope();
+        let view = invocation_mount_view(&scope).unwrap();
+        let (resolved, grant) = view
+            .resolve_with_grant(&ScopedPath::new("/skills/code-review/SKILL.md").unwrap())
+            .unwrap();
+        assert_eq!(
+            resolved.as_str(),
+            &format!(
+                "/tenants/{}/users/{}/skills/code-review/SKILL.md",
+                scope.tenant_id.as_str(),
+                scope.user_id.as_str()
+            )
+        );
+        assert!(grant.permissions.read);
+        assert!(grant.permissions.write);
+        assert!(grant.permissions.list);
+        assert!(grant.permissions.delete);
+        assert!(!grant.permissions.execute);
+    }
+
+    #[test]
+    fn invocation_mount_view_keeps_user_skills_isolated_from_system_skills() {
+        let scope = sample_scope();
+        let view = invocation_mount_view(&scope).unwrap();
+        let user_skill = view
+            .resolve(&ScopedPath::new("/skills/code-review/SKILL.md").unwrap())
+            .unwrap();
+        let system_skill = view
+            .resolve(&ScopedPath::new("/system/skills/code-review/SKILL.md").unwrap())
+            .unwrap();
+        assert_ne!(user_skill.as_str(), system_skill.as_str());
+        assert!(
+            user_skill
+                .as_str()
+                .starts_with("/tenants/tenant-a/users/user-1/skills/")
+        );
+        assert_eq!(system_skill.as_str(), "/system/skills/code-review/SKILL.md");
+    }
+
+    #[test]
+    fn invocation_mount_view_isolates_user_skills_between_tenants() {
+        let view_a = invocation_mount_view(&sample_scope()).unwrap();
+        let view_b = invocation_mount_view(&other_tenant_scope()).unwrap();
+        let path = ScopedPath::new("/skills/code-review/SKILL.md").unwrap();
+        let a = view_a.resolve(&path).unwrap();
+        let b = view_b.resolve(&path).unwrap();
+        assert_ne!(a.as_str(), b.as_str());
+        assert!(a.as_str().contains("tenant-a"));
+        assert!(b.as_str().contains("tenant-b"));
+    }
+
+    #[tokio::test]
+    async fn scoped_filesystem_rejects_system_skill_writes_but_allows_user_skill_writes() {
+        let root = Arc::new(InMemoryBackend::default());
+        let scoped = wrap_scoped(root);
+        let scope = sample_scope();
+        let system_path = ScopedPath::new("/system/skills/code-review/SKILL.md").unwrap();
+        let user_path = ScopedPath::new("/skills/code-review/SKILL.md").unwrap();
+
+        let error = scoped
+            .write_file(&scope, &system_path, b"system skill")
+            .await
+            .expect_err("system skills must remain read-only");
+        assert!(matches!(
+            error,
+            FilesystemError::PermissionDenied {
+                operation: FilesystemOperation::WriteFile,
+                ..
+            }
+        ));
+
+        scoped
+            .write_file(&scope, &user_path, b"user skill")
+            .await
+            .expect("user skills should be writable through the scoped alias");
+        let content = scoped
+            .read_file(&scope, &user_path)
+            .await
+            .expect("user skill should be readable");
+        assert_eq!(content, b"user skill");
     }
 }
 


### PR DESCRIPTION
## Summary
- add `/skills` to the per-user Reborn scoped mount aliases
- keep `/system/skills` as a separate read-only global mount
- add mount-view and scoped-filesystem regression tests for user skill isolation and system-skill write denial

## Context
PR 2 from #3473 first-party skills extension lane. This implements the storage mount slice from the contract added in #3824.

## Validation
- `cargo fmt --check -p ironclaw_reborn_composition`
- `git diff --check`
- `cargo test -p ironclaw_reborn_composition --features libsql mount_view_tests`
- `cargo test -p ironclaw_architecture`