### PR TITLE
[codex] Add filesystem-backed Reborn skill bundle source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4431,6 +4431,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "ironclaw_filesystem",
  "ironclaw_host_api",
  "ironclaw_host_runtime",
  "ironclaw_memory",

--- a/crates/ironclaw_filesystem/src/scoped.rs
+++ b/crates/ironclaw_filesystem/src/scoped.rs
@@ -298,6 +298,19 @@ where
         }
     }
 
+    /// Read the body bytes at `path` only when the backend can enforce the
+    /// supplied size bound before materializing oversized content.
+    pub async fn read_bytes_bounded(
+        &self,
+        scope: &ResourceScope,
+        path: &ScopedPath,
+        max_bytes: usize,
+    ) -> Result<Option<Vec<u8>>, FilesystemError> {
+        let virtual_path =
+            self.resolve_with_permission(scope, path, FilesystemOperation::ReadFile)?;
+        self.root.read_file_bounded(&virtual_path, max_bytes).await
+    }
+
     /// Write `body` as an opaque-file entry at `path` (no CAS precondition).
     /// Convenience wrapper over [`put`].
     pub async fn write_bytes(
@@ -562,6 +575,49 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn read_bytes_bounded_enforces_size_at_scoped_boundary() {
+        let scoped = scoped_in_memory(no_op(true, true, false, false));
+        scoped
+            .write_bytes(
+                &test_scope(),
+                &ScopedPath::new("/workspace/large.txt").unwrap(),
+                b"large body".to_vec(),
+            )
+            .await
+            .unwrap();
+
+        let body = scoped
+            .read_bytes_bounded(
+                &test_scope(),
+                &ScopedPath::new("/workspace/large.txt").unwrap(),
+                4,
+            )
+            .await
+            .unwrap();
+        assert_eq!(body, None);
+    }
+
+    #[tokio::test]
+    async fn read_bytes_bounded_denies_when_read_missing() {
+        let scoped = scoped_in_memory(no_op(false, true, false, false));
+        let err = scoped
+            .read_bytes_bounded(
+                &test_scope(),
+                &ScopedPath::new("/workspace/large.txt").unwrap(),
+                4,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            FilesystemError::PermissionDenied {
+                operation: FilesystemOperation::ReadFile,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_loop_support/Cargo.toml
+++ b/crates/ironclaw_loop_support/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 ironclaw_host_runtime = { path = "../ironclaw_host_runtime", version = "0.1.0" }
+ironclaw_filesystem = { path = "../ironclaw_filesystem", version = "0.1.0" }
 ironclaw_skills = { path = "../ironclaw_skills", version = "0.3.0", default-features = false }
 ironclaw_memory = { path = "../ironclaw_memory", version = "0.1.0" }
 ironclaw_threads = { path = "../ironclaw_threads", version = "0.1.0" }

--- a/crates/ironclaw_loop_support/src/filesystem_skill_bundle_source.rs
+++ b/crates/ironclaw_loop_support/src/filesystem_skill_bundle_source.rs
@@ -1,10 +1,12 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem, ScopedFilesystem};
 use ironclaw_host_api::{ResourceScope, ScopedPath};
-use ironclaw_skills::{MAX_PROMPT_FILE_SIZE, SkillTrust, normalize_line_endings, parse_skill_md};
+use ironclaw_skills::{MAX_PROMPT_FILE_SIZE, SkillTrust, parse_skill_md};
 use ironclaw_turns::run_profile::{LoopRunContext, SkillVisibility};
+use parking_lot::Mutex;
+use tracing::debug;
 
 use crate::{
     SkillBundleDescriptor, SkillBundleId, SkillBundleProvenance, SkillBundleSource,
@@ -12,7 +14,9 @@ use crate::{
 };
 
 const DEFAULT_MAX_BUNDLE_FILE_BYTES: usize = 256 * 1024;
+const DEFAULT_MAX_BUNDLES_PER_ROOT: usize = 100;
 
+/// One scoped filesystem root that can contain portable skill bundle folders.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FilesystemSkillBundleRoot {
     source_kind: SkillSourceKind,
@@ -22,6 +26,7 @@ pub struct FilesystemSkillBundleRoot {
 }
 
 impl FilesystemSkillBundleRoot {
+    /// Creates a skill bundle root with caller-supplied source metadata.
     pub fn new(
         source_kind: SkillSourceKind,
         root: ScopedPath,
@@ -36,6 +41,7 @@ impl FilesystemSkillBundleRoot {
         }
     }
 
+    /// Creates a built-in system skill root.
     pub fn system(root: ScopedPath) -> Self {
         Self::new(
             SkillSourceKind::System,
@@ -45,15 +51,17 @@ impl FilesystemSkillBundleRoot {
         )
     }
 
+    /// Creates a user-owned skill root.
     pub fn user(root: ScopedPath) -> Self {
         Self::new(
             SkillSourceKind::User,
             root,
-            Some(SkillTrust::Installed),
+            Some(SkillTrust::Trusted),
             Some(SkillVisibility::Visible),
         )
     }
 
+    /// Creates a tenant-shared skill root.
     pub fn tenant_shared(root: ScopedPath) -> Self {
         Self::new(
             SkillSourceKind::TenantShared,
@@ -63,28 +71,35 @@ impl FilesystemSkillBundleRoot {
         )
     }
 
+    /// Returns the descriptor source kind for bundles discovered under this root.
     pub fn source_kind(&self) -> SkillSourceKind {
         self.source_kind
     }
 
+    /// Returns the scoped filesystem path for this root.
     pub fn root(&self) -> &ScopedPath {
         &self.root
     }
 
+    /// Returns trust metadata applied to bundles discovered under this root.
     pub fn trust(&self) -> Option<&SkillTrust> {
         self.trust.as_ref()
     }
 
+    /// Returns visibility metadata applied to bundles discovered under this root.
     pub fn visibility(&self) -> Option<&SkillVisibility> {
         self.visibility.as_ref()
     }
 }
 
+/// Filesystem-backed skill bundle source over host-approved scoped roots.
 pub struct FilesystemSkillBundleSource<F> {
     filesystem: Arc<ScopedFilesystem<F>>,
     roots: Vec<FilesystemSkillBundleRoot>,
+    validated_manifests: Mutex<HashSet<ScopedPath>>,
     max_skill_md_bytes: usize,
     max_bundle_file_bytes: usize,
+    max_bundles_per_root: usize,
 }
 
 impl<F> std::fmt::Debug for FilesystemSkillBundleSource<F> {
@@ -93,8 +108,13 @@ impl<F> std::fmt::Debug for FilesystemSkillBundleSource<F> {
             .debug_struct("FilesystemSkillBundleSource")
             .field("filesystem", &"<ScopedFilesystem>")
             .field("roots", &self.roots)
+            .field(
+                "validated_manifests",
+                &self.validated_manifests.lock().len(),
+            )
             .field("max_skill_md_bytes", &self.max_skill_md_bytes)
             .field("max_bundle_file_bytes", &self.max_bundle_file_bytes)
+            .field("max_bundles_per_root", &self.max_bundles_per_root)
             .finish()
     }
 }
@@ -103,28 +123,44 @@ impl<F> FilesystemSkillBundleSource<F>
 where
     F: RootFilesystem,
 {
+    /// Creates a filesystem skill bundle source.
+    ///
+    /// Each source kind must appear at most once because bundle ids intentionally
+    /// expose source kind and name, not raw host root provenance.
     pub fn new(
         filesystem: Arc<ScopedFilesystem<F>>,
         roots: Vec<FilesystemSkillBundleRoot>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, SkillBundleSourceError> {
+        ensure_unique_source_kinds(&roots)?;
+        Ok(Self {
             filesystem,
             roots,
+            validated_manifests: Mutex::new(HashSet::new()),
             max_skill_md_bytes: MAX_PROMPT_FILE_SIZE as usize,
             max_bundle_file_bytes: DEFAULT_MAX_BUNDLE_FILE_BYTES,
-        }
+            max_bundles_per_root: DEFAULT_MAX_BUNDLES_PER_ROOT,
+        })
     }
 
+    /// Overrides the maximum allowed `SKILL.md` manifest size in bytes.
     pub fn with_max_skill_md_bytes(mut self, max_skill_md_bytes: usize) -> Self {
         self.max_skill_md_bytes = max_skill_md_bytes;
         self
     }
 
+    /// Overrides the maximum allowed supporting file size in bytes.
     pub fn with_max_bundle_file_bytes(mut self, max_bundle_file_bytes: usize) -> Self {
         self.max_bundle_file_bytes = max_bundle_file_bytes;
         self
     }
 
+    /// Overrides the maximum number of bundle directories scanned per root.
+    pub fn with_max_bundles_per_root(mut self, max_bundles_per_root: usize) -> Self {
+        self.max_bundles_per_root = max_bundles_per_root;
+        self
+    }
+
+    /// Returns the configured filesystem roots.
     pub fn roots(&self) -> &[FilesystemSkillBundleRoot] {
         &self.roots
     }
@@ -141,15 +177,30 @@ where
             Err(error) => return Err(map_filesystem_error(error)),
         };
 
+        let mut directory_entries = Vec::new();
         for entry in entries {
-            if entry.file_type != FileType::Directory {
-                continue;
+            if entry.file_type == FileType::Directory {
+                directory_entries.push(entry);
+                if directory_entries.len() > self.max_bundles_per_root {
+                    return Err(SkillBundleSourceError::BundleScanLimitExceeded);
+                }
             }
+        }
+
+        let skill_md_file = SkillFilePath::skill_md();
+        for entry in directory_entries {
             let bundle_id = match SkillBundleId::new(root.source_kind(), &entry.name) {
                 Ok(bundle_id) => bundle_id,
-                Err(_) => continue,
+                Err(_) => {
+                    debug!(
+                        bundle_name = %entry.name,
+                        source_kind = %root.source_kind(),
+                        "skipping invalid skill bundle directory name"
+                    );
+                    continue;
+                }
             };
-            let skill_md_path = bundle_scoped_path(root.root(), bundle_id.name(), "SKILL.md")?;
+            let skill_md_path = bundle_scoped_path(root.root(), &bundle_id, &skill_md_file)?;
             match self
                 .validate_bundle_manifest(scope, &skill_md_path, &bundle_id)
                 .await
@@ -158,6 +209,7 @@ where
                 Err(SkillBundleSourceError::FileNotFound) => continue,
                 Err(error) => return Err(error),
             }
+            self.validated_manifests.lock().insert(skill_md_path);
 
             descriptors.push(
                 SkillBundleDescriptor::new(
@@ -181,11 +233,10 @@ where
         let skill_md = self
             .read_bounded(scope, skill_md_path, self.max_skill_md_bytes)
             .await?;
-        let skill_md =
-            String::from_utf8(skill_md).map_err(|_| SkillBundleSourceError::InvalidSkillBundle)?;
-        let skill_md = normalize_line_endings(&skill_md);
+        let skill_md = String::from_utf8(skill_md)
+            .map_err(|_| SkillBundleSourceError::BundleUtf8DecodeFailed)?;
         let parsed =
-            parse_skill_md(&skill_md).map_err(|_| SkillBundleSourceError::InvalidSkillBundle)?;
+            parse_skill_md(&skill_md).map_err(|_| SkillBundleSourceError::ManifestParseFailed)?;
         if parsed.manifest.name != bundle_id.name() {
             return Err(SkillBundleSourceError::InvalidSkillBundle);
         }
@@ -198,26 +249,11 @@ where
         path: &ScopedPath,
         max_bytes: usize,
     ) -> Result<Vec<u8>, SkillBundleSourceError> {
-        let stat = self
-            .filesystem
-            .stat(scope, path)
+        self.filesystem
+            .read_bytes_bounded(scope, path, max_bytes)
             .await
-            .map_err(map_file_read_error)?;
-        if stat.file_type != FileType::File {
-            return Err(SkillBundleSourceError::FileNotFound);
-        }
-        if stat.len > max_bytes as u64 {
-            return Err(SkillBundleSourceError::ContentTooLarge);
-        }
-        let bytes = self
-            .filesystem
-            .read_bytes(scope, path)
-            .await
-            .map_err(map_file_read_error)?;
-        if bytes.len() > max_bytes {
-            return Err(SkillBundleSourceError::ContentTooLarge);
-        }
-        Ok(bytes)
+            .map_err(map_file_read_error)?
+            .ok_or(SkillBundleSourceError::ContentTooLarge)
     }
 }
 
@@ -251,14 +287,19 @@ where
             .find(|root| root.source_kind() == bundle_id.source_kind())
             .ok_or(SkillBundleSourceError::BundleNotFound)?;
         let scope = resource_scope_for_run(run_context);
-        let skill_md_path = bundle_scoped_path(root.root(), bundle_id.name(), "SKILL.md")?;
-        self.validate_bundle_manifest(&scope, &skill_md_path, bundle_id)
-            .await
-            .map_err(|error| match error {
-                SkillBundleSourceError::FileNotFound => SkillBundleSourceError::BundleNotFound,
-                other => other,
-            })?;
-        let scoped_path = bundle_scoped_path(root.root(), bundle_id.name(), path.as_str())?;
+        let skill_md_path = bundle_scoped_path(root.root(), bundle_id, &SkillFilePath::skill_md())?;
+        if !self.validated_manifests.lock().contains(&skill_md_path) {
+            self.validate_bundle_manifest(&scope, &skill_md_path, bundle_id)
+                .await
+                .map_err(|error| match error {
+                    SkillBundleSourceError::FileNotFound => SkillBundleSourceError::BundleNotFound,
+                    other => other,
+                })?;
+            self.validated_manifests
+                .lock()
+                .insert(skill_md_path.clone());
+        }
+        let scoped_path = bundle_scoped_path(root.root(), bundle_id, path)?;
         self.read_bounded(&scope, &scoped_path, self.max_bundle_file_bytes)
             .await
     }
@@ -274,16 +315,28 @@ fn resource_scope_for_run(run_context: &LoopRunContext) -> ResourceScope {
 
 fn bundle_scoped_path(
     root: &ScopedPath,
-    bundle_name: &str,
-    path: &str,
+    bundle_id: &SkillBundleId,
+    path: &SkillFilePath,
 ) -> Result<ScopedPath, SkillBundleSourceError> {
     ScopedPath::new(format!(
         "{}/{}/{}",
         root.as_str().trim_end_matches('/'),
-        bundle_name,
-        path
+        bundle_id.name(),
+        path.as_str()
     ))
     .map_err(|_| SkillBundleSourceError::InvalidFilePath)
+}
+
+fn ensure_unique_source_kinds(
+    roots: &[FilesystemSkillBundleRoot],
+) -> Result<(), SkillBundleSourceError> {
+    let mut seen = HashSet::new();
+    for root in roots {
+        if !seen.insert(root.source_kind()) {
+            return Err(SkillBundleSourceError::DuplicateSourceKind);
+        }
+    }
+    Ok(())
 }
 
 fn map_file_read_error(error: FilesystemError) -> SkillBundleSourceError {
@@ -312,6 +365,7 @@ fn map_filesystem_error(error: FilesystemError) -> SkillBundleSourceError {
         | FilesystemError::CorruptRecordVersion { .. }
         | FilesystemError::IndexSpecMissingAfterUpsert { .. }
         | FilesystemError::BackendInfrastructure { .. } => SkillBundleSourceError::Internal,
+        // FilesystemError is #[non_exhaustive], so a wildcard remains required.
         _ => SkillBundleSourceError::Internal,
     }
 }
@@ -377,7 +431,8 @@ mod tests {
                 FilesystemSkillBundleRoot::system(ScopedPath::new("/system/skills").unwrap()),
                 FilesystemSkillBundleRoot::user(ScopedPath::new("/skills").unwrap()),
             ],
-        );
+        )
+        .unwrap();
         (root, source)
     }
 
@@ -436,7 +491,7 @@ mod tests {
             ]
         );
         assert_eq!(descriptors[0].trust(), Some(&SkillTrust::Trusted));
-        assert_eq!(descriptors[1].trust(), Some(&SkillTrust::Installed));
+        assert_eq!(descriptors[1].trust(), Some(&SkillTrust::Trusted));
         assert_eq!(descriptors[0].visibility(), Some(&SkillVisibility::Visible));
     }
 
@@ -519,7 +574,61 @@ mod tests {
             .list_skill_bundles(&run_context().await)
             .await
             .unwrap_err();
-        assert_eq!(error, SkillBundleSourceError::InvalidSkillBundle);
+        assert_eq!(error, SkillBundleSourceError::ManifestParseFailed);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_rejects_non_utf8_skill_md() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/bad-skill/SKILL.md",
+            vec![0xff, 0xfe, 0xfd],
+        )
+        .await;
+
+        let error = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::BundleUtf8DecodeFailed);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_maps_manifest_permission_denied() {
+        let root = Arc::new(InMemoryBackend::default());
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/local-review/SKILL.md",
+            skill_md("local-review", "Local review"),
+        )
+        .await;
+        let view = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/skills").unwrap(),
+            VirtualPath::new("/tenants/tenant-a/users/user-a/skills").unwrap(),
+            MountPermissions {
+                read: false,
+                write: false,
+                list: true,
+                delete: false,
+                execute: false,
+            },
+        )])
+        .unwrap();
+        let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(Arc::clone(&root), view));
+        let source = FilesystemSkillBundleSource::new(
+            filesystem,
+            vec![FilesystemSkillBundleRoot::user(
+                ScopedPath::new("/skills").unwrap(),
+            )],
+        )
+        .unwrap();
+
+        let error = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::PermissionDenied);
     }
 
     #[tokio::test]
@@ -537,6 +646,96 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(error, SkillBundleSourceError::InvalidSkillBundle);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_skips_invalid_bundle_folder_names() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/valid-skill/SKILL.md",
+            skill_md("valid-skill", "Valid skill"),
+        )
+        .await;
+        for invalid_name in [
+            "has space",
+            "-starts-with-dash",
+            ".starts-with-dot",
+            "ümlaut",
+        ] {
+            write_root(
+                &root,
+                &format!("/tenants/tenant-a/users/user-a/skills/{invalid_name}/SKILL.md"),
+                skill_md(invalid_name, "Invalid skill"),
+            )
+            .await;
+        }
+
+        let descriptors = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap();
+        let ids: Vec<String> = descriptors
+            .iter()
+            .map(|descriptor| descriptor.id().to_string())
+            .collect();
+        assert_eq!(ids, vec!["user:valid-skill"]);
+    }
+
+    #[test]
+    fn filesystem_source_rejects_traversal_file_paths_before_read() {
+        for invalid in ["../sibling/SKILL.md", "..", "references/../SKILL.md"] {
+            assert_eq!(
+                SkillFilePath::new(invalid).unwrap_err(),
+                SkillBundleSourceError::InvalidFilePath
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_rejects_duplicate_source_kind_roots() {
+        let root = Arc::new(InMemoryBackend::default());
+        let view = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/skills").unwrap(),
+            VirtualPath::new("/tenants/tenant-a/users/user-a/skills").unwrap(),
+            MountPermissions::read_write_list_delete(),
+        )])
+        .unwrap();
+        let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(root, view));
+
+        let error = FilesystemSkillBundleSource::new(
+            filesystem,
+            vec![
+                FilesystemSkillBundleRoot::user(ScopedPath::new("/skills").unwrap()),
+                FilesystemSkillBundleRoot::user(ScopedPath::new("/skills/other").unwrap()),
+            ],
+        )
+        .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::DuplicateSourceKind);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_enforces_bundle_scan_limit() {
+        let (root, source) = mounted_source();
+        let source = source.with_max_bundles_per_root(1);
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/alpha/SKILL.md",
+            skill_md("alpha", "Alpha"),
+        )
+        .await;
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/beta/SKILL.md",
+            skill_md("beta", "Beta"),
+        )
+        .await;
+
+        let error = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::BundleScanLimitExceeded);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_loop_support/src/filesystem_skill_bundle_source.rs
+++ b/crates/ironclaw_loop_support/src/filesystem_skill_bundle_source.rs
@@ -1,0 +1,587 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem, ScopedFilesystem};
+use ironclaw_host_api::{ResourceScope, ScopedPath};
+use ironclaw_skills::{MAX_PROMPT_FILE_SIZE, SkillTrust, normalize_line_endings, parse_skill_md};
+use ironclaw_turns::run_profile::{LoopRunContext, SkillVisibility};
+
+use crate::{
+    SkillBundleDescriptor, SkillBundleId, SkillBundleProvenance, SkillBundleSource,
+    SkillBundleSourceError, SkillFilePath, SkillSourceKind, sort_skill_bundle_descriptors,
+};
+
+const DEFAULT_MAX_BUNDLE_FILE_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilesystemSkillBundleRoot {
+    source_kind: SkillSourceKind,
+    root: ScopedPath,
+    trust: Option<SkillTrust>,
+    visibility: Option<SkillVisibility>,
+}
+
+impl FilesystemSkillBundleRoot {
+    pub fn new(
+        source_kind: SkillSourceKind,
+        root: ScopedPath,
+        trust: Option<SkillTrust>,
+        visibility: Option<SkillVisibility>,
+    ) -> Self {
+        Self {
+            source_kind,
+            root,
+            trust,
+            visibility,
+        }
+    }
+
+    pub fn system(root: ScopedPath) -> Self {
+        Self::new(
+            SkillSourceKind::System,
+            root,
+            Some(SkillTrust::Trusted),
+            Some(SkillVisibility::Visible),
+        )
+    }
+
+    pub fn user(root: ScopedPath) -> Self {
+        Self::new(
+            SkillSourceKind::User,
+            root,
+            Some(SkillTrust::Installed),
+            Some(SkillVisibility::Visible),
+        )
+    }
+
+    pub fn tenant_shared(root: ScopedPath) -> Self {
+        Self::new(
+            SkillSourceKind::TenantShared,
+            root,
+            Some(SkillTrust::Installed),
+            Some(SkillVisibility::Visible),
+        )
+    }
+
+    pub fn source_kind(&self) -> SkillSourceKind {
+        self.source_kind
+    }
+
+    pub fn root(&self) -> &ScopedPath {
+        &self.root
+    }
+
+    pub fn trust(&self) -> Option<&SkillTrust> {
+        self.trust.as_ref()
+    }
+
+    pub fn visibility(&self) -> Option<&SkillVisibility> {
+        self.visibility.as_ref()
+    }
+}
+
+pub struct FilesystemSkillBundleSource<F> {
+    filesystem: Arc<ScopedFilesystem<F>>,
+    roots: Vec<FilesystemSkillBundleRoot>,
+    max_skill_md_bytes: usize,
+    max_bundle_file_bytes: usize,
+}
+
+impl<F> std::fmt::Debug for FilesystemSkillBundleSource<F> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FilesystemSkillBundleSource")
+            .field("filesystem", &"<ScopedFilesystem>")
+            .field("roots", &self.roots)
+            .field("max_skill_md_bytes", &self.max_skill_md_bytes)
+            .field("max_bundle_file_bytes", &self.max_bundle_file_bytes)
+            .finish()
+    }
+}
+
+impl<F> FilesystemSkillBundleSource<F>
+where
+    F: RootFilesystem,
+{
+    pub fn new(
+        filesystem: Arc<ScopedFilesystem<F>>,
+        roots: Vec<FilesystemSkillBundleRoot>,
+    ) -> Self {
+        Self {
+            filesystem,
+            roots,
+            max_skill_md_bytes: MAX_PROMPT_FILE_SIZE as usize,
+            max_bundle_file_bytes: DEFAULT_MAX_BUNDLE_FILE_BYTES,
+        }
+    }
+
+    pub fn with_max_skill_md_bytes(mut self, max_skill_md_bytes: usize) -> Self {
+        self.max_skill_md_bytes = max_skill_md_bytes;
+        self
+    }
+
+    pub fn with_max_bundle_file_bytes(mut self, max_bundle_file_bytes: usize) -> Self {
+        self.max_bundle_file_bytes = max_bundle_file_bytes;
+        self
+    }
+
+    pub fn roots(&self) -> &[FilesystemSkillBundleRoot] {
+        &self.roots
+    }
+
+    async fn list_root(
+        &self,
+        scope: &ResourceScope,
+        root: &FilesystemSkillBundleRoot,
+        descriptors: &mut Vec<SkillBundleDescriptor>,
+    ) -> Result<(), SkillBundleSourceError> {
+        let entries = match self.filesystem.list_dir(scope, root.root()).await {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => return Ok(()),
+            Err(error) => return Err(map_filesystem_error(error)),
+        };
+
+        for entry in entries {
+            if entry.file_type != FileType::Directory {
+                continue;
+            }
+            let bundle_id = match SkillBundleId::new(root.source_kind(), &entry.name) {
+                Ok(bundle_id) => bundle_id,
+                Err(_) => continue,
+            };
+            let skill_md_path = bundle_scoped_path(root.root(), bundle_id.name(), "SKILL.md")?;
+            match self
+                .validate_bundle_manifest(scope, &skill_md_path, &bundle_id)
+                .await
+            {
+                Ok(()) => {}
+                Err(SkillBundleSourceError::FileNotFound) => continue,
+                Err(error) => return Err(error),
+            }
+
+            descriptors.push(
+                SkillBundleDescriptor::new(
+                    bundle_id,
+                    root.trust().cloned(),
+                    root.visibility().copied(),
+                )
+                .with_provenance(SkillBundleProvenance::new(root.source_kind())),
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn validate_bundle_manifest(
+        &self,
+        scope: &ResourceScope,
+        skill_md_path: &ScopedPath,
+        bundle_id: &SkillBundleId,
+    ) -> Result<(), SkillBundleSourceError> {
+        let skill_md = self
+            .read_bounded(scope, skill_md_path, self.max_skill_md_bytes)
+            .await?;
+        let skill_md =
+            String::from_utf8(skill_md).map_err(|_| SkillBundleSourceError::InvalidSkillBundle)?;
+        let skill_md = normalize_line_endings(&skill_md);
+        let parsed =
+            parse_skill_md(&skill_md).map_err(|_| SkillBundleSourceError::InvalidSkillBundle)?;
+        if parsed.manifest.name != bundle_id.name() {
+            return Err(SkillBundleSourceError::InvalidSkillBundle);
+        }
+        Ok(())
+    }
+
+    async fn read_bounded(
+        &self,
+        scope: &ResourceScope,
+        path: &ScopedPath,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, SkillBundleSourceError> {
+        let stat = self
+            .filesystem
+            .stat(scope, path)
+            .await
+            .map_err(map_file_read_error)?;
+        if stat.file_type != FileType::File {
+            return Err(SkillBundleSourceError::FileNotFound);
+        }
+        if stat.len > max_bytes as u64 {
+            return Err(SkillBundleSourceError::ContentTooLarge);
+        }
+        let bytes = self
+            .filesystem
+            .read_bytes(scope, path)
+            .await
+            .map_err(map_file_read_error)?;
+        if bytes.len() > max_bytes {
+            return Err(SkillBundleSourceError::ContentTooLarge);
+        }
+        Ok(bytes)
+    }
+}
+
+#[async_trait]
+impl<F> SkillBundleSource for FilesystemSkillBundleSource<F>
+where
+    F: RootFilesystem + 'static,
+{
+    async fn list_skill_bundles(
+        &self,
+        run_context: &LoopRunContext,
+    ) -> Result<Vec<SkillBundleDescriptor>, SkillBundleSourceError> {
+        let scope = resource_scope_for_run(run_context);
+        let mut descriptors = Vec::new();
+        for root in &self.roots {
+            self.list_root(&scope, root, &mut descriptors).await?;
+        }
+        sort_skill_bundle_descriptors(&mut descriptors);
+        Ok(descriptors)
+    }
+
+    async fn read_skill_bundle_file(
+        &self,
+        run_context: &LoopRunContext,
+        bundle_id: &SkillBundleId,
+        path: &SkillFilePath,
+    ) -> Result<Vec<u8>, SkillBundleSourceError> {
+        let root = self
+            .roots
+            .iter()
+            .find(|root| root.source_kind() == bundle_id.source_kind())
+            .ok_or(SkillBundleSourceError::BundleNotFound)?;
+        let scope = resource_scope_for_run(run_context);
+        let skill_md_path = bundle_scoped_path(root.root(), bundle_id.name(), "SKILL.md")?;
+        self.validate_bundle_manifest(&scope, &skill_md_path, bundle_id)
+            .await
+            .map_err(|error| match error {
+                SkillBundleSourceError::FileNotFound => SkillBundleSourceError::BundleNotFound,
+                other => other,
+            })?;
+        let scoped_path = bundle_scoped_path(root.root(), bundle_id.name(), path.as_str())?;
+        self.read_bounded(&scope, &scoped_path, self.max_bundle_file_bytes)
+            .await
+    }
+}
+
+fn resource_scope_for_run(run_context: &LoopRunContext) -> ResourceScope {
+    let mut scope = run_context.scope.to_resource_scope();
+    if let Some(actor) = run_context.actor() {
+        scope.user_id = actor.user_id.clone();
+    }
+    scope
+}
+
+fn bundle_scoped_path(
+    root: &ScopedPath,
+    bundle_name: &str,
+    path: &str,
+) -> Result<ScopedPath, SkillBundleSourceError> {
+    ScopedPath::new(format!(
+        "{}/{}/{}",
+        root.as_str().trim_end_matches('/'),
+        bundle_name,
+        path
+    ))
+    .map_err(|_| SkillBundleSourceError::InvalidFilePath)
+}
+
+fn map_file_read_error(error: FilesystemError) -> SkillBundleSourceError {
+    if is_not_found(&error) {
+        return SkillBundleSourceError::FileNotFound;
+    }
+    map_filesystem_error(error)
+}
+
+fn map_filesystem_error(error: FilesystemError) -> SkillBundleSourceError {
+    match error {
+        FilesystemError::PermissionDenied { .. } => SkillBundleSourceError::PermissionDenied,
+        FilesystemError::NotFound { .. } => SkillBundleSourceError::BundleNotFound,
+        FilesystemError::Unsupported { .. } => SkillBundleSourceError::SourceUnavailable,
+        FilesystemError::Contract(_)
+        | FilesystemError::MountNotFound { .. }
+        | FilesystemError::PathOutsideMount { .. }
+        | FilesystemError::SymlinkEscape { .. }
+        | FilesystemError::MountConflict { .. }
+        | FilesystemError::Backend { .. }
+        | FilesystemError::VersionMismatch { .. }
+        | FilesystemError::IndexConflict { .. }
+        | FilesystemError::DescriptorOverclaims { .. }
+        | FilesystemError::SerializeIndexed { .. }
+        | FilesystemError::DeserializeIndexed { .. }
+        | FilesystemError::CorruptRecordVersion { .. }
+        | FilesystemError::IndexSpecMissingAfterUpsert { .. }
+        | FilesystemError::BackendInfrastructure { .. } => SkillBundleSourceError::Internal,
+        _ => SkillBundleSourceError::Internal,
+    }
+}
+
+fn is_not_found(error: &FilesystemError) -> bool {
+    matches!(error, FilesystemError::NotFound { .. })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_filesystem::{CasExpectation, Entry, InMemoryBackend, RootFilesystem};
+    use ironclaw_host_api::{
+        AgentId, MountAlias, MountGrant, MountPermissions, MountView, ProjectId, TenantId,
+        ThreadId, UserId, VirtualPath,
+    };
+    use ironclaw_turns::{
+        RunProfileResolutionRequest, RunProfileResolver, TurnActor, TurnId, TurnRunId, TurnScope,
+        run_profile::InMemoryRunProfileResolver,
+    };
+
+    fn skill_md(name: &str, description: &str) -> String {
+        format!("---\nname: {name}\ndescription: {description}\n---\nUse the {name} skill.\n")
+    }
+
+    async fn run_context() -> LoopRunContext {
+        let tenant_id = TenantId::new("tenant-a").unwrap();
+        let agent_id = AgentId::new("agent-a").unwrap();
+        let project_id = ProjectId::new("project-a").unwrap();
+        let thread_id = ThreadId::new("thread-a").unwrap();
+        let user_id = UserId::new("user-a").unwrap();
+        let scope = TurnScope::new(tenant_id, Some(agent_id), Some(project_id), thread_id);
+        let resolved = InMemoryRunProfileResolver::default()
+            .resolve_run_profile(RunProfileResolutionRequest::interactive_default())
+            .await
+            .unwrap();
+        LoopRunContext::new(scope, TurnId::new(), TurnRunId::new(), resolved)
+            .with_actor(TurnActor::new(user_id))
+    }
+
+    fn mounted_source() -> (
+        Arc<InMemoryBackend>,
+        FilesystemSkillBundleSource<InMemoryBackend>,
+    ) {
+        let root = Arc::new(InMemoryBackend::default());
+        let view = MountView::new(vec![
+            MountGrant::new(
+                MountAlias::new("/system/skills").unwrap(),
+                VirtualPath::new("/system/skills").unwrap(),
+                MountPermissions::read_only(),
+            ),
+            MountGrant::new(
+                MountAlias::new("/skills").unwrap(),
+                VirtualPath::new("/tenants/tenant-a/users/user-a/skills").unwrap(),
+                MountPermissions::read_write_list_delete(),
+            ),
+        ])
+        .unwrap();
+        let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(Arc::clone(&root), view));
+        let source = FilesystemSkillBundleSource::new(
+            filesystem,
+            vec![
+                FilesystemSkillBundleRoot::system(ScopedPath::new("/system/skills").unwrap()),
+                FilesystemSkillBundleRoot::user(ScopedPath::new("/skills").unwrap()),
+            ],
+        );
+        (root, source)
+    }
+
+    async fn write_root(root: &InMemoryBackend, path: &str, bytes: impl Into<Vec<u8>>) {
+        root.put(
+            &VirtualPath::new(path).unwrap(),
+            Entry::bytes(bytes.into()),
+            CasExpectation::Any,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_lists_valid_skill_bundles_in_deterministic_source_order() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/local-review/SKILL.md",
+            skill_md("local-review", "Local review"),
+        )
+        .await;
+        write_root(
+            &root,
+            "/system/skills/code-review/SKILL.md",
+            skill_md("code-review", "System review"),
+        )
+        .await;
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/code-review/SKILL.md",
+            skill_md("code-review", "User review"),
+        )
+        .await;
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/no-manifest/README.md",
+            "not a skill",
+        )
+        .await;
+
+        let descriptors = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap();
+        let ids: Vec<String> = descriptors
+            .iter()
+            .map(|descriptor| descriptor.id().to_string())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "system:code-review",
+                "user:code-review",
+                "user:local-review"
+            ]
+        );
+        assert_eq!(descriptors[0].trust(), Some(&SkillTrust::Trusted));
+        assert_eq!(descriptors[1].trust(), Some(&SkillTrust::Installed));
+        assert_eq!(descriptors[0].visibility(), Some(&SkillVisibility::Visible));
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_reads_bundle_relative_supporting_files() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/local-review/SKILL.md",
+            skill_md("local-review", "Local review"),
+        )
+        .await;
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/local-review/references/policy.md",
+            "policy text",
+        )
+        .await;
+
+        let bytes = source
+            .read_skill_bundle_file(
+                &run_context().await,
+                &SkillBundleId::new(SkillSourceKind::User, "local-review").unwrap(),
+                &SkillFilePath::new("references/policy.md").unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(bytes, b"policy text");
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_skips_directories_without_skill_md() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/no-manifest/README.md",
+            "not a skill",
+        )
+        .await;
+
+        let descriptors = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap();
+        assert!(descriptors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_rejects_reads_from_directories_without_skill_md() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/no-manifest/references/policy.md",
+            "not a skill",
+        )
+        .await;
+
+        let error = source
+            .read_skill_bundle_file(
+                &run_context().await,
+                &SkillBundleId::new(SkillSourceKind::User, "no-manifest").unwrap(),
+                &SkillFilePath::new("references/policy.md").unwrap(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::BundleNotFound);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_rejects_invalid_skill_md_frontmatter() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/bad-skill/SKILL.md",
+            "not frontmatter",
+        )
+        .await;
+
+        let error = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::InvalidSkillBundle);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_rejects_manifest_name_mismatches() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/folder-name/SKILL.md",
+            skill_md("manifest-name", "Mismatch"),
+        )
+        .await;
+
+        let error = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::InvalidSkillBundle);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_enforces_bounded_reads() {
+        let (root, source) = mounted_source();
+        let source = source.with_max_bundle_file_bytes(4);
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/local-review/SKILL.md",
+            skill_md("local-review", "Local review"),
+        )
+        .await;
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/local-review/references/large.md",
+            "too large",
+        )
+        .await;
+
+        let error = source
+            .read_skill_bundle_file(
+                &run_context().await,
+                &SkillBundleId::new(SkillSourceKind::User, "local-review").unwrap(),
+                &SkillFilePath::new("references/large.md").unwrap(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::ContentTooLarge);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_enforces_bounded_skill_md_reads() {
+        let (root, source) = mounted_source();
+        let source = source.with_max_skill_md_bytes(4);
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/local-review/SKILL.md",
+            skill_md("local-review", "Local review"),
+        )
+        .await;
+
+        let error = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::ContentTooLarge);
+    }
+}

--- a/crates/ironclaw_loop_support/src/filesystem_skill_bundle_source.rs
+++ b/crates/ironclaw_loop_support/src/filesystem_skill_bundle_source.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem, ScopedFilesystem};
-use ironclaw_host_api::{ResourceScope, ScopedPath};
+use ironclaw_host_api::{ResourceScope, ScopedPath, TenantId};
 use ironclaw_skills::{MAX_PROMPT_FILE_SIZE, SkillTrust, parse_skill_md};
 use ironclaw_turns::run_profile::{LoopRunContext, SkillVisibility};
 use parking_lot::Mutex;
@@ -21,6 +21,7 @@ const DEFAULT_MAX_BUNDLES_PER_ROOT: usize = 100;
 pub struct FilesystemSkillBundleRoot {
     source_kind: SkillSourceKind,
     root: ScopedPath,
+    tenant_id: Option<TenantId>,
     trust: Option<SkillTrust>,
     visibility: Option<SkillVisibility>,
 }
@@ -36,6 +37,7 @@ impl FilesystemSkillBundleRoot {
         Self {
             source_kind,
             root,
+            tenant_id: None,
             trust,
             visibility,
         }
@@ -62,13 +64,15 @@ impl FilesystemSkillBundleRoot {
     }
 
     /// Creates a tenant-shared skill root.
-    pub fn tenant_shared(root: ScopedPath) -> Self {
-        Self::new(
+    pub fn tenant_shared(root: ScopedPath, tenant_id: TenantId) -> Self {
+        let mut root = Self::new(
             SkillSourceKind::TenantShared,
             root,
             Some(SkillTrust::Installed),
             Some(SkillVisibility::Visible),
-        )
+        );
+        root.tenant_id = Some(tenant_id);
+        root
     }
 
     /// Returns the descriptor source kind for bundles discovered under this root.
@@ -79,6 +83,11 @@ impl FilesystemSkillBundleRoot {
     /// Returns the scoped filesystem path for this root.
     pub fn root(&self) -> &ScopedPath {
         &self.root
+    }
+
+    /// Returns the tenant that owns this root when the root is tenant-scoped.
+    pub fn tenant_id(&self) -> Option<&TenantId> {
+        self.tenant_id.as_ref()
     }
 
     /// Returns trust metadata applied to bundles discovered under this root.
@@ -206,7 +215,14 @@ where
                 .await
             {
                 Ok(()) => {}
-                Err(SkillBundleSourceError::FileNotFound) => continue,
+                Err(error) if is_skippable_manifest_error(&error) => {
+                    debug!(
+                        bundle_id = %bundle_id,
+                        error = ?error,
+                        "skipping invalid skill bundle manifest"
+                    );
+                    continue;
+                }
                 Err(error) => return Err(error),
             }
             self.validated_manifests.lock().insert(skill_md_path);
@@ -269,6 +285,9 @@ where
         let scope = resource_scope_for_run(run_context);
         let mut descriptors = Vec::new();
         for root in &self.roots {
+            if !root_visible_for_run(root, run_context) {
+                continue;
+            }
             self.list_root(&scope, root, &mut descriptors).await?;
         }
         sort_skill_bundle_descriptors(&mut descriptors);
@@ -284,11 +303,13 @@ where
         let root = self
             .roots
             .iter()
+            .filter(|root| root_visible_for_run(root, run_context))
             .find(|root| root.source_kind() == bundle_id.source_kind())
             .ok_or(SkillBundleSourceError::BundleNotFound)?;
         let scope = resource_scope_for_run(run_context);
         let skill_md_path = bundle_scoped_path(root.root(), bundle_id, &SkillFilePath::skill_md())?;
         if !self.validated_manifests.lock().contains(&skill_md_path) {
+            // Re-validates manifests before uncached reads for security defense-in-depth.
             self.validate_bundle_manifest(&scope, &skill_md_path, bundle_id)
                 .await
                 .map_err(|error| match error {
@@ -311,6 +332,15 @@ fn resource_scope_for_run(run_context: &LoopRunContext) -> ResourceScope {
         scope.user_id = actor.user_id.clone();
     }
     scope
+}
+
+fn root_visible_for_run(root: &FilesystemSkillBundleRoot, run_context: &LoopRunContext) -> bool {
+    match root.source_kind() {
+        SkillSourceKind::TenantShared => root
+            .tenant_id()
+            .is_some_and(|tenant_id| tenant_id == &run_context.scope.tenant_id),
+        SkillSourceKind::System | SkillSourceKind::User => true,
+    }
 }
 
 fn bundle_scoped_path(
@@ -349,6 +379,9 @@ fn map_file_read_error(error: FilesystemError) -> SkillBundleSourceError {
 fn map_filesystem_error(error: FilesystemError) -> SkillBundleSourceError {
     match error {
         FilesystemError::PermissionDenied { .. } => SkillBundleSourceError::PermissionDenied,
+        // Kept for API completeness: some callers route filesystem errors through
+        // this general mapper without first applying the list/read-specific
+        // not-found semantics.
         FilesystemError::NotFound { .. } => SkillBundleSourceError::BundleNotFound,
         FilesystemError::Unsupported { .. } => SkillBundleSourceError::SourceUnavailable,
         FilesystemError::Contract(_)
@@ -372,6 +405,17 @@ fn map_filesystem_error(error: FilesystemError) -> SkillBundleSourceError {
 
 fn is_not_found(error: &FilesystemError) -> bool {
     matches!(error, FilesystemError::NotFound { .. })
+}
+
+fn is_skippable_manifest_error(error: &SkillBundleSourceError) -> bool {
+    matches!(
+        error,
+        SkillBundleSourceError::FileNotFound
+            | SkillBundleSourceError::InvalidSkillBundle
+            | SkillBundleSourceError::BundleUtf8DecodeFailed
+            | SkillBundleSourceError::ManifestParseFailed
+            | SkillBundleSourceError::ContentTooLarge
+    )
 }
 
 #[cfg(test)]
@@ -561,7 +605,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn filesystem_source_rejects_invalid_skill_md_frontmatter() {
+    async fn filesystem_source_skips_invalid_skill_md_frontmatter() {
         let (root, source) = mounted_source();
         write_root(
             &root,
@@ -570,15 +614,15 @@ mod tests {
         )
         .await;
 
-        let error = source
+        let descriptors = source
             .list_skill_bundles(&run_context().await)
             .await
-            .unwrap_err();
-        assert_eq!(error, SkillBundleSourceError::ManifestParseFailed);
+            .unwrap();
+        assert!(descriptors.is_empty());
     }
 
     #[tokio::test]
-    async fn filesystem_source_rejects_non_utf8_skill_md() {
+    async fn filesystem_source_skips_non_utf8_skill_md() {
         let (root, source) = mounted_source();
         write_root(
             &root,
@@ -587,11 +631,11 @@ mod tests {
         )
         .await;
 
-        let error = source
+        let descriptors = source
             .list_skill_bundles(&run_context().await)
             .await
-            .unwrap_err();
-        assert_eq!(error, SkillBundleSourceError::BundleUtf8DecodeFailed);
+            .unwrap();
+        assert!(descriptors.is_empty());
     }
 
     #[tokio::test]
@@ -632,7 +676,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn filesystem_source_rejects_manifest_name_mismatches() {
+    async fn filesystem_source_skips_manifest_name_mismatches() {
         let (root, source) = mounted_source();
         write_root(
             &root,
@@ -641,11 +685,38 @@ mod tests {
         )
         .await;
 
-        let error = source
+        let descriptors = source
             .list_skill_bundles(&run_context().await)
             .await
-            .unwrap_err();
-        assert_eq!(error, SkillBundleSourceError::InvalidSkillBundle);
+            .unwrap();
+        assert!(descriptors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_skips_bad_manifest_without_hiding_valid_bundles() {
+        let (root, source) = mounted_source();
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/bad-skill/SKILL.md",
+            "not frontmatter",
+        )
+        .await;
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/good-skill/SKILL.md",
+            skill_md("good-skill", "Good skill"),
+        )
+        .await;
+
+        let descriptors = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap();
+        let ids: Vec<String> = descriptors
+            .iter()
+            .map(|descriptor| descriptor.id().to_string())
+            .collect();
+        assert_eq!(ids, vec!["user:good-skill"]);
     }
 
     #[tokio::test]
@@ -683,13 +754,104 @@ mod tests {
     }
 
     #[test]
-    fn filesystem_source_rejects_traversal_file_paths_before_read() {
-        for invalid in ["../sibling/SKILL.md", "..", "references/../SKILL.md"] {
+    fn filesystem_source_rejects_path_traversal_in_file_path() {
+        for invalid in [
+            "../../etc/passwd",
+            "../sibling/SKILL.md",
+            "..",
+            "references/../SKILL.md",
+        ] {
             assert_eq!(
                 SkillFilePath::new(invalid).unwrap_err(),
                 SkillBundleSourceError::InvalidFilePath
             );
         }
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_returns_bundle_not_found_when_no_root_matches_source_kind() {
+        let (_root, source) = mounted_source();
+
+        let error = source
+            .read_skill_bundle_file(
+                &run_context().await,
+                &SkillBundleId::new(SkillSourceKind::TenantShared, "shared-review").unwrap(),
+                &SkillFilePath::new("SKILL.md").unwrap(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::BundleNotFound);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_list_skill_bundles_aborts_on_root_error() {
+        let root = Arc::new(InMemoryBackend::default());
+        write_root(
+            &root,
+            "/tenants/tenant-a/users/user-a/skills/local-review/SKILL.md",
+            skill_md("local-review", "Local review"),
+        )
+        .await;
+        let view = MountView::new(vec![
+            MountGrant::new(
+                MountAlias::new("/system/skills").unwrap(),
+                VirtualPath::new("/system/skills").unwrap(),
+                MountPermissions::none(),
+            ),
+            MountGrant::new(
+                MountAlias::new("/skills").unwrap(),
+                VirtualPath::new("/tenants/tenant-a/users/user-a/skills").unwrap(),
+                MountPermissions::read_write_list_delete(),
+            ),
+        ])
+        .unwrap();
+        let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(root, view));
+        let source = FilesystemSkillBundleSource::new(
+            filesystem,
+            vec![
+                FilesystemSkillBundleRoot::system(ScopedPath::new("/system/skills").unwrap()),
+                FilesystemSkillBundleRoot::user(ScopedPath::new("/skills").unwrap()),
+            ],
+        )
+        .unwrap();
+
+        let error = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap_err();
+        assert_eq!(error, SkillBundleSourceError::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn filesystem_source_filters_tenant_shared_roots_by_tenant() {
+        let root = Arc::new(InMemoryBackend::default());
+        write_root(
+            &root,
+            "/tenant-shared/tenant-a/skills/team-review/SKILL.md",
+            skill_md("team-review", "Team review"),
+        )
+        .await;
+        let view = MountView::new(vec![MountGrant::new(
+            MountAlias::new("/tenant-shared/skills").unwrap(),
+            VirtualPath::new("/tenant-shared/tenant-a/skills").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap();
+        let filesystem = Arc::new(ScopedFilesystem::with_fixed_view(root, view));
+        let source = FilesystemSkillBundleSource::new(
+            filesystem,
+            vec![FilesystemSkillBundleRoot::tenant_shared(
+                ScopedPath::new("/tenant-shared/skills").unwrap(),
+                TenantId::new("tenant-b").unwrap(),
+            )],
+        )
+        .unwrap();
+
+        let descriptors = source
+            .list_skill_bundles(&run_context().await)
+            .await
+            .unwrap();
+        assert!(descriptors.is_empty());
     }
 
     #[tokio::test]
@@ -777,10 +939,10 @@ mod tests {
         )
         .await;
 
-        let error = source
+        let descriptors = source
             .list_skill_bundles(&run_context().await)
             .await
-            .unwrap_err();
-        assert_eq!(error, SkillBundleSourceError::ContentTooLarge);
+            .unwrap();
+        assert!(descriptors.is_empty());
     }
 }

--- a/crates/ironclaw_loop_support/src/lib.rs
+++ b/crates/ironclaw_loop_support/src/lib.rs
@@ -17,6 +17,7 @@ mod cancellation_port;
 mod capability_allow_set;
 mod capability_port;
 mod capability_surface_filter;
+mod filesystem_skill_bundle_source;
 pub mod identity_context;
 mod input_port;
 mod input_queue;
@@ -41,6 +42,7 @@ pub use capability_port::{
 pub use capability_surface_filter::{
     CapabilitySurfaceProfileFilter, CapabilitySurfaceVisibleFilter,
 };
+pub use filesystem_skill_bundle_source::{FilesystemSkillBundleRoot, FilesystemSkillBundleSource};
 pub use identity_context::{
     HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
     HostIdentityMessageContent, IdentityApplicability, IdentityBudget, IdentityFileName,

--- a/crates/ironclaw_loop_support/src/skill_bundle_source.rs
+++ b/crates/ironclaw_loop_support/src/skill_bundle_source.rs
@@ -289,6 +289,12 @@ pub enum SkillBundleSourceError {
     InvalidFilePath,
     #[error("skill bundle content is invalid")]
     InvalidSkillBundle,
+    #[error("skill bundle manifest is not valid UTF-8")]
+    BundleUtf8DecodeFailed,
+    #[error("skill bundle manifest failed to parse")]
+    ManifestParseFailed,
+    #[error("skill bundle source has duplicate source-kind roots")]
+    DuplicateSourceKind,
     #[error("skill bundle not found")]
     BundleNotFound,
     #[error("skill bundle file not found")]
@@ -297,6 +303,8 @@ pub enum SkillBundleSourceError {
     PermissionDenied,
     #[error("skill bundle content too large")]
     ContentTooLarge,
+    #[error("skill bundle source scan limit exceeded")]
+    BundleScanLimitExceeded,
     #[error("skill bundle source internal error")]
     Internal,
 }
@@ -416,6 +424,22 @@ mod tests {
             "skill bundle file path is invalid"
         );
         assert_eq!(
+            SkillBundleSourceError::InvalidSkillBundle.to_string(),
+            "skill bundle content is invalid"
+        );
+        assert_eq!(
+            SkillBundleSourceError::BundleUtf8DecodeFailed.to_string(),
+            "skill bundle manifest is not valid UTF-8"
+        );
+        assert_eq!(
+            SkillBundleSourceError::ManifestParseFailed.to_string(),
+            "skill bundle manifest failed to parse"
+        );
+        assert_eq!(
+            SkillBundleSourceError::DuplicateSourceKind.to_string(),
+            "skill bundle source has duplicate source-kind roots"
+        );
+        assert_eq!(
             SkillBundleSourceError::BundleNotFound.to_string(),
             "skill bundle not found"
         );
@@ -430,6 +454,10 @@ mod tests {
         assert_eq!(
             SkillBundleSourceError::ContentTooLarge.to_string(),
             "skill bundle content too large"
+        );
+        assert_eq!(
+            SkillBundleSourceError::BundleScanLimitExceeded.to_string(),
+            "skill bundle source scan limit exceeded"
         );
         assert_eq!(
             SkillBundleSourceError::Internal.to_string(),

--- a/crates/ironclaw_loop_support/src/skill_bundle_source.rs
+++ b/crates/ironclaw_loop_support/src/skill_bundle_source.rs
@@ -287,6 +287,8 @@ pub enum SkillBundleSourceError {
     InvalidBundleId,
     #[error("skill bundle file path is invalid")]
     InvalidFilePath,
+    #[error("skill bundle content is invalid")]
+    InvalidSkillBundle,
     #[error("skill bundle not found")]
     BundleNotFound,
     #[error("skill bundle file not found")]


### PR DESCRIPTION
## Summary
- add `FilesystemSkillBundleSource` over `ScopedFilesystem` virtual roots
- add configurable roots for `/system/skills`, `/skills`, and future tenant-shared skills with trust/visibility metadata
- discover direct `SKILL.md` bundles, parse manifests with `ironclaw_skills`, validate manifest/folder names, and read bundle-relative support files with byte limits
- fail closed with sanitized source errors for invalid bundles, oversized content, denied access, and unlisted bundle reads

## Context
PR 4 from #3473 first-party skills extension lane. This implements the filesystem source behind the source port added in #3844; the runtime adapter wiring remains the next PR.

## Validation
- `cargo fmt --check -p ironclaw_loop_support`
- `git diff --check`
- `cargo test -p ironclaw_loop_support filesystem_source`
- `cargo test -p ironclaw_loop_support`
- `cargo clippy -p ironclaw_loop_support --all-targets -- -D warnings`