### PR TITLE
test(reborn): cover project and agent isolation

### DIFF
--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -234,8 +234,6 @@ where
                 kind: "non_user_message".into(),
             });
         };
-        let source_binding_id = product_source_binding_id(envelope);
-        let submit_idempotency_key = submit_idempotency_key(envelope);
         let route_kind = route_kind_for_user_message(payload.trigger);
         let binding = self
             .binding_service
@@ -249,6 +247,8 @@ where
                 auth_claim: envelope.auth_claim().clone(),
             })
             .await?;
+        let source_binding_id = product_source_binding_id(envelope, &binding);
+        let submit_idempotency_key = submit_idempotency_key(envelope, &binding);
         let thread_scope = thread_scope_from_binding(&binding, route_kind)?;
         Ok(PreparedUserMessage {
             binding,
@@ -642,20 +642,39 @@ impl RefFactory for IdempotencyKey {
     }
 }
 
-fn product_source_binding_id(envelope: &ProductInboundEnvelope) -> String {
+fn product_source_binding_id(
+    envelope: &ProductInboundEnvelope,
+    binding: &ResolvedBinding,
+) -> String {
     format!(
-        "{}{}{}",
+        "{}{}{}{}{}",
         segment("adapter", envelope.adapter_id().as_str()),
         segment("installation", envelope.installation_id().as_str()),
+        segment(
+            "agent",
+            binding.agent_id.as_ref().map_or("", |id| id.as_str())
+        ),
+        segment(
+            "project",
+            binding.project_id.as_ref().map_or("", |id| id.as_str())
+        ),
         envelope.source_binding_key()
     )
 }
 
-fn submit_idempotency_key(envelope: &ProductInboundEnvelope) -> String {
+fn submit_idempotency_key(envelope: &ProductInboundEnvelope, binding: &ResolvedBinding) -> String {
     format!(
-        "{}{}{}",
+        "{}{}{}{}{}",
         segment("adapter", envelope.adapter_id().as_str()),
         segment("installation", envelope.installation_id().as_str()),
+        segment(
+            "agent",
+            binding.agent_id.as_ref().map_or("", |id| id.as_str())
+        ),
+        segment(
+            "project",
+            binding.project_id.as_ref().map_or("", |id| id.as_str())
+        ),
         segment("event", envelope.external_event_id().as_str())
     )
 }

--- a/crates/ironclaw_turns/src/memory.rs
+++ b/crates/ironclaw_turns/src/memory.rs
@@ -1258,6 +1258,9 @@ impl Inner {
             if record.scope != request.scope {
                 return Err(TurnError::ScopeNotFound);
             }
+            if record.actor != request.actor {
+                return Err(TurnError::Unauthorized);
+            }
             if record.status.is_terminal() {
                 return Ok(CancelRunResponse {
                     run_id: record.run_id,

--- a/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
+++ b/crates/ironclaw_turns/tests/turn_coordinator_contract.rs
@@ -3492,6 +3492,77 @@ async fn resume_turn_from_foreign_actor_is_denied_without_requeueing_run() {
 }
 
 #[tokio::test]
+async fn cancel_run_from_foreign_actor_is_denied_without_mutating_run() {
+    let (coordinator, store) = coordinator();
+    let run_id = accepted_run_id(
+        &coordinator
+            .submit_turn(submit_request("thread-a", "idem-submit-a"))
+            .await
+            .unwrap(),
+    );
+    let runner_id = TurnRunnerId::new();
+    let lease_token = TurnLeaseToken::new();
+    store
+        .claim_next_run(ClaimRunRequest {
+            runner_id,
+            lease_token,
+            scope_filter: None,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let gate_ref = GateRef::new("approval-gate").unwrap();
+    store
+        .block_run(BlockRunRequest {
+            run_id,
+            runner_id,
+            lease_token,
+            checkpoint_id: TurnCheckpointId::new(),
+            state_ref: block_state_ref(),
+            reason: BlockedReason::Approval {
+                gate_ref: gate_ref.clone(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let err = coordinator
+        .cancel_run(CancelRunRequest {
+            scope: scope("thread-a"),
+            actor: TurnActor::new(UserId::new("user2").unwrap()),
+            run_id,
+            reason: SanitizedCancelReason::UserRequested,
+            idempotency_key: IdempotencyKey::new("idem-cancel-foreign-actor").unwrap(),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(err, TurnError::Unauthorized);
+    assert_eq!(err.adapter_status_code(), 403);
+    let state = coordinator
+        .get_run_state(GetRunStateRequest {
+            scope: scope("thread-a"),
+            run_id,
+        })
+        .await
+        .unwrap();
+    assert_eq!(state.status, TurnStatus::BlockedApproval);
+    assert_eq!(state.gate_ref, Some(gate_ref));
+
+    let cancelled = coordinator
+        .cancel_run(CancelRunRequest {
+            scope: scope("thread-a"),
+            actor: TurnActor::new(UserId::new("user1").unwrap()),
+            run_id,
+            reason: SanitizedCancelReason::UserRequested,
+            idempotency_key: IdempotencyKey::new("idem-cancel-owner").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(cancelled.status, TurnStatus::Cancelled);
+}
+
+#[tokio::test]
 async fn resume_turn_with_wrong_gate_resolution_ref_is_invalid_request() {
     let (coordinator, store) = coordinator();
     let run_id = accepted_run_id(

--- a/tests/reborn_agent_scope_isolation_parity.rs
+++ b/tests/reborn_agent_scope_isolation_parity.rs
@@ -1,0 +1,144 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_loop_support::HostManagedModelResponse;
+use ironclaw_threads::{MessageKind, MessageStatus, ThreadMessageRecord};
+use ironclaw_turns::TurnStatus;
+use reborn_support::harness::{
+    RebornBinaryE2EHarness, RebornHarnessSharedStorage, RecordingTestCapabilityPort,
+    test_product_scope,
+};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+
+#[tokio::test]
+async fn reborn_agent_scope_isolation_parity() {
+    const ROOM: &str = "room-agent-shared";
+    const EVENT: &str = "event-agent-shared";
+
+    let shared_storage = RebornHarnessSharedStorage::new().expect("shared storage");
+    let agent_a_scope = test_product_scope(
+        "tenant-agent-e2e",
+        "host-user",
+        "agent-alpha-e2e",
+        Some("project-e2e"),
+    );
+    let agent_b_scope = test_product_scope(
+        "tenant-agent-e2e",
+        "host-user",
+        "agent-beta-e2e",
+        Some("project-e2e"),
+    );
+
+    let mut agent_a =
+        RebornBinaryE2EHarness::with_model_gateway_scope_shared_storage_unscoped_worker(
+            ROOM,
+            RebornTraceReplayModelGateway::with_responses([
+                HostManagedModelResponse::assistant_reply("agent alpha isolated reply"),
+            ]),
+            RecordingTestCapabilityPort::echo(),
+            agent_a_scope,
+            shared_storage.clone(),
+        )
+        .await
+        .expect("agent A harness");
+    let mut agent_b =
+        RebornBinaryE2EHarness::with_model_gateway_scope_shared_storage_unscoped_worker(
+            ROOM,
+            RebornTraceReplayModelGateway::with_responses([
+                HostManagedModelResponse::assistant_reply("agent beta isolated reply"),
+            ]),
+            RecordingTestCapabilityPort::echo(),
+            agent_b_scope,
+            shared_storage,
+        )
+        .await
+        .expect("agent B harness");
+
+    agent_a.start();
+    agent_b.start();
+
+    let alpha = agent_a
+        .submit_text_for(ROOM, "alice", EVENT, "agent alpha turn")
+        .await
+        .expect("submit agent A turn");
+    agent_a
+        .wait_for_submitted_status(&alpha, TurnStatus::Completed)
+        .await
+        .expect("agent A completed");
+
+    let beta = agent_b
+        .submit_text_for(ROOM, "alice", EVENT, "agent beta turn")
+        .await
+        .expect("submit agent B turn with same external event id");
+    agent_b
+        .wait_for_submitted_status(&beta, TurnStatus::Completed)
+        .await
+        .expect("agent B completed");
+
+    assert_ne!(alpha.scope.agent_id, beta.scope.agent_id);
+    assert_ne!(
+        alpha.thread_id, beta.thread_id,
+        "same external conversation under different agents must bind to distinct threads"
+    );
+    assert_ne!(
+        alpha.run_id, beta.run_id,
+        "same external event id under different agents must not replay the same run"
+    );
+
+    let alpha_history = agent_a
+        .history_for_submitted_thread(&alpha)
+        .await
+        .expect("agent A history");
+    let beta_history = agent_b
+        .history_for_submitted_thread(&beta)
+        .await
+        .expect("agent B history");
+
+    assert_history_contains_user(&alpha_history, "agent alpha turn");
+    assert_history_contains_assistant(&alpha_history, "agent alpha isolated reply");
+    assert_history_excludes(&alpha_history, "agent beta turn");
+    assert_history_excludes(&alpha_history, "agent beta isolated reply");
+
+    assert_history_contains_user(&beta_history, "agent beta turn");
+    assert_history_contains_assistant(&beta_history, "agent beta isolated reply");
+    assert_history_excludes(&beta_history, "agent alpha turn");
+    assert_history_excludes(&beta_history, "agent alpha isolated reply");
+
+    agent_a.assert_model_exhausted();
+    agent_b.assert_model_exhausted();
+    agent_a.shutdown().await;
+    agent_b.shutdown().await;
+}
+
+fn assert_history_contains_user(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::User
+                && message.status == MessageStatus::Submitted
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain submitted user message {text:?}"
+    );
+}
+
+fn assert_history_contains_assistant(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::Assistant
+                && message.status == MessageStatus::Finalized
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain finalized assistant reply {text:?}"
+    );
+}
+
+fn assert_history_excludes(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .all(|message| message.content.as_deref() != Some(text)),
+        "thread history should not contain message from another agent: {text:?}"
+    );
+}

--- a/tests/reborn_identity_project_scope_isolation_parity.rs
+++ b/tests/reborn_identity_project_scope_isolation_parity.rs
@@ -1,0 +1,253 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use ironclaw_loop_support::{
+    HostIdentityContextBuildError, HostIdentityContextCandidate, HostIdentityContextSource,
+    HostIdentityMessageContent, HostManagedModelMessageRole, HostManagedModelResponse,
+    IdentityApplicability, IdentityFileName,
+};
+use ironclaw_turns::{
+    LoopMessageRef, TurnStatus,
+    run_profile::{LoopRunContext, PromptMode},
+};
+use reborn_support::harness::{
+    RebornBinaryE2EHarness, RebornHarnessSharedStorage, RecordingTestCapabilityPort,
+    test_product_scope,
+};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+use tokio::sync::RwLock;
+
+const PROJECT_ALPHA_IDENTITY: &str = "Alice project alpha identity: carries amber notebook.";
+const PROJECT_BETA_IDENTITY: &str = "Alice project beta identity: carries violet notebook.";
+
+#[tokio::test]
+async fn reborn_identity_project_scope_isolation_parity() {
+    const ROOM: &str = "room-project-identity-shared";
+
+    let shared_storage = RebornHarnessSharedStorage::new().expect("shared storage");
+    let identity_source = Arc::new(ProjectIdentitySource::default());
+    let project_alpha = test_product_scope(
+        "tenant-project-identity-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-alpha-e2e"),
+    );
+    let project_beta = test_product_scope(
+        "tenant-project-identity-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-beta-e2e"),
+    );
+
+    let mut alpha = RebornBinaryE2EHarness::with_model_gateway_scope_identity_source_trigger_installation_shared_storage_unscoped_worker(
+        ROOM,
+        RebornTraceReplayModelGateway::with_responses([HostManagedModelResponse::assistant_reply(
+            "project alpha identity reply",
+        )]),
+        RecordingTestCapabilityPort::echo(),
+        project_alpha,
+        identity_source.clone(),
+        ironclaw_product_adapters::ProductTriggerReason::DirectChat,
+        "reborn-test",
+        "install-1",
+        "alice",
+        shared_storage.clone(),
+    )
+    .await
+    .expect("project alpha harness");
+    let mut beta = RebornBinaryE2EHarness::with_model_gateway_scope_identity_source_trigger_installation_shared_storage_unscoped_worker(
+        ROOM,
+        RebornTraceReplayModelGateway::with_responses([HostManagedModelResponse::assistant_reply(
+            "project beta identity reply",
+        )]),
+        RecordingTestCapabilityPort::echo(),
+        project_beta,
+        identity_source.clone(),
+        ironclaw_product_adapters::ProductTriggerReason::DirectChat,
+        "reborn-test",
+        "install-1",
+        "alice",
+        shared_storage,
+    )
+    .await
+    .expect("project beta harness");
+
+    let alpha_turn = alpha
+        .submit_text_for(ROOM, "alice", "event-project-alpha-identity", "alpha asks")
+        .await
+        .expect("submit project alpha turn");
+    let beta_turn = beta
+        .submit_text_for(ROOM, "alice", "event-project-beta-identity", "beta asks")
+        .await
+        .expect("submit project beta turn");
+
+    identity_source
+        .set_identity(
+            &ProjectIdentityKey::from_turn(&alpha_turn),
+            PROJECT_ALPHA_IDENTITY,
+        )
+        .await;
+    identity_source
+        .set_identity(
+            &ProjectIdentityKey::from_turn(&beta_turn),
+            PROJECT_BETA_IDENTITY,
+        )
+        .await;
+
+    alpha.start();
+    beta.start();
+
+    alpha
+        .wait_for_submitted_status(&alpha_turn, TurnStatus::Completed)
+        .await
+        .expect("project alpha completed");
+    beta.wait_for_submitted_status(&beta_turn, TurnStatus::Completed)
+        .await
+        .expect("project beta completed");
+
+    assert_ne!(alpha_turn.scope.project_id, beta_turn.scope.project_id);
+
+    let alpha_prompts: Vec<String> = alpha
+        .model_requests()
+        .iter()
+        .map(system_prompt_text)
+        .collect();
+    let beta_prompts: Vec<String> = beta
+        .model_requests()
+        .iter()
+        .map(system_prompt_text)
+        .collect();
+
+    assert_prompt_contains_only(
+        &alpha_prompts,
+        PROJECT_ALPHA_IDENTITY,
+        PROJECT_BETA_IDENTITY,
+        "project alpha",
+    );
+    assert_prompt_contains_only(
+        &beta_prompts,
+        PROJECT_BETA_IDENTITY,
+        PROJECT_ALPHA_IDENTITY,
+        "project beta",
+    );
+
+    let seen = identity_source.seen_keys().await;
+    assert!(seen.contains(&ProjectIdentityKey::from_turn(&alpha_turn)));
+    assert!(seen.contains(&ProjectIdentityKey::from_turn(&beta_turn)));
+
+    alpha.assert_model_exhausted();
+    beta.assert_model_exhausted();
+    alpha.shutdown().await;
+    beta.shutdown().await;
+}
+
+fn system_prompt_text(request: &ironclaw_loop_support::HostManagedModelRequest) -> String {
+    request
+        .messages
+        .iter()
+        .filter(|message| message.role == HostManagedModelMessageRole::System)
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn assert_prompt_contains_only(prompts: &[String], expected: &str, forbidden: &str, label: &str) {
+    assert!(
+        !prompts.is_empty()
+            && prompts
+                .iter()
+                .all(|prompt| prompt.contains(expected) && !prompt.contains(forbidden)),
+        "{label} prompt should contain only matching project identity; prompts={prompts:#?}"
+    );
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ProjectIdentityKey {
+    tenant_id: String,
+    user_id: String,
+    project_id: Option<String>,
+}
+
+impl ProjectIdentityKey {
+    fn from_turn(turn: &reborn_support::harness::SubmittedTurn) -> Self {
+        Self {
+            tenant_id: turn.scope.tenant_id.as_str().to_string(),
+            user_id: turn.actor.user_id.as_str().to_string(),
+            project_id: turn
+                .scope
+                .project_id
+                .as_ref()
+                .map(|id| id.as_str().to_string()),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ProjectIdentitySource {
+    identities: RwLock<HashMap<ProjectIdentityKey, HostIdentityContextCandidate>>,
+    seen: RwLock<Vec<ProjectIdentityKey>>,
+}
+
+impl ProjectIdentitySource {
+    async fn set_identity(&self, key: &ProjectIdentityKey, content: &str) {
+        let name = IdentityFileName::new("IDENTITY.md").expect("identity file name");
+        let candidate = HostIdentityContextCandidate::new_installed_summary_only(
+            name,
+            content.to_string(),
+            IdentityApplicability::Always,
+        );
+        self.identities.write().await.insert(key.clone(), candidate);
+    }
+
+    async fn seen_keys(&self) -> Vec<ProjectIdentityKey> {
+        self.seen.read().await.clone()
+    }
+}
+
+#[async_trait]
+impl HostIdentityContextSource for ProjectIdentitySource {
+    async fn load_identity_candidates(
+        &self,
+        run_context: &LoopRunContext,
+        _mode: PromptMode,
+    ) -> Result<Vec<HostIdentityContextCandidate>, HostIdentityContextBuildError> {
+        let actor = run_context
+            .actor()
+            .ok_or(HostIdentityContextBuildError::SourceUnavailable)?;
+        let key = ProjectIdentityKey {
+            tenant_id: run_context.scope.tenant_id.as_str().to_string(),
+            user_id: actor.user_id.as_str().to_string(),
+            project_id: run_context
+                .scope
+                .project_id
+                .as_ref()
+                .map(|id| id.as_str().to_string()),
+        };
+        {
+            let mut seen = self.seen.write().await;
+            if !seen.contains(&key) {
+                seen.push(key.clone());
+            }
+        }
+        self.identities
+            .read()
+            .await
+            .get(&key)
+            .cloned()
+            .map(|candidate| vec![candidate])
+            .ok_or(HostIdentityContextBuildError::SourceUnavailable)
+    }
+
+    async fn resolve_identity_message_content(
+        &self,
+        _run_context: &LoopRunContext,
+        _message_ref: &LoopMessageRef,
+    ) -> Result<Option<HostIdentityMessageContent>, HostIdentityContextBuildError> {
+        Ok(None)
+    }
+}

--- a/tests/reborn_project_scope_isolation_parity.rs
+++ b/tests/reborn_project_scope_isolation_parity.rs
@@ -1,0 +1,144 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_loop_support::HostManagedModelResponse;
+use ironclaw_threads::{MessageKind, MessageStatus, ThreadMessageRecord};
+use ironclaw_turns::TurnStatus;
+use reborn_support::harness::{
+    RebornBinaryE2EHarness, RebornHarnessSharedStorage, RecordingTestCapabilityPort,
+    test_product_scope,
+};
+use reborn_support::model_replay::RebornTraceReplayModelGateway;
+
+#[tokio::test]
+async fn reborn_project_scope_isolation_parity() {
+    const ROOM: &str = "room-project-shared";
+    const EVENT: &str = "event-project-shared";
+
+    let shared_storage = RebornHarnessSharedStorage::new().expect("shared storage");
+    let project_a_scope = test_product_scope(
+        "tenant-project-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-alpha-e2e"),
+    );
+    let project_b_scope = test_product_scope(
+        "tenant-project-e2e",
+        "host-user",
+        "agent-e2e",
+        Some("project-beta-e2e"),
+    );
+
+    let mut project_a =
+        RebornBinaryE2EHarness::with_model_gateway_scope_shared_storage_unscoped_worker(
+            ROOM,
+            RebornTraceReplayModelGateway::with_responses([
+                HostManagedModelResponse::assistant_reply("project alpha isolated reply"),
+            ]),
+            RecordingTestCapabilityPort::echo(),
+            project_a_scope,
+            shared_storage.clone(),
+        )
+        .await
+        .expect("project A harness");
+    let mut project_b =
+        RebornBinaryE2EHarness::with_model_gateway_scope_shared_storage_unscoped_worker(
+            ROOM,
+            RebornTraceReplayModelGateway::with_responses([
+                HostManagedModelResponse::assistant_reply("project beta isolated reply"),
+            ]),
+            RecordingTestCapabilityPort::echo(),
+            project_b_scope,
+            shared_storage,
+        )
+        .await
+        .expect("project B harness");
+
+    project_a.start();
+    project_b.start();
+
+    let alpha = project_a
+        .submit_text_for(ROOM, "alice", EVENT, "project alpha turn")
+        .await
+        .expect("submit project A turn");
+    project_a
+        .wait_for_submitted_status(&alpha, TurnStatus::Completed)
+        .await
+        .expect("project A completed");
+
+    let beta = project_b
+        .submit_text_for(ROOM, "alice", EVENT, "project beta turn")
+        .await
+        .expect("submit project B turn with same external event id");
+    project_b
+        .wait_for_submitted_status(&beta, TurnStatus::Completed)
+        .await
+        .expect("project B completed");
+
+    assert_ne!(alpha.scope.project_id, beta.scope.project_id);
+    assert_ne!(
+        alpha.thread_id, beta.thread_id,
+        "same external conversation under different projects must bind to distinct threads"
+    );
+    assert_ne!(
+        alpha.run_id, beta.run_id,
+        "same external event id under different projects must not replay the same run"
+    );
+
+    let alpha_history = project_a
+        .history_for_submitted_thread(&alpha)
+        .await
+        .expect("project A history");
+    let beta_history = project_b
+        .history_for_submitted_thread(&beta)
+        .await
+        .expect("project B history");
+
+    assert_history_contains_user(&alpha_history, "project alpha turn");
+    assert_history_contains_assistant(&alpha_history, "project alpha isolated reply");
+    assert_history_excludes(&alpha_history, "project beta turn");
+    assert_history_excludes(&alpha_history, "project beta isolated reply");
+
+    assert_history_contains_user(&beta_history, "project beta turn");
+    assert_history_contains_assistant(&beta_history, "project beta isolated reply");
+    assert_history_excludes(&beta_history, "project alpha turn");
+    assert_history_excludes(&beta_history, "project alpha isolated reply");
+
+    project_a.assert_model_exhausted();
+    project_b.assert_model_exhausted();
+    project_a.shutdown().await;
+    project_b.shutdown().await;
+}
+
+fn assert_history_contains_user(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::User
+                && message.status == MessageStatus::Submitted
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain submitted user message {text:?}"
+    );
+}
+
+fn assert_history_contains_assistant(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .any(|message| message.kind == MessageKind::Assistant
+                && message.status == MessageStatus::Finalized
+                && message.content.as_deref() == Some(text)),
+        "thread history should contain finalized assistant reply {text:?}"
+    );
+}
+
+fn assert_history_excludes(history: &[ThreadMessageRecord], text: &str) {
+    assert!(
+        history
+            .iter()
+            .all(|message| message.content.as_deref() != Some(text)),
+        "thread history should not contain message from another project: {text:?}"
+    );
+}

--- a/tests/reborn_wrong_scope_access_isolation_parity.rs
+++ b/tests/reborn_wrong_scope_access_isolation_parity.rs
@@ -101,6 +101,28 @@ async fn reborn_wrong_scope_access_isolation_parity() {
         "wrong actor resume must not mutate original run"
     );
 
+    assert!(
+        harness
+            .cancel_run_as(
+                submitted.scope.clone(),
+                wrong_actor,
+                submitted.run_id,
+                format!("wrong-actor-cancel-{}", submitted.run_id),
+            )
+            .await
+            .is_err(),
+        "wrong actor must not cancel another user's blocked run"
+    );
+    assert_eq!(
+        harness
+            .run_state(submitted.run_id)
+            .await
+            .expect("state after wrong actor cancel")
+            .status,
+        TurnStatus::BlockedApproval,
+        "wrong actor cancel must not mutate original run"
+    );
+
     harness
         .cancel_blocked_turn(submitted.run_id)
         .await

--- a/tests/support/reborn/product_workflow.rs
+++ b/tests/support/reborn/product_workflow.rs
@@ -197,7 +197,7 @@ where
         let binding = ResolvedBinding {
             tenant_id: self.scope.tenant_id.clone(),
             user_id: user_id_for_binding(&self.scope.tenant_id, &request)?,
-            thread_id: thread_id_for_binding(&self.scope.tenant_id, &request)?,
+            thread_id: thread_id_for_binding(&self.scope, &request)?,
             agent_id: Some(self.agent_id.clone()),
             project_id: self.project_id.clone(),
         };
@@ -269,7 +269,7 @@ where
         fingerprint: ActionFingerprintKey,
         received_at: DateTime<Utc>,
     ) -> Result<IdempotencyDecision, ProductWorkflowError> {
-        let path = ledger_path(&fingerprint)?;
+        let path = ledger_path(&self.scope, &fingerprint)?;
         let _guard = self.lock.lock().await;
         let Some(stored) =
             read_json::<F, StoredIdempotencyAction>(&self.filesystem, &self.scope, &path).await?
@@ -296,7 +296,7 @@ where
     }
 
     async fn settle(&self, action: ProductInboundAction) -> Result<(), ProductWorkflowError> {
-        let path = ledger_path(&action.fingerprint)?;
+        let path = ledger_path(&self.scope, &action.fingerprint)?;
         let _guard = self.lock.lock().await;
         let Some(stored) =
             read_json::<F, StoredIdempotencyAction>(&self.filesystem, &self.scope, &path).await?
@@ -320,7 +320,7 @@ where
     }
 
     async fn release(&self, action: ProductInboundAction) -> Result<(), ProductWorkflowError> {
-        let path = ledger_path(&action.fingerprint)?;
+        let path = ledger_path(&self.scope, &action.fingerprint)?;
         let _guard = self.lock.lock().await;
         let Some(stored) =
             read_json::<F, StoredIdempotencyAction>(&self.filesystem, &self.scope, &path).await?
@@ -482,10 +482,17 @@ fn binding_path(
     )
 }
 
-fn ledger_path(fingerprint: &ActionFingerprintKey) -> Result<ScopedPath, ProductWorkflowError> {
+fn ledger_path(
+    scope: &ResourceScope,
+    fingerprint: &ActionFingerprintKey,
+) -> Result<ScopedPath, ProductWorkflowError> {
+    let agent_id = scope.agent_id.as_ref().map_or("", AgentId::as_str);
+    let project_id = scope.project_id.as_ref().map_or("", ProjectId::as_str);
     hashed_scoped_path(
         "/workflow/idempotency",
         &[
+            agent_id,
+            project_id,
             fingerprint.adapter_id.as_str(),
             fingerprint.installation_id.as_str(),
             fingerprint.external_actor_ref.kind(),
@@ -527,13 +534,17 @@ fn user_id_for_binding(
 }
 
 fn thread_id_for_binding(
-    tenant_id: &TenantId,
+    scope: &ResourceScope,
     request: &ResolveBindingRequest,
 ) -> Result<ThreadId, ProductWorkflowError> {
+    let agent_id = scope.agent_id.as_ref().map_or("", AgentId::as_str);
+    let project_id = scope.project_id.as_ref().map_or("", ProjectId::as_str);
     scoped_id(
         "thread",
         &[
-            tenant_id.as_str(),
+            scope.tenant_id.as_str(),
+            agent_id,
+            project_id,
             request.installation_id.as_str(),
             &request.external_conversation_ref.conversation_fingerprint(),
         ],


### PR DESCRIPTION
## Summary
- add Reborn project binding/idempotency/history isolation E2E
- add Reborn agent binding/idempotency/history isolation E2E
- add injected project-scoped identity prompt isolation E2E
- gate cancel requests by the submitting actor, matching resume authorization behavior
- include agent/project scope in product workflow source-binding and submit-idempotency keys
- include agent/project scope in Reborn test workflow canonical thread derivation

## Coverage
- same external conversation/event under different projects does not replay or share history
- same external conversation/event under different agents does not replay or share history
- project-specific injected identity source only reaches prompts for the matching `(tenant, user, project)`
- same-scope wrong actor cannot cancel another actor's blocked run

## Boundary notes
- injected identity source only; no production memory-backed identity source
- no tool/workspace/memory/attachment isolation claim in this PR
- product workflow source/idempotency key changes are scope-hardening needed for project/agent isolation

## Validation
- `cargo test -q --features libsql --test reborn_project_scope_isolation_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_agent_scope_isolation_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_identity_project_scope_isolation_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_wrong_scope_access_isolation_parity -- --nocapture`
- `cargo test -p ironclaw_product_workflow`
- `cargo test -p ironclaw_turns`
- `cargo test -q --features libsql --test reborn_tenant_binding_scope_isolation_parity -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: validation still emits existing `ironclaw_llm` unused import warnings.
