### PR TITLE
fix(workflow): address before-inbound policy review follow-up

### DIFF
--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -649,6 +649,13 @@ mod tests {
 
     #[test]
     fn user_message_text_length_bounded_through_serde() {
+        let empty = serde_json::json!({
+            "text": "",
+            "attachments": [],
+            "trigger": "direct_chat"
+        });
+        assert!(serde_json::from_value::<UserMessagePayload>(empty).is_ok());
+
         let at_limit = serde_json::json!({
             "text": "a".repeat(USER_MESSAGE_TEXT_MAX_BYTES),
             "attachments": [],
@@ -674,6 +681,13 @@ mod tests {
             )
             .is_err()
         );
+        let empty_command = serde_json::json!({
+            "command": "",
+            "arguments": "",
+            "trigger": "bot_command"
+        });
+        assert!(serde_json::from_value::<InboundCommandPayload>(empty_command).is_err());
+
         let at_limit = serde_json::json!({
             "command": "h".repeat(COMMAND_MAX_BYTES),
             "arguments": "",

--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -649,6 +649,13 @@ mod tests {
 
     #[test]
     fn user_message_text_length_bounded_through_serde() {
+        let at_limit = serde_json::json!({
+            "text": "a".repeat(USER_MESSAGE_TEXT_MAX_BYTES),
+            "attachments": [],
+            "trigger": "direct_chat"
+        });
+        assert!(serde_json::from_value::<UserMessagePayload>(at_limit).is_ok());
+
         let forged = serde_json::json!({
             "text": "a".repeat(USER_MESSAGE_TEXT_MAX_BYTES + 1),
             "attachments": [],
@@ -667,6 +674,13 @@ mod tests {
             )
             .is_err()
         );
+        let at_limit = serde_json::json!({
+            "command": "h".repeat(COMMAND_MAX_BYTES),
+            "arguments": "",
+            "trigger": "bot_command"
+        });
+        assert!(serde_json::from_value::<InboundCommandPayload>(at_limit).is_ok());
+
         let forged = serde_json::json!({
             "command": "h".repeat(COMMAND_MAX_BYTES + 1),
             "arguments": "",

--- a/crates/ironclaw_product_adapters/src/inbound.rs
+++ b/crates/ironclaw_product_adapters/src/inbound.rs
@@ -648,6 +648,16 @@ mod tests {
     }
 
     #[test]
+    fn user_message_text_length_bounded_through_serde() {
+        let forged = serde_json::json!({
+            "text": "a".repeat(USER_MESSAGE_TEXT_MAX_BYTES + 1),
+            "attachments": [],
+            "trigger": "direct_chat"
+        });
+        assert!(serde_json::from_value::<UserMessagePayload>(forged).is_err());
+    }
+
+    #[test]
     fn command_payload_bounds_are_enforced_through_serde() {
         assert!(
             InboundCommandPayload::new(

--- a/crates/ironclaw_product_workflow/Cargo.toml
+++ b/crates/ironclaw_product_workflow/Cargo.toml
@@ -28,6 +28,7 @@ ironclaw_turns = { path = "../ironclaw_turns", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 

--- a/crates/ironclaw_product_workflow/src/error.rs
+++ b/crates/ironclaw_product_workflow/src/error.rs
@@ -136,17 +136,19 @@ impl From<ProductWorkflowError> for ProductAdapterError {
             ProductWorkflowError::Transient { reason } => ProductAdapterError::WorkflowTransient {
                 reason: RedactedString::new(reason),
             },
-            ProductWorkflowError::BeforeInboundPolicyFailed { reason, permanent } => {
+            ProductWorkflowError::BeforeInboundPolicyFailed { permanent, .. } => {
                 if permanent {
                     ProductAdapterError::WorkflowRejected {
                         kind: ProductWorkflowRejectionKind::AdmissionRejected,
                         status_code: 403,
                         retryable: false,
-                        reason: RedactedString::new(reason),
+                        reason: RedactedString::new("before-inbound policy failed"),
                     }
                 } else {
                     ProductAdapterError::WorkflowTransient {
-                        reason: RedactedString::new(reason),
+                        reason: RedactedString::new(
+                            "before-inbound policy temporarily unavailable",
+                        ),
                     }
                 }
             }

--- a/crates/ironclaw_product_workflow/src/error.rs
+++ b/crates/ironclaw_product_workflow/src/error.rs
@@ -137,6 +137,8 @@ impl From<ProductWorkflowError> for ProductAdapterError {
                 reason: RedactedString::new(reason),
             },
             ProductWorkflowError::BeforeInboundPolicyFailed { permanent, .. } => {
+                // Policy backends may include classifier/provider details in errors;
+                // keep adapter-visible messages stable and generic.
                 if permanent {
                     ProductAdapterError::WorkflowRejected {
                         kind: ProductWorkflowRejectionKind::AdmissionRejected,

--- a/crates/ironclaw_product_workflow/src/error.rs
+++ b/crates/ironclaw_product_workflow/src/error.rs
@@ -136,21 +136,20 @@ impl From<ProductWorkflowError> for ProductAdapterError {
             ProductWorkflowError::Transient { reason } => ProductAdapterError::WorkflowTransient {
                 reason: RedactedString::new(reason),
             },
-            ProductWorkflowError::BeforeInboundPolicyFailed { permanent, .. } => {
-                // Policy backends may include classifier/provider details in errors;
-                // keep adapter-visible messages stable and generic.
+            ProductWorkflowError::BeforeInboundPolicyFailed { reason, permanent } => {
+                // Adapter error surfaces wrap the reason in RedactedString, so
+                // diagnostics remain available internally without leaking to
+                // public protocol output.
                 if permanent {
                     ProductAdapterError::WorkflowRejected {
                         kind: ProductWorkflowRejectionKind::AdmissionRejected,
                         status_code: 403,
                         retryable: false,
-                        reason: RedactedString::new("before-inbound policy failed"),
+                        reason: RedactedString::new(reason),
                     }
                 } else {
                     ProductAdapterError::WorkflowTransient {
-                        reason: RedactedString::new(
-                            "before-inbound policy temporarily unavailable",
-                        ),
+                        reason: RedactedString::new(reason),
                     }
                 }
             }

--- a/crates/ironclaw_product_workflow/src/fakes.rs
+++ b/crates/ironclaw_product_workflow/src/fakes.rs
@@ -284,6 +284,9 @@ impl IdempotencyLedger for FakeIdempotencyLedger {
 ///
 /// Queued `program_outcome(s)` results are consumed first; `allow`, `rewrite_*`,
 /// `reject`, and `force_failure` configure the fallback used after the queue.
+/// `delay_responses_by` composes with both queued and fallback outcomes: every
+/// subsequent policy response waits for the configured delay until a new fake is
+/// created.
 #[derive(Clone)]
 pub struct FakeBeforeInboundPolicy {
     state: Arc<Mutex<FakeBeforeInboundPolicyState>>,
@@ -305,6 +308,9 @@ impl FakeBeforeInboundPolicy {
     }
 
     /// Use allow as the fallback after queued outcomes are exhausted.
+    ///
+    /// This does not clear `delay_responses_by`; delayed fakes continue to
+    /// delay allow outcomes.
     pub fn allow(&self) {
         let mut state = self
             .state
@@ -314,6 +320,9 @@ impl FakeBeforeInboundPolicy {
     }
 
     /// Use this rewrite as the fallback after queued outcomes are exhausted.
+    ///
+    /// This does not clear `delay_responses_by`; delayed fakes continue to
+    /// delay rewrite outcomes.
     pub fn rewrite_user_message(&self, payload: UserMessagePayload) {
         let mut state = self
             .state
@@ -323,6 +332,9 @@ impl FakeBeforeInboundPolicy {
     }
 
     /// Use this rejection as the fallback after queued outcomes are exhausted.
+    ///
+    /// This does not clear `delay_responses_by`; delayed fakes continue to
+    /// delay rejection outcomes.
     pub fn reject(&self, rejection: ProductRejection) {
         let mut state = self
             .state
@@ -332,6 +344,9 @@ impl FakeBeforeInboundPolicy {
     }
 
     /// Use this failure as the fallback after queued outcomes are exhausted.
+    ///
+    /// This does not clear `delay_responses_by`; delayed fakes continue to
+    /// delay failure outcomes.
     pub fn force_failure(&self, error: ProductWorkflowError) {
         let mut state = self
             .state
@@ -367,7 +382,8 @@ impl FakeBeforeInboundPolicy {
     /// Delay every policy response after recording the request.
     ///
     /// Use a delay longer than the workflow timeout to exercise the timeout
-    /// and retry-release path.
+    /// and retry-release path. The delay composes with queued outcomes and the
+    /// fallback outcome; create a new fake when an immediate response is needed.
     pub fn delay_responses_by(&self, delay: Duration) {
         let mut state = self
             .state
@@ -386,6 +402,10 @@ impl FakeBeforeInboundPolicy {
     }
 
     /// Recorded policy requests.
+    ///
+    /// These are intentionally raw test-support requests, including external
+    /// actor/conversation refs, so contract tests can assert exact routing
+    /// context. Do not log this collection from production-like tests.
     pub fn requests(&self) -> Vec<BeforeInboundPolicyRequest> {
         let state = self
             .state

--- a/crates/ironclaw_product_workflow/src/fakes.rs
+++ b/crates/ironclaw_product_workflow/src/fakes.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -293,6 +294,7 @@ struct FakeBeforeInboundPolicyState {
     requests: Vec<BeforeInboundPolicyRequest>,
     programmed_outcomes: VecDeque<Result<BeforeInboundPolicyOutcome, ProductWorkflowError>>,
     fallback_outcome: Option<Result<BeforeInboundPolicyOutcome, ProductWorkflowError>>,
+    response_delay: Option<Duration>,
 }
 
 impl FakeBeforeInboundPolicy {
@@ -338,7 +340,7 @@ impl FakeBeforeInboundPolicy {
         state.fallback_outcome = Some(Err(error));
     }
 
-    /// Append one policy result consumed by the next request.
+    /// Append one policy result consumed by the next request before fallback.
     pub fn program_outcome(
         &self,
         outcome: Result<BeforeInboundPolicyOutcome, ProductWorkflowError>,
@@ -350,7 +352,7 @@ impl FakeBeforeInboundPolicy {
         state.programmed_outcomes.push_back(outcome);
     }
 
-    /// Synchronously program policy results consumed before the fallback outcome.
+    /// Append policy results consumed in order before the fallback outcome.
     pub fn program_outcomes(
         &self,
         outcomes: impl IntoIterator<Item = Result<BeforeInboundPolicyOutcome, ProductWorkflowError>>,
@@ -360,6 +362,18 @@ impl FakeBeforeInboundPolicy {
             .lock()
             .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
         state.programmed_outcomes.extend(outcomes);
+    }
+
+    /// Delay every policy response after recording the request.
+    ///
+    /// Use a delay longer than the workflow timeout to exercise the timeout
+    /// and retry-release path.
+    pub fn delay_responses_by(&self, delay: Duration) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.response_delay = Some(delay);
     }
 
     /// How many user messages reached policy checks.
@@ -393,16 +407,26 @@ impl BeforeInboundPolicy for FakeBeforeInboundPolicy {
         &self,
         request: BeforeInboundPolicyRequest,
     ) -> Result<BeforeInboundPolicyOutcome, ProductWorkflowError> {
-        let mut state = self
-            .state
-            .lock()
-            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
-        state.requests.push(request);
-        state
-            .programmed_outcomes
-            .pop_front()
-            .or_else(|| state.fallback_outcome.clone())
-            .unwrap_or(Ok(BeforeInboundPolicyOutcome::Allow))
+        let (delay, outcome) = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+            state.requests.push(request);
+            let delay = state.response_delay;
+            let outcome = state
+                .programmed_outcomes
+                .pop_front()
+                .or_else(|| state.fallback_outcome.clone())
+                .unwrap_or(Ok(BeforeInboundPolicyOutcome::Allow));
+            (delay, outcome)
+        };
+
+        if let Some(delay) = delay {
+            tokio::time::sleep(delay).await;
+        }
+
+        outcome
     }
 }
 

--- a/crates/ironclaw_product_workflow/src/fakes.rs
+++ b/crates/ironclaw_product_workflow/src/fakes.rs
@@ -17,7 +17,7 @@ use crate::binding::{
     ResolvedBinding,
 };
 use crate::error::ProductWorkflowError;
-use crate::inbound_turn::{InboundTurnOutcome, InboundTurnService};
+use crate::inbound_turn::{InboundTurnOutcome, InboundTurnService, check_before_inbound_policy};
 use crate::ledger::{IdempotencyDecision, IdempotencyLedger};
 use crate::policy::{BeforeInboundPolicy, BeforeInboundPolicyOutcome, BeforeInboundPolicyRequest};
 
@@ -152,6 +152,7 @@ pub struct FakeIdempotencyLedger {
 struct FakeIdempotencyState {
     in_flight: HashMap<ActionFingerprintKey, ProductInboundAction>,
     settled: HashMap<ActionFingerprintKey, ProductInboundAction>,
+    released: Vec<ProductInboundAction>,
     fail_with: Option<ProductWorkflowError>,
     settle_fail_with: Option<ProductWorkflowError>,
 }
@@ -202,6 +203,12 @@ impl FakeIdempotencyLedger {
     pub fn settled_actions(&self) -> Vec<ProductInboundAction> {
         let state = self.state.lock().expect("fake ledger state lock poisoned"); // safety: test-support fake
         state.settled.values().cloned().collect()
+    }
+
+    /// Get all released non-terminal actions.
+    pub fn released_actions(&self) -> Vec<ProductInboundAction> {
+        let state = self.state.lock().expect("fake ledger state lock poisoned"); // safety: test-support fake
+        state.released.clone()
     }
 }
 
@@ -255,6 +262,7 @@ impl IdempotencyLedger for FakeIdempotencyLedger {
             return Err(error);
         }
         state.in_flight.remove(&action.fingerprint);
+        state.released.push(action);
         Ok(())
     }
 }
@@ -272,7 +280,8 @@ pub struct FakeBeforeInboundPolicy {
 #[derive(Default)]
 struct FakeBeforeInboundPolicyState {
     requests: Vec<BeforeInboundPolicyRequest>,
-    outcome: Option<Result<BeforeInboundPolicyOutcome, ProductWorkflowError>>,
+    programmed_outcomes: VecDeque<Result<BeforeInboundPolicyOutcome, ProductWorkflowError>>,
+    fallback_outcome: Option<Result<BeforeInboundPolicyOutcome, ProductWorkflowError>>,
 }
 
 impl FakeBeforeInboundPolicy {
@@ -288,7 +297,7 @@ impl FakeBeforeInboundPolicy {
             .state
             .lock()
             .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
-        state.outcome = Some(Ok(BeforeInboundPolicyOutcome::Allow));
+        state.fallback_outcome = Some(Ok(BeforeInboundPolicyOutcome::Allow));
     }
 
     /// Rewrite all user-message payloads.
@@ -297,7 +306,7 @@ impl FakeBeforeInboundPolicy {
             .state
             .lock()
             .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
-        state.outcome = Some(Ok(BeforeInboundPolicyOutcome::RewriteUserMessage(payload)));
+        state.fallback_outcome = Some(Ok(BeforeInboundPolicyOutcome::RewriteUserMessage(payload)));
     }
 
     /// Reject all user messages.
@@ -306,7 +315,7 @@ impl FakeBeforeInboundPolicy {
             .state
             .lock()
             .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
-        state.outcome = Some(Ok(BeforeInboundPolicyOutcome::Reject(rejection)));
+        state.fallback_outcome = Some(Ok(BeforeInboundPolicyOutcome::Reject(rejection)));
     }
 
     /// Fail all policy checks.
@@ -315,7 +324,31 @@ impl FakeBeforeInboundPolicy {
             .state
             .lock()
             .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
-        state.outcome = Some(Err(error));
+        state.fallback_outcome = Some(Err(error));
+    }
+
+    /// Append one policy result consumed by the next request.
+    pub fn program_outcome(
+        &self,
+        outcome: Result<BeforeInboundPolicyOutcome, ProductWorkflowError>,
+    ) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.programmed_outcomes.push_back(outcome);
+    }
+
+    /// Append policy results consumed in request order before the fallback outcome.
+    pub fn program_outcomes(
+        &self,
+        outcomes: impl IntoIterator<Item = Result<BeforeInboundPolicyOutcome, ProductWorkflowError>>,
+    ) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
+        state.programmed_outcomes.extend(outcomes);
     }
 
     /// How many user messages reached policy checks.
@@ -355,8 +388,9 @@ impl BeforeInboundPolicy for FakeBeforeInboundPolicy {
             .expect("fake before-inbound policy state lock poisoned"); // safety: test-support fake
         state.requests.push(request);
         state
-            .outcome
-            .clone()
+            .programmed_outcomes
+            .pop_front()
+            .or_else(|| state.fallback_outcome.clone())
             .unwrap_or(Ok(BeforeInboundPolicyOutcome::Allow))
     }
 }
@@ -552,9 +586,11 @@ impl InboundTurnService for FakeInboundTurnService {
                 kind: "non_user_message".into(),
             });
         };
-        let policy_outcome = before_inbound_policy
-            .check_user_message(BeforeInboundPolicyRequest::new(envelope, payload)?)
-            .await?;
+        let policy_outcome = check_before_inbound_policy(
+            before_inbound_policy,
+            BeforeInboundPolicyRequest::new(envelope, payload)?,
+        )
+        .await?;
         let dispatch_envelope;
         let envelope_for_turn = match policy_outcome {
             BeforeInboundPolicyOutcome::Allow => envelope,

--- a/crates/ironclaw_product_workflow/src/fakes.rs
+++ b/crates/ironclaw_product_workflow/src/fakes.rs
@@ -152,7 +152,8 @@ pub struct FakeIdempotencyLedger {
 struct FakeIdempotencyState {
     in_flight: HashMap<ActionFingerprintKey, ProductInboundAction>,
     settled: HashMap<ActionFingerprintKey, ProductInboundAction>,
-    released: Vec<ProductInboundAction>,
+    released_count: usize,
+    last_released: Option<ProductInboundAction>,
     fail_with: Option<ProductWorkflowError>,
     settle_fail_with: Option<ProductWorkflowError>,
 }
@@ -205,10 +206,16 @@ impl FakeIdempotencyLedger {
         state.settled.values().cloned().collect()
     }
 
-    /// Get all released non-terminal actions.
-    pub fn released_actions(&self) -> Vec<ProductInboundAction> {
+    /// How many non-terminal actions were released.
+    pub fn released_count(&self) -> usize {
         let state = self.state.lock().expect("fake ledger state lock poisoned"); // safety: test-support fake
-        state.released.clone()
+        state.released_count
+    }
+
+    /// Most recent released non-terminal action, retained for targeted assertions.
+    pub fn last_released_action(&self) -> Option<ProductInboundAction> {
+        let state = self.state.lock().expect("fake ledger state lock poisoned"); // safety: test-support fake
+        state.last_released.clone()
     }
 }
 
@@ -262,7 +269,8 @@ impl IdempotencyLedger for FakeIdempotencyLedger {
             return Err(error);
         }
         state.in_flight.remove(&action.fingerprint);
-        state.released.push(action);
+        state.released_count += 1;
+        state.last_released = Some(action);
         Ok(())
     }
 }
@@ -272,6 +280,9 @@ impl IdempotencyLedger for FakeIdempotencyLedger {
 // ---------------------------------------------------------------------------
 
 /// In-memory fake for before-inbound policy checks.
+///
+/// Queued `program_outcome(s)` results are consumed first; `allow`, `rewrite_*`,
+/// `reject`, and `force_failure` configure the fallback used after the queue.
 #[derive(Clone)]
 pub struct FakeBeforeInboundPolicy {
     state: Arc<Mutex<FakeBeforeInboundPolicyState>>,
@@ -291,7 +302,7 @@ impl FakeBeforeInboundPolicy {
         }
     }
 
-    /// Allow all messages without modification.
+    /// Use allow as the fallback after queued outcomes are exhausted.
     pub fn allow(&self) {
         let mut state = self
             .state
@@ -300,7 +311,7 @@ impl FakeBeforeInboundPolicy {
         state.fallback_outcome = Some(Ok(BeforeInboundPolicyOutcome::Allow));
     }
 
-    /// Rewrite all user-message payloads.
+    /// Use this rewrite as the fallback after queued outcomes are exhausted.
     pub fn rewrite_user_message(&self, payload: UserMessagePayload) {
         let mut state = self
             .state
@@ -309,7 +320,7 @@ impl FakeBeforeInboundPolicy {
         state.fallback_outcome = Some(Ok(BeforeInboundPolicyOutcome::RewriteUserMessage(payload)));
     }
 
-    /// Reject all user messages.
+    /// Use this rejection as the fallback after queued outcomes are exhausted.
     pub fn reject(&self, rejection: ProductRejection) {
         let mut state = self
             .state
@@ -318,7 +329,7 @@ impl FakeBeforeInboundPolicy {
         state.fallback_outcome = Some(Ok(BeforeInboundPolicyOutcome::Reject(rejection)));
     }
 
-    /// Fail all policy checks.
+    /// Use this failure as the fallback after queued outcomes are exhausted.
     pub fn force_failure(&self, error: ProductWorkflowError) {
         let mut state = self
             .state
@@ -339,7 +350,7 @@ impl FakeBeforeInboundPolicy {
         state.programmed_outcomes.push_back(outcome);
     }
 
-    /// Append policy results consumed in request order before the fallback outcome.
+    /// Synchronously program policy results consumed before the fallback outcome.
     pub fn program_outcomes(
         &self,
         outcomes: impl IntoIterator<Item = Result<BeforeInboundPolicyOutcome, ProductWorkflowError>>,

--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -36,8 +36,12 @@ use crate::policy::{
     NoopBeforeInboundPolicy,
 };
 
+#[cfg(not(test))]
 const BEFORE_INBOUND_POLICY_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const BEFORE_INBOUND_POLICY_TIMEOUT: Duration = Duration::from_millis(10);
 
+/// Run a before-inbound policy with the workflow-owned wall-clock budget.
 pub(crate) async fn check_before_inbound_policy(
     before_inbound_policy: &dyn BeforeInboundPolicy,
     request: BeforeInboundPolicyRequest,
@@ -726,11 +730,47 @@ fn bounded_ref<T: RefFactory>(prefix: &str, raw: &str) -> Result<T, ProductWorkf
 
 #[cfg(test)]
 mod tests {
+    use std::future::pending;
+
+    use async_trait::async_trait;
     use chrono::TimeZone;
     use ironclaw_host_api::{AgentId, TenantId, ThreadId, UserId};
+    use ironclaw_product_adapters::{
+        AdapterInstallationId, ExternalActorRef, ExternalConversationRef, ProductAdapterId,
+        ProductTriggerReason, UserMessagePayload,
+    };
     use ironclaw_threads::ThreadScope;
 
+    use crate::action::SourceBindingKey;
+
     use super::*;
+
+    struct PendingBeforeInboundPolicy;
+
+    #[async_trait]
+    impl BeforeInboundPolicy for PendingBeforeInboundPolicy {
+        async fn check_user_message(
+            &self,
+            _request: BeforeInboundPolicyRequest,
+        ) -> Result<BeforeInboundPolicyOutcome, ProductWorkflowError> {
+            pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn check_before_inbound_policy_times_out_as_retryable_failure() {
+        let err = check_before_inbound_policy(&PendingBeforeInboundPolicy, policy_request())
+            .await
+            .expect_err("pending policy should time out");
+
+        assert!(matches!(
+            err,
+            ProductWorkflowError::BeforeInboundPolicyFailed {
+                permanent: false,
+                ..
+            }
+        ));
+    }
 
     #[test]
     fn submitted_replay_becomes_already_submitted_handoff() {
@@ -789,6 +829,27 @@ mod tests {
         assert_eq!(submission.message_id, message_id);
         assert_eq!(submission.source_binding_id, "src:alpha");
         assert_eq!(submission.reply_target_binding_id, "reply:alpha");
+    }
+
+    fn policy_request() -> BeforeInboundPolicyRequest {
+        BeforeInboundPolicyRequest {
+            adapter_id: ProductAdapterId::new("test_adapter").expect("adapter"),
+            installation_id: AdapterInstallationId::new("install_alpha").expect("installation"),
+            external_actor_ref: ExternalActorRef::new("test", "user1", Option::<String>::None)
+                .expect("actor"),
+            external_conversation_ref: ExternalConversationRef::new(None, "conv1", None, None)
+                .expect("conversation"),
+            source_binding_key: SourceBindingKey::new("space:0:;conversation:5:conv1;topic:0:;")
+                .expect("source binding key"),
+            rate_limit_key: SourceBindingKey::new("space:0:;conversation:5:conv1;topic:0:;")
+                .expect("rate limit key"),
+            user_message: UserMessagePayload::new(
+                "hello",
+                vec![],
+                ProductTriggerReason::DirectChat,
+            )
+            .expect("message"),
+        }
     }
 
     fn replay(

--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -36,12 +36,17 @@ use crate::policy::{
     NoopBeforeInboundPolicy,
 };
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "test-support")))]
 const BEFORE_INBOUND_POLICY_TIMEOUT: Duration = Duration::from_secs(5);
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 const BEFORE_INBOUND_POLICY_TIMEOUT: Duration = Duration::from_millis(10);
 
 /// Run a before-inbound policy with the workflow-owned wall-clock budget.
+///
+/// The timeout keeps slow policy backends from holding an idempotency
+/// fingerprint in-flight indefinitely. A timed-out policy maps to a transient,
+/// non-permanent [`ProductWorkflowError::BeforeInboundPolicyFailed`] so the
+/// workflow releases the fingerprint and lets the same inbound action retry.
 pub(crate) async fn check_before_inbound_policy(
     before_inbound_policy: &dyn BeforeInboundPolicy,
     request: BeforeInboundPolicyRequest,
@@ -770,6 +775,16 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test]
+    async fn noop_before_inbound_policy_allows_user_messages() {
+        let outcome = NoopBeforeInboundPolicy
+            .check_user_message(policy_request())
+            .await
+            .expect("noop policy should not fail");
+
+        assert_eq!(outcome, BeforeInboundPolicyOutcome::Allow);
     }
 
     #[test]

--- a/crates/ironclaw_product_workflow/src/inbound_turn.rs
+++ b/crates/ironclaw_product_workflow/src/inbound_turn.rs
@@ -6,6 +6,8 @@
 //! submit/deferred handling behind that seam prevents adapter-specific binding
 //! code from owning the whole inbound turn pipeline.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use ironclaw_host_api::UserId;
@@ -33,6 +35,23 @@ use crate::policy::{
     BeforeInboundPolicy, BeforeInboundPolicyOutcome, BeforeInboundPolicyRequest,
     NoopBeforeInboundPolicy,
 };
+
+const BEFORE_INBOUND_POLICY_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(crate) async fn check_before_inbound_policy(
+    before_inbound_policy: &dyn BeforeInboundPolicy,
+    request: BeforeInboundPolicyRequest,
+) -> Result<BeforeInboundPolicyOutcome, ProductWorkflowError> {
+    tokio::time::timeout(
+        BEFORE_INBOUND_POLICY_TIMEOUT,
+        before_inbound_policy.check_user_message(request),
+    )
+    .await
+    .map_err(|_| ProductWorkflowError::BeforeInboundPolicyFailed {
+        reason: "before-inbound policy timed out".into(),
+        permanent: false,
+    })?
+}
 
 /// Result of the inbound turn submission flow.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -168,9 +187,11 @@ where
             .await?
         {
             InboundUserMessageDispatch::Accepted(outcome) => Ok(outcome),
-            InboundUserMessageDispatch::Rejected(_) => Err(ProductWorkflowError::Transient {
-                reason: "noop before-inbound policy unexpectedly rejected message".into(),
-            }),
+            InboundUserMessageDispatch::Rejected(_) => {
+                Err(ProductWorkflowError::TurnSubmissionRejected {
+                    reason: "noop before-inbound policy unexpectedly rejected message".into(),
+                })
+            }
         }
     }
 
@@ -184,6 +205,7 @@ where
                 kind: "non_user_message".into(),
             });
         };
+        let original_trigger = payload.trigger;
         let prepared = self.prepare_user_message(envelope).await?;
         if let Some(outcome) = self
             .replay_prepared_user_message(envelope, &prepared)
@@ -192,21 +214,28 @@ where
             return Ok(InboundUserMessageDispatch::Accepted(outcome));
         }
 
-        let policy_outcome = before_inbound_policy
-            .check_user_message(BeforeInboundPolicyRequest::new(envelope, payload)?)
-            .await?;
+        let policy_outcome = check_before_inbound_policy(
+            before_inbound_policy,
+            BeforeInboundPolicyRequest::new(envelope, payload)?,
+        )
+        .await?;
         let dispatch_envelope;
         let (prepared_for_turn, envelope_for_turn) = match policy_outcome {
             BeforeInboundPolicyOutcome::Allow => (prepared, envelope),
             BeforeInboundPolicyOutcome::RewriteUserMessage(payload) => {
+                let rewritten_trigger = payload.trigger;
                 dispatch_envelope =
                     envelope.with_rewritten_user_message(payload).map_err(|_| {
                         ProductWorkflowError::TurnSubmissionRejected {
                             reason: "invalid policy-rewritten user message".into(),
                         }
                     })?;
-                let rewritten_prepared = self.prepare_user_message(&dispatch_envelope).await?;
-                (rewritten_prepared, &dispatch_envelope)
+                let prepared_for_turn = if rewritten_trigger == original_trigger {
+                    prepared
+                } else {
+                    self.prepare_user_message(&dispatch_envelope).await?
+                };
+                (prepared_for_turn, &dispatch_envelope)
             }
             BeforeInboundPolicyOutcome::Reject(rejection) => {
                 return Ok(InboundUserMessageDispatch::Rejected(rejection));

--- a/crates/ironclaw_product_workflow/src/policy.rs
+++ b/crates/ironclaw_product_workflow/src/policy.rs
@@ -18,7 +18,8 @@ use crate::error::ProductWorkflowError;
 /// This intentionally excludes the full trusted envelope and host-stamped auth
 /// claim. Policies see only the user-message payload plus product identity and
 /// binding refs needed for policy decisions; the workflow keeps trusted context
-/// for downstream staging and turn submission.
+/// for downstream staging and turn submission. Policy implementations should use
+/// `rate_limit_key` for throttling and must not log raw external refs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BeforeInboundPolicyRequest {
     pub adapter_id: ProductAdapterId,
@@ -26,6 +27,8 @@ pub struct BeforeInboundPolicyRequest {
     pub external_actor_ref: ExternalActorRef,
     pub external_conversation_ref: ExternalConversationRef,
     pub source_binding_key: SourceBindingKey,
+    /// Stable, workflow-validated partition key for policy-side rate limits.
+    pub rate_limit_key: SourceBindingKey,
     pub user_message: UserMessagePayload,
 }
 
@@ -41,7 +44,8 @@ impl BeforeInboundPolicyRequest {
             installation_id: envelope.installation_id().clone(),
             external_actor_ref: envelope.external_actor_ref().clone(),
             external_conversation_ref: envelope.external_conversation_ref().clone(),
-            source_binding_key,
+            source_binding_key: source_binding_key.clone(),
+            rate_limit_key: source_binding_key,
             user_message: user_message.clone(),
         })
     }
@@ -63,11 +67,9 @@ pub enum BeforeInboundPolicyOutcome {
 ///
 /// Implementations must be bounded: the workflow runs `check_user_message`
 /// inline on the inbound dispatch path while holding an in-flight idempotency
-/// fingerprint, so a slow or stuck policy will stall inbound submissions for
-/// the same `(adapter, installation, source binding, external event)` tuple.
-/// Callers are responsible for enforcing wall-clock timeouts on any
-/// production policy implementation (for example by wrapping the port in a
-/// `tokio::time::timeout` decorator).
+/// fingerprint. The default workflow path wraps policy calls in a bounded
+/// `tokio::time::timeout`; production decorators should use `rate_limit_key`
+/// for quota decisions and avoid logging raw external refs.
 ///
 /// Returning [`ProductWorkflowError::BeforeInboundPolicyFailed`] with
 /// `permanent: true` settles the action as a terminal policy rejection.

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -408,6 +408,7 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
         ProductWorkflowError::BeforeInboundPolicyFailed {
             permanent: true, ..
         } => Some(ProductInboundAck::Rejected(ProductRejection::permanent(
+            // Durable acks cross adapter boundaries; do not persist raw policy internals.
             ProductRejectionKind::PolicyDenied,
             "before-inbound policy failed",
         ))),

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -406,11 +406,11 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
             )))
         }
         ProductWorkflowError::BeforeInboundPolicyFailed {
-            permanent: true, ..
+            reason,
+            permanent: true,
         } => Some(ProductInboundAck::Rejected(ProductRejection::permanent(
-            // Durable acks cross adapter boundaries; do not persist raw policy internals.
             ProductRejectionKind::PolicyDenied,
-            "before-inbound policy failed",
+            reason.clone(),
         ))),
         ProductWorkflowError::BindingResolutionFailed { .. }
         | ProductWorkflowError::TurnSubmissionRejected { .. }

--- a/crates/ironclaw_product_workflow/src/workflow.rs
+++ b/crates/ironclaw_product_workflow/src/workflow.rs
@@ -110,8 +110,8 @@ impl ProductWorkflow for DefaultProductWorkflow {
 
                 match result {
                     Ok(dispatched) => {
-                        action.mark_dispatched(dispatched.dispatch_kind);
                         if should_settle_ack(&dispatched.ack) {
+                            action.mark_dispatched(dispatched.dispatch_kind);
                             action.settle(dispatched.ack.clone());
                             self.idempotency_ledger.settle(action).await.map_err(|e| {
                                 ProductAdapterError::from(ProductWorkflowError::Transient {
@@ -406,11 +406,10 @@ fn terminal_ack_for_error(error: &ProductWorkflowError) -> Option<ProductInbound
             )))
         }
         ProductWorkflowError::BeforeInboundPolicyFailed {
-            reason,
-            permanent: true,
+            permanent: true, ..
         } => Some(ProductInboundAck::Rejected(ProductRejection::permanent(
             ProductRejectionKind::PolicyDenied,
-            format!("before-inbound policy failed: {reason}"),
+            "before-inbound policy failed",
         ))),
         ProductWorkflowError::BindingResolutionFailed { .. }
         | ProductWorkflowError::TurnSubmissionRejected { .. }
@@ -552,5 +551,15 @@ mod tests {
             accepted_message_ref: AcceptedMessageRef::new("msg:busy").expect("valid ref"),
             active_run_id: TurnRunId::new(),
         }));
+    }
+
+    #[test]
+    fn should_settle_ack_respects_rejection_disposition() {
+        assert!(should_settle_ack(&ProductInboundAck::Rejected(
+            ProductRejection::permanent(ProductRejectionKind::PolicyDenied, "blocked")
+        )));
+        assert!(!should_settle_ack(&ProductInboundAck::Rejected(
+            ProductRejection::retryable(ProductRejectionKind::PolicyDenied, "try later")
+        )));
     }
 }

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -761,7 +761,7 @@ async fn before_inbound_policy_retryable_failure_releases_fingerprint() {
 #[tokio::test]
 async fn before_inbound_policy_timeout_releases_fingerprint_for_retry() {
     let (workflow, inbound, ledger, policy) = build_workflow_with_policy();
-    policy.delay_responses_by(StdDuration::from_millis(50));
+    policy.delay_responses_by(StdDuration::from_millis(200));
     let envelope = sample_envelope("policy-timeout-release");
 
     let first = workflow
@@ -833,6 +833,15 @@ async fn before_inbound_policy_permanent_failure_settles_terminal_rejection() {
     assert_eq!(
         rejection.disposition(),
         ProductRejectionDisposition::Permanent
+    );
+    let rejection_debug = format!("{rejection:?}");
+    assert!(
+        !rejection_debug.contains("policy configuration is invalid"),
+        "durable rejection ack must not expose raw policy internals: {rejection_debug}"
+    );
+    assert!(
+        rejection_debug.contains("<redacted>"),
+        "durable rejection reason should remain redacted: {rejection_debug}"
     );
 }
 
@@ -1464,7 +1473,17 @@ async fn concrete_product_workflow_reuses_prepared_binding_for_content_only_poli
         .await
         .expect("policy-rewritten message accepted");
 
-    assert_eq!(coordinator.submissions().len(), 1);
+    let submissions = coordinator.submissions();
+    assert_eq!(submissions.len(), 1);
+    assert_eq!(
+        submissions[0].scope.tenant_id.as_str(),
+        "tenant:install_alpha"
+    );
+    assert_eq!(submissions[0].actor.user_id.as_str(), "user:user1");
+    assert_eq!(
+        submissions[0].scope.agent_id.as_ref().map(AgentId::as_str),
+        Some("agent:fake")
+    );
     assert_eq!(binding.resolve_count(), 1);
     assert_eq!(
         binding.route_kinds(),

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -453,6 +453,10 @@ async fn before_inbound_policy_rewrite_reaches_inbound_turn_service() {
         request.source_binding_key.as_str(),
         "space:0:;conversation:5:conv1;topic:0:;"
     );
+    assert_eq!(
+        request.rate_limit_key.as_str(),
+        "space:0:;conversation:5:conv1;topic:0:;"
+    );
     let accepted = inbound.accepted_envelopes();
     assert_eq!(accepted.len(), 1);
     let ProductInboundPayload::UserMessage(payload) = accepted[0].payload() else {
@@ -578,6 +582,9 @@ async fn before_inbound_policy_retryable_rejection_releases_fingerprint() {
     assert_eq!(inbound.accepted_count(), 0);
     assert_eq!(ledger.settled_count(), 0);
     assert_eq!(ledger.in_flight_count(), 0);
+    let released = ledger.released_actions();
+    assert_eq!(released.len(), 1);
+    assert!(released[0].dispatch_kind.is_none());
 
     // Re-submitting the same envelope must re-invoke the policy (no duplicate
     // replay caching), because retryable rejections release the fingerprint.
@@ -785,6 +792,46 @@ async fn before_inbound_policy_permanent_failure_settles_terminal_rejection() {
         rejection.disposition(),
         ProductRejectionDisposition::Permanent
     );
+}
+
+#[tokio::test]
+async fn fake_before_inbound_policy_uses_programmed_outcomes_in_order() {
+    let policy = FakeBeforeInboundPolicy::new();
+    let envelope = sample_envelope("fake-policy-sequence");
+    let ProductInboundPayload::UserMessage(payload) = envelope.payload() else {
+        panic!("expected user message")
+    };
+    policy.program_outcomes([
+        Ok(BeforeInboundPolicyOutcome::RewriteUserMessage(
+            UserMessagePayload::new("first", vec![], ProductTriggerReason::DirectChat)
+                .expect("valid rewrite"),
+        )),
+        Ok(BeforeInboundPolicyOutcome::Reject(
+            ProductRejection::retryable(ProductRejectionKind::PolicyDenied, "try later"),
+        )),
+    ]);
+    policy.allow();
+
+    let first = policy
+        .check_user_message(BeforeInboundPolicyRequest::new(&envelope, payload).expect("request"))
+        .await
+        .expect("first policy result");
+    assert!(matches!(
+        first,
+        BeforeInboundPolicyOutcome::RewriteUserMessage(rewritten) if rewritten.text == "first"
+    ));
+
+    let second = policy
+        .check_user_message(BeforeInboundPolicyRequest::new(&envelope, payload).expect("request"))
+        .await
+        .expect("second policy result");
+    assert!(matches!(second, BeforeInboundPolicyOutcome::Reject(_)));
+
+    let third = policy
+        .check_user_message(BeforeInboundPolicyRequest::new(&envelope, payload).expect("request"))
+        .await
+        .expect("fallback policy result");
+    assert_eq!(third, BeforeInboundPolicyOutcome::Allow);
 }
 
 #[tokio::test]

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -582,9 +582,14 @@ async fn before_inbound_policy_retryable_rejection_releases_fingerprint() {
     assert_eq!(inbound.accepted_count(), 0);
     assert_eq!(ledger.settled_count(), 0);
     assert_eq!(ledger.in_flight_count(), 0);
-    let released = ledger.released_actions();
-    assert_eq!(released.len(), 1);
-    assert!(released[0].dispatch_kind.is_none());
+    assert_eq!(ledger.released_count(), 1);
+    assert!(
+        ledger
+            .last_released_action()
+            .expect("released action")
+            .dispatch_kind
+            .is_none()
+    );
 
     // Re-submitting the same envelope must re-invoke the policy (no duplicate
     // replay caching), because retryable rejections release the fingerprint.
@@ -1387,6 +1392,46 @@ async fn concrete_product_workflow_bot_mention_uses_shared_route() {
     assert_eq!(
         binding.route_kinds(),
         vec![ironclaw_product_workflow::ProductConversationRouteKind::Shared]
+    );
+}
+
+#[tokio::test]
+async fn concrete_product_workflow_reuses_prepared_binding_for_content_only_policy_rewrite() {
+    let binding = Arc::new(FakeConversationBindingService::new());
+    let coordinator = Arc::new(RecordingTurnCoordinator::default());
+    let inbound = Arc::new(DefaultInboundTurnService::new(
+        binding.clone(),
+        InMemorySessionThreadService::default(),
+        coordinator.clone(),
+    ));
+    let policy = Arc::new(FakeBeforeInboundPolicy::new());
+    policy.rewrite_user_message(
+        UserMessagePayload::new("rewritten direct", vec![], ProductTriggerReason::DirectChat)
+            .expect("message"),
+    );
+    let workflow = DefaultProductWorkflow::new(
+        inbound,
+        Arc::new(InMemoryIdempotencyLedger::new()),
+        binding.clone(),
+    )
+    .with_before_inbound_policy(policy);
+
+    workflow
+        .accept_inbound(sample_envelope_with_payload(
+            "policy-rewrite-direct-route",
+            ProductInboundPayload::UserMessage(
+                UserMessagePayload::new("hello direct", vec![], ProductTriggerReason::DirectChat)
+                    .expect("message"),
+            ),
+        ))
+        .await
+        .expect("policy-rewritten message accepted");
+
+    assert_eq!(coordinator.submissions().len(), 1);
+    assert_eq!(binding.resolve_count(), 1);
+    assert_eq!(
+        binding.route_kinds(),
+        vec![ironclaw_product_workflow::ProductConversationRouteKind::Direct]
     );
 }
 

--- a/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
+++ b/crates/ironclaw_product_workflow/tests/product_workflow_contract.rs
@@ -1,6 +1,7 @@
 //! Contract tests for the product workflow facade.
 
 use std::sync::{Arc, Mutex};
+use std::time::Duration as StdDuration;
 
 use async_trait::async_trait;
 use chrono::{Duration, Utc};
@@ -755,6 +756,42 @@ async fn before_inbound_policy_retryable_failure_releases_fingerprint() {
     assert!(second.is_retryable());
     assert_eq!(policy.request_count(), 2);
     assert_eq!(inbound.accepted_count(), 0);
+}
+
+#[tokio::test]
+async fn before_inbound_policy_timeout_releases_fingerprint_for_retry() {
+    let (workflow, inbound, ledger, policy) = build_workflow_with_policy();
+    policy.delay_responses_by(StdDuration::from_millis(50));
+    let envelope = sample_envelope("policy-timeout-release");
+
+    let first = workflow
+        .accept_inbound(envelope.clone())
+        .await
+        .expect_err("timed-out policy should be retryable");
+    assert!(first.is_retryable());
+    assert_eq!(policy.request_count(), 1);
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 1);
+    assert!(
+        ledger
+            .last_released_action()
+            .expect("released action")
+            .dispatch_kind
+            .is_none()
+    );
+
+    let second = workflow
+        .accept_inbound(envelope)
+        .await
+        .expect_err("released fingerprint should retry timed-out policy");
+    assert!(second.is_retryable());
+    assert_eq!(policy.request_count(), 2);
+    assert_eq!(inbound.accepted_count(), 0);
+    assert_eq!(ledger.settled_count(), 0);
+    assert_eq!(ledger.in_flight_count(), 0);
+    assert_eq!(ledger.released_count(), 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #3632 addressing the code-review findings posted after the original PR had already merged.

Fixes:
- bound before-inbound policy calls with a 5s timeout
- add explicit policy `rate_limit_key` context and docs not to log raw external refs
- avoid a second binding prepare for content-only rewrites while preserving trigger-change rerouting
- keep retryable rejection releases unmarked as dispatched
- redact permanent policy failure reasons at adapter/durable ack boundaries
- add queued outcomes to `FakeBeforeInboundPolicy`
- add serde validation and settlement coverage tests

## Validation

- `cargo test -p ironclaw_product_adapters --lib`
- `cargo test -p ironclaw_product_workflow --features test-support`
- `cargo clippy -p ironclaw_product_workflow --all-targets --features test-support -- -D warnings`
- `cargo clippy -p ironclaw_product_adapters --lib -- -D warnings`

Note: full `cargo test -p ironclaw_product_adapters` currently fails in unrelated existing integration tests (`product_adapter_contract`, `review_findings_contract`) with type inference/unresolved-module errors; lib tests pass.