### PR TITLE
test(reborn): cover network and outbound isolation

### DIFF
--- a/tests/reborn_http_network_scope_isolation_parity.rs
+++ b/tests/reborn_http_network_scope_isolation_parity.rs
@@ -1,0 +1,172 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_host_api::{CapabilityId, NetworkPolicy, NetworkScheme, NetworkTargetPattern};
+use ironclaw_host_runtime::HTTP_CAPABILITY_ID;
+use ironclaw_loop_support::{HostManagedModelMessageRole, HostManagedModelResponse};
+use ironclaw_turns::TurnStatus;
+use reborn_support::{
+    harness::RebornBinaryE2EHarness,
+    model_replay::{
+        RebornModelReplayStep, RebornScriptedProviderToolCall, RebornTraceReplayModelGateway,
+    },
+};
+
+#[tokio::test]
+async fn reborn_http_network_scope_isolation_parity() {
+    let http = CapabilityId::new(HTTP_CAPABILITY_ID).expect("valid capability id");
+    let allowed_gateway = http_gateway(
+        http.clone(),
+        "call_http_allowed",
+        "allowed network policy reply",
+    );
+    let denied_gateway = http_gateway(
+        http.clone(),
+        "call_http_denied",
+        "denied network policy reply",
+    );
+
+    let mut allowed =
+        RebornBinaryE2EHarness::with_host_runtime_core_builtin_capabilities_network_policy(
+            "room-http-network-allowed",
+            allowed_gateway,
+            allow_api_example_policy(),
+        )
+        .await
+        .expect("allowed harness");
+    let mut denied =
+        RebornBinaryE2EHarness::with_host_runtime_core_builtin_capabilities_network_policy(
+            "room-http-network-denied",
+            denied_gateway,
+            deny_all_network_policy(),
+        )
+        .await
+        .expect("denied harness");
+
+    allowed.start();
+    denied.start();
+
+    let allowed_turn = allowed
+        .submit_text("event-http-network-allowed", "allowed http request")
+        .await
+        .expect("submit allowed turn");
+    allowed
+        .wait_for_submitted_status(&allowed_turn, TurnStatus::Completed)
+        .await
+        .expect("allowed run completed");
+
+    let denied_turn = denied
+        .submit_text("event-http-network-denied", "denied http request")
+        .await
+        .expect("submit denied turn");
+    let denied_state = denied
+        .wait_for_submitted_status(&denied_turn, TurnStatus::RecoveryRequired)
+        .await
+        .expect("denied run enters recovery after scoped network policy rejection");
+    assert!(
+        denied_state.failure.is_some(),
+        "denied network run should record sanitized failure"
+    );
+
+    assert!(
+        allowed
+            .capability_invocations()
+            .iter()
+            .any(|invocation| invocation.capability_id == http),
+        "allowed scope should invoke HTTP capability"
+    );
+    assert!(
+        denied
+            .capability_invocations()
+            .iter()
+            .any(|invocation| invocation.capability_id == http),
+        "denied scope should attempt HTTP capability before policy rejection"
+    );
+
+    let allowed_results = capability_result_text(&allowed);
+    assert!(
+        allowed_results.contains("accepted") && !allowed_results.contains("denied"),
+        "allowed scope should persist mocked HTTP response only: {allowed_results}"
+    );
+
+    let denied_results = tool_result_text(&denied);
+    assert!(
+        !denied_results.contains("accepted"),
+        "denied scope must not inherit allowed scope HTTP response: {denied_results}"
+    );
+    assert!(
+        denied.capability_results().is_empty(),
+        "denied scope must not persist a successful HTTP capability result"
+    );
+
+    allowed.assert_model_exhausted();
+    allowed.shutdown().await;
+    denied.shutdown().await;
+}
+
+fn http_gateway(
+    http: CapabilityId,
+    call_id: &'static str,
+    final_reply: &'static str,
+) -> RebornTraceReplayModelGateway {
+    RebornTraceReplayModelGateway::with_scripted_steps([
+        RebornModelReplayStep::ProviderToolCalls {
+            calls: vec![RebornScriptedProviderToolCall::new(
+                http,
+                call_id,
+                serde_json::json!({
+                    "url": "https://api.example.test/v1/items",
+                    "headers": {"x-request-id": call_id},
+                    "timeout_ms": 2500,
+                }),
+            )],
+            expected_tool_results: Vec::new(),
+        },
+        RebornModelReplayStep::Response {
+            response: HostManagedModelResponse::assistant_reply(final_reply),
+            expected_tool_results: Vec::new(),
+        },
+    ])
+}
+
+fn capability_result_text(harness: &RebornBinaryE2EHarness) -> String {
+    harness
+        .capability_results()
+        .iter()
+        .map(|result| result.output.to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn tool_result_text(harness: &RebornBinaryE2EHarness) -> String {
+    harness
+        .model_requests()
+        .iter()
+        .flat_map(|request| request.messages.iter())
+        .filter(|message| message.role == HostManagedModelMessageRole::ToolResult)
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn allow_api_example_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "api.example.test".to_string(),
+            port: None,
+        }],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(10_000),
+    }
+}
+
+fn deny_all_network_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        allowed_targets: Vec::new(),
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(10_000),
+    }
+}

--- a/tests/reborn_outbound_reply_target_scope_isolation_parity.rs
+++ b/tests/reborn_outbound_reply_target_scope_isolation_parity.rs
@@ -1,0 +1,86 @@
+#[allow(dead_code)]
+#[path = "support/reborn/mod.rs"]
+mod reborn_support;
+mod support;
+
+use ironclaw_product_adapters::{
+    DeliveryStatus, ExternalConversationRef, FakeProtocolHttpEgress, FinalReplyView,
+    ProductAdapter, ProductOutboundEnvelope, ProductOutboundPayload, ProductOutboundTarget,
+    ProductRenderOutcome, ProjectionCursor,
+};
+use ironclaw_turns::{ReplyTargetBindingRef, TurnRunId};
+use reborn_support::{
+    delivery::RecordingOutboundDeliverySink, test_adapter::RebornTestProductAdapter,
+};
+
+#[tokio::test]
+async fn reborn_outbound_reply_target_scope_isolation_parity() {
+    let adapter_a =
+        RebornTestProductAdapter::new("reborn-test", "install-alpha").expect("adapter alpha");
+    let adapter_b =
+        RebornTestProductAdapter::new("reborn-test", "install-beta").expect("adapter beta");
+    let target_a =
+        ReplyTargetBindingRef::new("reply:install-alpha:room-shared").expect("target alpha");
+    let target_b =
+        ReplyTargetBindingRef::new("reply:install-beta:room-shared").expect("target beta");
+    let sink_a = RecordingOutboundDeliverySink::new();
+    let sink_b = RecordingOutboundDeliverySink::new();
+    let egress = FakeProtocolHttpEgress::new(["api.example.test".to_string()]);
+
+    let envelope_a = outbound_envelope(&adapter_a, target_a.clone(), "alpha reply");
+    let envelope_b = outbound_envelope(&adapter_b, target_b.clone(), "beta reply");
+
+    let outcome_a = adapter_a
+        .render_outbound(envelope_a, &egress, &sink_a)
+        .await
+        .expect("render alpha outbound");
+    let outcome_b = adapter_b
+        .render_outbound(envelope_b, &egress, &sink_b)
+        .await
+        .expect("render beta outbound");
+
+    assert_eq!(outcome_a, ProductRenderOutcome::DeliveryRecorded);
+    assert_eq!(outcome_b, ProductRenderOutcome::DeliveryRecorded);
+
+    assert_delivered_only_to(&sink_a.statuses(), &target_a, &target_b, "alpha");
+    assert_delivered_only_to(&sink_b.statuses(), &target_b, &target_a, "beta");
+}
+
+fn outbound_envelope(
+    adapter: &RebornTestProductAdapter,
+    target_ref: ReplyTargetBindingRef,
+    text: &str,
+) -> ProductOutboundEnvelope {
+    ProductOutboundEnvelope::new(
+        adapter.adapter_id().clone(),
+        adapter.installation_id().clone(),
+        ProductOutboundTarget::new(
+            target_ref,
+            ExternalConversationRef::new(None, "room-shared", None, None)
+                .expect("conversation ref"),
+            None,
+        ),
+        ProjectionCursor::new("cursor:reply-target-scope").expect("projection cursor"),
+        ProductOutboundPayload::FinalReply(FinalReplyView {
+            turn_run_id: TurnRunId::new(),
+            text: text.to_string(),
+            generated_at: chrono::Utc::now(),
+        }),
+    )
+}
+
+fn assert_delivered_only_to(
+    statuses: &[DeliveryStatus],
+    expected: &ReplyTargetBindingRef,
+    forbidden: &ReplyTargetBindingRef,
+    label: &str,
+) {
+    assert_eq!(statuses.len(), 1, "{label} should record one delivery");
+    assert!(
+        matches!(
+            &statuses[0],
+            DeliveryStatus::Delivered { target, .. } if target == expected && target != forbidden
+        ),
+        "{label} delivery should target only matching reply binding; statuses={statuses:?}"
+    );
+}

--- a/tests/reborn_outbound_reply_target_scope_isolation_parity.rs
+++ b/tests/reborn_outbound_reply_target_scope_isolation_parity.rs
@@ -5,8 +5,8 @@ mod support;
 
 use ironclaw_product_adapters::{
     DeliveryStatus, ExternalConversationRef, FakeProtocolHttpEgress, FinalReplyView,
-    ProductAdapter, ProductOutboundEnvelope, ProductOutboundPayload, ProductOutboundTarget,
-    ProductRenderOutcome, ProjectionCursor,
+    ProductAdapter, ProductAdapterError, ProductOutboundEnvelope, ProductOutboundPayload,
+    ProductOutboundTarget, ProductRenderOutcome, ProjectionCursor,
 };
 use ironclaw_turns::{ReplyTargetBindingRef, TurnRunId};
 use reborn_support::{
@@ -29,6 +29,18 @@ async fn reborn_outbound_reply_target_scope_isolation_parity() {
 
     let envelope_a = outbound_envelope(&adapter_a, target_a.clone(), "alpha reply");
     let envelope_b = outbound_envelope(&adapter_b, target_b.clone(), "beta reply");
+    let misrouted_envelope_b =
+        outbound_envelope(&adapter_b, target_b.clone(), "misrouted beta reply");
+
+    let mismatch = adapter_a
+        .render_outbound(misrouted_envelope_b, &egress, &sink_a)
+        .await
+        .expect_err("adapter alpha must reject beta installation outbound");
+    assert_invalid_installation_id(mismatch);
+    assert!(
+        sink_a.statuses().is_empty(),
+        "misrouted beta outbound must not record delivery in alpha sink"
+    );
 
     let outcome_a = adapter_a
         .render_outbound(envelope_a, &egress, &sink_a)
@@ -83,4 +95,13 @@ fn assert_delivered_only_to(
         ),
         "{label} delivery should target only matching reply binding; statuses={statuses:?}"
     );
+}
+
+fn assert_invalid_installation_id(error: ProductAdapterError) {
+    match error {
+        ProductAdapterError::InvalidIdentifier { kind, .. } => {
+            assert_eq!(kind, "envelope.installation_id");
+        }
+        other => panic!("expected InvalidIdentifier, got: {other:?}"),
+    }
 }

--- a/tests/support/reborn/harness.rs
+++ b/tests/support/reborn/harness.rs
@@ -447,6 +447,24 @@ impl RebornBinaryE2EHarness {
         .await
     }
 
+    pub async fn with_host_runtime_core_builtin_capabilities_network_policy(
+        conversation_id: &str,
+        model_gateway: RebornTraceReplayModelGateway,
+        network_policy: NetworkPolicy,
+    ) -> HarnessResult<Self> {
+        let host_runtime = Arc::new(
+            HostRuntimeCapabilityHarness::core_builtin_tools_with_network_policy(network_policy)
+                .await?,
+        );
+        Self::with_model_gateway_capability_mode(
+            conversation_id,
+            model_gateway,
+            HarnessCapabilityMode::HostRuntime(host_runtime),
+            false,
+        )
+        .await
+    }
+
     pub async fn with_harness_blocked_evidence(
         conversation_id: &str,
         model_gateway: RebornTraceReplayModelGateway,
@@ -1312,6 +1330,12 @@ impl HostRuntimeCapabilityHarness {
     }
 
     async fn core_builtin_tools() -> HarnessResult<Self> {
+        Self::core_builtin_tools_with_network_policy(http_test_policy()).await
+    }
+
+    async fn core_builtin_tools_with_network_policy(
+        network_policy: NetworkPolicy,
+    ) -> HarnessResult<Self> {
         let root = Arc::new(tempfile::tempdir()?);
         let storage_root = root.path().join("local-dev");
         let workspace_root = storage_root.join("workspace");
@@ -1342,7 +1366,7 @@ impl HostRuntimeCapabilityHarness {
                 EffectKind::WriteFilesystem,
                 EffectKind::Network,
             ],
-            network_policy: http_test_policy(),
+            network_policy,
             user_id: UserId::new("reborn-e2e-core-builtins-user")?,
             invocations: Arc::new(Mutex::new(Vec::new())),
             results: Arc::new(Mutex::new(Vec::new())),

--- a/tests/support/reborn/test_adapter.rs
+++ b/tests/support/reborn/test_adapter.rs
@@ -143,6 +143,27 @@ impl ProductAdapter for RebornTestProductAdapter {
         _egress: &dyn ProtocolHttpEgress,
         delivery_sink: &dyn OutboundDeliverySink,
     ) -> Result<ProductRenderOutcome, ProductAdapterError> {
+        if envelope.adapter_id != self.adapter_id {
+            return Err(ProductAdapterError::InvalidIdentifier {
+                kind: "envelope.adapter_id",
+                reason: format!(
+                    "envelope adapter_id `{}` does not match this adapter `{}`",
+                    envelope.adapter_id.as_str(),
+                    self.adapter_id.as_str(),
+                ),
+            });
+        }
+        if envelope.installation_id != self.installation_id {
+            return Err(ProductAdapterError::InvalidIdentifier {
+                kind: "envelope.installation_id",
+                reason: format!(
+                    "envelope installation_id `{}` does not match this installation `{}`",
+                    envelope.installation_id.as_str(),
+                    self.installation_id.as_str(),
+                ),
+            });
+        }
+
         delivery_sink
             .record(DeliveryStatus::Delivered {
                 attempt_id: envelope.delivery_attempt_id,


### PR DESCRIPTION
## Summary
- add Reborn HTTP/network policy scope isolation E2E
- add outbound reply-target binding isolation test across adapter installations
- expose a Reborn harness constructor for core built-ins with custom `NetworkPolicy`

## Coverage
- allowed network policy can use the mocked HTTP host and persists the mocked response
- denied network policy cannot inherit the allowed scope response and records no successful HTTP capability result
- outbound rendering records delivery only to the matching `ReplyTargetBindingRef` for each adapter installation

## Boundary notes
- HTTP denied path currently enters `RecoveryRequired` after the scoped network policy rejection; this test asserts no successful result leaks across scopes
- outbound coverage is reply-target binding isolation in the test product adapter path, not full external delivery infra
- no production memory/attachment/tool-workspace isolation claim here

## Validation
- `cargo test -q --features libsql --test reborn_http_network_scope_isolation_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_outbound_reply_target_scope_isolation_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_trace_core_builtin_tools_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_project_scope_isolation_parity -- --nocapture`
- `cargo test -q --features libsql --test reborn_agent_scope_isolation_parity -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

Note: validation still emits existing `ironclaw_llm` unused import warnings.
